### PR TITLE
[Dev] Fix duplicate FSDP root finalization with MTP

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -842,12 +842,23 @@ class MegatronFSDP(torch.nn.Module):
             return args, kwargs
 
         def _root_post_backward(*unused):
+            # The combined 1F1B schedule finalizes each microbatch explicitly.
+            # A root autograd callback may already be queued for that same
+            # microbatch (notably when MTP shares the embedding parameter).
+            # Once the explicit call resets the pre-backward state, ignore the
+            # stale callback instead of reducing/resetting the bucket twice.
+            if not self._root_pre_backward_hook_issued:
+                return
+
             # Make sure all the gradients are handled.
             ordered_params = sorted(
                 list(self._params_require_handle_grad), key=lambda p: self.param_to_name[p]
             )
             for param in ordered_params:
                 _grad_acc(param)
+            # Root-owned/shared parameters do not pass through
+            # _process_post_backward_gradients(), so consume them here.
+            self._params_require_handle_grad.difference_update(ordered_params)
 
             # Reduce the remaining gradients.
             grad_reduce_every_bprop = self.data_parallel_sharding_strategy in [

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import gc
 
@@ -90,6 +90,17 @@ class TestFSDP1F1BOverlap:
             offload_modules=offload_modules,
         )
 
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    def test_fsdp_1f1b_mtp_multi_microbatch(self):
+        """MTP shared root parameters must be finalized once per microbatch."""
+        self._run_test_helper(
+            dispatcher_type="alltoall",
+            sharding_strategy="optim_grads_params",
+            mtp_num_layers=1,
+            mtp_loss_scaling_factor=0.1,
+            num_microbatches=2,
+        )
+
     def _run_test_helper(
         self,
         dispatcher_type="alltoall",
@@ -99,6 +110,9 @@ class TestFSDP1F1BOverlap:
         recompute_modules=None,
         offload_modules=None,
         flex_backend=None,
+        num_microbatches=1,
+        mtp_num_layers=None,
+        mtp_loss_scaling_factor=None,
     ):
         """Verify multi-step FSDP training with overlap produces identical
         per-step loss and final weights as standard FSDP training.
@@ -121,6 +135,9 @@ class TestFSDP1F1BOverlap:
         if offload_modules:
             extra_kwargs["fine_grained_activation_offloading"] = True
             extra_kwargs["offload_modules"] = offload_modules
+        if mtp_num_layers is not None:
+            extra_kwargs["mtp_num_layers"] = mtp_num_layers
+            extra_kwargs["mtp_loss_scaling_factor"] = mtp_loss_scaling_factor
 
         def _make_ddp_config():
             return DistributedDataParallelConfig(
@@ -167,8 +184,12 @@ class TestFSDP1F1BOverlap:
             for step in range(NUM_STEPS):
                 if hasattr(ref_fsdp, 'set_is_first_microbatch'):
                     ref_fsdp.set_is_first_microbatch()
-                ref_loss = fsdp_train_step(ref_fsdp, ref_opt, data)
-                test_loss = overlap_train_step(test_fsdp, test_opt, test_config, data)
+                ref_loss = fsdp_train_step(
+                    ref_fsdp, ref_opt, data, num_microbatches=num_microbatches
+                )
+                test_loss = overlap_train_step(
+                    test_fsdp, test_opt, test_config, data, num_microbatches=num_microbatches
+                )
 
                 assert torch.equal(ref_loss, test_loss), (
                     f"[rank {rank}] Loss mismatch at step {step}: "

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -352,10 +352,8 @@ def forward_step_func(data_iterator, model, return_schedule_plan=False):
     return output, loss_func
 
 
-def overlap_train_step(model, optimizer, config, data):
+def overlap_train_step(model, optimizer, config, data, num_microbatches=1):
     """One overlap forward-backward-optimizer step. Return scalar loss."""
-    from contextlib import nullcontext
-
     from megatron.core.pipeline_parallel.combined_1f1b import (
         combined_1f1b_schedule_for_no_pipelining,
     )
@@ -364,9 +362,9 @@ def overlap_train_step(model, optimizer, config, data):
     forward_data_store = []
     combined_1f1b_schedule_for_no_pipelining(
         forward_step_func=forward_step_func,
-        data_iterator=iter([data]),
+        data_iterator=iter([data] * num_microbatches),
         model=model,
-        num_microbatches=1,
+        num_microbatches=num_microbatches,
         input_tensor=None,
         output_tensor_grad=None,
         forward_data_store=forward_data_store,
@@ -374,24 +372,28 @@ def overlap_train_step(model, optimizer, config, data):
         collect_non_loss_data=False,
         first_val_step=None,
         forward_only=False,
-        no_sync_func=nullcontext,
+        no_sync_func=model.no_sync,
         total_num_tokens=torch.zeros([], dtype=torch.int, device="cuda"),
         check_first_val_step=lambda cond: cond,
     )
     torch.cuda.synchronize()
-    loss = forward_data_store[0]['lm loss'].detach().clone()
+    loss = sum(entry['lm loss'].detach().clone() for entry in forward_data_store)
+    loss /= num_microbatches
     optimizer.step()
     return loss
 
 
-def fsdp_train_step(model, optimizer, data):
+def fsdp_train_step(model, optimizer, data, num_microbatches=1):
     """One standard forward-backward-optimizer step through FSDP. Return scalar loss."""
     from megatron.core.transformer.module import float16_to_fp32
 
     optimizer.zero_grad()
-    loss = model(**data)
-    loss = float16_to_fp32(loss).sum()
-    loss.backward()
+    loss = torch.zeros([], dtype=torch.float32, device="cuda")
+    for _ in range(num_microbatches):
+        microbatch_loss = model(**data)
+        microbatch_loss = float16_to_fp32(microbatch_loss).sum()
+        (microbatch_loss / num_microbatches).backward()
+        loss += microbatch_loss.detach() / num_microbatches
     optimizer.step()
     return loss.detach().clone()
 


### PR DESCRIPTION
## Summary

- ignore a stale FSDP root post-backward callback after the combined 1F1B schedule has already finalized the same microbatch explicitly
- consume root-owned/shared parameters after their gradient accumulators run so they cannot be finalized twice
- add an MTP + combined 1F1B regression test with two microbatches and extend the shared test helpers to support multi-microbatch loss accumulation

## Root cause

With MTP, the prediction layer can share a root-owned embedding parameter with the main model. The autograd root callback may already be queued when combined 1F1B explicitly finalizes the microbatch. The explicit finalization resets the root pre-backward state, but the stale callback still runs later and attempts to reduce/reset the same bucket a second time.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev bash tools/autoformat.sh` with Megatron's required `black==26.3.0`: passed
- `tools/check_copyright.py` on all changed Python files: passed
- `python -m py_compile` on all changed Python files: passed
- added `TestFSDP1F1BOverlap.test_fsdp_1f1b_mtp_multi_microbatch` for upstream GPU CI
- the patch is patch-id equivalent to commit `8574a9970`, which was exercised by the 256-GPU DeepSeek-V3 full-model run `2585683`