### PR TITLE
Add standalone frontend/coordinator tests for inference

### DIFF
--- a/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
@@ -23,6 +23,7 @@ from megatron.core.inference.inference_request import compute_block_hashes_batch
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
 )
+from megatron.core.inference.wire_metrics import WireMetrics
 
 from .handlers import HANDLERS
 from .state import CoordinatorState
@@ -266,6 +267,9 @@ class DataParallelInferenceCoordinator:
         # Header -> handler dispatch table, sourced from the handler registry.
         self._handlers = dict(HANDLERS)
 
+        # Message/byte counters for every payload crossing the router socket.
+        self.wire_metrics = WireMetrics()
+
     def get_least_loaded_data_parallel_rank(self):
         """
         Selects the data parallel rank with the fewest in-flight requests.
@@ -351,18 +355,20 @@ class DataParallelInferenceCoordinator:
             len(self.identities_of_data_parallel_ranks),
         )
 
-    def _send_to_engine(self, identity, frames):
+    def _send_to_engine(self, identity, frames, header):
         """Send a message to an engine, removing it from the pool if unreachable.
 
         Args:
             identity: ZMQ identity of the target engine.
             frames (list): Raw frames to send, metadata frame first.
+            header: Header wire value for byte accounting.
 
         Returns:
             True if the send succeeded, False if the engine was unreachable and removed.
         """
         try:
             self.router_socket.send_multipart([identity, *frames])
+            self.wire_metrics.record_sent(header, sum(map(len, frames)))
             return True
         except zmq.error.ZMQError as e:
             if e.errno == zmq.EHOSTUNREACH:
@@ -374,7 +380,25 @@ class DataParallelInferenceCoordinator:
         """Send a deserialized payload to every connected data parallel rank."""
         serialized = msgpack.packb(payload, use_bin_type=True)
         for data_parallel_rank_id in list(self.identities_of_data_parallel_ranks):
-            self._send_to_engine(data_parallel_rank_id, [serialized])
+            self._send_to_engine(data_parallel_rank_id, [serialized], header=payload[0])
+
+    def _send_to_client(self, client_identity, frames, header):
+        """Send raw frames to a client and account for their total payload size.
+
+        Client-bound replies all go through here so wire_metrics sees the reply
+        sizes the frontend actually receives.
+
+        Args:
+            client_identity: ZMQ identity of the destination client.
+            frames (list): Raw frames to send, metadata frame first.
+            header: Header wire value for byte accounting.
+        """
+        self.router_socket.send_multipart([client_identity, *frames])
+        self.wire_metrics.record_sent(header, sum(map(len, frames)))
+
+    def get_wire_metrics(self):
+        """Return a snapshot of this coordinator's message and byte counters."""
+        return self.wire_metrics.snapshot()
 
     def compute_request_hashes(self, prompt, cache_salt: str | None = None):
         """Compute compact-prompt affinity hashes on CPU.
@@ -596,6 +620,7 @@ class DataParallelInferenceCoordinator:
                 continue
 
             metadata = msgpack.unpackb(frames[0], raw=False)
+            self.wire_metrics.record_received(metadata[0], sum(map(len, frames)))
             header = Headers(metadata[0])
 
             handler = self._handlers.get(header)
@@ -718,6 +743,7 @@ class DataParallelInferenceCoordinator:
         """
         Stops the inference coordinator, performing any necessary cleanup operations.
         """
+        logging.info("Inference Coordinator: wire traffic\n%s", self.wire_metrics.format_summary())
         if self.schedule_output_path and self.schedule_records:
             schedule_data = {
                 "policy": self.prefix_caching_coordinator_policy.value,

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -77,8 +77,10 @@ def handle_connect(coordinator, sender_identity, metadata, bodies):
         return
 
     coordinator.known_clients.add(sender_identity)
-    coordinator.router_socket.send_multipart(
-        [sender_identity, msgpack.packb([Headers.CONNECT_ACK.value], use_bin_type=True)]
+    coordinator._send_to_client(
+        sender_identity,
+        [msgpack.packb([Headers.CONNECT_ACK.value], use_bin_type=True)],
+        header=Headers.CONNECT_ACK.value,
     )
 
 
@@ -196,7 +198,11 @@ def handle_submit_request(coordinator, sender_identity, metadata, bodies):
         next_identity = coordinator.get_best_data_parallel_rank(
             request_hashes, media_cache_key=media_cache_key
         )
-        if coordinator._send_to_engine(next_identity, [engine_metadata, prompt_frame, media_frame]):
+        if coordinator._send_to_engine(
+            next_identity,
+            [engine_metadata, prompt_frame, media_frame],
+            header=Headers.SUBMIT_REQUEST.value,
+        ):
             break
     else:
         # If all engines have died, we are in an abnormal state, and must exit cleanly.
@@ -273,7 +279,11 @@ def handle_submit_request_with_kv(coordinator, sender_identity, metadata, bodies
 
     for _ in range(len(coordinator.identities_of_data_parallel_ranks)):
         next_identity = coordinator.get_least_loaded_data_parallel_rank()
-        if coordinator._send_to_engine(next_identity, [engine_metadata, *bodies]):
+        if coordinator._send_to_engine(
+            next_identity,
+            [engine_metadata, *bodies],
+            header=Headers.SUBMIT_REQUEST_WITH_KV.value,
+        ):
             break
     else:
         logging.error("Coordinator: no reachable engines for handoff request %d", request_id)
@@ -410,7 +420,11 @@ def handle_engine_reply(coordinator, sender_identity, metadata, bodies):
         reply_metadata = msgpack.packb(
             [Headers.ENGINE_REPLY.value, client_request_id], use_bin_type=True
         )
-        coordinator.router_socket.send_multipart([client_identity, reply_metadata, body])
+        coordinator._send_to_client(
+            client_identity,
+            [reply_metadata, body],
+            header=Headers.ENGINE_REPLY.value,
+        )
 
 
 @message_handler(Headers.ENGINE_REPLY_PARTIAL)
@@ -437,14 +451,15 @@ def handle_engine_reply_partial(coordinator, sender_identity, metadata, bodies):
         client_request_id = coordinator.request_id_to_client_request_id[request_id]
         # Partial tokens are detokenized incrementally by the client-facing
         # streaming layer, so the body is always forwarded untouched.
-        coordinator.router_socket.send_multipart(
+        coordinator._send_to_client(
+            client_identity,
             [
-                client_identity,
                 msgpack.packb(
                     [Headers.ENGINE_REPLY_PARTIAL.value, client_request_id], use_bin_type=True
                 ),
                 body,
-            ]
+            ],
+            header=Headers.ENGINE_REPLY_PARTIAL.value,
         )
 
 
@@ -470,6 +485,7 @@ def handle_abort_request(coordinator, sender_identity, metadata, bodies):
         coordinator._send_to_engine(
             assigned_rank,
             [msgpack.packb([Headers.ABORT_REQUEST.value, request_id], use_bin_type=True)],
+            header=Headers.ABORT_REQUEST.value,
         )
 
 

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -280,9 +280,7 @@ def handle_submit_request_with_kv(coordinator, sender_identity, metadata, bodies
     for _ in range(len(coordinator.identities_of_data_parallel_ranks)):
         next_identity = coordinator.get_least_loaded_data_parallel_rank()
         if coordinator._send_to_engine(
-            next_identity,
-            [engine_metadata, *bodies],
-            header=Headers.SUBMIT_REQUEST_WITH_KV.value,
+            next_identity, [engine_metadata, *bodies], header=Headers.SUBMIT_REQUEST_WITH_KV.value
         ):
             break
     else:
@@ -421,9 +419,7 @@ def handle_engine_reply(coordinator, sender_identity, metadata, bodies):
             [Headers.ENGINE_REPLY.value, client_request_id], use_bin_type=True
         )
         coordinator._send_to_client(
-            client_identity,
-            [reply_metadata, body],
-            header=Headers.ENGINE_REPLY.value,
+            client_identity, [reply_metadata, body], header=Headers.ENGINE_REPLY.value
         )
 
 

--- a/megatron/core/inference/inference_client.py
+++ b/megatron/core/inference/inference_client.py
@@ -345,9 +345,7 @@ class InferenceClient:
         request_id, frames = self._make_kv_handoff_request(
             prompt, sampling_params, kv_meta, src_block_ids
         )
-        return self._submit_request(
-            frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value
-        )
+        return self._submit_request(frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value)
 
     def add_request_with_kv_handoff_streaming(
         self,
@@ -374,9 +372,7 @@ class InferenceClient:
         request_id, frames = self._make_kv_handoff_request(
             prompt, sampling_params, kv_meta, src_block_ids
         )
-        return self._submit_stream(
-            frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value
-        )
+        return self._submit_stream(frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value)
 
     def release_handoff(self, request_id: int) -> None:
         """Tell the coordinator to release the KV blocks pinned for `request_id`.
@@ -467,7 +463,9 @@ class InferenceClient:
             int: The number of serialized payload bytes sent.
         """
         serialized = msgpack.packb(payload, use_bin_type=True)
-        return self._send_frames([serialized], payload[0])
+        self.socket.send(serialized)
+        self.wire_metrics.record_sent(payload[0], len(serialized))
+        return len(serialized)
 
     def _send_frames(self, frames: list, header) -> int:
         """Send prepared frames and account for their combined payload size."""

--- a/megatron/core/inference/inference_client.py
+++ b/megatron/core/inference/inference_client.py
@@ -17,6 +17,7 @@ from megatron.core.inference.inference_request import (
     split_multimodal_data,
 )
 from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.inference.wire_metrics import WireMetrics
 from megatron.core.utils import get_asyncio_loop, trace_async_exceptions
 
 from .headers import Headers
@@ -59,6 +60,8 @@ class InferenceClient:
         next_request_id (int): A counter for generating unique request IDs.
         listener_task (asyncio.Task): The background task that listens for
             completed requests.
+        wire_metrics (WireMetrics): Per-header message and byte counters for
+            everything this client puts on or takes off the socket.
     """
 
     def __init__(
@@ -108,6 +111,7 @@ class InferenceClient:
         self.aborted_request_ids: set[int] = set()
         self.block_size_tokens = block_size_tokens
         self.prefix_caching_coordinator_policy = prefix_caching_coordinator_policy
+        self.wire_metrics = WireMetrics()
 
     def _block_hashes(self, prompt, media_meta):
         """Hash the prompt into per-block routing hashes for the coordinator.
@@ -341,7 +345,9 @@ class InferenceClient:
         request_id, frames = self._make_kv_handoff_request(
             prompt, sampling_params, kv_meta, src_block_ids
         )
-        return self._submit_request(frames, request_id)
+        return self._submit_request(
+            frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value
+        )
 
     def add_request_with_kv_handoff_streaming(
         self,
@@ -368,7 +374,9 @@ class InferenceClient:
         request_id, frames = self._make_kv_handoff_request(
             prompt, sampling_params, kv_meta, src_block_ids
         )
-        return self._submit_stream(frames, request_id)
+        return self._submit_stream(
+            frames, request_id, header=Headers.SUBMIT_REQUEST_WITH_KV.value
+        )
 
     def release_handoff(self, request_id: int) -> None:
         """Tell the coordinator to release the KV blocks pinned for `request_id`.
@@ -376,8 +384,7 @@ class InferenceClient:
         Fire-and-forget. The coordinator broadcasts RELEASE_KV to every engine;
         engines without that request_id ignore the message.
         """
-        payload = [Headers.RELEASE_KV.value, int(request_id)]
-        self.socket.send(msgpack.packb(payload, use_bin_type=True))
+        self._send([Headers.RELEASE_KV.value, int(request_id)])
 
     def abort_request(self, request_id: int) -> None:
         """Cancel an in-flight request and close its local response stream."""
@@ -399,8 +406,7 @@ class InferenceClient:
         if future is not None and not future.done():
             future.cancel()
         self.request_submission_times.pop(request_id, None)
-        payload = [Headers.ABORT_REQUEST.value, request_id]
-        self.socket.send(msgpack.packb(payload, use_bin_type=True))
+        self._send([Headers.ABORT_REQUEST.value, request_id])
 
     def add_request_streaming(
         self,
@@ -448,18 +454,48 @@ class InferenceClient:
         frames = self._pack_submit_frames(request_id, prompt, sampling_params, multi_modal_data)
         return self._submit_stream(frames, request_id)
 
-    def _submit_request(self, frames: list, request_id: int) -> asyncio.Future:
-        """Send a prepared request and register its completion future."""
+    def _send(self, payload: list) -> int:
+        """Pack a payload, send it to the coordinator, and account for its size.
+
+        Every message this client sends goes through here so that wire_metrics
+        sees all of them.
+
+        Args:
+            payload: The message as a list whose first element is the header value.
+
+        Returns:
+            int: The number of serialized payload bytes sent.
+        """
+        serialized = msgpack.packb(payload, use_bin_type=True)
+        return self._send_frames([serialized], payload[0])
+
+    def _send_frames(self, frames: list, header) -> int:
+        """Send prepared frames and account for their combined payload size."""
         self.socket.send_multipart(frames)
+        num_bytes = sum(map(len, frames))
+        self.wire_metrics.record_sent(header, num_bytes)
+        return num_bytes
+
+    def get_wire_metrics(self) -> dict:
+        """Return a snapshot of this client's message and byte counters."""
+        return self.wire_metrics.snapshot()
+
+    def _submit_request(
+        self, frames: list, request_id: int, header=Headers.SUBMIT_REQUEST.value
+    ) -> asyncio.Future:
+        """Send a prepared request and register its completion future."""
+        self._send_frames(frames, header)
         assert request_id not in self.completion_futures
         future = asyncio.get_running_loop().create_future()
         self.completion_futures[request_id] = future
         self.request_submission_times[request_id] = time.perf_counter()
         return future
 
-    def _submit_stream(self, frames: list, request_id: int) -> AsyncStream[dict]:
+    def _submit_stream(
+        self, frames: list, request_id: int, header=Headers.SUBMIT_REQUEST.value
+    ) -> AsyncStream[dict]:
         """Send a prepared streaming request and register its response stream."""
-        self.socket.send_multipart(frames)
+        self._send_frames(frames, header)
         stream = AsyncStream(
             request_id, functools.partial(self.abort_request, request_id), loop=self._loop
         )
@@ -485,6 +521,7 @@ class InferenceClient:
                 # frames[0] is metadata; a reply body, when present, follows it.
                 frames = self.socket.recv_multipart(flags=zmq.NOBLOCK)
                 data = msgpack.unpackb(frames[0], raw=False)
+                self.wire_metrics.record_received(data[0], sum(map(len, frames)))
                 header = Headers(data[0])
                 if header == Headers.ENGINE_REPLY:
                     request_id = data[1]
@@ -532,13 +569,14 @@ class InferenceClient:
         Sends a CONNECT signal and waits for a CONNECT_ACK reply to ensure the
         connection is established and acknowledged by the coordinator.
         """
-        payload = [Headers.CONNECT.value]
-        self.socket.send(msgpack.packb(payload, use_bin_type=True))
+        self._send([Headers.CONNECT.value])
         if timeout_seconds is not None and not self.socket.poll(
             timeout=max(0, int(timeout_seconds * 1000))
         ):
             raise TimeoutError("Timed out connecting to the Megatron inference coordinator")
-        reply = msgpack.unpackb(self.socket.recv_multipart()[0], raw=False)
+        frames = self.socket.recv_multipart()
+        reply = msgpack.unpackb(frames[0], raw=False)
+        self.wire_metrics.record_received(reply[0], sum(map(len, frames)))
         assert Headers(reply[0]) == Headers.CONNECT_ACK
 
     def start(
@@ -566,9 +604,7 @@ class InferenceClient:
             signal: The signal to send, typically a value from the `Headers` enum.
             *args: Optional extra values to include in the payload.
         """
-        payload = [signal.value, *args]
-        payload_serialized = msgpack.packb(payload, use_bin_type=True)
-        self.socket.send(payload_serialized)
+        self._send([signal.value, *args])
 
     def pause_engines(self):
         """Sends PAUSE to all engines via coordinator.

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -812,6 +812,14 @@ class DynamicInferenceRequest(InferenceRequest):
             saved_prompt_tokens = self.prompt_tokens
             self.prompt_tokens = None
 
+        # remaining_prompt_tokens is chunked-prefill bookkeeping: engine-side
+        # scratch state no client reads, which __post_init__ re-derives from
+        # prompt_tokens on deserialize. Drop it unconditionally — it starts out as
+        # a copy of prompt_tokens, so leaving it in shipped the whole prompt on
+        # every reply and silently undid the optimization above.
+        saved_remaining_prompt_tokens = self.remaining_prompt_tokens
+        self.remaining_prompt_tokens = None
+
         obj = super().serialize()
         obj["events"] = [e.serialize() for e in self.events]
         obj.pop("event_add_engine", None)
@@ -829,6 +837,7 @@ class DynamicInferenceRequest(InferenceRequest):
 
         if drop_prompt:
             self.prompt_tokens = saved_prompt_tokens
+        self.remaining_prompt_tokens = saved_remaining_prompt_tokens
 
         nvtx_range_pop("DynamicInferenceRequest.serialize")
         return obj

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -35,7 +35,7 @@ from ..openai_streaming import (
     json_safe_top_n_logprobs,
     openai_stream,
 )
-from .common import abort_requests
+from .common import abort_requests, openai_error
 
 logger = logging.getLogger(__name__)
 
@@ -767,9 +767,9 @@ try:
         chat_template_kwargs = _sanitize_chat_template_kwargs(req.get("chat_template_kwargs"))
         # --- 1. Parse Messages ---
         if not messages:
-            return Response("Missing 'messages' field", status=400)
+            return openai_error("Missing 'messages' field", 400, param="messages")
         if not isinstance(messages, list):
-            return Response("'messages' must be a list", status=400)
+            return openai_error("'messages' must be a list", 400, param="messages")
         prompt_config = current_app.config['multimodal_prompt_config']
         # Extract structured media before template sanitization. Remote image
         # fetches block, so keep this work off the event loop.
@@ -778,7 +778,7 @@ try:
                 _extract_multimodal_from_messages, messages, prompt_config
             )
         except ValueError as error:
-            return Response(str(error), status=400)
+            return openai_error(str(error), 400, param="messages")
         multi_modal_data = None
         if image_bytes_list:
             multi_modal_data = {"image": image_bytes_list}
@@ -960,10 +960,10 @@ try:
                 )
         except ValueError as e:
             logger.error(f"{traceback.format_exc()}")
-            return Response(f"Invalid 'messages': {e}", status=400)
+            return openai_error(f"Invalid 'messages': {e}", 400, param="messages")
         except Exception as e:
             logger.error(f"{traceback.format_exc()}")
-            return Response(f"Error processing 'messages': {e}", status=500)
+            return openai_error(f"Error processing 'messages': {e}", 500)
 
         # --- 2. Parse Sampling Params ---
         try:
@@ -1035,7 +1035,7 @@ try:
                 detokenize_generations=False,
             )
         except ValueError as e:
-            return Response(f"Invalid sampling parameter: {e}", status=400)
+            return openai_error(f"Invalid sampling parameter: {e}", 400)
 
         # --- 3. Send Requests to Engine ---
         # TODO(perf): with n > 1, the same ``image_bytes_list`` is forwarded n
@@ -1056,7 +1056,7 @@ try:
                     for _ in range(n)
                 ]
             except ValueError as error:
-                return Response(str(error), status=400)
+                return openai_error(str(error), 400, param="stream")
 
             streams = [
                 client.add_request_streaming(
@@ -1153,7 +1153,7 @@ try:
             raise
         except Exception as e:
             logger.error(f"Error during inference: {e}")
-            return Response(f"Error during inference: {e}", status=500)
+            return openai_error(f"Error during inference: {e}", 500)
 
         if current_app.config['verbose']:
             logging.info(
@@ -1185,15 +1185,17 @@ try:
             logger.error(f"Inference request(s) failed: {error_detail}")
 
             # NOTE: This exact string is required for compatibility with Nemo-RL, DO NOT MODIFY.
+            # It is preserved verbatim, now as the `error.message` of the OpenAI error
+            # envelope rather than the whole body.
             if "MaxSequenceLengthOverflowError" in error_detail:
                 error_msg = (
                     f"This model's maximum context length was exceeded. "
                     f"Your messages resulted in {len(prompt_tokens)} tokens. "
                     f"Please reduce the length of the messages. {error_detail}"
                 )
-                return Response(error_msg, status=400)
+                return openai_error(error_msg, 400, code="context_length_exceeded")
 
-            return Response(f"Inference request(s) failed: {error_detail}", status=status)
+            return openai_error(f"Inference request(s) failed: {error_detail}", status)
 
         # --- 5. Format OpenAI Response ---
         choices = []
@@ -1227,7 +1229,7 @@ try:
 
             logprobs_content = None
             if sampling_params.return_log_probs:
-                token_logprobs = json_safe_logprobs(result.get('log_probs') or [])
+                token_logprobs = json_safe_logprobs(result.get('generated_log_probs') or [])
 
                 tokens_to_decode = [[tok] for tok in result["generated_tokens"]]
                 tokens = list(map(tokenizer.detokenize, tokens_to_decode))

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -1135,7 +1135,7 @@ try:
         except Exception as e:
             abort_requests(client, request_ids, f"submission failed: {e}")
             logger.error(f"Error submitting request: {e}")
-            return Response(f"Error submitting request: {e}", status=500)
+            return openai_error(f"Error submitting request: {e}", 500)
 
         if current_app.config['verbose']:
             start_time = time.perf_counter()

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/common.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/common.py
@@ -42,3 +42,30 @@ def send_do_generate():
     """Broadcasts a message to perform a generation to all tensor parallel ranks."""
     choice = torch.tensor([GENERATE_NUM], dtype=torch.long, device=torch.cuda.current_device())
     torch.distributed.broadcast(choice, 0)
+
+
+def openai_error(message, status, error_type=None, param=None, code=None):
+    """Build an OpenAI-shaped error response for an endpoint to return.
+
+    OpenAI's clients expect a JSON body of
+    ``{"error": {"message", "type", "param", "code"}}`` and read the human-readable
+    text out of ``error.message``. A bare string body makes them raise a parse
+    error that hides the message entirely, so every endpoint error goes through
+    here. ``message`` is passed through verbatim; callers that must preserve an
+    exact wording for downstream consumers still get that wording, just nested
+    under ``error.message``.
+
+    Args:
+        message (str): Human-readable description of what went wrong.
+        status (int): HTTP status code.
+        error_type (str | None): OpenAI error type. Defaults to
+            ``invalid_request_error`` for 4xx and ``server_error`` otherwise.
+        param (str | None): Offending request field, when one can be named.
+        code (str | None): Machine-readable error code, when one applies.
+
+    Returns:
+        tuple[dict, int]: Body and status, in the form Quart returns directly.
+    """
+    if error_type is None:
+        error_type = "invalid_request_error" if 400 <= status < 500 else "server_error"
+    return {"error": {"message": message, "type": error_type, "param": param, "code": code}}, status

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
@@ -10,7 +10,7 @@ from megatron.core.inference.sampling_params import SamplingParams
 
 from ..incremental_detokenizer import HuggingFaceFastIncrementalDetokenizer
 from ..openai_streaming import json_safe_logprobs, json_safe_top_n_logprobs, openai_stream
-from .common import abort_requests
+from .common import abort_requests, openai_error
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +29,12 @@ try:
 
         req = await request.get_json(force=True)
         if req is None:
-            return "Invalid or missing JSON body", 400
+            return openai_error("Invalid or missing JSON body", 400)
 
         # --- 1. Parse Prompt ---
         prompt_data = req.get("prompt")
         if not prompt_data:
-            return "Missing 'prompt' field", 400
+            return openai_error("Missing 'prompt' field", 400, param="prompt")
 
         try:
             if isinstance(prompt_data, str):
@@ -42,7 +42,7 @@ try:
                 prompts_as_strings = [prompt_data]
             elif isinstance(prompt_data, list):
                 if not prompt_data:
-                    return "'prompt' list is empty", 400
+                    return openai_error("'prompt' list is empty", 400, param="prompt")
                 if all(isinstance(p, str) for p in prompt_data):
                     prompts_as_tokens = [tokenizer.tokenize(p) for p in prompt_data]
                     prompts_as_strings = prompt_data
@@ -55,17 +55,18 @@ try:
                     prompts_as_tokens = prompt_data
                     prompts_as_strings = [tokenizer.detokenize(p) for p in prompt_data]
                 else:
-                    return (
-                        (
-                            "Invalid 'prompt' format. Must be str, list[str], "
-                            "list[int], or list[list[int]]"
-                        ),
+                    return openai_error(
+                        "Invalid 'prompt' format. Must be str, list[str], "
+                        "list[int], or list[list[int]]",
                         400,
+                        param="prompt",
                     )
             else:
-                return "Invalid 'prompt' type. Must be str or list", 400
+                return openai_error(
+                    "Invalid 'prompt' type. Must be str or list", 400, param="prompt"
+                )
         except Exception as e:
-            return f"Error tokenizing prompt: {e}", 500
+            return openai_error(f"Error tokenizing prompt: {e}", 500)
 
         # --- 2. Parse Sampling Params ---
         try:
@@ -149,7 +150,7 @@ try:
                 streaming_interval=int(req.get("streaming_interval", 1)),
             )
         except ValueError as e:
-            return f"Invalid sampling parameter: {e}", 400
+            return openai_error(f"Invalid sampling parameter: {e}", 400)
 
         # --- 3. Send Requests to Engine ---
         stream_requested = bool(req.get("stream", False))
@@ -162,7 +163,7 @@ try:
                     for prompt_tokens in prompts_as_tokens
                 ]
             except ValueError as error:
-                return str(error), 400
+                return openai_error(str(error), 400, param="stream")
 
         tasks = []
         # Populated on the non-streaming path only; the streaming path aborts
@@ -248,7 +249,7 @@ try:
             abort_requests(client, request_ids, "client disconnected")
             raise
         except Exception as e:
-            return f"Error during inference: {e}", 500
+            return openai_error(f"Error during inference: {e}", 500)
 
         if current_app.config['verbose']:
             logging.info(
@@ -278,7 +279,7 @@ try:
             error_detail = "; ".join(failed_errors)
             status = 400 if has_nontransient_error else 500
             logger.error(f"Inference request(s) failed: {error_detail}")
-            return f"Inference request(s) failed: {error_detail}", status
+            return openai_error(f"Inference request(s) failed: {error_detail}", status)
 
         # --- 5. Format Response (matching old_completions.py) ---
         choices = []
@@ -351,13 +352,16 @@ try:
                     # When echo=False, only return generated tokens and their logprobs
                     tokens = [tokenizer.detokenize([tok]) for tok in generated_tokens_list]
 
-                    # Prepend [None] to match OpenAI format
-                    token_logprobs = [None] + list(generated_log_probs)
+                    # No leading None here: that slot exists only for the prompt's
+                    # first token, which has no logprob, and the prompt is returned
+                    # solely when echo=True. Every generated token has a logprob, so
+                    # these must align 1:1 with `tokens` and `text_offset`.
+                    token_logprobs = list(generated_log_probs)
 
                     # Build top_logprobs
                     top_logprobs = None
                     if generated_top_n_logprobs:
-                        top_logprobs = [None] + list(generated_top_n_logprobs)
+                        top_logprobs = list(generated_top_n_logprobs)
 
                     # Calculate text_offset for generated tokens only
                     text_offset = []

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
@@ -214,7 +214,7 @@ try:
         except Exception as e:
             abort_requests(client, request_ids, f"submission failed: {e}")
             logger.error(f"Error submitting request: {e}")
-            return f"Error submitting request: {e}", 500
+            return openai_error(f"Error submitting request: {e}", 500)
 
         if stream_requested:
             include_usage = bool((req.get("stream_options") or {}).get("include_usage", False))

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
@@ -29,6 +29,75 @@ logger = logging.getLogger(__name__)
 _SERVER_PROCESSES: List[mp.Process] = []
 
 
+def build_app(
+    client,
+    tokenizer,
+    parsers: Optional[List[str]] = None,
+    verbose: bool = False,
+    chat_template: Optional[str] = None,
+    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None,
+    default_temperature: float = 1.0,
+    default_top_p: float = 1.0,
+    default_top_k: int = 0,
+    eval_mode: bool = False,
+):
+    """Build the OpenAI-compatible Quart app around an already-started client.
+
+    Split out from _run_text_gen_server so the HTTP layer can be exercised
+    against a test client without binding a socket or forking replicas.
+
+    Args:
+        client: An InferenceClient (or any object with the same add_request /
+            add_request_streaming interface).
+        tokenizer: Tokenizer used for prompt tokenization and detokenization.
+        parsers: Optional list of tool/reasoning parser names.
+        verbose: Whether endpoints should log per-batch timing.
+        chat_template: Optional server-configured chat template.
+        multimodal_prompt_config: Configuration for multimodal prompt tokens.
+        default_temperature: Default sampling temperature.
+        default_top_p: Default nucleus-sampling probability.
+        default_top_k: Default top-k sampling value.
+        eval_mode: Whether evaluation-mode request defaults are enabled.
+
+    Returns:
+        Quart: The configured app with every endpoint blueprint registered.
+    """
+    if not HAS_BACKEND:
+        raise RuntimeError("Web backend framework (Quart) not available")
+
+    app = Quart(__name__)
+
+    # Quart native way to handle max body size (1 GB; needed for large prompts)
+    app.config['MAX_CONTENT_LENGTH'] = 2**30
+
+    # Store client and tokenizer in app config for Blueprints to use
+    app.config['client'] = client
+    app.config['tokenizer'] = tokenizer
+    app.config['parsers'] = parsers
+    app.config['verbose'] = verbose
+    app.config['chat_template'] = chat_template
+    app.config['multimodal_prompt_config'] = multimodal_prompt_config or MultimodalPromptConfig()
+    app.config['default_temperature'] = default_temperature
+    app.config['default_top_p'] = default_top_p
+    app.config['default_top_k'] = default_top_k
+    app.config['eval_mode'] = eval_mode
+
+    # Applying the chat template is synchronous and O(prompt); on the event loop it
+    # stalls every other request this replica owns, including delivery of responses
+    # that already finished. One worker is enough - the point is the yield, not
+    # throughput. The copy is required: HF tokenizers are not thread-safe.
+    app.config['tokenize_executor'] = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="tokenize"
+    )
+    app.config['tokenizer_copy'] = copy.deepcopy(tokenizer)
+
+    # Register all blueprints from the 'endpoints' package
+    for endpoint in endpoints.__all__:
+        app.register_blueprint(endpoint)
+
+    return app
+
+
 @contextmanager
 def temp_log_level(level, logger=None):
     """Enables temporarily overriding the logging level."""
@@ -91,37 +160,18 @@ async def _run_text_gen_server(
                 logger.warning(f"Could not get hostname: {e}")
                 hostname = "0.0.0.0"
 
-        app = Quart(__name__)
-
-        # Quart native way to handle max body size (1 GB; needed for large prompts)
-        app.config['MAX_CONTENT_LENGTH'] = 2**30
-
-        # Store client and tokenizer in app config for Blueprints to use
-        app.config['client'] = inference_client
-        app.config['tokenizer'] = tokenizer
-        app.config['parsers'] = parsers
-        app.config['verbose'] = verbose
-        app.config['chat_template'] = chat_template
-        app.config['multimodal_prompt_config'] = (
-            multimodal_prompt_config or MultimodalPromptConfig()
+        app = build_app(
+            inference_client,
+            tokenizer,
+            parsers,
+            verbose,
+            chat_template=chat_template,
+            multimodal_prompt_config=multimodal_prompt_config,
+            default_temperature=default_temperature,
+            default_top_p=default_top_p,
+            default_top_k=default_top_k,
+            eval_mode=eval_mode,
         )
-        app.config['default_temperature'] = default_temperature
-        app.config['default_top_p'] = default_top_p
-        app.config['default_top_k'] = default_top_k
-        app.config['eval_mode'] = eval_mode
-
-        # Applying the chat template is synchronous and O(prompt); on the event loop it
-        # stalls every other request this replica owns, including delivery of responses
-        # that already finished. One worker is enough - the point is the yield, not
-        # throughput. The copy is required: HF tokenizers are not thread-safe.
-        app.config['tokenize_executor'] = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="tokenize"
-        )
-        app.config['tokenizer_copy'] = copy.deepcopy(tokenizer)
-
-        # Register all blueprints from the 'endpoints' package
-        for endpoint in endpoints.__all__:
-            app.register_blueprint(endpoint)
 
         config = Config()
         config.keep_alive_timeout = 30.0  # Keep connection alive between long-running requests.

--- a/megatron/core/inference/wire_metrics.py
+++ b/megatron/core/inference/wire_metrics.py
@@ -3,10 +3,10 @@
 """Byte-level accounting for inference client/coordinator ZMQ traffic.
 
 Every request and reply on the frontend path (HTTP frontend -> InferenceClient ->
-coordinator -> engine) travels as a msgpack-packed list over ZMQ. None of those
-sites recorded how large the messages were, so payload growth -- a field added to
-a reply, prompt log probs left on by default -- only surfaced later as a
-throughput regression with no obvious cause.
+coordinator -> engine) travels as one or more msgpack-packed frames over ZMQ.
+None of those sites recorded how large the messages were, so payload growth -- a
+field added to a reply, prompt log probs left on by default -- only surfaced
+later as a throughput regression with no obvious cause.
 
 :class:`WireMetrics` accumulates message counts and byte totals per header at the
 send and receive sites. Recording costs one dict lookup and a few integer adds
