### PR TITLE
Batch-invariant mode: native NVLS multimem option, and training-side mirror for true on-policy RL

### DIFF
--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -212,12 +212,18 @@ def _batch_invariant_token_align(token_count: int) -> int:
     the same M-alignment class as eager steps: TE rmsnorm (and other
     M-sensitive kernels) switch reduction codepaths at M % 32, and the eager
     path already pads token counts to TOKEN_ROUNDER (64) multiples.  Without
-    this floor, auto-sizing injects 1- and 2-token decode buckets whose
+    this alignment, auto-sizing injects 1- and 2-token decode buckets whose
     graphed norms execute in a different bit-class, breaking cross-batch
     bit-equality.  Request counts are untouched (mirrors eager semantics).
     """
-    rounded_up = math.ceil(token_count / 64) * 64
-    return max(64, rounded_up)
+    # Lazy import (dynamic_context imports this module at its top level).
+    # Tying to TOKEN_ROUNDER keeps the graph-bucket alignment and the eager
+    # path's padding multiple from drifting apart.
+    from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+
+    rounder = DynamicInferenceContext.TOKEN_ROUNDER
+    rounded_up = math.ceil(token_count / rounder) * rounder
+    return max(rounder, rounded_up)
 
 
 def _batch_invariant_mode_enabled() -> bool:
@@ -372,7 +378,7 @@ class CUDAGraphBatchDimensionBuilder:
                 [1, 2, 4] + list(range(8, 256, 8)) + list(range(256, cuda_graph_max_tokens + 1, 16))
             )
             if _batch_invariant_mode_enabled():
-                # Batch-invariant mode: floor every bucket to a 64-multiple
+                # Batch-invariant mode: align every bucket up to a 64-multiple
                 # (see _batch_invariant_token_align) and dedupe collisions.
                 sizes = [_batch_invariant_token_align(s) for s in sizes]
             # TP-align and dedupe in order; preserve original ordering for parity.
@@ -466,12 +472,12 @@ class CUDAGraphBatchDimensionBuilder:
             batch_dim = InferenceBatchDimensions(token_count, prefill_req_count, decode_req_count)
             if batch_dim.is_valid(max_requests, max_sequence_length, num_speculative_tokens):
                 if _batch_invariant_mode_enabled():
-                    # Batch-invariant mode: floor the bucket's token count to a
-                    # 64-multiple (see _batch_invariant_token_align). The floor
-                    # is alignment PADDING, mirroring the eager path's
+                    # Batch-invariant mode: align the bucket's token count up
+                    # to a 64-multiple (see _batch_invariant_token_align). The
+                    # alignment is PADDING, mirroring the eager path's
                     # TOKEN_ROUNDER (which already yields token counts above
                     # what the requests produce), so validity is judged on the
-                    # unpadded dims; request counts are untouched. Flooring can
+                    # unpadded dims; request counts are untouched. Aligning can
                     # collide previously-distinct buckets, so skip duplicates.
                     batch_dim = InferenceBatchDimensions(
                         _batch_invariant_token_align(token_count),

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -175,7 +175,7 @@ class InferenceBatchDimensions:
         if ep_zmq_communicator is not None:
             # CPU-only sync via ZMQ: avoids a NCCL AllReduce kernel on the
             # compute stream plus the H2D/D2H pair that sandwiches it.
-            (max_token_count, max_is_non_decode) = ep_zmq_communicator.sync_all_reduce_max(
+            max_token_count, max_is_non_decode = ep_zmq_communicator.sync_all_reduce_max(
                 local_batch_dims.token_count, int(is_non_decode)
             )
         else:

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -216,7 +216,8 @@ def _batch_invariant_token_floor(token_count: int) -> int:
     graphed norms execute in a different bit-class, breaking cross-batch
     bit-equality.  Request counts are untouched (mirrors eager semantics).
     """
