### PR TITLE
Forward rotary_base and rope_scaling_factor to LLaVAModel in the VLM builders

### DIFF
--- a/examples/multimodal/model.py
+++ b/examples/multimodal/model.py
@@ -217,6 +217,7 @@ def model_provider(
         patch_dim=args.patch_dim,
         language_rotary_base=args.rotary_base,
         language_rope_scaling=args.use_rope_scaling,
+        language_rope_scaling_factor=args.rope_scaling_factor,
         hybrid_layer_pattern=args.hybrid_layer_pattern,
         fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
         image_token_index=image_token_index,

--- a/pretrain_vlm.py
+++ b/pretrain_vlm.py
@@ -205,6 +205,7 @@ def model_provider(
         parallel_output=parallel_output,
         language_position_embedding_type=args.position_embedding_type,
         language_rotary_percent=args.rotary_percent,
+        language_rotary_base=args.rotary_base,
         language_rope_scaling=args.use_rope_scaling,
         language_rope_scaling_factor=args.rope_scaling_factor,
         pre_process=parallel_state.is_pipeline_first_stage(),

--- a/pretrain_vlm.py
+++ b/pretrain_vlm.py
@@ -206,6 +206,7 @@ def model_provider(
         language_position_embedding_type=args.position_embedding_type,
         language_rotary_percent=args.rotary_percent,
         language_rope_scaling=args.use_rope_scaling,
+        language_rope_scaling_factor=args.rope_scaling_factor,
         pre_process=parallel_state.is_pipeline_first_stage(),
         post_process=parallel_state.is_pipeline_last_stage(),
         add_encoder=parallel_state.is_pipeline_first_stage(),


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

### What

Two RoPE arguments are parsed but never forwarded to `LLaVAModel`, so they are silently ignored on the VLM path. `LLaVAModel` already accepts both and forwards them to the language model — only the call sites needed updating.

| Argument | `pretrain_vlm.py` | `examples/multimodal/model.py` |
|---|---|---|
| `language_rotary_base` | ❌ → fixed here | ✅ already passed |
| `language_rope_scaling_factor` | ❌ → fixed here | ❌ → fixed here |

**`rope_scaling_factor`** (commit 1) — `--rope-scaling-factor` never reaches the model, which keeps `LLaVAModel`'s default of `8.0`. This is the VLM half of #6305, which states that `pretrain_vlm.py` and `examples/multimodal/model.py` "have the same issue on the LLaVA path... a separate call surface and not covered by the linked PR". Complements #6306, which covers the GPT/post-training paths.

**`rotary_base`** (commit 2, #6585) — `--rotary-base` never reaches the model, which keeps the default of `10000`. Unlike RoPE scaling this is not opt-in: it applies to every RoPE model on this path and must match the pretrained checkpoint (Llama 3.x uses `500000`). The sibling call site in `examples/multimodal/model.py:218` already passes it, which is what makes this an oversight rather than an intentional difference.

Both values are forwarded into the **language** model (`llava_model.py:254-256` → `GPTModel` → `RotaryEmbedding`); the vision encoder never sees them. There is no fallback via the config — base `TransformerConfig` has no `rotary_base` field (the only one in `transformer_config.py` belongs to `MLATransformerConfig`, and `gpt_model.py:166` excludes multi-latent attention from this branch), so the keyword argument is the only path.

### History

Both appear to be plumbing that was added to the model but never wired at the call site:

- `617dc63c0` ("Make rotary base configurable in LlavaModel", 2024-06-27) added `language_rotary_base` to `llava_model.py` only — `+2` lines in one file, no call site updated. `63be779b4` later updated `examples/multimodal/model.py`; `pretrain_vlm.py` never was.
- `8c98d2def` ("llama3.2 support", 2025-01-31) added `language_rope_scaling_factor` to `llava_model.py` and updated **zero** call sites.

### Testing

These call sites are not currently unit tested — no test in the repo imports `pretrain_vlm.model_provider`, and exercising it requires an initialized `torch.distributed` process group (`pretrain_vlm.py:89`) plus a fully-populated args namespace, so a mock-based test would be fragile. The change is a three-line argument forwarding, verified by inspection against the sibling call site and against the equivalent GPT-path fix in #6306. Happy to add a test if maintainers would like one, and glad to follow whatever approach #6306 settles on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