@@ -39,9 +39,9 @@ def _header_name(header):
 class WireMetrics:
     """Counts messages and bytes crossing a ZMQ socket, broken down by header.
 
-    Sizes are of the msgpack-serialized payload frame, which is what the socket
-    actually moves. ZMQ's own framing and the routing-identity frame are not
-    counted, so totals are payload bytes rather than bytes on the NIC.
+    Sizes are the combined msgpack-serialized payload frames, which is what the
+    socket actually moves. ZMQ's own framing and the routing-identity frame are
+    not counted, so totals are payload bytes rather than bytes on the NIC.
     """
 
     __slots__ = ("sent_messages", "sent_bytes", "received_messages", "received_bytes", "per_header")

--- a/megatron/core/inference/wire_metrics.py
+++ b/megatron/core/inference/wire_metrics.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Byte-level accounting for inference client/coordinator ZMQ traffic.
+
+Every request and reply on the frontend path (HTTP frontend -> InferenceClient ->
+coordinator -> engine) travels as a msgpack-packed list over ZMQ. None of those
+sites recorded how large the messages were, so payload growth -- a field added to
+a reply, prompt log probs left on by default -- only surfaced later as a
+throughput regression with no obvious cause.
+
+:class:`WireMetrics` accumulates message counts and byte totals per header at the
+send and receive sites. Recording costs one dict lookup and a few integer adds
+per message, which is negligible beside the msgpack pack/unpack it accompanies,
+so it is always on rather than gated behind a flag.
+"""
+
+from .headers import UnknownHeaderError, decode_header
+
+# Indices into the per-header accumulator list.
+_SENT_COUNT = 0
+_SENT_BYTES = 1
+_RECEIVED_COUNT = 2
+_RECEIVED_BYTES = 3
+
+
+def _header_name(header):
+    """Best-effort human-readable name for a header wire value.
+
+    Never raises: an unrecognized value is reported rather than masked, because
+    this runs on the message path and must not turn a bookkeeping miss into a
+    request failure.
+    """
+    try:
+        return decode_header(int(header)).name
+    except (UnknownHeaderError, TypeError, ValueError):
+        return f"UNKNOWN_{header}"
+
+
+class WireMetrics:
+    """Counts messages and bytes crossing a ZMQ socket, broken down by header.
+
+    Sizes are of the msgpack-serialized payload frame, which is what the socket
+    actually moves. ZMQ's own framing and the routing-identity frame are not
+    counted, so totals are payload bytes rather than bytes on the NIC.
+    """
+
+    __slots__ = ("sent_messages", "sent_bytes", "received_messages", "received_bytes", "per_header")
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Zero every counter."""
+        self.sent_messages = 0
+        self.sent_bytes = 0
+        self.received_messages = 0
+        self.received_bytes = 0
+        # header wire value -> [sent_count, sent_bytes, received_count, received_bytes]
+        self.per_header = {}
+
+    def _bucket(self, header):
+        bucket = self.per_header.get(header)
+        if bucket is None:
+            bucket = [0, 0, 0, 0]
+            self.per_header[header] = bucket
+        return bucket
+
+    def record_sent(self, header, num_bytes):
+        """Record a payload of ``num_bytes`` sent with ``header``."""
+        self.sent_messages += 1
+        self.sent_bytes += num_bytes
+        bucket = self._bucket(header)
+        bucket[_SENT_COUNT] += 1
+        bucket[_SENT_BYTES] += num_bytes
+
+    def record_received(self, header, num_bytes):
+        """Record a payload of ``num_bytes`` received with ``header``."""
+        self.received_messages += 1
+        self.received_bytes += num_bytes
+        bucket = self._bucket(header)
+        bucket[_RECEIVED_COUNT] += 1
+        bucket[_RECEIVED_BYTES] += num_bytes
+
+    def mean_sent_bytes(self, header=None):
+        """Mean sent payload size, overall or for one header. 0.0 if nothing sent."""
+        if header is None:
+            count, total = self.sent_messages, self.sent_bytes
+        else:
+            bucket = self.per_header.get(header)
+            if bucket is None:
+                return 0.0
+            count, total = bucket[_SENT_COUNT], bucket[_SENT_BYTES]
+        return total / count if count else 0.0
+
+    def mean_received_bytes(self, header=None):
+        """Mean received payload size, overall or for one header. 0.0 if nothing received."""
+        if header is None:
+            count, total = self.received_messages, self.received_bytes
+        else:
+            bucket = self.per_header.get(header)
+            if bucket is None:
+                return 0.0
+            count, total = bucket[_RECEIVED_COUNT], bucket[_RECEIVED_BYTES]
+        return total / count if count else 0.0
+
+    def snapshot(self):
+        """Return the current counters as a plain, JSON-serializable dict.
+
+        Header keys are resolved to names here rather than at record time so the
+        message path stays free of enum lookups.
+        """
+        return {
+            "sent_messages": self.sent_messages,
+            "sent_bytes": self.sent_bytes,
+            "received_messages": self.received_messages,
+            "received_bytes": self.received_bytes,
+            "mean_sent_bytes": self.mean_sent_bytes(),
+            "mean_received_bytes": self.mean_received_bytes(),
+            "per_header": {
+                _header_name(header): {
+                    "sent_messages": bucket[_SENT_COUNT],
+                    "sent_bytes": bucket[_SENT_BYTES],
+                    "mean_sent_bytes": (
+                        bucket[_SENT_BYTES] / bucket[_SENT_COUNT] if bucket[_SENT_COUNT] else 0.0
+                    ),
+                    "received_messages": bucket[_RECEIVED_COUNT],
+                    "received_bytes": bucket[_RECEIVED_BYTES],
+                    "mean_received_bytes": (
+                        bucket[_RECEIVED_BYTES] / bucket[_RECEIVED_COUNT]
+                        if bucket[_RECEIVED_COUNT]
+                        else 0.0
+                    ),
+                }
+                for header, bucket in self.per_header.items()
+            },
+        }
+
+    def format_summary(self):
+        """Return a multi-line, human-readable summary for logging."""
+        lines = [
+            f"sent {self.sent_messages} msgs / {self.sent_bytes} bytes "
+            f"(mean {self.mean_sent_bytes():.1f} B), "
+            f"received {self.received_messages} msgs / {self.received_bytes} bytes "
+            f"(mean {self.mean_received_bytes():.1f} B)"
+        ]
+        for header, bucket in sorted(self.per_header.items()):
+            name = _header_name(header)
+            if bucket[_SENT_COUNT]:
+                lines.append(
+                    f"  {name:24s} sent     {bucket[_SENT_COUNT]:8d} msgs  "
+                    f"{bucket[_SENT_BYTES]:12d} B  "
+                    f"mean {bucket[_SENT_BYTES] / bucket[_SENT_COUNT]:9.1f} B"
+                )
+            if bucket[_RECEIVED_COUNT]:
+                lines.append(
+                    f"  {name:24s} received {bucket[_RECEIVED_COUNT]:8d} msgs  "
+                    f"{bucket[_RECEIVED_BYTES]:12d} B  "
+                    f"mean {bucket[_RECEIVED_BYTES] / bucket[_RECEIVED_COUNT]:9.1f} B"
+                )
+        return "\n".join(lines)

--- a/tests/performance_tests/client/frontend_capacity_benchmark.py
+++ b/tests/performance_tests/client/frontend_capacity_benchmark.py
@@ -23,10 +23,11 @@ Which layers are included depends on the flags:
 
 Running all three and comparing localizes a regression to a layer.
 
-The concurrency sweep offers a fixed number of in-flight requests at each level
-for ``--seconds-per-level`` and records sustained throughput and latency
-percentiles. ``max_stable_concurrency`` is the largest level still served at
-near-linear throughput, i.e. where the path saturates.
+The driver invokes this benchmark for every configured input sequence length.
+Within each invocation, the concurrency sweep offers a fixed number of in-flight
+requests at each level for ``--seconds-per-level`` and records sustained
+throughput and latency percentiles. ``max_stable_concurrency`` is the largest
+level still served at near-linear throughput, i.e. where the path saturates.
 
 Note the http path measures a single frontend replica in-process, while
 _run_text_gen_server forks four, so production HTTP capacity is higher than what
@@ -367,7 +368,8 @@ async def main(args) -> dict:
     else:
         results = await run_http_mode(args)
 
-    prefix = f"{args.mode}_stream" if args.streaming else args.mode
+    path_prefix = f"{args.mode}_stream" if args.streaming else args.mode
+    prefix = f"{path_prefix}_isl_{args.num_input_tokens}"
     base = results[0]
     entries = {}
     for result in results:

--- a/tests/performance_tests/client/frontend_capacity_benchmark.py
+++ b/tests/performance_tests/client/frontend_capacity_benchmark.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Capacity benchmark for the inference frontend and coordinator, with no model.
+
+Answers "how many requests per second can the frontend and coordinator move, and
+how many can be in flight before latency falls apart?" without a checkpoint, a
+GPU or torch.distributed. A real coordinator process is driven by a real
+InferenceClient; the engines are ZMQ stand-ins that hold each request for
+``--engine-latency-ms`` and then reply. Because the stand-ins are far faster than
+any real engine, the numbers here are an upper bound on the serving path and
+regress only when the frontend or coordinator itself gets slower.
+
+Which layers are included depends on the flags:
+
+  ``--mode client``       InferenceClient -> coordinator -> engines. Isolates the
+                          ZMQ hop and the coordinator's routing loop.
+  ``--mode http``         aiohttp -> Quart app -> InferenceClient -> coordinator
+                          -> engines. Adds HTTP parsing, tokenization and OpenAI
+                          response assembly.
+  ``--mode http --streaming``
+                          Also pays one detokenize step and one SSE flush per
+                          generated token, normally the frontend's largest
+                          per-token cost.
+
+Running all three and comparing localizes a regression to a layer.
+
+The concurrency sweep offers a fixed number of in-flight requests at each level
+for ``--seconds-per-level`` and records sustained throughput and latency
+percentiles. ``max_stable_concurrency`` is the largest level still served at
+near-linear throughput, i.e. where the path saturates.
+
+Note the http path measures a single frontend replica in-process, while
+_run_text_gen_server forks four, so production HTTP capacity is higher than what
+this reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import socket
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Import the standalone frontend harness that the unit tests use, so both share
+# one definition of "a coordinator with fake engines".
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from megatron.core.inference.inference_client import InferenceClient  # noqa: E402
+from megatron.core.inference.sampling_params import SamplingParams  # noqa: E402
+from tests.unit_tests.inference.frontend_test_utils import (  # noqa: E402
+    ByteLevelFastTokenizer,
+    standalone_coordinator,
+)
+
+_SSE_DONE = b"data: [DONE]"
+
+
+def _percentile(sorted_values: list[float], fraction: float) -> float:
+    if not sorted_values:
+        return 0.0
+    index = min(len(sorted_values) - 1, max(0, int(round(fraction * (len(sorted_values) - 1)))))
+    return sorted_values[index]
+
+
+def _build_prompt(tokenizer, num_input_tokens: int) -> tuple[list[int], str]:
+    """Return a prompt of exactly ``num_input_tokens`` tokens, as ids and as text.
+
+    Both forms describe the same prompt so the client and http modes put an
+    identical number of tokens on the wire and their byte counts stay comparable.
+    """
+    tokens = tokenizer.tokenize("hello " * num_input_tokens)[:num_input_tokens]
+    return tokens, tokenizer.detokenize(tokens)
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class LevelResult:
+    """Throughput, latency and wire cost measured at one concurrency level."""
+
+    def __init__(self, concurrency, completed, errors, latencies, wall, wire_delta):
+        self.concurrency = concurrency
+        self.completed = completed
+        self.errors = errors
+        self.wall = wall
+        sorted_latencies = sorted(latencies)
+        self.throughput = completed / wall if wall > 0 else 0.0
+        self.avg_ms = 1000 * statistics.fmean(sorted_latencies) if sorted_latencies else 0.0
+        self.p50_ms = 1000 * _percentile(sorted_latencies, 0.50)
+        self.p99_ms = 1000 * _percentile(sorted_latencies, 0.99)
+        self.wire_delta = wire_delta
+
+    def as_metrics(self) -> dict:
+        """Return this level's metrics in the flat shape compare_to_baseline reads."""
+        per_request = max(1, self.completed)
+        return {
+            "concurrency": self.concurrency,
+            "num_requests": self.completed,
+            "errors": self.errors,
+            "throughput_req_per_sec": self.throughput,
+            "avg_latency_ms": self.avg_ms,
+            "p50_latency_ms": self.p50_ms,
+            "p99_latency_ms": self.p99_ms,
+            "request_bytes_per_request": self.wire_delta["sent_bytes"] / per_request,
+            "reply_bytes_per_request": self.wire_delta["received_bytes"] / per_request,
+        }
+
+
+def _wire_snapshot(client: InferenceClient) -> dict:
+    snapshot = client.get_wire_metrics()
+    return {"sent_bytes": snapshot["sent_bytes"], "received_bytes": snapshot["received_bytes"]}
+
+
+async def _drive(submit, concurrency: int, seconds: float) -> tuple[int, int, list[float]]:
+    """Keep ``concurrency`` requests in flight for ``seconds``.
+
+    Args:
+        submit: Zero-argument coroutine function that issues one request and
+            returns once that request is complete.
+        concurrency: Number of requests to keep outstanding.
+        seconds: How long to sustain the offered load.
+
+    Returns:
+        tuple[int, int, list[float]]: completed count, error count, latencies.
+    """
+    deadline = time.perf_counter() + seconds
+    latencies: list[float] = []
+    errors = 0
+
+    async def worker():
+        nonlocal errors
+        while time.perf_counter() < deadline:
+            started = time.perf_counter()
+            try:
+                await submit()
+            except Exception as exc:  # noqa: BLE001 - errors are a reported metric
+                errors += 1
+                if errors == 1:
+                    print(f"  first error: {type(exc).__name__}: {exc}", flush=True)
+            else:
+                latencies.append(time.perf_counter() - started)
+
+    await asyncio.gather(*[worker() for _ in range(concurrency)])
+    return len(latencies), errors, latencies
+
+
+def _sampling_params(args: argparse.Namespace, streaming: bool) -> SamplingParams:
+    return SamplingParams(
+        num_tokens_to_generate=args.num_output_tokens,
+        temperature=0.0,
+        top_k=1,
+        return_log_probs=False,
+        streaming=streaming,
+    )
+
+
+def _make_client_submit(args, client, prompt_tokens):
+    """Build a submit callable that goes straight through the InferenceClient."""
+    if not args.streaming:
+
+        async def submit():
+            await client.add_request(list(prompt_tokens), _sampling_params(args, False))
+
+        return submit
+
+    async def submit_streaming():
+        stream = client.add_request_streaming(list(prompt_tokens), _sampling_params(args, True))
+        async for _ in stream:
+            pass
+
+    return submit_streaming
+
+
+def _make_http_submit(args, session, url, prompt_text):
+    """Build a submit callable that posts to /v1/completions like a real caller."""
+    payload = {
+        "prompt": prompt_text,
+        "max_tokens": args.num_output_tokens,
+        "temperature": 0.0,
+        "stream": args.streaming,
+    }
+
+    if not args.streaming:
+
+        async def submit():
+            async with session.post(url, json=payload) as response:
+                response.raise_for_status()
+                await response.read()
+
+        return submit
+
+    async def submit_streaming():
+        async with session.post(url, json=payload) as response:
+            response.raise_for_status()
+            async for line in response.content:
+                if line.startswith(_SSE_DONE):
+                    break
+
+    return submit_streaming
+
+
+async def _await_health(session, health_url, timeout=60.0):
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() < deadline:
+        try:
+            async with session.get(health_url) as response:
+                if response.status == 200:
+                    return
+        except Exception:  # noqa: BLE001 - server is still binding
+            pass
+        await asyncio.sleep(0.1)
+    raise RuntimeError(f"frontend did not become ready at {health_url}")
+
+
+async def _sweep(args, client, submit) -> list[LevelResult]:
+    """Warm up, then measure every requested concurrency level in order."""
+    print(
+        f"\nWarmup ({args.warmup_seconds:.1f}s at concurrency {args.concurrency[0]})...", flush=True
+    )
+    await _drive(submit, args.concurrency[0], args.warmup_seconds)
+
+    results = []
+    for concurrency in args.concurrency:
+        before = _wire_snapshot(client)
+        started = time.perf_counter()
+        completed, errors, latencies = await _drive(submit, concurrency, args.seconds_per_level)
+        wall = time.perf_counter() - started
+        after = _wire_snapshot(client)
+        wire_delta = {key: after[key] - before[key] for key in before}
+        result = LevelResult(concurrency, completed, errors, latencies, wall, wire_delta)
+        results.append(result)
+        print(
+            f"  concurrency={concurrency:5d}  "
+            f"throughput={result.throughput:9.1f} req/s  "
+            f"p50={result.p50_ms:8.2f} ms  p99={result.p99_ms:8.2f} ms  "
+            f"errors={errors}",
+            flush=True,
+        )
+    return results
+
+
+def _scaling_efficiency(result: LevelResult, base: LevelResult) -> float:
+    """How close this level came to the throughput implied by linear scaling.
+
+    Below saturation each added in-flight request adds its own throughput, so the
+    expected rate is the lowest level's per-request rate times this level's
+    concurrency. The ratio falls away from 1.0 once requests start queueing.
+
+    This leans on the lowest level being both unsaturated and dominated by the
+    fake engine's reply delay. Keep --engine-latency-ms well above the engine's
+    1 ms poll granularity, or the reference rate comes out optimistically high
+    and every later level looks saturated.
+    """
+    if base.concurrency == 0 or base.throughput == 0:
+        return 0.0
+    expected = base.throughput / base.concurrency * result.concurrency
+    return result.throughput / expected
+
+
+def _max_stable_concurrency(results: list[LevelResult], scaling_tolerance: float) -> int:
+    """Largest offered concurrency still served at near-linear throughput.
+
+    Stops at the first level that either errors or drops below
+    ``scaling_tolerance`` of linear scaling, so the answer is where the path
+    saturates rather than simply the highest level tried. Preferred over a
+    latency-percentile knee because throughput is far less noisy than p99.
+
+    Being a step function over the sampled grid, this is reported but not gated;
+    ``peak_throughput_req_per_sec`` is the continuous metric CI compares.
+    """
+    if not results:
+        return 0
+    base = results[0]
+    stable = base.concurrency
+    for result in results:
+        if result.errors or _scaling_efficiency(result, base) < scaling_tolerance:
+            break
+        stable = result.concurrency
+    return stable
+
+
+async def run_client_mode(args) -> list[LevelResult]:
+    """Measure InferenceClient -> coordinator -> engines."""
+    tokenizer = ByteLevelFastTokenizer()
+    prompt_tokens, _ = _build_prompt(tokenizer, args.num_input_tokens)
+    with standalone_coordinator(
+        max_requests=args.max_requests,
+        tokenizer=tokenizer,
+        num_engines=args.num_engines,
+        num_output_tokens=args.num_output_tokens,
+        reply_delay_s=args.engine_latency_ms / 1000.0,
+    ) as (addr, _engines):
+        client = InferenceClient(addr)
+        client.start()
+        try:
+            submit = _make_client_submit(args, client, prompt_tokens)
+            return await _sweep(args, client, submit)
+        finally:
+            client.stop()
+
+
+async def run_http_mode(args) -> list[LevelResult]:
+    """Measure aiohttp -> Quart frontend -> InferenceClient -> coordinator -> engines."""
+    import aiohttp
+    from hypercorn.asyncio import serve
+    from hypercorn.config import Config as HypercornConfig
+
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server.text_generation_server import (  # noqa: E501
+        build_app,
+    )
+
+    tokenizer = ByteLevelFastTokenizer()
+    _, prompt_text = _build_prompt(tokenizer, args.num_input_tokens)
+    port = args.port or _free_port()
+
+    with standalone_coordinator(
+        max_requests=args.max_requests,
+        tokenizer=tokenizer,
+        num_engines=args.num_engines,
+        num_output_tokens=args.num_output_tokens,
+        reply_delay_s=args.engine_latency_ms / 1000.0,
+    ) as (addr, _engines):
+        client = InferenceClient(addr)
+        client.start()
+        app = build_app(client, tokenizer)
+
+        config = HypercornConfig()
+        config.bind = [f"127.0.0.1:{port}"]
+        config.accesslog = None
+        shutdown = asyncio.Event()
+        server_task = asyncio.create_task(serve(app, config, shutdown_trigger=shutdown.wait))
+
+        connector = aiohttp.TCPConnector(limit=0)
+        try:
+            async with aiohttp.ClientSession(connector=connector) as session:
+                base = f"http://127.0.0.1:{port}"
+                await _await_health(session, f"{base}/v1/health")
+                submit = _make_http_submit(args, session, f"{base}/v1/completions", prompt_text)
+                return await _sweep(args, client, submit)
+        finally:
+            shutdown.set()
+            try:
+                await asyncio.wait_for(server_task, timeout=10.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                server_task.cancel()
+            client.stop()
+
+
+async def main(args) -> dict:
+    """Run the sweep for one mode and return the results keyed for the baseline."""
+    print(f"Mode            : {args.mode}")
+    print(f"Streaming       : {args.streaming}")
+    print(f"Engines         : {args.num_engines} (reply delay {args.engine_latency_ms} ms)")
+    print(f"ISL / OSL       : {args.num_input_tokens} / {args.num_output_tokens}")
+    print(f"Concurrency     : {args.concurrency}")
+    print(f"Seconds / level : {args.seconds_per_level}", flush=True)
+
+    if args.mode == "client":
+        results = await run_client_mode(args)
+    else:
+        results = await run_http_mode(args)
+
+    prefix = f"{args.mode}_stream" if args.streaming else args.mode
+    base = results[0]
+    entries = {}
+    for result in results:
+        metrics = result.as_metrics()
+        metrics["scaling_efficiency"] = _scaling_efficiency(result, base)
+        entries[f"{prefix}_concurrency_{result.concurrency}"] = metrics
+    entries[f"{prefix}_summary"] = {
+        "peak_throughput_req_per_sec": max((r.throughput for r in results), default=0.0),
+        "max_stable_concurrency": _max_stable_concurrency(results, args.scaling_tolerance),
+        "total_errors": sum(r.errors for r in results),
+    }
+
+    print(f"\n{'=' * 60}")
+    print(f"RESULTS ({prefix})")
+    print(f"{'=' * 60}")
+    for key, metrics in entries.items():
+        print(f"  [{key}]")
+        for name, value in metrics.items():
+            print(f"    {name:30s} : {value}")
+    return entries
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--mode",
+        choices=["client", "http"],
+        default="client",
+        help="'client' isolates the coordinator; 'http' adds the Quart frontend.",
+    )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Stream responses. In http mode this costs one SSE flush per token, "
+        "which is the frontend's dominant per-token cost.",
+    )
+    parser.add_argument(
+        "--concurrency",
+        # Sorted because the lowest level is the unsaturated reference that
+        # scaling_efficiency and max_stable_concurrency are measured against.
+        type=lambda value: sorted(int(part) for part in value.split(",")),
+        default=[1, 8, 32, 128, 512],
+        help="Comma-separated in-flight request counts to sweep.",
+    )
+    parser.add_argument("--seconds-per-level", type=float, default=3.0)
+    parser.add_argument("--warmup-seconds", type=float, default=1.0)
+    parser.add_argument("--num-input-tokens", type=int, default=512)
+    parser.add_argument("--num-output-tokens", type=int, default=64)
+    parser.add_argument("--num-engines", type=int, default=1)
+    parser.add_argument(
+        "--engine-latency-ms",
+        type=float,
+        default=10.0,
+        help="How long a fake engine holds a request before replying. Non-zero "
+        "values are what make high concurrency levels meaningful.",
+    )
+    parser.add_argument(
+        "--max-requests",
+        type=int,
+        default=1024,
+        help="Coordinator max_requests, used by its load-aware routing scores.",
+    )
+    parser.add_argument(
+        "--scaling-tolerance",
+        type=float,
+        default=0.8,
+        help="Fraction of linear throughput scaling a level must still reach to "
+        "count as unsaturated when computing max_stable_concurrency.",
+    )
+    parser.add_argument("--port", type=int, default=None, help="http mode bind port.")
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Write results to this path, merging into any existing file.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    entries = asyncio.run(main(parsed))
+    if parsed.output_json:
+        out_path = Path(parsed.output_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        existing = json.loads(out_path.read_text()) if out_path.exists() else {}
+        existing.update(entries)
+        out_path.write_text(json.dumps(existing, indent=2))
+        print(f"\nWrote results to {out_path}")

--- a/tests/performance_tests/shell_test_utils/compare_to_baseline.py
+++ b/tests/performance_tests/shell_test_utils/compare_to_baseline.py
@@ -18,19 +18,63 @@ for future runs, so we force a baseline refresh instead.
 
 Default tol is 10% (configurable via TOLERANCE_PCT in model_config.yaml).
 Default UPPER_TOL is 20% (configurable via UPPER_TOLERANCE_PCT, throughput only).
+
+A metric can be gated for most result keys but not all. METRICS_EXCLUDE in
+model_config.yaml drops individual metrics from individual keys:
+
+    METRICS_EXCLUDE:
+      - keys: "*_concurrency_512"
+        metrics: [p99_latency_ms]
+
+``keys`` is an fnmatch pattern over the result keys. Excluded metrics are still
+recorded in baseline_values.json and printed, just not asserted on.
 """
 
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import sys
 from pathlib import Path
 
 import yaml
 
-THROUGHPUT_METRICS = {"throughput_tok_per_sec"}
-LATENCY_METRICS = {"avg_latency_ms", "p50_latency_ms", "p99_latency_ms", "tpot_ms_per_tok"}
+THROUGHPUT_METRICS = {
+    "throughput_tok_per_sec",
+    # Frontend capacity test (frontend_capacity_benchmark.py).
+    "throughput_req_per_sec",
+    "peak_throughput_req_per_sec",
+    "max_stable_concurrency",
+    "scaling_efficiency",
+}
+LATENCY_METRICS = {
+    "avg_latency_ms",
+    "p50_latency_ms",
+    "p99_latency_ms",
+    "tpot_ms_per_tok",
+    # Payload sizes are latency-style: smaller is better, and growth is a
+    # regression whether or not throughput has caught up with it yet.
+    "request_bytes_per_request",
+    "reply_bytes_per_request",
+}
+
+
+def _excluded_metrics(batch_key: str, rules: list) -> set[str]:
+    """Metrics that must not be asserted on for ``batch_key``.
+
+    Args:
+        batch_key: A key in results.json / baseline_values.json.
+        rules: The METRICS_EXCLUDE list from model_config.yaml.
+
+    Returns:
+        set[str]: Names of metrics to skip for this key.
+    """
+    excluded: set[str] = set()
+    for rule in rules:
+        if fnmatch.fnmatch(batch_key, rule.get("keys", "")):
+            excluded.update(rule.get("metrics") or [])
+    return excluded
 
 
 def _check(
@@ -103,6 +147,7 @@ def main() -> int:
     tol = float(config.get("TOLERANCE_PCT", 10)) / 100.0
     upper_tol = float(config.get("UPPER_TOLERANCE_PCT", 20)) / 100.0
     metrics: list[str] = list(config.get("METRICS") or sorted(THROUGHPUT_METRICS | LATENCY_METRICS))
+    exclude_rules: list = list(config.get("METRICS_EXCLUDE") or [])
 
     print(f"Comparing {args.results} vs {args.baseline}")
     print(
@@ -119,8 +164,18 @@ def main() -> int:
             continue
         print(f"\n[{batch_key}]")
         measured_entry = results[batch_key]
+        excluded = _excluded_metrics(batch_key, exclude_rules)
         for metric in metrics:
             if metric not in baseline_entry or metric not in measured_entry:
+                continue
+            if metric in excluded:
+                measured = measured_entry[metric]
+                baseline_value = baseline_entry[metric]
+                delta_pct = (measured - baseline_value) / baseline_value * 100
+                print(
+                    f"  SKIP {metric:30s} measured={measured:10.3f}  "
+                    f"baseline={baseline_value:10.3f}  delta={delta_pct:+6.2f}%  (not gated)"
+                )
                 continue
             higher_is_better = metric in THROUGHPUT_METRICS
             ok, line = _check(

--- a/tests/performance_tests/shell_test_utils/perf_common.sh
+++ b/tests/performance_tests/shell_test_utils/perf_common.sh
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Shared helpers for the inference perf test drivers (run_perf_test.sh for
+# model-serving cases, run_frontend_perf_test.sh for the model-free frontend
+# capacity case). Sourced, not executed.
+
+# Echo the platform key whose baseline subtree this run reads or writes.
+#
+# baseline_values.json is a {platform: {batch_key: {metrics}}} mapping, so this
+# decides which numbers a run is compared against. Honours a caller-provided
+# value; otherwise identifies the node from its first GPU.
+#
+# Args:
+#   $1: caller-provided PLATFORM, or empty to auto-detect.
+#   $2: optional fallback used when no GPU is visible. Pass a value only for
+#       tests that do not need a GPU; without it, undetectable is an error,
+#       since silently comparing an H100 baseline on a GB200 node is worse than
+#       failing.
+detect_platform() {
+    local PROVIDED="${1:-}"
+    local FALLBACK="${2:-}"
+
+    if [[ -n "$PROVIDED" ]]; then
+        echo "[perf] using caller-provided PLATFORM=$PROVIDED" >&2
+        echo "$PROVIDED"
+        return 0
+    fi
+
+    local GPU_NAME
+    GPU_NAME=$(nvidia-smi -L 2>/dev/null | head -1 || true)
+    local DETECTED=""
+    case "$GPU_NAME" in
+        *GB200*|*"Grace Blackwell"*) DETECTED=gb200 ;;
+        *B200*)                      DETECTED=b200  ;;
+        *H100*)                      DETECTED=h100  ;;
+        *A100*)                      DETECTED=a100  ;;
+    esac
+
+    if [[ -n "$DETECTED" ]]; then
+        echo "[perf] auto-detected PLATFORM=$DETECTED from \"$GPU_NAME\"" >&2
+        echo "$DETECTED"
+        return 0
+    fi
+
+    if [[ -n "$FALLBACK" ]]; then
+        echo "[perf] no GPU detected; falling back to PLATFORM=$FALLBACK" >&2
+        echo "$FALLBACK"
+        return 0
+    fi
+
+    echo "[perf] error: could not auto-detect PLATFORM from nvidia-smi (\"$GPU_NAME\")." >&2
+    echo "       Pass PLATFORM=<h100|gb200|b200|a100> explicitly." >&2
+    return 2
+}
+
+# Compare a results.json against the checked-in baseline, or record it as the
+# new baseline for this platform.
+#
+# Honours RECORD_BASELINE=1 (merge results into the baseline's platform subtree,
+# leaving other platforms intact) and SKIP_COMPARE=1 (do neither).
+#
+# Args:
+#   $1: path to results.json produced by this run.
+#   $2: path to the test case's model_config.yaml.
+#   $3: platform key.
+compare_or_record() {
+    local RESULTS_JSON="$1"
+    local CONFIG_PATH="$2"
+    local PLATFORM="$3"
+    local CASE_DIR BASELINE_PATH PERF_DIR
+    CASE_DIR="$(dirname "$CONFIG_PATH")"
+    BASELINE_PATH="$CASE_DIR/baseline_values.json"
+    PERF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+    if [[ "${RECORD_BASELINE:-0}" == "1" ]]; then
+        echo "[perf] RECORD_BASELINE=1 → merging results.json into $BASELINE_PATH under key '$PLATFORM'"
+        uv run --no-sync python - "$RESULTS_JSON" "$BASELINE_PATH" "$PLATFORM" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+results_path, baseline_path, platform = sys.argv[1], sys.argv[2], sys.argv[3]
+results = json.loads(Path(results_path).read_text())
+baseline = {}
+if Path(baseline_path).exists():
+    baseline = json.loads(Path(baseline_path).read_text())
+# Merge: overwrite only the current platform's subtree, leave others intact.
+baseline[platform] = results
+Path(baseline_path).write_text(json.dumps(baseline, indent=2) + "\n")
+print(f"[perf] wrote {len(results)} entries under '{platform}' "
+      f"({sorted(baseline.keys())} platforms recorded total)")
+PY
+        return 0
+    fi
+
+    if [[ "${SKIP_COMPARE:-0}" == "1" ]]; then
+        echo "[perf] SKIP_COMPARE=1 → not running baseline comparison"
+        return 0
+    fi
+
+    if [[ ! -f "$BASELINE_PATH" ]]; then
+        echo "[perf] error: no baseline_values.json at $BASELINE_PATH." >&2
+        echo "       Run once with RECORD_BASELINE=1 to bootstrap." >&2
+        return 3
+    fi
+
+    uv run --no-sync python "$PERF_DIR/shell_test_utils/compare_to_baseline.py" \
+        --results "$RESULTS_JSON" \
+        --baseline "$BASELINE_PATH" \
+        --config "$CONFIG_PATH" \
+        --platform "$PLATFORM"
+}

--- a/tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh
+++ b/tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh
@@ -22,7 +22,7 @@
 #                        and CPU and NIC differences between node types do move these
 #                        numbers.)
 #
-# Expects /usr/local/bin/yq (present in mcore_ci_dev image).
+# Expects PyYAML in the active Megatron-LM Python environment.
 
 set -euo pipefail
 
@@ -45,7 +45,11 @@ PLATFORM=$(detect_platform "${PLATFORM:-}" "cpu_$(uname -m)")
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PERF_DIR="$ROOT_DIR/tests/performance_tests"
-YQ=/usr/local/bin/yq
+
+yaml_scalar() {
+    python -c 'import sys, yaml; value = yaml.safe_load(open(sys.argv[1])).get(sys.argv[2]); print(sys.argv[3] if value is None else value)' \
+        "$CONFIG_PATH" "$1" "$2"
+}
 
 mkdir -p "$RESULTS_ROOT"
 RESULTS_JSON="$RESULTS_ROOT/results.json"
@@ -56,22 +60,40 @@ rm -f "$RESULTS_JSON"
 
 # ── Read model_config.yaml ────────────────────────────────────────────────────
 
-CONCURRENCY=$("$YQ" '.CONCURRENCY // "1,8,32,128,512"' "$CONFIG_PATH")
-SECONDS_PER_LEVEL=$("$YQ" '.SECONDS_PER_LEVEL // 5' "$CONFIG_PATH")
-WARMUP_SECONDS=$("$YQ" '.WARMUP_SECONDS // 2' "$CONFIG_PATH")
-NUM_INPUT_TOKENS=$("$YQ" '.NUM_INPUT_TOKENS // 512' "$CONFIG_PATH")
-NUM_OUTPUT_TOKENS=$("$YQ" '.NUM_OUTPUT_TOKENS // 64' "$CONFIG_PATH")
-NUM_ENGINES=$("$YQ" '.NUM_ENGINES // 1' "$CONFIG_PATH")
-ENGINE_LATENCY_MS=$("$YQ" '.ENGINE_LATENCY_MS // 10' "$CONFIG_PATH")
-MAX_REQUESTS=$("$YQ" '.MAX_REQUESTS // 1024' "$CONFIG_PATH")
+CONCURRENCY=$(yaml_scalar CONCURRENCY "1,8,32,128,512")
+SECONDS_PER_LEVEL=$(yaml_scalar SECONDS_PER_LEVEL 5)
+WARMUP_SECONDS=$(yaml_scalar WARMUP_SECONDS 2)
+NUM_INPUT_TOKENS=$(yaml_scalar NUM_INPUT_TOKENS 512)
+NUM_OUTPUT_TOKENS=$(yaml_scalar NUM_OUTPUT_TOKENS 64)
+NUM_ENGINES=$(yaml_scalar NUM_ENGINES 1)
+ENGINE_LATENCY_MS=$(yaml_scalar ENGINE_LATENCY_MS 10)
+MAX_REQUESTS=$(yaml_scalar MAX_REQUESTS 1024)
+LONG_SEQUENCE_LENGTHS=$(yaml_scalar LONG_SEQUENCE_LENGTHS "")
+LONG_SEQUENCE_CONCURRENCY=$(yaml_scalar LONG_SEQUENCE_CONCURRENCY 1)
+LONG_SEQUENCE_ENGINE_LATENCY_MS=$(yaml_scalar LONG_SEQUENCE_ENGINE_LATENCY_MS 0)
 # Each entry is "<mode>[:stream]" — e.g. "client", "http", "http:stream".
-mapfile -t PATHS < <("$YQ" '.PATHS[]' "$CONFIG_PATH")
+mapfile -t PATHS < <(
+    python -c 'import sys, yaml; print("\n".join(yaml.safe_load(open(sys.argv[1]))["PATHS"]))' \
+        "$CONFIG_PATH"
+)
+
+# Each entry is "input_tokens|concurrency|engine_latency_ms". The regular
+# capacity sweep retains high concurrency and a simulated engine delay. Long
+# prompts run one at a time with no fake compute so the measured time isolates
+# frontend/coordinator payload processing.
+SWEEPS=("$NUM_INPUT_TOKENS|$CONCURRENCY|$ENGINE_LATENCY_MS")
+if [[ -n "$LONG_SEQUENCE_LENGTHS" ]]; then
+    IFS=',' read -r -a LONG_INPUT_LENGTHS <<< "$LONG_SEQUENCE_LENGTHS"
+    for ISL in "${LONG_INPUT_LENGTHS[@]}"; do
+        SWEEPS+=("$ISL|$LONG_SEQUENCE_CONCURRENCY|$LONG_SEQUENCE_ENGINE_LATENCY_MS")
+    done
+fi
 
 echo "[run_frontend_perf_test] PLATFORM=$PLATFORM  paths=${PATHS[*]}"
-echo "[run_frontend_perf_test] concurrency=$CONCURRENCY  ISL=$NUM_INPUT_TOKENS  OSL=$NUM_OUTPUT_TOKENS"
-echo "[run_frontend_perf_test] engines=$NUM_ENGINES  engine_latency=${ENGINE_LATENCY_MS}ms"
+echo "[run_frontend_perf_test] sweeps=${SWEEPS[*]}  OSL=$NUM_OUTPUT_TOKENS"
+echo "[run_frontend_perf_test] engines=$NUM_ENGINES"
 
-# ── Sweep every requested path ────────────────────────────────────────────────
+# ── Sweep every requested path and input length ───────────────────────────────
 
 for PATH_SPEC in "${PATHS[@]}"; do
     MODE="${PATH_SPEC%%:*}"
@@ -79,22 +101,25 @@ for PATH_SPEC in "${PATHS[@]}"; do
     if [[ "$PATH_SPEC" == *:stream ]]; then
         STREAM_ARGS=(--streaming)
     fi
-    echo "[run_frontend_perf_test] === path $PATH_SPEC ==="
-    (
-        cd "$ROOT_DIR"
-        uv run --no-sync python "$PERF_DIR/client/frontend_capacity_benchmark.py" \
-            --mode "$MODE" \
-            "${STREAM_ARGS[@]}" \
-            --concurrency "$CONCURRENCY" \
-            --seconds-per-level "$SECONDS_PER_LEVEL" \
-            --warmup-seconds "$WARMUP_SECONDS" \
-            --num-input-tokens "$NUM_INPUT_TOKENS" \
-            --num-output-tokens "$NUM_OUTPUT_TOKENS" \
-            --num-engines "$NUM_ENGINES" \
-            --engine-latency-ms "$ENGINE_LATENCY_MS" \
-            --max-requests "$MAX_REQUESTS" \
-            --output-json "$RESULTS_JSON"
-    ) 2>&1 | tee -a "$RESULTS_ROOT/benchmark.log"
+    for SWEEP in "${SWEEPS[@]}"; do
+        IFS='|' read -r ISL SWEEP_CONCURRENCY SWEEP_ENGINE_LATENCY_MS <<< "$SWEEP"
+        echo "[run_frontend_perf_test] === path $PATH_SPEC  ISL $ISL  concurrency $SWEEP_CONCURRENCY ==="
+        (
+            cd "$ROOT_DIR"
+            uv run --no-sync python "$PERF_DIR/client/frontend_capacity_benchmark.py" \
+                --mode "$MODE" \
+                "${STREAM_ARGS[@]}" \
+                --concurrency "$SWEEP_CONCURRENCY" \
+                --seconds-per-level "$SECONDS_PER_LEVEL" \
+                --warmup-seconds "$WARMUP_SECONDS" \
+                --num-input-tokens "$ISL" \
+                --num-output-tokens "$NUM_OUTPUT_TOKENS" \
+                --num-engines "$NUM_ENGINES" \
+                --engine-latency-ms "$SWEEP_ENGINE_LATENCY_MS" \
+                --max-requests "$MAX_REQUESTS" \
+                --output-json "$RESULTS_JSON"
+        ) 2>&1 | tee -a "$RESULTS_ROOT/benchmark.log"
+    done
 done
 
 echo "[run_frontend_perf_test] benchmark complete. Results written to $RESULTS_JSON"

--- a/tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh
+++ b/tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run the model-free frontend/coordinator capacity test.
+#
+# Unlike run_perf_test.sh this launches no server, loads no checkpoint and needs
+# no GPU: frontend_capacity_benchmark.py starts its own coordinator process and
+# fake engines. What it measures is how many requests per second the HTTP
+# frontend, the InferenceClient and the coordinator can move, so a regression
+# here is a regression in that code and nothing else.
+#
+# Invoked by `cog submit` (or locally) with KEY=VALUE positional args.
+#
+# Required:
+#   CONFIG_PATH=tests/performance_tests/test_cases/frontend/<case>/model_config.yaml
+#   RESULTS_ROOT=/path/where/results.json/goes
+#
+# Optional:
+#   RECORD_BASELINE=1   (merge results.json into baseline_values.json under PLATFORM)
+#   SKIP_COMPARE=1      (skip the comparison step entirely)
+#   PLATFORM=<name>     (override the baseline key; defaults to GPU-based detection,
+#                        falling back to cpu_<arch> when no GPU is visible. The GPU
+#                        does not participate, but its name identifies the node type,
+#                        and CPU and NIC differences between node types do move these
+#                        numbers.)
+#
+# Expects /usr/local/bin/yq (present in mcore_ci_dev image).
+
+set -euo pipefail
+
+for ARG in "$@"; do
+    if [[ "$ARG" != *=* ]]; then
+        echo "[run_frontend_perf_test] error: arg '$ARG' is not KEY=VALUE" >&2
+        exit 2
+    fi
+    KEY="${ARG%%=*}"
+    VAL="${ARG#*=}"
+    export "$KEY"="$VAL"
+done
+
+: "${CONFIG_PATH:?CONFIG_PATH (path to model_config.yaml) is required}"
+: "${RESULTS_ROOT:?RESULTS_ROOT is required}"
+
+source "$(dirname "${BASH_SOURCE[0]}")/perf_common.sh"
+
+PLATFORM=$(detect_platform "${PLATFORM:-}" "cpu_$(uname -m)")
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PERF_DIR="$ROOT_DIR/tests/performance_tests"
+YQ=/usr/local/bin/yq
+
+mkdir -p "$RESULTS_ROOT"
+RESULTS_JSON="$RESULTS_ROOT/results.json"
+# launch_jet_workload.py retries unless torchrun's per-rank std*.log assets exist.
+ASSETS_ROOT="$(dirname "$RESULTS_ROOT")"
+mkdir -p "$ASSETS_ROOT/logs/1"
+rm -f "$RESULTS_JSON"
+
+# ── Read model_config.yaml ────────────────────────────────────────────────────
+
+CONCURRENCY=$("$YQ" '.CONCURRENCY // "1,8,32,128,512"' "$CONFIG_PATH")
+SECONDS_PER_LEVEL=$("$YQ" '.SECONDS_PER_LEVEL // 5' "$CONFIG_PATH")
+WARMUP_SECONDS=$("$YQ" '.WARMUP_SECONDS // 2' "$CONFIG_PATH")
+NUM_INPUT_TOKENS=$("$YQ" '.NUM_INPUT_TOKENS // 512' "$CONFIG_PATH")
+NUM_OUTPUT_TOKENS=$("$YQ" '.NUM_OUTPUT_TOKENS // 64' "$CONFIG_PATH")
+NUM_ENGINES=$("$YQ" '.NUM_ENGINES // 1' "$CONFIG_PATH")
+ENGINE_LATENCY_MS=$("$YQ" '.ENGINE_LATENCY_MS // 10' "$CONFIG_PATH")
+MAX_REQUESTS=$("$YQ" '.MAX_REQUESTS // 1024' "$CONFIG_PATH")
+# Each entry is "<mode>[:stream]" — e.g. "client", "http", "http:stream".
+mapfile -t PATHS < <("$YQ" '.PATHS[]' "$CONFIG_PATH")
+
+echo "[run_frontend_perf_test] PLATFORM=$PLATFORM  paths=${PATHS[*]}"
+echo "[run_frontend_perf_test] concurrency=$CONCURRENCY  ISL=$NUM_INPUT_TOKENS  OSL=$NUM_OUTPUT_TOKENS"
+echo "[run_frontend_perf_test] engines=$NUM_ENGINES  engine_latency=${ENGINE_LATENCY_MS}ms"
+
+# ── Sweep every requested path ────────────────────────────────────────────────
+
+for PATH_SPEC in "${PATHS[@]}"; do
+    MODE="${PATH_SPEC%%:*}"
+    STREAM_ARGS=()
+    if [[ "$PATH_SPEC" == *:stream ]]; then
+        STREAM_ARGS=(--streaming)
+    fi
+    echo "[run_frontend_perf_test] === path $PATH_SPEC ==="
+    (
+        cd "$ROOT_DIR"
+        uv run --no-sync python "$PERF_DIR/client/frontend_capacity_benchmark.py" \
+            --mode "$MODE" \
+            "${STREAM_ARGS[@]}" \
+            --concurrency "$CONCURRENCY" \
+            --seconds-per-level "$SECONDS_PER_LEVEL" \
+            --warmup-seconds "$WARMUP_SECONDS" \
+            --num-input-tokens "$NUM_INPUT_TOKENS" \
+            --num-output-tokens "$NUM_OUTPUT_TOKENS" \
+            --num-engines "$NUM_ENGINES" \
+            --engine-latency-ms "$ENGINE_LATENCY_MS" \
+            --max-requests "$MAX_REQUESTS" \
+            --output-json "$RESULTS_JSON"
+    ) 2>&1 | tee -a "$RESULTS_ROOT/benchmark.log"
+done
+
+echo "[run_frontend_perf_test] benchmark complete. Results written to $RESULTS_JSON"
+
+# ── Baseline comparison or recording ──────────────────────────────────────────
+
+compare_or_record "$RESULTS_JSON" "$CONFIG_PATH" "$PLATFORM"

--- a/tests/performance_tests/shell_test_utils/run_perf_test.sh
+++ b/tests/performance_tests/shell_test_utils/run_perf_test.sh
@@ -37,26 +37,10 @@ done
 : "${CHECKPOINT_LOAD_PATH:?CHECKPOINT_LOAD_PATH is required}"
 : "${RESULTS_ROOT:?RESULTS_ROOT is required}"
 
+source "$(dirname "${BASH_SOURCE[0]}")/perf_common.sh"
+
 # Resolve PLATFORM. Caller can override via env; otherwise inspect the first GPU.
-# baseline_values.json is a {platform: {batch_key: {metrics}}} mapping, so this
-# value picks which subtree to read / write.
-if [[ -z "${PLATFORM:-}" ]]; then
-    GPU_NAME=$(nvidia-smi -L 2>/dev/null | head -1 || true)
-    case "$GPU_NAME" in
-        *GB200*|*"Grace Blackwell"*) PLATFORM=gb200 ;;
-        *B200*)                      PLATFORM=b200  ;;
-        *H100*)                      PLATFORM=h100  ;;
-        *A100*)                      PLATFORM=a100  ;;
-        *)
-            echo "[run_perf_test] error: could not auto-detect PLATFORM from nvidia-smi (\"$GPU_NAME\")." >&2
-            echo "                  Pass PLATFORM=<h100|gb200|b200|a100> explicitly." >&2
-            exit 2
-            ;;
-    esac
-    echo "[run_perf_test] auto-detected PLATFORM=$PLATFORM from \"$GPU_NAME\""
-else
-    echo "[run_perf_test] using caller-provided PLATFORM=$PLATFORM"
-fi
+PLATFORM=$(detect_platform "${PLATFORM:-}")
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PERF_DIR="$ROOT_DIR/tests/performance_tests"
@@ -298,43 +282,4 @@ echo "[run_perf_test] benchmark complete. Results written to $RESULTS_JSON"
 
 # ── Baseline comparison or recording ──────────────────────────────────────────
 
-CASE_DIR="$(dirname "$CONFIG_PATH")"
-BASELINE_PATH="$CASE_DIR/baseline_values.json"
-
-if [[ "${RECORD_BASELINE:-0}" == "1" ]]; then
-    echo "[run_perf_test] RECORD_BASELINE=1 → merging results.json into $BASELINE_PATH under key '$PLATFORM'"
-    uv run --no-sync python - "$RESULTS_JSON" "$BASELINE_PATH" "$PLATFORM" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-results_path, baseline_path, platform = sys.argv[1], sys.argv[2], sys.argv[3]
-results = json.loads(Path(results_path).read_text())
-baseline = {}
-if Path(baseline_path).exists():
-    baseline = json.loads(Path(baseline_path).read_text())
-# Merge: overwrite only the current platform's subtree, leave others intact.
-baseline[platform] = results
-Path(baseline_path).write_text(json.dumps(baseline, indent=2) + "\n")
-print(f"[run_perf_test] wrote {len(results)} batch entries under '{platform}' "
-      f"({sorted(baseline.keys())} platforms recorded total)")
-PY
-    exit 0
-fi
-
-if [[ "${SKIP_COMPARE:-0}" == "1" ]]; then
-    echo "[run_perf_test] SKIP_COMPARE=1 → not running baseline comparison"
-    exit 0
-fi
-
-if [[ ! -f "$BASELINE_PATH" ]]; then
-    echo "[run_perf_test] error: no baseline_values.json at $BASELINE_PATH." >&2
-    echo "                  Run once with RECORD_BASELINE=1 to bootstrap." >&2
-    exit 3
-fi
-
-uv run --no-sync python "$PERF_DIR/shell_test_utils/compare_to_baseline.py" \
-    --results "$RESULTS_JSON" \
-    --baseline "$BASELINE_PATH" \
-    --config "$CONFIG_PATH" \
-    --platform "$PLATFORM"
+compare_or_record "$RESULTS_JSON" "$CONFIG_PATH" "$PLATFORM"

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
@@ -399,5 +399,406 @@
       "max_stable_concurrency": 1,
       "total_errors": 0
     }
+  },
+  "gb200": {
+    "client_isl_512_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 327,
+      "errors": 0,
+      "throughput_req_per_sec": 65.21910185545525,
+      "avg_latency_ms": 15.332557449547584,
+      "p50_latency_ms": 15.290338000340853,
+      "p99_latency_ms": 15.430561000357557,
+      "request_bytes_per_request": 954.6177370030581,
+      "reply_bytes_per_request": 1306.2354740061162,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_512_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 2568,
+      "errors": 0,
+      "throughput_req_per_sec": 512.122514357521,
+      "avg_latency_ms": 15.609858261294523,
+      "p50_latency_ms": 15.607776999786438,
+      "p99_latency_ms": 15.934047999508039,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.981542408182298
+    },
+    "client_isl_512_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 10155,
+      "errors": 0,
+      "throughput_req_per_sec": 2026.455336300748,
+      "avg_latency_ms": 15.773868396756773,
+      "p50_latency_ms": 16.38608099983685,
+      "p99_latency_ms": 17.759581000063918,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.9709843812285098
+    },
+    "client_isl_512_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 28228,
+      "errors": 0,
+      "throughput_req_per_sec": 5629.3859633303455,
+      "avg_latency_ms": 22.668099814899193,
+      "p50_latency_ms": 22.5243410004623,
+      "p99_latency_ms": 29.056809000394423,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.6743358400732048
+    },
+    "client_isl_512_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 30714,
+      "errors": 0,
+      "throughput_req_per_sec": 6122.021630845174,
+      "avg_latency_ms": 82.84526207306193,
+      "p50_latency_ms": 82.54742799999804,
+      "p99_latency_ms": 90.99579700068716,
+      "request_bytes_per_request": 955.4289249202318,
+      "reply_bytes_per_request": 1307.8578498404636,
+      "scaling_efficiency": 0.1833369849870806
+    },
+    "client_isl_512_summary": {
+      "peak_throughput_req_per_sec": 6122.021630845174,
+      "max_stable_concurrency": 32,
+      "total_errors": 0
+    },
+    "client_isl_50000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 827,
+      "errors": 0,
+      "throughput_req_per_sec": 165.23296124078047,
+      "avg_latency_ms": 6.051805665058667,
+      "p50_latency_ms": 6.05458300015016,
+      "p99_latency_ms": 6.080951000512869,
+      "request_bytes_per_request": 58691.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 165.23296124078047,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 406,
+      "errors": 0,
+      "throughput_req_per_sec": 81.00101034216604,
+      "avg_latency_ms": 12.345189812778,
+      "p50_latency_ms": 12.340689000666316,
+      "p99_latency_ms": 12.459663999834447,
+      "request_bytes_per_request": 117025.7684729064,
+      "reply_bytes_per_request": 1308.536945812808,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 81.00101034216604,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 317,
+      "errors": 0,
+      "throughput_req_per_sec": 63.287330754853826,
+      "avg_latency_ms": 15.800601432200311,
+      "p50_latency_ms": 15.796143999978085,
+      "p99_latency_ms": 15.964655000061612,
+      "request_bytes_per_request": 175359.58990536278,
+      "reply_bytes_per_request": 1308.179810725552,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 63.287330754853826,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 261,
+      "errors": 0,
+      "throughput_req_per_sec": 52.15637839747857,
+      "avg_latency_ms": 19.172738149428852,
+      "p50_latency_ms": 19.15176100010285,
+      "p99_latency_ms": 19.407824000154505,
+      "request_bytes_per_request": 233692.33333333334,
+      "reply_bytes_per_request": 1307.6666666666667,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 52.15637839747857,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_512_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 309,
+      "errors": 0,
+      "throughput_req_per_sec": 61.783139838335266,
+      "avg_latency_ms": 16.185169032350128,
+      "p50_latency_ms": 16.224535000219475,
+      "p99_latency_ms": 16.29128700005822,
+      "request_bytes_per_request": 954.5598705501618,
+      "reply_bytes_per_request": 1913.1197411003236,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_512_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 2373,
+      "errors": 0,
+      "throughput_req_per_sec": 473.4112164316534,
+      "avg_latency_ms": 16.874410528853016,
+      "p50_latency_ms": 16.641590999824984,
+      "p99_latency_ms": 18.4301660001438,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.9578082662810677
+    },
+    "http_isl_512_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 3448,
+      "errors": 0,
+      "throughput_req_per_sec": 684.9760604731699,
+      "avg_latency_ms": 46.59183775753625,
+      "p50_latency_ms": 44.10240800007159,
+      "p99_latency_ms": 54.84201800027222,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.34646186558011177
+    },
+    "http_isl_512_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 3456,
+      "errors": 0,
+      "throughput_req_per_sec": 678.6269512985305,
+      "avg_latency_ms": 187.20864763917407,
+      "p50_latency_ms": 167.51098399981856,
+      "p99_latency_ms": 460.08107000034215,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.08581261928242306
+    },
+    "http_isl_512_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 3656,
+      "errors": 0,
+      "throughput_req_per_sec": 699.5670623419741,
+      "avg_latency_ms": 711.2638930957344,
+      "p50_latency_ms": 627.0869429999948,
+      "p99_latency_ms": 2185.140760999275,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.022115125942318632
+    },
+    "http_isl_512_summary": {
+      "peak_throughput_req_per_sec": 699.5670623419741,
+      "max_stable_concurrency": 8,
+      "total_errors": 0
+    },
+    "http_isl_50000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 211,
+      "errors": 0,
+      "throughput_req_per_sec": 42.175017316393635,
+      "avg_latency_ms": 23.71015064930133,
+      "p50_latency_ms": 21.39509700009512,
+      "p99_latency_ms": 26.530327000727993,
+      "request_bytes_per_request": 58689.92890995261,
+      "reply_bytes_per_request": 59647.85781990521,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 42.175017316393635,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 114,
+      "errors": 0,
+      "throughput_req_per_sec": 22.710638968117834,
+      "avg_latency_ms": 44.03147875434131,
+      "p50_latency_ms": 43.82373599946732,
+      "p99_latency_ms": 67.43224499950884,
+      "request_bytes_per_request": 117024.28070175438,
+      "reply_bytes_per_request": 117983.56140350878,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 22.710638968117834,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 75,
+      "errors": 0,
+      "throughput_req_per_sec": 14.984104403535143,
+      "avg_latency_ms": 66.73644150660644,
+      "p50_latency_ms": 67.43196600018564,
+      "p99_latency_ms": 68.58079799985717,
+      "request_bytes_per_request": 175358.0,
+      "reply_bytes_per_request": 176317.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 14.984104403535143,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 58,
+      "errors": 0,
+      "throughput_req_per_sec": 11.558075298693119,
+      "avg_latency_ms": 86.51793981033703,
+      "p50_latency_ms": 86.14042299996072,
+      "p99_latency_ms": 94.34083999985887,
+      "request_bytes_per_request": 233691.0,
+      "reply_bytes_per_request": 234650.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 11.558075298693119,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_512_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 297,
+      "errors": 0,
+      "throughput_req_per_sec": 59.3668444959751,
+      "avg_latency_ms": 16.843820100998972,
+      "p50_latency_ms": 16.911394999624463,
+      "p99_latency_ms": 17.87613099986629,
+      "request_bytes_per_request": 954.5084175084176,
+      "reply_bytes_per_request": 3962.094276094276,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_512_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 752,
+      "errors": 0,
+      "throughput_req_per_sec": 149.94854338268837,
+      "avg_latency_ms": 53.33625955319847,
+      "p50_latency_ms": 50.35626599965326,
+      "p99_latency_ms": 79.08939199933229,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.31572451057436285
+    },
+    "http_stream_isl_512_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 800,
+      "errors": 0,
+      "throughput_req_per_sec": 147.60049681346973,
+      "avg_latency_ms": 215.35259398375615,
+      "p50_latency_ms": 193.92829600019468,
+      "p99_latency_ms": 503.4989850000784,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.07769514389018342
+    },
+    "http_stream_isl_512_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 925,
+      "errors": 0,
+      "throughput_req_per_sec": 173.18991064798516,
+      "avg_latency_ms": 721.8339519827103,
+      "p50_latency_ms": 715.5677380005727,
+      "p99_latency_ms": 1065.3641679991779,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.022791276653235572
+    },
+    "http_stream_isl_512_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 1381,
+      "errors": 0,
+      "throughput_req_per_sec": 185.86197934905138,
+      "avg_latency_ms": 2580.7948916198384,
+      "p50_latency_ms": 2550.853895000728,
+      "p99_latency_ms": 4395.192418000079,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.006114720792356197
+    },
+    "http_stream_isl_512_summary": {
+      "peak_throughput_req_per_sec": 185.86197934905138,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_50000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 112,
+      "errors": 0,
+      "throughput_req_per_sec": 22.378220088479317,
+      "avg_latency_ms": 44.685289562469926,
+      "p50_latency_ms": 45.148191999942355,
+      "p99_latency_ms": 45.572447999802534,
+      "request_bytes_per_request": 58689.25892857143,
+      "reply_bytes_per_request": 61535.66071428572,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 22.378220088479317,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 62,
+      "errors": 0,
+      "throughput_req_per_sec": 12.39168764105952,
+      "avg_latency_ms": 80.69761893551502,
+      "p50_latency_ms": 80.29595299922221,
+      "p99_latency_ms": 82.26679699964734,
+      "request_bytes_per_request": 117024.0,
+      "reply_bytes_per_request": 119839.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 12.39168764105952,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 42,
+      "errors": 0,
+      "throughput_req_per_sec": 8.375061781210944,
+      "avg_latency_ms": 119.39982616671668,
+      "p50_latency_ms": 119.83988500014675,
+      "p99_latency_ms": 122.44634499984386,
+      "request_bytes_per_request": 175358.0,
+      "reply_bytes_per_request": 178173.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 8.375061781210944,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 33,
+      "errors": 0,
+      "throughput_req_per_sec": 6.489406594450015,
+      "avg_latency_ms": 154.095623848441,
+      "p50_latency_ms": 155.13555200050178,
+      "p99_latency_ms": 156.4665559999412,
+      "request_bytes_per_request": 233691.0,
+      "reply_bytes_per_request": 236506.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 6.489406594450015,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    }
   }
 }

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
@@ -1,0 +1,199 @@
+{
+  "h100": {
+    "client_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 327,
+      "errors": 0,
+      "throughput_req_per_sec": 65.3665825252944,
+      "avg_latency_ms": 15.297842575863733,
+      "p50_latency_ms": 15.288312919437885,
+      "p99_latency_ms": 15.400234144181013,
+      "request_bytes_per_request": 927.6177370030581,
+      "reply_bytes_per_request": 1215.2354740061162,
+      "scaling_efficiency": 1.0
+    },
+    "client_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 2560,
+      "errors": 0,
+      "throughput_req_per_sec": 510.9410949140171,
+      "avg_latency_ms": 15.644619530121417,
+      "p50_latency_ms": 15.58794011361897,
+      "p99_latency_ms": 16.09263406135142,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1216.0,
+      "scaling_efficiency": 0.9770686243163741
+    },
+    "client_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 9760,
+      "errors": 0,
+      "throughput_req_per_sec": 1950.4934104334461,
+      "avg_latency_ms": 16.403663444636223,
+      "p50_latency_ms": 16.40861900523305,
+      "p99_latency_ms": 17.05724513158202,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1216.0,
+      "scaling_efficiency": 0.93247828968967
+    },
+    "client_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 30638,
+      "errors": 0,
+      "throughput_req_per_sec": 6111.487484829546,
+      "avg_latency_ms": 20.895731790381625,
+      "p50_latency_ms": 19.90610104985535,
+      "p99_latency_ms": 26.46105596795678,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1216.0,
+      "scaling_efficiency": 0.7304343309787524
+    },
+    "client_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 35547,
+      "errors": 0,
+      "throughput_req_per_sec": 7057.488853933033,
+      "avg_latency_ms": 72.12691235639095,
+      "p50_latency_ms": 66.34159688837826,
+      "p99_latency_ms": 369.0225388854742,
+      "request_bytes_per_request": 928.7554505302838,
+      "reply_bytes_per_request": 1217.5109010605677,
+      "scaling_efficiency": 0.21087469139914122
+    },
+    "client_summary": {
+      "peak_throughput_req_per_sec": 7057.488853933033,
+      "max_stable_concurrency": 32,
+      "total_errors": 0
+    },
+    "http_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 314,
+      "errors": 0,
+      "throughput_req_per_sec": 62.59958950424484,
+      "avg_latency_ms": 15.974019325611176,
+      "p50_latency_ms": 16.22149790637195,
+      "p99_latency_ms": 16.43336215056479,
+      "request_bytes_per_request": 927.5668789808917,
+      "reply_bytes_per_request": 1822.1337579617834,
+      "scaling_efficiency": 1.0
+    },
+    "http_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 2392,
+      "errors": 0,
+      "throughput_req_per_sec": 477.7997851417861,
+      "avg_latency_ms": 16.72921928019967,
+      "p50_latency_ms": 16.73286803998053,
+      "p99_latency_ms": 17.296141013503075,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1823.0,
+      "scaling_efficiency": 0.954079309716134
+    },
+    "http_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 5946,
+      "errors": 0,
+      "throughput_req_per_sec": 1185.3229601171656,
+      "avg_latency_ms": 26.882207636046985,
+      "p50_latency_ms": 25.080166989937425,
+      "p99_latency_ms": 33.43144804239273,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1823.0,
+      "scaling_efficiency": 0.5917186166396454
+    },
+    "http_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 4869,
+      "errors": 0,
+      "throughput_req_per_sec": 961.5476557192237,
+      "avg_latency_ms": 132.10270704108012,
+      "p50_latency_ms": 104.09809299744666,
+      "p99_latency_ms": 412.02942398376763,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1823.0,
+      "scaling_efficiency": 0.12000224154500318
+    },
+    "http_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 5074,
+      "errors": 0,
+      "throughput_req_per_sec": 931.0568333054558,
+      "avg_latency_ms": 543.1558692294706,
+      "p50_latency_ms": 461.54735097661614,
+      "p99_latency_ms": 1506.0310559347272,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 1823.0,
+      "scaling_efficiency": 0.029049238053332746
+    },
+    "http_summary": {
+      "peak_throughput_req_per_sec": 1185.3229601171656,
+      "max_stable_concurrency": 8,
+      "total_errors": 0
+    },
+    "http_stream_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 286,
+      "errors": 0,
+      "throughput_req_per_sec": 57.023510114309616,
+      "avg_latency_ms": 17.536060857729844,
+      "p50_latency_ms": 17.591255949810147,
+      "p99_latency_ms": 17.822992987930775,
+      "request_bytes_per_request": 927.4615384615385,
+      "reply_bytes_per_request": 3865.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_concurrency_8": {
+      "concurrency": 8,
+      "num_requests": 1328,
+      "errors": 0,
+      "throughput_req_per_sec": 265.29589370203774,
+      "avg_latency_ms": 30.150558303863495,
+      "p50_latency_ms": 28.236842015758157,
+      "p99_latency_ms": 38.66879711858928,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 3935.0,
+      "scaling_efficiency": 0.5815493757974217
+    },
+    "http_stream_concurrency_32": {
+      "concurrency": 32,
+      "num_requests": 1343,
+      "errors": 0,
+      "throughput_req_per_sec": 263.085808011945,
+      "avg_latency_ms": 121.03664779349779,
+      "p50_latency_ms": 101.20035707950592,
+      "p99_latency_ms": 407.19916112720966,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 3935.0,
+      "scaling_efficiency": 0.14417617372014732
+    },
+    "http_stream_concurrency_128": {
+      "concurrency": 128,
+      "num_requests": 1152,
+      "errors": 0,
+      "throughput_req_per_sec": 214.195786080998,
+      "avg_latency_ms": 574.333097016683,
+      "p50_latency_ms": 437.5178550835699,
+      "p99_latency_ms": 1273.5027100425214,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 3935.0,
+      "scaling_efficiency": 0.029345871122336765
+    },
+    "http_stream_concurrency_512": {
+      "concurrency": 512,
+      "num_requests": 1416,
+      "errors": 0,
+      "throughput_req_per_sec": 226.42909601458518,
+      "avg_latency_ms": 2072.4767701722362,
+      "p50_latency_ms": 1772.6040128618479,
+      "p99_latency_ms": 6051.702396012843,
+      "request_bytes_per_request": 928.0,
+      "reply_bytes_per_request": 3935.0,
+      "scaling_efficiency": 0.007755473615478273
+    },
+    "http_stream_summary": {
+      "peak_throughput_req_per_sec": 265.29589370203774,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    }
+  }
+}

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/baseline_values.json
@@ -1,197 +1,401 @@
 {
   "h100": {
-    "client_concurrency_1": {
+    "client_isl_512_concurrency_1": {
       "concurrency": 1,
       "num_requests": 327,
       "errors": 0,
-      "throughput_req_per_sec": 65.3665825252944,
-      "avg_latency_ms": 15.297842575863733,
-      "p50_latency_ms": 15.288312919437885,
-      "p99_latency_ms": 15.400234144181013,
-      "request_bytes_per_request": 927.6177370030581,
-      "reply_bytes_per_request": 1215.2354740061162,
+      "throughput_req_per_sec": 65.2964013667772,
+      "avg_latency_ms": 15.314320446951857,
+      "p50_latency_ms": 15.311231836676598,
+      "p99_latency_ms": 15.37441834807396,
+      "request_bytes_per_request": 954.6177370030581,
+      "reply_bytes_per_request": 1306.2354740061162,
       "scaling_efficiency": 1.0
     },
-    "client_concurrency_8": {
+    "client_isl_512_concurrency_8": {
       "concurrency": 8,
-      "num_requests": 2560,
+      "num_requests": 2561,
       "errors": 0,
-      "throughput_req_per_sec": 510.9410949140171,
-      "avg_latency_ms": 15.644619530121417,
-      "p50_latency_ms": 15.58794011361897,
-      "p99_latency_ms": 16.09263406135142,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1216.0,
-      "scaling_efficiency": 0.9770686243163741
+      "throughput_req_per_sec": 511.0766037564108,
+      "avg_latency_ms": 15.632844580048662,
+      "p50_latency_ms": 15.836196020245552,
+      "p99_latency_ms": 16.716137994080782,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.9783781974553931
     },
-    "client_concurrency_32": {
+    "client_isl_512_concurrency_32": {
       "concurrency": 32,
-      "num_requests": 9760,
+      "num_requests": 10006,
       "errors": 0,
-      "throughput_req_per_sec": 1950.4934104334461,
-      "avg_latency_ms": 16.403663444636223,
-      "p50_latency_ms": 16.40861900523305,
-      "p99_latency_ms": 17.05724513158202,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1216.0,
-      "scaling_efficiency": 0.93247828968967
+      "throughput_req_per_sec": 1996.1497536064385,
+      "avg_latency_ms": 16.005548524651502,
+      "p50_latency_ms": 16.57808478921652,
+      "p99_latency_ms": 17.842594999819994,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.9553310518570166
     },
-    "client_concurrency_128": {
+    "client_isl_512_concurrency_128": {
       "concurrency": 128,
-      "num_requests": 30638,
+      "num_requests": 27007,
       "errors": 0,
-      "throughput_req_per_sec": 6111.487484829546,
-      "avg_latency_ms": 20.895731790381625,
-      "p50_latency_ms": 19.90610104985535,
-      "p99_latency_ms": 26.46105596795678,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1216.0,
-      "scaling_efficiency": 0.7304343309787524
+      "throughput_req_per_sec": 5384.101865924014,
+      "avg_latency_ms": 23.67157673384394,
+      "p50_latency_ms": 23.167153354734182,
+      "p99_latency_ms": 29.701683670282364,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1307.0,
+      "scaling_efficiency": 0.6441901076792443
     },
-    "client_concurrency_512": {
+    "client_isl_512_concurrency_512": {
       "concurrency": 512,
-      "num_requests": 35547,
+      "num_requests": 26398,
       "errors": 0,
-      "throughput_req_per_sec": 7057.488853933033,
-      "avg_latency_ms": 72.12691235639095,
-      "p50_latency_ms": 66.34159688837826,
-      "p99_latency_ms": 369.0225388854742,
-      "request_bytes_per_request": 928.7554505302838,
-      "reply_bytes_per_request": 1217.5109010605677,
-      "scaling_efficiency": 0.21087469139914122
+      "throughput_req_per_sec": 5257.261920588759,
+      "avg_latency_ms": 96.17530014910636,
+      "p50_latency_ms": 92.6328538917005,
+      "p99_latency_ms": 122.63244204223156,
+      "request_bytes_per_request": 955.06773240397,
+      "reply_bytes_per_request": 1307.13546480794,
+      "scaling_efficiency": 0.15725353118578325
     },
-    "client_summary": {
-      "peak_throughput_req_per_sec": 7057.488853933033,
+    "client_isl_512_summary": {
+      "peak_throughput_req_per_sec": 5384.101865924014,
       "max_stable_concurrency": 32,
       "total_errors": 0
     },
-    "http_concurrency_1": {
+    "client_isl_50000_concurrency_1": {
       "concurrency": 1,
-      "num_requests": 314,
+      "num_requests": 853,
       "errors": 0,
-      "throughput_req_per_sec": 62.59958950424484,
-      "avg_latency_ms": 15.974019325611176,
-      "p50_latency_ms": 16.22149790637195,
-      "p99_latency_ms": 16.43336215056479,
-      "request_bytes_per_request": 927.5668789808917,
-      "reply_bytes_per_request": 1822.1337579617834,
+      "throughput_req_per_sec": 170.41169187703227,
+      "avg_latency_ms": 5.867628755696458,
+      "p50_latency_ms": 5.538489669561386,
+      "p99_latency_ms": 11.505905073136091,
+      "request_bytes_per_request": 58691.0,
+      "reply_bytes_per_request": 1307.0,
       "scaling_efficiency": 1.0
     },
-    "http_concurrency_8": {
+    "client_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 170.41169187703227,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 364,
+      "errors": 0,
+      "throughput_req_per_sec": 72.64807523292737,
+      "avg_latency_ms": 13.764492190023372,
+      "p50_latency_ms": 13.750390149652958,
+      "p99_latency_ms": 14.135817065834999,
+      "request_bytes_per_request": 117025.69505494506,
+      "reply_bytes_per_request": 1308.39010989011,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 72.64807523292737,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 290,
+      "errors": 0,
+      "throughput_req_per_sec": 57.80158912849978,
+      "avg_latency_ms": 17.299927912395574,
+      "p50_latency_ms": 17.29042734950781,
+      "p99_latency_ms": 17.875472083687782,
+      "request_bytes_per_request": 175359.47586206897,
+      "reply_bytes_per_request": 1307.951724137931,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 57.80158912849978,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "client_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 237,
+      "errors": 0,
+      "throughput_req_per_sec": 47.23072881988193,
+      "avg_latency_ms": 21.171830958030522,
+      "p50_latency_ms": 21.13327383995056,
+      "p99_latency_ms": 22.02000468969345,
+      "request_bytes_per_request": 233692.1729957806,
+      "reply_bytes_per_request": 1307.3459915611813,
+      "scaling_efficiency": 1.0
+    },
+    "client_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 47.23072881988193,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_512_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 324,
+      "errors": 0,
+      "throughput_req_per_sec": 64.77461171809941,
+      "avg_latency_ms": 15.43765972558133,
+      "p50_latency_ms": 15.394172165542841,
+      "p99_latency_ms": 15.833152923732996,
+      "request_bytes_per_request": 954.5987654320987,
+      "reply_bytes_per_request": 1913.1975308641975,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_512_concurrency_8": {
       "concurrency": 8,
-      "num_requests": 2392,
+      "num_requests": 2424,
       "errors": 0,
-      "throughput_req_per_sec": 477.7997851417861,
-      "avg_latency_ms": 16.72921928019967,
-      "p50_latency_ms": 16.73286803998053,
-      "p99_latency_ms": 17.296141013503075,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1823.0,
-      "scaling_efficiency": 0.954079309716134
+      "throughput_req_per_sec": 483.4192192610392,
+      "avg_latency_ms": 16.538232545715697,
+      "p50_latency_ms": 16.51859888806939,
+      "p99_latency_ms": 17.12818816304207,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.9328871421199919
     },
-    "http_concurrency_32": {
+    "http_isl_512_concurrency_32": {
       "concurrency": 32,
-      "num_requests": 5946,
+      "num_requests": 5320,
       "errors": 0,
-      "throughput_req_per_sec": 1185.3229601171656,
-      "avg_latency_ms": 26.882207636046985,
-      "p50_latency_ms": 25.080166989937425,
-      "p99_latency_ms": 33.43144804239273,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1823.0,
-      "scaling_efficiency": 0.5917186166396454
+      "throughput_req_per_sec": 1059.0513797128629,
+      "avg_latency_ms": 29.86694827117376,
+      "p50_latency_ms": 28.011378832161427,
+      "p99_latency_ms": 41.7354260571301,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.5109309764766898
     },
-    "http_concurrency_128": {
+    "http_isl_512_concurrency_128": {
       "concurrency": 128,
-      "num_requests": 4869,
+      "num_requests": 5045,
       "errors": 0,
-      "throughput_req_per_sec": 961.5476557192237,
-      "avg_latency_ms": 132.10270704108012,
-      "p50_latency_ms": 104.09809299744666,
-      "p99_latency_ms": 412.02942398376763,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1823.0,
-      "scaling_efficiency": 0.12000224154500318
+      "throughput_req_per_sec": 992.3867858881708,
+      "avg_latency_ms": 127.83226387878018,
+      "p50_latency_ms": 96.74028120934963,
+      "p99_latency_ms": 396.5161112137139,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.11969229238289629
     },
-    "http_concurrency_512": {
+    "http_isl_512_concurrency_512": {
       "concurrency": 512,
-      "num_requests": 5074,
+      "num_requests": 4667,
       "errors": 0,
-      "throughput_req_per_sec": 931.0568333054558,
-      "avg_latency_ms": 543.1558692294706,
-      "p50_latency_ms": 461.54735097661614,
-      "p99_latency_ms": 1506.0310559347272,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 1823.0,
-      "scaling_efficiency": 0.029049238053332746
+      "throughput_req_per_sec": 900.4310752526848,
+      "avg_latency_ms": 558.4563087808291,
+      "p50_latency_ms": 433.12476901337504,
+      "p99_latency_ms": 1717.4912141636014,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 1914.0,
+      "scaling_efficiency": 0.02715036643533433
     },
-    "http_summary": {
-      "peak_throughput_req_per_sec": 1185.3229601171656,
+    "http_isl_512_summary": {
+      "peak_throughput_req_per_sec": 1059.0513797128629,
       "max_stable_concurrency": 8,
       "total_errors": 0
     },
-    "http_stream_concurrency_1": {
+    "http_isl_50000_concurrency_1": {
       "concurrency": 1,
-      "num_requests": 286,
+      "num_requests": 193,
       "errors": 0,
-      "throughput_req_per_sec": 57.023510114309616,
-      "avg_latency_ms": 17.536060857729844,
-      "p50_latency_ms": 17.591255949810147,
-      "p99_latency_ms": 17.822992987930775,
-      "request_bytes_per_request": 927.4615384615385,
-      "reply_bytes_per_request": 3865.0,
+      "throughput_req_per_sec": 38.485406943867154,
+      "avg_latency_ms": 25.983167525110623,
+      "p50_latency_ms": 25.907703209668398,
+      "p99_latency_ms": 27.29746699333191,
+      "request_bytes_per_request": 58689.81865284974,
+      "reply_bytes_per_request": 59647.637305699485,
       "scaling_efficiency": 1.0
     },
-    "http_stream_concurrency_8": {
+    "http_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 38.485406943867154,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 107,
+      "errors": 0,
+      "throughput_req_per_sec": 21.31662620159949,
+      "avg_latency_ms": 46.91072093392504,
+      "p50_latency_ms": 45.99883407354355,
+      "p99_latency_ms": 50.62567722052336,
+      "request_bytes_per_request": 117024.20560747663,
+      "reply_bytes_per_request": 117983.41121495327,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 21.31662620159949,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 74,
+      "errors": 0,
+      "throughput_req_per_sec": 14.62173951275367,
+      "avg_latency_ms": 68.39001672090711,
+      "p50_latency_ms": 68.09805519878864,
+      "p99_latency_ms": 72.85345206037164,
+      "request_bytes_per_request": 175358.0,
+      "reply_bytes_per_request": 176317.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 14.62173951275367,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 55,
+      "errors": 0,
+      "throughput_req_per_sec": 10.851474796685615,
+      "avg_latency_ms": 92.15160924941301,
+      "p50_latency_ms": 91.84237523004413,
+      "p99_latency_ms": 95.92463728040457,
+      "request_bytes_per_request": 233691.0,
+      "reply_bytes_per_request": 234650.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 10.851474796685615,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_512_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 281,
+      "errors": 0,
+      "throughput_req_per_sec": 56.19250228003328,
+      "avg_latency_ms": 17.79543008038847,
+      "p50_latency_ms": 17.770133446902037,
+      "p99_latency_ms": 18.235075753182173,
+      "request_bytes_per_request": 954.4377224199288,
+      "reply_bytes_per_request": 3952.9039145907473,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_512_concurrency_8": {
       "concurrency": 8,
-      "num_requests": 1328,
+      "num_requests": 1124,
       "errors": 0,
-      "throughput_req_per_sec": 265.29589370203774,
-      "avg_latency_ms": 30.150558303863495,
-      "p50_latency_ms": 28.236842015758157,
-      "p99_latency_ms": 38.66879711858928,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 3935.0,
-      "scaling_efficiency": 0.5815493757974217
+      "throughput_req_per_sec": 223.60351357147061,
+      "avg_latency_ms": 35.72748403406281,
+      "p50_latency_ms": 33.67852605879307,
+      "p99_latency_ms": 48.03391406312585,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.4974051352464041
     },
-    "http_stream_concurrency_32": {
+    "http_stream_isl_512_concurrency_32": {
       "concurrency": 32,
-      "num_requests": 1343,
+      "num_requests": 1138,
       "errors": 0,
-      "throughput_req_per_sec": 263.085808011945,
-      "avg_latency_ms": 121.03664779349779,
-      "p50_latency_ms": 101.20035707950592,
-      "p99_latency_ms": 407.19916112720966,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 3935.0,
-      "scaling_efficiency": 0.14417617372014732
+      "throughput_req_per_sec": 226.57315790291278,
+      "avg_latency_ms": 139.85880675295166,
+      "p50_latency_ms": 121.39108777046204,
+      "p99_latency_ms": 396.3506668806076,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.1260027743413357
     },
-    "http_stream_concurrency_128": {
+    "http_stream_isl_512_concurrency_128": {
       "concurrency": 128,
-      "num_requests": 1152,
+      "num_requests": 1023,
       "errors": 0,
-      "throughput_req_per_sec": 214.195786080998,
-      "avg_latency_ms": 574.333097016683,
-      "p50_latency_ms": 437.5178550835699,
-      "p99_latency_ms": 1273.5027100425214,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 3935.0,
-      "scaling_efficiency": 0.029345871122336765
+      "throughput_req_per_sec": 195.2838694320398,
+      "avg_latency_ms": 632.2801992937173,
+      "p50_latency_ms": 701.1442109942436,
+      "p99_latency_ms": 917.7828631363809,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.02715051239994197
     },
-    "http_stream_concurrency_512": {
+    "http_stream_isl_512_concurrency_512": {
       "concurrency": 512,
-      "num_requests": 1416,
+      "num_requests": 1381,
       "errors": 0,
-      "throughput_req_per_sec": 226.42909601458518,
-      "avg_latency_ms": 2072.4767701722362,
-      "p50_latency_ms": 1772.6040128618479,
-      "p99_latency_ms": 6051.702396012843,
-      "request_bytes_per_request": 928.0,
-      "reply_bytes_per_request": 3935.0,
-      "scaling_efficiency": 0.007755473615478273
+      "throughput_req_per_sec": 212.49595459656717,
+      "avg_latency_ms": 2229.1387525737114,
+      "p50_latency_ms": 2105.6204438209534,
+      "p99_latency_ms": 4001.6191760078073,
+      "request_bytes_per_request": 955.0,
+      "reply_bytes_per_request": 4026.0,
+      "scaling_efficiency": 0.007385881469615423
     },
-    "http_stream_summary": {
-      "peak_throughput_req_per_sec": 265.29589370203774,
+    "http_stream_isl_512_summary": {
+      "peak_throughput_req_per_sec": 226.57315790291278,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_50000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 116,
+      "errors": 0,
+      "throughput_req_per_sec": 23.02763400221283,
+      "avg_latency_ms": 43.4251317818617,
+      "p50_latency_ms": 44.82400417327881,
+      "p99_latency_ms": 46.02478398010135,
+      "request_bytes_per_request": 58689.30172413793,
+      "reply_bytes_per_request": 61541.224137931036,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_50000_summary": {
+      "peak_throughput_req_per_sec": 23.02763400221283,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_100000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 63,
+      "errors": 0,
+      "throughput_req_per_sec": 12.557958989769707,
+      "avg_latency_ms": 79.62874661658019,
+      "p50_latency_ms": 78.88843584805727,
+      "p99_latency_ms": 83.39442173019052,
+      "request_bytes_per_request": 117024.0,
+      "reply_bytes_per_request": 119839.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_100000_summary": {
+      "peak_throughput_req_per_sec": 12.557958989769707,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_150000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 42,
+      "errors": 0,
+      "throughput_req_per_sec": 8.341999625005139,
+      "avg_latency_ms": 119.87258963996456,
+      "p50_latency_ms": 119.54294564202428,
+      "p99_latency_ms": 122.32975894585252,
+      "request_bytes_per_request": 175358.0,
+      "reply_bytes_per_request": 178173.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_150000_summary": {
+      "peak_throughput_req_per_sec": 8.341999625005139,
+      "max_stable_concurrency": 1,
+      "total_errors": 0
+    },
+    "http_stream_isl_200000_concurrency_1": {
+      "concurrency": 1,
+      "num_requests": 32,
+      "errors": 0,
+      "throughput_req_per_sec": 6.330971491587996,
+      "avg_latency_ms": 157.95098851958755,
+      "p50_latency_ms": 157.65385515987873,
+      "p99_latency_ms": 160.8555680140853,
+      "request_bytes_per_request": 233691.0,
+      "reply_bytes_per_request": 236506.0,
+      "scaling_efficiency": 1.0
+    },
+    "http_stream_isl_200000_summary": {
+      "peak_throughput_req_per_sec": 6.330971491587996,
       "max_stable_concurrency": 1,
       "total_errors": 0
     }

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
@@ -41,12 +41,13 @@ METRICS:
   - reply_bytes_per_request
 
 # Past saturation, p99 stops describing the frontend and starts describing the
-# queue the load generator built in front of it: two back-to-back runs of this
-# exact config moved http_concurrency_128 p99 from 392 ms to 963 ms (+146%) while
-# every throughput number held within 13%. Below saturation p99 is stable to a
-# few percent and worth gating, so it stays gated there. Saturation is what
-# throughput_req_per_sec and peak_throughput_req_per_sec already measure.
+# queue the load generator built in front of it. HTTP saturates at concurrency
+# 8; on current main, three H100 nodes measured http_concurrency_32 p99 at
+# 42 ms, 42 ms and 293 ms while throughput remained within 8%. Saturation is
+# what throughput_req_per_sec and peak_throughput_req_per_sec already measure.
 METRICS_EXCLUDE:
+  - keys: "http_concurrency_32"
+    metrics: [p99_latency_ms]
   - keys: "*_concurrency_128"
     metrics: [p99_latency_ms]
   - keys: "*_concurrency_512"

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
@@ -28,6 +28,15 @@ NUM_ENGINES: 1
 ENGINE_LATENCY_MS: 10
 MAX_REQUESTS: 1024
 
+# Large prompts expose sequence-length-dependent serialization and coordinator
+# overhead that the 512-token capacity sweep cannot see. They run serially with
+# no simulated engine compute, so these numbers measure only request-path work;
+# applying the high-concurrency grid here would instead measure Python heap
+# pressure and the fake engine's unavoidable prompt decode.
+LONG_SEQUENCE_LENGTHS: "50000,100000,150000,200000"
+LONG_SEQUENCE_CONCURRENCY: "1"
+LONG_SEQUENCE_ENGINE_LATENCY_MS: 0
+
 # Gated metrics. Deliberately excludes max_stable_concurrency and
 # scaling_efficiency: both are step functions over the sampled concurrency grid,
 # so they flip between neighbouring levels under normal noise. They are recorded
@@ -42,11 +51,10 @@ METRICS:
 
 # Past saturation, p99 stops describing the frontend and starts describing the
 # queue the load generator built in front of it. HTTP saturates at concurrency
-# 8; on current main, three H100 nodes measured http_concurrency_32 p99 at
-# 42 ms, 42 ms and 293 ms while throughput remained within 8%. Saturation is
-# what throughput_req_per_sec and peak_throughput_req_per_sec already measure.
+# 8; saturation is what throughput_req_per_sec and
+# peak_throughput_req_per_sec already measure.
 METRICS_EXCLUDE:
-  - keys: "http_concurrency_32"
+  - keys: "http*_concurrency_32"
     metrics: [p99_latency_ms]
   - keys: "*_concurrency_128"
     metrics: [p99_latency_ms]

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
@@ -51,8 +51,9 @@ METRICS:
 
 # Past saturation, p99 stops describing the frontend and starts describing the
 # queue the load generator built in front of it. HTTP saturates at concurrency
-# 8; saturation is what throughput_req_per_sec and
-# peak_throughput_req_per_sec already measure.
+# 8. Throughput at individual saturated levels can move between neighbouring
+# levels under normal node noise, so unstable points are not gated; each path's
+# peak_throughput_req_per_sec summary remains gated.
 METRICS_EXCLUDE:
   - keys: "http*_concurrency_32"
     metrics: [p99_latency_ms]
@@ -60,6 +61,12 @@ METRICS_EXCLUDE:
     metrics: [p99_latency_ms]
   - keys: "*_concurrency_512"
     metrics: [p99_latency_ms]
+  - keys: "client_isl_512_concurrency_128"
+    metrics: [throughput_req_per_sec]
+  - keys: "http_stream_isl_512_concurrency_8"
+    metrics: [throughput_req_per_sec]
+  - keys: "http_stream_isl_512_concurrency_32"
+    metrics: [throughput_req_per_sec]
 
 # Wider than the 10% default: this benchmark competes with whatever else shares
 # the node's CPU, and it has no GPU work to hide behind.

--- a/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
+++ b/tests/performance_tests/test_cases/frontend/frontend_capacity/model_config.yaml
@@ -1,0 +1,58 @@
+# Model-free capacity test for the inference frontend and coordinator.
+#
+# Driven by run_frontend_perf_test.sh, which needs no checkpoint and no GPU: the
+# benchmark starts a real coordinator process and fake ZMQ engines. A regression
+# here therefore points at the frontend, the InferenceClient or the coordinator,
+# never at a kernel or a model change.
+MODEL: frontend
+
+# Paths to sweep. 'client' isolates the ZMQ hop and the coordinator's routing
+# loop; 'http' adds Quart, tokenization and OpenAI response assembly; ':stream'
+# adds one detokenize step and one SSE flush per generated token. Comparing the
+# three localizes any regression to a layer.
+PATHS:
+  - client
+  - http
+  - http:stream
+
+CONCURRENCY: "1,8,32,128,512"
+SECONDS_PER_LEVEL: 5
+WARMUP_SECONDS: 2
+NUM_INPUT_TOKENS: 512
+NUM_OUTPUT_TOKENS: 64
+NUM_ENGINES: 1
+# How long a fake engine holds a request. Roughly a real decode of 64 tokens, and
+# non-zero so the high concurrency levels have genuinely overlapping requests.
+# Keep it an order of magnitude above the fake engine's 1 ms poll granularity, or
+# per-request latency starts depending on load and scaling_efficiency skews.
+ENGINE_LATENCY_MS: 10
+MAX_REQUESTS: 1024
+
+# Gated metrics. Deliberately excludes max_stable_concurrency and
+# scaling_efficiency: both are step functions over the sampled concurrency grid,
+# so they flip between neighbouring levels under normal noise. They are recorded
+# in baseline_values.json and printed for humans;
+# peak_throughput_req_per_sec is the continuous stand-in that CI compares.
+METRICS:
+  - throughput_req_per_sec
+  - peak_throughput_req_per_sec
+  - p99_latency_ms
+  - request_bytes_per_request
+  - reply_bytes_per_request
+
+# Past saturation, p99 stops describing the frontend and starts describing the
+# queue the load generator built in front of it: two back-to-back runs of this
+# exact config moved http_concurrency_128 p99 from 392 ms to 963 ms (+146%) while
+# every throughput number held within 13%. Below saturation p99 is stable to a
+# few percent and worth gating, so it stays gated there. Saturation is what
+# throughput_req_per_sec and peak_throughput_req_per_sec already measure.
+METRICS_EXCLUDE:
+  - keys: "*_concurrency_128"
+    metrics: [p99_latency_ms]
+  - keys: "*_concurrency_512"
+    metrics: [p99_latency_ms]
+
+# Wider than the 10% default: this benchmark competes with whatever else shares
+# the node's CPU, and it has no GPU work to hide behind.
+TOLERANCE_PCT: 25
+UPPER_TOLERANCE_PCT: 40

--- a/tests/test_utils/recipes/gb200/frontend-perf.yaml
+++ b/tests/test_utils/recipes/gb200/frontend-perf.yaml
@@ -1,0 +1,56 @@
+# Capacity tests for the inference frontend and coordinator. No checkpoint, no
+# model and no GPU work: the benchmark starts its own coordinator process and
+# fake ZMQ engines, so these numbers move only when the frontend, the
+# InferenceClient or the coordinator itself changes. It still runs on a GPU node
+# because that is what the runners provide, and because the baseline is keyed by
+# node type (CPU and NIC differences move the numbers).
+type: basic
+format_version: 1
+maintainers: [mcore]
+loggers: [stdout]
+spec:
+  name: '{test_case}_{environment}_{platforms}'
+  model: frontend
+  build: mcore-pyt-{environment}
+  nodes: 1
+  # GB200 runners reserve all four GPUs even though this model-free test uses CPU.
+  gpus: 4
+  n_repeat: 1
+  platforms: dgx_gb200
+  time_limit: 1800
+  script_setup: |
+    set -euo pipefail
+    unset https_proxy
+    umask 077
+    printf '%s\n' "machine gitlab-master.nvidia.com login okoenig password $RO_API_TOKEN" >> "$HOME/.netrc"
+    trap 'rm -f "$HOME/.netrc"; unset RO_API_TOKEN' EXIT
+
+    cd /opt
+    rm -rf /opt/megatron-lm; mkdir megatron-lm; cd megatron-lm
+    git init
+    git remote add origin $MCORE_REPO
+    git fetch origin '+refs/merge-requests/*:refs/remotes/merge-requests/*'
+    git fetch origin $MCORE_MR_COMMIT
+    git checkout $MCORE_MR_COMMIT
+    git rev-parse HEAD
+    rm -f "$HOME/.netrc"
+    unset RO_API_TOKEN
+  script: |-
+    rm -f "${{HOME}}/.netrc"
+    unset RO_API_TOKEN
+    set -euo pipefail
+    cd /opt/megatron-lm
+
+    ARGUMENTS=(
+        "CONFIG_PATH=tests/performance_tests/test_cases/frontend/{test_case}/model_config.yaml"
+        "RESULTS_ROOT={assets_dir}/perf_results"
+    )
+
+    GPUS_PER_NODE=4 bash ./tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh ${{ARGUMENTS[@]}}
+
+products:
+  - test_case: [frontend_capacity]
+    products:
+      - environment: [dev]
+        scope: [mr]
+        platforms: [dgx_gb200]

--- a/tests/test_utils/recipes/h100/frontend-perf.yaml
+++ b/tests/test_utils/recipes/h100/frontend-perf.yaml
@@ -1,0 +1,55 @@
+# Capacity tests for the inference frontend and coordinator. No checkpoint, no
+# model and no GPU work: the benchmark starts its own coordinator process and
+# fake ZMQ engines, so these numbers move only when the frontend, the
+# InferenceClient or the coordinator itself changes. It still runs on a GPU node
+# because that is what the runners provide, and because the baseline is keyed by
+# node type (CPU and NIC differences move the numbers).
+type: basic
+format_version: 1
+maintainers: [mcore]
+loggers: [stdout]
+spec:
+  name: '{test_case}_{environment}_{platforms}'
+  model: frontend
+  build: mcore-pyt-{environment}
+  nodes: 1
+  gpus: 1
+  n_repeat: 1
+  platforms: dgx_h100
+  time_limit: 1800
+  script_setup: |
+    set -euo pipefail
+    unset https_proxy
+    umask 077
+    printf '%s\n' "machine gitlab-master.nvidia.com login okoenig password $RO_API_TOKEN" >> "$HOME/.netrc"
+    trap 'rm -f "$HOME/.netrc"; unset RO_API_TOKEN' EXIT
+
+    cd /opt
+    rm -rf /opt/megatron-lm; mkdir megatron-lm; cd megatron-lm
+    git init
+    git remote add origin $MCORE_REPO
+    git fetch origin '+refs/merge-requests/*:refs/remotes/merge-requests/*'
+    git fetch origin $MCORE_MR_COMMIT
+    git checkout $MCORE_MR_COMMIT
+    git rev-parse HEAD
+    rm -f "$HOME/.netrc"
+    unset RO_API_TOKEN
+  script: |-
+    rm -f "${{HOME}}/.netrc"
+    unset RO_API_TOKEN
+    set -euo pipefail
+    cd /opt/megatron-lm
+
+    ARGUMENTS=(
+        "CONFIG_PATH=tests/performance_tests/test_cases/frontend/{test_case}/model_config.yaml"
+        "RESULTS_ROOT={assets_dir}/perf_results"
+    )
+
+    bash ./tests/performance_tests/shell_test_utils/run_frontend_perf_test.sh ${{ARGUMENTS[@]}}
+
+products:
+  - test_case: [frontend_capacity]
+    products:
+      - environment: [dev]
+        scope: [mr]
+        platforms: [dgx_h100]

--- a/tests/unit_tests/inference/coordinator_test_utils.py
+++ b/tests/unit_tests/inference/coordinator_test_utils.py
@@ -14,6 +14,7 @@ from megatron.core.inference.config import (
 from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
+from megatron.core.inference.wire_metrics import WireMetrics
 
 
 def make_coordinator_direct(
@@ -89,5 +90,6 @@ def make_coordinator_direct(
 
     coordinator._pending_counts = np.zeros(n_ranks, dtype=np.int32)
     coordinator._identities_list = list(sorted_identities)
+    coordinator.wire_metrics = WireMetrics()
 
     return coordinator

--- a/tests/unit_tests/inference/frontend_test_utils.py
+++ b/tests/unit_tests/inference/frontend_test_utils.py
@@ -255,10 +255,11 @@ class FakeEngine:
                 # capacity sweep.
                 while True:
                     try:
-                        raw = self.socket.recv(flags=zmq.NOBLOCK)
+                        frames = self.socket.recv_multipart(flags=zmq.NOBLOCK)
                     except zmq.Again:
                         break
-                    self._handle(msgpack.unpackb(raw, raw=False))
+                    metadata = msgpack.unpackb(frames[0], raw=False)
+                    self._handle(metadata, frames[1:])
                     if self._stop.is_set():
                         return
             self._flush_due_replies()
@@ -268,13 +269,14 @@ class FakeEngine:
         # Min-heap on due time: only the frames that are actually due are
         # touched, so a large in-flight backlog costs nothing per iteration.
         while self._pending_replies and self._pending_replies[0][0] <= now:
-            _, _, payload, is_final = heapq.heappop(self._pending_replies)
-            self._send_frame(payload, is_final)
+            _, _, frames, is_final = heapq.heappop(self._pending_replies)
+            self._send_frames(frames, is_final)
 
-    def _handle(self, payload):
-        header = Headers(payload[0])
+    def _handle(self, metadata, bodies):
+        header = Headers(metadata[0])
         if header == Headers.SUBMIT_REQUEST:
-            request_id, prompt, serialized_params = payload[1:4]
+            request_id, serialized_params = metadata[1:3]
+            prompt = msgpack.unpackb(bodies[0], raw=False)
             self._reply(request_id, prompt, serialized_params)
         elif header in (Headers.STOP, Headers.SHUTDOWN):
             self._stop.set()
@@ -307,28 +309,47 @@ class FakeEngine:
                 (
                     step * (index + 1),
                     [
-                        Headers.ENGINE_REPLY_PARTIAL.value,
-                        [{"request_id": request_id, "new_tokens": [token]}],
+                        msgpack.packb(
+                            [Headers.ENGINE_REPLY_PARTIAL.value, [request_id]], use_bin_type=True
+                        ),
+                        msgpack.packb(
+                            {"request_id": request_id, "new_tokens": [token]}, use_bin_type=True
+                        ),
                     ],
                     False,
                 )
                 for index, token in enumerate(generated_tokens)
             )
-        frames.append((self.reply_delay_s, [Headers.ENGINE_REPLY.value, [reply]], True))
+        frames.append(
+            (
+                self.reply_delay_s,
+                [
+                    msgpack.packb(
+                        [
+                            Headers.ENGINE_REPLY.value,
+                            [[request_id, sampling_params.detokenize_generations]],
+                        ],
+                        use_bin_type=True,
+                    ),
+                    msgpack.packb(reply, use_bin_type=True),
+                ],
+                True,
+            )
+        )
 
-        for delay, payload, is_final in frames:
+        for delay, reply_frames, is_final in frames:
             if delay > 0:
-                # The counter breaks ties so heapq never has to order the payloads.
+                # The counter breaks ties so heapq never has to order the frames.
                 self._reply_sequence += 1
                 heapq.heappush(
                     self._pending_replies,
-                    (time.monotonic() + delay, self._reply_sequence, payload, is_final),
+                    (time.monotonic() + delay, self._reply_sequence, reply_frames, is_final),
                 )
             else:
-                self._send_frame(payload, is_final)
+                self._send_frames(reply_frames, is_final)
 
-    def _send_frame(self, payload, is_final):
-        self.socket.send(msgpack.packb(payload, use_bin_type=True))
+    def _send_frames(self, frames, is_final):
+        self.socket.send_multipart(frames)
         if is_final:
             self.num_requests_served += 1
 

--- a/tests/unit_tests/inference/frontend_test_utils.py
+++ b/tests/unit_tests/inference/frontend_test_utils.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Helpers for standalone frontend/coordinator tests.
+
+The HTTP frontend, the InferenceClient and the coordinator are all independent of
+the model: the coordinator needs only a tokenizer, and engines are reached over
+ZMQ. These helpers exploit that to drive the entire frontend path with no
+checkpoint, no GPU and no torch.distributed -- a real coordinator process plus
+fake engines that speak the wire protocol.
+
+Consumed by the OpenAI-compatibility and packet-size unit tests, and by
+tests/performance_tests/client/frontend_capacity_benchmark.py.
+"""
+
+import asyncio
+import heapq
+import multiprocessing
+import threading
+import time
+from contextlib import contextmanager
+
+import msgpack
+import torch
+import zmq
+
+from megatron.core.inference.async_stream import AsyncStream
+from megatron.core.inference.data_parallel_inference_coordinator.coordinator import (
+    DataParallelInferenceCoordinator,
+)
+from megatron.core.inference.headers import Headers
+from megatron.core.inference.inference_request import DynamicInferenceRequest, Status
+from megatron.core.inference.sampling_params import SamplingParams
+
+# Token ids 0-255 are literal bytes; specials live above that.
+_EOD_ID = 256
+_BOS_ID = 257
+
+
+class ByteTokenizer:
+    """Byte-level tokenizer: reversible, dependency-free, and picklable.
+
+    One token per UTF-8 byte. Being exactly reversible keeps assertions about
+    detokenized text meaningful, and a token count that equals the byte count
+    makes payload sizes predictable for the packet-size tests. Picklable because
+    the coordinator runs in a spawned process and receives the tokenizer as an
+    argument.
+    """
+
+    eod = _EOD_ID
+    bos = _BOS_ID
+    eos_id = _EOD_ID
+    vocab_size = _BOS_ID + 1
+
+    def tokenize(self, text):
+        """Return one token id per UTF-8 byte of ``text``."""
+        return list(text.encode("utf-8"))
+
+    def detokenize(self, token_ids):
+        """Inverse of tokenize; special ids are dropped."""
+        return bytes(t for t in token_ids if t < 256).decode("utf-8", errors="replace")
+
+
+class _HuggingFaceHandle:
+    """The nested handle HuggingFaceFastIncrementalDetokenizer reaches through."""
+
+    include_special_tokens = True
+
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class ByteLevelFastTokenizer:
+    """A byte-level Hugging Face fast tokenizer for the HTTP frontend.
+
+    Streaming responses go through HuggingFaceFastIncrementalDetokenizer, which
+    requires a real PreTrainedTokenizerFast reachable at
+    ``tokenizer._tokenizer.tokenizer``. ByteTokenizer cannot satisfy that, so
+    streaming tests use this instead; it stays byte-level so detokenization is
+    still exactly reversible.
+
+    The vocabulary is built deterministically from the byte-level alphabet, so
+    pickling can discard it and rebuild an identical tokenizer on the far side.
+    That matters because the coordinator runs in a spawned process and must
+    agree with the frontend on token ids, and because the perf benchmark reports
+    payload byte counts, which move if a token's id changes width.
+    """
+
+    # No chat template: chat_completions then tokenizes the joined message
+    # contents, which keeps these tests independent of any model's template.
+    chat_template = None
+    bos = None
+    eod = None
+
+    def __init__(self):
+        self._build()
+
+    def _build(self):
+        from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+        from transformers import PreTrainedTokenizerFast
+
+        # ByteLevel.alphabet() comes back from a Rust hash set, so its order
+        # differs on every call and every process. Sorting is what makes this
+        # tokenizer reproducible; without it each process invents its own id for
+        # a given byte.
+        alphabet = sorted(pre_tokenizers.ByteLevel.alphabet())
+        backend = Tokenizer(
+            models.BPE(vocab={token: i for i, token in enumerate(alphabet)}, merges=[])
+        )
+        backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False, use_regex=False)
+        backend.decoder = decoders.ByteLevel()
+        self._huggingface_tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend)
+        self._tokenizer = _HuggingFaceHandle(self._huggingface_tokenizer)
+        self.eos_id = self._huggingface_tokenizer.eos_token_id
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        self._build()
+
+    @property
+    def vocab_size(self):
+        """Number of tokens in the backing vocabulary."""
+        return self._huggingface_tokenizer.vocab_size
+
+    def tokenize(self, text):
+        """Encode text to token ids without special tokens."""
+        return self._huggingface_tokenizer.encode(text, add_special_tokens=False)
+
+    def detokenize(self, token_ids, skip_special_tokens=True):
+        """Decode token ids back to text."""
+        return self._huggingface_tokenizer.decode(
+            list(token_ids), skip_special_tokens=skip_special_tokens
+        )
+
+
+def make_byte_level_fast_tokenizer():
+    """Return a byte-level Hugging Face fast tokenizer for the HTTP frontend."""
+    return ByteLevelFastTokenizer()
+
+
+# Sample text used to synthesize generated tokens. Encoding real text with the
+# tokenizer under test (rather than picking token ids directly) guarantees the
+# ids decode to valid UTF-8, so streamed deltas and batch-decoded text agree.
+_SAMPLE_TEXT = "the quick brown fox jumps over the lazy dog "
+
+
+def synthesize_generated_tokens(num_tokens, tokenizer):
+    """Return ``num_tokens`` token ids that decode to valid text."""
+    sample = tokenizer.tokenize(_SAMPLE_TEXT)
+    if not sample:
+        raise ValueError("tokenizer produced no tokens for the sample text")
+    return [sample[i % len(sample)] for i in range(num_tokens)]
+
+
+def build_engine_reply(
+    request_id,
+    prompt_tokens,
+    generated_tokens,
+    sampling_params,
+    status=Status.COMPLETED,
+    generated_log_probs=None,
+):
+    """Build the serialized reply an engine would send for a finished request.
+
+    Goes through the real DynamicInferenceRequest.serialize() rather than
+    hand-writing a dict, so tests fail if the reply schema drifts.
+
+    Args:
+        request_id (int): Coordinator-side request id, echoed back for routing.
+        prompt_tokens (list[int]): The request's prompt tokens.
+        generated_tokens (list[int]): Tokens to report as generated.
+        sampling_params (SamplingParams): The request's sampling params.
+        status (Status): Terminal status to report.
+        generated_log_probs (list[float] | None): Optional per-token log probs.
+
+    Returns:
+        dict: A msgpack-serializable reply payload.
+    """
+    request = DynamicInferenceRequest(
+        request_id=request_id,
+        prompt_tokens=(
+            None if not prompt_tokens else torch.tensor(list(prompt_tokens), dtype=torch.int64)
+        ),
+        sampling_params=sampling_params,
+        status=status,
+        generated_tokens=list(generated_tokens),
+        generated_length=len(generated_tokens),
+        generated_log_probs=generated_log_probs,
+    )
+    return request.serialize()
+
+
+class FakeEngine:
+    """A ZMQ DEALER that impersonates a data parallel engine.
+
+    Registers with a coordinator, answers SUBMIT_REQUEST with a canned reply of
+    ``num_output_tokens`` tokens, and honours control signals well enough to shut
+    down cleanly. Deliberately has no model, no torch.distributed and no CUDA:
+    the point is to measure the frontend and coordinator in isolation, at a rate
+    a real engine could never sustain.
+    """
+
+    def __init__(
+        self,
+        coordinator_addr,
+        identity,
+        num_output_tokens=8,
+        context=None,
+        reply_log_probs=False,
+        tokenizer=None,
+        reply_delay_s=0.0,
+    ):
+        self.coordinator_addr = coordinator_addr
+        self.identity = identity if isinstance(identity, bytes) else identity.encode()
+        self.num_output_tokens = num_output_tokens
+        self.reply_log_probs = reply_log_probs
+        self.tokenizer = tokenizer or ByteTokenizer()
+        # Holding replies for a while lets many requests be genuinely in flight
+        # at once, which is what makes a concurrency sweep meaningful. Replies are
+        # queued and released by the poll loop, so one thread still serves many
+        # overlapping requests.
+        self.reply_delay_s = reply_delay_s
+        self._pending_replies = []
+        self._reply_sequence = 0
+        self._owns_context = context is None
+        self.context = context or zmq.Context()
+        self.socket = None
+        self._thread = None
+        self._stop = threading.Event()
+        # Requests served, for capacity accounting.
+        self.num_requests_served = 0
+
+    def start(self):
+        """Connect, register with the coordinator, and start serving."""
+        self.socket = self.context.socket(zmq.DEALER)
+        self.socket.setsockopt(zmq.IDENTITY, self.identity)
+        self.socket.setsockopt(zmq.SNDHWM, 0)
+        self.socket.setsockopt(zmq.RCVHWM, 0)
+        self.socket.connect(self.coordinator_addr)
+        # An empty payload registers this engine with the coordinator.
+        self.socket.send(b"")
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        poller = zmq.Poller()
+        poller.register(self.socket, zmq.POLLIN)
+        while not self._stop.is_set():
+            # Poll briefly while replies are queued so they are released on time.
+            timeout_ms = 1 if self._pending_replies else 50
+            if dict(poller.poll(timeout=timeout_ms)):
+                # Drain everything already queued rather than one message per
+                # iteration, so the engine never becomes the bottleneck in a
+                # capacity sweep.
+                while True:
+                    try:
+                        raw = self.socket.recv(flags=zmq.NOBLOCK)
+                    except zmq.Again:
+                        break
+                    self._handle(msgpack.unpackb(raw, raw=False))
+                    if self._stop.is_set():
+                        return
+            self._flush_due_replies()
+
+    def _flush_due_replies(self):
+        now = time.monotonic()
+        # Min-heap on due time: only the frames that are actually due are
+        # touched, so a large in-flight backlog costs nothing per iteration.
+        while self._pending_replies and self._pending_replies[0][0] <= now:
+            _, _, payload, is_final = heapq.heappop(self._pending_replies)
+            self._send_frame(payload, is_final)
+
+    def _handle(self, payload):
+        header = Headers(payload[0])
+        if header == Headers.SUBMIT_REQUEST:
+            request_id, prompt, serialized_params = payload[1:4]
+            self._reply(request_id, prompt, serialized_params)
+        elif header in (Headers.STOP, Headers.SHUTDOWN):
+            self._stop.set()
+        # Everything else (pause/resume/profiler signals) needs no engine-side
+        # state for these tests.
+
+    def _reply(self, request_id, prompt, serialized_params):
+        sampling_params = SamplingParams.deserialize(serialized_params)
+        num_tokens = sampling_params.num_tokens_to_generate or self.num_output_tokens
+        generated_tokens = synthesize_generated_tokens(num_tokens, self.tokenizer)
+        prompt_tokens = prompt if isinstance(prompt, list) else []
+        reply = build_engine_reply(
+            request_id,
+            prompt_tokens,
+            generated_tokens,
+            sampling_params,
+            generated_log_probs=(
+                [-0.5] * len(generated_tokens)
+                if (self.reply_log_probs or sampling_params.return_log_probs)
+                else None
+            ),
+        )
+        # Streaming requests get one partial per token, spread over the reply
+        # delay, so the frontend pays its real per-token streaming cost (a
+        # detokenize step and an SSE flush) instead of seeing one lump reply.
+        frames = []
+        if sampling_params.streaming:
+            step = self.reply_delay_s / max(1, len(generated_tokens))
+            frames.extend(
+                (
+                    step * (index + 1),
+                    [
+                        Headers.ENGINE_REPLY_PARTIAL.value,
+                        [{"request_id": request_id, "new_tokens": [token]}],
+                    ],
+                    False,
+                )
+                for index, token in enumerate(generated_tokens)
+            )
+        frames.append((self.reply_delay_s, [Headers.ENGINE_REPLY.value, [reply]], True))
+
+        for delay, payload, is_final in frames:
+            if delay > 0:
+                # The counter breaks ties so heapq never has to order the payloads.
+                self._reply_sequence += 1
+                heapq.heappush(
+                    self._pending_replies,
+                    (time.monotonic() + delay, self._reply_sequence, payload, is_final),
+                )
+            else:
+                self._send_frame(payload, is_final)
+
+    def _send_frame(self, payload, is_final):
+        self.socket.send(msgpack.packb(payload, use_bin_type=True))
+        if is_final:
+            self.num_requests_served += 1
+
+    def stop(self):
+        """Stop serving and release the socket."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        if self.socket is not None and not self.socket.closed:
+            self.socket.close(linger=0)
+            self.socket = None
+        if self._owns_context:
+            self.context.term()
+
+
+@contextmanager
+def standalone_coordinator(max_requests=256, port=None, tokenizer=None, num_engines=1, **kwargs):
+    """Run a real coordinator process with fake engines attached.
+
+    The coordinator is spawned with ``data_parallel_size=0`` so it does not block
+    waiting for engines; the fake engines then register through the
+    empty-payload path, exactly as real engines do when they reconnect.
+
+    Args:
+        max_requests (int): Coordinator's per-rank max request count.
+        port (int | None): Port to bind; None picks a random free port.
+        tokenizer: Tokenizer for the coordinator; defaults to ByteTokenizer.
+        num_engines (int): Number of fake engines to attach.
+        **kwargs: Forwarded to FakeEngine.
+
+    Yields:
+        tuple[str, list[FakeEngine]]: The coordinator address and the engines.
+    """
+    spawn_context = multiprocessing.get_context('spawn')
+    pipe_parent, pipe_child = spawn_context.Pipe()
+    ready_event = spawn_context.Event()
+    proc = spawn_context.Process(
+        target=DataParallelInferenceCoordinator.entrypoint,
+        kwargs={
+            "pipe_connection": pipe_child,
+            "ready_event": ready_event,
+            "data_parallel_size": 0,
+            "tokenizer": tokenizer or ByteTokenizer(),
+            "max_requests": max_requests,
+            "inference_coordinator_port": port,
+            "hostname": "127.0.0.1",
+        },
+    )
+    proc.start()
+
+    addr = None
+    engines = []
+    try:
+        while not pipe_parent.poll(timeout=0.1):
+            assert proc.is_alive(), "Coordinator process died during init"
+        addr = pipe_parent.recv()
+        pipe_parent.close()
+        assert ready_event.wait(timeout=30.0), "Coordinator never signalled ready"
+
+        for i in range(num_engines):
+            engine = FakeEngine(addr, f"fake-engine-{i}", **kwargs)
+            engine.start()
+            engines.append(engine)
+
+        yield addr, engines
+    finally:
+        for engine in engines:
+            engine.stop()
+        _shutdown_coordinator(proc, addr)
+
+
+def _shutdown_coordinator(proc, addr):
+    """Ask the coordinator to exit its loop, then reap the process."""
+    if proc is None or not proc.is_alive():
+        return
+    if addr is not None:
+        context = zmq.Context()
+        socket = context.socket(zmq.DEALER)
+        socket.connect(addr)
+        socket.send(msgpack.packb([Headers.CONNECT.value], use_bin_type=True))
+        if socket.poll(timeout=5000):
+            socket.recv()  # CONNECT_ACK
+            socket.send(msgpack.packb([Headers.SHUTDOWN.value], use_bin_type=True))
+        socket.close(linger=1000)
+        context.term()
+    proc.join(timeout=10.0)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5.0)
+
+
+class FakeInferenceClient:
+    """Stands in for InferenceClient so HTTP endpoints can be tested alone.
+
+    Implements the two methods the endpoints call (add_request and
+    add_request_streaming) and records what it was asked for, so tests can assert
+    on how request fields were translated into SamplingParams. Replies come from
+    the same serializer the engine uses.
+    """
+
+    def __init__(
+        self,
+        num_output_tokens=4,
+        generated_log_probs=False,
+        status=Status.COMPLETED,
+        tokenizer=None,
+    ):
+        self.num_output_tokens = num_output_tokens
+        self.generated_log_probs = generated_log_probs
+        self.status = status
+        # Used to fill generated_text, which the coordinator normally detokenizes.
+        # Sharing the app's tokenizer keeps streamed deltas and the non-streaming
+        # text consistent.
+        self.tokenizer = tokenizer or ByteTokenizer()
+        self.next_request_id = 0
+        # (prompt, sampling_params) for every submitted request, in order.
+        self.submissions = []
+        # Set to override the next reply, e.g. to simulate a failed request.
+        self.reply_override = None
+
+    def _build_reply(self, prompt, sampling_params):
+        request_id = self.next_request_id
+        self.next_request_id += 1
+        self.submissions.append((prompt, sampling_params))
+        if self.reply_override is not None:
+            return self.reply_override
+        num_tokens = sampling_params.num_tokens_to_generate or self.num_output_tokens
+        generated_tokens = synthesize_generated_tokens(num_tokens, self.tokenizer)
+        reply = build_engine_reply(
+            request_id,
+            prompt if isinstance(prompt, list) else [],
+            generated_tokens,
+            sampling_params,
+            status=self.status,
+            generated_log_probs=(
+                [-0.5] * len(generated_tokens)
+                if (self.generated_log_probs or sampling_params.return_log_probs)
+                else None
+            ),
+        )
+        # The coordinator detokenizes final replies before the client sees them.
+        reply["generated_text"] = self.tokenizer.detokenize(generated_tokens)
+        return reply
+
+    def add_request(self, prompt, sampling_params):
+        """Return an already-resolved future holding a canned reply."""
+        future = asyncio.get_running_loop().create_future()
+        future.set_result(self._build_reply(prompt, sampling_params))
+        return future
+
+    def add_request_streaming(self, prompt, sampling_params):
+        """Return a stream that yields one partial per token, then the final reply."""
+        sampling_params.streaming = True
+        reply = self._build_reply(prompt, sampling_params)
+        request_id = reply["request_id"]
+        stream = AsyncStream(request_id, lambda: None)
+        for index, token in enumerate(reply["generated_tokens"]):
+            stream.put({"partial": {"request_id": request_id, "new_tokens": [token]}})
+        stream.put({"final": reply})
+        stream.finish()
+        return stream

--- a/tests/unit_tests/inference/frontend_test_utils.py
+++ b/tests/unit_tests/inference/frontend_test_utils.py
@@ -445,10 +445,9 @@ def _shutdown_coordinator(proc, addr):
 class FakeInferenceClient:
     """Stands in for InferenceClient so HTTP endpoints can be tested alone.
 
