### PR TITLE
fix(ci): route scoped tokens through community bot

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -87,8 +87,8 @@ jobs:
           && vars.DISABLE_EXTERNAL_CONTRIBUTOR == 'true' && steps.check-sso.outputs.is_member != 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BOT_ID }}
-          private-key: ${{ secrets.BOT_KEY }}
+          app-id: ${{ vars.COMMUNITY_BOT_ID }}
+          private-key: ${{ secrets.COMMUNITY_BOT_KEY }}
           owner: NVIDIA-NeMo
           permission-members: read
 
@@ -100,8 +100,8 @@ jobs:
           && vars.DISABLE_EXTERNAL_CONTRIBUTOR == 'true' && steps.check-sso.outputs.is_member != 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BOT_ID }}
-          private-key: ${{ secrets.BOT_KEY }}
+          app-id: ${{ vars.COMMUNITY_BOT_ID }}
+          private-key: ${{ secrets.COMMUNITY_BOT_KEY }}
           owner: NVIDIA
           permission-members: read
 
@@ -1402,8 +1402,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BOT_ID }}
-          private-key: ${{ secrets.BOT_KEY }}
+          app-id: ${{ vars.COMMUNITY_BOT_ID }}
+          private-key: ${{ secrets.COMMUNITY_BOT_KEY }}
           permission-statuses: write
 
       - name: Generate fake coverage report
@@ -1497,8 +1497,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BOT_ID }}
-          private-key: ${{ secrets.BOT_KEY }}
+          app-id: ${{ vars.COMMUNITY_BOT_ID }}
+          private-key: ${{ secrets.COMMUNITY_BOT_KEY }}
           permission-issues: write
 
       - name: Comment on PR with action run URL


### PR DESCRIPTION
## Background

Several `cicd-main.yml` jobs request permissions that the default bot installation does not grant. Merge queue notification token creation failed with HTTP 422 for `issues: write`, and `Coverage_Fake` failed identically for `statuses: write`. The conditional NVIDIA and NVIDIA-NeMo membership tokens also select the default app even though its NVIDIA installation rejects `members: read` and it is not installed in NVIDIA-NeMo.

## What changed

- Use Community Bot credentials for merge queue issue comments.
- Use Community Bot credentials for fake coverage status creation.
- Use Community Bot credentials for NVIDIA and NVIDIA-NeMo membership lookups.
- Retain the default bot for its verified read-only `contents` and `pull-requests` consumers.

## Details

Each token remains scoped to its existing operation. This changes only the selected GitHub App and private-key secret; requested permissions and workflow behavior are unchanged.

## Tested

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.parse_file(ARGV.fetch(0))' .github/workflows/cicd-main.yml`
- `actionlint` 1.7.12 comparison against `github/main`; no new findings
- Verified default-app `issues: write` failure in run 32161271558, job 95790498250
- Verified default-app `statuses: write` failure in run 32164831609, job 95802430057
- Verified default-app `members: read` failure in run 31693800618, job 94426840875
- Verified Community Bot token creation with `issues: write`, `members: read`, and `pull-requests: write` in run 32162022942, job 95792891044
