### PR TITLE
fix(ci): request pull request permission for queue comments

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -1499,7 +1499,7 @@ jobs:
         with:
           app-id: ${{ vars.COMMUNITY_BOT_ID }}
           private-key: ${{ secrets.COMMUNITY_BOT_KEY }}
-          permission-issues: write
+          permission-pull-requests: write
 
       - name: Comment on PR with action run URL
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
## Background

PR #6632 moved merge queue notifications to the Community Bot. The replacement app now mints its token successfully, but run 32176033203 failed when posting to PR #6620 with HTTP 403 `Resource not accessible by integration`.

The target is an open, unlocked pull request. GitHub's response identifies `pull_requests=write` as an accepted permission for the comment endpoint, while the token requested only `issues: write`.

## What changed

- Request `pull-requests: write` for the merge queue PR-comment token.

## Details

The Community Bot and comment operation are unchanged. The token remains scoped to one repository and now requests the permission matching the target resource and the job's existing `pull-requests: write` declaration.

## Tested

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.parse_file(ARGV.fetch(0))' .github/workflows/cicd-main.yml`
- `actionlint` 1.7.12 comparison against `github/main`; no new findings
- Verified Community Bot token creation succeeded before the PR-comment HTTP 403 in run 32176033203, job 95838085460
- Verified Community Bot previously minted `pull-requests: write` successfully in run 32162022942, job 95792891044
