### PR TITLE
Optimize MIMO pipeline communication

### DIFF
--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -384,7 +384,7 @@ class BridgeCommunicator:
                         self.current_rank,
                         dest_rank,
                     )
-                    dist.send(tensor_split, dst=dest_rank, group=self.bridge_pg)
+                self._run_batched_payload_p2p(tensor_splits, rank_info.send_to_ranks, op="send")
 
     def recv_forward(self) -> torch.Tensor:
         """Receive forward activation tensor.
@@ -433,8 +433,14 @@ class BridgeCommunicator:
                     dtype=self.comm_dtype,
                     requires_grad=True,
                 )
-                dist.recv(tensor_to_recv, src=src_rank, group=self.bridge_pg)
-                if logger.isEnabledFor(logging.DEBUG):
+                received_tensors_list.append(tensor_to_recv)
+            self._run_batched_payload_p2p(
+                received_tensors_list, rank_info.recv_from_ranks, op="recv"
+            )
+            if logger.isEnabledFor(logging.DEBUG):
+                for src_rank, tensor_to_recv in zip(
+                    rank_info.recv_from_ranks, received_tensors_list
+                ):
                     logger.debug(
                         "[Bridge Communicator] [receive_forward] Rank %s "
                         "received tensor from src rank %s shape %s sum %s",
@@ -443,7 +449,6 @@ class BridgeCommunicator:
                         tensor_to_recv.shape,
                         tensor_to_recv.sum(),
                     )
-                received_tensors_list.append(tensor_to_recv)
             aggregated_tensor = torch.cat(received_tensors_list, dim=self._batch_dim)
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
@@ -527,7 +532,6 @@ class BridgeCommunicator:
             self._communicate_shapes(tensor_to_send_prev=tensor_splits)
             if num_receives > 0:
                 for src_rank, tensor_split in zip(rank_info.recv_from_ranks, tensor_splits):
-                    # Send the gradient split back to the source rank
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug(
                             "[Bridge Communicator] [send_backward] Rank %s "
@@ -537,7 +541,7 @@ class BridgeCommunicator:
                             tensor_split.shape,
                             tensor_split.sum(),
                         )
-                    dist.send(tensor_split, dst=src_rank, group=self.bridge_pg)
+                self._run_batched_payload_p2p(tensor_splits, rank_info.recv_from_ranks, op="send")
 
     def recv_backward(self) -> torch.Tensor:
         """Receive backward gradient tensor.
@@ -579,8 +583,12 @@ class BridgeCommunicator:
                 grad_tensor = torch.empty(
                     grad_shape, device=torch.cuda.current_device(), dtype=self.comm_dtype
                 )
-                dist.recv(grad_tensor, src=dest_rank, group=self.bridge_pg)
-                if logger.isEnabledFor(logging.DEBUG):
+                received_gradients_list.append(grad_tensor)
+            self._run_batched_payload_p2p(
+                received_gradients_list, rank_info.send_to_ranks, op="recv"
+            )
+            if logger.isEnabledFor(logging.DEBUG):
+                for dest_rank, grad_tensor in zip(rank_info.send_to_ranks, received_gradients_list):
                     logger.debug(
                         "[Bridge Communicator] [receive_backward] Rank %s "
                         "received gradient from dest rank %s shape %s sum %s",
@@ -589,7 +597,6 @@ class BridgeCommunicator:
                         grad_tensor.shape,
                         grad_tensor.sum(),
                     )
-                received_gradients_list.append(grad_tensor)
 
             # Concatenate received gradients
             aggregated_gradient = torch.cat(received_gradients_list, dim=self._batch_dim)
@@ -924,6 +931,31 @@ class BridgeCommunicator:
                 received_activation.shape,
             )
             return received_activation
