### PR TITLE
Fix LayerWise buffer routing to respect use_muon = False

### DIFF
--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -39,13 +39,13 @@ def is_managed_by_layer_wise_optimizer(param: torch.nn.Parameter) -> bool:
     """Whether a parameter is managed by :class:`LayerWiseDistributedOptimizer`.
 
     Returns True for the 2D matrix-like weight parameters that Muon orthogonalizes
-    via Newton-Schulz, and False for embeddings, biases, LayerNorm weights, and
-    any other non-matrix parameter (which are handled by Adam through a separate
-    :class:`DistributedOptimizer`).
+    via Newton-Schulz, and False for parameters routed to Muon's scalar fallback:
+    explicit ``use_muon=False`` exclusions, embeddings, and non-matrix parameters.
 
-    Mirrors the routing rule applied by ``_get_param_groups`` /
-    ``default_param_overrides`` for Muon.
+    This DDP-buffer ownership rule must match Muon's parameter-group routing.
     """
+    if not getattr(param, 'use_muon', True):
+        return False
     if not param.dim() == 2:
         return False
     if getattr(param, 'is_embedding_or_output_parameter', False):

--- a/tests/unit_tests/distributed/test_layer_wise_param_layout.py
+++ b/tests/unit_tests/distributed/test_layer_wise_param_layout.py
@@ -51,9 +51,7 @@ class TestLayerwiseParameterRouting:
             pytest.param((16, 8), {"use_muon": False}, id="explicit-exclusion"),
             pytest.param((16, 8), {"use_muon": True}, id="explicit-opt-in"),
             pytest.param(
-                (16, 8),
-                {"is_embedding_or_output_parameter": True},
-                id="embedding-or-output",
+                (16, 8), {"is_embedding_or_output_parameter": True}, id="embedding-or-output"
             ),
             pytest.param((16,), {}, id="vector"),
             pytest.param((16,), {"use_muon": False}, id="excluded-vector"),

--- a/tests/unit_tests/distributed/test_layer_wise_param_layout.py
+++ b/tests/unit_tests/distributed/test_layer_wise_param_layout.py
@@ -13,7 +13,12 @@ from unittest import mock
 import pytest
 import torch
 
-from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
+from megatron.core.optimizer.emerging_optimizers import _is_muon_excluded
+from megatron.core.optimizer.layer_wise_optimizer import (
+    LayerWiseDistributedOptimizer,
+    is_managed_by_layer_wise_optimizer,
+    tag_params_for_buffer_routing,
+)
 from megatron.core.optimizer.param_layout import BufferKey, pad_param_start, pad_to_divisor
 
 # ---------------------------------------------------------------------------
@@ -35,6 +40,25 @@ def _make_ddp_config(pad_for_high_busbw=False, grad_reduce_in_fp32=True):
     cfg.pad_buckets_for_high_nccl_busbw = pad_for_high_busbw
     cfg.grad_reduce_in_fp32 = grad_reduce_in_fp32
     return cfg
+
+
+class TestLayerwiseParameterRouting:
+
+    def test_explicit_muon_exclusion_matches_optimizer_routing(self):
+        param = _make_param((16, 8), use_muon=False)
+
+        assert _is_muon_excluded(param)
+        assert not is_managed_by_layer_wise_optimizer(param)
+
+    def test_tags_excluded_matrix_separately_from_muon_matrix(self):
+        model = torch.nn.Module()
+        model.muon_weight = _make_param((16, 8))
+        model.scalar_weight = _make_param((16, 8), use_muon=False)
+
+        tag_params_for_buffer_routing([model])
+
+        assert model.muon_weight.is_managed_by_layer_wise_optimizer
+        assert not model.scalar_weight.is_managed_by_layer_wise_optimizer
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/distributed/test_layer_wise_param_layout.py
+++ b/tests/unit_tests/distributed/test_layer_wise_param_layout.py
@@ -44,11 +44,26 @@ def _make_ddp_config(pad_for_high_busbw=False, grad_reduce_in_fp32=True):
 
 class TestLayerwiseParameterRouting:
 
-    def test_explicit_muon_exclusion_matches_optimizer_routing(self):
-        param = _make_param((16, 8), use_muon=False)
+    @pytest.mark.parametrize(
+        ("shape", "attrs"),
+        [
+            pytest.param((16, 8), {}, id="matrix"),
+            pytest.param((16, 8), {"use_muon": False}, id="explicit-exclusion"),
+            pytest.param((16, 8), {"use_muon": True}, id="explicit-opt-in"),
+            pytest.param(
+                (16, 8),
+                {"is_embedding_or_output_parameter": True},
+                id="embedding-or-output",
+            ),
+            pytest.param((16,), {}, id="vector"),
+            pytest.param((16,), {"use_muon": False}, id="excluded-vector"),
+            pytest.param((4, 4, 4), {}, id="non-matrix"),
+        ],
+    )
+    def test_layer_wise_ownership_matches_muon_routing(self, shape, attrs):
+        param = _make_param(shape, **attrs)
 
