### PR TITLE
feat(determinism): Make the channel-last conv1d deterministic

### DIFF
--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -37,10 +37,15 @@ Selected by `torch.are_deterministic_algorithms_enabled()` or
 | MoE routing map and probabilities | `megatron/core/transformer/moe/moe_utils.py` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
 | Vocab-parallel embedding | `megatron/core/tensor_parallel/layers.py` | direct indexing `weight[idx]` (deterministic backward) | `F.embedding` (non-deterministic atomic backward) |
 | Gated-delta-net kernel | `megatron/core/ssm/gated_delta_net.py` | torch `chunk_gated_delta_rule` | FLA fused kernel |
-| Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net.py` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
+| Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net/` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
 | Mamba/SSM Triton ops | `megatron/core/ssm/ops/common/determinism.py` | one fixed autotune config plus a zero-initialized tiled workspace reduced with an ordered `sum` | timing-based autotune, uninitialized workspace |
+| Mamba/GDP causal conv1d | `megatron/core/ssm/causal_conv1d.py` | causal_conv1d >= 1.6.0 — per-block workspace for the weight and bias gradients, reduced with an ordered `sum` | `atomicAdd` accumulation (order varies per launch) |
 | Transformer Engine attention | `megatron/core/extensions/transformer_engine.py` | requires `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, under which TE selects only backends that support deterministic execution (including deterministic FlashAttention backward) | TE picks freely, including atomic-accumulation attention backward |
 | Inference DP scheduling and RL rollout order | `megatron/core/inference/engines/dynamic_engine.py`, `megatron/rl/rl_utils.py` | sort by stable key | completion order |
+
+The two conv rows are different kernels. Mamba and GDP call Dao-AILab's
+`causal_conv1d`, which has its own deterministic reduction; gated-delta-net binds
+FLA's, which does not, so it falls back to `F.conv1d`.
 
 The following environment controls make the rest of the step deterministic.
 The flag `--deterministic-mode` validates and defaults these settings. For
@@ -51,6 +56,7 @@ details, refer to `megatron/training/determinism.py`.
 - `CUBLAS_WORKSPACE_CONFIG=:4096:8` (or `:16:8`).
 - `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`.
 - `MAMBA_DETERMINISTIC` must not be disabled.
+- `CAUSAL_CONV1D_DETERMINISTIC` must not be disabled. Needs causal_conv1d >= 1.6.0.
 
 ## Operations Without Determinism Support
 

--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -23,7 +23,7 @@ When enabled, Megatron applies the env vars and config overrides below via `mega
 
 ## Environment variables
 
-Each variable may be set by the launcher or left unset. If set, the value must be one that has been validated as deterministic — anything else fails hard with an assertion. If unset, `apply_determinism_env` fills the canonical default (except `MAMBA_DETERMINISTIC`, which the Mamba SSM helper auto-detects from `torch.are_deterministic_algorithms_enabled()`). Must be set before the first cuBLAS / Transformer Engine call — `apply_determinism_to_args` runs early in `validate_args` to guarantee this.
+Each variable may be set by the launcher or left unset. If set, the value must be one that has been validated as deterministic — anything else fails hard with an assertion. If unset, `apply_determinism_env` fills the canonical default (except `MAMBA_DETERMINISTIC` and `CAUSAL_CONV1D_DETERMINISTIC`, which their kernels auto-detect from `torch.are_deterministic_algorithms_enabled()`). Must be set before the first cuBLAS / Transformer Engine call — `apply_determinism_to_args` runs early in `validate_args` to guarantee this.
 
 | Variable | Accepted values (or unset) | Default filled if unset | Reason |
 |---|---|---|---|
@@ -31,6 +31,7 @@ Each variable may be set by the launcher or left unset. If set, the value must b
 | `NVTE_ALLOW_NONDETERMINISTIC_ALGO` | `0` | `0` | Forces Transformer Engine to use deterministic algorithms |
 | `CUBLAS_WORKSPACE_CONFIG` | `:4096:8` or `:16:8` | `:4096:8` | Deterministic cuBLAS workspace (both sizes are reproducible per NVIDIA docs; `:4096:8` is faster, `:16:8` uses less memory) |
 | `MAMBA_DETERMINISTIC` | any string starting with `'1'` | *(none — SSM auto-detects)* | Mamba SSM auto-follows `torch.are_deterministic_algorithms_enabled()` when unset; only an explicit non-deterministic override is rejected |
