### PR TITLE
Auto TP mode for per-weight GTP mode selection in Dist Muon (dense only)

### DIFF
--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -174,6 +174,79 @@ _EMERGING_OPTIMIZERS: Dict[str, EmergingOptimizerEntry] = {}
 # ===========================================================================
 
 
+# tp_mode="auto" selects tp_mode per weight (Dense/GTP weights only)
+_AUTO_TP_MODES = ("duplicated", "distributed")
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    """HW spec for different GPU. Use for cost model when selecting TP mode.
+    Bandwidths are UNIDIRECTIONAL."""
+
+    bf16_peak_tflops: float  # dense, fp32_matmul_prec = "medium" for now
+    bw_intra_gbps: float  # collectives staying inside one NVLink domain
+    bw_inter_gbps: float  # collectives crossing domains, over the fabric
+
+
+_PROFILES = {
+    # Keys are matched as a substring of the reported device name ("NVIDIA GB200").
+    # Both bandwidths are PER GPU. Only run on GB200 & GB300 for now.
+    # TODO: May need to add other HW Spec
+    "GB200": HardwareProfile(bf16_peak_tflops=2500.0, bw_intra_gbps=900.0, bw_inter_gbps=100.0),
+    "GB300": HardwareProfile(bf16_peak_tflops=2500.0, bw_intra_gbps=900.0, bw_inter_gbps=100.0),
+}
+
+
+def _hardware_profile() -> Optional[HardwareProfile]:
+    """Profile for the local GPU, or None when the hardware is not in the registry."""
+    try:
+        name = torch.cuda.get_device_properties(0).name
+    except Exception:  # noqa: BLE001 - no CUDA device: fall back, do not fail
+        return None
+    return next((prof for key, prof in _PROFILES.items() if key in name), None)
+
+
+def _select_tp_mode(
+    m: int,
+    n: int,
+    group_size: int,
+    steps: int,
+    use_syrk: bool,
+    elem_size: int,
+    communication_crosses_domain: bool,
+    profile: Optional[HardwareProfile] = None,
+    candidates: tuple[str, ...] = _AUTO_TP_MODES,
+) -> str:
+    """Cost model for per weight tp_mode selection. Mirrors the op sequence in
+    scaled_orthogonalize_fn_with_gtp_remat -- keep in sync.
+    """
+    min_dim, max_dim = min(m, n), max(m, n)
+    m_partitioned = (
+        m // group_size
+    )  # dist orthogonalizes the [n, m/group_size] shard; transpose is forced
+    gram = 1 if use_syrk else 2  # SYRK halves the two gram ops
+    # Per NS step: gram X@X.T + gram A@A + GEMM B@X.
+    flops = {
+        "duplicated": steps
+        * (gram * (min_dim * min_dim * max_dim + min_dim**3) + 2 * min_dim * min_dim * max_dim),
+        "distributed": steps * (gram * (n * n * m_partitioned + n**3) + 2 * n * n * m_partitioned),
+    }
+    if profile is None:
+        return "duplicated" if communication_crosses_domain else min(candidates, key=flops.get)
+
+    ring_fraction = (
+        group_size - 1
+    ) / group_size  # ring: each rank moves (group_size-1)/group_size of the buffer
+    num_bytes = {
+        "duplicated": m * n * elem_size * ring_fraction,  # one all-gather
+        "distributed": steps * 2 * n * n * elem_size * ring_fraction,  # gram all-reduce per step
+    }
+    bw = (profile.bw_inter_gbps if communication_crosses_domain else profile.bw_intra_gbps) * 1e9
+    peak = profile.bf16_peak_tflops * 1e12
+    cost = {mode: flops[mode] / peak + num_bytes[mode] / bw for mode in candidates}
+    return min(candidates, key=cost.get)
+
+
 class TensorParallelMuon(OrthogonalizedOptimizer):
     """Tensor Parallel Muon optimizer."""
 
@@ -194,7 +267,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         scale_mode: str = "spectral",
         extra_scale_factor: float = 1.0,
         pg_collection: Optional[ProcessGroupCollection] = None,
-        tp_mode: Literal["blockwise", "duplicated", "distributed"] = "duplicated",
+        tp_mode: Literal["blockwise", "duplicated", "distributed", "auto"] = "duplicated",
         use_syrk: bool = False,
     ) -> None:
         if num_ns_steps < 1:
@@ -210,6 +283,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             grad: torch.Tensor,
             tp_group: torch.distributed.ProcessGroup,
             partition_dim: int | None = None,
