### PR TITLE
Mamba: Bug Fix for No Intermediate State Case

### DIFF
--- a/megatron/core/ssm/ops/mamba2/mamba_ssm.py
+++ b/megatron/core/ssm/ops/mamba2/mamba_ssm.py
@@ -366,7 +366,6 @@ def selective_state_update(
             intermediate_ssm_states.stride(4),
         )
     else:
-        intermediate_ssm_states = x  # Dummy pointer
         int_state_strides = (0, 0, 0, 0, 0)
 
     batch, seq_len, nheads, dim = x.shape

--- a/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
+++ b/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Unit tests for ``selective_state_update`` (megatron/core/ssm/ops/mamba2/mamba_ssm.py)."""
+# Unit tests for `selective_state_update` (megatron/core/ssm/ops/mamba2/mamba_ssm.py).
 
 import pytest
 import torch
@@ -17,14 +17,14 @@ def _requires_cuda():
 class TestSelectiveStateUpdateInputPurity:
     """Regression tests: selective_state_update must never mutate its inputs.
 
-    When called WITHOUT ``intermediate_ssm_states``, the launcher used to
-    substitute ``x`` as a dummy pointer with all-zero strides. The
-    ``HAS_INT_STATE`` heuristic (``int_state_ptr is not None``) then saw a
+    When called WITHOUT `intermediate_ssm_states`, the launcher used to
+    substitute `x` as a dummy pointer with all-zero strides. The
+    `HAS_INT_STATE` heuristic (`int_state_ptr is not None`) then saw a
     non-None pointer and enabled the intermediate-state dump, which collapsed
-    its whole store grid onto ``x[0, 0, 0, 0]`` — corrupting ``x`` after the
-    call and racing other programs' loads of ``x`` (nondeterministic
+    its whole store grid onto `x[0, 0, 0, 0]` — corrupting `x` after the
+    call and racing other programs' loads of `x` (nondeterministic
     head-0/dim-0 output errors). This hit every hybrid non-spec decode step.
-    The fix passes ``None`` instead of a dummy.
+    The fix passes `None` instead of a dummy.
     """
 
     def setup_method(self, method):

--- a/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
+++ b/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for ``selective_state_update`` (megatron/core/ssm/ops/mamba_ssm.py)."""
+
+import pytest
+import torch
+
+from megatron.core.ssm.ops.mamba2.mamba_ssm import selective_state_update
+
+
+def _requires_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+@pytest.mark.internal
+class TestSelectiveStateUpdateInputPurity:
+    """Regression tests: selective_state_update must never mutate its inputs.
+
+    When called WITHOUT ``intermediate_ssm_states``, the launcher used to
+    substitute ``x`` as a dummy pointer with all-zero strides. The
+    ``HAS_INT_STATE`` heuristic (``int_state_ptr is not None``) then saw a
+    non-None pointer and enabled the intermediate-state dump, which collapsed
+    its whole store grid onto ``x[0, 0, 0, 0]`` — corrupting ``x`` after the
+    call and racing other programs' loads of ``x`` (nondeterministic
+    head-0/dim-0 output errors). This hit every hybrid non-spec decode step.
+    The fix passes ``None`` instead of a dummy.
+    """
+
+    def setup_method(self, method):
+        _requires_cuda()
+
+    @pytest.mark.parametrize("seq_len", [1, 3])
+    def test_inputs_not_mutated_without_intermediates(self, seq_len):
+        """seq_len == 1 is the production non-spec decode shape."""
+        torch.manual_seed(0)
+        device = "cuda"
+        B, nheads, headdim, dstate, ngroups = 4, 8, 64, 64, 2
+        x = torch.randn(B, seq_len, nheads, headdim, device=device)
+        dt = torch.randn(B, seq_len, nheads, device=device).unsqueeze(-1).expand(
+            B, seq_len, nheads, headdim
+        )
+        A = (-torch.rand(nheads, device=device) - 1.0).view(nheads, 1, 1).expand(
+            nheads, headdim, dstate
+        )
+        Bm = torch.randn(B, seq_len, ngroups, dstate, device=device)
+        Cm = torch.randn(B, seq_len, ngroups, dstate, device=device)
+        D = torch.randn(nheads, device=device).unsqueeze(-1).expand(nheads, headdim)
+        dt_bias = (torch.rand(nheads, device=device) - 4.0).unsqueeze(-1).expand(
+            nheads, headdim
+        )
+        state = torch.randn(B, nheads, headdim, dstate, device=device)
+        inputs = {"x": x, "dt": dt, "A": A, "B": Bm, "C": Cm, "D": D, "dt_bias": dt_bias}
+        before = {k: v.clone() for k, v in inputs.items()}
+
+        selective_state_update(
+            state, x, dt, A, Bm, Cm, D, z=None, dt_bias=dt_bias, dt_softplus=True,
+            state_batch_indices=torch.arange(B, dtype=torch.int64, device=device),
+        )
+        torch.cuda.synchronize()
+
+        for name, tensor in inputs.items():
+            assert torch.equal(tensor, before[name]), (
+                f"selective_state_update mutated input '{name}' when called "
+                f"without intermediate_ssm_states (dummy-pointer regression)"
+            )