+| `CAUSAL_CONV1D_DETERMINISTIC` | any string starting with `'1'` | *(none — the kernel auto-detects)* | causal_conv1d ≥ 1.6.0 auto-follows `torch.are_deterministic_algorithms_enabled()` when unset, reducing the conv weight/bias gradients through a workspace instead of `atomicAdd`; the Mamba and GDP mixers reject a deterministic run without it |
 
 If you override `NCCL_ALGO`, the value must be a subset of `{Ring, CollnetDirect, CollnetChain, ^NVLS}`. `Tree` is intentionally excluded: its intra-node chain reduction order is not user-controllable, and the inter-node tree topology can vary across runs without a pinned topology file, so it cannot be vouched for as bit-exact across stacks. `^NVLS` is accepted (banning NVLS is a legitimate user choice on hardware that exposes it); the user is responsible for ensuring whatever NCCL falls back to is deterministic on their environment.
 

--- a/megatron/core/ssm/causal_conv1d.py
+++ b/megatron/core/ssm/causal_conv1d.py
@@ -1,15 +1,63 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Causal convolution over contiguous context-parallel sequence shards."""
+"""Causal convolution over contiguous context-parallel sequence shards, and the determinism
+guard the SSM mixers apply to the causal_conv1d backward."""
+
+import os
 
 import torch
 
 from megatron.core.tensor_parallel.mappings import all_to_all
+from megatron.core.utils import is_causal_conv1d_min_version
 
 try:
     from causal_conv1d import causal_conv1d_fn
 except ImportError:
     causal_conv1d_fn = None
+
+
+def _use_causal_conv1d_deterministic_mode():
+    """Whether causal_conv1d's backward will take its deterministic reduction.
+
+    Mirrors the kernel's own ``use_deterministic_mode()`` (``csrc/causal_conv1d.cpp``): only a
+    leading ``'1'`` or ``'0'`` decides, anything else falls through to torch.
+    """
+    env = os.environ.get('CAUSAL_CONV1D_DETERMINISTIC')
+    if env:
+        if env[0] == '1':
+            return True
+        if env[0] == '0':
+            return False
+    return torch.are_deterministic_algorithms_enabled()
+
+
+def assert_causal_conv1d_deterministic(deterministic_mode):
+    """Refuse a deterministic run whose convolution cannot be bit-reproducible.
+
+    The conv backward combines each weight-gradient element's per-block partials with
+    ``atomicAdd``, which fixes no order; 1.6.0+ uses a per-block workspace and an ordered
+    reduce instead. Worst on the channel-last layout GDP and Mamba's fused path both feed the
+    conv, where an element takes ``batch * ceil(seqlen / 128)`` contributions rather than the
+    channels-first ``batch``.
+
+    Call once at construction. Keyed on ``deterministic_mode``, not torch's global flag, which
+    unrelated tests set and never restore.
+    """
+    if not deterministic_mode or causal_conv1d_fn is None:
+        return
+
+    assert _use_causal_conv1d_deterministic_mode(), (
+        "deterministic_mode requires a deterministic causal_conv1d backward. Enable it with "
+        "torch.use_deterministic_algorithms(True) (which --deterministic-mode does) or "
+        "CAUSAL_CONV1D_DETERMINISTIC=1."
+    )
+    # https://github.com/Dao-AILab/causal-conv1d/pull/88 added the deterministic reduction.
+    conv1d_min = "1.6.0"
+    assert is_causal_conv1d_min_version(conv1d_min), (
+        f"causal_conv1d >= {conv1d_min} is required for deterministic_mode: older builds "
+        "reduce the conv weight and bias gradients with atomicAdd, which is not "
+        "bit-reproducible, and ignore CAUSAL_CONV1D_DETERMINISTIC."
+    )
 
 
 def _exchange_initial_states(

--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -26,6 +26,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic
 from megatron.core.ssm.gdp_context_parallel import GDPContextParallel
 
 # Decode uses the in-repo Triton conv update, which accepts int64 slot indices.
@@ -354,6 +355,9 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
 
             if self.conv_init is not None:
                 nn.init.uniform_(self.conv1d.weight, -self.conv_init, self.conv_init)
+
+        # _prepare_qkv feeds the conv channel-last; see assert_causal_conv1d_deterministic.
+        assert_causal_conv1d_deterministic(config.deterministic_mode)
 
         self.activation = "silu"
         self.act = nn.SiLU()

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -23,6 +23,7 @@ from megatron.core.inference.contexts.attention_context.triton.tensor_ops import
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic
 from megatron.core.ssm.ops.common.causal_conv1d_triton import causal_conv1d_update
 from megatron.core.ssm.ops.common.intermediate_extraction import (
     scatter_intermediate_conv,
@@ -366,6 +367,9 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
                     nn.init.uniform_(self.conv1d_weight, -self.conv_init, self.conv_init)
                 else:
                     nn.init.kaiming_uniform_(self.conv1d_weight, a=math.sqrt(5))
+
+        # Both of this mixer's conv layouts need it; see assert_causal_conv1d_deterministic.
+        assert_causal_conv1d_deterministic(config.deterministic_mode)
 
         self.activation = "silu"
         self.act = nn.SiLU()

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -72,8 +72,9 @@ def apply_determinism_env(env: MutableMapping[str, str]) -> None:
       :data:`ACCEPTED_NCCL_ALGO_TOKENS`.
     * ``NVTE_ALLOW_NONDETERMINISTIC_ALGO`` / ``CUBLAS_WORKSPACE_CONFIG`` —
       if set, must be in :data:`ACCEPTED_ENV_VAR_VALUES`.
-    * ``MAMBA_DETERMINISTIC`` — if set (non-empty), must start with ``'1'``;
-      unset auto-follows :func:`torch.are_deterministic_algorithms_enabled`.
+    * ``MAMBA_DETERMINISTIC`` / ``CAUSAL_CONV1D_DETERMINISTIC`` — if set
+      (non-empty), must start with ``'1'``; unset auto-follows
+      :func:`torch.are_deterministic_algorithms_enabled`.
 
     After validation, ``setdefault`` fills every key in
     :data:`DETERMINISM_ENV_VAR_DEFAULTS` that has not been set — a value the
@@ -100,14 +101,15 @@ def apply_determinism_env(env: MutableMapping[str, str]) -> None:
             f"{name}={val!r} is not a deterministic setting. Accepted: {sorted(accepted)}."
         )
 
-    # Mamba SSM auto-follows torch when MAMBA_DETERMINISTIC is unset; only
-    # reject an explicit non-deterministic override.
-    mamba = env.get("MAMBA_DETERMINISTIC")
-    if mamba:
-        assert mamba[0] == "1", (
-            f"MAMBA_DETERMINISTIC={mamba!r} disables Mamba SSM determinism under "
-            "--deterministic-mode. Unset it or set to '1'."
-        )
+    # Mamba SSM and causal_conv1d auto-follow torch when unset; only reject an
+    # explicit non-deterministic override.
+    for name in ("MAMBA_DETERMINISTIC", "CAUSAL_CONV1D_DETERMINISTIC"):
+        value = env.get(name)
+        if value:
+            assert value[0] == "1", (
+                f"{name}={value!r} disables SSM determinism under "
+                "--deterministic-mode. Unset it or set to '1'."
+            )
 
     # setdefault preserves any launcher-set value that just passed validation.
     for k, v in DETERMINISM_ENV_VAR_DEFAULTS.items():
@@ -125,7 +127,8 @@ def apply_determinism_to_args(args) -> None:
     2. Calls :func:`apply_determinism_env` on ``os.environ`` — validates
        every determinism-relevant env var (``NCCL_ALGO``,
        ``NVTE_ALLOW_NONDETERMINISTIC_ALGO``, ``CUBLAS_WORKSPACE_CONFIG``,
-       ``MAMBA_DETERMINISTIC``) and setdefaults the canonical values.
+       ``MAMBA_DETERMINISTIC``, ``CAUSAL_CONV1D_DETERMINISTIC``) and
+       setdefaults the canonical values.
     3. Calls ``torch.use_deterministic_algorithms(True)``.
 
     Incompatible options are rejected with an explicit error rather than

--- a/tests/unit_tests/determinism/correctness/test_ssm_conv1d.py
+++ b/tests/unit_tests/determinism/correctness/test_ssm_conv1d.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Determinism checks for the SSM causal convolution.
+
+Operator-level rather than model-level: the conv's channel-last backward reduces its weight
+gradient over ``micro_batch * ceil(seq_len / 128)`` blocks with ``atomicAdd``, and the model
+cells in this directory run 32x2, which is two blocks -- too few to expose a regression.
+"""
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm import causal_conv1d as causal_conv1d_module
+from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic
+from megatron.core.ssm.mamba_mixer import MambaMixer
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.determinism.configs import hybrid_base
+from tests.unit_tests.determinism.utils import (
+    assert_bit_exact,
+    capture_rng_state,
+    collect_grads,
+    restore_rng_state,
+    zero_grads,
+)
+from tests.unit_tests.test_utilities import Utils
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+
+    HAVE_CAUSAL_CONV1D = True
+except ImportError:
+    HAVE_CAUSAL_CONV1D = False
+
+# The deterministic conv backward landed in causal_conv1d 1.6.0; older builds ignore the flag.
+DETERMINISTIC_CONV1D_MIN = "1.6.0"
+HAVE_DETERMINISTIC_CAUSAL_CONV1D = (
+    HAVE_CAUSAL_CONV1D
+    and causal_conv1d_module.is_causal_conv1d_min_version(DETERMINISTIC_CONV1D_MIN)
+)
+
+requires_deterministic_conv1d = pytest.mark.skipif(
+    not (HAVE_DETERMINISTIC_CAUSAL_CONV1D and torch.cuda.is_available()),
+    reason=f"needs a GPU and causal_conv1d >= {DETERMINISTIC_CONV1D_MIN}",
+)
+
+GRAD_NAMES = ("dx", "dweight", "dbias")
+
+# 4 * ceil(1024 / 128) = 32 contending blocks for the mixer, 2 * ceil(4096 / 128) = 64 for the
+# kernel, against a measurement where 1 contributor never drifts and 32 always does.
+_SEQ_LEN = 1024
+_MICRO_BATCH = 4
+_KERNEL_SHAPE = dict(batch=2, dim=256, seq_len=4096, width=4)
+
+
+def _channel_last_conv_inputs(batch, dim, seq_len, width):
+    """Build a channel-last [B, D, L] conv input plus weight, bias and an output gradient."""
+    torch.manual_seed(7)
+    x = (
+        torch.randn(batch, seq_len, dim, device="cuda", dtype=torch.bfloat16)
+        .transpose(1, 2)
+        .detach()
+        .requires_grad_()
+    )
+    assert x.stride(1) == 1, "these tests are about the channel-last kernel"
+    weight = torch.randn(dim, width, device="cuda", dtype=torch.float32, requires_grad=True)
+    bias = torch.randn(dim, device="cuda", dtype=torch.float32, requires_grad=True)
+    grad = torch.randn(batch, seq_len, dim, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    return x, weight, bias, grad
+
+
+def _conv_backward(x, weight, bias, grad):
+    out = causal_conv1d_fn(x=x, weight=weight, bias=bias, activation="silu")
+    return torch.autograd.grad(out, (x, weight, bias), grad_outputs=grad)
+
+
+def _build_mixer(deterministic_mode=True):
+    """A bare MambaMixer on the suite's shared hybrid config."""
+    Utils.initialize_model_parallel()
+    model_parallel_cuda_manual_seed(123)
+    config = TransformerConfig(
+        **(hybrid_base() | {"num_layers": 1, "deterministic_mode": deterministic_mode})
+    )
+    mixer = MambaMixer(
+        config,
+        hybrid_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
+        config.hidden_size,
+        layer_number=1,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
+    )
+    return mixer.cuda()
+
+
+def _fake_min_version(monkeypatch, supported):
+    monkeypatch.setattr(
+        causal_conv1d_module, "is_causal_conv1d_min_version", lambda *_a, **_kw: supported
+    )
+
+
+@requires_deterministic_conv1d
+@pytest.mark.parametrize("deterministic", [False, True])
+def test_kernel_replays_bitwise(monkeypatch, deterministic):
+    """The channel-last backward replays bit-for-bit only under the deterministic reduction.
+
+    The ``False`` arm asserts that the hardware is nondeterministic, so it is sized with
+    margin: 64 contending blocks, against 19 of 19 replays differing on GB300 at 16. ``dx`` is
+    written by disjoint stores, not the reduction, so it is reproducible either way. The env
+    var is read on each backward call.
+    """
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1" if deterministic else "0")
+    replays = 8
+    inputs = _channel_last_conv_inputs(**_KERNEL_SHAPE)
+    first, differing = None, dict.fromkeys(GRAD_NAMES, 0)
+    for _ in range(replays):
+        got = _conv_backward(*inputs)
+        if first is None:
+            first = got
+            continue
+        for name, ref, cur in zip(GRAD_NAMES, first, got):
+            differing[name] += not torch.equal(ref, cur)
+
+    assert differing["dx"] == 0
+    if deterministic:
+        assert differing["dweight"] == 0 and differing["dbias"] == 0
+    else:
+        assert differing["dweight"] > 0, (
+            f"the default channel-last backward was bit-reproducible over {replays} replays. "
+            "Either upstream made it deterministic -- in which case drop this control -- or "
+            "this GPU serialized the contending blocks, which the shape above is meant to "
+            "prevent."
+        )
+
+
+@requires_deterministic_conv1d
+def test_deterministic_reduction_agrees_with_the_default_one(monkeypatch):
+    """The deterministic path must reorder the same sum, not compute a different one.
+
+    Two summation orders cannot be bitwise equal in fp32, so the bar is the gap relative to
+    each tensor's own magnitude: measured ~6e-07, a few ulps, against a 1e-5 bound. ``rtol=0``
+    with the magnitude in ``atol`` because per element the gap reaches ~1e-2, where a
+    ``dweight`` entry near zero cancels much larger products. ``dx`` skips the reduction.
+    """
+    inputs = _channel_last_conv_inputs(**_KERNEL_SHAPE)
+
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "0")
+    default = _conv_backward(*inputs)
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
+    deterministic = _conv_backward(*inputs)
+
+    for name, ref, got in zip(GRAD_NAMES, default, deterministic):
+        if name == "dx":
+            assert torch.equal(ref, got), "dx does not go through the reduction"
+            continue
+        torch.testing.assert_close(
+            got,
+            ref,
+            rtol=0,
+            atol=float(ref.abs().max()) * 1e-5,
+            msg=f"{name} moved by more than fp32 accumulation error",
+        )
+
+
+class TestMambaMixerDeterminism:
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @requires_deterministic_conv1d
+    def test_mixer_replays_bit_exactly(self, monkeypatch):
+        """Two runs of one mixer agree bitwise under the deterministic conv reduction.
+
+        ``MAMBA_DETERMINISTIC`` pins the SSD scan, whose nondeterminism would otherwise reach
+        the conv weight gradient, so a failure points at the convolution.
+        """
+        monkeypatch.setenv("MAMBA_DETERMINISTIC", "1")
+        monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
+        mixer = _build_mixer()
+        hidden_size = mixer.config.hidden_size
+        torch.manual_seed(7)
+        hidden_states = torch.randn(_SEQ_LEN, _MICRO_BATCH, hidden_size, device="cuda")
+        grad = torch.randn(_SEQ_LEN, _MICRO_BATCH, hidden_size, device="cuda")
+
+        def fwd_bwd():
+            output, _ = mixer(hidden_states)
+            output.backward(grad)
+            return output.detach().clone(), collect_grads([mixer])
+
+        state = capture_rng_state()
+        out_a, grads_a = fwd_bwd()
+        # Drain run A's collectives and autograd post-hooks, as BitExactRunner._two_runs does;
+        # otherwise B overlaps A's tail.
+        torch.cuda.synchronize()
+        restore_rng_state(state)
+        zero_grads(mixer)
+        out_b, grads_b = fwd_bwd()
+
+        assert_bit_exact(out_a, grads_a, out_b, grads_b)
+
+    @pytest.mark.skipif(not HAVE_CAUSAL_CONV1D, reason="causal_conv1d is not installed")
+    def test_deterministic_mode_requires_a_deterministic_conv(self, monkeypatch):
+        """``MambaMixer.__init__`` actually calls the guard, so a disabled reduction raises."""
+        monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "0")
+        with pytest.raises(AssertionError, match="deterministic causal_conv1d backward"):
+            _build_mixer(deterministic_mode=True)
+
+
+@pytest.mark.parametrize("env", ["1", None])
+def test_guard_accepts_an_enabled_kernel(monkeypatch, env):
+    """Both ways the kernel can be enabled: the env var, and the torch flag it falls back to.
+
+    ``None`` is what ``--deterministic-mode`` produces: env unset plus
+    ``torch.use_deterministic_algorithms(True)``.
+    """
+    monkeypatch.setattr(torch, "are_deterministic_algorithms_enabled", lambda: True)
+    if env is None:
+        monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
+    else:
+        monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", env)
+    _fake_min_version(monkeypatch, True)
+    assert_causal_conv1d_deterministic(deterministic_mode=True)
+
+
+def test_guard_rejects_what_cannot_deliver_it(monkeypatch):
+    """Both failure modes raise; neither is inherited from torch's flag alone, which unrelated
+    tests set globally and never restore."""
+    _fake_min_version(monkeypatch, True)
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "0")
+    with pytest.raises(AssertionError, match="deterministic causal_conv1d backward"):
+        assert_causal_conv1d_deterministic(deterministic_mode=True)
+
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
+    _fake_min_version(monkeypatch, False)
+    with pytest.raises(AssertionError, match="is required for deterministic_mode"):
+        assert_causal_conv1d_deterministic(deterministic_mode=True)
+
+    # Same state, but the run never asked: must return rather than raise.
+    monkeypatch.setattr(torch, "are_deterministic_algorithms_enabled", lambda: True)
+    assert_causal_conv1d_deterministic(deterministic_mode=False)

