### PR TITLE
fix(tests): restrict result extraction to rank zero

### DIFF
--- a/tests/functional_tests/shell_test_utils/run_ci_test.sh
+++ b/tests/functional_tests/shell_test_utils/run_ci_test.sh
@@ -386,7 +386,7 @@ for i in $(seq 1 $N_REPEAT); do
         SKIP_PYTEST=1
     fi
 
-    if [[ ${SKIP_PYTEST:-0} != 1 || "$TEST_TYPE" == "release" ]]; then
+    if [[ "$NODE_RANK" -eq 0 && (${SKIP_PYTEST:-0} != 1 || "$TEST_TYPE" == "release") ]]; then
         # Save run results
         export PYTHONPATH=$ROOT_DIR
         if [[ "$TEST_TYPE" == "release" ]]; then
@@ -438,7 +438,7 @@ for i in $(seq 1 $N_REPEAT); do
         ALLOW_NONDETERMINISTIC_ALGO_ARG="--allow-nondeterministic-algo"
     fi
 
-    if [[ "$SLURM_NODEID" -eq 0 ]]; then
+    if [[ "$NODE_RANK" -eq 0 ]]; then
         echo "Running pytest checks against golden values"
 
         # For pretraining jobs


### PR DESCRIPTION
## Background / motivation

Multi-node functional tests execute `run_ci_test.sh` once per node. The first-run
TensorBoard extraction was outside the rank-zero validation guard, so every node
could open and overwrite the same output JSON before rank zero consumed it.

## What changed

- Run first-run TensorBoard result extraction only when `NODE_RANK == 0`.
- Use the normalized `NODE_RANK` value for the existing pytest validation guard.

## Details

The second-run extraction for checkpoint-resume tests already runs inside the
rank-zero block. This change makes first-run extraction consistent while
preserving the single-node default and non-SLURM launchers that set `NODE_RANK`
directly.

Linked issue: none (small bug fix).

## Tested

- `bash -n tests/functional_tests/shell_test_utils/run_ci_test.sh` — passed.
- `shellcheck -S error tests/functional_tests/shell_test_utils/run_ci_test.sh` — passed.
- `uv run --no-sync pytest -q tests/test_utils/test_training_script_secret_redaction.py` — 2 passed.
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh` — passed; no Python changes to format.
- Pipeline ID: not started before PR creation.

- [x] I, the PR author, have personally reviewed every line of this PR.
- [ ] Relevant GPU functional tests will run in CI.