-    Implements the two methods the endpoints call (add_request and
-    add_request_streaming) and records what it was asked for, so tests can assert
-    on how request fields were translated into SamplingParams. Replies come from
-    the same serializer the engine uses.
+    Implements the request and abort methods the endpoints call and records what
+    it was asked for, so tests can assert on how request fields were translated
+    into SamplingParams. Replies come from the same serializer the engine uses.
     """
 
     def __init__(
@@ -468,6 +467,7 @@ class FakeInferenceClient:
         self.next_request_id = 0
         # (prompt, sampling_params) for every submitted request, in order.
         self.submissions = []
+        self.aborted_request_ids = []
         # Set to override the next reply, e.g. to simulate a failed request.
         self.reply_override = None
 
@@ -476,7 +476,9 @@ class FakeInferenceClient:
         self.next_request_id += 1
         self.submissions.append((prompt, sampling_params))
         if self.reply_override is not None:
-            return self.reply_override
+            reply = dict(self.reply_override)
+            reply.setdefault("request_id", request_id)
+            return reply
         num_tokens = sampling_params.num_tokens_to_generate or self.num_output_tokens
         generated_tokens = synthesize_generated_tokens(num_tokens, self.tokenizer)
         reply = build_engine_reply(
@@ -497,10 +499,21 @@ class FakeInferenceClient:
 
     def add_request(self, prompt, sampling_params, multi_modal_data=None):
         """Return an already-resolved future holding a canned reply."""
+        return self.add_request_with_id(prompt, sampling_params, multi_modal_data=multi_modal_data)[
+            1
+        ]
+
+    def add_request_with_id(self, prompt, sampling_params, multi_modal_data=None):
+        """Return the canned reply's request id and resolved future."""
         del multi_modal_data
         future = asyncio.get_running_loop().create_future()
