### PR TITLE
fix: prevent local CUDA graph stream aliasing

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -97,7 +97,56 @@ except:
 
 _IS_GRAPH_CAPTURING = False
 _IS_GRAPH_WARMUP = False
+_CUDA_GRAPH_STREAM_POOL_SIZE = 3
+_CUDA_GRAPH_STREAM_POOLS = {}
+_CUDA_GRAPH_STREAM_NEXT_SLOT = defaultdict(int)
 logger = logging.getLogger(__name__)
+
+
+def _get_cuda_graph_stream() -> torch.cuda.Stream:
+    """Assign local CUDA-graph runners across a bounded set of distinct streams.
+
+    PyTorch obtains streams from a bounded per-device pool, so repeatedly constructing
+    ``torch.cuda.Stream`` objects can eventually return the same underlying CUDA stream.
+    Assigning capture and replay streams explicitly makes that sharing intentional.
+
+    ``CUDA_DEVICE_MAX_CONNECTIONS`` controls how CUDA maps logical streams to hardware work
+    queues. It does not make PyTorch stream handles unique and cannot prevent stream aliasing.
+    """
+    device = torch.cuda.current_device()
+    pool = _CUDA_GRAPH_STREAM_POOLS.get(device)
+    if pool is None:
+        # CUDA recommends at least as many connections as independently active streams. GTP can
+        # concurrently use graph, GTP/EGTP AG and RS, EP, DDP, and activation-offload streams, so
+        # CUDA's default of eight connections can introduce false dependencies between them.
+        max_connections = os.getenv("CUDA_DEVICE_MAX_CONNECTIONS")
+        warning_reason = None
+        if max_connections is None:
+            warning_reason = "is unset (CUDA defaults to 8)"
+        else:
+            try:
+                max_connections_value = int(max_connections)
+            except ValueError:
+                warning_reason = f"must be an integer from 1 to 32, but is {max_connections!r}"
+            else:
+                if max_connections_value < 16:
+                    warning_reason = f"is {max_connections_value}"
+
+        if warning_reason is not None and GTP_CONFIG.is_active():
+            logger.warning(
+                "CUDA_DEVICE_MAX_CONNECTIONS %s. For GTP workloads, consider setting it to "
+                "16 or 32 before process startup to avoid implicit stream aliasing.",
+                warning_reason,
+            )
+
+        pool = tuple(torch.cuda.Stream(device=device) for _ in range(_CUDA_GRAPH_STREAM_POOL_SIZE))
+        if len({stream.cuda_stream for stream in pool}) != len(pool):
+            raise RuntimeError("CUDA graph stream pool contains aliased streams")
+        _CUDA_GRAPH_STREAM_POOLS[device] = pool
+
+    slot = _CUDA_GRAPH_STREAM_NEXT_SLOT[device]
+    _CUDA_GRAPH_STREAM_NEXT_SLOT[device] = (slot + 1) % len(pool)
+    return pool[slot]
 
 
 def _get_tensor_alias_chain(tensor):
@@ -953,6 +1002,7 @@ class _CudaGraphRunner(torch.nn.Module):
         self.func = super(MegatronModule, self.base_module).__call__ if func is None else func
         self.is_first_layer = getattr(base_module, "is_first_layer", True)
         self.is_last_layer = getattr(base_module, "is_last_layer", True)
+        self.capture_stream = _get_cuda_graph_stream()
 
         # We use this attribute to record the value of 'is_first_microbatch' each fwd cudagraph
         # replay so that way we only update the value of this flag in FP8GlobalStateManager when
@@ -981,7 +1031,7 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.num_warmup_steps = max(self.num_warmup_steps, 2)
 
                 self.use_stream = True
-                self.stream = torch.cuda.Stream()
+                self.stream = self.capture_stream
                 self.fwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
                 self.bwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
                 # Register (chain, group) side streams before the first forward.
@@ -1336,7 +1386,10 @@ class _CudaGraphRunner(torch.nn.Module):
                     gc.freeze()
 
                 with torch.cuda.graph(
-                    self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
+                    self.fwd_graph,
+                    pool=self.mempool,
+                    stream=self.capture_stream,
+                    capture_error_mode="thread_local",
                 ):
 
                     self._sync_against_side_streams(self.fwd_side_streams)