+            tp_mode_this_group: str = tp_mode,
         ) -> torch.Tensor:
             log_single_rank(
                 logger,
@@ -230,7 +304,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
                 coefficient_type=coefficient_type,
                 tp_group=tp_group,
                 partition_dim=partition_dim,
-                tp_mode="duplicated" if tp_mode == "blockwise" else tp_mode,
+                tp_mode="duplicated" if tp_mode_this_group == "blockwise" else tp_mode_this_group,
                 **ns_kwargs,
             )
             scale_factor = get_muon_scale_factor(size[0], size[1], mode=scale_mode)
@@ -241,6 +315,12 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         self.split_qkv = split_qkv
         self.is_qkv_fn = is_qkv_fn
         self.qkv_split_shapes = qkv_split_shapes
+        # For the tp_mode="auto" cost model (_resolve_tp_mode / _select_tp_mode).
+        self.num_ns_steps = num_ns_steps
+        self.use_syrk = use_syrk
+        self.elem_size = 2 if fp32_matmul_prec == "medium" else 4  # bf16 vs tf32/fp32
+        self._tp_mode_cache: Dict[tuple, str] = {}
+        self._hw_profile = _hardware_profile() if tp_mode == "auto" else None
 
         weight_decay_method = "decoupled" if use_decoupled_weight_decay else "l2"
         # Use explicit class call instead of super() so that subclasses with
@@ -275,11 +355,38 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         """Re-append ``pad_length`` zero rows to dim 0 (no-op if ``pad_length == 0``)."""
         return torch.nn.functional.pad(t, (0, 0, 0, pad_length)) if pad_length else t
 