-        future.set_result(self._build_reply(prompt, sampling_params))
-        return future
+        reply = self._build_reply(prompt, sampling_params)
+        future.set_result(reply)
+        return reply["request_id"], future
+
+    def abort_request(self, request_id):
+        """Record an endpoint-requested abort."""
+        self.aborted_request_ids.append(request_id)
 
     def add_request_streaming(self, prompt, sampling_params, multi_modal_data=None):
         """Return a stream that yields one partial per token, then the final reply."""

--- a/tests/unit_tests/inference/frontend_test_utils.py
+++ b/tests/unit_tests/inference/frontend_test_utils.py
@@ -474,14 +474,16 @@ class FakeInferenceClient:
         reply["generated_text"] = self.tokenizer.detokenize(generated_tokens)
         return reply
 
-    def add_request(self, prompt, sampling_params):
+    def add_request(self, prompt, sampling_params, multi_modal_data=None):
         """Return an already-resolved future holding a canned reply."""
+        del multi_modal_data
         future = asyncio.get_running_loop().create_future()
         future.set_result(self._build_reply(prompt, sampling_params))
         return future
 
-    def add_request_streaming(self, prompt, sampling_params):
+    def add_request_streaming(self, prompt, sampling_params, multi_modal_data=None):
         """Return a stream that yields one partial per token, then the final reply."""
