### PR TITLE
Add ReplaySSM state management for Mamba speculative decoding

### DIFF
--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -308,6 +308,24 @@ class InferenceConfig:
     num_speculative_tokens: int = 0
     """The number of speculative tokens to generate for decode steps."""
 
+    mamba_replay_ssm: bool = False
+    """For Mamba speculative decoding: enable ReplaySSM-style state management
+    (https://tridao.me/blog/2026/replayssm/). Instead of writing the SSM state to HBM every decode
+    step (and checkpointing per-draft states for rollback), keep a checkpoint state plus a small
+    per-(layer, slot) ring buffer of cached SSM inputs (post-conv `x`/`B` and raw `dt`).
+    Decode outputs are computed directly from the checkpoint and the cached inputs without
+    materializing intermediate states; the checkpoint is re-materialized only on (early-)flush
+    steps, and speculative rollback becomes a device-side ring-pointer move. Requires a per-head
+    scalar `A` (Mamba-2 / TIE_HDIM). Only affects the SSM state; conv-state rollback is
+    unchanged. No effect when `num_speculative_tokens == 0`."""
+
+    mamba_replay_buffer_len: int = 16
+    """ReplaySSM committed-history buffer length `B` (tokens). The logical flush threshold is
+    `L = B + W` where `W = 1 + num_speculative_tokens` is the verification-window length, and
+    the physical ring buffer is padded to the next power of two of `L`. A flush is scheduled one
+    window early (`write_pos + 2W > L`) so a full window always fits. Must satisfy `B >= W`.
+    Only used when `mamba_replay_ssm` is True."""
+
     enable_prefix_caching: bool = False
     """Whether to enable prefix caching for KV cache block sharing."""
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -389,6 +389,38 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
         self._async_sched_token_offsets = None
 
+        # Intermediate (rollback) buffers checkpoint the state after every verification
+        # window position (the guaranteed-accepted free token + the drafted tokens).
+        self.num_mamba_intermediate_states = self.num_speculative_tokens + 1
+
+        # ReplaySSM: keep the live SSM state as a
+        # checkpoint plus a per-(layer, slot) circular ring buffer of cached post-conv inputs
+        # (x|B packed, raw dt). Verification outputs are computed directly from the checkpoint
+        # and the cached inputs (no intermediate SSM states at all); the checkpoint is
+        # re-materialized only on (early-)flush steps; speculative rollback is a device-side
+        # ring-pointer move. Only affects the SSM state; the conv intermediate machinery is
+        # unchanged. Inert when num_speculative_tokens == 0.
+        self.mamba_replay_ssm = (
+            inference_config.mamba_replay_ssm and self.num_speculative_tokens > 0
+        )
+        if self.mamba_replay_ssm:
+            # W = verification-window length (guaranteed bonus token + drafts).
+            self.mamba_replay_window = self.num_speculative_tokens + 1
+            # B = committed-history buffer length (config).
+            self.mamba_replay_buffer_len = inference_config.mamba_replay_buffer_len
+            assert self.mamba_replay_buffer_len >= self.mamba_replay_window, (
+                f"mamba_replay_buffer_len ({self.mamba_replay_buffer_len}) must be >= "
+                f"1 + num_speculative_tokens ({self.mamba_replay_window})"
+            )
+            # L = logical flush threshold; the physical ring is the next power of two.
+            self.mamba_replay_flush_threshold = (
+                self.mamba_replay_buffer_len + self.mamba_replay_window
+            )
+            self.mamba_replay_cache_buf_len = 1 << (
+                self.mamba_replay_flush_threshold - 1
+            ).bit_length()
+            self.mamba_replay_block_spec = 1 << (self.mamba_replay_window - 1).bit_length()
+
         # Cache the PP group we should use for PP collectives inside the context.
         # If the model provides a pg_collection with a pp group, prefer it.
         # Otherwise:
@@ -508,21 +540,53 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         mamba_states_memory_per_request = 0
         if self.is_hybrid_model:
-            mamba_states_memory_per_request += (
+            _nheads, _headdim, _dstate = self.mamba_ssm_states_shape
+            if self.mamba_replay_ssm:
+                # Infer the (TP-local) number of SSM groups from the conv/ssm shapes
+                # (only the ReplaySSM buffers/kernels need it):
+                #   conv_dim = d_inner + 2*ngroups*d_state, with d_inner = nheads*headdim.
+                _bc = self.mamba_conv_states_shape[0] - _nheads * _headdim
+                assert _bc > 0 and _bc % (2 * _dstate) == 0, (
+                    f"mamba_replay_ssm cannot infer ngroups from "
+                    f"conv_dim={self.mamba_conv_states_shape[0]}, "
+                    f"nheads={_nheads}, headdim={_headdim}, dstate={_dstate}"
+                )
+                self.mamba_ngroups_local = _bc // (2 * _dstate)
+                assert _nheads % self.mamba_ngroups_local == 0
+                self.mamba_nheads_per_group = _nheads // self.mamba_ngroups_local
+
+            conv_bytes_per_layer = (
                 math.prod(self.mamba_conv_states_shape) * self.mamba_conv_states_dtype.itemsize
             )
-            mamba_states_memory_per_request += (
+            ssm_bytes_per_layer = (
                 math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
             )
-            mamba_states_memory_per_request *= self.num_mamba_layers
+            mamba_states_memory_per_request += (
+                conv_bytes_per_layer + ssm_bytes_per_layer
+            ) * self.num_mamba_layers
             if self.num_speculative_tokens > 0:
-                # Add memory for intermediate conv and SSM states
+                # Conv intermediate (checkpointed full conv windows).
                 intermediate_memory_per_request = (
-                    math.prod(self.mamba_conv_states_shape) * self.mamba_conv_states_dtype.itemsize
-                    + math.prod(self.mamba_ssm_states_shape) * self.mamba_ssm_states_dtype.itemsize
+                    conv_bytes_per_layer
+                    * self.num_mamba_layers
+                    * self.num_mamba_intermediate_states
                 )
-                intermediate_memory_per_request *= self.num_mamba_layers
-                intermediate_memory_per_request *= self.num_speculative_tokens + 1
+                if self.mamba_replay_ssm:
+                    # ReplaySSM ring buffers instead of SSM intermediates: post-conv x|B
+                    # cache (conv-state precision) + raw-dt cache (fp32) per ring slot.
+                    _buf = self.mamba_replay_cache_buf_len
+                    _cache_conv_dim = _nheads * _headdim + self.mamba_ngroups_local * _dstate
+                    _replay_bytes = (
+                        _buf * _cache_conv_dim * self.mamba_conv_states_dtype.itemsize
+                        + _nheads * _buf * 4
+                    )
+                    intermediate_memory_per_request += _replay_bytes * self.num_mamba_layers
+                else:
+                    intermediate_memory_per_request += (
+                        ssm_bytes_per_layer
+                        * self.num_mamba_layers
+                        * self.num_mamba_intermediate_states
+                    )
                 mamba_states_memory_per_request += intermediate_memory_per_request
 
         # Unified memory and general tensor management.
@@ -886,11 +950,27 @@ class DynamicInferenceContext(BaseInferenceContext):
             ]
 
             if self.num_speculative_tokens > 0:
-                spec_multiplier = self.num_speculative_tokens + 1
-                spec_bytes_per_req = mamba_bytes_per_req * spec_multiplier
+                conv_int_bytes = mamba_conv_bytes * self.num_mamba_intermediate_states
+                if self.mamba_replay_ssm:
+                    _ne, _he, _ds = self.mamba_ssm_states_shape
+                    _rb = (
+                        self.mamba_replay_cache_buf_len
+                        * (_ne * _he + self.mamba_ngroups_local * _ds)
+                        * self.mamba_conv_states_dtype.itemsize
+                        + _ne * self.mamba_replay_cache_buf_len * 4
+                    )
+                    ssm_int_bytes = _rb * self.num_mamba_layers
+                    spec_label = (
+                        f"ReplaySSM ring buffers, buf={self.mamba_replay_cache_buf_len}"
+                    )
+                else:
+                    ssm_int_bytes = mamba_ssm_bytes * self.num_mamba_intermediate_states
+                    spec_label = "full intermediate states"
+                spec_bytes_per_req = conv_int_bytes + ssm_int_bytes
                 spec_total_bytes = spec_bytes_per_req * self.max_requests
                 log_lines += [
-                    f"  Mamba speculative buffers (num_speculative_tokens={self.num_speculative_tokens}):",
+                    f"  Mamba speculative buffers ({spec_label}, "
+                    f"num_speculative_tokens={self.num_speculative_tokens}):",
                     f"    per_request:           {get_mem_size_str(spec_bytes_per_req)}",
                     f"    total ({self.max_requests} requests):  {get_mem_size_str(spec_total_bytes)}",
                 ]
@@ -1004,22 +1084,78 @@ class DynamicInferenceContext(BaseInferenceContext):
                     (
                         self.num_mamba_layers,
                         self.max_requests,
-                        self.num_speculative_tokens + 1,
+                        self.num_mamba_intermediate_states,
                         *self.mamba_conv_states_shape,
                     ),
                     dtype=self.mamba_conv_states_dtype,
                     device=torch.cuda.current_device(),
                 )
