### PR TITLE
cp: `Update release notes page (6520)` into `core_r0.19.0`

### DIFF
--- a/docs/get-started/releasenotes.md
+++ b/docs/get-started/releasenotes.md
@@ -9,11 +9,17 @@
 
 # Release Notes
 
+We publish release notes for every [major release](https://github.com/NVIDIA/Megatron-LM/releases).
 
 ## Roadmaps
 
 Stay up-to-date with the development roadmaps and planned features:
 
-- **[MoE Q3-Q4 2025 Roadmap](https://github.com/NVIDIA/Megatron-LM/issues/1729)** - Comprehensive MoE feature development including DeepSeek-V3, Qwen3, advanced parallelism, FP8 optimizations, and Blackwell enhancements.
-- **[GPT-OSS Implementation Tracker](https://github.com/NVIDIA/Megatron-LM/issues/1739)** - Advanced features including YaRN RoPE scaling, attention sinks, and custom activation functions.
+- **Q3 2026**
+  - [General Roadmap](https://github.com/NVIDIA/Megatron-LM/issues/5676)
+- **Q2 2026**
+  - [General Roadmap](https://github.com/NVIDIA/Megatron-LM/issues/4815)
+  - [MoE-focused Roadmap](https://github.com/NVIDIA/Megatron-LM/issues/4815)
+- **Q3-Q4 2025**
+  - [MoE-focused Roadmap](https://github.com/NVIDIA/Megatron-LM/issues/1729)
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Backports #6520 to `core_r0.19.0`.

This updates `docs/get-started/releasenotes.md` with a link to major release notes and the current roadmap links, keeping the 0.19.0 documentation aligned with `main`.

## Validation

- Confirmed the resulting file blob exactly matches #6520.
- `uv run --group docs sphinx-build docs /tmp/megatron-docs-6520.k2OKU1` (passed)

Unit and functional tests are not applicable to this documentation-only change.