### PR TITLE
ci(release): exercise docs metadata preparation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_merge_group == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_bump.yml@6dfd1b435cca9e3c2640f7b31c4f37e42c6bf796 # v1.4.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_bump.yml@dd5b4dcb2201e6db8f3656a3ac1e8490356e02c0 # PR NVIDIA-NeMo/FW-CI-templates#554
     with:
       release-branch-pattern: "core_[rv][0-9]*.[0-9]*.[0-9]*"
       release-ref: ${{ inputs.release-ref || github.sha }}
@@ -93,6 +93,10 @@ jobs:
       restrict-to-admins: true
       app-id: ${{ vars.BOT_ID }}
       library-name: Megatron Core
+      prepare-release-docs: true
+      docs-version-directory: docs
+      docs-target-path: megatron-core/developer-guide
+      publish-as-latest: true
       bump-targets: |
         [
           {"python-package": "megatron.core", "src-dir": ""},
@@ -112,7 +116,7 @@ jobs:
       )
     uses: ./.github/workflows/_build_test_publish_wheel.yml
     with:
-      ref: ${{ inputs.release-ref || github.sha }}
+      ref: ${{ needs.bump.outputs.prepared-release-ref || inputs.release-ref || github.sha }}
       dry-run: ${{ inputs.dry-run || false }}
       no-publish: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}
     secrets: inherit  # pragma: allowlist secret
@@ -125,7 +129,7 @@ jobs:
       && !cancelled()
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_finalize.yml@6a2f81195fd910ae91d3c001d2e32ceb6d82e975 # v1.0.0
     with:
-      release-ref: ${{ inputs.release-ref || github.sha }}
+      release-ref: ${{ needs.bump.outputs.prepared-release-ref || inputs.release-ref || github.sha }}
       release-version: ${{ needs.bump.outputs.release-version }}
       library-name: Megatron Core
       pypi-name: megatron-core


### PR DESCRIPTION
## Background

Companion validation for [NVIDIA-NeMo/FW-CI-templates#554](https://github.com/NVIDIA-NeMo/FW-CI-templates/pull/554). Megatron-LM `core_v0.18.2` contains package version `0.18.2` but docs metadata version `0.18.0`.

## What changed

- Pin `_release_bump.yml` to the FW-CI-templates PR commit.
- Enable release docs metadata preparation.
- Propagate the prepared release SHA to wheel build and release finalization.

## Details

```mermaid
flowchart LR
    A[core_v0.18.2 SHA] --> B[Dry-run release bump]
    B --> C[Prepare docs as 0.18.2]
    C --> D[Validate conf, project, and picker]
    D --> E[No push or publication]
```

This PR must not merge with the temporary FW-CI commit pin. After FW-CI-templates#554 is released, replace the pin with the released immutable tag SHA.

## Tested

- `git diff --check`
- `actionlint .github/workflows/release.yaml` — workflow parsed; only pre-existing SC2086 findings remain in the untouched release-summary block.
- [Release dry-run 32137179908](https://github.com/NVIDIA/Megatron-LM/actions/runs/32137179908) — `success`; bump job [95711180977](https://github.com/NVIDIA/Megatron-LM/actions/runs/32137179908/job/95711180977) resolved `0.18.2`, prepared and validated `docs/conf.py`, `docs/project.json`, and `docs/versions1.json`, and skipped push/merge under `dry-run=true`; all wheel builds, dry-run release finalization, docs build/linkcheck, and dry-run docs publication succeeded.