+    def _resolve_tp_mode(self, m: int, n: int, group_size: int) -> str:
+        """Cached per-shape mode for tp_mode="auto", dense (GTP) weights only.
+
+        communication_crosses_domain=False always: this is only called for dense weights
+        (see scaled_orthogonalize_fn_with_gtp_remat), and GTP stays inside one NVLink domain.
+        """
+        key = (m, n, group_size)
+        if key not in self._tp_mode_cache:
+            self._tp_mode_cache[key] = _select_tp_mode(
+                m,
+                n,
+                group_size,
+                self.num_ns_steps,
+                self.use_syrk,
+                self.elem_size,
+                communication_crosses_domain=False,
+                profile=self._hw_profile,
+            )
+            log_single_rank(
+                logger,
+                logging.INFO,
+                f"muon tp_mode=auto (dense): ({m}, {n}) group_size={group_size} -> "
+                f"{self._tp_mode_cache[key]}",
+            )
+        return self._tp_mode_cache[key]
+
     def scaled_orthogonalize_fn_with_gtp_remat(self, p, grad, tp_group, partition_dim):
         """Orthogonalize a (possibly GTP-sharded) momentum, then reshard.
 
         When GTP is inactive this is a plain passthrough to ``scaled_orthogonalize_fn``.
-        Otherwise, ``self.tp_mode`` controls how GTP sharding is handled:
+        Otherwise, ``mode`` (``self.tp_mode``, or resolved per-weight when
+        ``self.tp_mode == "auto"``) controls how GTP sharding is handled:
 
         - **blockwise**: orthogonalize the local GTP shard independently, no collective.
         - **duplicated**: all-gather over GTP, run whole-matrix NS (TP-aware), reshard.
@@ -301,20 +408,34 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             else None
         )
 
-        if gtp_remat_group is None or get_pg_size(gtp_remat_group) <= 1:
-            return self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
-
         # Parameters with is_gtp_weight_remat=False are not sharded along the
         # GTP process group, and do not require all-gathering prior to
         # orthogonalization.
-        if not getattr(p, 'is_gtp_weight_remat', False):
-            return self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
+        gtp_active = (
+            gtp_remat_group is not None
+            and get_pg_size(gtp_remat_group) > 1
+            and getattr(p, 'is_gtp_weight_remat', False)
+        )
+        gtp_remat_size = get_pg_size(gtp_remat_group) if gtp_active else 1
 
-        gtp_remat_size = get_pg_size(gtp_remat_group)
+        mode = self.tp_mode
+        if mode == "auto":
+            # Scoped to dense (GTP) weights for now; expert weights keep today's default.
+            mode = (
+                self._resolve_tp_mode(p.shape[0] * gtp_remat_size, p.shape[1], gtp_remat_size)
+                if gtp_active and not is_expert
+                else "duplicated"
+            )
+
+        if not gtp_active:
+            return self.scaled_orthogonalize_fn(
+                grad, tp_group, partition_dim, tp_mode_this_group=mode
+            )
+
         gtp_rank = get_pg_rank(gtp_remat_group)
         pad_length = getattr(p, 'pad_length', 0)
 
-        if self.tp_mode == "blockwise":
+        if mode == "blockwise":
             # Local block NS on this rank's GTP row-shard (shape [M/gtp_remat_size, K]):
             # partition_dim=None makes scaled_orthogonalize_fn run a plain Newton-Schulz on
             # the shard with no GTP/TP collective. pad_length can exceed one shard's row
@@ -327,17 +448,20 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
                 # Entirely padding: grad is exact zero, and NS(0) = 0.
                 return torch.zeros_like(grad)
             result = self.scaled_orthogonalize_fn(
-                self._strip_pad(grad, local_pad_length), tp_group, None
+                self._strip_pad(grad, local_pad_length), tp_group, None, tp_mode_this_group=mode
             )
             return self._restore_pad(result, local_pad_length)
 
-        if self.tp_mode == "duplicated":
+        if mode == "duplicated":
             # All-gather over GTP (dim 0), strip/restore padding exactly (every rank now
             # holds the same padded tensor), orthogonalize the whole matrix
             # (scaled_orthogonalize_fn handles any TP sharding per tp_mode), reshard dim 0.
             gathered_grad = self._all_gather_tensor(grad, gtp_remat_group, 0)
             result = self.scaled_orthogonalize_fn(
-                self._strip_pad(gathered_grad, pad_length), tp_group, partition_dim
+                self._strip_pad(gathered_grad, pad_length),
+                tp_group,
+                partition_dim,
+                tp_mode_this_group=mode,
             )
             result = self._restore_pad(result, pad_length)
             reshard_size = result.size(0) // gtp_remat_size
@@ -357,7 +481,9 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
 
         if not needs_two_step_communication:
             # GTP is the only sharding axis: distribute NS over it on the local dim-0 row shard.
-            return self.scaled_orthogonalize_fn(grad, gtp_remat_group, partition_dim=0)
+            return self.scaled_orthogonalize_fn(
+                grad, gtp_remat_group, partition_dim=0, tp_mode_this_group=mode
+            )
 
         # GTP + TP: distributed NS can only operate over one (group, dim) at a
         # time. Distribute over the larger group so that the NS GEMMs are sharded
@@ -372,7 +498,9 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             larger_group, larger_dim = tp_group, partition_dim
 
         gathered_grad = self._all_gather_tensor(grad, smaller_group, smaller_dim)
-        orthogonalized_grad = self.scaled_orthogonalize_fn(gathered_grad, larger_group, larger_dim)
+        orthogonalized_grad = self.scaled_orthogonalize_fn(
+            gathered_grad, larger_group, larger_dim, tp_mode_this_group=mode
+        )
         shard_size = orthogonalized_grad.size(smaller_dim) // get_pg_size(smaller_group)
         reshard_rank = get_pg_rank(smaller_group)
         return orthogonalized_grad.narrow(
@@ -465,7 +593,7 @@ class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):
         scale_mode: The type of scale factor to use for the update.
         extra_scale_factor: The additional scale factor to use for the update.
         pg_collection: Process group collection for distributed training.
-        tp_mode: Tensor parallel mode ("blockwise", "duplicated", or "distributed").
+        tp_mode: Tensor parallel mode ("blockwise", "duplicated", "distributed", or "auto").
         use_syrk: Whether to use the Triton SYRK kernel for the Gram matrix in
             Newton-Schulz. Requires emerging_optimizers >= 0.4.0.
         moment2_method: Method for second moment accumulation ("adamuon" or "normuon").
@@ -490,7 +618,7 @@ class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):
         scale_mode: str = "spectral",
         extra_scale_factor: float = 1.0,
         pg_collection: Optional[ProcessGroupCollection] = None,
-        tp_mode: Literal["blockwise", "duplicated", "distributed"] = "duplicated",
+        tp_mode: Literal["blockwise", "duplicated", "distributed", "auto"] = "duplicated",
         use_syrk: bool = False,
         moment2_method: Literal["adamuon", "normuon"] = "adamuon",
         beta2: float = 0.95,

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -283,7 +283,8 @@ class OptimizerConfig:
     """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes
     each shard independently, which makes the update rule depend on the parallelism config;
     "duplicated" and "distributed" both orthogonalize the whole matrix, so results do not