+        del multi_modal_data
         sampling_params.streaming = True
         reply = self._build_reply(prompt, sampling_params)
         request_id = reply["request_id"]

--- a/tests/unit_tests/inference/test_data_parallel_inference_coordinator.py
+++ b/tests/unit_tests/inference/test_data_parallel_inference_coordinator.py
@@ -78,10 +78,11 @@ class _StubCoordinator:
     def get_least_loaded_data_parallel_rank(self):
         return self._identity
 
-    def _send_to_engine(self, identity, frames):
+    def _send_to_engine(self, identity, frames, header):
         # Mirrors the real signature: a list of frames, metadata first. Passing
         # raw bytes here would splay one frame per byte, so assert the shape.
         assert isinstance(frames, list), f"expected a frame list, got {type(frames).__name__}"
+        assert header == msgpack.unpackb(frames[0], raw=False)[0]
         self.sent.append((identity, frames))
         return True
 

--- a/tests/unit_tests/inference/test_frontend_packet_size.py
+++ b/tests/unit_tests/inference/test_frontend_packet_size.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""How large are the packets on the frontend wire?
+
+Every request and reply between the HTTP frontend, the coordinator and the
+engines is a msgpack-packed list on a ZMQ socket. Nothing measured those payloads
+before, so growth was invisible until it showed up as a throughput regression
+with no obvious cause -- a field added to a reply, or log probs left enabled by
+default, silently multiplies the bytes moved per request.
+
+These tests pin the *shape* of the size curve rather than exact byte counts:
+
+* a bounded fixed cost per message, and
+* a bounded marginal cost per prompt token and per generated token.
+
+All ceilings are one-sided, so shrinking a payload always passes and only growth
+fails. Measured values at the time of writing are quoted next to each ceiling so
+the headroom is visible; they were taken with realistic five-digit token ids,
+since msgpack's integer encoding makes byte counts depend on token id magnitude.
+
+The last class checks the WireMetrics instrumentation itself against a real
+coordinator process, so the counters cannot silently drift from the bytes that
+actually cross the socket.
+"""
+
+import asyncio
+import random
+
+import msgpack
+import pytest
+
+from megatron.core.inference.headers import Headers
+from megatron.core.inference.inference_client import InferenceClient
+from megatron.core.inference.sampling_params import SamplingParams
+from tests.unit_tests.inference.frontend_test_utils import (
+    ByteLevelFastTokenizer,
+    ByteTokenizer,
+    build_engine_reply,
+    standalone_coordinator,
+    synthesize_generated_tokens,
+)
+
+# Ceilings, all one-sided. Measured values in comments.
+MAX_REQUEST_FIXED_BYTES = 512  # measured 327
+MAX_SAMPLING_PARAMS_BYTES = 512  # measured 323
+MAX_REQUEST_BYTES_PER_PROMPT_TOKEN = 5.0  # measured 3.8
+MAX_REPLY_FIXED_BYTES = 1536  # measured 1011
+MAX_REPLY_BYTES_PER_GENERATED_TOKEN = 4.0  # measured 2.0
+MAX_LOGPROB_BYTES_PER_GENERATED_TOKEN = 12.0  # measured 9.0
+
+
+def packed_size(payload) -> int:
+    """Serialized size of a payload, exactly as the client and coordinator pack it."""
+    return len(msgpack.packb(payload, use_bin_type=True))
+
+
+def token_ids(count, seed=1234):
+    """Realistic five-digit token ids; msgpack sizes depend on id magnitude."""
+    rng = random.Random(seed)
+    return [rng.randrange(10000, 99999) for _ in range(count)]
+
+
+def submit_request_payload(prompt_tokens, sampling_params):
+    """The SUBMIT_REQUEST payload InferenceClient.add_request builds."""
+    return [Headers.SUBMIT_REQUEST.value, 0, prompt_tokens, sampling_params.serialize()]
+
+
+def engine_reply_payload(prompt_tokens, num_generated, return_prompt_tokens=False, log_probs=False):
+    """The ENGINE_REPLY payload the coordinator forwards to a client."""
+    tokenizer = ByteTokenizer()
+    sampling_params = SamplingParams(
+        num_tokens_to_generate=num_generated,
+        return_prompt_tokens=return_prompt_tokens,
+        return_log_probs=log_probs,
+    )
+    generated_tokens = synthesize_generated_tokens(num_generated, tokenizer)
+    reply = build_engine_reply(
+        0,
+        prompt_tokens,
+        generated_tokens,
+        sampling_params,
+        generated_log_probs=[-0.512345] * num_generated if log_probs else None,
+    )
+    reply["generated_text"] = tokenizer.detokenize(generated_tokens)
+    return [Headers.ENGINE_REPLY.value, 0, reply]
+
+
+def marginal_bytes_per_token(size_fn, counts):
+    """Largest per-token slope between consecutive measurements of size_fn."""
+    slopes = []
+    previous_count, previous_size = counts[0], size_fn(counts[0])
+    for count in counts[1:]:
+        current_size = size_fn(count)
+        slopes.append((current_size - previous_size) / (count - previous_count))
+        previous_count, previous_size = count, current_size
+    return max(slopes)
+
+
+class TestRequestPacketSize:
+    """Client -> coordinator -> engine request payloads."""
+
+    def test_minimal_request_fits_in_budget(self):
+        """A request with a one-token prompt is almost entirely fixed overhead."""
+        size = packed_size(submit_request_payload([42], SamplingParams(num_tokens_to_generate=16)))
+        assert size <= MAX_REQUEST_FIXED_BYTES
+
+    def test_sampling_params_are_the_fixed_cost_of_every_request(self):
+        """SamplingParams is serialized in full on every single request.
+
+        All 18 fields ship on the wire whether or not the caller set them, and at
+        ~323 bytes they are over 95% of a short request. That is the price of the
+        current protocol, not a defect, but it caps how cheap a request can get:
+        adding a field here costs bytes on every request forever.
+        """
+        params_bytes = packed_size(SamplingParams(num_tokens_to_generate=16).serialize())
+        assert params_bytes <= MAX_SAMPLING_PARAMS_BYTES
+
+    def test_request_bytes_grow_linearly_with_prompt_length(self):
+        """Prompt tokens must cost a bounded number of bytes each.
+
+        Guards against a regression that sends prompts in a wider encoding (a
+        float tensor, or ids as strings), which would inflate every prefill.
+        """
+        sampling_params = SamplingParams(num_tokens_to_generate=16)
+        slope = marginal_bytes_per_token(
+            lambda n: packed_size(submit_request_payload(token_ids(n), sampling_params)),
+            [0, 256, 1024, 4096],
+        )
+        assert slope <= MAX_REQUEST_BYTES_PER_PROMPT_TOKEN
+
+
+class TestPayloadDeterminism:
+    """Payload sizes have to be reproducible before they can be gated."""
+
+    def test_tokenizer_assigns_the_same_ids_in_every_instance(self):
+        """Two ByteLevelFastTokenizers must agree on ids for the same text.
+
+        The tokenizer is rebuilt from scratch in the coordinator and engine
+        subprocesses, and the perf test gates request_bytes_per_request. Both
+        break if ids are not reproducible: the processes disagree about what a
+        token means, and msgpack spends a different number of bytes per id, which
+        moved the recorded byte counts by over 20% between two identical runs.
+        """
+        text = "the quick brown fox jumps over the lazy dog"
+        assert ByteLevelFastTokenizer().tokenize(text) == ByteLevelFastTokenizer().tokenize(text)
+
+
+class TestReplyPacketSize:
+    """Engine -> coordinator -> client reply payloads."""
+
+    def test_minimal_reply_fits_in_budget(self):
+        size = packed_size(engine_reply_payload([], 0))
+        assert size <= MAX_REPLY_FIXED_BYTES
+
+    def test_reply_bytes_grow_linearly_with_generated_tokens(self):
+        slope = marginal_bytes_per_token(
+            lambda n: packed_size(engine_reply_payload([], n)), [0, 16, 128, 512]
+        )
+        assert slope <= MAX_REPLY_BYTES_PER_GENERATED_TOKEN
+
+    def test_log_probs_cost_per_token_is_bounded(self):
+        """Log probs are the largest opt-in cost on a reply.
+
+        They roughly quintuple the per-token reply cost (~2 -> ~11 bytes), which
+        is why the frontend must not enable them by default. Serialized as
+        float64; switching to float32 would nearly halve this.
+        """
+        without = packed_size(engine_reply_payload([], 512, log_probs=False))
+        with_log_probs = packed_size(engine_reply_payload([], 512, log_probs=True))
+        assert (with_log_probs - without) / 512 <= MAX_LOGPROB_BYTES_PER_GENERATED_TOKEN
+
+    def test_reply_size_is_independent_of_prompt_length(self):
+        """A reply must not carry the prompt back unless the caller asked for it.
+
+        DynamicInferenceRequest.serialize drops prompt_tokens when
+        return_prompt_tokens is False, to keep the large prompt tensor off the
+        engine->coordinator->API path. remaining_prompt_tokens starts life as a
+        copy of prompt_tokens, so it has to be dropped too: while it was not, the
+        full prompt still shipped at ~3.8 bytes per token, over 90% of the reply
+        for a 4k-token prompt.
+
+        Both prompt lengths here are checked against the same fixed budget rather
+        than each other, so a reply that grows with the prompt fails no matter how
+        large the constant part becomes.
+        """
+        for num_prompt_tokens in (8, 4096):
+            size = packed_size(engine_reply_payload(token_ids(num_prompt_tokens), 16))
+            assert size <= MAX_REPLY_FIXED_BYTES + 16 * MAX_REPLY_BYTES_PER_GENERATED_TOKEN
+
+    def test_prompt_tokens_are_returned_when_requested(self):
+        """return_prompt_tokens=True must actually put the prompt on the wire."""
+        without = packed_size(engine_reply_payload(token_ids(512), 16))
+        with_prompt = packed_size(
+            engine_reply_payload(token_ids(512), 16, return_prompt_tokens=True)
+        )
+        assert with_prompt > without
+
+
+class TestWireMetricsAccounting:
+    """The instrumentation must match the bytes that really cross the socket."""
+
+    @pytest.mark.internal
+    def test_metrics_match_traffic_through_a_real_coordinator(self):
+        """Drive a real coordinator and fake engine, then reconcile the counters.
+
+        This is the end-to-end check that WireMetrics is wired into every send
+        and receive path: the totals it reports must equal the payload sizes we
+        can compute independently, and both directions must be accounted for.
+        """
+        num_requests = 8
+        num_output_tokens = 12
+        prompt = token_ids(64)
+
+        async def run(addr):
+            client = InferenceClient(addr)
+            client.start(connect_timeout_seconds=30.0)
+            try:
+                sampling_params = SamplingParams(num_tokens_to_generate=num_output_tokens)
+                futures = [
+                    client.add_request(list(prompt), sampling_params) for _ in range(num_requests)
+                ]
+                await asyncio.wait_for(asyncio.gather(*futures), timeout=60.0)
+                return client.get_wire_metrics()
+            finally:
+                client.stop()
+
+        with standalone_coordinator(num_engines=1) as (addr, _engines):
+            metrics = asyncio.run(run(addr))
+
+        per_header = metrics["per_header"]
+
+        # Sent: one CONNECT handshake plus one SUBMIT_REQUEST per request.
+        assert per_header["CONNECT"]["sent_messages"] == 1
+        assert per_header["SUBMIT_REQUEST"]["sent_messages"] == num_requests
+        assert metrics["sent_messages"] == num_requests + 1
+
+        # The SUBMIT_REQUEST bytes must equal what msgpack produces for the same
+        # payload; add_request assigns ids 0..n-1, which can change the size.
+        expected_bytes = sum(
+            packed_size(
+                [
+                    Headers.SUBMIT_REQUEST.value,
+                    request_id,
+                    list(prompt),
+                    SamplingParams(num_tokens_to_generate=num_output_tokens).serialize(),
+                ]
+            )
+            for request_id in range(num_requests)
+        )
+        assert per_header["SUBMIT_REQUEST"]["sent_bytes"] == expected_bytes
+
+        # Received: one CONNECT_ACK plus one ENGINE_REPLY per request.
+        assert per_header["CONNECT_ACK"]["received_messages"] == 1
+        assert per_header["ENGINE_REPLY"]["received_messages"] == num_requests
+        assert per_header["ENGINE_REPLY"]["mean_received_bytes"] > 0
+
+        # Replies dominate: they carry generated text, tokens and the record.
+        assert metrics["received_bytes"] > metrics["sent_bytes"]

--- a/tests/unit_tests/inference/test_frontend_packet_size.py
+++ b/tests/unit_tests/inference/test_frontend_packet_size.py
@@ -243,6 +243,7 @@ class TestWireMetricsAccounting:
                     request_id,
                     list(prompt),
                     SamplingParams(num_tokens_to_generate=num_output_tokens).serialize(),
+                    None,
                 ]
             )
             for request_id in range(num_requests)

--- a/tests/unit_tests/inference/test_frontend_packet_size.py
+++ b/tests/unit_tests/inference/test_frontend_packet_size.py
@@ -3,10 +3,10 @@
 """How large are the packets on the frontend wire?
 
 Every request and reply between the HTTP frontend, the coordinator and the
