### PR TITLE
Group linked profiler events

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -17,15 +17,15 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
 def collect_linked_kernels(
     prof: TorchProfiler, cpu_event_name_substring: str
 ) -> list[FunctionEvent]:
-    """Collect device kernel events linked to matching CPU op instances.
+    """Collect kernels and D2D memcpys linked to matching CPU op instances.
 
     Device events are attributed by their launching CPU op rather than searched by their
     own name: device-side names vary across GPU architectures and kernel libraries -- for
     example a matmul kernel is named ``nvjet_``/``cutlass_``/``cublas_``... while its
     CPU op is simply ``aten::mm``.
 
-    Zero-CTA all-gather copy-engine memcpys are not kernels and are intentionally not
-    returned.
+    Zero-CTA all-gather copy-engine D2D memcpys are included, while P2P copies,
+    host-to-device copies, and memset activities are excluded.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
@@ -46,7 +46,8 @@ def collect_linked_kernels(
     for event in events:
         if event.device_type != DeviceType.CUDA:
             continue
-        if event.activity_type != "kernel":
+        is_d2d_memcpy = event.activity_type == "gpu_memcpy" and event.name.startswith("Memcpy DtoD")
+        if event.activity_type != "kernel" and not is_d2d_memcpy:
             continue
         if event.linked_correlation_id not in matching_correlations:
             continue

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -7,6 +7,13 @@ from torch.autograd.profiler_util import FunctionEvent
 from torch.profiler import profile as TorchProfiler
 
 
+class EventGroup(list[FunctionEvent]):
+    """CUDA events linked to one CPU profiler event."""
+
+    def __repr__(self) -> str:
+        return repr([event.name for event in self])
+
+
 def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
     return (
         first.time_range.start < second.time_range.end
@@ -14,43 +21,48 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
     )
 
 
-def collect_linked_kernels(
+def event_groups_overlap(first: EventGroup, second: EventGroup) -> bool:
+    for first_event in first:
+        for second_event in second:
+            if events_overlap(first_event, second_event):
+                return True
+    return False
+
+
+def collect_linked_event_groups(
     prof: TorchProfiler, cpu_event_name_substring: str
-) -> list[FunctionEvent]:
-    """Collect kernels and D2D memcpys linked to matching CPU op instances.
+) -> list[EventGroup]:
+    """Collect CUDA events grouped by linked CPU event.
 
     Device events are attributed by their launching CPU op rather than searched by their
     own name: device-side names vary across GPU architectures and kernel libraries -- for
     example a matmul kernel is named ``nvjet_``/``cutlass_``/``cublas_``... while its
     CPU op is simply ``aten::mm``.
 
-    Zero-CTA all-gather copy-engine D2D memcpys are included, while P2P copies,
-    host-to-device copies, and memset activities are excluded.
+    Each group contains the CUDA events linked to one matching CPU event, including kernels
+    and memcpys.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
     # is the "no device correlation" sentinel and is skipped.
     events = prof.events()
-    matching_correlations: set[int] = set()
+    groups_by_correlation: dict[int, EventGroup] = {}
     for event in events:
         if event.device_type != DeviceType.CPU or not event.linked_correlation_id:
             continue
         node = event
         while node is not None:
             if cpu_event_name_substring in node.name:
-                matching_correlations.add(event.linked_correlation_id)
+                groups_by_correlation[event.linked_correlation_id] = EventGroup()
                 break
             node = node.cpu_parent
 
-    linked_kernels: list[FunctionEvent] = []
     for event in events:
         if event.device_type != DeviceType.CUDA:
             continue
-        is_d2d_memcpy = event.activity_type == "gpu_memcpy" and event.name.startswith("Memcpy DtoD")
-        if event.activity_type != "kernel" and not is_d2d_memcpy:
+        group = groups_by_correlation.get(event.linked_correlation_id)
+        if group is None:
             continue
-        if event.linked_correlation_id not in matching_correlations:
-            continue
-        linked_kernels.append(event)
+        group.append(event)
 
-    return linked_kernels
+    return list(groups_by_correlation.values())

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -23,7 +23,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
-from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_kernels
+from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_event_groups
 
 logger = logging.getLogger(__name__)
 
@@ -497,16 +497,16 @@ def test_hsdp_defers_dp_outer_allreduce_to_last_microbatch(distributed_setup):
         train_one_step()
         torch.cuda.synchronize(device)
 
-    reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
-    allreduce_kernels = collect_linked_kernels(prof, _ALLREDUCE_OP_NAME_SUBSTRING)
+    reduce_scatter_groups = collect_linked_event_groups(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    allreduce_groups = collect_linked_event_groups(prof, _ALLREDUCE_OP_NAME_SUBSTRING)
     # One DP-outer all-reduce per parameter group -- each child layer plus the
     # root unit's bias -- fired only on the last microbatch. Plain DP fires none.
-    assert len(allreduce_kernels) == num_children + 1, [event.name for event in prof.events()]
+    assert len(allreduce_groups) == num_children + 1, [event.name for event in prof.events()]
     # DP-inner reduce-scatter runs every microbatch; the DP-outer all-reduce runs
     # only on the last, so the counts differ by exactly the microbatch factor.
-    assert len(reduce_scatter_kernels) == len(allreduce_kernels) * num_microbatches, (
-        f"Expected reduce-scatter ({len(reduce_scatter_kernels)}) to be {num_microbatches}x "
-        f"the DP-outer all-reduce count ({len(allreduce_kernels)})."
+    assert len(reduce_scatter_groups) == len(allreduce_groups) * num_microbatches, (
+        f"Expected reduce-scatter ({len(reduce_scatter_groups)}) to be {num_microbatches}x "
+        f"the DP-outer all-reduce count ({len(allreduce_groups)})."
     )
 
 
@@ -561,16 +561,16 @@ def test_hfsdp_reduce_scatters_dp_outer_on_last_microbatch(distributed_setup):
         train_one_step()
         torch.cuda.synchronize(device)
 
-    reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
-    allreduce_kernels = collect_linked_kernels(prof, _ALLREDUCE_OP_NAME_SUBSTRING)
+    reduce_scatter_groups = collect_linked_event_groups(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    allreduce_groups = collect_linked_event_groups(prof, _ALLREDUCE_OP_NAME_SUBSTRING)
     # HFSDP reduce-scatters the DP-outer axis, so it never all-reduces.
-    assert not allreduce_kernels, [event.name for event in prof.events()]
+    assert not allreduce_groups, [event.name for event in prof.events()]
     # Per group (each child layer plus the root bias): one DP-inner reduce-scatter
     # every microbatch plus one DP-outer reduce-scatter on the last microbatch.
     expected = (num_microbatches + 1) * (num_children + 1)
-    assert len(reduce_scatter_kernels) == expected, (
+    assert len(reduce_scatter_groups) == expected, (
         f"Expected {expected} reduce-scatters ((num_microbatches + 1) x (num_children + 1)), "
-        f"got {len(reduce_scatter_kernels)}."
+        f"got {len(reduce_scatter_groups)}."
     )
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -2,6 +2,8 @@
 
 """Communication-overlap tests for the minimal Megatron-FSDP path."""
 
+from itertools import chain
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -20,8 +22,8 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import (
-    collect_linked_kernels,
-    events_overlap,
+    collect_linked_event_groups,
+    event_groups_overlap,
 )
 
 
@@ -167,18 +169,17 @@ def test_overlaps_communication_and_compute(
         # drop the CUDA events.
         torch.cuda.synchronize(device)
 
-    gemm_kernels = collect_linked_kernels(prof, _GEMM_OP_NAME_SUBSTRING)
+    gemm_groups = collect_linked_event_groups(prof, _GEMM_OP_NAME_SUBSTRING)
     # Each child Linear runs one forward and two backward matmuls per microbatch.
     # aten::mm may also launch auxiliary kernels, so check only the matmul lower bound.
     expected_gemm_count = 6 * num_children
-    assert len(gemm_kernels) >= expected_gemm_count, (
-        f"Expected at least {expected_gemm_count} kernels linked to GEMMs, got "
-        f"{len(gemm_kernels)}: "
-        f"{[kernel.name for kernel in gemm_kernels]}"
+    assert len(gemm_groups) >= expected_gemm_count, (
+        f"Expected at least {expected_gemm_count} groups linked to GEMMs, got "
+        f"{len(gemm_groups)}: {gemm_groups}"
     )
 
-    allgather_kernels = collect_linked_kernels(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    allgather_groups = collect_linked_event_groups(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_groups = collect_linked_event_groups(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # ZeRO-1/2 all-gather once per optimizer step. ZeRO-1 reduces only the second
     # microbatch, while ZeRO-2 reduces both. ZeRO-3 gathers for every forward and
     # backward and reduces every microbatch.
@@ -204,22 +205,22 @@ def test_overlaps_communication_and_compute(
         expected_reduce_scatter_overlap_count,
     ) = expected_collective_counts[placements_factory]
 
-    expected_allgather_kernel_count = 0 if use_symmetric_memory else expected_allgather_count
-    # Zero-CTA moves the all-gather to copy-engine memcpys, so it should not emit
-    # all-gather kernels.
-    assert len(allgather_kernels) == expected_allgather_kernel_count, (
-        f"Expected {expected_allgather_kernel_count} all-gather kernels, got "
-        f"{len(allgather_kernels)}: {[kernel.name for kernel in allgather_kernels]}"
+    assert len(allgather_groups) == expected_allgather_count, (
+        f"Expected {expected_allgather_count} all-gather groups, got "
+        f"{len(allgather_groups)}: {allgather_groups}"
     )
-    assert len(reduce_scatter_kernels) == expected_reduce_scatter_count, (
-        f"Expected {expected_reduce_scatter_count} reduce-scatter kernels, got "
-        f"{len(reduce_scatter_kernels)}: {[kernel.name for kernel in reduce_scatter_kernels]}"
+    assert len(reduce_scatter_groups) == expected_reduce_scatter_count, (
+        f"Expected {expected_reduce_scatter_count} reduce-scatter groups, got "
+        f"{len(reduce_scatter_groups)}: {reduce_scatter_groups}"
     )
 
-    allgather_streams = {kernel.device_resource_id for kernel in allgather_kernels}
-    reduce_scatter_streams = {kernel.device_resource_id for kernel in reduce_scatter_kernels}
-    gemm_streams = {kernel.device_resource_id for kernel in gemm_kernels}
-    if allgather_kernels:
+    allgather_events = list(chain.from_iterable(allgather_groups))
+    reduce_scatter_events = list(chain.from_iterable(reduce_scatter_groups))
+    gemm_events = list(chain.from_iterable(gemm_groups))
+    allgather_streams = {event.device_resource_id for event in allgather_events}
+    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
+    gemm_streams = {event.device_resource_id for event in gemm_events}
+    if allgather_events:
         assert len(allgather_streams) == 1
         if unify_communication_stream:
             assert allgather_streams == reduce_scatter_streams
@@ -230,20 +231,21 @@ def test_overlaps_communication_and_compute(
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
     allgather_overlap_count = sum(
-        any(events_overlap(kernel, gemm) for gemm in gemm_kernels) for kernel in allgather_kernels
+        any(event_groups_overlap(group, gemm_group) for gemm_group in gemm_groups)
+        for group in allgather_groups
     )
     reduce_scatter_overlap_count = sum(
-        any(events_overlap(kernel, gemm) for gemm in gemm_kernels)
-        for kernel in reduce_scatter_kernels
+        any(event_groups_overlap(group, gemm_group) for gemm_group in gemm_groups)
+        for group in reduce_scatter_groups
     )
     if not use_symmetric_memory:
         assert allgather_overlap_count == expected_allgather_overlap_count, (
             f"Expected exactly {expected_allgather_overlap_count} all-gathers to "
-            f"overlap compute, got {allgather_overlap_count}/{len(allgather_kernels)}."
+            f"overlap compute, got {allgather_overlap_count}/{len(allgather_groups)}."
         )
     assert reduce_scatter_overlap_count == expected_reduce_scatter_overlap_count, (
         f"Expected exactly {expected_reduce_scatter_overlap_count} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_kernels)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_groups)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -2,6 +2,8 @@
 
 """Unit tests for experimental FSDP symmetric-memory staging."""
 
+from itertools import chain
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -16,7 +18,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     fully_shard,
     fully_shard_context,
 )
-from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_kernels
+from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_event_groups
 
 # Each sharded Linear's collective must be large enough that NCCL selects its
 # symmetric-memory (ncclSymk*) kernels over ring. Sub-KB collectives fall back to
@@ -112,44 +114,51 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         msg="Symmetric-memory FSDP losses did not match default FSDP losses.",
     )
 
-    allgather_kernels_without_symm_mem = collect_linked_kernels(
+    allgather_groups_without_symm_mem = collect_linked_event_groups(
         prof_without_symm_mem, _ALL_GATHER_OP_NAME_SUBSTRING
     )
-    reduce_scatter_kernels_without_symm_mem = collect_linked_kernels(
+    reduce_scatter_groups_without_symm_mem = collect_linked_event_groups(
         prof_without_symm_mem, _REDUCE_SCATTER_OP_NAME_SUBSTRING
     )
-    assert all("ncclSymk" not in kernel.name for kernel in allgather_kernels_without_symm_mem)
-    assert all("ncclSymk" not in kernel.name for kernel in reduce_scatter_kernels_without_symm_mem)
+    assert all(
+        "ncclSymk" not in event.name
+        for event in chain.from_iterable(allgather_groups_without_symm_mem)
+    )
+    assert all(
+        "ncclSymk" not in event.name
+        for event in chain.from_iterable(reduce_scatter_groups_without_symm_mem)
+    )
 
-    allgather_kernels_with_symm_mem = collect_linked_kernels(
+    allgather_groups_with_symm_mem = collect_linked_event_groups(
         prof_with_symm_mem, _ALL_GATHER_OP_NAME_SUBSTRING
     )
-    reduce_scatter_kernels_with_symm_mem = collect_linked_kernels(
+    reduce_scatter_groups_with_symm_mem = collect_linked_event_groups(
         prof_with_symm_mem, _REDUCE_SCATTER_OP_NAME_SUBSTRING
     )
     # 2 sharded modules (fc1, fc2), one reduce-scatter each per microbatch step.
-    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * 2
-    assert len(reduce_scatter_kernels_with_symm_mem) == expected_reduce_scatter_kernel_count, (
-        "Unexpected NCCL symmetric-memory reduce-scatter kernel count. "
-        f"Observed reduce-scatter kernels: "
-        f"{[kernel.name for kernel in reduce_scatter_kernels_with_symm_mem[:20]]}"
+    expected_reduce_scatter_group_count = num_training_steps * num_microbatches * 2
+    assert len(reduce_scatter_groups_with_symm_mem) == expected_reduce_scatter_group_count, (
+        "Unexpected NCCL symmetric-memory reduce-scatter group count. "
+        f"Observed reduce-scatter events: {reduce_scatter_groups_with_symm_mem[:20]}"
     )
-    assert all("ncclSymk" in kernel.name for kernel in reduce_scatter_kernels_with_symm_mem), (
-        "Expected all symmetric-memory reduce-scatter kernels to be ncclSymk kernels. "
-        f"Observed reduce-scatter kernels: "
-        f"{[kernel.name for kernel in reduce_scatter_kernels_with_symm_mem[:20]]}"
+    assert all(
+        "ncclSymk" in event.name
+        for event in chain.from_iterable(reduce_scatter_groups_with_symm_mem)
+    ), (
+        "Expected all symmetric-memory reduce-scatter events to be ncclSymk kernels. "
+        f"Observed reduce-scatter events: {reduce_scatter_groups_with_symm_mem[:20]}"
     )
 
-    expected_allgather_kernel_count = 2 * expected_reduce_scatter_kernel_count
-    assert len(allgather_kernels_with_symm_mem) == expected_allgather_kernel_count, (
-        "Unexpected NCCL symmetric-memory all-gather kernel count. "
-        f"Observed all-gather kernels: "
-        f"{[kernel.name for kernel in allgather_kernels_with_symm_mem[:20]]}"
+    expected_allgather_group_count = 2 * expected_reduce_scatter_group_count
+    assert len(allgather_groups_with_symm_mem) == expected_allgather_group_count, (
+        "Unexpected NCCL symmetric-memory all-gather group count. "
+        f"Observed all-gather events: {allgather_groups_with_symm_mem[:20]}"
     )
-    assert all("ncclSymk" in kernel.name for kernel in allgather_kernels_with_symm_mem), (
-        "Expected all symmetric-memory all-gather kernels to be ncclSymk kernels. "
-        f"Observed all-gather kernels: "
-        f"{[kernel.name for kernel in allgather_kernels_with_symm_mem[:20]]}"
+    assert all(
+        "ncclSymk" in event.name for event in chain.from_iterable(allgather_groups_with_symm_mem)
+    ), (
+        "Expected all symmetric-memory all-gather events to be ncclSymk kernels. "
+        f"Observed all-gather events: {allgather_groups_with_symm_mem[:20]}"
     )
 
 
@@ -210,25 +219,24 @@ def test_fully_shard_zero_cta_moves_all_gather_to_copy_engine(distributed_setup)
             optimizer.step()
         torch.cuda.synchronize()
 
-    allgather_kernels = collect_linked_kernels(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    allgather_groups = collect_linked_event_groups(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_groups = collect_linked_event_groups(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # Two sharded modules each all-gather in forward and backward on every training step.
-    assert len(allgather_kernels) == num_training_steps * 2 * 2, (
-        "Expected zero-CTA all-gather D2D memcpys. "
-        f"Observed all-gather kernels: {[kernel.name for kernel in allgather_kernels[:20]]}"
+    assert len(allgather_groups) == num_training_steps * 2 * 2, (
+        "Expected zero-CTA all-gather groups. "
+        f"Observed all-gather events: {allgather_groups[:20]}"
     )
     # The reduce-scatter's reduction cannot run on the copy engine, so it stays a
     # symmetric-memory kernel (an SM-launched NVLS multicast reduce): one per sharded
     # module (fc1, fc2) per training step.
-    expected_reduce_scatter_kernel_count = num_training_steps * 2
-    assert len(reduce_scatter_kernels) == expected_reduce_scatter_kernel_count, (
-        f"Expected {expected_reduce_scatter_kernel_count} symmetric-memory reduce-scatter "
-        f"kernels under zero-CTA. Observed reduce-scatter kernels: "
-        f"{[kernel.name for kernel in reduce_scatter_kernels[:20]]}"
+    expected_reduce_scatter_group_count = num_training_steps * 2
+    assert len(reduce_scatter_groups) == expected_reduce_scatter_group_count, (
+        f"Expected {expected_reduce_scatter_group_count} symmetric-memory reduce-scatter "
+        f"groups under zero-CTA. Observed reduce-scatter events: {reduce_scatter_groups[:20]}"
     )
-    assert all("ncclSymk" in kernel.name for kernel in reduce_scatter_kernels), (
-        "Expected all zero-CTA reduce-scatter kernels to be ncclSymk kernels. "
-        f"Observed reduce-scatter kernels: {[kernel.name for kernel in reduce_scatter_kernels[:20]]}"
+    assert all("ncclSymk" in event.name for event in chain.from_iterable(reduce_scatter_groups)), (
+        "Expected all zero-CTA reduce-scatter events to be ncclSymk kernels. "
+        f"Observed reduce-scatter events: {reduce_scatter_groups[:20]}"
     )
 
     # Release the dedicated communicator (leaks only on a test failure above, which is fine).

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -212,9 +212,9 @@ def test_fully_shard_zero_cta_moves_all_gather_to_copy_engine(distributed_setup)
 
     allgather_kernels = collect_linked_kernels(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
     reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
-    # Zero-CTA moves the all-gather to the copy engine: no symmetric-memory all-gather kernel.
-    assert not allgather_kernels, (
-        f"Expected no symmetric-memory all-gather kernel under zero-CTA. "
+    # Two sharded modules each all-gather in forward and backward on every training step.
+    assert len(allgather_kernels) == num_training_steps * 2 * 2, (
+        "Expected zero-CTA all-gather D2D memcpys. "
         f"Observed all-gather kernels: {[kernel.name for kernel in allgather_kernels[:20]]}"
     )
     # The reduce-scatter's reduction cannot run on the copy engine, so it stays a


### PR DESCRIPTION
## What

Group CUDA profiler events by linked correlation ID instead of returning a flat device-event list. The helper includes kernels and memcpy activities, and returns one `EventGroup` per linked CPU profiler event.

Update MFSDP profiler tests to count collective operations at the group level and compare whole event groups for overlap.

## Why

Zero-CTA all-gathers execute on the copy engine and appear as memcpy activities rather than CUDA kernels. Previously, the kernel-only helper could not observe them, so the overlap test skipped zero-CTA all-gathers. Grouping linked events makes those overlap assertions independent of how a collective is decomposed into device activities.

## Validation

- `isort`, Black, Ruff, and `git diff --check`