@@ -1464,7 +1517,7 @@ class _CudaGraphRunner(torch.nn.Module):
         capture_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext(None)
         with (
             capture_comm_context as capture_comms,
-            torch.cuda.graph(self.bwd_graph, pool=self.mempool),
+            torch.cuda.graph(self.bwd_graph, pool=self.mempool, stream=self.capture_stream),
         ):
 
             grad_inputs = torch.autograd.grad(

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -98,23 +98,24 @@ except:
 _IS_GRAPH_CAPTURING = False
 _IS_GRAPH_WARMUP = False
 _CUDA_GRAPH_STREAM_POOL_SIZE = 3
-_CUDA_GRAPH_STREAM_POOLS = {}
-_CUDA_GRAPH_STREAM_NEXT_SLOT = defaultdict(int)
+_CUDA_GRAPH_STREAM_POOLS = None
+_CUDA_GRAPH_STREAM_NEXT_SLOT = 0
 logger = logging.getLogger(__name__)
 
 
 def _get_cuda_graph_stream() -> torch.cuda.Stream:
     """Assign local CUDA-graph runners across a bounded set of distinct streams.
 
-    PyTorch obtains streams from a bounded per-device pool, so repeatedly constructing
+    PyTorch obtains streams from a bounded pool, so repeatedly constructing
     ``torch.cuda.Stream`` objects can eventually return the same underlying CUDA stream.
     Assigning capture and replay streams explicitly makes that sharing intentional.
 
     ``CUDA_DEVICE_MAX_CONNECTIONS`` controls how CUDA maps logical streams to hardware work
     queues. It does not make PyTorch stream handles unique and cannot prevent stream aliasing.
     """
-    device = torch.cuda.current_device()
-    pool = _CUDA_GRAPH_STREAM_POOLS.get(device)
+    global _CUDA_GRAPH_STREAM_POOLS, _CUDA_GRAPH_STREAM_NEXT_SLOT
+
+    pool = _CUDA_GRAPH_STREAM_POOLS
     if pool is None:
         # CUDA recommends at least as many connections as independently active streams. GTP can
         # concurrently use graph, GTP/EGTP AG and RS, EP, DDP, and activation-offload streams, so
@@ -139,13 +140,13 @@ def _get_cuda_graph_stream() -> torch.cuda.Stream:
                 warning_reason,
             )
 
-        pool = tuple(torch.cuda.Stream(device=device) for _ in range(_CUDA_GRAPH_STREAM_POOL_SIZE))
+        pool = tuple(torch.cuda.Stream() for _ in range(_CUDA_GRAPH_STREAM_POOL_SIZE))
         if len({stream.cuda_stream for stream in pool}) != len(pool):
             raise RuntimeError("CUDA graph stream pool contains aliased streams")
-        _CUDA_GRAPH_STREAM_POOLS[device] = pool
+        _CUDA_GRAPH_STREAM_POOLS = pool
 
-    slot = _CUDA_GRAPH_STREAM_NEXT_SLOT[device]
-    _CUDA_GRAPH_STREAM_NEXT_SLOT[device] = (slot + 1) % len(pool)
+    slot = _CUDA_GRAPH_STREAM_NEXT_SLOT
+    _CUDA_GRAPH_STREAM_NEXT_SLOT = (slot + 1) % len(pool)
     return pool[slot]
 
 
@@ -1002,7 +1003,6 @@ class _CudaGraphRunner(torch.nn.Module):
         self.func = super(MegatronModule, self.base_module).__call__ if func is None else func
         self.is_first_layer = getattr(base_module, "is_first_layer", True)
         self.is_last_layer = getattr(base_module, "is_last_layer", True)
-        self.capture_stream = _get_cuda_graph_stream()
 
         # We use this attribute to record the value of 'is_first_microbatch' each fwd cudagraph
         # replay so that way we only update the value of this flag in FP8GlobalStateManager when
@@ -1031,7 +1031,7 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.num_warmup_steps = max(self.num_warmup_steps, 2)
 
                 self.use_stream = True
-                self.stream = self.capture_stream
+                self.stream = _get_cuda_graph_stream()
                 self.fwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
                 self.bwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
                 # Register (chain, group) side streams before the first forward.
