### PR TITLE
Support meta-device initialization in MFSDP v2

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -60,6 +60,7 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -608,6 +609,52 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 module, mesh=dp_mesh, placements=placements, mixed_precision_policy=self.mp_policy
             )
         super().__init__(config=config, module=module)
+        if config.init_model_with_meta_device:
+            self._reset_parameters_for_meta_device_init()
+
+    def _reset_parameters_for_meta_device_init(self) -> None:
+        """Initialize meta-device parameters one FSDP unit at a time.
+
+        ``fully_shard`` materializes sharded buffers for meta parameters without
+        initializing their values. For each FSDP unit, materialize its full
+        parameters, invoke each direct parameter owner's reset method once, copy
+        the initialized values into the sharded optimizer and compute buffers,
+        and release the full parameters before processing the next unit.
+        """
+        for fsdp_module in self.module.modules():
+            if not isinstance(fsdp_module, FsdpModule):
+                continue
+
+            fsdp_module._unshard_parameter_groups()
+            if fsdp_module._unshard_event is not None:
+                fsdp_module.context.current_stream().wait_event(fsdp_module._unshard_event)
+
+            parameter_owners = []
+            seen_parameter_owners = set()
+            for group in fsdp_module.parameter_groups:
+                for fsdp_parameter in group.fsdp_parameters:
+                    parameter_fqn = fsdp_parameter.fqns[0]
+                    module_fqn, separator, _ = parameter_fqn.rpartition(".")
+                    owner = fsdp_module.get_submodule(module_fqn) if separator else fsdp_module
+                    if owner not in seen_parameter_owners:
+                        seen_parameter_owners.add(owner)
+                        parameter_owners.append(owner)
+
+            for owner in parameter_owners:
+                if hasattr(owner, "reset_parameters"):
+                    owner.reset_parameters()
+                elif hasattr(owner, "_reset_parameters"):
+                    owner._reset_parameters()
+                else:
+                    raise ValueError(
+                        "MFSDP v2 meta-device initialization requires every direct "
+                        f"parameter owner to define reset_parameters() or _reset_parameters(); "
+                        f"{type(owner).__name__} defines neither."
+                    )
+
+            for group in fsdp_module.parameter_groups:
+                group.sync_model_weight_from_unsharded_weight()
+            fsdp_module._reshard_parameter_groups()
 
     @staticmethod
     def _validate_config(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -274,6 +274,30 @@ class FsdpParameterGroup:
             self.model_weight.placements, out=self.model_weight
         )
 
+    def sync_model_weight_from_unsharded_weight(self) -> None:
+        """Copy an initialized full weight into the sharded persistent buffers.
+
+        Meta-device initialization runs independently on every rank. Broadcast
+        the full weight from coordinate zero along each mesh axis before
+        redistributing it into the optimizer and compute-weight layouts so all
+        replicas start from identical values.
+        """
+        unsharded = self._unsharded_model_weight
+        for mesh_dim in range(self.mesh.ndim):
+            group = self.mesh.get_group(mesh_dim=mesh_dim)
+            if torch.distributed.get_world_size(group) == 1:
+                continue
+            src_rank = torch.distributed.get_global_rank(group, 0)
+            torch.distributed.broadcast(unsharded.local_buffer, src=src_rank, group=group)
+
+        if self.main_weight is not self.model_weight:
+            unsharded.cast(self.main_weight.dtype).redistribute(
+                self.main_weight.placements, out=self.main_weight
+            )
+        unsharded.cast(self.model_weight.dtype).redistribute(
+            self.model_weight.placements, out=self.model_weight
+        )
+
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
         with self._symmetric_memory_context():

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -30,6 +30,39 @@ from tests.unit_tests.test_utilities import Utils
 logger = logging.getLogger(__name__)
 
 
+class _RankInitializedLinear(torch.nn.Linear):
+    """Linear whose CUDA reset values identify the rank that initialized it."""
+
+    def reset_parameters(self) -> None:
+        if self.weight.is_meta:
+            return
+        rank = torch.distributed.get_rank()
+        with torch.no_grad():
+            self.weight.fill_(rank + 2)
+            if self.bias is not None:
+                self.bias.fill_(rank + 3)
+
+
+class _RankInitializedModel(torch.nn.Module):
+    """Exercise reset methods on both an FSDP root and a nested parameter owner."""
+
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.root_bias = torch.nn.Parameter(torch.empty(hidden_size))
+        self.linear = _RankInitializedLinear(hidden_size, hidden_size)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        if self.root_bias.is_meta:
+            return
+        rank = torch.distributed.get_rank()
+        with torch.no_grad():
+            self.root_bias.fill_(rank + 1)
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        return self.linear(input_tensor) + self.root_bias
+
+
 def _build_layer(config: TransformerConfig) -> TransformerLayer:
     return TransformerLayer(
         config=config,
@@ -103,6 +136,39 @@ class TestMcoreAdapterDense:
         }
         assert child_parameter_names
         assert root_parameter_names == {"1.weight", "1.bias"}
+
+    def test_initializes_meta_device_parameters(self):
+        hidden_size = 4
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=1,
+            ffn_hidden_size=8,
+            init_model_with_meta_device=True,
+        )
+        with torch.device("meta"):
+            model = _RankInitializedModel(hidden_size)
+
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+            ),
+            module=model,
+            pg_collection=self.pg_collection,
+        )
+
+        assert all(not parameter.is_meta for parameter in model.parameters())
+        input_tensor = torch.ones(2, hidden_size, device="cuda")
+        output = model(input_tensor)
+        # Rank zero initializes weight=2, linear bias=3, and root bias=1. The
+        # adapter broadcasts those values before resharding, so every DP rank
+        # computes hidden_size * 2 + 3 + 1.
+        expected = torch.full_like(output, hidden_size * 2 + 4)
+        torch.testing.assert_close(output, expected)
 
     def test_nccl_ub_enables_symmetric_memory(self, monkeypatch):
         config = TransformerConfig(


### PR DESCRIPTION
## Summary

- initialize MFSDP v2 parameters that were constructed on the meta device
- process one FSDP unit at a time so initialization does not materialize the full model
- synchronize initialized values across each parameter mesh before updating persistent sharded buffers
- cover both root-owned and nested parameter owners with a distributed test

This change is extracted from #6484 and is independent of the 1F1B overlap integration.

## Test plan

- `python -m torch.distributed.run --standalone --nproc-per-node=4 --module pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py::TestMcoreAdapterDense::test_initializes_meta_device_parameters --experimental`
- `python -m torch.distributed.run --standalone --nproc-per-node=4 --module pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py --experimental -k 'not nccl_ub'` (5 passed, 1 deselected)

The existing `nccl_ub` test requires PyTorch 2.12 or newer and was not applicable to the PyTorch 2.11 validation environment.