--- a/tests/unit_tests/ssm/test_gated_delta_product.py
+++ b/tests/unit_tests/ssm/test_gated_delta_product.py
@@ -8,8 +8,9 @@ subgraph from the same saved input. So enabling it must not move the numerics at
 Any drift would mean the replay observed a different weight, a different RNG state, or
 a stale storage after the output-discarding checkpoint shared the recomputed one back.
 
-The one exception is `conv1d.weight`, see NONDETERMINISTIC_PARAMS below: its gradient is
-not reproducible run to run, for reasons that have nothing to do with recompute.
+`conv1d.weight` used to be exempt, because the conv backward reduced it with atomicAdd. The
+fixture below turns on the kernel's deterministic reduction instead, so it is held to the same
+bitwise bar as everything else.
 """
 
 import pytest
@@ -99,35 +100,20 @@ def _run(mixer, hidden_states, grads):
     return out.detach().clone(), x.grad.clone(), param_grads
 
 
-# `causal_conv1d_fn` accumulates its weight gradient across blocks with atomicAdd on the
-# channels-last layout the mixer feeds it, so the reduction order -- and with it the
-# last-place rounding -- varies from launch to launch. Two runs of the *same* mixer can
-# therefore disagree on this tensor. It is unrelated to recompute and to FP8: it
-# reproduces with recompute disabled, in plain BF16, and the conv sees the identical
-# layout and dtypes either way. Everything else here must still match bitwise, so scope
-# the tolerance to this one tensor rather than loosening the whole comparison.
-NONDETERMINISTIC_PARAMS = ("conv1d.weight",)
+@pytest.fixture(autouse=True)
+def deterministic_conv1d(monkeypatch):
+    """Hold the conv backward to its deterministic reduction for every test in this module.
 