-                self.mamba_intermediate_ssm_states = torch.empty(
-                    (
-                        self.num_mamba_layers,
-                        self.max_requests,
-                        self.num_speculative_tokens + 1,
-                        *self.mamba_ssm_states_shape,
-                    ),
-                    dtype=self.mamba_ssm_states_dtype,
-                    device=torch.cuda.current_device(),
-                )
+                if self.mamba_replay_ssm:
+                    # ReplaySSM: circular ring buffers of cached SSM inputs replace the
+                    # intermediate SSM state buffer entirely. The live mamba_ssm_states
+                    # tensor becomes the checkpoint (stale between flush steps).
+                    nheads, headdim, dstate = self.mamba_ssm_states_shape
+                    d_inner = nheads * headdim
+                    cache_conv_dim = d_inner + self.mamba_ngroups_local * dstate
+                    buf = self.mamba_replay_cache_buf_len
+                    device = torch.cuda.current_device()
+                    # Circular post-conv input cache (packed x|B; C is never cached —
+                    # the kernels read it fresh from the current step's conv output).
+                    self.mamba_replay_conv_cache = torch.zeros(
+                        (self.num_mamba_layers, self.max_requests, buf, cache_conv_dim),
+                        dtype=self.mamba_conv_states_dtype,
+                        device=device,
+                    )
+                    # Raw-dt cache (fp32; dt_bias + softplus are applied on read).
+                    self.mamba_replay_dt_cache = torch.zeros(
+                        (self.num_mamba_layers, self.max_requests, nheads, buf),
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    # Slot-keyed ring cursors, shared across all Mamba layers (every
+                    # layer commits the same tokens). Advanced only by the commit
+                    # kernel; reset in _execute_pending_mamba_ops.
+                    self.mamba_replay_write_pos = torch.zeros(
+                        (self.max_requests,), dtype=torch.int32, device=device
+                    )
+                    self.mamba_replay_origin = torch.zeros(
+                        (self.max_requests,), dtype=torch.int32, device=device
+                    )
+                    self.mamba_replay_is_flush = torch.zeros(
+                        (self.max_requests,), dtype=torch.int8, device=device
+                    )
+                    # Per-step scratch for the precomputed B·C inner products (fixed
+                    # address for CUDA graphs; rewritten by every layer within a step).
+                    self.mamba_replay_bc_pre = torch.zeros(
+                        (
+                            self.max_requests,
+                            self.mamba_ngroups_local,
+                            buf,
+                            self.mamba_replay_block_spec,
+                        ),
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    # Fixed query_start_loc: every decode request occupies exactly W
+                    # (window) tokens in the packed decode token stream.
+                    self.mamba_replay_qsl = torch.arange(
+                        0,
+                        (self.max_requests + 1) * self.mamba_replay_window,
+                        self.mamba_replay_window,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                else:
+                    self.mamba_intermediate_ssm_states = torch.empty(
+                        (
+                            self.num_mamba_layers,
+                            self.max_requests,
+                            self.num_mamba_intermediate_states,
+                            *self.mamba_ssm_states_shape,
+                        ),
+                        dtype=self.mamba_ssm_states_dtype,
+                        device=torch.cuda.current_device(),
+                    )
             if (
                 self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD
                 and not self._uses_torch_memory_saver
@@ -1040,12 +1176,25 @@ class DynamicInferenceContext(BaseInferenceContext):
                             self.mamba_intermediate_conv_states, device="cpu"
                         ).pin_memory()
                     )
-                    self._offloadable_tensor_names.add("mamba_intermediate_ssm_states")
-                    self._offloadable_cpu_backups["mamba_intermediate_ssm_states"] = (
-                        torch.empty_like(
-                            self.mamba_intermediate_ssm_states, device="cpu"
-                        ).pin_memory()
-                    )
+                    if self.mamba_replay_ssm:
+                        for _rname in (
+                            "mamba_replay_conv_cache",
+                            "mamba_replay_dt_cache",
+                            "mamba_replay_write_pos",
+                            "mamba_replay_origin",
+                            "mamba_replay_is_flush",
+                        ):
+                            self._offloadable_tensor_names.add(_rname)
+                            self._offloadable_cpu_backups[_rname] = torch.empty_like(
+                                getattr(self, _rname), device="cpu"
+                            ).pin_memory()
+                    else:
+                        self._offloadable_tensor_names.add("mamba_intermediate_ssm_states")
+                        self._offloadable_cpu_backups["mamba_intermediate_ssm_states"] = (
+                            torch.empty_like(
+                                self.mamba_intermediate_ssm_states, device="cpu"
+                            ).pin_memory()
+                        )
         else:
             self.mamba_metadata = None
 
@@ -1787,12 +1936,29 @@ class DynamicInferenceContext(BaseInferenceContext):
         mamba_layer_number = self.layer_map[layer_number - 1]
         if intermediate:
             conv_state = self.mamba_intermediate_conv_states[mamba_layer_number]
-            ssm_state = self.mamba_intermediate_ssm_states[mamba_layer_number]
+            # In ReplaySSM mode there is no full intermediate SSM buffer.
+            ssm_state = (
+                None
+                if self.mamba_replay_ssm
+                else self.mamba_intermediate_ssm_states[mamba_layer_number]
+            )
         else:
             conv_state = self.mamba_conv_states[mamba_layer_number]
             ssm_state = self.mamba_ssm_states[mamba_layer_number]
 
         return (conv_state, ssm_state)
+
+    def mamba_replay_cache(self, layer_number: int) -> Tuple[Tensor, Tensor]:
+        """Returns the per-layer ReplaySSM ring buffers `(post_conv_cache, dt_cache)`.
+
+        Only valid when `mamba_replay_ssm` is enabled.
+        """
+        assert self.is_hybrid_model and self.mamba_replay_ssm
+        mamba_layer_number = self.layer_map[layer_number - 1]
+        return (
+            self.mamba_replay_conv_cache[mamba_layer_number],
+            self.mamba_replay_dt_cache[mamba_layer_number],
+        )
 
     # =========================================================================
     # Mamba prefix cache infrastructure
@@ -2275,10 +2441,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self.request_query_lengths[0:N],
             )
 
-            # 5. Mamba state: allocate slots for dummy requests.
-            self.mamba_metadata.request_to_mamba_state_idx[0:N] = (
-                self.mamba_metadata.batch_allocate_slots(N)
-            )
+            # 5. Mamba state: allocate slots for dummy requests. Queue them for
+            # zeroing like every other allocation site so the deferred Mamba ops
+            # (state zeroing + ReplaySSM cursor reset) treat them uniformly.
+            _dummy_slots = self.mamba_metadata.batch_allocate_slots(N)
+            self.mamba_metadata.request_to_mamba_state_idx[0:N] = _dummy_slots
+            self._pending_mamba_zeros.extend(_dummy_slots.tolist())
 
     def initialize_attention_state(
         self,
@@ -2572,6 +2740,20 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         if not (self._pending_mamba_restores or self._pending_mamba_zeros):
             return
+
+        # ReplaySSM: any slot that is (re)initialized — zeroed for a new request or
+        # restored from the prefix cache — starts with an empty ring buffer. The
+        # restored/zeroed state is the checkpoint; cursors must reset with it.
+        if self.mamba_replay_ssm:
+            _reset_slots = [m for _, _, m in self._pending_mamba_restores]
+            _reset_slots += list(self._pending_mamba_zeros)
+            if _reset_slots:
+                _idx = torch.tensor(
+                    _reset_slots, dtype=torch.long, device=self.mamba_replay_write_pos.device
+                )
+                self.mamba_replay_write_pos[_idx] = 0
+                self.mamba_replay_origin[_idx] = 0
+                self.mamba_replay_is_flush[_idx] = 0
 
         # Restore cached Mamba state to live buffers.  On failure, fall back to zeroing.
         for request_idx, block_id, mamba_idx in self._pending_mamba_restores:

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -370,6 +370,23 @@ class MambaSlotAllocator:
         mamba_indices = self.context.mamba_metadata.request_to_mamba_state_idx[
             req_tensor_cpu
         ].tolist()
+        # ReplaySSM: the live SSM state is a lazy checkpoint that may lag behind the
+        # ring buffer during decode. EOS-state saves, however, only ever happen for
+        # requests that just finished prefill (see compute_and_store_offsets), whose
+        # ring is empty (write_pos == 0) — so the live state is exact here. Enforce
+        # that assumption loudly: if this path ever starts saving decode-phase
+        # states, the save must first fold the ring into the state (after the
+        # step's commit, never between the forward pass and the commit).
+        if getattr(self.context, "mamba_replay_ssm", False):
+            _slots = [m for m in mamba_indices if m >= 0]
+            if _slots:
+                _wp = self.context.mamba_replay_write_pos[
+                    torch.tensor(_slots, dtype=torch.long, device=device)
+                ]
+                assert not bool((_wp != 0).any().item()), (
+                    "ReplaySSM: EOS-state save for a slot with a non-empty ring "
+                    "buffer; the live SSM state is stale and must be flushed first."
+                )
         mamba_idx_tensor = torch.tensor(mamba_indices, dtype=torch.int64, device=device)
         # Fancy-indexed copy (2 kernel launches instead of 2E)
         self.conv_states[:, slot_tensor] = self.context.mamba_conv_states[:, mamba_idx_tensor]

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -498,6 +498,40 @@ class DynamicInferenceEngine(AbstractEngine):
             raise ValueError(f"Cannot wait for transient state {state}")
         await event.wait()
 
+    def _warmup_replay_ssm_commit(self):
+        """Pre-compile the ReplaySSM commit kernel (it runs eagerly per decode step,
+        outside the CUDA graphs, so its first-call Triton compile would otherwise land
+        on the first real decode step). The dummy call marks every row as prefill, so
+        the kernel is a complete no-op on the ring cursors."""
+        context = self.context
+        if not (
+            getattr(context, "is_hybrid_model", False)
+            and getattr(context, "mamba_replay_ssm", False)
+        ):
+            return
+        from megatron.core.ssm.ops.mamba2.mamba_ssm_replay import commit_replayssm_spec
+
+        device = torch.cuda.current_device()
+        n = context.max_requests
+        prefill_status = torch.ones(n, dtype=torch.int32, device=device)
+        # int32 to match the real call (request_to_mamba_state_idx is int32);
+        # a different index dtype would compile a separate Triton specialization.
+        state_idx = torch.arange(n, dtype=torch.int32, device=device)
+        accepted_counts = torch.zeros(n, dtype=torch.int64, device=device)
+        with torch.inference_mode():
+            commit_replayssm_spec(
+                write_pos=context.mamba_replay_write_pos,
+                post_conv_state_pos=context.mamba_replay_origin,
+                is_flush=context.mamba_replay_is_flush,
+                accepted_draft_counts=accepted_counts,
+                prefill_status=prefill_status,
+                state_batch_indices=state_idx,
+                max_cache_len=context.mamba_replay_flush_threshold,
+                max_spec_len=context.mamba_replay_window,
+                cache_buf_len=context.mamba_replay_cache_buf_len,
+            )
+        torch.cuda.synchronize()
+
     def create_cuda_graphs(self, reset_context: bool = True):
         """Create cuda graphs.
 
@@ -516,6 +550,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         context = self.context
         controller = self.controller
+
+        # Pre-compile the ReplaySSM commit kernel (no autotune; compile-only warmup).
+        self._warmup_replay_ssm_commit()
 
         time_start = time.time()
         mem_stats_start = torch.cuda.memory_stats()

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -71,6 +71,7 @@ from megatron.core.inference.text_generation_controllers.mtp_utils_triton import
     prepare_next_forward_pass,
     verify_speculative_tokens,
 )
+from megatron.core.ssm.ops.mamba2.mamba_ssm_replay import commit_replayssm_spec
 
 
 @dataclass
@@ -913,6 +914,7 @@ class TextGenerationController:
             mamba_state_idx = context.mamba_metadata.request_to_mamba_state_idx[
                 active_request_slice
             ].to(cuda_device, non_blocking=True)
+            # Conv state rollback (full-window checkpoint copy).
             mamba_state_selective_copy(
                 intermediate_states=context.mamba_intermediate_conv_states,
                 current_states=context.mamba_conv_states,
@@ -921,14 +923,33 @@ class TextGenerationController:
                 accepted_counts=accepted_counts_gpu,
                 num_layers=context.num_mamba_layers,
             )
-            mamba_state_selective_copy(
-                intermediate_states=context.mamba_intermediate_ssm_states,
-                current_states=context.mamba_ssm_states,
-                prefill_status=prefill_status_gpu,
-                state_idx=mamba_state_idx,
-                accepted_counts=accepted_counts_gpu,
-                num_layers=context.num_mamba_layers,
-            )
+            # SSM state rollback: ReplaySSM ring-pointer commit, or the full
+            # intermediate-state copy.
+            if context.mamba_replay_ssm:
+                # ReplaySSM: no state copy at all. Advance each slot's ring cursor by
+                # (accepted drafts + bonus token); rejected drafts are simply left
+                # behind the new write_pos and get overwritten next step. Also
+                # precomputes the next step's per-slot flush flag on device.
+                commit_replayssm_spec(
+                    write_pos=context.mamba_replay_write_pos,
+                    post_conv_state_pos=context.mamba_replay_origin,
+                    is_flush=context.mamba_replay_is_flush,
+                    accepted_draft_counts=accepted_counts_gpu,
+                    prefill_status=prefill_status_gpu,
+                    state_batch_indices=mamba_state_idx,
+                    max_cache_len=context.mamba_replay_flush_threshold,
+                    max_spec_len=context.mamba_replay_window,
+                    cache_buf_len=context.mamba_replay_cache_buf_len,
+                )
+            else:
+                mamba_state_selective_copy(
+                    intermediate_states=context.mamba_intermediate_ssm_states,
+                    current_states=context.mamba_ssm_states,
+                    prefill_status=prefill_status_gpu,
+                    state_idx=mamba_state_idx,
+                    accepted_counts=accepted_counts_gpu,
+                    num_layers=context.num_mamba_layers,
+                )
 
         return blocks_to_release, remove_mask
 

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -30,6 +30,7 @@ from megatron.core.ssm.ops.common.intermediate_extraction import (
 )
 from megatron.core.ssm.ops.mamba2.batch_invariant_decode import MambaBatchInvariantDecode
 from megatron.core.ssm.ops.mamba2.mamba_ssm import selective_state_update
+from megatron.core.ssm.ops.mamba2.mamba_ssm_replay import selective_state_update_replayssm_spec
 from megatron.core.ssm.ssm_inference import SSMDynamicInferenceMixin
 from megatron.core.ssm.utils import _split_tensor_factory
 from megatron.core.tensor_parallel import get_cuda_rng_tracker
@@ -1062,6 +1063,7 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
         batch_indices: Optional[torch.Tensor] = None,
         intermediate_conv_state: Optional[torch.Tensor] = None,
         intermediate_ssm_state: Optional[torch.Tensor] = None,
+        replay_context: Optional[DynamicInferenceContext] = None,
     ) -> torch.Tensor:
         """
         Performs SSM computation for inference decode step.
@@ -1077,6 +1079,10 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
                 sequence step (for speculative decoding rollback).
             intermediate_ssm_state: Optional buffer for storing SSM state at each
                 sequence step (for speculative decoding rollback).
+            replay_context: When ReplaySSM is enabled
+                (`context.mamba_replay_ssm`), the dynamic inference context; the
+                SSM step then reads the ring buffers / cursors from it and runs the
+                ReplaySSM kernels instead of `selective_state_update`.
 
         Returns:
             The output tensor of shape (b, s, d).
@@ -1143,6 +1149,62 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
                 conv_state_indices=batch_indices,
                 intermediate_conv_states=intermediate_conv_state,
             ).to(xBC_dtype)
+
+        if replay_context is not None:
+            # ReplaySSM path: consume the packed post-conv output (x|B|C channel-last)
+            # and the raw per-head dt directly — no split, no dt broadcast, no
+            # intermediate SSM states. The live ssm_state is the checkpoint: it is
+            # only written on (early-)flush steps inside the kernel; rollback is the
+            # commit kernel's ring-pointer move in the controller.
+            context = replay_context
+            layer_idx = self.layer_number - self.pp_layer_offset
+            A = self._get_decode_A_neg_exp()
+            assert A.stride(-1) == 0 and A.stride(-2) == 0, (
+                "mamba_replay_ssm requires a per-head scalar A (Mamba-2 / TIE_HDIM)"
+            )
+            conv_out = xBC.reshape(batch_size * seq_len, -1)
+            dt_raw = dt.reshape(batch_size * seq_len, self.nheads_local_tp)
+            replay_conv_cache, replay_dt_cache = context.mamba_replay_cache(layer_idx)
+            replay_write_pos = context.mamba_replay_write_pos
+            replay_origin = context.mamba_replay_origin
+            replay_is_flush = context.mamba_replay_is_flush
+            replay_bc_pre = context.mamba_replay_bc_pre
+            replay_qsl = context.mamba_replay_qsl
+            flush_threshold = context.mamba_replay_flush_threshold
+            window = context.mamba_replay_window
+            assert seq_len == window, (
+                f"ReplaySSM decode window mismatch: seq_len={seq_len}, window={window}"
+            )
+            z_replay = None
+            if not self.rmsnorm:
+                z_replay = z.reshape(batch_size * seq_len, self.nheads_local_tp, self.headdim)
+            out = selective_state_update_replayssm_spec(
+                state_checkpoint=ssm_state,
+                post_conv_cache=replay_conv_cache,
+                dt_cache=replay_dt_cache,
+                conv_out=conv_out,
+                dt_spec=dt_raw,
+                A=A,
+                write_pos=replay_write_pos,
+                post_conv_state_pos=replay_origin,
+                is_flush=replay_is_flush,
+                query_start_loc=replay_qsl[: batch_size + 1],
+                state_batch_indices=batch_indices,
+                max_cache_len=flush_threshold,
+                max_spec_len=window,
+                d_inner=self.d_inner_local_tp,
+                ngroups=self.ngroups_local_tp,
+                dstate=self.d_state,
+                D=self.D.unsqueeze(-1).expand(self.nheads_local_tp, self.headdim),
+                z=z_replay,
+                dt_bias=self.dt_bias,
+                dt_softplus=True,
+                bc_pre=replay_bc_pre,
+            )
+            y = out.view(batch_size, seq_len, -1).to(dtype)
+            if self.rmsnorm:
+                y = self.norm(y, None if self.config.batch_invariant_mode else z)
+            return y
 
         x, B, C = torch.split(
             xBC,

--- a/megatron/core/ssm/ops/mamba2/mamba_ssm_replay.py
+++ b/megatron/core/ssm/ops/mamba2/mamba_ssm_replay.py
@@ -1,0 +1,875 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, The vLLM team. Copyright (c) 2026, ReplaySSM contributors.
+
+# ReplaySSM speculative-decode kernels for Mamba-2, adapted from
+# https://github.com/Johnny-Liou/ReplaySSM (a vLLM fork implementing
+# https://tridao.me/blog/2026/replayssm/), file
+# vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_spec.py.
+# This source code is licensed under the Apache license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Idea: instead of writing the SSM state to HBM at every decode step (and
+# checkpointing one full state per draft token for speculative rollback), keep a
+# checkpoint state `S0` plus a small circular ring buffer of cached SSM inputs
+# (post-conv `x` and `B`, raw `dt`) per (layer, state slot). Verification
+# outputs for the whole speculative window are computed directly from `S0` and
+# the cached inputs with causal masking (GEMM-shaped, no intermediate states);
+# the checkpoint is re-materialized only on (early-)flush steps; and rollback of
+# rejected drafts is a device-side ring-pointer move (the commit kernel).
+#
+# Megatron adaptations vs. the vLLM original:
+#   * `null_block_id` is -1 (Megatron pads `batch_indices_decode` with -1;
+#     vLLM reserves physical block 0). The verify kernel additionally writes
+#     zeros to padded rows' outputs (matching Megatron's baseline
+#     `_selective_scan_update_kernel` behavior) instead of leaving them
+#     untouched.
+#   * The commit kernel takes Megatron's `accepted_draft_counts` (0..T drafts;
+#     the guaranteed-accepted bonus token is added inside the kernel) and a
+#     `prefill_status` gate so prefill rows never advance their cursors.
+#   * Launch configs are the hard-coded spec tables from the fork's
+#     `replayssm_config.py` (no Triton autotuning anywhere — graph-capture
+#     friendly), Blackwell detected via the device capability major version.
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    from megatron.core.ssm.ops.mamba2.mamba_ssm import softplus
+
+    HAVE_TRITON = True
+except ImportError:
+    from unittest.mock import MagicMock
+
+    from megatron.core.utils import null_decorator
+
+    triton = MagicMock()
+    triton.jit = null_decorator
+    tl = MagicMock()
+    HAVE_TRITON = False
+
+NULL_SLOT_ID = -1
+
+
+# ---------------------------------------------------------------------------
+# Launch-config selection (ported from replayssm_config.py; spec kernels only).
+# Hard-coded heuristics, no autotune: fixed configs keep CUDA-graph capture and
+# the first real decode step deterministic.
+# ---------------------------------------------------------------------------
+_config_overrides: dict = {}
+
+
+def _is_blackwell() -> bool:
+    try:
+        return torch.cuda.get_device_capability()[0] == 10
+    except Exception:  # pragma: no cover - no CUDA device
+        return False
+
+
+def _dstate_tile(dstate: int, tile: int) -> int:
+    return max(16, min(tile, triton.next_power_of_2(dstate)))
+
+
+def get_replay_spec_config(kernel: str, dstate: int, base_block: int, max_spec_len: int) -> tuple:
+    """Launch config `(block_size_m, num_warps, dstate_tile, num_stages)` for
+    `kernel` in {"mamba2_spec_verify", "mamba2_spec_flush"} (override > tuned default)."""
+    if kernel in _config_overrides:
+        return _config_overrides[kernel]
+    bw = _is_blackwell()
+    if kernel == "mamba2_spec_verify":
+        bsm = 64 if (bw or base_block <= 16) else 32
+        return bsm, 2, _dstate_tile(dstate, 64), 2
+    if kernel == "mamba2_spec_flush":
+        if base_block <= 16:
+            return 32, 2, _dstate_tile(dstate, 64), 2
+        if bw:
+            return 64, 2, _dstate_tile(dstate, 128), 2
+        return 32, 1, _dstate_tile(dstate, 128), 2
+    raise ValueError(f"unknown ReplaySSM spec kernel config key: {kernel}")
+
+
+# ======================================================================
+# Fused scatter + precompute  (grid: (batch, ngroups))
+#
+# Scatters all conv_dim channels (x|B, partitioned by group) + dt of the
+# fresh spec tokens into the circular post-conv / dt caches at
+# `(origin + write_pos + s) % buf`, and computes `bc[k, s] = B_full[k] . C[s]`
+# over the window (history B from the cache + fresh spec B, no read-back).
+# ======================================================================
+@triton.heuristics({"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])})
+@triton.jit
+def _fused_scatter_precompute_kernel(
+    conv_out_ptr,  # (total_tokens, conv_dim) packed channel-last conv output
+    dt_spec_ptr,  # (total_tokens, nheads) packed raw dt
+    post_conv_cache_ptr,  # (num_slots, buf, cache_conv_dim) circular
+    dt_cache_ptr,  # (num_slots, nheads, buf) circular, fp32
+    write_pos_ptr,  # (num_state_slots,) slot-keyed
+    post_origin_ptr,  # (num_state_slots,) slot-keyed
+    bc_pre_ptr,  # (max_bs, ngroups, buf, block_spec) dense per-row scratch
+    state_batch_indices_ptr,  # (batch,) state slot per dense decode row
+    query_start_loc_ptr,  # (batch + 1,) packed token offsets
+    null_block_id,
+    batch,
+    ngroups,
+    nheads,
+    dstate,
+    d_inner,
+    conv_dim,
+    max_cache_len,
+    stride_conv_out_tok,
+    stride_conv_out_c,
+    stride_dt_spec_tok,
+    stride_dt_spec_h,
+    stride_post_conv_cache_b,
+    stride_post_conv_cache_pos,
+    stride_post_conv_cache_c,
+    stride_dt_cache_b,
+    stride_dt_cache_h,
+    stride_dt_cache_pos,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_state_indices_batch,
+    RATIO: tl.constexpr,
+    RATIO_P: tl.constexpr,
+    NCX: tl.constexpr,
+    BLOCK_CX: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    BLOCK_HL: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_g = tl.program_id(1)
+    state_batch_idx = tl.load(state_batch_indices_ptr + pid_b * stride_state_indices_batch).to(
+        tl.int64
+    )
+    if state_batch_idx == null_block_id:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+    spec_valid = offs_s < spec_len
+    nmask = offs_n < dstate
+    phys_spec = (post_origin + write_pos + offs_s) & (CACHE_BUF_LEN - 1)
+
+    b_c0 = d_inner + pid_g * dstate
+    c_c0 = d_inner + ngroups * dstate + pid_g * dstate
+
+    src_base = conv_out_ptr + bos * stride_conv_out_tok
+    # fresh spec B / C  [S, N]
+    B_spec = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    C_spec = tl.load(
+        src_base
+        + (c_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    cache_base = post_conv_cache_ptr + state_batch_idx * stride_post_conv_cache_b
+    # scatter B (C is not cached; read fresh from conv_out)
+    tl.store(
+        cache_base
+        + phys_spec[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        B_spec,
+        mask=spec_valid[:, None] & nmask[None, :],
+    )
+
+    # scatter x channels owned by this group: [g*RATIO_P, (g+1)*RATIO_P)
+    gx0 = pid_g * RATIO_P
+    for i in tl.static_range(NCX):
+        offs_cx = i * BLOCK_CX + tl.arange(0, BLOCK_CX)
+        cxm = offs_cx < RATIO_P
+        gx = gx0 + offs_cx
+        xv = tl.load(
+            src_base + gx[None, :] * stride_conv_out_c + offs_s[:, None] * stride_conv_out_tok,
+            mask=spec_valid[:, None] & cxm[None, :],
+            other=0.0,
+        )
+        tl.store(
+            cache_base
+            + phys_spec[:, None] * stride_post_conv_cache_pos
+            + gx[None, :] * stride_post_conv_cache_c,
+            xv,
+            mask=spec_valid[:, None] & cxm[None, :],
+        )
+
+    # scatter dt for this group's heads
+    offs_hl = tl.arange(0, BLOCK_HL)
+    hlm = offs_hl < RATIO
+    gh = pid_g * RATIO + offs_hl
+    dt_base = dt_spec_ptr + bos * stride_dt_spec_tok
+    dtv = tl.load(
+        dt_base + offs_s[:, None] * stride_dt_spec_tok + gh[None, :] * stride_dt_spec_h,
+        mask=spec_valid[:, None] & hlm[None, :],
+        other=0.0,
+    )
+    dtc_base = dt_cache_ptr + state_batch_idx * stride_dt_cache_b
+    tl.store(
+        dtc_base + gh[None, :] * stride_dt_cache_h + phys_spec[:, None] * stride_dt_cache_pos,
+        dtv,
+        mask=spec_valid[:, None] & hlm[None, :],
+    )
+
+    # bc: history B from cache + fresh spec B  (no read-back of spec B)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    hist_mask = offs_k < write_pos
+    cache_valid = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_tok = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_off = offs_k - write_pos
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    B_hist = tl.load(
+        cache_base
+        + phys_k[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        mask=hist_mask[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_specrows = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + spec_off[:, None] * stride_conv_out_tok,
+        mask=spec_tok[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_full = tl.where(spec_tok[:, None], B_specrows, B_hist)
+    B_full = tl.where(cache_valid[:, None], B_full.to(tl.float32), 0.0).to(
+        conv_out_ptr.dtype.element_ty
+    )
+    bc = tl.dot(
+        B_full, tl.trans(C_spec.to(conv_out_ptr.dtype.element_ty)), input_precision="tf32x3"
+    ).to(tl.float32)
+    bc_ptrs = (
+        bc_pre_ptr
+        + pid_b * stride_bc_pre_batch
+        + pid_g * stride_bc_pre_group
+        + offs_k[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec
+    )
+    tl.store(bc_ptrs, bc.to(bc_pre_ptr.dtype.element_ty), mask=cache_valid[:, None] & spec_valid[None, :])
+
+
+# ======================================================================
+# Verify launch (non-flush rows): per-draft output from the fixed checkpoint
+# S_0, no state write. dstate-tiled. Flush rows early-exit.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics({"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])})
+@triton.jit
+def _replayssm_spec_nf_kernel(
+    state_ptr, x_cache_ptr, dt_cache_ptr, B_cache_ptr, C_src_ptr, bc_pre_ptr,
+    D_ptr, z_ptr, dt_bias_ptr, A_ptr, out_ptr, is_flush_flags_ptr, write_pos_ptr,
+    post_origin_ptr, state_batch_indices_ptr, query_start_loc_ptr, null_block_id,
+    batch, nheads, dim, dstate, max_cache_len, nheads_ngroups_ratio,
+    stride_state_batch, stride_state_head, stride_state_dim, stride_state_dstate,
+    stride_x_cache_batch, stride_x_cache_head, stride_x_cache_dim, stride_x_cache_pos,
+    stride_dt_cache_batch, stride_dt_cache_head, stride_dt_cache_pos,
+    stride_B_cache_batch, stride_B_cache_group, stride_B_cache_dstate, stride_B_cache_pos,
+    stride_C_src_tok, stride_C_src_c,
+    stride_bc_pre_batch, stride_bc_pre_group, stride_bc_pre_pos, stride_bc_pre_spec,
+    stride_D_head, stride_D_dim, stride_z_tok, stride_z_head, stride_z_dim,
+    stride_dt_bias_head, stride_A_head, stride_out_tok, stride_out_head, stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr, HAS_DT_BIAS: tl.constexpr, HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr, CACHE_BUF_LEN: tl.constexpr, DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr, BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(state_batch_indices_ptr + pid_b * stride_state_indices_batch).to(
+        tl.int64
+    )
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    if state_batch_idx == null_block_id:
+        # Megatron padding slot: write zeros to this row's outputs (the baseline
+        # selective_state_update kernel does the same) and exit.
+        o_base = out_ptr + bos * stride_out_tok + pid_h * stride_out_head
+        zeros = tl.zeros([BLOCK_SIZE_SPEC, BLOCK_SIZE_M], dtype=tl.float32)
+        tl.store(
+            o_base + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+            zeros,
+            mask=(offs_s[:, None] < spec_len) & (offs_m[None, :] < dim),
+        )
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) != 0:
+        return
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    hist_mask = offs_k < write_pos
+    cache_valid_mask = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_token_mask = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_cache_pos = write_pos + offs_s
+    spec_prefix_mask = (
+        spec_valid_mask[:, None]
+        & spec_token_mask[None, :]
+        & (offs_k[None, :] <= spec_cache_pos[:, None])
+    )
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    C_src_ptr += bos * stride_C_src_tok + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    bc_pre_ptr += pid_b * stride_bc_pre_batch + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # dt over the window (+ bias / softplus), then the per-draft decay weights.
+    # Re-mask after each op: softplus(0 + bias) != 0 would poison the cumsum.
+    dt_blk = tl.load(
+        dt_cache_ptr + phys_k * stride_dt_cache_pos, mask=cache_valid_mask, other=0.0
+    ).to(tl.float32)
+    dt_blk = tl.where(cache_valid_mask, dt_blk, 0.0)
+    if HAS_DT_BIAS:
+        dt_blk = tl.where(cache_valid_mask, dt_blk + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_blk = tl.where(cache_valid_mask, tl.where(dt_blk <= 20.0, softplus(dt_blk), dt_blk), 0.0)
+    dt_cum = tl.cumsum(dt_blk, axis=0)
+    hist_total = tl.sum(tl.where(hist_mask, dt_blk, 0.0), axis=0)
+    spec_cum = tl.sum(tl.where(spec_prefix_mask, dt_blk[None, :], 0.0), axis=1)
+    spec_cum = tl.where(spec_valid_mask, spec_cum, 0.0)
+    spec_total = hist_total + spec_cum
+    checkpoint_decay = tl.where(spec_valid_mask, tl.exp(tl.minimum(A_val * spec_total, 0.0)), 0.0)
+
+    # Causal weighted sum over cached values: spec_contrib = x_cache @ factor.
+    x_blk = tl.load(
+        x_cache_ptr + phys_k[None, :] * stride_x_cache_pos + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & cache_valid_mask[None, :],
+        other=0.0,
+    )
+    x_ty = x_blk.to(x_cache_ptr.dtype.element_ty)
+    bc = tl.load(
+        bc_pre_ptr + offs_k[:, None] * stride_bc_pre_pos + offs_s[None, :] * stride_bc_pre_spec,
+        mask=cache_valid_mask[:, None] & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    spec_scale = dt_blk[:, None] * tl.exp(
+        tl.minimum(A_val * (spec_total[None, :] - dt_cum[:, None]), 0.0)
+    )
+    causal = spec_valid_mask[None, :] & cache_valid_mask[:, None] & (
+        offs_k[:, None] <= spec_cache_pos[None, :]
+    )
+    factor = tl.where(causal, bc * spec_scale, 0.0)
+    spec_contrib = tl.dot(
+        x_ty, factor.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3"
+    ).to(tl.float32)
+
+    # Decayed checkpoint readout S_0 @ C, dstate-tiled. tf32x3 keeps fp32-act
+    # parity; bf16 act uses single-pass tf32 (the flag is a no-op on bf16 inputs).
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        st = tl.load(
+            state_ptr + offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate,
+            mask=(offs_m[:, None] < dim) & nmask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr + offs_s[:, None] * stride_C_src_tok + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(st, tl.trans(c_chunk), input_precision="tf32x3").to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(st, tl.trans(c_chunk), input_precision="tf32").to(tl.float32)
+    checkpoint_out *= checkpoint_decay[None, :]
+    out = tl.trans(checkpoint_out + spec_contrib)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr + offs_m[None, :] * stride_x_cache_dim + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(tl.float32)
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+# ======================================================================
+# Flush launch (flush rows): reconstruct the committed-history state S_1, store
+# it as the checkpoint, and read the output via S_1 + the intra-spec window.
+# Non-flush rows early-exit. dstate-tiled.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics({"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])})
+@triton.jit
+def _replayssm_spec_fl_kernel(
+    state_ptr, x_cache_ptr, dt_cache_ptr, B_cache_ptr, C_src_ptr, bc_pre_ptr,
+    D_ptr, z_ptr, dt_bias_ptr, A_ptr, out_ptr, is_flush_flags_ptr, write_pos_ptr,
+    post_origin_ptr, state_batch_indices_ptr, query_start_loc_ptr, null_block_id,
+    batch, nheads, dim, dstate, max_cache_len, nheads_ngroups_ratio,
+    stride_state_batch, stride_state_head, stride_state_dim, stride_state_dstate,
+    stride_x_cache_batch, stride_x_cache_head, stride_x_cache_dim, stride_x_cache_pos,
+    stride_dt_cache_batch, stride_dt_cache_head, stride_dt_cache_pos,
+    stride_B_cache_batch, stride_B_cache_group, stride_B_cache_dstate, stride_B_cache_pos,
+    stride_C_src_tok, stride_C_src_c,
+    stride_bc_pre_batch, stride_bc_pre_group, stride_bc_pre_pos, stride_bc_pre_spec,
+    stride_D_head, stride_D_dim, stride_z_tok, stride_z_head, stride_z_dim,
+    stride_dt_bias_head, stride_A_head, stride_out_tok, stride_out_head, stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr, HAS_DT_BIAS: tl.constexpr, HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr, CACHE_BUF_LEN: tl.constexpr, DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr, BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(state_batch_indices_ptr + pid_b * stride_state_indices_batch).to(
+        tl.int64
+    )
+    if state_batch_idx == null_block_id:
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) == 0:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    spec_cache_pos = write_pos + offs_s
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+    hist_mask = offs_k < write_pos
+    phys_h = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    B_cache_ptr += state_batch_idx * stride_B_cache_batch + (
+        pid_h // nheads_ngroups_ratio
+    ) * stride_B_cache_group
+    C_src_ptr += bos * stride_C_src_tok + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    bc_pre_ptr += pid_b * stride_bc_pre_batch + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # History decay (for the S_1 reconstruction) and spec-prefix decay (output).
+    dt_h = tl.load(dt_cache_ptr + phys_h * stride_dt_cache_pos, mask=hist_mask, other=0.0).to(
+        tl.float32
+    )
+    dt_h = tl.where(hist_mask, dt_h, 0.0)
+    if HAS_DT_BIAS:
+        dt_h = tl.where(hist_mask, dt_h + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_h = tl.where(hist_mask, tl.where(dt_h <= 20.0, softplus(dt_h), dt_h), 0.0)
+    hist_cum = tl.cumsum(dt_h, axis=0)
+    hist_total = tl.sum(dt_h, axis=0)
+    hist_decay = tl.exp(tl.minimum(A_val * hist_total, 0.0))
+    hist_scale = tl.where(
+        hist_mask, dt_h * tl.exp(tl.minimum(A_val * (hist_total - hist_cum), 0.0)), 0.0
+    )
+    dt_s = tl.load(dt_cache_ptr + phys_spec * stride_dt_cache_pos, mask=spec_valid_mask, other=0.0).to(
+        tl.float32
+    )
+    dt_s = tl.where(spec_valid_mask, dt_s, 0.0)
+    if HAS_DT_BIAS:
+        dt_s = tl.where(spec_valid_mask, dt_s + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_s = tl.where(spec_valid_mask, tl.where(dt_s <= 20.0, softplus(dt_s), dt_s), 0.0)
+    spec_cum = tl.cumsum(dt_s, axis=0)
+    spec_decay = tl.where(spec_valid_mask, tl.exp(tl.minimum(A_val * spec_cum, 0.0)), 0.0)
+    x_hist = tl.load(
+        x_cache_ptr + phys_h[None, :] * stride_x_cache_pos + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & hist_mask[None, :],
+        other=0.0,
+    )
+    x_hist_ty = x_hist.to(x_cache_ptr.dtype.element_ty)
+
+    # Reconstruct S_1 = S_0 * hist_decay + (x_hist @ scaled B_hist), store it, and
+    # accumulate the checkpoint readout S_1 @ C. dstate-tiled.
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        B_block = tl.load(
+            B_cache_ptr + phys_h[:, None] * stride_B_cache_pos + offs_n[None, :] * stride_B_cache_dstate,
+            mask=hist_mask[:, None] & nmask[None, :],
+            other=0.0,
+        )
+        B_hist_scaled = (
+            tl.where(hist_mask[:, None], B_block.to(tl.float32), 0.0) * hist_scale[:, None]
+        ).to(x_cache_ptr.dtype.element_ty)
+        delta = tl.dot(x_hist_ty, B_hist_scaled, input_precision="tf32x3").to(tl.float32)
+        st_ptrs = state_ptr + offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
+        st = tl.load(st_ptrs, mask=(offs_m[:, None] < dim) & nmask[None, :], other=0.0)
+        S1 = st.to(tl.float32) * hist_decay + delta
+        if write_pos > 0:
+            tl.store(st_ptrs, S1.to(st.dtype), mask=(offs_m[:, None] < dim) & nmask[None, :])
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr + offs_s[:, None] * stride_C_src_tok + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(S1, tl.trans(c_chunk), input_precision="tf32x3").to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(S1, tl.trans(c_chunk), input_precision="tf32").to(tl.float32)
+    checkpoint_out *= spec_decay[None, :]
+
+    # Intra-spec window contribution: intra = x_spec @ factor_intra (causal T x T).
+    bc_spec = tl.load(
+        bc_pre_ptr + (write_pos + offs_k)[:, None] * stride_bc_pre_pos + offs_s[None, :] * stride_bc_pre_spec,
+        mask=(offs_k[:, None] < spec_len) & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.load(
+        dt_cache_ptr + ((post_origin + write_pos + offs_k) & (CACHE_BUF_LEN - 1)) * stride_dt_cache_pos,
+        mask=offs_k < spec_len,
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.where(offs_k < spec_len, dt_k, 0.0)
+    if HAS_DT_BIAS:
+        dt_k = tl.where(offs_k < spec_len, dt_k + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_k = tl.where(offs_k < spec_len, tl.where(dt_k <= 20.0, softplus(dt_k), dt_k), 0.0)
+    speccum_k = tl.cumsum(dt_k, axis=0)
+    causal = (offs_k[:, None] < spec_len) & spec_valid_mask[None, :] & (
+        offs_k[:, None] <= offs_s[None, :]
+    )
+    decay_ks = tl.exp(tl.minimum(A_val * (spec_cum[None, :] - speccum_k[:, None]), 0.0))
+    factor_intra = tl.where(causal, bc_spec * dt_k[:, None] * decay_ks, 0.0)
+    x_src = tl.load(
+        x_cache_ptr
+        + ((post_origin + write_pos + offs_k)[None, :] & (CACHE_BUF_LEN - 1)) * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & (offs_k[None, :] < spec_len),
+        other=0.0,
+    ).to(x_cache_ptr.dtype.element_ty)
+    intra = tl.dot(x_src, factor_intra.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3").to(
+        tl.float32
+    )
+    out = tl.trans(checkpoint_out + intra)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr + offs_m[None, :] * stride_x_cache_dim + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(tl.float32)
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+@triton.jit
+def _advance_write_pos_origin_kernel(
+    write_pos_ptr,
+    post_origin_ptr,
+    is_flush_ptr,
+    accepted_draft_counts_ptr,  # (batch,) accepted DRAFT tokens (0..T-1); bonus added here
+    prefill_status_ptr,  # (batch,) 0 = decode, 1 = prefill (skipped)
+    state_batch_indices_ptr,
+    null_block_id,
+    batch,
+    stride_state_indices_batch,
+    MAX_CACHE_LEN: tl.constexpr,
+    MAX_SPEC_LEN: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    row_mask = offs < batch
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + offs * stride_state_indices_batch,
+        mask=row_mask,
+        other=null_block_id,
+    ).to(tl.int64)
+    prefill = tl.load(prefill_status_ptr + offs, mask=row_mask, other=1).to(tl.int32)
+    valid = row_mask & (state_batch_idx != null_block_id) & (prefill == 0)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx, mask=valid, other=0).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx, mask=valid, other=0).to(tl.int32)
+    is_flush_cur = tl.load(is_flush_ptr + state_batch_idx, mask=valid, other=0).to(tl.int32)
+    accepted = tl.load(accepted_draft_counts_ptr + offs, mask=valid, other=0).to(tl.int32)
+    # The guaranteed-accepted bonus (free) token at window position 0 is always
+    # committed on top of the accepted drafts.
+    total_commit = tl.where(valid, accepted + 1, 0).to(tl.int32)
+    flush_now = (total_commit > 0) & (is_flush_cur != 0)
+    new_origin = tl.where(
+        flush_now, (post_origin + write_pos) & (CACHE_BUF_LEN - 1), post_origin
+    ).to(tl.int32)
+    new_wp = tl.where(
+        total_commit <= 0,
+        write_pos,
+        tl.where(is_flush_cur != 0, total_commit, write_pos + total_commit),
+    ).to(tl.int32)
+    # Early-flush one window early so every verify step satisfies
+    # write_pos + spec_len <= max_cache_len (the spec window never overflows).
+    next_is_flush = ((new_wp + 2 * MAX_SPEC_LEN) > MAX_CACHE_LEN).to(tl.int8)
+    tl.store(post_origin_ptr + state_batch_idx, new_origin, mask=valid)
+    tl.store(write_pos_ptr + state_batch_idx, new_wp, mask=valid)
+    tl.store(is_flush_ptr + state_batch_idx, next_is_flush, mask=valid)
+
+
+def selective_state_update_replayssm_spec(
+    state_checkpoint: torch.Tensor,  # (num_slots, H, P, N) checkpoint (flush updates in place)
+    post_conv_cache: torch.Tensor,  # (num_slots, cache_buf_len, cache_conv_dim) circular
+    dt_cache: torch.Tensor,  # (num_slots, H, cache_buf_len) circular, fp32
+    conv_out: torch.Tensor,  # (total_tokens, conv_dim) packed channel-last post-conv output
+    dt_spec: torch.Tensor,  # (total_tokens, H) packed raw dt
+    A: torch.Tensor,  # (H, P, N) TIE_HDIM (A.stride(-1)==A.stride(-2)==0)
+    write_pos: torch.Tensor,  # (num_state_slots,) int32 slot-keyed cursor
+    post_conv_state_pos: torch.Tensor,  # (num_state_slots,) int32 circular origin
+    is_flush: torch.Tensor,  # (num_state_slots,) int8 slot-keyed flag
+    query_start_loc: torch.Tensor,  # (batch + 1,) int32 packed offsets
+    state_batch_indices: torch.Tensor,  # (batch,) state slot per row (-1 = padding)
+    max_cache_len: int,  # logical flush threshold L = B + max_spec_len
+    max_spec_len: int,
+    d_inner: int,
+    ngroups: int,
+    dstate: int,
+    D: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    dt_softplus: bool = True,
+    out: torch.Tensor | None = None,
+    bc_pre: torch.Tensor | None = None,
+    null_block_id: int = NULL_SLOT_ID,
+) -> torch.Tensor:
+    """One Mamba-2 speculative verify step on the circular post-conv input cache.
+
+    `conv_out` is the packed channel-last post-conv output (`x | B | C`).
+    `max_cache_len` is the logical flush threshold `L = B + max_spec_len`; the
+    physical pow2 ring (= `post_conv_cache.shape[1]` = `next_pow2(L)`) wraps
+    the ring, while the history/cache tile is `next_pow2(L - max_spec_len)`.
+    Fuses scatter + bc-precompute in one `(batch, ngroups)` launch, then runs
+    two dedicated launches (verify + flush) with device-side row routing. Cursors
+    are slot-keyed and advanced once per step by :func:`commit_replayssm_spec`.
+    """
+    num_slots, nheads, dim, n_state = state_checkpoint.shape
+    assert n_state == dstate
+    total_tokens, conv_dim = conv_out.shape
+    buf = post_conv_cache.shape[1]
+    cache_buf_len = buf
+    assert cache_buf_len & (cache_buf_len - 1) == 0, "cache_buf_len must be a power of two"
+    assert d_inner == nheads * dim
+    cache_conv_dim = d_inner + ngroups * dstate  # x|B only (no C)
+    assert post_conv_cache.shape == (num_slots, buf, cache_conv_dim)
+    assert dt_cache.shape == (num_slots, nheads, buf)
+    assert dt_spec.shape == (total_tokens, nheads)
+    assert A.shape == (nheads, dim, dstate) and A.stride(-1) == 0 and A.stride(-2) == 0
+    batch = state_batch_indices.shape[0]
+    assert query_start_loc.shape[0] == batch + 1
+
+    if out is None:
+        out = torch.empty(total_tokens, nheads, dim, device=conv_out.device, dtype=conv_out.dtype)
+    if total_tokens == 0:
+        return out
+
+    L = max_cache_len
+    base_block = max(1, L - max_spec_len)
+    main_block = max(16, triton.next_power_of_2(base_block))  # history/cache tile
+    block_spec = max(1, triton.next_power_of_2(max_spec_len))
+    pre_block = max(16, triton.next_power_of_2(L))  # precompute window tile
+    block_dstate = triton.next_power_of_2(dstate)
+
+    bsm_v, nw_v, dt_v, ns_v = get_replay_spec_config(
+        "mamba2_spec_verify", dstate=dstate, base_block=base_block, max_spec_len=max_spec_len
+    )
+    bsm_f, nw_f, dt_f, ns_f = get_replay_spec_config(
+        "mamba2_spec_flush", dstate=dstate, base_block=base_block, max_spec_len=max_spec_len
+    )
+    dt_v = max(16, min(dt_v, block_dstate))
+    nds_v = triton.cdiv(block_dstate, dt_v)
+    dt_f = max(16, min(dt_f, block_dstate))
+    nds_f = triton.cdiv(block_dstate, dt_f)
+
+    if bc_pre is None:
+        bc_pre = torch.empty(
+            batch, ngroups, buf, block_spec, device=conv_out.device, dtype=torch.float32
+        )
+    sis = state_batch_indices.stride(0)
+
+    # --- fused scatter + precompute (full-window bc over [0, L)) ---
+    ratio = nheads // ngroups
+    ratio_p = ratio * dim
+    BLOCK_CX = 256
+    NCX = triton.cdiv(ratio_p, BLOCK_CX)
+    block_hl = max(1, triton.next_power_of_2(ratio))
+    _fused_scatter_precompute_kernel[(batch, ngroups)](
+        conv_out, dt_spec, post_conv_cache, dt_cache, write_pos, post_conv_state_pos,
+        bc_pre, state_batch_indices, query_start_loc, null_block_id, batch, ngroups,
+        nheads, dstate, d_inner, conv_dim, L,
+        conv_out.stride(0), conv_out.stride(1), dt_spec.stride(0), dt_spec.stride(1),
+        post_conv_cache.stride(0), post_conv_cache.stride(1), post_conv_cache.stride(2),
+        dt_cache.stride(0), dt_cache.stride(1), dt_cache.stride(2),
+        bc_pre.stride(0), bc_pre.stride(1), bc_pre.stride(2), bc_pre.stride(3), sis,
+        RATIO=ratio, RATIO_P=ratio_p, NCX=NCX, BLOCK_CX=BLOCK_CX, CACHE_BUF_LEN=cache_buf_len,
+        BLOCK_SIZE_CACHE=pre_block, BLOCK_SIZE_SPEC=block_spec, BLOCK_HL=block_hl, num_warps=4,
+    )
+
+    # views into the circular post-conv cache: x | B on the channel axis
+    x_view = (
+        post_conv_cache[:, :, :d_inner].view(num_slots, buf, nheads, dim).permute(0, 2, 1, 3)
+    )
+    B_view = (
+        post_conv_cache[:, :, d_inner : d_inner + ngroups * dstate]
+        .view(num_slots, buf, ngroups, dstate)
+        .permute(0, 2, 1, 3)
+    )
+    # C is not cached; the kernels read it fresh from this conv_out slice.
+    C_src = conv_out[:, d_inner + ngroups * dstate :]
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+
+    def _args(bsm):
+        grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads)
+        return grid, (
+            state_checkpoint, x_view, dt_cache, B_view, C_src, bc_pre, D, z, dt_bias, A,
+            out, is_flush, write_pos, post_conv_state_pos, state_batch_indices,
+            query_start_loc, null_block_id, batch, nheads, dim, dstate, L, nheads // ngroups,
+            state_checkpoint.stride(0), state_checkpoint.stride(1),
+            state_checkpoint.stride(2), state_checkpoint.stride(3),
+            x_view.stride(0), x_view.stride(1), x_view.stride(3), x_view.stride(2),
+            dt_cache.stride(0), dt_cache.stride(1), dt_cache.stride(2),
+            B_view.stride(0), B_view.stride(1), B_view.stride(3), B_view.stride(2),
+            C_src.stride(0), C_src.stride(1),
+            bc_pre.stride(0), bc_pre.stride(1), bc_pre.stride(2), bc_pre.stride(3),
+            D.stride(0) if D is not None else 0, D.stride(1) if D is not None else 0,
+            z_strides[0], z_strides[1], z_strides[2],
+            dt_bias.stride(0) if dt_bias is not None else 0,
+            A.stride(0), out.stride(0), out.stride(1), out.stride(2), sis, dt_softplus, bsm,
+        )
+
+    grid, base = _args(bsm_v)
+    _replayssm_spec_nf_kernel[grid](
+        *base, main_block, block_spec,
+        CACHE_BUF_LEN=cache_buf_len, DSTATE_TILE=dt_v, NDS=nds_v, num_warps=nw_v, num_stages=ns_v,
+    )
+    grid, base = _args(bsm_f)
+    _replayssm_spec_fl_kernel[grid](
+        *base, main_block, block_spec,
+        CACHE_BUF_LEN=cache_buf_len, DSTATE_TILE=dt_f, NDS=nds_f, num_warps=nw_f, num_stages=ns_f,
+    )
+    return out
+
+
+def commit_replayssm_spec(
+    write_pos: torch.Tensor,
+    post_conv_state_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    accepted_draft_counts: torch.Tensor,  # (batch,) accepted DRAFT tokens (bonus added in-kernel)
+    prefill_status: torch.Tensor,  # (batch,) int 0 = decode, 1 = prefill (skipped)
+    state_batch_indices: torch.Tensor,  # (batch,) state slot per row (-1 = padding)
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    cache_buf_len: int | None = None,  # physical pow2 buffer next_pow2(L)
+    null_block_id: int = NULL_SLOT_ID,
+) -> None:
+    """CUDA-graph-safe slot-keyed commit (the entire speculative rollback).
+
+    Advances `write_pos` by `accepted_draft_counts + 1` (the guaranteed
+    bonus token) per decode row and the circular origin on flush steps (an O(1)
+    bump), and precomputes the next step's `is_flush`. Rejected drafts are
+    simply left behind the new `write_pos` and get overwritten by the next
+    step's scatter — no state copy is needed.
+    """
+    batch = state_batch_indices.shape[0]
+    if batch == 0:
+        return
+    if cache_buf_len is None:
+        cache_buf_len = max(1, triton.next_power_of_2(max_cache_len))
+    BLOCK = max(1, triton.next_power_of_2(batch))
+    _advance_write_pos_origin_kernel[(1,)](
+        write_pos,
+        post_conv_state_pos,
+        is_flush,
+        accepted_draft_counts,
+        prefill_status,
+        state_batch_indices,
+        null_block_id,
+        batch,
+        state_batch_indices.stride(0),
+        MAX_CACHE_LEN=max_cache_len,
+        MAX_SPEC_LEN=max_spec_len,
+        CACHE_BUF_LEN=cache_buf_len,
+        BLOCK_SIZE=BLOCK,
+        num_warps=1,
+    )
+
+
+__all__ = [
+    "selective_state_update_replayssm_spec",
+    "commit_replayssm_spec",
+    "get_replay_spec_config",
+    "NULL_SLOT_ID",
+]

--- a/megatron/core/ssm/ssm_inference.py
+++ b/megatron/core/ssm/ssm_inference.py
@@ -157,6 +157,12 @@ class SSMDynamicInferenceMixin:
             zxBCdt_decode = zxBCdt[:decode_token_count] if prefill_req_count > 0 else zxBCdt
             # Reshape from [N*S, 1, d] to [N, S, d] for the decode kernels.
             zxBCdt_decode = zxBCdt_decode.squeeze(1).view(decode_req_count, seq_len, -1)
+            # ReplaySSM (Mamba-2 speculative decoding): hand the hook the context so
+            # it can read the ring buffers / cursors itself. Passed only when the
+            # feature is enabled, so hooks that do not support it are unaffected.
+            replay_kwargs = {}
+            if getattr(context, "mamba_replay_ssm", False):
+                replay_kwargs = {"replay_context": context}
             y_decode = self.ssm_decode(
                 zxBCdt_decode,
                 conv_state,
@@ -164,6 +170,7 @@ class SSMDynamicInferenceMixin:
                 batch_indices=context.mamba_metadata.batch_indices_decode,
                 intermediate_conv_state=int_conv_state,
                 intermediate_ssm_state=int_ssm_state,
+                **replay_kwargs,
             )
             # Flatten back to [N*S, 1, d] to match the merge logic.
             y_decode = y_decode.view(decode_token_count, 1, -1)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2112,6 +2112,19 @@ def _add_inference_args(parser):
                        help="Enable chunked prefill (disabled by default)")
     group.add_argument('--num-speculative-tokens', type=int, default=0,
                        help='Number of speculative tokens generated during decode')
+    group.add_argument('--mamba-replay-ssm',
+                       dest='mamba_replay_ssm',
+                       action='store_true', default=False,
+                       help='For Mamba speculative decoding: enable ReplaySSM state management '
+                            '(checkpoint SSM state + ring buffer of cached post-conv inputs, '
+                            'output-only decode, flush-on-buffer-full, pointer-move rollback). '
+                            'Requires a per-head scalar A (Mamba-2 / TIE_HDIM).')
+    group.add_argument('--mamba-replay-buffer-len',
+                       dest='mamba_replay_buffer_len',
+                       type=int, default=16,
+                       help='ReplaySSM committed-history buffer length B (tokens). Logical flush '
+                            'threshold is B + (1 + num_speculative_tokens); must satisfy '
+                            'B >= 1 + num_speculative_tokens.')
     group.add_argument('--inference-dynamic-batching-prefix-caching',
                        dest='inference_dynamic_batching_enable_prefix_caching',
                        action=argparse.BooleanOptionalAction,

--- a/megatron/training/config/inference_config.py
+++ b/megatron/training/config/inference_config.py
@@ -173,6 +173,15 @@ class InferenceSetupConfig:
     num_speculative_tokens: int = 0
     """Number of speculative tokens generated during decode."""
 
+    mamba_replay_ssm: bool = False
+    """For Mamba speculative decoding: enable ReplaySSM state management — checkpoint SSM state +
+    ring buffer of cached inputs, output-only decode, flush-on-buffer-full, and pointer-move
+    rollback. Requires a per-head scalar A (Mamba-2 / TIE_HDIM). Mirrors `--mamba-replay-ssm`."""
+
+    mamba_replay_buffer_len: int = 16
+    """ReplaySSM committed-history buffer length B (tokens); logical flush threshold is
+    B + (1 + num_speculative_tokens). Mirrors `--mamba-replay-buffer-len`."""
+
     # ---------------- Prefix caching ----------------
 
     inference_dynamic_batching_enable_prefix_caching: bool = False
@@ -375,6 +384,8 @@ class InferenceSetupConfig:
             metrics_writer=metrics_writer,
             logging_step_interval=self.inference_logging_step_interval,
             num_speculative_tokens=self.num_speculative_tokens,
+            mamba_replay_ssm=self.mamba_replay_ssm,
+            mamba_replay_buffer_len=self.mamba_replay_buffer_len,
             use_synchronous_zmq_collectives=self.inference_use_synchronous_zmq_collectives,
             disable_ep_consensus=self.inference_disable_ep_consensus,
             sampling_backend=self.inference_dynamic_batching_sampling_backend,

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -157,6 +157,8 @@ class DynamicEngineTestConfig:
     static_kv_memory_pointers: bool = True
     track_generated_token_events: bool = False
     num_speculative_tokens: int = 0
+    mamba_replay_ssm: bool = False
+    mamba_replay_buffer_len: int = 16
     position_embedding_type: str = "learned_absolute"
     sampling_backend: str = 'torch'
     temperature: float = 1.0
@@ -324,6 +326,8 @@ class DynamicInferenceEngineTestBase:
                 unified_memory_level=0,  # unit tests currently broken with UVM
                 track_generated_token_events=test_config.track_generated_token_events,
                 num_speculative_tokens=test_config.num_speculative_tokens,
+                mamba_replay_ssm=test_config.mamba_replay_ssm,
+                mamba_replay_buffer_len=test_config.mamba_replay_buffer_len,
                 sampling_backend=test_config.sampling_backend,
                 async_sched_mode=test_config.async_sched_mode,
                 logprobs_mode=test_config.logprobs_mode,
@@ -5624,8 +5628,9 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
         ["all_accepted", "all_rejected", "partial"],
         ids=["accept_all", "reject_all", "partial_reject"],
     )
+    @pytest.mark.parametrize("mamba_replay_ssm", [False, True], ids=["baseline", "replay"])
     @torch.inference_mode()
-    def test_speculative_decoding_mamba_hybrid(self, rejection_mode):
+    def test_speculative_decoding_mamba_hybrid(self, rejection_mode, mamba_replay_ssm):
         """Test speculative decoding with a Mamba hybrid model.
 
         Exercises the intermediate Mamba state commit/rewind path with
@@ -5652,6 +5657,9 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
             max_prompt_length=4,
             num_tokens_to_generate=num_tokens_to_generate,
             num_speculative_tokens=2,
+            mamba_replay_ssm=mamba_replay_ssm,
+            # Small buffer so multiple flush cycles happen within 8 generated tokens.
+            mamba_replay_buffer_len=4,
             materialize_only_last_token_logits=False,
             model_provider="hybrid",
         )

--- a/tests/unit_tests/ssm/ops/mamba2/test_mamba_ssm_replay.py
+++ b/tests/unit_tests/ssm/ops/mamba2/test_mamba_ssm_replay.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the ReplaySSM speculative-decode kernels (mamba_ssm_replay.py).
+
+Oracle layering (mirrors the ReplaySSM upstream test suite):
+  * the baseline `selective_state_update` kernel, stepped over the same token
+    window from the same checkpoint, provides per-position ground-truth outputs
+    and states;
+  * a non-flush verify must leave the checkpoint BITWISE untouched;
+  * a multi-step random-acceptance rollback drives the scatter/verify/flush and
+    commit kernels through ring wraparound and flush boundaries, checking
+    accepted-position outputs against the baseline and the checkpoint against
+    baseline snapshots keyed by the cumulative folded-token count.
+"""
+
+import pytest
+import torch
+
+from megatron.core.ssm.ops.mamba2.mamba_ssm import selective_state_update
+from megatron.core.ssm.ops.mamba2.mamba_ssm_replay import (
+    commit_replayssm_spec,
+    selective_state_update_replayssm_spec,
+)
+
+DEVICE = "cuda"
+
+
+def _requires_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+def _tolerances(state_dtype, act_dtype):
+    if state_dtype == torch.float32 and act_dtype == torch.float32:
+        return 1e-4, 1e-3
+    return 6e-2, 2e-1
+
+
+def _geometry(name):
+    # (nheads, headdim, dstate, ngroups)
+    return {"small": (8, 64, 64, 4), "tiny": (4, 64, 16, 1), "super120b": (128, 64, 128, 8)}[name]
+
+
+def _make_tied_inputs(nheads, headdim, dstate, device, dtype=torch.float32):
+    """Per-head scalar A (< 0) and dt_bias with the TIE_HDIM broadcast layout."""
+    A_head = -torch.rand(nheads, device=device, dtype=torch.float32) - 1.0
+    A = A_head.view(nheads, 1, 1).expand(nheads, headdim, dstate)
+    dt_bias = torch.rand(nheads, device=device, dtype=torch.float32) - 4.0
+    D = torch.randn(nheads, device=device, dtype=torch.float32)
+    return A, dt_bias, D
+
+
+def _pack_conv_out(x, B, C):
+    """Pack (S, H, P), (S, G, N), (S, G, N) -> (S, H*P + 2*G*N) channel-last."""
+    S = x.shape[0]
+    return torch.cat([x.reshape(S, -1), B.reshape(S, -1), C.reshape(S, -1)], dim=-1)
+
+
+def _baseline_window(state, x, dt, A, B, C, D, dt_bias, headdim):
+    """Run the baseline selective_state_update over a (1, S, ...) window in place
+    on `state` and return the per-position outputs (S, H, P)."""
+    S, nheads = dt.shape
+    dt_b = dt.unsqueeze(0).unsqueeze(-1).expand(1, S, nheads, headdim)
+    dt_bias_b = dt_bias.unsqueeze(-1).expand(nheads, headdim)
+    D_b = D.unsqueeze(-1).expand(nheads, headdim)
+    # Always provide a (throwaway) intermediate buffer: without one the baseline
+    # launcher passes x as a zero-stride dummy pointer for the intermediate-state
+    # dump, which scribbles state values onto x[0, 0, 0, 0] and races other
+    # programs' loads of x, corrupting the oracle.
+    dstate = state.shape[-1]
+    scratch = torch.empty(
+        1, S, nheads, headdim, dstate, device=x.device, dtype=state.dtype
+    )
+    out = selective_state_update(
+        state,
+        x.unsqueeze(0),
+        dt_b,
+        A,
+        B.unsqueeze(0),
+        C.unsqueeze(0),
+        D_b,
+        z=None,
+        dt_bias=dt_bias_b,
+        dt_softplus=True,
+        state_batch_indices=torch.zeros(1, dtype=torch.int64, device=x.device),
+        intermediate_ssm_states=scratch,
+    )
+    return out.squeeze(0).float()
+
+
+def _scatter_history(conv_cache, dt_cache, slot, x_hist, B_hist, dt_hist, d_inner):
+    """Write committed history [0, wp) into the ring at origin 0 (test setup)."""
+    wp = x_hist.shape[0]
+    if wp == 0:
+        return
+    conv_cache[slot, :wp, :d_inner] = x_hist.reshape(wp, -1).to(conv_cache.dtype)
+    conv_cache[slot, :wp, d_inner:] = B_hist.reshape(wp, -1).to(conv_cache.dtype)
+    dt_cache[slot, :, :wp] = dt_hist.t().to(dt_cache.dtype)
+
+
+class _ReplayRig:
+    """Single-layer ReplaySSM buffers + geometry for kernel-level tests."""
+
+    def __init__(self, num_slots, nheads, headdim, dstate, ngroups, buffer_len, window,
+                 state_dtype=torch.float32, act_dtype=torch.float32):
+        self.nheads, self.headdim, self.dstate, self.ngroups = nheads, headdim, dstate, ngroups
+        self.d_inner = nheads * headdim
+        self.window = window
+        self.L = buffer_len + window
+        self.buf = 1 << (self.L - 1).bit_length()
+        self.block_spec = 1 << (window - 1).bit_length()
+        self.state = torch.randn(
+            num_slots, nheads, headdim, dstate, device=DEVICE, dtype=state_dtype
+        ) * 0.1
+        cache_conv_dim = self.d_inner + ngroups * dstate
+        self.conv_cache = torch.zeros(
+            num_slots, self.buf, cache_conv_dim, device=DEVICE, dtype=act_dtype
+        )
+        self.dt_cache = torch.zeros(num_slots, nheads, self.buf, device=DEVICE, dtype=torch.float32)
+        self.write_pos = torch.zeros(num_slots, dtype=torch.int32, device=DEVICE)
+        self.origin = torch.zeros(num_slots, dtype=torch.int32, device=DEVICE)
+        self.is_flush = torch.zeros(num_slots, dtype=torch.int8, device=DEVICE)
+
+    def run_step(self, conv_out, dt_raw, A, D, dt_bias, sbi, qsl, bc_pre=None):
+        return selective_state_update_replayssm_spec(
+            state_checkpoint=self.state,
+            post_conv_cache=self.conv_cache,
+            dt_cache=self.dt_cache,
+            conv_out=conv_out,
+            dt_spec=dt_raw,
+            A=A,
+            write_pos=self.write_pos,
+            post_conv_state_pos=self.origin,
+            is_flush=self.is_flush,
+            query_start_loc=qsl,
+            state_batch_indices=sbi,
+            max_cache_len=self.L,
+            max_spec_len=self.window,
+            d_inner=self.d_inner,
+            ngroups=self.ngroups,
+            dstate=self.dstate,
+            D=D.unsqueeze(-1).expand(self.nheads, self.headdim),
+            z=None,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            bc_pre=bc_pre,
+        )
+
+
+@pytest.mark.internal
+class TestReplaySpecVerify:
+    """Single-step verify: outputs match the baseline recurrence; the checkpoint
+    is bitwise untouched on non-flush rows; padded rows produce zeros."""
+
+    def setup_method(self, method):
+        _requires_cuda()
+
+    @pytest.mark.parametrize("geometry", ["small", "tiny", "super120b"])
+    @pytest.mark.parametrize("window", [2, 3, 5])
+    @pytest.mark.parametrize(
+        "state_dtype,act_dtype",
+        [(torch.float32, torch.float32), (torch.float32, torch.bfloat16),
+         (torch.bfloat16, torch.bfloat16)],
+        ids=["s32_a32", "s32_a16", "s16_a16"],
+    )
+    def test_verify_matches_baseline(self, geometry, window, state_dtype, act_dtype):
+        torch.manual_seed(0)
+        nheads, headdim, dstate, ngroups = _geometry(geometry)
+        buffer_len = 16
+        rig = _ReplayRig(2, nheads, headdim, dstate, ngroups, buffer_len, window,
+                         state_dtype, act_dtype)
+        A, dt_bias, D = _make_tied_inputs(nheads, headdim, dstate, DEVICE)
+        slot = 1
+        C_fill = buffer_len - window  # max non-flush committed fill
+        for wp in sorted({0, C_fill // 2, C_fill}):
+            rig.write_pos.zero_(); rig.origin.zero_(); rig.is_flush.zero_()
+            rig.write_pos[slot] = wp
+            # committed history + fresh window (round-tripped through the activation
+            # dtype so oracle and kernel consume identical values)
+            x_h = torch.randn(wp, nheads, headdim, device=DEVICE).to(act_dtype).float()
+            B_h = torch.randn(wp, ngroups, dstate, device=DEVICE).to(act_dtype).float()
+            dt_h = torch.randn(wp, nheads, device=DEVICE) * 0.5
+            _scatter_history(rig.conv_cache, rig.dt_cache, slot, x_h, B_h, dt_h, rig.d_inner)
+            x_w = torch.randn(window, nheads, headdim, device=DEVICE).to(act_dtype).float()
+            B_w = torch.randn(window, ngroups, dstate, device=DEVICE).to(act_dtype).float()
+            C_w = torch.randn(window, ngroups, dstate, device=DEVICE).to(act_dtype).float()
+            dt_w = torch.randn(window, nheads, device=DEVICE) * 0.5
+
+            state_before = rig.state.clone()
+            conv_out = _pack_conv_out(x_w, B_w, C_w).to(act_dtype)
+            sbi = torch.tensor([slot], dtype=torch.int64, device=DEVICE)
+            qsl = torch.tensor([0, window], dtype=torch.int32, device=DEVICE)
+            out = rig.run_step(conv_out, dt_w, A, D, dt_bias, sbi, qsl)
+
+            # Oracle: baseline over history + window from the same checkpoint.
+            st = state_before[slot : slot + 1].float().clone()
+            x_all = torch.cat([x_h, x_w]); B_all = torch.cat([B_h, B_w])
+            dt_all = torch.cat([dt_h, dt_w])
+            # History C is irrelevant for the window outputs; use zeros.
+            C_all = torch.cat([torch.zeros(wp, ngroups, dstate, device=DEVICE), C_w])
+            ref = _baseline_window(st, x_all, dt_all, A, B_all, C_all, D, dt_bias, headdim)
+            rtol, atol = _tolerances(state_dtype, act_dtype)
+            torch.testing.assert_close(
+                out[:window].float(), ref[wp:].float(), rtol=rtol, atol=atol
+            )
+            # Non-flush verify must not touch the checkpoint (bitwise).
+            assert torch.equal(rig.state, state_before)
+
+    def test_padded_rows_zeroed_and_unused_slots_untouched(self):
+        torch.manual_seed(1)
+        nheads, headdim, dstate, ngroups = _geometry("tiny")
+        window = 3
+        rig = _ReplayRig(6, nheads, headdim, dstate, ngroups, 8, window)
+        A, dt_bias, D = _make_tied_inputs(nheads, headdim, dstate, DEVICE)
+        batch = 3  # rows: slot 2, padding (-1), slot 4
+        sbi = torch.tensor([2, -1, 4], dtype=torch.int64, device=DEVICE)
+        qsl = torch.arange(0, (batch + 1) * window, window, dtype=torch.int32, device=DEVICE)
+        x_w = torch.randn(batch * window, nheads, headdim, device=DEVICE)
+        B_w = torch.randn(batch * window, ngroups, dstate, device=DEVICE)
+        C_w = torch.randn(batch * window, ngroups, dstate, device=DEVICE)
+        dt_w = torch.randn(batch * window, nheads, device=DEVICE) * 0.5
+        conv_out = _pack_conv_out(x_w, B_w, C_w)
+        state_before = rig.state.clone()
+        out = rig.run_step(conv_out, dt_w, A, D, dt_bias, sbi, qsl)
+        # Padding row -> zeros.
+        assert torch.all(out[window : 2 * window] == 0)
+        # Unused state slots bitwise untouched.
+        for s in (0, 1, 3, 5):
+            assert torch.equal(rig.state[s], state_before[s])
+
+
+@pytest.mark.internal
+class TestReplayCommit:
+    """Commit kernel semantics: pointer math, early-flush flag, prefill gating."""
+
+    def setup_method(self, method):
+        _requires_cuda()
+
+    def _commit(self, rig, accepted, prefill, sbi):
+        commit_replayssm_spec(
+            write_pos=rig.write_pos,
+            post_conv_state_pos=rig.origin,
+            is_flush=rig.is_flush,
+            accepted_draft_counts=accepted,
+            prefill_status=prefill,
+            state_batch_indices=sbi,
+            max_cache_len=rig.L,
+            max_spec_len=rig.window,
+            cache_buf_len=rig.buf,
+        )
+
+    def test_pointer_math_and_early_flush(self):
+        nheads, headdim, dstate, ngroups = _geometry("tiny")
+        window = 3  # W; L = 8 + 3 = 11, buf = 16
+        rig = _ReplayRig(4, nheads, headdim, dstate, ngroups, 8, window)
+        sbi = torch.tensor([0, 1, 2, 3], dtype=torch.int64, device=DEVICE)
+        prefill = torch.tensor([0, 0, 1, 0], dtype=torch.int32, device=DEVICE)
+        rig.write_pos.copy_(torch.tensor([0, 4, 5, 2], dtype=torch.int32))
+        rig.origin.copy_(torch.tensor([0, 6, 1, 2], dtype=torch.int32))
+        rig.is_flush.copy_(torch.tensor([0, 1, 0, 0], dtype=torch.int8))
+        accepted = torch.tensor([2, 1, 2, 0], dtype=torch.int64, device=DEVICE)
+        self._commit(rig, accepted, prefill, sbi)
+        # Row 0: non-flush -> wp = 0 + (2+1) = 3; origin unchanged.
+        # Row 1: flush -> origin = (6+4) & 15 = 10; wp = (1+1) = 2.
+        # Row 2: prefill -> untouched.
+        # Row 3: non-flush -> wp = 2 + 1 = 3.
+        assert rig.write_pos.cpu().tolist() == [3, 2, 5, 3]
+        assert rig.origin.cpu().tolist() == [0, 10, 1, 2]
+        # next_is_flush = (wp + 2W > L) = (wp + 6 > 11)
+        assert rig.is_flush.cpu().tolist() == [0, 0, 0, 0]
+        # Push row 0 over the early-flush threshold: wp 3 -> 6, 6 + 6 > 11.
+        self._commit(rig, accepted, prefill, sbi)
+        assert rig.write_pos.cpu().tolist()[0] == 6
+        assert rig.is_flush.cpu().tolist()[0] == 1
+
+    def test_null_slot_skipped(self):
+        nheads, headdim, dstate, ngroups = _geometry("tiny")
+        rig = _ReplayRig(2, nheads, headdim, dstate, ngroups, 8, 2)
+        sbi = torch.tensor([-1, 1], dtype=torch.int64, device=DEVICE)
+        prefill = torch.zeros(2, dtype=torch.int32, device=DEVICE)
+        accepted = torch.ones(2, dtype=torch.int64, device=DEVICE)
+        self._commit(rig, accepted, prefill, sbi)
+        assert rig.write_pos.cpu().tolist() == [0, 2]
+
+
+@pytest.mark.internal
+class TestReplayMultiStepRollback:
+    """40 steps of scatter/verify/flush + commit with random per-step acceptance,
+    tracking the baseline recurrence over the accepted token stream. Exercises
+    ring wraparound, flush cadence, and rollback."""
+
+    def setup_method(self, method):
+        _requires_cuda()
+
+    @pytest.mark.parametrize("buffer_len", [8, 16])
+    @pytest.mark.parametrize("window", [2, 3, 5])
+    @pytest.mark.parametrize(
+        "state_dtype,act_dtype",
+        [(torch.float32, torch.float32), (torch.float32, torch.bfloat16)],
+        ids=["s32_a32", "s32_a16"],
+    )
+    def test_rollback_tracks_baseline(self, buffer_len, window, state_dtype, act_dtype):
+        torch.manual_seed(42)
+        gen = torch.Generator().manual_seed(43)
+        nheads, headdim, dstate, ngroups = _geometry("small")
+        rig = _ReplayRig(2, nheads, headdim, dstate, ngroups, buffer_len, window,
+                         state_dtype, act_dtype)
+        A, dt_bias, D = _make_tied_inputs(nheads, headdim, dstate, DEVICE)
+        slot = 1
+        sbi = torch.tensor([slot], dtype=torch.int64, device=DEVICE)
+        qsl = torch.tensor([0, window], dtype=torch.int32, device=DEVICE)
+        prefill = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        rtol, atol = _tolerances(state_dtype, act_dtype)
+
+        state_base = rig.state[slot : slot + 1].float().clone()
+        snapshots = {0: state_base.clone()}
+        total_accepted = 0
+        n_folded = 0
+
+        for step in range(40):
+            # Round-trip window inputs through the activation dtype so the oracle
+            # consumes exactly the values the kernel caches (otherwise the input
+            # rounding gap compounds across flush folds over 40 steps).
+            x_w = torch.randn(window, nheads, headdim, device=DEVICE).to(act_dtype).float()
+            B_w = torch.randn(window, ngroups, dstate, device=DEVICE).to(act_dtype).float()
+            C_w = torch.randn(window, ngroups, dstate, device=DEVICE).to(act_dtype).float()
+            dt_w = torch.randn(window, nheads, device=DEVICE) * 0.5
+            conv_out = _pack_conv_out(x_w, B_w, C_w).to(act_dtype)
+
+            wp_before = int(rig.write_pos[slot].item())
+            flush_before = int(rig.is_flush[slot].item())
+
+            out = rig.run_step(conv_out, dt_w, A, D, dt_bias, sbi, qsl)
+            if flush_before and wp_before > 0:
+                n_folded += wp_before
+
+            # accepted drafts in [0, window - 1]; total commit = accepted + 1
+            k_drafts = int(torch.randint(0, window, (1,), generator=gen).item())
+            n_commit = k_drafts + 1
+
+            # Baseline consumes exactly the committed tokens.
+            ref = _baseline_window(
+                state_base, x_w[:n_commit], dt_w[:n_commit], A, B_w[:n_commit],
+                C_w[:n_commit], D, dt_bias, headdim,
+            )
+            for _ in range(n_commit):
+                total_accepted += 1
+            snapshots[total_accepted] = state_base.clone()
+            torch.testing.assert_close(
+                out[:n_commit].float(), ref, rtol=rtol, atol=atol
+            )
+
+            accepted = torch.tensor([k_drafts], dtype=torch.int64, device=DEVICE)
+            commit_replayssm_spec(
+                write_pos=rig.write_pos,
+                post_conv_state_pos=rig.origin,
+                is_flush=rig.is_flush,
+                accepted_draft_counts=accepted,
+                prefill_status=prefill,
+                state_batch_indices=sbi,
+                max_cache_len=rig.L,
+                max_spec_len=rig.window,
+                cache_buf_len=rig.buf,
+            )
+
+            if n_folded in snapshots:
+                torch.testing.assert_close(
+                    rig.state[slot].float(),
+                    snapshots[n_folded].squeeze(0),
+                    rtol=rtol,
+                    atol=atol,
+                )
+
+        assert n_folded > 0, "the ring never flushed; the test is vacuous"
+
+    def test_perturbation_is_detected(self):
+        """Anti-vacuity: corrupting one cached history value must break parity."""
+        torch.manual_seed(7)
+        nheads, headdim, dstate, ngroups = _geometry("small")
+        window = 3
+        rig = _ReplayRig(2, nheads, headdim, dstate, ngroups, 16, window)
+        A, dt_bias, D = _make_tied_inputs(nheads, headdim, dstate, DEVICE)
+        slot = 1
+        wp = 5
+        rig.write_pos[slot] = wp
+        x_h = torch.randn(wp, nheads, headdim, device=DEVICE)
+        B_h = torch.randn(wp, ngroups, dstate, device=DEVICE)
+        dt_h = torch.randn(wp, nheads, device=DEVICE) * 0.5
+        _scatter_history(rig.conv_cache, rig.dt_cache, slot, x_h, B_h, dt_h, rig.d_inner)
+        rig.conv_cache[slot, wp - 1, 0] += 5.0  # corrupt one cached x value
+        x_w = torch.randn(window, nheads, headdim, device=DEVICE)
+        B_w = torch.randn(window, ngroups, dstate, device=DEVICE)
+        C_w = torch.randn(window, ngroups, dstate, device=DEVICE)
+        dt_w = torch.randn(window, nheads, device=DEVICE) * 0.5
+        sbi = torch.tensor([slot], dtype=torch.int64, device=DEVICE)
+        qsl = torch.tensor([0, window], dtype=torch.int32, device=DEVICE)
+        out = rig.run_step(_pack_conv_out(x_w, B_w, C_w), dt_w, A, D, dt_bias, sbi, qsl)
+        st = rig.state[slot : slot + 1].float().clone()
+        x_all = torch.cat([x_h, x_w]); B_all = torch.cat([B_h, B_w])
+        dt_all = torch.cat([dt_h, dt_w])
+        C_all = torch.cat([torch.zeros(wp, ngroups, dstate, device=DEVICE), C_w])
+        ref = _baseline_window(st, x_all, dt_all, A, B_all, C_all, D, dt_bias, headdim)
+        with pytest.raises(AssertionError):
+            torch.testing.assert_close(out[:window].float(), ref[wp:], rtol=1e-4, atol=1e-3)


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

Implement ReplaySSM (https://tridao.me/blog/2026/replayssm/) for Mamba-2 speculative decoding in the dynamic inference engine, behind --mamba-replay-ssm / --mamba-replay-buffer-len. Instead of checkpointing a full SSM state per verification-window position, keep the live state as a lazily-updated checkpoint plus a per-(layer, slot) circular ring buffer of cached post-conv inputs (packed x|B at conv-state precision, raw fp32 dt). Verification outputs for the whole window are computed directly from the checkpoint and the cached inputs with causal masking (no intermediate states are materialized); the checkpoint is re-materialized only on early-flush steps (write_pos + 2W > L, guaranteeing the window always fits); and speculative rollback becomes a device-side ring-pointer commit with no state copy. The conv-state rollback path is unchanged.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
