### PR TITLE
MXfp8 Inference Fixes and clean up

### DIFF
--- a/megatron/core/inference/moe/activations.py
+++ b/megatron/core/inference/moe/activations.py
@@ -9,6 +9,11 @@ from unittest.mock import MagicMock
 
 import torch
 
+from megatron.core.inference.quantization.mxfp8_quantize import (
+    MXFP8_BLOCK_SIZE,
+    MXFP8_SCALE_COL_BLOCK,
+    MXFP8_SCALE_ROW_BLOCK,
+)
 from megatron.core.utils import null_decorator
 
 try:
@@ -226,11 +231,8 @@ def _squared_relu_quantize_kernel(
                 # Load and apply squared ReLU
                 x = tl.load(input_ptr + row * K + offs, mask=mask, other=0.0).to(tl.float32)
                 relu = tl.maximum(x, 0.0)
-                # Match the unfused training/inference contract exactly:
-                # squared ReLU materializes a BF16 activation before the next
-                # MXFP8 quantization. Keeping the product in FP32 here changes
-                # quantization bins and compounds across MoE layers.
-                # Convert back to FP32 for the scale reduction and reciprocal.
+                # Match training and unfused inference: squared ReLU is materialized
+                # in BF16 before MXFP8 quantization, which determines the MXFP8 bins.
                 activated = (relu * relu).to(tl.bfloat16).to(tl.float32)
 
                 # Per-group-of-32 quantization
@@ -287,18 +289,20 @@ def squared_relu_and_quantize_mxfp8(
     from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 
     M, K = x.shape
-    assert K % 32 == 0
+    assert K % MXFP8_BLOCK_SIZE == 0
 
-    scale_cols = K // 32
-    n_row_blocks = _ceil_div(M, 128)
-    n_col_blocks = _ceil_div(scale_cols, 4)
-    total_scale_bytes = n_row_blocks * n_col_blocks * 512
+    scale_cols = K // MXFP8_BLOCK_SIZE
+    n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
+    n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
+    total_scale_bytes = (
+        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
+    )
 
     out_fp8 = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=x.device)
 
     BLOCK_K = triton.next_power_of_2(K)
-    BLOCK_GROUPS = BLOCK_K // 32
+    BLOCK_GROUPS = BLOCK_K // MXFP8_BLOCK_SIZE
     NUM_BLOCKS = min(M, 512)
 
     _squared_relu_quantize_kernel[(NUM_BLOCKS,)](

--- a/megatron/core/inference/moe/activations.py
+++ b/megatron/core/inference/moe/activations.py
@@ -230,6 +230,7 @@ def _squared_relu_quantize_kernel(
                 # squared ReLU materializes a BF16 activation before the next
                 # MXFP8 quantization. Keeping the product in FP32 here changes
                 # quantization bins and compounds across MoE layers.
+                # Convert back to FP32 for the scale reduction and reciprocal.
                 activated = (relu * relu).to(tl.bfloat16).to(tl.float32)
 
                 # Per-group-of-32 quantization

--- a/megatron/core/inference/moe/activations.py
+++ b/megatron/core/inference/moe/activations.py
@@ -226,7 +226,11 @@ def _squared_relu_quantize_kernel(
                 # Load and apply squared ReLU
                 x = tl.load(input_ptr + row * K + offs, mask=mask, other=0.0).to(tl.float32)
                 relu = tl.maximum(x, 0.0)
-                activated = relu * relu
+                # Match the unfused training/inference contract exactly:
+                # squared ReLU materializes a BF16 activation before the next
+                # MXFP8 quantization. Keeping the product in FP32 here changes
+                # quantization bins and compounds across MoE layers.
+                activated = (relu * relu).to(tl.bfloat16).to(tl.float32)
 
                 # Per-group-of-32 quantization
                 x_grouped = tl.reshape(activated, [BLOCK_GROUPS, 32])

--- a/megatron/core/inference/moe/activations.py
+++ b/megatron/core/inference/moe/activations.py
@@ -294,9 +294,7 @@ def squared_relu_and_quantize_mxfp8(
     scale_cols = K // MXFP8_BLOCK_SIZE
     n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
     n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
-    total_scale_bytes = (
-        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
-    )
+    total_scale_bytes = n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
 
     out_fp8 = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=x.device)

--- a/megatron/core/inference/moe/fused_moe.py
+++ b/megatron/core/inference/moe/fused_moe.py
@@ -20,6 +20,7 @@ from megatron.core.inference.moe.permute import (
     permute_tokens,
     unpermute_tokens,
 )
+from megatron.core.inference.quantization.mxfp8_quantize import MXFP8_SCALE_ROW_BLOCK
 from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 
 from . import batch_invariant
@@ -188,6 +189,7 @@ def mcore_fused_moe(
             num_local_experts,
             valid_tokens,
             alignment=expert_alignment,
+            row_alignment=MXFP8_SCALE_ROW_BLOCK if use_mxfp8 else 1,
             return_batch_invariant_inverse_map=batch_invariant_mode,
         )
         hidden_states, permuted_probs, permutation_map, offs = permuted[:4]

--- a/megatron/core/inference/moe/permute.py
+++ b/megatron/core/inference/moe/permute.py
@@ -688,16 +688,12 @@ def permute_and_quantize_mxfp8(
         max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
     )
     # Keep data rows consistent with the swizzled scale layout's fixed row block.
-    output_size = (
-        _ceil_div(unaligned_output_size, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
-    )
+    output_size = _ceil_div(unaligned_output_size, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
 
     scale_cols = K // MXFP8_BLOCK_SIZE
     n_row_blocks = _ceil_div(output_size, MXFP8_SCALE_ROW_BLOCK)
     n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
-    total_scale_bytes = (
-        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
-    )
+    total_scale_bytes = n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
 
     out_fp8 = torch.empty(output_size, K, dtype=torch.float8_e4m3fn, device=hidden_states.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=hidden_states.device)

--- a/megatron/core/inference/moe/permute.py
+++ b/megatron/core/inference/moe/permute.py
@@ -674,7 +674,11 @@ def permute_and_quantize_mxfp8(
         tokens_per_expert, alignment=alignment
     )
     # Output sized at max to keep allocations fixed across steps (CUDA graph compatible).
-    output_size = max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
+    unaligned_output_size = (
+        max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
+    )
+    # Keep data rows consistent with the swizzled scale layout's row padding.
+    output_size = _ceil_div(unaligned_output_size, alignment) * alignment
 
     scale_cols = K // 32
     n_row_blocks = _ceil_div(output_size, 128)

--- a/megatron/core/inference/moe/permute.py
+++ b/megatron/core/inference/moe/permute.py
@@ -13,6 +13,11 @@ from unittest.mock import MagicMock
 
 import torch
 
+from megatron.core.inference.quantization.mxfp8_quantize import (
+    MXFP8_BLOCK_SIZE,
+    MXFP8_SCALE_COL_BLOCK,
+    MXFP8_SCALE_ROW_BLOCK,
+)
 from megatron.core.utils import null_decorator
 
 from . import batch_invariant
@@ -299,6 +304,7 @@ def permute_tokens(
     valid_tokens: torch.Tensor,
     alignment: int = 1,
     return_batch_invariant_inverse_map: bool = False,
+    row_alignment: int = 1,
 ) -> tuple:
     """Permute tokens into expert-grouped order.
 
@@ -317,6 +323,7 @@ def permute_tokens(
         alignment: per-expert token alignment (default 1).
         return_batch_invariant_inverse_map: if True, also return the map used by
             batch-invariant unpermute.
+        row_alignment: alignment for the fixed output-buffer row count (default 1).
 
     Returns:
         By default, returns the original 4-tuple:
@@ -349,7 +356,10 @@ def permute_tokens(
         tokens_per_expert, alignment=alignment
     )
     # Output sized at max to keep allocations fixed across steps (CUDA graph compatible).
-    output_size = max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
+    unaligned_output_size = (
+        max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
+    )
+    output_size = _ceil_div(unaligned_output_size, row_alignment) * row_alignment
 
     permuted_hidden = torch.empty(
         output_size, hidden_dim, dtype=hidden_states.dtype, device=hidden_states.device
@@ -656,14 +666,11 @@ def permute_and_quantize_mxfp8(
         - permutation_map: [output_size] int32, original token index or -1 for padding
         - inclusive_offsets: [num_local_experts] int32 cumulative offsets for scaled_grouped_mm
     """
-    from megatron.core.inference.quantization.mxfp8_tensor import (
-        MXFP8_SCALE_ROW_BLOCK,
-        MXFP8Tensor,
-    )
+    from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 
     max_tokens, K = hidden_states.shape
     topk = probs.shape[1]
-    assert K % 32 == 0
+    assert K % MXFP8_BLOCK_SIZE == 0
 
     # Count how many (token, topk) pairs are routed to each local expert.
     # Rows beyond valid_tokens are ignored.
@@ -685,10 +692,12 @@ def permute_and_quantize_mxfp8(
         _ceil_div(unaligned_output_size, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
     )
 
-    scale_cols = K // 32
+    scale_cols = K // MXFP8_BLOCK_SIZE
     n_row_blocks = _ceil_div(output_size, MXFP8_SCALE_ROW_BLOCK)
-    n_col_blocks = _ceil_div(scale_cols, 4)
-    total_scale_bytes = n_row_blocks * n_col_blocks * 512
+    n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
+    total_scale_bytes = (
+        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
+    )
 
     out_fp8 = torch.empty(output_size, K, dtype=torch.float8_e4m3fn, device=hidden_states.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=hidden_states.device)
@@ -697,7 +706,7 @@ def permute_and_quantize_mxfp8(
     init_permutation_map(permutation_map, inclusive_expert_offsets[-1:])
 
     BLOCK_K = triton.next_power_of_2(K)
-    BLOCK_GROUPS = BLOCK_K // 32
+    BLOCK_GROUPS = BLOCK_K // MXFP8_BLOCK_SIZE
     max_pairs = max_tokens * topk
     NUM_BLOCKS = min(max_pairs, 512)
     _permute_quantize_mxfp8_kernel[(NUM_BLOCKS,)](

--- a/megatron/core/inference/moe/permute.py
+++ b/megatron/core/inference/moe/permute.py
@@ -656,7 +656,10 @@ def permute_and_quantize_mxfp8(
         - permutation_map: [output_size] int32, original token index or -1 for padding
         - inclusive_offsets: [num_local_experts] int32 cumulative offsets for scaled_grouped_mm
     """
-    from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+    from megatron.core.inference.quantization.mxfp8_tensor import (
+        MXFP8_SCALE_ROW_BLOCK,
+        MXFP8Tensor,
+    )
 
     max_tokens, K = hidden_states.shape
     topk = probs.shape[1]
@@ -677,11 +680,13 @@ def permute_and_quantize_mxfp8(
     unaligned_output_size = (
         max_tokens * min(topk, num_local_experts) + alignment * num_local_experts
     )
-    # Keep data rows consistent with the swizzled scale layout's row padding.
-    output_size = _ceil_div(unaligned_output_size, alignment) * alignment
+    # Keep data rows consistent with the swizzled scale layout's fixed row block.
+    output_size = (
+        _ceil_div(unaligned_output_size, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
+    )
 
     scale_cols = K // 32
-    n_row_blocks = _ceil_div(output_size, 128)
+    n_row_blocks = _ceil_div(output_size, MXFP8_SCALE_ROW_BLOCK)
     n_col_blocks = _ceil_div(scale_cols, 4)
     total_scale_bytes = n_row_blocks * n_col_blocks * 512
 

--- a/megatron/core/inference/quantization/mxfp8_quantize.py
+++ b/megatron/core/inference/quantization/mxfp8_quantize.py
@@ -14,6 +14,10 @@ Usage:
 
 import torch
 
+MXFP8_BLOCK_SIZE = 32
+MXFP8_SCALE_ROW_BLOCK = 128
+MXFP8_SCALE_COL_BLOCK = 4
+
 try:
     import triton
     import triton.language as tl
@@ -171,18 +175,22 @@ def mxfp8_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.is_cuda and x.dim() == 2
     assert x.dtype in (torch.bfloat16, torch.float16, torch.float32)
     M, K = x.shape
-    assert K % 32 == 0, f"K ({K}) must be divisible by 32"
+    assert K % MXFP8_BLOCK_SIZE == 0, (
+        f"K ({K}) must be divisible by {MXFP8_BLOCK_SIZE}"
+    )
 
-    scale_cols = K // 32
-    n_row_blocks = _ceil_div(M, 128)
-    n_col_blocks = _ceil_div(scale_cols, 4)
-    total_scale_bytes = n_row_blocks * n_col_blocks * 512
+    scale_cols = K // MXFP8_BLOCK_SIZE
+    n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
+    n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
+    total_scale_bytes = (
+        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
+    )
 
     out_data = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=x.device)
 
     BLOCK_K = triton.next_power_of_2(K)
-    BLOCK_GROUPS = BLOCK_K // 32
+    BLOCK_GROUPS = BLOCK_K // MXFP8_BLOCK_SIZE
 
     _mxfp8_quant_swizzle_kernel[(M,)](
         out_data,

--- a/megatron/core/inference/quantization/mxfp8_quantize.py
+++ b/megatron/core/inference/quantization/mxfp8_quantize.py
@@ -175,16 +175,12 @@ def mxfp8_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.is_cuda and x.dim() == 2
     assert x.dtype in (torch.bfloat16, torch.float16, torch.float32)
     M, K = x.shape
-    assert K % MXFP8_BLOCK_SIZE == 0, (
-        f"K ({K}) must be divisible by {MXFP8_BLOCK_SIZE}"
-    )
+    assert K % MXFP8_BLOCK_SIZE == 0, f"K ({K}) must be divisible by {MXFP8_BLOCK_SIZE}"
 
     scale_cols = K // MXFP8_BLOCK_SIZE
     n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
     n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
-    total_scale_bytes = (
-        n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
-    )
+    total_scale_bytes = n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
 
     out_data = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x.device)
     out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=x.device)

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -13,6 +13,11 @@ except ImportError:
     HAVE_FLASHINFER = False
 
 from megatron.core.inference.quantization.mxfp8_quantize import (
+    MXFP8_BLOCK_SIZE,
+    MXFP8_SCALE_COL_BLOCK,
+    MXFP8_SCALE_ROW_BLOCK,
+)
+from megatron.core.inference.quantization.mxfp8_quantize import (
     mxfp8_quantize as mcore_mxfp8_quantize,
 )
 
@@ -37,9 +42,10 @@ def ensure_mxfp8_scale_dtype(scale: torch.Tensor) -> torch.Tensor:
 
 
 MXFP8Backend = Literal["flashinfer", "triton"]
-MXFP8_BLOCK_SIZE = 32
-MXFP8_SCALE_ROW_BLOCK = 128
-MXFP8_SCALE_COL_BLOCK = 4
+_MXFP8_SCALE_DTYPES: dict[MXFP8Backend, torch.dtype] = {
+    "flashinfer": torch.uint8,
+    "triton": torch.float8_e8m0fnu,
+}
 
 
 def validate_mxfp8_tensor(
@@ -48,14 +54,7 @@ def validate_mxfp8_tensor(
     expected_backend: Optional[MXFP8Backend] = None,
     tensor_name: str = "MXFP8 tensor",
 ) -> None:
-    """Thoroughly validate an MXFP8 tensor for GEMM consumers, courtesy of Codex.
-
-    MXFP8 scales may be transported as raw bytes, but persistent compute
-    tensors must expose the dtype required by their GEMM consumer: ``uint8``
-    for FlashInfer or semantic E8M0 for PyTorch. Validating this at the refit
-    boundary produces an actionable error before a scaled GEMM reports an
-    opaque implementation-selection failure.
-    """
+    """Thorough MXFP8 validation for GEMM consumers, courtesy of Codex."""
     if tensor.data.ndim != 2:
         raise ValueError(
             f"{tensor_name} data must be 2D before grouped-weight stacking; "
@@ -71,10 +70,7 @@ def validate_mxfp8_tensor(
             f"{tensor_name} backend is {tensor.backend!r}; expected "
             f"{expected_backend!r} for the configured GEMM consumer."
         )
-    expected_scale_dtype = {
-        "flashinfer": torch.uint8,
-        "triton": torch.float8_e8m0fnu,
-    }.get(backend)
+    expected_scale_dtype = _MXFP8_SCALE_DTYPES.get(backend)
     if expected_scale_dtype is None:
         raise ValueError(
             f"{tensor_name} has no valid MXFP8 backend; got {backend!r}. "
@@ -143,8 +139,8 @@ class MXFP8Tensor:
             return self.scale
         if K is None:
             K = self.data.shape[-1]
-        n_col_blocks = _ceil_div(K // 32, 4)
-        padded_cols = n_col_blocks * 4
+        n_col_blocks = _ceil_div(K // MXFP8_BLOCK_SIZE, MXFP8_SCALE_COL_BLOCK)
+        padded_cols = n_col_blocks * MXFP8_SCALE_COL_BLOCK
         return self.scale.reshape(-1, padded_cols)
 
     @classmethod
@@ -181,10 +177,8 @@ class MXFP8Tensor:
                 f"Unknown MXFP8 quantization backend: '{backend}'. "
                 "Must be 'triton' or 'flashinfer'."
             )
-        tensor = cls(
+        return cls(
             data=data,
             scale=scale,
             backend=backend,
         )
-        validate_mxfp8_tensor(tensor, expected_backend=backend)
-        return tensor

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -24,9 +24,7 @@ def _ceil_div(a, b):
 def ensure_mxfp8_scale_dtype(scale: torch.Tensor) -> torch.Tensor:
     """Return the E8M0 view required by PyTorch scaled GEMM APIs.
 
-    FlashInfer exposes the same MXFP8 scale bytes as ``uint8``.  Converting
-    between these API views must be zero-copy; numerical dtype conversion would
-    corrupt the exponent encoding.
+    FlashInfer exposes the same MXFP8 scale bytes as ``uint8``.
     """
     if scale.dtype == torch.uint8:
         return scale.view(torch.float8_e8m0fnu)
@@ -50,7 +48,7 @@ def validate_mxfp8_tensor(
     expected_backend: Optional[MXFP8Backend] = None,
     tensor_name: str = "MXFP8 tensor",
 ) -> None:
-    """Validate the storage contract required by MXFP8 GEMM consumers.
+    """Thoroughly validate an MXFP8 tensor for GEMM consumers, courtesy of Codex.
 
     MXFP8 scales may be transported as raw bytes, but persistent compute
     tensors must expose the dtype required by their GEMM consumer: ``uint8``
@@ -129,7 +127,7 @@ class MXFP8Tensor:
 
     data: torch.Tensor  # [M, K] fp8_e4m3fn
     scale: torch.Tensor  # 1D swizzled or [M, K // 32] unswizzled scales
-    backend: Optional[MXFP8Backend] = None  # quantization and GEMM storage contract
+    backend: Optional[MXFP8Backend] = None  # quantization and GEMM backend
 
     def size(self, idx: Optional[int] = None):
         """Wrapper for calling self.data.size()"""
@@ -161,10 +159,8 @@ class MXFP8Tensor:
         Args:
             x: [M, K] BF16 tensor on CUDA.
             group_size: MXFP8 group size (default 32).
-            backend: ``'triton'`` selects the PyTorch scaled-GEMM storage
-                     contract and uses MCore's fused Triton quantize/swizzle
-                     kernel. ``'flashinfer'`` uses FlashInfer for both
-                     quantization and the dense GEMM.
+            backend: 'triton' (fused quantize + swizzle Triton kernel) or
+                     'flashinfer' (single fused FlashInfer CUDA kernel).
         """
         assert x.is_cuda and x.dim() == 2
         assert x.shape[-1] % group_size == 0

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -39,6 +39,9 @@ def ensure_mxfp8_scale_dtype(scale: torch.Tensor) -> torch.Tensor:
 
 
 MXFP8Backend = Literal["flashinfer", "triton"]
+MXFP8_BLOCK_SIZE = 32
+MXFP8_SCALE_ROW_BLOCK = 128
+MXFP8_SCALE_COL_BLOCK = 4
 
 
 def validate_mxfp8_tensor(
@@ -75,7 +78,11 @@ def validate_mxfp8_tensor(
         "triton": torch.float8_e8m0fnu,
     }.get(backend)
     if expected_scale_dtype is None:
-        raise ValueError(f"{tensor_name} has no valid MXFP8 backend; got {backend!r}.")
+        raise ValueError(
+            f"{tensor_name} has no valid MXFP8 backend; got {backend!r}. "
+            "Construct it via MXFP8Tensor.from_bf16(..., backend=...) or pass "
+            "backend= explicitly to MXFP8Tensor."
+        )
     if tensor.scale.dtype != expected_scale_dtype:
         raise TypeError(
             f"{tensor_name} scales for backend {backend!r} must use "
@@ -83,28 +90,46 @@ def validate_mxfp8_tensor(
         )
 
     rows, cols = tensor.data.shape
-    if cols % 32 != 0:
+    if cols % MXFP8_BLOCK_SIZE != 0:
         raise ValueError(
-            f"{tensor_name} K dimension must be divisible by the MXFP8 block size 32, "
+            f"{tensor_name} K dimension must be divisible by the MXFP8 block size "
+            f"{MXFP8_BLOCK_SIZE}, "
             f"got {cols}."
         )
-    padded_rows = _ceil_div(rows, 128) * 128
-    padded_scale_cols = _ceil_div(cols // 32, 4) * 4
-    expected_scale_elements = padded_rows * padded_scale_cols
-    if tensor.scale.numel() != expected_scale_elements:
+    scale_cols = cols // MXFP8_BLOCK_SIZE
+    if tensor.scale.ndim == 2:
+        expected_scale_shape = (rows, scale_cols)
+        if tuple(tensor.scale.shape) != expected_scale_shape:
+            raise ValueError(
+                f"{tensor_name} 2D scale has shape {tuple(tensor.scale.shape)}; "
+                f"expected {expected_scale_shape} for data shape {tuple(tensor.data.shape)}."
+            )
+    elif tensor.scale.ndim == 1:
+        padded_rows = _ceil_div(rows, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
+        padded_scale_cols = (
+            _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK) * MXFP8_SCALE_COL_BLOCK
+        )
+        expected_scale_elements = padded_rows * padded_scale_cols
+        if tensor.scale.numel() != expected_scale_elements:
+            raise ValueError(
+                f"{tensor_name} swizzled scale storage has {tensor.scale.numel()} elements; "
+                f"expected {expected_scale_elements} for data shape "
+                f"{tuple(tensor.data.shape)}."
+            )
+    else:
         raise ValueError(
-            f"{tensor_name} scale storage has {tensor.scale.numel()} elements; "
-            f"expected {expected_scale_elements} for data shape {tuple(tensor.data.shape)}."
+            f"{tensor_name} scale must be a 1D swizzled tensor or a 2D unswizzled "
+            f"tensor, got shape {tuple(tensor.scale.shape)}."
         )
 
 
 @dataclass
 class MXFP8Tensor:
-    """MXFP8 tensor wrapper storing quantized fp8_e4m3 data and swizzled e8m0 scales."""
+    """MXFP8 tensor wrapper storing quantized data and E8M0 scale bytes."""
 
     data: torch.Tensor  # [M, K] fp8_e4m3fn
-    scale: torch.Tensor  # 1D, swizzled cuBLAS blocked layout, e8m0
-    backend: Optional[MXFP8Backend] = None
+    scale: torch.Tensor  # 1D swizzled or [M, K // 32] unswizzled scales
+    backend: Optional[MXFP8Backend] = None  # quantization and GEMM storage contract
 
     def size(self, idx: Optional[int] = None):
         """Wrapper for calling self.data.size()"""

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -100,9 +100,7 @@ def validate_mxfp8_tensor(
             )
     elif tensor.scale.ndim == 1:
         padded_rows = _ceil_div(rows, MXFP8_SCALE_ROW_BLOCK) * MXFP8_SCALE_ROW_BLOCK
-        padded_scale_cols = (
-            _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK) * MXFP8_SCALE_COL_BLOCK
-        )
+        padded_scale_cols = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK) * MXFP8_SCALE_COL_BLOCK
         expected_scale_elements = padded_rows * padded_scale_cols
         if tensor.scale.numel() != expected_scale_elements:
             raise ValueError(
@@ -144,12 +142,7 @@ class MXFP8Tensor:
         return self.scale.reshape(-1, padded_cols)
 
     @classmethod
-    def from_bf16(
-        cls,
-        x: torch.Tensor,
-        group_size: int = 32,
-        backend: MXFP8Backend = "flashinfer",
-    ):
+    def from_bf16(cls, x: torch.Tensor, group_size: int = 32, backend: MXFP8Backend = "flashinfer"):
         """Quantize BF16 tensor to MXFP8.
 
         Args:
@@ -166,9 +159,7 @@ class MXFP8Tensor:
             if scale.dtype == torch.float8_e8m0fnu:
                 scale = scale.view(torch.uint8)
             elif scale.dtype != torch.uint8:
-                raise TypeError(
-                    f"FlashInfer MXFP8 scales must be uint8 bytes, got {scale.dtype}."
-                )
+                raise TypeError(f"FlashInfer MXFP8 scales must be uint8 bytes, got {scale.dtype}.")
         elif backend == "triton":
             data, scale = mcore_mxfp8_quantize(x)
             scale = ensure_mxfp8_scale_dtype(scale)
@@ -177,8 +168,4 @@ class MXFP8Tensor:
                 f"Unknown MXFP8 quantization backend: '{backend}'. "
                 "Must be 'triton' or 'flashinfer'."
             )
-        return cls(
-            data=data,
-            scale=scale,
-            backend=backend,
-        )
+        return cls(data=data, scale=scale, backend=backend)

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 import torch
 
@@ -21,13 +21,90 @@ def _ceil_div(a, b):
     return (a + b - 1) // b
 
 
+def ensure_mxfp8_scale_dtype(scale: torch.Tensor) -> torch.Tensor:
+    """Return the E8M0 view required by PyTorch scaled GEMM APIs.
+
+    FlashInfer exposes the same MXFP8 scale bytes as ``uint8``.  Converting
+    between these API views must be zero-copy; numerical dtype conversion would
+    corrupt the exponent encoding.
+    """
+    if scale.dtype == torch.uint8:
+        return scale.view(torch.float8_e8m0fnu)
+    if scale.dtype != torch.float8_e8m0fnu:
+        raise TypeError(
+            "MXFP8 scales must use torch.float8_e8m0fnu or its uint8 byte "
+            f"representation, got {scale.dtype}."
+        )
+    return scale
+
+
+MXFP8Backend = Literal["flashinfer", "triton"]
+
+
+def validate_mxfp8_tensor(
+    tensor: "MXFP8Tensor",
+    *,
+    expected_backend: Optional[MXFP8Backend] = None,
+    tensor_name: str = "MXFP8 tensor",
+) -> None:
+    """Validate the storage contract required by MXFP8 GEMM consumers.
+
+    MXFP8 scales may be transported as raw bytes, but persistent compute
+    tensors must expose the dtype required by their GEMM consumer: ``uint8``
+    for FlashInfer or semantic E8M0 for PyTorch. Validating this at the refit
+    boundary produces an actionable error before a scaled GEMM reports an
+    opaque implementation-selection failure.
+    """
+    if tensor.data.ndim != 2:
+        raise ValueError(
+            f"{tensor_name} data must be 2D before grouped-weight stacking; "
+            f"got shape {tuple(tensor.data.shape)}."
+        )
+    if tensor.data.dtype != torch.float8_e4m3fn:
+        raise TypeError(
+            f"{tensor_name} data must use torch.float8_e4m3fn, got {tensor.data.dtype}."
+        )
+    backend = expected_backend if expected_backend is not None else tensor.backend
+    if expected_backend is not None and tensor.backend != expected_backend:
+        raise ValueError(
+            f"{tensor_name} backend is {tensor.backend!r}; expected "
+            f"{expected_backend!r} for the configured GEMM consumer."
+        )
+    expected_scale_dtype = {
+        "flashinfer": torch.uint8,
+        "triton": torch.float8_e8m0fnu,
+    }.get(backend)
+    if expected_scale_dtype is None:
+        raise ValueError(f"{tensor_name} has no valid MXFP8 backend; got {backend!r}.")
+    if tensor.scale.dtype != expected_scale_dtype:
+        raise TypeError(
+            f"{tensor_name} scales for backend {backend!r} must use "
+            f"{expected_scale_dtype}, got {tensor.scale.dtype}."
+        )
+
+    rows, cols = tensor.data.shape
+    if cols % 32 != 0:
+        raise ValueError(
+            f"{tensor_name} K dimension must be divisible by the MXFP8 block size 32, "
+            f"got {cols}."
+        )
+    padded_rows = _ceil_div(rows, 128) * 128
+    padded_scale_cols = _ceil_div(cols // 32, 4) * 4
+    expected_scale_elements = padded_rows * padded_scale_cols
+    if tensor.scale.numel() != expected_scale_elements:
+        raise ValueError(
+            f"{tensor_name} scale storage has {tensor.scale.numel()} elements; "
+            f"expected {expected_scale_elements} for data shape {tuple(tensor.data.shape)}."
+        )
+
+
 @dataclass
 class MXFP8Tensor:
     """MXFP8 tensor wrapper storing quantized fp8_e4m3 data and swizzled e8m0 scales."""
 
     data: torch.Tensor  # [M, K] fp8_e4m3fn
     scale: torch.Tensor  # 1D, swizzled cuBLAS blocked layout, e8m0
-    backend: Optional[str] = None  # quantization backend: 'flashinfer' or 'triton'
+    backend: Optional[MXFP8Backend] = None
 
     def size(self, idx: Optional[int] = None):
         """Wrapper for calling self.data.size()"""
@@ -48,25 +125,45 @@ class MXFP8Tensor:
         return self.scale.reshape(-1, padded_cols)
 
     @classmethod
-    def from_bf16(cls, x: torch.Tensor, group_size: int = 32, backend: str = "flashinfer"):
+    def from_bf16(
+        cls,
+        x: torch.Tensor,
+        group_size: int = 32,
+        backend: MXFP8Backend = "flashinfer",
+    ):
         """Quantize BF16 tensor to MXFP8.
 
         Args:
             x: [M, K] BF16 tensor on CUDA.
             group_size: MXFP8 group size (default 32).
-            backend: 'triton' (fused quantize + swizzle Triton kernel) or
-                     'flashinfer' (single fused FlashInfer CUDA kernel).
+            backend: ``'triton'`` selects the PyTorch scaled-GEMM storage
+                     contract and uses MCore's fused Triton quantize/swizzle
+                     kernel. ``'flashinfer'`` uses FlashInfer for both
+                     quantization and the dense GEMM.
         """
         assert x.is_cuda and x.dim() == 2
         assert x.shape[-1] % group_size == 0
         if backend == "flashinfer":
             assert HAVE_FLASHINFER, "FlashInfer not available"
-            return cls(*flashinfer_mxfp8_quantize(x), backend=backend)
+            data, scale = flashinfer_mxfp8_quantize(x)
+            if scale.dtype == torch.float8_e8m0fnu:
+                scale = scale.view(torch.uint8)
+            elif scale.dtype != torch.uint8:
+                raise TypeError(
+                    f"FlashInfer MXFP8 scales must be uint8 bytes, got {scale.dtype}."
+                )
         elif backend == "triton":
-            xq, xs = mcore_mxfp8_quantize(x)
-            return cls(data=xq, scale=xs, backend=backend)
+            data, scale = mcore_mxfp8_quantize(x)
+            scale = ensure_mxfp8_scale_dtype(scale)
         else:
             raise ValueError(
                 f"Unknown MXFP8 quantization backend: '{backend}'. "
                 "Must be 'triton' or 'flashinfer'."
             )
+        tensor = cls(
+            data=data,
+            scale=scale,
+            backend=backend,
+        )
+        validate_mxfp8_tensor(tensor, expected_backend=backend)
+        return tensor

--- a/megatron/core/inference/quantization/utils.py
+++ b/megatron/core/inference/quantization/utils.py
@@ -137,18 +137,22 @@ def collect_mxfp8_param_metadata(
     return metadata
 
 
+@torch.inference_mode(False)
+@torch.no_grad()
 def quantize_params_to_mxfp8(
     model: torch.nn.Module,
     persistent_buffers: Optional[Dict[str, MXFP8Tensor]] = None,
     _prefix: str = "",
     backend: str = "flashinfer",
 ) -> Dict[str, MXFP8Tensor]:
-    """Quantize model parameters to MXFP8Tensor format.
+    """Quantize model parameters to mutable MXFP8Tensor storage.
 
     Handles both TEMXFP8Tensor (fp8_param=True) and BF16/FP16 nn.Parameter
     inputs.  When *persistent_buffers* is provided, new quantized values are
     ``copy_()``'d into the existing MXFP8Tensor objects so that CUDA-graph
-    device-pointer captures remain valid.
+    device-pointer captures remain valid.  Persistent buffers are deliberately
+    created outside inference mode so later refits can update them regardless
+    of the caller's execution mode.
 
     Args:
         model: The model whose parameters should be quantized.

--- a/megatron/core/inference/quantization/utils.py
+++ b/megatron/core/inference/quantization/utils.py
@@ -87,9 +87,7 @@ def resolve_mxfp8_backend(
     )
 
 
-def quantize_model_to_mxfp8(
-    model: torch.nn.Module, backend: MXFP8Backend = "flashinfer"
-) -> None:
+def quantize_model_to_mxfp8(model: torch.nn.Module, backend: MXFP8Backend = "flashinfer") -> None:
     """Convert TE MXFP8 weights to mcore MXFP8Tensor format.
 
     Recursively walks the model and replaces each TEMXFP8Tensor parameter
@@ -245,9 +243,7 @@ def quantize_params_to_mxfp8(
                 )
                 new_tensor = MXFP8Tensor.from_bf16(bf16_data, backend=backend)
                 persistent_tensor.data.copy_(new_tensor.data)
-                persistent_tensor.scale.view(torch.uint8).copy_(
-                    new_tensor.scale.view(torch.uint8)
-                )
+                persistent_tensor.scale.view(torch.uint8).copy_(new_tensor.scale.view(torch.uint8))
                 mcore_tensor = persistent_tensor
             else:
                 # First call: create new MXFP8Tensor

--- a/megatron/core/inference/quantization/utils.py
+++ b/megatron/core/inference/quantization/utils.py
@@ -1,13 +1,19 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from typing import Dict, Optional, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 import torch
 
 from megatron.core.inference.quantization.mxfp8_tensor import (
+    MXFP8Backend,
     MXFP8Tensor,
     validate_mxfp8_tensor,
 )
+
+if TYPE_CHECKING:
+    from megatron.core.inference.moe import InferenceGroupedGemmBackend
 
 try:
     from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor as TEMXFP8Tensor
@@ -53,7 +59,37 @@ def _verify_te_to_mcore_mxfp8_conversion(te_dequantized, fi_quantized: MXFP8Tens
         raise ValueError(f"MXFP8 sanity check failed. Diff norm: {diff_norm}")
 
 
-def quantize_model_to_mxfp8(model: torch.nn.Module, backend: str = "flashinfer") -> None:
+def resolve_mxfp8_backend(
+    inference_grouped_gemm_backend: str | InferenceGroupedGemmBackend,
+) -> MXFP8Backend:
+    """Resolve the MXFP8 quantizer required by an inference grouped-GEMM backend.
+
+    Args:
+        inference_grouped_gemm_backend: The configured backend, either as its raw
+            string value or as the enum produced by ``TransformerConfig``.
+
+    Returns:
+        The MXFP8 quantization backend to use.
+
+    Raises:
+        ValueError: If the grouped-GEMM backend does not support MXFP8.
+    """
+    grouped_gemm_backend = getattr(
+        inference_grouped_gemm_backend, "value", inference_grouped_gemm_backend
+    )
+    if grouped_gemm_backend == "torch":
+        return "triton"
+    if grouped_gemm_backend == "flashinfer":
+        return "flashinfer"
+    raise ValueError(
+        "MXFP8 inference does not support "
+        f"inference_grouped_gemm_backend={grouped_gemm_backend!r}."
+    )
+
+
+def quantize_model_to_mxfp8(
+    model: torch.nn.Module, backend: MXFP8Backend = "flashinfer"
+) -> None:
     """Convert TE MXFP8 weights to mcore MXFP8Tensor format.
 
     Recursively walks the model and replaces each TEMXFP8Tensor parameter
@@ -87,6 +123,11 @@ def quantize_model_to_mxfp8(model: torch.nn.Module, backend: str = "flashinfer")
                 # numerical differences between TE and mcore MXFP8 formats
                 te_dequantized = val.dequantize()
                 mcore_quantized = MXFP8Tensor.from_bf16(te_dequantized, backend=backend)
+                validate_mxfp8_tensor(
+                    mcore_quantized,
+                    expected_backend=backend,
+                    tensor_name=f"quantized MXFP8 parameter {key!r}",
+                )
                 _verify_te_to_mcore_mxfp8_conversion(te_dequantized, mcore_quantized)
                 del model._parameters[key]
                 setattr(model, key, mcore_quantized)
@@ -98,7 +139,7 @@ def quantize_model_to_mxfp8(model: torch.nn.Module, backend: str = "flashinfer")
 
 
 def _should_quantize_param(val: torch.Tensor) -> bool:
-    """Return True if a parameter should be quantized to FlashInfer MXFP8."""
+    """Return True if a parameter should be converted to an MCore MXFP8 tensor."""
     if not val.is_cuda:
         return False
     if HAVE_TE and isinstance(val, TEMXFP8Tensor):
@@ -146,7 +187,7 @@ def quantize_params_to_mxfp8(
     model: torch.nn.Module,
     persistent_buffers: Optional[Dict[str, MXFP8Tensor]] = None,
     _prefix: str = "",
-    backend: str = "flashinfer",
+    backend: MXFP8Backend = "flashinfer",
 ) -> Dict[str, MXFP8Tensor]:
     """Quantize model parameters to mutable MXFP8Tensor storage.
 
@@ -162,7 +203,7 @@ def quantize_params_to_mxfp8(
         persistent_buffers: If not ``None``, a dict mapping fully-qualified
             parameter names to previously-created ``MXFP8Tensor`` objects.
             Updated in-place and returned.
-        _prefix: Internal recursion prefix – callers should not set this.
+        _prefix: Internal recursion prefix; callers should not set this.
         backend: 'flashinfer' or 'triton' quantization backend.
 
     Returns:
@@ -217,6 +258,12 @@ def quantize_params_to_mxfp8(
                     _verify_te_to_mcore_mxfp8_conversion(bf16_data, mcore_tensor)
 
                 persistent_buffers[fqn] = mcore_tensor
+
+            validate_mxfp8_tensor(
+                mcore_tensor,
+                expected_backend=backend,
+                tensor_name=f"quantized MXFP8 parameter {fqn!r}",
+            )
 
             # Replace nn.Parameter with MXFP8Tensor attribute
             del model._parameters[key]

--- a/megatron/core/inference/quantization/utils.py
+++ b/megatron/core/inference/quantization/utils.py
@@ -4,7 +4,10 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+from megatron.core.inference.quantization.mxfp8_tensor import (
+    MXFP8Tensor,
+    validate_mxfp8_tensor,
+)
 
 try:
     from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor as TEMXFP8Tensor
@@ -193,10 +196,18 @@ def quantize_params_to_mxfp8(
 
             if fqn in persistent_buffers:
                 # Subsequent call: copy into existing tensors to preserve addresses
+                persistent_tensor = persistent_buffers[fqn]
+                validate_mxfp8_tensor(
+                    persistent_tensor,
+                    expected_backend=backend,
+                    tensor_name=f"persistent MXFP8 parameter {fqn!r}",
+                )
                 new_tensor = MXFP8Tensor.from_bf16(bf16_data, backend=backend)
-                persistent_buffers[fqn].data.copy_(new_tensor.data)
-                persistent_buffers[fqn].scale.copy_(new_tensor.scale)
-                mcore_tensor = persistent_buffers[fqn]
+                persistent_tensor.data.copy_(new_tensor.data)
+                persistent_tensor.scale.view(torch.uint8).copy_(
+                    new_tensor.scale.view(torch.uint8)
+                )
+                mcore_tensor = persistent_tensor
             else:
                 # First call: create new MXFP8Tensor
                 mcore_tensor = MXFP8Tensor.from_bf16(bf16_data, backend=backend)

--- a/megatron/core/resharding/refit.py
+++ b/megatron/core/resharding/refit.py
@@ -17,6 +17,7 @@ from megatron.core import parallel_state
 from megatron.core.inference.quantization.utils import (
     _should_quantize_param,
     quantize_params_to_mxfp8,
+    resolve_mxfp8_backend,
 )
 from megatron.core.models.common.language_module.language_module import LanguageModule
 from megatron.core.utils import unwrap_model
@@ -237,7 +238,7 @@ def _build_or_get_plan(
 
 
 def _needs_mxfp8_conversion(model) -> bool:
-    """Check if a model uses FlashInfer MXFP8 inference and needs weight conversion."""
+    """Check if a model uses optimized MXFP8 inference and needs weight conversion."""
     if model is None:
         return False
     lm = model[0] if isinstance(model, (list, tuple)) else model
@@ -279,15 +280,15 @@ def _setup_mxfp8_transform_on_plan(plan, target_model) -> None:
             convertible.add(f"decoder.{name}")
 
     # 2. Quantize decoder weights → persistent MXFP8Tensor buffers.
-    # MXFP8 inference is supported by the torch grouped-GEMM path, whose
-    # persistent buffers require the Triton quantizer's E8M0 storage contract.
-    persistent_buffers = quantize_params_to_mxfp8(decoder, backend="triton")
+    backend = resolve_mxfp8_backend(lm.config.inference_grouped_gemm_backend)
+    persistent_buffers = quantize_params_to_mxfp8(decoder, backend=backend)
 
     # 3. Build the transform and attach it to the plan.
     plan.transform = MXFP8ReshardTransform(
         convertible_params=convertible,
         persistent_buffers=persistent_buffers,
         buffer_key_prefix="decoder.",
+        backend=backend,
     )
 
 
@@ -309,8 +310,8 @@ def prepare_swap_model_weights(
     (``config.transformer_impl == 'inference_optimized'`` and
     ``config.fp8_recipe == 'mxfp8'``), this function also:
       - computes which parameters are eligible for MXFP8 conversion,
-      - quantizes the target decoder weights to persistent FlashInfer
-        MXFP8Tensor buffers (whose addresses are later baked into CUDA graphs),
+      - quantizes the target decoder weights to persistent MXFP8Tensor buffers
+        (whose addresses are later baked into CUDA graphs),
       - creates an ``MXFP8ReshardTransform`` that subsequent
         ``swap_model_weights`` calls use automatically.
 

--- a/megatron/core/resharding/refit.py
+++ b/megatron/core/resharding/refit.py
@@ -254,7 +254,7 @@ def _setup_mxfp8_transform_on_plan(plan, target_model) -> None:
     If the *target_model* uses an inference-optimized layer spec with MXFP8,
     this function:
       1. Computes which params are eligible for MXFP8 conversion.
-      2. Quantizes the target model's decoder weights to FlashInfer MXFP8Tensor
+      2. Quantizes the target model's decoder weights to MXFP8Tensor
          (creating persistent buffers whose addresses are later captured by
          CUDA graphs).
       3. Builds an ``MXFP8ReshardTransform`` and attaches it to ``plan.transform``.
@@ -279,7 +279,9 @@ def _setup_mxfp8_transform_on_plan(plan, target_model) -> None:
             convertible.add(f"decoder.{name}")
 
     # 2. Quantize decoder weights → persistent MXFP8Tensor buffers.
-    persistent_buffers = quantize_params_to_mxfp8(decoder)
+    # MXFP8 inference is supported by the torch grouped-GEMM path, whose
+    # persistent buffers require the Triton quantizer's E8M0 storage contract.
+    persistent_buffers = quantize_params_to_mxfp8(decoder, backend="triton")
 
     # 3. Build the transform and attach it to the plan.
     plan.transform = MXFP8ReshardTransform(

--- a/megatron/core/resharding/transforms.py
+++ b/megatron/core/resharding/transforms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 Reshard transforms for custom send/recv/writeback during weight transfer.
 
 - ReshardTransform: base class for pluggable format conversion hooks.
-- MXFP8ReshardTransform: writes received BF16 data into persistent FlashInfer
+- MXFP8ReshardTransform: writes received BF16 data into persistent
   MXFP8Tensor buffers so CUDA-graph device-pointer captures remain valid.
 """
 
@@ -115,15 +115,6 @@ def _ensure_sendable(param: torch.Tensor) -> torch.Tensor:
     return param.data
 
 
-def _require_mxfp8_backend(
-    backend: MXFP8Backend | None, tensor_name: str
-) -> MXFP8Backend:
-    """Return a configured MXFP8 backend or raise an actionable error."""
-    if backend is None:
-        raise ValueError(f"{tensor_name} has no MXFP8 backend.")
-    return backend
-
-
 class MXFP8ReshardTransform(ReshardTransform):
     """MXFP8 format-conversion transform for reshard.
 
@@ -166,8 +157,9 @@ class MXFP8ReshardTransform(ReshardTransform):
         convert_on_send: if True, convert BF16 → MXFP8 on the sender and
             transmit two tensors (data + scale).  If False (default),
             transmit BF16 and convert on the receiver in ``finalize_recv``.
-        backend: backend used for sender-side conversion. It is inferred from
-            persistent buffers on the receiver.
+        backend: backend used for conversion. It is inferred from persistent
+            buffers on the receiver. A sender with no persistent buffers must
+            provide it explicitly.
     """
 
     def __init__(
@@ -183,27 +175,18 @@ class MXFP8ReshardTransform(ReshardTransform):
         self.buffer_key_prefix = buffer_key_prefix
         self.convert_on_send = convert_on_send
         self.backend = backend
-        buffer_backends: set[MXFP8Backend] = set()
+        if self.backend is None and self.persistent_buffers:
+            self.backend = next(iter(self.persistent_buffers.values())).backend
+        if self.convert_on_send:
+            assert self.backend is not None, "backend is required for sender-side conversion"
         for name, buffer in self.persistent_buffers.items():
             validate_mxfp8_tensor(
                 buffer,
-                expected_backend=backend,
+                expected_backend=self.backend,
                 tensor_name=f"persistent refit buffer {name!r}",
             )
-            buffer_backends.add(
-                _require_mxfp8_backend(buffer.backend, f"persistent refit buffer {name!r}")
-            )
-        if len(buffer_backends) > 1:
-            raise ValueError(
-                "All persistent MXFP8 refit buffers must use the same backend; "
-                f"got {sorted(buffer_backends)}."
-            )
-        if self.backend is None and buffer_backends:
-            self.backend = next(iter(buffer_backends))
-        if self.convert_on_send:
-            _require_mxfp8_backend(self.backend, "MXFP8 sender-side conversion")
         # Accumulation buffers for 1D-scale params that arrive in partial slices.
-        # The 1D swizzled FlashInfer scale can't be updated partially; we collect
+        # A 1D swizzled scale can't be updated partially; we collect
         # all BF16 slices here and quantize the full weight once it's assembled.
         # Maps buf_key -> (full-size BF16 accumulation tensor, elements written so far).
         self._pending_1d: dict = {}
@@ -217,8 +200,7 @@ class MXFP8ReshardTransform(ReshardTransform):
         src_data = _ensure_sendable(src_param)
         if self.convert_on_send:
             bf16_data = src_data[src_slice].contiguous().to(torch.bfloat16)
-            backend = _require_mxfp8_backend(self.backend, "MXFP8 sender-side conversion")
-            mxfp8 = MXFP8Tensor.from_bf16(bf16_data, backend=backend)
+            mxfp8 = MXFP8Tensor.from_bf16(bf16_data, backend=self.backend)
             return [mxfp8.data.contiguous(), mxfp8.scale.contiguous()]
         else:
             # BF16 on the wire — same as the default reshard path.
@@ -272,10 +254,11 @@ class MXFP8ReshardTransform(ReshardTransform):
             # (1D scale is rejected at prepare_recv time, so only 2D reaches here.)
             buf.data[dst_slice].copy_(recv_buffers[0])
             scale_slice = _scale_slice_from_data_slice(dst_slice)
-            recv_scale = ensure_mxfp8_scale_dtype(recv_buffers[1])
-            buf.scale[scale_slice].view(torch.uint8).copy_(recv_scale.view(torch.uint8))
+            # copy_ is not implemented for float8_e8m0fnu, so copy its raw bytes.
+            recv_scale = ensure_mxfp8_scale_dtype(recv_buffers[1]).view(torch.uint8)
+            buf.scale[scale_slice].view(torch.uint8).copy_(recv_scale)
         elif buf.scale.ndim == 1:
-            # 1D swizzled scale (FlashInfer format) encodes scale values across the
+            # A 1D swizzled scale encodes scale values across the
             # full weight tensor; partial updates would corrupt the swizzle layout.
             # Accumulate BF16 slices and quantize once all slices are assembled.
             if buf_key not in self._pending_1d:
@@ -297,10 +280,7 @@ class MXFP8ReshardTransform(ReshardTransform):
                         f"1D-scale param {param_name!r}: received {written} elements, "
                         f"expected {buf.data.numel()} (duplicate or missing slices?)"
                     )
-                backend = _require_mxfp8_backend(
-                    buf.backend, f"Persistent MXFP8 buffer {buf_key!r}"
-                )
-                mxfp8 = MXFP8Tensor.from_bf16(accum, backend=backend)
+                mxfp8 = MXFP8Tensor.from_bf16(accum, backend=buf.backend)
                 buf.data.copy_(mxfp8.data)
                 buf.scale.view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))
                 del self._pending_1d[buf_key]
@@ -309,10 +289,7 @@ class MXFP8ReshardTransform(ReshardTransform):
         else:
             # 2D scale: each scale row covers exactly one data row, so partial
             # row-wise updates are independent and can be applied immediately.
-            backend = _require_mxfp8_backend(
-                buf.backend, f"Persistent MXFP8 buffer {buf_key!r}"
-            )
-            mxfp8 = MXFP8Tensor.from_bf16(recv_buffers[0], backend=backend)
+            mxfp8 = MXFP8Tensor.from_bf16(recv_buffers[0], backend=buf.backend)
             buf.data[dst_slice].copy_(mxfp8.data)
             scale_slice = _scale_slice_from_data_slice(dst_slice)
             buf.scale[scale_slice].view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))

--- a/megatron/core/resharding/transforms.py
+++ b/megatron/core/resharding/transforms.py
@@ -12,7 +12,11 @@ Reshard transforms for custom send/recv/writeback during weight transfer.
 import torch
 
 from megatron.core.fp8_utils import dequantize_fp8_tensor, is_mxfp8tensor
-from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+from megatron.core.inference.quantization.mxfp8_tensor import (
+    MXFP8Tensor,
+    ensure_mxfp8_scale_dtype,
+    validate_mxfp8_tensor,
+)
 
 
 class ReshardTransform:
@@ -165,6 +169,8 @@ class MXFP8ReshardTransform(ReshardTransform):
         self.persistent_buffers = persistent_buffers
         self.buffer_key_prefix = buffer_key_prefix
         self.convert_on_send = convert_on_send
+        for name, buffer in persistent_buffers.items():
+            validate_mxfp8_tensor(buffer, tensor_name=f"persistent refit buffer {name!r}")
         # Accumulation buffers for 1D-scale params that arrive in partial slices.
         # The 1D swizzled FlashInfer scale can't be updated partially; we collect
         # all BF16 slices here and quantize the full weight once it's assembled.
@@ -235,7 +241,8 @@ class MXFP8ReshardTransform(ReshardTransform):
             # (1D scale is rejected at prepare_recv time, so only 2D reaches here.)
             buf.data[dst_slice].copy_(recv_buffers[0])
             scale_slice = _scale_slice_from_data_slice(dst_slice)
-            buf.scale[scale_slice].copy_(recv_buffers[1])
+            recv_scale = ensure_mxfp8_scale_dtype(recv_buffers[1])
+            buf.scale[scale_slice].view(torch.uint8).copy_(recv_scale.view(torch.uint8))
         elif buf.scale.ndim == 1:
             # 1D swizzled scale (FlashInfer format) encodes scale values across the
             # full weight tensor; partial updates would corrupt the swizzle layout.
@@ -261,7 +268,7 @@ class MXFP8ReshardTransform(ReshardTransform):
                     )
                 mxfp8 = MXFP8Tensor.from_bf16(accum)
                 buf.data.copy_(mxfp8.data)
-                buf.scale.copy_(mxfp8.scale)
+                buf.scale.view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))
                 del self._pending_1d[buf_key]
             else:
                 self._pending_1d[buf_key][1] = written
@@ -271,4 +278,6 @@ class MXFP8ReshardTransform(ReshardTransform):
             mxfp8 = MXFP8Tensor.from_bf16(recv_buffers[0])
             buf.data[dst_slice].copy_(mxfp8.data)
             scale_slice = _scale_slice_from_data_slice(dst_slice)
-            buf.scale[scale_slice].copy_(mxfp8.scale)
+            buf.scale[scale_slice].view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))
+
+        validate_mxfp8_tensor(buf, tensor_name=f"refitted parameter {param_name!r}")

--- a/megatron/core/resharding/transforms.py
+++ b/megatron/core/resharding/transforms.py
@@ -13,6 +13,7 @@ import torch
 
 from megatron.core.fp8_utils import dequantize_fp8_tensor, is_mxfp8tensor
 from megatron.core.inference.quantization.mxfp8_tensor import (
+    MXFP8Backend,
     MXFP8Tensor,
     ensure_mxfp8_scale_dtype,
     validate_mxfp8_tensor,
@@ -114,6 +115,15 @@ def _ensure_sendable(param: torch.Tensor) -> torch.Tensor:
     return param.data
 
 
+def _require_mxfp8_backend(
+    backend: MXFP8Backend | None, tensor_name: str
+) -> MXFP8Backend:
+    """Return a configured MXFP8 backend or raise an actionable error."""
+    if backend is None:
+        raise ValueError(f"{tensor_name} has no MXFP8 backend.")
+    return backend
+
+
 class MXFP8ReshardTransform(ReshardTransform):
     """MXFP8 format-conversion transform for reshard.
 
@@ -156,6 +166,8 @@ class MXFP8ReshardTransform(ReshardTransform):
         convert_on_send: if True, convert BF16 → MXFP8 on the sender and
             transmit two tensors (data + scale).  If False (default),
             transmit BF16 and convert on the receiver in ``finalize_recv``.
+        backend: backend storage contract for sender-side conversion. It is
+            inferred from persistent buffers on the receiver.
     """
 
     def __init__(
@@ -164,13 +176,32 @@ class MXFP8ReshardTransform(ReshardTransform):
         persistent_buffers: dict,
         buffer_key_prefix: str = "",
         convert_on_send: bool = False,
+        backend: MXFP8Backend | None = None,
     ):
         self.convertible_params = convertible_params
         self.persistent_buffers = persistent_buffers
         self.buffer_key_prefix = buffer_key_prefix
         self.convert_on_send = convert_on_send
-        for name, buffer in persistent_buffers.items():
-            validate_mxfp8_tensor(buffer, tensor_name=f"persistent refit buffer {name!r}")
+        self.backend = backend
+        buffer_backends: set[MXFP8Backend] = set()
+        for name, buffer in self.persistent_buffers.items():
+            validate_mxfp8_tensor(
+                buffer,
+                expected_backend=backend,
+                tensor_name=f"persistent refit buffer {name!r}",
+            )
+            buffer_backends.add(
+                _require_mxfp8_backend(buffer.backend, f"persistent refit buffer {name!r}")
+            )
+        if len(buffer_backends) > 1:
+            raise ValueError(
+                "All persistent MXFP8 refit buffers must use the same backend; "
+                f"got {sorted(buffer_backends)}."
+            )
+        if self.backend is None and buffer_backends:
+            self.backend = next(iter(buffer_backends))
+        if self.convert_on_send:
+            _require_mxfp8_backend(self.backend, "MXFP8 sender-side conversion")
         # Accumulation buffers for 1D-scale params that arrive in partial slices.
         # The 1D swizzled FlashInfer scale can't be updated partially; we collect
         # all BF16 slices here and quantize the full weight once it's assembled.
@@ -185,9 +216,9 @@ class MXFP8ReshardTransform(ReshardTransform):
     def prepare_send(self, param_name, src_slice, src_param):
         src_data = _ensure_sendable(src_param)
         if self.convert_on_send:
-
             bf16_data = src_data[src_slice].contiguous().to(torch.bfloat16)
-            mxfp8 = MXFP8Tensor.from_bf16(bf16_data)
+            backend = _require_mxfp8_backend(self.backend, "MXFP8 sender-side conversion")
+            mxfp8 = MXFP8Tensor.from_bf16(bf16_data, backend=backend)
             return [mxfp8.data.contiguous(), mxfp8.scale.contiguous()]
         else:
             # BF16 on the wire — same as the default reshard path.
@@ -266,7 +297,10 @@ class MXFP8ReshardTransform(ReshardTransform):
                         f"1D-scale param {param_name!r}: received {written} elements, "
                         f"expected {buf.data.numel()} (duplicate or missing slices?)"
                     )
-                mxfp8 = MXFP8Tensor.from_bf16(accum)
+                backend = _require_mxfp8_backend(
+                    buf.backend, f"Persistent MXFP8 buffer {buf_key!r}"
+                )
+                mxfp8 = MXFP8Tensor.from_bf16(accum, backend=backend)
                 buf.data.copy_(mxfp8.data)
                 buf.scale.view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))
                 del self._pending_1d[buf_key]
@@ -275,9 +309,10 @@ class MXFP8ReshardTransform(ReshardTransform):
         else:
             # 2D scale: each scale row covers exactly one data row, so partial
             # row-wise updates are independent and can be applied immediately.
-            mxfp8 = MXFP8Tensor.from_bf16(recv_buffers[0])
+            backend = _require_mxfp8_backend(
+                buf.backend, f"Persistent MXFP8 buffer {buf_key!r}"
+            )
+            mxfp8 = MXFP8Tensor.from_bf16(recv_buffers[0], backend=backend)
             buf.data[dst_slice].copy_(mxfp8.data)
             scale_slice = _scale_slice_from_data_slice(dst_slice)
             buf.scale[scale_slice].view(torch.uint8).copy_(mxfp8.scale.view(torch.uint8))
-
-        validate_mxfp8_tensor(buf, tensor_name=f"refitted parameter {param_name!r}")

--- a/megatron/core/resharding/transforms.py
+++ b/megatron/core/resharding/transforms.py
@@ -166,8 +166,8 @@ class MXFP8ReshardTransform(ReshardTransform):
         convert_on_send: if True, convert BF16 → MXFP8 on the sender and
             transmit two tensors (data + scale).  If False (default),
             transmit BF16 and convert on the receiver in ``finalize_recv``.
-        backend: backend storage contract for sender-side conversion. It is
-            inferred from persistent buffers on the receiver.
+        backend: backend used for sender-side conversion. It is inferred from
+            persistent buffers on the receiver.
     """
 
     def __init__(

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -23,7 +23,11 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_geglu import quick_gelu, weighted_bias_quick_geglu_impl
 from megatron.core.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
 from megatron.core.fusions.fused_weighted_squared_relu import weighted_squared_relu_impl
-from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor, ensure_mxfp8_scale_dtype
+from megatron.core.inference.quantization.mxfp8_tensor import (
+    MXFP8Tensor,
+    ensure_mxfp8_scale_dtype,
+    validate_mxfp8_tensor,
+)
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -1054,6 +1058,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             return McoreActivationType.SWIGLU
         raise ValueError(f"No mcore_fused_moe ActivationType mapping for activation_func={func}")
 
+    @torch.inference_mode(False)
     def _build_concatenated_mxfp8_weights(self):
         """Build stacked MXFP8 weight tensors from per-expert MXFP8Tensor attributes.
 
@@ -1084,6 +1089,11 @@ class InferenceGroupedMLP(TEGroupedMLP):
                         f"Expected MXFP8Tensor for {linear_name}.weight{i}, "
                         f"got {type(w).__name__}. Was quantize_model_to_mxfp8 called?"
                     )
+                validate_mxfp8_tensor(
+                    mxfp8,
+                    expected_backend="triton",
+                    tensor_name=f"{linear_name}.weight{i}",
+                )
                 q_list.append(mxfp8.data)
                 s_list.append(mxfp8.scale)
 
@@ -1106,11 +1116,9 @@ class InferenceGroupedMLP(TEGroupedMLP):
                 if isinstance(w, MXFP8Tensor):
                     w.data = stacked_data[i]
                     w.scale = stacked_scale[i]
-                    w.backend = "triton"
                 elif hasattr(w, 'data') and isinstance(w.data, MXFP8Tensor):
                     w.data.data = stacked_data[i]
                     w.data.scale = stacked_scale[i]
-                    w.data.backend = "triton"
 
     @torch.inference_mode(False)  # needed for non-colocated inference.
     def _build_concatenated_weights(self):

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -25,9 +25,9 @@ from megatron.core.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
 from megatron.core.fusions.fused_weighted_squared_relu import weighted_squared_relu_impl
 from megatron.core.inference.quantization.mxfp8_tensor import (
     MXFP8Tensor,
-    ensure_mxfp8_scale_dtype,
     validate_mxfp8_tensor,
 )
+from megatron.core.inference.quantization.utils import resolve_mxfp8_backend
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -1058,7 +1058,9 @@ class InferenceGroupedMLP(TEGroupedMLP):
             return McoreActivationType.SWIGLU
         raise ValueError(f"No mcore_fused_moe ActivationType mapping for activation_func={func}")
 
+    # Later refits update these buffers, so create normal tensors without tracking gradients.
     @torch.inference_mode(False)
+    @torch.no_grad()
     def _build_concatenated_mxfp8_weights(self):
         """Build stacked MXFP8 weight tensors from per-expert MXFP8Tensor attributes.
 
@@ -1075,6 +1077,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
         intended for non-colocated inference.
         """
 
+        backend = resolve_mxfp8_backend(self.inference_grouped_gemm_backend)
         for linear_name, buf_name in [('linear_fc1', '_fc1_weight'), ('linear_fc2', '_fc2_weight')]:
             linear = getattr(self, linear_name)
             q_list, s_list = [], []
@@ -1091,21 +1094,19 @@ class InferenceGroupedMLP(TEGroupedMLP):
                     )
                 validate_mxfp8_tensor(
                     mxfp8,
-                    expected_backend="triton",
+                    expected_backend=backend,
                     tensor_name=f"{linear_name}.weight{i}",
                 )
                 q_list.append(mxfp8.data)
                 s_list.append(mxfp8.scale)
 
             stacked_data = torch.stack(q_list, dim=0).contiguous()
-            stacked_scale = ensure_mxfp8_scale_dtype(
-                torch.stack(s_list, dim=0).contiguous()
-            )
+            stacked_scale = torch.stack(s_list, dim=0).contiguous()
 
             setattr(
                 self,
                 buf_name,
-                MXFP8Tensor(data=stacked_data, scale=stacked_scale, backend="triton"),
+                MXFP8Tensor(data=stacked_data, scale=stacked_scale, backend=backend),
             )
 
             # Redirect per-expert weight .data to views into the stacked buffer,

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -23,7 +23,7 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_geglu import quick_gelu, weighted_bias_quick_geglu_impl
 from megatron.core.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
 from megatron.core.fusions.fused_weighted_squared_relu import weighted_squared_relu_impl
-from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor, ensure_mxfp8_scale_dtype
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -1088,9 +1088,15 @@ class InferenceGroupedMLP(TEGroupedMLP):
                 s_list.append(mxfp8.scale)
 
             stacked_data = torch.stack(q_list, dim=0).contiguous()
-            stacked_scale = torch.stack(s_list, dim=0).contiguous()
+            stacked_scale = ensure_mxfp8_scale_dtype(
+                torch.stack(s_list, dim=0).contiguous()
+            )
 
-            setattr(self, buf_name, MXFP8Tensor(data=stacked_data, scale=stacked_scale))
+            setattr(
+                self,
+                buf_name,
+                MXFP8Tensor(data=stacked_data, scale=stacked_scale, backend="triton"),
+            )
 
             # Redirect per-expert weight .data to views into the stacked buffer,
             # mirroring _build_concatenated_weights. This frees the original
@@ -1100,9 +1106,11 @@ class InferenceGroupedMLP(TEGroupedMLP):
                 if isinstance(w, MXFP8Tensor):
                     w.data = stacked_data[i]
                     w.scale = stacked_scale[i]
+                    w.backend = "triton"
                 elif hasattr(w, 'data') and isinstance(w.data, MXFP8Tensor):
                     w.data.data = stacked_data[i]
                     w.data.scale = stacked_scale[i]
+                    w.data.backend = "triton"
 
     @torch.inference_mode(False)  # needed for non-colocated inference.
     def _build_concatenated_weights(self):

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -23,10 +23,7 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_geglu import quick_gelu, weighted_bias_quick_geglu_impl
 from megatron.core.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
 from megatron.core.fusions.fused_weighted_squared_relu import weighted_squared_relu_impl
-from megatron.core.inference.quantization.mxfp8_tensor import (
-    MXFP8Tensor,
-    validate_mxfp8_tensor,
-)
+from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor, validate_mxfp8_tensor
 from megatron.core.inference.quantization.utils import resolve_mxfp8_backend
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
@@ -1093,9 +1090,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
                         f"got {type(w).__name__}. Was quantize_model_to_mxfp8 called?"
                     )
                 validate_mxfp8_tensor(
-                    mxfp8,
-                    expected_backend=backend,
-                    tensor_name=f"{linear_name}.weight{i}",
+                    mxfp8, expected_backend=backend, tensor_name=f"{linear_name}.weight{i}"
                 )
                 q_list.append(mxfp8.data)
                 s_list.append(mxfp8.scale)
@@ -1104,9 +1099,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             stacked_scale = torch.stack(s_list, dim=0).contiguous()
 
             setattr(
-                self,
-                buf_name,
-                MXFP8Tensor(data=stacked_data, scale=stacked_scale, backend=backend),
+                self, buf_name, MXFP8Tensor(data=stacked_data, scale=stacked_scale, backend=backend)
             )
 
             # Redirect per-expert weight .data to views into the stacked buffer,

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -10,6 +10,7 @@ import torch
 
 from megatron.core import tensor_parallel, utils
 from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.inference.moe import InferenceGroupedGemmBackend
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.process_groups_config import ProcessGroupCollection, resolve_gtp_remat_group
 from megatron.core.transformer.module import MegatronModule
@@ -353,12 +354,11 @@ class MoELayer(BaseMoELayer):
 
         # Inference-optimized mode setup
         if config.transformer_impl == "inference_optimized":
-            if config.inference_grouped_gemm_backend == 'auto':
+            if config.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.FLASHINFER:
                 assert HAVE_FLASHINFER, (
-                    "inference_grouped_gemm_backend='auto'"
-                    "requires flashinfer-python. "
+                    "inference_grouped_gemm_backend='flashinfer' requires flashinfer-python. "
                     "Install flashinfer-python or set "
-                    "inference_grouped_gemm_backend to 'torch' or 'te'."
+                    "inference_grouped_gemm_backend to 'torch' or 'vllm'."
                 )
 
                 # Verify that pre-compiled FlashInfer CUTLASS kernels are available
@@ -368,14 +368,14 @@ class MoELayer(BaseMoELayer):
                 from megatron.core.inference.utils import check_flashinfer_jit_cache_installed
 
                 check_flashinfer_jit_cache_installed()
-            elif config.inference_grouped_gemm_backend == 'torch':
+            elif config.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.TORCH:
                 assert hasattr(torch.nn.functional, 'grouped_mm') or hasattr(
                     torch, '_grouped_mm'
                 ), (
                     "inference_grouped_gemm_backend='torch' requires "
                     "torch.nn.functional.grouped_mm (> torch 2.10) or torch._grouped_mm (<= 2.10)."
                 )
-            elif config.inference_grouped_gemm_backend == 'vllm':
+            elif config.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.VLLM:
                 assert HAVE_TRITON, (
                     "inference_grouped_gemm_backend='vllm' requires Triton. "
                     "Install triton (pip install triton)."

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -12,7 +12,10 @@ from megatron.core.inference.engines import DynamicInferenceEngine
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
 )
-from megatron.core.inference.quantization.utils import quantize_model_to_mxfp8
+from megatron.core.inference.quantization.utils import (
+    quantize_model_to_mxfp8,
+    resolve_mxfp8_backend,
+)
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
 )
@@ -109,14 +112,7 @@ def get_model_for_inference() -> MegatronModule:
     model.eval()
 
     if args.transformer_impl == "inference_optimized" and args.fp8_recipe == "mxfp8":
-        backend = args.inference_grouped_gemm_backend
-        if backend == "auto" or backend == "torch":
-            quant_backend = "triton"
-        elif backend == "te":
-            raise ValueError(
-                "MXFP8 quantization is not supported with "
-                "inference_grouped_gemm_backend='te'."
-            )
+        quant_backend = resolve_mxfp8_backend(args.inference_grouped_gemm_backend)
         quantize_model_to_mxfp8(unwrap_model(model), backend=quant_backend)
     return model
 

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -7,12 +7,31 @@ from types import SimpleNamespace
 import pytest
 
 from megatron.core.inference.config import AsyncScheduleMode, InferenceConfig
+from megatron.core.inference.moe import InferenceGroupedGemmBackend
+from megatron.core.inference.quantization.utils import resolve_mxfp8_backend
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.training.arguments import _add_inference_args
 from megatron.training.config.inference_config import InferenceSetupConfig
 
 
 class TestInferenceConfig:
+    @pytest.mark.parametrize(
+        ("grouped_gemm_backend", "expected_backend"),
+        [
+            ("torch", "triton"),
+            (InferenceGroupedGemmBackend.TORCH, "triton"),
+            ("flashinfer", "flashinfer"),
+            (InferenceGroupedGemmBackend.FLASHINFER, "flashinfer"),
+        ],
+    )
+    def test_resolve_mxfp8_backend(self, grouped_gemm_backend, expected_backend):
+        assert resolve_mxfp8_backend(grouped_gemm_backend) == expected_backend
+
+    @pytest.mark.parametrize("grouped_gemm_backend", ["vllm", InferenceGroupedGemmBackend.VLLM])
+    def test_resolve_mxfp8_backend_rejects_unsupported_backend(self, grouped_gemm_backend):
+        with pytest.raises(ValueError, match="does not support inference_grouped_gemm_backend"):
+            resolve_mxfp8_backend(grouped_gemm_backend)
+
     def test_mutual_exclusivity_with_transformer_config(self):
         """
         Ensure mutual exclusivity between fields in `InferenceConfig` and

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -702,6 +702,10 @@ class TestPermuteAndQuantizeMxfp8:
         assert result.data.shape[0] == 8704
         assert result.scale_2d().shape[0] == result.data.shape[0]
 
+    @pytest.mark.skipif(
+        torch.cuda.get_device_capability()[0] < 10,
+        reason="MXFP8 scaled_grouped_mm requires Blackwell (SM 100+)",
+    )
     def test_unfused_moe_accepts_non_aligned_fixed_token_capacity(self):
         """The separate-quantization route feeds matching rows to scaled_grouped_mm."""
         from megatron.core.inference.moe.fused_moe import ActivationType, mcore_fused_moe

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -261,9 +261,7 @@ class TestMxfp8Quantize:
 class TestMXFP8Tensor:
 
     def test_restore_uint8_scale_dtype_after_resharding(self):
-        from megatron.core.inference.quantization.mxfp8_tensor import (
-            ensure_mxfp8_scale_dtype,
-        )
+        from megatron.core.inference.quantization.mxfp8_tensor import ensure_mxfp8_scale_dtype
 
         scale_bytes = torch.arange(16, dtype=torch.uint8)
         scale = ensure_mxfp8_scale_dtype(scale_bytes)
@@ -272,9 +270,7 @@ class TestMXFP8Tensor:
         torch.testing.assert_close(scale.view(torch.uint8), scale_bytes)
 
     def test_reject_invalid_scale_dtype(self):
-        from megatron.core.inference.quantization.mxfp8_tensor import (
-            ensure_mxfp8_scale_dtype,
-        )
+        from megatron.core.inference.quantization.mxfp8_tensor import ensure_mxfp8_scale_dtype
 
         with pytest.raises(TypeError, match="MXFP8 scales must use"):
             ensure_mxfp8_scale_dtype(torch.ones(16, dtype=torch.bfloat16))
@@ -699,14 +695,7 @@ class TestPermuteAndQuantizeMxfp8:
 
         hidden, probs, routing_map = self._make_inputs(72, 2688, 6, 128)
         permuted, _, _, _ = permute_tokens(
-            hidden,
-            probs,
-            routing_map,
-            0,
-            64,
-            _vt(72),
-            alignment=128,
-            row_alignment=128,
+            hidden, probs, routing_map, 0, 64, _vt(72), alignment=128, row_alignment=128
         )
         result = MXFP8Tensor.from_bf16(permuted, backend="triton")
 
@@ -719,19 +708,12 @@ class TestPermuteAndQuantizeMxfp8:
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 
         num_tokens, hidden_size, topk, num_experts = 72, 128, 2, 4
-        hidden, probs, routing_map = self._make_inputs(
-            num_tokens, hidden_size, topk, num_experts
-        )
+        hidden, probs, routing_map = self._make_inputs(num_tokens, hidden_size, topk, num_experts)
 
         def stack_weights() -> MXFP8Tensor:
             per_expert = [
                 MXFP8Tensor.from_bf16(
-                    torch.randn(
-                        hidden_size,
-                        hidden_size,
-                        device="cuda",
-                        dtype=torch.bfloat16,
-                    ),
+                    torch.randn(hidden_size, hidden_size, device="cuda", dtype=torch.bfloat16),
                     backend="triton",
                 )
                 for _ in range(num_experts)

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -260,9 +260,28 @@ class TestMxfp8Quantize:
 
 class TestMXFP8Tensor:
 
+    def test_restore_uint8_scale_dtype_after_resharding(self):
+        from megatron.core.inference.quantization.mxfp8_tensor import (
+            ensure_mxfp8_scale_dtype,
+        )
+
+        scale_bytes = torch.arange(16, dtype=torch.uint8)
+        scale = ensure_mxfp8_scale_dtype(scale_bytes)
+
+        assert scale.dtype == torch.float8_e8m0fnu
+        torch.testing.assert_close(scale.view(torch.uint8), scale_bytes)
+
+    def test_reject_invalid_scale_dtype(self):
+        from megatron.core.inference.quantization.mxfp8_tensor import (
+            ensure_mxfp8_scale_dtype,
+        )
+
+        with pytest.raises(TypeError, match="MXFP8 scales must use"):
+            ensure_mxfp8_scale_dtype(torch.ones(16, dtype=torch.bfloat16))
+
     @pytest.mark.parametrize("M,K", [(16, 128), (64, 256), (128, 2688)])
     def test_from_bf16_triton(self, M, K):
-        """from_bf16 with triton backend produces correct data and scales."""
+        """The Triton backend produces correct data and scales."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 
         torch.manual_seed(42)
@@ -440,7 +459,7 @@ class TestSquaredReluAndQuantizeMxfp8:
         perm_map = _make_permutation_map(M, num_padding=0)
 
         # PyTorch reference: squared ReLU in fp32, then downcast to bf16, then quantize
-        activated_ref = torch.relu(x.float()).pow(2)
+        activated_ref = torch.relu(x.float()).pow(2).to(torch.bfloat16)
         _, ref_data = ref_to_mxfp(activated_ref)
 
         # Fused kernel
@@ -460,7 +479,7 @@ class TestSquaredReluAndQuantizeMxfp8:
         perm_map = _make_permutation_map(M, num_padding=0)
 
         # PyTorch reference
-        activated_ref = torch.relu(x.float()).pow(2)
+        activated_ref = torch.relu(x.float()).pow(2).to(torch.bfloat16)
         ref_scales_2d, _ = ref_to_mxfp(activated_ref)
         ref_swizzled = ref_swizzle(ref_scales_2d)
 
@@ -485,7 +504,7 @@ class TestSquaredReluAndQuantizeMxfp8:
 
         # PyTorch reference (only real rows)
         real_rows = M - num_padding
-        activated_ref = torch.relu(x[:real_rows].float()).pow(2)
+        activated_ref = torch.relu(x[:real_rows].float()).pow(2).to(torch.bfloat16)
         _, ref_data = ref_to_mxfp(activated_ref)
 
         # Fused kernel
@@ -633,6 +652,17 @@ class TestPermuteAndQuantizeMxfp8:
         assert isinstance(result, MXFP8Tensor)
         assert result.backend == "triton"
         assert result.data.dtype == torch.float8_e4m3fn
+
+    def test_fixed_buffer_rows_match_swizzled_scale_padding(self):
+        from megatron.core.inference.moe.permute import permute_and_quantize_mxfp8
+
+        hidden, probs, routing_map = self._make_inputs(72, 2688, 6, 128)
+        result, _, _, _ = permute_and_quantize_mxfp8(
+            hidden, probs, routing_map, 0, 64, _vt(72), alignment=128
+        )
+
+        assert result.data.shape[0] == 8704
+        assert result.scale_2d().shape[0] == result.data.shape[0]
 
     @pytest.mark.parametrize("alignment", [128])
     def test_offsets_aligned(self, alignment):

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -279,6 +279,33 @@ class TestMXFP8Tensor:
         with pytest.raises(TypeError, match="MXFP8 scales must use"):
             ensure_mxfp8_scale_dtype(torch.ones(16, dtype=torch.bfloat16))
 
+    def test_validate_unswizzled_2d_scale_geometry(self):
+        from megatron.core.inference.quantization.mxfp8_tensor import (
+            MXFP8Tensor,
+            validate_mxfp8_tensor,
+        )
+
+        data = torch.empty((64, 128), dtype=torch.float8_e4m3fn, device="cuda")
+        scale = torch.empty((64, 4), dtype=torch.uint8, device="cuda")
+
+        validate_mxfp8_tensor(MXFP8Tensor(data, scale, backend="flashinfer"))
+
+        invalid = MXFP8Tensor(data, scale[:63], backend="flashinfer")
+        with pytest.raises(ValueError, match="2D scale has shape"):
+            validate_mxfp8_tensor(invalid)
+
+    def test_missing_backend_error_is_actionable(self):
+        from megatron.core.inference.quantization.mxfp8_tensor import (
+            MXFP8Tensor,
+            validate_mxfp8_tensor,
+        )
+
+        data = torch.empty((128, 128), dtype=torch.float8_e4m3fn, device="cuda")
+        scale = torch.empty(512, dtype=torch.uint8, device="cuda")
+
+        with pytest.raises(ValueError, match="backend= explicitly"):
+            validate_mxfp8_tensor(MXFP8Tensor(data, scale))
+
     @pytest.mark.parametrize("M,K", [(16, 128), (64, 256), (128, 2688)])
     def test_from_bf16_triton(self, M, K):
         """The Triton backend produces correct data and scales."""
@@ -430,9 +457,8 @@ class TestSquaredReluAndQuantizeMxfp8:
     """Compare fused squared_relu + mxfp8 quantize against PyTorch reference.
 
     Reference: torch.relu(x.float()).pow(2).to(bf16) -> ref_to_mxfp -> ref_swizzle.
-    The fused kernel computes squared ReLU in fp32 and quantizes to MXFP8 in one pass,
-    so the PyTorch fp32 reference is the correct baseline (not the unfused Triton path
-    which has an intermediate bf16 roundtrip).
+    The fused kernel matches the BF16 materialization used by training and the
+    unfused inference path before quantizing to MXFP8.
     """
 
     @pytest.mark.parametrize(
@@ -653,15 +679,17 @@ class TestPermuteAndQuantizeMxfp8:
         assert result.backend == "triton"
         assert result.data.dtype == torch.float8_e4m3fn
 
-    def test_fixed_buffer_rows_match_swizzled_scale_padding(self):
+    @pytest.mark.parametrize("alignment", [64, 128])
+    def test_fixed_buffer_rows_match_swizzled_scale_padding(self, alignment):
         from megatron.core.inference.moe.permute import permute_and_quantize_mxfp8
 
         hidden, probs, routing_map = self._make_inputs(72, 2688, 6, 128)
         result, _, _, _ = permute_and_quantize_mxfp8(
-            hidden, probs, routing_map, 0, 64, _vt(72), alignment=128
+            hidden, probs, routing_map, 0, 64, _vt(72), alignment=alignment
         )
 
-        assert result.data.shape[0] == 8704
+        unaligned_rows = 72 * 6 + alignment * 64
+        assert result.data.shape[0] == ceil_div(unaligned_rows, 128) * 128
         assert result.scale_2d().shape[0] == result.data.shape[0]
 
     @pytest.mark.parametrize("alignment", [128])

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -692,6 +692,72 @@ class TestPermuteAndQuantizeMxfp8:
         assert result.data.shape[0] == ceil_div(unaligned_rows, 128) * 128
         assert result.scale_2d().shape[0] == result.data.shape[0]
 
+    def test_unfused_fixed_buffer_rows_match_swizzled_scale_padding(self):
+        """The disable-fused-quant route preserves the same MXFP8 row invariant."""
+        from megatron.core.inference.moe.permute import permute_tokens
+        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+
+        hidden, probs, routing_map = self._make_inputs(72, 2688, 6, 128)
+        permuted, _, _, _ = permute_tokens(
+            hidden,
+            probs,
+            routing_map,
+            0,
+            64,
+            _vt(72),
+            alignment=128,
+            row_alignment=128,
+        )
+        result = MXFP8Tensor.from_bf16(permuted, backend="triton")
+
+        assert result.data.shape[0] == 8704
+        assert result.scale_2d().shape[0] == result.data.shape[0]
+
+    def test_unfused_moe_accepts_non_aligned_fixed_token_capacity(self):
+        """The separate-quantization route feeds matching rows to scaled_grouped_mm."""
+        from megatron.core.inference.moe.fused_moe import ActivationType, mcore_fused_moe
+        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+
+        num_tokens, hidden_size, topk, num_experts = 72, 128, 2, 4
+        hidden, probs, routing_map = self._make_inputs(
+            num_tokens, hidden_size, topk, num_experts
+        )
+
+        def stack_weights() -> MXFP8Tensor:
+            per_expert = [
+                MXFP8Tensor.from_bf16(
+                    torch.randn(
+                        hidden_size,
+                        hidden_size,
+                        device="cuda",
+                        dtype=torch.bfloat16,
+                    ),
+                    backend="triton",
+                )
+                for _ in range(num_experts)
+            ]
+            return MXFP8Tensor(
+                data=torch.stack([weight.data for weight in per_expert]),
+                scale=torch.stack([weight.scale for weight in per_expert]),
+                backend="triton",
+            )
+
+        output = mcore_fused_moe(
+            hidden,
+            probs,
+            stack_weights(),
+            stack_weights(),
+            ActivationType.SQUARED_RELU,
+            num_experts,
+            0,
+            _vt(num_tokens),
+            routing_map,
+            disable_fused_quant_kernels=True,
+        )
+
+        assert output.shape == hidden.shape
+        assert torch.isfinite(output).all()
+
     @pytest.mark.parametrize("alignment", [128])
     def test_offsets_aligned(self, alignment):
         """Inclusive offsets are multiples of alignment."""

--- a/tests/unit_tests/resharding/test_mxfp8_refit.py
+++ b/tests/unit_tests/resharding/test_mxfp8_refit.py
@@ -122,6 +122,41 @@ class TestMXFP8ReshardTransform:
             overlap = torch.randn(M // 2 + 1, K, dtype=torch.bfloat16, device="cuda")
             t.finalize_recv("decoder.weight", (slice(M // 2 - 1, M), slice(None)), [overlap])
 
+    def test_repeated_finalize_updates_persistent_buffer_outside_inference_mode(self, monkeypatch):
+        from megatron.core.inference.quantization import utils as quantization_utils
+        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+        from megatron.core.resharding.transforms import MXFP8ReshardTransform
+
+        M, K = 64, 128
+        monkeypatch.setattr(quantization_utils, "_should_quantize_param", lambda _param: True)
+        with torch.inference_mode():
+            model = torch.nn.Linear(K, M, bias=False).to(dtype=torch.bfloat16, device="cuda")
+            buffers = quantization_utils.quantize_params_to_mxfp8(model, backend="triton")
+        buf = buffers["weight"]
+        assert not torch.is_inference(buf.data)
+        assert not torch.is_inference(buf.scale)
+
+        transform = MXFP8ReshardTransform(
+            convertible_params={"decoder.weight"},
+            persistent_buffers=buffers,
+            buffer_key_prefix="decoder.",
+        )
+        data_ptr = buf.data.data_ptr()
+        scale_ptr = buf.scale.data_ptr()
+
+        for _ in range(2):
+            assert torch.is_grad_enabled()
+            assert not torch.is_inference_mode_enabled()
+            new_data = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+            transform.finalize_recv("decoder.weight", (slice(None), slice(None)), [new_data])
+            expected = MXFP8Tensor.from_bf16(new_data)
+            assert torch.equal(buf.data, expected.data)
+            assert torch.equal(buf.scale.view(torch.uint8), expected.scale.view(torch.uint8))
+            assert buf.data.data_ptr() == data_ptr
+            assert buf.scale.data_ptr() == scale_ptr
+            assert buf.backend == "triton"
+            assert buf.scale.dtype == torch.float8_e8m0fnu
+
 
 # ===========================================================================
 # quantize_params_to_mxfp8

--- a/tests/unit_tests/resharding/test_mxfp8_refit.py
+++ b/tests/unit_tests/resharding/test_mxfp8_refit.py
@@ -30,15 +30,6 @@ class TestMXFP8ReshardTransform:
     logic that avoids corrupting swizzled scales from partial updates.
     """
 
-    def _make_persistent_buffers(self, shapes):
-        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
-
-        buffers = {}
-        for name, (M, K) in shapes.items():
-            x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-            buffers[name] = MXFP8Tensor.from_bf16(x)
-        return buffers
-
     @pytest.mark.skipif(not _HAVE_FLASHINFER, reason="test requires FlashInfer")
     def test_finalize_recv_bf16_2d_scale(self):
         """Receiver-side conversion with 2D scale: immediate per-slice quantization."""
@@ -160,6 +151,56 @@ class TestMXFP8ReshardTransform:
             assert buf.backend == "triton"
             assert buf.scale.dtype == torch.float8_e8m0fnu
 
+    def test_sender_side_conversion_supports_explicit_triton_backend(self):
+        """A sender without persistent buffers can select the Triton wire format."""
+        from megatron.core.resharding.transforms import MXFP8ReshardTransform
+
+        transform = MXFP8ReshardTransform(
+            convertible_params={"decoder.weight"},
+            persistent_buffers={},
+            convert_on_send=True,
+            backend="triton",
+        )
+        source = torch.nn.Parameter(
+            torch.randn(64, 128, dtype=torch.bfloat16, device="cuda"), requires_grad=False
+        )
+        data, scale = transform.prepare_send(
+            "decoder.weight", (slice(None), slice(None)), source
+        )
+
+        assert data.dtype == torch.float8_e4m3fn
+        assert scale.dtype == torch.float8_e8m0fnu
+
+    def test_sender_side_conversion_requires_explicit_backend(self):
+        """A sender without persistent buffers cannot infer its wire format."""
+        from megatron.core.resharding.transforms import MXFP8ReshardTransform
+
+        with pytest.raises(AssertionError, match="backend is required for sender-side conversion"):
+            MXFP8ReshardTransform(
+                convertible_params={"decoder.weight"},
+                persistent_buffers={},
+                convert_on_send=True,
+            )
+
+    def test_mixed_persistent_buffer_backends_are_rejected(self):
+        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+        from megatron.core.resharding.transforms import MXFP8ReshardTransform
+
+        triton_buffer = MXFP8Tensor.from_bf16(
+            torch.randn(64, 128, dtype=torch.bfloat16, device="cuda"), backend="triton"
+        )
+        flashinfer_buffer = MXFP8Tensor(
+            data=triton_buffer.data.clone(),
+            scale=triton_buffer.scale.view(torch.uint8).clone(),
+            backend="flashinfer",
+        )
+
+        with pytest.raises(ValueError, match="backend is 'flashinfer'; expected 'triton'"):
+            MXFP8ReshardTransform(
+                convertible_params={"first", "second"},
+                persistent_buffers={"first": triton_buffer, "second": flashinfer_buffer},
+            )
+
     def test_concatenated_moe_buffers_remain_refittable(self):
         """Lazy MoE stacking must not replace persistent storage with inference tensors."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
@@ -172,6 +213,7 @@ class TestMXFP8ReshardTransform:
         num_experts, M, K = 2, 64, 128
         grouped_mlp = Namespace()
         grouped_mlp.num_local_experts = num_experts
+        grouped_mlp.inference_grouped_gemm_backend = "torch"
         buffers = {}
         for linear_name in ("linear_fc1", "linear_fc2"):
             linear = Namespace()

--- a/tests/unit_tests/resharding/test_mxfp8_refit.py
+++ b/tests/unit_tests/resharding/test_mxfp8_refit.py
@@ -164,9 +164,7 @@ class TestMXFP8ReshardTransform:
         source = torch.nn.Parameter(
             torch.randn(64, 128, dtype=torch.bfloat16, device="cuda"), requires_grad=False
         )
-        data, scale = transform.prepare_send(
-            "decoder.weight", (slice(None), slice(None)), source
-        )
+        data, scale = transform.prepare_send("decoder.weight", (slice(None), slice(None)), source)
 
         assert data.dtype == torch.float8_e4m3fn
         assert scale.dtype == torch.float8_e8m0fnu
@@ -177,9 +175,7 @@ class TestMXFP8ReshardTransform:
 
         with pytest.raises(AssertionError, match="backend is required for sender-side conversion"):
             MXFP8ReshardTransform(
-                convertible_params={"decoder.weight"},
-                persistent_buffers={},
-                convert_on_send=True,
+                convertible_params={"decoder.weight"}, persistent_buffers={}, convert_on_send=True
             )
 
     def test_mixed_persistent_buffer_backends_are_rejected(self):
@@ -220,8 +216,7 @@ class TestMXFP8ReshardTransform:
             setattr(grouped_mlp, linear_name, linear)
             for expert_idx in range(num_experts):
                 tensor = MXFP8Tensor.from_bf16(
-                    torch.randn(M, K, dtype=torch.bfloat16, device="cuda"),
-                    backend="triton",
+                    torch.randn(M, K, dtype=torch.bfloat16, device="cuda"), backend="triton"
                 )
                 setattr(linear, f"weight{expert_idx}", tensor)
                 buffers[f"{linear_name}.weight{expert_idx}"] = tensor

--- a/tests/unit_tests/resharding/test_mxfp8_refit.py
+++ b/tests/unit_tests/resharding/test_mxfp8_refit.py
@@ -12,10 +12,9 @@ try:
 except ImportError:
     _HAVE_FLASHINFER = False
 
-pytestmark = [
-    pytest.mark.skipif(not _IS_BLACKWELL, reason="MXFP8 tests require Blackwell GPU (SM >= 10)"),
-    pytest.mark.skipif(not _HAVE_FLASHINFER, reason="MXFP8 tests require FlashInfer"),
-]
+pytestmark = pytest.mark.skipif(
+    not _IS_BLACKWELL, reason="MXFP8 tests require Blackwell GPU (SM >= 10)"
+)
 
 
 # ===========================================================================
@@ -40,6 +39,7 @@ class TestMXFP8ReshardTransform:
             buffers[name] = MXFP8Tensor.from_bf16(x)
         return buffers
 
+    @pytest.mark.skipif(not _HAVE_FLASHINFER, reason="test requires FlashInfer")
     def test_finalize_recv_bf16_2d_scale(self):
         """Receiver-side conversion with 2D scale: immediate per-slice quantization."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
@@ -65,6 +65,7 @@ class TestMXFP8ReshardTransform:
         assert torch.equal(buf.data, expected.data)
         assert torch.equal(buf.scale, expected.scale)
 
+    @pytest.mark.skipif(not _HAVE_FLASHINFER, reason="test requires FlashInfer")
     def test_finalize_recv_bf16_1d_scale_accumulation(self):
         """Receiver-side conversion with 1D scale: accumulate slices then quantize."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
@@ -98,6 +99,7 @@ class TestMXFP8ReshardTransform:
         assert torch.equal(buf.data, expected.data)
         assert torch.equal(buf.scale, expected.scale)
 
+    @pytest.mark.skipif(not _HAVE_FLASHINFER, reason="test requires FlashInfer")
     def test_finalize_recv_1d_scale_wrong_element_count(self):
         """1D accumulation should raise if total elements don't match (duplicate slices)."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
@@ -122,15 +124,16 @@ class TestMXFP8ReshardTransform:
             overlap = torch.randn(M // 2 + 1, K, dtype=torch.bfloat16, device="cuda")
             t.finalize_recv("decoder.weight", (slice(M // 2 - 1, M), slice(None)), [overlap])
 
-    def test_repeated_finalize_updates_persistent_buffer_outside_inference_mode(self, monkeypatch):
+    def test_repeated_finalize_updates_persistent_buffer_outside_inference_mode(self):
+        """Persistent buffers created in inference mode remain mutable across refits."""
         from megatron.core.inference.quantization import utils as quantization_utils
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
         from megatron.core.resharding.transforms import MXFP8ReshardTransform
 
         M, K = 64, 128
-        monkeypatch.setattr(quantization_utils, "_should_quantize_param", lambda _param: True)
         with torch.inference_mode():
             model = torch.nn.Linear(K, M, bias=False).to(dtype=torch.bfloat16, device="cuda")
+            _pre_quantize_linear(model)
             buffers = quantization_utils.quantize_params_to_mxfp8(model, backend="triton")
         buf = buffers["weight"]
         assert not torch.is_inference(buf.data)
@@ -149,13 +152,61 @@ class TestMXFP8ReshardTransform:
             assert not torch.is_inference_mode_enabled()
             new_data = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
             transform.finalize_recv("decoder.weight", (slice(None), slice(None)), [new_data])
-            expected = MXFP8Tensor.from_bf16(new_data)
+            expected = MXFP8Tensor.from_bf16(new_data, backend="triton")
             assert torch.equal(buf.data, expected.data)
             assert torch.equal(buf.scale.view(torch.uint8), expected.scale.view(torch.uint8))
             assert buf.data.data_ptr() == data_ptr
             assert buf.scale.data_ptr() == scale_ptr
             assert buf.backend == "triton"
             assert buf.scale.dtype == torch.float8_e8m0fnu
+
+    def test_concatenated_moe_buffers_remain_refittable(self):
+        """Lazy MoE stacking must not replace persistent storage with inference tensors."""
+        from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
+        from megatron.core.resharding.transforms import MXFP8ReshardTransform
+        from megatron.core.transformer.moe.experts import InferenceGroupedMLP
+
+        class Namespace:
+            pass
+
+        num_experts, M, K = 2, 64, 128
+        grouped_mlp = Namespace()
+        grouped_mlp.num_local_experts = num_experts
+        buffers = {}
+        for linear_name in ("linear_fc1", "linear_fc2"):
+            linear = Namespace()
+            setattr(grouped_mlp, linear_name, linear)
+            for expert_idx in range(num_experts):
+                tensor = MXFP8Tensor.from_bf16(
+                    torch.randn(M, K, dtype=torch.bfloat16, device="cuda"),
+                    backend="triton",
+                )
+                setattr(linear, f"weight{expert_idx}", tensor)
+                buffers[f"{linear_name}.weight{expert_idx}"] = tensor
+
+        with torch.inference_mode():
+            InferenceGroupedMLP._build_concatenated_mxfp8_weights(grouped_mlp)
+
+        assert not torch.is_inference(grouped_mlp._fc1_weight.data)
+        assert not torch.is_inference(grouped_mlp._fc1_weight.scale)
+        assert not torch.is_inference(grouped_mlp._fc2_weight.data)
+        assert not torch.is_inference(grouped_mlp._fc2_weight.scale)
+
+        transform = MXFP8ReshardTransform(
+            convertible_params=set(buffers), persistent_buffers=buffers
+        )
+        for name, buf in buffers.items():
+            data_ptr = buf.data.data_ptr()
+            scale_ptr = buf.scale.data_ptr()
+            new_data = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+            transform.finalize_recv(name, (slice(None), slice(None)), [new_data])
+            expected = MXFP8Tensor.from_bf16(new_data, backend="triton")
+
+            assert torch.equal(buf.data, expected.data)
+            assert torch.equal(buf.scale.view(torch.uint8), expected.scale.view(torch.uint8))
+            assert buf.data.data_ptr() == data_ptr
+            assert buf.scale.data_ptr() == scale_ptr
+            assert buf.backend == "triton"
 
 
 # ===========================================================================
@@ -180,6 +231,7 @@ def _pre_quantize_linear(model: torch.nn.Module) -> None:
             submodule.weight = torch.nn.Parameter(te_mxfp8, requires_grad=False)
 
 
+@pytest.mark.skipif(not _HAVE_FLASHINFER, reason="tests require FlashInfer")
 class TestQuantizeParamsToMXFP8:
     """Tests for persistent buffer quantization (quantization/utils.py).
 
@@ -217,6 +269,19 @@ class TestQuantizeParamsToMXFP8:
         assert buffers["weight"].data.data_ptr() == data_ptr
         assert buffers["weight"].scale.data_ptr() == scale_ptr
 
+    def test_persistent_buffer_reuse_rejects_backend_change(self):
+        """A refresh cannot reinterpret persistent scale bytes under a new backend."""
+        from megatron.core.inference.quantization.utils import quantize_params_to_mxfp8
+
+        model = torch.nn.Linear(128, 64, bias=False).to(dtype=torch.bfloat16, device="cuda")
+        _pre_quantize_linear(model)
+        buffers = quantize_params_to_mxfp8(model, backend="flashinfer")
+
+        model2 = torch.nn.Linear(128, 64, bias=False).to(dtype=torch.bfloat16, device="cuda")
+        _pre_quantize_linear(model2)
+        with pytest.raises(ValueError, match="expected 'triton'"):
+            quantize_params_to_mxfp8(model2, persistent_buffers=buffers, backend="triton")
+
     def test_nested_module_fqn(self):
         """Recursive quantization should produce correct fully-qualified names."""
         from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
@@ -237,6 +302,7 @@ class TestQuantizeParamsToMXFP8:
 # ===========================================================================
 
 
+@pytest.mark.skipif(not _HAVE_FLASHINFER, reason="tests require FlashInfer")
 class TestMXFP8RefitIntegration:
     """Integration tests simulating the full send→recv→finalize refit flow."""
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.
  - Align fixed MoE activation buffers with the 128-row swizzled-scale layout, fixing
  `scaled_grouped_mm` failures caused by mismatched data and scale rows.
  - Preserve and validate backend-specific MXFP8 scale formats across model loading,
  refit, and expert-weight stacking.
  - Restore raw scale bytes to the E8M0 view required by PyTorch scaled GEMMs.
  - Keep persistent MXFP8 buffers mutable and update them in place so CUDA-graph-
  captured addresses remain stable across refits.
  - Resolve the quantization format from the configured GEMM backend: `torch` uses
  the Triton producer, FlashInfer uses its native format, and unsupported vLLM MXFP8
  is rejected.
  - Round fused squared-ReLU activations to BF16 before quantization, matching
  training and unfused inference MXFP8 bins.
  - Replace duplicated MXFP8 layout values with shared constants.
# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
