### PR TITLE
[Dev] Enable dense routing maps for Flex dispatch

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -3624,9 +3624,13 @@ if HAVE_TE and is_te_min_version("2.7.0.dev"):
             "qb_bin_bounds",
             "qb_histogram_mode",
         }.issubset(_fused_topk_sig.parameters)
+        fused_topk_with_score_function_supports_topk_indices = (
+            "topk_indices" in _fused_topk_sig.parameters
+        )
         del _fused_topk_sig
     except (TypeError, ValueError):
         fused_topk_with_score_function_supports_qb = False
+        fused_topk_with_score_function_supports_topk_indices = False
 
 else:
     fused_topk_with_score_function = None
@@ -3634,6 +3638,7 @@ else:
     fused_moe_aux_loss = None
     fused_topk_with_score_function_supports_qb = False
     mark_qb_bin_bounds_validated = None
+    fused_topk_with_score_function_supports_topk_indices = False
 
 
 def set_save_original_input(module):

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -3,7 +3,8 @@
 # Copyright (c) 2025 DeepSeek
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
-from typing import Optional
+import inspect
+from typing import Callable, Optional
 
 from megatron.core.utils import internal_api
 
@@ -490,12 +491,37 @@ else:
     deepepv2_combine = None
 
 
+def _has_parameter(function: Callable, parameter: str) -> bool:
+    """Return whether a callable exposes a named parameter."""
+    try:
+        return parameter in inspect.signature(function).parameters
+    except (TypeError, ValueError):
+        return False
+
+
 try:
     from deep_ep import HybridEPBuffer
 
     HAVE_HYBRIDEP = True
+    HAVE_HYBRIDEP_EXPLICIT_DENSE_ROUTING = _has_parameter(
+        HybridEPBuffer.dispatch_with_permute, "dense_routing"
+    )
+    try:
+        import hybrid_ep_cpp
+
+        HAVE_HYBRIDEP_INFERRED_DENSE_ROUTING = hasattr(
+            hybrid_ep_cpp.HybridEpConfigInstance(), "topk"
+        )
+    except (ImportError, AttributeError, TypeError, ValueError):
+        HAVE_HYBRIDEP_INFERRED_DENSE_ROUTING = False
+    HAVE_HYBRIDEP_DENSE_ROUTING = (
+        HAVE_HYBRIDEP_EXPLICIT_DENSE_ROUTING or HAVE_HYBRIDEP_INFERRED_DENSE_ROUTING
+    )
 except ImportError:
     HAVE_HYBRIDEP = False
+    HAVE_HYBRIDEP_EXPLICIT_DENSE_ROUTING = False
+    HAVE_HYBRIDEP_INFERRED_DENSE_ROUTING = False
+    HAVE_HYBRIDEP_DENSE_ROUTING = False
 
 _hybrid_ep_buffer = None
 
@@ -597,16 +623,16 @@ class HybridEPDispatch(torch.autograd.Function):
         num_permuted_tokens=None,
         pad_multiple=None,
         num_sms_preprocessing_api=108,
+        topk_idx=None,
+        num_of_experts=None,
     ):
         '''
         Forward pass of fused dispatch of the HybridEP backend
         '''
         if fused or num_blocks_permute is not None or num_blocks_unpermute is not None:
-            import inspect
             import warnings
 
-            sig = inspect.signature(HybridEPBuffer.dispatch_with_permute)
-            if 'fuse_permute_dispatch' not in sig.parameters:
+            if not _has_parameter(HybridEPBuffer.dispatch_with_permute, 'fuse_permute_dispatch'):
                 warnings.warn(
                     "Current DeepEP version does not support fused permute dispatch or "
                     "num_blocks_permute/num_blocks_unpermute. Falling back to unfused "
@@ -636,7 +662,25 @@ class HybridEPDispatch(torch.autograd.Function):
         # If we provide the num_permuted_tokens, we do not need to use sync to
         # wait for the data in pinned memory ready
         non_blocking = num_permuted_tokens is not None
-        # Process the dispatch
+        if topk_idx is not None and not HAVE_HYBRIDEP_DENSE_ROUTING:
+            raise RuntimeError(
+                "HybridEP topk_idx was provided, but the installed HybridEPBuffer does not "
+                "support dense topk_idx metadata. Use a newer HybridEP backend or pass a sparse "
+                "routing_map without topk_idx."
+            )
+
+        use_dense = topk_idx is not None and HAVE_HYBRIDEP_DENSE_ROUTING
+        if use_dense:
+            assert num_of_experts is not None, "num_of_experts is required for dense routing"
+            dense_kwargs = {"dense_routing": True} if HAVE_HYBRIDEP_EXPLICIT_DENSE_ROUTING else {}
+            dispatch_kwargs = {
+                "topk_idx": topk_idx,
+                "num_of_experts": num_of_experts,
+                **dense_kwargs,
+            }
+        else:
+            dispatch_kwargs = {"routing_map": routing_map}
+
         (
             dispatched_hidden,
             dispatched_probs,
@@ -645,7 +689,6 @@ class HybridEPDispatch(torch.autograd.Function):
             handle,
         ) = _hybrid_ep_buffer.dispatch_with_permute(
             hidden=x,
-            routing_map=routing_map,
             probs=probs,
             scaling_factor=None,
             num_of_experts_per_rank=num_local_experts,
@@ -653,6 +696,7 @@ class HybridEPDispatch(torch.autograd.Function):
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=non_blocking,
             **({"fuse_permute_dispatch": fused} if fused else {}),
+            **dispatch_kwargs,
         )
 
         ctx.handle = handle
@@ -683,6 +727,8 @@ class HybridEPDispatch(torch.autograd.Function):
             combined_hidden,
             None,
             combined_probs,
+            None,
+            None,
             None,
             None,
             None,
@@ -753,6 +799,8 @@ if HAVE_HYBRIDEP:
         num_permuted_tokens=None,
         pad_multiple=None,
         num_sms_preprocessing_api=108,
+        topk_idx=None,
+        num_of_experts=None,
     ):
         '''
         Perform fused dispatch for "permute + dispatch a2a + permute" using the
@@ -786,6 +834,10 @@ if HAVE_HYBRIDEP:
                 is performed.
             num_sms_preprocessing_api (int):
                 Number of SMs used by the preprocessing (metadata scan) kernel.
+            topk_idx (torch.Tensor, optional):
+                Dense top-k expert indices with shape [num_tokens, topk].
+            num_of_experts (int, optional):
+                Total number of experts. Required when topk_idx is provided.
         '''
         return HybridEPDispatch.apply(
             x,
@@ -801,6 +853,8 @@ if HAVE_HYBRIDEP:
             num_permuted_tokens,
             pad_multiple,
             num_sms_preprocessing_api,
+            topk_idx,
+            num_of_experts,
         )
 
     @internal_api
@@ -842,6 +896,7 @@ def ensure_nccl_ep_bootstrapped(
     max_tokens_per_rank,
     recv_capacity_per_rank,
     hidden_dim,
+    num_topk,
     num_sms=0,
     zero_copy=False,
 ):