-
-def _assert_grad_matches(name, recomputed_grad, base_grad):
-    """Compare one gradient: bitwise, unless the kernel that produced it is unstable."""
-    if name in NONDETERMINISTIC_PARAMS:
-        # Reordering shifts an element by a few ulps of its own value, so the budget is
-        # relative: BF16 carries 8 mantissa bits, so 2**-6 is four ulps. atol only has to
-        # cover elements too close to zero for rtol to mean anything, and is derived from
-        # the tensor's magnitude so it cannot go stale if these tests change shape.
-        atol = float(base_grad.abs().max()) * 2**-11
-        torch.testing.assert_close(
-            recomputed_grad, base_grad, rtol=2**-6, atol=atol, msg=f"{name} gradient drifted"
-        )
-    else:
-        torch.testing.assert_close(
-            recomputed_grad, base_grad, rtol=0, atol=0, msg=f"{name} gradient drifted"
-        )
+    Without it, `causal_conv1d_fn` accumulates its weight gradient across blocks with atomicAdd
+    on the channel-last layout the mixer feeds it, so two runs of the *same* mixer disagree on
+    `conv1d.weight` and a parity test has to tolerate a drifting gradient. Set per-test rather
+    than process-wide because the env var is read on each backward call.
+    """
+    monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
 
 
 def _assert_replay_matches(baseline, recomputed):
-    """Compare a (output, input grad, param grads) triple; exact but for the conv weight."""
+    """Compare a (output, input grad, param grads) triple; every tensor bitwise."""
     base_out, base_input_grad, base_param_grads = baseline
     recomp_out, recomp_input_grad, recomp_param_grads = recomputed
 
@@ -137,7 +123,9 @@ def _assert_replay_matches(baseline, recomputed):
     )
     assert set(recomp_param_grads) == set(base_param_grads)
     for name, base_grad in base_param_grads.items():
-        _assert_grad_matches(name, recomp_param_grads[name], base_grad)
+        torch.testing.assert_close(
+            recomp_param_grads[name], base_grad, rtol=0, atol=0, msg=f"{name} gradient drifted"
+        )
 
 
 @pytest.mark.skipif(not HAVE_GDP_DEPS, reason="requires mamba-ssm, einops, causal-conv1d and FLA")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
As titled add determinism support for (channel-last) conv1d

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
