### PR TITLE
Fix nondeterministic optimizer parameter group ordering

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -371,7 +371,7 @@ def _get_param_groups(
     # Need to pick one of the param_override_tuples to use for the param group.
     param_groups = []
     # Sort keys, None first.
-    for key in sorted(params_key, key=lambda x: (x[0] is not None, x[0])):
+    for key in sorted(params_key, key=lambda x: (x[0] is not None, x[0], x[1])):
         param_override_tuple, is_expert_parallel = key
         params = params_map[key] if key in params_map else []
         if param_override_tuple is None:


### PR DESCRIPTION
## Problem

When MoE parameters are split across pipeline-parallel stages, optimizer parameter groups can be constructed in different orders on different ranks. The expert/non-expert flag is part of the group identity, but it was omitted from the sorting key.

This can make `ChainedOptimizer` execute gradient-statistics collectives in different orders. Overlapping process groups then wait for different collectives, causing a distributed hang during gradient-norm calculation.

## Scenario

The issue occurs when pipeline-parallel stages have different local parameter traversal orders and the model contains both expert-parallel and non-expert parameter groups with the same parameter override tuple.

## Fix

Include `is_expert_parallel` in the parameter-group sorting key so all ranks construct the groups in the same deterministic order.

## Validation

The change is limited to the parameter-group sorting key and preserves the existing optimizer-group construction path.
