### PR TITLE
Scope activation offload summaries to model ranks

### DIFF
--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -17,7 +17,6 @@ try:
 except ImportError:
     from megatron.core.telemetry.fallbacks import trace_fn as _otel_trace_fn
 
-from megatron.core._rank_utils import log_single_rank
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
@@ -53,11 +52,12 @@ def _te_do_not_offload(tensor):
 def print_offload_summary_table(
     total_offload_bytes: Dict[str, int],
     local_duplicate_summary: Optional[Dict[str, Tuple[int, int]]] = None,
+    process_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
     """
-    Print offload bytes and warn about duplicate copies across all ranks.
+    Print offload bytes and warn about duplicate copies across participating ranks.
 
-    Gathers both summaries in one object collective and reports them on rank 0.
+    Gathers both summaries in one object collective and reports them on group rank 0.
     The table has rows representing ranks and columns representing groups.
 
     The reported bytes are every byte copied to CPU, so a redundant copy of an
@@ -67,18 +67,19 @@ def print_offload_summary_table(
         total_offload_bytes: Dict mapping group names to offload bytes for this rank.
         local_duplicate_summary: Dict mapping group names to redundant-copy counts
             and bytes for this rank.
+        process_group: Ranks participating in fine-grained activation offloading.
     """
     # pylint: disable=bad-builtin
     assert torch.distributed.is_initialized()
-    rank = torch.distributed.get_rank()
-    world_size = torch.distributed.get_world_size()
+    rank = torch.distributed.get_rank(group=process_group)
+    world_size = torch.distributed.get_world_size(group=process_group)
 
     local_summary = {
         "offload_bytes": dict(total_offload_bytes),
         "duplicate_summary": dict(local_duplicate_summary or {}),
     }
     all_summaries = [None] * world_size
-    torch.distributed.all_gather_object(all_summaries, local_summary)
+    torch.distributed.all_gather_object(all_summaries, local_summary, group=process_group)
 
     if rank == 0:
         details = []
@@ -89,12 +90,10 @@ def print_offload_summary_table(
                     f"{duplicate_bytes / (1024 * 1024):.2f} MB"
                 )
         if details:
-            log_single_rank(
-                logger,
-                logging.WARNING,
+            logger.warning(
                 "Fine-grained activation offloading is copying the same tensor storage to CPU "
                 "more than once within an offload group, wasting host memory and PCIe bandwidth "
-                f"({', '.join(details)}). Offloading proceeds with the duplicated copies.",
+                f"({', '.join(details)}). Offloading proceeds with the duplicated copies."
             )
 
         all_group_names = sorted(
@@ -145,7 +144,7 @@ def print_offload_summary_table(
         print(totals_row)
         print("=" * len(header) + "\n")
 
-    torch.distributed.barrier()
+    torch.distributed.barrier(group=process_group)
 
 
 class OffloadTensorPool:
@@ -549,7 +548,7 @@ class PipelineOffloadManager:
             group_hook(name, forced_released_tensors)
         self._delayed_offload_groups = []
 
-    def reset(self):
+    def reset(self, process_group: Optional[torch.distributed.ProcessGroup] = None):
         """Reset manager state for a new training iteration."""
         self._inside_context = False
         self._cur_forward_chunk = None
@@ -560,7 +559,7 @@ class PipelineOffloadManager:
 
         # Call post_warmup_callback after warmup to collect the offload information.
         if self._is_warmup and len(self._cached_chunks_forward) > 0:
-            self.post_warmup_callback()
+            self.post_warmup_callback(process_group=process_group)
         self._cached_chunks_index_backward = 0
         self._cached_chunks_index_forward = 0
 
@@ -607,7 +606,7 @@ class PipelineOffloadManager:
         for chunk in self._cached_chunks_forward:
             chunk.do_offload = True
 
-    def post_warmup_callback(self):
+    def post_warmup_callback(self, process_group: Optional[torch.distributed.ProcessGroup] = None):
         """Callback after warmup."""
         # pylint: disable=bad-builtin
         debug_rank("post_warmup_callback")
@@ -703,6 +702,7 @@ class PipelineOffloadManager:
         print_offload_summary_table(
             total_offload_bytes,
             {name: tuple(summary) for name, summary in local_duplicate_summary.items()},
+            process_group=process_group,
         )
 
     def push(self, handler):
@@ -1575,9 +1575,9 @@ class FineGrainedActivationOffloadingInterface:
         return FineGrainedOffloadingBackwardRecordFunction.apply(tensor)
 
     @staticmethod
-    def reset():
+    def reset(process_group: Optional[torch.distributed.ProcessGroup] = None):
         """Reset the chunk handler."""
-        PipelineOffloadManager.get_instance().reset()
+        PipelineOffloadManager.get_instance().reset(process_group=process_group)
 
     @staticmethod
     def reset_instance():

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -709,6 +709,17 @@ def _build_default_pg_collection() -> ProcessGroupCollection:
     return pg_collection
 
 
+def _reset_activation_offload(
+    pg_collection: Union[ProcessGroupCollection, MultiModuleProcessGroupCollection],
+) -> None:
+    """Reset activation offload state for single-model and MIMO language ranks."""
+    if isinstance(pg_collection, MultiModuleProcessGroupCollection):
+        if not pg_collection.has_language_model():
+            return
+        pg_collection = pg_collection.get_language_model_collection()
+    off_interface.reset(process_group=pg_collection.tp_dp_cp)
+
+
 def forward_backward_no_pipelining(
     *,
     forward_step_func,
@@ -860,7 +871,7 @@ def forward_backward_no_pipelining(
         )
 
     if getattr(config, 'fine_grained_activation_offloading', False):
-        off_interface.reset()
+        _reset_activation_offload(pg_collection)
     # Reset all_gather_pipeline bucket status before next validation iteration
     if forward_only:
         for model_chunk in [model]:
@@ -2086,7 +2097,7 @@ def forward_backward_pipelining_with_interleaving(
         )
 
     if getattr(config, 'fine_grained_activation_offloading', False):
-        off_interface.reset()
+        _reset_activation_offload(pg_collection)
     # Restore config.grad_sync_func and config.param_sync_func.
     if forward_only:
         config.grad_sync_func, config.param_sync_func = grad_sync_func, param_sync_func
@@ -2480,7 +2491,7 @@ def forward_backward_pipelining_without_interleaving(
         )
 
     if getattr(config, 'fine_grained_activation_offloading', False):
-        off_interface.reset()
+        _reset_activation_offload(pg_collection)
 
     if config.timers is not None:
         config.timers('forward-backward').stop()

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -46,6 +46,42 @@ def _make_chunk_handler_for_offload_checker(min_offloaded_tensor_size: int = 1):
     return handler
 
 
+def test_offload_summary_uses_explicit_process_group(monkeypatch):
+    from megatron.core.pipeline_parallel import fine_grained_activation_offload as off_module
+
+    process_group = object()
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_rank",
+        lambda *, group=None: 0 if group is process_group else pytest.fail("wrong process group"),
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_world_size",
+        lambda *, group=None: 1 if group is process_group else pytest.fail("wrong process group"),
+    )
+
+    def all_gather_object(output, value, *, group=None):
+        assert group is process_group
+        output[0] = value
+
+    def barrier(*, group=None):
+        assert group is process_group
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", all_gather_object)
+    monkeypatch.setattr(torch.distributed, "barrier", barrier)
+    warning_messages = []
+    monkeypatch.setattr(off_module.logger, "warning", warning_messages.append)
+
+    off_module.print_offload_summary_table(
+        {"decoder": 1024}, {"decoder": (1, 1024)}, process_group=process_group
+    )
+
+    assert len(warning_messages) == 1
+    assert "same tensor storage" in warning_messages[0]
+
+
 def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
     handler = _make_chunk_handler_for_offload_checker()
 

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -17,7 +17,10 @@ from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
-from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.process_groups_config import (
+    MultiModuleProcessGroupCollection,
+    ProcessGroupCollection,
+)
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer.cuda_graphs import (
     convert_schedule_table_to_order,
@@ -26,6 +29,28 @@ from megatron.core.transformer.cuda_graphs import (
 from tests.unit_tests.test_utilities import Utils
 
 rank = Utils.rank
+
+
+def test_reset_activation_offload_uses_language_model_group(mocker):
+    reset = mocker.patch.object(schedule.off_interface, "reset")
+    language_group = object()
+    collection = MultiModuleProcessGroupCollection(
+        module_pgs={
+            "encoder_1": object(),
+            "encoder_2": object(),
+            "llm": SimpleNamespace(tp_dp_cp=language_group),
+        },
+        language_model_module_name="llm",
+    )
+    schedule._reset_activation_offload(collection)
+    reset.assert_called_once_with(process_group=language_group)
+
+    reset.reset_mock()
+    collection = MultiModuleProcessGroupCollection(
+        module_pgs={"encoder_1": object(), "encoder_2": object()}
+    )
+    schedule._reset_activation_offload(collection)
+    reset.assert_not_called()
 
 
 def _populate_embedding_and_position_groups(pp_group):


### PR DESCRIPTION
## What changed

- Run fine-grained activation offload summary collectives on the model's `tp_dp_cp` process group.
- In heterogeneous MIMO, reset and report only on language-model ranks; encoder-only ranks are skipped, including ranks with multiple colocated encoders.
- Preserve the existing behavior for single-model training.

## Why

The summary currently uses the global process group even though only ranks that cache matching offload groups enter the post-warmup summary. With LLM-only offload modules in heterogeneous MIMO, that can wait for encoder ranks that never enter the collective.

## Validation

- CMH job `3140904`: explicit subgroup collective path passed two focused tests.
- Final LLM-only guard: Black 26.3.0, isort, `py_compile`, and `git diff --check` passed.