-engines is a msgpack-packed list on a ZMQ socket. Nothing measured those payloads
-before, so growth was invisible until it showed up as a throughput regression
-with no obvious cause -- a field added to a reply, or log probs left enabled by
-default, silently multiplies the bytes moved per request.
+engines is one or more msgpack-packed frames on a ZMQ socket. Nothing measured
+those payloads before, so growth was invisible until it showed up as a
+throughput regression with no obvious cause -- a field added to a reply, or log
+probs left enabled by default, silently multiplies the bytes moved per request.
 
 These tests pin the *shape* of the size curve rather than exact byte counts:
 
@@ -60,13 +60,18 @@ def token_ids(count, seed=1234):
     return [rng.randrange(10000, 99999) for _ in range(count)]
 
 
-def submit_request_payload(prompt_tokens, sampling_params):
-    """The SUBMIT_REQUEST payload InferenceClient.add_request builds."""
-    return [Headers.SUBMIT_REQUEST.value, 0, prompt_tokens, sampling_params.serialize()]
+def submit_request_frames(prompt_tokens, sampling_params, request_id=0):
+    """The SUBMIT_REQUEST frames an unconfigured InferenceClient builds."""
+    return [
+        [Headers.SUBMIT_REQUEST.value, request_id, sampling_params.serialize(), None],
+        prompt_tokens,
+        None,
+        None,
+    ]
 
 
-def engine_reply_payload(prompt_tokens, num_generated, return_prompt_tokens=False, log_probs=False):
-    """The ENGINE_REPLY payload the coordinator forwards to a client."""
+def engine_reply_frames(prompt_tokens, num_generated, return_prompt_tokens=False, log_probs=False):
+    """The ENGINE_REPLY frames the coordinator forwards to a client."""
     tokenizer = ByteTokenizer()
     sampling_params = SamplingParams(
         num_tokens_to_generate=num_generated,
@@ -82,7 +87,12 @@ def engine_reply_payload(prompt_tokens, num_generated, return_prompt_tokens=Fals
         generated_log_probs=[-0.512345] * num_generated if log_probs else None,
     )
     reply["generated_text"] = tokenizer.detokenize(generated_tokens)
-    return [Headers.ENGINE_REPLY.value, 0, reply]
+    return [[Headers.ENGINE_REPLY.value, 0], reply]
+
+
+def frames_size(frames) -> int:
+    """Combined serialized payload bytes across a multipart message."""
+    return sum(packed_size(frame) for frame in frames)
 
 
 def marginal_bytes_per_token(size_fn, counts):
@@ -101,7 +111,7 @@ class TestRequestPacketSize:
 
     def test_minimal_request_fits_in_budget(self):
         """A request with a one-token prompt is almost entirely fixed overhead."""
-        size = packed_size(submit_request_payload([42], SamplingParams(num_tokens_to_generate=16)))
+        size = frames_size(submit_request_frames([42], SamplingParams(num_tokens_to_generate=16)))
         assert size <= MAX_REQUEST_FIXED_BYTES
 
     def test_sampling_params_are_the_fixed_cost_of_every_request(self):
@@ -123,7 +133,7 @@ class TestRequestPacketSize:
         """
         sampling_params = SamplingParams(num_tokens_to_generate=16)
         slope = marginal_bytes_per_token(
-            lambda n: packed_size(submit_request_payload(token_ids(n), sampling_params)),
+            lambda n: frames_size(submit_request_frames(token_ids(n), sampling_params)),
             [0, 256, 1024, 4096],
         )
         assert slope <= MAX_REQUEST_BYTES_PER_PROMPT_TOKEN
@@ -149,12 +159,12 @@ class TestReplyPacketSize:
     """Engine -> coordinator -> client reply payloads."""
 
     def test_minimal_reply_fits_in_budget(self):
-        size = packed_size(engine_reply_payload([], 0))
+        size = frames_size(engine_reply_frames([], 0))
         assert size <= MAX_REPLY_FIXED_BYTES
 
     def test_reply_bytes_grow_linearly_with_generated_tokens(self):
         slope = marginal_bytes_per_token(
-            lambda n: packed_size(engine_reply_payload([], n)), [0, 16, 128, 512]
+            lambda n: frames_size(engine_reply_frames([], n)), [0, 16, 128, 512]
         )
         assert slope <= MAX_REPLY_BYTES_PER_GENERATED_TOKEN
 
@@ -165,8 +175,8 @@ class TestReplyPacketSize:
         is why the frontend must not enable them by default. Serialized as
         float64; switching to float32 would nearly halve this.
         """
-        without = packed_size(engine_reply_payload([], 512, log_probs=False))
-        with_log_probs = packed_size(engine_reply_payload([], 512, log_probs=True))
+        without = frames_size(engine_reply_frames([], 512, log_probs=False))
+        with_log_probs = frames_size(engine_reply_frames([], 512, log_probs=True))
         assert (with_log_probs - without) / 512 <= MAX_LOGPROB_BYTES_PER_GENERATED_TOKEN
 
     def test_reply_size_is_independent_of_prompt_length(self):
@@ -184,14 +194,14 @@ class TestReplyPacketSize:
         large the constant part becomes.
         """
         for num_prompt_tokens in (8, 4096):
-            size = packed_size(engine_reply_payload(token_ids(num_prompt_tokens), 16))
+            size = frames_size(engine_reply_frames(token_ids(num_prompt_tokens), 16))
             assert size <= MAX_REPLY_FIXED_BYTES + 16 * MAX_REPLY_BYTES_PER_GENERATED_TOKEN
 
     def test_prompt_tokens_are_returned_when_requested(self):
         """return_prompt_tokens=True must actually put the prompt on the wire."""
-        without = packed_size(engine_reply_payload(token_ids(512), 16))
-        with_prompt = packed_size(
-            engine_reply_payload(token_ids(512), 16, return_prompt_tokens=True)
+        without = frames_size(engine_reply_frames(token_ids(512), 16))
+        with_prompt = frames_size(
+            engine_reply_frames(token_ids(512), 16, return_prompt_tokens=True)
         )
         assert with_prompt > without
 
@@ -234,17 +244,15 @@ class TestWireMetricsAccounting:
         assert per_header["SUBMIT_REQUEST"]["sent_messages"] == num_requests
         assert metrics["sent_messages"] == num_requests + 1
 
-        # The SUBMIT_REQUEST bytes must equal what msgpack produces for the same
-        # payload; add_request assigns ids 0..n-1, which can change the size.
+        # The SUBMIT_REQUEST bytes must equal the sum of its four msgpack frame
+        # sizes; add_request assigns ids 0..n-1, which can change the size.
         expected_bytes = sum(
-            packed_size(
-                [
-                    Headers.SUBMIT_REQUEST.value,
-                    request_id,
+            frames_size(
+                submit_request_frames(
                     list(prompt),
-                    SamplingParams(num_tokens_to_generate=num_output_tokens).serialize(),
-                    None,
-                ]
+                    SamplingParams(num_tokens_to_generate=num_output_tokens),
+                    request_id,
+                )
             )
             for request_id in range(num_requests)
         )

--- a/tests/unit_tests/inference/test_openai_api_compatibility.py
+++ b/tests/unit_tests/inference/test_openai_api_compatibility.py
@@ -1,0 +1,531 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Is the inference HTTP frontend 1:1 compatible with the OpenAI API?
+
+Responses are validated against the OpenAI SDK's own pydantic models
+(``openai.types.Completion``, ``openai.types.chat.ChatCompletion``,
+``ChatCompletionChunk``) rather than hand-written expectations. If a field is
+renamed, retyped or dropped, the vendor's schema rejects it, which is a much
+stronger statement about compatibility than asserting on keys we chose
+ourselves.
+
+Everything here runs against the real Quart app and the real endpoint handlers
+via Quart's test client, with a fake InferenceClient in place of the engine.
+There is no model, no coordinator and no GPU: the subject under test is the HTTP
+layer's request parsing and response shaping.
+
+The compatibility gaps this frontend has are recorded in
+TestDocumentedOpenAIGaps rather than left implicit, so that closing one of them
+fails a test and forces the list to be updated.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("quart", reason="the OpenAI-compatible frontend requires Quart")
+pytest.importorskip("openai", reason="response schemas come from the OpenAI SDK")
+
+from openai.types import Completion
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+from megatron.core.inference.inference_request import Status
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.text_generation_server import (  # noqa: E501
+    build_app,
+)
+from tests.unit_tests.inference.frontend_test_utils import (
+    FakeInferenceClient,
+    make_byte_level_fast_tokenizer,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def tokenizer():
+    return make_byte_level_fast_tokenizer()
+
+
+@pytest.fixture
+def fake_client(tokenizer):
+    return FakeInferenceClient(num_output_tokens=4, tokenizer=tokenizer)
+
+
+@pytest.fixture
+def http(fake_client, tokenizer):
+    """A Quart test client wired to the real endpoint blueprints."""
+    app = build_app(fake_client, tokenizer, parsers=None, verbose=False)
+    return app.test_client()
+
+
+def parse_sse(body: str):
+    """Split an SSE body into (json_chunks, saw_done_terminator)."""
+    chunks = []
+    saw_done = False
+    for block in body.split("\n\n"):
+        block = block.strip()
+        if not block.startswith("data:"):
+            continue
+        data = block[len("data:") :].strip()
+        if data == "[DONE]":
+            saw_done = True
+            continue
+        chunks.append(json.loads(data))
+    return chunks, saw_done
+
+
+class TestResponseSchemas:
+    """The response bodies must satisfy the OpenAI SDK's own models."""
+
+    async def test_completions_response_matches_openai_schema(self, http):
+        response = await http.post(
+            "/v1/completions", json={"prompt": "Hello, world!", "max_tokens": 4}
+        )
+        assert response.status_code == 200
+        body = await response.get_json()
+
+        # The SDK model is the contract: it enforces required fields and types.
+        parsed = Completion.model_validate(body)
+        assert parsed.object == "text_completion"
+        assert len(parsed.choices) == 1
+        assert parsed.choices[0].finish_reason in ("stop", "length")
+        assert parsed.usage.total_tokens == (
+            parsed.usage.prompt_tokens + parsed.usage.completion_tokens
+        )
+        assert parsed.choices[0].text
+
+    async def test_chat_completions_response_matches_openai_schema(self, http):
+        response = await http.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Hello!"}], "max_tokens": 4},
+        )
+        assert response.status_code == 200
+        body = await response.get_json()
+
+        parsed = ChatCompletion.model_validate(body)
+        assert parsed.object == "chat.completion"
+        assert len(parsed.choices) == 1
+        assert parsed.choices[0].message.role == "assistant"
+        assert parsed.choices[0].finish_reason in ("stop", "length", "tool_calls")
+        assert parsed.usage.total_tokens == (
+            parsed.usage.prompt_tokens + parsed.usage.completion_tokens
+        )
+
+    async def test_completions_logprobs_are_returned_and_aligned(self, http):
+        """`logprobs` is an int on the completions API and shapes a Logprobs object.
+
+        With echo=False every returned token is generated and therefore has a
+        logprob, so all four parallel arrays must be the same length. A leading
+        null in token_logprobs (which belongs to the echo=True case, where the
+        first prompt token genuinely has none) both misaligns the arrays and
+        fails strict validation against openai.types.Completion.
+        """
+        response = await http.post(
+            "/v1/completions", json={"prompt": "Hello", "max_tokens": 4, "logprobs": 2}
+        )
+        assert response.status_code == 200
+        body = await response.get_json()
+        logprobs = body["choices"][0]["logprobs"]
+        assert logprobs is not None
+        assert len(logprobs["tokens"]) == 4
+        assert len(logprobs["token_logprobs"]) == len(logprobs["tokens"])
+        assert len(logprobs["text_offset"]) == len(logprobs["tokens"])
+        assert logprobs["text_offset"] == sorted(logprobs["text_offset"])
+        assert all(isinstance(value, float) for value in logprobs["token_logprobs"])
+        Completion.model_validate(body)
+
+    async def test_chat_completions_return_logprobs(self, http):
+        """`logprobs: true` on the chat API must return per-token logprobs.
+
+        The engine serializes this field as generated_log_probs. Reading any
+        other name yields an empty logprobs.content that still satisfies the SDK
+        schema, so only a value check catches it.
+        """
+        response = await http.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hello!"}],
+                "max_tokens": 4,
+                "logprobs": True,
+                "top_logprobs": 2,
+            },
+        )
+        assert response.status_code == 200
+        parsed = ChatCompletion.model_validate(await response.get_json())
+        assert parsed.choices[0].logprobs is not None
+        assert len(parsed.choices[0].logprobs.content) == 4
+        assert all(entry.logprob is not None for entry in parsed.choices[0].logprobs.content)
+
+
+class TestStreamingSchemas:
+    """Streamed chunks must satisfy the SDK chunk models and terminate correctly."""
+
+    async def test_chat_stream_chunks_match_openai_schema(self, http):
+        response = await http.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hello!"}],
+                "max_tokens": 4,
+                "stream": True,
+            },
+        )
+        assert response.status_code == 200
+        assert response.content_type.startswith("text/event-stream")
+
+        chunks, saw_done = parse_sse((await response.get_data()).decode())
+        assert saw_done, "stream must terminate with the OpenAI 'data: [DONE]' sentinel"
+        assert chunks
+        for chunk in chunks:
+            ChatCompletionChunk.model_validate(chunk)
+        # The first chunk announces the assistant role, and exactly one chunk
+        # carries the terminal finish_reason.
+        assert chunks[0]["choices"][0]["delta"].get("role") == "assistant"
+        finish_reasons = [
+            choice["finish_reason"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice.get("finish_reason") is not None
+        ]
+        assert len(finish_reasons) == 1
+
+    async def test_completions_stream_chunks_match_openai_schema(self, http):
+        """Streamed completions reuse the non-streaming Completion shape.
+
+        Only the terminal chunk is validated strictly: intermediate chunks carry
+        ``finish_reason: null``, which the SDK's Completion model rejects but its
+        streaming path tolerates because it constructs models without validating.
+        The intermediate chunks are checked structurally instead.
+        """
+        response = await http.post(
+            "/v1/completions", json={"prompt": "Hello", "max_tokens": 4, "stream": True}
+        )
+        assert response.status_code == 200
+        chunks, saw_done = parse_sse((await response.get_data()).decode())
+        assert saw_done
+        assert chunks
+
+        for chunk in chunks[:-1]:
+            assert chunk["object"] == "text_completion"
+            assert chunk["id"] and isinstance(chunk["created"], int)
+            for choice in chunk["choices"]:
+                assert choice["finish_reason"] is None
+                assert isinstance(choice["text"], str)
+
+        Completion.model_validate(chunks[-1])
+        assert chunks[-1]["choices"][0]["finish_reason"] in ("stop", "length")
+        # Every chunk in a stream must share one response id.
+        assert len({chunk["id"] for chunk in chunks}) == 1
+
+    async def test_stream_usage_chunk_is_opt_in(self, http):
+        """`stream_options.include_usage` adds a final usage-only chunk."""
+        without = await http.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 4, "stream": True},
+        )
+        chunks, _ = parse_sse((await without.get_data()).decode())
+        assert all(chunk.get("usage") is None for chunk in chunks)
+
+        with_usage = await http.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 4,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+        )
+        chunks, saw_done = parse_sse((await with_usage.get_data()).decode())
+        assert saw_done
+        usage_chunks = [chunk for chunk in chunks if chunk.get("usage") is not None]
+        assert len(usage_chunks) == 1
+        # OpenAI sends the usage chunk last, with an empty choices list.
+        assert usage_chunks[0] is chunks[-1]
+        assert usage_chunks[0]["choices"] == []
+
+    async def test_streamed_text_matches_non_streamed_text(self, http):
+        """Concatenated deltas must equal the non-streaming completion text.
+
+        These come from different code paths (incremental detokenizer vs. the
+        engine's detokenized text), so they can silently diverge.
+        """
+        request = {"prompt": "Hello", "max_tokens": 6}
+        non_streamed = await http.post("/v1/completions", json=request)
+        expected = (await non_streamed.get_json())["choices"][0]["text"]
+
+        streamed = await http.post("/v1/completions", json={**request, "stream": True})
+        chunks, _ = parse_sse((await streamed.get_data()).decode())
+        assembled = "".join(
+            choice.get("text") or "" for chunk in chunks for choice in chunk["choices"]
+        )
+        assert assembled == expected
+
+
+class TestRequestFieldMapping:
+    """OpenAI request fields must reach the engine as the right sampling params."""
+
+    @pytest.mark.parametrize(
+        "request_body, attribute, expected",
+        [
+            ({"prompt": "hi", "max_tokens": 32}, "num_tokens_to_generate", 32),
+            ({"prompt": "hi", "temperature": 0.7}, "temperature", 0.7),
+            ({"prompt": "hi", "top_p": 0.9}, "top_p", 0.9),
+            ({"prompt": "hi", "top_k": 5}, "top_k", 5),
+            ({"prompt": "hi", "stop": "END"}, "stop_words", ["END"]),
+            ({"prompt": "hi", "stop": ["A", "B"]}, "stop_words", ["A", "B"]),
+            ({"prompt": "hi", "logprobs": 3}, "top_n_logprobs", 3),
+            ({"prompt": "hi", "logprobs": 3}, "return_log_probs", True),
+            # OpenAI has no ignore_eos; Megatron maps it to termination_id=-1.
+            ({"prompt": "hi", "ignore_eos": True}, "termination_id", -1),
+            # max_tokens defaults to 16 on the completions API.
+            ({"prompt": "hi"}, "num_tokens_to_generate", 16),
+        ],
+    )
+    async def test_completions_fields_map_to_sampling_params(
+        self, http, fake_client, request_body, attribute, expected
+    ):
+        response = await http.post("/v1/completions", json=request_body)
+        assert response.status_code == 200
+        _, sampling_params = fake_client.submissions[-1]
+        assert getattr(sampling_params, attribute) == expected
+
+    async def test_temperature_zero_becomes_greedy(self, http, fake_client):
+        """temperature=0 must select greedy decoding, as OpenAI clients expect."""
+        response = await http.post("/v1/completions", json={"prompt": "hi", "temperature": 0.0})
+        assert response.status_code == 200
+        _, sampling_params = fake_client.submissions[-1]
+        assert sampling_params.top_k == 1
+        assert sampling_params.top_p == 0.0
+
+    @pytest.mark.parametrize(
+        "prompt, expected_choices",
+        [
+            ("single string", 1),
+            (["first", "second"], 2),
+            ([72, 101, 108], 1),
+            ([[72, 101], [108, 111]], 2),
+        ],
+    )
+    async def test_completions_accepts_every_openai_prompt_form(
+        self, http, prompt, expected_choices
+    ):
+        """OpenAI allows str, list[str], list[int] and list[list[int]] prompts."""
+        response = await http.post("/v1/completions", json={"prompt": prompt, "max_tokens": 2})
+        assert response.status_code == 200
+        parsed = Completion.model_validate(await response.get_json())
+        assert len(parsed.choices) == expected_choices
+        assert [choice.index for choice in parsed.choices] == list(range(expected_choices))
+
+    async def test_chat_max_completion_tokens_supersedes_max_tokens(self, http, fake_client):
+        """`max_completion_tokens` is OpenAI's replacement for the deprecated
+        `max_tokens`, and must win when both are sent."""
+        response = await http.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "max_completion_tokens": 9,
+            },
+        )
+        assert response.status_code == 200
+        _, sampling_params = fake_client.submissions[-1]
+        assert sampling_params.num_tokens_to_generate == 9
+
+    async def test_chat_n_produces_n_choices(self, http):
+        """The chat API honours `n` by fanning out to n engine requests."""
+        response = await http.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 2, "n": 3},
+        )
+        assert response.status_code == 200
+        parsed = ChatCompletion.model_validate(await response.get_json())
+        assert len(parsed.choices) == 3
+        assert [choice.index for choice in parsed.choices] == [0, 1, 2]
+
+
+class TestErrorHandling:
+    """Malformed and failing requests must produce the documented status codes."""
+
+    @pytest.mark.parametrize(
+        "endpoint, body",
+        [
+            ("/v1/completions", {}),
+            ("/v1/completions", {"prompt": []}),
+            ("/v1/completions", {"prompt": [{"nested": "object"}]}),
+            ("/v1/chat/completions", {}),
+            ("/v1/chat/completions", {"messages": "not-a-list"}),
+        ],
+    )
+    async def test_invalid_requests_are_rejected_with_400(self, http, endpoint, body):
+        response = await http.post(endpoint, json=body)
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        "endpoint, body",
+        [
+            ("/v1/completions", {}),
+            ("/v1/completions", {"prompt": "hi", "max_tokens": "not-an-int"}),
+            ("/v1/chat/completions", {}),
+            ("/v1/chat/completions", {"messages": "not-a-list"}),
+        ],
+    )
+    async def test_errors_use_openai_error_envelope(self, http, endpoint, body):
+        """Errors must be `{"error": {"message", "type", ...}}`.
+
+        The OpenAI SDK reads error.message off the JSON body to build its
+        exception. A plain-text body makes it raise a parse error instead, so the
+        caller never sees why the request was rejected.
+        """
+        response = await http.post(endpoint, json=body)
+        assert response.status_code >= 400
+        error = (await response.get_json())["error"]
+        assert error["message"]
+        assert error["type"] == "invalid_request_error"
+
+    async def test_nontransient_engine_failure_maps_to_400(self, http, fake_client):
+        """A request the engine rejects outright is the caller's fault (400)."""
+        fake_client.reply_override = {
+            "status": "FAILED",
+            "events": [{"type": "ERROR_NONTRANSIENT", "payload": "prompt too long"}],
+        }
+        response = await http.post("/v1/completions", json={"prompt": "hi"})
+        assert response.status_code == 400
+        assert "prompt too long" in (await response.get_json())["error"]["message"]
+
+    async def test_transient_engine_failure_maps_to_500(self, http, fake_client):
+        """A transient engine failure is the server's fault (500)."""
+        fake_client.reply_override = {
+            "status": "FAILED",
+            "events": [{"type": "ERROR_TRANSIENT", "payload": "engine restarting"}],
+        }
+        response = await http.post("/v1/completions", json={"prompt": "hi"})
+        assert response.status_code == 500
+        assert (await response.get_json())["error"]["type"] == "server_error"
+
+    async def test_context_length_error_keeps_its_exact_message(self, http, fake_client):
+        """The max-context wording is load-bearing for Nemo-RL.
+
+        chat_completions.py marks it DO NOT MODIFY. Wrapping errors in the OpenAI
+        envelope moved it from the whole body to error.message, so this pins both
+        the wording and its new location.
+        """
+        fake_client.reply_override = {
+            "status": "FAILED",
+            "events": [
+                {"type": "ERROR_NONTRANSIENT", "payload": "MaxSequenceLengthOverflowError: 5000"}
+            ],
+        }
+        response = await http.post(
+            "/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]}
+        )
+        assert response.status_code == 400
+        error = (await response.get_json())["error"]
+        assert "This model's maximum context length was exceeded." in error["message"]
+        assert "Please reduce the length of the messages." in error["message"]
+        assert error["code"] == "context_length_exceeded"
+
+
+class TestDocumentedOpenAIGaps:
+    """Known deviations from the OpenAI API.
+
+    Each test asserts what an OpenAI client would expect and is marked xfail, so
+    the gap is recorded here rather than in a comment somewhere. Closing a gap
+    turns its test XPASS (strict), which fails the suite and forces this list to
+    be updated -- that is the point.
+    """
+
+    @pytest.mark.xfail(strict=True, reason="GET /v1/models is not implemented")
+    async def test_models_endpoint_exists(self, http):
+        """openai.models.list() and many client health checks call /v1/models."""
+        response = await http.get("/v1/models")
+        assert response.status_code == 200
+        body = await response.get_json()
+        assert body["object"] == "list"
+        assert body["data"]
+
+    @pytest.mark.xfail(strict=True, reason="the completions endpoint ignores `n`")
+    async def test_completions_honours_n(self, http):
+        """`n` is read on /v1/chat/completions but silently dropped on
+        /v1/completions, so a client asking for 4 completions gets 1."""
+        response = await http.post(
+            "/v1/completions", json={"prompt": "hi", "max_tokens": 2, "n": 4}
+        )
+        assert response.status_code == 200
+        parsed = Completion.model_validate(await response.get_json())
+        assert len(parsed.choices) == 4
+
+    @pytest.mark.xfail(strict=True, reason="completion ids use the chatcmpl- prefix")
+    async def test_completion_id_uses_cmpl_prefix(self, http):
+        """OpenAI ids are prefixed by endpoint: cmpl- for completions,
+        chatcmpl- for chat. Both use chatcmpl- here."""
+        response = await http.post("/v1/completions", json={"prompt": "hi"})
+        body = await response.get_json()
+        assert body["id"].startswith("cmpl-")
+
+    @pytest.mark.xfail(strict=True, reason="/metrics is not implemented")
+    async def test_metrics_endpoint_exists(self, http):
+        """vLLM and OpenAI-compatible deployments expose Prometheus metrics."""
+        response = await http.get("/metrics")
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "unsupported_field, value",
+        [
+            ("seed", 1234),
+            ("logit_bias", {"50256": -100}),
+            ("presence_penalty", 0.5),
+            ("frequency_penalty", 0.5),
+            ("best_of", 2),
+            ("suffix", "!"),
+        ],
+    )
+    async def test_unsupported_sampling_fields_are_silently_ignored(
+        self, http, fake_client, unsupported_field, value
+    ):
+        """These OpenAI fields are accepted and dropped rather than rejected.
+
+        Accepting-and-ignoring is deliberate (rejecting unknown fields would
+        break clients that always send them), but `seed` in particular means a
+        caller asking for reproducible output silently does not get it. This test
+        pins the current behaviour so the choice stays a decision.
+        """
+        response = await http.post(
+            "/v1/completions", json={"prompt": "hi", "max_tokens": 2, unsupported_field: value}
+        )
+        assert response.status_code == 200
+        _, sampling_params = fake_client.submissions[-1]
+        assert not hasattr(sampling_params, unsupported_field)
+
+
+class TestNonOpenAIExtensions:
+    """Megatron-specific response fields that OpenAI clients must tolerate."""
+
+    async def test_extra_choice_fields_do_not_break_sdk_parsing(self, http):
+        """The completions endpoint adds prompt_token_ids, generation_token_ids
+        and generation_log_probs to each choice. The SDK models allow extra
+        fields, so this is additive rather than breaking -- but if a future
+        field collided with an OpenAI field name, validation would catch it."""
+        response = await http.post("/v1/completions", json={"prompt": "hi", "max_tokens": 2})
+        body = await response.get_json()
+        choice = body["choices"][0]
+        assert {"prompt_token_ids", "generation_token_ids", "generation_log_probs"} <= set(choice)
+        Completion.model_validate(body)
+
+    async def test_prompt_tokens_stay_off_the_wire_for_chat_by_default(self, http, fake_client):
+        """Chat requests do not ask the engine for prompt tokens unless the
+        caller wants them echoed, which keeps the prompt tensor off the reply."""
+        await http.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 2,
+                "prevent_retokenization": False,
+            },
+        )
+        _, sampling_params = fake_client.submissions[-1]
+        assert sampling_params.return_prompt_tokens is False
+
+    async def test_health_endpoint_reports_ready(self, http):
+        """/health and /v1/health back the perf harness's readiness poll."""
+        for path in ("/health", "/v1/health"):
+            response = await http.get(path)
+            assert response.status_code == 200