+
+    def _run_batched_payload_p2p(
+        self, tensors: List[torch.Tensor], peers: List[int], *, op: str
+    ) -> None:
+        """Launch one payload operation per peer in a single P2P batch."""
+        if len(tensors) != len(peers):
+            raise ValueError(
+                f"expected one payload tensor per peer, got {len(tensors)} tensors "
+                f"for {len(peers)} peers"
+            )
+        if op == "send":
+            p2p_op = dist.isend
+        elif op == "recv":
+            p2p_op = dist.irecv
+        else:
+            raise ValueError(f"unsupported bridge P2P operation: {op}")
+
+        ops = [
+            dist.P2POp(p2p_op, tensor, peer, self.bridge_pg) for tensor, peer in zip(tensors, peers)
+        ]
+        if not ops:
+            return
+        requests = dist.batch_isend_irecv(ops)
+        for request in requests:
+            request.wait()
 
     def _communicate_shapes(
         self,

--- a/megatron/core/pipeline_parallel/multimodule_communicator.py
+++ b/megatron/core/pipeline_parallel/multimodule_communicator.py
@@ -199,6 +199,10 @@ class MultiModulePipelineCommunicator:
                     return True
         return False
 
+    def is_module_pp_first_stage(self, module_name: str) -> bool:
+        """Return True if the current rank is the module's first PP stage."""
+        return self.rank_module_map[module_name].pp_rank == 0
+
     @property
     def is_pp_last_stage(self):
         """Return True if the current rank has the absolute last stage in the overall model.

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -2255,6 +2255,13 @@ def forward_backward_pipelining_without_interleaving(
 
     disable_grad_sync()
 
+    grad_sync_first_stage = p2p_communicator.is_pp_first_stage
+    if isinstance(p2p_communicator, MultiModulePipelineCommunicator):
+        grad_sync_first_stage = all(
+            p2p_communicator.is_module_pp_first_stage(module_name)
+            for module_name in p2p_communicator.rank_module_map
+        )
+
     # Compute number of warmup microbatches.
     num_warmup_microbatches = p2p_communicator.total_stages - p2p_communicator.current_stage - 1
     num_warmup_microbatches = min(num_warmup_microbatches, num_microbatches)
@@ -2412,7 +2419,7 @@ def forward_backward_pipelining_without_interleaving(
             # Enable grad sync for the last microbatch in the batch if the full
             # backward pass completes in the 1F1B stage.
             if num_warmup_microbatches == 0 and last_iteration:
-                if config.grad_sync_func is None or p2p_communicator.is_pp_first_stage:
+                if config.grad_sync_func is None or grad_sync_first_stage:
                     enable_grad_sync()
 
             input_tensor_grad = backward_func(
@@ -2439,7 +2446,7 @@ def forward_backward_pipelining_without_interleaving(
             # pipeline stages do grad reduction during pipeline
             # bubble.
             if i == num_warmup_microbatches - 1:
-                if config.grad_sync_func is None or p2p_communicator.is_pp_first_stage:
+                if config.grad_sync_func is None or grad_sync_first_stage:
                     enable_grad_sync()
 
             input_tensor = input_tensors.pop(0)

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -270,6 +270,73 @@ class TestBridgeCommunicatorSplitMetadata:
         with pytest.raises(ValueError, match="expected 3 tensors for shape communication, got 2"):
             BridgeCommunicator._as_per_peer_tensors(tensors, expected_count=3)
 
+    @pytest.mark.parametrize(
+        "op, expected_callable",
+        [("send", torch.distributed.isend), ("recv", torch.distributed.irecv)],
+    )
+    def test_batched_payload_launches_all_peers_before_waiting(
+        self, monkeypatch, op, expected_callable
+    ):
+        bridge = self._bridge()
+        bridge.bridge_pg = object()
+        peers = [17, 5, 29]
+        tensors = [torch.empty((3, 2)), torch.empty((0, 2)), torch.empty((7, 2))]
+        created_ops = []
+        calls = []
+
+        class FakeOp:
+            def __init__(self, p2p_op, tensor, peer, group):
+                self.op = p2p_op
+                self.tensor = tensor
+                self.peer = peer
+                self.group = group
+                created_ops.append(self)
+                calls.append(("construct", peer))
+
+        class FakeWork:
+            def __init__(self, index):
+                self.index = index
+
+            def wait(self):
+                assert len(created_ops) == len(peers)
+                calls.append(("wait", self.index))
+
+        def fake_batch(ops):
+            assert list(ops) == created_ops
+            calls.append(("launch", tuple(item.peer for item in ops)))
+            return [FakeWork(index) for index in range(len(ops))]
+
+        monkeypatch.setattr(torch.distributed, "P2POp", FakeOp)
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", fake_batch)
+
+        bridge._run_batched_payload_p2p(tensors, peers, op=op)
+
+        assert calls == [
+            ("construct", 17),
+            ("construct", 5),
+            ("construct", 29),
+            ("launch", (17, 5, 29)),
+            ("wait", 0),
+            ("wait", 1),
+            ("wait", 2),
+        ]
+        assert [item.op for item in created_ops] == [expected_callable] * len(peers)
+        assert all(item.tensor is tensor for item, tensor in zip(created_ops, tensors))
+        assert [item.peer for item in created_ops] == peers
+        assert all(item.group is bridge.bridge_pg for item in created_ops)
+
+    def test_batched_payload_rejects_invalid_mapping_before_launch(self, monkeypatch):
+        bridge = self._bridge()
+        bridge.bridge_pg = object()
+        monkeypatch.setattr(
+            torch.distributed,
+            "batch_isend_irecv",
+            lambda _ops: (_ for _ in ()).throw(AssertionError("invalid batch was launched")),
+        )
+
+        with pytest.raises(ValueError, match="one payload tensor per peer"):
+            bridge._run_batched_payload_p2p([torch.empty(1)], [4, 5], op="send")
+
 
 class TestBridgeCommunicator:
 

--- a/tests/unit_tests/pipeline_parallel/test_multimodule_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_multimodule_communicator.py
@@ -79,6 +79,11 @@ class TestMultiModulePipelineCommunicator:
         assert mllm_comm.config == config
         assert mllm_comm.current_rank == dist.get_rank()
 
+        for module_name, rank_module_info in mllm_comm.rank_module_map.items():
+            assert mllm_comm.is_module_pp_first_stage(module_name) == (
+                rank_module_info.pp_rank == 0
+            )
+
     def test_compute_total_pipeline_stages(self):
         """Test compute_total_pipeline_stages for overall chain and until specific ranks."""
 

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -15,6 +15,7 @@ import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core import ModelParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -567,6 +568,125 @@ def test_forward_backward_func_without_pipeline_parallel(mocker):
     for i, j in zip(losses_reduced, loss_reduced_expected):
         assert i['loss_reduced'] == j['loss_reduced']
     Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize(
+    "communicator_base,module_first_stage,pipeline_stages",
+    [
+        (P2PCommunicator, None, 1),
+        (MultiModulePipelineCommunicator, True, 1),
+        (MultiModulePipelineCommunicator, True, 2),
+    ],
+)
+def test_schedule_enables_grad_sync_on_first_stage(
+    monkeypatch, communicator_base, module_first_stage, pipeline_stages
+):
+    events = []
+
+    @contextmanager
+    def no_sync():
+        events.append("enter_no_sync")
+        try:
+            yield
+        finally:
+            events.append("exit_no_sync")
+
+    config = SimpleNamespace(
+        overlap_p2p_comm=False,
+        variable_seq_lengths=True,
+        finalize_model_grads_func=None,
+        timers=None,
+        no_sync_func=no_sync,
+        num_microbatches_with_partial_activation_checkpoints=None,
+        deallocate_pipeline_outputs=False,
+        grad_sync_func=lambda _parameters: events.append("grad_sync"),
+        calculate_per_token_loss=False,
+    )
+    model = SimpleNamespace(config=config, parameters=lambda: [])
+
+    is_multimodule = communicator_base is MultiModulePipelineCommunicator
+
+    class FakeCommunicator(communicator_base):
+        total_stages = pipeline_stages
+        current_stage = 0
+        is_pp_first_stage = not is_multimodule
+        is_pp_last_stage = True
+
+        def __init__(self):
+            self.config = config
+            if is_multimodule:
+                self.rank_module_map = {"llm": SimpleNamespace()}
+
+        def is_module_pp_first_stage(self, _module_name):
+            return module_first_stage
+
+        @staticmethod
+        def recv_forward(*_args):
+            return {"llm": None} if is_multimodule else None
+
+        @staticmethod
+        def send_forward_recv_backward(*_args):
+            return None
+
+        @staticmethod
+        def send_forward(*_args):
+            return None
+
+        @staticmethod
+        def recv_backward(*_args):
+            return None
+
+        @staticmethod
+        def send_backward(*_args):
+            return None
+
+    monkeypatch.setattr(
+        schedule,
+        "forward_step",
+        lambda *_args, **_kwargs: (
+            {"llm": torch.tensor(1.0)} if is_multimodule else torch.tensor(1.0),
+            torch.tensor(0),
+        ),
+    )
+    monkeypatch.setattr(
+        schedule, "backward_step", lambda *_args, **_kwargs: events.append("backward") or None
+    )
+    monkeypatch.setattr(
+        schedule,
+        "backward_step_multimodule",
+        lambda *_args, **_kwargs: events.append("backward") or {"llm": None},
+    )
+    monkeypatch.setattr(schedule, "deallocate_output_tensor", lambda *_args: None)
+    real_zeros = torch.zeros
+    monkeypatch.setattr(
+        schedule.torch,
+        "zeros",
+        lambda *args, **kwargs: real_zeros(
+            *args, **{key: value for key, value in kwargs.items() if key != "device"}
+        ),
+    )
+
+    if is_multimodule:
+        pg_collection = SimpleNamespace(
+            has_language_model=lambda: False, language_model_module_name=None
+        )
+    else:
+        pg_collection = ProcessGroupCollection()
+        pg_collection.tp = SimpleNamespace(size=lambda: 1)
+        pg_collection.cp = SimpleNamespace(size=lambda: 1)
+
+    schedule.forward_backward_pipelining_without_interleaving(
+        forward_step_func=None,
+        data_iterator=None,
+        model=model,
+        num_microbatches=1,
+        seq_length=1,
+        micro_batch_size=1,
+        p2p_communicator=FakeCommunicator(),
+        pg_collection=pg_collection,
+    )
+
+    assert events == ["enter_no_sync", "exit_no_sync", "backward"]
 
 
 def test_forward_backward_func_with_pipeline_parallel(mocker):


### PR DESCRIPTION
## What

- Batch plain bridge fan-in/fan-out payload P2P operations while preserving tensor-to-peer order.
- Enable gradient overlap on the first pipeline stage of each active MIMO module, with stock `P2PCommunicator` behavior unchanged.


## Validation

- CMH1 job 3115832: 2 nodes x 4 GPUs, exact commit archive, all three focused pipeline test files; 122 passed on each node-local launcher, Slurm exit 0.
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh` passed Black, isort, Pylint (10.00/10), and Ruff.
- Python compile and `git diff --check` passed.