@@ -1386,10 +1386,7 @@ class _CudaGraphRunner(torch.nn.Module):
                     gc.freeze()
 
                 with torch.cuda.graph(
-                    self.fwd_graph,
-                    pool=self.mempool,
-                    stream=self.capture_stream,
-                    capture_error_mode="thread_local",
+                    self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
                 ):
 
                     self._sync_against_side_streams(self.fwd_side_streams)
@@ -1517,7 +1514,7 @@ class _CudaGraphRunner(torch.nn.Module):
         capture_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext(None)
         with (
             capture_comm_context as capture_comms,
-            torch.cuda.graph(self.bwd_graph, pool=self.mempool, stream=self.capture_stream),
+            torch.cuda.graph(self.bwd_graph, pool=self.mempool),
         ):
 
             grad_inputs = torch.autograd.grad(

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -70,20 +70,17 @@ fp8_available, _ = check_fp8_support()
 
 
 def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
-    device = 0
     created_streams = []
 
     class FakeStream:
-        def __init__(self, device):
-            assert device == 0
+        def __init__(self):
             self.cuda_stream = len(created_streams) + 1
             created_streams.append(self)
 
-    monkeypatch.setattr(torch.cuda, "current_device", lambda: device)
     monkeypatch.setattr(torch.cuda, "Stream", FakeStream)
     monkeypatch.setenv("CUDA_DEVICE_MAX_CONNECTIONS", "32")
-    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", {})
-    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", {device: 0})
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", None)
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", 0)
 
     pool_size = cuda_graphs_module._CUDA_GRAPH_STREAM_POOL_SIZE
     assigned = [cuda_graphs_module._get_cuda_graph_stream() for _ in range(2 * pool_size)]

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from transformer_engine.pytorch.fp8 import check_fp8_support
 
+import megatron.core.transformer.cuda_graphs as cuda_graphs_module
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt.gpt_layer_specs import (
@@ -66,6 +67,30 @@ from megatron.training.training import setup_model_and_optimizer
 from tests.unit_tests.test_utilities import Utils
 
 fp8_available, _ = check_fp8_support()
+
+
+def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
+    device = 0
+    created_streams = []
+
+    class FakeStream:
+        def __init__(self, device):
+            assert device == 0
+            self.cuda_stream = len(created_streams) + 1
+            created_streams.append(self)
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: device)
+    monkeypatch.setattr(torch.cuda, "Stream", FakeStream)
+    monkeypatch.setenv("CUDA_DEVICE_MAX_CONNECTIONS", "32")
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", {})
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", {device: 0})
+
+    pool_size = cuda_graphs_module._CUDA_GRAPH_STREAM_POOL_SIZE
+    assigned = [cuda_graphs_module._get_cuda_graph_stream() for _ in range(2 * pool_size)]
+
+    assert len(created_streams) == pool_size
+    assert len({stream.cuda_stream for stream in created_streams}) == pool_size
+    assert assigned[:pool_size] == assigned[pool_size:]
 
 
 def _base_cuda_graph_config(**kwargs) -> TransformerConfig:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Prevent accidental CUDA stream aliasing between local CUDA graph runners.

## Problem

  PyTorch creates CUDA streams from a bounded per-device stream pool. Repeated
  `torch.cuda.Stream()` construction can therefore return different Python objects backed by the
  same native CUDA stream.

  Local CUDA graph runners previously created their synchronization/replay stream independently
  from the stream selected during graph capture. Once the underlying stream pool wrapped, these
  streams could alias accidentally, violating the runner's stream and event ordering assumptions
  and causing stream-mismatch or incorrect execution ordering.

  `CUDA_DEVICE_MAX_CONNECTIONS` does not prevent this aliasing. It controls how logical CUDA
  streams map to hardware work queues, rather than the uniqueness of their native stream handles.

  ## Solution

  This PR:

  - Creates a bounded per-device pool of local CUDA graph streams.
  - Assigns runners to these streams deterministically in round-robin order.
  - Uses the runner's assigned stream consistently for forward capture, backward capture, replay,
    and synchronization.
  - Warns when `CUDA_DEVICE_MAX_CONNECTIONS` is unset, invalid, or below 16 for GTP workloads.

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