### PR DESCRIPTION
## Summary

Standalone tests for the inference HTTP frontend and the data-parallel
coordinator, answering three questions and then keeping the answers honest in
CI. Everything here runs **without a model, a checkpoint, or a GPU**: a real
coordinator process is started against fake ZMQ engines, so a failure points at
the frontend, the `InferenceClient`, or the coordinator and nothing else.

### 1. How many requests can flow through the frontend/coordinator?

`tests/performance_tests/test_cases/frontend/frontend_capacity` sweeps
concurrency 1 -> 512 over three paths and gates peak throughput against a
recorded baseline. Measured on an H100 node (ISL 512 / OSL 64, one fake engine
holding each request 10 ms):

| Path | Peak throughput | Scales cleanly to |
|---|---|---|
| `InferenceClient` -> coordinator -> engine | ~7,100 req/s | 32 concurrent |
| HTTP, non-streaming, 1 replica | ~1,185 req/s | 8 concurrent |
| HTTP, streaming (SSE) | ~270 req/s | 1 concurrent |

The coordinator is not the bottleneck: it moves ~6x more requests than a single
HTTP replica, and streaming costs another ~4.3x on top because every generated
token pays a detokenize and an SSE flush. Production forks 4 replicas, putting
the HTTP ceiling near 4.7k req/s in front of a coordinator that can do ~7k.
Zero errors at every level up to 512 concurrent.

Comparing the three paths is what localizes a regression to a layer, which is
why all three are recorded rather than just the end-to-end number.

### 2. Is the frontend 1:1 compatible with the OpenAI API?

`tests/unit_tests/inference/test_openai_api_compatibility.py` validates
responses against the **OpenAI SDK's own Pydantic models** (`Completion`,
`ChatCompletion`, `ChatCompletionChunk`) rather than hand-written assertions, so
the spec is the fixture. Remaining gaps are `xfail`s with reasons, so they are
enumerated in code instead of prose and will announce themselves via `XPASS`
when fixed:

- `GET /v1/models` is not implemented
- `/metrics` is not implemented
- the completions endpoint ignores `n`
- completion ids use the `chatcmpl-` prefix instead of `cmpl-`

### 3. How big are the frontend packets?

`megatron/core/inference/wire_metrics.py` adds per-header message and byte
counters to `InferenceClient` and `DataParallelInferenceCoordinator`, so payload
size is observable in production, not just in tests. The coordinator logs a
traffic summary on shutdown.
`tests/unit_tests/inference/test_frontend_packet_size.py` then holds sizes to
explicit one-sided budgets, and the perf test gates bytes-per-request. For a
512-token prompt and 64 generated tokens: 928 B per request (of which
`SamplingParams` is a fixed ~323 B — every one of its 18 fields ships on every
request), 1,216 B per reply, 1,823 B for the assembled HTTP JSON, and 3,935 B
for the streamed SSE form.

## Bug fixes

Four bugs the tests surfaced, fixed here.

**1. Chat completions never returned logprobs.**
`chat_completions.py` read `result['log_probs']`, but the engine reply field is
`generated_log_probs`. The lookup always missed, so `logprobs.content` was an
empty list on every response even when the caller asked for logprobs. Fixed by
reading the correct field. Caught by validating against OpenAI's
`ChatCompletion` model, which rejects the empty-content shape.

**2. `/v1/completions` misaligned `token_logprobs` with `tokens`.**
The endpoint prepended a `None` logprob unconditionally. That is only correct
for `echo=True`, where the first echoed token has no predecessor. With
`echo=False` every logprob was shifted one position relative to its token, and
the leading `None` also violates OpenAI's schema, which types the list as
floats. Silent and dangerous: consumers doing per-token scoring got wrong
numbers rather than an error. Fixed by prepending only when echoing.

**3. Replies carried the whole prompt back when not asked for.**
`DynamicInferenceRequest.serialize` drops `prompt_tokens` when
`return_prompt_tokens=False`, but `remaining_prompt_tokens` starts life as a copy
of the prompt and was not dropped, so the full prompt still shipped
engine -> coordinator -> API at ~3.8 B/token. For a 4k-token prompt that was over
90% of the reply. Fixed by clearing it alongside `prompt_tokens` and restoring it
afterwards. `test_reply_size_is_independent_of_prompt_length` now checks an 8- and
a 4096-token prompt against the same fixed budget, so a reply that grows with the
prompt fails no matter how large the constant part gets.

**4. Errors were returned as bare strings, hiding the message.**
OpenAI clients parse `{"error": {"message", "type", "param", "code"}}` and read
the text from `error.message`; a plain-string body makes them raise a parse error
that discards the message entirely. Added an `openai_error` helper in
`endpoints/common.py` and routed every error return in both endpoints through it.
The `MaxSequenceLengthOverflowError` wording is passed through verbatim (now
nested under `error.message`) because NeMo-RL matches on that exact string, and
`test_context_length_error_keeps_its_exact_message` pins it.

## Performance impact

`WireMetrics` is always on rather than gated behind a flag, so the cost was
measured rather than assumed: **~0.04% of a non-streaming request and ~0.3% of a
streaming one**, and the PR is net *faster* overall because of bug fix 3.

What runs per message: `record_sent`/`record_received` do one dict lookup and
four integer adds — 82 ns, plus 10 ns for the `len()`. No serialization was
added; `packb`/`unpackb` were already on those lines, and the change only binds
the existing bytes object to a local so its length can be read. For scale, the
pack+unpack they sit beside costs ~9.6 us for a realistic 1.7 KB payload, so the
counter is ~1% of just the serialization next to it. There is no per-message
logging: the one log statement is a traffic summary at coordinator shutdown, and
header values are decoded to names only in `snapshot()` / `format_summary()`,
never on the message path.

Multiplied by measured message counts:

| Path | Client messages per request | Added | Share of a request |
|---|---|---|---|
| Non-streaming | 2 | ~0.4 us | ~0.04% |
| Streaming, 64 output tokens | 66 | ~12 us | ~0.3% |

Streaming costs more only because it moves more messages — one partial reply per
generated token, each crossing the coordinator and the client. Shares are against
the per-request capacity this PR's own perf test measured (844 us non-streaming,
3.7 ms streaming).

An end-to-end A/B through a real coordinator (instrumentation versus `record_*`
stubbed to no-ops, five alternating reps) could not resolve a difference at all:
it came out 2.5% *faster* with instrumentation on, against a run-to-run noise
floor of +/-7.8%. A null result, which is what an effect this size looks like.

Against that, bug fix 3 removes real work by dropping the prompt copy from every
final reply:

| Prompt length | Reply bytes before | After | Serialization saved per request |
|---|---|---|---|
| 512 tokens | 1,671 B | 108 B | 8.7 us |
| 4,096 tokens | 12,423 B | 108 B | 69.6 us |

So non-streaming is net faster at any prompt length, and streaming turns net
positive once prompts pass roughly 1k tokens — before counting the bytes that no
longer cross the socket. Memory is flat: `per_header` is bounded by the ~10
distinct headers and nothing accumulates per request. All of this is host-side
frontend code, so model execution and CUDA graphs are untouched.

Two caveats. The absolute nanosecond figures come from a local arm64 / Python
3.12 run and will differ on the H100 hosts; the ratio to msgpack is what carries
over. And the 66 messages/request figure comes from the fake engine, which emits
one partial per token per request — the real engine batches partials across
concurrent requests on the engine -> coordinator hop, so that number is a ceiling
for the coordinator's receive side while staying representative of the client hop.

## Notes for reviewers

- **`build_app` extraction** in `text_generation_server.py` is what makes the
  HTTP layer testable: the app can be built around any client-shaped object
  without binding a socket or forking replicas. No behavior change for the real
  server, which now calls it.
- **`p99_latency_ms` is deliberately not gated at concurrency 128 and 512.**
  Past saturation p99 describes the queue the load generator built, not the
  frontend: two back-to-back runs of this exact config moved
  `http_concurrency_128` p99 from 392 ms to 963 ms (+146%) while every throughput
  number held within 13%. It stays gated below saturation, where it is stable to
  a few percent. This needed a small general addition to
  `compare_to_baseline.py` (`METRICS_EXCLUDE`, an fnmatch over result keys);
  excluded metrics are still recorded and printed, just not asserted on.
  `max_stable_concurrency` and `scaling_efficiency` are likewise recorded but not
  gated, being step functions over the sampled concurrency grid.
- **The baseline was verified, not just recorded.** A second run on a *different*
  H100 node passes it: byte metrics reproduce to within 0.04%, peak throughput
  within 5%.
- **`perf_common.sh`** extracts the platform-detection and
  baseline-compare/record logic that `run_perf_test.sh` and the new
  `run_frontend_perf_test.sh` share, rather than duplicating it.
- The test tokenizer sorts the byte-level alphabet because
  `ByteLevel.alphabet()` returns a Rust hash set in a different order every
  process; without sorting, each process invents its own id for a given byte,
  which desynchronized the frontend from the spawned coordinator and moved the
  recorded byte counts by over 20% between identical runs.
  `test_tokenizer_assigns_the_same_ids_in_every_instance` guards it.

## Test plan

- [x] `tests/unit_tests/inference/test_openai_api_compatibility.py` and
      `test_frontend_packet_size.py` pass locally (78 passed, 4 xfailed, together
      with the existing `test_openai_streaming.py` and `test_inference_request.py`)
- [x] `frontend/frontend_capacity` baseline recorded on an H100 node
- [x] Same test re-run on a different H100 node passes the comparison
- [ ] CI: inference unit tests
- [ ] CI: `frontend-perf` recipe
