### PR TITLE
fix(gtp+grad-reduce-in-fp32): emit the wgrad in main_grad's dtype so the reduce-scatter honours FP32

### DIFF
--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -551,6 +551,25 @@ def linear_with_frozen_weight(
     return LinearWithFrozenWeight.apply(*args)
 
 
+def _wgrad_gemm(out, grad_output, total_input):
+    """Weight-gradient GEMM into ``out``, which may be wider than the inputs (bf16 -> fp32).
+
+    Returns ``out``, filled with the weight gradient.
+    """
+    # Import here to avoid circular import
+    from megatron.core.extensions.transformer_engine import te_general_gemm
+
+    if te_general_gemm is not None:
+        # torch.matmul cannot widen via out=, so TE's GEMM does the mixed-precision output.
+        te_general_gemm(
+            total_input, grad_output, out_dtype=out.dtype, layout="NT", out=out, grad=True
+        )
+    else:
+        # matmul rejects an out= of a different dtype, so land in the compute dtype and cast.
+        out.copy_(grad_output.t().matmul(total_input))
+    return out
+
+
 class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
     """See linear_with_grad_accumulation_and_async_allreduce"""
 
@@ -689,23 +708,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                 # In case of Megatron-FSDP, need to create main grad buffers in-place
                 if hasattr(weight, "__fsdp_param__"):
                     weight.main_grad = weight.get_main_grad()
-                    # Import here to avoid circular import
-                    from megatron.core.extensions.transformer_engine import te_general_gemm
-
-                    if te_general_gemm is not None:
-                        # Use TE general_gemm to support mixed-precision output
-                        # (e.g. bf16 input -> fp32 main_grad) which torch.matmul
-                        # does not support via the out= parameter.
-                        te_general_gemm(
-                            total_input,
-                            grad_output,
-                            out_dtype=weight.main_grad.dtype,
-                            layout="NT",
-                            out=weight.main_grad,
-                            grad=True,
-                        )
-                    else:
-                        torch.matmul(grad_output.t(), total_input, out=weight.main_grad)
+                    _wgrad_gemm(weight.main_grad, grad_output, total_input)
                 else:
                     if weight.main_grad.dtype == torch.float32:
                         fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32(
@@ -752,6 +755,17 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                 weight.grad_added_to_main_grad = True
             else:
                 grad_weight = None
+        elif ctx.gtp_remat_size > 1 and sharded_weight.main_grad.dtype != total_input.dtype:
+            # Fusion is off for GTP (main_grad is SHARDED, the GEMM output is not), so the wgrad
+            # takes three hops, and get_wgrad_tensor() types it from main_grad:
+            #
+            #                                          epilogue     RS       accum
+            #   --accumulate-allreduce-grads-in-fp32     fp32  --->  fp32 --->  fp32   <- here
+            #   --grad-reduce-in-bf16                    bf16  --->  bf16 --->  bf16   <- else
+            #
+            # This branch widens the epilogue to main_grad's dtype, so the RS no longer rounds
+            # across ranks before the fp32 accum sees the value.
+            grad_weight = _wgrad_gemm(sharded_weight.get_wgrad_tensor(), grad_output, total_input)
         else:
             grad_weight = grad_output.t().matmul(total_input)
         grad_bias = grad_output.sum(dim=0) if use_bias else None

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1197,6 +1197,23 @@ def validate_args(args, defaults={}):
         elif not args.accumulate_allreduce_grads_in_fp32 and args.main_grads_dtype == torch.float32:
             args.accumulate_allreduce_grads_in_fp32 = True
             print_rank_0('accumulate and all-reduce gradients in fp32 for bfloat16 data type.')
+
+    if args.accumulate_allreduce_grads_in_fp32:
+        # The FP32-accumulation reduce-scatters only exist to recover FP32 accumulation from a
+        # lower-precision wire dtype. With FP32 main_grads the plain ring reduce-scatter already
+        # sums in FP32 on both axes, so they buy no precision and cost one extra
+        # unsharded-wgrad-sized scratch buffer per in-flight reduce-scatter.
+        for arg_name in (
+            'ddp_reduce_scatter_with_fp32_accumulation',
+            'gtp_remat_reduce_scatter_with_fp32_accumulation',
+        ):
+            if getattr(args, arg_name, False):
+                setattr(args, arg_name, False)
+                warn_rank_0(
+                    f"Setting args.{arg_name} to False since "
+                    "--accumulate-allreduce-grads-in-fp32 already reduces in fp32"
+                )
+
     if args.cuda_graph_impl == "full_iteration":
         assert not args.check_for_nan_in_loss_and_grad, \
         "--no-check-for-nan-in-loss-and-grad should be set with --cuda-graph-impl=full_iteration for training."

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -307,6 +307,75 @@ class TestLayerNormLinearGTP:
 
 
 # ---------------------------------------------------------------------------
+# Megatron linear: the wgrad handed to the reduce-scatter carries main_grad's dtype
+# ---------------------------------------------------------------------------
+
+
+def _worker_wgrad_rs_dtype(rank, world_size, port):
+    """With an FP32 main_grad, the gtp_remat reduce-scatter must run in FP32, not the compute dtype.
+
+    Guards a SILENT failure: a bf16 wgrad makes the RS round at every rank, which leaves gradients
+    finite and merely less precise, so the value-based tests here pass either way.
+
+    Covers Megatron's linear (layers.py); TE types its wgrad from main_grad via grad_buffer().
+    """
+    from megatron.core.tensor_parallel.generalized_tensor_parallelism import GTPShardedParam
+    from megatron.core.tensor_parallel.gtp_api import wrap_module_params_gtp
+    from megatron.core.tensor_parallel.layers import (
+        linear_with_grad_accumulation_and_async_allreduce,
+    )
+
+    torch.manual_seed(0)
+    batch, in_f, out_f = 16, 64, 128  # out_f % (16*world_size)==0 -> no padding
+    layer = nn.Linear(in_f, out_f, bias=False, dtype=torch.bfloat16, device="cuda")
+    wrap_module_params_gtp(layer, ["weight"], dist.new_group(list(range(world_size))))
+    layer.weight.main_grad = torch.zeros(layer.weight.shape, dtype=torch.float32, device="cuda")
+
+    seen = []
+    captured = []
+    original = GTPShardedParam.wgrad_reduce_scatter
+
+    def recording_rs(self, wgrad, nvtx_label=None):
+        seen.append(wgrad.dtype)
+        captured.append(wgrad.detach().float().clone())
+        return original(self, wgrad, nvtx_label=nvtx_label)
+
+    try:
+        GTPShardedParam.wgrad_reduce_scatter = recording_rs
+        inp = torch.randn(batch, in_f, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        linear_with_grad_accumulation_and_async_allreduce(
+            input=inp,
+            weight=layer.weight,
+            bias=None,
+            gradient_accumulation_fusion=True,
+            allreduce_dgrad=False,
+            sequence_parallel=False,
+            gtp_remat_size=world_size,
+        ).sum().backward()
+    finally:
+        GTPShardedParam.wgrad_reduce_scatter = original
+
+    # Every rank asserts: the tally is rank-local.
+    assert seen, "wgrad_reduce_scatter was never reached -- the weight is not GTP-sharded"
+    assert set(seen) == {torch.float32}, (
+        f"gtp_remat reduce-scatter ran in {set(seen)} with an FP32 main_grad. The wgrad must carry "
+        f"main_grad's dtype, or the cross-rank sum rounds before main_grad ever sees it."
+    )
+    # The widened branch is the only caller of _wgrad_gemm here, so pin the VALUE too: a wrong
+    # layout/operand order would still be FP32 and still reduce-scatter cleanly. grad_output is
+    # all ones (loss = .sum()), so every wgrad row is just the input column sum -- computed in
+    # FP32 without a GEMM, the reference carries no BF16 rounding and the tolerance stays tight.
+    expected = inp.detach().float().sum(dim=0).expand(out_f, in_f)
+    torch.testing.assert_close(captured[0], expected, rtol=1e-5, atol=1e-4)
+
+
+class TestGTPWgradRSDtype:
+    def test_wgrad_rs_follows_main_grad_dtype(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_wgrad_rs_dtype, 4)
+
+
+# ---------------------------------------------------------------------------
 # GroupedLinear forward/backward smoke test
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Emit the wgrad in main_grad's dtype so the reduce-scatter honours FP32

GTP turns gradient-accumulation fusion off (main_grad is sharded, the GEMM output is not), and the plain matmul it fell back to emits the compute dtype, so the gtp_remat reduce-scatter summed in BF16 across ranks. Now:

```
                                  dgrad epilogue     RS      accum
  --accumulate-allreduce-grads-in-fp32   fp32  ---> fp32 ---> fp32  <- this fix
  --grad-reduce-in-bf16                  bf16  ---> bf16 ---> bf16  (unchanged)

```

The fixed row was `bf16 ---> bf16 ---> fp32`: the RS rounded across ranks before the FP32 accumulator ever saw the value.

## Example for `GTP+grad-reduce-in-fp32`

- before fix: the `output_layer`'s wgrad_out dtype is `bf16` but not expected `fp32`
```
INFO:megatron.core.tensor_parallel.generalized_tensor_parallelism:[GTP Cache] +640.0 MB  
(shape=(32768, 10240), dtype=torch.bfloat16)   param: module.module.output_layer.weight op: RS(grad) 
```
- after fix: the wgrad_out's dtype is now 'fp32', then the following up GTP-RS (or DDP-RS) will also be in `fp32 reduction`, thus no need to enable `gtp_remat_reduce_scatter_with_fp32_accumulation` or `ddp_reduce_scatter_with_fp32_accumuation` anymore in this case.
```
INFO:megatron.core.tensor_parallel.generalized_tensor_parallelism:[GTP Cache] +1280.0 MB 
(shape=(32768, 10240), dtype=torch.float32)  param: module.module.output_layer.weight op: RS(grad)
```

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