-        assert _is_muon_excluded(param)
-        assert not is_managed_by_layer_wise_optimizer(param)
+        assert is_managed_by_layer_wise_optimizer(param) == (not _is_muon_excluded(param))
 
     def test_tags_excluded_matrix_separately_from_muon_matrix(self):
         model = torch.nn.Module()

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -59,6 +59,19 @@ class TinyModel(nn.Module):
         return self.fc1(x)
 
 
+class MuonExcludedMatrixModel(nn.Module):
+    """Model with a 2D matrix explicitly routed to the scalar optimizer."""
+
+    def __init__(self):
+        super().__init__()
+        self.scalar = nn.Linear(10, 8)
+        self.muon = nn.Linear(8, 5)
+        self.scalar.weight.use_muon = False
+
+    def forward(self, x):
+        return self.muon(F.relu(self.scalar(x)))
+
+
 @pytest.mark.skipif(
     int(os.getenv('WORLD_SIZE', '1')) == 1, reason="Multi-rank test requires WORLD_SIZE > 1"
 )
@@ -298,6 +311,27 @@ class TestLayerWiseOptimizer:
                         raise AssertionError(
                             f"Parameter {name} differs between rank 0 and rank {i}. {str(e)}"
                         ) from None
+
+    def test_explicit_muon_exclusion_updates_with_param_layout(self):
+        """An excluded 2D matrix is updated and synchronized by the scalar DistOpt."""
+        model, optimizer, pg_collection = self.create_model_and_optimizer(
+            model_class=MuonExcludedMatrixModel, use_param_layout=True
+        )
+        excluded_weight = model.module.scalar.weight
+        initial_weight = excluded_weight.detach().clone()
+
+        output = model(torch.randn(16, 10, dtype=torch.bfloat16, device='cuda'))
+        output.sum().backward()
+        update_successful, _, _ = optimizer.step()
+
+        assert update_successful
+        assert not torch.equal(excluded_weight, initial_weight)
+
+        dp_size = get_pg_size(pg_collection.dp_cp)
+        gathered = [torch.empty_like(excluded_weight) for _ in range(dp_size)]
+        torch.distributed.all_gather(gathered, excluded_weight, group=pg_collection.dp_cp)
+        for replica in gathered[1:]:
+            torch.testing.assert_close(gathered[0], replica, rtol=0, atol=0)
 
     def test_get_grad_norm(self):
         """Test LayerWiseDistributedOptimizer gradient norm computation."""


### PR DESCRIPTION
## Summary of this PR

This PR makes a change to respect explicit `use_muon=False` exclusions when assigning parameters to LayerWise optimizer buffers.

## Problem

The problem is with a 2D parameter with `use_muon=False` (for instance, the `in_proj` params in Mamba2, GDP etc).

In that case, the Muon parameter-group routing already sends this parameter to the configured scalar optimizer. The layout-based LayerWise path classified the same parameter only by shape and embedding metadata, so it still tagged that matrix as LayerWise-managed.

That disagreement leaves this parameter unassigned: The scalar `DistributedOptimizer` filters out LayerWise buffers, while the `LayerWiseDistributedOptimizer` receives only Muon parameter groups. The excluded
matrix therefore has no optimizer that can update it in the layout-based path.

## Simple fix

`is_managed_by_layer_wise_optimizer()` now returns `False` for a parameter marked `use_muon=False` before applying its normal matrix and embedding checks. This makes DDP buffer ownership agree with Muon's existing parameter-group routing.

## Tests

- CPU routing test verifies that Muon's exclusion predicate and LayerWise ownership agree for an explicitly excluded 2D matrix.
- CPU tagging test verifies that an ordinary 2D matrix and an excluded 2D matrix land in different ownership classes.
- Eight-rank distributed test verifies that the excluded matrix is actually updated by the scalar distributed optimizer and remains bitwise identical across DP ranks.
- Existing layout and LayerWise optimizer tests remain enabled in the post-fix gate.
- A pre-fix snapshot with the new tests reproduces both failures; the same tests pass with the one-line fix.
  

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
This PR makes a change to respect explicit `use_muon=False` exclusions when assigning parameters to LayerWise optimizer buffers.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
