### PR TITLE
[MCore] Add SiTU-GLU activation fallbacks

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -594,6 +594,10 @@ if HAVE_TE and is_te_min_version("1.13.0"):
         def __new__(cls, config: TransformerConfig):
 
             layer_type = None
+            if config.use_situ_glu:
+                from megatron.core.fusions.cutedsl_situ_glu import make_situ_glu
+
+                return make_situ_glu(beta1=config.situ_glu_beta1, beta2=config.situ_glu_beta2)
             if config.gated_linear_unit:
                 if config.activation_func == F.silu:
                     layer_type = te.pytorch.ops.SwiGLU

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -594,10 +594,6 @@ if HAVE_TE and is_te_min_version("1.13.0"):
         def __new__(cls, config: TransformerConfig):
 
             layer_type = None
-            if config.use_situ_glu:
-                from megatron.core.fusions.cutedsl_situ_glu import make_situ_glu
-
-                return make_situ_glu(beta1=config.situ_glu_beta1, beta2=config.situ_glu_beta2)
             if config.gated_linear_unit:
                 if config.activation_func == F.silu:
                     layer_type = te.pytorch.ops.SwiGLU
@@ -618,7 +614,16 @@ if HAVE_TE and is_te_min_version("1.13.0"):
             activation_func_kwargs = {}
             if config.activation_func_fp8_input_store:
                 activation_func_kwargs["cache_quantized_input"] = True
-            layer = layer_type(**activation_func_kwargs)
+            if config.use_situ_glu:
+                from megatron.core.fusions.cutedsl_situ_glu import make_situ_glu
+
+                layer = make_situ_glu(
+                    beta1=config.situ_glu_beta1,
+                    beta2=config.situ_glu_beta2,
+                    **activation_func_kwargs,
+                )
+            else:
+                layer = layer_type(**activation_func_kwargs)
             return layer
 
 else:

--- a/megatron/core/fusions/cutedsl_situ_glu.py
+++ b/megatron/core/fusions/cutedsl_situ_glu.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""CuTe DSL SiTU-GLU activation and cuDNN grouped-MLP integration."""
+"""SiTU-GLU activation builders with an MCore-local CuTe DSL fallback."""
 
 from __future__ import annotations
 
-import inspect
 import math
+from collections.abc import Sequence
 from functools import lru_cache
-from typing import Optional
+from typing import Any, Optional
 
 import torch
+from transformer_engine.pytorch.cpu_offload import is_cpu_offload_enabled, mark_activation_offload
+from transformer_engine.pytorch.ops._common import maybe_dequantize
+from transformer_engine.pytorch.ops.op import BasicOperation, OperationContext
+from transformer_engine.pytorch.utils import clear_tensor_data
 
 
 def situ_glu_reference(
@@ -365,347 +369,174 @@ class CuTeDSLSiTUGLU(torch.nn.Module):
         return _SiTUGLUFunction.apply(input_, self.beta1, self.beta2, self.interleave_size)
 
 
-try:
-    from transformer_engine.pytorch.ops import ScaledSwiGLU as _ScaledSwiGLU
-except ImportError:
-    _ScaledSwiGLU = torch.nn.Module
+def _get_te_situ_glu_ops() -> Optional[tuple[type[torch.nn.Module], type[torch.nn.Module]]]:
+    """Import the complete public Transformer Engine SiTU-GLU interface."""
+    try:
+        from transformer_engine.pytorch.ops import ScaledSiTUGLU, SiTUGLU
+    except ImportError:
+        return None
+    return SiTUGLU, ScaledSiTUGLU
 
 
-class ScaledSiTUGLU(_ScaledSwiGLU):
-    """TE scaled activation shell recognized by its fused grouped-MLP matcher."""
+class CuTeDSLScaledSiTUGLU(BasicOperation):
+    """MCore-local scaled SiTU-GLU fallback for TE's operation-fuser interface."""
 
-    def __init__(self, beta1: float = 4.0, beta2: float = 25.0, **kwargs) -> None:
-        super().__init__(**kwargs)
+    num_extra_inputs: int = 1
+
+    def __init__(
+        self,
+        glu_interleave_size: Optional[int] = None,
+        *,
+        activation_recompute_in_mlp: bool = False,
+        beta1: float = 4.0,
+        beta2: float = 25.0,
+    ) -> None:
+        super().__init__()
+        if activation_recompute_in_mlp:
+            raise ValueError(
+                f"{self.__class__.__name__} does not support activation recomputation "
+                "in the fused grouped MLP"
+            )
         self.beta1, self.beta2 = _validate_betas(beta1, beta2)
+        self.glu_interleave_size = glu_interleave_size
+        if self.glu_interleave_size is not None:
+            self.glu_interleave_size = int(self.glu_interleave_size)
+            if self.glu_interleave_size <= 0:
+                raise ValueError("SiTU-GLU interleave size must be positive when set.")
 
-    def _glu_forward(self, input_: torch.Tensor) -> torch.Tensor:
-        # TE's legacy _ScaledGLU API removes interleaving before this callback.
-        return _situ_glu_forward(input_, self.beta1, self.beta2)
+    def op_forward(self, *args, **kwargs) -> None:
+        """Reject direct BasicOperation execution with a hidden scale input."""
+        raise RuntimeError(
+            f"{self.__class__.__name__} expects its row scales as an operation-fuser input."
+        )
 
-    def _glu_backward(self, grad_output: torch.Tensor, input_: torch.Tensor) -> torch.Tensor:
-        # TE's legacy _ScaledGLU API restores interleaving after this callback.
-        return _situ_glu_backward(grad_output, input_, self.beta1, self.beta2)
+    def op_backward(self, *args, **kwargs) -> None:
+        """Reject direct BasicOperation backward with a hidden scale input."""
+        raise RuntimeError(
+            f"{self.__class__.__name__} expects its row scales as an operation-fuser input."
+        )
 