-    change as TP changes. Defaults to "duplicated"."""
+    change as TP changes. "auto" select between duplicated and distributed mode per-weight for
+    dense weights. Defaults to "duplicated"."""
 
     muon_use_syrk: bool = False
     """Use the Triton SYRK kernel for the Gram matrix in Newton-Schulz iteration."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2648,11 +2648,13 @@ def _add_regularization_args(parser):
     group.add_argument('--muon-num-ns-steps', type=int, default=5,
                        help='Number of Newton-Schulz steps for Muon optimizer')
     group.add_argument('--muon-tp-mode', type=str, default='duplicated',
-                       choices=['blockwise', 'duplicated', 'distributed'],
+                       choices=['blockwise', 'duplicated', 'distributed', 'auto'],
                        help='How to perform NS calculation for tensor model parallel weights. '
                        'blockwise orthogonalizes each shard on its own, so the update rule '
                        'depends on the parallelism config; duplicated and distributed both '
-                       'orthogonalize the whole matrix and give TP-invariant results.')
+                       'orthogonalize the whole matrix and give TP-invariant results; auto '
+                       'select between duplicated and distributed mode per-weight for '
+                       'dense weights.')
     group.add_argument('--muon-use-syrk', action='store_true',
                        help='Use the Triton SYRK kernel for the Gram matrix '
                        'in Newton-Schulz iteration.')

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
@@ -230,7 +230,7 @@ def _worker_gtp_blockwise(rank, world_size, port):
 class TestGTPMuonDistributedNS:
     """Distributed-NS orthogonalization matches full-matrix NS, per shard."""
 
-    @pytest.mark.parametrize("tp_mode", ["distributed", "duplicated"])
+    @pytest.mark.parametrize("tp_mode", ["distributed", "duplicated", "auto"])
     @pytest.mark.parametrize("world_size", _GTP_ONLY_WORLD_SIZES)
     def test_gtp_only_parity(self, world_size, tp_mode):
         _requires_multi_gpu(world_size)

--- a/tests/unit_tests/test_emerging_optimizers.py
+++ b/tests/unit_tests/test_emerging_optimizers.py
@@ -12,10 +12,12 @@ from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.emerging_optimizers import (
+    _PROFILES,
     HAVE_EMERGING_OPTIMIZERS,
     TensorParallelAdaptiveMuon,
     TensorParallelMuon,
     _get_qkv_split_shapes,
+    _select_tp_mode,
     get_supported_coefficient_types,
     validate_coefficient_type,
 )
@@ -64,6 +66,123 @@ class Net(nn.Module):
 # ===========================================================================
 # Muon optimizer tests
 # ===========================================================================
+
+
+def test_select_tp_mode_flops_only_fallback():
+    """Without a hardware profile, select by FLOPs or the cross-domain fallback."""
+    assert (
+        _select_tp_mode(
+            m=8192,
+            n=1024,
+            group_size=8,
+            steps=5,
+            use_syrk=False,
+            elem_size=2,
+            communication_crosses_domain=False,
+            profile=None,
+        )
+        == "distributed"
+    )
+    assert (
+        _select_tp_mode(
+            m=8192,
+            n=1024,
+            group_size=8,
+            steps=5,
+            use_syrk=False,
+            elem_size=2,
+            communication_crosses_domain=True,
+            profile=None,
+        )
+        == "duplicated"
+    )
+
+
+def test_select_tp_mode_with_profile():
+    """A hardware profile selects different modes for tall and wide matrices."""
+    profile = _PROFILES["GB200"]
+
+    assert (
+        _select_tp_mode(
+            m=8192,
+            n=1024,
+            group_size=8,
+            steps=5,
+            use_syrk=False,
+            elem_size=2,
+            communication_crosses_domain=False,
+            profile=profile,
+        )
+        == "distributed"
+    )
+    assert (
+        _select_tp_mode(
+            m=1024,
+            n=8192,
+            group_size=8,
+            steps=5,
+            use_syrk=False,
+            elem_size=2,
+            communication_crosses_domain=False,
+            profile=profile,
+        )
+        == "duplicated"
+    )
+
+
+def test_select_tp_mode_syrk_changes_selection():
+    """SYRK halves the Gram-op cost differently per mode -- can flip the selected mode."""
+    assert (
+        _select_tp_mode(
+            m=640,
+            n=1024,
+            group_size=8,
+            steps=5,
+            use_syrk=False,
+            elem_size=2,
+            communication_crosses_domain=False,
+            profile=None,
+        )
+        == "duplicated"
+    )
+    assert (
+        _select_tp_mode(
+            m=640,
+            n=1024,
+            group_size=8,
+            steps=5,
+            use_syrk=True,
+            elem_size=2,
+            communication_crosses_domain=False,
+            profile=None,
+        )
+        == "distributed"
+    )
+
+
+def test_resolve_tp_mode_caches(monkeypatch):
+    """Repeated resolution of the same shape invokes the cost model only once."""
+    call_count = 0
+
+    def mock_select_tp_mode(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        return "distributed"
+
+    monkeypatch.setattr(
+        "megatron.core.optimizer.emerging_optimizers._select_tp_mode", mock_select_tp_mode
+    )
+
+    optimizer = TensorParallelMuon(
+        params=[torch.nn.Parameter(torch.zeros(1))], tp_mode="auto", pg_collection=None
+    )
+
+    first = optimizer._resolve_tp_mode(4096, 1024, 8)
+    second = optimizer._resolve_tp_mode(4096, 1024, 8)
+
+    assert first == second == "distributed"
+    assert call_count == 1
+    assert list(optimizer._tp_mode_cache) == [(4096, 1024, 8)]
 
 
 def test_muon_qkv_split_shapes():
@@ -119,7 +238,7 @@ def test_muon_optimizer_gtp_remat_pad_length_scale_correction(monkeypatch, tp_mo
 
     calls = []
 
-    def fake_orthogonalize(grad, tp_group, partition_dim=None):
+    def fake_orthogonalize(grad, tp_group, partition_dim=None, tp_mode_this_group=None):
         calls.append((grad.clone(), tp_group, partition_dim))
         return grad + 100
 
@@ -183,7 +302,7 @@ def test_muon_optimizer_gtp_remat_blockwise_pad_spans_multiple_ranks(
 
     calls = []
 
-    def fake_orthogonalize(grad, tp_group, partition_dim=None):
+    def fake_orthogonalize(grad, tp_group, partition_dim=None, tp_mode_this_group=None):
         calls.append(grad.clone())
         return grad  # identity: makes the strip/restore round-trip directly checkable
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds `tp_mode="auto"` to select between duplicated and distributed Newton–Schulz execution per dense GTP weight using a shape- and hardware-aware cost model.

## Motivation

No single Muon TP mode performs best for every weight:

- `duplicated` all-gathers the full matrix and runs Newton–Schulz using the smaller matrix dimension.
- `distributed` keeps the GTP shard and avoids redundant full-matrix computation, but its forced transpose may produce a larger Gram matrix and requires extra all-reduce during each NS step.

The best choice depends on the global matrix shape, GTP group size, number of NS steps, selected kernel, and communication bandwidth.

## Implementation

This PR:

- Adds `auto` as a valid value for `--muon-tp-mode`.
- Introduces a cost model that compares projected duplicated and distributed execution time.
- Accounts for:
  - Newton–Schulz GEMM FLOPs;
  - SYRK usage;
  - all-gather versus per-step Gram all-reduce traffic;
  - GTP group size;
  - BF16 versus FP32 element size;
  - intra-domain communication bandwidth.
- Adds hardware profiles for GB200 and GB300.
- Falls back to a FLOPs-only comparison when the GPU is not in the hardware-profile registry.
- Resolves the mode once per distinct `(M, N, GTP size)` shape and caches the result.
- Logs the selected mode for each new dense weight shape.
- Leaves existing explicit `blockwise`, `duplicated`, and `distributed` behavior unchanged.

The initial scope is dense GTP weights. Expert weights continue using the existing duplicated fallback when `auto` is selected.

## Compatibility

This feature is opt-in. Existing configurations are unaffected unless:

```text
--muon-tp-mode auto
```

is specified.

## Issue tracking

Depends on: #6380

This work builds on PR #6380. Commit ead6625 was from PR #6380, and cherry-picked into this branch to support development and validation. PR #6380 must merge first; afterward, this branch will be rebased onto main so this PR contains only the tp_mode="auto" changes (commit 1a9bbe9).

## Contribution process

### Validation

- [x] Verify cost-model decisions for representative dense weight shapes
- [x] Verify fallback behavior on GPUs without a registered hardware profile
- [x] Verify explicit TP modes remain unchanged
- [x] Verify expert weights retain the duplicated fallback

### Performance results

- [x] On a 128-GPU GB200 Nemotron-3 Ultra-scale workload, `tp_mode="auto"` reduced Dist-Muon runtime from **1,736 ms to 1,115 ms** versus duplicated-only mode—a 35.8% reduction (1.56× speedup).
- [x] On the 12K-GPU GB300 Nemotron-4 Dist-Muon proxy benchmark, it reduced **dense** dist_muon runtime from **94.7 ms to 81.3 ms**—a 14.2% reduction (1.16× speedup).
