### PR TITLE
Add hybrid SSM state handoff

### DIFF
--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -747,7 +747,7 @@ class MambaMetadata:
         self.mamba_state_free_slot_count -= 1
         mamba_idx = self.mamba_state_free_slots[self.mamba_state_free_slot_count]
 
-        return mamba_idx
+        return int(mamba_idx)
 
     def detach_state_slot(self, request_idx: int) -> int:
         """Detach and return a request's live state slot without freeing it."""
@@ -785,7 +785,7 @@ class MambaMetadata:
             self.mamba_state_free_slot_count : self.mamba_state_free_slot_count + num_slots
         ]
 
-        return mamba_idx
+        return mamba_idx.clone()
 
     def _return_slots(self, mamba_indices: torch.Tensor) -> None:
         """Return live state slots to the free-slot stack."""

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -752,6 +752,16 @@ class MambaMetadata:
 
         return mamba_idx
 
+    def free_slot(self, mamba_idx: int) -> None:
+        """Return one unbound slot to the live Mamba state pool."""
+
+        if not 0 <= mamba_idx < self.max_requests:
+            raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
+        if self.mamba_state_free_slot_count >= self.max_requests:
+            raise RuntimeError("Cannot free a Mamba state slot when the pool is already full")
+        self.mamba_state_free_slots[self.mamba_state_free_slot_count] = mamba_idx
+        self.mamba_state_free_slot_count += 1
+
     def batch_allocate_slots(self, num_slots: int) -> Optional[torch.Tensor]:
         """
         Allocates new slots for the given number of requests in the Mamba state buffers.

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -106,9 +106,6 @@ class MambaMetadata:
             self.max_requests, dtype=torch.int32, device='cpu'
         )
         self.mamba_state_free_slot_count = self.max_requests
-        # A finished handoff request may keep its live state as a transfer source.
-        self._retained_state_slots = torch.zeros(self.max_requests, dtype=torch.bool, device='cpu')
-        self._retained_state_slot_count = 0
 
         # Intermediate state extraction buffers (CUDA graph compatible). Sized by
         # the per-step token-budget cap shared from DynamicInferenceContext.
@@ -152,19 +149,14 @@ class MambaMetadata:
 
     def reset(self) -> None:
         """
-        Reset request mappings while preserving externally retained live slots.
+        Resets all Mamba states and frees all allocated slots.
         """
         self.request_to_mamba_state_idx.fill_(-1)
 
         self.reset_varlen_metadata()
 
-        if self._retained_state_slot_count:
-            free_slots = torch.nonzero(~self._retained_state_slots, as_tuple=True)[0]
-            self.mamba_state_free_slots[: free_slots.numel()] = free_slots.to(torch.int32)
-            self.mamba_state_free_slot_count = free_slots.numel()
-        else:
-            torch.arange(self.max_requests, out=self.mamba_state_free_slots)
-            self.mamba_state_free_slot_count = self.max_requests
+        torch.arange(self.max_requests, out=self.mamba_state_free_slots)
+        self.mamba_state_free_slot_count = self.max_requests
 
     def reset_varlen_metadata(self) -> None:
         """Resets varlen metadata."""
@@ -757,35 +749,24 @@ class MambaMetadata:
 
         return mamba_idx
 
-    def retain_state_slot(self, mamba_idx: int) -> None:
-        """Retain a live state slot independently of its active request."""
+    def detach_state_slot(self, request_idx: int) -> int:
+        """Detach and return a request's live state slot without freeing it."""
 
-        if not 0 <= mamba_idx < self.max_requests:
-            raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
-        if self._retained_state_slots[mamba_idx]:
-            raise RuntimeError(f"Mamba state slot {mamba_idx} is already retained")
-        self._retained_state_slots[mamba_idx] = True
-        self._retained_state_slot_count += 1
+        mamba_idx = int(self.request_to_mamba_state_idx[request_idx].item())
+        if mamba_idx < 0:
+            raise RuntimeError(f"Request index {request_idx} has no live Mamba state slot")
+        self.request_to_mamba_state_idx[request_idx] = -1
+        return mamba_idx
 
     def free_slot(self, mamba_idx: int) -> None:
         """Return one unbound slot to the live Mamba state pool."""
 
         if not 0 <= mamba_idx < self.max_requests:
             raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
-        if self._retained_state_slots[mamba_idx]:
-            raise RuntimeError(f"Cannot free retained Mamba state slot {mamba_idx}")
-        self._return_slots(torch.tensor([mamba_idx], dtype=torch.int32, device='cpu'))
-
-    def release_retained_state_slot(self, mamba_idx: int) -> None:
-        """Release a live state slot retained after its request completed."""
-
-        if not 0 <= mamba_idx < self.max_requests:
-            raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
-        if not self._retained_state_slots[mamba_idx]:
-            raise RuntimeError(f"Mamba state slot {mamba_idx} is not retained")
-        self._retained_state_slots[mamba_idx] = False
-        self._retained_state_slot_count -= 1
-        self._return_slots(torch.tensor([mamba_idx], dtype=torch.int32, device='cpu'))
+        if self.mamba_state_free_slot_count >= self.max_requests:
+            raise RuntimeError("Cannot free a Mamba state slot when the pool is already full")
+        self.mamba_state_free_slots[self.mamba_state_free_slot_count] = mamba_idx
+        self.mamba_state_free_slot_count += 1
 
     def batch_allocate_slots(self, num_slots: int) -> Optional[torch.Tensor]:
         """
@@ -830,10 +811,6 @@ class MambaMetadata:
 
         # Filter out any invalid indices (e.g., -1)
         mamba_indices_to_free = mamba_indices_to_free[mamba_indices_to_free != -1]
-        if self._retained_state_slot_count:
-            mamba_indices_to_free = mamba_indices_to_free[
-                ~self._retained_state_slots[mamba_indices_to_free.long()]
-            ]
         self._return_slots(mamba_indices_to_free)
 
         # Invalidate the Mamba state index for the finished requests

--- a/megatron/core/inference/contexts/attention_context/mamba_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mamba_metadata.py
@@ -106,6 +106,9 @@ class MambaMetadata:
             self.max_requests, dtype=torch.int32, device='cpu'
         )
         self.mamba_state_free_slot_count = self.max_requests
+        # A finished handoff request may keep its live state as a transfer source.
+        self._retained_state_slots = torch.zeros(self.max_requests, dtype=torch.bool, device='cpu')
+        self._retained_state_slot_count = 0
 
         # Intermediate state extraction buffers (CUDA graph compatible). Sized by
         # the per-step token-budget cap shared from DynamicInferenceContext.
@@ -149,17 +152,19 @@ class MambaMetadata:
 
     def reset(self) -> None:
         """
-        Resets all Mamba states and frees all allocated slots.
+        Reset request mappings while preserving externally retained live slots.
         """
         self.request_to_mamba_state_idx.fill_(-1)
 
         self.reset_varlen_metadata()
 
-        # Re-initialize the free slot pool
-        self.mamba_state_free_slots = torch.arange(
-            self.max_requests, dtype=torch.int32, device='cpu'
-        )
-        self.mamba_state_free_slot_count = self.max_requests
+        if self._retained_state_slot_count:
+            free_slots = torch.nonzero(~self._retained_state_slots, as_tuple=True)[0]
+            self.mamba_state_free_slots[: free_slots.numel()] = free_slots.to(torch.int32)
+            self.mamba_state_free_slot_count = free_slots.numel()
+        else:
+            torch.arange(self.max_requests, out=self.mamba_state_free_slots)
+            self.mamba_state_free_slot_count = self.max_requests
 
     def reset_varlen_metadata(self) -> None:
         """Resets varlen metadata."""
@@ -752,15 +757,35 @@ class MambaMetadata:
 
         return mamba_idx
 
+    def retain_state_slot(self, mamba_idx: int) -> None:
+        """Retain a live state slot independently of its active request."""
+
+        if not 0 <= mamba_idx < self.max_requests:
+            raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
+        if self._retained_state_slots[mamba_idx]:
+            raise RuntimeError(f"Mamba state slot {mamba_idx} is already retained")
+        self._retained_state_slots[mamba_idx] = True
+        self._retained_state_slot_count += 1
+
     def free_slot(self, mamba_idx: int) -> None:
         """Return one unbound slot to the live Mamba state pool."""
 
         if not 0 <= mamba_idx < self.max_requests:
             raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
-        if self.mamba_state_free_slot_count >= self.max_requests:
-            raise RuntimeError("Cannot free a Mamba state slot when the pool is already full")
-        self.mamba_state_free_slots[self.mamba_state_free_slot_count] = mamba_idx
-        self.mamba_state_free_slot_count += 1
+        if self._retained_state_slots[mamba_idx]:
+            raise RuntimeError(f"Cannot free retained Mamba state slot {mamba_idx}")
+        self._return_slots(torch.tensor([mamba_idx], dtype=torch.int32, device='cpu'))
+
+    def release_retained_state_slot(self, mamba_idx: int) -> None:
+        """Release a live state slot retained after its request completed."""
+
+        if not 0 <= mamba_idx < self.max_requests:
+            raise ValueError(f"Mamba state slot {mamba_idx} is outside the live state pool")
+        if not self._retained_state_slots[mamba_idx]:
+            raise RuntimeError(f"Mamba state slot {mamba_idx} is not retained")
+        self._retained_state_slots[mamba_idx] = False
+        self._retained_state_slot_count -= 1
+        self._return_slots(torch.tensor([mamba_idx], dtype=torch.int32, device='cpu'))
 
     def batch_allocate_slots(self, num_slots: int) -> Optional[torch.Tensor]:
         """
@@ -781,6 +806,18 @@ class MambaMetadata:
 
         return mamba_idx
 
+    def _return_slots(self, mamba_indices: torch.Tensor) -> None:
+        """Return live state slots to the free-slot stack."""
+
+        if mamba_indices.numel() == 0:
+            return
+        start = self.mamba_state_free_slot_count
+        end = start + mamba_indices.numel()
+        if end > self.max_requests:
+            raise RuntimeError("Mamba state free-slot pool overflow")
+        self.mamba_state_free_slots[start:end] = mamba_indices.to(torch.int32)
+        self.mamba_state_free_slot_count = end
+
     def free_slots(self, request_indices: torch.Tensor) -> None:
         """
         Frees the Mamba state slots associated with the given request indices.
@@ -793,14 +830,11 @@ class MambaMetadata:
 
         # Filter out any invalid indices (e.g., -1)
         mamba_indices_to_free = mamba_indices_to_free[mamba_indices_to_free != -1]
-        num_to_free = len(mamba_indices_to_free)
-
-        if num_to_free > 0:
-            # Add the freed indices back to the free slot pool
-            start_idx = self.mamba_state_free_slot_count
-            end_idx = start_idx + num_to_free
-            self.mamba_state_free_slots[start_idx:end_idx] = mamba_indices_to_free
-            self.mamba_state_free_slot_count = end_idx
+        if self._retained_state_slot_count:
+            mamba_indices_to_free = mamba_indices_to_free[
+                ~self._retained_state_slots[mamba_indices_to_free.long()]
+            ]
+        self._return_slots(mamba_indices_to_free)
 
         # Invalidate the Mamba state index for the finished requests
         self.request_to_mamba_state_idx[request_indices] = -1

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -901,17 +901,14 @@ class DynamicInferenceContext(BaseInferenceContext):
                 and prefix_caching_mamba_gb is not None
                 and prefix_caching_mamba_gb > 0
             ):
+                assert self.mamba_slot_allocator is not None
                 prefix_cache_bytes = int(prefix_caching_mamba_gb * 1024**3)
-                # Mirror the split done in _allocate_mamba_cache so this preview
-                # matches what is actually allocated: the "scratch" buffers
-                # (intermediate_ssm_out/intermediate_conv_out) are reserved from the
-                # budget first, then the rest sizes the "durable" cache
-                # (ssm_states/conv_states). mamba_bytes_per_req is the shared
-                # per-slot footprint of both.
+                # The allocator contains the PP-synchronized durable capacity.
+                # Scratch remains stage-local because it is temporary forward
+                # storage and does not participate in prefix-cache matching.
                 scratch_slots = self.max_mamba_intermediate_states_per_step
                 scratch_bytes = scratch_slots * mamba_bytes_per_req
-                durable_slots = (prefix_cache_bytes - scratch_bytes) // mamba_bytes_per_req
-                durable_slots = max(durable_slots, 0)
+                durable_slots = self.mamba_slot_allocator.max_slots
                 log_lines += [
                     f"  Mamba prefix cache:",
                     f"    budget:                {get_mem_size_str(prefix_cache_bytes)}",
@@ -1826,6 +1823,23 @@ class DynamicInferenceContext(BaseInferenceContext):
         scratch_slots = self.max_mamba_intermediate_states_per_step
         scratch_bytes = scratch_slots * per_slot_bytes
         max_slots = (total_bytes - scratch_bytes) // per_slot_bytes  # durable slots
+
+        # Prefix-cache state is replicated across pipeline stages. Use the
+        # smallest stage-local capacity so identical cache operations produce
+        # identical block-to-slot mappings on every stage. A recurrent prefix
+        # is executable only when all stages retain its state, so additional
+        # slots on an individual stage would not increase usable cache capacity.
+        if get_pg_size(self.pipeline_parallel_group) > 1:
+            max_slots_tensor = torch.tensor(
+                max_slots, dtype=torch.int64, device=torch.cuda.current_device()
+            )
+            torch.distributed.all_reduce(
+                max_slots_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.pipeline_parallel_group,
+            )
+            max_slots = int(max_slots_tensor.item())
+
         if max_slots < 1:
             raise ValueError(
                 f"Mamba prefix cache budget (prefix_caching_mamba_gb={mamba_gb:.4g} GB) "
@@ -3511,6 +3525,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             sa._intermediate_offsets_cpu[request_indexes] = 0
             sa._intermediate_block_ids_cpu[request_indexes] = -1
             sa._eos_cache_block_id_cpu[request_indexes] = -1
+            sa._eos_handoff_required_cpu[request_indexes] = False
 
     def _get_paused_request_count_within_block_budget(self) -> int:
         """Count the left-most paused requests whose blocks fit the paused budget."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -1823,6 +1823,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         scratch_slots = self.max_mamba_intermediate_states_per_step
         scratch_bytes = scratch_slots * per_slot_bytes
         max_slots = (total_bytes - scratch_bytes) // per_slot_bytes  # durable slots
+        local_max_slots = max_slots
 
         # Prefix-cache state is replicated across pipeline stages. Use the
         # smallest stage-local capacity so identical cache operations produce
@@ -1841,6 +1842,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_slots = int(max_slots_tensor.item())
 
         if max_slots < 1:
+            if local_max_slots >= 1:
+                raise ValueError(
+                    f"Mamba prefix cache budget (prefix_caching_mamba_gb={mamba_gb:.4g} GB) "
+                    f"has room for {local_max_slots} durable slots on this pipeline stage, but "
+                    f"another stage has room for fewer than one. Cache capacity is mirrored to "
+                    f"the minimum across stages; increase prefix_caching_mamba_gb, reduce "
+                    f"max_tokens, or rebalance the Mamba layers."
+                )
             raise ValueError(
                 f"Mamba prefix cache budget (prefix_caching_mamba_gb={mamba_gb:.4g} GB) "
                 f"is too small. The CUDA-graph extraction scratch reserves "
@@ -3088,10 +3097,14 @@ class DynamicInferenceContext(BaseInferenceContext):
         Check if the request can be added to the context.
         """
         # Note that for hybrid models checking the total request count is sufficient
-        # because we allocate a single set of Mamba state tensors for each request
+        # because we allocate a single set of Mamba state tensors for each request.
         request_can_be_added = (
             self.total_request_count < self.max_requests and self.paused_request_count == 0
         )
+        # A handoff is the exception: it keeps its live recurrent-state slot after
+        # its request row is removed, so both capacities must be checked independently.
+        if self.is_hybrid_model and self.kv_block_allocator.enable_handoff_pinning:
+            request_can_be_added &= self.mamba_metadata.mamba_state_free_slot_count > 0
 
         matched_block_ids, num_blocks_from_pool, _, _, _, effective_prefill_chunk_length = (
             self._compute_prefix_match(req, req.remaining_prompt_length)

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3525,7 +3525,6 @@ class DynamicInferenceContext(BaseInferenceContext):
             sa._intermediate_offsets_cpu[request_indexes] = 0
             sa._intermediate_block_ids_cpu[request_indexes] = -1
             sa._eos_cache_block_id_cpu[request_indexes] = -1
-            sa._eos_handoff_required_cpu[request_indexes] = False
 
     def _get_paused_request_count_within_block_budget(self) -> int:
         """Count the left-most paused requests whose blocks fit the paused budget."""

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -109,13 +109,8 @@ class MambaSlotAllocator:
         self._intermediate_block_ids_cpu = torch.full(
             (context.max_requests, k), -1, dtype=torch.int32, device='cpu'
         )
-        # Track each request's end-of-prefill SSM state by its KV block ID.
-        # Handoff states are marked so they are cached before optional prefix snapshots.
         self._eos_cache_block_id_cpu = torch.full(
             (context.max_requests,), -1, dtype=torch.int32, device='cpu'
-        )
-        self._eos_handoff_required_cpu = torch.zeros(
-            context.max_requests, dtype=torch.bool, device='cpu'
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
@@ -492,25 +487,22 @@ class MambaSlotAllocator:
             self._has_intermediates = True
         self._intermediate_counts_cpu[current_id] = count
 
-        # A handoff needs the exact post-prompt recurrent state, including for a
-        # partial final KV block. Ordinary prefix caching stores only block-boundary
-        # states because only complete blocks have reusable hashes.
-        handoff_required = req.sampling_params.do_kv_handoff
-        cache_final_state = last_aligned_abs == prompt_len or handoff_required
-        if is_last_chunk and cache_final_state and prompt_len > 0:
-            last_block_idx = (prompt_len - 1) // bs
+        # Block-aligned EOS: when the prompt length is exactly block-aligned, the
+        # request's live final state IS the last block boundary's state and can be
+        # cached directly. Only valid on the final chunk (otherwise the live state
+        # is mid-prompt). Non-block-aligned prompts cache their last complete block
+        # via the intermediate-extraction path above instead.
+        if is_last_chunk and last_aligned_abs == prompt_len and prompt_len > 0:
+            last_block_idx = prompt_len // bs - 1
             if last_block_idx >= 0:
                 self._eos_cache_block_id_cpu[current_id] = ctx.request_to_kv_block_ids[current_id][
                     last_block_idx
                 ]
-                self._eos_handoff_required_cpu[current_id] = handoff_required
                 self._has_intermediates = True
             else:
                 self._eos_cache_block_id_cpu[current_id] = -1
-                self._eos_handoff_required_cpu[current_id] = False
         else:
             self._eos_cache_block_id_cpu[current_id] = -1
-            self._eos_handoff_required_cpu[current_id] = False
 
     def get_intermediate_cpu_data(self):
         """Get intermediate offsets and counts as CPU tensor slices for current prefill batch.
@@ -556,31 +548,6 @@ class MambaSlotAllocator:
     # Intermediate state commit
     # =========================================================================
 
-    def _allocate_slots_up_to_capacity(
-        self, block_ids: list, required_count: int
-    ) -> tuple[list[int], list[int]]:
-        """Allocate required candidates plus as many optional candidates as fit."""
-
-        try:
-            return list(range(len(block_ids))), self.allocate_slots_batch(block_ids)
-        except MambaSlotCapacityError as error:
-            # Keep existing slots and the earliest new blocks that fit.
-            existing_slots = self.block_to_slot[block_ids].tolist()
-            required_new = sum(slot < 0 for slot in existing_slots[:required_count])
-            if required_new > error.available:
-                raise MambaSlotCapacityError(required_new, error.available) from error
-            kept_indices: list[int] = []
-            new_slots_kept = 0
-            for index, slot in enumerate(existing_slots):
-                if slot >= 0:
-                    kept_indices.append(index)
-                elif new_slots_kept < error.available:
-                    kept_indices.append(index)
-                    new_slots_kept += 1
-
-            kept_bids = [block_ids[index] for index in kept_indices]
-            return kept_indices, self.allocate_slots_batch(kept_bids)
-
     def commit_intermediate_states(self) -> None:
         """Commit intermediate states from pre-allocated output buffers to cache.
 
@@ -590,50 +557,48 @@ class MambaSlotAllocator:
         collected = self._collect_commit_data()
         if collected is None:
             return
-        # Each candidate is (block ID, hash, source index, source is live,
-        # handoff required). Required states win both capacity and duplicate
-        # block IDs over optional reusable prefix snapshots.
-        required = [snapshot for snapshot in collected if snapshot[4]]
-        ordered = list(required)
-        ordered.extend(snapshot for snapshot in collected if not snapshot[4])
-        snapshots = []
-        claimed_bids = set()
-        for block_id, block_hash, source_index, source_is_live, _ in ordered:
-            if block_id in claimed_bids:
-                continue
-            snapshots.append((block_id, block_hash, source_index, source_is_live))
-            claimed_bids.add(block_id)
+        intermediate_bids, src_offsets, eos_bids, eos_ctx_indices, all_hashes = collected
 
-        required_count = len({snapshot[0] for snapshot in required})
-        kept_indices, slots = self._allocate_slots_up_to_capacity(
-            [block_id for block_id, _, _, _ in snapshots], required_count
-        )
-        if not kept_indices:
-            self._clear_intermediate_state()
-            return
+        # These snapshots only improve future cache hits; the active requests
+        # continue from their live Mamba state if durable capacity is exhausted.
+        all_bids = intermediate_bids + eos_bids
+        n_intermediate = len(intermediate_bids)
+        try:
+            all_slots = self.allocate_slots_batch(all_bids)
+        except MambaSlotCapacityError as error:
+            existing_slots = self.block_to_slot[all_bids].tolist()
+            kept_indices = []
+            kept_new_bids = set()
+            for index, (block_id, slot) in enumerate(zip(all_bids, existing_slots)):
+                if slot >= 0 or block_id in kept_new_bids:
+                    kept_indices.append(index)
+                elif len(kept_new_bids) < error.available:
+                    kept_new_bids.add(block_id)
+                    kept_indices.append(index)
 
-        intermediate_sources = []
-        intermediate_slots = []
-        live_sources = []
-        live_slots = []
-        committed_bids = []
-        committed_hashes = []
-        for index, slot in zip(kept_indices, slots):
-            block_id, block_hash, source_index, source_is_live = snapshots[index]
-            committed_bids.append(block_id)
-            committed_hashes.append(block_hash)
-            if source_is_live:
-                live_sources.append(source_index)
-                live_slots.append(slot)
-            else:
-                intermediate_sources.append(source_index)
-                intermediate_slots.append(slot)
+            if not kept_indices:
+                self._clear_intermediate_state()
+                return
 
-        if intermediate_sources:
-            self._copy_intermediate_to_cache(intermediate_sources, intermediate_slots)
-        if live_sources:
-            self.store_from_live_batch(live_slots, live_sources)
-        self.register_block_hashes_batch(committed_bids, committed_hashes)
+            all_bids = [all_bids[index] for index in kept_indices]
+            all_hashes = [all_hashes[index] for index in kept_indices]
+            src_offsets = [src_offsets[index] for index in kept_indices if index < n_intermediate]
+            eos_ctx_indices = [
+                eos_ctx_indices[index - n_intermediate]
+                for index in kept_indices
+                if index >= n_intermediate
+            ]
+            all_slots = self.allocate_slots_batch(all_bids)
+            n_intermediate = len(src_offsets)
+
+        # Copy intermediate states from output buffers to cache
+        self._copy_intermediate_to_cache(src_offsets, all_slots[:n_intermediate])
+
+        # Copy EOS states from live buffers to cache
+        self.store_from_live_batch(all_slots[n_intermediate:], eos_ctx_indices)
+
+        # Register hashes for all committed blocks
+        self.register_block_hashes_batch(all_bids, all_hashes)
 
         self._clear_intermediate_state()
 
@@ -641,8 +606,9 @@ class MambaSlotAllocator:
         """Extract commit data from GPU intermediate state tracking.
 
         Returns:
-            Candidate tuples of (block ID, hash, source index, source is live,
-            handoff required), or None if nothing needs to be committed.
+            Tuple of (intermediate_bids, src_offsets, eos_bids, eos_ctx_indices,
+            all_hashes) or None if nothing to commit. all_hashes covers
+            intermediate_bids + eos_bids in that order.
         """
         ctx = self.context
         metadata = ctx.mamba_metadata
@@ -665,9 +631,6 @@ class MambaSlotAllocator:
         eos_bids_cpu = self._eos_cache_block_id_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
-        eos_handoff_required_cpu = self._eos_handoff_required_cpu[
-            prefill_start : prefill_start + prefill_count
-        ].tolist()
 
         # Flatten intermediate block IDs and source offsets
         intermediate_bids = []
@@ -680,42 +643,26 @@ class MambaSlotAllocator:
                     src_offsets.append(ssm_offset + j)
                 ssm_offset += count
 
-        # Collect aligned EOS block IDs, live context indices, and handoff flags.
+        # Collect EOS block IDs and their context indices
         eos_bids = []
         eos_ctx_indices = []
-        eos_handoff_required = []
-        for req_batch_idx, (eos_bid, handoff_required) in enumerate(
-            zip(eos_bids_cpu, eos_handoff_required_cpu)
-        ):
+        for req_batch_idx in range(prefill_count):
+            eos_bid = eos_bids_cpu[req_batch_idx]
             if eos_bid >= 0:
                 eos_bids.append(eos_bid)
                 eos_ctx_indices.append(prefill_start + req_batch_idx)
-                eos_handoff_required.append(bool(handoff_required))
 
         if not intermediate_bids and not eos_bids:
             self._clear_intermediate_state()
             return None
 
-        # Fetch all hashes from the allocator's CPU bookkeeping in one indexed read.
+        # Single batch hash fetch for all block IDs (1 GPU sync)
         all_bids_for_hash = intermediate_bids + eos_bids
         device = ctx.kv_block_allocator.block_hashes.device
         bid_tensor = torch.tensor(all_bids_for_hash, dtype=torch.int64, device=device)
         all_hashes = ctx.kv_block_allocator.block_hashes[bid_tensor].tolist()
 
-        intermediate_count = len(intermediate_bids)
-        snapshots = [
-            (block_id, block_hash, source_offset, False, False)
-            for block_id, block_hash, source_offset in zip(
-                intermediate_bids, all_hashes[:intermediate_count], src_offsets
-            )
-        ]
-        snapshots.extend(
-            (block_id, block_hash, context_index, True, handoff_required)
-            for block_id, block_hash, context_index, handoff_required in zip(
-                eos_bids, all_hashes[intermediate_count:], eos_ctx_indices, eos_handoff_required
-            )
-        )
-        return snapshots
+        return intermediate_bids, src_offsets, eos_bids, eos_ctx_indices, all_hashes
 
     def _copy_intermediate_to_cache(self, src_offsets: list, slots: list) -> None:
         """Copy intermediate states from output buffers to cache slots.
@@ -747,7 +694,6 @@ class MambaSlotAllocator:
             self._intermediate_offsets_cpu[prefill_start:end].fill_(0)
             self._intermediate_block_ids_cpu[prefill_start:end].fill_(-1)
             self._eos_cache_block_id_cpu[prefill_start:end].fill_(-1)
-            self._eos_handoff_required_cpu[prefill_start:end].fill_(False)
         self._has_intermediates = False
 
     # =========================================================================
@@ -767,5 +713,4 @@ class MambaSlotAllocator:
         self._intermediate_counts_cpu.fill_(0)
         self._intermediate_block_ids_cpu.fill_(-1)
         self._eos_cache_block_id_cpu.fill_(-1)
-        self._eos_handoff_required_cpu.fill_(False)
         self._has_intermediates = False

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -556,22 +556,27 @@ class MambaSlotAllocator:
     # Intermediate state commit
     # =========================================================================
 
-    def _allocate_slots_up_to_capacity(self, block_ids: list) -> tuple[list[int], list[int]]:
-        """Allocate candidates that fit and return their original indices and slots."""
+    def _allocate_slots_up_to_capacity(
+        self, block_ids: list, required_count: int
+    ) -> tuple[list[int], list[int]]:
+        """Allocate required candidates plus as many optional candidates as fit."""
 
         try:
             return list(range(len(block_ids))), self.allocate_slots_batch(block_ids)
         except MambaSlotCapacityError as error:
-            # Keep existing slots and the earliest unique new blocks that fit.
+            # Keep existing slots and the earliest new blocks that fit.
             existing_slots = self.block_to_slot[block_ids].tolist()
+            required_new = sum(slot < 0 for slot in existing_slots[:required_count])
+            if required_new > error.available:
+                raise MambaSlotCapacityError(required_new, error.available) from error
             kept_indices: list[int] = []
-            kept_new_bids: set[int] = set()
-            for index, (block_id, slot) in enumerate(zip(block_ids, existing_slots)):
-                if slot >= 0 or block_id in kept_new_bids:
+            new_slots_kept = 0
+            for index, slot in enumerate(existing_slots):
+                if slot >= 0:
                     kept_indices.append(index)
-                elif len(kept_new_bids) < error.available:
-                    kept_new_bids.add(block_id)
+                elif new_slots_kept < error.available:
                     kept_indices.append(index)
+                    new_slots_kept += 1
 
             kept_bids = [block_ids[index] for index in kept_indices]
             return kept_indices, self.allocate_slots_batch(kept_bids)
@@ -585,82 +590,50 @@ class MambaSlotAllocator:
         collected = self._collect_commit_data()
         if collected is None:
             return
-        (
-            intermediate_bids,
-            src_offsets,
-            eos_bids,
-            eos_ctx_indices,
-            eos_handoff_required,
-            all_hashes,
-        ) = collected
+        # Each candidate is (block ID, hash, source index, source is live,
+        # handoff required). Required states win both capacity and duplicate
+        # block IDs over optional reusable prefix snapshots.
+        required = [snapshot for snapshot in collected if snapshot[4]]
+        ordered = list(required)
+        ordered.extend(snapshot for snapshot in collected if not snapshot[4])
+        snapshots = []
+        claimed_bids = set()
+        for block_id, block_hash, source_index, source_is_live, _ in ordered:
+            if block_id in claimed_bids:
+                continue
+            snapshots.append((block_id, block_hash, source_index, source_is_live))
+            claimed_bids.add(block_id)
 
-        # Reserve slots for exact handoff states before optional prefix snapshots.
-        handoff_eos_indices = [
-            index for index, required in enumerate(eos_handoff_required) if required
-        ]
-        requested_handoff_bids = [eos_bids[index] for index in handoff_eos_indices]
-        requested_handoff_ctx_indices = [eos_ctx_indices[index] for index in handoff_eos_indices]
-        requested_handoff_hashes = [
-            all_hashes[len(intermediate_bids) + index] for index in handoff_eos_indices
-        ]
-        if requested_handoff_bids:
-            kept_handoffs, handoff_slots = self._allocate_slots_up_to_capacity(
-                requested_handoff_bids
-            )
-            handoff_bids = [requested_handoff_bids[index] for index in kept_handoffs]
-            handoff_ctx_indices = [requested_handoff_ctx_indices[index] for index in kept_handoffs]
-            handoff_hashes = [requested_handoff_hashes[index] for index in kept_handoffs]
-            self.store_from_live_batch(handoff_slots, handoff_ctx_indices)
-            self.register_block_hashes_batch(handoff_bids, handoff_hashes)
-
-        # Remove optional snapshots for blocks claimed by exact handoff state.
-        handoff_bid_set = set(requested_handoff_bids)
-        optional_eos_indices = [
-            index
-            for index, block_id in enumerate(eos_bids)
-            if index not in handoff_eos_indices and block_id not in handoff_bid_set
-        ]
-        eos_bids = [eos_bids[index] for index in optional_eos_indices]
-        eos_ctx_indices = [eos_ctx_indices[index] for index in optional_eos_indices]
-        eos_hashes = [all_hashes[len(intermediate_bids) + index] for index in optional_eos_indices]
-        keep_intermediate = [
-            index
-            for index, block_id in enumerate(intermediate_bids)
-            if block_id not in handoff_bid_set
-        ]
-        intermediate_bids = [intermediate_bids[index] for index in keep_intermediate]
-        src_offsets = [src_offsets[index] for index in keep_intermediate]
-        intermediate_hashes = [all_hashes[index] for index in keep_intermediate]
-        all_hashes = intermediate_hashes + eos_hashes
-
-        # Fill the remaining capacity with optional reusable prefix snapshots.
-        all_bids = intermediate_bids + eos_bids
-        n_intermediate = len(intermediate_bids)
-        kept_indices, all_slots = self._allocate_slots_up_to_capacity(all_bids)
-        if all_bids and not kept_indices:
+        required_count = len({snapshot[0] for snapshot in required})
+        kept_indices, slots = self._allocate_slots_up_to_capacity(
+            [block_id for block_id, _, _, _ in snapshots], required_count
+        )
+        if not kept_indices:
             self._clear_intermediate_state()
             return
-        if len(kept_indices) != len(all_bids):
-            # Keep block, hash, and state-source lists aligned after truncation.
-            all_bids = [all_bids[index] for index in kept_indices]
-            all_hashes = [all_hashes[index] for index in kept_indices]
-            src_offsets = [src_offsets[index] for index in kept_indices if index < n_intermediate]
-            eos_ctx_indices = [
-                eos_ctx_indices[index - n_intermediate]
-                for index in kept_indices
-                if index >= n_intermediate
-            ]
-            n_intermediate = len(src_offsets)
 
-        if all_bids:
-            # Intermediate snapshots come from the extraction buffers.
-            self._copy_intermediate_to_cache(src_offsets, all_slots[:n_intermediate])
+        intermediate_sources = []
+        intermediate_slots = []
+        live_sources = []
+        live_slots = []
+        committed_bids = []
+        committed_hashes = []
+        for index, slot in zip(kept_indices, slots):
+            block_id, block_hash, source_index, source_is_live = snapshots[index]
+            committed_bids.append(block_id)
+            committed_hashes.append(block_hash)
+            if source_is_live:
+                live_sources.append(source_index)
+                live_slots.append(slot)
+            else:
+                intermediate_sources.append(source_index)
+                intermediate_slots.append(slot)
 
-            # End-of-prefill snapshots come from the live request state.
-            self.store_from_live_batch(all_slots[n_intermediate:], eos_ctx_indices)
-
-            # Publish hashes only after their state has been copied.
-            self.register_block_hashes_batch(all_bids, all_hashes)
+        if intermediate_sources:
+            self._copy_intermediate_to_cache(intermediate_sources, intermediate_slots)
+        if live_sources:
+            self.store_from_live_batch(live_slots, live_sources)
+        self.register_block_hashes_batch(committed_bids, committed_hashes)
 
         self._clear_intermediate_state()
 
@@ -668,10 +641,8 @@ class MambaSlotAllocator:
         """Extract commit data from GPU intermediate state tracking.
 
         Returns:
-            Tuple of (intermediate_bids, src_offsets, eos_bids, eos_ctx_indices,
-            eos_handoff_required, all_hashes), or None if nothing needs to be
-            committed. ``all_hashes`` covers ``intermediate_bids + eos_bids``
-            in that order.
+            Candidate tuples of (block ID, hash, source index, source is live,
+            handoff required), or None if nothing needs to be committed.
         """
         ctx = self.context
         metadata = ctx.mamba_metadata
@@ -725,20 +696,26 @@ class MambaSlotAllocator:
             self._clear_intermediate_state()
             return None
 
-        # Single batch hash fetch for all block IDs (1 GPU sync)
+        # Fetch all hashes from the allocator's CPU bookkeeping in one indexed read.
         all_bids_for_hash = intermediate_bids + eos_bids
         device = ctx.kv_block_allocator.block_hashes.device
         bid_tensor = torch.tensor(all_bids_for_hash, dtype=torch.int64, device=device)
         all_hashes = ctx.kv_block_allocator.block_hashes[bid_tensor].tolist()
 
-        return (
-            intermediate_bids,
-            src_offsets,
-            eos_bids,
-            eos_ctx_indices,
-            eos_handoff_required,
-            all_hashes,
+        intermediate_count = len(intermediate_bids)
+        snapshots = [
+            (block_id, block_hash, source_offset, False, False)
+            for block_id, block_hash, source_offset in zip(
+                intermediate_bids, all_hashes[:intermediate_count], src_offsets
+            )
+        ]
+        snapshots.extend(
+            (block_id, block_hash, context_index, True, handoff_required)
+            for block_id, block_hash, context_index, handoff_required in zip(
+                eos_bids, all_hashes[intermediate_count:], eos_ctx_indices, eos_handoff_required
+            )
         )
+        return snapshots
 
     def _copy_intermediate_to_cache(self, src_offsets: list, slots: list) -> None:
         """Copy intermediate states from output buffers to cache slots.

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -109,8 +109,13 @@ class MambaSlotAllocator:
         self._intermediate_block_ids_cpu = torch.full(
             (context.max_requests, k), -1, dtype=torch.int32, device='cpu'
         )
+        # Track each request's end-of-prefill SSM state by its KV block ID.
+        # Handoff states are marked so they are cached before optional prefix snapshots.
         self._eos_cache_block_id_cpu = torch.full(
             (context.max_requests,), -1, dtype=torch.int32, device='cpu'
+        )
+        self._eos_handoff_required_cpu = torch.zeros(
+            context.max_requests, dtype=torch.bool, device='cpu'
         )
         # CPU flag to skip GPU sync when no intermediates exist
         self._has_intermediates = False
@@ -487,22 +492,25 @@ class MambaSlotAllocator:
             self._has_intermediates = True
         self._intermediate_counts_cpu[current_id] = count
 
-        # Block-aligned EOS: when the prompt length is exactly block-aligned, the
-        # request's live final state IS the last block boundary's state and can be
-        # cached directly. Only valid on the final chunk (otherwise the live state
-        # is mid-prompt). Non-block-aligned prompts cache their last complete block
-        # via the intermediate-extraction path above instead.
-        if is_last_chunk and last_aligned_abs == prompt_len and prompt_len > 0:
-            last_block_idx = prompt_len // bs - 1
+        # A handoff needs the exact post-prompt recurrent state, including for a
+        # partial final KV block. Ordinary prefix caching stores only block-boundary
+        # states because only complete blocks have reusable hashes.
+        handoff_required = req.sampling_params.do_kv_handoff
+        cache_final_state = last_aligned_abs == prompt_len or handoff_required
+        if is_last_chunk and cache_final_state and prompt_len > 0:
+            last_block_idx = (prompt_len - 1) // bs
             if last_block_idx >= 0:
                 self._eos_cache_block_id_cpu[current_id] = ctx.request_to_kv_block_ids[current_id][
                     last_block_idx
                 ]
+                self._eos_handoff_required_cpu[current_id] = handoff_required
                 self._has_intermediates = True
             else:
                 self._eos_cache_block_id_cpu[current_id] = -1
+                self._eos_handoff_required_cpu[current_id] = False
         else:
             self._eos_cache_block_id_cpu[current_id] = -1
+            self._eos_handoff_required_cpu[current_id] = False
 
     def get_intermediate_cpu_data(self):
         """Get intermediate offsets and counts as CPU tensor slices for current prefill batch.
@@ -548,6 +556,26 @@ class MambaSlotAllocator:
     # Intermediate state commit
     # =========================================================================
 
+    def _allocate_slots_up_to_capacity(self, block_ids: list) -> tuple[list[int], list[int]]:
+        """Allocate candidates that fit and return their original indices and slots."""
+
+        try:
+            return list(range(len(block_ids))), self.allocate_slots_batch(block_ids)
+        except MambaSlotCapacityError as error:
+            # Keep existing slots and the earliest unique new blocks that fit.
+            existing_slots = self.block_to_slot[block_ids].tolist()
+            kept_indices: list[int] = []
+            kept_new_bids: set[int] = set()
+            for index, (block_id, slot) in enumerate(zip(block_ids, existing_slots)):
+                if slot >= 0 or block_id in kept_new_bids:
+                    kept_indices.append(index)
+                elif len(kept_new_bids) < error.available:
+                    kept_new_bids.add(block_id)
+                    kept_indices.append(index)
+
+            kept_bids = [block_ids[index] for index in kept_indices]
+            return kept_indices, self.allocate_slots_batch(kept_bids)
+
     def commit_intermediate_states(self) -> None:
         """Commit intermediate states from pre-allocated output buffers to cache.
 
@@ -557,29 +585,63 @@ class MambaSlotAllocator:
         collected = self._collect_commit_data()
         if collected is None:
             return
-        intermediate_bids, src_offsets, eos_bids, eos_ctx_indices, all_hashes = collected
+        (
+            intermediate_bids,
+            src_offsets,
+            eos_bids,
+            eos_ctx_indices,
+            eos_handoff_required,
+            all_hashes,
+        ) = collected
 
-        # These snapshots only improve future cache hits; the active requests
-        # continue from their live Mamba state if durable capacity is exhausted.
+        # Reserve slots for exact handoff states before optional prefix snapshots.
+        handoff_eos_indices = [
+            index for index, required in enumerate(eos_handoff_required) if required
+        ]
+        requested_handoff_bids = [eos_bids[index] for index in handoff_eos_indices]
+        requested_handoff_ctx_indices = [eos_ctx_indices[index] for index in handoff_eos_indices]
+        requested_handoff_hashes = [
+            all_hashes[len(intermediate_bids) + index] for index in handoff_eos_indices
+        ]
+        if requested_handoff_bids:
+            kept_handoffs, handoff_slots = self._allocate_slots_up_to_capacity(
+                requested_handoff_bids
+            )
+            handoff_bids = [requested_handoff_bids[index] for index in kept_handoffs]
+            handoff_ctx_indices = [requested_handoff_ctx_indices[index] for index in kept_handoffs]
+            handoff_hashes = [requested_handoff_hashes[index] for index in kept_handoffs]
+            self.store_from_live_batch(handoff_slots, handoff_ctx_indices)
+            self.register_block_hashes_batch(handoff_bids, handoff_hashes)
+
+        # Remove optional snapshots for blocks claimed by exact handoff state.
+        handoff_bid_set = set(requested_handoff_bids)
+        optional_eos_indices = [
+            index
+            for index, block_id in enumerate(eos_bids)
+            if index not in handoff_eos_indices and block_id not in handoff_bid_set
+        ]
+        eos_bids = [eos_bids[index] for index in optional_eos_indices]
+        eos_ctx_indices = [eos_ctx_indices[index] for index in optional_eos_indices]
+        eos_hashes = [all_hashes[len(intermediate_bids) + index] for index in optional_eos_indices]
+        keep_intermediate = [
+            index
+            for index, block_id in enumerate(intermediate_bids)
+            if block_id not in handoff_bid_set
+        ]
+        intermediate_bids = [intermediate_bids[index] for index in keep_intermediate]
+        src_offsets = [src_offsets[index] for index in keep_intermediate]
+        intermediate_hashes = [all_hashes[index] for index in keep_intermediate]
+        all_hashes = intermediate_hashes + eos_hashes
+
+        # Fill the remaining capacity with optional reusable prefix snapshots.
         all_bids = intermediate_bids + eos_bids
         n_intermediate = len(intermediate_bids)
-        try:
-            all_slots = self.allocate_slots_batch(all_bids)
-        except MambaSlotCapacityError as error:
-            existing_slots = self.block_to_slot[all_bids].tolist()
-            kept_indices = []
-            kept_new_bids = set()
-            for index, (block_id, slot) in enumerate(zip(all_bids, existing_slots)):
-                if slot >= 0 or block_id in kept_new_bids:
-                    kept_indices.append(index)
-                elif len(kept_new_bids) < error.available:
-                    kept_new_bids.add(block_id)
-                    kept_indices.append(index)
-
-            if not kept_indices:
-                self._clear_intermediate_state()
-                return
-
+        kept_indices, all_slots = self._allocate_slots_up_to_capacity(all_bids)
+        if all_bids and not kept_indices:
+            self._clear_intermediate_state()
+            return
+        if len(kept_indices) != len(all_bids):
+            # Keep block, hash, and state-source lists aligned after truncation.
             all_bids = [all_bids[index] for index in kept_indices]
             all_hashes = [all_hashes[index] for index in kept_indices]
             src_offsets = [src_offsets[index] for index in kept_indices if index < n_intermediate]
@@ -588,17 +650,17 @@ class MambaSlotAllocator:
                 for index in kept_indices
                 if index >= n_intermediate
             ]
-            all_slots = self.allocate_slots_batch(all_bids)
             n_intermediate = len(src_offsets)
 
-        # Copy intermediate states from output buffers to cache
-        self._copy_intermediate_to_cache(src_offsets, all_slots[:n_intermediate])
+        if all_bids:
+            # Intermediate snapshots come from the extraction buffers.
+            self._copy_intermediate_to_cache(src_offsets, all_slots[:n_intermediate])
 
-        # Copy EOS states from live buffers to cache
-        self.store_from_live_batch(all_slots[n_intermediate:], eos_ctx_indices)
+            # End-of-prefill snapshots come from the live request state.
+            self.store_from_live_batch(all_slots[n_intermediate:], eos_ctx_indices)
 
-        # Register hashes for all committed blocks
-        self.register_block_hashes_batch(all_bids, all_hashes)
+            # Publish hashes only after their state has been copied.
+            self.register_block_hashes_batch(all_bids, all_hashes)
 
         self._clear_intermediate_state()
 
@@ -607,8 +669,9 @@ class MambaSlotAllocator:
 
         Returns:
             Tuple of (intermediate_bids, src_offsets, eos_bids, eos_ctx_indices,
-            all_hashes) or None if nothing to commit. all_hashes covers
-            intermediate_bids + eos_bids in that order.
+            eos_handoff_required, all_hashes), or None if nothing needs to be
+            committed. ``all_hashes`` covers ``intermediate_bids + eos_bids``
+            in that order.
         """
         ctx = self.context
         metadata = ctx.mamba_metadata
@@ -631,6 +694,9 @@ class MambaSlotAllocator:
         eos_bids_cpu = self._eos_cache_block_id_cpu[
             prefill_start : prefill_start + prefill_count
         ].tolist()
+        eos_handoff_required_cpu = self._eos_handoff_required_cpu[
+            prefill_start : prefill_start + prefill_count
+        ].tolist()
 
         # Flatten intermediate block IDs and source offsets
         intermediate_bids = []
@@ -643,14 +709,17 @@ class MambaSlotAllocator:
                     src_offsets.append(ssm_offset + j)
                 ssm_offset += count
 
-        # Collect EOS block IDs and their context indices
+        # Collect aligned EOS block IDs, live context indices, and handoff flags.
         eos_bids = []
         eos_ctx_indices = []
-        for req_batch_idx in range(prefill_count):
-            eos_bid = eos_bids_cpu[req_batch_idx]
+        eos_handoff_required = []
+        for req_batch_idx, (eos_bid, handoff_required) in enumerate(
+            zip(eos_bids_cpu, eos_handoff_required_cpu)
+        ):
             if eos_bid >= 0:
                 eos_bids.append(eos_bid)
                 eos_ctx_indices.append(prefill_start + req_batch_idx)
+                eos_handoff_required.append(bool(handoff_required))
 
         if not intermediate_bids and not eos_bids:
             self._clear_intermediate_state()
@@ -662,7 +731,14 @@ class MambaSlotAllocator:
         bid_tensor = torch.tensor(all_bids_for_hash, dtype=torch.int64, device=device)
         all_hashes = ctx.kv_block_allocator.block_hashes[bid_tensor].tolist()
 
-        return intermediate_bids, src_offsets, eos_bids, eos_ctx_indices, all_hashes
+        return (
+            intermediate_bids,
+            src_offsets,
+            eos_bids,
+            eos_ctx_indices,
+            eos_handoff_required,
+            all_hashes,
+        )
 
     def _copy_intermediate_to_cache(self, src_offsets: list, slots: list) -> None:
         """Copy intermediate states from output buffers to cache slots.
@@ -694,6 +770,7 @@ class MambaSlotAllocator:
             self._intermediate_offsets_cpu[prefill_start:end].fill_(0)
             self._intermediate_block_ids_cpu[prefill_start:end].fill_(-1)
             self._eos_cache_block_id_cpu[prefill_start:end].fill_(-1)
+            self._eos_handoff_required_cpu[prefill_start:end].fill_(False)
         self._has_intermediates = False
 
     # =========================================================================
@@ -713,4 +790,5 @@ class MambaSlotAllocator:
         self._intermediate_counts_cpu.fill_(0)
         self._intermediate_block_ids_cpu.fill_(-1)
         self._eos_cache_block_id_cpu.fill_(-1)
+        self._eos_handoff_required_cpu.fill_(False)
         self._has_intermediates = False

--- a/megatron/core/inference/disaggregation/decode_admission.py
+++ b/megatron/core/inference/disaggregation/decode_admission.py
@@ -35,12 +35,14 @@ def admit_prefilled_decode(
     prompt_block_ids: list[int],
     continuation_block_ids: list[int],
     input_tokens: list[int],
+    ssm_state_idx: int | None = None,
 ) -> None:
-    """Admit imported KV state directly as an active decode request.
+    """Admit imported KV/SSM state directly as an active decode request.
 
     The imported prompt blocks already carry one allocator reference. This
-    function transfers that ownership to the live request and schedules the
-    sampled first token (plus any MTP proposals) as the next decode query.
+    function transfers that ownership to the live request, binds the exact
+    post-prompt recurrent state, and schedules the sampled first token (plus
+    any MTP proposals) as the next decode query.
     """
 
     input_token_count = len(input_tokens)
@@ -70,6 +72,10 @@ def admit_prefilled_decode(
         )
     if request.get_metadata_types() != context.request_metadata_types:
         raise ValueError("Imported request metadata does not match the decode context")
+
+    if context.is_hybrid_model:
+        if ssm_state_idx is None:
+            raise ValueError("A hybrid decode request requires an exact imported SSM state")
 
     current_id = context.total_request_count
     all_block_ids = prompt_block_ids + continuation_block_ids
@@ -128,6 +134,10 @@ def admit_prefilled_decode(
     context.token_to_block_idx[token_start:token_end] = block_ids_tensor[
         token_positions // context.block_size_tokens
     ]
+
+    if context.is_hybrid_model:
+        assert ssm_state_idx is not None
+        context.mamba_metadata.request_to_mamba_state_idx[current_id] = ssm_state_idx
 
     context.active_token_count = token_end
     context.total_request_count += 1

--- a/megatron/core/inference/disaggregation/engine.py
+++ b/megatron/core/inference/disaggregation/engine.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Dynamic inference engine composed with KV-cache handoff behavior."""
+"""Dynamic inference engine composed with the KV/state hand-off behavior."""
 
 from megatron.core.inference.disaggregation.inference_state_handoff import (
     InferenceStateHandoffMixin,
@@ -9,7 +9,7 @@ from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngin
 
 
 class DisaggDynamicInferenceEngine(InferenceStateHandoffMixin, DynamicInferenceEngine):
-    """Dynamic inference engine with prefill/decode KV-cache handoff support.
+    """Dynamic inference engine with prefill/decode state hand-off support.
 
     Used by both control planes: the Dynamo integration and the
     coordinator-native 2-hop mode.

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -55,7 +55,6 @@ class _PreparedHandoffMetadata:
     local_blocks: list[int]  # Full prompt block table, including a partial tail.
     kv_meta: Any
     ssm_meta: Any
-    local_ssm_slots: list[int]
     resume_tokens: list[int]
 
 
@@ -66,7 +65,6 @@ class InferenceStateHandoffMixin:
         """Initialize state without importing or constructing a transfer backend."""
 
         self._pinned_handoff_blocks: Dict[int, list] = {}  # Request ID -> pinned KV block IDs.
-        self._pinned_handoff_ssm_slots: Dict[int, list] = {}  # Request ID -> prefill SSM slots.
         self._kv_transfer_agent = None
         self._kv_peer_metas = None  # KV descriptors for this PP stage's TP ranks.
         self._pp_kv_peer_metas = None  # Each PP stage's set of TP KV descriptors.
@@ -226,8 +224,8 @@ class InferenceStateHandoffMixin:
                     "Hybrid prefill handoff requires an SSM state cache. Pass "
                     "--inference-dynamic-batching-prefix-caching-mamba-gb <GB>."
                 )
-            if role == "decode":
-                assert ssm_cache is None, (
+            if role == "decode" and ssm_cache is not None:
+                raise RuntimeError(
                     "A hybrid decode handoff writes directly into live SSM state; "
                     "do not configure prefix_caching_mamba_gb on the decode engine"
                 )
@@ -410,24 +408,27 @@ class InferenceStateHandoffMixin:
                 "SEND_KV for request %d with no pinned hand-off blocks; skipping", request_id
             )
             return
+
+        ssm_pushes = []
+        if self._ssm_transfer_agents:
+            slot = self.context.mamba_slot_allocator.get_slot(block_ids[-1])
+            if slot < 0:
+                raise RuntimeError(f"No pinned SSM state for handoff request {request_id}")
+            for state_kind in _SSM_STATE_KINDS:
+                try:
+                    peer_metas = [entry["ssm"][state_kind] for entry in decode_metas]
+                except (KeyError, TypeError) as error:
+                    raise RuntimeError(
+                        f"Decode metadata is missing {state_kind} SSM transfer state"
+                    ) from error
+                ssm_pushes.append((self._ssm_transfer_agents[state_kind], peer_metas, [slot]))
+
         kv_peer = {"tp_metas": list(decode_metas)}
         handles = [self._kv_transfer_agent.begin_push_blocks(kv_peer, block_ids)]
-        if self._ssm_transfer_agents:
-            # Reuse the exact slots advertised in the handoff metadata. The
-            # allocator can acquire more cached SSM states between metadata
-            # capture and SEND_KV; recomputing here would make the sender post
-            # more NCCL operations than the decode peer posted receives for.
-            slots = self._pinned_handoff_ssm_slots.get(request_id, [])
-            if slots:
-                for state_kind, agent in self._ssm_transfer_agents.items():
-                    peer = {
-                        "tp_metas": [
-                            e["ssm"][state_kind]
-                            for e in decode_metas
-                            if isinstance(e, dict) and e.get("ssm")
-                        ]
-                    }
-                    handles.append(agent.begin_push_blocks(peer, slots))
+        # The final KV block remains pinned until RELEASE_KV, so its SSM slot
+        # cannot be evicted or reused while these sends are active.
+        for agent, peer_metas, slots in ssm_pushes:
+            handles.append(agent.begin_push_blocks({"tp_metas": peer_metas}, slots))
         self._pending_kv_pushes.append((request_id, handles))
         logging.info(
             "DISAGG_PREFILL_PUSH request_id=%d blocks=%d ssm=%d",
@@ -463,34 +464,22 @@ class InferenceStateHandoffMixin:
         Side: prefill engine; pull and push transport paths.
         """
 
-        handoffs = [
-            (request, list(block_ids))
-            for request, block_ids in requests_and_blocks
-            if request.sampling_params.do_kv_handoff
-        ]
+        handoffs = []
+        for request, block_ids in requests_and_blocks:
+            if not request.sampling_params.do_kv_handoff:
+                continue
+            prompt_block_count = (
+                len(request.prompt_tokens) + self.context.block_size_tokens - 1
+            ) // self.context.block_size_tokens
+            handoffs.append((request, list(block_ids[:prompt_block_count])))
         if not handoffs:
             return {}
         if self._kv_peer_metas is None:
             raise RuntimeError("KV handoff requested before transfer setup")
 
-        candidate_blocks_by_request = {}
-        for request, block_ids in handoffs:
-            prompt_block_count = (
-                len(request.prompt_tokens) + self.context.block_size_tokens - 1
-            ) // self.context.block_size_tokens
-            candidate_blocks_by_request[request.request_id] = block_ids[:prompt_block_count]
-
         pp_size = get_pg_size(self.pg_collection.pp)
         try:
-            local_final_ssm_slots = {}
-            if self._ssm_transfer_agents:
-                ssm_cache = self.context.mamba_slot_allocator
-                for request, _ in handoffs:
-                    candidate_blocks = candidate_blocks_by_request[request.request_id]
-                    if candidate_blocks:
-                        local_final_ssm_slots[request.request_id] = ssm_cache.get_slot(
-                            candidate_blocks[-1]
-                        )
+            ssm_cache = self.context.mamba_slot_allocator if self._ssm_transfer_agents else None
 
             static_pp_metas = self._pp_kv_peer_metas or [self._kv_peer_metas]
             static_pp_ssm_metas = self._pp_ssm_peer_metas or [self._tp_ssm_peer_metas]
@@ -506,8 +495,7 @@ class InferenceStateHandoffMixin:
                 )
 
             prepared = {}
-            for request, _ in handoffs:
-                candidate_blocks = candidate_blocks_by_request[request.request_id]
+            for request, candidate_blocks in handoffs:
                 resume_tokens = list(decode_tokens_by_request.get(request.request_id, []))
                 expected_resume_tokens = self.context.num_speculative_tokens + 1
                 if len(resume_tokens) != expected_resume_tokens:
@@ -520,9 +508,10 @@ class InferenceStateHandoffMixin:
                     raise RuntimeError(
                         "Cannot create a decode-only handoff without the prompt KV state"
                     )
-                final_position = len(candidate_blocks) - 1
-                final_ssm_slot = local_final_ssm_slots.get(request.request_id, -1)
-                if self._ssm_transfer_agents and final_ssm_slot < 0:
+                final_ssm_slot = (
+                    ssm_cache.get_slot(candidate_blocks[-1]) if ssm_cache is not None else -1
+                )
+                if ssm_cache is not None and final_ssm_slot < 0:
                     raise RuntimeError(
                         "Cannot create a hybrid decode-only handoff without the exact final "
                         "SSM state"
@@ -544,15 +533,12 @@ class InferenceStateHandoffMixin:
                     kv_meta = self._kv_peer_metas
 
                 ssm_meta = None
-                local_ssm_slots = []
                 if self._ssm_transfer_agents:
-                    positions = [final_position]
-                    local_ssm_slots = [final_ssm_slot]
                     stage_state_metas = [
-                        self._ssm_stage_transfer_meta(static_meta, local_ssm_slots)
+                        self._ssm_stage_transfer_meta(static_meta, final_ssm_slot)
                         for static_meta in static_pp_ssm_metas
                     ]
-                    ssm_meta = {"positions": positions}
+                    ssm_meta = {}
                     for state_kind in _SSM_STATE_KINDS:
                         if pp_size > 1:
                             ssm_meta[state_kind] = {
@@ -568,20 +554,20 @@ class InferenceStateHandoffMixin:
                     local_blocks=block_ids,
                     kv_meta=kv_meta,
                     ssm_meta=ssm_meta,
-                    local_ssm_slots=local_ssm_slots,
                     resume_tokens=resume_tokens,
                 )
             return prepared
         except Exception:
-            for block_ids in candidate_blocks_by_request.values():
+            for _, block_ids in handoffs:
                 self._release_pinned_handoff_blocks(block_ids)
             raise
 
     @staticmethod
-    def _ssm_stage_transfer_meta(static_metas: dict, selected_slots: list[int]) -> dict:
-        """Attach selected recurrent slots to one stage's static descriptors."""
+    def _ssm_stage_transfer_meta(static_metas: dict, selected_slot: int) -> dict:
+        """Attach the final recurrent-state slot to one stage's descriptors."""
 
         state_metas = {}
+        selected_slots = [selected_slot]
         for state_kind in _SSM_STATE_KINDS:
             state_static_metas = static_metas.get(state_kind)
             if state_static_metas is None:
@@ -613,14 +599,12 @@ class InferenceStateHandoffMixin:
         ssm_meta = prepared.ssm_meta
 
         self._pinned_handoff_blocks[rid] = list(block_ids)
-        self._pinned_handoff_ssm_slots[rid] = prepared.local_ssm_slots
 
         if isinstance(kv_meta, list):
             kv_meta = {"tp_metas": kv_meta}
         else:
             # TP=1 caches one static metadata dictionary for the engine. Keep
-            # request-specific SSM metadata out of that shared object so a
-            # later handoff cannot overwrite an earlier request's positions.
+            # request-specific SSM metadata out of that shared object.
             kv_meta = dict(kv_meta)
         kv_meta["resume_tokens"] = prepared.resume_tokens
         if ssm_meta is not None:
@@ -635,7 +619,7 @@ class InferenceStateHandoffMixin:
             "DISAGG_PREFILL_HANDOFF request_id=%d pinned_blocks=%d ssm_blocks=%d",
             rid,
             len(block_ids),
-            len(ssm_meta["positions"]) if ssm_meta is not None else 0,
+            int(ssm_meta is not None),
         )
 
     def release_handoff_blocks(self, request_id: int) -> None:
@@ -644,7 +628,6 @@ class InferenceStateHandoffMixin:
         Side: prefill engine; pull and push transport paths.
         """
         block_ids = self._pinned_handoff_blocks.pop(request_id, None)
-        self._pinned_handoff_ssm_slots.pop(request_id, None)
         if not block_ids:
             return
         released = self._release_pinned_handoff_blocks(block_ids)
@@ -693,6 +676,14 @@ class InferenceStateHandoffMixin:
                 "Decode has SSM state transfer agents but the handoff contains no "
                 "SSM metadata; prefill and decode must use the same hybrid model"
             )
+        if local_has_ssm:
+            if not isinstance(ssm_meta, dict):
+                raise RuntimeError("SSM handoff metadata must be a mapping")
+            missing_state_kinds = [kind for kind in _SSM_STATE_KINDS if kind not in ssm_meta]
+            if missing_state_kinds:
+                raise RuntimeError(
+                    f"SSM handoff metadata is missing state kinds {missing_state_kinds}"
+                )
         if not self.context.is_hybrid_model and ssm_meta is not None:
             raise RuntimeError("Transformer decode received SSM metadata from a hybrid prefill")
         if self._kv_transfer_agent is None:
@@ -725,13 +716,6 @@ class InferenceStateHandoffMixin:
                 "Decode-only handoff requires every prompt KV block, including the partial tail: "
                 f"expected {expected_blocks}, got {num_blocks}"
             )
-        if local_has_ssm:
-            positions = [int(pos) for pos in ssm_meta.get("positions", [])]
-            if positions != [expected_blocks - 1]:
-                raise RuntimeError(
-                    "Hybrid decode-only handoff requires the exact final SSM state; "
-                    f"received positions {positions}"
-                )
         future = self._loop.create_future()
         handoff = DeferredKvHandoff(
             request_id=request_id,
@@ -1239,7 +1223,8 @@ class InferenceStateHandoffMixin:
 
         handles = {}
         pending.handles = handles
-        for state_kind, agent in self._ssm_transfer_agents.items():
+        for state_kind in _SSM_STATE_KINDS:
+            agent = self._ssm_transfer_agents[state_kind]
             handles[state_kind] = agent.begin_pull_blocks(
                 ssm_meta[state_kind], [], [pending.live_slot]
             )

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -820,7 +820,7 @@ class InferenceStateHandoffMixin:
         ssm_import = None
         if ssm_meta:
             try:
-                ssm_import = self._reserve_ssm_handoff_import(ssm_meta, local_blocks)
+                ssm_import = self._reserve_ssm_handoff_import()
             except Exception:
                 allocator.release_memory_blocks(owned_blocks_tensor)
                 raise
@@ -944,11 +944,6 @@ class InferenceStateHandoffMixin:
         if self.context.is_hybrid_model:
             if pending.ssm is None:
                 raise RuntimeError("Hybrid decode-only handoff is missing transferred SSM state")
-            final_block_position = len(pending.local_blocks) - 1
-            if pending.ssm.position != final_block_position:
-                raise RuntimeError(
-                    "Hybrid decode-only handoff requires the exact post-prompt SSM state"
-                )
 
     def _finalize_kv_handoff_import(self, pending: PendingKvImport) -> None:
         """Register transferred blocks and admit the decode request.
@@ -1039,8 +1034,7 @@ class InferenceStateHandoffMixin:
                     pending.resume_tokens,
                     ssm_state_idx=(pending.ssm.live_slot if pending.ssm is not None else None),
                 )
-                if pending.ssm is not None:
-                    pending.ssm.live_slot = None
+                pending.ssm = None
                 pending.local_blocks = []
                 pending.continuation_blocks = []
                 if self.use_coordinator and self.is_mp_coordinator:
@@ -1100,9 +1094,9 @@ class InferenceStateHandoffMixin:
             self.context.kv_block_allocator.release_memory_blocks(block_tensor)
         pending.local_blocks = []
         pending.continuation_blocks = []
-        if pending.ssm is not None and pending.ssm.live_slot is not None:
+        if pending.ssm is not None:
             self.context.mamba_metadata.free_slot(pending.ssm.live_slot)
-            pending.ssm.live_slot = None
+            pending.ssm = None
 
     @staticmethod
     def _wait_for_transfer_handles(*handles) -> bool:
@@ -1224,25 +1218,19 @@ class InferenceStateHandoffMixin:
             )
         return ready
 
