### PR TITLE
Add shard plan/owner-based compute planning API for MFSDP v2

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Pure shard-planning and owner-compute packing logic for the Muon + M-FSDPv2 owner-compute P2P
+algorithm.
+
+The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
+is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
+`assign_owner_work` balances Newton-Schulz work across owner ranks, and the pack/unpack helpers
+(`pack_owner_work`/`pack_update_shards`/`unpack_update_shards`) build the flat P2P send/recv
+buffers. `reconstruct_full_tensor` stitches gathered shards back into the full matrix on the owner.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+
+import torch
+
+from .layout import non_leading_numel
+
+
+@dataclasses.dataclass(frozen=True)
+class ShardPlan:
+    """How a single 2D parameter's full matrix is split across the DP group.
+
+    M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously in rank order, so rank `r` owns the
+    contiguous global row range `[start, start + count)` where `start`/`count` come from the flat
+    DBuffer layout. A rank with `count == 0` holds no shard of this parameter.
+    """
+
+    full_shape: torch.Size
+    rank_rows: tuple[tuple[int, int], ...]
+    row_size: int
+
+    def __post_init__(self) -> None:
+        if len(self.full_shape) != 2:
+            raise ValueError(f"ShardPlan requires a 2D full_shape, got {self.full_shape}.")
+        if len(self.rank_rows) == 0:
+            raise ValueError("ShardPlan requires at least one rank.")
+        if self.row_size != non_leading_numel(self.full_shape):
+            raise ValueError(
+                f"ShardPlan row_size {self.row_size} != full_shape row size "
+                f"{non_leading_numel(self.full_shape)}."
+            )
+
+    @property
+    def world_size(self) -> int:
+        """Number of ranks in the DP group for this parameter."""
+        return len(self.rank_rows)
+
+    def rank_row_count(self, rank: int) -> int:
+        """Return the number of rows owned by `rank`."""
+        return self.rank_rows[rank][1]
+
+    def shard_numel(self, rank: int) -> int:
+        """Return the number of elements in `rank`'s shard."""
+        return self.rank_row_count(rank) * self.row_size
+
+    def owner_candidates(self) -> tuple[int, ...]:
+        """Return the ranks that hold a non-empty shard of this parameter."""
+        return tuple(r for r, (_, count) in enumerate(self.rank_rows) if count > 0)
+
+    def is_boundary(self) -> bool:
+        """True if more than one rank owns a non-empty shard of this parameter."""
+        return sum(1 for _, count in self.rank_rows if count > 0) > 1
+
+    def full_numel(self) -> int:
+        """Return the total number of elements in the full (unsharded) parameter."""
+        return self.full_shape.numel()
+
+
+def compute_shard_plan(
+    full_shape: torch.Size, tensor_flat_offset: int, rank_flat_shard_size: int, world_size: int
+) -> ShardPlan:
+    """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
+
+    Args:
+        full_shape: Global `(rows, cols)` shape of the parameter.
+        tensor_flat_offset: Flat-element offset of this parameter inside the DBuffer's global
+            layout.
+        rank_flat_shard_size: Flat elements each DP rank owns (uniform for the even all-`Flat`
+            layout: `layout.size // world_size`).
+        world_size: DP group size.
+
+    Returns:
+        The `ShardPlan` describing which rows each rank owns.
+    """
+    if len(full_shape) != 2:
+        raise ValueError(f"compute_shard_plan requires a 2D shape, got {full_shape}.")
+    row_size = non_leading_numel(full_shape)
+    if row_size <= 0:
+        raise ValueError(f"compute_shard_plan requires non-empty rows, got shape {full_shape}.")
+    tensor_end = tensor_flat_offset + full_shape.numel()
+
+    rank_rows: list[tuple[int, int]] = []
+    for rank in range(world_size):
+        rank_start = rank * rank_flat_shard_size
+        rank_end = rank_start + rank_flat_shard_size
+        overlap_start = max(tensor_flat_offset, rank_start)
+        overlap_end = min(tensor_end, rank_end)
+        if overlap_start >= overlap_end:
+            rank_rows.append((0, 0))
+            continue
+        if (overlap_start - tensor_flat_offset) % row_size != 0:
+            raise RuntimeError(
+                f"Flat shard boundary is not row-aligned for shape {full_shape}: "
+                f"overlap_start={overlap_start}, tensor_flat_offset={tensor_flat_offset}."
+            )
+        overlap_numel = overlap_end - overlap_start
+        if overlap_numel % row_size != 0:
+            raise RuntimeError(
+                f"Flat shard overlap is not row-aligned for shape {full_shape}: "
+                f"overlap_numel={overlap_numel}, row_size={row_size}."
+            )
+        row_start = (overlap_start - tensor_flat_offset) // row_size
+        row_count = overlap_numel // row_size
+        rank_rows.append((row_start, row_count))
+    return ShardPlan(
+        full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size
+    )
+
+
+def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int, int]:
+    """Assign one owner rank to each boundary parameter, balanced by NS cost.
+
+    Only ranks that own a non-empty shard of a parameter are eligible owners. Assignment greedily
+    gives each parameter to its eligible rank with the smallest running cost total, where a
+    parameter's cost is the Newton-Schulz compute estimate `numel * (min(rows, cols) * num_steps +
+    1)`.
+
+    Args:
+        plans: Shard plans indexed by their position in the input sequence.
+        num_ns_steps: Newton-Schulz iteration count used in the cost estimate.
+
+    Returns:
+        Mapping from parameter index (in `plans`) to owner rank.
+    """
+    assignments: dict[int, int] = {}
+    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
+    for param_index, plan in enumerate(plans):
+        candidates = plan.owner_candidates()
+        if not candidates:
+            raise RuntimeError(
+                f"No eligible owner for parameter {param_index} with shape {plan.full_shape}; "
+                "no rank owns a shard."
+            )
+        if not plan.is_boundary():
+            # Fully local: the single owning rank is the owner with no communication.
+            assignments[param_index] = candidates[0]
+            continue
+        rows, cols = plan.full_shape
+        short_dim = min(rows, cols)
+        cost = float(plan.full_numel() * (short_dim * num_ns_steps + 1))
+        owner = min(candidates, key=lambda r: (running[r], r))
+        assignments[param_index] = owner
+        running[owner] += cost
+    return assignments
+
+
+@dataclasses.dataclass
+class OwnerGatherPlan:
+    """Metadata and send buffers for the owner-gather P2P step of one chunk.
+
+    The owner keeps its own shard locally (no self-send), so it only receives from the other
+    shard-holding ranks and reconstructs each owned matrix by concatenating shards in rank order
+    (own shard at the owner's rank rows).
+
+    Attributes:
+        send_buffers: Per-destination-owner flat send buffer (this rank's pre-NS shards for that
+            owner's params, in param order). Only owners other than this rank appear.
+        recv_sizes: Per-source-rank element count this rank (as an owner) receives. Only sources
+            other than this rank appear.
+        own_shards: This rank's local shard per owned parameter (used directly in reconstruction,
+            not communicated).
+        recv_offsets: Per `(param_index, src_rank)` of `(offset, numel, row_count)` describing where
+            this param's shard lands inside the recv buffer received from `src_rank`.
+    """
+
+    send_buffers: dict[int, torch.Tensor]
+    recv_sizes: dict[int, int]
+    own_shards: dict[int, torch.Tensor]
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+
+def pack_owner_work(
+    plans: Sequence[ShardPlan],
+    owners: dict[int, int],
+    local_shards: Sequence[torch.Tensor],
+    world_size: int,
+    this_rank: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> OwnerGatherPlan:
+    """Pack this rank's pre-NS shards into per-owner P2P send buffers.
+
+    Args:
+        plans: Shard plans in parameter order.
+        owners: Mapping from parameter index to owner rank.
+        local_shards: This rank's local pre-NS shard per parameter.
+        world_size: DP group size.
+        this_rank: This rank's DP index.
+        device: Device for the send buffers (the pre-NS device).
+        dtype: Dtype for the send buffers (the pre-NS dtype).
+
+    Returns:
+        The `OwnerGatherPlan` for this rank.
+    """
+    send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+    recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
+    for param_index, plan in enumerate(plans):
+        owner = owners[param_index]
+        if owner != this_rank:
+            send_sizes[owner] += plan.shard_numel(this_rank)
+        else:
+            for src in range(world_size):
+                if src == this_rank:
+                    continue
+                recv_sizes[src] += plan.shard_numel(src)
+
+    send_buffers: dict[int, torch.Tensor] = {}
+    for owner, size in send_sizes.items():
+        send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
+
+    # Fill each owner's send buffer in param order.
+    cursors: dict[int, int] = {o: 0 for o in send_buffers}
+    own_shards: dict[int, torch.Tensor] = {}
+    for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
+        owner = owners[param_index]
+        if owner == this_rank:
+            own_shards[param_index] = shard
+            continue
+        numel = plan.shard_numel(this_rank)
+        if numel == 0:
+            continue
+        buf = send_buffers[owner]
+        buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
+        cursors[owner] += numel
+
+    # Per (owned param, src) recv offset within the recv buffer from src.
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+    for src in range(world_size):
+        if src == this_rank:
+            continue
+        offset = 0
+        for param_index in owned_indices:
+            plan = plans[param_index]
+            numel = plan.shard_numel(src)
+            recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
+            offset += numel
+
+    return OwnerGatherPlan(
+        send_buffers=send_buffers,
+        recv_sizes=recv_sizes,
+        own_shards=own_shards,
+        recv_offsets=recv_offsets,
+    )
+
+
+def reconstruct_full_tensor(
+        param_index: int,
+        plan: ShardPlan,
+        gather_plan: OwnerGatherPlan,
+        recv_buffers: dict[int, torch.Tensor],
+        owner_rank: int,
+) -> torch.Tensor:
+    """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
+
+    Concatenates shards in rank order: the owner's own local shard at its rank rows and each
+    source's received shard at that source's rank rows. The shard content lives in `gather_plan`
+    (`own_shards` + `recv_offsets`), so this works for the pre-NS owner-gather path and for a weight
+    gather plan alike – pass a weight gather plan built with `pack_owner_work` to reconstruct the
+    full weight parameter instead.
+
+    Args:
+        param_index: Index of the parameter within the chunk.
+        plan: Shard plan for this parameter.
+        gather_plan: This rank's owner-gather plan (own_shards, recv_offsets).
+        recv_buffers: Per-source-rank received buffer (only sources that sent).
+        owner_rank: The owner rank (== the rank running reconstruction).
+
+    Returns:
+        The full `(rows, cols)` tensor.
+    """
+    world_size = plan.world_size
+    shards: list[torch.Tensor] = []
+    for src in range(world_size):
+        row_count = plan.rank_row_count(src)
+        if src == owner_rank:
+            shards.append(gather_plan.own_shards[param_index])
+        elif row_count == 0:
+            continue
+        else:
+            offset, numel, _ = gather_plan.recv_offsets[(param_index, src)]
+            buf = recv_buffers[src]
+            shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
+    if len(shards) == 1:
+        return shards[0].contiguous()
+    return torch.cat(shards, dim=0)
+
+
+@dataclasses.dataclass
+class OwnerScatterPlan:
+    """Metadata and send buffers for the owner-scatter P2P step of one chunk.
+
+    The owner keeps its own update shard (applied directly), so it only sends to the other
+    shard-holding ranks.
+
+    Attributes:
+        send_buffers: Per-destination-rank flat send buffer (this owner's update shards for the
+            params it owns, in param order). Only destinations other than this rank appear.
+        recv_sizes: Per-owner-rank element count this rank (as a destination) receives. Only owners
+            other than this rank appear.
+        recv_offsets: Per `(param_index, owner_rank)` of `(offset, numel, row_count)` describing
+            where this param's update shard lands inside the recv buffer received from `owner_rank`.
+    """
+
+    send_buffers: dict[int, torch.Tensor]
+    recv_sizes: dict[int, int]
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+
+def pack_update_shards(
+    full_updates: dict[int, torch.Tensor],
+    plans: Sequence[ShardPlan],
+    owners: dict[int, int],
+    world_size: int,
+    this_rank: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> OwnerScatterPlan:
+    """Pack this owner rank's full updates into per-destination P2P send buffers.
+
+    Args:
+        full_updates: Full update matrix per owned parameter index.
+        plans: Shard plans in parameter order.
+        owners: Mapping from parameter index to owner rank.
+        world_size: DP group size.
+        this_rank: This rank's DP index.
+        device: Device for the send buffers (the update device).
+        dtype: Dtype for the send buffers (the update dtype).
+
+    Returns:
+        The `OwnerScatterPlan` for this rank.
+    """
+    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+    send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
+    recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+    for param_index in owned_indices:
+        plan = plans[param_index]
+        for dest in range(world_size):
+            if dest == this_rank:
+                continue
+            send_sizes[dest] += plan.shard_numel(dest)
+    for param_index, plan in enumerate(plans):
+        owner = owners[param_index]
+        if owner == this_rank:
+            continue
+        recv_sizes[owner] += plan.shard_numel(this_rank)
+
+    send_buffers: dict[int, torch.Tensor] = {}
+    for dest, size in send_sizes.items():
+        send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
+
+    cursors: dict[int, int] = {d: 0 for d in send_buffers}
+    for dest in range(world_size):
+        if dest == this_rank:
+            continue
+        for param_index in owned_indices:
+            plan = plans[param_index]
+            row_start, row_count = plan.rank_rows[dest]
+            numel = row_count * plan.row_size
+            if numel == 0:
+                continue
+            full = full_updates[param_index]
+            buf = send_buffers[dest]
+            buf[cursors[dest] : cursors[dest] + numel].copy_(
+                full[row_start : row_start + row_count].reshape(-1)
+            )
+            cursors[dest] += numel
+
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    for owner in range(world_size):
+        if owner == this_rank:
+            continue
+        offset = 0
+        for param_index, plan in enumerate(plans):
+            if owners[param_index] != owner:
+                continue
+            numel = plan.shard_numel(this_rank)
+            recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
+            offset += numel
+
+    return OwnerScatterPlan(
+        send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets
+    )
+
+
+def unpack_update_shards(
+    scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
+) -> dict[int, torch.Tensor]:
+    """Extract this rank's local update shards from the per-owner recv buffers.
+
+    Args:
+        scatter_plan: This rank's owner-scatter plan (recv_offsets).
+        recv_buffers: Per-owner-rank received buffer (only owners that sent).
+
+    Returns:
+        Mapping from parameter index to the local update shard `(row_count, cols)`, for parameters
+        this rank does NOT own.
+    """
+    updates: dict[int, torch.Tensor] = {}
+    for (param_index, owner), (offset, numel, row_count) in scatter_plan.recv_offsets.items():
+        if numel == 0:
+            continue
+        buf = recv_buffers[owner]
+        row_size = numel // row_count if row_count else 1
+        updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
+    return updates

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -192,7 +192,7 @@ def assign_owner_work(
 
 @dataclasses.dataclass
 class OwnerGatherPlan:
-    """Metadata and send buffers for the owner-gather P2P step of one chunk.
+    """Metadata and send buffers for the owner-gather P2P step of a set of parameters.
 
     The owner keeps its own shard locally (no self-send), so it only receives from the other
     shard-holding ranks and reconstructs each owned matrix by concatenating shards in rank order
@@ -301,7 +301,7 @@ class OwnerGatherPlan:
         source's received shard at that source's rank rows.
 
         Args:
-            param_index: Index of the parameter within the chunk.
+            param_index: Index of the parameter within the sequence of plans passed to `pack`.
             plan: Shard plan for this parameter.
             recv_buffers: Per-source-rank received buffer (only sources that sent).
             owner_rank: The owner rank (== the rank running reconstruction).
@@ -324,7 +324,7 @@ class OwnerGatherPlan:
 
 @dataclasses.dataclass
 class OwnerScatterPlan:
-    """Metadata and send buffers for the owner-scatter P2P step of one chunk.
+    """Metadata and send buffers for the owner-scatter P2P step of a set of parameters.
 
     The owner keeps its own result shard (applied directly), so it only sends to the other
     shard-holding ranks.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -6,10 +6,10 @@ algorithm.
 
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
 is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
-`assign_owner_work` balances Newton-Schulz work across owner ranks, and the pack/unpack helpers
-(`pack_owner_work`/`pack_update_shards`) build the flat P2P send/recv buffers.
-`OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
-and `OwnerScatterPlan.unpack` extracts received update shards.
+`assign_owner_work` balances Newton-Schulz work across owner ranks. `ShardPlan.from_flat_layout`
+builds a plan from DBuffer layout metadata, `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the
+flat P2P send/recv buffers, `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into
+the full matrix on the owner, and `OwnerScatterPlan.unpack` extracts received update shards.
 """
 
 from __future__ import annotations
@@ -194,6 +194,80 @@ class OwnerGatherPlan:
     own_shards: dict[int, torch.Tensor]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
 
+    @classmethod
+    def pack(
+        cls,
+        plans: Sequence[ShardPlan],
+        owners: dict[int, int],
+        local_shards: Sequence[torch.Tensor],
+        world_size: int,
+        this_rank: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> OwnerGatherPlan:
+        """Pack this rank's pre-NS shards into per-owner P2P send buffers.
+
+        Args:
+            plans: Shard plans in parameter order.
+            owners: Mapping from parameter index to owner rank.
+            local_shards: This rank's local pre-NS shard per parameter.
+            world_size: DP group size.
+            this_rank: This rank's DP index.
+            device: Device for the send buffers (the pre-NS device).
+            dtype: Dtype for the send buffers (the pre-NS dtype).
+        """
+        send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+        recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
+        for param_index, plan in enumerate(plans):
+            owner = owners[param_index]
+            if owner != this_rank:
+                send_sizes[owner] += plan.shard_numel(this_rank)
+            else:
+                for src in range(world_size):
+                    if src == this_rank:
+                        continue
+                    recv_sizes[src] += plan.shard_numel(src)
+
+        send_buffers: dict[int, torch.Tensor] = {}
+        for owner, size in send_sizes.items():
+            send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
+
+        # Fill each owner's send buffer in param order.
+        cursors: dict[int, int] = {o: 0 for o in send_buffers}
+        own_shards: dict[int, torch.Tensor] = {}
+        for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
+            owner = owners[param_index]
+            if owner == this_rank:
+                own_shards[param_index] = shard
+                continue
+            numel = plan.shard_numel(this_rank)
+            if numel == 0:
+                continue
+            buf = send_buffers[owner]
+            buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
+            cursors[owner] += numel
+
+        # Per (owned param, src) recv offset within the recv buffer from src.
+        recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+        owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+        for src in range(world_size):
+            if src == this_rank:
+                continue
+            offset = 0
+            for param_index in owned_indices:
+                plan = plans[param_index]
+                numel = plan.shard_numel(src)
+                recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
+                offset += numel
+
+        return cls(
+            send_buffers=send_buffers,
+            recv_sizes=recv_sizes,
+            own_shards=own_shards,
+            recv_offsets=recv_offsets,
+        )
+
     def reconstruct_full(
         self,
         param_index: int,
@@ -228,82 +302,6 @@ class OwnerGatherPlan:
         return torch.cat(shards, dim=0)
 
 
-def pack_owner_work(
-    plans: Sequence[ShardPlan],
-    owners: dict[int, int],
-    local_shards: Sequence[torch.Tensor],
-    world_size: int,
-    this_rank: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> OwnerGatherPlan:
-    """Pack this rank's pre-NS shards into per-owner P2P send buffers.
-
-    Args:
-        plans: Shard plans in parameter order.
-        owners: Mapping from parameter index to owner rank.
-        local_shards: This rank's local pre-NS shard per parameter.
-        world_size: DP group size.
-        this_rank: This rank's DP index.
-        device: Device for the send buffers (the pre-NS device).
-        dtype: Dtype for the send buffers (the pre-NS dtype).
-
-    Returns:
-        The `OwnerGatherPlan` for this rank.
-    """
-    send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
-    recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
-    for param_index, plan in enumerate(plans):
-        owner = owners[param_index]
-        if owner != this_rank:
-            send_sizes[owner] += plan.shard_numel(this_rank)
-        else:
-            for src in range(world_size):
-                if src == this_rank:
-                    continue
-                recv_sizes[src] += plan.shard_numel(src)
-
-    send_buffers: dict[int, torch.Tensor] = {}
-    for owner, size in send_sizes.items():
-        send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
-
-    # Fill each owner's send buffer in param order.
-    cursors: dict[int, int] = {o: 0 for o in send_buffers}
-    own_shards: dict[int, torch.Tensor] = {}
-    for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
-        owner = owners[param_index]
-        if owner == this_rank:
-            own_shards[param_index] = shard
-            continue
-        numel = plan.shard_numel(this_rank)
-        if numel == 0:
-            continue
-        buf = send_buffers[owner]
-        buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
-        cursors[owner] += numel
-
-    # Per (owned param, src) recv offset within the recv buffer from src.
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
-    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-    for src in range(world_size):
-        if src == this_rank:
-            continue
-        offset = 0
-        for param_index in owned_indices:
-            plan = plans[param_index]
-            numel = plan.shard_numel(src)
-            recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
-            offset += numel
-
-    return OwnerGatherPlan(
-        send_buffers=send_buffers,
-        recv_sizes=recv_sizes,
-        own_shards=own_shards,
-        recv_offsets=recv_offsets,
-    )
-
-
 @dataclasses.dataclass
 class OwnerScatterPlan:
     """Metadata and send buffers for the owner-scatter P2P step of one chunk.
@@ -324,6 +322,79 @@ class OwnerScatterPlan:
     recv_sizes: dict[int, int]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
 
+    @classmethod
+    def pack(
+        cls,
+        full_updates: dict[int, torch.Tensor],
+        plans: Sequence[ShardPlan],
+        owners: dict[int, int],
+        world_size: int,
+        this_rank: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> OwnerScatterPlan:
+        """Pack this owner rank's full updates into per-destination P2P send buffers.
+
+        Args:
+            full_updates: Full update matrix per owned parameter index.
+            plans: Shard plans in parameter order.
+            owners: Mapping from parameter index to owner rank.
+            world_size: DP group size.
+            this_rank: This rank's DP index.
+            device: Device for the send buffers (the update device).
+            dtype: Dtype for the send buffers (the update dtype).
+        """
+        owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+        send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
+        recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+        for param_index in owned_indices:
+            plan = plans[param_index]
+            for dest in range(world_size):
+                if dest == this_rank:
+                    continue
+                send_sizes[dest] += plan.shard_numel(dest)
+        for param_index, plan in enumerate(plans):
+            owner = owners[param_index]
+            if owner == this_rank:
+                continue
+            recv_sizes[owner] += plan.shard_numel(this_rank)
+
+        send_buffers: dict[int, torch.Tensor] = {}
+        for dest, size in send_sizes.items():
+            send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
+
+        cursors: dict[int, int] = {d: 0 for d in send_buffers}
+        for dest in range(world_size):
+            if dest == this_rank:
+                continue
+            for param_index in owned_indices:
+                plan = plans[param_index]
+                row_start, row_count = plan.rank_rows[dest]
+                numel = row_count * plan.row_size
+                if numel == 0:
+                    continue
+                full = full_updates[param_index]
+                buf = send_buffers[dest]
+                buf[cursors[dest] : cursors[dest] + numel].copy_(
+                    full[row_start : row_start + row_count].reshape(-1)
+                )
+                cursors[dest] += numel
+
+        recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+        for owner in range(world_size):
+            if owner == this_rank:
+                continue
+            offset = 0
+            for param_index, plan in enumerate(plans):
+                if owners[param_index] != owner:
+                    continue
+                numel = plan.shard_numel(this_rank)
+                recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
+                offset += numel
+
+        return cls(send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets)
+
     def unpack(self, recv_buffers: dict[int, torch.Tensor]) -> dict[int, torch.Tensor]:
         """Extract this rank's local update shards from the per-owner recv buffers.
 
@@ -342,80 +413,3 @@ class OwnerScatterPlan:
             row_size = numel // row_count if row_count else 1
             updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
         return updates
-
-
-def pack_update_shards(
-    full_updates: dict[int, torch.Tensor],
-    plans: Sequence[ShardPlan],
-    owners: dict[int, int],
-    world_size: int,
-    this_rank: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> OwnerScatterPlan:
-    """Pack this owner rank's full updates into per-destination P2P send buffers.
-
-    Args:
-        full_updates: Full update matrix per owned parameter index.
-        plans: Shard plans in parameter order.
-        owners: Mapping from parameter index to owner rank.
-        world_size: DP group size.
-        this_rank: This rank's DP index.
-        device: Device for the send buffers (the update device).
-        dtype: Dtype for the send buffers (the update dtype).
-
-    Returns:
-        The `OwnerScatterPlan` for this rank.
-    """
-    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-    send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
-    recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
-    for param_index in owned_indices:
-        plan = plans[param_index]
-        for dest in range(world_size):
-            if dest == this_rank:
-                continue
-            send_sizes[dest] += plan.shard_numel(dest)
-    for param_index, plan in enumerate(plans):
-        owner = owners[param_index]
-        if owner == this_rank:
-            continue
-        recv_sizes[owner] += plan.shard_numel(this_rank)
-
-    send_buffers: dict[int, torch.Tensor] = {}
-    for dest, size in send_sizes.items():
-        send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
-
-    cursors: dict[int, int] = {d: 0 for d in send_buffers}
-    for dest in range(world_size):
-        if dest == this_rank:
-            continue
-        for param_index in owned_indices:
-            plan = plans[param_index]
-            row_start, row_count = plan.rank_rows[dest]
-            numel = row_count * plan.row_size
-            if numel == 0:
-                continue
-            full = full_updates[param_index]
-            buf = send_buffers[dest]
-            buf[cursors[dest] : cursors[dest] + numel].copy_(
-                full[row_start : row_start + row_count].reshape(-1)
-            )
-            cursors[dest] += numel
-
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
-    for owner in range(world_size):
-        if owner == this_rank:
-            continue
-        offset = 0
-        for param_index, plan in enumerate(plans):
-            if owners[param_index] != owner:
-                continue
-            numel = plan.shard_numel(this_rank)
-            recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
-            offset += numel
-
-    return OwnerScatterPlan(
-        send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets
-    )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
-Pure shard-planning and owner-compute packing logic for M-FSDPv2's all-`Flat` layout.
+Pure shard-planning and owner-compute packing logic for MFSDP v2's all-`Flat` layout.
 
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
-is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
+is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
 `assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
 function. `ShardPlan.from_flat_layout` builds a plan from DBuffer layout metadata,
 `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
@@ -27,7 +27,7 @@ from .layout import non_leading_numel
 class ShardPlan:
     """How a single 2D parameter's full matrix is split across the DP group.
 
-    M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously in rank order, so rank `r` owns the
+    MFSDP v2's all-`Flat` layout shards dim-0 rows contiguously in rank order, so rank `r` owns the
     contiguous global row range `[start, start + count)` where `start`/`count` come from the flat
     DBuffer layout. A rank with `count == 0` holds no shard of this parameter.
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -1,22 +1,22 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
-Pure shard-planning and owner-compute packing logic for the Muon + M-FSDPv2 owner-compute P2P
-algorithm.
+Pure shard-planning and owner-compute packing logic for M-FSDPv2's all-`Flat` layout.
 
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
 is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
-`assign_owner_work` balances Newton-Schulz work across owner ranks. `ShardPlan.from_flat_layout`
-builds a plan from DBuffer layout metadata, `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the
-flat P2P send/recv buffers, `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into
-the full matrix on the owner, and `OwnerScatterPlan.unpack` extracts received update shards.
+`assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
+function. `ShardPlan.from_flat_layout` builds a plan from DBuffer layout metadata,
+`OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
+`OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
+and `OwnerScatterPlan.unpack` extracts received result shards.
 """
 
 from __future__ import annotations
 
 import dataclasses
 import functools
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import torch
 
@@ -133,23 +133,26 @@ class ShardPlan:
         return self.full_shape.numel()
 
 
-def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int, int]:
-    """Assign one owner rank to each boundary parameter, balanced by NS cost.
+def assign_owner_work(
+    plans: Sequence[ShardPlan], cost_fn: Callable[[ShardPlan], float]
+) -> dict[int, int]:
+    """Assign one owner rank to each boundary parameter, balanced by cost.
 
     Only ranks that own a non-empty shard of a parameter are eligible owners. Assignment greedily
-    gives each parameter to its eligible rank with the smallest running cost total, where a
-    parameter's cost is the Newton-Schulz compute estimate `numel * (min(rows, cols) * num_steps +
-    1)`.
+    gives each parameter to its eligible rank with the smallest running cost total.
 
     Args:
         plans: Shard plans indexed by their position in the input sequence.
-        num_ns_steps: Newton-Schulz iteration count used in the cost estimate.
+        cost_fn: Callable that returns a positive cost estimate for a given shard plan. The greedy
+            balancer minimizes the maximum running cost total across ranks, so the cost should
+            reflect the relative compute weight of owning each parameter (e.g., an orthogonalization
+            cost estimate).
 
     Returns:
         Mapping from parameter index (in `plans`) to owner rank.
     """
     assignments: dict[int, int] = {}
-    running: dict[int, int] = {r: 0 for r in range(plans[0].world_size)} if plans else {}
+    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
     for param_index, plan in enumerate(plans):
         candidates = plan.owner_candidates()
         if not candidates:
@@ -161,9 +164,7 @@ def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int
             # Fully local: the single owning rank is the owner with no communication.
             assignments[param_index] = candidates[0]
             continue
-        rows, cols = plan.full_shape
-        short_dim = min(rows, cols)
-        cost = plan.full_numel() * (short_dim * num_ns_steps + 1)
+        cost = cost_fn(plan)
         owner = min(candidates, key=lambda r: (running[r], r))
         assignments[param_index] = owner
         running[owner] += cost
@@ -179,8 +180,8 @@ class OwnerGatherPlan:
     (own shard at the owner's rank rows).
 
     Attributes:
-        send_buffers: Per-destination-owner flat send buffer (this rank's pre-NS shards for that
-            owner's params, in param order). Only owners other than this rank appear.
+        send_buffers: Per-destination-owner flat send buffer (this rank's shards for that owner's
+            params, in param order). Only owners other than this rank appear.
         recv_sizes: Per-source-rank element count this rank (as an owner) receives. Only sources
             other than this rank appear.
         own_shards: This rank's local shard per owned parameter (used directly in reconstruction,
@@ -206,16 +207,16 @@ class OwnerGatherPlan:
         device: torch.device,
         dtype: torch.dtype,
     ) -> OwnerGatherPlan:
-        """Pack this rank's pre-NS shards into per-owner P2P send buffers.
+        """Pack this rank's local shards into per-owner P2P send buffers.
 
         Args:
             plans: Shard plans in parameter order.
             owners: Mapping from parameter index to owner rank.
-            local_shards: This rank's local pre-NS shard per parameter.
+            local_shards: This rank's local shard per parameter.
             world_size: DP group size.
             this_rank: This rank's DP index.
-            device: Device for the send buffers (the pre-NS device).
-            dtype: Dtype for the send buffers (the pre-NS dtype).
+            device: Device for the send buffers.
+            dtype: Dtype for the send buffers.
         """
         send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
         recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
@@ -306,16 +307,16 @@ class OwnerGatherPlan:
 class OwnerScatterPlan:
     """Metadata and send buffers for the owner-scatter P2P step of one chunk.
 
-    The owner keeps its own update shard (applied directly), so it only sends to the other
+    The owner keeps its own result shard (applied directly), so it only sends to the other
     shard-holding ranks.
 
     Attributes:
-        send_buffers: Per-destination-rank flat send buffer (this owner's update shards for the
+        send_buffers: Per-destination-rank flat send buffer (this owner's result shards for the
             params it owns, in param order). Only destinations other than this rank appear.
         recv_sizes: Per-owner-rank element count this rank (as a destination) receives. Only owners
             other than this rank appear.
         recv_offsets: Per `(param_index, owner_rank)` of `(offset, numel, row_count)` describing
-            where this param's update shard lands inside the recv buffer received from `owner_rank`.
+            where this param's result shard lands inside the recv buffer received from `owner_rank`.
     """
 
     send_buffers: dict[int, torch.Tensor]
@@ -325,7 +326,7 @@ class OwnerScatterPlan:
     @classmethod
     def pack(
         cls,
-        full_updates: dict[int, torch.Tensor],
+        full_results: dict[int, torch.Tensor],
         plans: Sequence[ShardPlan],
         owners: dict[int, int],
         world_size: int,
@@ -334,16 +335,16 @@ class OwnerScatterPlan:
         device: torch.device,
         dtype: torch.dtype,
     ) -> OwnerScatterPlan:
-        """Pack this owner rank's full updates into per-destination P2P send buffers.
+        """Pack this owner rank's full results into per-destination P2P send buffers.
 
         Args:
-            full_updates: Full update matrix per owned parameter index.
+            full_results: Full result tensor per owned parameter index.
             plans: Shard plans in parameter order.
             owners: Mapping from parameter index to owner rank.
             world_size: DP group size.
             this_rank: This rank's DP index.
-            device: Device for the send buffers (the update device).
-            dtype: Dtype for the send buffers (the update dtype).
+            device: Device for the send buffers.
+            dtype: Dtype for the send buffers.
         """
         owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
         send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
@@ -374,7 +375,7 @@ class OwnerScatterPlan:
                 numel = row_count * plan.row_size
                 if numel == 0:
                     continue
-                full = full_updates[param_index]
+                full = full_results[param_index]
                 buf = send_buffers[dest]
                 buf[cursors[dest] : cursors[dest] + numel].copy_(
                     full[row_start : row_start + row_count].reshape(-1)
@@ -396,20 +397,20 @@ class OwnerScatterPlan:
         return cls(send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets)
 
     def unpack(self, recv_buffers: dict[int, torch.Tensor]) -> dict[int, torch.Tensor]:
-        """Extract this rank's local update shards from the per-owner recv buffers.
+        """Extract this rank's local result shards from the per-owner recv buffers.
 
         Args:
             recv_buffers: Per-owner-rank received buffer (only owners that sent).
 
         Returns:
-            Mapping from parameter index to the local update shard `(row_count, cols)`, for
+            Mapping from parameter index to the local result shard `(row_count, cols)`, for
             parameters this rank does NOT own.
         """
-        updates: dict[int, torch.Tensor] = {}
+        results: dict[int, torch.Tensor] = {}
         for (param_index, owner), (offset, numel, row_count) in self.recv_offsets.items():
             if numel == 0:
                 continue
             buf = recv_buffers[owner]
             row_size = numel // row_count if row_count else 1
-            updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
-        return updates
+            results[param_index] = buf[offset : offset + numel].view(row_count, row_size)
+        return results

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -149,7 +149,7 @@ def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int
         Mapping from parameter index (in `plans`) to owner rank.
     """
     assignments: dict[int, int] = {}
-    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
+    running: dict[int, int] = {r: 0 for r in range(plans[0].world_size)} if plans else {}
     for param_index, plan in enumerate(plans):
         candidates = plan.owner_candidates()
         if not candidates:
@@ -163,7 +163,7 @@ def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int
             continue
         rows, cols = plan.full_shape
         short_dim = min(rows, cols)
-        cost = float(plan.full_numel() * (short_dim * num_ns_steps + 1))
+        cost = plan.full_numel() * (short_dim * num_ns_steps + 1)
         owner = min(candidates, key=lambda r: (running[r], r))
         assignments[param_index] = owner
         running[owner] += cost

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -15,6 +15,7 @@ and `OwnerScatterPlan.unpack` extracts received update shards.
 from __future__ import annotations
 
 import dataclasses
+import functools
 from collections.abc import Sequence
 
 import torch
@@ -117,10 +118,12 @@ class ShardPlan:
         """Return the number of elements in `rank`'s shard."""
         return self.rank_row_count(rank) * self.row_size
 
+    @functools.lru_cache(maxsize=None)
     def owner_candidates(self) -> tuple[int, ...]:
         """Return the ranks that hold a non-empty shard of this parameter."""
         return tuple(r for r, (_, count) in enumerate(self.rank_rows) if count > 0)
 
+    @functools.lru_cache(maxsize=None)
     def is_boundary(self) -> bool:
         """True if more than one rank owns a non-empty shard of this parameter."""
         return sum(1 for _, count in self.rank_rows if count > 0) > 1

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -7,8 +7,9 @@ algorithm.
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
 is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
 `assign_owner_work` balances Newton-Schulz work across owner ranks, and the pack/unpack helpers
-(`pack_owner_work`/`pack_update_shards`/`unpack_update_shards`) build the flat P2P send/recv
-buffers. `reconstruct_full_tensor` stitches gathered shards back into the full matrix on the owner.
+(`pack_owner_work`/`pack_update_shards`) build the flat P2P send/recv buffers.
+`OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
+and `OwnerScatterPlan.unpack` extracts received update shards.
 """
 
 from __future__ import annotations
@@ -28,6 +29,12 @@ class ShardPlan:
     M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously in rank order, so rank `r` owns the
     contiguous global row range `[start, start + count)` where `start`/`count` come from the flat
     DBuffer layout. A rank with `count == 0` holds no shard of this parameter.
+
+    Attributes:
+        full_shape: Global `(rows, cols)` shape of the parameter.
+        rank_rows: Per-rank `(row_start, row_count)` tuples; `row_count == 0` means the rank holds
+            no shard.
+        row_size: Number of elements per row (= `full_shape[1:].numel()`).
     """
 
     full_shape: torch.Size
@@ -44,6 +51,58 @@ class ShardPlan:
                 f"ShardPlan row_size {self.row_size} != full_shape row size "
                 f"{non_leading_numel(self.full_shape)}."
             )
+
+    @classmethod
+    def from_flat_layout(
+        cls,
+        full_shape: torch.Size,
+        tensor_flat_offset: int,
+        rank_flat_shard_size: int,
+        world_size: int,
+    ) -> ShardPlan:
+        """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
+
+        Args:
+            full_shape: Global `(rows, cols)` shape of the parameter.
+            tensor_flat_offset: Flat-element offset of this parameter inside the DBuffer's global
+                layout.
+            rank_flat_shard_size: Flat elements each DP rank owns (uniform for the even all-`Flat`
+                layout: `layout.size // world_size`).
+            world_size: DP group size.
+        """
+        if len(full_shape) != 2:
+            raise ValueError(f"ShardPlan.from_flat_layout requires a 2D shape, got {full_shape}.")
+        row_size = non_leading_numel(full_shape)
+        if row_size <= 0:
+            raise ValueError(
+                f"ShardPlan.from_flat_layout requires non-empty rows, got shape {full_shape}."
+            )
+        tensor_end = tensor_flat_offset + full_shape.numel()
+
+        rank_rows: list[tuple[int, int]] = []
+        for rank in range(world_size):
+            rank_start = rank * rank_flat_shard_size
+            rank_end = rank_start + rank_flat_shard_size
+            overlap_start = max(tensor_flat_offset, rank_start)
+            overlap_end = min(tensor_end, rank_end)
+            if overlap_start >= overlap_end:
+                rank_rows.append((0, 0))
+                continue
+            if (overlap_start - tensor_flat_offset) % row_size != 0:
+                raise RuntimeError(
+                    f"Flat shard boundary is not row-aligned for shape {full_shape}: "
+                    f"overlap_start={overlap_start}, tensor_flat_offset={tensor_flat_offset}."
+                )
+            overlap_numel = overlap_end - overlap_start
+            if overlap_numel % row_size != 0:
+                raise RuntimeError(
+                    f"Flat shard overlap is not row-aligned for shape {full_shape}: "
+                    f"overlap_numel={overlap_numel}, row_size={row_size}."
+                )
+            row_start = (overlap_start - tensor_flat_offset) // row_size
+            row_count = overlap_numel // row_size
+            rank_rows.append((row_start, row_count))
+        return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
 
     @property
     def world_size(self) -> int:
@@ -69,57 +128,6 @@ class ShardPlan:
     def full_numel(self) -> int:
         """Return the total number of elements in the full (unsharded) parameter."""
         return self.full_shape.numel()
-
-
-def compute_shard_plan(
-    full_shape: torch.Size, tensor_flat_offset: int, rank_flat_shard_size: int, world_size: int
-) -> ShardPlan:
-    """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
-
-    Args:
-        full_shape: Global `(rows, cols)` shape of the parameter.
-        tensor_flat_offset: Flat-element offset of this parameter inside the DBuffer's global
-            layout.
-        rank_flat_shard_size: Flat elements each DP rank owns (uniform for the even all-`Flat`
-            layout: `layout.size // world_size`).
-        world_size: DP group size.
-
-    Returns:
-        The `ShardPlan` describing which rows each rank owns.
-    """
-    if len(full_shape) != 2:
-        raise ValueError(f"compute_shard_plan requires a 2D shape, got {full_shape}.")
-    row_size = non_leading_numel(full_shape)
-    if row_size <= 0:
-        raise ValueError(f"compute_shard_plan requires non-empty rows, got shape {full_shape}.")
-    tensor_end = tensor_flat_offset + full_shape.numel()
-
-    rank_rows: list[tuple[int, int]] = []
-    for rank in range(world_size):
-        rank_start = rank * rank_flat_shard_size
-        rank_end = rank_start + rank_flat_shard_size
-        overlap_start = max(tensor_flat_offset, rank_start)
-        overlap_end = min(tensor_end, rank_end)
-        if overlap_start >= overlap_end:
-            rank_rows.append((0, 0))
-            continue
-        if (overlap_start - tensor_flat_offset) % row_size != 0:
-            raise RuntimeError(
-                f"Flat shard boundary is not row-aligned for shape {full_shape}: "
-                f"overlap_start={overlap_start}, tensor_flat_offset={tensor_flat_offset}."
-            )
-        overlap_numel = overlap_end - overlap_start
-        if overlap_numel % row_size != 0:
-            raise RuntimeError(
-                f"Flat shard overlap is not row-aligned for shape {full_shape}: "
-                f"overlap_numel={overlap_numel}, row_size={row_size}."
-            )
-        row_start = (overlap_start - tensor_flat_offset) // row_size
-        row_count = overlap_numel // row_size
-        rank_rows.append((row_start, row_count))
-    return ShardPlan(
-        full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size
-    )
 
 
 def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int, int]:
@@ -182,6 +190,39 @@ class OwnerGatherPlan:
     recv_sizes: dict[int, int]
     own_shards: dict[int, torch.Tensor]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+    def reconstruct_full(
+        self,
+        param_index: int,
+        plan: ShardPlan,
+        recv_buffers: dict[int, torch.Tensor],
+        owner_rank: int,
+    ) -> torch.Tensor:
+        """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
+
+        Concatenates shards in rank order: the owner's own local shard at its rank rows and each
+        source's received shard at that source's rank rows.
+
+        Args:
+            param_index: Index of the parameter within the chunk.
+            plan: Shard plan for this parameter.
+            recv_buffers: Per-source-rank received buffer (only sources that sent).
+            owner_rank: The owner rank (== the rank running reconstruction).
+        """
+        shards: list[torch.Tensor] = []
+        for src in range(plan.world_size):
+            row_count = plan.rank_row_count(src)
+            if src == owner_rank:
+                shards.append(self.own_shards[param_index])
+            elif row_count == 0:
+                continue
+            else:
+                offset, numel, _ = self.recv_offsets[(param_index, src)]
+                buf = recv_buffers[src]
+                shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
+        if len(shards) == 1:
+            return shards[0].contiguous()
+        return torch.cat(shards, dim=0)
 
 
 def pack_owner_work(
@@ -260,48 +301,6 @@ def pack_owner_work(
     )
 
 
-def reconstruct_full_tensor(
-        param_index: int,
-        plan: ShardPlan,
-        gather_plan: OwnerGatherPlan,
-        recv_buffers: dict[int, torch.Tensor],
-        owner_rank: int,
-) -> torch.Tensor:
-    """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
-
-    Concatenates shards in rank order: the owner's own local shard at its rank rows and each
-    source's received shard at that source's rank rows. The shard content lives in `gather_plan`
-    (`own_shards` + `recv_offsets`), so this works for the pre-NS owner-gather path and for a weight
-    gather plan alike – pass a weight gather plan built with `pack_owner_work` to reconstruct the
-    full weight parameter instead.
-
-    Args:
-        param_index: Index of the parameter within the chunk.
-        plan: Shard plan for this parameter.
-        gather_plan: This rank's owner-gather plan (own_shards, recv_offsets).
-        recv_buffers: Per-source-rank received buffer (only sources that sent).
-        owner_rank: The owner rank (== the rank running reconstruction).
-
-    Returns:
-        The full `(rows, cols)` tensor.
-    """
-    world_size = plan.world_size
-    shards: list[torch.Tensor] = []
-    for src in range(world_size):
-        row_count = plan.rank_row_count(src)
-        if src == owner_rank:
-            shards.append(gather_plan.own_shards[param_index])
-        elif row_count == 0:
-            continue
-        else:
-            offset, numel, _ = gather_plan.recv_offsets[(param_index, src)]
-            buf = recv_buffers[src]
-            shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
-    if len(shards) == 1:
-        return shards[0].contiguous()
-    return torch.cat(shards, dim=0)
-
-
 @dataclasses.dataclass
 class OwnerScatterPlan:
     """Metadata and send buffers for the owner-scatter P2P step of one chunk.
@@ -321,6 +320,25 @@ class OwnerScatterPlan:
     send_buffers: dict[int, torch.Tensor]
     recv_sizes: dict[int, int]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+    def unpack(self, recv_buffers: dict[int, torch.Tensor]) -> dict[int, torch.Tensor]:
+        """Extract this rank's local update shards from the per-owner recv buffers.
+
+        Args:
+            recv_buffers: Per-owner-rank received buffer (only owners that sent).
+
+        Returns:
+            Mapping from parameter index to the local update shard `(row_count, cols)`, for
+            parameters this rank does NOT own.
+        """
+        updates: dict[int, torch.Tensor] = {}
+        for (param_index, owner), (offset, numel, row_count) in self.recv_offsets.items():
+            if numel == 0:
+                continue
+            buf = recv_buffers[owner]
+            row_size = numel // row_count if row_count else 1
+            updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
+        return updates
 
 
 def pack_update_shards(
@@ -398,26 +416,3 @@ def pack_update_shards(
     return OwnerScatterPlan(
         send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets
     )
-
-
-def unpack_update_shards(
-    scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
-) -> dict[int, torch.Tensor]:
-    """Extract this rank's local update shards from the per-owner recv buffers.
-
-    Args:
-        scatter_plan: This rank's owner-scatter plan (recv_offsets).
-        recv_buffers: Per-owner-rank received buffer (only owners that sent).
-
-    Returns:
-        Mapping from parameter index to the local update shard `(row_count, cols)`, for parameters
-        this rank does NOT own.
-    """
-    updates: dict[int, torch.Tensor] = {}
-    for (param_index, owner), (offset, numel, row_count) in scatter_plan.recv_offsets.items():
-        if numel == 0:
-            continue
-        buf = recv_buffers[owner]
-        row_size = numel // row_count if row_count else 1
-        updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
-    return updates

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -6,7 +6,7 @@ Pure shard-planning and owner-compute packing logic for MFSDP v2's all-`Flat` l
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
 is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
 `assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
-function. `ShardPlan.from_flat_layout` builds a plan from DBuffer layout metadata,
+function. `ShardPlan.from_layout_params` builds a plan from DBuffer layout metadata,
 `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
 `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
 and `OwnerScatterPlan.unpack` extracts received result shards.
@@ -54,7 +54,7 @@ class ShardPlan:
             )
 
     @classmethod
-    def from_flat_layout(
+    def from_layout_params(
         cls,
         full_shape: torch.Size,
         tensor_flat_offset: int,
@@ -72,11 +72,11 @@ class ShardPlan:
             world_size: DP group size.
         """
         if len(full_shape) != 2:
-            raise ValueError(f"ShardPlan.from_flat_layout requires a 2D shape, got {full_shape}.")
+            raise ValueError(f"ShardPlan.from_layout_params requires a 2D shape, got {full_shape}.")
         row_size = non_leading_numel(full_shape)
         if row_size <= 0:
             raise ValueError(
-                f"ShardPlan.from_flat_layout requires non-empty rows, got shape {full_shape}."
+                f"ShardPlan.from_layout_params requires non-empty rows, got shape {full_shape}."
             )
         tensor_end = tensor_flat_offset + full_shape.numel()
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -198,6 +198,58 @@ class OwnerGatherPlan:
     shard-holding ranks and reconstructs each owned matrix by concatenating shards in rank order
     (own shard at the owner's rank rows).
 
+    Example:
+
+    ```
+    # We are also using some pseudocode here for brevity.
+
+    # Assume:
+    torch.distributed.get_world_size() == 2
+    torch.distributed.get_rank() == 0  # We're observing from rank 0
+    param_0: torch.Tensor
+    param_1: torch.Tensor
+    # Params are in this order as observed by MFSDP.
+    model.param_groups == [{"params": [param_0, param_1]}]
+    # Both params are owned by rank 1 (was previously determined using `ShardPlan`s).
+    param_0.owner == 1
+    param_1.owner == 1
+
+    param_0.shape == (6, 4)  # Global shape.
+    param_1.shape == (4, 4)  # Global shape.
+    param_0.local_shard.shape == (3, 4)  # Rank 0 has shard indexed by `[0:3, ...]`.
+    param_1.local_shard.shape == (2, 4)  # Rank 0 has shard indexed by `[0:2, ...]`.
+    param_0.local_shard.numel == 12
+    param_1.local_shard.numel == 8
+
+    owner_gather_plan.send_buffers == {1: tensor(20)}  # 12 + 8 = 20 elements
+    # `owner_gather_plan.send_buffers[1]` represents the following in its packed flat buffer:
+    #   +--------------------+-------------------+
+    #   | param_0 (12 elems) | param_1 (8 elems) |
+    #   +--------------------+-------------------+
+    #                 byte order: -->
+
+    # Rank 0 owns nothing
+    owner_gather_plan.recv_sizes == {}
+    owner_gather_plan.own_shards == {}
+    owner_gather_plan.recv_offsets == {}
+
+    # ---
+
+    # Same settings as above, now observing from rank 1 (the owner):
+    torch.distributed.get_rank() == 1
+
+    param_0.local_shard.shape == (3, 4)  # Rank 1 has shard indexed by `[3:6, ...]`.
+    param_1.local_shard.shape == (2, 4)  # Rank 1 has shard indexed by `[2:4, ...]`.
+
+    send_buffers = {}  # Rank 1 owns everything.
+    recv_sizes = {0: 20}  # 12 + 8 = 20 elements from rank 0
+    own_shards = {0: param_0.local_shard, 1: param_1.local_shard}  # rank 1's own shards
+    recv_offsets = {
+        (0, 0): (0, 12, 3),  # `param_0` from rank 0: offset 0, 12 elems, 3 rows
+        (1, 0): (12, 8, 2),  # `param_1` from rank 0: offset 12, 8 elems, 2 rows
+    }
+    ```
+
     Attributes:
         send_buffers: Per-destination-owner flat send buffer (this rank's shards for that owner's
             params, in param order). Only owners other than this rank appear.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Sequence
 
 import torch
 
-from .layout import non_leading_numel
+from .layout import GlobalLayout, non_leading_numel
 
 
 @dataclasses.dataclass(frozen=True)
@@ -104,6 +104,25 @@ class ShardPlan:
             row_count = overlap_numel // row_size
             rank_rows.append((row_start, row_count))
         return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
+
+    @classmethod
+    def from_layout(cls, layout: GlobalLayout, tensor_index: int, world_size: int) -> ShardPlan:
+        """Build a shard plan for one parameter from a `GlobalLayout`.
+
+        Extracts the parameter's shape, flat offset, and per-rank shard size from `layout` and
+        delegates to `from_layout_params`.
+
+        Args:
+            layout: The DBuffer global layout that contains the parameter.
+            tensor_index: Index of the parameter within `layout`.
+            world_size: DP group size.
+        """
+        return cls.from_layout_params(
+            layout.tensor_shapes[tensor_index],
+            layout.tensor_to_offset[tensor_index],
+            layout.size // world_size,
+            world_size,
+        )
 
     @property
     def world_size(self) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -383,9 +383,6 @@ class OwnerScatterPlan:
         owners: dict[int, int],
         dp_size: int,
         this_rank: int,
-        *,
-        device: torch.device,
-        dtype: torch.dtype,
     ) -> Self:
         """Pack this owner rank's full results into per-destination P2P send buffers.
 
@@ -395,9 +392,11 @@ class OwnerScatterPlan:
             owners: Mapping from parameter index to owner rank.
             dp_size: DP group size.
             this_rank: This rank's DP index.
-            device: Device for the send buffers.
-            dtype: Dtype for the send buffers.
         """
+        if full_results:
+            first = next(iter(full_results.values()))
+            device = first.device
+            dtype = first.dtype
         owned_indices = [i for i in range(len(layouts)) if owners[i] == this_rank]
         send_sizes: dict[int, int] = {}
         recv_sizes: dict[int, int] = {}

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -144,7 +144,7 @@ class ShardPlan:
     @functools.lru_cache(maxsize=None)
     def is_boundary(self) -> bool:
         """True if more than one rank owns a non-empty shard of this parameter."""
-        return sum(1 for _, count in self.rank_rows if count > 0) > 1
+        return any(0 < count < self.full_shape[0] for _, count in self.rank_rows)
 
     def full_numel(self) -> int:
         """Return the total number of elements in the full (unsharded) parameter."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -273,9 +273,6 @@ class OwnerGatherPlan:
         local_shards: Sequence[torch.Tensor],
         dp_size: int,
         this_rank: int,
-        *,
-        device: torch.device,
-        dtype: torch.dtype,
     ) -> Self:
         """Pack this rank's local shards into per-owner P2P send buffers.
 
@@ -285,9 +282,9 @@ class OwnerGatherPlan:
             local_shards: This rank's local shard per parameter.
             dp_size: DP group size.
             this_rank: This rank's DP index.
-            device: Device for the send buffers.
-            dtype: Dtype for the send buffers.
         """
+        device = local_shards[0].device
+        dtype = local_shards[0].dtype
         send_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
         recv_sizes: dict[int, int] = {sender: 0 for sender in range(dp_size) if sender != this_rank}
         for param_index, plan in enumerate(plans):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -289,8 +289,8 @@ class OwnerGatherPlan:
             device: Device for the send buffers.
             dtype: Dtype for the send buffers.
         """
-        send_sizes: dict[int, int] = {o: 0 for o in range(dp_size) if o != this_rank}
-        recv_sizes: dict[int, int] = {s: 0 for s in range(dp_size) if s != this_rank}
+        send_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
+        recv_sizes: dict[int, int] = {sender: 0 for sender in range(dp_size) if sender != this_rank}
         for param_index, plan in enumerate(plans):
             owner = owners[param_index]
             if owner != this_rank:
@@ -306,7 +306,7 @@ class OwnerGatherPlan:
             send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
 
         # Fill each owner's send buffer in param order.
-        cursors: dict[int, int] = {o: 0 for o in send_buffers}
+        cursors: dict[int, int] = {owner: 0 for owner in send_buffers}
         own_shards: dict[int, torch.Tensor] = {}
         for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
             owner = owners[param_index]
@@ -418,8 +418,10 @@ class OwnerScatterPlan:
             dtype: Dtype for the send buffers.
         """
         owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-        send_sizes: dict[int, int] = {d: 0 for d in range(dp_size) if d != this_rank}
-        recv_sizes: dict[int, int] = {o: 0 for o in range(dp_size) if o != this_rank}
+        send_sizes: dict[int, int] = {
+            receiver: 0 for receiver in range(dp_size) if receiver != this_rank
+        }
+        recv_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
         for param_index in owned_indices:
             plan = plans[param_index]
             for dest in range(dp_size):
@@ -436,7 +438,7 @@ class OwnerScatterPlan:
         for dest, size in send_sizes.items():
             send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
 
-        cursors: dict[int, int] = {d: 0 for d in send_buffers}
+        cursors: dict[int, int] = {receiver: 0 for receiver in send_buffers}
         for dest in range(dp_size):
             if dest == this_rank:
                 continue

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -317,7 +317,7 @@ class OwnerGatherPlan:
             if numel == 0:
                 continue
             buf = send_buffers[owner]
-            buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
+            buf[cursors[owner] : cursors[owner] + numel].copy_(shard.flatten())
             cursors[owner] += numel
 
         # Per (owned param, src) recv offset within the recv buffer from src.
@@ -449,7 +449,7 @@ class OwnerScatterPlan:
                 full = full_results[param_index]
                 buf = send_buffers[dest]
                 buf[cursors[dest] : cursors[dest] + numel].copy_(
-                    full[row_start : row_start + row_count].reshape(-1)
+                    full[row_start : row_start + row_count].flatten()
                 )
                 cursors[dest] += numel
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -13,7 +13,6 @@ and `OwnerScatterPlan.unpack` extracts received result shards.
 """
 
 import dataclasses
-import functools
 from collections.abc import Callable, Sequence
 from typing import Self
 
@@ -136,12 +135,10 @@ class ShardPlan:
         """Return the number of elements in `rank`'s shard."""
         return self.rank_row_count(rank) * self.row_size
 
-    @functools.lru_cache(maxsize=None)
     def owner_candidates(self) -> tuple[int, ...]:
         """Return the ranks that hold a non-empty shard of this parameter."""
         return tuple(r for r, (_, count) in enumerate(self.rank_rows) if count > 0)
 
-    @functools.lru_cache(maxsize=None)
     def is_boundary(self) -> bool:
         """True if more than one rank owns a non-empty shard of this parameter."""
         return any(0 < count < self.full_shape[0] for _, count in self.rank_rows)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -156,8 +156,9 @@ def assign_owner_work(
 ) -> dict[int, int]:
     """Assign one owner rank to each boundary parameter, balanced by cost.
 
-    Only ranks that own a non-empty shard of a parameter are eligible owners. Assignment greedily
-    gives each parameter to its eligible rank with the smallest running cost total.
+    Non-boundary parameters stay on their original rank and are skipped. Only ranks that own a
+    non-empty shard of a parameter are eligible owners. Assignment greedily gives each boundary
+    parameter to its eligible rank with the smallest running cost total.
 
     Args:
         plans: Shard plans indexed by their position in the input sequence.
@@ -167,21 +168,20 @@ def assign_owner_work(
             cost estimate).
 
     Returns:
-        Mapping from parameter index (in `plans`) to owner rank.
+        Mapping from boundary parameter index (in `plans`) to owner rank. Non-boundary parameters
+        are absent, as they stay on their original rank.
     """
     assignments: dict[int, int] = {}
     running: dict[int, float] = {r: 0.0 for r in range(plans[0].dp_size)} if plans else {}
     for param_index, plan in enumerate(plans):
+        if not plan.is_boundary():
+            continue
         candidates = plan.owner_candidates()
         if not candidates:
             raise RuntimeError(
                 f"No eligible owner for parameter {param_index} with shape {plan.full_shape}; "
                 "no rank owns a shard."
             )
-        if not plan.is_boundary():
-            # Fully local: the single owning rank is the owner with no communication.
-            assignments[param_index] = candidates[0]
-            continue
         cost = cost_fn(plan)
         owner = min(candidates, key=lambda r: running[r])
         assignments[param_index] = owner

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -136,8 +136,9 @@ def assign_owner_work(
     """Assign one owner rank to each boundary parameter, balanced by cost.
 
     Non-boundary parameters stay on their original rank and are skipped. Only ranks that own a
-    non-empty shard of a parameter are eligible owners. Assignment greedily gives each boundary
-    parameter to its eligible rank with the smallest running cost total.
+    non-empty shard of a parameter are eligible owners. Boundary parameters are processed in
+    descending cost order, and each is greedily given to its eligible rank with the smallest running
+    cost total.
 
     Args:
         layouts: Parameter layouts indexed by their position in the input sequence.
@@ -151,17 +152,27 @@ def assign_owner_work(
         are absent, as they stay on their original rank.
     """
     assignments: dict[int, int] = {}
-    running: dict[int, float] = {r: 0.0 for r in range(layouts[0].dp_size)} if layouts else {}
-    for param_index, layout in enumerate(layouts):
-        if not layout.is_boundary():
-            continue
+    if not layouts:
+        return assignments
+    running: dict[int, float] = {r: 0.0 for r in range(layouts[0].dp_size)}
+    # Sort boundary params by descending cost (longest processing time first).
+    boundary_costs = sorted(
+        (
+            (param_index, cost_fn(layout))
+            for param_index, layout in enumerate(layouts)
+            if layout.is_boundary()
+        ),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    for param_index, cost in boundary_costs:
+        layout = layouts[param_index]
         candidates = layout.owner_candidates()
         if not candidates:
             raise RuntimeError(
                 f"No eligible owner for parameter {param_index} with shape {layout.full_shape}; "
                 "no rank owns a shard."
             )
-        cost = cost_fn(layout)
         owner = min(candidates, key=lambda r: running[r])
         assignments[param_index] = owner
         running[owner] += cost

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -369,7 +369,7 @@ class OwnerGatherPlan:
                 buf = recv_buffers[src]
                 shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
         if len(shards) == 1:
-            return shards[0].contiguous()
+            return shards[0]
         return torch.cat(shards, dim=0)
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -231,14 +231,16 @@ class OwnerGatherPlan:
             other than this rank appear.
         own_shards: This rank's local shard per owned parameter (used directly in reconstruction,
             not communicated).
-        recv_offsets: Per `(param_index, src_rank)` of `(offset, numel, row_count)` describing where
-            this param's shard lands inside the recv buffer received from `src_rank`.
+        recv_offsets: Per `(param_index, src_rank)`, the flat offset of this param's shard inside
+            the recv buffer received from `src_rank`.
     """
 
+    plans: tuple[ParameterLayout, ...]
+    this_rank: int
     send_buffers: dict[int, torch.Tensor]
     recv_sizes: dict[int, int]
     own_shards: dict[int, torch.Tensor]
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+    recv_offsets: dict[tuple[int, int], int]
 
     @classmethod
     def pack(
@@ -292,19 +294,19 @@ class OwnerGatherPlan:
             cursors[owner] += numel
 
         # Per (owned param, src) recv offset within the recv buffer from src.
-        recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+        recv_offsets: dict[tuple[int, int], int] = {}
         owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
         for src in range(dp_size):
             if src == this_rank:
                 continue
             offset = 0
             for param_index in owned_indices:
-                plan = plans[param_index]
-                numel = plan.shard_numel(src)
-                recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
-                offset += numel
+                recv_offsets[(param_index, src)] = offset
+                offset += plans[param_index].shard_numel(src)
 
         return cls(
+            plans=tuple(plans),
+            this_rank=this_rank,
             send_buffers=send_buffers,
             recv_sizes=recv_sizes,
             own_shards=own_shards,
@@ -312,26 +314,21 @@ class OwnerGatherPlan:
         )
 
     def reconstruct_full(
-        self,
-        param_index: int,
-        plan: ParameterLayout,
-        recv_buffers: dict[int, torch.Tensor],
-        owner_rank: int,
+        self, param_index: int, recv_buffers: dict[int, torch.Tensor]
     ) -> torch.Tensor:
         """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
 
-        Concatenates shards in rank order: the owner's own local shard at its rank rows and each
+        Concatenates shards in rank order: this rank's own local shard at its rank rows and each
         source's received shard at that source's rank rows.
 
         Args:
             param_index: Index of the parameter within the sequence of plans passed to `pack`.
-            plan: Shard plan for this parameter.
             recv_buffers: Per-source-rank received buffer (only sources that sent).
-            owner_rank: The owner rank (== the rank running reconstruction).
         """
+        plan = self.plans[param_index]
         shards: list[torch.Tensor] = []
         for src in range(plan.dp_size):
-            if src == owner_rank:
+            if src == self.this_rank:
                 shards.append(self.own_shards[param_index])
                 continue
 
@@ -339,7 +336,8 @@ class OwnerGatherPlan:
             if row_count == 0:
                 continue
 
-            offset, numel, _ = self.recv_offsets[(param_index, src)]
+            offset = self.recv_offsets[(param_index, src)]
+            numel = plan.shard_numel(src)
             buf = recv_buffers[src]
             shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
         if len(shards) == 1:
@@ -359,13 +357,15 @@ class OwnerScatterPlan:
             params it owns, in param order). Only destinations other than this rank appear.
         recv_sizes: Per-owner-rank element count this rank (as a destination) receives. Only owners
             other than this rank appear.
-        recv_offsets: Per `(param_index, owner_rank)` of `(offset, numel, row_count)` describing
-            where this param's result shard lands inside the recv buffer received from `owner_rank`.
+        recv_offsets: Per `(param_index, owner_rank)`, the flat offset of this param's result shard
+            inside the recv buffer received from `owner_rank`.
     """
 
+    plans: tuple[ParameterLayout, ...]
+    this_rank: int
     send_buffers: dict[int, torch.Tensor]
     recv_sizes: dict[int, int]
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+    recv_offsets: dict[tuple[int, int], int]
 
     @classmethod
     def pack(
@@ -428,7 +428,7 @@ class OwnerScatterPlan:
                 )
                 cursors[dest] += numel
 
-        recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+        recv_offsets: dict[tuple[int, int], int] = {}
         for owner in range(dp_size):
             if owner == this_rank:
                 continue
@@ -436,11 +436,16 @@ class OwnerScatterPlan:
             for param_index, plan in enumerate(plans):
                 if owners[param_index] != owner:
                     continue
-                numel = plan.shard_numel(this_rank)
-                recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
-                offset += numel
+                recv_offsets[(param_index, owner)] = offset
+                offset += plan.shard_numel(this_rank)
 
-        return cls(send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets)
+        return cls(
+            plans=tuple(plans),
+            this_rank=this_rank,
+            send_buffers=send_buffers,
+            recv_sizes=recv_sizes,
+            recv_offsets=recv_offsets,
+        )
 
     def unpack(self, recv_buffers: dict[int, torch.Tensor]) -> dict[int, torch.Tensor]:
         """Extract this rank's local result shards from the per-owner recv buffers.
@@ -453,10 +458,12 @@ class OwnerScatterPlan:
             parameters this rank does NOT own.
         """
         results: dict[int, torch.Tensor] = {}
-        for (param_index, owner), (offset, numel, row_count) in self.recv_offsets.items():
+        for (param_index, owner), offset in self.recv_offsets.items():
+            plan = self.plans[param_index]
+            numel = plan.shard_numel(self.this_rank)
             if numel == 0:
                 continue
+            row_count = plan.rank_row_count(self.this_rank)
             buf = recv_buffers[owner]
-            row_size = numel // row_count if row_count else 1
-            results[param_index] = buf[offset : offset + numel].view(row_count, row_size)
+            results[param_index] = buf[offset : offset + numel].view(row_count, plan.row_size)
         return results

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -3,10 +3,10 @@
 """
 Pure shard-planning and owner-compute packing logic for MFSDP v2's all-`Flat` layout.
 
-The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
-is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
+The central data structure is `ParameterLayout`, which describes how a single 2D parameter's full
+matrix is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
 `assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
-function. `ShardPlan.from_layout` builds a plan from DBuffer layout metadata,
+function. `ParameterLayout.from_layout` builds a plan from DBuffer layout metadata,
 `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
 `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
 and `OwnerScatterPlan.unpack` extracts received result shards.
@@ -22,7 +22,7 @@ from .layout import GlobalLayout, non_leading_numel
 
 
 @dataclasses.dataclass(frozen=True)
-class ShardPlan:
+class ParameterLayout:
     """How a single 2D parameter's full matrix is split across the DP group.
 
     MFSDP v2's all-`Flat` layout shards dim-0 rows contiguously in rank order, so rank `r` owns the
@@ -42,12 +42,12 @@ class ShardPlan:
 
     def __post_init__(self) -> None:
         if len(self.full_shape) != 2:
-            raise ValueError(f"ShardPlan requires a 2D full_shape, got {self.full_shape}.")
+            raise ValueError(f"ParameterLayout requires a 2D full_shape, got {self.full_shape}.")
         if len(self.rank_rows) == 0:
-            raise ValueError("ShardPlan requires at least one rank.")
+            raise ValueError("ParameterLayout requires at least one rank.")
         if self.row_size != non_leading_numel(self.full_shape):
             raise ValueError(
-                f"ShardPlan row_size {self.row_size} != full_shape row size "
+                f"ParameterLayout row_size {self.row_size} != full_shape row size "
                 f"{non_leading_numel(self.full_shape)}."
             )
 
@@ -67,11 +67,11 @@ class ShardPlan:
         rank_flat_shard_size = layout.size // dp_size
 
         if len(full_shape) != 2:
-            raise ValueError(f"ShardPlan.from_layout requires a 2D shape, got {full_shape}.")
+            raise ValueError(f"ParameterLayout.from_layout requires a 2D shape, got {full_shape}.")
         row_size = non_leading_numel(full_shape)
         if row_size <= 0:
             raise ValueError(
-                f"ShardPlan.from_layout requires non-empty rows, got shape {full_shape}."
+                f"ParameterLayout.from_layout requires non-empty rows, got shape {full_shape}."
             )
         tensor_end = tensor_flat_offset + full_shape.numel()
 
@@ -127,7 +127,7 @@ class ShardPlan:
 
 
 def assign_owner_work(
-    plans: Sequence[ShardPlan], cost_fn: Callable[[ShardPlan], float]
+    plans: Sequence[ParameterLayout], cost_fn: Callable[[ParameterLayout], float]
 ) -> dict[int, int]:
     """Assign one owner rank to each boundary parameter, balanced by cost.
 
@@ -184,7 +184,7 @@ class OwnerGatherPlan:
     param_1: torch.Tensor
     # Params are in this order as observed by MFSDP.
     model.param_groups == [{"params": [param_0, param_1]}]
-    # Both params are owned by rank 1 (was previously determined using `ShardPlan`s).
+    # Both params are owned by rank 1 (was previously determined using `ParameterLayout`s).
     param_0.owner == 1
     param_1.owner == 1
 
@@ -243,7 +243,7 @@ class OwnerGatherPlan:
     @classmethod
     def pack(
         cls,
-        plans: Sequence[ShardPlan],
+        plans: Sequence[ParameterLayout],
         owners: dict[int, int],
         local_shards: Sequence[torch.Tensor],
         dp_size: int,
@@ -314,7 +314,7 @@ class OwnerGatherPlan:
     def reconstruct_full(
         self,
         param_index: int,
-        plan: ShardPlan,
+        plan: ParameterLayout,
         recv_buffers: dict[int, torch.Tensor],
         owner_rank: int,
     ) -> torch.Tensor:
@@ -371,7 +371,7 @@ class OwnerScatterPlan:
     def pack(
         cls,
         full_results: dict[int, torch.Tensor],
-        plans: Sequence[ShardPlan],
+        plans: Sequence[ParameterLayout],
         owners: dict[int, int],
         dp_size: int,
         this_rank: int,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -4,9 +4,9 @@
 Pure shard-planning and owner-compute packing logic for MFSDP v2's all-`Flat` layout.
 
 The central data structure is `ParameterLayout`, which describes how a single 2D parameter's full
-matrix is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
+matrix is split across the DP group under MFSDP v2's all-`Flat` layout. Given parameter layouts,
 `assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
-function. `ParameterLayout.from_layout` builds a plan from DBuffer layout metadata,
+function. `ParameterLayout.from_layout` builds a layout from DBuffer layout metadata,
 `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
 `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
 and `OwnerScatterPlan.unpack` extracts received result shards.
@@ -52,7 +52,7 @@ class ParameterLayout:
 
     @classmethod
     def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> Self:
-        """Build a shard plan for one parameter from a `GlobalLayout`.
+        """Build a parameter layout for one parameter from a `GlobalLayout`.
 
         Computes the per-rank row ranges for the given 2D parameter in a flat DBuffer layout.
 
@@ -131,7 +131,7 @@ class ParameterLayout:
 
 
 def assign_owner_work(
-    plans: Sequence[ParameterLayout], cost_fn: Callable[[ParameterLayout], float]
+    layouts: Sequence[ParameterLayout], cost_fn: Callable[[ParameterLayout], float]
 ) -> dict[int, int]:
     """Assign one owner rank to each boundary parameter, balanced by cost.
 
@@ -140,28 +140,28 @@ def assign_owner_work(
     parameter to its eligible rank with the smallest running cost total.
 
     Args:
-        plans: Shard plans indexed by their position in the input sequence.
-        cost_fn: Callable that returns a positive cost estimate for a given shard plan. The greedy
-            balancer minimizes the maximum running cost total across ranks, so the cost should
-            reflect the relative compute weight of owning each parameter (e.g., an orthogonalization
-            cost estimate).
+        layouts: Parameter layouts indexed by their position in the input sequence.
+        cost_fn: Callable that returns a positive cost estimate for a given parameter layout. The
+            greedy balancer minimizes the maximum running cost total across ranks, so the cost
+            should reflect the relative compute weight of owning each parameter (e.g., an
+            orthogonalization cost estimate).
 
     Returns:
-        Mapping from boundary parameter index (in `plans`) to owner rank. Non-boundary parameters
+        Mapping from boundary parameter index (in `layouts`) to owner rank. Non-boundary parameters
         are absent, as they stay on their original rank.
     """
     assignments: dict[int, int] = {}
-    running: dict[int, float] = {r: 0.0 for r in range(plans[0].dp_size)} if plans else {}
-    for param_index, plan in enumerate(plans):
-        if not plan.is_boundary():
+    running: dict[int, float] = {r: 0.0 for r in range(layouts[0].dp_size)} if layouts else {}
+    for param_index, layout in enumerate(layouts):
+        if not layout.is_boundary():
             continue
-        candidates = plan.owner_candidates()
+        candidates = layout.owner_candidates()
         if not candidates:
             raise RuntimeError(
-                f"No eligible owner for parameter {param_index} with shape {plan.full_shape}; "
+                f"No eligible owner for parameter {param_index} with shape {layout.full_shape}; "
                 "no rank owns a shard."
             )
-        cost = cost_fn(plan)
+        cost = cost_fn(layout)
         owner = min(candidates, key=lambda r: running[r])
         assignments[param_index] = owner
         running[owner] += cost
@@ -239,7 +239,7 @@ class OwnerGatherPlan:
             the recv buffer received from `src_rank`.
     """
 
-    plans: tuple[ParameterLayout, ...]
+    layouts: tuple[ParameterLayout, ...]
     this_rank: int
     send_buffers: dict[int, torch.Tensor]
     recv_sizes: dict[int, int]
@@ -249,7 +249,7 @@ class OwnerGatherPlan:
     @classmethod
     def pack(
         cls,
-        plans: Sequence[ParameterLayout],
+        layouts: Sequence[ParameterLayout],
         owners: dict[int, int],
         local_shards: Sequence[torch.Tensor],
         dp_size: int,
@@ -258,7 +258,7 @@ class OwnerGatherPlan:
         """Pack this rank's local shards into per-owner P2P send buffers.
 
         Args:
-            plans: Shard plans in parameter order.
+            layouts: Parameter layouts in parameter order.
             owners: Mapping from parameter index to owner rank.
             local_shards: This rank's local shard per parameter.
             dp_size: DP group size.
@@ -268,15 +268,15 @@ class OwnerGatherPlan:
         dtype = local_shards[0].dtype
         send_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
         recv_sizes: dict[int, int] = {sender: 0 for sender in range(dp_size) if sender != this_rank}
-        for param_index, plan in enumerate(plans):
+        for param_index, layout in enumerate(layouts):
             owner = owners[param_index]
             if owner != this_rank:
-                send_sizes[owner] += plan.shard_numel(this_rank)
+                send_sizes[owner] += layout.shard_numel(this_rank)
                 continue
             for src in range(dp_size):
                 if src == this_rank:
                     continue
-                recv_sizes[src] += plan.shard_numel(src)
+                recv_sizes[src] += layout.shard_numel(src)
 
         send_buffers: dict[int, torch.Tensor] = {}
         for owner, size in send_sizes.items():
@@ -285,12 +285,12 @@ class OwnerGatherPlan:
         # Fill each owner's send buffer in param order.
         cursors: dict[int, int] = {owner: 0 for owner in send_buffers}
         own_shards: dict[int, torch.Tensor] = {}
-        for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
+        for param_index, (layout, shard) in enumerate(zip(layouts, local_shards)):
             owner = owners[param_index]
             if owner == this_rank:
                 own_shards[param_index] = shard
                 continue
-            numel = plan.shard_numel(this_rank)
+            numel = layout.shard_numel(this_rank)
             if numel == 0:
                 continue
             buf = send_buffers[owner]
@@ -299,17 +299,17 @@ class OwnerGatherPlan:
 
         # Per (owned param, src) recv offset within the recv buffer from src.
         recv_offsets: dict[tuple[int, int], int] = {}
-        owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+        owned_indices = [i for i in range(len(layouts)) if owners[i] == this_rank]
         for src in range(dp_size):
             if src == this_rank:
                 continue
             offset = 0
             for param_index in owned_indices:
                 recv_offsets[(param_index, src)] = offset
-                offset += plans[param_index].shard_numel(src)
+                offset += layouts[param_index].shard_numel(src)
 
         return cls(
-            plans=tuple(plans),
+            layouts=tuple(layouts),
             this_rank=this_rank,
             send_buffers=send_buffers,
             recv_sizes=recv_sizes,
@@ -326,24 +326,24 @@ class OwnerGatherPlan:
         source's received shard at that source's rank rows.
 
         Args:
-            param_index: Index of the parameter within the sequence of plans passed to `pack`.
+            param_index: Index of the parameter within the sequence of layouts passed to `pack`.
             recv_buffers: Per-source-rank received buffer (only sources that sent).
         """
-        plan = self.plans[param_index]
+        layout = self.layouts[param_index]
         shards: list[torch.Tensor] = []
-        for src in range(plan.dp_size):
+        for src in range(layout.dp_size):
             if src == self.this_rank:
                 shards.append(self.own_shards[param_index])
                 continue
 
-            row_count = plan.rank_row_count(src)
+            row_count = layout.rank_row_count(src)
             if row_count == 0:
                 continue
 
             offset = self.recv_offsets[(param_index, src)]
-            numel = plan.shard_numel(src)
+            numel = layout.shard_numel(src)
             buf = recv_buffers[src]
-            shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
+            shards.append(buf[offset : offset + numel].view(row_count, layout.row_size))
         if len(shards) == 1:
             return shards[0]
         return torch.cat(shards, dim=0)
@@ -365,7 +365,7 @@ class OwnerScatterPlan:
             inside the recv buffer received from `owner_rank`.
     """
 
-    plans: tuple[ParameterLayout, ...]
+    layouts: tuple[ParameterLayout, ...]
     this_rank: int
     send_buffers: dict[int, torch.Tensor]
     recv_sizes: dict[int, int]
@@ -375,7 +375,7 @@ class OwnerScatterPlan:
     def pack(
         cls,
         full_results: dict[int, torch.Tensor],
-        plans: Sequence[ParameterLayout],
+        layouts: Sequence[ParameterLayout],
         owners: dict[int, int],
         dp_size: int,
         this_rank: int,
@@ -387,29 +387,29 @@ class OwnerScatterPlan:
 
         Args:
             full_results: Full result tensor per owned parameter index.
-            plans: Shard plans in parameter order.
+            layouts: Parameter layouts in parameter order.
             owners: Mapping from parameter index to owner rank.
             dp_size: DP group size.
             this_rank: This rank's DP index.
             device: Device for the send buffers.
             dtype: Dtype for the send buffers.
         """
-        owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+        owned_indices = [i for i in range(len(layouts)) if owners[i] == this_rank]
         send_sizes: dict[int, int] = {
             receiver: 0 for receiver in range(dp_size) if receiver != this_rank
         }
         recv_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
         for param_index in owned_indices:
-            plan = plans[param_index]
+            layout = layouts[param_index]
             for dest in range(dp_size):
                 if dest == this_rank:
                     continue
-                send_sizes[dest] += plan.shard_numel(dest)
-        for param_index, plan in enumerate(plans):
+                send_sizes[dest] += layout.shard_numel(dest)
+        for param_index, layout in enumerate(layouts):
             owner = owners[param_index]
             if owner == this_rank:
                 continue
-            recv_sizes[owner] += plan.shard_numel(this_rank)
+            recv_sizes[owner] += layout.shard_numel(this_rank)
 
         send_buffers: dict[int, torch.Tensor] = {}
         for dest, size in send_sizes.items():
@@ -420,10 +420,10 @@ class OwnerScatterPlan:
             if dest == this_rank:
                 continue
             for param_index in owned_indices:
-                plan = plans[param_index]
-                row_count = plan.rank_row_count(dest)
-                row_start = plan.rank_row_start(dest)
-                numel = row_count * plan.row_size
+                layout = layouts[param_index]
+                row_count = layout.rank_row_count(dest)
+                row_start = layout.rank_row_start(dest)
+                numel = row_count * layout.row_size
                 if numel == 0:
                     continue
                 full = full_results[param_index]
@@ -438,14 +438,14 @@ class OwnerScatterPlan:
             if owner == this_rank:
                 continue
             offset = 0
-            for param_index, plan in enumerate(plans):
+            for param_index, layout in enumerate(layouts):
                 if owners[param_index] != owner:
                     continue
                 recv_offsets[(param_index, owner)] = offset
-                offset += plan.shard_numel(this_rank)
+                offset += layout.shard_numel(this_rank)
 
         return cls(
-            plans=tuple(plans),
+            layouts=tuple(layouts),
             this_rank=this_rank,
             send_buffers=send_buffers,
             recv_sizes=recv_sizes,
@@ -464,11 +464,11 @@ class OwnerScatterPlan:
         """
         results: dict[int, torch.Tensor] = {}
         for (param_index, owner), offset in self.recv_offsets.items():
-            plan = self.plans[param_index]
-            numel = plan.shard_numel(self.this_rank)
+            layout = self.layouts[param_index]
+            numel = layout.shard_numel(self.this_rank)
             if numel == 0:
                 continue
-            row_count = plan.rank_row_count(self.this_rank)
+            row_count = layout.rank_row_count(self.this_rank)
             buf = recv_buffers[owner]
-            results[param_index] = buf[offset : offset + numel].view(row_count, plan.row_size)
+            results[param_index] = buf[offset : offset + numel].view(row_count, layout.row_size)
         return results

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -183,7 +183,7 @@ def assign_owner_work(
             assignments[param_index] = candidates[0]
             continue
         cost = cost_fn(plan)
-        owner = min(candidates, key=lambda r: (running[r], r))
+        owner = min(candidates, key=lambda r: running[r])
         assignments[param_index] = owner
         running[owner] += cost
     return assignments

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -12,11 +12,10 @@ function. `ShardPlan.from_layout_params` builds a plan from DBuffer layout metad
 and `OwnerScatterPlan.unpack` extracts received result shards.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import functools
 from collections.abc import Callable, Sequence
+from typing import Self
 
 import torch
 
@@ -60,7 +59,7 @@ class ShardPlan:
         tensor_flat_offset: int,
         rank_flat_shard_size: int,
         dp_size: int,
-    ) -> ShardPlan:
+    ) -> Self:
         """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
 
         Args:
@@ -106,7 +105,7 @@ class ShardPlan:
         return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
 
     @classmethod
-    def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> ShardPlan:
+    def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> Self:
         """Build a shard plan for one parameter from a `GlobalLayout`.
 
         Extracts the parameter's shape, flat offset, and per-rank shard size from `layout` and
@@ -277,7 +276,7 @@ class OwnerGatherPlan:
         *,
         device: torch.device,
         dtype: torch.dtype,
-    ) -> OwnerGatherPlan:
+    ) -> Self:
         """Pack this rank's local shards into per-owner P2P send buffers.
 
         Args:
@@ -405,7 +404,7 @@ class OwnerScatterPlan:
         *,
         device: torch.device,
         dtype: torch.dtype,
-    ) -> OwnerScatterPlan:
+    ) -> Self:
         """Pack this owner rank's full results into per-destination P2P send buffers.
 
         Args:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -230,9 +230,9 @@ class OwnerGatherPlan:
 
     Attributes:
         send_buffers: Per-destination-owner flat send buffer (this rank's shards for that owner's
-            params, in param order). Only owners other than this rank appear.
+            params, in param order). Only owners with non-zero send size appear.
         recv_sizes: Per-source-rank element count this rank (as an owner) receives. Only sources
-            other than this rank appear.
+            with non-zero total size appear.
         own_shards: This rank's local shard per owned parameter (used directly in reconstruction,
             not communicated).
         recv_offsets: Per `(param_index, src_rank)`, the flat offset of this param's shard inside
@@ -266,17 +266,21 @@ class OwnerGatherPlan:
         """
         device = local_shards[0].device
         dtype = local_shards[0].dtype
-        send_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
-        recv_sizes: dict[int, int] = {sender: 0 for sender in range(dp_size) if sender != this_rank}
+        send_sizes: dict[int, int] = {}
+        recv_sizes: dict[int, int] = {}
         for param_index, layout in enumerate(layouts):
             owner = owners[param_index]
             if owner != this_rank:
-                send_sizes[owner] += layout.shard_numel(this_rank)
+                send_numel = layout.shard_numel(this_rank)
+                if send_numel > 0:
+                    send_sizes[owner] = send_sizes.get(owner, 0) + send_numel
                 continue
             for src in range(dp_size):
                 if src == this_rank:
                     continue
-                recv_sizes[src] += layout.shard_numel(src)
+                recv_numel = layout.shard_numel(src)
+                if recv_numel > 0:
+                    recv_sizes[src] = recv_sizes.get(src, 0) + recv_numel
 
         send_buffers: dict[int, torch.Tensor] = {}
         for owner, size in send_sizes.items():
@@ -358,9 +362,9 @@ class OwnerScatterPlan:
 
     Attributes:
         send_buffers: Per-destination-rank flat send buffer (this owner's result shards for the
-            params it owns, in param order). Only destinations other than this rank appear.
+            params it owns, in param order). Only destinations with non-zero send size appear.
         recv_sizes: Per-owner-rank element count this rank (as a destination) receives. Only owners
-            other than this rank appear.
+            with non-zero total size appear.
         recv_offsets: Per `(param_index, owner_rank)`, the flat offset of this param's result shard
             inside the recv buffer received from `owner_rank`.
     """
@@ -395,21 +399,23 @@ class OwnerScatterPlan:
             dtype: Dtype for the send buffers.
         """
         owned_indices = [i for i in range(len(layouts)) if owners[i] == this_rank]
-        send_sizes: dict[int, int] = {
-            receiver: 0 for receiver in range(dp_size) if receiver != this_rank
-        }
-        recv_sizes: dict[int, int] = {owner: 0 for owner in range(dp_size) if owner != this_rank}
+        send_sizes: dict[int, int] = {}
+        recv_sizes: dict[int, int] = {}
         for param_index in owned_indices:
             layout = layouts[param_index]
             for dest in range(dp_size):
                 if dest == this_rank:
                     continue
-                send_sizes[dest] += layout.shard_numel(dest)
+                numel = layout.shard_numel(dest)
+                if numel > 0:
+                    send_sizes[dest] = send_sizes.get(dest, 0) + numel
         for param_index, layout in enumerate(layouts):
             owner = owners[param_index]
             if owner == this_rank:
                 continue
-            recv_sizes[owner] += layout.shard_numel(this_rank)
+            numel = layout.shard_numel(this_rank)
+            if numel > 0:
+                recv_sizes[owner] = recv_sizes.get(owner, 0) + numel
 
         send_buffers: dict[int, torch.Tensor] = {}
         for dest, size in send_sizes.items():

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -359,15 +359,17 @@ class OwnerGatherPlan:
         """
         shards: list[torch.Tensor] = []
         for src in range(plan.dp_size):
-            row_count = plan.rank_row_count(src)
             if src == owner_rank:
                 shards.append(self.own_shards[param_index])
-            elif row_count == 0:
                 continue
-            else:
-                offset, numel, _ = self.recv_offsets[(param_index, src)]
-                buf = recv_buffers[src]
-                shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
+
+            row_count = plan.rank_row_count(src)
+            if row_count == 0:
+                continue
+
+            offset, numel, _ = self.recv_offsets[(param_index, src)]
+            buf = recv_buffers[src]
+            shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
         if len(shards) == 1:
             return shards[0]
         return torch.cat(shards, dim=0)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -31,19 +31,18 @@ class ParameterLayout:
 
     Attributes:
         full_shape: Global `(rows, cols)` shape of the parameter.
-        rank_rows: Per-rank `(row_start, row_count)` tuples; `row_count == 0` means the rank holds
-            no shard.
+        row_counts: Per-rank row count; `0` means the rank holds no shard.
         row_size: Number of elements per row (= `full_shape[1:].numel()`).
     """
 
     full_shape: torch.Size
-    rank_rows: tuple[tuple[int, int], ...]
+    row_counts: tuple[int, ...]
     row_size: int
 
     def __post_init__(self) -> None:
         if len(self.full_shape) != 2:
             raise ValueError(f"ParameterLayout requires a 2D full_shape, got {self.full_shape}.")
-        if len(self.rank_rows) == 0:
+        if len(self.row_counts) == 0:
             raise ValueError("ParameterLayout requires at least one rank.")
         if self.row_size != non_leading_numel(self.full_shape):
             raise ValueError(
@@ -75,14 +74,14 @@ class ParameterLayout:
             )
         tensor_end = tensor_flat_offset + full_shape.numel()
 
-        rank_rows: list[tuple[int, int]] = []
+        row_counts: list[int] = []
         for rank in range(dp_size):
             rank_start = rank * rank_flat_shard_size
             rank_end = rank_start + rank_flat_shard_size
             overlap_start = max(tensor_flat_offset, rank_start)
             overlap_end = min(tensor_end, rank_end)
             if overlap_start >= overlap_end:
-                rank_rows.append((0, 0))
+                row_counts.append(0)
                 continue
             if (overlap_start - tensor_flat_offset) % row_size != 0:
                 raise RuntimeError(
@@ -95,19 +94,24 @@ class ParameterLayout:
                     f"Flat shard overlap is not row-aligned for shape {full_shape}: "
                     f"overlap_numel={overlap_numel}, row_size={row_size}."
                 )
-            row_start = (overlap_start - tensor_flat_offset) // row_size
             row_count = overlap_numel // row_size
-            rank_rows.append((row_start, row_count))
-        return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
+            row_counts.append(row_count)
+        return cls(
+            full_shape=torch.Size(full_shape), row_counts=tuple(row_counts), row_size=row_size
+        )
 
     @property
     def dp_size(self) -> int:
         """Number of ranks in the DP group for this parameter."""
-        return len(self.rank_rows)
+        return len(self.row_counts)
+
+    def rank_row_start(self, rank: int) -> int:
+        """Return the starting row of `rank`'s shard within the full tensor."""
+        return sum(self.row_counts[:rank])
 
     def rank_row_count(self, rank: int) -> int:
         """Return the number of rows owned by `rank`."""
-        return self.rank_rows[rank][1]
+        return self.row_counts[rank]
 
     def shard_numel(self, rank: int) -> int:
         """Return the number of elements in `rank`'s shard."""
@@ -115,11 +119,11 @@ class ParameterLayout:
 
     def owner_candidates(self) -> tuple[int, ...]:
         """Return the ranks that hold a non-empty shard of this parameter."""
-        return tuple(r for r, (_, count) in enumerate(self.rank_rows) if count > 0)
+        return tuple(r for r, count in enumerate(self.row_counts) if count > 0)
 
     def is_boundary(self) -> bool:
         """True if more than one rank owns a non-empty shard of this parameter."""
-        return any(0 < count < self.full_shape[0] for _, count in self.rank_rows)
+        return any(0 < count < self.full_shape[0] for count in self.row_counts)
 
     def full_numel(self) -> int:
         """Return the total number of elements in the full (unsharded) parameter."""
@@ -417,7 +421,8 @@ class OwnerScatterPlan:
                 continue
             for param_index in owned_indices:
                 plan = plans[param_index]
-                row_start, row_count = plan.rank_rows[dest]
+                row_count = plan.rank_row_count(dest)
+                row_start = plan.rank_row_start(dest)
                 numel = row_count * plan.row_size
                 if numel == 0:
                     continue

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -294,11 +294,11 @@ class OwnerGatherPlan:
             owner = owners[param_index]
             if owner != this_rank:
                 send_sizes[owner] += plan.shard_numel(this_rank)
-            else:
-                for src in range(dp_size):
-                    if src == this_rank:
-                        continue
-                    recv_sizes[src] += plan.shard_numel(src)
+                continue
+            for src in range(dp_size):
+                if src == this_rank:
+                    continue
+                recv_sizes[src] += plan.shard_numel(src)
 
         send_buffers: dict[int, torch.Tensor] = {}
         for owner, size in send_sizes.items():

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -6,7 +6,7 @@ Pure shard-planning and owner-compute packing logic for MFSDP v2's all-`Flat` l
 The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
 is split across the DP group under MFSDP v2's all-`Flat` layout. Given shard plans,
 `assign_owner_work` balances owner-compute work across owner ranks using a caller-supplied cost
-function. `ShardPlan.from_layout_params` builds a plan from DBuffer layout metadata,
+function. `ShardPlan.from_layout` builds a plan from DBuffer layout metadata,
 `OwnerGatherPlan.pack`/`OwnerScatterPlan.pack` build the flat P2P send/recv buffers,
 `OwnerGatherPlan.reconstruct_full` stitches gathered shards back into the full matrix on the owner,
 and `OwnerScatterPlan.unpack` extracts received result shards.
@@ -52,29 +52,26 @@ class ShardPlan:
             )
 
     @classmethod
-    def from_layout_params(
-        cls,
-        full_shape: torch.Size,
-        tensor_flat_offset: int,
-        rank_flat_shard_size: int,
-        dp_size: int,
-    ) -> Self:
-        """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
+    def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> Self:
+        """Build a shard plan for one parameter from a `GlobalLayout`.
+
+        Computes the per-rank row ranges for the given 2D parameter in a flat DBuffer layout.
 
         Args:
-            full_shape: Global `(rows, cols)` shape of the parameter.
-            tensor_flat_offset: Flat-element offset of this parameter inside the DBuffer's global
-                layout.
-            rank_flat_shard_size: Flat elements each DP rank owns (uniform for the even all-`Flat`
-                layout: `layout.size // dp_size`).
+            layout: The DBuffer global layout that contains the parameter.
+            tensor_index: Index of the parameter within `layout`.
             dp_size: DP group size.
         """
+        full_shape = layout.tensor_shapes[tensor_index]
+        tensor_flat_offset = layout.tensor_to_offset[tensor_index]
+        rank_flat_shard_size = layout.size // dp_size
+
         if len(full_shape) != 2:
-            raise ValueError(f"ShardPlan.from_layout_params requires a 2D shape, got {full_shape}.")
+            raise ValueError(f"ShardPlan.from_layout requires a 2D shape, got {full_shape}.")
         row_size = non_leading_numel(full_shape)
         if row_size <= 0:
             raise ValueError(
-                f"ShardPlan.from_layout_params requires non-empty rows, got shape {full_shape}."
+                f"ShardPlan.from_layout requires non-empty rows, got shape {full_shape}."
             )
         tensor_end = tensor_flat_offset + full_shape.numel()
 
@@ -102,25 +99,6 @@ class ShardPlan:
             row_count = overlap_numel // row_size
             rank_rows.append((row_start, row_count))
         return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
-
-    @classmethod
-    def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> Self:
-        """Build a shard plan for one parameter from a `GlobalLayout`.
-
-        Extracts the parameter's shape, flat offset, and per-rank shard size from `layout` and
-        delegates to `from_layout_params`.
-
-        Args:
-            layout: The DBuffer global layout that contains the parameter.
-            tensor_index: Index of the parameter within `layout`.
-            dp_size: DP group size.
-        """
-        return cls.from_layout_params(
-            layout.tensor_shapes[tensor_index],
-            layout.tensor_to_offset[tensor_index],
-            layout.size // dp_size,
-            dp_size,
-        )
 
     @property
     def dp_size(self) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -59,7 +59,7 @@ class ShardPlan:
         full_shape: torch.Size,
         tensor_flat_offset: int,
         rank_flat_shard_size: int,
-        world_size: int,
+        dp_size: int,
     ) -> ShardPlan:
         """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
 
@@ -68,8 +68,8 @@ class ShardPlan:
             tensor_flat_offset: Flat-element offset of this parameter inside the DBuffer's global
                 layout.
             rank_flat_shard_size: Flat elements each DP rank owns (uniform for the even all-`Flat`
-                layout: `layout.size // world_size`).
-            world_size: DP group size.
+                layout: `layout.size // dp_size`).
+            dp_size: DP group size.
         """
         if len(full_shape) != 2:
             raise ValueError(f"ShardPlan.from_layout_params requires a 2D shape, got {full_shape}.")
@@ -81,7 +81,7 @@ class ShardPlan:
         tensor_end = tensor_flat_offset + full_shape.numel()
 
         rank_rows: list[tuple[int, int]] = []
-        for rank in range(world_size):
+        for rank in range(dp_size):
             rank_start = rank * rank_flat_shard_size
             rank_end = rank_start + rank_flat_shard_size
             overlap_start = max(tensor_flat_offset, rank_start)
@@ -106,7 +106,7 @@ class ShardPlan:
         return cls(full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size)
 
     @classmethod
-    def from_layout(cls, layout: GlobalLayout, tensor_index: int, world_size: int) -> ShardPlan:
+    def from_layout(cls, layout: GlobalLayout, tensor_index: int, dp_size: int) -> ShardPlan:
         """Build a shard plan for one parameter from a `GlobalLayout`.
 
         Extracts the parameter's shape, flat offset, and per-rank shard size from `layout` and
@@ -115,17 +115,17 @@ class ShardPlan:
         Args:
             layout: The DBuffer global layout that contains the parameter.
             tensor_index: Index of the parameter within `layout`.
-            world_size: DP group size.
+            dp_size: DP group size.
         """
         return cls.from_layout_params(
             layout.tensor_shapes[tensor_index],
             layout.tensor_to_offset[tensor_index],
-            layout.size // world_size,
-            world_size,
+            layout.size // dp_size,
+            dp_size,
         )
 
     @property
-    def world_size(self) -> int:
+    def dp_size(self) -> int:
         """Number of ranks in the DP group for this parameter."""
         return len(self.rank_rows)
 
@@ -171,7 +171,7 @@ def assign_owner_work(
         Mapping from parameter index (in `plans`) to owner rank.
     """
     assignments: dict[int, int] = {}
-    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
+    running: dict[int, float] = {r: 0.0 for r in range(plans[0].dp_size)} if plans else {}
     for param_index, plan in enumerate(plans):
         candidates = plan.owner_candidates()
         if not candidates:
@@ -272,7 +272,7 @@ class OwnerGatherPlan:
         plans: Sequence[ShardPlan],
         owners: dict[int, int],
         local_shards: Sequence[torch.Tensor],
-        world_size: int,
+        dp_size: int,
         this_rank: int,
         *,
         device: torch.device,
@@ -284,19 +284,19 @@ class OwnerGatherPlan:
             plans: Shard plans in parameter order.
             owners: Mapping from parameter index to owner rank.
             local_shards: This rank's local shard per parameter.
-            world_size: DP group size.
+            dp_size: DP group size.
             this_rank: This rank's DP index.
             device: Device for the send buffers.
             dtype: Dtype for the send buffers.
         """
-        send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
-        recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
+        send_sizes: dict[int, int] = {o: 0 for o in range(dp_size) if o != this_rank}
+        recv_sizes: dict[int, int] = {s: 0 for s in range(dp_size) if s != this_rank}
         for param_index, plan in enumerate(plans):
             owner = owners[param_index]
             if owner != this_rank:
                 send_sizes[owner] += plan.shard_numel(this_rank)
             else:
-                for src in range(world_size):
+                for src in range(dp_size):
                     if src == this_rank:
                         continue
                     recv_sizes[src] += plan.shard_numel(src)
@@ -323,7 +323,7 @@ class OwnerGatherPlan:
         # Per (owned param, src) recv offset within the recv buffer from src.
         recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
         owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-        for src in range(world_size):
+        for src in range(dp_size):
             if src == this_rank:
                 continue
             offset = 0
@@ -359,7 +359,7 @@ class OwnerGatherPlan:
             owner_rank: The owner rank (== the rank running reconstruction).
         """
         shards: list[torch.Tensor] = []
-        for src in range(plan.world_size):
+        for src in range(plan.dp_size):
             row_count = plan.rank_row_count(src)
             if src == owner_rank:
                 shards.append(self.own_shards[param_index])
@@ -400,7 +400,7 @@ class OwnerScatterPlan:
         full_results: dict[int, torch.Tensor],
         plans: Sequence[ShardPlan],
         owners: dict[int, int],
-        world_size: int,
+        dp_size: int,
         this_rank: int,
         *,
         device: torch.device,
@@ -412,17 +412,17 @@ class OwnerScatterPlan:
             full_results: Full result tensor per owned parameter index.
             plans: Shard plans in parameter order.
             owners: Mapping from parameter index to owner rank.
-            world_size: DP group size.
+            dp_size: DP group size.
             this_rank: This rank's DP index.
             device: Device for the send buffers.
             dtype: Dtype for the send buffers.
         """
         owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-        send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
-        recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+        send_sizes: dict[int, int] = {d: 0 for d in range(dp_size) if d != this_rank}
+        recv_sizes: dict[int, int] = {o: 0 for o in range(dp_size) if o != this_rank}
         for param_index in owned_indices:
             plan = plans[param_index]
-            for dest in range(world_size):
+            for dest in range(dp_size):
                 if dest == this_rank:
                     continue
                 send_sizes[dest] += plan.shard_numel(dest)
@@ -437,7 +437,7 @@ class OwnerScatterPlan:
             send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
 
         cursors: dict[int, int] = {d: 0 for d in send_buffers}
-        for dest in range(world_size):
+        for dest in range(dp_size):
             if dest == this_rank:
                 continue
             for param_index in owned_indices:
@@ -454,7 +454,7 @@ class OwnerScatterPlan:
                 cursors[dest] += numel
 
         recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
-        for owner in range(world_size):
+        for owner in range(dp_size):
             if owner == this_rank:
                 continue
             offset = 0

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -12,10 +12,10 @@ communication is simulated in-process by `_simulate_p2p`.
 import torch
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
+    OwnerGatherPlan,
+    OwnerScatterPlan,
     ShardPlan,
     assign_owner_work,
-    pack_owner_work,
-    pack_update_shards,
 )
 
 # ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ def test_pack_and_reconstruct_round_trip():
     per_rank_send = []
     per_rank_gather = []
     for r in range(world_size):
-        gather = pack_owner_work(
+        gather = OwnerGatherPlan.pack(
             plans,
             owners,
             per_rank_local[r],
@@ -183,7 +183,7 @@ def test_pack_and_unpack_update_round_trip():
     per_rank_send = []
     per_rank_scatter = []
     for r in range(world_size):
-        scatter = pack_update_shards(
+        scatter = OwnerScatterPlan.pack(
             full_updates_by_rank[r],
             plans,
             owners,

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -3,7 +3,7 @@
 """
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
-These tests exercise `ShardPlan.from_flat_layout`, `assign_owner_work`, `OwnerGatherPlan.pack`,
+These tests exercise `ShardPlan.from_layout_params`, `assign_owner_work`, `OwnerGatherPlan.pack`,
 `OwnerGatherPlan.reconstruct_full`, `OwnerScatterPlan.pack`, and `OwnerScatterPlan.unpack` without a
 process group or any `torch.distributed` dependency. P2P communication is simulated in-process by
 `_simulate_p2p`.
@@ -43,7 +43,7 @@ def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
 
 def test_compute_shard_plan_even_split():
     """A matrix exactly divisible by world_size splits evenly across ranks."""
-    plan = ShardPlan.from_flat_layout(
+    plan = ShardPlan.from_layout_params(
         torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, world_size=2
     )
     assert plan.full_shape == torch.Size((8, 4))
@@ -57,7 +57,7 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     """A small matrix landing across a rank boundary is split unevenly."""
     # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
     # owns [9,18). Tensor occupies [0,18) fully.
-    plan = ShardPlan.from_flat_layout(
+    plan = ShardPlan.from_layout_params(
         torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, world_size=2
     )
     assert plan.rank_rows == ((0, 3), (3, 3))
@@ -68,7 +68,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     """A matrix fully contained in one rank's flat shard is fully local."""
     # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
     # elements fits entirely in rank0.
-    plan = ShardPlan.from_flat_layout(
+    plan = ShardPlan.from_layout_params(
         torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, world_size=2
     )
     assert plan.rank_rows == ((0, 4), (0, 0))
@@ -79,7 +79,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
 def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
     # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
-    plan = ShardPlan.from_flat_layout(
+    plan = ShardPlan.from_layout_params(
         torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, world_size=2
     )
     assert plan.rank_rows == ((0, 0), (0, 4))
@@ -146,8 +146,8 @@ def test_pack_and_reconstruct_round_trip():
     torch.manual_seed(0)
     world_size = 2
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
-    plan0 = ShardPlan.from_flat_layout(torch.Size((6, 3)), 0, 9, world_size)
-    plan1 = ShardPlan.from_flat_layout(torch.Size((4, 2)), 0, 4, world_size)
+    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, world_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -189,8 +189,8 @@ def test_pack_and_unpack_result_round_trip():
     """Scattered result shards match the owner's full result sliced per rank."""
     torch.manual_seed(1)
     world_size = 2
-    plan0 = ShardPlan.from_flat_layout(torch.Size((6, 3)), 0, 9, world_size)
-    plan1 = ShardPlan.from_flat_layout(torch.Size((4, 2)), 0, 4, world_size)
+    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, world_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -225,14 +225,14 @@ def test_pack_and_unpack_result_round_trip():
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
 
 
-def test_from_flat_layout_per_rank_data_not_uniform():
+def test_from_layout_params_per_rank_data_not_uniform():
     """Flat sharding with uniform buffer size but non-uniform per-rank tensor data.
 
     `GlobalLayout.build` pads the total size to a multiple of `chunk_size * dp_size` so every rank's
     flat buffer is the same size. However, the actual tensor data per rank is not necessarily
     uniform.
 
-    This test verifies `from_flat_layout` correctly computes the non-uniform per-rank row counts
+    This test verifies `from_layout_params` correctly computes the non-uniform per-rank row counts
     from a uniform `rank_flat_shard_size`.
     """
     # 5 rows, 4 cols = 20 elements. dp_size = 3.
@@ -242,7 +242,7 @@ def test_from_flat_layout_per_rank_data_not_uniform():
     #   rank 0: [0, 8)   -> 8 elements -> 2 rows
     #   rank 1: [8, 16)  -> 8 elements -> 2 rows
     #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
-    plan = ShardPlan.from_flat_layout(torch.Size((5, 4)), 0, 8, 3)
+    plan = ShardPlan.from_layout_params(torch.Size((5, 4)), 0, 8, 3)
     assert plan.rank_rows == ((0, 2), (2, 2), (4, 1))
     assert plan.shard_numel(0) == 8
     assert plan.shard_numel(1) == 8

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -3,24 +3,19 @@
 """
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
-These tests exercise `ShardPlan`, `compute_shard_plan`, `assign_owner_work`, `pack_owner_work`,
-`reconstruct_full_tensor`, `pack_update_shards`, and `unpack_update_shards` without a process group
-or any `torch.distributed` dependency. P2P communication is simulated in-process by `_simulate_p2p`.
+These tests exercise `ShardPlan`, `ShardPlan.from_flat_layout`, `assign_owner_work`,
+`pack_owner_work`, `OwnerGatherPlan.reconstruct_full`, `pack_update_shards`, and
+`OwnerScatterPlan.unpack` without a process group or any `torch.distributed` dependency. P2P
+communication is simulated in-process by `_simulate_p2p`.
 """
 
-import pytest
 import torch
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
-    OwnerGatherPlan,
-    OwnerScatterPlan,
     ShardPlan,
     assign_owner_work,
-    compute_shard_plan,
     pack_owner_work,
     pack_update_shards,
-    reconstruct_full_tensor,
-    unpack_update_shards,
 )
 
 # ---------------------------------------------------------------------------
@@ -30,7 +25,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan im
 
 def test_compute_shard_plan_even_split():
     """A matrix exactly divisible by world_size splits evenly across ranks."""
-    plan = compute_shard_plan(
+    plan = ShardPlan.from_flat_layout(
         torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, world_size=2
     )
     assert plan.full_shape == torch.Size((8, 4))
@@ -42,9 +37,9 @@ def test_compute_shard_plan_even_split():
 
 def test_compute_shard_plan_boundary_param_split_across_ranks():
     """A small matrix landing across a rank boundary is split unevenly."""
-    # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0
-    # owns flat [0,9), rank1 owns [9,18). Tensor occupies [0,18) fully.
-    plan = compute_shard_plan(
+    # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
+    # owns [9,18). Tensor occupies [0,18) fully.
+    plan = ShardPlan.from_flat_layout(
         torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, world_size=2
     )
     assert plan.rank_rows == ((0, 3), (3, 3))
@@ -53,9 +48,9 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
 
 def test_compute_shard_plan_fully_local_param_on_one_rank():
     """A matrix fully contained in one rank's flat shard is fully local."""
-    # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor
-    # at offset 0 with 8 elements fits entirely in rank0.
-    plan = compute_shard_plan(
+    # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
+    # elements fits entirely in rank0.
+    plan = ShardPlan.from_flat_layout(
         torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, world_size=2
     )
     assert plan.rank_rows == ((0, 4), (0, 0))
@@ -66,7 +61,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
 def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
     # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
-    plan = compute_shard_plan(
+    plan = ShardPlan.from_flat_layout(
         torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, world_size=2
     )
     assert plan.rank_rows == ((0, 0), (0, 4))
@@ -133,8 +128,8 @@ def test_pack_and_reconstruct_round_trip():
     torch.manual_seed(0)
     world_size = 2
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
-    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)  # rank0: 3 rows, rank1: 3 rows
-    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)  # rank0: 2 rows, rank1: 2 rows
+    plan0 = ShardPlan.from_flat_layout(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = ShardPlan.from_flat_layout(torch.Size((4, 2)), 0, 4, world_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -165,10 +160,10 @@ def test_pack_and_reconstruct_round_trip():
     recv = _simulate_p2p(per_rank_send, world_size)
 
     # Rank0 owns param0; reconstruct and compare to full_p0.
-    full0 = reconstruct_full_tensor(0, plan0, per_rank_gather[0], recv[0], owner_rank=0)
+    full0 = per_rank_gather[0].reconstruct_full(0, plan0, recv[0], owner_rank=0)
     torch.testing.assert_close(full0, full_p0, atol=0, rtol=0)
     # Rank1 owns param1; reconstruct and compare to full_p1.
-    full1 = reconstruct_full_tensor(1, plan1, per_rank_gather[1], recv[1], owner_rank=1)
+    full1 = per_rank_gather[1].reconstruct_full(1, plan1, recv[1], owner_rank=1)
     torch.testing.assert_close(full1, full_p1, atol=0, rtol=0)
 
 
@@ -176,8 +171,8 @@ def test_pack_and_unpack_update_round_trip():
     """Scattered update shards match the owner's full update sliced per rank."""
     torch.manual_seed(1)
     world_size = 2
-    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)
-    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)
+    plan0 = ShardPlan.from_flat_layout(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = ShardPlan.from_flat_layout(torch.Size((4, 2)), 0, 4, world_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -203,7 +198,7 @@ def test_pack_and_unpack_update_round_trip():
     recv = _simulate_p2p(per_rank_send, world_size)
 
     for r in range(world_size):
-        received = unpack_update_shards(per_rank_scatter[r], recv[r])
+        received = per_rank_scatter[r].unpack(recv[r])
         # Rank r receives the update shard for the param it does NOT own.
         other = 1 - r
         plan = plans[other]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Pure CPU tests for the shard-planning and owner-compute packing logic.
+
+These tests exercise `ShardPlan`, `compute_shard_plan`, `assign_owner_work`, `pack_owner_work`,
+`reconstruct_full_tensor`, `pack_update_shards`, and `unpack_update_shards` without a process group
+or any `torch.distributed` dependency. P2P communication is simulated in-process by `_simulate_p2p`.
+"""
+
+import pytest
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
+    OwnerGatherPlan,
+    OwnerScatterPlan,
+    ShardPlan,
+    assign_owner_work,
+    compute_shard_plan,
+    pack_owner_work,
+    pack_update_shards,
+    reconstruct_full_tensor,
+    unpack_update_shards,
+)
+
+# ---------------------------------------------------------------------------
+# Shard-plan math
+# ---------------------------------------------------------------------------
+
+
+def test_compute_shard_plan_even_split():
+    """A matrix exactly divisible by world_size splits evenly across ranks."""
+    plan = compute_shard_plan(
+        torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, world_size=2
+    )
+    assert plan.full_shape == torch.Size((8, 4))
+    assert plan.row_size == 4
+    assert plan.rank_rows == ((0, 4), (4, 4))
+    assert plan.shard_numel(0) == 16
+    assert plan.shard_numel(1) == 16
+
+
+def test_compute_shard_plan_boundary_param_split_across_ranks():
+    """A small matrix landing across a rank boundary is split unevenly."""
+    # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0
+    # owns flat [0,9), rank1 owns [9,18). Tensor occupies [0,18) fully.
+    plan = compute_shard_plan(
+        torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, world_size=2
+    )
+    assert plan.rank_rows == ((0, 3), (3, 3))
+    assert plan.is_boundary()
+
+
+def test_compute_shard_plan_fully_local_param_on_one_rank():
+    """A matrix fully contained in one rank's flat shard is fully local."""
+    # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor
+    # at offset 0 with 8 elements fits entirely in rank0.
+    plan = compute_shard_plan(
+        torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, world_size=2
+    )
+    assert plan.rank_rows == ((0, 4), (0, 0))
+    assert not plan.is_boundary()
+    assert plan.owner_candidates() == (0,)
+
+
+def test_compute_shard_plan_empty_rank_has_zero_rows():
+    """A rank whose flat shard does not overlap the tensor owns zero rows."""
+    # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
+    plan = compute_shard_plan(
+        torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, world_size=2
+    )
+    assert plan.rank_rows == ((0, 0), (0, 4))
+    assert plan.is_boundary() is False
+    assert plan.owner_candidates() == (1,)
+
+
+# ---------------------------------------------------------------------------
+# Owner assignment balancing
+# ---------------------------------------------------------------------------
+
+
+def test_assign_owner_work_balances_by_cost():
+    """Owners are balanced so the cheapest eligible rank takes each parameter."""
+    # Two boundary params, all four ranks eligible for each.
+    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
+    plan1 = ShardPlan(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
+    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
+    # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
+    assert owners == {0: 0, 1: 1}
+
+
+def test_assign_owner_work_only_eligible_ranks_can_own():
+    """A rank with an empty shard can never be the owner."""
+    # Only ranks 0 and 2 have shards for both params.
+    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    plan1 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
+    assert all(owners[i] in (0, 2) for i in owners)
+    # Two equal-cost params split across the two eligible ranks.
+    assert owners[0] != owners[1]
+
+
+def test_assign_owner_work_fully_local_owner_is_single_candidate():
+    """A fully local parameter is assigned to its single owning rank."""
+    plan = ShardPlan(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
+    owners = assign_owner_work([plan], num_ns_steps=3)
+    assert owners == {0: 0}
+
+
+# ---------------------------------------------------------------------------
+# Pack / reconstruct round trip (simulated P2P)
+# ---------------------------------------------------------------------------
+
+
+def _simulate_p2p(
+    per_rank_send_buffers: list[dict[int, torch.Tensor]], world_size: int
+) -> list[dict[int, torch.Tensor]]:
+    """Deliver per-owner send buffers to their owners (CPU sim of batch_isend_irecv).
+
+    Returns, per rank, the dict of `{src_rank: received_buffer}` it receives.
+    """
+    per_rank_recv: list[dict[int, torch.Tensor]] = [dict() for _ in range(world_size)]
+    for src in range(world_size):
+        for dst, buf in per_rank_send_buffers[src].items():
+            if buf.numel() == 0:
+                continue
+            per_rank_recv[dst][src] = buf.clone()
+    return per_rank_recv
+
+
+def test_pack_and_reconstruct_round_trip():
+    """Gathered + reconstructed pre-NS matches the concatenation of local shards."""
+    torch.manual_seed(0)
+    world_size = 2
+    # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
+    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)  # rank0: 3 rows, rank1: 3 rows
+    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)  # rank0: 2 rows, rank1: 2 rows
+    plans = [plan0, plan1]
+    owners = {0: 0, 1: 1}
+
+    # Build per-rank local shards as distinct values so reconstruction is checkable.
+    full_p0 = torch.arange(18, dtype=torch.float32).reshape(6, 3)
+    full_p1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
+    per_rank_local = []
+    for r in range(world_size):
+        rs0, rc0 = plan0.rank_rows[r]
+        rs1, rc1 = plan1.rank_rows[r]
+        per_rank_local.append([full_p0[rs0 : rs0 + rc0].clone(), full_p1[rs1 : rs1 + rc1].clone()])
+
+    per_rank_send = []
+    per_rank_gather = []
+    for r in range(world_size):
+        gather = pack_owner_work(
+            plans,
+            owners,
+            per_rank_local[r],
+            world_size,
+            r,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+        per_rank_send.append(gather.send_buffers)
+        per_rank_gather.append(gather)
+
+    recv = _simulate_p2p(per_rank_send, world_size)
+
+    # Rank0 owns param0; reconstruct and compare to full_p0.
+    full0 = reconstruct_full_tensor(0, plan0, per_rank_gather[0], recv[0], owner_rank=0)
+    torch.testing.assert_close(full0, full_p0, atol=0, rtol=0)
+    # Rank1 owns param1; reconstruct and compare to full_p1.
+    full1 = reconstruct_full_tensor(1, plan1, per_rank_gather[1], recv[1], owner_rank=1)
+    torch.testing.assert_close(full1, full_p1, atol=0, rtol=0)
+
+
+def test_pack_and_unpack_update_round_trip():
+    """Scattered update shards match the owner's full update sliced per rank."""
+    torch.manual_seed(1)
+    world_size = 2
+    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)
+    plans = [plan0, plan1]
+    owners = {0: 0, 1: 1}
+
+    full_update0 = torch.arange(18, dtype=torch.float32).reshape(6, 3) + 1.0
+    full_update1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 2.0
+    full_updates_by_rank = {0: {0: full_update0}, 1: {1: full_update1}}
+
+    per_rank_send = []
+    per_rank_scatter = []
+    for r in range(world_size):
+        scatter = pack_update_shards(
+            full_updates_by_rank[r],
+            plans,
+            owners,
+            world_size,
+            r,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+        per_rank_send.append(scatter.send_buffers)
+        per_rank_scatter.append(scatter)
+
+    recv = _simulate_p2p(per_rank_send, world_size)
+
+    for r in range(world_size):
+        received = unpack_update_shards(per_rank_scatter[r], recv[r])
+        # Rank r receives the update shard for the param it does NOT own.
+        other = 1 - r
+        plan = plans[other]
+        rs, rc = plan.rank_rows[r]
+        expected = full_updates_by_rank[owners[other]][other][rs : rs + rc]
+        torch.testing.assert_close(received[other], expected, atol=0, rtol=0)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -4,10 +4,12 @@
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
 These tests exercise `ShardPlan`, `ShardPlan.from_flat_layout`, `assign_owner_work`,
-`pack_owner_work`, `OwnerGatherPlan.reconstruct_full`, `pack_update_shards`, and
+`pack_owner_work`, `OwnerGatherPlan.reconstruct_full`, `pack_result_shards`, and
 `OwnerScatterPlan.unpack` without a process group or any `torch.distributed` dependency. P2P
 communication is simulated in-process by `_simulate_p2p`.
 """
+
+from collections.abc import Callable
 
 import torch
 
@@ -17,6 +19,22 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan im
     ShardPlan,
     assign_owner_work,
 )
+
+
+def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
+    """Cost function matching the Newton-Schulz orthogonalization estimate.
+
+    `numel * (min(rows, cols) * num_steps + 1)` – used by the tests to exercise the greedy balancer
+    with a non-trivial cost.
+    """
+
+    def cost_fn(plan: ShardPlan) -> int:
+        rows, cols = plan.full_shape
+        short_dim = min(rows, cols)
+        return plan.full_numel() * (short_dim * num_ns_steps + 1)
+
+    return cost_fn
+
 
 # ---------------------------------------------------------------------------
 # Shard-plan math
@@ -79,8 +97,8 @@ def test_assign_owner_work_balances_by_cost():
     # Two boundary params, all four ranks eligible for each.
     plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
     plan1 = ShardPlan(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
-    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
     # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
+    owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert owners == {0: 0, 1: 1}
 
 
@@ -89,7 +107,7 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
     # Only ranks 0 and 2 have shards for both params.
     plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
     plan1 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
-    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
+    owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert all(owners[i] in (0, 2) for i in owners)
     # Two equal-cost params split across the two eligible ranks.
     assert owners[0] != owners[1]
@@ -98,7 +116,7 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
 def test_assign_owner_work_fully_local_owner_is_single_candidate():
     """A fully local parameter is assigned to its single owning rank."""
     plan = ShardPlan(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
-    owners = assign_owner_work([plan], num_ns_steps=3)
+    owners = assign_owner_work([plan], _ns_cost(3))
     assert owners == {0: 0}
 
 
@@ -124,7 +142,7 @@ def _simulate_p2p(
 
 
 def test_pack_and_reconstruct_round_trip():
-    """Gathered + reconstructed pre-NS matches the concatenation of local shards."""
+    """Gathered + reconstructed shards matches the concatenation of local shards."""
     torch.manual_seed(0)
     world_size = 2
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
@@ -167,8 +185,8 @@ def test_pack_and_reconstruct_round_trip():
     torch.testing.assert_close(full1, full_p1, atol=0, rtol=0)
 
 
-def test_pack_and_unpack_update_round_trip():
-    """Scattered update shards match the owner's full update sliced per rank."""
+def test_pack_and_unpack_result_round_trip():
+    """Scattered result shards match the owner's full result sliced per rank."""
     torch.manual_seed(1)
     world_size = 2
     plan0 = ShardPlan.from_flat_layout(torch.Size((6, 3)), 0, 9, world_size)
@@ -176,15 +194,15 @@ def test_pack_and_unpack_update_round_trip():
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
-    full_update0 = torch.arange(18, dtype=torch.float32).reshape(6, 3) + 1.0
-    full_update1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 2.0
-    full_updates_by_rank = {0: {0: full_update0}, 1: {1: full_update1}}
+    full_result0 = torch.arange(18, dtype=torch.float32).reshape(6, 3) + 1.0
+    full_result1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 2.0
+    full_results_by_rank = {0: {0: full_result0}, 1: {1: full_result1}}
 
     per_rank_send = []
     per_rank_scatter = []
     for r in range(world_size):
         scatter = OwnerScatterPlan.pack(
-            full_updates_by_rank[r],
+            full_results_by_rank[r],
             plans,
             owners,
             world_size,
@@ -199,11 +217,11 @@ def test_pack_and_unpack_update_round_trip():
 
     for r in range(world_size):
         received = per_rank_scatter[r].unpack(recv[r])
-        # Rank r receives the update shard for the param it does NOT own.
+        # Rank r receives the result shard for the param it does NOT own.
         other = 1 - r
         plan = plans[other]
         rs, rc = plan.rank_rows[r]
-        expected = full_updates_by_rank[owners[other]][other][rs : rs + rc]
+        expected = full_results_by_rank[owners[other]][other][rs : rs + rc]
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -205,3 +205,31 @@ def test_pack_and_unpack_update_round_trip():
         rs, rc = plan.rank_rows[r]
         expected = full_updates_by_rank[owners[other]][other][rs : rs + rc]
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
+
+
+def test_from_flat_layout_per_rank_data_not_uniform():
+    """Flat sharding with uniform buffer size but non-uniform per-rank tensor data.
+
+    `GlobalLayout.build` pads the total size to a multiple of `chunk_size * dp_size` so every rank's
+    flat buffer is the same size. However, the actual tensor data per rank is not necessarily
+    uniform.
+
+    This test verifies `from_flat_layout` correctly computes the non-uniform per-rank row counts
+    from a uniform `rank_flat_shard_size`.
+    """
+    # 5 rows, 4 cols = 20 elements. dp_size = 3.
+    # GlobalLayout.build pads to 24 (next multiple of chunk_size * dp_size = 4 * 3 = 12),
+    # so rank_flat_shard_size = 24 // 3 = 8 (uniform buffer per rank).
+    # But the tensor occupies only 20 of 24 elements:
+    #   rank 0: [0, 8)   -> 8 elements -> 2 rows
+    #   rank 1: [8, 16)  -> 8 elements -> 2 rows
+    #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
+    plan = ShardPlan.from_flat_layout(torch.Size((5, 4)), 0, 8, 3)
+    assert plan.rank_rows == ((0, 2), (2, 2), (4, 1))
+    assert plan.shard_numel(0) == 8
+    assert plan.shard_numel(1) == 8
+    assert plan.shard_numel(2) == 4
+    assert plan.rank_row_count(0) == 2
+    assert plan.rank_row_count(1) == 2
+    assert plan.rank_row_count(2) == 1
+    assert plan.is_boundary()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -3,10 +3,10 @@
 """
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
-These tests exercise `ShardPlan`, `ShardPlan.from_flat_layout`, `assign_owner_work`,
-`pack_owner_work`, `OwnerGatherPlan.reconstruct_full`, `pack_result_shards`, and
-`OwnerScatterPlan.unpack` without a process group or any `torch.distributed` dependency. P2P
-communication is simulated in-process by `_simulate_p2p`.
+These tests exercise `ShardPlan.from_flat_layout`, `assign_owner_work`, `OwnerGatherPlan.pack`,
+`OwnerGatherPlan.reconstruct_full`, `OwnerScatterPlan.pack`, and `OwnerScatterPlan.unpack` without a
+process group or any `torch.distributed` dependency. P2P communication is simulated in-process by
+`_simulate_p2p`.
 """
 
 from collections.abc import Callable

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -113,11 +113,11 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
     assert owners[0] != owners[1]
 
 
-def test_assign_owner_work_fully_local_owner_is_single_candidate():
-    """A fully local parameter is assigned to its single owning rank."""
+def test_assign_owner_work_skips_non_boundary():
+    """Non-boundary parameters stay on their original rank – no assignment needed."""
     plan = ShardPlan(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
     owners = assign_owner_work([plan], _ns_cost(3))
-    assert owners == {0: 0}
+    assert owners == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -119,6 +119,21 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
     assert owners[0] != owners[1]
 
 
+def test_assign_owner_work_lpt_sorts_by_descending_cost():
+    """Params are assigned in descending cost order, not input order.
+
+    With two boundary params (cheap first, expensive second in input order), LPT processes the
+    expensive one first.
+    """
+    # Cheap param listed FIRST in input order.
+    layout_cheap = ParameterLayout(torch.Size((8, 1)), (1, 1, 1, 1), 1)
+    # Expensive param listed SECOND in input order.
+    layout_expensive = ParameterLayout(torch.Size((8, 8)), (2, 2, 2, 2), 8)
+    owners = assign_owner_work([layout_cheap, layout_expensive], _ns_cost(5))
+    # LPT: expensive (index 1) → rank0 first, then cheap (index 0) → rank1.
+    assert owners == {0: 1, 1: 0}
+
+
 def test_assign_owner_work_skips_non_boundary():
     """Non-boundary parameters stay on their original rank – no assignment needed."""
     layout = ParameterLayout(torch.Size((4, 2)), (4, 0), 2)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -57,7 +57,7 @@ def test_compute_shard_plan_even_split():
     plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.full_shape == torch.Size((8, 4))
     assert plan.row_size == 4
-    assert plan.rank_rows == ((0, 4), (4, 4))
+    assert plan.row_counts == (4, 4)
     assert plan.shard_numel(0) == 16
     assert plan.shard_numel(1) == 16
 
@@ -68,7 +68,7 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     # owns [9,18). Tensor occupies [0,18) fully.
     layout = _layout([(6, 3)], [0], 18)
     plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.rank_rows == ((0, 3), (3, 3))
+    assert plan.row_counts == (3, 3)
     assert plan.is_boundary()
 
 
@@ -78,7 +78,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     # elements fits entirely in rank0.
     layout = _layout([(4, 2)], [0], 24)
     plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.rank_rows == ((0, 4), (0, 0))
+    assert plan.row_counts == (4, 0)
     assert not plan.is_boundary()
     assert plan.owner_candidates() == (0,)
 
@@ -88,7 +88,7 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
     # Tensor at offset 12 (entirely in rank1). rank0 gets (0,0).
     layout = _layout([(4, 3)], [12], 24)
     plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.rank_rows == ((0, 0), (0, 4))
+    assert plan.row_counts == (0, 4)
     assert plan.is_boundary() is False
     assert plan.owner_candidates() == (1,)
 
@@ -101,8 +101,8 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
 def test_assign_owner_work_balances_by_cost():
     """Owners are balanced so the cheapest eligible rank takes each parameter."""
     # Two boundary params, all four ranks eligible for each.
-    plan0 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
-    plan1 = ParameterLayout(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
+    plan0 = ParameterLayout(torch.Size((8, 8)), (4, 4, 4, 4), 8)  # cost 64*41
+    plan1 = ParameterLayout(torch.Size((4, 4)), (2, 2, 2, 2), 4)  # cost 16*21
     # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
     owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert owners == {0: 0, 1: 1}
@@ -111,8 +111,8 @@ def test_assign_owner_work_balances_by_cost():
 def test_assign_owner_work_only_eligible_ranks_can_own():
     """A rank with an empty shard can never be the owner."""
     # Only ranks 0 and 2 have shards for both params.
-    plan0 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
-    plan1 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    plan0 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
+    plan1 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
     owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert all(owners[i] in (0, 2) for i in owners)
     # Two equal-cost params split across the two eligible ranks.
@@ -121,7 +121,7 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
 
 def test_assign_owner_work_skips_non_boundary():
     """Non-boundary parameters stay on their original rank – no assignment needed."""
-    plan = ParameterLayout(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
+    plan = ParameterLayout(torch.Size((4, 2)), (4, 0), 2)
     owners = assign_owner_work([plan], _ns_cost(3))
     assert owners == {}
 
@@ -164,8 +164,8 @@ def test_pack_and_reconstruct_round_trip():
     full_p1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
     per_rank_local = []
     for r in range(dp_size):
-        rs0, rc0 = plan0.rank_rows[r]
-        rs1, rc1 = plan1.rank_rows[r]
+        rs0, rc0 = plan0.rank_row_start(r), plan0.rank_row_count(r)
+        rs1, rc1 = plan1.rank_row_start(r), plan1.rank_row_count(r)
         per_rank_local.append([full_p0[rs0 : rs0 + rc0].clone(), full_p1[rs1 : rs1 + rc1].clone()])
 
     per_rank_send = []
@@ -222,7 +222,7 @@ def test_pack_and_unpack_result_round_trip():
         # Rank r receives the result shard for the param it does NOT own.
         other = 1 - r
         plan = plans[other]
-        rs, rc = plan.rank_rows[r]
+        rs, rc = plan.rank_row_start(r), plan.rank_row_count(r)
         expected = full_results_by_rank[owners[other]][other][rs : rs + rc]
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
 
@@ -246,7 +246,7 @@ def test_from_layout_per_rank_data_not_uniform():
     #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
     layout = _layout([(5, 4)], [0], 24)
     plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=3)
-    assert plan.rank_rows == ((0, 2), (2, 2), (4, 1))
+    assert plan.row_counts == (2, 2, 1)
     assert plan.shard_numel(0) == 8
     assert plan.shard_numel(1) == 8
     assert plan.shard_numel(2) == 4

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -178,10 +178,10 @@ def test_pack_and_reconstruct_round_trip():
     recv = _simulate_p2p(per_rank_send, dp_size)
 
     # Rank0 owns param0; reconstruct and compare to full_p0.
-    full0 = per_rank_gather[0].reconstruct_full(0, plan0, recv[0], owner_rank=0)
+    full0 = per_rank_gather[0].reconstruct_full(0, recv[0])
     torch.testing.assert_close(full0, full_p0, atol=0, rtol=0)
     # Rank1 owns param1; reconstruct and compare to full_p1.
-    full1 = per_rank_gather[1].reconstruct_full(1, plan1, recv[1], owner_rank=1)
+    full1 = per_rank_gather[1].reconstruct_full(1, recv[1])
     torch.testing.assert_close(full1, full_p1, atol=0, rtol=0)
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -42,9 +42,9 @@ def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
 
 
 def test_compute_shard_plan_even_split():
-    """A matrix exactly divisible by world_size splits evenly across ranks."""
+    """A matrix exactly divisible by dp_size splits evenly across ranks."""
     plan = ShardPlan.from_layout_params(
-        torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, world_size=2
+        torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, dp_size=2
     )
     assert plan.full_shape == torch.Size((8, 4))
     assert plan.row_size == 4
@@ -58,7 +58,7 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
     # owns [9,18). Tensor occupies [0,18) fully.
     plan = ShardPlan.from_layout_params(
-        torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, world_size=2
+        torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, dp_size=2
     )
     assert plan.rank_rows == ((0, 3), (3, 3))
     assert plan.is_boundary()
@@ -69,7 +69,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
     # elements fits entirely in rank0.
     plan = ShardPlan.from_layout_params(
-        torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, world_size=2
+        torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, dp_size=2
     )
     assert plan.rank_rows == ((0, 4), (0, 0))
     assert not plan.is_boundary()
@@ -80,7 +80,7 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
     # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
     plan = ShardPlan.from_layout_params(
-        torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, world_size=2
+        torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, dp_size=2
     )
     assert plan.rank_rows == ((0, 0), (0, 4))
     assert plan.is_boundary() is False
@@ -126,14 +126,14 @@ def test_assign_owner_work_fully_local_owner_is_single_candidate():
 
 
 def _simulate_p2p(
-    per_rank_send_buffers: list[dict[int, torch.Tensor]], world_size: int
+    per_rank_send_buffers: list[dict[int, torch.Tensor]], dp_size: int
 ) -> list[dict[int, torch.Tensor]]:
     """Deliver per-owner send buffers to their owners (CPU sim of batch_isend_irecv).
 
     Returns, per rank, the dict of `{src_rank: received_buffer}` it receives.
     """
-    per_rank_recv: list[dict[int, torch.Tensor]] = [dict() for _ in range(world_size)]
-    for src in range(world_size):
+    per_rank_recv: list[dict[int, torch.Tensor]] = [dict() for _ in range(dp_size)]
+    for src in range(dp_size):
         for dst, buf in per_rank_send_buffers[src].items():
             if buf.numel() == 0:
                 continue
@@ -144,10 +144,10 @@ def _simulate_p2p(
 def test_pack_and_reconstruct_round_trip():
     """Gathered + reconstructed shards matches the concatenation of local shards."""
     torch.manual_seed(0)
-    world_size = 2
+    dp_size = 2
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
-    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, world_size)
-    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, world_size)
+    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, dp_size)
+    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -155,19 +155,19 @@ def test_pack_and_reconstruct_round_trip():
     full_p0 = torch.arange(18, dtype=torch.float32).reshape(6, 3)
     full_p1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
     per_rank_local = []
-    for r in range(world_size):
+    for r in range(dp_size):
         rs0, rc0 = plan0.rank_rows[r]
         rs1, rc1 = plan1.rank_rows[r]
         per_rank_local.append([full_p0[rs0 : rs0 + rc0].clone(), full_p1[rs1 : rs1 + rc1].clone()])
 
     per_rank_send = []
     per_rank_gather = []
-    for r in range(world_size):
+    for r in range(dp_size):
         gather = OwnerGatherPlan.pack(
             plans,
             owners,
             per_rank_local[r],
-            world_size,
+            dp_size,
             r,
             device=torch.device("cpu"),
             dtype=torch.float32,
@@ -175,7 +175,7 @@ def test_pack_and_reconstruct_round_trip():
         per_rank_send.append(gather.send_buffers)
         per_rank_gather.append(gather)
 
-    recv = _simulate_p2p(per_rank_send, world_size)
+    recv = _simulate_p2p(per_rank_send, dp_size)
 
     # Rank0 owns param0; reconstruct and compare to full_p0.
     full0 = per_rank_gather[0].reconstruct_full(0, plan0, recv[0], owner_rank=0)
@@ -188,9 +188,9 @@ def test_pack_and_reconstruct_round_trip():
 def test_pack_and_unpack_result_round_trip():
     """Scattered result shards match the owner's full result sliced per rank."""
     torch.manual_seed(1)
-    world_size = 2
-    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, world_size)
-    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, world_size)
+    dp_size = 2
+    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, dp_size)
+    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -200,12 +200,12 @@ def test_pack_and_unpack_result_round_trip():
 
     per_rank_send = []
     per_rank_scatter = []
-    for r in range(world_size):
+    for r in range(dp_size):
         scatter = OwnerScatterPlan.pack(
             full_results_by_rank[r],
             plans,
             owners,
-            world_size,
+            dp_size,
             r,
             device=torch.device("cpu"),
             dtype=torch.float32,
@@ -213,9 +213,9 @@ def test_pack_and_unpack_result_round_trip():
         per_rank_send.append(scatter.send_buffers)
         per_rank_scatter.append(scatter)
 
-    recv = _simulate_p2p(per_rank_send, world_size)
+    recv = _simulate_p2p(per_rank_send, dp_size)
 
-    for r in range(world_size):
+    for r in range(dp_size):
         received = per_rank_scatter[r].unpack(recv[r])
         # Rank r receives the result shard for the param it does NOT own.
         other = 1 - r

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -203,15 +203,7 @@ def test_pack_and_unpack_result_round_trip():
     per_rank_send = []
     per_rank_scatter = []
     for r in range(dp_size):
-        scatter = OwnerScatterPlan.pack(
-            full_results_by_rank[r],
-            layouts,
-            owners,
-            dp_size,
-            r,
-            device=torch.device("cpu"),
-            dtype=torch.float32,
-        )
+        scatter = OwnerScatterPlan.pack(full_results_by_rank[r], layouts, owners, dp_size, r)
         per_rank_send.append(scatter.send_buffers)
         per_rank_scatter.append(scatter)
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -29,10 +29,10 @@ def _ns_cost(num_ns_steps: int) -> Callable[[ParameterLayout], int]:
     with a non-trivial cost.
     """
 
-    def cost_fn(plan: ParameterLayout) -> int:
-        rows, cols = plan.full_shape
+    def cost_fn(layout: ParameterLayout) -> int:
+        rows, cols = layout.full_shape
         short_dim = min(rows, cols)
-        return plan.full_numel() * (short_dim * num_ns_steps + 1)
+        return layout.full_numel() * (short_dim * num_ns_steps + 1)
 
     return cost_fn
 
@@ -47,19 +47,19 @@ def _layout(shapes, offsets, size) -> GlobalLayout:
 
 
 # ---------------------------------------------------------------------------
-# Shard-plan math
+# Shard-layout math
 # ---------------------------------------------------------------------------
 
 
 def test_compute_shard_plan_even_split():
     """A matrix exactly divisible by dp_size splits evenly across ranks."""
     layout = _layout([(8, 4)], [0], 32)
-    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.full_shape == torch.Size((8, 4))
-    assert plan.row_size == 4
-    assert plan.row_counts == (4, 4)
-    assert plan.shard_numel(0) == 16
-    assert plan.shard_numel(1) == 16
+    layout = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
+    assert layout.full_shape == torch.Size((8, 4))
+    assert layout.row_size == 4
+    assert layout.row_counts == (4, 4)
+    assert layout.shard_numel(0) == 16
+    assert layout.shard_numel(1) == 16
 
 
 def test_compute_shard_plan_boundary_param_split_across_ranks():
@@ -67,9 +67,9 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
     # owns [9,18). Tensor occupies [0,18) fully.
     layout = _layout([(6, 3)], [0], 18)
-    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.row_counts == (3, 3)
-    assert plan.is_boundary()
+    layout = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
+    assert layout.row_counts == (3, 3)
+    assert layout.is_boundary()
 
 
 def test_compute_shard_plan_fully_local_param_on_one_rank():
@@ -77,20 +77,20 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
     # elements fits entirely in rank0.
     layout = _layout([(4, 2)], [0], 24)
-    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.row_counts == (4, 0)
-    assert not plan.is_boundary()
-    assert plan.owner_candidates() == (0,)
+    layout = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
+    assert layout.row_counts == (4, 0)
+    assert not layout.is_boundary()
+    assert layout.owner_candidates() == (0,)
 
 
 def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
     # Tensor at offset 12 (entirely in rank1). rank0 gets (0,0).
     layout = _layout([(4, 3)], [12], 24)
-    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
-    assert plan.row_counts == (0, 4)
-    assert plan.is_boundary() is False
-    assert plan.owner_candidates() == (1,)
+    layout = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
+    assert layout.row_counts == (0, 4)
+    assert layout.is_boundary() is False
+    assert layout.owner_candidates() == (1,)
 
 
 # ---------------------------------------------------------------------------
@@ -101,19 +101,19 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
 def test_assign_owner_work_balances_by_cost():
     """Owners are balanced so the cheapest eligible rank takes each parameter."""
     # Two boundary params, all four ranks eligible for each.
-    plan0 = ParameterLayout(torch.Size((8, 8)), (4, 4, 4, 4), 8)  # cost 64*41
-    plan1 = ParameterLayout(torch.Size((4, 4)), (2, 2, 2, 2), 4)  # cost 16*21
+    layout0 = ParameterLayout(torch.Size((8, 8)), (4, 4, 4, 4), 8)  # cost 64*41
+    layout1 = ParameterLayout(torch.Size((4, 4)), (2, 2, 2, 2), 4)  # cost 16*21
     # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
-    owners = assign_owner_work([plan0, plan1], _ns_cost(5))
+    owners = assign_owner_work([layout0, layout1], _ns_cost(5))
     assert owners == {0: 0, 1: 1}
 
 
 def test_assign_owner_work_only_eligible_ranks_can_own():
     """A rank with an empty shard can never be the owner."""
     # Only ranks 0 and 2 have shards for both params.
-    plan0 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
-    plan1 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
-    owners = assign_owner_work([plan0, plan1], _ns_cost(5))
+    layout0 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
+    layout1 = ParameterLayout(torch.Size((8, 8)), (4, 0, 4, 0), 8)
+    owners = assign_owner_work([layout0, layout1], _ns_cost(5))
     assert all(owners[i] in (0, 2) for i in owners)
     # Two equal-cost params split across the two eligible ranks.
     assert owners[0] != owners[1]
@@ -121,8 +121,8 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
 
 def test_assign_owner_work_skips_non_boundary():
     """Non-boundary parameters stay on their original rank – no assignment needed."""
-    plan = ParameterLayout(torch.Size((4, 2)), (4, 0), 2)
-    owners = assign_owner_work([plan], _ns_cost(3))
+    layout = ParameterLayout(torch.Size((4, 2)), (4, 0), 2)
+    owners = assign_owner_work([layout], _ns_cost(3))
     assert owners == {}
 
 
@@ -154,9 +154,9 @@ def test_pack_and_reconstruct_round_trip():
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
     layout0 = _layout([(6, 3)], [0], 18)
     layout1 = _layout([(4, 2)], [0], 8)
-    plan0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
-    plan1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
-    plans = [plan0, plan1]
+    layout0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    layout1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
+    layouts = [layout0, layout1]
     owners = {0: 0, 1: 1}
 
     # Build per-rank local shards as distinct values so reconstruction is checkable.
@@ -164,14 +164,14 @@ def test_pack_and_reconstruct_round_trip():
     full_p1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
     per_rank_local = []
     for r in range(dp_size):
-        rs0, rc0 = plan0.rank_row_start(r), plan0.rank_row_count(r)
-        rs1, rc1 = plan1.rank_row_start(r), plan1.rank_row_count(r)
+        rs0, rc0 = layout0.rank_row_start(r), layout0.rank_row_count(r)
+        rs1, rc1 = layout1.rank_row_start(r), layout1.rank_row_count(r)
         per_rank_local.append([full_p0[rs0 : rs0 + rc0].clone(), full_p1[rs1 : rs1 + rc1].clone()])
 
     per_rank_send = []
     per_rank_gather = []
     for r in range(dp_size):
-        gather = OwnerGatherPlan.pack(plans, owners, per_rank_local[r], dp_size, r)
+        gather = OwnerGatherPlan.pack(layouts, owners, per_rank_local[r], dp_size, r)
         per_rank_send.append(gather.send_buffers)
         per_rank_gather.append(gather)
 
@@ -191,9 +191,9 @@ def test_pack_and_unpack_result_round_trip():
     dp_size = 2
     layout0 = _layout([(6, 3)], [0], 18)
     layout1 = _layout([(4, 2)], [0], 8)
-    plan0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
-    plan1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
-    plans = [plan0, plan1]
+    layout0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    layout1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
+    layouts = [layout0, layout1]
     owners = {0: 0, 1: 1}
 
     full_result0 = torch.arange(18, dtype=torch.float32).reshape(6, 3) + 1.0
@@ -205,7 +205,7 @@ def test_pack_and_unpack_result_round_trip():
     for r in range(dp_size):
         scatter = OwnerScatterPlan.pack(
             full_results_by_rank[r],
-            plans,
+            layouts,
             owners,
             dp_size,
             r,
@@ -221,8 +221,8 @@ def test_pack_and_unpack_result_round_trip():
         received = per_rank_scatter[r].unpack(recv[r])
         # Rank r receives the result shard for the param it does NOT own.
         other = 1 - r
-        plan = plans[other]
-        rs, rc = plan.rank_row_start(r), plan.rank_row_count(r)
+        layout = layouts[other]
+        rs, rc = layout.rank_row_start(r), layout.rank_row_count(r)
         expected = full_results_by_rank[owners[other]][other][rs : rs + rc]
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
 
@@ -245,12 +245,12 @@ def test_from_layout_per_rank_data_not_uniform():
     #   rank 1: [8, 16)  -> 8 elements -> 2 rows
     #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
     layout = _layout([(5, 4)], [0], 24)
-    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=3)
-    assert plan.row_counts == (2, 2, 1)
-    assert plan.shard_numel(0) == 8
-    assert plan.shard_numel(1) == 8
-    assert plan.shard_numel(2) == 4
-    assert plan.rank_row_count(0) == 2
-    assert plan.rank_row_count(1) == 2
-    assert plan.rank_row_count(2) == 1
-    assert plan.is_boundary()
+    layout = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=3)
+    assert layout.row_counts == (2, 2, 1)
+    assert layout.shard_numel(0) == 8
+    assert layout.shard_numel(1) == 8
+    assert layout.shard_numel(2) == 4
+    assert layout.rank_row_count(0) == 2
+    assert layout.rank_row_count(1) == 2
+    assert layout.rank_row_count(2) == 1
+    assert layout.is_boundary()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -163,15 +163,7 @@ def test_pack_and_reconstruct_round_trip():
     per_rank_send = []
     per_rank_gather = []
     for r in range(dp_size):
-        gather = OwnerGatherPlan.pack(
-            plans,
-            owners,
-            per_rank_local[r],
-            dp_size,
-            r,
-            device=torch.device("cpu"),
-            dtype=torch.float32,
-        )
+        gather = OwnerGatherPlan.pack(plans, owners, per_rank_local[r], dp_size, r)
         per_rank_send.append(gather.send_buffers)
         per_rank_gather.append(gather)
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -3,7 +3,7 @@
 """
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
-These tests exercise `ShardPlan.from_layout`, `assign_owner_work`, `OwnerGatherPlan.pack`,
+These tests exercise `ParameterLayout.from_layout`, `assign_owner_work`, `OwnerGatherPlan.pack`,
 `OwnerGatherPlan.reconstruct_full`, `OwnerScatterPlan.pack`, and `OwnerScatterPlan.unpack` without a
 process group or any `torch.distributed` dependency. P2P communication is simulated in-process by
 `_simulate_p2p`.
@@ -17,19 +17,19 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
     OwnerGatherPlan,
     OwnerScatterPlan,
-    ShardPlan,
+    ParameterLayout,
     assign_owner_work,
 )
 
 
-def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
+def _ns_cost(num_ns_steps: int) -> Callable[[ParameterLayout], int]:
     """Cost function matching the Newton-Schulz orthogonalization estimate.
 
     `numel * (min(rows, cols) * num_steps + 1)` – used by the tests to exercise the greedy balancer
     with a non-trivial cost.
     """
 
-    def cost_fn(plan: ShardPlan) -> int:
+    def cost_fn(plan: ParameterLayout) -> int:
         rows, cols = plan.full_shape
         short_dim = min(rows, cols)
         return plan.full_numel() * (short_dim * num_ns_steps + 1)
@@ -54,7 +54,7 @@ def _layout(shapes, offsets, size) -> GlobalLayout:
 def test_compute_shard_plan_even_split():
     """A matrix exactly divisible by dp_size splits evenly across ranks."""
     layout = _layout([(8, 4)], [0], 32)
-    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
+    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.full_shape == torch.Size((8, 4))
     assert plan.row_size == 4
     assert plan.rank_rows == ((0, 4), (4, 4))
@@ -67,7 +67,7 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
     # owns [9,18). Tensor occupies [0,18) fully.
     layout = _layout([(6, 3)], [0], 18)
-    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
+    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 3), (3, 3))
     assert plan.is_boundary()
 
@@ -77,7 +77,7 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
     # elements fits entirely in rank0.
     layout = _layout([(4, 2)], [0], 24)
-    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
+    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 4), (0, 0))
     assert not plan.is_boundary()
     assert plan.owner_candidates() == (0,)
@@ -87,7 +87,7 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
     # Tensor at offset 12 (entirely in rank1). rank0 gets (0,0).
     layout = _layout([(4, 3)], [12], 24)
-    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
+    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 0), (0, 4))
     assert plan.is_boundary() is False
     assert plan.owner_candidates() == (1,)
@@ -101,8 +101,8 @@ def test_compute_shard_plan_empty_rank_has_zero_rows():
 def test_assign_owner_work_balances_by_cost():
     """Owners are balanced so the cheapest eligible rank takes each parameter."""
     # Two boundary params, all four ranks eligible for each.
-    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
-    plan1 = ShardPlan(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
+    plan0 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
+    plan1 = ParameterLayout(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
     # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
     owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert owners == {0: 0, 1: 1}
@@ -111,8 +111,8 @@ def test_assign_owner_work_balances_by_cost():
 def test_assign_owner_work_only_eligible_ranks_can_own():
     """A rank with an empty shard can never be the owner."""
     # Only ranks 0 and 2 have shards for both params.
-    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
-    plan1 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    plan0 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    plan1 = ParameterLayout(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
     owners = assign_owner_work([plan0, plan1], _ns_cost(5))
     assert all(owners[i] in (0, 2) for i in owners)
     # Two equal-cost params split across the two eligible ranks.
@@ -121,7 +121,7 @@ def test_assign_owner_work_only_eligible_ranks_can_own():
 
 def test_assign_owner_work_skips_non_boundary():
     """Non-boundary parameters stay on their original rank – no assignment needed."""
-    plan = ShardPlan(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
+    plan = ParameterLayout(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
     owners = assign_owner_work([plan], _ns_cost(3))
     assert owners == {}
 
@@ -154,8 +154,8 @@ def test_pack_and_reconstruct_round_trip():
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
     layout0 = _layout([(6, 3)], [0], 18)
     layout1 = _layout([(4, 2)], [0], 8)
-    plan0 = ShardPlan.from_layout(layout0, tensor_index=0, dp_size=dp_size)
-    plan1 = ShardPlan.from_layout(layout1, tensor_index=0, dp_size=dp_size)
+    plan0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    plan1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -191,8 +191,8 @@ def test_pack_and_unpack_result_round_trip():
     dp_size = 2
     layout0 = _layout([(6, 3)], [0], 18)
     layout1 = _layout([(4, 2)], [0], 8)
-    plan0 = ShardPlan.from_layout(layout0, tensor_index=0, dp_size=dp_size)
-    plan1 = ShardPlan.from_layout(layout1, tensor_index=0, dp_size=dp_size)
+    plan0 = ParameterLayout.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    plan1 = ParameterLayout.from_layout(layout1, tensor_index=0, dp_size=dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -245,7 +245,7 @@ def test_from_layout_per_rank_data_not_uniform():
     #   rank 1: [8, 16)  -> 8 elements -> 2 rows
     #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
     layout = _layout([(5, 4)], [0], 24)
-    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=3)
+    plan = ParameterLayout.from_layout(layout, tensor_index=0, dp_size=3)
     assert plan.rank_rows == ((0, 2), (2, 2), (4, 1))
     assert plan.shard_numel(0) == 8
     assert plan.shard_numel(1) == 8

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -3,7 +3,7 @@
 """
 Pure CPU tests for the shard-planning and owner-compute packing logic.
 
-These tests exercise `ShardPlan.from_layout_params`, `assign_owner_work`, `OwnerGatherPlan.pack`,
+These tests exercise `ShardPlan.from_layout`, `assign_owner_work`, `OwnerGatherPlan.pack`,
 `OwnerGatherPlan.reconstruct_full`, `OwnerScatterPlan.pack`, and `OwnerScatterPlan.unpack` without a
 process group or any `torch.distributed` dependency. P2P communication is simulated in-process by
 `_simulate_p2p`.
@@ -13,6 +13,7 @@ from collections.abc import Callable
 
 import torch
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.layout import GlobalLayout
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
     OwnerGatherPlan,
     OwnerScatterPlan,
@@ -36,6 +37,15 @@ def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
     return cost_fn
 
 
+def _layout(shapes, offsets, size) -> GlobalLayout:
+    """Construct a `GlobalLayout` directly (bypassing `GlobalLayout.build`)."""
+    return GlobalLayout(
+        tensor_shapes=tuple(torch.Size(s) for s in shapes),
+        tensor_to_offset=tuple(offsets),
+        size=size,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shard-plan math
 # ---------------------------------------------------------------------------
@@ -43,9 +53,8 @@ def _ns_cost(num_ns_steps: int) -> Callable[[ShardPlan], int]:
 
 def test_compute_shard_plan_even_split():
     """A matrix exactly divisible by dp_size splits evenly across ranks."""
-    plan = ShardPlan.from_layout_params(
-        torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, dp_size=2
-    )
+    layout = _layout([(8, 4)], [0], 32)
+    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.full_shape == torch.Size((8, 4))
     assert plan.row_size == 4
     assert plan.rank_rows == ((0, 4), (4, 4))
@@ -57,9 +66,8 @@ def test_compute_shard_plan_boundary_param_split_across_ranks():
     """A small matrix landing across a rank boundary is split unevenly."""
     # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0 owns flat [0,9), rank1
     # owns [9,18). Tensor occupies [0,18) fully.
-    plan = ShardPlan.from_layout_params(
-        torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, dp_size=2
-    )
+    layout = _layout([(6, 3)], [0], 18)
+    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 3), (3, 3))
     assert plan.is_boundary()
 
@@ -68,9 +76,8 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
     """A matrix fully contained in one rank's flat shard is fully local."""
     # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor at offset 0 with 8
     # elements fits entirely in rank0.
-    plan = ShardPlan.from_layout_params(
-        torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, dp_size=2
-    )
+    layout = _layout([(4, 2)], [0], 24)
+    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 4), (0, 0))
     assert not plan.is_boundary()
     assert plan.owner_candidates() == (0,)
@@ -78,10 +85,9 @@ def test_compute_shard_plan_fully_local_param_on_one_rank():
 
 def test_compute_shard_plan_empty_rank_has_zero_rows():
     """A rank whose flat shard does not overlap the tensor owns zero rows."""
-    # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
-    plan = ShardPlan.from_layout_params(
-        torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, dp_size=2
-    )
+    # Tensor at offset 12 (entirely in rank1). rank0 gets (0,0).
+    layout = _layout([(4, 3)], [12], 24)
+    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=2)
     assert plan.rank_rows == ((0, 0), (0, 4))
     assert plan.is_boundary() is False
     assert plan.owner_candidates() == (1,)
@@ -146,8 +152,10 @@ def test_pack_and_reconstruct_round_trip():
     torch.manual_seed(0)
     dp_size = 2
     # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
-    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, dp_size)
-    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, dp_size)
+    layout0 = _layout([(6, 3)], [0], 18)
+    layout1 = _layout([(4, 2)], [0], 8)
+    plan0 = ShardPlan.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    plan1 = ShardPlan.from_layout(layout1, tensor_index=0, dp_size=dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -181,8 +189,10 @@ def test_pack_and_unpack_result_round_trip():
     """Scattered result shards match the owner's full result sliced per rank."""
     torch.manual_seed(1)
     dp_size = 2
-    plan0 = ShardPlan.from_layout_params(torch.Size((6, 3)), 0, 9, dp_size)
-    plan1 = ShardPlan.from_layout_params(torch.Size((4, 2)), 0, 4, dp_size)
+    layout0 = _layout([(6, 3)], [0], 18)
+    layout1 = _layout([(4, 2)], [0], 8)
+    plan0 = ShardPlan.from_layout(layout0, tensor_index=0, dp_size=dp_size)
+    plan1 = ShardPlan.from_layout(layout1, tensor_index=0, dp_size=dp_size)
     plans = [plan0, plan1]
     owners = {0: 0, 1: 1}
 
@@ -217,15 +227,15 @@ def test_pack_and_unpack_result_round_trip():
         torch.testing.assert_close(received[other], expected, atol=0, rtol=0)
 
 
-def test_from_layout_params_per_rank_data_not_uniform():
+def test_from_layout_per_rank_data_not_uniform():
     """Flat sharding with uniform buffer size but non-uniform per-rank tensor data.
 
     `GlobalLayout.build` pads the total size to a multiple of `chunk_size * dp_size` so every rank's
     flat buffer is the same size. However, the actual tensor data per rank is not necessarily
     uniform.
 
-    This test verifies `from_layout_params` correctly computes the non-uniform per-rank row counts
-    from a uniform `rank_flat_shard_size`.
+    This test verifies `from_layout` correctly computes the non-uniform per-rank row counts from a
+    uniform `rank_flat_shard_size`.
     """
     # 5 rows, 4 cols = 20 elements. dp_size = 3.
     # GlobalLayout.build pads to 24 (next multiple of chunk_size * dp_size = 4 * 3 = 12),
@@ -234,7 +244,8 @@ def test_from_layout_params_per_rank_data_not_uniform():
     #   rank 0: [0, 8)   -> 8 elements -> 2 rows
     #   rank 1: [8, 16)  -> 8 elements -> 2 rows
     #   rank 2: [16, 24) -> 4 elements -> 1 row  (4 elements of padding)
-    plan = ShardPlan.from_layout_params(torch.Size((5, 4)), 0, 8, 3)
+    layout = _layout([(5, 4)], [0], 24)
+    plan = ShardPlan.from_layout(layout, tensor_index=0, dp_size=3)
     assert plan.rank_rows == ((0, 2), (2, 2), (4, 1))
     assert plan.shard_numel(0) == 8
     assert plan.shard_numel(1) == 8


### PR DESCRIPTION
- [X] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Expose an API for shard-planning and owner-compute-based assignment and packing logic.

A `ShardPlan` calculates how a given parameter is split across DP ranks and makes the metadata accessible for further computation. `Owner{Gather,Scatter}Plan`s set up the send/recv buffers for collectives.

## Issue tracking

Linked issue: Ref https://github.com/NVIDIA/Megatron-LM/issues/5533