@@ -860,6 +915,7 @@ def ensure_nccl_ep_bootstrapped(
         recv_capacity_per_rank (int): Per-rank receive-buffer capacity in tokens. Must be
             ``>= max_tokens_per_rank``; runtime overflow hard-traps (no soft drop).
         hidden_dim (int): Token hidden size.
+        num_topk (int): Per-token top-k over ``ep_group``; sizes NCCL EP's internal buffers.
         num_sms (int): SM cap passed to TE as ``max_num_sms`` (0 lets TE/NCCL choose).
     """
     if not HAVE_TE_EP:
@@ -875,6 +931,7 @@ def ensure_nccl_ep_bootstrapped(
         max_tokens_per_rank=max_tokens_per_rank,
         recv_capacity_per_rank=recv_capacity_per_rank,
         hidden_dim=hidden_dim,
+        num_topk=num_topk,
         max_num_sms=num_sms,
         zero_copy=zero_copy,
     )

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -662,13 +662,6 @@ class HybridEPDispatch(torch.autograd.Function):
         # If we provide the num_permuted_tokens, we do not need to use sync to
         # wait for the data in pinned memory ready
         non_blocking = num_permuted_tokens is not None
-        if topk_idx is not None and not HAVE_HYBRIDEP_DENSE_ROUTING:
-            raise RuntimeError(
-                "HybridEP topk_idx was provided, but the installed HybridEPBuffer does not "
-                "support dense topk_idx metadata. Use a newer HybridEP backend or pass a sparse "
-                "routing_map without topk_idx."
-            )
-
         use_dense = topk_idx is not None and HAVE_HYBRIDEP_DENSE_ROUTING
         if use_dense:
             assert num_of_experts is not None, "num_of_experts is required for dense routing"
@@ -679,6 +672,9 @@ class HybridEPDispatch(torch.autograd.Function):
                 **dense_kwargs,
             }
         else:
+            assert routing_map is not None, (
+                "routing_map is required when dense HybridEP routing is unavailable"
+            )
             dispatch_kwargs = {"routing_map": routing_map}
 
         (

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -672,9 +672,9 @@ class HybridEPDispatch(torch.autograd.Function):
                 **dense_kwargs,
             }
         else:
-            assert routing_map is not None, (
-                "routing_map is required when dense HybridEP routing is unavailable"
-            )
+            assert (
+                routing_map is not None
+            ), "routing_map is required when dense HybridEP routing is unavailable"
             dispatch_kwargs = {"routing_map": routing_map}
 
         (

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -751,7 +751,8 @@ def topk_routing_with_score_function(
                   entries correspond to the top-k selected experts per token.
                 - routing_map (torch.Tensor): Shape [num_tokens, num_experts]. Boolean mask where
                   True indicates the token is routed to that expert (i.e. the expert was in the
-                  token's top-k selection).
+                  token's top-k selection). When topk_indices is provided, this is instead that
+                  [num_tokens, topk] dense index buffer.
             When dense_output=True:
                 - probs (torch.Tensor): Shape [num_tokens, topk]. The normalized routing
                   probabilities for each token's top-k selected experts.
@@ -817,7 +818,7 @@ def topk_routing_with_score_function(
                 qb_bin_bounds=qb_bin_bounds,
                 qb_histogram_mode="fused_atomic",
             )
-        if fused_topk_with_score_function_supports_topk_indices:
+        if fused_topk_with_score_function_supports_topk_indices and topk_indices is not None:
             kwargs["topk_indices"] = topk_indices
         return fused_topk_with_score_function(**kwargs)
 
@@ -916,11 +917,6 @@ def topk_routing_with_score_function(
 
     if dense_output:
         return probs, top_indices
-
-    if topk_indices is not None:
-        topk_indices.copy_(top_indices.to(topk_indices.dtype))
-        routing_probs = torch.zeros_like(logits).scatter(1, top_indices, probs)
-        return routing_probs, topk_indices
 
     if torch.are_deterministic_algorithms_enabled():
         # build [num_tokens, num_experts] from [num_tokens, topk]

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -38,6 +38,7 @@ if HAVE_TE:
         fused_sort_chunks_by_index_with_probs,
         fused_topk_with_score_function,
         fused_topk_with_score_function_supports_qb,
+        fused_topk_with_score_function_supports_topk_indices,
         fused_unpermute,
         te_general_gemm,
     )
@@ -55,6 +56,7 @@ else:
         te_general_gemm,
     ) = (None, None, None, None, None, None, None, None, None, None)
     fused_topk_with_score_function_supports_qb = False
+    fused_topk_with_score_function_supports_topk_indices = False
 
 
 def switch_load_balancing_loss_func(
@@ -709,6 +711,7 @@ def topk_routing_with_score_function(
     dense_output: bool = False,
     qb_histogram: Optional[torch.Tensor] = None,
     qb_bin_bounds: Optional[torch.Tensor] = None,
+    topk_indices: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Compute the routing probabilities and map for top-k selection with score function.
 
@@ -737,6 +740,8 @@ def topk_routing_with_score_function(
                                                with shape [num_experts, num_bins].
         qb_bin_bounds (torch.Tensor, optional): FP32 CUDA tensor containing the lower and upper
                                                 K3 Quantile Balancing histogram bounds.
+        topk_indices (torch.Tensor, optional): Optional dense top-k index output buffer with shape
+                                               [num_tokens, topk]. Only used by the fused TE path.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]:
@@ -812,6 +817,8 @@ def topk_routing_with_score_function(
                 qb_bin_bounds=qb_bin_bounds,
                 qb_histogram_mode="fused_atomic",
             )
+        if fused_topk_with_score_function_supports_topk_indices:
+            kwargs["topk_indices"] = topk_indices
         return fused_topk_with_score_function(**kwargs)
 
     def _compute_topk(
@@ -909,6 +916,11 @@ def topk_routing_with_score_function(
 
     if dense_output:
         return probs, top_indices
+
+    if topk_indices is not None:
+        topk_indices.copy_(top_indices.to(topk_indices.dtype))
+        routing_probs = torch.zeros_like(logits).scatter(1, top_indices, probs)
+        return routing_probs, topk_indices
 
     if torch.are_deterministic_algorithms_enabled():
         # build [num_tokens, num_experts] from [num_tokens, topk]

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -394,7 +394,7 @@ class TopKRouter(Router):
             return torch.int64
         if backend != "hybridep":
             return None
-        if not self.config.moe_hybridep_use_dense_routing_map:
+        if self.config.moe_hybridep_routing_map_mode != "indices":
             return None
         if not HAVE_HYBRIDEP_DENSE_ROUTING:
             return None

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -776,10 +776,7 @@ class TopKRouter(Router):
 
     @jit_fuser
     def _apply_expert_bias(
-        self,
-        routing_map: torch.Tensor,
-        padding_mask: Optional[torch.Tensor] = None,
-        use_dense_indices: bool = False,
+        self, routing_map: torch.Tensor, padding_mask: Optional[torch.Tensor] = None
     ):
         """
         Update expert bias and tokens_per_expert
@@ -787,6 +784,7 @@ class TopKRouter(Router):
         """
         if self.enable_expert_bias and torch.is_grad_enabled():
             with torch.no_grad():
+                use_dense_indices = routing_map.dtype != torch.bool
                 if padding_mask is not None:
                     flat_mask = padding_mask.reshape(-1)
                     assert (
@@ -876,7 +874,8 @@ class TopKRouter(Router):
         Returns:
             probs (torch.Tensor): The probabilities of token to experts assignment.
             routing_map (torch.Tensor): The mapping of token to experts assignment,
-                with shape [num_tokens, num_experts].
+                with shape [num_tokens, num_experts], or dense top-k indices with shape
+                [num_tokens, topk] for supported Flex backends.
         """
         seq_length, bsz = logits.shape[:2]
         logits = logits.view(-1, self.config.num_moe_experts)
@@ -889,7 +888,6 @@ class TopKRouter(Router):
         logits = self.apply_z_loss(logits, padding_mask=padding_mask)
 
         # Calculate probs and routing_map for token dispatching
-        topk_indices = None
         if self.is_hash_layer:
             assert input_ids is not None, (
                 "input_ids is required for hash-based routing but was None. "
@@ -913,10 +911,13 @@ class TopKRouter(Router):
                     "histogram APIs do not accept a valid-token mask."
                 )
             topk_indices_dtype = self._dense_route_indices_dtype()
-            if topk_indices_dtype is not None:
-                topk_indices = torch.empty(
+            topk_indices = (
+                torch.empty(
                     (logits.shape[0], self.topk), dtype=topk_indices_dtype, device=logits.device
                 )
+                if topk_indices_dtype is not None
+                else None
+            )
             probs, routing_map = topk_routing_with_score_function(
                 logits,
                 self.topk,
@@ -1002,9 +1003,7 @@ class TopKRouter(Router):
             )
 
         # Optionally apply expert bias
-        self._apply_expert_bias(
-            routing_map, padding_mask=padding_mask, use_dense_indices=topk_indices is not None
-        )
+        self._apply_expert_bias(routing_map, padding_mask=padding_mask)
 
         return probs, routing_map
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -10,6 +10,7 @@ from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.fused_a2a import HAVE_HYBRIDEP_DENSE_ROUTING
 from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 from megatron.core.transformer.moe.moe_utils import (
     MoEAuxLossAutoScaler,
@@ -18,6 +19,7 @@ from megatron.core.transformer.moe.moe_utils import (
     apply_random_logits,
     apply_router_token_dropping,
     compute_routing_scores_for_aux_loss,
+    fused_topk_with_score_function_supports_topk_indices,
     get_tokens_per_expert_and_token_count,
     router_gating_linear,
     sinkhorn,
@@ -26,6 +28,8 @@ from megatron.core.transformer.moe.moe_utils import (
 )
 from megatron.core.transformer.moe.router_replay import RouterReplay
 from megatron.core.transformer.transformer_config import TransformerConfig
+
+_HYBRIDEP_INT16_EXPERT_LIMIT = 1 << 15
 
 
 @dataclass(frozen=True)
@@ -76,6 +80,7 @@ class Router(ABC, MegatronModule):
             else hash_moe_layer_threshold
         )
         self.tp_group = pg_collection.tp
+        self.expt_tp_group = pg_collection.expt_tp
         self.cp_group = pg_collection.cp
         self.tp_cp_group = pg_collection.tp_cp
         self.tp_dp_cp_group = pg_collection.tp_dp_cp
@@ -372,6 +377,32 @@ class TopKRouter(Router):
             if self.get_aux_loss_coeff(aux_loss_type) > 0:
                 return True
         return False
+
+    def _dense_route_indices_dtype(self) -> Optional[torch.dtype]:
+        """Return the route-index dtype for Flex backends that consume dense top-k indices."""
+        if not self.config.moe_router_fusion:
+            return None
+        if self.config.moe_token_dispatcher_type != "flex":
+            return None
+        if self.config.moe_expert_capacity_factor is not None:
+            return None
+        if not fused_topk_with_score_function_supports_topk_indices:
+            return None
+
+        backend = self.config.moe_flex_dispatcher_backend
+        if backend in ("deepep", "deepepv2", "ncclep"):
+            return torch.int64
+        if backend != "hybridep":
+            return None
+        if not self.config.moe_hybridep_use_dense_routing_map:
+            return None
+        if not HAVE_HYBRIDEP_DENSE_ROUTING:
+            return None
+
+        num_experts = self.expt_tp_group.size() * self.config.num_moe_experts
+        if num_experts <= _HYBRIDEP_INT16_EXPERT_LIMIT:
+            return torch.int16
+        return None
 
     def _apply_aux_loss(
         self,
@@ -745,7 +776,10 @@ class TopKRouter(Router):
 
     @jit_fuser
     def _apply_expert_bias(
-        self, routing_map: torch.Tensor, padding_mask: Optional[torch.Tensor] = None
+        self,
+        routing_map: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        use_dense_indices: bool = False,
     ):
         """
         Update expert bias and tokens_per_expert
@@ -758,8 +792,21 @@ class TopKRouter(Router):
                     assert (
                         flat_mask.shape[0] == routing_map.shape[0]
                     ), f"padding_mask flat {flat_mask.shape} vs routing_map {routing_map.shape}"
-                    routing_map = routing_map & (~flat_mask).unsqueeze(-1)
-                self.local_tokens_per_expert += routing_map.sum(dim=0)
+                    if use_dense_indices:
+                        routing_map = routing_map[~flat_mask]
+                    else:
+                        routing_map = routing_map & (~flat_mask).unsqueeze(-1)
+                if use_dense_indices:
+                    expert_indices = routing_map.reshape(-1).to(torch.long)
+                    token_counts = torch.ones_like(
+                        expert_indices, dtype=self.local_tokens_per_expert.dtype
+                    )
+                    if torch.are_deterministic_algorithms_enabled():
+                        self.local_tokens_per_expert.index_add_(0, expert_indices, token_counts)
+                    else:
+                        self.local_tokens_per_expert.scatter_add_(0, expert_indices, token_counts)
+                else:
+                    self.local_tokens_per_expert += routing_map.sum(dim=0)
 
     def _hash_routing(self, logits: torch.Tensor, input_ids: torch.Tensor):
         """Hash-based routing: expert indices come from the tid2eid lookup table.
@@ -842,6 +889,7 @@ class TopKRouter(Router):
         logits = self.apply_z_loss(logits, padding_mask=padding_mask)
 
         # Calculate probs and routing_map for token dispatching
+        topk_indices = None
         if self.is_hash_layer:
             assert input_ids is not None, (
                 "input_ids is required for hash-based routing but was None. "
@@ -864,6 +912,11 @@ class TopKRouter(Router):
                     "Quantile Balancing does not yet support padding masks because the "
                     "histogram APIs do not accept a valid-token mask."
                 )
+            topk_indices_dtype = self._dense_route_indices_dtype()
+            if topk_indices_dtype is not None:
+                topk_indices = torch.empty(
+                    (logits.shape[0], self.topk), dtype=topk_indices_dtype, device=logits.device
+                )
             probs, routing_map = topk_routing_with_score_function(
                 logits,
                 self.topk,
@@ -877,6 +930,7 @@ class TopKRouter(Router):
                 router_replay=self.router_replay,
                 qb_histogram=self.qb_histogram if accumulate_qb_histogram else None,
                 qb_bin_bounds=self.qb_bin_bounds if accumulate_qb_histogram else None,
+                topk_indices=topk_indices,
             )
 
         # Dropless HybridEP consumes the sparse routing map directly, so exclude padding
@@ -891,7 +945,10 @@ class TopKRouter(Router):
         if padding_mask is not None and use_dropless_hybridep:
             valid_tokens = (~padding_mask).unsqueeze(-1)
             probs = probs * valid_tokens
-            routing_map = routing_map & valid_tokens
+            if routing_map.dtype == torch.bool:
+                routing_map = routing_map & valid_tokens
+            else:
+                routing_map = routing_map.masked_fill(padding_mask.unsqueeze(-1), -1)
 
         # Apply token dropping to probs and routing_map.
         if self.config.moe_expert_capacity_factor is not None:
@@ -945,7 +1002,9 @@ class TopKRouter(Router):
             )
 
         # Optionally apply expert bias
-        self._apply_expert_bias(routing_map, padding_mask=padding_mask)
+        self._apply_expert_bias(
+            routing_map, padding_mask=padding_mask, use_dense_indices=topk_indices is not None
+        )
 
         return probs, routing_map
 

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -19,6 +19,7 @@ from megatron.core.tensor_parallel import (
 )
 from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.fused_a2a import (
+    HAVE_HYBRIDEP_DENSE_ROUTING,
     HYBRIDEP_TOKEN_ALIGNMENT,
     deepepv2_combine,
     deepepv2_dispatch,
@@ -47,6 +48,8 @@ from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
+
+_HYBRIDEP_INT16_EXPERT_LIMIT = 1 << 15
 
 """ We use the following notation throughout this file:
      H: hidden size
@@ -1013,6 +1016,7 @@ class _DispatchManager(ABC):
         "token_indices",
         "tokens_per_expert",
         "routing_map",
+        "topk_idx",
         "dispatched_probs",
         "dispatched_indices",
         "dispatched_routing_map",
@@ -1078,6 +1082,7 @@ class _HybridEPManager(_DispatchManager):
         num_local_experts: int,
         num_experts: int,
         config: TransformerConfig,
+        router_topk: Optional[int] = None,
     ):
         """
         Initialize the HybridEP dispatcher.
@@ -1088,11 +1093,13 @@ class _HybridEPManager(_DispatchManager):
             num_local_experts (int): The number of local experts.
             num_experts (int): The total number of experts in the group.
             config (TransformerConfig): The configuration for the transformer model.
+            router_topk (int, optional): The top-k width after expert-TP expansion.
         """
         self.group = group
         self.num_local_experts = num_local_experts
         self.num_experts = num_experts
         self.config = config
+        self.router_topk = router_topk if router_topk is not None else config.moe_router_topk
         self.permute_fusion = config.moe_permute_fusion
         self.capacity_factor = config.moe_expert_capacity_factor
         # Drop and pad the input to capacity.
@@ -1142,17 +1149,61 @@ class _HybridEPManager(_DispatchManager):
             padded_num_tokens += -padded_num_tokens % HYBRIDEP_TOKEN_ALIGNMENT
         self._padded_num_tokens = padded_num_tokens
 
-        routing_map = routing_map.reshape(num_tokens, self.num_experts)
         probs = probs.reshape(num_tokens, self.num_experts)
+        provided_topk_idx = None
+
+        if routing_map.dtype == torch.bool:
+            routing_map = routing_map.reshape(num_tokens, self.num_experts)
+            if padded_num_tokens > num_tokens:
+                pad_rows = padded_num_tokens - num_tokens
+                routing_map = torch.cat(
+                    [routing_map, routing_map.new_zeros((pad_rows, self.num_experts))], dim=0
+                )
+            self.routing_map = routing_map
+        else:
+            if not HAVE_HYBRIDEP_DENSE_ROUTING:
+                raise RuntimeError(
+                    "HybridEP dense routing map was provided, but the installed HybridEPBuffer "
+                    "does not support dense topk_idx metadata. Use a newer HybridEP backend or "
+                    "disable dense routing."
+                )
+            self.routing_map = None
+            provided_topk_idx = routing_map.reshape(num_tokens, self.router_topk).contiguous()
+            if padded_num_tokens > num_tokens:
+                pad_rows = padded_num_tokens - num_tokens
+                provided_topk_idx = torch.cat(
+                    [
+                        provided_topk_idx,
+                        provided_topk_idx.new_full((pad_rows, self.router_topk), -1),
+                    ],
+                    dim=0,
+                )
+
         if padded_num_tokens > num_tokens:
             pad_rows = padded_num_tokens - num_tokens
-            routing_map = torch.cat(
-                [routing_map, routing_map.new_zeros((pad_rows, self.num_experts))], dim=0
-            )
             probs = torch.cat([probs, probs.new_zeros((pad_rows, self.num_experts))], dim=0)
 
-        self.routing_map = routing_map
         self.token_probs = probs
+
+        if provided_topk_idx is not None:
+            if self.num_experts > _HYBRIDEP_INT16_EXPERT_LIMIT:
+                raise RuntimeError(
+                    "HybridEP dense routing requires int16 expert ids, but the expert-TP-expanded "
+                    f"expert count is {self.num_experts}; the maximum is "
+                    f"{_HYBRIDEP_INT16_EXPERT_LIMIT}."
+                )
+            self.topk_idx = provided_topk_idx.to(torch.int16)
+        elif (
+            HAVE_HYBRIDEP_DENSE_ROUTING
+            and self.config.moe_hybridep_use_dense_routing_map
+            and self.num_experts <= _HYBRIDEP_INT16_EXPERT_LIMIT
+        ):
+            _, self.topk_idx = torch.topk(self.token_probs, self.router_topk, dim=-1)
+            self.topk_idx = self.topk_idx.to(torch.int16)
+            invalid_routes = ~self.routing_map.gather(1, self.topk_idx.long())
+            self.topk_idx = self.topk_idx.masked_fill(invalid_routes, -1)
+        else:
+            self.topk_idx = None
 
         if self.moe_expert_rank_capacity_factor is not None:
             pad_multiple = get_align_size_for_quantization(self.config)
@@ -1221,6 +1272,8 @@ class _HybridEPManager(_DispatchManager):
                 pad_multiple=self.pad_multiple,
                 fused=self.config.moe_permute_fusion_into_hybridep,
                 num_sms_preprocessing_api=self.config.moe_hybridep_num_sms_preprocessing,
+                topk_idx=self.topk_idx,
+                num_of_experts=self.num_experts,
             )
         )
         if self.moe_expert_rank_capacity_factor is not None:
@@ -1353,10 +1406,16 @@ class _DeepepManager(_DispatchManager):
     def setup_metadata(self, routing_map: torch.Tensor, probs: torch.Tensor):
         num_tokens = routing_map.shape[0]
 
-        routing_map = routing_map.reshape(num_tokens, self.num_experts)
         probs = probs.reshape(num_tokens, self.num_experts)
-        # Convert the format of routing map from multihot to indices.
-        self.token_probs, self.token_indices = torch.topk(probs, self.router_topk, dim=-1)
+        if routing_map.dtype == torch.bool:
+            routing_map = routing_map.reshape(num_tokens, self.num_experts)
+            # Convert the format of routing map from multihot to indices.
+            self.token_probs, self.token_indices = torch.topk(probs, self.router_topk, dim=-1)
+        else:
+            self.token_indices = routing_map.reshape(num_tokens, self.router_topk).contiguous()
+            if self.token_indices.dtype != torch.int64:
+                self.token_indices = self.token_indices.to(torch.int64)
+            self.token_probs = probs.gather(1, self.token_indices)
         # Mask the indices of dropped tokens with -1
         if self.capacity_factor is not None:
             mask = self.token_probs == 0
@@ -1741,8 +1800,15 @@ class _NCCLEPManager(_DispatchManager):
     def setup_metadata(self, routing_map: torch.Tensor, probs: torch.Tensor):
         num_tokens = routing_map.shape[0]
         probs = probs.reshape(num_tokens, self.num_experts)
-        # Convert the multihot routing map to (topk weights, topk indices), like DeepEP.
-        self.token_probs, self.token_indices = torch.topk(probs, self.router_topk, dim=-1)
+        if routing_map.dtype == torch.bool:
+            # Convert the multihot routing map to (topk weights, topk indices).
+            self.token_probs, self.token_indices = torch.topk(probs, self.router_topk, dim=-1)
+        else:
+            # Consume TE's direct top-k output without reconstructing it from a sparse map.
+            self.token_indices = routing_map.reshape(num_tokens, self.router_topk).contiguous()
+            if self.token_indices.dtype != torch.int64:
+                self.token_indices = self.token_indices.to(torch.int64)
+            self.token_probs = probs.gather(1, self.token_indices)
         self.num_local_tokens = num_tokens
 
     def _ensure_bootstrap(self):
@@ -1769,6 +1835,7 @@ class _NCCLEPManager(_DispatchManager):
             max_tokens_per_rank=self._max_tokens_per_rank,
             recv_capacity_per_rank=self._recv_capacity,
             hidden_dim=self.hidden_dim,
+            num_topk=self.router_topk,
             num_sms=(
                 self.config.moe_flex_dispatcher_num_sms
                 if self.config.moe_flex_dispatcher_num_sms is not None
@@ -1909,8 +1976,13 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
                 num_local_experts=self.num_local_experts,
                 num_experts=self.tp_size * self.config.num_moe_experts,
                 config=self.config,
+                router_topk=self.tp_size * self.config.moe_router_topk,
             )
-            self.cudagraph_attrs = ['_comm_manager.token_probs', '_comm_manager.routing_map']
+            self.cudagraph_attrs = [
+                '_comm_manager.token_probs',
+                '_comm_manager.routing_map',
+                '_comm_manager.topk_idx',
+            ]
         elif self.config.moe_flex_dispatcher_backend == "ncclep":
             assert self.tp_size * self.ep_size > 1, "NCCL EP dispatcher requires TPxEP > 1"
             self._comm_manager = _NCCLEPManager(
@@ -1938,20 +2010,33 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         This design decouples the communication group from underlying model parallelism groups,
         such that the communication strategy of tokens can be agnostic of TP size and EP size.
 
-        This function expands the routing_map from shape [num_local_tokens, num_experts] to
-        [num_local_tokens, world_size, num_local_experts]. Each element in the routing_map
-        indicates whether a token should be sent to a specific rank. Specifically, the
-        routing_map is replicated across TP group since each TP ranks in a TP group should
-        receive the same tokens.
+        Bool routing maps are expanded from [num_local_tokens, num_experts] to
+        [num_local_tokens, world_size, num_local_experts]. Dense top-k indices are expanded
+        from [num_local_tokens, topk] to [num_local_tokens, topk * expert_tp_size].
         """
         num_local_tokens = routing_map.shape[0]
         world_size = self.tp_size * self.ep_size
-        # Organize routing map and probs to [num_local_tokens, world_size, num_local_experts]
-        routing_map = (
-            routing_map.reshape(num_local_tokens, self.ep_size, 1, self.num_local_experts)
-            .expand(-1, -1, self.tp_size, -1)
-            .reshape(num_local_tokens, world_size, self.num_local_experts)
-        ).contiguous()
+        if routing_map.dtype == torch.bool:
+            routing_map = (
+                routing_map.reshape(num_local_tokens, self.ep_size, 1, self.num_local_experts)
+                .expand(-1, -1, self.tp_size, -1)
+                .reshape(num_local_tokens, world_size, self.num_local_experts)
+            ).contiguous()
+        else:
+            topk_indices = routing_map.long()
+            invalid_routes = topk_indices < 0
+            expert_parallel_idx = topk_indices // self.num_local_experts
+            local_expert_idx = topk_indices % self.num_local_experts
+            tensor_parallel_idx = torch.arange(
+                self.tp_size, device=routing_map.device, dtype=topk_indices.dtype
+            ).view(1, 1, self.tp_size)
+            expanded_indices = (
+                expert_parallel_idx.unsqueeze(-1) * self.tp_size + tensor_parallel_idx
+            ) * self.num_local_experts + local_expert_idx.unsqueeze(-1)
+            expanded_indices = expanded_indices.masked_fill(invalid_routes.unsqueeze(-1), -1)
+            routing_map = (
+                expanded_indices.reshape(num_local_tokens, -1).to(routing_map.dtype).contiguous()
+            )
         probs = (
             probs.reshape(num_local_tokens, self.ep_size, 1, self.num_local_experts)
             .expand(-1, -1, self.tp_size, -1)

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1195,7 +1195,7 @@ class _HybridEPManager(_DispatchManager):
             self.topk_idx = provided_topk_idx.to(torch.int16)
         elif (
             HAVE_HYBRIDEP_DENSE_ROUTING
-            and self.config.moe_hybridep_use_dense_routing_map
+            and self.config.moe_hybridep_routing_map_mode == "indices"
             and self.num_experts <= _HYBRIDEP_INT16_EXPERT_LIMIT
         ):
             _, self.topk_idx = torch.topk(self.token_probs, self.router_topk, dim=-1)

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -993,9 +993,8 @@ class _DispatchManager(ABC):
     """
     A manager class to handle dispatch and combine processes for MoE models.
 
-    DispatcherManager handles token dispatching according to the routing_map of format
-    [num_local_tokens, world_size, num_instances]. The routing_map is a 3D tensor where each
-    element indicates whether a token should be sent to a specific rank.
+    DispatcherManager handles token dispatching from either a bool routing map of shape
+    [num_local_tokens, world_size, num_instances] or dense top-k expert indices.
 
     num_instances is the maximum number of tokens instances dispatched into a target rank, it
     can be the number of local experts, or the size of sub_group.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1089,11 +1089,11 @@ class TransformerConfig(ModelParallelConfig):
     moe_hybridep_num_sms_preprocessing: int = 108
     """Number of SMs to use for HybridEP preprocessing (metadata scan kernel)."""
 
-    moe_hybridep_use_dense_routing_map: bool = False
-    """Use dense top-k routing indices for HybridEP when supported. Disabled by default;
-    enable explicitly to reduce HybridEP routing metadata size. Dense-required Flex backends use
-    direct indices automatically when Transformer Engine supports them; older versions fall back
-    to the sparse bool routing-map path."""
+    moe_hybridep_routing_map_mode: Literal['indices', 'bool'] = 'indices'
+    """Routing-map format for HybridEP. ``indices`` requests int16 top-k indices and is the
+    default, while ``bool`` forces the bool token-to-expert map. Index routing remains gated on
+    Transformer Engine and HybridEP support and the int16 expert limit; unsupported configurations
+    fall back to the bool routing-map path."""
 
     moe_ncclep_static_shape: bool = False
     """For the 'ncclep' flex dispatcher: feed the experts the full fixed-size receive buffer
@@ -2256,6 +2256,9 @@ class TransformerConfig(ModelParallelConfig):
                     "Flex token dispatcher with deepep/deepepv2 backend does not support "
                     "moe_pad_expert_input_to_capacity"
                 )
+
+        if self.moe_hybridep_routing_map_mode not in ("indices", "bool"):
+            raise ValueError("moe_hybridep_routing_map_mode must be one of 'indices' or 'bool'.")
 
         if self.moe_flex_dispatcher_backend == "ncclep":
             if self.moe_token_dispatcher_type != "flex":

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1089,6 +1089,12 @@ class TransformerConfig(ModelParallelConfig):
     moe_hybridep_num_sms_preprocessing: int = 108
     """Number of SMs to use for HybridEP preprocessing (metadata scan kernel)."""
 
+    moe_hybridep_use_dense_routing_map: bool = False
+    """Use dense top-k routing indices for HybridEP when supported. Disabled by default;
+    enable explicitly to reduce HybridEP routing metadata size. Dense-required Flex backends use
+    direct indices automatically when Transformer Engine supports them; older versions fall back
+    to the sparse bool routing-map path."""
+
     moe_ncclep_static_shape: bool = False
     """For the 'ncclep' flex dispatcher: feed the experts the full fixed-size receive buffer
     instead of narrowing to the (data-dependent) number of received tokens, removing the D2H sync

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1965,6 +1965,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
     _set_arg('moe_router_score_function', force=True)
     _set_arg('moe_router_enable_expert_bias', force=True)
     _set_arg('moe_router_topk_scaling_factor', force=True)
+    _set_arg('moe_hybridep_routing_map_mode', force=True)
 
     # Mamba args.
     _set_arg('mamba_state_dim', force=True)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1965,7 +1965,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
     _set_arg('moe_router_score_function', force=True)
     _set_arg('moe_router_enable_expert_bias', force=True)
     _set_arg('moe_router_topk_scaling_factor', force=True)
-    _set_arg('moe_hybridep_routing_map_mode', force=True)
+    _set_arg('moe_hybridep_routing_map_mode', force=False)
 
     # Mamba args.
     _set_arg('mamba_state_dim', force=True)

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -210,6 +210,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_hybridep_num_sms_preprocessing": 108,
     "moe_hybridep_num_blocks_permute": None,
     "moe_hybridep_num_blocks_unpermute": None,
+    "moe_hybridep_routing_map_mode": "indices",
     "moe_input_jitter_eps": None,
     "moe_latent_size": None,
     "moe_latent_up_projection_rmsnorm": False,

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -164,17 +164,20 @@ def test_load_args_restores_glu_activation_from_checkpoint(checkpoint_args):
 
 
 @pytest.mark.parametrize(
-    ("checkpoint_args", "expected_mode"),
+    ("runtime_mode", "checkpoint_args", "expected_mode"),
     [
-        (SimpleNamespace(moe_hybridep_routing_map_mode="bool"), "bool"),
-        (SimpleNamespace(), "indices"),
+        ("indices", SimpleNamespace(moe_hybridep_routing_map_mode="bool"), "indices"),
+        (None, SimpleNamespace(moe_hybridep_routing_map_mode="bool"), "bool"),
+        (None, SimpleNamespace(), None),
     ],
 )
-def test_load_args_restores_hybridep_routing_map_mode(checkpoint_args, expected_mode):
+def test_load_args_preserves_runtime_hybridep_routing_map_mode(
+    runtime_mode, checkpoint_args, expected_mode
+):
     args = SimpleNamespace(
         load="checkpoint",
         iteration=0,
-        moe_hybridep_routing_map_mode="indices",
+        moe_hybridep_routing_map_mode=runtime_mode,
         use_tokenizer_model_from_checkpoint_args=False,
         use_mp_args_from_checkpoint_args=False,
     )

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -163,6 +163,32 @@ def test_load_args_restores_glu_activation_from_checkpoint(checkpoint_args):
     assert restored_args.situ_glu_beta2 == checkpoint_args.situ_glu_beta2
 
 
+@pytest.mark.parametrize(
+    ("checkpoint_args", "expected_mode"),
+    [
+        (SimpleNamespace(moe_hybridep_routing_map_mode="bool"), "bool"),
+        (SimpleNamespace(), "indices"),
+    ],
+)
+def test_load_args_restores_hybridep_routing_map_mode(checkpoint_args, expected_mode):
+    args = SimpleNamespace(
+        load="checkpoint",
+        iteration=0,
+        moe_hybridep_routing_map_mode="indices",
+        use_tokenizer_model_from_checkpoint_args=False,
+        use_mp_args_from_checkpoint_args=False,
+    )
+    state_dict = {"args": checkpoint_args, "iteration": 12}
+
+    with mock.patch(
+        "megatron.training.checkpointing._load_base_checkpoint",
+        return_value=(state_dict, "checkpoint", False, CheckpointType.LEGACY),
+    ):
+        restored_args, _ = load_args_from_checkpoint(args)
+
+    assert restored_args.moe_hybridep_routing_map_mode == expected_mode
+
+
 def create_checkpoint(load_path, ckpt_format):
     """Setup a dummy checkpoint directory."""
     iteration = 123

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -40,19 +40,19 @@ HAVE_DENSE_ROUTER_FUSION = (
 
 
 @pytest.mark.parametrize(
-    "backend,use_hybridep_dense,num_experts,capacity_factor,expected_dtype",
+    "backend,routing_map_mode,num_experts,capacity_factor,expected_dtype",
     [
-        ("deepep", False, 8, None, torch.int64),
-        ("deepepv2", False, 8, None, torch.int64),
-        ("ncclep", False, 8, None, torch.int64),
-        ("hybridep", False, 8, None, None),
-        ("hybridep", True, 1 << 15, None, torch.int16),
-        ("hybridep", True, (1 << 15) + 1, None, None),
-        ("hybridep", True, 8, 1.0, None),
+        ("deepep", "bool", 8, None, torch.int64),
+        ("deepepv2", "bool", 8, None, torch.int64),
+        ("ncclep", "bool", 8, None, torch.int64),
+        ("hybridep", "bool", 8, None, None),
+        ("hybridep", "indices", 1 << 15, None, torch.int16),
+        ("hybridep", "indices", (1 << 15) + 1, None, None),
+        ("hybridep", "indices", 8, 1.0, None),
     ],
 )
 def test_dense_route_indices_dtype(
-    monkeypatch, backend, use_hybridep_dense, num_experts, capacity_factor, expected_dtype
+    monkeypatch, backend, routing_map_mode, num_experts, capacity_factor, expected_dtype
 ):
     monkeypatch.setattr(router_module, "fused_topk_with_score_function_supports_topk_indices", True)
     monkeypatch.setattr(router_module, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
@@ -62,7 +62,7 @@ def test_dense_route_indices_dtype(
             moe_token_dispatcher_type="flex",
             moe_expert_capacity_factor=capacity_factor,
             moe_flex_dispatcher_backend=backend,
-            moe_hybridep_use_dense_routing_map=use_hybridep_dense,
+            moe_hybridep_routing_map_mode=routing_map_mode,
             num_moe_experts=num_experts,
         ),
         expt_tp_group=SimpleNamespace(size=lambda: 1),
@@ -287,7 +287,7 @@ class TestTop2Router:
         self.router.config.moe_router_fusion = True
         self.router.config.moe_token_dispatcher_type = "flex"
         self.router.config.moe_flex_dispatcher_backend = "hybridep"
-        self.router.config.moe_hybridep_use_dense_routing_map = True
+        self.router.config.moe_hybridep_routing_map_mode = "indices"
         hidden_states = torch.randn(
             (8, 2, self.router.config.hidden_size), device="cuda", dtype=torch.bfloat16
         )

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -95,6 +95,10 @@ def test_fused_router_only_forwards_supported_topk_indices(monkeypatch, supports
     if supports_topk_indices:
         assert received_kwargs["topk_indices"] is topk_indices
 
+    received_kwargs.clear()
+    topk_routing_with_score_function(logits, 2, fused=True)
+    assert "topk_indices" not in received_kwargs
+
 
 class TestTop2Router:
     def setup_method(self, method):
@@ -230,6 +234,7 @@ class TestTop2Router:
         self.router.config.moe_router_fusion = router_fusion
         self.router.config.moe_token_dispatcher_type = "flex"
         self.router.config.moe_flex_dispatcher_backend = "hybridep"
+        self.router.config.moe_hybridep_routing_map_mode = "bool"
         seq_len = 32
         batch_size = 2
         hidden_size = self.router.config.hidden_size
@@ -637,9 +642,7 @@ class TestAuxLossFreeTop2Router:
         previous_deterministic = torch.are_deterministic_algorithms_enabled()
         torch.use_deterministic_algorithms(deterministic)
         try:
-            self.router._apply_expert_bias(
-                topk_indices, padding_mask=padding_mask, use_dense_indices=True
-            )
+            self.router._apply_expert_bias(topk_indices, padding_mask=padding_mask)
         finally:
             torch.use_deterministic_algorithms(previous_deterministic)
 

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
 
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 import torch
 
+import megatron.core.transformer.moe.moe_utils as moe_utils
+import megatron.core.transformer.moe.router as router_module
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_logging import MoEMetricsTracker
@@ -13,6 +16,7 @@ from megatron.core.transformer.moe.moe_utils import (
     get_default_pg_collection,
     get_updated_expert_bias,
     router_gating_linear,
+    topk_routing_with_score_function,
 )
 from megatron.core.transformer.moe.router import Router, TopKRouter
 from megatron.core.transformer.spec_utils import get_submodules
@@ -29,6 +33,67 @@ try:
     HAVE_ROUTER_FUSION = _fused_topk_with_score_function is not None
 except Exception:  # pragma: no cover - defensive
     HAVE_ROUTER_FUSION = False
+
+HAVE_DENSE_ROUTER_FUSION = (
+    HAVE_ROUTER_FUSION and moe_utils.fused_topk_with_score_function_supports_topk_indices
+)
+
+
+@pytest.mark.parametrize(
+    "backend,use_hybridep_dense,num_experts,capacity_factor,expected_dtype",
+    [
+        ("deepep", False, 8, None, torch.int64),
+        ("deepepv2", False, 8, None, torch.int64),
+        ("ncclep", False, 8, None, torch.int64),
+        ("hybridep", False, 8, None, None),
+        ("hybridep", True, 1 << 15, None, torch.int16),
+        ("hybridep", True, (1 << 15) + 1, None, None),
+        ("hybridep", True, 8, 1.0, None),
+    ],
+)
+def test_dense_route_indices_dtype(
+    monkeypatch, backend, use_hybridep_dense, num_experts, capacity_factor, expected_dtype
+):
+    monkeypatch.setattr(router_module, "fused_topk_with_score_function_supports_topk_indices", True)
+    monkeypatch.setattr(router_module, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
+    router = SimpleNamespace(
+        config=SimpleNamespace(
+            moe_router_fusion=True,
+            moe_token_dispatcher_type="flex",
+            moe_expert_capacity_factor=capacity_factor,
+            moe_flex_dispatcher_backend=backend,
+            moe_hybridep_use_dense_routing_map=use_hybridep_dense,
+            num_moe_experts=num_experts,
+        ),
+        expt_tp_group=SimpleNamespace(size=lambda: 1),
+    )
+
+    assert TopKRouter._dense_route_indices_dtype(router) == expected_dtype
+
+
+@pytest.mark.parametrize("supports_topk_indices", [False, True])
+def test_fused_router_only_forwards_supported_topk_indices(monkeypatch, supports_topk_indices):
+    received_kwargs = {}
+
+    def fake_fused_router(**kwargs):
+        received_kwargs.update(kwargs)
+        return torch.zeros_like(kwargs["logits"]), kwargs.get(
+            "topk_indices", torch.zeros_like(kwargs["logits"], dtype=torch.bool)
+        )
+
+    monkeypatch.setattr(moe_utils, "HAVE_TE", True)
+    monkeypatch.setattr(moe_utils, "fused_topk_with_score_function", fake_fused_router)
+    monkeypatch.setattr(
+        moe_utils, "fused_topk_with_score_function_supports_topk_indices", supports_topk_indices
+    )
+    logits = torch.randn(4, 8)
+    topk_indices = torch.empty(4, 2, dtype=torch.int64)
+
+    topk_routing_with_score_function(logits, 2, fused=True, topk_indices=topk_indices)
+
+    assert ("topk_indices" in received_kwargs) is supports_topk_indices
+    if supports_topk_indices:
+        assert received_kwargs["topk_indices"] is topk_indices
 
 
 class TestTop2Router:
@@ -210,6 +275,33 @@ class TestTop2Router:
 
             # Verify that probs for valid tokens are similar
             assert torch.equal(probs_valid_part, probs_without_mask)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or not HAVE_DENSE_ROUTER_FUSION,
+        reason="TE dense fused router output is not available",
+    )
+    def test_hybridep_dense_routing_masks_padding(self, monkeypatch):
+        monkeypatch.setattr(router_module, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
+        self.router = self.router.cuda()
+        self.router.config.moe_router_fusion = True
+        self.router.config.moe_token_dispatcher_type = "flex"
+        self.router.config.moe_flex_dispatcher_backend = "hybridep"
+        self.router.config.moe_hybridep_use_dense_routing_map = True
+        hidden_states = torch.randn(
+            (8, 2, self.router.config.hidden_size), device="cuda", dtype=torch.bfloat16
+        )
+        padding_mask = torch.zeros((8, 2), dtype=torch.bool, device="cuda")
+        padding_mask[4:, :] = True
+
+        with torch.no_grad():
+            probs, routing_map = self.router(hidden_states, padding_mask=padding_mask)
+
+        padding_rows = padding_mask.reshape(-1)
+        assert routing_map.dtype == torch.int16
+        assert routing_map.shape == (16, self.router.config.moe_router_topk)
+        assert torch.all(routing_map[padding_rows] == -1)
+        assert torch.count_nonzero(probs[padding_rows]) == 0
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -531,6 +623,59 @@ class TestAuxLossFreeTop2Router:
 
         # Print some debug info
         print("Updated bias after first forward pass:", updated_bias)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("deterministic", [False, True])
+    def test_dense_expert_bias_token_counts(self, deterministic):
+        self.router = self.router.cuda()
+        self.router.local_tokens_per_expert.zero_()
+        topk_indices = torch.tensor(
+            [[0, 3], [1, 4], [0, 7], [2, 5]], device="cuda", dtype=torch.int16
+        )
+        padding_mask = torch.tensor([False, True, False, False], device="cuda")
+
+        previous_deterministic = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(deterministic)
+        try:
+            self.router._apply_expert_bias(
+                topk_indices, padding_mask=padding_mask, use_dense_indices=True
+            )
+        finally:
+            torch.use_deterministic_algorithms(previous_deterministic)
+
+        expected = torch.tensor([2, 0, 1, 1, 0, 1, 0, 1], device="cuda", dtype=torch.float32)
+        torch.testing.assert_close(self.router.local_tokens_per_expert, expected)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or not HAVE_DENSE_ROUTER_FUSION,
+        reason="TE dense fused router output is not available",
+    )
+    def test_fused_dense_routing_with_expert_bias(self):
+        self.router = self.router.cuda()
+        self.router.config.moe_router_fusion = True
+        self.router.config.moe_token_dispatcher_type = "flex"
+        self.router.config.moe_flex_dispatcher_backend = "deepep"
+        self.router.local_tokens_per_expert.zero_()
+        self.router.expert_bias.copy_(
+            torch.arange(self.router.config.num_moe_experts, device="cuda", dtype=torch.float32)
+        )
+        hidden_states = torch.randn(
+            (4, 2, self.router.config.hidden_size), device="cuda"
+        ).bfloat16()
+        padding_mask = torch.tensor(
+            [[False, True], [False, False], [True, False], [False, False]], device="cuda"
+        )
+
+        _, topk_indices = self.router(hidden_states, padding_mask=padding_mask)
+
+        assert topk_indices.dtype == torch.int64
+        assert topk_indices.shape == (8, self.router.config.moe_router_topk)
+        expected = torch.bincount(
+            topk_indices[~padding_mask.reshape(-1)].reshape(-1),
+            minlength=self.router.config.num_moe_experts,
+        ).to(torch.float32)
+        torch.testing.assert_close(self.router.local_tokens_per_expert, expected)
 
     @pytest.mark.internal
     @pytest.mark.skipif(

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -337,7 +337,7 @@ class MoEModelTestContainer:
         probs, indices = apply_module(moe_layer.router)(hidden_states)
         probs = torch.ones_like(probs) / moe_layer.router.topk
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -380,7 +380,7 @@ class MoEModelTestContainer:
         restored_hidden_states_answer = hidden_states * local_probss.sum(dim=1).unsqueeze(1)
         restored_hidden_states_answer = restored_hidden_states_answer.to(dtype=self.test_dtype)
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -431,7 +431,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -449,7 +449,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         permuted_input_2 = permuted_input_2 * permuted_probs_2.unsqueeze(-1)
@@ -502,7 +502,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert_1, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert_1, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -519,7 +519,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert_2, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert_2, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         assert (

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -6,12 +6,28 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import megatron.core.transformer.moe.fused_a2a as fused_a2a
+import megatron.core.transformer.moe.token_dispatcher as token_dispatcher
 from megatron.core import config, parallel_state
+from megatron.core.extensions.transformer_engine import (
+    fused_topk_with_score_function_supports_topk_indices,
+)
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
-from megatron.core.transformer.moe.fused_a2a import HYBRIDEP_TOKEN_ALIGNMENT, reset_hybrid_ep_buffer
+from megatron.core.transformer.moe.fused_a2a import (
+    HAVE_HYBRIDEP_DENSE_ROUTING,
+    HYBRIDEP_TOKEN_ALIGNMENT,
+    reset_hybrid_ep_buffer,
+)
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import get_capacity
-from megatron.core.transformer.moe.token_dispatcher import MoETokenDispatcher, _HybridEPManager
+from megatron.core.transformer.moe.token_dispatcher import (
+    MoEFlexTokenDispatcher,
+    MoETokenDispatcher,
+    _DeepepManager,
+    _DeepepV2Manager,
+    _HybridEPManager,
+    _NCCLEPManager,
+)
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
@@ -80,9 +96,12 @@ def test_set_cudagraph_attr_supports_nested_paths():
 
 def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     manager = object.__new__(_HybridEPManager)
-    manager.config = SimpleNamespace(moe_hybridep_pad_variable_tokens=True)
+    manager.config = SimpleNamespace(
+        moe_hybridep_pad_variable_tokens=True, moe_hybridep_use_dense_routing_map=False
+    )
     manager.group = object()
     manager.num_experts = 2
+    manager.router_topk = 1
     manager.moe_expert_rank_capacity_factor = None
     manager.drop_and_pad = False
 
@@ -106,6 +125,112 @@ def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     assert manager.token_probs.shape == (expected_num_tokens, manager.num_experts)
     assert not manager.routing_map[local_num_tokens:].any()
     assert not manager.token_probs[local_num_tokens:].any()
+
+
+def test_hybridep_sparse_fallback_marks_empty_routes_invalid(monkeypatch):
+    monkeypatch.setattr(token_dispatcher, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
+    manager = object.__new__(_HybridEPManager)
+    manager.config = SimpleNamespace(
+        moe_hybridep_pad_variable_tokens=False, moe_hybridep_use_dense_routing_map=True
+    )
+    manager.group = object()
+    manager.num_experts = 2
+    manager.router_topk = 1
+    manager.moe_expert_rank_capacity_factor = None
+    manager.drop_and_pad = False
+
+    routing_map = torch.tensor([[True, False], [False, False]])
+    probs = torch.tensor([[1.0, 0.0], [0.0, 0.0]])
+
+    manager.setup_metadata(routing_map, probs)
+
+    assert torch.equal(manager.topk_idx, torch.tensor([[0], [-1]], dtype=torch.int16))
+
+
+def test_hybridep_dense_input_requires_backend_support(monkeypatch):
+    monkeypatch.setattr(token_dispatcher, "HAVE_HYBRIDEP_DENSE_ROUTING", False)
+    manager = object.__new__(_HybridEPManager)
+    manager.config = SimpleNamespace(
+        moe_hybridep_pad_variable_tokens=False, moe_hybridep_use_dense_routing_map=True
+    )
+    manager.group = object()
+    manager.num_experts = 4
+    manager.router_topk = 2
+    manager.moe_expert_rank_capacity_factor = None
+    manager.drop_and_pad = False
+
+    with pytest.raises(RuntimeError, match="does not support dense topk_idx metadata"):
+        manager.setup_metadata(torch.tensor([[0, 2]], dtype=torch.int16), torch.ones(1, 4))
+
+
+def test_flex_dense_metadata_preserves_invalid_routes():
+    dispatcher = object.__new__(MoEFlexTokenDispatcher)
+    dispatcher.tp_size = 2
+    dispatcher.ep_size = 2
+    dispatcher.num_local_experts = 2
+    routing_map = torch.tensor([[0, -1], [3, 1]], dtype=torch.int16)
+    probs = torch.ones((2, 4))
+
+    expanded_routes, _ = dispatcher._initialize_metadata(routing_map, probs)
+
+    expected = torch.tensor([[0, 2, -1, -1], [5, 7, 1, 3]], dtype=torch.int16)
+    assert torch.equal(expanded_routes, expected)
+
+
+@pytest.mark.parametrize("manager_cls", [_DeepepManager, _DeepepV2Manager, _NCCLEPManager])
+def test_dense_required_manager_accepts_dense_indices(monkeypatch, manager_cls):
+    manager = object.__new__(manager_cls)
+    manager.num_experts = 4
+    manager.router_topk = 2
+    if isinstance(manager, _DeepepManager):
+        manager.capacity_factor = None
+    dense_indices = torch.tensor([[0, 2], [3, 1]], dtype=torch.int16)
+    probs = torch.tensor([[0.6, 0.0, 0.4, 0.0], [0.0, 0.3, 0.0, 0.7]])
+
+    monkeypatch.setattr(
+        torch, "topk", lambda *args, **kwargs: pytest.fail("dense routing must not call torch.topk")
+    )
+    manager.setup_metadata(dense_indices, probs)
+
+    assert manager.token_indices.dtype == torch.int64
+    assert torch.equal(manager.token_indices, dense_indices.long())
+    torch.testing.assert_close(manager.token_probs, torch.tensor([[0.6, 0.4], [0.7, 0.3]]))
+
+
+@pytest.mark.parametrize("explicit_dense_routing", [False, True])
+def test_hybridep_dispatch_supports_inferred_and_explicit_dense_apis(
+    monkeypatch, explicit_dense_routing
+):
+    class FakeHybridEPBuffer:
+        def __init__(self):
+            self.kwargs = None
+
+        def dispatch_with_permute(self, **kwargs):
+            self.kwargs = kwargs
+            return (
+                kwargs["hidden"],
+                kwargs["probs"],
+                None,
+                torch.ones(2, dtype=torch.int32),
+                ("handle",),
+            )
+
+    fake_buffer = FakeHybridEPBuffer()
+    monkeypatch.setattr(fused_a2a, "_hybrid_ep_buffer", fake_buffer)
+    monkeypatch.setattr(fused_a2a, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
+    monkeypatch.setattr(fused_a2a, "HAVE_HYBRIDEP_EXPLICIT_DENSE_ROUTING", explicit_dense_routing)
+    hidden = torch.randn(2, 4)
+    probs = torch.randn(2, 4)
+    topk_idx = torch.tensor([[0, 1], [2, 3]], dtype=torch.int16)
+
+    fused_a2a.HybridEPDispatch.forward(
+        SimpleNamespace(), hidden, None, probs, object(), 2, topk_idx=topk_idx, num_of_experts=4
+    )
+
+    assert fake_buffer.kwargs["topk_idx"] is topk_idx
+    assert fake_buffer.kwargs["num_of_experts"] == 4
+    assert "routing_map" not in fake_buffer.kwargs
+    assert ("dense_routing" in fake_buffer.kwargs) is explicit_dense_routing
 
 
 class MoEModelTestContainer:
@@ -167,7 +292,11 @@ class MoEModelTestContainer:
             sequence_parallel=tp_size > 1,
             add_bias_linear=kwargs.get("add_bias_linear", False),
             moe_permute_fusion=kwargs.get("moe_permute_fusion", False),
+            moe_router_fusion=kwargs.get("moe_router_fusion", False),
             moe_flex_dispatcher_backend=kwargs.get("moe_flex_dispatcher_backend", None),
+            moe_hybridep_use_dense_routing_map=kwargs.get(
+                "moe_hybridep_use_dense_routing_map", False
+            ),
             moe_expert_rank_capacity_factor=kwargs.get("moe_expert_rank_capacity_factor", None),
             calculate_per_token_loss=kwargs.get("calculate_per_token_loss", False),
         )
@@ -210,7 +339,7 @@ class MoEModelTestContainer:
         probs, indices = apply_module(moe_layer.router)(hidden_states)
         probs = torch.ones_like(probs) / moe_layer.router.topk
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -253,7 +382,7 @@ class MoEModelTestContainer:
         restored_hidden_states_answer = hidden_states * local_probss.sum(dim=1).unsqueeze(1)
         restored_hidden_states_answer = restored_hidden_states_answer.to(dtype=self.test_dtype)
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -304,7 +433,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -322,7 +451,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         permuted_input_2 = permuted_input_2 * permuted_probs_2.unsqueeze(-1)
@@ -375,7 +504,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert_1, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert_1, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -392,7 +521,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert_2, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert_2, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         assert (
@@ -529,6 +658,58 @@ class TestFlexDispatcher:
     def teardown_method(self, method):
         reset_hybrid_ep_buffer()
         Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.internal
+    @pytest.mark.parametrize("use_dense_routing", [False, True])
+    def test_hybridep_dense_routing_forward_backward(self, use_dense_routing):
+        if not is_hybrid_ep_available():
+            pytest.skip("Hybrid EP is not available")
+        if use_dense_routing and (
+            not fused_topk_with_score_function_supports_topk_indices
+            or not HAVE_HYBRIDEP_DENSE_ROUTING
+        ):
+            pytest.skip("Dense TE/HybridEP routing APIs are not available")
+
+        container = MoEModelTestContainer(
+            tp_size=1,
+            ep_size=8,
+            pp_size=1,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_token_dispatcher_type="flex",
+            moe_router_fusion=True,
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_use_dense_routing_map=use_dense_routing,
+            hidden_size=1024,
+            test_dtype=torch.bfloat16,
+        )
+        container.dispatcher_dropless_test()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.internal
+    @pytest.mark.parametrize("backend", ["deepep", "deepepv2", "ncclep"])
+    def test_dense_required_backend_forward_backward(self, backend):
+        skip_if_flex_backend_unavailable(backend)
+        if not fused_topk_with_score_function_supports_topk_indices:
+            pytest.skip("Dense TE routing output is not available")
+
+        container = MoEModelTestContainer(
+            tp_size=1,
+            ep_size=8,
+            pp_size=1,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_token_dispatcher_type="flex",
+            moe_router_fusion=True,
+            moe_flex_dispatcher_backend=backend,
+            moe_expert_rank_capacity_factor=8.0 if backend == "ncclep" else None,
+            hidden_size=1024,
+            test_dtype=torch.bfloat16,
+        )
+        container.dispatcher_dropless_test()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.internal

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -337,7 +337,7 @@ class MoEModelTestContainer:
         probs, indices = apply_module(moe_layer.router)(hidden_states)
         probs = torch.ones_like(probs) / moe_layer.router.topk
 
-        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
+        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -380,7 +380,7 @@ class MoEModelTestContainer:
         restored_hidden_states_answer = hidden_states * local_probss.sum(dim=1).unsqueeze(1)
         restored_hidden_states_answer = restored_hidden_states_answer.to(dtype=self.test_dtype)
 
-        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
+        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -431,7 +431,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        permuted_input_1, tokens_per_expert, permuted_probs_1 = token_permutation(
+        (permuted_input_1, tokens_per_expert, permuted_probs_1) = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -449,7 +449,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        permuted_input_2, tokens_per_expert, permuted_probs_2 = token_permutation(
+        (permuted_input_2, tokens_per_expert, permuted_probs_2) = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         permuted_input_2 = permuted_input_2 * permuted_probs_2.unsqueeze(-1)
@@ -502,7 +502,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        permuted_input_1, tokens_per_expert_1, permuted_probs_1 = token_permutation(
+        (permuted_input_1, tokens_per_expert_1, permuted_probs_1) = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -519,7 +519,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        permuted_input_2, tokens_per_expert_2, permuted_probs_2 = token_permutation(
+        (permuted_input_2, tokens_per_expert_2, permuted_probs_2) = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         assert (

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -97,7 +97,7 @@ def test_set_cudagraph_attr_supports_nested_paths():
 def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     manager = object.__new__(_HybridEPManager)
     manager.config = SimpleNamespace(
-        moe_hybridep_pad_variable_tokens=True, moe_hybridep_use_dense_routing_map=False
+        moe_hybridep_pad_variable_tokens=True, moe_hybridep_routing_map_mode="bool"
     )
     manager.group = object()
     manager.num_experts = 2
@@ -131,7 +131,7 @@ def test_hybridep_sparse_fallback_marks_empty_routes_invalid(monkeypatch):
     monkeypatch.setattr(token_dispatcher, "HAVE_HYBRIDEP_DENSE_ROUTING", True)
     manager = object.__new__(_HybridEPManager)
     manager.config = SimpleNamespace(
-        moe_hybridep_pad_variable_tokens=False, moe_hybridep_use_dense_routing_map=True
+        moe_hybridep_pad_variable_tokens=False, moe_hybridep_routing_map_mode="indices"
     )
     manager.group = object()
     manager.num_experts = 2
@@ -151,7 +151,7 @@ def test_hybridep_dense_input_requires_backend_support(monkeypatch):
     monkeypatch.setattr(token_dispatcher, "HAVE_HYBRIDEP_DENSE_ROUTING", False)
     manager = object.__new__(_HybridEPManager)
     manager.config = SimpleNamespace(
-        moe_hybridep_pad_variable_tokens=False, moe_hybridep_use_dense_routing_map=True
+        moe_hybridep_pad_variable_tokens=False, moe_hybridep_routing_map_mode="indices"
     )
     manager.group = object()
     manager.num_experts = 4
@@ -294,9 +294,7 @@ class MoEModelTestContainer:
             moe_permute_fusion=kwargs.get("moe_permute_fusion", False),
             moe_router_fusion=kwargs.get("moe_router_fusion", False),
             moe_flex_dispatcher_backend=kwargs.get("moe_flex_dispatcher_backend", None),
-            moe_hybridep_use_dense_routing_map=kwargs.get(
-                "moe_hybridep_use_dense_routing_map", False
-            ),
+            moe_hybridep_routing_map_mode=kwargs.get("moe_hybridep_routing_map_mode", "bool"),
             moe_expert_rank_capacity_factor=kwargs.get("moe_expert_rank_capacity_factor", None),
             calculate_per_token_loss=kwargs.get("calculate_per_token_loss", False),
         )
@@ -661,11 +659,11 @@ class TestFlexDispatcher:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.internal
-    @pytest.mark.parametrize("use_dense_routing", [False, True])
-    def test_hybridep_dense_routing_forward_backward(self, use_dense_routing):
+    @pytest.mark.parametrize("routing_map_mode", ["bool", "indices"])
+    def test_hybridep_routing_map_modes_forward_backward(self, routing_map_mode):
         if not is_hybrid_ep_available():
             pytest.skip("Hybrid EP is not available")
-        if use_dense_routing and (
+        if routing_map_mode == "indices" and (
             not fused_topk_with_score_function_supports_topk_indices
             or not HAVE_HYBRIDEP_DENSE_ROUTING
         ):
@@ -681,7 +679,7 @@ class TestFlexDispatcher:
             moe_token_dispatcher_type="flex",
             moe_router_fusion=True,
             moe_flex_dispatcher_backend="hybridep",
-            moe_hybridep_use_dense_routing_map=use_dense_routing,
+            moe_hybridep_routing_map_mode=routing_map_mode,
             hidden_size=1024,
             test_dtype=torch.bfloat16,
         )


### PR DESCRIPTION
## Rebase update (2026-09-07)

Rebased the authentic `dev` PR onto current `dev` at `0f9c777f7` (`[dev] [DeepSeek-V4] Add compact BF16 and MXFP8 DSA indexer support (#5992)`). The eight-commit series rebased cleanly apart from one test-file conflict caused by new adjacent checkpoint tests; the resolution preserves both current `dev` coverage and this PR's runtime/checkpoint HybridEP routing-mode cases. New head: `2ea7c0487`.

Post-rebase audit:

- No unresolved GitHub review threads.
- `git diff --check`, changed-file Ruff, and Python byte-compilation pass.
- The final diff remains scoped to dense routing and its tests; no dependency or lockfile changes.
- `moe_hybridep_routing_map_mode: "indices"` remains in `GOLDEN_CONFIG`.

Local validation used `nvcr.io/nvidia/pytorch:26.04-py3` on 2x NVIDIA A100 80GB PCIe with the companion rebased TE source/native extension:

- Checkpoint routing-mode cases: 3 passed on each of 2 ranks.
- Two-GPU-compatible focused router cases: 10 passed on each rank.
- Focused dispatcher metadata/API cases: 9 passed on each rank.
- Direct A100 integration equivalence passed for TE int16 and int64 dense output, with and without Quantile Balancing, including routing probabilities, route identities, backward gradients, and QB histograms.
- Dependency audit: no broken requirements.

The real transport and expert-bias additions whose existing fixtures explicitly initialize EP=8 could not be rerun on this 2-GPU host; attempting the latter reached the expected topology guard (`world_size (2) is not divisible by ... (8)`) before the test body. They retain the earlier EP8 validation below and remain intended for functional CI.

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Enable MCore Flex dispatchers to consume Transformer Engine's direct dense top-k routing indices whenever the selected backend requires dense metadata and the installed TE exposes the optional `topk_indices` output buffer.

DeepEP v1, DeepEP v2, and NCCL-EP now request `int64 [num_tokens, topk]` indices automatically. HybridEP now uses `moe_hybridep_routing_map_mode`, which defaults to `"indices"`; set it to `"bool"` to force the boolean map. Index mode uses `int16` only when the installed backend reports dense-routing support and falls back to bool above the `int16` expert limit or when support is unavailable. Non-Flex dispatchers and older TE combinations preserve the bool router-output path, and dispatcher compatibility paths reconstruct indices when a dense consumer requires them.

The dispatcher managers accept both representations, so direct TE output avoids reconstructing indices with `torch.topk` while compatibility paths remain intact. Dense padding routes remain `-1`, expert-TP expansion preserves invalid routes, and expert-bias counts are accumulated from the selected indices.

Companion main PR: #6615.

## Previous testing

- Checkpoint argument restoration: 2 passed (`"bool"` is restored; a missing legacy field keeps `"indices"`).
- Focused router, routing-map, dispatcher-metadata, padding, and feature-detection coverage: 27 passed.
- Real HybridEP EP=8 forward/backward passed for both `moe_hybridep_routing_map_mode="bool"` and `"indices"` using upstream HybridEP. The indices case validates the direct dense `int16 [num_tokens, topk]` path from TE through MCore into HybridEP.
- Dense expert-bias accounting passed in deterministic and non-deterministic modes, including fused dense routing.
- `git diff --check`, Ruff, and `py_compile` passed.

Real DeepEP v1, DeepEP v2, and NCCL-EP transport were not rerun in this validation. Their dense representation selection and compatibility-manager paths remain covered by focused tests.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.nvidia.com/megatron-core/developer-guide/latest/developer-guide/advanced.html#typing)
- [x] I have added relevant documentation
- [ ] I have run the autoformatter on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

When the PR is ready, mark it ready for review after conflicts are resolved and CI is passing.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied automatically and final reviewers are assigned.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied automatically.

### Merge

Any member of `mcore-engineers` will be able to merge the PR.