-    def _reserve_ssm_handoff_import(self, ssm_meta: dict, local_blocks: list) -> PendingSSMImport:
+    def _reserve_ssm_handoff_import(self) -> PendingSSMImport:
         """Reserve the live request slot that receives exact SSM state."""
 
-        positions = [int(pos) for pos in ssm_meta.get("positions", [])]
         if not self._ssm_transfer_agents:
             raise RuntimeError(
                 "Received SSM handoff state but this decode engine has no "
                 "SSM transfer agents. Ensure KV transfer was initialized on a "
                 "hybrid decode engine."
             )
-        if positions != [len(local_blocks) - 1]:
-            raise ValueError(
-                "Hybrid decode-only handoff requires one exact final SSM state; "
-                f"received positions {positions}"
-            )
         live_slot = self.context.mamba_metadata.allocate_slot()
         if live_slot is None:
             raise RuntimeError("Live SSM slot capacity changed during handoff admission")
-        return PendingSSMImport(handles={}, live_slot=int(live_slot), position=positions[0])
+        return PendingSSMImport(handles={}, live_slot=int(live_slot))
 
     def _start_ssm_handoff_import(
         self, request_id: int, ssm_meta: dict, pending: PendingSSMImport
@@ -1251,7 +1239,6 @@ class InferenceStateHandoffMixin:
 
         handles = {}
         pending.handles = handles
-        assert pending.live_slot is not None
         for state_kind, agent in self._ssm_transfer_agents.items():
             handles[state_kind] = agent.begin_pull_blocks(
                 ssm_meta[state_kind], [], [pending.live_slot]

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -391,6 +391,10 @@ class InferenceStateHandoffMixin:
         """
         block_ids = self._pinned_handoff_blocks.get(request_id)
         if not block_ids:
+            if self._ssm_transfer_agents and request_id in self._pinned_handoff_ssm_slots:
+                raise RuntimeError(
+                    f"Handoff request {request_id} has detached SSM state but no pinned KV blocks"
+                )
             logging.warning(
                 "SEND_KV for request %d with no pinned hand-off blocks; skipping", request_id
             )

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -53,6 +53,7 @@ class _PreparedHandoffMetadata:
     """Per-request metadata assembled once for a completed prefill batch."""
 
     local_blocks: list[int]  # Full prompt block table, including a partial tail.
+    local_ssm_slot: int | None
     kv_meta: Any
     ssm_meta: Any
     resume_tokens: list[int]
@@ -65,6 +66,7 @@ class InferenceStateHandoffMixin:
         """Initialize state without importing or constructing a transfer backend."""
 
         self._pinned_handoff_blocks: Dict[int, list] = {}  # Request ID -> pinned KV block IDs.
+        self._pinned_handoff_ssm_slots: Dict[int, int] = {}  # Request ID -> retained live slot.
         self._kv_transfer_agent = None
         self._kv_peer_metas = None  # KV descriptors for this PP stage's TP ranks.
         self._pp_kv_peer_metas = None  # Each PP stage's set of TP KV descriptors.
@@ -182,9 +184,9 @@ class InferenceStateHandoffMixin:
             raise RuntimeError(
                 "Cannot reset while KV handoff transfers may still access cache storage"
             )
-        if self._pinned_handoff_blocks:
+        if self._pinned_handoff_blocks or self._pinned_handoff_ssm_slots:
             raise RuntimeError(
-                "Cannot reset while KV handoff blocks remain pinned; wait for RELEASE_KV"
+                "Cannot reset while handoff state remains pinned; wait for RELEASE_KV"
             )
         self._handoff_completion_notifications.clear()
 
@@ -218,13 +220,7 @@ class InferenceStateHandoffMixin:
         if role not in ("prefill", "decode"):
             raise ValueError(f"KV transfer role must be 'prefill' or 'decode', got {role!r}")
         if self.context.is_hybrid_model:
-            ssm_cache = self.context.mamba_slot_allocator
-            if role == "prefill" and ssm_cache is None:
-                raise RuntimeError(
-                    "Hybrid prefill handoff requires an SSM state cache. Pass "
-                    "--inference-dynamic-batching-prefix-caching-mamba-gb <GB>."
-                )
-            if role == "decode" and ssm_cache is not None:
+            if role == "decode" and self.context.mamba_slot_allocator is not None:
                 raise RuntimeError(
                     "A hybrid decode handoff writes directly into live SSM state; "
                     "do not configure prefix_caching_mamba_gb on the decode engine"
@@ -290,19 +286,12 @@ class InferenceStateHandoffMixin:
             layer_end=layer_end,
         )
 
-        # Prefill sends from pinned snapshots; decode receives directly into
-        # live request slots and therefore has no durable recurrent cache.
+        # Both roles transfer directly between live recurrent-state slots. Prefill
+        # retains its source slot until decode acknowledges transfer completion.
         if self.context.is_hybrid_model:
-            ssm_cache = self.context.mamba_slot_allocator
-            if role == "prefill":
-                assert ssm_cache is not None
-                conv_states = ssm_cache.conv_states
-                recurrent_states = ssm_cache.ssm_states
-                state_slot_count = ssm_cache.max_slots
-            else:
-                conv_states = self.context.mamba_conv_states
-                recurrent_states = self.context.mamba_ssm_states
-                state_slot_count = self.context.max_requests
+            conv_states = self.context.mamba_conv_states
+            recurrent_states = self.context.mamba_ssm_states
+            state_slot_count = self.context.max_requests
 
             conv_shape = conv_states.shape
             ssm_shape = recurrent_states.shape
@@ -393,7 +382,7 @@ class InferenceStateHandoffMixin:
         self._pp_ssm_peer_metas = [entry["ssm"] for entry in gathered_stage_metas]
 
     def push_handoff_kv(self, request_id: int, decode_metas: list) -> None:
-        """Push a pinned hand-off's KV and SSM snapshots to the decode
+        """Push a pinned hand-off's KV and live SSM state to the decode
         instance described by `decode_metas` (two-sided transports only).
 
         The decode posted its matching receives when SUBMIT_REQUEST_WITH_KV
@@ -411,9 +400,9 @@ class InferenceStateHandoffMixin:
 
         ssm_pushes = []
         if self._ssm_transfer_agents:
-            slot = self.context.mamba_slot_allocator.get_slot(block_ids[-1])
-            if slot < 0:
-                raise RuntimeError(f"No pinned SSM state for handoff request {request_id}")
+            slot = self._pinned_handoff_ssm_slots.get(request_id)
+            if slot is None:
+                raise RuntimeError(f"No retained SSM state for handoff request {request_id}")
             for state_kind in _SSM_STATE_KINDS:
                 try:
                     peer_metas = [entry["ssm"][state_kind] for entry in decode_metas]
@@ -425,8 +414,8 @@ class InferenceStateHandoffMixin:
 
         kv_peer = {"tp_metas": list(decode_metas)}
         handles = [self._kv_transfer_agent.begin_push_blocks(kv_peer, block_ids)]
-        # The final KV block remains pinned until RELEASE_KV, so its SSM slot
-        # cannot be evicted or reused while these sends are active.
+        # The source live slot remains retained until RELEASE_KV, so request
+        # cleanup cannot reuse it while these sends are active.
         for agent, peer_metas, slots in ssm_pushes:
             handles.append(agent.begin_push_blocks({"tp_metas": peer_metas}, slots))
         self._pending_kv_pushes.append((request_id, handles))
@@ -456,7 +445,7 @@ class InferenceStateHandoffMixin:
 
     def _prepare_handoff_metadata_batch(
         self,
-        requests_and_blocks: list[tuple["DynamicInferenceRequest", list[int]]],
+        requests_and_state: list[tuple["DynamicInferenceRequest", list[int], int | None]],
         decode_tokens_by_request: Dict[int, list[int]],
     ) -> dict[int, _PreparedHandoffMetadata]:
         """Assemble metadata for all handoffs completed by one engine step.
@@ -465,13 +454,13 @@ class InferenceStateHandoffMixin:
         """
 
         handoffs = []
-        for request, block_ids in requests_and_blocks:
+        for request, block_ids, ssm_slot in requests_and_state:
             if not request.sampling_params.do_kv_handoff:
                 continue
             prompt_block_count = (
                 len(request.prompt_tokens) + self.context.block_size_tokens - 1
             ) // self.context.block_size_tokens
-            handoffs.append((request, list(block_ids[:prompt_block_count])))
+            handoffs.append((request, list(block_ids[:prompt_block_count]), ssm_slot))
         if not handoffs:
             return {}
         if self._kv_peer_metas is None:
@@ -479,8 +468,6 @@ class InferenceStateHandoffMixin:
 
         pp_size = get_pg_size(self.pg_collection.pp)
         try:
-            ssm_cache = self.context.mamba_slot_allocator if self._ssm_transfer_agents else None
-
             static_pp_metas = self._pp_kv_peer_metas or [self._kv_peer_metas]
             static_pp_ssm_metas = self._pp_ssm_peer_metas or [self._tp_ssm_peer_metas]
             if len(static_pp_metas) != pp_size:
@@ -495,7 +482,7 @@ class InferenceStateHandoffMixin:
                 )
 
             prepared = {}
-            for request, candidate_blocks in handoffs:
+            for request, candidate_blocks, ssm_slot in handoffs:
                 resume_tokens = list(decode_tokens_by_request.get(request.request_id, []))
                 expected_resume_tokens = self.context.num_speculative_tokens + 1
                 if len(resume_tokens) != expected_resume_tokens:
@@ -508,10 +495,7 @@ class InferenceStateHandoffMixin:
                     raise RuntimeError(
                         "Cannot create a decode-only handoff without the prompt KV state"
                     )
-                final_ssm_slot = (
-                    ssm_cache.get_slot(candidate_blocks[-1]) if ssm_cache is not None else -1
-                )
-                if ssm_cache is not None and final_ssm_slot < 0:
+                if self._ssm_transfer_agents and ssm_slot is None:
                     raise RuntimeError(
                         "Cannot create a hybrid decode-only handoff without the exact final "
                         "SSM state"
@@ -535,7 +519,7 @@ class InferenceStateHandoffMixin:
                 ssm_meta = None
                 if self._ssm_transfer_agents:
                     stage_state_metas = [
-                        self._ssm_stage_transfer_meta(static_meta, final_ssm_slot)
+                        self._ssm_stage_transfer_meta(static_meta, ssm_slot)
                         for static_meta in static_pp_ssm_metas
                     ]
                     ssm_meta = {}
@@ -552,14 +536,16 @@ class InferenceStateHandoffMixin:
 
                 prepared[request.request_id] = _PreparedHandoffMetadata(
                     local_blocks=block_ids,
+                    local_ssm_slot=ssm_slot,
                     kv_meta=kv_meta,
                     ssm_meta=ssm_meta,
                     resume_tokens=resume_tokens,
                 )
             return prepared
         except Exception:
-            for _, block_ids in handoffs:
+            for _, block_ids, ssm_slot in handoffs:
                 self._release_pinned_handoff_blocks(block_ids)
+                self._release_pinned_handoff_ssm_slot(ssm_slot)
             raise
 
     @staticmethod
@@ -599,6 +585,8 @@ class InferenceStateHandoffMixin:
         ssm_meta = prepared.ssm_meta
 
         self._pinned_handoff_blocks[rid] = list(block_ids)
+        if prepared.local_ssm_slot is not None:
+            self._pinned_handoff_ssm_slots[rid] = prepared.local_ssm_slot
 
         if isinstance(kv_meta, list):
             kv_meta = {"tp_metas": kv_meta}
@@ -628,11 +616,16 @@ class InferenceStateHandoffMixin:
         Side: prefill engine; pull and push transport paths.
         """
         block_ids = self._pinned_handoff_blocks.pop(request_id, None)
-        if not block_ids:
+        ssm_slot = self._pinned_handoff_ssm_slots.pop(request_id, None)
+        if not block_ids and ssm_slot is None:
             return
-        released = self._release_pinned_handoff_blocks(block_ids)
+        released = self._release_pinned_handoff_blocks(block_ids or [])
+        self._release_pinned_handoff_ssm_slot(ssm_slot)
         logging.info(
-            "DISAGG_PREFILL_RELEASE request_id=%d released_blocks=%d", request_id, released
+            "DISAGG_PREFILL_RELEASE request_id=%d released_blocks=%d ssm=%d",
+            request_id,
+            released,
+            int(ssm_slot is not None),
         )
 
     def _release_pinned_handoff_blocks(self, block_ids: list) -> int:
@@ -645,6 +638,12 @@ class InferenceStateHandoffMixin:
         allocator = self.context.kv_block_allocator
         allocator.release_memory_blocks(torch.tensor(block_ids, dtype=torch.int32, device="cpu"))
         return len(block_ids)
+
+    def _release_pinned_handoff_ssm_slot(self, ssm_slot: int | None) -> None:
+        """Release a prefill live-state slot after its handoff ownership ends."""
+
+        if ssm_slot is not None:
+            self.context.mamba_metadata.release_retained_state_slot(ssm_slot)
 
     def add_request_with_kv_handoff(
         self,

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -66,13 +66,11 @@ class InferenceStateHandoffMixin:
         """Initialize state without importing or constructing a transfer backend."""
 
         self._pinned_handoff_blocks: Dict[int, list] = {}  # Request ID -> pinned KV block IDs.
-        self._pinned_handoff_ssm_slots: Dict[int, int] = {}  # Request ID -> retained live slot.
+        self._pinned_handoff_ssm_slots: Dict[int, int] = {}  # Request ID -> detached live slot.
         self._kv_transfer_agent = None
         self._kv_peer_metas = None  # KV descriptors for this PP stage's TP ranks.
         self._pp_kv_peer_metas = None  # Each PP stage's set of TP KV descriptors.
         self._ssm_transfer_agents = {}
-        self._ssm_peer_metas = {}  # State kind -> this rank's transport descriptor.
-        self._tp_ssm_peer_metas = {}  # State kind -> descriptors for this PP stage's TP ranks.
         self._pp_ssm_peer_metas = None  # Each PP stage's TP SSM descriptors.
         self._deferred_kv_handoffs = deque()
         self._pending_kv_imports = deque()
@@ -287,7 +285,7 @@ class InferenceStateHandoffMixin:
         )
 
         # Both roles transfer directly between live recurrent-state slots. Prefill
-        # retains its source slot until decode acknowledges transfer completion.
+        # detaches its source slot until decode acknowledges transfer completion.
         if self.context.is_hybrid_model:
             conv_states = self.context.mamba_conv_states
             recurrent_states = self.context.mamba_ssm_states
@@ -331,29 +329,29 @@ class InferenceStateHandoffMixin:
                     recurrent_states.shape[-2] * recurrent_states.shape[-1],
                 ),
             }