-    return max(64, ((token_count + 63) // 64) * 64)
+    rounded_up = math.ceil(token_count / 64) * 64
+    return max(64, rounded_up)
 
 
 def _batch_invariant_mode_enabled() -> bool:

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -205,6 +205,29 @@ class InferenceBatchDimensions:
         return adjusted_batch_dim
 
 
+def _batch_invariant_token_floor(token_count: int) -> int:
+    """Floor a CUDA-graph bucket token count to a 64-multiple (min 64).
+
+    Under batch-invariant mode every graphed step must execute norms/GEMMs in
+    the same M-alignment class as eager steps: TE rmsnorm (and other
+    M-sensitive kernels) switch reduction codepaths at M % 32, and the eager
+    path already pads token counts to TOKEN_ROUNDER (64) multiples.  Without
+    this floor, auto-sizing injects 1- and 2-token decode buckets whose
+    graphed norms execute in a different bit-class, breaking cross-batch
+    bit-equality.  Request counts are untouched (mirrors eager semantics).
+    """
+    return max(64, ((token_count + 63) // 64) * 64)
+
+
+def _batch_invariant_mode_enabled() -> bool:
+    # Lazy import to avoid a circular dependency at module import time.
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        is_batch_invariant_mode_enabled,
+    )
+
+    return is_batch_invariant_mode_enabled()
+
+
 class CUDAGraphBatchDimensionBuilder:
     """Builder for creating and managing CUDA graph batch dimensions.
 
@@ -278,6 +301,11 @@ class CUDAGraphBatchDimensionBuilder:
         ), f"cuda_graph_max_tokens must be > 0, got {cuda_graph_max_tokens}"
 
         rounder = CUDAGraphBatchDimensionBuilder.CUDA_GRAPH_ROUNDER
+        if _batch_invariant_mode_enabled():
+            # Batch-invariant mode: 64-multiple token ladder (see
+            # _batch_invariant_token_floor).
+            rounder = 64
+            cuda_graph_max_tokens = _batch_invariant_token_floor(cuda_graph_max_tokens)
 
         # Cuda graph step size.
         cuda_graph_step_size = cuda_graph_max_tokens / num_cuda_graphs
@@ -311,7 +339,8 @@ class CUDAGraphBatchDimensionBuilder:
 
         # Always include the endpoints: cuda_graph_max_tokens (largest) and tp_size (smallest).
         sizes.add(cuda_graph_max_tokens)
-        sizes.add(tp_size)
+        # Batch-invariant mode: smallest bucket is 64, never tp_size.
+        sizes.add(64 if _batch_invariant_mode_enabled() else tp_size)
 
         cuda_graph_token_counts = sorted(sizes, reverse=True)
 
@@ -341,6 +370,10 @@ class CUDAGraphBatchDimensionBuilder:
             sizes = (
                 [1, 2, 4] + list(range(8, 256, 8)) + list(range(256, cuda_graph_max_tokens + 1, 16))
             )
+            if _batch_invariant_mode_enabled():
+                # Batch-invariant mode: floor every bucket to a 64-multiple
+                # (see _batch_invariant_token_floor) and dedupe collisions.
+                sizes = [_batch_invariant_token_floor(s) for s in sizes]
             # TP-align and dedupe in order; preserve original ordering for parity.
             sizes = list(dict.fromkeys(round_up_to_nearest_multiple(s, tp_size) for s in sizes))
             sizes = [s for s in sizes if s <= cuda_graph_max_tokens]
@@ -429,9 +462,15 @@ class CUDAGraphBatchDimensionBuilder:
 
         def add_if_valid(token_count: int, prefill_req_count: int, decode_req_count: int) -> None:
             """Helper to create and append batch dimension to list only if it's valid."""
+            if _batch_invariant_mode_enabled():
+                # Batch-invariant mode: floor EVERY bucket's token count to a
+                # 64-multiple (see _batch_invariant_token_floor); the flooring
+                # can collide previously-distinct buckets, so skip duplicates.
+                token_count = _batch_invariant_token_floor(token_count)
             batch_dim = InferenceBatchDimensions(token_count, prefill_req_count, decode_req_count)
             if batch_dim.is_valid(max_requests, max_sequence_length, num_speculative_tokens):
-                cuda_graph_batch_dimensions_list.append(batch_dim)
+                if batch_dim not in cuda_graph_batch_dimensions_list:
+                    cuda_graph_batch_dimensions_list.append(batch_dim)
 
         # Cuda graph token-counts
         # (i.e., token counts used by cuda-graph steps, both decode and non-decode).

--- a/megatron/core/inference/batch_dimensions_utils.py
+++ b/megatron/core/inference/batch_dimensions_utils.py
@@ -205,8 +205,8 @@ class InferenceBatchDimensions:
         return adjusted_batch_dim
 
 
-def _batch_invariant_token_floor(token_count: int) -> int:
-    """Floor a CUDA-graph bucket token count to a 64-multiple (min 64).
+def _batch_invariant_token_align(token_count: int) -> int:
+    """Round a CUDA-graph bucket token count UP to a 64-multiple (min 64).
 
     Under batch-invariant mode every graphed step must execute norms/GEMMs in
     the same M-alignment class as eager steps: TE rmsnorm (and other
@@ -304,9 +304,9 @@ class CUDAGraphBatchDimensionBuilder:
         rounder = CUDAGraphBatchDimensionBuilder.CUDA_GRAPH_ROUNDER
         if _batch_invariant_mode_enabled():
             # Batch-invariant mode: 64-multiple token ladder (see
-            # _batch_invariant_token_floor).
+            # _batch_invariant_token_align).
             rounder = 64
-            cuda_graph_max_tokens = _batch_invariant_token_floor(cuda_graph_max_tokens)
+            cuda_graph_max_tokens = _batch_invariant_token_align(cuda_graph_max_tokens)
 
         # Cuda graph step size.
         cuda_graph_step_size = cuda_graph_max_tokens / num_cuda_graphs
@@ -373,8 +373,8 @@ class CUDAGraphBatchDimensionBuilder:
             )
             if _batch_invariant_mode_enabled():
                 # Batch-invariant mode: floor every bucket to a 64-multiple
-                # (see _batch_invariant_token_floor) and dedupe collisions.
-                sizes = [_batch_invariant_token_floor(s) for s in sizes]
+                # (see _batch_invariant_token_align) and dedupe collisions.
+                sizes = [_batch_invariant_token_align(s) for s in sizes]
             # TP-align and dedupe in order; preserve original ordering for parity.
             sizes = list(dict.fromkeys(round_up_to_nearest_multiple(s, tp_size) for s in sizes))
             sizes = [s for s in sizes if s <= cuda_graph_max_tokens]
@@ -463,13 +463,21 @@ class CUDAGraphBatchDimensionBuilder:
 
         def add_if_valid(token_count: int, prefill_req_count: int, decode_req_count: int) -> None:
             """Helper to create and append batch dimension to list only if it's valid."""
-            if _batch_invariant_mode_enabled():
-                # Batch-invariant mode: floor EVERY bucket's token count to a
-                # 64-multiple (see _batch_invariant_token_floor); the flooring
-                # can collide previously-distinct buckets, so skip duplicates.
-                token_count = _batch_invariant_token_floor(token_count)
             batch_dim = InferenceBatchDimensions(token_count, prefill_req_count, decode_req_count)
             if batch_dim.is_valid(max_requests, max_sequence_length, num_speculative_tokens):
+                if _batch_invariant_mode_enabled():
+                    # Batch-invariant mode: floor the bucket's token count to a
+                    # 64-multiple (see _batch_invariant_token_align). The floor
+                    # is alignment PADDING, mirroring the eager path's
+                    # TOKEN_ROUNDER (which already yields token counts above
+                    # what the requests produce), so validity is judged on the
+                    # unpadded dims; request counts are untouched. Flooring can
+                    # collide previously-distinct buckets, so skip duplicates.
+                    batch_dim = InferenceBatchDimensions(
+                        _batch_invariant_token_align(token_count),
+                        prefill_req_count,
+                        decode_req_count,
+                    )
                 if batch_dim not in cuda_graph_batch_dimensions_list:
                     cuda_graph_batch_dimensions_list.append(batch_dim)
 

--- a/megatron/core/inference/moe/batch_invariant.py
+++ b/megatron/core/inference/moe/batch_invariant.py
@@ -21,6 +21,7 @@ from megatron.core.utils import null_decorator
 try:
     import triton
     import triton.language as tl
+    from triton.language.extra import libdevice
 
     HAVE_TRITON = True
 except ImportError:
@@ -145,6 +146,70 @@ def swiglu_with_probs(
         num_rows,
         BLOCK_SIZE=block_size,
         NUM_BLOCKS=num_blocks,
+    )
+    return out
+
+
+@triton.jit
+def _weighted_silu_mul_bounded_kernel(
+    in_ptr0, in_ptr1, out_ptr0, bound_ptr, xnumel, HALF_N: tl.constexpr, XBLOCK: tl.constexpr
+):
+    """Device-bounded weighted SwiGLU with training-parity rounding.
+
+    The per-element instruction sequence is copied VERBATIM from Inductor's
+    emitted Triton for the training fused weighted-swiglu
+    (bf16 -> fp32 silu(gate) * up * prob -> bf16, single final rounding), so a
+    token's activation bits match the training forward exactly. Elementwise
+    kernels have no cross-element reduction, so only the per-element sequence
+    determines bits; the schedule below is a persistent 1D grid (static launch,
+    CUDA-graph-safe) striding while xoffset < a DEVICE element bound
+    (= valid_tokens * topk * HALF_N — the live prefix of the flat token-major
+    layout). Rows beyond the bound are neither read nor written.
+    """
+    xbound = tl.load(bound_ptr)
+    num_progs = tl.num_programs(0)
+    xoffset = tl.program_id(0) * XBLOCK
+    while xoffset < xbound:
+        xindex = xoffset + tl.arange(0, XBLOCK)[:]
+        xmask = (xindex < xbound) & (xindex < xnumel)
+        x0 = xindex % HALF_N
+        x1 = xindex // HALF_N
+        tmp0 = tl.load(in_ptr0 + (x0 + 2 * HALF_N * x1), xmask).to(tl.float32)
+        tmp8 = tl.load(in_ptr0 + (HALF_N + x0 + 2 * HALF_N * x1), xmask).to(tl.float32)
+        tmp11 = tl.load(in_ptr1 + (x1), xmask, eviction_policy='evict_last')
+        tmp1 = tmp0.to(tl.float32)
+        tmp2 = -tmp1
+        tmp3 = libdevice.exp(tmp2)
+        tmp4 = tl.full([1], 1.0, tl.float32)
+        tmp5 = tmp3 + tmp4
+        tmp6 = tmp1 / tmp5
+        tmp7 = tmp6.to(tl.float32)
+        tmp9 = tmp7 * tmp8
+        tmp10 = tmp9.to(tl.float32)
+        tmp12 = tmp10 * tmp11
+        tmp13 = tmp12.to(tl.float32)
+        tl.store(out_ptr0 + xindex, tmp13, xmask)
+        xoffset += num_progs * XBLOCK
+
+
+def weighted_silu_mul_bounded(
+    y: torch.Tensor,
+    weights_flat: torch.Tensor,
+    bound_elems: torch.Tensor,
+    num_programs: int = 1184,
+    xblock: int = 1024,
+) -> torch.Tensor:
+    """SwiGLU with routing weights applied at the activation (training parity).
+
+    y: [rows, 2*half_n] bf16 (gate | up); weights_flat: [rows] fp32 routing
+    probabilities; bound_elems: device scalar = live_rows * half_n.
+    Returns [rows, half_n] bf16; rows beyond the live bound are untouched.
+    """
+    rows, two_half_n = y.shape
+    half_n = two_half_n // 2
+    out = torch.empty(rows, half_n, dtype=y.dtype, device=y.device)
+    _weighted_silu_mul_bounded_kernel[(num_programs,)](
+        y, weights_flat, out, bound_elems, rows * half_n, HALF_N=half_n, XBLOCK=xblock
     )
     return out
 

--- a/megatron/core/inference/moe/batch_invariant.py
+++ b/megatron/core/inference/moe/batch_invariant.py
@@ -196,7 +196,7 @@ def weighted_silu_mul_bounded(
     y: torch.Tensor,
     weights_flat: torch.Tensor,
     bound_elems: torch.Tensor,
-    num_programs: int = 1184,
+    num_programs: Optional[int] = None,
     xblock: int = 1024,
 ) -> torch.Tensor:
     """SwiGLU with routing weights applied at the activation (training parity).
@@ -204,9 +204,19 @@ def weighted_silu_mul_bounded(
     y: [rows, 2*half_n] bf16 (gate | up); weights_flat: [rows] fp32 routing
     probabilities; bound_elems: device scalar = live_rows * half_n.
     Returns [rows, half_n] bf16; rows beyond the live bound are untouched.
+
+    num_programs defaults to SMs * 8 waves (Inductor's persistent-grid sizing;
+    1184 on the B200 this was captured from). Grid size cannot affect bits:
+    the kernel is elementwise with each program owning a disjoint strided
+    index range, so it is an occupancy knob only.
     """
     rows, two_half_n = y.shape
     half_n = two_half_n // 2
+    if num_programs is None:
+        # Lazy import: permute.py imports this module at its top level.
+        from megatron.core.inference.moe.permute import _get_num_sms
+
+        num_programs = _get_num_sms(y.device) * 8
     out = torch.empty(rows, half_n, dtype=y.dtype, device=y.device)
     _weighted_silu_mul_bounded_kernel[(num_programs,)](
         y, weights_flat, out, bound_elems, rows * half_n, HALF_N=half_n, XBLOCK=xblock

--- a/megatron/core/inference/moe/batch_invariant.py
+++ b/megatron/core/inference/moe/batch_invariant.py
@@ -86,6 +86,69 @@ def _squared_relu_with_probs_kernel(
                     tl.store(output_ptr + row * hidden_size + cols, value, mask=mask)
 
 
+@triton.jit
+def _swiglu_with_probs_kernel(
+    input_ptr,
+    output_ptr,
+    permutation_map_ptr,
+    n_used_ptr,
+    probs_ptr,
+    ffn_size,  # output width; input row width is 2*ffn_size (gate | up)
+    max_rows,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_BLOCKS: tl.constexpr,
+):
+    """Apply gated SiLU (SwiGLU) and router probabilities in training order.
+
+    Matches the training fused weighted-swiglu rounding: SiLU(gate)*up*prob is
+    computed in FP32 with a single BF16 round at the end. Input row width is
+    2*ffn_size: gate = first half, up = second half (megatron chunk
+    convention). Fixed NUM_BLOCKS CTAs iterating rows -> CUDA-graph safe.
+    """
+    pid = tl.program_id(0)
+    n_used = tl.load(n_used_ptr)
+    if pid >= n_used:
+        return
+    two_n = 2 * ffn_size
+
+    for row in tl.range(pid, max_rows, NUM_BLOCKS):
+        if row < n_used:
+            if tl.load(permutation_map_ptr + row) >= 0:
+                prob = tl.load(probs_ptr + row)
+                for offset in tl.range(0, ffn_size, BLOCK_SIZE):
+                    cols = offset + tl.arange(0, BLOCK_SIZE)
+                    mask = cols < ffn_size
+                    gate = tl.load(input_ptr + row * two_n + cols, mask=mask).to(tl.float32)
+                    up = tl.load(input_ptr + row * two_n + ffn_size + cols, mask=mask).to(
+                        tl.float32
+                    )
+                    value = gate * tl.sigmoid(gate) * up * prob
+                    tl.store(output_ptr + row * ffn_size + cols, value.to(tl.bfloat16), mask=mask)
+
+
+def swiglu_with_probs(
+    x: torch.Tensor, permutation_map: torch.Tensor, n_used: torch.Tensor, probs: torch.Tensor
+) -> torch.Tensor:
+    """Gated-SiLU counterpart of squared_relu_with_probs (SwiGLU models)."""
+    num_rows, two_ffn = x.shape
+    ffn_size = two_ffn // 2
+    out = torch.empty(num_rows, ffn_size, dtype=x.dtype, device=x.device)
+    block_size = min(triton.next_power_of_2(ffn_size), 1024)
+    num_blocks = min(num_rows, 512)
+    _swiglu_with_probs_kernel[(num_blocks,)](
+        x,
+        out,
+        permutation_map,
+        n_used,
+        probs,
+        ffn_size,
+        num_rows,
+        BLOCK_SIZE=block_size,
+        NUM_BLOCKS=num_blocks,
+    )
+    return out
+
+
 def squared_relu_with_probs(
     x: torch.Tensor, permutation_map: torch.Tensor, n_used: torch.Tensor, probs: torch.Tensor
 ) -> torch.Tensor:

--- a/megatron/core/inference/moe/fused_moe.py
+++ b/megatron/core/inference/moe/fused_moe.py
@@ -208,9 +208,14 @@ def mcore_fused_moe(
     n_used = offs[-1:]
     if batch_invariant_mode:
         # Match training: BF16 activation, FP32 probability multiply, then BF16 before FC2.
-        activation_out = batch_invariant.squared_relu_with_probs(
-            fc1_output, permutation_map, n_used, permuted_probs
-        )
+        if activation_type == ActivationType.SWIGLU:
+            activation_out = batch_invariant.swiglu_with_probs(
+                fc1_output, permutation_map, n_used, permuted_probs
+            )
+        else:
+            activation_out = batch_invariant.squared_relu_with_probs(
+                fc1_output, permutation_map, n_used, permuted_probs
+            )
     else:
         activation_out = activation_func(fc1_output, permutation_map, n_used)
     # Fused activation+quant returns MXFP8Tensor; otherwise quantize separately.

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -29,8 +29,8 @@ if not HAVE_TRITON:
     triton.jit = null_decorator
     tl = MagicMock()
 
-from megatron.core.inference.moe.activations import bounded_silu_mul
 from megatron.core.inference.moe import batch_invariant
+from megatron.core.inference.moe.activations import bounded_silu_mul
 from megatron.core.inference.moe.fused_moe import ActivationType
 from megatron.core.inference.moe.permute import (
     _get_num_sms,
@@ -683,9 +683,7 @@ def vllm_fused_moe(
             # (single bf16 round of fp32 silu(gate)*up*prob). The reduction
             # below then sums with unit weights. Device-bounded to the live
             # valid_tokens*topk prefix; CUDA-graph safe.
-            bound_elems = valid_tokens.to(torch.int64) * (
-                topk * (intermediate1.shape[1] // 2)
-            )
+            bound_elems = valid_tokens.to(torch.int64) * (topk * (intermediate1.shape[1] // 2))
             intermediate1 = batch_invariant.weighted_silu_mul_bounded(
                 intermediate1, topk_weights_flat, bound_elems
             )

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -30,6 +30,7 @@ if not HAVE_TRITON:
     tl = MagicMock()
 
 from megatron.core.inference.moe.activations import bounded_silu_mul
+from megatron.core.inference.moe import batch_invariant
 from megatron.core.inference.moe.fused_moe import ActivationType
 from megatron.core.inference.moe.permute import (
     _get_num_sms,
@@ -452,6 +453,8 @@ def _moe_sum_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_K: tl.constexpr,
     NUM_K_BLOCKS: tl.constexpr,
+    APPLY_WEIGHTS: tl.constexpr = True,
+    ACC_FP64: tl.constexpr = False,
 ):
     """Reduce topk dimension with routing weight application.
 
@@ -483,16 +486,23 @@ def _moe_sum_kernel(
             offs_k = k_idx * BLOCK_K + tl.arange(0, BLOCK_K)
             k_mask = offs_k < K
 
-            acc = tl.zeros([BLOCK_K], dtype=tl.float32)
+            acc = tl.zeros([BLOCK_K], dtype=tl.float64 if ACC_FP64 else tl.float32)
             for t in range(topk):
                 eid = tl.load(routing_map_ptr + token_id * topk + t)
                 lid = eid - local_expert_start
                 if lid >= 0 and lid < num_local_experts:
                     v = tl.load(input_ptr + base + t * K + offs_k, mask=k_mask, other=0.0)
-                    w = tl.load(topk_weights_ptr + token_id * topk + t)
-                    acc += v.to(tl.float32) * w
+                    if ACC_FP64:
+                        if APPLY_WEIGHTS:
+                            w = tl.load(topk_weights_ptr + token_id * topk + t)
+                            acc += v.to(tl.float64) * w.to(tl.float64)
+                        else:
+                            acc += v.to(tl.float64)
+                    else:
+                        w = tl.load(topk_weights_ptr + token_id * topk + t)
+                        acc += v.to(tl.float32) * w
 
-            tl.store(output_ptr + token_id_i64 * K + offs_k, acc, mask=k_mask)
+            tl.store(output_ptr + token_id_i64 * K + offs_k, acc.to(tl.float32), mask=k_mask)
 
 
 def _moe_sum(
@@ -506,6 +516,8 @@ def _moe_sum(
     local_expert_start: int,
     num_local_experts: int,
     out: Optional[torch.Tensor] = None,
+    apply_weights: bool = True,
+    acc_fp64: bool = False,
 ) -> torch.Tensor:
     """Fused topk reduction: [max_tokens*topk, K] bf16 → [max_tokens, K].
 
@@ -536,6 +548,8 @@ def _moe_sum(
         BLOCK_M=BLOCK_M,
         BLOCK_K=BLOCK_K,
         NUM_K_BLOCKS=NUM_K_BLOCKS,
+        APPLY_WEIGHTS=apply_weights,
+        ACC_FP64=acc_fp64,
     )
     return out
 
@@ -596,7 +610,17 @@ def vllm_fused_moe(
     # Mirror upstream vLLM: pick the full launch config (tile sizes, warps,
     # stages) host-side from the token-count hint, not from the worst-case
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
-    config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
+    batch_invariant_mode = batch_invariant.enabled()
+    if batch_invariant_mode:
+        # Batch-invariant mode: the config must not depend on the token count.
+        # _get_default_config is a step function of M, so different co-batch
+        # sizes would otherwise select different tile shapes and change the
+        # fp32 accumulation grouping (batch-variant bits). Pin the large-M
+        # config for every launch; grid SIZING below may still use the hint
+        # (the kernel strides, so grid size never changes per-tile math).
+        config = _get_default_config(M=1 << 30, E=num_local_experts, top_k=topk)
+    else:
+        config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
 
     sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
@@ -645,10 +669,23 @@ def vllm_fused_moe(
         fuse_squared_relu=not is_swiglu,
     )
     if is_swiglu:
-        # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
-        # SiLU(gate) * up over the valid_tokens*topk live rows only.
-        n_rows = (valid_tokens * topk).to(torch.int32)
-        intermediate1 = bounded_silu_mul(intermediate1, n_rows)
+        if batch_invariant_mode:
+            # Match training: routing probabilities multiply at the activation
+            # (before FC2), with the training kernel's exact rounding sequence
+            # (single bf16 round of fp32 silu(gate)*up*prob). The reduction
+            # below then sums with unit weights. Device-bounded to the live
+            # valid_tokens*topk prefix; CUDA-graph safe.
+            bound_elems = valid_tokens.to(torch.int64) * (
+                topk * (intermediate1.shape[1] // 2)
+            )
+            intermediate1 = batch_invariant.weighted_silu_mul_bounded(
+                intermediate1, topk_weights_flat, bound_elems
+            )
+        else:
+            # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
+            # SiLU(gate) * up over the valid_tokens*topk live rows only.
+            n_rows = (valid_tokens * topk).to(torch.int32)
+            intermediate1 = bounded_silu_mul(intermediate1, n_rows)
 
     # FC2: [max_tokens*topk, N] → [max_tokens*topk, K], without routing weights.
     # Routing weights are applied in the reduction kernel to avoid an extra
@@ -687,4 +724,9 @@ def vllm_fused_moe(
         local_expert_start,
         num_local_experts,
         out=out,
+        # Batch-invariant mode: probs were already applied at the activation
+        # for SwiGLU (training parity), so the reduction uses unit weights;
+        # fp64 accumulation makes the topk sum order-independent by precision.
+        apply_weights=not (batch_invariant_mode and is_swiglu),
+        acc_fp64=batch_invariant_mode,
     )

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -736,5 +736,5 @@ def vllm_fused_moe(
         # for SwiGLU (training parity), so the reduction uses unit weights;
         # fp64 accumulation makes the topk sum order-independent by precision.
         apply_weights=not (batch_invariant_mode and is_swiglu),
-        acc_fp64=batch_invariant_mode,
+        acc_fp64=batch_invariant_mode and is_swiglu,
     )

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -611,16 +611,17 @@ def vllm_fused_moe(
     # stages) host-side from the token-count hint, not from the worst-case
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
     batch_invariant_mode = batch_invariant.enabled()
+    config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
     if batch_invariant_mode:
-        # Batch-invariant mode: the config must not depend on the token count.
-        # _get_default_config is a step function of M, so different co-batch
-        # sizes would otherwise select different tile shapes and change the
-        # fp32 accumulation grouping (batch-variant bits). Pin the large-M
-        # config for every launch; grid SIZING below may still use the hint
-        # (the kernel strides, so grid size never changes per-tile math).
-        config = _get_default_config(M=1 << 30, E=num_local_experts, top_k=topk)
-    else:
-        config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
+        # Batch-invariant mode: pin only the K-reduction recipe. The kernel
+        # accumulates in fp32 with no split-K, so bits depend solely on the
+        # K-loop grouping (BLOCK_SIZE_K); M/N tile shapes, tile grouping and
+        # pipeline depth reorder nothing in the accumulation (bf16 products
+        # are exact in fp32 — only the addition order matters). Keeping the
+        # M/N tiling adaptive preserves the decode-tuned configs; pinning
+        # BLOCK_SIZE_K removes the one field _get_default_config varies that
+        # could change the summation order across co-batch sizes.
+        config['BLOCK_SIZE_K'] = 64
 
     sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -524,7 +524,8 @@ def _moe_sum(
     """Fused topk reduction: [max_tokens*topk, K] bf16 → [max_tokens, K].
 
     Applies routing weights and reduces over topk in a single kernel.
-    Accumulates in fp32. When `out` is None, allocates and returns an fp32
+    Accumulates in fp32, or fp64 when `acc_fp64` is set (the output buffer
+    stays fp32 either way). When `out` is None, allocates and returns an fp32
     buffer. When `out` is provided (e.g. the RSV symmetric memory tensor),
     writes directly into it — tl.store handles the cast to the buffer's dtype.
     Only writes the first valid_tokens rows; rows beyond are left untouched

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -529,6 +529,13 @@ def _moe_sum(
     (downstream RSV reads only the valid range). Only accumulates contributions
     from local experts; non-local topk slots are skipped (their values in
     `input` are undefined).
+
+    Args:
+        apply_weights: multiply each slot by its routing probability (default).
+            Pass False when the probabilities were already applied upstream
+            (e.g. at the activation in batch-invariant mode).
+        acc_fp64: accumulate the topk sum in fp64, making the reduction
+            order-independent by precision.
     """
     if out is None:
         out = torch.empty(max_tokens, K, dtype=torch.float32, device=input.device)

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -492,15 +492,17 @@ def _moe_sum_kernel(
                 lid = eid - local_expert_start
                 if lid >= 0 and lid < num_local_experts:
                     v = tl.load(input_ptr + base + t * K + offs_k, mask=k_mask, other=0.0)
-                    if ACC_FP64:
-                        if APPLY_WEIGHTS:
-                            w = tl.load(topk_weights_ptr + token_id * topk + t)
+                    if APPLY_WEIGHTS:
+                        w = tl.load(topk_weights_ptr + token_id * topk + t)
+                        if ACC_FP64:
                             acc += v.to(tl.float64) * w.to(tl.float64)
                         else:
-                            acc += v.to(tl.float64)
+                            acc += v.to(tl.float32) * w
                     else:
-                        w = tl.load(topk_weights_ptr + token_id * topk + t)
-                        acc += v.to(tl.float32) * w
+                        if ACC_FP64:
+                            acc += v.to(tl.float64)
+                        else:
+                            acc += v.to(tl.float32)
 
             tl.store(output_ptr + token_id_i64 * K + offs_k, acc.to(tl.float32), mask=k_mask)
 

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -26,9 +26,9 @@ from megatron.core.tensor_parallel.mappings import (
     reduce_scatter_to_sequence_parallel_region,
 )
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+    get_batch_invariant_backend,
     is_batch_invariant_mode_enabled,
     rmsnorm_batch_invariant,
-    get_batch_invariant_backend,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_tensor_model_parallel_group_if_none

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -28,6 +28,7 @@ from megatron.core.tensor_parallel.mappings import (
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
     is_batch_invariant_mode_enabled,
     rmsnorm_batch_invariant,
+    get_batch_invariant_backend,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_tensor_model_parallel_group_if_none
@@ -47,7 +48,10 @@ except ImportError:
 
 def _te_rms_norm_kernel(x: torch.Tensor, weight: torch.Tensor, eps: float):
     # Use the same RMSNorm kernel as the training recompute.
-    if is_batch_invariant_mode_enabled():
+    if is_batch_invariant_mode_enabled() and get_batch_invariant_backend() != "te_native":
+        # te_native keeps the native TE RMSNorm: the 64-multiple alignment
+        # discipline holds its M%32 reduction bit-class constant, so kernel
+        # substitution is unnecessary (and native is faster).
         return rmsnorm_batch_invariant(x, weight, eps).to(x.dtype)
     x_shape = x.shape
     x = x.view(-1, x.size(-1))

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -1694,7 +1694,10 @@ def enable_batch_invariant_mode(backend: str = "deepgemm"):
             "deepgemm" (default) routes bf16 CUDA inputs through DeepGEMM
             `bf16_gemm_nn`. "triton" routes through the batch-invariant
             Triton `matmul_persistent` kernel (works for bf16/fp16/fp32 and
-            on any CUDA device). Grouped GEMM always uses DeepGEMM regardless.
+            on any CUDA device). "te_native" keeps the native cuBLASLt
+            kernels (aten and TE) and obtains invariance via workspace
+            starvation instead of kernel substitution. Grouped GEMM uses
+            DeepGEMM for "deepgemm"/"triton"; "te_native" leaves it native.
     """
     global _batch_invariant_MODE, _batch_invariant_LIB, _BATCH_INVARIANT_BACKEND
     if _batch_invariant_MODE:

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -526,7 +526,7 @@ def mean_dim(
 
 # Production uses DeepGEMM for bf16 and the deterministic Triton kernel for
 # intentional higher-precision operations such as the fp32 MoE router.
-_BATCH_INVARIANT_BACKENDS = ("deepgemm", "triton")
+_BATCH_INVARIANT_BACKENDS = ("deepgemm", "triton", "te_native")
 _BATCH_INVARIANT_BACKEND: str = "deepgemm"
 
 
@@ -625,47 +625,53 @@ def _import_module_if_available(name: str):
     return importlib.import_module(name)
 
 
-def _te_patch_for_batch_invariant():
+def _te_patch_for_batch_invariant(skip_gemm: bool = False):
     """Patch Transformer Engine modules to use batch-invariant GEMM and RMSNorm.
 
     This monkey-patches TE's GEMM and RMSNorm entry points to dispatch to the
     batch-invariant implementations when batch-invariant mode is enabled.
     Safe no-op if TE is unavailable.
+
+    Args:
+        skip_gemm: leave TE's native general_gemm in place (used by the
+            "te_native" backend, where GEMM batch invariance comes from
+            cuBLASLt workspace starvation rather than kernel substitution).
     """
     global _TE_GENERAL_GEMM_ORIG, _TE_RMSNORM_ORIG_FWD, _MEG_TE_GENERAL_GEMM_ORIG
     import transformer_engine.pytorch as te
     import transformer_engine.pytorch.cpp_extensions as te_cpp
 
-    # Patch general_gemm once
-    if _TE_GENERAL_GEMM_ORIG is None and hasattr(te_cpp, "general_gemm"):
-        _TE_GENERAL_GEMM_ORIG = te_cpp.general_gemm
-        te_cpp.general_gemm = _te_general_gemm_patched
+    if not skip_gemm:
+        # Patch general_gemm once
+        if _TE_GENERAL_GEMM_ORIG is None and hasattr(te_cpp, "general_gemm"):
+            _TE_GENERAL_GEMM_ORIG = te_cpp.general_gemm
+            te_cpp.general_gemm = _te_general_gemm_patched
 
-    # Also patch the symbol imported inside TE's module.linear
-    # (from ..cpp_extensions import general_gemm)
-    import transformer_engine.pytorch.module.linear as te_linear_mod
+        # Also patch the symbol imported inside TE's module.linear
+        # (from ..cpp_extensions import general_gemm)
+        import transformer_engine.pytorch.module.linear as te_linear_mod
 
-    if hasattr(te_linear_mod, "general_gemm"):
-        if "module.linear.general_gemm" not in _TE_GEMM_FUNC_ORIGS:
-            _TE_GEMM_FUNC_ORIGS["module.linear.general_gemm"] = te_linear_mod.general_gemm
-            te_linear_mod.general_gemm = _te_general_gemm_patched
+        if hasattr(te_linear_mod, "general_gemm"):
+            if "module.linear.general_gemm" not in _TE_GEMM_FUNC_ORIGS:
+                _TE_GEMM_FUNC_ORIGS["module.linear.general_gemm"] = te_linear_mod.general_gemm
+                te_linear_mod.general_gemm = _te_general_gemm_patched
 
-    # Also patch the symbol imported inside TE's module.layernorm_linear
-    import transformer_engine.pytorch.module.layernorm_linear as te_layernorm_linear_mod
+        # Also patch the symbol imported inside TE's module.layernorm_linear
+        import transformer_engine.pytorch.module.layernorm_linear as te_layernorm_linear_mod
 
-    if hasattr(te_layernorm_linear_mod, "general_gemm"):
-        if "module.layernorm_linear.general_gemm" not in _TE_GEMM_FUNC_ORIGS:
-            _TE_GEMM_FUNC_ORIGS["module.layernorm_linear.general_gemm"] = (
-                te_layernorm_linear_mod.general_gemm
-            )
-            te_layernorm_linear_mod.general_gemm = _te_general_gemm_patched
+        if hasattr(te_layernorm_linear_mod, "general_gemm"):
+            if "module.layernorm_linear.general_gemm" not in _TE_GEMM_FUNC_ORIGS:
+                _TE_GEMM_FUNC_ORIGS["module.layernorm_linear.general_gemm"] = (
+                    te_layernorm_linear_mod.general_gemm
+                )
+                te_layernorm_linear_mod.general_gemm = _te_general_gemm_patched
 
-    # Also patch the symbol imported into Megatron's TE wrapper module
-    import megatron.core.extensions.transformer_engine as meg_te
+        # Also patch the symbol imported into Megatron's TE wrapper module
+        import megatron.core.extensions.transformer_engine as meg_te
 
-    if _MEG_TE_GENERAL_GEMM_ORIG is None and hasattr(meg_te, "general_gemm"):
-        _MEG_TE_GENERAL_GEMM_ORIG = meg_te.general_gemm
-        meg_te.general_gemm = _te_general_gemm_patched
+        if _MEG_TE_GENERAL_GEMM_ORIG is None and hasattr(meg_te, "general_gemm"):
+            _MEG_TE_GENERAL_GEMM_ORIG = meg_te.general_gemm
+            meg_te.general_gemm = _te_general_gemm_patched
 
     # Patch RMSNorm.forward once (class may be on te or te.pytorch)
     rms_cls = getattr(te, "RMSNorm", None)
@@ -1636,6 +1642,42 @@ def is_batch_invariant_mode_enabled():
     return _batch_invariant_MODE
 
 
+_TE_NATIVE_WORKSPACE_BYTES = 1024
+
+
+def _enable_te_native_workspace_starvation(workspace_bytes: int = _TE_NATIVE_WORKSPACE_BYTES):
+    """Make the NATIVE cuBLASLt GEMM kernels batch-invariant via workspace starvation.
+
+    cuBLASLt selects split-K reduction variants per M (the co-batch token count),
+    which changes the fp32 accumulation order across batch compositions. Split-K
+    variants require workspace; starving the workspace to ~1KB disqualifies them,
+    pinning every M to the same serial-K reduction recipe — batch-invariant at
+    native kernel speed, with no kernel substitution. (Tile shape selection may
+    still vary with M, but M/N tiling does not affect bits: bf16 products are
+    exact in fp32, so only the K-reduction order matters.)
+
+    Two knobs must both land:
+    - cuBLASLt env pins for kernels that honor them (set before first use).
+    - Transformer Engine's own workspace: TE (<= 2.15 verified) hardcodes 32MiB in
+      get_cublas_workspace_size_bytes() and ignores CUBLASLT_WORKSPACE_SIZE, so the
+      env pin alone never engages for TE-launched GEMMs — patch the size fn and
+      clear its lru_cache.
+    """
+    import os
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":0:0")
+    os.environ.setdefault("CUBLASLT_WORKSPACE_SIZE", "0")
+    try:
+        import transformer_engine.pytorch.cpp_extensions.gemm as _te_gemm_mod
+
+        if hasattr(_te_gemm_mod, "get_cublas_workspace_size_bytes"):
+            _te_gemm_mod.get_cublas_workspace_size_bytes = lambda: workspace_bytes
+            if hasattr(getattr(_te_gemm_mod, "get_cublas_workspace", None), "cache_clear"):
+                _te_gemm_mod.get_cublas_workspace.cache_clear()
+    except ImportError:
+        pass
+
+
 def enable_batch_invariant_mode(backend: str = "deepgemm"):
     """Enable global batch-invariant mode and patch Aten/TE kernels.
 
@@ -1663,12 +1705,25 @@ def enable_batch_invariant_mode(backend: str = "deepgemm"):
     dispatch_key = getattr(torch.accelerator.current_accelerator(), "type", "cpu").upper()
     _batch_invariant_MODE = True
     _batch_invariant_LIB = torch.library.Library("aten", "IMPL")
-    _batch_invariant_LIB.impl("aten::mm", mm_batch_invariant, dispatch_key)
-    _batch_invariant_LIB.impl("aten::addmm", addmm_batch_invariant, dispatch_key)
+    if backend == "te_native":
+        # Keep the NATIVE cuBLASLt kernels for every dense GEMM (aten and TE);
+        # batch invariance comes from workspace starvation (split-K
+        # disqualified => fixed K-reduction recipe at every M) instead of
+        # kernel substitution — native speed, verified bitwise-identical to
+        # the training forward in NeMo-RL true on-policy GRPO (gen_kl == 0.0).
+        _enable_te_native_workspace_starvation()
+    else:
+        _batch_invariant_LIB.impl("aten::mm", mm_batch_invariant, dispatch_key)
+        _batch_invariant_LIB.impl("aten::addmm", addmm_batch_invariant, dispatch_key)
     _batch_invariant_LIB.impl("aten::_log_softmax", _log_softmax_batch_invariant, dispatch_key)
     _batch_invariant_LIB.impl("aten::mean.dim", mean_batch_invariant, dispatch_key)
-    # Also patch Transformer Engine kernels when available
-    _te_patch_for_batch_invariant()
+    # Also patch Transformer Engine kernels when available (te_native keeps
+    # TE's native GEMMs — invariance comes from the starved workspace — but
+    # still applies the non-GEMM TE patches, e.g. the attention gate).
+    if backend == "te_native":
+        _te_patch_for_batch_invariant(skip_gemm=True)
+    else:
+        _te_patch_for_batch_invariant()
     # Pin the Mamba autotuners so rollout and training processes can't end
     # up on different tile configs (and therefore different fp32 reduction
     # orders) through autotune timing noise.

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -1745,12 +1745,20 @@ def _disable_te_native_workspace_starvation():
     _TE_NATIVE_ENV_ORIG.clear()
 
 
+_BATCH_INVARIANT_COLLECTIVE = "ordered"
+
+
+def get_batch_invariant_collective() -> str:
+    """Return the active batch-invariant cross-rank combine collective."""
+    return _BATCH_INVARIANT_COLLECTIVE
+
+
 def get_batch_invariant_backend() -> str:
     """Return the active batch-invariant GEMM backend name."""
     return _BATCH_INVARIANT_BACKEND
 
 
-def enable_batch_invariant_mode(backend: str = "te_native"):
+def enable_batch_invariant_mode(backend: str = "te_native", collective: str = "ordered"):
     """Enable global batch-invariant mode and patch Aten/TE kernels.
 
     Args:
@@ -1765,8 +1773,11 @@ def enable_batch_invariant_mode(backend: str = "te_native"):
             DeepGEMM for "deepgemm"/"triton"; "te_native" leaves it native.
     """
     global _batch_invariant_MODE, _batch_invariant_LIB, _BATCH_INVARIANT_BACKEND
+    global _BATCH_INVARIANT_COLLECTIVE
     if _batch_invariant_MODE:
         return
+    assert collective in ("ordered", "multimem"), f"Unknown collective {collective!r}"
+    _BATCH_INVARIANT_COLLECTIVE = collective
     if backend not in _BATCH_INVARIANT_BACKENDS:
         raise ValueError(
             f"Unknown batch-invariant backend {backend!r}; "

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -1647,6 +1647,10 @@ def is_batch_invariant_mode_enabled():
 
 _TE_NATIVE_WORKSPACE_BYTES = 1024
 
+# Originals saved by _enable_te_native_workspace_starvation for restoration.
+_TE_WORKSPACE_SIZE_FN_ORIG = None
+_TE_NATIVE_ENV_ORIG: dict = {}
+
 
 def _enable_te_native_workspace_starvation(workspace_bytes: int = _TE_NATIVE_WORKSPACE_BYTES):
     """Make the NATIVE cuBLASLt GEMM kernels batch-invariant via workspace starvation.
@@ -1666,19 +1670,69 @@ def _enable_te_native_workspace_starvation(workspace_bytes: int = _TE_NATIVE_WOR
       env pin alone never engages for TE-launched GEMMs — patch the size fn and
       clear its lru_cache.
     """
+    import logging
     import os
 
-    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":0:0")
-    os.environ.setdefault("CUBLASLT_WORKSPACE_SIZE", "0")
+    global _TE_WORKSPACE_SIZE_FN_ORIG
+    logger = logging.getLogger(__name__)
+
+    # CUBLASLT_WORKSPACE_SIZE must be pinned (not setdefault): a preset value
+    # (e.g. from a determinism launcher) large enough for split-K would make
+    # te_native silently non-invariant on the aten GEMM path.
+    for var, pinned in (("CUBLASLT_WORKSPACE_SIZE", "0"),):
+        prev = os.environ.get(var)
+        if prev is not None and prev != pinned:
+            logger.warning(
+                "te_native batch-invariant backend overriding %s=%s with %s "
+                "(split-K disqualification requires a starved workspace).",
+                var,
+                prev,
+                pinned,
+            )
+        _TE_NATIVE_ENV_ORIG[var] = prev
+        os.environ[var] = pinned
+    if torch.cuda.is_initialized():
+        logger.warning(
+            "te_native backend enabled after CUDA initialization; cuBLASLt "
+            "handles created earlier may retain their original workspace and "
+            "remain batch-variant. Enable batch-invariant mode before the "
+            "first GEMM."
+        )
     try:
         import transformer_engine.pytorch.cpp_extensions.gemm as _te_gemm_mod
 
-        if hasattr(_te_gemm_mod, "get_cublas_workspace_size_bytes"):
+        if _TE_WORKSPACE_SIZE_FN_ORIG is None and hasattr(
+            _te_gemm_mod, "get_cublas_workspace_size_bytes"
+        ):
+            _TE_WORKSPACE_SIZE_FN_ORIG = _te_gemm_mod.get_cublas_workspace_size_bytes
             _te_gemm_mod.get_cublas_workspace_size_bytes = lambda: workspace_bytes
             if hasattr(getattr(_te_gemm_mod, "get_cublas_workspace", None), "cache_clear"):
                 _te_gemm_mod.get_cublas_workspace.cache_clear()
     except ImportError:
         pass
+
+
+def _disable_te_native_workspace_starvation():
+    """Restore the TE workspace function and env pinned by the te_native backend."""
+    import os
+
+    global _TE_WORKSPACE_SIZE_FN_ORIG
+    if _TE_WORKSPACE_SIZE_FN_ORIG is not None:
+        try:
+            import transformer_engine.pytorch.cpp_extensions.gemm as _te_gemm_mod
+
+            _te_gemm_mod.get_cublas_workspace_size_bytes = _TE_WORKSPACE_SIZE_FN_ORIG
+            if hasattr(getattr(_te_gemm_mod, "get_cublas_workspace", None), "cache_clear"):
+                _te_gemm_mod.get_cublas_workspace.cache_clear()
+        except ImportError:
+            pass
+        _TE_WORKSPACE_SIZE_FN_ORIG = None
+    for var, prev in _TE_NATIVE_ENV_ORIG.items():
+        if prev is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = prev
+    _TE_NATIVE_ENV_ORIG.clear()
 
 
 def get_batch_invariant_backend() -> str:
@@ -1755,6 +1809,7 @@ def disable_batch_invariant_mode():
     _batch_invariant_LIB = None
     # Restore Transformer Engine kernels if previously patched
     _te_unpatch_for_batch_invariant()
+    _disable_te_native_workspace_starvation()
     _unpin_mamba_autotuners()
 
 

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -625,7 +625,7 @@ def _import_module_if_available(name: str):
     return importlib.import_module(name)
 
 
-def _te_patch_for_batch_invariant(skip_gemm: bool = False):
+def _te_patch_for_batch_invariant(skip_gemm: bool = False, skip_rmsnorm: bool = False):
     """Patch Transformer Engine modules to use batch-invariant GEMM and RMSNorm.
 
     This monkey-patches TE's GEMM and RMSNorm entry points to dispatch to the
@@ -672,6 +672,9 @@ def _te_patch_for_batch_invariant(skip_gemm: bool = False):
         if _MEG_TE_GENERAL_GEMM_ORIG is None and hasattr(meg_te, "general_gemm"):
             _MEG_TE_GENERAL_GEMM_ORIG = meg_te.general_gemm
             meg_te.general_gemm = _te_general_gemm_patched
+
+    if skip_rmsnorm:
+        return
 
     # Patch RMSNorm.forward once (class may be on te or te.pytorch)
     rms_cls = getattr(te, "RMSNorm", None)
@@ -1678,6 +1681,11 @@ def _enable_te_native_workspace_starvation(workspace_bytes: int = _TE_NATIVE_WOR
         pass
 
 
+def get_batch_invariant_backend() -> str:
+    """Return the active batch-invariant GEMM backend name."""
+    return _BATCH_INVARIANT_BACKEND
+
+
 def enable_batch_invariant_mode(backend: str = "deepgemm"):
     """Enable global batch-invariant mode and patch Aten/TE kernels.
 
@@ -1721,7 +1729,11 @@ def enable_batch_invariant_mode(backend: str = "deepgemm"):
     # TE's native GEMMs — invariance comes from the starved workspace — but
     # still applies the non-GEMM TE patches, e.g. the attention gate).
     if backend == "te_native":
-        _te_patch_for_batch_invariant(skip_gemm=True)
+        # te_native also keeps TE's NATIVE RMSNorm: its M%32 reduction
+        # bit-class is held constant by the 64-multiple alignment discipline
+        # (CUDA-graph bucket floor + eager TOKEN_ROUNDER + scoring-side
+        # sequence-length rounding), so no kernel substitution is needed.
+        _te_patch_for_batch_invariant(skip_gemm=True, skip_rmsnorm=True)
     else:
         _te_patch_for_batch_invariant()
     # Pin the Mamba autotuners so rollout and training processes can't end

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -1686,13 +1686,14 @@ def get_batch_invariant_backend() -> str:
     return _BATCH_INVARIANT_BACKEND
 
 
-def enable_batch_invariant_mode(backend: str = "deepgemm"):
+def enable_batch_invariant_mode(backend: str = "te_native"):
     """Enable global batch-invariant mode and patch Aten/TE kernels.
 
     Args:
         backend: which kernel to dispatch `aten::mm`/`aten::addmm` through.
-            "deepgemm" (default) routes bf16 CUDA inputs through DeepGEMM
-            `bf16_gemm_nn`. "triton" routes through the batch-invariant
+            "te_native" (default) keeps the native cuBLASLt kernels and obtains
+            invariance via workspace starvation. "deepgemm" routes bf16 CUDA
+            inputs through DeepGEMM `bf16_gemm_nn`. "triton" routes through the batch-invariant
             Triton `matmul_persistent` kernel (works for bf16/fp16/fp32 and
             on any CUDA device). "te_native" keeps the native cuBLASLt
             kernels (aten and TE) and obtains invariance via workspace

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -633,9 +633,15 @@ def _te_patch_for_batch_invariant(skip_gemm: bool = False, skip_rmsnorm: bool = 
     Safe no-op if TE is unavailable.
 
     Args:
-        skip_gemm: leave TE's native general_gemm in place (used by the
-            "te_native" backend, where GEMM batch invariance comes from
-            cuBLASLt workspace starvation rather than kernel substitution).
+        skip_gemm: leave TE's native GEMMs (general_gemm and grouped GEMM) in
+            place (used by the "te_native" backend, where GEMM batch
+            invariance comes from cuBLASLt workspace starvation rather than
+            kernel substitution).
+        skip_rmsnorm: leave TE's native normalization in place (RMSNorm
+            class/module functions and the fused-module apply_normalization
+            entry). Used by "te_native", where the norm's M%32 reduction
+            bit-class is held constant by the 64-multiple alignment
+            discipline instead of kernel substitution.
     """
     global _TE_GENERAL_GEMM_ORIG, _TE_RMSNORM_ORIG_FWD, _MEG_TE_GENERAL_GEMM_ORIG
     import transformer_engine.pytorch as te
@@ -673,7 +679,15 @@ def _te_patch_for_batch_invariant(skip_gemm: bool = False, skip_rmsnorm: bool = 
             _MEG_TE_GENERAL_GEMM_ORIG = meg_te.general_gemm
             meg_te.general_gemm = _te_general_gemm_patched
 
+        # Patch TE.general_grouped_gemm at every known import site so that
+        # TEGroupedMLP (forward + dgrad + wgrad) goes through DeepGEMM in bf16.
+        # Grouped GEMMs are a GEMM concern: under skip_gemm ("te_native") they
+        # stay native, covered by the same cuBLASLt workspace starvation.
+        _te_patch_general_grouped_gemm()
+
     if skip_rmsnorm:
+        # Everything below patches normalization only (RMSNorm class/module
+        # functions and the fused-module apply_normalization entry).
         return
 
     # Patch RMSNorm.forward once (class may be on te or te.pytorch)
@@ -716,10 +730,6 @@ def _te_patch_for_batch_invariant(skip_gemm: bool = False, skip_rmsnorm: bool = 
             orig = getattr(te_layernorm_mod, name)
             _TE_RMSNORM_FUNC_ORIGS[name] = orig
             setattr(te_layernorm_mod, name, _make_rmsnorm_patched(orig))
-
-    # Patch TE.general_grouped_gemm at every known import site so that
-    # TEGroupedMLP (forward + dgrad + wgrad) goes through DeepGEMM in bf16.
-    _te_patch_general_grouped_gemm()
 
     # Patch the fused-module normalization entry (`apply_normalization`). TE's
     # fused LayerNormLinear / LayerNormMLP call this instead of RMSNorm.forward,
@@ -1783,9 +1793,11 @@ def enable_batch_invariant_mode(backend: str = "te_native"):
         _batch_invariant_LIB.impl("aten::addmm", addmm_batch_invariant, dispatch_key)
     _batch_invariant_LIB.impl("aten::_log_softmax", _log_softmax_batch_invariant, dispatch_key)
     _batch_invariant_LIB.impl("aten::mean.dim", mean_batch_invariant, dispatch_key)
-    # Also patch Transformer Engine kernels when available (te_native keeps
-    # TE's native GEMMs — invariance comes from the starved workspace — but
-    # still applies the non-GEMM TE patches, e.g. the attention gate).
+    # Also patch Transformer Engine kernels when available. Under te_native
+    # BOTH skips are set, so no TE kernel is substituted at all: GEMMs (dense
+    # and grouped) stay native under the starved workspace, and norms stay
+    # native under the 64-multiple alignment discipline. (The TE attention
+    # version gate is a separate standalone assert, not part of this patch.)
     if backend == "te_native":
         # te_native also keeps TE's NATIVE RMSNorm: its M%32 reduction
         # bit-class is held constant by the 64-multiple alignment discipline

--- a/megatron/core/transformer/moe/batch_invariant.py
+++ b/megatron/core/transformer/moe/batch_invariant.py
@@ -60,8 +60,25 @@ def unpermute(
     shapes and adds contributions by EP rank then top-k slot, matching the
     inference NVLS rank-ordered combine.
     """
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        get_batch_invariant_collective,
+    )
+
     input_dtype = permuted_tokens.dtype
-    output_tokens = torch.zeros(restore_shape, dtype=torch.float32, device=permuted_tokens.device)
+    # Mirror the inference engine's summation tree exactly:
+    # - When probs is None the activations were probability-weighted upstream
+    #   (gated/SwiGLU convention) and the engine's within-rank _moe_sum
+    #   accumulates in fp64 with unit weights -> mirror in fp64, round each
+    #   rank partial to fp32 (the engine stores fp32 partials into the RSV
+    #   buffer before the collective).
+    # - The cross-rank stage matches the configured collective: "multimem"
+    #   returns the correctly-rounded exact fp32 sum of the partials (mirror =
+    #   fp64 accumulate, single final rounding); "ordered" is an ascending
+    #   rank-order fp32 chain.
+    within_rank_fp64 = probs is None
+    cross_rank_fp64 = get_batch_invariant_collective() == "multimem"
+    acc_dtype = torch.float64 if cross_rank_fp64 else torch.float32
+    output_tokens = torch.zeros(restore_shape, dtype=acc_dtype, device=permuted_tokens.device)
     ep_size = parallel_state.get_expert_model_parallel_world_size() or 1
     assert num_experts % ep_size == 0, "batch-invariant MoE expects contiguous EP shards"
     experts_per_rank = num_experts // ep_size
@@ -69,8 +86,11 @@ def unpermute(
     inverse_experts = inverse_map[1]
     topk = inverse_rows.size(1)
 
+    partial_dtype = torch.float64 if within_rank_fp64 else torch.float32
     for ep_rank in range(ep_size):
-        rank_partial = torch.zeros_like(output_tokens)
+        rank_partial = torch.zeros(
+            restore_shape, dtype=partial_dtype, device=permuted_tokens.device
+        )
         start_expert = ep_rank * experts_per_rank
         end_expert = start_expert + experts_per_rank
 
@@ -80,13 +100,15 @@ def unpermute(
             valid_mask = (row_ids >= 0) & (expert_ids >= start_expert) & (expert_ids < end_expert)
 
             safe_rows = row_ids.clamp_min(0)
-            chunk = permuted_tokens.index_select(0, safe_rows).to(torch.float32)
+            chunk = permuted_tokens.index_select(0, safe_rows).to(partial_dtype)
             if probs is not None:
                 safe_experts = expert_ids.clamp_min(0)
-                chunk = chunk * probs.gather(1, safe_experts.unsqueeze(1)).to(torch.float32)
+                chunk = chunk * probs.gather(1, safe_experts.unsqueeze(1)).to(partial_dtype)
             chunk.masked_fill_(~valid_mask.unsqueeze(-1), 0.0)
             rank_partial += chunk
 
-        output_tokens += rank_partial
+        # The engine stores each rank's partial as fp32 (the RSV buffer dtype)
+        # before the cross-rank reduction; mirror that rounding point.
+        output_tokens += rank_partial.to(torch.float32).to(acc_dtype)
 
-    return output_tokens.to(dtype=input_dtype)
+    return output_tokens.to(torch.float32).to(dtype=input_dtype)

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -641,10 +641,11 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             dtype=rsv["tensor"].dtype,
             device=hidden_states.device,
         )
-        use_ordered = (
-            batch_invariant.enabled()
-            and getattr(self.config, "batch_invariant_collective", "ordered") == "ordered"
+        from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+            get_batch_invariant_collective,
         )
+
+        use_ordered = batch_invariant.enabled() and get_batch_invariant_collective() == "ordered"
         # Under batch-invariant mode the "multimem" option keeps the native
         # NVLS in-switch reduce: measured correctly-rounded (exact fp32 sum,
         # bitwise-equal to an fp64 reference), deterministic and

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -641,10 +641,17 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             dtype=rsv["tensor"].dtype,
             device=hidden_states.device,
         )
+        use_ordered = (
+            batch_invariant.enabled()
+            and getattr(self.config, "batch_invariant_collective", "ordered") == "ordered"
+        )
+        # Under batch-invariant mode the "multimem" option keeps the native
+        # NVLS in-switch reduce: measured correctly-rounded (exact fp32 sum,
+        # bitwise-equal to an fp64 reference), deterministic and
+        # batch-invariant; "ordered" (default) uses the explicit fixed
+        # rank-order fp32 kernel, deterministic by construction anywhere.
         reduce_scatter_v = (
-            batch_invariant.ordered_reduce_scatter_v
-            if batch_invariant.enabled()
-            else multimem_reduce_scatter_v
+            batch_invariant.ordered_reduce_scatter_v if use_ordered else multimem_reduce_scatter_v
         )
         reduce_scatter_v(
             output,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1131,7 +1131,7 @@ class TransformerConfig(ModelParallelConfig):
        training and inference as the kernels are not full optimized.
        Defaults to False."""
 
-    batch_invariant_backend: str = "te_native"
+    batch_invariant_backend: Literal["te_native", "deepgemm", "triton"] = "te_native"
     """Which batch-invariant GEMM backend to use when batch_invariant_mode is
     enabled: "te_native" (default: keep the native cuBLASLt kernels and obtain
     invariance via workspace starvation — lowest overhead, no extra

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1131,6 +1131,13 @@ class TransformerConfig(ModelParallelConfig):
        training and inference as the kernels are not full optimized.
        Defaults to False."""
 
+    batch_invariant_backend: str = "deepgemm"
+    """Which batch-invariant GEMM backend to use when batch_invariant_mode is
+    enabled: "deepgemm" (DeepGEMM bf16 kernels), "triton" (persistent Triton
+    matmul; any dtype), or "te_native" (keep the native cuBLASLt kernels and
+    obtain invariance via workspace starvation — lowest overhead, and the
+    configuration verified bitwise-identical to the TE training forward)."""
+
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1581,9 +1581,13 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
             if self.batch_invariant_mode:
-                if self.inference_grouped_gemm_backend != InferenceGroupedGemmBackend.TORCH:
+                if self.inference_grouped_gemm_backend not in (
+                    InferenceGroupedGemmBackend.TORCH,
+                    InferenceGroupedGemmBackend.VLLM,
+                ):
                     raise ValueError(
-                        "batch_invariant_mode requires " "inference_grouped_gemm_backend='torch'."
+                        "batch_invariant_mode requires inference_grouped_gemm_backend "
+                        "'torch' or 'vllm'."
                     )
                 if (
                     self.expert_model_parallel_size > 1

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2987,6 +2987,17 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.batch_invariant_mode:
+            from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+                _BATCH_INVARIANT_BACKENDS,
+            )
+
+            # argparse validates via the Literal annotation; guard here too so
+            # programmatic TransformerConfig construction fails at build time
+            # rather than inside enable_batch_invariant_mode() after model init.
+            assert self.batch_invariant_backend in _BATCH_INVARIANT_BACKENDS, (
+                f"Unknown batch_invariant_backend {self.batch_invariant_backend!r}; "
+                f"expected one of {_BATCH_INVARIANT_BACKENDS}."
+            )
             assert self.params_dtype == torch.bfloat16, (
                 "Batch invariant mode supports BF16 model parameters only; "
                 f"got {self.params_dtype}."

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1139,6 +1139,16 @@ class TransformerConfig(ModelParallelConfig):
     training forward), "deepgemm" (DeepGEMM bf16 kernels), or "triton"
     (persistent Triton matmul; any dtype)."""
 
+    batch_invariant_collective: Literal["ordered", "multimem"] = "ordered"
+    """Cross-rank EP combine collective under batch_invariant_mode. "ordered"
+    (default) reduces with an explicit fixed rank-order fp32 Triton kernel —
+    deterministic by construction on any hardware. "multimem" keeps the native
+    NVLS in-switch reduce-scatter: measured to return the correctly-rounded
+    exact fp32 sum (bitwise-equal to an fp64 reference over 16.7M adversarial
+    channels on B200), deterministic and batch-invariant, with better scaling
+    at large NVLink domains; software paths that must match it bitwise should
+    accumulate in fp64."""
+
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1131,12 +1131,13 @@ class TransformerConfig(ModelParallelConfig):
        training and inference as the kernels are not full optimized.
        Defaults to False."""
 
-    batch_invariant_backend: str = "deepgemm"
+    batch_invariant_backend: str = "te_native"
     """Which batch-invariant GEMM backend to use when batch_invariant_mode is
-    enabled: "deepgemm" (DeepGEMM bf16 kernels), "triton" (persistent Triton
-    matmul; any dtype), or "te_native" (keep the native cuBLASLt kernels and
-    obtain invariance via workspace starvation — lowest overhead, and the
-    configuration verified bitwise-identical to the TE training forward)."""
+    enabled: "te_native" (default: keep the native cuBLASLt kernels and obtain
+    invariance via workspace starvation — lowest overhead, no extra
+    dependencies, and the configuration verified bitwise-identical to the TE
+    training forward), "deepgemm" (DeepGEMM bf16 kernels), or "triton"
+    (persistent Triton matmul; any dtype)."""
 
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
@@ -3020,9 +3021,19 @@ class TransformerConfig(ModelParallelConfig):
                         "Batch-invariant MoE training requires "
                         "moe_token_dispatcher_type='alltoall'."
                     )
-                assert HAVE_DEEPGEMM_BF16, (
+                # DeepGEMM is used by the "deepgemm"/"triton" backends, and by
+                # the torch inference grouped-GEMM path under any backend. The
+                # "te_native" backend with the vLLM inference backend (or the
+                # training path, where TE grouped GEMM stays native) does not
+                # need it.
+                needs_deepgemm = self.batch_invariant_backend in ("deepgemm", "triton") or (
+                    self.transformer_impl == "inference_optimized"
+                    and self.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.TORCH
+                )
+                assert not needs_deepgemm or HAVE_DEEPGEMM_BF16, (
                     "batch_invariant_mode=True with MoE requires DeepGEMM with bf16 "
-                    "grouped-GEMM bindings (m_grouped_bf16_gemm_nt_contiguous). "
+                    "grouped-GEMM bindings (m_grouped_bf16_gemm_nt_contiguous) for "
+                    "this backend combination. "
                     "Install via `uv pip install -e .[batch_invariant]`."
                 )
                 assert not (

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -101,8 +101,11 @@ def initialize_megatron(
 
     if args.batch_invariant_mode:
         backend = args.batch_invariant_backend
-        print_rank_0(f"Enabling batch invariant mode globally (backend={backend})")
-        enable_batch_invariant_mode(backend)
+        collective = args.batch_invariant_collective
+        print_rank_0(
+            f"Enabling batch invariant mode globally (backend={backend}, collective={collective})"
+        )
+        enable_batch_invariant_mode(backend, collective)
 
     # torch.distributed initialization
     def finish_mpu_init():

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -100,7 +100,7 @@ def initialize_megatron(
     )
 
     if args.batch_invariant_mode:
-        backend = getattr(args, "batch_invariant_backend", "deepgemm")
+        backend = getattr(args, "batch_invariant_backend", "te_native")
         print_rank_0(f"Enabling batch invariant mode globally (backend={backend})")
         enable_batch_invariant_mode(backend)
 

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -100,8 +100,9 @@ def initialize_megatron(
     )
 
     if args.batch_invariant_mode:
-        print_rank_0("Enabling batch invariant mode globally")
-        enable_batch_invariant_mode()
+        backend = getattr(args, "batch_invariant_backend", "deepgemm")
+        print_rank_0(f"Enabling batch invariant mode globally (backend={backend})")
+        enable_batch_invariant_mode(backend)
 
     # torch.distributed initialization
     def finish_mpu_init():

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -100,7 +100,7 @@ def initialize_megatron(
     )
 
     if args.batch_invariant_mode:
-        backend = getattr(args, "batch_invariant_backend", "te_native")
+        backend = args.batch_invariant_backend
         print_rank_0(f"Enabling batch invariant mode globally (backend={backend})")
         enable_batch_invariant_mode(backend)
 

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -23,6 +23,12 @@ from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
     _BATCH_INVARIANT_BACKENDS,
     set_batch_invariant_mode,
 )
+from megatron.core.inference.moe.batch_invariant import HAVE_TRITON
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not HAVE_TRITON,
+    reason="batch-invariant MoE kernels require CUDA and Triton",
+)
 
 
 def _vt(n):

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -165,6 +165,30 @@ class TestMoeSumOptions:
         ref = inp.view(max_tokens, topk, K).to(torch.float64).sum(dim=1).to(torch.float32)
         assert torch.equal(out, ref)
 
+    def test_unit_weights_fp32_matches_sequential_reference(self):
+        from megatron.core.inference.moe.vllm_fused_moe import _moe_sum
+
+        inp, probs, routing, max_tokens, topk, K, E = self._setup()
+        out = _moe_sum(
+            inp,
+            probs,
+            max_tokens,
+            topk,
+            K,
+            _vt(max_tokens),
+            routing,
+            0,
+            E,
+            apply_weights=False,
+            acc_fp64=False,
+        )
+        # unit weights => pure sequential fp32 adds (no FMA), so a same-order
+        # torch reference is bitwise-reproducible
+        ref = torch.zeros(max_tokens, K, device="cuda", dtype=torch.float32)
+        for t in range(topk):
+            ref += inp.view(max_tokens, topk, K)[:, t].float()
+        assert torch.equal(out, ref)
+
     def test_default_weighted_fp32_deterministic_and_correct(self):
         from megatron.core.inference.moe.vllm_fused_moe import _moe_sum
 

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -57,6 +57,31 @@ class TestCudaGraphBucket64Floor:
                 f"(num_cuda_graphs={num_cuda_graphs})"
             )
 
+    def test_non_multiple_max_requests_keeps_largest_decode_bucket(self):
+        # Regression: the floor must PAD buckets, not invalidate them. With
+        # max_requests=100 (not a 64-multiple), the largest decode bucket must
+        # survive with its request budget intact and an aligned token count.
+        with set_batch_invariant_mode(True, backend="triton"):
+            dims, _ = CUDAGraphBatchDimensionBuilder.generate_cuda_graph_batch_dimensions_list(
+                tp_size=1,
+                num_cuda_graphs=16,
+                cuda_graph_max_tokens=2048,
+                cuda_graph_mixed_prefill_request_count=None,
+                max_requests=100,
+                max_tokens=2048,
+                max_sequence_length=4096,
+                use_cuda_graphs_for_non_decode_steps=False,
+            )
+        decode_dims = [d for d in dims if d.prefill_req_count == 0 and d.decode_req_count > 0]
+        assert decode_dims, "no decode buckets survived"
+        largest = max(decode_dims, key=lambda d: d.decode_req_count)
+        assert (
+            largest.decode_req_count == 100
+        ), f"largest decode bucket lost its request budget: {largest}"
+        assert (
+            largest.token_count % 64 == 0 and largest.token_count >= 128
+        ), f"largest decode bucket not aligned/padded: {largest}"
+
     def test_auto_sizing_injects_small_buckets_without_bi(self):
         # Guard for the non-BI behavior this floor exists to counteract: the
         # auto (-1) ladder includes 1/2-token buckets when BI mode is off.
@@ -270,9 +295,20 @@ class TestTeNativeBackend:
         )
 
         try:
+            import transformer_engine.pytorch.cpp_extensions.gemm as te_gemm_mod
+
+            ws_fn_before = te_gemm_mod.get_cublas_workspace_size_bytes
+            have_te = True
+        except ImportError:
+            have_te = False
+        env_before = os.environ.get("CUBLASLT_WORKSPACE_SIZE")
+        try:
             enable_batch_invariant_mode("te_native")
             assert is_batch_invariant_mode_enabled()
             assert get_batch_invariant_backend() == "te_native"
+            assert os.environ.get("CUBLASLT_WORKSPACE_SIZE") == "0"
+            if have_te:
+                assert te_gemm_mod.get_cublas_workspace_size_bytes() == 1024
             # te_native must NOT reroute aten::mm — native kernels stay
             a = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
             b = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
@@ -280,3 +316,8 @@ class TestTeNativeBackend:
         finally:
             disable_batch_invariant_mode()
         assert not is_batch_invariant_mode_enabled()
+        # the workspace patch and env pin must be fully restored (no leak
+        # into subsequent non-BI work in the same process)
+        if have_te:
+            assert te_gemm_mod.get_cublas_workspace_size_bytes is ws_fn_before
+        assert os.environ.get("CUBLASLT_WORKSPACE_SIZE") == env_before

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for batch-invariant mode on the vLLM Triton fused-MoE backend.
+
+Covers:
+- CUDA-graph bucket token counts floored to 64-multiples under batch-invariant mode
+- swiglu_with_probs / weighted_silu_mul_bounded: training-parity rounding vs reference
+- _moe_sum apply_weights / acc_fp64 options
+- vllm_fused_moe end-to-end batch invariance for gated (SwiGLU) models
+- te_native backend registration
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("TRITON_CACHE_DIR", os.path.join(tempfile.gettempdir(), "triton_test_cache"))
+
+import pytest
+import torch
+
+from megatron.core.inference.batch_dimensions_utils import CUDAGraphBatchDimensionBuilder
+from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+    _BATCH_INVARIANT_BACKENDS,
+    set_batch_invariant_mode,
+)
+
+
+def _vt(n):
+    return torch.tensor(n, dtype=torch.int32, device="cuda")
+
+
+# ---------------------------------------------------------------------------
+# CUDA-graph bucket 64-multiple floor
+# ---------------------------------------------------------------------------
+
+
+class TestCudaGraphBucket64Floor:
+
+    @pytest.mark.parametrize("num_cuda_graphs", [-1, 8, 16])
+    def test_bucket_token_counts_are_64_multiples(self, num_cuda_graphs):
+        with set_batch_invariant_mode(True, backend="triton"):
+            dims, token_counts = (
+                CUDAGraphBatchDimensionBuilder.generate_cuda_graph_batch_dimensions_list(
+                    tp_size=1,
+                    num_cuda_graphs=num_cuda_graphs,
+                    cuda_graph_max_tokens=2048,
+                    cuda_graph_mixed_prefill_request_count=None,
+                    max_requests=512,
+                    max_tokens=2048,
+                    max_sequence_length=4096,
+                    use_cuda_graphs_for_non_decode_steps=False,
+                )
+            )
+        for bd in dims:
+            assert bd.token_count % 64 == 0 and bd.token_count >= 64, (
+                f"bucket token_count {bd.token_count} violates the 64-multiple floor "
+                f"(num_cuda_graphs={num_cuda_graphs})"
+            )
+
+    def test_auto_sizing_injects_small_buckets_without_bi(self):
+        # Guard for the non-BI behavior this floor exists to counteract: the
+        # auto (-1) ladder includes 1/2-token buckets when BI mode is off.
+        dims, _ = CUDAGraphBatchDimensionBuilder.generate_cuda_graph_batch_dimensions_list(
+            tp_size=1,
+            num_cuda_graphs=-1,
+            cuda_graph_max_tokens=2048,
+            cuda_graph_mixed_prefill_request_count=None,
+            max_requests=512,
+            max_tokens=2048,
+            max_sequence_length=4096,
+            use_cuda_graphs_for_non_decode_steps=False,
+        )
+        assert any(bd.token_count < 64 for bd in dims)
+
+
+# ---------------------------------------------------------------------------
+# Training-parity weighted SwiGLU kernels
+# ---------------------------------------------------------------------------
+
+
+def _weighted_swiglu_reference(y, probs_flat):
+    """bf16(fp32 silu(gate) * up * prob) with a single final rounding."""
+    half = y.shape[1] // 2
+    gate = y[:, :half].float()
+    up = y[:, half:].float()
+    return (torch.nn.functional.silu(gate) * up * probs_flat[:, None]).to(y.dtype)
+
+
+class TestWeightedSwigluKernels:
+
+    def test_swiglu_with_probs_value_deterministic_and_row_local(self):
+        from megatron.core.inference.moe import batch_invariant
+
+        torch.manual_seed(7)
+        rows, ffn = 512, 256
+        y = (torch.randn(rows, 2 * ffn, device="cuda") * 2.0).bfloat16()
+        probs = torch.rand(rows, device="cuda", dtype=torch.float32)
+        perm_map = torch.arange(rows, device="cuda", dtype=torch.int32)
+        n_used = _vt(rows)
+        out = batch_invariant.swiglu_with_probs(y, perm_map, n_used, probs)
+        # value correctness (tolerance-based: sigmoid instruction sequences may
+        # legitimately differ from the torch reference by 1 ulp on rare values)
+        # compare at bf16 (bf16 tolerances): sigmoid instruction sequences may
+        # legitimately differ from the torch reference by 1 bf16 ulp
+        torch.testing.assert_close(out, _weighted_swiglu_reference(y, probs))
+        # bitwise repeat-determinism
+        for _ in range(5):
+            assert torch.equal(
+                batch_invariant.swiglu_with_probs(y, perm_map, n_used, probs), out
+            )
+        # row-locality: a row's bits do not depend on co-batch size
+        half_out = batch_invariant.swiglu_with_probs(
+            y[:128].contiguous(), perm_map[:128], _vt(128), probs[:128]
+        )
+        assert torch.equal(half_out, out[:128])
+
+    def test_weighted_silu_mul_bounded_bound_and_invariance(self):
+        from megatron.core.inference.moe import batch_invariant
+
+        torch.manual_seed(8)
+        rows, ffn, live = 512, 256, 300
+        y = (torch.randn(rows, 2 * ffn, device="cuda") * 2.0).bfloat16()
+        probs = torch.rand(rows, device="cuda", dtype=torch.float32)
+        bound = torch.tensor(live * ffn, dtype=torch.int64, device="cuda")
+        out = batch_invariant.weighted_silu_mul_bounded(y, probs, bound)
+        torch.testing.assert_close(
+            out[:live], _weighted_swiglu_reference(y[:live], probs[:live])
+        )
+        # rows beyond the device bound are neither read nor written: NaN-poison
+        # the tail and require the live rows to stay BITWISE identical
+        y2 = y.clone()
+        y2[live:] = float("nan")
+        out2 = batch_invariant.weighted_silu_mul_bounded(y2, probs, bound)
+        assert torch.equal(out2[:live], out[:live])
+
+
+# ---------------------------------------------------------------------------
+# _moe_sum options
+# ---------------------------------------------------------------------------
+
+
+class TestMoeSumOptions:
+
+    def _setup(self):
+        torch.manual_seed(9)
+        max_tokens, topk, K, E = 64, 4, 128, 8
+        inp = (torch.randn(max_tokens * topk, K, device="cuda")).bfloat16()
+        probs = torch.rand(max_tokens, topk, device="cuda", dtype=torch.float32)
+        routing = torch.randint(0, E, (max_tokens, topk), device="cuda", dtype=torch.int64)
+        return inp, probs, routing, max_tokens, topk, K, E
+
+    def test_unit_weights_fp64_matches_fp64_reference(self):
+        from megatron.core.inference.moe.vllm_fused_moe import _moe_sum
+
+        inp, probs, routing, max_tokens, topk, K, E = self._setup()
+        out = _moe_sum(
+            inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E,
+            apply_weights=False, acc_fp64=True,
+        )
+        ref = (
+            inp.view(max_tokens, topk, K).to(torch.float64).sum(dim=1).to(torch.float32)
+        )
+        assert torch.equal(out, ref)
+
+    def test_default_weighted_fp32_deterministic_and_correct(self):
+        from megatron.core.inference.moe.vllm_fused_moe import _moe_sum
+
+        inp, probs, routing, max_tokens, topk, K, E = self._setup()
+        out = _moe_sum(inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E)
+        # value correctness (tolerance-based: the kernel's acc += v*w compiles
+        # to FMA, which a mul-then-add torch reference cannot match bitwise)
+        ref = torch.zeros(max_tokens, K, device="cuda", dtype=torch.float32)
+        for t in range(topk):
+            ref += inp.view(max_tokens, topk, K)[:, t].float() * probs[:, t : t + 1]
+        torch.testing.assert_close(out, ref)
+        # bitwise repeat-determinism of the default path
+        for _ in range(5):
+            assert torch.equal(
+                _moe_sum(inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E),
+                out,
+            )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end batch invariance (gated / SwiGLU)
+# ---------------------------------------------------------------------------
+
+
+class TestVllmFusedMoeBatchInvariance:
+
+    def test_same_tokens_bitwise_across_cobatch_sizes(self):
+        from megatron.core.inference.moe import ActivationType
+        from megatron.core.inference.moe.vllm_fused_moe import vllm_fused_moe
+
+        torch.manual_seed(11)
+        max_tokens, K, ffn, E, topk = 256, 128, 64, 8, 4
+        hidden = (torch.randn(max_tokens, K, device="cuda") * 0.05).bfloat16()
+        fc1 = (torch.randn(E, 2 * ffn, K, device="cuda") * 0.02).bfloat16()
+        fc2 = (torch.randn(E, K, ffn, device="cuda") * 0.02).bfloat16()
+        routing = torch.stack(
+            [torch.randperm(E, device="cuda")[:topk] for _ in range(max_tokens)]
+        ).long()
+        probs = torch.rand(max_tokens, topk, device="cuda", dtype=torch.float32)
+        probs = probs / probs.sum(-1, keepdim=True)
+
+        def run(valid, hint):
+            with set_batch_invariant_mode(True, backend="triton"):
+                return vllm_fused_moe(
+                    hidden, probs, fc1, fc2,
+                    activation_type=ActivationType.SWIGLU,
+                    num_local_experts=E, local_expert_start=0,
+                    valid_tokens=_vt(valid), routing_map=routing,
+                    num_tokens_hint=hint,
+                )
+
+        # the first 64 tokens, computed in co-batches of different sizes and
+        # hint classes, must be bitwise identical
+        small = run(valid=64, hint=64)[:64]
+        large = run(valid=256, hint=256)[:64]
+        assert torch.equal(small, large)
+
+
+# ---------------------------------------------------------------------------
+# te_native backend registration
+# ---------------------------------------------------------------------------
+
+
+class TestTeNativeBackend:
+
+    def test_backend_registered(self):
+        assert "te_native" in _BATCH_INVARIANT_BACKENDS
+
+    def test_enable_disable_roundtrip(self):
+        from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+            disable_batch_invariant_mode,
+            enable_batch_invariant_mode,
+            get_batch_invariant_backend,
+            is_batch_invariant_mode_enabled,
+        )
+
+        try:
+            enable_batch_invariant_mode("te_native")
+            assert is_batch_invariant_mode_enabled()
+            assert get_batch_invariant_backend() == "te_native"
+            # te_native must NOT reroute aten::mm — native kernels stay
+            a = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+            b = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+            torch.mm(a, b)  # should not raise / not require DeepGEMM
+        finally:
+            disable_batch_invariant_mode()
+        assert not is_batch_invariant_mode_enabled()

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -105,9 +105,7 @@ class TestWeightedSwigluKernels:
         torch.testing.assert_close(out, _weighted_swiglu_reference(y, probs))
         # bitwise repeat-determinism
         for _ in range(5):
-            assert torch.equal(
-                batch_invariant.swiglu_with_probs(y, perm_map, n_used, probs), out
-            )
+            assert torch.equal(batch_invariant.swiglu_with_probs(y, perm_map, n_used, probs), out)
         # row-locality: a row's bits do not depend on co-batch size
         half_out = batch_invariant.swiglu_with_probs(
             y[:128].contiguous(), perm_map[:128], _vt(128), probs[:128]
@@ -123,9 +121,7 @@ class TestWeightedSwigluKernels:
         probs = torch.rand(rows, device="cuda", dtype=torch.float32)
         bound = torch.tensor(live * ffn, dtype=torch.int64, device="cuda")
         out = batch_invariant.weighted_silu_mul_bounded(y, probs, bound)
-        torch.testing.assert_close(
-            out[:live], _weighted_swiglu_reference(y[:live], probs[:live])
-        )
+        torch.testing.assert_close(out[:live], _weighted_swiglu_reference(y[:live], probs[:live]))
         # rows beyond the device bound are neither read nor written: NaN-poison
         # the tail and require the live rows to stay BITWISE identical
         y2 = y.clone()
@@ -154,12 +150,19 @@ class TestMoeSumOptions:
 
         inp, probs, routing, max_tokens, topk, K, E = self._setup()
         out = _moe_sum(
-            inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E,
-            apply_weights=False, acc_fp64=True,
+            inp,
+            probs,
+            max_tokens,
+            topk,
+            K,
+            _vt(max_tokens),
+            routing,
+            0,
+            E,
+            apply_weights=False,
+            acc_fp64=True,
         )
-        ref = (
-            inp.view(max_tokens, topk, K).to(torch.float64).sum(dim=1).to(torch.float32)
-        )
+        ref = inp.view(max_tokens, topk, K).to(torch.float64).sum(dim=1).to(torch.float32)
         assert torch.equal(out, ref)
 
     def test_default_weighted_fp32_deterministic_and_correct(self):
@@ -176,8 +179,7 @@ class TestMoeSumOptions:
         # bitwise repeat-determinism of the default path
         for _ in range(5):
             assert torch.equal(
-                _moe_sum(inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E),
-                out,
+                _moe_sum(inp, probs, max_tokens, topk, K, _vt(max_tokens), routing, 0, E), out
             )
 
 
@@ -206,10 +208,15 @@ class TestVllmFusedMoeBatchInvariance:
         def run(valid, hint):
             with set_batch_invariant_mode(True, backend="triton"):
                 return vllm_fused_moe(
-                    hidden, probs, fc1, fc2,
+                    hidden,
+                    probs,
+                    fc1,
+                    fc2,
                     activation_type=ActivationType.SWIGLU,
-                    num_local_experts=E, local_expert_start=0,
-                    valid_tokens=_vt(valid), routing_map=routing,
+                    num_local_experts=E,
+                    local_expert_start=0,
+                    valid_tokens=_vt(valid),
+                    routing_map=routing,
                     num_tokens_hint=hint,
                 )
 

--- a/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
+++ b/tests/unit_tests/inference/test_vllm_fused_moe_batch_invariant.py
@@ -154,6 +154,22 @@ class TestWeightedSwigluKernels:
         out2 = batch_invariant.weighted_silu_mul_bounded(y2, probs, bound)
         assert torch.equal(out2[:live], out[:live])
 
+    def test_weighted_silu_mul_bounded_grid_size_is_bit_inert(self):
+        # num_programs is an occupancy knob only: the kernel is elementwise
+        # with disjoint per-program index ranges, so any grid size must give
+        # bitwise-identical output (incl. 1184 = the B200 Inductor capture).
+        from megatron.core.inference.moe import batch_invariant
+
+        torch.manual_seed(11)
+        rows, ffn, live = 512, 256, 300
+        y = (torch.randn(rows, 2 * ffn, device="cuda") * 2.0).bfloat16()
+        probs = torch.rand(rows, device="cuda", dtype=torch.float32)
+        bound = torch.tensor(live * ffn, dtype=torch.int64, device="cuda")
+        ref = batch_invariant.weighted_silu_mul_bounded(y, probs, bound)  # derived default
+        for np_ in (1, 148, 1184, 4096):
+            out = batch_invariant.weighted_silu_mul_bounded(y, probs, bound, num_programs=np_)
+            assert torch.equal(out[:live], ref[:live]), f"bits changed at num_programs={np_}"
+
 
 # ---------------------------------------------------------------------------
 # _moe_sum options

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -32,6 +32,19 @@ def test_ep_a2a_overlap_rejects_unsupported_mtp_layer_counts(mtp_num_layers: int
         _make_overlap_config(mtp_num_layers)
 
 
+def test_batch_invariant_backend_rejects_unknown_value_at_construction():
+    # Programmatic construction bypasses argparse's Literal choices, so
+    # __post_init__ must catch typos before model init.
+    with pytest.raises(AssertionError, match="Unknown batch_invariant_backend"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+            batch_invariant_mode=True,
+            batch_invariant_backend="te-native",
+        )
+
+
 def test_gdp_num_householder_defaults_to_three():
     config = TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4)
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

tacked on https://github.com/NVIDIA/Megatron-LM/pull/6521. The first 23 commits are that PR; only the top 2 commits are new here. Will rebase to a clean 2-commit diff once https://github.com/NVIDIA/Megatron-LM/pull/6521 merges; until then, please review only the top 2.

1. Multimem works under batch-invariant mode (cec2534f)
Batch-invariant mode currently forces the ordered software reduce-scatter for the expert-parallel combine, on the assumption that the in-switch NVLS multimem reduction has unspecified summation order and therefore unspecified bits. We measured its semantics, and it is stronger than ordered: the fp32 multimem reduce-scatter returns the correctly-rounded exact sum of its operands — its output matched fp32(fp64_exact_sum) on 100.000% of 16.7M adversarially-constructed channels. An exact sum has no order to vary, so it is batch-invariant by construction, at native speed and with no kernel to maintain.

This commit adds batch_invariant_collective: Literal["ordered", "multimem"] = "ordered" to TransformerConfig. The default is unchanged, and the ordered kernel remains the fallback for non-NVLS paths. bf16 multimem stays excluded — its accumulation truncates and the exact-sum property does not hold there.

2. And therefore true on-policy RL (272c8603)
https://github.com/NVIDIA/Megatron-LM/pull/6521 makes generation batch-invariant; true on-policy RL needs more: the training forward must reproduce generation's bits for the sampled tokens, so the importance ratio is exactly 1 and the policy gradient unbiased. The last structural difference between the two forwards is this combine: inference reduces in-switch, training transports and sums locally — two different summation trees over the same addends.

The exact-sum property is what makes closing this gap simple: an exact sum is reproducible by any fp64 accumulation order, so training does not need to imitate the switch — it only needs to sum exactly. Under batch-invariant mode, the training/scoring unpermute now accumulates in the matching tree: within-rank top-k partials in fp64 where routing probabilities were pre-applied at the activation, one fp32 rounding at the reduce-scatter boundary, cross-rank accumulation matched to the selected collective (multimem → fp64 exact-sum mirror; ordered → the ordered tree). Default paths untouched.

Result: generation ≡ training bitwise, certified in full-learning-rate GRPO — generation–training KL error exactly 0.0 at every step, per-token importance ratio identically 1.0, at a 2% generation overhead vs the same engine with determinism off (NeMo-RL integration: NVIDIA-NeMo/RL#3531).



:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