--- a/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
+++ b/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
@@ -37,24 +37,35 @@ class TestSelectiveStateUpdateInputPurity:
         device = "cuda"
         B, nheads, headdim, dstate, ngroups = 4, 8, 64, 64, 2
         x = torch.randn(B, seq_len, nheads, headdim, device=device)
-        dt = torch.randn(B, seq_len, nheads, device=device).unsqueeze(-1).expand(
-            B, seq_len, nheads, headdim
+        dt = (
+            torch.randn(B, seq_len, nheads, device=device)
+            .unsqueeze(-1)
+            .expand(B, seq_len, nheads, headdim)
         )
-        A = (-torch.rand(nheads, device=device) - 1.0).view(nheads, 1, 1).expand(
-            nheads, headdim, dstate
+        A = (
+            (-torch.rand(nheads, device=device) - 1.0)
+            .view(nheads, 1, 1)
+            .expand(nheads, headdim, dstate)
         )
         Bm = torch.randn(B, seq_len, ngroups, dstate, device=device)
         Cm = torch.randn(B, seq_len, ngroups, dstate, device=device)
         D = torch.randn(nheads, device=device).unsqueeze(-1).expand(nheads, headdim)
-        dt_bias = (torch.rand(nheads, device=device) - 4.0).unsqueeze(-1).expand(
-            nheads, headdim
-        )
+        dt_bias = (torch.rand(nheads, device=device) - 4.0).unsqueeze(-1).expand(nheads, headdim)
         state = torch.randn(B, nheads, headdim, dstate, device=device)
         inputs = {"x": x, "dt": dt, "A": A, "B": Bm, "C": Cm, "D": D, "dt_bias": dt_bias}
         before = {k: v.clone() for k, v in inputs.items()}
 
         selective_state_update(
-            state, x, dt, A, Bm, Cm, D, z=None, dt_bias=dt_bias, dt_softplus=True,
+            state,
+            x,
+            dt,
+            A,
+            Bm,
+            Cm,
+            D,
+            z=None,
+            dt_bias=dt_bias,
+            dt_softplus=True,
             state_batch_indices=torch.arange(B, dtype=torch.int64, device=device),
         )
         torch.cuda.synchronize()

--- a/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
+++ b/tests/unit_tests/ssm/ops/mamba2/test_selective_state_update.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Unit tests for ``selective_state_update`` (megatron/core/ssm/ops/mamba_ssm.py)."""
+"""Unit tests for ``selective_state_update`` (megatron/core/ssm/ops/mamba2/mamba_ssm.py)."""
 
 import pytest
 import torch


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

For hybrid models, in the non-speculative decoding case wherein there are no intermediate states, the `intermediate_ssm_states` pointer gets set to a dummy value `x`. However, in the actual state update kernel, since `{"HAS_INT_STATE": lambda args: args["int_state_ptr"]` occurs at launch time, `HAS_INT_STATE` becomes `True` due to `int_state_ptr` being set to the dummy `x` rather than just being `None`. So the current code accidentally ends up launching programs which all modify the `x` tensor at stride `(0, 0, 0, 0, 0)`. Since the scheduler determines which programs launch first, if any program that is not `pid = 0` launches first, it ends up corrupting the data in `x` at the stride belonging to `pid = 0`.

Also we don't have any reason to be modifying the input `x` in the first place. So this is how I test this non-deterministic bug in the unit test. I check whether the input to the selective state update function is the same before and after the function is run. This helps indirectly validate that `x` is not being accidentally modified.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