-    def _scaled_glu_forward(self, input_: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
-        """Implement the TE 2.17+ scaled-GLU fallback API."""
+    def fuser_forward(
+        self,
+        basic_op_ctxs: list[OperationContext],
+        input_: torch.Tensor,
+        *,
+        basic_op_extra_inputs: Sequence[Sequence[Optional[torch.Tensor]]],
+        prev_op_grad_output_quantizer: Optional[Any],
+        next_op_input_quantizer: Optional[Any],
+        basic_op_kwargs: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, Sequence[Sequence[Optional[torch.Tensor]]]]:
+        """Apply local SiTU-GLU and the routed-token row scales."""
+        del prev_op_grad_output_quantizer, next_op_input_quantizer, basic_op_kwargs
+        scales = basic_op_extra_inputs[0][0]
+        if torch.is_autocast_enabled():
+            dtype = torch.get_autocast_dtype("cuda")
+        elif isinstance(input_, torch.Tensor):
+            dtype = input_.dtype
+        else:
+            dtype = scales.dtype
+        input_ = maybe_dequantize(input_, dtype)
+        scales = maybe_dequantize(scales, dtype)
         output = _situ_glu_forward(
             input_, self.beta1, self.beta2, int(self.glu_interleave_size or 0)
         )
-        return output * scales.unsqueeze(-1)
+        output = output * scales.unsqueeze(-1)
 
-    def _scaled_glu_backward(
+        ctx = basic_op_ctxs[0]
+        if ctx.requires_grad:
+            if is_cpu_offload_enabled():
+                mark_activation_offload(input_)
+            ctx.input_requires_grad = True
+            ctx.extra_input_requires_grad = scales.requires_grad
+            ctx.dtype = dtype
+            ctx.save_for_backward(input_, scales)
+        return output, [()]
+
+    def fuser_backward(
         self,
+        basic_op_ctxs: list[OperationContext],
         grad_output: torch.Tensor,
-        input_: torch.Tensor,
-        scales: torch.Tensor,
         *,
-        compute_scale_grad: bool,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Implement the TE 2.17+ scaled-dGLU fallback API."""
-        output = None
-        if compute_scale_grad:
-            output = _situ_glu_forward(
-                input_, self.beta1, self.beta2, int(self.glu_interleave_size or 0)
-            )
+        basic_op_grad_extra_outputs: Sequence[Sequence[Optional[torch.Tensor]]],
+    ) -> tuple[
+        torch.Tensor,
+        Sequence[Sequence[Optional[torch.Tensor]]],
+        Sequence[Sequence[Optional[torch.Tensor]]],
+    ]:
+        """Differentiate the local activation and optional row scales."""
+        del basic_op_grad_extra_outputs
+        ctx = basic_op_ctxs[0]
+        input_, scales = ctx.saved_tensors
+        input_ = maybe_dequantize(input_, ctx.dtype)
+        scales = maybe_dequantize(scales, ctx.dtype)
+        grad_output = maybe_dequantize(grad_output, ctx.dtype)
+        interleave_size = int(self.glu_interleave_size or 0)
         grad_input = _situ_glu_backward(
-            grad_output * scales.unsqueeze(-1),
-            input_,
-            self.beta1,
-            self.beta2,
-            int(self.glu_interleave_size or 0),
+            grad_output * scales.unsqueeze(-1), input_, self.beta1, self.beta2, interleave_size
         )
         grad_scales = None
-        if output is not None:
+        if ctx.extra_input_requires_grad:
+            output = _situ_glu_forward(input_, self.beta1, self.beta2, interleave_size)
             grad_scales = torch.linalg.vecdot(output, grad_output)
-        return grad_input, grad_scales
+        clear_tensor_data(ctx.saved_tensors[0])
+        return grad_input, [()], [(grad_scales,)]
 
 
-def make_situ_glu(beta1: float = 4.0, beta2: float = 25.0) -> torch.nn.Module:
-    """Construct native TE SiTU-GLU when available, otherwise the local CuTe fallback."""
+def make_situ_glu(
+    beta1: float = 4.0,
+    beta2: float = 25.0,
+    *,
+    cache_quantized_input: bool = False,
+    glu_interleave_size: Optional[int] = None,
+) -> torch.nn.Module:
+    """Construct native TE SiTU-GLU or the standalone MCore CuTe fallback."""
     beta1, beta2 = _validate_betas(beta1, beta2)
-    try:
-        from transformer_engine.pytorch import ops as te_ops
-    except ImportError:
-        te_ops = None
-    native_cls = getattr(te_ops, "SiTUGLU", None)
-    if native_cls is not None:
-        return native_cls(beta1=beta1, beta2=beta2)
-    return CuTeDSLSiTUGLU(beta1=beta1, beta2=beta2)
+    te_ops = _get_te_situ_glu_ops()
+    if te_ops is not None:
+        situ_glu, _ = te_ops
+        return situ_glu(
+            beta1=beta1,
+            beta2=beta2,
+            cache_quantized_input=cache_quantized_input,
+            glu_interleave_size=glu_interleave_size,
+        )
+    if cache_quantized_input:
+        raise RuntimeError(
+            "activation_func_fp8_input_store for SiTU-GLU requires "
+            "https://github.com/NVIDIA/TransformerEngine/pull/3402."
+        )
+    return CuTeDSLSiTUGLU(beta1=beta1, beta2=beta2, interleave_size=int(glu_interleave_size or 0))
 
 
 def make_scaled_situ_glu(
-    beta1: float = 4.0, beta2: float = 25.0, *, install_grouped_fallback: bool = False, **kwargs
+    beta1: float = 4.0,
+    beta2: float = 25.0,
+    *,
+    glu_interleave_size: Optional[int] = None,
+    activation_recompute_in_mlp: bool = False,
 ) -> torch.nn.Module:
-    """Construct native TE scaled SiTU-GLU or install and use the local fused fallback."""
+    """Construct native TE scaled SiTU-GLU or the MCore CuTe fuser fallback."""
     beta1, beta2 = _validate_betas(beta1, beta2)
-    try:
-        from transformer_engine.pytorch import ops as te_ops
-    except ImportError:
-        te_ops = None
-    native_cls = getattr(te_ops, "ScaledSiTUGLU", None)
-    if native_cls is not None:
-        return native_cls(beta1=beta1, beta2=beta2, **kwargs)
-    if install_grouped_fallback:
-        install_grouped_situ_glu_kernels(beta1, beta2)
-    return ScaledSiTUGLU(beta1=beta1, beta2=beta2, **kwargs)
-
-
-_GROUPED_KERNELS_INSTALLED = False
-_GROUPED_KERNEL_PARAMETERS: Optional[tuple[float, float]] = None
-
-
-def _install_operand_major_mode_compat() -> bool:
-    """Restore the nvgpu re-export expected by cuDNN Frontend 1.26.0."""
-    from cutlass.cute import nvgpu
-
-    if hasattr(nvgpu, "OperandMajorMode"):
-        return False
-    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
-
-    nvgpu.OperandMajorMode = OperandMajorMode
-    return True
-
-
-def _install_nvvm_atomicrmw_compat() -> None:
-    """Bridge the explicit-result NVVM binding used by some CuTe DSL wheels."""
-    nvvm = cutlass._mlir.dialects.nvvm
-    atomicrmw = nvvm.atomicrmw
-    parameters = inspect.signature(atomicrmw).parameters
-    result = parameters.get("res")
-    if result is None or result.default is not inspect.Parameter.empty:
-        return
-    if getattr(atomicrmw, "_mcore_infers_result_type", False):
-        return
-
-    def atomicrmw_with_inferred_result(*args, **kwargs):
-        if not args and "res" not in kwargs:
-            return atomicrmw(kwargs["a"].type, **kwargs)
-        return atomicrmw(*args, **kwargs)
-
-    atomicrmw_with_inferred_result._mcore_infers_result_type = True
-    nvvm.atomicrmw = atomicrmw_with_inferred_result
-
-
-def _install_blockscaled_tiled_mma_compat() -> None:
-    """Adapt the CuTe DSL 4.4 helper to the 4.5 call shape used by cuDNN 1.26."""
-    from cutlass.utils import blackwell_helpers
-
-    make_tiled_mma = blackwell_helpers.make_blockscaled_trivial_tiled_mma
-    parameters = inspect.signature(make_tiled_mma).parameters
-    if "b_dtype" in parameters:
-        return
-    if getattr(make_tiled_mma, "_mcore_accepts_separate_ab_dtypes", False):
-        return
-
-    def make_tiled_mma_with_separate_ab_dtypes(*args, loc=None, ip=None, **kwargs):
-        if "b_dtype" in kwargs:
-            a_dtype = kwargs.pop("a_dtype")
-            b_dtype = kwargs.pop("b_dtype")
-            if a_dtype is not b_dtype:
-                raise TypeError("CuTe DSL 4.4 block-scaled MMA requires matching A/B dtypes.")
-            kwargs["ab_dtype"] = a_dtype
-        elif len(args) >= 2 and inspect.isclass(args[1]):
-            a_dtype, b_dtype = args[:2]
-            if a_dtype is not b_dtype:
-                raise TypeError("CuTe DSL 4.4 block-scaled MMA requires matching A/B dtypes.")
-            args = (a_dtype, *args[2:])
-        return make_tiled_mma(*args, loc=loc, ip=ip, **kwargs)
-
-    make_tiled_mma_with_separate_ab_dtypes._mcore_accepts_separate_ab_dtypes = True
-    blackwell_helpers.make_blockscaled_trivial_tiled_mma = make_tiled_mma_with_separate_ab_dtypes
-
-
-def _install_pointer_property_compat() -> None:
-    """Expose the pointer accessor expected by cuDNN 1.26 on CuTe DSL 4.4."""
-    from cutlass.cute import core
-
-    if hasattr(core._Pointer, "ptr"):
-        return
-    core._Pointer.ptr = property(lambda self: self)
-
-
-def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
-    """Replace cuDNN Frontend's SwiGLU kernel classes before their first compilation."""
-    global _GROUPED_KERNEL_PARAMETERS, _GROUPED_KERNELS_INSTALLED
-    beta1, beta2 = _validate_betas(beta1, beta2)
-    if _GROUPED_KERNELS_INSTALLED:
-        if _GROUPED_KERNEL_PARAMETERS != (beta1, beta2):
-            raise RuntimeError(
-                "Grouped SiTU-GLU kernels are already installed with "
-                f"beta1={_GROUPED_KERNEL_PARAMETERS[0]}, beta2={_GROUPED_KERNEL_PARAMETERS[1]}."
-            )
-        return
-    if not _CUTE_AVAILABLE:
-        raise RuntimeError("Grouped SiTU-GLU requires nvidia-cutlass-dsl.")
-    installed_operand_major_mode_compat = _install_operand_major_mode_compat()
-    _install_blockscaled_tiled_mma_compat()
-    _install_pointer_property_compat()
-    _install_nvvm_atomicrmw_compat()
-
-    from cudnn.grouped_gemm.grouped_gemm_dglu import api as dglu_api
-    from cudnn.grouped_gemm.grouped_gemm_dglu.moe_blockscaled_grouped_gemm_dglu_dbias import (
-        BlockScaledMoEGroupedGemmDgluDbiasKernel,
-    )
-    from cudnn.grouped_gemm.grouped_gemm_glu import api as glu_api
-    from cudnn.grouped_gemm.grouped_gemm_glu.moe_blockscaled_grouped_gemm_glu_bias import (
-        BlockScaledMoEGroupedGemmGluBiasKernel,
-    )
-
-    try:
-        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
-
-        # pylint: disable-next=line-too-long
-        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
-            BlockScaledMoEGroupedGemmGluHadamardKernel,
+    te_ops = _get_te_situ_glu_ops()
+    if te_ops is not None:
+        _, scaled_situ_glu = te_ops
+        return scaled_situ_glu(
+            glu_interleave_size=glu_interleave_size,
+            activation_recompute_in_mlp=activation_recompute_in_mlp,
+            beta1=beta1,
+            beta2=beta2,
         )
-    except ImportError:
-        try:
-            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
-
-            # pylint: disable-next=line-too-long
-            from cudnn.gemm.cutedsl.grouped.glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
-                BlockScaledMoEGroupedGemmGluHadamardKernel,
-            )
-        except ImportError:
-            glu_hadamard_api = None
-            BlockScaledMoEGroupedGemmGluHadamardKernel = None
-
-    required_forward = {"tCompute", "acc_vec_up", "acc_vec_gate", "mProb"}
-    required_backward = {
-        "acc_vec",
-        "ab1_vec_load",
-        "ab2_vec_load",
-        "mProb",
-        "beta_val",
-        "square_alpha",
-        "dprob_swiglu",
-    }
-    if set(inspect.signature(BlockScaledMoEGroupedGemmGluBiasKernel.swiglu_act).parameters) != (
-        required_forward | {"self"}
-    ):
-        raise RuntimeError("Unsupported cuDNN Frontend grouped GLU kernel signature.")
-    if set(inspect.signature(BlockScaledMoEGroupedGemmDgluDbiasKernel.dswiglu).parameters) != (
-        required_backward | {"self"}
-    ):
-        raise RuntimeError("Unsupported cuDNN Frontend grouped dGLU kernel signature.")
-    if BlockScaledMoEGroupedGemmGluHadamardKernel is not None and set(
-        inspect.signature(BlockScaledMoEGroupedGemmGluHadamardKernel.swiglu_act).parameters
-    ) != (required_forward | {"self"}):
-        raise RuntimeError("Unsupported cuDNN Frontend grouped GLU-Hadamard kernel signature.")
-
-    class _SiTUForwardKernel(BlockScaledMoEGroupedGemmGluBiasKernel):
-        @cute.jit
-        def swiglu_act(
-            self, tCompute, acc_vec_up, acc_vec_gate, mProb
-        ):  # pylint: disable=missing-function-docstring
-            inv_beta1 = cutlass.Float32(1.0 / beta1)
-            inv_beta2 = cutlass.Float32(1.0 / beta2)
-            beta_product = cutlass.Float32(beta1 * beta2)
-            for index in cutlass.range_constexpr(cute.size(tCompute)):
-                gate = acc_vec_gate[index]
-                up = acc_vec_up[index]
-                gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
-                up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
-                if cutlass.const_expr(beta1 == 4.0):
-                    reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
-                    sigmoid = 0.5 + gate_tanh * reciprocal
-                else:
-                    sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
-                tCompute[index] = beta_product * gate_tanh * sigmoid * up_tanh * mProb
-
-    class _SiTUBackwardKernel(BlockScaledMoEGroupedGemmDgluDbiasKernel):
-        @cute.jit
-        def dswiglu(
-            self,
-            acc_vec,
-            ab1_vec_load,
-            ab2_vec_load,
-            mProb,
-            beta_val,
-            square_alpha,
-            dprob_swiglu=None,
-        ):  # pylint: disable=missing-function-docstring
-            dgate = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
-            dup = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
-            inv_beta1 = cutlass.Float32(1.0 / beta1)
-            inv_beta2 = cutlass.Float32(1.0 / beta2)
-            for index in cutlass.range_constexpr(cute.size(acc_vec)):
-                grad = acc_vec[index] * square_alpha
-                gate = ab1_vec_load[index].to(self.acc_dtype) * beta_val
-                up = ab2_vec_load[index].to(self.acc_dtype) * beta_val
-                gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
-                up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
-                if cutlass.const_expr(beta1 == 4.0):
-                    reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
-                    sigmoid = 0.5 + gate_tanh * reciprocal
-                    gate_grad = (1.0 - gate_tanh * gate_tanh) * (
-                        0.5 + 2.0 * gate_tanh * reciprocal * reciprocal
-                    )
-                else:
-                    sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
-                    gate_grad = (1.0 - gate_tanh * gate_tanh) * sigmoid
-                    gate_grad += beta1 * gate_tanh * sigmoid * (1.0 - sigmoid)
-                gate_value = beta1 * gate_tanh * sigmoid
-                up_value = beta2 * up_tanh
-                up_grad = 1.0 - up_tanh * up_tanh
-                dgate[index] = grad * mProb * up_value * gate_grad
-                dup[index] = grad * mProb * gate_value * up_grad
-                if cutlass.const_expr(self.generate_dprob):
-                    dprob_swiglu[index] = grad * gate_value * up_value
-            dprob = None
-            if cutlass.const_expr(self.generate_dprob):
-                dprob = dprob_swiglu.load()
-            return dgate.load(), dup.load(), dprob
-
-    if BlockScaledMoEGroupedGemmGluHadamardKernel is not None:
-
-        class _SiTUForwardHadamardKernel(BlockScaledMoEGroupedGemmGluHadamardKernel):
-            @cute.jit
-            def swiglu_act(
-                self, tCompute, acc_vec_up, acc_vec_gate, mProb
-            ):  # pylint: disable=missing-function-docstring
-                inv_beta1 = cutlass.Float32(1.0 / beta1)
-                inv_beta2 = cutlass.Float32(1.0 / beta2)
-                beta_product = cutlass.Float32(beta1 * beta2)
-                for index in cutlass.range_constexpr(cute.size(tCompute)):
-                    gate = acc_vec_gate[index]
-                    up = acc_vec_up[index]
-                    gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
-                    up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
-                    if cutlass.const_expr(beta1 == 4.0):
-                        reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
-                        sigmoid = 0.5 + gate_tanh * reciprocal
-                    else:
-                        sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
-                    tCompute[index] = beta_product * gate_tanh * sigmoid * up_tanh * mProb
-
-    glu_api.BlockScaledMoEGroupedGemmGluBiasKernel = _SiTUForwardKernel
-    dglu_api.BlockScaledMoEGroupedGemmDgluDbiasKernel = _SiTUBackwardKernel
-    glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
-    dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
-    if glu_hadamard_api is not None:
-        glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel = _SiTUForwardHadamardKernel
-        glu_hadamard_api._cache_of_GroupedGemmGluHadamardSm100Objects.clear()
-
-    # CuTe DSL 4.4.2 needs the OperandMajorMode compatibility export above. TE may
-    # have queried support before this hook ran, cached False, and skipped registering
-    # its existing grouped-MLP fusion rule. Re-evaluate and register that TE rule now.
-    if installed_operand_major_mode_compat:
-        from transformer_engine.pytorch.ops.fused import grouped_mlp as te_grouped_mlp
-
-        fused_op = te_grouped_mlp.GroupedMLP_CuTeGEMMGLU
-        fused_op.is_supported.cache_clear()
-        if fused_op.is_supported():
-            te_grouped_mlp.register_forward_backward_fusion(te_grouped_mlp.fuse_ops, prepend=True)
-
-    _GROUPED_KERNEL_PARAMETERS = (beta1, beta2)
-    _GROUPED_KERNELS_INSTALLED = True
+    return CuTeDSLScaledSiTUGLU(
+        glu_interleave_size=glu_interleave_size,
+        activation_recompute_in_mlp=activation_recompute_in_mlp,
+        beta1=beta1,
+        beta2=beta2,
+    )
 
 
 __all__ = [
     "CuTeDSLSiTUGLU",
-    "ScaledSiTUGLU",
-    "install_grouped_situ_glu_kernels",
+    "CuTeDSLScaledSiTUGLU",
     "make_scaled_situ_glu",
     "make_situ_glu",
     "situ_glu_reference",

--- a/megatron/core/fusions/cutedsl_situ_glu.py
+++ b/megatron/core/fusions/cutedsl_situ_glu.py
@@ -331,6 +331,7 @@ class _SiTUGLUFunction(torch.autograd.Function):
     def forward(
         ctx, input_: torch.Tensor, beta1: float, beta2: float, interleave_size: int
     ) -> torch.Tensor:
+        """Run SiTU-GLU forward and save its input for the custom backward."""
         ctx.save_for_backward(input_)
         ctx.beta1 = beta1
         ctx.beta2 = beta2
@@ -339,6 +340,7 @@ class _SiTUGLUFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
+        """Compute the input gradient for the custom SiTU-GLU operation."""
         (input_,) = ctx.saved_tensors
         return (
             _situ_glu_backward(grad_output, input_, ctx.beta1, ctx.beta2, ctx.interleave_size),
@@ -359,6 +361,7 @@ class CuTeDSLSiTUGLU(torch.nn.Module):
             raise ValueError("SiTU-GLU interleave size must be non-negative.")
 
     def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Apply standalone SiTU-GLU to the input tensor."""
         return _SiTUGLUFunction.apply(input_, self.beta1, self.beta2, self.interleave_size)
 
 
@@ -550,12 +553,16 @@ def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
 
     try:
         from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
+
+        # pylint: disable-next=line-too-long
         from cudnn.grouped_gemm.grouped_gemm_glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
             BlockScaledMoEGroupedGemmGluHadamardKernel,
         )
     except ImportError:
         try:
             from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
+
+            # pylint: disable-next=line-too-long
             from cudnn.gemm.cutedsl.grouped.glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
                 BlockScaledMoEGroupedGemmGluHadamardKernel,
             )
@@ -588,7 +595,9 @@ def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
 
     class _SiTUForwardKernel(BlockScaledMoEGroupedGemmGluBiasKernel):
         @cute.jit
-        def swiglu_act(self, tCompute, acc_vec_up, acc_vec_gate, mProb):
+        def swiglu_act(
+            self, tCompute, acc_vec_up, acc_vec_gate, mProb
+        ):  # pylint: disable=missing-function-docstring
             inv_beta1 = cutlass.Float32(1.0 / beta1)
             inv_beta2 = cutlass.Float32(1.0 / beta2)
             beta_product = cutlass.Float32(beta1 * beta2)
@@ -615,7 +624,7 @@ def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
             beta_val,
             square_alpha,
             dprob_swiglu=None,
-        ):
+        ):  # pylint: disable=missing-function-docstring
             dgate = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
             dup = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
             inv_beta1 = cutlass.Float32(1.0 / beta1)
@@ -652,7 +661,9 @@ def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
 
         class _SiTUForwardHadamardKernel(BlockScaledMoEGroupedGemmGluHadamardKernel):
             @cute.jit
-            def swiglu_act(self, tCompute, acc_vec_up, acc_vec_gate, mProb):
+            def swiglu_act(
+                self, tCompute, acc_vec_up, acc_vec_gate, mProb
+            ):  # pylint: disable=missing-function-docstring
                 inv_beta1 = cutlass.Float32(1.0 / beta1)
                 inv_beta2 = cutlass.Float32(1.0 / beta2)
                 beta_product = cutlass.Float32(beta1 * beta2)

--- a/megatron/core/fusions/cutedsl_situ_glu.py
+++ b/megatron/core/fusions/cutedsl_situ_glu.py
@@ -1,0 +1,701 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CuTe DSL SiTU-GLU activation and cuDNN grouped-MLP integration."""
+
+from __future__ import annotations
+
+import inspect
+import math
+from functools import lru_cache
+from typing import Optional
+
+import torch
+
+
+def situ_glu_reference(
+    input_: torch.Tensor, beta1: float = 4.0, beta2: float = 25.0
+) -> torch.Tensor:
+    """Compute SiTU-GLU with the gate in the first half of the last dimension."""
+    gate, up = input_.chunk(2, dim=-1)
+    return (beta1 * torch.tanh(gate / beta1) * torch.sigmoid(gate)) * (
+        beta2 * torch.tanh(up / beta2)
+    )
+
+
+def _validate_betas(beta1: float, beta2: float) -> tuple[float, float]:
+    beta1 = float(beta1)
+    beta2 = float(beta2)
+    if not math.isfinite(beta1) or beta1 <= 0.0:
+        raise ValueError(f"SiTU-GLU beta1 must be finite and positive, got {beta1}.")
+    if not math.isfinite(beta2) or beta2 <= 0.0:
+        raise ValueError(f"SiTU-GLU beta2 must be finite and positive, got {beta2}.")
+    return beta1, beta2
+
+
+try:
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+    _CUTE_AVAILABLE = True
+except ImportError:
+    cuda = None
+    cutlass = None
+    cute = None
+    from_dlpack = None
+    make_fake_stream = None
+    _CUTE_AVAILABLE = False
+
+
+if _CUTE_AVAILABLE:
+
+    @cute.kernel
+    def _situ_glu_forward_kernel(
+        input_: cute.Tensor,
+        output: cute.Tensor,
+        rows: cutlass.Int32,
+        width: cutlass.Int32,
+        beta1: cutlass.Float32,
+        beta2: cutlass.Float32,
+        inv_beta1: cutlass.Float32,
+        inv_beta2: cutlass.Float32,
+        beta_product: cutlass.Float32,
+        interleave_size: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        index = bidx * 256 + tidx
+        elements = rows * width
+        if index < elements:
+            row = index // width
+            col = index - row * width
+            gate_col = col
+            up_col = col + width
+            if interleave_size > 0:
+                block = col // interleave_size
+                offset = col - block * interleave_size
+                gate_col = block * 2 * interleave_size + offset
+                up_col = gate_col + interleave_size
+            gate = cutlass.Float32(input_[row, gate_col])
+            up = cutlass.Float32(input_[row, up_col])
+            gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
+            up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
+            sigmoid = cutlass.Float32(0.0)
+            if beta1 == cutlass.Float32(4.0):
+                reciprocal = cute.arch.rcp_approx(cutlass.Float32(1.0) + gate_tanh * gate_tanh)
+                sigmoid = cutlass.Float32(0.5) + gate_tanh * reciprocal
+            else:
+                sigmoid = cute.arch.rcp_approx(
+                    cutlass.Float32(1.0) + cute.math.exp(-gate, fastmath=True)
+                )
+            output[row, col] = (beta_product * gate_tanh * sigmoid * up_tanh).to(
+                output.element_type
+            )
+
+    @cute.jit
+    def _situ_glu_forward_launch(
+        input_: cute.Tensor,
+        output: cute.Tensor,
+        rows: cutlass.Int32,
+        width: cutlass.Int32,
+        beta1: cutlass.Float32,
+        beta2: cutlass.Float32,
+        inv_beta1: cutlass.Float32,
+        inv_beta2: cutlass.Float32,
+        beta_product: cutlass.Float32,
+        interleave_size: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        _situ_glu_forward_kernel(
+            input_,
+            output,
+            rows,
+            width,
+            beta1,
+            beta2,
+            inv_beta1,
+            inv_beta2,
+            beta_product,
+            interleave_size,
+        ).launch(grid=(cute.ceil_div(rows * width, 256), 1, 1), block=(256, 1, 1), stream=stream)
+
+    @cute.kernel
+    def _situ_glu_backward_kernel(
+        grad_output: cute.Tensor,
+        input_: cute.Tensor,
+        grad_input: cute.Tensor,
+        rows: cutlass.Int32,
+        width: cutlass.Int32,
+        beta1: cutlass.Float32,
+        beta2: cutlass.Float32,
+        inv_beta1: cutlass.Float32,
+        inv_beta2: cutlass.Float32,
+        interleave_size: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        index = bidx * 256 + tidx
+        elements = rows * width
+        if index < elements:
+            row = index // width
+            col = index - row * width
+            grad = cutlass.Float32(grad_output[row, col])
+            gate_col = col
+            up_col = col + width
+            if interleave_size > 0:
+                block = col // interleave_size
+                offset = col - block * interleave_size
+                gate_col = block * 2 * interleave_size + offset
+                up_col = gate_col + interleave_size
+            gate = cutlass.Float32(input_[row, gate_col])
+            up = cutlass.Float32(input_[row, up_col])
+            gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
+            up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
+            sigmoid = cutlass.Float32(0.0)
+            gate_grad = cutlass.Float32(0.0)
+            if beta1 == cutlass.Float32(4.0):
+                reciprocal = cute.arch.rcp_approx(cutlass.Float32(1.0) + gate_tanh * gate_tanh)
+                sigmoid = cutlass.Float32(0.5) + gate_tanh * reciprocal
+                gate_grad = (cutlass.Float32(1.0) - gate_tanh * gate_tanh) * (
+                    cutlass.Float32(0.5)
+                    + cutlass.Float32(2.0) * gate_tanh * reciprocal * reciprocal
+                )
+            else:
+                sigmoid = cute.arch.rcp_approx(
+                    cutlass.Float32(1.0) + cute.math.exp(-gate, fastmath=True)
+                )
+                gate_grad = (cutlass.Float32(1.0) - gate_tanh * gate_tanh) * sigmoid
+                gate_grad += beta1 * gate_tanh * sigmoid * (cutlass.Float32(1.0) - sigmoid)
+            gate_value = beta1 * gate_tanh * sigmoid
+            up_value = beta2 * up_tanh
+            up_grad = cutlass.Float32(1.0) - up_tanh * up_tanh
+            grad_input[row, gate_col] = (grad * up_value * gate_grad).to(grad_input.element_type)
+            grad_input[row, up_col] = (grad * gate_value * up_grad).to(grad_input.element_type)
+
+    @cute.jit
+    def _situ_glu_backward_launch(
+        grad_output: cute.Tensor,
+        input_: cute.Tensor,
+        grad_input: cute.Tensor,
+        rows: cutlass.Int32,
+        width: cutlass.Int32,
+        beta1: cutlass.Float32,
+        beta2: cutlass.Float32,
+        inv_beta1: cutlass.Float32,
+        inv_beta2: cutlass.Float32,
+        interleave_size: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        _situ_glu_backward_kernel(
+            grad_output,
+            input_,
+            grad_input,
+            rows,
+            width,
+            beta1,
+            beta2,
+            inv_beta1,
+            inv_beta2,
+            interleave_size,
+        ).launch(grid=(cute.ceil_div(rows * width, 256), 1, 1), block=(256, 1, 1), stream=stream)
+
+
+def _gpu_arch() -> str:
+    capability = torch.cuda.get_device_capability()
+    arch = {(9, 0): "sm_90a", (10, 0): "sm_100a", (10, 3): "sm_103a"}.get(capability)
+    if arch is None:
+        raise RuntimeError(
+            f"SiTU-GLU CuTe DSL kernels do not support compute capability {capability}."
+        )
+    return arch
+
+
+def _cute_tensor(tensor: torch.Tensor):
+    tensor = from_dlpack(tensor.detach(), assumed_align=16, enable_tvm_ffi=True)
+    return tensor.mark_layout_dynamic(leading_dim=1)
+
+
+@lru_cache(maxsize=None)
+def _compile_forward(dtype: torch.dtype, device_index: int, rows: int, double_width: int):
+    with torch.cuda.device(device_index):
+        fake_input = torch.empty((rows, double_width), device="cuda", dtype=dtype)
+        fake_output = torch.empty((rows, double_width // 2), device="cuda", dtype=dtype)
+        return cute.compile(
+            _situ_glu_forward_launch,
+            _cute_tensor(fake_input),
+            _cute_tensor(fake_output),
+            cutlass.Int32(1),
+            cutlass.Int32(1),
+            cutlass.Float32(4.0),
+            cutlass.Float32(25.0),
+            cutlass.Float32(0.25),
+            cutlass.Float32(0.04),
+            cutlass.Float32(100.0),
+            cutlass.Int32(0),
+            make_fake_stream(use_tvm_ffi_env_stream=False),
+            options=f"--enable-tvm-ffi --gpu-arch {_gpu_arch()}",
+        )
+
+
+@lru_cache(maxsize=None)
+def _compile_backward(dtype: torch.dtype, device_index: int, rows: int, double_width: int):
+    with torch.cuda.device(device_index):
+        fake_grad = torch.empty((rows, double_width // 2), device="cuda", dtype=dtype)
+        fake_input = torch.empty((rows, double_width), device="cuda", dtype=dtype)
+        return cute.compile(
+            _situ_glu_backward_launch,
+            _cute_tensor(fake_grad),
+            _cute_tensor(fake_input),
+            _cute_tensor(fake_input),
+            cutlass.Int32(1),
+            cutlass.Int32(1),
+            cutlass.Float32(4.0),
+            cutlass.Float32(25.0),
+            cutlass.Float32(0.25),
+            cutlass.Float32(0.04),
+            cutlass.Int32(0),
+            make_fake_stream(use_tvm_ffi_env_stream=False),
+            options=f"--enable-tvm-ffi --gpu-arch {_gpu_arch()}",
+        )
+
+
+def _validate_input(input_: torch.Tensor, interleave_size: int = 0) -> torch.Tensor:
+    if not _CUTE_AVAILABLE:
+        raise RuntimeError("SiTU-GLU requires the nvidia-cutlass-dsl package.")
+    if not input_.is_cuda:
+        raise ValueError("SiTU-GLU CuTe DSL kernels require a CUDA tensor.")
+    if input_.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError("SiTU-GLU CuTe DSL kernels support BF16 and FP16 tensors.")
+    if input_.shape[-1] % 2:
+        raise ValueError("SiTU-GLU input width must be even.")
+    if interleave_size < 0:
+        raise ValueError("SiTU-GLU interleave size must be non-negative.")
+    if interleave_size and input_.shape[-1] % (2 * interleave_size):
+        raise ValueError("SiTU-GLU input width must be divisible by twice the interleave size.")
+    return input_.contiguous().view(-1, input_.shape[-1])
+
+
+def _situ_glu_forward(
+    input_: torch.Tensor, beta1: float, beta2: float, interleave_size: int = 0
+) -> torch.Tensor:
+    input_2d = _validate_input(input_, interleave_size)
+    rows, double_width = input_2d.shape
+    output = torch.empty((rows, double_width // 2), device=input_.device, dtype=input_.dtype)
+    launcher = _compile_forward(input_.dtype, input_.device.index, rows, double_width)
+    launcher(
+        input_2d,
+        output,
+        cutlass.Int32(rows),
+        cutlass.Int32(double_width // 2),
+        cutlass.Float32(beta1),
+        cutlass.Float32(beta2),
+        cutlass.Float32(1.0 / beta1),
+        cutlass.Float32(1.0 / beta2),
+        cutlass.Float32(beta1 * beta2),
+        cutlass.Int32(interleave_size),
+        cuda.CUstream(torch.cuda.current_stream(input_.device).cuda_stream),
+    )
+    return output.view(*input_.shape[:-1], double_width // 2)
+
+
+def _situ_glu_backward(
+    grad_output: torch.Tensor,
+    input_: torch.Tensor,
+    beta1: float,
+    beta2: float,
+    interleave_size: int = 0,
+) -> torch.Tensor:
+    input_2d = _validate_input(input_, interleave_size)
+    grad_output_2d = grad_output.contiguous().view(-1, grad_output.shape[-1])
+    grad_input = torch.empty_like(input_2d)
+    rows, double_width = input_2d.shape
+    launcher = _compile_backward(input_.dtype, input_.device.index, rows, double_width)
+    launcher(
+        grad_output_2d,
+        input_2d,
+        grad_input,
+        cutlass.Int32(rows),
+        cutlass.Int32(double_width // 2),
+        cutlass.Float32(beta1),
+        cutlass.Float32(beta2),
+        cutlass.Float32(1.0 / beta1),
+        cutlass.Float32(1.0 / beta2),
+        cutlass.Int32(interleave_size),
+        cuda.CUstream(torch.cuda.current_stream(input_.device).cuda_stream),
+    )
+    return grad_input.view_as(input_)
+
+
+class _SiTUGLUFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx, input_: torch.Tensor, beta1: float, beta2: float, interleave_size: int
+    ) -> torch.Tensor:
+        ctx.save_for_backward(input_)
+        ctx.beta1 = beta1
+        ctx.beta2 = beta2
+        ctx.interleave_size = interleave_size
+        return _situ_glu_forward(input_, beta1, beta2, interleave_size)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (input_,) = ctx.saved_tensors
+        return (
+            _situ_glu_backward(grad_output, input_, ctx.beta1, ctx.beta2, ctx.interleave_size),
+            None,
+            None,
+            None,
+        )
+
+
+class CuTeDSLSiTUGLU(torch.nn.Module):
+    """Standalone SiTU-GLU used by shared experts and unfused routed experts."""
+
+    def __init__(self, beta1: float = 4.0, beta2: float = 25.0, interleave_size: int = 0) -> None:
+        super().__init__()
+        self.beta1, self.beta2 = _validate_betas(beta1, beta2)
+        self.interleave_size = int(interleave_size)
+        if self.interleave_size < 0:
+            raise ValueError("SiTU-GLU interleave size must be non-negative.")
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        return _SiTUGLUFunction.apply(input_, self.beta1, self.beta2, self.interleave_size)
+
+
+try:
+    from transformer_engine.pytorch.ops import ScaledSwiGLU as _ScaledSwiGLU
+except ImportError:
+    _ScaledSwiGLU = torch.nn.Module
+
+
+class ScaledSiTUGLU(_ScaledSwiGLU):
+    """TE scaled activation shell recognized by its fused grouped-MLP matcher."""
+
+    def __init__(self, beta1: float = 4.0, beta2: float = 25.0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.beta1, self.beta2 = _validate_betas(beta1, beta2)
+
+    def _glu_forward(self, input_: torch.Tensor) -> torch.Tensor:
+        # TE's legacy _ScaledGLU API removes interleaving before this callback.
+        return _situ_glu_forward(input_, self.beta1, self.beta2)
+
+    def _glu_backward(self, grad_output: torch.Tensor, input_: torch.Tensor) -> torch.Tensor:
+        # TE's legacy _ScaledGLU API restores interleaving after this callback.
+        return _situ_glu_backward(grad_output, input_, self.beta1, self.beta2)
+
+    def _scaled_glu_forward(self, input_: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+        """Implement the TE 2.17+ scaled-GLU fallback API."""
+        output = _situ_glu_forward(
+            input_, self.beta1, self.beta2, int(self.glu_interleave_size or 0)
+        )
+        return output * scales.unsqueeze(-1)
+
+    def _scaled_glu_backward(
+        self,
+        grad_output: torch.Tensor,
+        input_: torch.Tensor,
+        scales: torch.Tensor,
+        *,
+        compute_scale_grad: bool,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Implement the TE 2.17+ scaled-dGLU fallback API."""
+        output = None
+        if compute_scale_grad:
+            output = _situ_glu_forward(
+                input_, self.beta1, self.beta2, int(self.glu_interleave_size or 0)
+            )
+        grad_input = _situ_glu_backward(
+            grad_output * scales.unsqueeze(-1),
+            input_,
+            self.beta1,
+            self.beta2,
+            int(self.glu_interleave_size or 0),
+        )
+        grad_scales = None
+        if output is not None:
+            grad_scales = torch.linalg.vecdot(output, grad_output)
+        return grad_input, grad_scales
+
+
+def make_situ_glu(beta1: float = 4.0, beta2: float = 25.0) -> torch.nn.Module:
+    """Construct native TE SiTU-GLU when available, otherwise the local CuTe fallback."""
+    beta1, beta2 = _validate_betas(beta1, beta2)
+    try:
+        from transformer_engine.pytorch import ops as te_ops
+    except ImportError:
+        te_ops = None
+    native_cls = getattr(te_ops, "SiTUGLU", None)
+    if native_cls is not None:
+        return native_cls(beta1=beta1, beta2=beta2)
+    return CuTeDSLSiTUGLU(beta1=beta1, beta2=beta2)
+
+
+def make_scaled_situ_glu(
+    beta1: float = 4.0, beta2: float = 25.0, *, install_grouped_fallback: bool = False, **kwargs
+) -> torch.nn.Module:
+    """Construct native TE scaled SiTU-GLU or install and use the local fused fallback."""
+    beta1, beta2 = _validate_betas(beta1, beta2)
+    try:
+        from transformer_engine.pytorch import ops as te_ops
+    except ImportError:
+        te_ops = None
+    native_cls = getattr(te_ops, "ScaledSiTUGLU", None)
+    if native_cls is not None:
+        return native_cls(beta1=beta1, beta2=beta2, **kwargs)
+    if install_grouped_fallback:
+        install_grouped_situ_glu_kernels(beta1, beta2)
+    return ScaledSiTUGLU(beta1=beta1, beta2=beta2, **kwargs)
+
+
+_GROUPED_KERNELS_INSTALLED = False
+_GROUPED_KERNEL_PARAMETERS: Optional[tuple[float, float]] = None
+
+
+def _install_operand_major_mode_compat() -> bool:
+    """Restore the nvgpu re-export expected by cuDNN Frontend 1.26.0."""
+    from cutlass.cute import nvgpu
+
+    if hasattr(nvgpu, "OperandMajorMode"):
+        return False
+    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
+
+    nvgpu.OperandMajorMode = OperandMajorMode
+    return True
+
+
+def _install_nvvm_atomicrmw_compat() -> None:
+    """Bridge the explicit-result NVVM binding used by some CuTe DSL wheels."""
+    nvvm = cutlass._mlir.dialects.nvvm
+    atomicrmw = nvvm.atomicrmw
+    parameters = inspect.signature(atomicrmw).parameters
+    result = parameters.get("res")
+    if result is None or result.default is not inspect.Parameter.empty:
+        return
+    if getattr(atomicrmw, "_mcore_infers_result_type", False):
+        return
+
+    def atomicrmw_with_inferred_result(*args, **kwargs):
+        if not args and "res" not in kwargs:
+            return atomicrmw(kwargs["a"].type, **kwargs)
+        return atomicrmw(*args, **kwargs)
+
+    atomicrmw_with_inferred_result._mcore_infers_result_type = True
+    nvvm.atomicrmw = atomicrmw_with_inferred_result
+
+
+def _install_blockscaled_tiled_mma_compat() -> None:
+    """Adapt the CuTe DSL 4.4 helper to the 4.5 call shape used by cuDNN 1.26."""
+    from cutlass.utils import blackwell_helpers
+
+    make_tiled_mma = blackwell_helpers.make_blockscaled_trivial_tiled_mma
+    parameters = inspect.signature(make_tiled_mma).parameters
+    if "b_dtype" in parameters:
+        return
+    if getattr(make_tiled_mma, "_mcore_accepts_separate_ab_dtypes", False):
+        return
+
+    def make_tiled_mma_with_separate_ab_dtypes(*args, loc=None, ip=None, **kwargs):
+        if "b_dtype" in kwargs:
+            a_dtype = kwargs.pop("a_dtype")
+            b_dtype = kwargs.pop("b_dtype")
+            if a_dtype is not b_dtype:
+                raise TypeError("CuTe DSL 4.4 block-scaled MMA requires matching A/B dtypes.")
+            kwargs["ab_dtype"] = a_dtype
+        elif len(args) >= 2 and inspect.isclass(args[1]):
+            a_dtype, b_dtype = args[:2]
+            if a_dtype is not b_dtype:
+                raise TypeError("CuTe DSL 4.4 block-scaled MMA requires matching A/B dtypes.")
+            args = (a_dtype, *args[2:])
+        return make_tiled_mma(*args, loc=loc, ip=ip, **kwargs)
+
+    make_tiled_mma_with_separate_ab_dtypes._mcore_accepts_separate_ab_dtypes = True
+    blackwell_helpers.make_blockscaled_trivial_tiled_mma = make_tiled_mma_with_separate_ab_dtypes
+
+
+def _install_pointer_property_compat() -> None:
+    """Expose the pointer accessor expected by cuDNN 1.26 on CuTe DSL 4.4."""
+    from cutlass.cute import core
+
+    if hasattr(core._Pointer, "ptr"):
+        return
+    core._Pointer.ptr = property(lambda self: self)
+
+
+def install_grouped_situ_glu_kernels(beta1: float, beta2: float) -> None:
+    """Replace cuDNN Frontend's SwiGLU kernel classes before their first compilation."""
+    global _GROUPED_KERNEL_PARAMETERS, _GROUPED_KERNELS_INSTALLED
+    beta1, beta2 = _validate_betas(beta1, beta2)
+    if _GROUPED_KERNELS_INSTALLED:
+        if _GROUPED_KERNEL_PARAMETERS != (beta1, beta2):
+            raise RuntimeError(
+                "Grouped SiTU-GLU kernels are already installed with "
+                f"beta1={_GROUPED_KERNEL_PARAMETERS[0]}, beta2={_GROUPED_KERNEL_PARAMETERS[1]}."
+            )
+        return
+    if not _CUTE_AVAILABLE:
+        raise RuntimeError("Grouped SiTU-GLU requires nvidia-cutlass-dsl.")
+    installed_operand_major_mode_compat = _install_operand_major_mode_compat()
+    _install_blockscaled_tiled_mma_compat()
+    _install_pointer_property_compat()
+    _install_nvvm_atomicrmw_compat()
+
+    from cudnn.grouped_gemm.grouped_gemm_dglu import api as dglu_api
+    from cudnn.grouped_gemm.grouped_gemm_dglu.moe_blockscaled_grouped_gemm_dglu_dbias import (
+        BlockScaledMoEGroupedGemmDgluDbiasKernel,
+    )
+    from cudnn.grouped_gemm.grouped_gemm_glu import api as glu_api
+    from cudnn.grouped_gemm.grouped_gemm_glu.moe_blockscaled_grouped_gemm_glu_bias import (
+        BlockScaledMoEGroupedGemmGluBiasKernel,
+    )
+
+    try:
+        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
+        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
+            BlockScaledMoEGroupedGemmGluHadamardKernel,
+        )
+    except ImportError:
+        try:
+            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
+            from cudnn.gemm.cutedsl.grouped.glu_hadamard.moe_blockscaled_grouped_gemm_glu_hadamard import (
+                BlockScaledMoEGroupedGemmGluHadamardKernel,
+            )
+        except ImportError:
+            glu_hadamard_api = None
+            BlockScaledMoEGroupedGemmGluHadamardKernel = None
+
+    required_forward = {"tCompute", "acc_vec_up", "acc_vec_gate", "mProb"}
+    required_backward = {
+        "acc_vec",
+        "ab1_vec_load",
+        "ab2_vec_load",
+        "mProb",
+        "beta_val",
+        "square_alpha",
+        "dprob_swiglu",
+    }
+    if set(inspect.signature(BlockScaledMoEGroupedGemmGluBiasKernel.swiglu_act).parameters) != (
+        required_forward | {"self"}
+    ):
+        raise RuntimeError("Unsupported cuDNN Frontend grouped GLU kernel signature.")
+    if set(inspect.signature(BlockScaledMoEGroupedGemmDgluDbiasKernel.dswiglu).parameters) != (
+        required_backward | {"self"}
+    ):
+        raise RuntimeError("Unsupported cuDNN Frontend grouped dGLU kernel signature.")
+    if BlockScaledMoEGroupedGemmGluHadamardKernel is not None and set(
+        inspect.signature(BlockScaledMoEGroupedGemmGluHadamardKernel.swiglu_act).parameters
+    ) != (required_forward | {"self"}):
+        raise RuntimeError("Unsupported cuDNN Frontend grouped GLU-Hadamard kernel signature.")
+
+    class _SiTUForwardKernel(BlockScaledMoEGroupedGemmGluBiasKernel):
+        @cute.jit
+        def swiglu_act(self, tCompute, acc_vec_up, acc_vec_gate, mProb):
+            inv_beta1 = cutlass.Float32(1.0 / beta1)
+            inv_beta2 = cutlass.Float32(1.0 / beta2)
+            beta_product = cutlass.Float32(beta1 * beta2)
+            for index in cutlass.range_constexpr(cute.size(tCompute)):
+                gate = acc_vec_gate[index]
+                up = acc_vec_up[index]
+                gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
+                up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
+                if cutlass.const_expr(beta1 == 4.0):
+                    reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
+                    sigmoid = 0.5 + gate_tanh * reciprocal
+                else:
+                    sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
+                tCompute[index] = beta_product * gate_tanh * sigmoid * up_tanh * mProb
+
+    class _SiTUBackwardKernel(BlockScaledMoEGroupedGemmDgluDbiasKernel):
+        @cute.jit
+        def dswiglu(
+            self,
+            acc_vec,
+            ab1_vec_load,
+            ab2_vec_load,
+            mProb,
+            beta_val,
+            square_alpha,
+            dprob_swiglu=None,
+        ):
+            dgate = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            dup = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            inv_beta1 = cutlass.Float32(1.0 / beta1)
+            inv_beta2 = cutlass.Float32(1.0 / beta2)
+            for index in cutlass.range_constexpr(cute.size(acc_vec)):
+                grad = acc_vec[index] * square_alpha
+                gate = ab1_vec_load[index].to(self.acc_dtype) * beta_val
+                up = ab2_vec_load[index].to(self.acc_dtype) * beta_val
+                gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
+                up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
+                if cutlass.const_expr(beta1 == 4.0):
+                    reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
+                    sigmoid = 0.5 + gate_tanh * reciprocal
+                    gate_grad = (1.0 - gate_tanh * gate_tanh) * (
+                        0.5 + 2.0 * gate_tanh * reciprocal * reciprocal
+                    )
+                else:
+                    sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
+                    gate_grad = (1.0 - gate_tanh * gate_tanh) * sigmoid
+                    gate_grad += beta1 * gate_tanh * sigmoid * (1.0 - sigmoid)
+                gate_value = beta1 * gate_tanh * sigmoid
+                up_value = beta2 * up_tanh
+                up_grad = 1.0 - up_tanh * up_tanh
+                dgate[index] = grad * mProb * up_value * gate_grad
+                dup[index] = grad * mProb * gate_value * up_grad
+                if cutlass.const_expr(self.generate_dprob):
+                    dprob_swiglu[index] = grad * gate_value * up_value
+            dprob = None
+            if cutlass.const_expr(self.generate_dprob):
+                dprob = dprob_swiglu.load()
+            return dgate.load(), dup.load(), dprob
+
+    if BlockScaledMoEGroupedGemmGluHadamardKernel is not None:
+
+        class _SiTUForwardHadamardKernel(BlockScaledMoEGroupedGemmGluHadamardKernel):
+            @cute.jit
+            def swiglu_act(self, tCompute, acc_vec_up, acc_vec_gate, mProb):
+                inv_beta1 = cutlass.Float32(1.0 / beta1)
+                inv_beta2 = cutlass.Float32(1.0 / beta2)
+                beta_product = cutlass.Float32(beta1 * beta2)
+                for index in cutlass.range_constexpr(cute.size(tCompute)):
+                    gate = acc_vec_gate[index]
+                    up = acc_vec_up[index]
+                    gate_tanh = cute.math.tanh(gate * inv_beta1, fastmath=True)
+                    up_tanh = cute.math.tanh(up * inv_beta2, fastmath=True)
+                    if cutlass.const_expr(beta1 == 4.0):
+                        reciprocal = cute.arch.rcp_approx(1.0 + gate_tanh * gate_tanh)
+                        sigmoid = 0.5 + gate_tanh * reciprocal
+                    else:
+                        sigmoid = cute.arch.rcp_approx(1.0 + cute.math.exp(-gate, fastmath=True))
+                    tCompute[index] = beta_product * gate_tanh * sigmoid * up_tanh * mProb
+
+    glu_api.BlockScaledMoEGroupedGemmGluBiasKernel = _SiTUForwardKernel
+    dglu_api.BlockScaledMoEGroupedGemmDgluDbiasKernel = _SiTUBackwardKernel
+    glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
+    dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
+    if glu_hadamard_api is not None:
+        glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel = _SiTUForwardHadamardKernel
+        glu_hadamard_api._cache_of_GroupedGemmGluHadamardSm100Objects.clear()
+
+    # CuTe DSL 4.4.2 needs the OperandMajorMode compatibility export above. TE may
+    # have queried support before this hook ran, cached False, and skipped registering
+    # its existing grouped-MLP fusion rule. Re-evaluate and register that TE rule now.
+    if installed_operand_major_mode_compat:
+        from transformer_engine.pytorch.ops.fused import grouped_mlp as te_grouped_mlp
+
+        fused_op = te_grouped_mlp.GroupedMLP_CuTeGEMMGLU
+        fused_op.is_supported.cache_clear()
+        if fused_op.is_supported():
+            te_grouped_mlp.register_forward_backward_fusion(te_grouped_mlp.fuse_ops, prepend=True)
+
+    _GROUPED_KERNEL_PARAMETERS = (beta1, beta2)
+    _GROUPED_KERNELS_INSTALLED = True
+
+
+__all__ = [
+    "CuTeDSLSiTUGLU",
+    "ScaledSiTUGLU",
+    "install_grouped_situ_glu_kernels",
+    "make_scaled_situ_glu",
+    "make_situ_glu",
+    "situ_glu_reference",
+]

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -425,6 +425,11 @@ class TEGroupedMLP(MegatronModule):
         )
         if not (use_glu_fusion or use_srelu_fusion):
             return False
+        if getattr(self.config, "use_situ_glu", False):
+            if self.config.activation_func != F.silu:
+                return False
+            if self.config.moe_mlp_glu_interleave_size != 32:
+                return False
         if self.config.activation_func == F.silu:
             if self.config.activation_func_clamp_value is not None:
                 if not is_te_min_version("2.17.0.dev0"):
@@ -537,7 +542,22 @@ class TEGroupedMLP(MegatronModule):
         # Activation and post-multiply probs (SwiGLU, clamped GLU, or SReLU).
         glu_interleave = self.config.moe_mlp_glu_interleave_size
         activation_recompute_in_mlp = bool(getattr(self, "activation_recompute", False))
-        if self.config.activation_func == F.silu and self.config.gated_linear_unit:
+        if getattr(self.config, "use_situ_glu", False):
+            from megatron.core.fusions.cutedsl_situ_glu import make_scaled_situ_glu
+
+            situ_kwargs = {"glu_interleave_size": glu_interleave}
+            if (
+                "activation_recompute_in_mlp"
+                in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
+            ):
+                situ_kwargs["activation_recompute_in_mlp"] = activation_recompute_in_mlp
+            op = make_scaled_situ_glu(
+                beta1=self.config.situ_glu_beta1,
+                beta2=self.config.situ_glu_beta2,
+                install_grouped_fallback=bool(self.config.fp8 or self.config.fp4),
+                **situ_kwargs,
+            )
+        elif self.config.activation_func == F.silu and self.config.gated_linear_unit:
             clamp_value = self.config.activation_func_clamp_value
             if clamp_value is not None:
                 clamped_glu_kwargs = {

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -545,17 +545,11 @@ class TEGroupedMLP(MegatronModule):
         if getattr(self.config, "use_situ_glu", False):
             from megatron.core.fusions.cutedsl_situ_glu import make_scaled_situ_glu
 
-            situ_kwargs = {"glu_interleave_size": glu_interleave}
-            if (
-                "activation_recompute_in_mlp"
-                in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
-            ):
-                situ_kwargs["activation_recompute_in_mlp"] = activation_recompute_in_mlp
             op = make_scaled_situ_glu(
                 beta1=self.config.situ_glu_beta1,
                 beta2=self.config.situ_glu_beta2,
-                install_grouped_fallback=bool(self.config.fp8 or self.config.fp4),
-                **situ_kwargs,
+                glu_interleave_size=glu_interleave,
+                activation_recompute_in_mlp=activation_recompute_in_mlp,
             )
         elif self.config.activation_func == F.silu and self.config.gated_linear_unit:
             clamp_value = self.config.activation_func_clamp_value

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -437,6 +437,11 @@ class FusedSharedExpertMLP(SharedExpertMLP):
                 "moe_shared_expert_glu_interleave_size to be set when "
                 "use_grouped_gemm_for_shared_expert=True."
             )
+        if (
+            getattr(self.config, "use_situ_glu", False)
+            and self.config.moe_shared_expert_glu_interleave_size != 32
+        ):
+            raise ValueError("Fused shared-expert SiTU-GLU requires 32-wide GLU interleaving.")
         if not isinstance(self.linear_fc1, te.pytorch.Linear):
             raise ValueError(
                 f"{self.__class__.__name__} expects FC1 to be Transformer Engine Linear, "
@@ -491,7 +496,16 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         ops.append(op)
 
         clamp_value = self.config.activation_func_clamp_value
-        if clamp_value is None:
+        if getattr(self.config, "use_situ_glu", False):
+            from megatron.core.fusions.cutedsl_situ_glu import make_scaled_situ_glu
+
+            activation_op = make_scaled_situ_glu(
+                beta1=self.config.situ_glu_beta1,
+                beta2=self.config.situ_glu_beta2,
+                install_grouped_fallback=True,
+                glu_interleave_size=glu_interleave_size,
+            )
+        elif clamp_value is None:
             activation_op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size)
         else:
             activation_op = te.pytorch.ops.ScaledClampedQGeGLU(

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -502,7 +502,6 @@ class FusedSharedExpertMLP(SharedExpertMLP):
             activation_op = make_scaled_situ_glu(
                 beta1=self.config.situ_glu_beta1,
                 beta2=self.config.situ_glu_beta2,
-                install_grouped_fallback=True,
                 glu_interleave_size=glu_interleave_size,
             )
         elif clamp_value is None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1170,6 +1170,18 @@ class TransformerConfig(ModelParallelConfig):
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
 
+    use_situ_glu: bool = False
+    """Use SiTU-GLU in every gated dense, routed-expert, and shared-expert FFN."""
+
+    situ_glu_impl: Literal['cutedsl'] = "cutedsl"
+    """SiTU-GLU implementation backend. Only the MCore CuTe DSL fallback is available."""
+
+    situ_glu_beta1: float = 4.0
+    """SiTU-GLU gate tanh soft-cap."""
+
+    situ_glu_beta2: float = 25.0
+    """SiTU-GLU up-branch tanh soft-cap."""
+
     use_te_rng_tracker: bool = False
     """ Whether to use the TE or MCore version of the RNG tracker. """
 
@@ -2411,6 +2423,48 @@ class TransformerConfig(ModelParallelConfig):
                     "If you don't want to use TransformerEngine activation function, set "
                     "use_te_activation_func to False"
                 )
+
+        if self.use_situ_glu:
+            if not self.gated_linear_unit:
+                raise ValueError("use_situ_glu requires gated_linear_unit=True.")
+            if not self.use_te_activation_func:
+                raise ValueError("use_situ_glu requires use_te_activation_func=True.")
+            if self.activation_func != F.silu:
+                raise ValueError("use_situ_glu requires activation_func=F.silu.")
+            if self.activation_func_clamp_value is not None:
+                raise ValueError(
+                    "use_situ_glu is incompatible with activation_func_clamp_value; "
+                    "use situ_glu_beta1 and situ_glu_beta2 for its tanh soft caps."
+                )
+            if self.activation_func_fp8_input_store:
+                raise ValueError("use_situ_glu does not support activation_func_fp8_input_store.")
+            if self.fp8 is not None and self.fp8_recipe not in (Fp8Recipe.mxfp8, "mxfp8"):
+                raise ValueError(
+                    "The CuTe DSL SiTU-GLU implementation supports FP8 only with "
+                    "fp8_recipe='mxfp8'."
+                )
+            if self.fp4 is not None and self.fp4_recipe not in (Fp4Recipe.nvfp4, "nvfp4"):
+                raise ValueError(
+                    "The CuTe DSL SiTU-GLU implementation supports FP4 only with "
+                    "fp4_recipe='nvfp4'."
+                )
+            if (
+                self.num_moe_experts is not None
+                and self.moe_grouped_gemm
+                and self.use_transformer_engine_op_fuser
+                and (self.fp8 is not None or self.fp4 is not None)
+                and self.moe_mlp_glu_interleave_size != 32
+            ):
+                raise ValueError(
+                    "Fused block-scaled MoE SiTU-GLU requires "
+                    "moe_mlp_glu_interleave_size=32, matching TE's grouped-MLP layout."
+                )
+            if self.situ_glu_impl != "cutedsl":
+                raise ValueError(f"Unsupported SiTU-GLU implementation: {self.situ_glu_impl}.")
+            if not math.isfinite(self.situ_glu_beta1) or self.situ_glu_beta1 <= 0:
+                raise ValueError("situ_glu_beta1 must be finite and positive.")
+            if not math.isfinite(self.situ_glu_beta2) or self.situ_glu_beta2 <= 0:
+                raise ValueError("situ_glu_beta2 must be finite and positive.")
 
         if self.activation_func_fp8_input_store:
             if self.activation_func != F.silu or not self.gated_linear_unit:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1173,9 +1173,6 @@ class TransformerConfig(ModelParallelConfig):
     use_situ_glu: bool = False
     """Use SiTU-GLU in every gated dense, routed-expert, and shared-expert FFN."""
 
-    situ_glu_impl: Literal['cutedsl'] = "cutedsl"
-    """SiTU-GLU implementation backend. Only the MCore CuTe DSL fallback is available."""
-
     situ_glu_beta1: float = 4.0
     """SiTU-GLU gate tanh soft-cap."""
 
@@ -2459,8 +2456,6 @@ class TransformerConfig(ModelParallelConfig):
                     "Fused block-scaled MoE SiTU-GLU requires "
                     "moe_mlp_glu_interleave_size=32, matching TE's grouped-MLP layout."
                 )
-            if self.situ_glu_impl != "cutedsl":
-                raise ValueError(f"Unsupported SiTU-GLU implementation: {self.situ_glu_impl}.")
             if not math.isfinite(self.situ_glu_beta1) or self.situ_glu_beta1 <= 0:
                 raise ValueError("situ_glu_beta1 must be finite and positive.")
             if not math.isfinite(self.situ_glu_beta2) or self.situ_glu_beta2 <= 0:

--- a/megatron/training/argument_utils.py
+++ b/megatron/training/argument_utils.py
@@ -311,17 +311,25 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['num_layers_in_last_pipeline_stage']= args.decoder_last_pipeline_num_layers
     kw_args['fp8_param'] = args.fp8_param_gather
     kw_args['fp4_param'] = args.fp4_param_gather
-    if args.swiglu:
+    use_situ_glu = getattr(args, 'use_situ_glu', False)
+    if args.swiglu and use_situ_glu:
+        raise ValueError("--swiglu and --situ-glu select different GLU activations.")
+    if use_situ_glu:
+        kw_args['activation_func'] = F.silu
+        kw_args['gated_linear_unit'] = True
+        kw_args['use_te_activation_func'] = True
+        kw_args['bias_activation_fusion'] = False
+    elif args.swiglu:
         kw_args['activation_func'] = F.silu
         kw_args['gated_linear_unit'] = True
         kw_args['bias_activation_fusion'] = args.bias_swiglu_fusion
     else:
         kw_args['bias_activation_fusion'] = args.bias_gelu_fusion
     if args.squared_relu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['activation_func'] = squared_relu
     elif args.quick_geglu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['gated_linear_unit'] = True
         kw_args['activation_func'] = quick_gelu
     if args.init_method_xavier_uniform:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,15 +6,15 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+from pathlib import Path
 
 import torch
 
+from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -23,23 +23,24 @@ from megatron.core.transformer.cuda_graph_config import (
     validate_deprecated_cuda_graph_modules_migration_inputs,
 )
 from megatron.core.transformer.enums import AttnBackend, CudaGraphModule, InferenceCudaGraphScope
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
 )
+from megatron.training.argument_utils import (  # noqa: F401 # pylint: disable=unused-import
+    ArgumentGroupFactory,
+    core_transformer_config_from_args,
+)
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
-
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args  # noqa: F401 # pylint: disable=unused-import
-
 
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
@@ -398,8 +399,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -756,8 +758,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -2416,8 +2420,8 @@ def _add_network_size_args(parser):
         action='store_true',
         dest='use_situ_glu',
         help=(
-            'Use SiTU-GLU in all gated dense and MoE FFNs. The MCore CuTe DSL fallback '
-            'supports BF16, MXFP8, and NVFP4 execution.'
+            'Use SiTU-GLU in all gated dense and MoE FFNs. Native Transformer Engine '
+            'operators are preferred; otherwise MCore uses its local CuTe DSL fallback.'
         ),
     )
     group.add_argument('--quick-geglu', action='store_true',
@@ -2812,8 +2816,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3696,7 +3699,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1282,8 +1282,17 @@ def validate_args(args, defaults={}):
         _check_arg_is_not_none(args, req_arg)
 
     # Checks.
+    if args.use_situ_glu:
+        if args.swiglu or args.quick_geglu or args.squared_relu:
+            raise ValueError(
+                "--situ-glu is mutually exclusive with --swiglu, --quick-geglu, "
+                "and --squared-relu."
+            )
+        args.use_te_activation_func = True
+        args.bias_swiglu_fusion = False
+
     if args.ffn_hidden_size is None:
-        if args.swiglu:
+        if args.swiglu or args.use_situ_glu:
             # reduce the dimnesion for MLP since projections happens on
             # two linear layers. this keeps the number of paramters in
             # the same ballpark as the counterpart with 4*h size
@@ -2315,6 +2324,8 @@ def _add_network_size_args(parser):
         "bias_dropout_fusion",
         "apply_rope_fusion",
         "mamba_training_ssm_states_dtype",
+        # handled with the other model activation flags
+        "use_situ_glu",
         # internal/derived: controlled only via --tensor-parallel-num-weight-shards
         "gtp_weight_remat_size",
         # internal/derived: controlled only via --expert-tensor-parallel-num-weight-shards
@@ -2399,6 +2410,16 @@ def _add_network_size_args(parser):
                        help='Use squared relu activation instead of default gelu')
     group.add_argument('--swiglu', action='store_true',
                        help='Use gated linear units and SiLU activation instead of default gelu')
+    group.add_argument(
+        '--situ-glu',
+        '--moe-use-situ-glu',
+        action='store_true',
+        dest='use_situ_glu',
+        help=(
+            'Use SiTU-GLU in all gated dense and MoE FFNs. The MCore CuTe DSL fallback '
+            'supports BF16, MXFP8, and NVFP4 execution.'
+        ),
+    )
     group.add_argument('--quick-geglu', action='store_true',
                        help='Use quick geglu activation instead of default gelu')
     group.add_argument('--onnx-safe', type=bool, required=False,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1697,7 +1697,7 @@ def _localize_redundant_extra_states(state_dict):
 def preprocess_fsdp_dtensor_state_dict(args, raw_state_dict, model):
     state_dict = raw_state_dict.copy()
     handle_fp8_extra_state_case(state_dict['model'])
-    if args.swiglu:
+    if args.swiglu or getattr(args, "use_situ_glu", False):
         if 'optimizer' in state_dict:
             model_state_dict, optimizer_state_dict = handle_swiglu_in_state_dict(
                 model, state_dict['model'], state_dict['optimizer']

--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -18,7 +18,7 @@ def compute_weight_and_optimizer_memory(args, verbose=False):
         args.num_query_groups = args.num_attention_heads
     # MoE.
     num_experts = 1 if args.num_experts is None else args.num_experts
-    gated_linear_multiplier = 3 / 2 if args.swiglu else 1
+    gated_linear_multiplier = 3 / 2 if args.swiglu or getattr(args, "use_situ_glu", False) else 1
 
     shared_expert_ffn_hidden_size = (
         0

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1067,7 +1067,7 @@ def num_floating_point_operations(
         fma_expansion_factor = 2
         # - 3x (SwiGLU enabled): h->2*ffn_h GEMM and ffn_h->h GEMM are stacked.
         # - 2x (SwiGLU disabled): h->ffn_h GEMM and ffn_h->h GEMM are stacked.
-        ffn_expansion_factor = 3 if args.swiglu else 2
+        ffn_expansion_factor = 3 if args.swiglu or getattr(args, "use_situ_glu", False) else 2
 
         # self_attn is split into a token-linear part (projections, multiplied by
         # ``batch_size * args.seq_length`` like all other token-linear work) and a
@@ -1366,7 +1366,7 @@ def num_floating_point_operations(
             gqa_groups=args.num_query_groups,
             kv_channels=args.kv_channels,
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
-            swiglu=args.swiglu,
+            swiglu=args.swiglu or getattr(args, "use_situ_glu", False),
             use_gated_delta_product=_uses_gated_delta_product_spec(args),
             moe_latent_size=args.moe_latent_size,
             moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None

--- a/tests/unit_tests/fusions/test_cutedsl_situ_glu.py
+++ b/tests/unit_tests/fusions/test_cutedsl_situ_glu.py
@@ -10,9 +10,8 @@ import torch.nn.functional as F
 
 from megatron.core.extensions.transformer_engine import TEActivationOp
 from megatron.core.fusions.cutedsl_situ_glu import (
+    CuTeDSLScaledSiTUGLU,
     CuTeDSLSiTUGLU,
-    ScaledSiTUGLU,
-    install_grouped_situ_glu_kernels,
     make_scaled_situ_glu,
     make_situ_glu,
     situ_glu_reference,
@@ -53,6 +52,7 @@ def test_situ_glu_selects_common_te_activation_builder(monkeypatch, precision_kw
     import transformer_engine.pytorch as te
 
     monkeypatch.delattr(te.ops, "SiTUGLU", raising=False)
+    monkeypatch.delattr(te.ops, "ScaledSiTUGLU", raising=False)
     config = TransformerConfig(
         num_layers=1,
         hidden_size=32,
@@ -69,33 +69,86 @@ def test_situ_glu_selects_common_te_activation_builder(monkeypatch, precision_kw
     assert isinstance(activation, CuTeDSLSiTUGLU)
 
 
-def test_situ_glu_prefers_native_te_op(monkeypatch):
+def test_situ_glu_prefers_complete_native_te_interface(monkeypatch):
     import transformer_engine.pytorch as te
 
     class NativeSiTUGLU(torch.nn.Module):
-        def __init__(self, beta1, beta2):
+        def __init__(self, *, beta1, beta2, cache_quantized_input=False, glu_interleave_size=None):
             super().__init__()
             self.beta1 = beta1
             self.beta2 = beta2
+            self.cache_quantized_input = cache_quantized_input
+            self.glu_interleave_size = glu_interleave_size
+
+    class NativeScaledSiTUGLU(torch.nn.Module):
+        def __init__(
+            self, glu_interleave_size=None, *, activation_recompute_in_mlp=False, beta1, beta2
+        ):
+            super().__init__()
+            self.beta1 = beta1
+            self.beta2 = beta2
+            self.glu_interleave_size = glu_interleave_size
+            self.activation_recompute_in_mlp = activation_recompute_in_mlp
 
     monkeypatch.setattr(te.ops, "SiTUGLU", NativeSiTUGLU, raising=False)
+    monkeypatch.setattr(te.ops, "ScaledSiTUGLU", NativeScaledSiTUGLU, raising=False)
 
     activation = make_situ_glu(beta1=4.0, beta2=25.0)
+    scaled_activation = make_scaled_situ_glu(beta1=4.0, beta2=25.0, glu_interleave_size=32)
 
     assert isinstance(activation, NativeSiTUGLU)
     assert activation.beta1 == 4.0
     assert activation.beta2 == 25.0
+    assert isinstance(scaled_activation, NativeScaledSiTUGLU)
+    assert scaled_activation.glu_interleave_size == 32
+    assert not scaled_activation.activation_recompute_in_mlp
+
+
+def test_situ_glu_falls_back_when_te_interface_is_incomplete(monkeypatch):
+    import transformer_engine.pytorch as te
+
+    monkeypatch.setattr(te.ops, "SiTUGLU", torch.nn.Identity, raising=False)
+    monkeypatch.delattr(te.ops, "ScaledSiTUGLU", raising=False)
+
+    assert isinstance(make_situ_glu(), CuTeDSLSiTUGLU)
+    assert isinstance(make_scaled_situ_glu(), CuTeDSLScaledSiTUGLU)
+
+
+def test_swiglu_keeps_existing_te_activation_path():
+    import transformer_engine.pytorch as te
+
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=32,
+        num_attention_heads=4,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        use_te_activation_func=True,
+        use_situ_glu=False,
+    )
+
+    assert isinstance(TEActivationOp(config), te.ops.SwiGLU)
 
 
 def test_scaled_situ_glu_bf16_fallback_does_not_require_cudnn(monkeypatch):
     import transformer_engine.pytorch as te
 
+    monkeypatch.delattr(te.ops, "SiTUGLU", raising=False)
     monkeypatch.delattr(te.ops, "ScaledSiTUGLU", raising=False)
-    activation = make_scaled_situ_glu(
-        beta1=4.0, beta2=25.0, install_grouped_fallback=False, glu_interleave_size=None
-    )
+    activation = make_scaled_situ_glu(beta1=4.0, beta2=25.0, glu_interleave_size=None)
 
-    assert isinstance(activation, ScaledSiTUGLU)
+    assert isinstance(activation, CuTeDSLScaledSiTUGLU)
+    assert not isinstance(activation, te.ops.ScaledSwiGLU)
+
+
+def test_scaled_situ_glu_fallback_rejects_activation_recompute(monkeypatch):
+    import transformer_engine.pytorch as te
+
+    monkeypatch.delattr(te.ops, "SiTUGLU", raising=False)
+    monkeypatch.delattr(te.ops, "ScaledSiTUGLU", raising=False)
+
+    with pytest.raises(ValueError, match="does not support activation recomputation"):
+        make_scaled_situ_glu(activation_recompute_in_mlp=True)
 
 
 @pytest.mark.parametrize(
@@ -174,38 +227,12 @@ def test_cutedsl_situ_glu_interleaved_forward_backward(dtype):
     )
 
 
-def test_grouped_situ_glu_installs_with_cutedsl_baseline(monkeypatch):
-    import transformer_engine.pytorch as te
-    from cudnn.grouped_gemm.grouped_gemm_dglu import api as dglu_api
-    from cudnn.grouped_gemm.grouped_gemm_glu import api as glu_api
-
-    try:
-        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
-    except ImportError:
-        try:
-            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
-        except ImportError:
-            glu_hadamard_api = None
-
-    monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
-    te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported.cache_clear()
-    install_grouped_situ_glu_kernels(4.0, 25.0)
-
-    assert glu_api.BlockScaledMoEGroupedGemmGluBiasKernel.__name__ == "_SiTUForwardKernel"
-    assert dglu_api.BlockScaledMoEGroupedGemmDgluDbiasKernel.__name__ == "_SiTUBackwardKernel"
-    if glu_hadamard_api is not None:
-        assert (
-            glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel.__name__
-            == "_SiTUForwardHadamardKernel"
-        )
-    assert te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported()
-
-
+@pytest.mark.parametrize("activation", ["swiglu", "situglu"])
 @pytest.mark.parametrize("precision", ["bf16", "mxfp8", "nvfp4"])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.internal
-def test_mcore_moe_situ_glu_forward_backward_uses_expected_backend(precision):
-    """Run a real MCore MoE and prove block-scaled cases select TE's fused op."""
+def test_mcore_moe_glu_forward_backward_uses_expected_backend(precision, activation):
+    """Run a real MCore MoE and prove SwiGLU and SiTU-GLU select the expected backend."""
     if torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("Fused block-scaled grouped MLP requires Blackwell")
     if int(os.environ.get("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "0")) <= 0:
@@ -250,7 +277,7 @@ def test_mcore_moe_situ_glu_forward_backward_uses_expected_backend(precision):
         gated_linear_unit=True,
         activation_func=F.silu,
         use_te_activation_func=True,
-        use_situ_glu=True,
+        use_situ_glu=activation == "situglu",
         bias_activation_fusion=False,
         bf16=True,
         params_dtype=torch.bfloat16,
@@ -284,23 +311,22 @@ def test_mcore_moe_situ_glu_forward_backward_uses_expected_backend(precision):
     assert torch.isfinite(output).all()
     assert all(parameter.grad is not None for parameter in layer.experts.parameters())
     (ops,) = layer.experts._fused_ops
-    assert isinstance(ops[1], ScaledSiTUGLU)
+    if activation == "situglu":
+        native_scaled_situ_glu = getattr(te.ops, "ScaledSiTUGLU", None)
+        if native_scaled_situ_glu is None:
+            assert isinstance(ops[1], CuTeDSLScaledSiTUGLU)
+        else:
+            assert isinstance(ops[1], native_scaled_situ_glu)
+        expect_fused_glu = native_scaled_situ_glu is not None
+    else:
+        assert isinstance(ops[1], te.ops.ScaledSwiGLU)
+        expect_fused_glu = True
     assert ops._module_groups is not None
     fuser = ops._module_groups[0]
     fused_types = tuple(type(op) for op, _ in fuser._forward_ops)
-    if precision in ("mxfp8", "nvfp4"):
+    if expect_fused_glu and precision in ("mxfp8", "nvfp4"):
         assert te.ops.fused.GroupedMLP_CuTeGEMMGLU in fused_types
     else:
         assert te.ops.fused.GroupedMLP_CuTeGEMMGLU not in fused_types
-    if precision == "nvfp4":
-        try:
-            from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
-        except ImportError:
-            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
-
-        assert (
-            glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel.__name__
-            == "_SiTUForwardHadamardKernel"
-        )
 
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/fusions/test_cutedsl_situ_glu.py
+++ b/tests/unit_tests/fusions/test_cutedsl_situ_glu.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import argparse
+import os
+from contextlib import nullcontext
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.extensions.transformer_engine import TEActivationOp
+from megatron.core.fusions.cutedsl_situ_glu import (
+    CuTeDSLSiTUGLU,
+    ScaledSiTUGLU,
+    install_grouped_situ_glu_kernels,
+    make_scaled_situ_glu,
+    make_situ_glu,
+    situ_glu_reference,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def test_situ_glu_reference_formula():
+    input_ = torch.tensor([[0.5, -1.0, 2.0, -3.0]], dtype=torch.float64)
+    gate, up = input_.chunk(2, dim=-1)
+    expected = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+    expected = expected * 25.0 * torch.tanh(up / 25.0)
+    torch.testing.assert_close(situ_glu_reference(input_), expected)
+
+
+@pytest.mark.parametrize("flag", ["--situ-glu", "--moe-use-situ-glu"])
+def test_situ_glu_cli_aliases_enable_the_global_activation(flag):
+    from megatron.training.arguments import _add_network_size_args
+
+    parser = argparse.ArgumentParser()
+    _add_network_size_args(parser)
+
+    args = parser.parse_args([flag])
+
+    assert args.use_situ_glu is True
+
+
+@pytest.mark.parametrize(
+    "precision_kwargs",
+    [
+        {"bf16": True},
+        {"fp8": "hybrid", "fp8_recipe": "mxfp8"},
+        {"fp4": "e2m1", "fp4_recipe": "nvfp4"},
+    ],
+    ids=["bf16", "mxfp8", "nvfp4"],
+)
+def test_situ_glu_selects_common_te_activation_builder(monkeypatch, precision_kwargs):
+    import transformer_engine.pytorch as te
+
+    monkeypatch.delattr(te.ops, "SiTUGLU", raising=False)
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=32,
+        num_attention_heads=4,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        use_te_activation_func=True,
+        use_situ_glu=True,
+        **precision_kwargs,
+    )
+
+    activation = TEActivationOp(config)
+
+    assert isinstance(activation, CuTeDSLSiTUGLU)
+
+
+def test_situ_glu_prefers_native_te_op(monkeypatch):
+    import transformer_engine.pytorch as te
+
+    class NativeSiTUGLU(torch.nn.Module):
+        def __init__(self, beta1, beta2):
+            super().__init__()
+            self.beta1 = beta1
+            self.beta2 = beta2
+
+    monkeypatch.setattr(te.ops, "SiTUGLU", NativeSiTUGLU, raising=False)
+
+    activation = make_situ_glu(beta1=4.0, beta2=25.0)
+
+    assert isinstance(activation, NativeSiTUGLU)
+    assert activation.beta1 == 4.0
+    assert activation.beta2 == 25.0
+
+
+def test_scaled_situ_glu_bf16_fallback_does_not_require_cudnn(monkeypatch):
+    import transformer_engine.pytorch as te
+
+    monkeypatch.delattr(te.ops, "ScaledSiTUGLU", raising=False)
+    activation = make_scaled_situ_glu(
+        beta1=4.0, beta2=25.0, install_grouped_fallback=False, glu_interleave_size=None
+    )
+
+    assert isinstance(activation, ScaledSiTUGLU)
+
+
+@pytest.mark.parametrize(
+    ("precision_kwargs", "error"),
+    [
+        ({"fp8": "hybrid", "fp8_recipe": "delayed"}, "supports FP8 only"),
+        (
+            {"fp4": "e2m1", "fp4_recipe": "custom", "fp4_quantizer_factory": "test.fake.factory"},
+            "supports FP4 only",
+        ),
+    ],
+)
+def test_situ_glu_rejects_unsupported_quantization_recipe(precision_kwargs, error):
+    with pytest.raises(ValueError, match=error):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            activation_func=F.silu,
+            gated_linear_unit=True,
+            use_te_activation_func=True,
+            use_situ_glu=True,
+            **precision_kwargs,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cutedsl_situ_glu_forward_backward(dtype):
+    torch.manual_seed(1234)
+    input_ref = torch.randn(5, 64, device="cuda", dtype=dtype, requires_grad=True)
+    input_cute = input_ref.detach().clone().requires_grad_(True)
+    grad = torch.randn(5, 32, device="cuda", dtype=dtype)
+
+    output_ref = situ_glu_reference(input_ref)
+    output_ref.backward(grad)
+
+    output_cute = CuTeDSLSiTUGLU()(input_cute)
+    output_cute.backward(grad)
+
+    torch.testing.assert_close(output_cute, output_ref, rtol=2.0e-2, atol=2.0e-2)
+    torch.testing.assert_close(input_cute.grad, input_ref.grad, rtol=3.0e-2, atol=3.0e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cutedsl_situ_glu_interleaved_forward_backward(dtype):
+    torch.manual_seed(4321)
+    rows = 5
+    width = 64
+    interleave_size = 8
+    input_ref = torch.randn(rows, width, device="cuda", dtype=dtype, requires_grad=True)
+    input_interleaved = (
+        input_ref.detach()
+        .reshape(rows, 2, width // (2 * interleave_size), interleave_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(rows, width)
+        .requires_grad_(True)
+    )
+    grad = torch.randn(rows, width // 2, device="cuda", dtype=dtype)
+
+    output_ref = situ_glu_reference(input_ref)
+    output_ref.backward(grad)
+
+    output_cute = CuTeDSLSiTUGLU(interleave_size=interleave_size)(input_interleaved)
+    output_cute.backward(grad)
+    grad_interleaved_ref = (
+        input_ref.grad.reshape(rows, 2, width // (2 * interleave_size), interleave_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(rows, width)
+    )
+
+    torch.testing.assert_close(output_cute, output_ref, rtol=2.0e-2, atol=2.0e-2)
+    torch.testing.assert_close(
+        input_interleaved.grad, grad_interleaved_ref, rtol=3.0e-2, atol=3.0e-2
+    )
+
+
+def test_grouped_situ_glu_installs_with_cutedsl_baseline(monkeypatch):
+    import transformer_engine.pytorch as te
+    from cudnn.grouped_gemm.grouped_gemm_dglu import api as dglu_api
+    from cudnn.grouped_gemm.grouped_gemm_glu import api as glu_api
+
+    try:
+        from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
+    except ImportError:
+        try:
+            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
+        except ImportError:
+            glu_hadamard_api = None
+
+    monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
+    te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported.cache_clear()
+    install_grouped_situ_glu_kernels(4.0, 25.0)
+
+    assert glu_api.BlockScaledMoEGroupedGemmGluBiasKernel.__name__ == "_SiTUForwardKernel"
+    assert dglu_api.BlockScaledMoEGroupedGemmDgluDbiasKernel.__name__ == "_SiTUBackwardKernel"
+    if glu_hadamard_api is not None:
+        assert (
+            glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel.__name__
+            == "_SiTUForwardHadamardKernel"
+        )
+    assert te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported()
+
+
+@pytest.mark.parametrize("precision", ["bf16", "mxfp8", "nvfp4"])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.internal
+def test_mcore_moe_situ_glu_forward_backward_uses_expected_backend(precision):
+    """Run a real MCore MoE and prove block-scaled cases select TE's fused op."""
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Fused block-scaled grouped MLP requires Blackwell")
+    if int(os.environ.get("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "0")) <= 0:
+        pytest.skip("NVTE_CUTEDSL_FUSED_GROUPED_MLP is not enabled")
+
+    import transformer_engine.pytorch as te
+
+    from megatron.core.fp4_utils import get_fp4_context
+    from megatron.core.fp8_utils import get_fp8_context
+    from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_layer_with_transformer_engine_submodules,
+    )
+    from megatron.core.transformer.module import Float16Module
+    from megatron.core.transformer.moe.experts import TEGroupedMLP
+    from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
+    from megatron.core.transformer.spec_utils import get_submodules
+    from megatron.training.initialize import _set_random_seed
+    from tests.unit_tests.test_utilities import Utils
+
+    Utils.destroy_model_parallel()
+    Utils.initialize_model_parallel(1, 1)
+    precision_kwargs = {}
+    if precision == "mxfp8":
+        precision_kwargs = {"fp8": "hybrid", "fp8_recipe": "mxfp8"}
+    elif precision == "nvfp4":
+        precision_kwargs = {"fp4": "e2m1", "fp4_recipe": "nvfp4"}
+
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=256,
+        ffn_hidden_size=512,
+        num_attention_heads=8,
+        num_moe_experts=4,
+        moe_router_topk=2,
+        moe_router_load_balancing_type="none",
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=True,
+        use_transformer_engine_op_fuser=True,
+        moe_mlp_glu_interleave_size=32,
+        use_cpu_initialization=False,
+        add_bias_linear=False,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        use_te_activation_func=True,
+        use_situ_glu=True,
+        bias_activation_fusion=False,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        **precision_kwargs,
+    )
+    _set_random_seed(seed_=123, data_parallel_random_init=False)
+    submodules = get_submodules(
+        get_gpt_layer_with_transformer_engine_submodules(
+            config.num_moe_experts, moe_grouped_gemm=True
+        ).mlp
+    )
+    assert isinstance(submodules, MoESubmodules)
+    layer = MoELayer(config, submodules)
+    layer = Float16Module(layer.config, layer).module.cuda()
+    assert isinstance(layer.experts, TEGroupedMLP)
+    assert layer.experts._with_fused_impl
+
+    hidden_states = torch.randn(
+        (4096, 1, config.hidden_size), dtype=torch.bfloat16, device="cuda", requires_grad=True
+    )
+    context = nullcontext()
+    if precision == "mxfp8":
+        context = get_fp8_context(config)
+    elif precision == "nvfp4":
+        context = get_fp4_context(config)
+    with context:
+        output, _ = layer(hidden_states)
+    output.float().square().mean().backward()
+
+    assert hidden_states.grad is not None
+    assert torch.isfinite(output).all()
+    assert all(parameter.grad is not None for parameter in layer.experts.parameters())
+    (ops,) = layer.experts._fused_ops
+    assert isinstance(ops[1], ScaledSiTUGLU)
+    assert ops._module_groups is not None
+    fuser = ops._module_groups[0]
+    fused_types = tuple(type(op) for op, _ in fuser._forward_ops)
+    if precision in ("mxfp8", "nvfp4"):
+        assert te.ops.fused.GroupedMLP_CuTeGEMMGLU in fused_types
+    else:
+        assert te.ops.fused.GroupedMLP_CuTeGEMMGLU not in fused_types
+    if precision == "nvfp4":
+        try:
+            from cudnn.grouped_gemm.grouped_gemm_glu_hadamard import api as glu_hadamard_api
+        except ImportError:
+            from cudnn.gemm.cutedsl.grouped.glu_hadamard import api as glu_hadamard_api
+
+        assert (
+            glu_hadamard_api.BlockScaledMoEGroupedGemmGluHadamardKernel.__name__
+            == "_SiTUForwardHadamardKernel"
+        )
+
+    Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -100,6 +100,17 @@ def _make_hybrid_args(*, num_layers=4, hidden_size=512, num_attention_heads=8, s
     return args
 
 
+def test_situ_glu_counts_the_same_ffn_gemms_as_swiglu():
+    swiglu_args = _make_gpt_args(swiglu=True)
+    swiglu_args.use_situ_glu = False
+    situ_glu_args = _make_gpt_args(swiglu=False)
+    situ_glu_args.use_situ_glu = True
+
+    assert num_floating_point_operations(
+        situ_glu_args, batch_size=8
+    ) == num_floating_point_operations(swiglu_args, batch_size=8)
+
+
 class TestBSHDBackwardCompat:
     """For unpacked BSHD, the new optional arg must not change the result."""
 

--- a/tests/unit_tests/training/test_weight_and_optimizer_memory.py
+++ b/tests/unit_tests/training/test_weight_and_optimizer_memory.py
@@ -33,12 +33,22 @@ def _make_args(**overrides):
         swiglu=False,
         tensor_model_parallel_size=2,
         untie_embeddings_and_output_weights=False,
+        use_situ_glu=False,
         use_distributed_optimizer=True,
         world_size=32,
     )
     for name, value in overrides.items():
         setattr(args, name, value)
     return args
+
+
+def test_situ_glu_counts_the_same_ffn_parameters_as_swiglu():
+    swiglu_args = _make_args(swiglu=True)
+    situ_glu_args = _make_args(use_situ_glu=True)
+
+    assert compute_weight_and_optimizer_memory(
+        situ_glu_args
+    ) == compute_weight_and_optimizer_memory(swiglu_args)
 
 
 def test_weight_and_optimizer_memory_accounts_for_expert_parallelism():

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -141,6 +141,9 @@ def _fake_shared_expert(**config_kwargs):
         fp4_recipe="nvfp4",
         fp8=True,
         fp8_recipe="mxfp8",
+        use_situ_glu=False,
+        situ_glu_beta1=4.0,
+        situ_glu_beta2=25.0,
     )
     for key, value in config_kwargs.items():
         setattr(config, key, value)
@@ -218,6 +221,7 @@ def test_validate_fused_grouped_swiglu_requires_clamped_te_support(monkeypatch, 
         ({"activation_func": F.gelu}, None, "SwiGLU activation"),
         ({"gated_linear_unit": False}, None, "SwiGLU activation"),
         ({"moe_shared_expert_glu_interleave_size": None}, None, "glu_interleave_size"),
+        ({"use_situ_glu": True, "moe_shared_expert_glu_interleave_size": 16}, None, "32-wide"),
         ({}, "linear_fc1", "FC1"),
         ({}, "linear_fc2", "FC2"),
     ],
@@ -265,6 +269,31 @@ def test_make_fused_grouped_swiglu_ops_builds_grouped_pipeline(monkeypatch):
     assert fc2_op.kwargs["bias"] is False
     assert fc2_op.kwargs["accumulate_into_main_grad"] is False
     assert fc2_op.weight0 is shared_expert.linear_fc2.weight
+
+
+def test_make_fused_grouped_situ_glu_ops_uses_local_or_native_builder(monkeypatch):
+    from megatron.core.fusions import cutedsl_situ_glu
+
+    _patch_fake_shared_expert_te(monkeypatch)
+    shared_expert = _fake_shared_expert(use_situ_glu=True)
+    calls = []
+
+    class FakeScaledSiTUGLU(torch.nn.Module):
+        pass
+
+    def make_scaled_situ_glu(**kwargs):
+        calls.append(kwargs)
+        return FakeScaledSiTUGLU()
+
+    monkeypatch.setattr(cutedsl_situ_glu, "make_scaled_situ_glu", make_scaled_situ_glu)
+
+    ops = shared_expert._make_fused_grouped_swiglu_ops()
+
+    _, activation_op, _ = list(ops.children())
+    assert isinstance(activation_op, FakeScaledSiTUGLU)
+    assert calls == [
+        {"beta1": 4.0, "beta2": 25.0, "install_grouped_fallback": True, "glu_interleave_size": 32}
+    ]
 
 
 def test_make_fused_grouped_swiglu_ops_builds_clamped_activation(monkeypatch):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Add SiTU-GLU as a global FFN activation on `main`. MCore uses the public interface proposed by https://github.com/NVIDIA/TransformerEngine/pull/3402 when the complete native interface is installed and otherwise falls back atomically to MCore-local CuTe DSL operations.

Paired dev-target PR: https://github.com/NVIDIA/Megatron-LM/pull/6635

## Activation

The activation follows Kimi K3 Stable-LatentMoE:

```text
T_g = beta1 * tanh(G / beta1) * sigmoid(G)
T_u = beta2 * tanh(U / beta2)
Y   = T_g * T_u
```

K3 uses `beta1=4` and `beta2=25`. For `beta1=4`, the local implementation reuses `a = tanh(G / 4)` and evaluates `sigmoid(G)` exactly as `0.5 + a / (1 + a^2)`, avoiding a separate exponential.

Reference: [Kimi K3 technical report, Figure 4 and Equation 12](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf).

## Implementation

- Add `--situ-glu`, with `--moe-use-situ-glu` as a compatibility alias, and apply it to gated dense, routed-expert, and shared-expert FFNs.
- Import `SiTUGLU` and `ScaledSiTUGLU` together from the public interface in https://github.com/NVIDIA/TransformerEngine/pull/3402:
  - if both imports succeed, construct the native operations with the same beta, interleave, cached-input, and activation-recompute arguments;
  - if either import is unavailable, use the matching MCore-local standalone and scaled CuTe DSL operations.
- Preserve the existing `SwiGLU` and `ScaledSwiGLU` selection paths unchanged.
- Keep the local scaled fallback as a distinct TE-fuser `BasicOperation`; it is not a `ScaledSwiGLU` subclass and therefore cannot be mistaken for SwiGLU by TE's grouped-MLP matcher.
- Remove the former global cuDNN frontend class replacement and all CuTe DSL compatibility monkeypatches.
- Preserve SwiGLU-compatible checkpoint conversion, FLOP accounting, and memory estimation.

Native block-scaled grouped SiTU-GLU fusion is supplied by https://github.com/NVIDIA/cudnn-frontend/pull/645. MCore does not duplicate or patch those kernels.

## Validation

Baseline B200 environment (TE `2.20.0.dev0`, cuDNN frontend `1.26.0`, CuTe DSL `4.5.2`):

- All 23 focused tests pass on the main-target worktree.
- Real MCore MoE forward/backward passes for BF16, MXFP8, and NVFP4 with the local SiTU-GLU fallback.
- Real MCore fused grouped-MLP forward/backward passes for the pre-existing SwiGLU path under MXFP8 and NVFP4; the realized fuser plan contains `GroupedMLP_CuTeGEMMGLU`.
- Tests verify complete-native-interface preference, atomic fallback for an incomplete TE interface, activation-recompute contract handling, and preservation of the ordinary SwiGLU path.

Native-interface environment (https://github.com/NVIDIA/TransformerEngine/pull/3402, https://github.com/NVIDIA/cudnn-frontend/pull/645, CuTe DSL `4.6.2`):

- BF16 native SiTU-GLU and SwiGLU forward/backward pass.
- NVFP4 fused SiTU-GLU and SwiGLU forward/backward pass on the main-target worktree, and both select `GroupedMLP_CuTeGEMMGLU`.
- MXFP8 fused SwiGLU forward/backward passes on the equivalent dev-target implementation. Native SiTU-GLU reaches the fused forward path; its dSiTU backward kernel currently hits a `vector.from_elements` BF16-to-FP32x2 verifier error inside the dependency implementation. No MCore or cuDNN frontend workaround is included here.

The commits are SSH-signed and signed off. `git diff --check` and the repository `tools/autoformat.sh` pass; pylint rates the changed files 10/10 and Ruff reports no errors.

## Scope and dependencies

This PR owns the MCore configuration, selection logic, and local fallback. It does not change grouped-GEMM fusion policy or patch Transformer Engine/cuDNN frontend internals.

This PR does not depend on Quantile Balancing or https://github.com/NVIDIA/Megatron-LM/pull/6638. The paired integration checkout was used only to verify that the independent features coexist.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: TODO — link a Megatron-LM feature-request issue before marking this draft ready for review.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