-            backend_factory = getattr(self._kv_transfer_agent, "new_registered_buffer", backend_cls)
             for state_kind, (memory_buffer, width, state_dim) in state_specs.items():
-                self._ssm_transfer_agents[state_kind] = backend_factory(
-                    agent_name=f"{role}-ssm-{state_kind}-rank{rank}",
-                    memory_buffer=memory_buffer,
-                    expected_num_blocks=state_slot_count,
-                    heads_per_partition=width,
-                    head_dim=state_dim,
-                    tokens_per_block=1,
-                    ssm_layout=ssm_layout,
-                    ssm_state_kind=state_kind,
+                self._ssm_transfer_agents[state_kind] = (
+                    self._kv_transfer_agent.new_registered_buffer(
+                        agent_name=f"{role}-ssm-{state_kind}-rank{rank}",
+                        memory_buffer=memory_buffer,
+                        expected_num_blocks=state_slot_count,
+                        heads_per_partition=width,
+                        head_dim=state_dim,
+                        tokens_per_block=1,
+                        ssm_layout=ssm_layout,
+                        ssm_state_kind=state_kind,
+                    )
                 )
-            self._ssm_peer_metas = {
+            ssm_peer_metas = {
                 state_kind: agent.export_meta()
                 for state_kind, agent in self._ssm_transfer_agents.items()
             }
+        else:
+            ssm_peer_metas = {}
 
         # Transport descriptors do not change between requests. Collect each
         # stage's TP descriptors once and reuse them for every handoff.
-        local_peer_metas = {
-            "kv": self._kv_transfer_agent.export_meta(),
-            "ssm": self._ssm_peer_metas,
-        }
+        local_peer_metas = {"kv": self._kv_transfer_agent.export_meta(), "ssm": ssm_peer_metas}
         if torch.distributed.is_initialized() and tp_size > 1:
             gathered_tp_metas: list = [None] * tp_size
             torch.distributed.all_gather_object(
@@ -363,15 +361,15 @@ class InferenceStateHandoffMixin:
             if any(kinds != ssm_state_kinds[0] for kinds in ssm_state_kinds[1:]):
                 raise RuntimeError("SSM handoff agents are not configured on every TP rank")
             self._kv_peer_metas = [entry["kv"] for entry in gathered_tp_metas]
-            self._tp_ssm_peer_metas = {
+            tp_ssm_peer_metas = {
                 state_kind: [entry["ssm"][state_kind] for entry in gathered_tp_metas]
                 for state_kind in ssm_state_kinds[0]
             }
         else:
             self._kv_peer_metas = local_peer_metas["kv"]
-            self._tp_ssm_peer_metas = dict(local_peer_metas["ssm"])
+            tp_ssm_peer_metas = dict(local_peer_metas["ssm"])
 
-        local_stage_metas = {"kv": self._kv_peer_metas, "ssm": self._tp_ssm_peer_metas}
+        local_stage_metas = {"kv": self._kv_peer_metas, "ssm": tp_ssm_peer_metas}
         gathered_stage_metas = [local_stage_metas]
         if torch.distributed.is_initialized() and pp_size > 1:
             gathered_stage_metas = [None] * pp_size
@@ -402,7 +400,7 @@ class InferenceStateHandoffMixin:
         if self._ssm_transfer_agents:
             slot = self._pinned_handoff_ssm_slots.get(request_id)
             if slot is None:
-                raise RuntimeError(f"No retained SSM state for handoff request {request_id}")
+                raise RuntimeError(f"No detached SSM state for handoff request {request_id}")
             for state_kind in _SSM_STATE_KINDS:
                 try:
                     peer_metas = [entry["ssm"][state_kind] for entry in decode_metas]
@@ -414,7 +412,7 @@ class InferenceStateHandoffMixin:
 
         kv_peer = {"tp_metas": list(decode_metas)}
         handles = [self._kv_transfer_agent.begin_push_blocks(kv_peer, block_ids)]
-        # The source live slot remains retained until RELEASE_KV, so request
+        # The source live slot remains detached until RELEASE_KV, so request
         # cleanup cannot reuse it while these sends are active.
         for agent, peer_metas, slots in ssm_pushes:
             handles.append(agent.begin_push_blocks({"tp_metas": peer_metas}, slots))
@@ -463,13 +461,14 @@ class InferenceStateHandoffMixin:
             handoffs.append((request, list(block_ids[:prompt_block_count]), ssm_slot))
         if not handoffs:
             return {}
-        if self._kv_peer_metas is None:
-            raise RuntimeError("KV handoff requested before transfer setup")
 
-        pp_size = get_pg_size(self.pg_collection.pp)
         try:
+            if self._kv_peer_metas is None:
+                raise RuntimeError("KV handoff requested before transfer setup")
+
+            pp_size = get_pg_size(self.pg_collection.pp)
             static_pp_metas = self._pp_kv_peer_metas or [self._kv_peer_metas]
-            static_pp_ssm_metas = self._pp_ssm_peer_metas or [self._tp_ssm_peer_metas]
+            static_pp_ssm_metas = self._pp_ssm_peer_metas or [{}]
             if len(static_pp_metas) != pp_size:
                 raise RuntimeError(
                     f"Expected static metadata for {pp_size} pipeline stages, "
@@ -543,7 +542,10 @@ class InferenceStateHandoffMixin:
                 )
             return prepared
         except Exception:
-            for _, block_ids, ssm_slot in handoffs:
+            # The controller temporarily transfers ownership for every finished
+            # request on a prefill engine, including regular requests. Return all
+            # of it if metadata preparation aborts before the per-request loop.
+            for _, block_ids, ssm_slot in requests_and_state:
                 self._release_pinned_handoff_blocks(block_ids)
                 self._release_pinned_handoff_ssm_slot(ssm_slot)
             raise
@@ -643,7 +645,7 @@ class InferenceStateHandoffMixin:
         """Release a prefill live-state slot after its handoff ownership ends."""
 
         if ssm_slot is not None:
-            self.context.mamba_metadata.release_retained_state_slot(ssm_slot)
+            self.context.mamba_metadata.free_slot(ssm_slot)
 
     def add_request_with_kv_handoff(
         self,
@@ -912,7 +914,7 @@ class InferenceStateHandoffMixin:
 
         handles = [pending.handle]
         if pending.ssm is not None:
-            handles.extend(pending.ssm.handles.values())
+            handles.extend(pending.ssm.handles)
         return [handle for handle in handles if handle is not None]
 
     def _validate_decode_ready_handoff(self, pending: PendingKvImport) -> None:
@@ -1213,18 +1215,17 @@ class InferenceStateHandoffMixin:
         live_slot = self.context.mamba_metadata.allocate_slot()
         if live_slot is None:
             raise RuntimeError("Live SSM slot capacity changed during handoff admission")
-        return PendingSSMImport(handles={}, live_slot=int(live_slot))
+        return PendingSSMImport(handles=[], live_slot=int(live_slot))
 
     def _start_ssm_handoff_import(
         self, request_id: int, ssm_meta: dict, pending: PendingSSMImport
     ) -> None:
         """Post transfers into slots already reserved for one handoff."""
 
-        handles = {}
-        pending.handles = handles
+        pending.handles.clear()
         for state_kind in _SSM_STATE_KINDS:
             agent = self._ssm_transfer_agents[state_kind]
-            handles[state_kind] = agent.begin_pull_blocks(
-                ssm_meta[state_kind], [], [pending.live_slot]
+            pending.handles.append(
+                agent.begin_pull_blocks(ssm_meta[state_kind], [], [pending.live_slot])
             )
         logging.debug("DISAGG_DECODE_SSM_IMPORT_SUBMIT request_id=%d ssm_blocks=%d", request_id, 1)

--- a/megatron/core/inference/disaggregation/inference_state_handoff.py
+++ b/megatron/core/inference/disaggregation/inference_state_handoff.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Engine-side lifecycle for disaggregated prefill/decode KV-cache handoff."""
+"""Engine-side lifecycle for disaggregated prefill/decode state handoff."""
 
 from __future__ import annotations
 
@@ -23,7 +23,9 @@ from megatron.core.inference.disaggregation.handoff_completion_tracker import (
 from megatron.core.inference.disaggregation.pending_handoff_imports import (
     DeferredKvHandoff,
     PendingKvImport,
+    PendingSSMImport,
 )
+from megatron.core.inference.disaggregation.ssm_reshard import SSMShardLayout, SSMStateDims
 from megatron.core.inference.disaggregation.transfer_backends.base import (
     construct_kv_transfer_backend_class,
 )
@@ -43,6 +45,8 @@ if TYPE_CHECKING:
     from megatron.core.inference.inference_request import DynamicInferenceRequest
     from megatron.core.inference.sampling_params import SamplingParams
 
+_SSM_STATE_KINDS = ("conv", "recurrent")
+
 
 @dataclass(frozen=True)
 class _PreparedHandoffMetadata:
@@ -50,19 +54,26 @@ class _PreparedHandoffMetadata:
 
     local_blocks: list[int]  # Full prompt block table, including a partial tail.
     kv_meta: Any
+    ssm_meta: Any
+    local_ssm_slots: list[int]
     resume_tokens: list[int]
 
 
 class InferenceStateHandoffMixin:
-    """Optional KV-cache handoff behavior composed into the dynamic engine."""
+    """Optional KV/SSM handoff behavior composed into the dynamic engine."""
 
     def _initialize_disaggregation_state(self) -> None:
         """Initialize state without importing or constructing a transfer backend."""
 
         self._pinned_handoff_blocks: Dict[int, list] = {}  # Request ID -> pinned KV block IDs.
+        self._pinned_handoff_ssm_slots: Dict[int, list] = {}  # Request ID -> prefill SSM slots.
         self._kv_transfer_agent = None
         self._kv_peer_metas = None  # KV descriptors for this PP stage's TP ranks.
         self._pp_kv_peer_metas = None  # Each PP stage's set of TP KV descriptors.
+        self._ssm_transfer_agents = {}
+        self._ssm_peer_metas = {}  # State kind -> this rank's transport descriptor.
+        self._tp_ssm_peer_metas = {}  # State kind -> descriptors for this PP stage's TP ranks.
+        self._pp_ssm_peer_metas = None  # Each PP stage's TP SSM descriptors.
         self._deferred_kv_handoffs = deque()
         self._pending_kv_imports = deque()
         self._quarantined_kv_imports: list[PendingKvImport] = []
@@ -209,9 +220,17 @@ class InferenceStateHandoffMixin:
         if role not in ("prefill", "decode"):
             raise ValueError(f"KV transfer role must be 'prefill' or 'decode', got {role!r}")
         if self.context.is_hybrid_model:
-            raise RuntimeError(
-                "Hybrid models require recurrent-state handoff in addition to KV-cache handoff"
-            )
+            ssm_cache = self.context.mamba_slot_allocator
+            if role == "prefill" and ssm_cache is None:
+                raise RuntimeError(
+                    "Hybrid prefill handoff requires an SSM state cache. Pass "
+                    "--inference-dynamic-batching-prefix-caching-mamba-gb <GB>."
+                )
+            if role == "decode":
+                assert ssm_cache is None, (
+                    "A hybrid decode handoff writes directly into live SSM state; "
+                    "do not configure prefix_caching_mamba_gb on the decode engine"
+                )
         self._kv_transfer_role = role
         backend_cls = construct_kv_transfer_backend_class(backend)
 
@@ -235,21 +254,24 @@ class InferenceStateHandoffMixin:
         tp_size = get_pg_size(self.pg_collection.tp)
         tp_rank = get_pg_rank(self.pg_collection.tp)
 
-        # Compute this PP rank's global attention-layer range.
+        # Compute this PP rank's global attention- and SSM-layer ranges.
         pp_size = get_pg_size(self.pg_collection.pp)
         pp_rank = get_pg_rank(self.pg_collection.pp)
         local_num_layers = self.context.num_attention_layers
+        local_num_ssm_layers = self.context.num_mamba_layers
 
         if pp_size > 1 and torch.distributed.is_initialized():
             layer_counts: list = [None] * pp_size
             torch.distributed.all_gather_object(
-                layer_counts, local_num_layers, group=self.pg_collection.pp
+                layer_counts, (local_num_layers, local_num_ssm_layers), group=self.pg_collection.pp
             )
-            layer_start = sum(layer_counts[:pp_rank])
-            num_layers_global = sum(layer_counts)
+            layer_start = sum(counts[0] for counts in layer_counts[:pp_rank])
+            num_layers_global = sum(counts[0] for counts in layer_counts)
+            ssm_layer_start = sum(counts[1] for counts in layer_counts[:pp_rank])
         else:
             layer_start = 0
             num_layers_global = local_num_layers
+            ssm_layer_start = 0
         layer_end = layer_start + local_num_layers
 
         self._kv_transfer_agent = backend_cls(
@@ -270,25 +292,110 @@ class InferenceStateHandoffMixin:
             layer_end=layer_end,
         )
 
+        # Prefill sends from pinned snapshots; decode receives directly into
+        # live request slots and therefore has no durable recurrent cache.
+        if self.context.is_hybrid_model:
+            ssm_cache = self.context.mamba_slot_allocator
+            if role == "prefill":
+                assert ssm_cache is not None
+                conv_states = ssm_cache.conv_states
+                recurrent_states = ssm_cache.ssm_states
+                state_slot_count = ssm_cache.max_slots
+            else:
+                conv_states = self.context.mamba_conv_states
+                recurrent_states = self.context.mamba_ssm_states
+                state_slot_count = self.context.max_requests
+
+            conv_shape = conv_states.shape
+            ssm_shape = recurrent_states.shape
+            nheads_local = int(ssm_shape[-3])
+            nheads_global = nheads_local * tp_size
+            configured_nheads = model_config.mamba_num_heads
+            if configured_nheads is not None and configured_nheads != nheads_global:
+                raise ValueError(
+                    f"SSM state shape implies {nheads_global} global heads, "
+                    f"but model config specifies {configured_nheads}"
+                )
+            ssm_dims = SSMStateDims(
+                nheads=nheads_global,
+                headdim=int(ssm_shape[-2]),
+                d_state=int(ssm_shape[-1]),
+                ngroups=int(model_config.mamba_num_groups),
+                d_conv=int(conv_shape[-1]),
+            )
+            ssm_layout = SSMShardLayout(
+                global_rank=rank,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+                layer_start=ssm_layer_start,
+                num_layers=local_num_ssm_layers,
+                dims=ssm_dims,
+            )
+            if int(conv_shape[-2]) != ssm_layout.conv_dim_local:
+                raise ValueError(
+                    "SSM conv state shape does not match the model TP layout: "
+                    f"{conv_shape[-2]} vs {ssm_layout.conv_dim_local}"
+                )
+            state_specs = {
+                "conv": (conv_states, conv_states.shape[-2], conv_states.shape[-1]),
+                "recurrent": (
+                    recurrent_states,
+                    recurrent_states.shape[-3],
+                    recurrent_states.shape[-2] * recurrent_states.shape[-1],
+                ),
+            }
+            backend_factory = getattr(self._kv_transfer_agent, "new_registered_buffer", backend_cls)
+            for state_kind, (memory_buffer, width, state_dim) in state_specs.items():
+                self._ssm_transfer_agents[state_kind] = backend_factory(
+                    agent_name=f"{role}-ssm-{state_kind}-rank{rank}",
+                    memory_buffer=memory_buffer,
+                    expected_num_blocks=state_slot_count,
+                    heads_per_partition=width,
+                    head_dim=state_dim,
+                    tokens_per_block=1,
+                    ssm_layout=ssm_layout,
+                    ssm_state_kind=state_kind,
+                )
+            self._ssm_peer_metas = {
+                state_kind: agent.export_meta()
+                for state_kind, agent in self._ssm_transfer_agents.items()
+            }
+
         # Transport descriptors do not change between requests. Collect each
         # stage's TP descriptors once and reuse them for every handoff.
-        self._kv_peer_metas = self._kv_transfer_agent.export_meta()
+        local_peer_metas = {
+            "kv": self._kv_transfer_agent.export_meta(),
+            "ssm": self._ssm_peer_metas,
+        }
         if torch.distributed.is_initialized() and tp_size > 1:
             gathered_tp_metas: list = [None] * tp_size
             torch.distributed.all_gather_object(
-                gathered_tp_metas, self._kv_peer_metas, group=self.pg_collection.tp
+                gathered_tp_metas, local_peer_metas, group=self.pg_collection.tp
             )
-            self._kv_peer_metas = gathered_tp_metas
+            ssm_state_kinds = [set(entry["ssm"]) for entry in gathered_tp_metas]
+            if any(kinds != ssm_state_kinds[0] for kinds in ssm_state_kinds[1:]):
+                raise RuntimeError("SSM handoff agents are not configured on every TP rank")
+            self._kv_peer_metas = [entry["kv"] for entry in gathered_tp_metas]
+            self._tp_ssm_peer_metas = {
+                state_kind: [entry["ssm"][state_kind] for entry in gathered_tp_metas]
+                for state_kind in ssm_state_kinds[0]
+            }
+        else:
+            self._kv_peer_metas = local_peer_metas["kv"]
+            self._tp_ssm_peer_metas = dict(local_peer_metas["ssm"])
 
-        self._pp_kv_peer_metas = [self._kv_peer_metas]
+        local_stage_metas = {"kv": self._kv_peer_metas, "ssm": self._tp_ssm_peer_metas}
+        gathered_stage_metas = [local_stage_metas]
         if torch.distributed.is_initialized() and pp_size > 1:
-            self._pp_kv_peer_metas = [None] * pp_size
+            gathered_stage_metas = [None] * pp_size
             torch.distributed.all_gather_object(
-                self._pp_kv_peer_metas, self._kv_peer_metas, group=self.pg_collection.pp
+                gathered_stage_metas, local_stage_metas, group=self.pg_collection.pp
             )
+        self._pp_kv_peer_metas = [entry["kv"] for entry in gathered_stage_metas]
+        self._pp_ssm_peer_metas = [entry["ssm"] for entry in gathered_stage_metas]
 
     def push_handoff_kv(self, request_id: int, decode_metas: list) -> None:
-        """Push a pinned hand-off's KV to the decode
+        """Push a pinned hand-off's KV and SSM snapshots to the decode
         instance described by `decode_metas` (two-sided transports only).
 
         The decode posted its matching receives when SUBMIT_REQUEST_WITH_KV
@@ -305,8 +412,29 @@ class InferenceStateHandoffMixin:
             return
         kv_peer = {"tp_metas": list(decode_metas)}
         handles = [self._kv_transfer_agent.begin_push_blocks(kv_peer, block_ids)]
+        if self._ssm_transfer_agents:
+            # Reuse the exact slots advertised in the handoff metadata. The
+            # allocator can acquire more cached SSM states between metadata
+            # capture and SEND_KV; recomputing here would make the sender post
+            # more NCCL operations than the decode peer posted receives for.
+            slots = self._pinned_handoff_ssm_slots.get(request_id, [])
+            if slots:
+                for state_kind, agent in self._ssm_transfer_agents.items():
+                    peer = {
+                        "tp_metas": [
+                            e["ssm"][state_kind]
+                            for e in decode_metas
+                            if isinstance(e, dict) and e.get("ssm")
+                        ]
+                    }
+                    handles.append(agent.begin_push_blocks(peer, slots))
         self._pending_kv_pushes.append((request_id, handles))
-        logging.info("DISAGG_PREFILL_PUSH request_id=%d blocks=%d", request_id, len(block_ids))
+        logging.info(
+            "DISAGG_PREFILL_PUSH request_id=%d blocks=%d ssm=%d",
+            request_id,
+            len(block_ids),
+            len(handles) - 1,
+        )
 
     def _poll_pending_kv_pushes(self) -> int:
         """Reap completed push sends; unfinished ones stay pending.
@@ -354,11 +482,27 @@ class InferenceStateHandoffMixin:
 
         pp_size = get_pg_size(self.pg_collection.pp)
         try:
+            local_final_ssm_slots = {}
+            if self._ssm_transfer_agents:
+                ssm_cache = self.context.mamba_slot_allocator
+                for request, _ in handoffs:
+                    candidate_blocks = candidate_blocks_by_request[request.request_id]
+                    if candidate_blocks:
+                        local_final_ssm_slots[request.request_id] = ssm_cache.get_slot(
+                            candidate_blocks[-1]
+                        )
+
             static_pp_metas = self._pp_kv_peer_metas or [self._kv_peer_metas]
+            static_pp_ssm_metas = self._pp_ssm_peer_metas or [self._tp_ssm_peer_metas]
             if len(static_pp_metas) != pp_size:
                 raise RuntimeError(
                     f"Expected static metadata for {pp_size} pipeline stages, "
                     f"got {len(static_pp_metas)}"
+                )
+            if len(static_pp_ssm_metas) != pp_size:
+                raise RuntimeError(
+                    f"Expected static SSM metadata for {pp_size} pipeline stages, "
+                    f"got {len(static_pp_ssm_metas)}"
                 )
 
             prepared = {}
@@ -376,10 +520,17 @@ class InferenceStateHandoffMixin:
                     raise RuntimeError(
                         "Cannot create a decode-only handoff without the prompt KV state"
                     )
+                final_position = len(candidate_blocks) - 1
+                final_ssm_slot = local_final_ssm_slots.get(request.request_id, -1)
+                if self._ssm_transfer_agents and final_ssm_slot < 0:
+                    raise RuntimeError(
+                        "Cannot create a hybrid decode-only handoff without the exact final "
+                        "SSM state"
+                    )
                 block_ids = candidate_blocks
                 if pp_size > 1:
                     # Model-parallel ranks receive the same request stream and
-                    # use synchronized KV cache capacities.
+                    # use synchronized KV and recurrent-state cache capacities.
                     # Their deterministic allocators therefore assign the same
                     # physical IDs, while transport descriptors remain stage- and
                     # rank-specific metadata collected once during setup.
@@ -392,14 +543,56 @@ class InferenceStateHandoffMixin:
                 else:
                     kv_meta = self._kv_peer_metas
 
+                ssm_meta = None
+                local_ssm_slots = []
+                if self._ssm_transfer_agents:
+                    positions = [final_position]
+                    local_ssm_slots = [final_ssm_slot]
+                    stage_state_metas = [
+                        self._ssm_stage_transfer_meta(static_meta, local_ssm_slots)
+                        for static_meta in static_pp_ssm_metas
+                    ]
+                    ssm_meta = {"positions": positions}
+                    for state_kind in _SSM_STATE_KINDS:
+                        if pp_size > 1:
+                            ssm_meta[state_kind] = {
+                                "pp_metas": [
+                                    {"tp_metas": stage_meta[state_kind]}
+                                    for stage_meta in stage_state_metas
+                                ]
+                            }
+                        else:
+                            ssm_meta[state_kind] = stage_state_metas[0][state_kind]
+
                 prepared[request.request_id] = _PreparedHandoffMetadata(
-                    local_blocks=block_ids, kv_meta=kv_meta, resume_tokens=resume_tokens
+                    local_blocks=block_ids,
+                    kv_meta=kv_meta,
+                    ssm_meta=ssm_meta,
+                    local_ssm_slots=local_ssm_slots,
+                    resume_tokens=resume_tokens,
                 )
             return prepared
         except Exception:
             for block_ids in candidate_blocks_by_request.values():
                 self._release_pinned_handoff_blocks(block_ids)
             raise
+
+    @staticmethod
+    def _ssm_stage_transfer_meta(static_metas: dict, selected_slots: list[int]) -> dict:
+        """Attach selected recurrent slots to one stage's static descriptors."""
+
+        state_metas = {}
+        for state_kind in _SSM_STATE_KINDS:
+            state_static_metas = static_metas.get(state_kind)
+            if state_static_metas is None:
+                raise RuntimeError(f"Missing static {state_kind} SSM handoff metadata")
+            if isinstance(state_static_metas, list):
+                state_metas[state_kind] = [
+                    {**meta, "block_ids": selected_slots} for meta in state_static_metas
+                ]
+            else:
+                state_metas[state_kind] = {**state_static_metas, "block_ids": selected_slots}
+        return state_metas
 
     def _capture_handoff_meta(
         self, request: "DynamicInferenceRequest", prepared: _PreparedHandoffMetadata | None
@@ -417,23 +610,33 @@ class InferenceStateHandoffMixin:
         rid = request.request_id
         block_ids = prepared.local_blocks
         kv_meta = prepared.kv_meta
+        ssm_meta = prepared.ssm_meta
 
         self._pinned_handoff_blocks[rid] = list(block_ids)
+        self._pinned_handoff_ssm_slots[rid] = prepared.local_ssm_slots
 
         if isinstance(kv_meta, list):
             kv_meta = {"tp_metas": kv_meta}
         else:
             # TP=1 caches one static metadata dictionary for the engine. Keep
-            # request-specific fields out of that shared object.
+            # request-specific SSM metadata out of that shared object so a
+            # later handoff cannot overwrite an earlier request's positions.
             kv_meta = dict(kv_meta)
         kv_meta["resume_tokens"] = prepared.resume_tokens
+        if ssm_meta is not None:
+            kv_meta["ssm"] = ssm_meta
 
         request.disaggregated_params = {
             "request_id": rid,
             "block_ids": block_ids,
             "kv_meta": kv_meta,
         }
-        logging.info("DISAGG_PREFILL_HANDOFF request_id=%d pinned_blocks=%d", rid, len(block_ids))
+        logging.info(
+            "DISAGG_PREFILL_HANDOFF request_id=%d pinned_blocks=%d ssm_blocks=%d",
+            rid,
+            len(block_ids),
+            len(ssm_meta["positions"]) if ssm_meta is not None else 0,
+        )
 
     def release_handoff_blocks(self, request_id: int) -> None:
         """Release blocks pinned by a previous do_kv_handoff completion.
@@ -441,6 +644,7 @@ class InferenceStateHandoffMixin:
         Side: prefill engine; pull and push transport paths.
         """
         block_ids = self._pinned_handoff_blocks.pop(request_id, None)
+        self._pinned_handoff_ssm_slots.pop(request_id, None)
         if not block_ids:
             return
         released = self._release_pinned_handoff_blocks(block_ids)
@@ -480,6 +684,17 @@ class InferenceStateHandoffMixin:
                 "the prefill-skip path uses the prefix-cache match logic."
             )
 
+        ssm_meta = kv_meta.get("ssm") if isinstance(kv_meta, dict) else None
+        local_has_ssm = bool(self._ssm_transfer_agents)
+        if self.context.is_hybrid_model and not local_has_ssm:
+            raise RuntimeError("Hybrid decode received a handoff before SSM transfer setup")
+        if local_has_ssm and ssm_meta is None:
+            raise RuntimeError(
+                "Decode has SSM state transfer agents but the handoff contains no "
+                "SSM metadata; prefill and decode must use the same hybrid model"
+            )
+        if not self.context.is_hybrid_model and ssm_meta is not None:
+            raise RuntimeError("Transformer decode received SSM metadata from a hybrid prefill")
         if self._kv_transfer_agent is None:
             raise RuntimeError("KV handoff received without a transfer backend")
 
@@ -510,6 +725,13 @@ class InferenceStateHandoffMixin:
                 "Decode-only handoff requires every prompt KV block, including the partial tail: "
                 f"expected {expected_blocks}, got {num_blocks}"
             )
+        if local_has_ssm:
+            positions = [int(pos) for pos in ssm_meta.get("positions", [])]
+            if positions != [expected_blocks - 1]:
+                raise RuntimeError(
+                    "Hybrid decode-only handoff requires the exact final SSM state; "
+                    f"received positions {positions}"
+                )
         future = self._loop.create_future()
         handoff = DeferredKvHandoff(
             request_id=request_id,
@@ -560,6 +782,7 @@ class InferenceStateHandoffMixin:
             if isinstance(handoff.kv_meta, dict)
             else []
         )
+        ssm_meta = handoff.kv_meta.get("ssm") if isinstance(handoff.kv_meta, dict) else None
         continuation_block_count = (
             additional_decode_blocks(
                 len(handoff.prompt), len(resume_tokens), self.context.block_size_tokens
@@ -570,6 +793,8 @@ class InferenceStateHandoffMixin:
         if not self._handoff_capacity_available(
             num_blocks_to_import + continuation_block_count, cached_blocks
         ):
+            return False
+        if ssm_meta and self.context.mamba_metadata.mamba_state_free_slot_count < 1:
             return False
 
         allocator.retain_memory_blocks(cached_blocks)
@@ -586,8 +811,20 @@ class InferenceStateHandoffMixin:
         imported_blocks = allocated_blocks[:num_blocks_to_import]
         continuation_blocks = allocated_blocks[num_blocks_to_import:]
         local_blocks = cached_blocks + imported_blocks
+        owned_blocks_tensor = torch.tensor(
+            local_blocks + continuation_blocks, dtype=torch.int32, device="cpu"
+        )
+
         handle = None
         start_error = None
+        ssm_import = None
+        if ssm_meta:
+            try:
+                ssm_import = self._reserve_ssm_handoff_import(ssm_meta, local_blocks)
+            except Exception:
+                allocator.release_memory_blocks(owned_blocks_tensor)
+                raise
+
         try:
             transfer_meta, transfer_src_blocks = drop_transfer_prefix_blocks(
                 handoff.kv_meta, handoff.src_block_ids, len(cached_blocks)
@@ -595,6 +832,8 @@ class InferenceStateHandoffMixin:
             handle = self._kv_transfer_agent.begin_pull_blocks(
                 transfer_meta, transfer_src_blocks, imported_blocks
             )
+            if ssm_import is not None:
+                self._start_ssm_handoff_import(handoff.request_id, ssm_meta, ssm_import)
         except Exception as exc:
             start_error = exc
 
@@ -607,6 +846,7 @@ class InferenceStateHandoffMixin:
             cached_prefix_block_count=len(cached_blocks),
             handle=handle,
             future=handoff.future,
+            ssm=ssm_import,
             resume_tokens=resume_tokens,
             continuation_blocks=continuation_blocks,
             local_error=start_error,
@@ -682,12 +922,15 @@ class InferenceStateHandoffMixin:
 
     @staticmethod
     def _pending_transfer_handles(pending: PendingKvImport) -> list:
-        """Return this decode import's active KV transfer handles.
+        """Return this decode import's active KV and SSM transfer handles.
 
         Side: decode engine; pull and push transport paths.
         """
 
-        return [pending.handle] if pending.handle is not None else []
+        handles = [pending.handle]
+        if pending.ssm is not None:
+            handles.extend(pending.ssm.handles.values())
+        return [handle for handle in handles if handle is not None]
 
     def _validate_decode_ready_handoff(self, pending: PendingKvImport) -> None:
         """Validate that transferred state can start decode without prompt execution."""
@@ -698,6 +941,14 @@ class InferenceStateHandoffMixin:
                 "Decode-only handoff is missing its sampled token or MTP proposals: "
                 f"expected {expected_tokens}, got {len(pending.resume_tokens)}"
             )
+        if self.context.is_hybrid_model:
+            if pending.ssm is None:
+                raise RuntimeError("Hybrid decode-only handoff is missing transferred SSM state")
+            final_block_position = len(pending.local_blocks) - 1
+            if pending.ssm.position != final_block_position:
+                raise RuntimeError(
+                    "Hybrid decode-only handoff requires the exact post-prompt SSM state"
+                )
 
     def _finalize_kv_handoff_import(self, pending: PendingKvImport) -> None:
         """Register transferred blocks and admit the decode request.
@@ -786,7 +1037,10 @@ class InferenceStateHandoffMixin:
                     local_blocks,
                     pending.continuation_blocks,
                     pending.resume_tokens,
+                    ssm_state_idx=(pending.ssm.live_slot if pending.ssm is not None else None),
                 )
+                if pending.ssm is not None:
+                    pending.ssm.live_slot = None
                 pending.local_blocks = []
                 pending.continuation_blocks = []
                 if self.use_coordinator and self.is_mp_coordinator:
@@ -846,6 +1100,9 @@ class InferenceStateHandoffMixin:
             self.context.kv_block_allocator.release_memory_blocks(block_tensor)
         pending.local_blocks = []
         pending.continuation_blocks = []
+        if pending.ssm is not None and pending.ssm.live_slot is not None:
+            self.context.mamba_metadata.free_slot(pending.ssm.live_slot)
+            pending.ssm.live_slot = None
 
     @staticmethod
     def _wait_for_transfer_handles(*handles) -> bool:
@@ -966,3 +1223,37 @@ class InferenceStateHandoffMixin:
                 self._loop.create_task, self._notify_cond_for_new_request()
             )
         return ready
+
+    def _reserve_ssm_handoff_import(self, ssm_meta: dict, local_blocks: list) -> PendingSSMImport:
+        """Reserve the live request slot that receives exact SSM state."""
+
+        positions = [int(pos) for pos in ssm_meta.get("positions", [])]
+        if not self._ssm_transfer_agents:
+            raise RuntimeError(
+                "Received SSM handoff state but this decode engine has no "
+                "SSM transfer agents. Ensure KV transfer was initialized on a "
+                "hybrid decode engine."
+            )
+        if positions != [len(local_blocks) - 1]:
+            raise ValueError(
+                "Hybrid decode-only handoff requires one exact final SSM state; "
+                f"received positions {positions}"
+            )
+        live_slot = self.context.mamba_metadata.allocate_slot()
+        if live_slot is None:
+            raise RuntimeError("Live SSM slot capacity changed during handoff admission")
+        return PendingSSMImport(handles={}, live_slot=int(live_slot), position=positions[0])
+
+    def _start_ssm_handoff_import(
+        self, request_id: int, ssm_meta: dict, pending: PendingSSMImport
+    ) -> None:
+        """Post transfers into slots already reserved for one handoff."""
+
+        handles = {}
+        pending.handles = handles
+        assert pending.live_slot is not None
+        for state_kind, agent in self._ssm_transfer_agents.items():
+            handles[state_kind] = agent.begin_pull_blocks(
+                ssm_meta[state_kind], [], [pending.live_slot]
+            )
+        logging.debug("DISAGG_DECODE_SSM_IMPORT_SUBMIT request_id=%d ssm_blocks=%d", request_id, 1)

--- a/megatron/core/inference/disaggregation/pending_handoff_imports.py
+++ b/megatron/core/inference/disaggregation/pending_handoff_imports.py
@@ -29,7 +29,7 @@ class DeferredKvHandoff:
 class PendingSSMImport:
     """Exact SSM state being transferred into a reserved live request slot."""
 
-    handles: dict[str, Any]
+    handles: list[Any]
     live_slot: int
 
 

--- a/megatron/core/inference/disaggregation/pending_handoff_imports.py
+++ b/megatron/core/inference/disaggregation/pending_handoff_imports.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""State records for KV-cache imports awaiting completion."""
+"""State records for KV-cache and SSM-state imports awaiting completion."""
 
 from __future__ import annotations
 
@@ -26,6 +26,15 @@ class DeferredKvHandoff:
 
 
 @dataclass(kw_only=True)
+class PendingSSMImport:
+    """Exact SSM state being transferred into a reserved live request slot."""
+
+    handles: dict[str, Any]
+    live_slot: int | None
+    position: int
+
+
+@dataclass(kw_only=True)
 class PendingKvImport:
     """Decode request waiting for an asynchronous KV-cache import."""
 
@@ -37,6 +46,7 @@ class PendingKvImport:
     cached_prefix_block_count: int
     handle: Any
     future: asyncio.Future
+    ssm: PendingSSMImport | None = None
     resume_tokens: List[int] = field(default_factory=list)  # Sampled token, then MTP proposals.
     continuation_blocks: List[int] = field(default_factory=list)  # Empty KV for resume writes.
     local_error: Exception | None = None  # Exact local error, if this rank failed.

--- a/megatron/core/inference/disaggregation/pending_handoff_imports.py
+++ b/megatron/core/inference/disaggregation/pending_handoff_imports.py
@@ -30,8 +30,7 @@ class PendingSSMImport:
     """Exact SSM state being transferred into a reserved live request slot."""
 
     handles: dict[str, Any]
-    live_slot: int | None
-    position: int
+    live_slot: int
 
 
 @dataclass(kw_only=True)

--- a/megatron/core/inference/disaggregation/transfer_backends/base.py
+++ b/megatron/core/inference/disaggregation/transfer_backends/base.py
@@ -109,20 +109,28 @@ def compute_buffer_geometry(
     )
 
     shape = list(memory_buffer.shape)
-    candidates = [i for i, dim in enumerate(shape) if dim == expected_num_blocks]
-    if not candidates:
-        raise RuntimeError(
-            f"{backend_name}: no axis in memory_buffer shape {shape} matches "
-            f"expected_num_blocks={expected_num_blocks}. Layout is unrecognized; "
-            "bug in caller or new Megatron tensor shape."
-        )
-    if len(candidates) > 1:
-        raise RuntimeError(
-            f"{backend_name}: ambiguous blocks axis in shape {shape} "
-            f"(expected_num_blocks={expected_num_blocks} matches multiple axes "
-            f"{candidates}). Caller must pass a more distinctive value."
-        )
-    blocks_axis = candidates[0]
+    if ssm_layout is not None:
+        blocks_axis = 1
+        if len(shape) <= blocks_axis or shape[blocks_axis] != expected_num_blocks:
+            raise RuntimeError(
+                f"{backend_name}: SSM state shape {shape} does not have "
+                f"expected_num_blocks={expected_num_blocks} on slot axis 1"
+            )
+    else:
+        candidates = [i for i, dim in enumerate(shape) if dim == expected_num_blocks]
+        if not candidates:
+            raise RuntimeError(
+                f"{backend_name}: no axis in memory_buffer shape {shape} matches "
+                f"expected_num_blocks={expected_num_blocks}. Layout is unrecognized; "
+                "bug in caller or new Megatron tensor shape."
+            )
+        if len(candidates) > 1:
+            raise RuntimeError(
+                f"{backend_name}: ambiguous blocks axis in shape {shape} "
+                f"(expected_num_blocks={expected_num_blocks} matches multiple axes "
+                f"{candidates}). Caller must pass a more distinctive value."
+            )
+        blocks_axis = candidates[0]
 
     elements_per_slice = 1
     for dim in shape[blocks_axis + 1 :]:

--- a/megatron/core/inference/disaggregation/transfer_backends/nccl.py
+++ b/megatron/core/inference/disaggregation/transfer_backends/nccl.py
@@ -162,6 +162,11 @@ class NcclTransferBackend:
             list(memory_buffer.shape),
         )
 
+    def new_registered_buffer(self, **kwargs) -> "NcclTransferBackend":
+        """Create a transfer backend for another state buffer."""
+
+        return type(self)(**kwargs)
+
     def export_meta(self) -> Dict[str, Any]:
         """The shared geometry schema plus this rank's NCCL address."""
         meta = export_geometry_meta(self._geometry, self._ssm_layout)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -376,10 +376,10 @@ class DynamicInferenceEngine(AbstractEngine):
         self._raise_kv_handoff_not_enabled("KV handoff completion notification")
 
     def _prepare_handoff_metadata_batch(
-        self, requests_and_blocks: list[tuple], decode_tokens_by_request: Dict[int, list[int]]
+        self, requests_and_state: list[tuple], decode_tokens_by_request: Dict[int, list[int]]
     ) -> dict:
         """Hook overridden by the KV-handoff engine composition."""
-        if any(request.sampling_params.do_kv_handoff for request, _ in requests_and_blocks):
+        if any(request.sampling_params.do_kv_handoff for request, *_ in requests_and_state):
             self._raise_kv_handoff_not_enabled("KV handoff completion")
         return {}
 
@@ -388,6 +388,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def _release_pinned_handoff_blocks(self, block_ids: list) -> int:
         return 0
+
+    def _release_pinned_handoff_ssm_slot(self, ssm_slot: int | None) -> None:
+        return None
 
     def setup_kv_transfer(self, role: str, backend: str = "nixl") -> None:
         """Raising stub; the hand-off engine composition overrides it."""
@@ -437,6 +440,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.waiting_request_ids = deque()
         if hasattr(self, "_pinned_handoff_blocks"):
             self._pinned_handoff_blocks.clear()
+            self._pinned_handoff_ssm_slots.clear()
         self.failed_request_ids = []
         # Generated token count already streamed for each request.
         self._partial_emit_lengths: Dict[int, int] = {}
@@ -1367,6 +1371,7 @@ class DynamicInferenceEngine(AbstractEngine):
         pre_fwd_step_count: Optional[int] = None,
         finished_routing_block_ids: Optional[Dict[int, list[int]]] = None,
         finished_handoff_block_ids: Optional[Dict[int, list[int]]] = None,
+        finished_handoff_ssm_slots: Optional[Dict[int, int]] = None,
         finished_handoff_decode_tokens: Optional[Dict[int, list[int]]] = None,
     ) -> Tuple[List[DynamicInferenceRequest], List[DynamicInferenceRequest]]:
         """
@@ -1391,6 +1396,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 finished requests, saved before update_requests released them.
                 Used for per-block routing reconstruction.
             finished_handoff_block_ids: Prompt KV block IDs retained for state handoff.
+            finished_handoff_ssm_slots: Live SSM slots retained for state handoff.
             finished_handoff_decode_tokens: First sampled token and optional MTP proposals
                 needed to resume directly from imported prefill state on decode.
 
@@ -1428,9 +1434,14 @@ class DynamicInferenceEngine(AbstractEngine):
         # finished requests using the KV blocks retained before context cleanup.
         request_id_list = request_ids.tolist()
         handoff_blocks_by_request = finished_handoff_block_ids or {}
+        handoff_ssm_slots_by_request = finished_handoff_ssm_slots or {}
         prepared_handoff_metadata = self._prepare_handoff_metadata_batch(
             [
-                (self.get_request(request_id), handoff_blocks_by_request.get(request_id, []))
+                (
+                    self.get_request(request_id),
+                    handoff_blocks_by_request.get(request_id, []),
+                    handoff_ssm_slots_by_request.get(request_id),
+                )
                 for request_id in request_id_list
                 if request_id in finished_request_ids
             ],
@@ -1580,9 +1591,12 @@ class DynamicInferenceEngine(AbstractEngine):
                             request, prepared_handoff_metadata.get(request_id)
                         )
                     # A prefill-role engine may also serve regular requests; release the
-                    # temporary block references when no handoff was requested.
-                    elif handoff_blocks:
+                    # temporary state ownership when no handoff was requested.
+                    elif handoff_blocks or request_id in handoff_ssm_slots_by_request:
                         self._release_pinned_handoff_blocks(handoff_blocks)
+                        self._release_pinned_handoff_ssm_slot(
+                            handoff_ssm_slots_by_request.get(request_id)
+                        )
                     finished_entry = self.requests.pop(request_id)
                     finished_request = finished_entry.record[-1]
                     finished_request.generated_length = len(finished_request.generated_tokens)
@@ -2420,6 +2434,7 @@ class DynamicInferenceEngine(AbstractEngine):
             top_n_logprobs = step_result.get("top_n_logprobs", None)
             finished_routing_block_ids = step_result.get("finished_routing_block_ids", None)
             finished_handoff_block_ids = step_result.get("finished_handoff_block_ids", None)
+            finished_handoff_ssm_slots = step_result.get("finished_handoff_ssm_slots", None)
             finished_handoff_decode_tokens = step_result.get("finished_handoff_decode_tokens", None)
             cuda_graph_request_count = step_result["cuda_graph_request_count"]
 
@@ -2443,6 +2458,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 pre_fwd_step_count=context_state.get("step_count"),
                 finished_routing_block_ids=finished_routing_block_ids,
                 finished_handoff_block_ids=finished_handoff_block_ids,
+                finished_handoff_ssm_slots=finished_handoff_ssm_slots,
                 finished_handoff_decode_tokens=finished_handoff_decode_tokens,
             )
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1396,7 +1396,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 finished requests, saved before update_requests released them.
                 Used for per-block routing reconstruction.
             finished_handoff_block_ids: Prompt KV block IDs retained for state handoff.
-            finished_handoff_ssm_slots: Live SSM slots retained for state handoff.
+            finished_handoff_ssm_slots: Live SSM slots detached for state handoff.
             finished_handoff_decode_tokens: First sampled token and optional MTP proposals
                 needed to resume directly from imported prefill state on decode.
 

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -396,6 +396,7 @@ class DynamicInferenceRequest(InferenceRequest):
     # KV handoff metadata describing this request's pinned prefill state.
     # Used by decode-side pulls and prefill-side pushes.
     # Shape: {"request_id", "block_ids", "kv_meta"}.
+    # Hybrid models may add kv_meta["ssm"] for recurrent state.
     disaggregated_params: Optional[dict] = None
 
     def __post_init__(self):

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -1908,7 +1908,7 @@ class TextGenerationController:
         sampled_tokens_cpu: Tensor,
         sampled_mtp_tokens_cpu: Optional[Tensor],
     ) -> Tuple[Dict[int, List[int]], Dict[int, int], Dict[int, List[int]]]:
-        """Retain completed prompt state and capture tokens needed to resume decode."""
+        """Preserve completed prompt state and capture tokens needed to resume decode."""
 
         context = self.inference_wrapped_model.inference_context
         allocator = context.kv_block_allocator
@@ -1928,15 +1928,12 @@ class TextGenerationController:
                 # active=1, retain=2, request cleanup=1, coordinator RELEASE_KV=0.
                 allocator.retain_memory_blocks(valid_blocks)
                 if context.is_hybrid_model:
-                    ssm_slot = int(
-                        context.mamba_metadata.request_to_mamba_state_idx[finished_idx].item()
+                    # Transfer ownership out of the finished request before normal
+                    # cleanup; the slot stays absent from the free-slot stack until
+                    # the prefill engine receives RELEASE_KV.
+                    finished_ssm_slots[request_id] = context.mamba_metadata.detach_state_slot(
+                        finished_idx
                     )
-                    if ssm_slot < 0:
-                        raise RuntimeError(
-                            f"Finished hybrid request {request_id} has no live SSM state slot"
-                        )
-                    context.mamba_metadata.retain_state_slot(ssm_slot)
-                    finished_ssm_slots[request_id] = ssm_slot
 
             active_idx = finished_idx - context.paused_request_count
             decode_tokens = [int(sampled_tokens_cpu[active_idx].item())]

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -176,6 +176,7 @@ class _AsyncScheduleRequestResult:
     newly_paused_request_ids: Optional[Tensor] = None
     evict_request_ids: Optional[Tensor] = None
     finished_handoff_block_ids: Dict[int, List[int]] = field(default_factory=dict)
+    finished_handoff_ssm_slots: Dict[int, int] = field(default_factory=dict)
     finished_handoff_decode_tokens: Dict[int, List[int]] = field(default_factory=dict)
 
 
@@ -1906,15 +1907,16 @@ class TextGenerationController:
         finished_idxs: Tensor,
         sampled_tokens_cpu: Tensor,
         sampled_mtp_tokens_cpu: Optional[Tensor],
-    ) -> Tuple[Dict[int, List[int]], Dict[int, List[int]]]:
-        """Retain completed prompt blocks and capture tokens needed to resume decode."""
+    ) -> Tuple[Dict[int, List[int]], Dict[int, int], Dict[int, List[int]]]:
+        """Retain completed prompt state and capture tokens needed to resume decode."""
 
         context = self.inference_wrapped_model.inference_context
         allocator = context.kv_block_allocator
         finished_block_ids: Dict[int, List[int]] = {}
+        finished_ssm_slots: Dict[int, int] = {}
         decode_tokens_by_request: Dict[int, List[int]] = {}
         if not allocator.enable_handoff_pinning or finished_idxs.numel() == 0:
-            return finished_block_ids, decode_tokens_by_request
+            return finished_block_ids, finished_ssm_slots, decode_tokens_by_request
 
         for finished_idx in finished_idxs.tolist():
             request_id = int(context.request_ids[finished_idx].item())
@@ -1925,6 +1927,16 @@ class TextGenerationController:
                 # Retain across context cleanup. For an exclusively owned block:
                 # active=1, retain=2, request cleanup=1, coordinator RELEASE_KV=0.
                 allocator.retain_memory_blocks(valid_blocks)
+                if context.is_hybrid_model:
+                    ssm_slot = int(
+                        context.mamba_metadata.request_to_mamba_state_idx[finished_idx].item()
+                    )
+                    if ssm_slot < 0:
+                        raise RuntimeError(
+                            f"Finished hybrid request {request_id} has no live SSM state slot"
+                        )
+                    context.mamba_metadata.retain_state_slot(ssm_slot)
+                    finished_ssm_slots[request_id] = ssm_slot
 
             active_idx = finished_idx - context.paused_request_count
             decode_tokens = [int(sampled_tokens_cpu[active_idx].item())]
@@ -1934,7 +1946,7 @@ class TextGenerationController:
                 )
             decode_tokens_by_request[request_id] = decode_tokens
 
-        return finished_block_ids, decode_tokens_by_request
+        return finished_block_ids, finished_ssm_slots, decode_tokens_by_request
 
     def _dynamic_step_context_bookkeeping(self) -> Dict[str, Tensor]:
         """Update the dynamic inference context after sampling.
@@ -2009,7 +2021,7 @@ class TextGenerationController:
 
         # Retain finished prefill blocks before request cleanup releases them;
         # the handoff path owns this reference until the decode transfer completes.
-        finished_handoff_block_ids, finished_handoff_decode_tokens = (
+        finished_handoff_block_ids, finished_handoff_ssm_slots, finished_handoff_decode_tokens = (
             self._collect_finished_handoff_state(
                 finished_idxs, sampled_tokens_cpu, sampled_mtp_tokens_cpu
             )
@@ -2036,6 +2048,7 @@ class TextGenerationController:
             "sample": sampled_tokens_cpu,
             "finished_routing_block_ids": finished_routing_block_ids,
             "finished_handoff_block_ids": finished_handoff_block_ids,
+            "finished_handoff_ssm_slots": finished_handoff_ssm_slots,
             "finished_handoff_decode_tokens": finished_handoff_decode_tokens,
             **(update_result or {}),
         }
@@ -2749,7 +2762,7 @@ class TextGenerationController:
         finished_idxs = (
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
         )
-        finished_handoff_block_ids, finished_handoff_decode_tokens = (
+        finished_handoff_block_ids, finished_handoff_ssm_slots, finished_handoff_decode_tokens = (
             self._collect_finished_handoff_state(
                 finished_idxs, sampled_tokens_cpu, sample_result.sampled_mtp_tokens_cpu_view
             )
@@ -2773,6 +2786,7 @@ class TextGenerationController:
             finished_request_ids=finished_request_ids,
             survivor_idxs=survivor_idxs,
             finished_handoff_block_ids=finished_handoff_block_ids,
+            finished_handoff_ssm_slots=finished_handoff_ssm_slots,
             finished_handoff_decode_tokens=finished_handoff_decode_tokens,
         )
 
@@ -2804,7 +2818,7 @@ class TextGenerationController:
         finished_idxs = (
             torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
         )
-        finished_handoff_block_ids, finished_handoff_decode_tokens = (
+        finished_handoff_block_ids, finished_handoff_ssm_slots, finished_handoff_decode_tokens = (
             self._collect_finished_handoff_state(
                 finished_idxs, sampled_tokens_cpu, sample_result.sampled_mtp_tokens_cpu_view
             )
@@ -2832,6 +2846,7 @@ class TextGenerationController:
             newly_paused_request_ids=update_result.get("newly_paused_request_ids"),
             evict_request_ids=update_result.get("evict_request_ids"),
             finished_handoff_block_ids=finished_handoff_block_ids,
+            finished_handoff_ssm_slots=finished_handoff_ssm_slots,
             finished_handoff_decode_tokens=finished_handoff_decode_tokens,
         )
 
@@ -2875,6 +2890,7 @@ class TextGenerationController:
                 "sample": request_result.sampled_tokens_cpu,
                 "finished_routing_block_ids": {},
                 "finished_handoff_block_ids": request_result.finished_handoff_block_ids,
+                "finished_handoff_ssm_slots": request_result.finished_handoff_ssm_slots,
                 "finished_handoff_decode_tokens": request_result.finished_handoff_decode_tokens,
                 "newly_paused_request_ids": request_result.newly_paused_request_ids,
                 "evict_request_ids": request_result.evict_request_ids,

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -51,20 +51,18 @@ class TestMambaMetadata:
         assert metadata.mamba_state_free_slot_count == 2
         assert int(metadata.allocate_slot()) == slot
 
-    def test_retained_live_slot_survives_request_cleanup_and_reset(self, monkeypatch):
-        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+    def test_detached_live_slot_survives_request_cleanup(self):
         metadata = MambaMetadata(max_requests=2, max_tokens=4, max_intermediate_count=1)
         slot = int(metadata.allocate_slot())
         metadata.request_to_mamba_state_idx[0] = slot
 
-        metadata.retain_state_slot(slot)
+        assert metadata.detach_state_slot(0) == slot
         metadata.free_slots(torch.tensor([0], dtype=torch.int64))
-        metadata.reset()
 
         assert metadata.mamba_state_free_slot_count == 1
         assert int(metadata.allocate_slot()) != slot
 
-        metadata.release_retained_state_slot(slot)
+        metadata.free_slot(slot)
 
         assert metadata.mamba_state_free_slot_count == 1
         assert int(metadata.allocate_slot()) == slot

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -51,6 +51,23 @@ class TestMambaMetadata:
         assert metadata.mamba_state_free_slot_count == 2
         assert int(metadata.allocate_slot()) == slot
 
+    def test_allocated_slots_do_not_alias_free_slot_stack(self):
+        metadata = MambaMetadata(max_requests=3, max_tokens=4, max_intermediate_count=1)
+
+        slot_to_release = metadata.allocate_slot()
+        allocated_slot = metadata.allocate_slot()
+        metadata.free_slot(slot_to_release)
+
+        assert isinstance(allocated_slot, int)
+        assert allocated_slot == 1
+
+        metadata.reset()
+        slot_to_release = metadata.allocate_slot()
+        allocated_slots = metadata.batch_allocate_slots(2)
+        metadata.free_slot(slot_to_release)
+
+        assert torch.equal(allocated_slots, torch.tensor([0, 1], dtype=torch.int32))
+
     def test_detached_live_slot_survives_request_cleanup(self):
         metadata = MambaMetadata(max_requests=2, max_tokens=4, max_intermediate_count=1)
         slot = int(metadata.allocate_slot())

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -40,6 +40,17 @@ class TestMambaMetadata:
 
         assert metadata._batch_indices_decode_buffer.dtype == dtype
 
+    def test_free_unbound_live_slot(self):
+        metadata = MambaMetadata(max_requests=2, max_tokens=4, max_intermediate_count=1)
+
+        slot = int(metadata.allocate_slot())
+        assert metadata.mamba_state_free_slot_count == 1
+
+        metadata.free_slot(slot)
+
+        assert metadata.mamba_state_free_slot_count == 2
+        assert int(metadata.allocate_slot()) == slot
+
     def _run_update_test(
         self,
         metadata: MambaMetadata,

--- a/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
+++ b/tests/unit_tests/inference/contexts/attention_metadata/test_mamba_metadata.py
@@ -51,6 +51,24 @@ class TestMambaMetadata:
         assert metadata.mamba_state_free_slot_count == 2
         assert int(metadata.allocate_slot()) == slot
 
+    def test_retained_live_slot_survives_request_cleanup_and_reset(self, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+        metadata = MambaMetadata(max_requests=2, max_tokens=4, max_intermediate_count=1)
+        slot = int(metadata.allocate_slot())
+        metadata.request_to_mamba_state_idx[0] = slot
+
+        metadata.retain_state_slot(slot)
+        metadata.free_slots(torch.tensor([0], dtype=torch.int64))
+        metadata.reset()
+
+        assert metadata.mamba_state_free_slot_count == 1
+        assert int(metadata.allocate_slot()) != slot
+
+        metadata.release_retained_state_slot(slot)
+
+        assert metadata.mamba_state_free_slot_count == 1
+        assert int(metadata.allocate_slot()) == slot
+
     def _run_update_test(
         self,
         metadata: MambaMetadata,

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -2015,6 +2015,32 @@ class TestDynamicContext:
         self._restore_model_parallel()
 
     @pytest.mark.internal
+    def test_mamba_cache_error_identifies_limiting_pipeline_stage(self):
+        context = object.__new__(DynamicInferenceContext)
+        context.mamba_conv_states_shape = (1,)
+        context.mamba_ssm_states_shape = (1,)
+        context.mamba_conv_states_dtype = torch.float32
+        context.mamba_ssm_states_dtype = torch.float32
+        context.num_mamba_layers = 1
+        context.max_mamba_intermediate_states_per_step = 1
+        context.pipeline_parallel_group = object()
+
+        def reduce_to_remote_capacity(tensor, **_kwargs):
+            tensor.fill_(0)
+
+        get_pg_size = "megatron.core.inference.contexts.dynamic_context.get_pg_size"
+        with (
+            mock.patch(get_pg_size, return_value=2),
+            mock.patch.object(
+                torch.distributed, "all_reduce", side_effect=reduce_to_remote_capacity
+            ),
+            pytest.raises(ValueError, match="another stage has room for fewer than one") as error,
+        ):
+            context._allocate_mamba_cache(32 / 1024**3)
+
+        assert "room for 3 durable slots on this pipeline stage" in str(error.value)
+
+    @pytest.mark.internal
     @rounder_override(64)
     def test_uneven_decoder_pp_layer_map_matches_get_num_layers_to_build(self):
         """Uneven PP (num_layers_in_first/last): KV layer_map length matches this rank's layer count.

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -1941,7 +1941,7 @@ class TestDynamicContext:
     @rounder_override(64)
     def test_pipeline_parallel_uneven_layers(self):
         """
-        Test that DynamicInferenceContext synchronizes the total block count across
+        Test that DynamicInferenceContext synchronizes cache capacities across
         pipeline stages when they have unequal layer counts.
         """
         pp_size = 2
@@ -1986,26 +1986,31 @@ class TestDynamicContext:
                 block_size_tokens=16,
                 max_tokens=1024,
                 unified_memory_level=0,
+                enable_prefix_caching=True,
+                prefix_caching_mamba_gb=0.05,
+                mamba_inference_state_config=mamba_inference_state_config,
             ),
         )
 
-        # Collect the total block counts on each rank (CUDA needed for NCCL all_gather)
-        local_total_blocks = torch.tensor(
-            [context.kv_block_allocator.pool_size], device='cuda', dtype=torch.long
+        # Collect cache capacities on each rank (CUDA needed for NCCL all_gather).
+        local_capacities = torch.tensor(
+            [context.kv_block_allocator.pool_size, context.mamba_slot_allocator.max_slots],
+            device='cuda',
+            dtype=torch.long,
         )
-        gathered_block_counts = [torch.zeros_like(local_total_blocks) for _ in range(pp_size)]
+        gathered_capacities = [torch.zeros_like(local_capacities) for _ in range(pp_size)]
         torch.distributed.all_gather(
-            gathered_block_counts,
-            local_total_blocks,
+            gathered_capacities,
+            local_capacities,
             group=parallel_state.get_pipeline_model_parallel_group(),
         )
-        all_counts = [t.item() for t in gathered_block_counts]
+        all_capacities = [tuple(t.tolist()) for t in gathered_capacities]
 
-        # Verify that there is only 1 unique value across all ranks
-        unique_counts = set(all_counts)
+        # Both allocators must remain mirrored across pipeline stages.
+        unique_capacities = set(all_capacities)
         assert (
-            len(unique_counts) == 1
-        ), f"Block counts were not synchronized across ranks. Gathered: {all_counts}"
+            len(unique_capacities) == 1
+        ), f"Cache capacities were not synchronized across ranks. Gathered: {all_capacities}"
 
         self._restore_model_parallel()
 
@@ -3330,7 +3335,7 @@ class TestDynamicContext:
         prefix_skip = 2 * bs - 1
         eff_chunk = chunk_length - prefix_skip
 
-        (_, _, _, _, prefix_skip, eff_chunk) = ctx._compute_prefix_match(req2, chunk_length)
+        _, _, _, _, prefix_skip, eff_chunk = ctx._compute_prefix_match(req2, chunk_length)
         expected_active = tokens_before_chunk_2 + eff_chunk
         assert ctx.active_token_count == expected_active
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -14,6 +14,9 @@ from megatron.core.inference.contexts.mamba_slot_allocator import (
     MambaSlotAllocator,
     MambaSlotCapacityError,
 )
+from megatron.core.inference.disaggregation.inference_state_handoff import (
+    InferenceStateHandoffMixin,
+)
 from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
@@ -959,18 +962,29 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
             self._mctx(prefix_caching_mamba_gb=1e-5)
 
     @pytest.mark.internal
-    def test_hybrid_admission_requires_free_live_state_slot(self):
+    def test_hybrid_admission_resumes_after_handoff_releases_live_slot(self):
         ctx = self._mctx(max_requests=1, rounder=1)
         ctx.kv_block_allocator.enable_handoff_pinning = True
         slot = ctx.mamba_metadata.allocate_slot()
+        assert slot is not None
         ctx.mamba_metadata.request_to_mamba_state_idx[0] = slot
         ctx.mamba_metadata.detach_state_slot(0)
+        request = self._req(ctx, self._prompt(ctx.block_size_tokens))
 
-        request_available, _, _ = ctx.check_availability(
-            self._req(ctx, self._prompt(ctx.block_size_tokens))
-        )
+        request_available, _, _ = ctx.check_availability(request)
 
         assert not request_available
+
+        engine = InferenceStateHandoffMixin()
+        engine.context = ctx
+        engine._initialize_disaggregation_state()
+        engine._pinned_handoff_ssm_slots[7] = slot
+        engine.release_handoff_blocks(7)
+
+        request_available, _, _ = ctx.check_availability(request)
+
+        assert request_available
+        assert ctx.mamba_metadata.mamba_state_free_slot_count == 1
 
     @pytest.mark.internal
     def test_mamba_prefill_skip_and_zero_prefill(self):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -1452,7 +1452,7 @@ def test_mamba_lru_eviction_selects_only_requested_oldest_slots(monkeypatch):
 @pytest.mark.parametrize("max_slots", [0, 1])
 def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, max_slots):
     allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=max_slots)
-    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (2, 102, 0, True, False)]
+    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [101, 102])
     copy_calls = []
     store_calls = []
     register_calls = []
@@ -1467,59 +1467,9 @@ def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, m
     expected_slot = 0 if max_slots else -1
     assert allocator.block_to_slot.tolist() == [-1, expected_slot, -1]
     assert copy_calls == ([([0], [0])] if max_slots else [])
-    assert store_calls == []
+    assert store_calls == ([([], [])] if max_slots else [])
     assert register_calls == ([([1], [101])] if max_slots else [])
     assert clear_calls == [True]
-
-
-def test_required_handoff_state_takes_priority_over_optional_checkpoints(monkeypatch):
-    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
-    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (2, -1, 0, True, True)]
-    copy_calls = []
-    store_calls = []
-    register_calls = []
-    clear_calls = []
-    allocator._copy_intermediate_to_cache = lambda *args: copy_calls.append(args)
-    allocator.store_from_live_batch = lambda *args: store_calls.append(args)
-    allocator.register_block_hashes_batch = lambda *args: register_calls.append(args)
-    allocator._clear_intermediate_state = lambda: clear_calls.append(True)
-
-    allocator.commit_intermediate_states()
-
-    assert allocator.block_to_slot.tolist() == [-1, -1, 0]
-    assert copy_calls == []
-    assert store_calls == [([0], [0])]
-    assert register_calls == [([2], [-1])]
-    assert clear_calls == [True]
-
-
-def test_required_handoff_state_replaces_optional_snapshot_for_same_block(monkeypatch):
-    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=2, max_slots=1)
-    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (1, 101, 0, True, True)]
-    store_calls = []
-    register_calls = []
-    allocator._copy_intermediate_to_cache = lambda *_: pytest.fail(
-        "optional state must not overwrite the exact handoff state"
-    )
-    allocator.store_from_live_batch = lambda *args: store_calls.append(args)
-    allocator.register_block_hashes_batch = lambda *args: register_calls.append(args)
-    allocator._clear_intermediate_state = lambda: None
-
-    allocator.commit_intermediate_states()
-
-    assert store_calls == [([0], [0])]
-    assert register_calls == [([1], [101])]
-
-
-def test_exact_handoff_state_allocation_is_atomic(monkeypatch):
-    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
-    allocator._collect_commit_data = lambda: [(1, -1, 0, True, True), (2, -1, 1, True, True)]
-    allocator.store_from_live_batch = lambda *_: pytest.fail("required state must not be copied")
-
-    with pytest.raises(MambaSlotCapacityError, match="requires 2 new durable slots"):
-        allocator.commit_intermediate_states()
-
-    assert allocator.block_to_slot.tolist() == [-1, -1, -1]
 
 
 class TestMambaSlotAllocator(PrefixCachingTestBase):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -1452,7 +1452,7 @@ def test_mamba_lru_eviction_selects_only_requested_oldest_slots(monkeypatch):
 @pytest.mark.parametrize("max_slots", [0, 1])
 def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, max_slots):
     allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=max_slots)
-    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [False], [101, 102])
+    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (2, 102, 0, True, False)]
     copy_calls = []
     store_calls = []
     register_calls = []
@@ -1467,14 +1467,14 @@ def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, m
     expected_slot = 0 if max_slots else -1
     assert allocator.block_to_slot.tolist() == [-1, expected_slot, -1]
     assert copy_calls == ([([0], [0])] if max_slots else [])
-    assert store_calls == ([([], [])] if max_slots else [])
+    assert store_calls == []
     assert register_calls == ([([1], [101])] if max_slots else [])
     assert clear_calls == [True]
 
 
 def test_required_handoff_state_takes_priority_over_optional_checkpoints(monkeypatch):
     allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
-    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [True], [101, -1])
+    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (2, -1, 0, True, True)]
     copy_calls = []
     store_calls = []
     register_calls = []
@@ -1493,18 +1493,33 @@ def test_required_handoff_state_takes_priority_over_optional_checkpoints(monkeyp
     assert clear_calls == [True]
 
 
-def test_exact_handoff_states_use_available_capacity_without_failing_batch(monkeypatch):
-    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
-    allocator._collect_commit_data = lambda: ([], [], [1, 2], [0, 1], [True, True], [-1, -1])
+def test_required_handoff_state_replaces_optional_snapshot_for_same_block(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=2, max_slots=1)
+    allocator._collect_commit_data = lambda: [(1, 101, 0, False, False), (1, 101, 0, True, True)]
     store_calls = []
+    register_calls = []
+    allocator._copy_intermediate_to_cache = lambda *_: pytest.fail(
+        "optional state must not overwrite the exact handoff state"
+    )
     allocator.store_from_live_batch = lambda *args: store_calls.append(args)
-    allocator.register_block_hashes_batch = lambda *_: None
+    allocator.register_block_hashes_batch = lambda *args: register_calls.append(args)
     allocator._clear_intermediate_state = lambda: None
 
     allocator.commit_intermediate_states()
 
-    assert allocator.block_to_slot.tolist() == [-1, 0, -1]
     assert store_calls == [([0], [0])]
+    assert register_calls == [([1], [101])]
+
+
+def test_exact_handoff_state_allocation_is_atomic(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
+    allocator._collect_commit_data = lambda: [(1, -1, 0, True, True), (2, -1, 1, True, True)]
+    allocator.store_from_live_batch = lambda *_: pytest.fail("required state must not be copied")
+
+    with pytest.raises(MambaSlotCapacityError, match="requires 2 new durable slots"):
+        allocator.commit_intermediate_states()
+
+    assert allocator.block_to_slot.tolist() == [-1, -1, -1]
 
 
 class TestMambaSlotAllocator(PrefixCachingTestBase):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -959,6 +959,20 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
             self._mctx(prefix_caching_mamba_gb=1e-5)
 
     @pytest.mark.internal
+    def test_hybrid_admission_requires_free_live_state_slot(self):
+        ctx = self._mctx(max_requests=1, rounder=1)
+        ctx.kv_block_allocator.enable_handoff_pinning = True
+        slot = ctx.mamba_metadata.allocate_slot()
+        ctx.mamba_metadata.request_to_mamba_state_idx[0] = slot
+        ctx.mamba_metadata.detach_state_slot(0)
+
+        request_available, _, _ = ctx.check_availability(
+            self._req(ctx, self._prompt(ctx.block_size_tokens))
+        )
+
+        assert not request_available
+
+    @pytest.mark.internal
     def test_mamba_prefill_skip_and_zero_prefill(self):
         # mamba match limits prefill skip
         ctx = self._mctx()

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -814,7 +814,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
 
         req2 = self._req(ctx, prompt.clone(), request_id=2)
         # no prefill skipping
-        (matched, _, _, _, prefix_skip, eff_chunk) = ctx._compute_prefix_match(req2, len(prompt))
+        matched, _, _, _, prefix_skip, eff_chunk = ctx._compute_prefix_match(req2, len(prompt))
         assert len(matched) == 3 and prefix_skip == 0 and eff_chunk == len(prompt)
 
         ctx.add_request(req2)
@@ -970,7 +970,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         self._mamba_allocate_and_register(ctx, self._block_ids(ctx, 0, 3)[:1])
         req2 = self._req(ctx, prompt.clone(), request_id=2)
         req2._mamba_num_matched_blocks = 1
-        (matched, _, _, _, prefix_skip, eff_chunk) = ctx._compute_prefix_match(req2, len(prompt))
+        matched, _, _, _, prefix_skip, eff_chunk = ctx._compute_prefix_match(req2, len(prompt))
         assert len(matched) == 3 and prefix_skip == bs and eff_chunk == len(prompt) - bs
 
         # no mamba match means no skip
@@ -979,7 +979,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         ctx2.add_request(self._req(ctx2, p2.clone()))
         req2b = self._req(ctx2, p2.clone(), request_id=2)
         req2b._mamba_num_matched_blocks = 0
-        (m2, _, _, _, ps2, ec2) = ctx2._compute_prefix_match(req2b, len(p2))
+        m2, _, _, _, ps2, ec2 = ctx2._compute_prefix_match(req2b, len(p2))
         assert len(m2) == 3 and ps2 == 0 and ec2 == len(p2)
 
         # zero prefill for hybrid (mamba-cached, block-aligned)
@@ -989,7 +989,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         self._mamba_allocate_and_register(ctx3, self._block_ids(ctx3, 0, 3))
         req3 = self._req(ctx3, p3.clone(), request_id=2)
         req3._mamba_num_matched_blocks = 3
-        (m3, _, _, _, ps3, ec3) = ctx3._compute_prefix_match(req3, len(p3))
+        m3, _, _, _, ps3, ec3 = ctx3._compute_prefix_match(req3, len(p3))
         assert len(m3) == 3 and ps3 == 2 * bs and ec3 == bs
 
         # KV-only prefix skip with non-block-aligned prompt: all 3 full blocks
@@ -1001,7 +1001,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         req4a = self._req(ctx4, p4.clone())
         ctx4.add_request(req4a)
         req4b = self._req(ctx4, p4.clone(), request_id=2)
-        (m4, _, _, _, ps4, ec4) = ctx4._compute_prefix_match(req4b, len(p4))
+        m4, _, _, _, ps4, ec4 = ctx4._compute_prefix_match(req4b, len(p4))
         assert len(m4) == 3 and ps4 == 3 * bs4 and ec4 == tail
         ctx4.add_request(req4b)
 
@@ -1070,7 +1070,7 @@ class TestMambaPrefixCaching(PrefixCachingTestBase):
         self._mamba_allocate_and_register(ctx, self._block_ids(ctx, 0, 4)[:2])
         req2 = self._req(ctx, prompt.clone(), request_id=2)
         req2._mamba_num_matched_blocks = 2
-        (matched, _, _, overall, prefix_skip, _) = ctx._compute_prefix_match(req2, len(prompt))
+        matched, _, _, overall, prefix_skip, _ = ctx._compute_prefix_match(req2, len(prompt))
         # Copy block IDs to slot 1 so compute_and_store_offsets can resolve EOS block
         ctx.request_to_kv_block_ids[1] = ctx.request_to_kv_block_ids[0]
         msa.compute_and_store_offsets(
@@ -1452,7 +1452,7 @@ def test_mamba_lru_eviction_selects_only_requested_oldest_slots(monkeypatch):
 @pytest.mark.parametrize("max_slots", [0, 1])
 def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, max_slots):
     allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=max_slots)
-    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [101, 102])
+    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [False], [101, 102])
     copy_calls = []
     store_calls = []
     register_calls = []
@@ -1470,6 +1470,41 @@ def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, m
     assert store_calls == ([([], [])] if max_slots else [])
     assert register_calls == ([([1], [101])] if max_slots else [])
     assert clear_calls == [True]
+
+
+def test_required_handoff_state_takes_priority_over_optional_checkpoints(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
+    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [True], [101, -1])
+    copy_calls = []
+    store_calls = []
+    register_calls = []
+    clear_calls = []
+    allocator._copy_intermediate_to_cache = lambda *args: copy_calls.append(args)
+    allocator.store_from_live_batch = lambda *args: store_calls.append(args)
+    allocator.register_block_hashes_batch = lambda *args: register_calls.append(args)
+    allocator._clear_intermediate_state = lambda: clear_calls.append(True)
+
+    allocator.commit_intermediate_states()
+
+    assert allocator.block_to_slot.tolist() == [-1, -1, 0]
+    assert copy_calls == []
+    assert store_calls == [([0], [0])]
+    assert register_calls == [([2], [-1])]
+    assert clear_calls == [True]
+
+
+def test_exact_handoff_states_use_available_capacity_without_failing_batch(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=1)
+    allocator._collect_commit_data = lambda: ([], [], [1, 2], [0, 1], [True, True], [-1, -1])
+    store_calls = []
+    allocator.store_from_live_batch = lambda *args: store_calls.append(args)
+    allocator.register_block_hashes_batch = lambda *_: None
+    allocator._clear_intermediate_state = lambda: None
+
+    allocator.commit_intermediate_states()
+
+    assert allocator.block_to_slot.tolist() == [-1, 0, -1]
+    assert store_calls == [([0], [0])]
 
 
 class TestMambaSlotAllocator(PrefixCachingTestBase):
@@ -1923,7 +1958,7 @@ class TestPrefixCacheReuse(PrefixCachingTestBase):
 
         # request 2 shares the first 4 blocks, adds 2 new blocks
         req2 = self._req(ctx, self._prompt(bs * 6), request_id=2)
-        (matched, _, _, _, prefix_skip, _) = ctx._compute_prefix_match(req2, bs * 6)
+        matched, _, _, _, prefix_skip, _ = ctx._compute_prefix_match(req2, bs * 6)
         assert len(matched) == 4 and prefix_skip == bs * 4
         ctx.add_request(req2)
 

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -98,7 +98,6 @@ class _MambaMetadata:
         self.mamba_state_free_slot_count = available
         self.next_slot = 20
         self.freed = []
-        self.released_retained = []
 
     def allocate_slot(self):
         if self.mamba_state_free_slot_count == 0:
@@ -110,10 +109,6 @@ class _MambaMetadata:
 
     def free_slot(self, slot):
         self.freed.append(slot)
-        self.mamba_state_free_slot_count += 1
-
-    def release_retained_state_slot(self, slot):
-        self.released_retained.append(slot)
         self.mamba_state_free_slot_count += 1
 
 
@@ -321,7 +316,7 @@ def test_completed_exact_ssm_handoff_enters_decode_without_waiting_queue(handoff
         cached_prefix_block_count=0,
         handle=None,
         future=handoff_loop.create_future(),
-        ssm=PendingSSMImport(handles={}, live_slot=20),
+        ssm=PendingSSMImport(handles=[], live_slot=20),
         resume_tokens=[55],
     )
 
@@ -396,6 +391,9 @@ def test_handoff_roles_use_live_ssm_buffers_and_decode_rejects_durable_cache():
 
         def export_meta(self):
             return {"transport": "test"}
+
+        def new_registered_buffer(self, **kwargs):
+            return type(self)(**kwargs)
 
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
@@ -550,13 +548,13 @@ def test_reset_rejects_pinned_prefill_blocks(handoff_loop):
     assert engine._pinned_handoff_blocks == {7: [10]}
 
 
-def test_release_handoff_returns_retained_prefill_ssm_slot(handoff_loop):
+def test_release_handoff_returns_detached_prefill_ssm_slot(handoff_loop):
     engine = _HandoffHarness(handoff_loop, hybrid=True)
     engine._pinned_handoff_ssm_slots[7] = 3
 
     engine.release_handoff_blocks(7)
 
-    assert engine.context.mamba_metadata.released_retained == [3]
+    assert engine.context.mamba_metadata.freed == [3]
     assert engine._pinned_handoff_ssm_slots == {}
 
 
@@ -841,13 +839,48 @@ def test_handoff_metadata_batches_completed_requests_across_pipeline(monkeypatch
     assert requests[1].disaggregated_params["kv_meta"]["pp_metas"][1]["block_ids"] == [12, 13, 14]
 
 
+def test_handoff_metadata_error_releases_all_finished_state():
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    engine.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
+    engine.context = SimpleNamespace(block_size_tokens=4, num_speculative_tokens=0)
+    engine._kv_peer_metas = None
+    engine._release_pinned_handoff_blocks = mock.Mock()
+    engine._release_pinned_handoff_ssm_slot = mock.Mock()
+    regular = SimpleNamespace(
+        request_id=7,
+        prompt_tokens=[1, 2, 3, 4],
+        sampling_params=SamplingParams(do_kv_handoff=False),
+    )
+    handoff = SimpleNamespace(
+        request_id=8, prompt_tokens=[1, 2, 3, 4], sampling_params=SamplingParams(do_kv_handoff=True)
+    )
+
+    with (
+        mock.patch(
+            "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_size",
+            return_value=1,
+        ),
+        pytest.raises(RuntimeError, match="transfer setup"),
+    ):
+        engine._prepare_handoff_metadata_batch(
+            [(regular, [10], 3), (handoff, [11], 4)], decode_tokens_by_request={}
+        )
+
+    assert engine._release_pinned_handoff_blocks.call_args_list == [
+        mock.call([10]),
+        mock.call([11]),
+    ]
+    assert engine._release_pinned_handoff_ssm_slot.call_args_list == [mock.call(3), mock.call(4)]
+
+
 def test_hybrid_handoff_keeps_partial_block_for_exact_decode_resume():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
     engine.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
     engine.context = SimpleNamespace(block_size_tokens=4, num_speculative_tokens=0)
     engine._kv_peer_metas = {"global_rank": 0}
-    engine._tp_ssm_peer_metas = {"conv": {"global_rank": 0}, "recurrent": {"global_rank": 0}}
+    engine._pp_ssm_peer_metas = [{"conv": {"global_rank": 0}, "recurrent": {"global_rank": 0}}]
     engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
     engine._release_pinned_handoff_blocks = mock.Mock()
     request = SimpleNamespace(
@@ -1098,8 +1131,7 @@ def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
             for state in ("conv", "recurrent")
         }
 
-    engine._tp_ssm_peer_metas = stage_ssm_metas(0)
-    engine._pp_ssm_peer_metas = [engine._tp_ssm_peer_metas, stage_ssm_metas(1)]
+    engine._pp_ssm_peer_metas = [stage_ssm_metas(0), stage_ssm_metas(1)]
     engine.context = SimpleNamespace(
         block_size_tokens=4, num_speculative_tokens=0, memory_buffer=torch.empty(1)
     )

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -320,7 +320,7 @@ def test_completed_exact_ssm_handoff_enters_decode_without_waiting_queue(handoff
         cached_prefix_block_count=0,
         handle=None,
         future=handoff_loop.create_future(),
-        ssm=PendingSSMImport(handles={}, live_slot=20, position=0),
+        ssm=PendingSSMImport(handles={}, live_slot=20),
         resume_tokens=[55],
     )
 
@@ -336,7 +336,7 @@ def test_completed_exact_ssm_handoff_enters_decode_without_waiting_queue(handoff
     assert pending.local_blocks == []
     assert pending.continuation_blocks == []
     admit.assert_called_once_with(engine.context, request, [10], [11], [55], ssm_state_idx=20)
-    assert pending.ssm.live_slot is None
+    assert pending.ssm is None
 
 
 def test_setup_pins_handoff_outputs_only_on_prefill():
@@ -482,7 +482,7 @@ def test_releasing_pending_hybrid_import_returns_live_slot(handoff_loop):
     pending = engine._pending_kv_imports[0]
     engine._release_pending_kv_import(pending)
 
-    assert pending.ssm.live_slot is None
+    assert pending.ssm is None
     assert engine.context.mamba_metadata.freed == [20]
     assert engine.context.mamba_metadata.mamba_state_free_slot_count == 1
 

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -98,6 +98,7 @@ class _MambaMetadata:
         self.mamba_state_free_slot_count = available
         self.next_slot = 20
         self.freed = []
+        self.released_retained = []
 
     def allocate_slot(self):
         if self.mamba_state_free_slot_count == 0:
@@ -109,6 +110,10 @@ class _MambaMetadata:
 
     def free_slot(self, slot):
         self.freed.append(slot)
+        self.mamba_state_free_slot_count += 1
+
+    def release_retained_state_slot(self, slot):
+        self.released_retained.append(slot)
         self.mamba_state_free_slot_count += 1
 
 
@@ -381,7 +386,7 @@ def test_setup_pins_handoff_outputs_only_on_prefill():
         assert allocator.enable_handoff_pinning
 
 
-def test_decode_role_uses_live_ssm_buffers_and_rejects_durable_cache():
+def test_handoff_roles_use_live_ssm_buffers_and_decode_rejects_durable_cache():
     class _Backend:
         instances = []
 
@@ -435,6 +440,19 @@ def test_decode_role_uses_live_ssm_buffers_and_rejects_durable_cache():
         engine.context.mamba_conv_states = torch.empty(1, 8, 18, 3)
         engine.context.mamba_ssm_states = torch.empty(1, 8, 2, 4, 5)
         engine.setup_kv_transfer("decode")
+
+    assert _Backend.instances[1].kwargs["memory_buffer"] is engine.context.mamba_conv_states
+    assert _Backend.instances[2].kwargs["memory_buffer"] is engine.context.mamba_ssm_states
+    assert [backend.kwargs["expected_num_blocks"] for backend in _Backend.instances[1:]] == [8, 8]
+
+    _Backend.instances.clear()
+    engine.context.mamba_slot_allocator = object()
+    with (
+        mock.patch(backend_factory, return_value=_Backend),
+        mock.patch(pg_size, return_value=1),
+        mock.patch(pg_rank, return_value=0),
+    ):
+        engine.setup_kv_transfer("prefill")
 
     assert _Backend.instances[1].kwargs["memory_buffer"] is engine.context.mamba_conv_states
     assert _Backend.instances[2].kwargs["memory_buffer"] is engine.context.mamba_ssm_states
@@ -526,10 +544,20 @@ def test_reset_rejects_pinned_prefill_blocks(handoff_loop):
     engine = _HandoffHarness(handoff_loop)
     engine._pinned_handoff_blocks[7] = [10]
 
-    with pytest.raises(RuntimeError, match="KV handoff blocks remain pinned"):
+    with pytest.raises(RuntimeError, match="handoff state remains pinned"):
         engine._reset_pending_kv_imports()
 
     assert engine._pinned_handoff_blocks == {7: [10]}
+
+
+def test_release_handoff_returns_retained_prefill_ssm_slot(handoff_loop):
+    engine = _HandoffHarness(handoff_loop, hybrid=True)
+    engine._pinned_handoff_ssm_slots[7] = 3
+
+    engine.release_handoff_blocks(7)
+
+    assert engine.context.mamba_metadata.released_retained == [3]
+    assert engine._pinned_handoff_ssm_slots == {}
 
 
 def test_reset_does_not_release_unsafe_import_destinations(handoff_loop):
@@ -793,7 +821,8 @@ def test_handoff_metadata_batches_completed_requests_across_pipeline(monkeypatch
         ),
     ):
         prepared = engine._prepare_handoff_metadata_batch(
-            zip(requests, local_blocks), {7: [71], 8: [81]}
+            [(request, blocks, None) for request, blocks in zip(requests, local_blocks)],
+            {7: [71], 8: [81]},
         )
         for request in requests:
             engine._capture_handoff_meta(request, prepared[request.request_id])
@@ -816,10 +845,7 @@ def test_hybrid_handoff_keeps_partial_block_for_exact_decode_resume():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
     engine.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
-    engine.context = SimpleNamespace(
-        block_size_tokens=4, num_speculative_tokens=0, mamba_slot_allocator=mock.Mock()
-    )
-    engine.context.mamba_slot_allocator.get_slot.return_value = 9
+    engine.context = SimpleNamespace(block_size_tokens=4, num_speculative_tokens=0)
     engine._kv_peer_metas = {"global_rank": 0}
     engine._tp_ssm_peer_metas = {"conv": {"global_rank": 0}, "recurrent": {"global_rank": 0}}
     engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
@@ -834,12 +860,12 @@ def test_hybrid_handoff_keeps_partial_block_for_exact_decode_resume():
     with mock.patch(
         "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_size", return_value=1
     ):
-        prepared = engine._prepare_handoff_metadata_batch([(request, [10, 11, 12])], {7: [99]})
+        prepared = engine._prepare_handoff_metadata_batch([(request, [10, 11, 12], 9)], {7: [99]})
         engine._capture_handoff_meta(request, prepared[7])
 
     assert request.disaggregated_params["block_ids"] == [10, 11, 12]
     assert request.disaggregated_params["kv_meta"]["resume_tokens"] == [99]
-    engine.context.mamba_slot_allocator.get_slot.assert_called_once_with(12)
+    assert engine._pinned_handoff_ssm_slots == {7: 9}
     engine._release_pinned_handoff_blocks.assert_not_called()
 
 
@@ -1020,11 +1046,10 @@ def test_decode_role_rejects_prompt_scheduling(handoff_loop):
 def test_push_handoff_uses_final_pinned_blocks_ssm_slot():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
-    engine.context = SimpleNamespace(mamba_slot_allocator=mock.Mock())
-    engine.context.mamba_slot_allocator.get_slot.return_value = 3
     engine._kv_transfer_agent = mock.Mock()
     engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
     engine._pinned_handoff_blocks[7] = [20, 21]
+    engine._pinned_handoff_ssm_slots[7] = 3
     decode_metas = [
         {"ssm": {"conv": {"agent": "decode-conv"}, "recurrent": {"agent": "decode-ssm"}}}
     ]
@@ -1040,17 +1065,15 @@ def test_push_handoff_uses_final_pinned_blocks_ssm_slot():
     engine._ssm_transfer_agents["recurrent"].begin_push_blocks.assert_called_once_with(
         {"tp_metas": [{"agent": "decode-ssm"}]}, [3]
     )
-    engine.context.mamba_slot_allocator.get_slot.assert_called_once_with(21)
 
 
 def test_push_handoff_validates_ssm_metadata_before_posting_sends():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
-    engine.context = SimpleNamespace(mamba_slot_allocator=mock.Mock())
-    engine.context.mamba_slot_allocator.get_slot.return_value = 3
     engine._kv_transfer_agent = mock.Mock()
     engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
     engine._pinned_handoff_blocks[7] = [20]
+    engine._pinned_handoff_ssm_slots[7] = 3
 
     with pytest.raises(RuntimeError, match="recurrent SSM transfer state"):
         engine.push_handoff_kv(7, [{"ssm": {"conv": {"agent": "decode"}}}])
@@ -1078,10 +1101,7 @@ def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
     engine._tp_ssm_peer_metas = stage_ssm_metas(0)
     engine._pp_ssm_peer_metas = [engine._tp_ssm_peer_metas, stage_ssm_metas(1)]
     engine.context = SimpleNamespace(
-        block_size_tokens=4,
-        num_speculative_tokens=0,
-        mamba_slot_allocator=mock.Mock(),
-        memory_buffer=torch.empty(1),
+        block_size_tokens=4, num_speculative_tokens=0, memory_buffer=torch.empty(1)
     )
     requests = [
         SimpleNamespace(
@@ -1098,8 +1118,7 @@ def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
         ),
     ]
     local_blocks = [[10, 11, 12, 13], [14, 15, 16]]
-    slots = {10: 100, 11: 101, 12: 102, 13: 103, 14: 110, 15: 111, 16: 112}
-    engine.context.mamba_slot_allocator.get_slot.side_effect = lambda block: slots[block]
+    live_slots = [103, 112]
 
     pg_size = "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_size"
     with (
@@ -1110,15 +1129,16 @@ def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
         ),
     ):
         prepared = engine._prepare_handoff_metadata_batch(
-            zip(requests, local_blocks), {2: [90], 3: [91]}
+            [
+                (request, blocks, slot)
+                for request, blocks, slot in zip(requests, local_blocks, live_slots)
+            ],
+            {2: [90], 3: [91]},
         )
         for request in requests:
             engine._capture_handoff_meta(request, prepared[request.request_id])
 
-    assert engine.context.mamba_slot_allocator.get_slot.call_args_list == [
-        mock.call(13),
-        mock.call(16),
-    ]
+    assert engine._pinned_handoff_ssm_slots == {2: 103, 3: 112}
     first_ssm = requests[0].disaggregated_params["kv_meta"]["ssm"]
     assert [
         [tp_meta["block_ids"] for tp_meta in stage["tp_metas"]]

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -26,6 +26,7 @@ from megatron.core.inference.disaggregation.inference_state_handoff import (
 from megatron.core.inference.disaggregation.pending_handoff_imports import (
     DeferredKvHandoff,
     PendingKvImport,
+    PendingSSMImport,
 )
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
@@ -92,6 +93,25 @@ class _KvAllocator:
         return None
 
 
+class _MambaMetadata:
+    def __init__(self, available):
+        self.mamba_state_free_slot_count = available
+        self.next_slot = 20
+        self.freed = []
+
+    def allocate_slot(self):
+        if self.mamba_state_free_slot_count == 0:
+            return None
+        slot = self.next_slot
+        self.next_slot += 1
+        self.mamba_state_free_slot_count -= 1
+        return slot
+
+    def free_slot(self, slot):
+        self.freed.append(slot)
+        self.mamba_state_free_slot_count += 1
+
+
 class _SchedulerHarness:
     def schedule_waiting_requests(self):
         if not self.waiting_request_ids:
@@ -106,7 +126,7 @@ class _SchedulerHarness:
 
 
 class _HandoffHarness(InferenceStateHandoffMixin, _SchedulerHarness):
-    def __init__(self, loop):
+    def __init__(self, loop, *, hybrid=False, available=0):
         self._loop = loop
         self._initialize_disaggregation_state()
         self.context = SimpleNamespace(
@@ -118,11 +138,15 @@ class _HandoffHarness(InferenceStateHandoffMixin, _SchedulerHarness):
             max_requests=8,
             active_token_count=0,
             max_tokens=8,
-            is_hybrid_model=False,
+            is_hybrid_model=hybrid,
             kv_block_allocator=_KvAllocator(),
+            mamba_slot_allocator=None,
+            mamba_metadata=_MambaMetadata(available) if hybrid else None,
             memory_buffer=torch.empty(1),
         )
         self._kv_transfer_agent = _TransferAgent()
+        if hybrid:
+            self._ssm_transfer_agents = {"conv": _TransferAgent(), "recurrent": _TransferAgent()}
         self.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
         self.waiting_request_ids = deque()
         self.requests = {}
@@ -159,8 +183,16 @@ class _HandoffHarness(InferenceStateHandoffMixin, _SchedulerHarness):
         return False, 0
 
 
-def _meta(request_id):
-    return {"request_id": request_id, "resume_tokens": [99]}
+def _meta(request_id, positions):
+    return {
+        "request_id": request_id,
+        "resume_tokens": [99],
+        "ssm": {
+            "positions": positions,
+            "conv": {"request_id": request_id},
+            "recurrent": {"request_id": request_id},
+        },
+    }
 
 
 def _drain_loop(loop):
@@ -199,7 +231,7 @@ def handoff_loop():
     loop.close()
 
 
-def test_prefilled_decode_admission_uses_imported_kv_without_prompt_tokens():
+def test_prefilled_decode_admission_uses_exact_ssm_state_without_prompt_tokens():
     metadata_types = DynamicInferenceRequest.get_metadata_types()
     context = SimpleNamespace(
         block_size_tokens=4,
@@ -210,6 +242,7 @@ def test_prefilled_decode_admission_uses_imported_kv_without_prompt_tokens():
         max_requests=2,
         active_token_count=0,
         max_tokens=8,
+        is_hybrid_model=True,
         request_metadata_types=metadata_types,
         request_metadata={label: torch.empty(2, dtype=dtype) for label, dtype in metadata_types},
         request_to_kv_block_ids=torch.full((2, 4), -1, dtype=torch.int32),
@@ -228,6 +261,9 @@ def test_prefilled_decode_admission_uses_imported_kv_without_prompt_tokens():
         token_to_local_position_within_kv_block=torch.zeros(8, dtype=torch.int32),
         token_to_block_idx=torch.full((8,), -1, dtype=torch.int32),
     )
+    context.mamba_metadata = SimpleNamespace(
+        request_to_mamba_state_idx=torch.full((2,), -1, dtype=torch.int32)
+    )
     request = DynamicInferenceRequest(
         request_id=7,
         prompt_tokens=torch.arange(3),
@@ -239,7 +275,7 @@ def test_prefilled_decode_admission_uses_imported_kv_without_prompt_tokens():
         can_admit_prefilled_decode(context, 3)
     context.chunked_prefill_request_id = -1
     assert additional_decode_blocks(3, 3, 4) == 1
-    admit_prefilled_decode(context, request, [10], [11], [40, 41, 42])
+    admit_prefilled_decode(context, request, [10], [11], [40, 41, 42], 10)
 
     assert context.total_request_count == 1
     assert context.num_prefill_requests == 0
@@ -250,11 +286,12 @@ def test_prefilled_decode_admission_uses_imported_kv_without_prompt_tokens():
     assert context.token_to_input_ids[:3].tolist() == [40, 41, 42]
     assert context.token_to_pos_ids[:3].tolist() == [3, 4, 5]
     assert context.token_to_block_idx[:3].tolist() == [10, 11, 11]
+    assert context.mamba_metadata.request_to_mamba_state_idx[0].item() == 10
     assert request.remaining_prompt_length == 0
 
 
-def test_completed_kv_handoff_enters_decode_without_waiting_queue(handoff_loop):
-    engine = _HandoffHarness(handoff_loop)
+def test_completed_exact_ssm_handoff_enters_decode_without_waiting_queue(handoff_loop):
+    engine = _HandoffHarness(handoff_loop, hybrid=True)
     engine.context.num_speculative_tokens = 0
     engine.use_coordinator = False
     engine.is_mp_coordinator = False
@@ -283,6 +320,7 @@ def test_completed_kv_handoff_enters_decode_without_waiting_queue(handoff_loop):
         cached_prefix_block_count=0,
         handle=None,
         future=handoff_loop.create_future(),
+        ssm=PendingSSMImport(handles={}, live_slot=20, position=0),
         resume_tokens=[55],
     )
 
@@ -297,7 +335,8 @@ def test_completed_kv_handoff_enters_decode_without_waiting_queue(handoff_loop):
     assert list(engine.waiting_request_ids) == []
     assert pending.local_blocks == []
     assert pending.continuation_blocks == []
-    admit.assert_called_once_with(engine.context, request, [10], [11], [55])
+    admit.assert_called_once_with(engine.context, request, [10], [11], [55], ssm_state_idx=20)
+    assert pending.ssm.live_slot is None
 
 
 def test_setup_pins_handoff_outputs_only_on_prefill():
@@ -321,6 +360,7 @@ def test_setup_pins_handoff_outputs_only_on_prefill():
         num_attention_heads_per_partition=1,
         hidden_size_per_attention_head=1,
         block_size_tokens=4,
+        num_mamba_layers=0,
     )
     model_config = SimpleNamespace(num_query_groups=1, num_attention_heads=1)
     engine.controller = SimpleNamespace(
@@ -345,11 +385,116 @@ def test_setup_pins_handoff_outputs_only_on_prefill():
         assert allocator.enable_handoff_pinning
 
 
+def test_decode_role_uses_live_ssm_buffers_and_rejects_durable_cache():
+    class _Backend:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+        def export_meta(self):
+            return {"transport": "test"}
+
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    engine.context = SimpleNamespace(
+        kv_block_allocator=SimpleNamespace(
+            enable_prefix_caching=True, enable_handoff_pinning=False, pool_size=8
+        ),
+        memory_buffer=torch.empty(2, 1, 8, 4, 1, 1),
+        is_hybrid_model=True,
+        num_attention_layers=1,
+        num_mamba_layers=1,
+        num_attention_heads_per_partition=1,
+        hidden_size_per_attention_head=1,
+        block_size_tokens=4,
+        mamba_slot_allocator=object(),
+    )
+    model_config = SimpleNamespace(
+        num_query_groups=1, num_attention_heads=1, mamba_num_heads=2, mamba_num_groups=1
+    )
+    engine.controller = SimpleNamespace(
+        inference_wrapped_model=SimpleNamespace(model=SimpleNamespace(config=model_config))
+    )
+    engine.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
+
+    backend_factory = (
+        "megatron.core.inference.disaggregation.inference_state_handoff."
+        "construct_kv_transfer_backend_class"
+    )
+    pg_size = "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_size"
+    pg_rank = "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_rank"
+    with (
+        mock.patch(backend_factory, return_value=_Backend),
+        mock.patch(pg_size, return_value=1),
+        mock.patch(pg_rank, return_value=0),
+    ):
+        with pytest.raises(AssertionError, match="directly into live SSM state"):
+            engine.setup_kv_transfer("decode")
+
+        _Backend.instances.clear()
+        engine.context.mamba_slot_allocator = None
+        engine.context.max_requests = 8
+        engine.context.mamba_conv_states = torch.empty(1, 8, 18, 3)
+        engine.context.mamba_ssm_states = torch.empty(1, 8, 2, 4, 5)
+        engine.setup_kv_transfer("decode")
+
+    assert _Backend.instances[1].kwargs["memory_buffer"] is engine.context.mamba_conv_states
+    assert _Backend.instances[2].kwargs["memory_buffer"] is engine.context.mamba_ssm_states
+    assert [backend.kwargs["expected_num_blocks"] for backend in _Backend.instances[1:]] == [8, 8]
+
+
+def test_capacity_miss_defers_before_any_transfer(handoff_loop):
+    engine = _HandoffHarness(handoff_loop, hybrid=True, available=0)
+    future = engine.add_request_with_kv_handoff(
+        7, [1, 2, 3, 4, 5], SamplingParams(num_tokens_to_generate=2), _meta(7, [1]), [100, 101]
+    )
+
+    assert not future.done()
+    assert engine.pending_kv_import_count == 1
+    assert [item.request_id for item in engine._deferred_kv_handoffs] == [7]
+    assert not engine._pending_kv_imports
+    assert not engine._kv_transfer_agent.calls
+    assert not engine._ssm_transfer_agents["conv"].calls
+    assert engine.context.kv_block_allocator.releases == []
+
+    engine.context.mamba_metadata.mamba_state_free_slot_count = 1
+    assert engine._poll_pending_kv_imports() == 0
+    _drain_loop(handoff_loop)
+
+    assert not engine._deferred_kv_handoffs
+    assert len(engine._pending_kv_imports) == 1
+    assert len(engine._kv_transfer_agent.calls) == 1
+    assert len(engine._ssm_transfer_agents["conv"].calls) == 1
+    assert len(engine._ssm_transfer_agents["recurrent"].calls) == 1
+    assert engine._pending_kv_imports[0].ssm.live_slot == 20
+    assert engine.context.mamba_metadata.mamba_state_free_slot_count == 0
+
+
+def test_releasing_pending_hybrid_import_returns_live_slot(handoff_loop):
+    engine = _HandoffHarness(handoff_loop, hybrid=True, available=1)
+    engine.add_request_with_kv_handoff(
+        7, [1, 2, 3, 4], SamplingParams(num_tokens_to_generate=2), _meta(7, [0]), [100]
+    )
+    _drain_loop(handoff_loop)
+
+    pending = engine._pending_kv_imports[0]
+    engine._release_pending_kv_import(pending)
+
+    assert pending.ssm.live_slot is None
+    assert engine.context.mamba_metadata.freed == [20]
+    assert engine.context.mamba_metadata.mamba_state_free_slot_count == 1
+
+
 def test_reset_cancels_capacity_queued_handoffs(handoff_loop):
     engine = _HandoffHarness(handoff_loop)
-    engine.context.kv_block_allocator.capacity_available = False
     future = engine.add_request_with_kv_handoff(
-        3, [3] * 4, SamplingParams(num_tokens_to_generate=2), _meta(3), [103]
+        3,
+        [3] * 4,
+        SamplingParams(num_tokens_to_generate=2),
+        {"request_id": 3, "resume_tokens": [99]},
+        [103],
     )
 
     engine._reset_pending_kv_imports()
@@ -627,6 +772,7 @@ def test_handoff_metadata_batches_completed_requests_across_pipeline(monkeypatch
     )
     engine._kv_peer_metas = {"global_rank": 0}
     engine._pp_kv_peer_metas = [{"global_rank": 0}, {"global_rank": 1}]
+    engine._pp_ssm_peer_metas = [{}, {}]
     requests = [
         SimpleNamespace(
             request_id=7,
@@ -670,12 +816,17 @@ def test_handoff_metadata_batches_completed_requests_across_pipeline(monkeypatch
     assert requests[1].disaggregated_params["kv_meta"]["pp_metas"][1]["block_ids"] == [12, 13, 14]
 
 
-def test_handoff_keeps_partial_block_for_exact_decode_resume():
+def test_hybrid_handoff_keeps_partial_block_for_exact_decode_resume():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
     engine.pg_collection = SimpleNamespace(tp=None, pp=None, mp=None)
-    engine.context = SimpleNamespace(block_size_tokens=4, num_speculative_tokens=0)
+    engine.context = SimpleNamespace(
+        block_size_tokens=4, num_speculative_tokens=0, mamba_slot_allocator=mock.Mock()
+    )
+    engine.context.mamba_slot_allocator.get_slot.return_value = 9
     engine._kv_peer_metas = {"global_rank": 0}
+    engine._tp_ssm_peer_metas = {"conv": {"global_rank": 0}, "recurrent": {"global_rank": 0}}
+    engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
     engine._release_pinned_handoff_blocks = mock.Mock()
     request = SimpleNamespace(
         request_id=7,
@@ -691,7 +842,10 @@ def test_handoff_keeps_partial_block_for_exact_decode_resume():
         engine._capture_handoff_meta(request, prepared[7])
 
     assert request.disaggregated_params["block_ids"] == [10, 11, 12]
+    assert request.disaggregated_params["kv_meta"]["ssm"]["positions"] == [2]
     assert request.disaggregated_params["kv_meta"]["resume_tokens"] == [99]
+    assert engine._pinned_handoff_ssm_slots[7] == [9]
+    engine.context.mamba_slot_allocator.get_slot.assert_called_once_with(12)
     engine._release_pinned_handoff_blocks.assert_not_called()
 
 
@@ -735,7 +889,9 @@ def test_nixl_handoff_reuses_decode_cached_prefix(handoff_loop):
     assert engine.context.kv_block_allocator.registered_parent_hashes == [hashes[1]]
     assert engine.get_request(5).generated_tokens == [99]
     assert 5 not in engine.waiting_request_ids
-    admit.assert_called_once_with(engine.context, engine.get_request(5), [10, 11, 12], [13], [99])
+    admit.assert_called_once_with(
+        engine.context, engine.get_request(5), [10, 11, 12], [13], [99], ssm_state_idx=None
+    )
 
 
 def test_decode_handoff_defers_until_kv_capacity_is_available(handoff_loop):
@@ -865,3 +1021,102 @@ def test_decode_role_rejects_prompt_scheduling(handoff_loop):
 
     with pytest.raises(RuntimeError, match="cannot schedule prompt prefill"):
         engine.schedule_waiting_requests()
+
+
+def test_push_handoff_reuses_ssm_slots_advertised_during_capture():
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    engine.context = SimpleNamespace(mamba_slot_allocator=mock.Mock())
+    engine.context.mamba_slot_allocator.get_slot.side_effect = AssertionError(
+        "SEND_KV must use the captured SSM slots"
+    )
+    engine._kv_transfer_agent = mock.Mock()
+    engine._ssm_transfer_agents = {"conv": mock.Mock()}
+    engine._pinned_handoff_blocks[7] = [20, 21]
+    engine._pinned_handoff_ssm_slots[7] = [3]
+    decode_metas = [{"ssm": {"conv": {"agent": "decode"}}}]
+
+    engine.push_handoff_kv(7, decode_metas)
+
+    engine._kv_transfer_agent.begin_push_blocks.assert_called_once_with(
+        {"tp_metas": decode_metas}, [20, 21]
+    )
+    engine._ssm_transfer_agents["conv"].begin_push_blocks.assert_called_once_with(
+        {"tp_metas": [{"agent": "decode"}]}, [3]
+    )
+
+
+def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    tp_group = object()
+    pp_group = object()
+    engine.pg_collection = SimpleNamespace(tp=tp_group, pp=pp_group, mp=object())
+    engine._kv_peer_metas = [{"rank": "s0t0"}, {"rank": "s0t1"}]
+    engine._pp_kv_peer_metas = [engine._kv_peer_metas, [{"rank": "s1t0"}, {"rank": "s1t1"}]]
+    engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
+
+    def stage_ssm_metas(stage):
+        return {
+            state: [{"rank": f"s{stage}t{tp}"} for tp in range(2)]
+            for state in ("conv", "recurrent")
+        }
+
+    engine._tp_ssm_peer_metas = stage_ssm_metas(0)
+    engine._pp_ssm_peer_metas = [engine._tp_ssm_peer_metas, stage_ssm_metas(1)]
+    engine.context = SimpleNamespace(
+        block_size_tokens=4,
+        num_speculative_tokens=0,
+        mamba_slot_allocator=mock.Mock(),
+        memory_buffer=torch.empty(1),
+    )
+    requests = [
+        SimpleNamespace(
+            request_id=2,
+            prompt_tokens=[0] * 16,
+            sampling_params=SamplingParams(do_kv_handoff=True),
+            disaggregated_params=None,
+        ),
+        SimpleNamespace(
+            request_id=3,
+            prompt_tokens=[0] * 12,
+            sampling_params=SamplingParams(do_kv_handoff=True),
+            disaggregated_params=None,
+        ),
+    ]
+    local_blocks = [[10, 11, 12, 13], [14, 15, 16]]
+    slots = {10: 100, 11: 101, 12: 102, 13: 103, 14: 110, 15: 111, 16: 112}
+    engine.context.mamba_slot_allocator.get_slot.side_effect = lambda block: slots[block]
+
+    pg_size = "megatron.core.inference.disaggregation.inference_state_handoff.get_pg_size"
+    with (
+        mock.patch(pg_size, return_value=2),
+        mock.patch(
+            "torch.distributed.all_gather_into_tensor",
+            side_effect=AssertionError("handoff metadata must not run a collective"),
+        ),
+    ):
+        prepared = engine._prepare_handoff_metadata_batch(
+            zip(requests, local_blocks), {2: [90], 3: [91]}
+        )
+        for request in requests:
+            engine._capture_handoff_meta(request, prepared[request.request_id])
+
+    assert engine.context.mamba_slot_allocator.get_slot.call_args_list == [
+        mock.call(13),
+        mock.call(16),
+    ]
+    assert engine._pinned_handoff_ssm_slots == {2: [103], 3: [112]}
+    first_ssm = requests[0].disaggregated_params["kv_meta"]["ssm"]
+    second_ssm = requests[1].disaggregated_params["kv_meta"]["ssm"]
+    assert first_ssm["positions"] == [3]
+    assert second_ssm["positions"] == [2]
+    assert [
+        [tp_meta["block_ids"] for tp_meta in stage["tp_metas"]]
+        for stage in first_ssm["conv"]["pp_metas"]
+    ] == [[[103], [103]], [[103], [103]]]
+    assert (
+        requests[0].disaggregated_params["kv_meta"]
+        is not requests[1].disaggregated_params["kv_meta"]
+    )
+    assert all("ssm" not in meta for meta in engine._kv_peer_metas)

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -1100,6 +1100,21 @@ def test_push_handoff_uses_final_pinned_blocks_ssm_slot():
     )
 
 
+def test_push_handoff_rejects_ssm_state_without_kv_blocks():
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    engine._kv_transfer_agent = mock.Mock()
+    engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
+    engine._pinned_handoff_ssm_slots[7] = 3
+
+    with pytest.raises(RuntimeError, match="detached SSM state but no pinned KV blocks"):
+        engine.push_handoff_kv(7, [])
+
+    engine._kv_transfer_agent.begin_push_blocks.assert_not_called()
+    engine._ssm_transfer_agents["conv"].begin_push_blocks.assert_not_called()
+    engine._ssm_transfer_agents["recurrent"].begin_push_blocks.assert_not_called()
+
+
 def test_push_handoff_validates_ssm_metadata_before_posting_sends():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -183,15 +183,11 @@ class _HandoffHarness(InferenceStateHandoffMixin, _SchedulerHarness):
         return False, 0
 
 
-def _meta(request_id, positions):
+def _meta(request_id):
     return {
         "request_id": request_id,
         "resume_tokens": [99],
-        "ssm": {
-            "positions": positions,
-            "conv": {"request_id": request_id},
-            "recurrent": {"request_id": request_id},
-        },
+        "ssm": {"conv": {"request_id": request_id}, "recurrent": {"request_id": request_id}},
     }
 
 
@@ -430,7 +426,7 @@ def test_decode_role_uses_live_ssm_buffers_and_rejects_durable_cache():
         mock.patch(pg_size, return_value=1),
         mock.patch(pg_rank, return_value=0),
     ):
-        with pytest.raises(AssertionError, match="directly into live SSM state"):
+        with pytest.raises(RuntimeError, match="directly into live SSM state"):
             engine.setup_kv_transfer("decode")
 
         _Backend.instances.clear()
@@ -448,7 +444,7 @@ def test_decode_role_uses_live_ssm_buffers_and_rejects_durable_cache():
 def test_capacity_miss_defers_before_any_transfer(handoff_loop):
     engine = _HandoffHarness(handoff_loop, hybrid=True, available=0)
     future = engine.add_request_with_kv_handoff(
-        7, [1, 2, 3, 4, 5], SamplingParams(num_tokens_to_generate=2), _meta(7, [1]), [100, 101]
+        7, [1, 2, 3, 4, 5], SamplingParams(num_tokens_to_generate=2), _meta(7), [100, 101]
     )
 
     assert not future.done()
@@ -475,7 +471,7 @@ def test_capacity_miss_defers_before_any_transfer(handoff_loop):
 def test_releasing_pending_hybrid_import_returns_live_slot(handoff_loop):
     engine = _HandoffHarness(handoff_loop, hybrid=True, available=1)
     engine.add_request_with_kv_handoff(
-        7, [1, 2, 3, 4], SamplingParams(num_tokens_to_generate=2), _meta(7, [0]), [100]
+        7, [1, 2, 3, 4], SamplingParams(num_tokens_to_generate=2), _meta(7), [100]
     )
     _drain_loop(handoff_loop)
 
@@ -842,9 +838,7 @@ def test_hybrid_handoff_keeps_partial_block_for_exact_decode_resume():
         engine._capture_handoff_meta(request, prepared[7])
 
     assert request.disaggregated_params["block_ids"] == [10, 11, 12]
-    assert request.disaggregated_params["kv_meta"]["ssm"]["positions"] == [2]
     assert request.disaggregated_params["kv_meta"]["resume_tokens"] == [99]
-    assert engine._pinned_handoff_ssm_slots[7] == [9]
     engine.context.mamba_slot_allocator.get_slot.assert_called_once_with(12)
     engine._release_pinned_handoff_blocks.assert_not_called()
 
@@ -1023,18 +1017,17 @@ def test_decode_role_rejects_prompt_scheduling(handoff_loop):
         engine.schedule_waiting_requests()
 
 
-def test_push_handoff_reuses_ssm_slots_advertised_during_capture():
+def test_push_handoff_uses_final_pinned_blocks_ssm_slot():
     engine = object.__new__(InferenceStateHandoffMixin)
     engine._initialize_disaggregation_state()
     engine.context = SimpleNamespace(mamba_slot_allocator=mock.Mock())
-    engine.context.mamba_slot_allocator.get_slot.side_effect = AssertionError(
-        "SEND_KV must use the captured SSM slots"
-    )
+    engine.context.mamba_slot_allocator.get_slot.return_value = 3
     engine._kv_transfer_agent = mock.Mock()
-    engine._ssm_transfer_agents = {"conv": mock.Mock()}
+    engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
     engine._pinned_handoff_blocks[7] = [20, 21]
-    engine._pinned_handoff_ssm_slots[7] = [3]
-    decode_metas = [{"ssm": {"conv": {"agent": "decode"}}}]
+    decode_metas = [
+        {"ssm": {"conv": {"agent": "decode-conv"}, "recurrent": {"agent": "decode-ssm"}}}
+    ]
 
     engine.push_handoff_kv(7, decode_metas)
 
@@ -1042,8 +1035,28 @@ def test_push_handoff_reuses_ssm_slots_advertised_during_capture():
         {"tp_metas": decode_metas}, [20, 21]
     )
     engine._ssm_transfer_agents["conv"].begin_push_blocks.assert_called_once_with(
-        {"tp_metas": [{"agent": "decode"}]}, [3]
+        {"tp_metas": [{"agent": "decode-conv"}]}, [3]
     )
+    engine._ssm_transfer_agents["recurrent"].begin_push_blocks.assert_called_once_with(
+        {"tp_metas": [{"agent": "decode-ssm"}]}, [3]
+    )
+    engine.context.mamba_slot_allocator.get_slot.assert_called_once_with(21)
+
+
+def test_push_handoff_validates_ssm_metadata_before_posting_sends():
+    engine = object.__new__(InferenceStateHandoffMixin)
+    engine._initialize_disaggregation_state()
+    engine.context = SimpleNamespace(mamba_slot_allocator=mock.Mock())
+    engine.context.mamba_slot_allocator.get_slot.return_value = 3
+    engine._kv_transfer_agent = mock.Mock()
+    engine._ssm_transfer_agents = {"conv": mock.Mock(), "recurrent": mock.Mock()}
+    engine._pinned_handoff_blocks[7] = [20]
+
+    with pytest.raises(RuntimeError, match="recurrent SSM transfer state"):
+        engine.push_handoff_kv(7, [{"ssm": {"conv": {"agent": "decode"}}}])
+
+    engine._kv_transfer_agent.begin_push_blocks.assert_not_called()
+    engine._ssm_transfer_agents["conv"].begin_push_blocks.assert_not_called()
 
 
 def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
@@ -1106,11 +1119,7 @@ def test_hybrid_handoff_uses_mirrored_slots_without_request_collectives():
         mock.call(13),
         mock.call(16),
     ]
-    assert engine._pinned_handoff_ssm_slots == {2: [103], 3: [112]}
     first_ssm = requests[0].disaggregated_params["kv_meta"]["ssm"]
-    second_ssm = requests[1].disaggregated_params["kv_meta"]["ssm"]
-    assert first_ssm["positions"] == [3]
-    assert second_ssm["positions"] == [2]
     assert [
         [tp_meta["block_ids"] for tp_meta in stage["tp_metas"]]
         for stage in first_ssm["conv"]["pp_metas"]

--- a/tests/unit_tests/inference/test_kv_transfer_backends.py
+++ b/tests/unit_tests/inference/test_kv_transfer_backends.py
@@ -135,6 +135,27 @@ def test_ssm_geometry_uses_conv_and_recurrent_state_names():
         )
 
 
+def test_ssm_geometry_uses_explicit_live_slot_axis():
+    layout = SSMShardLayout(
+        global_rank=0,
+        tp_size=1,
+        tp_rank=0,
+        layer_start=0,
+        num_layers=3,
+        dims=SSMStateDims(nheads=2, headdim=4, d_state=5, ngroups=1, d_conv=3),
+    )
+    geometry = base.compute_buffer_geometry(
+        torch.zeros(3, 3, 2, 4, 5),
+        expected_num_blocks=3,
+        backend_name="test",
+        heads_per_partition=2,
+        ssm_layout=layout,
+        ssm_state_kind="recurrent",
+    )
+
+    assert geometry.blocks_axis == 1
+
+
 def test_nixl_direct_backend_exports_metadata_with_fake_agent(monkeypatch):
     from megatron.core.inference.disaggregation.transfer_backends import nixl as nixl_mod
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -1053,17 +1053,14 @@ def test_async_bookkeeping_retains_finished_handoff_state():
     context.kv_block_allocator.retain_memory_blocks.assert_called_once_with([10, 11])
 
 
-def test_finished_hybrid_handoff_retains_live_ssm_slot():
+def test_finished_hybrid_handoff_detaches_live_ssm_slot():
     context = _make_async_sched_context(total_request_count=2)
     context.is_hybrid_model = True
     context.kv_block_allocator = SimpleNamespace(
         enable_handoff_pinning=True, retain_memory_blocks=mock.Mock()
     )
     context.request_to_kv_block_ids = torch.tensor([[10, 11, -1], [12, 13, -1]], dtype=torch.int32)
-    context.mamba_metadata = SimpleNamespace(
-        request_to_mamba_state_idx=torch.tensor([4, 7], dtype=torch.int32),
-        retain_state_slot=mock.Mock(),
-    )
+    context.mamba_metadata = SimpleNamespace(detach_state_slot=mock.Mock(return_value=7))
     controller = _make_async_sched_controller(context)
 
     blocks, ssm_slots, decode_tokens = controller._collect_finished_handoff_state(
@@ -1073,7 +1070,7 @@ def test_finished_hybrid_handoff_retains_live_ssm_slot():
     assert blocks == {11: [12, 13]}
     assert ssm_slots == {11: 7}
     assert decode_tokens == {11: [92]}
-    context.mamba_metadata.retain_state_slot.assert_called_once_with(7)
+    context.mamba_metadata.detach_state_slot.assert_called_once_with(1)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -1048,8 +1048,32 @@ def test_async_bookkeeping_retains_finished_handoff_state():
     )
 
     assert result.finished_handoff_block_ids == {11: [10, 11]}
+    assert result.finished_handoff_ssm_slots == {}
     assert result.finished_handoff_decode_tokens == {11: [99]}
     context.kv_block_allocator.retain_memory_blocks.assert_called_once_with([10, 11])
+
+
+def test_finished_hybrid_handoff_retains_live_ssm_slot():
+    context = _make_async_sched_context(total_request_count=2)
+    context.is_hybrid_model = True
+    context.kv_block_allocator = SimpleNamespace(
+        enable_handoff_pinning=True, retain_memory_blocks=mock.Mock()
+    )
+    context.request_to_kv_block_ids = torch.tensor([[10, 11, -1], [12, 13, -1]], dtype=torch.int32)
+    context.mamba_metadata = SimpleNamespace(
+        request_to_mamba_state_idx=torch.tensor([4, 7], dtype=torch.int32),
+        retain_state_slot=mock.Mock(),
+    )
+    controller = _make_async_sched_controller(context)
+
+    blocks, ssm_slots, decode_tokens = controller._collect_finished_handoff_state(
+        torch.tensor([1]), torch.tensor([91, 92]), None
+    )
+
+    assert blocks == {11: [12, 13]}
+    assert ssm_slots == {11: 7}
+    assert decode_tokens == {11: [92]}
+    context.mamba_metadata.retain_state_slot.assert_called_once_with(7)
 
 
 @pytest.mark.parametrize(
@@ -1161,6 +1185,7 @@ def test_async_sched_step_overlap_order():
             newly_paused_request_ids=None,
             evict_request_ids=None,
             finished_handoff_block_ids={},
+            finished_handoff_ssm_slots={},
             finished_handoff_decode_tokens={},
         )
     )
@@ -1290,6 +1315,7 @@ def test_async_sched_step_yields_after_resolution_outside_inference_mode():
             newly_paused_request_ids=None,
             evict_request_ids=None,
             finished_handoff_block_ids={},
+            finished_handoff_ssm_slots={},
             finished_handoff_decode_tokens={},
         )
     )
@@ -1433,6 +1459,7 @@ def test_async_sched_no_overlap_updates_before_admission(
         newly_paused_request_ids=torch.tensor([10]),
         evict_request_ids=torch.tensor([11]),
         finished_handoff_block_ids={},
+        finished_handoff_ssm_slots={},
         finished_handoff_decode_tokens={},
     )
     input_ids = torch.empty(1, dtype=torch.int64)
@@ -1539,6 +1566,7 @@ def test_async_sched_no_overlap_finishes_with_matching_ep_base_forward():
         newly_paused_request_ids=None,
         evict_request_ids=None,
         finished_handoff_block_ids={},
+        finished_handoff_ssm_slots={},
         finished_handoff_decode_tokens={},
     )
     controller._run_async_sched_sample = mock.Mock(return_value=sample_result)
@@ -1591,6 +1619,7 @@ def test_async_sched_mtp_overlap_step_order():
         newly_paused_request_ids=None,
         evict_request_ids=None,
         finished_handoff_block_ids={},
+        finished_handoff_ssm_slots={},
         finished_handoff_decode_tokens={},
     )
     input_ids = torch.empty(9, dtype=torch.int64)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

## Summary

  This MR extends native disaggregated prefill/decode handoff to hybrid models containing both attention and SSM layers. This change transfers both the convolution and recurrent SSM state so the decode engine can begin immediately without replaying any prompt tokens.

  ## Design

  1. Prefill computes the prompt normally.
  2. The exact post-prompt SSM state is saved in the SSM prefix cache, including for prompts ending in a partial KV block.
  3. Exact handoff states are allocated before optional reusable prefix snapshots so cache pressure cannot cause optional checkpoints to displace required handoff state.
  4. The corresponding KV blocks and SSM slots remain pinned until decode reports that the transfer is complete.
  5. Handoff metadata describes the KV blocks, SSM slots, model-parallel layout, and resume tokens.

  ### Transfer

  KV and SSM state use the configured native transfer backend. Separate transfer views are created for:

  - Attention KV state.
  - SSM convolution state.
  - SSM recurrent state.

  The transfer metadata includes pipeline-layer ranges and tensor-parallel layouts, allowing the destination to import and reshard state when the prefill and decode workers use different supported parallel layouts.

  Cached KV prefix blocks already present on decode are still reused; only the missing KV suffix is transferred. The exact final SSM state is transferred for hybrid requests.

  ### Decode

  1. Decode reserves destination KV blocks and an SSM cache slot.
  2. KV, convolution state, and recurrent state are imported.
  3. The request is admitted only after all required state is ready.
  4. A live SSM slot is assigned and populated from the imported state before the first decode forward.
  5. Decode starts directly from the sampled continuation token, with no prompt prefill on the decode worker.

  ```text
  Prefill worker                         Decode worker
  --------------                         -------------
  Run prompt
  Capture final KV + SSM state
  Pin source storage
          |
          | recurrent state
          | resume token(s)
          v
                                         Reserve destination storage
                                         Import and reshard state
                                         Restore live SSM state
                                         Admit directly to decode
          <--- release acknowledgement
  Release pinned source storage

  ## Notes

  - SSM cache capacity is synchronized to the smallest pipeline-stage capacity because a usable recurrent checkpoint must exist on every required stage.
  - Slot allocation is preflighted before allocator state is mutated.
  - Exact handoff states take priority over optional prefix-cache snapshots.
  - When only partial optional capacity is available, the snapshots that fit are retained instead of dropping the entire batch.
  - Block IDs, hashes, source offsets, and destination slots remain aligned when allocation is truncated.
  - Hashes are registered only after their corresponding state has been copied.

 
