### PR TITLE
[Dev] Integrate FSDP prefetch and dense-inner UBR for combined 1F1B

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -190,6 +190,15 @@ class DistributedDataParallelConfig:
       when nccl_ub is set.
     """
 
+    fsdp_ubr_registration_scope: str = 'all'
+    """Communicator scope for FSDP NCCL user-buffer registration.
+
+    ``all`` preserves the default behavior and registers dense, expert, independent
+    all-gather, and outer-DP groups. ``dense_inner`` registers only the communicator
+    used by dense inner-FSDP parameter all-gathers; expert and outer-DP collectives
+    remain unregistered and use ordinary NCCL kernels.
+    """
+
     fsdp_manual_registration: bool = False
     """If true, manually register the FSDP communication buffers to NCCL user buffer.
       This option is only effective when use_megatron_fsdp and nccl_ub is set.
@@ -281,6 +290,11 @@ class DistributedDataParallelConfig:
         import os
 
         """Check the validity of the config."""
+        if self.fsdp_ubr_registration_scope not in ("all", "dense_inner"):
+            raise ValueError(
+                "fsdp_ubr_registration_scope must be one of: all, dense_inner; "
+                f"got {self.fsdp_ubr_registration_scope!r}."
+            )
         if self.reuse_grad_buf_for_mxfp8_param_ag:
             assert self.fp8_param_gather, "Reuse grad buffer only when keeping params in MXFP8."
 

--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -152,6 +152,13 @@ class DistributedDataParallelConfig:
       This option will be automatically set to True when nccl_ub=True.
     """
 
+    fsdp_buffer_count: int = 2
+    """Number of persistent buffers allocated for each Megatron FSDP communication pool.
+      The default of two preserves the conventional double-buffer behavior. Combined 1F1B
+      overlap may require three buffers because a backward/recompute unit, the current
+      forward unit, and its forward-prefetched successor can be live concurrently.
+    """
+
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False
     """Whether to fall back to persistent buffer when a bucket does not
        fit FSDP double buffer size. If true, FSDP will use the persistently 
@@ -311,3 +318,4 @@ class DistributedDataParallelConfig:
         if self.megatron_fsdp_max_pool_double_buffer:
             # MaxPoolAllocator is a type of double-buffer allocator.
             self.fsdp_double_buffer = True
+        assert self.fsdp_buffer_count >= 2, "fsdp_buffer_count must be at least 2."

--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -229,7 +229,9 @@ class DistributedDataParallelConfig:
 
     megatron_fsdp_prefetch_recompute_forward_weights: bool = False
     """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
-      recomputation during backward before prefetching backward transpose weights.
+      recomputation during backward. Full-layer recomputation prefetches them from
+      the unit pre-backward hook; selective ``mla_up_proj`` recomputation prefetches
+      only the marked up-projection modules.
     """
 
     megatron_fsdp_cache_param_bucket_views: bool = False

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -233,6 +233,9 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.zero_grad_buffer = self.module.zero_grad_buffer
         self.broadcast_params = self.module.broadcast_params
         self.synchronize_param_gather = self.module.synchronize_param_gather
+        self.prefetch_recompute_forward_parameters = (
+            self.module.prefetch_recompute_forward_parameters
+        )
         self.module.state_dict_for_save_checkpoint = self.module.state_dict
         self.state_dict_for_save_checkpoint = self.state_dict
         self.module.config = config

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -167,10 +167,13 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self._annotate_tensor_parallelism(module)
 
         if config.overlap_moe_expert_parallel_comm:
-            assert not ddp_config.fsdp_double_buffer, (
-                "1F1B overlap with FSDP does not support double buffer. "
-                "Please set fsdp_double_buffer=False in the ddp config."
-            )
+            if ddp_config.fsdp_double_buffer:
+                assert ddp_config.fsdp_buffer_count >= 3, (
+                    "1F1B overlap with persistent Megatron-FSDP communication buffers "
+                    "requires fsdp_buffer_count >= 3. A backward/recompute unit, the "
+                    "current forward unit, and its forward-prefetched successor can be "
+                    "live concurrently."
+                )
             assert config.cuda_graph_impl in ("none", "full_iteration"), (
                 "1F1B overlap with FSDP does not support per-layer CUDA graphs "
                 f"(cuda_graph_impl={config.cuda_graph_impl!r}). "

--- a/megatron/core/distributed/fsdp/src/README.md
+++ b/megatron/core/distributed/fsdp/src/README.md
@@ -160,8 +160,10 @@ Megatron-FSDP's `fully_shard_*` API has a comprehensive set of arguments for fin
     - Defaults to `False`, but will be automatically enabled in Megatron-LM.
 - `disable_symmetric_registration` will disable NCCL window (i.e. symmetric) registration when using `nccl_ub`. 
     - Defaults to `False`.
-- `fsdp_double_buffer` will use persistently allocated double buffers for temporarily-defined memory needed in `MegatronFSDP` communications. Having persistent double buffers may increase peak VRAM utilization, but is required to register NCCL user buffers (`nccl_ub=True`) for `MegatronFSDP`. Currently, this is only supported for simple repetitive model structures such as GPT.
+- `fsdp_double_buffer` will use persistently allocated buffers for temporarily-defined memory needed in `MegatronFSDP` communications. Having persistent buffers may increase peak VRAM utilization, but is required to register NCCL user buffers (`nccl_ub=True`) for `MegatronFSDP`.
     - Defaults to `False`. Automatically overridden to `True` when `nccl_ub` is enabled.
+- `fsdp_buffer_count` controls the number of persistent buffers in each FSDP communication pool.
+    - Defaults to two. Combined 1F1B overlap with forward prefetch requires at least three because a backward/recompute unit, the current forward unit, and its prefetched successor can be live concurrently.
 - `maxpool_double_buffer` will use a max-pooling algorithm to build a sufficient pool of buffers that can support all layers of hybrid / asymmetrical model architectures like Nemotron.
     - Defaults to `False`. Highly-recommended for hybrid architectures when using `fsdp_double_buffer=True` to double-buffer every layer of the model.
 - `preproc_state_dict_for_dcp_ckpt` adds `model.state_dict()` and `optimizer.state_dict()` post-hooks that modify the model and optimizer state in preparation for `torch.distributed.checkpoint.{save,load}` ([Torch DCP](https://docs.pytorch.org/docs/stable/distributed.checkpoint.html)) checkpointing. Specifically, it adds `__create_write_items__` and `__create_chunk_list__` methods to Tensors utilized by Torch DCP to redistribute parameters when saving and loading model and optimizer checkpoints. Can be deactivated should the user need a custom distributed checkpointing strategy.

--- a/megatron/core/distributed/fsdp/src/README.md
+++ b/megatron/core/distributed/fsdp/src/README.md
@@ -160,6 +160,18 @@ Megatron-FSDP's `fully_shard_*` API has a comprehensive set of arguments for fin
     - Defaults to `False`, but will be automatically enabled in Megatron-LM.
 - `disable_symmetric_registration` will disable NCCL window (i.e. symmetric) registration when using `nccl_ub`. 
     - Defaults to `False`.
+- `fsdp_ubr_registration_scope` controls which FSDP communicators register the NCCL
+  memory pool. `all` preserves the default dense/expert/outer registration behavior.
+  `dense_inner` registers only the communicator used by dense inner-FSDP parameter
+  all-gathers; expert and outer-DP collectives remain unregistered and use ordinary
+  NCCL kernels. It also isolates dense parameter and transpose-parameter MaxPool
+  storage from the ordinary expert pool so rank-dependent expert traffic cannot change
+  the registered pool's physical segment order, then packs the registered dense buffers
+  into one aligned arena so their offsets and the single physical registration segment
+  are identical across ranks. This is useful when dense inner AG dominates communication
+  and the outer-DP payload is small. The isolated-pool path requires
+  `maxpool_double_buffer=True`.
+    - Defaults to `all`.
 - `fsdp_double_buffer` will use persistently allocated buffers for temporarily-defined memory needed in `MegatronFSDP` communications. Having persistent buffers may increase peak VRAM utilization, but is required to register NCCL user buffers (`nccl_ub=True`) for `MegatronFSDP`.
     - Defaults to `False`. Automatically overridden to `True` when `nccl_ub` is enabled.
 - `fsdp_buffer_count` controls the number of persistent buffers in each FSDP communication pool.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -83,6 +83,13 @@ class DistributedDataParallelConfig:
       This option will be automatically set to True when nccl_ub=True.
     """
 
+    fsdp_buffer_count: int = 2
+    """Number of persistent buffers allocated for each Megatron FSDP communication pool.
+      The default of two preserves the conventional double-buffer behavior. Combined 1F1B
+      overlap may require three buffers because a backward/recompute unit, the current
+      forward unit, and its forward-prefetched successor can be live concurrently.
+    """
+
     fsdp_all_gather_in_start_param_sync: bool = True
     """
     If True, use all-gather during the initial Megatron-FSDP parameter
@@ -218,3 +225,4 @@ class DistributedDataParallelConfig:
         if self.megatron_fsdp_max_pool_double_buffer:
             # MaxPoolAllocator is a type of double-buffer allocator.
             self.fsdp_double_buffer = True
+        assert self.fsdp_buffer_count >= 2, "fsdp_buffer_count must be at least 2."

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -157,7 +157,9 @@ class DistributedDataParallelConfig:
 
     megatron_fsdp_prefetch_recompute_forward_weights: bool = False
     """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
-      recomputation during backward before prefetching backward transpose weights.
+      recomputation during backward. Full-layer recomputation prefetches them from
+      the unit pre-backward hook; selective ``mla_up_proj`` recomputation prefetches
+      only the marked up-projection modules.
     """
 
     megatron_fsdp_cache_param_bucket_views: bool = False

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -121,6 +121,14 @@ class DistributedDataParallelConfig:
       when nccl_ub is set.
     """
 
+    fsdp_ubr_registration_scope: str = 'all'
+    """Communicator scope for FSDP NCCL user-buffer registration.
+
+    ``all`` registers every supported FSDP communicator. ``dense_inner`` registers
+    only dense inner-FSDP parameter all-gathers, leaving expert and outer-DP
+    collectives on ordinary NCCL kernels.
+    """
+
     fsdp_manual_registration: bool = False
     """If true, manually register the FSDP communication buffers to NCCL user buffer.
       This option is only effective when use_megatron_fsdp and nccl_ub is set.
@@ -209,6 +217,11 @@ class DistributedDataParallelConfig:
         import os
 
         """Check the validity of the config."""
+        if self.fsdp_ubr_registration_scope not in ("all", "dense_inner"):
+            raise ValueError(
+                "fsdp_ubr_registration_scope must be one of: all, dense_inner; "
+                f"got {self.fsdp_ubr_registration_scope!r}."
+            )
         if self.megatron_fsdp_prefetch_recompute_forward_weights:
             assert self.data_parallel_sharding_strategy == "optim_grads_params", (
                 "megatron_fsdp_prefetch_recompute_forward_weights is only supported with "

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
@@ -91,6 +91,7 @@ def fully_shard_model(
     fsdp_buffer_count: int = 2,
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
+    fsdp_ubr_registration_scope: str = 'all',
     enable_fine_grained_param_gather: bool = False,
     prefetch_recompute_forward_weights: bool = False,
     cache_param_bucket_views: bool = False,
@@ -252,6 +253,11 @@ def fully_shard_model(
             This option forces conventional (local) UB registration when nccl_ub is set.
             Defaults to False.
 
+        fsdp_ubr_registration_scope (str):
+            FSDP communicator scope for NCCL user-buffer registration. ``all`` preserves
+            the default behavior; ``dense_inner`` registers only dense inner-FSDP
+            parameter all-gathers. Defaults to ``all``.
+
         enable_fine_grained_param_gather (bool):
             Whether to enable "fine-grained" param all-gather, which can improve performance
             when using MXFP8 parameters with activation recomputation. Specifically, it
@@ -394,6 +400,7 @@ def fully_shard_model(
         fsdp_buffer_count=fsdp_buffer_count,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
+        fsdp_ubr_registration_scope=fsdp_ubr_registration_scope,
         megatron_fsdp_prefetch_recompute_forward_weights=prefetch_recompute_forward_weights,
         megatron_fsdp_cache_param_bucket_views=cache_param_bucket_views,
         megatron_fsdp_use_decoupled_grad=use_decoupled_grad,
@@ -704,6 +711,7 @@ def fully_shard(
     fsdp_buffer_count: int = 2,
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
+    fsdp_ubr_registration_scope: str = 'all',
     enable_fine_grained_param_gather: bool = False,
     prefetch_recompute_forward_weights: bool = False,
     cache_param_bucket_views: bool = False,
@@ -760,6 +768,7 @@ def fully_shard(
         fsdp_buffer_count=fsdp_buffer_count,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
+        fsdp_ubr_registration_scope=fsdp_ubr_registration_scope,
         enable_fine_grained_param_gather=enable_fine_grained_param_gather,
         prefetch_recompute_forward_weights=prefetch_recompute_forward_weights,
         cache_param_bucket_views=cache_param_bucket_views,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/fully_shard.py
@@ -88,6 +88,7 @@ def fully_shard_model(
     keep_fp8_transpose_cache: bool = False,
     nccl_ub: bool = False,
     fsdp_double_buffer: bool = False,
+    fsdp_buffer_count: int = 2,
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
     enable_fine_grained_param_gather: bool = False,
@@ -238,6 +239,10 @@ def fully_shard_model(
         fsdp_double_buffer (bool):
             Whether to use double buffer for FSDP. Defaults to False.
 
+        fsdp_buffer_count (int):
+            Number of persistent buffers allocated for each FSDP communication pool.
+            Defaults to two.
+
         fsdp_db_use_persist_buf_on_alloc_fail (bool):
             Whether to fall back to persistent buffer allocator when a bucket does not
             fit FSDP double buffer size.
@@ -386,6 +391,7 @@ def fully_shard_model(
         keep_fp8_transpose_cache=keep_fp8_transpose_cache,  # pylint: disable=C0301
         nccl_ub=nccl_ub,
         fsdp_double_buffer=fsdp_double_buffer or nccl_ub,
+        fsdp_buffer_count=fsdp_buffer_count,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
         megatron_fsdp_prefetch_recompute_forward_weights=prefetch_recompute_forward_weights,
@@ -695,6 +701,7 @@ def fully_shard(
     keep_fp8_transpose_cache: bool = False,
     nccl_ub: bool = False,
     fsdp_double_buffer: bool = False,
+    fsdp_buffer_count: int = 2,
     fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
     disable_symmetric_registration: bool = False,
     enable_fine_grained_param_gather: bool = False,
@@ -750,6 +757,7 @@ def fully_shard(
         keep_fp8_transpose_cache=keep_fp8_transpose_cache,
         nccl_ub=nccl_ub,
         fsdp_double_buffer=fsdp_double_buffer,
+        fsdp_buffer_count=fsdp_buffer_count,
         fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
         disable_symmetric_registration=disable_symmetric_registration,
         enable_fine_grained_param_gather=enable_fine_grained_param_gather,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -165,6 +165,9 @@ class MegatronFSDP(torch.nn.Module):
         disable_symmetric_registration (bool): Whether to disable symmetric (window) registration
             for NCCL userbuffer registration. This option will force to use conventional (local)
             userbuffer registration when nccl_ub is set.
+        fsdp_ubr_registration_scope (str): FSDP communicator scope for NCCL user-buffer
+            registration. ``all`` preserves the default behavior; ``dense_inner`` registers
+            only dense inner-FSDP parameter all-gathers.
         enable_fine_grained_param_gather (bool): Whether to enable "fine-grained" param all-gather,
             which can improve performance when using MXFP8 parameters with activation recomputation.
         enable_fine_grained_param_gather_backward_hook (bool): Register pre-backward unshard hooks
@@ -212,6 +215,7 @@ class MegatronFSDP(torch.nn.Module):
         fsdp_buffer_count: int = 2,
         fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
         disable_symmetric_registration: bool = False,
+        fsdp_ubr_registration_scope: str = 'all',
         enable_fine_grained_param_gather_hook: bool = False,
         enable_fine_grained_param_gather_backward_hook: bool = False,
         fine_grained_recurse_module_types: Optional[Tuple[Type[nn.Module], ...]] = None,
@@ -259,6 +263,7 @@ class MegatronFSDP(torch.nn.Module):
                 fsdp_buffer_count=fsdp_buffer_count,
                 fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
                 disable_symmetric_registration=disable_symmetric_registration,
+                fsdp_ubr_registration_scope=fsdp_ubr_registration_scope,
                 check_for_nan_in_grad=False,
             )
         else:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -270,6 +270,11 @@ class MegatronFSDP(torch.nn.Module):
         self.prefetch_recompute_forward_weights = (
             self.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
         )
+        self._selective_recompute_forward_weight_modules = [
+            submodule
+            for submodule in self.module.modules()
+            if getattr(submodule, "_fsdp_recompute_forward_weight", False)
+        ]
         recurse_types = fine_grained_recurse_module_types or ()
         self.fine_grained_recurse_module_types: Tuple[Type[nn.Module], ...] = recurse_types
         self.report_nan_in_param_grad = report_nan_in_param_grad
@@ -500,6 +505,37 @@ class MegatronFSDP(torch.nn.Module):
             # we want to overwrite the `main_grad` which is enabled by this
             # attribute.
             param.overwrite_main_grad = True
+
+    @torch.compiler.disable
+    def prefetch_recompute_forward_parameters(self, module: nn.Module):
+        """Asynchronously gather selective-recompute forward weights for ``module``.
+
+        Selective activation recomputation only replays a subset of a layer. The
+        replayed parameterized modules opt in with
+        ``_fsdp_recompute_forward_weight``. This method starts their rowwise
+        all-gather without waiting; their normal pre-forward hooks wait before
+        the recompute region consumes the weights.
+        """
+        if (
+            not self.prefetch_recompute_forward_weights
+            or not self._selective_recompute_forward_weight_modules
+        ):
+            return
+
+        module_set = set(module.modules())
+        params = []
+        seen_params = set()
+        for recompute_module in self._selective_recompute_forward_weight_modules:
+            if recompute_module not in module_set:
+                continue
+            for param in recompute_module.parameters():
+                if param not in seen_params:
+                    seen_params.add(param)
+                    params.append(param)
+
+        self.all_gather_and_wait_parameters_ready(
+            params=params, prefetch=False, wait_bucket_ready=False, bwd=False
+        )
 
     def _register_fsdp_hooks(self, root_module):
         """Register necessary hooks for Fully Sharded Data Parallel (FSDP) execution on the model.
@@ -897,7 +933,10 @@ class MegatronFSDP(torch.nn.Module):
             param_list = _param_list_for_submodule_unshard(module, "backward")
 
             # All-gather / unshard the module parameters before the backward pass.
-            if self.prefetch_recompute_forward_weights:
+            if (
+                self.prefetch_recompute_forward_weights
+                and not self._selective_recompute_forward_weight_modules
+            ):
                 self.all_gather_and_wait_parameters_ready(
                     param_list,
                     prefetch=False,
@@ -920,6 +959,17 @@ class MegatronFSDP(torch.nn.Module):
                 self.all_gather_and_wait_parameters_ready(
                     param_list, prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER, bwd=True
                 )
+                if (
+                    self.prefetch_recompute_forward_weights
+                    and self._selective_recompute_forward_weight_modules
+                    and not self.enable_fine_grained_param_gather_backward_hook
+                ):
+                    # The regular forward/backward schedule enters an FSDP unit through
+                    # this unit-level pre-backward hook. Start the selective-recompute
+                    # rowwise gather after its backward-layout weights are ready, leaving
+                    # the layer's MLP backward compute to hide the communication before
+                    # attention backward replays mla_up_proj.
+                    self.prefetch_recompute_forward_parameters(module)
 
         self._root_pre_backward_hook_issued = False
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -158,6 +158,8 @@ class MegatronFSDP(torch.nn.Module):
         fsdp_double_buffer (bool): Whether to use persistently allocated double buffers
             for the temporary memory needed in the FSDP communication. This flag is
             automatically set to True when nccl_ub is True.
+        fsdp_buffer_count (int): Number of persistent buffers allocated for each FSDP
+            communication pool. Defaults to two.
         fsdp_db_use_persist_buf_on_alloc_fail (bool): Whether to fall back to persistent buffer
             allocator when a bucket does not fit FSDP double buffer size.
         disable_symmetric_registration (bool): Whether to disable symmetric (window) registration
@@ -207,6 +209,7 @@ class MegatronFSDP(torch.nn.Module):
         keep_fp8_transpose_cache: bool = False,
         nccl_ub: bool = False,
         fsdp_double_buffer: bool = False,
+        fsdp_buffer_count: int = 2,
         fsdp_db_use_persist_buf_on_alloc_fail: bool = False,
         disable_symmetric_registration: bool = False,
         enable_fine_grained_param_gather_hook: bool = False,
@@ -253,6 +256,7 @@ class MegatronFSDP(torch.nn.Module):
                 keep_fp8_transpose_cache=keep_fp8_transpose_cache,  # pylint: disable=C0301
                 nccl_ub=nccl_ub,
                 fsdp_double_buffer=fsdp_double_buffer or nccl_ub,
+                fsdp_buffer_count=fsdp_buffer_count,
                 fsdp_db_use_persist_buf_on_alloc_fail=fsdp_db_use_persist_buf_on_alloc_fail,
                 disable_symmetric_registration=disable_symmetric_registration,
                 check_for_nan_in_grad=False,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -892,12 +892,23 @@ class MegatronFSDP(torch.nn.Module):
             return args, kwargs
 
         def _root_post_backward(*unused):
+            # The combined 1F1B schedule finalizes each microbatch explicitly.
+            # A root autograd callback may already be queued for that same
+            # microbatch (notably when MTP shares the embedding parameter).
+            # Once the explicit call resets the pre-backward state, ignore the
+            # stale callback instead of reducing/resetting the bucket twice.
+            if not self._root_pre_backward_hook_issued:
+                return
+
             # Make sure all the gradients are handled.
             ordered_params = sorted(
                 list(self._params_require_handle_grad), key=lambda p: self.param_to_name[p]
             )
             for param in ordered_params:
                 _grad_acc(param)
+            # Root-owned/shared parameters do not pass through
+            # _process_post_backward_gradients(), so consume them here.
+            self._params_require_handle_grad.difference_update(ordered_params)
 
             # Reduce the remaining gradients.
             grad_reduce_every_bprop = self.data_parallel_sharding_strategy in [

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -537,6 +537,20 @@ class MegatronFSDP(torch.nn.Module):
             params=params, prefetch=False, wait_bucket_ready=False, bwd=False
         )
 
+    def prepare_forward_module(self, module: nn.Module) -> None:
+        """Prepare an FSDP unit for a genuine forward scheduled during backward.
+
+        The root pre-backward hook marks every submodule ``PRE_BACKWARD`` so
+        activation-recomputation forwards do not issue forward-order prefetches
+        or eagerly reshard their parameters. The EP-overlap 1F1B schedule also
+        executes a genuine forward for another microbatch inside that backward
+        window. Clear the marker only for that forward layer; recomputation in
+        the independently scheduled backward layer remains ``PRE_BACKWARD``.
+        """
+        for submodule in module.modules():
+            if submodule._training_state == TrainingState.PRE_BACKWARD:
+                submodule._training_state = TrainingState.IDLE
+
     def _register_fsdp_hooks(self, root_module):
         """Register necessary hooks for Fully Sharded Data Parallel (FSDP) execution on the model.
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -6,6 +6,7 @@ import copy
 import dataclasses
 import functools
 import gc
+import hashlib
 import inspect
 import logging
 import math
@@ -103,6 +104,27 @@ except ImportError:
         nccl_allocator = None
 
 NCCL_MEMORY_POOL = None
+
+
+def _mem_pool_registration_signature(pool) -> Tuple[int, ...]:
+    """Return segment sizes in the order used by ProcessGroupNCCL registration.
+
+    ProcessGroupNCCL sorts a memory-pool snapshot by ``registration_counter``
+    and collectively registers every segment in that order.  A different
+    number or ordering of segment sizes across ranks can therefore deadlock
+    ``register_mem_pool`` before NCCL has a chance to report a useful error.
+    Addresses are intentionally excluded: each rank owns a different local
+    address, while collective registration requires the segment layout to
+    match.
+    """
+    snapshot = list(pool.snapshot())
+
+    def registration_order(item):
+        index, segment = item
+        return (segment.get("registration_counter", index), index)
+
+    ordered_segments = sorted(enumerate(snapshot), key=registration_order)
+    return tuple(int(segment["total_size"]) for _, segment in ordered_segments)
 
 
 def _p_assert(cond: Any, s: str, raise_assertion_error: bool = True) -> None:
@@ -1091,6 +1113,84 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
             required_by_slot[(dtype, bucket_offset)] += 1
         return all(
             required <= available_by_slot[slot] for slot, required in required_by_slot.items()
+        )
+
+    def materialization_requirements(
+        self, bucket_specs: Dict[int, Tuple[int, torch.dtype]]
+    ) -> Dict[Tuple[torch.dtype, int], int]:
+        """Return the maximum exact runtime size required by each pool slot."""
+        required_slot_sizes = {}
+        for bucket_id, (size, dtype) in bucket_specs.items():
+            if self.fsdp_param_groups[bucket_id].fsdp_unit_id is None:
+                continue
+            _, bucket_offset = self.bucket_alloc_index[bucket_id]
+            if dtype == "float8":
+                dtype = torch.uint8
+            slot = (dtype, bucket_offset)
+            required_slot_sizes[slot] = max(size, required_slot_sizes.get(slot, 0))
+        return required_slot_sizes
+
+    def materialization_requests(
+        self, bucket_specs: Dict[int, Tuple[int, torch.dtype]]
+    ) -> List[Tuple[int, torch.dtype, str]]:
+        """Return every backing tensor required to materialize this pool.
+
+        The returned requests are independent of parameter-group traversal order,
+        allowing callers to merge requests from multiple MaxPool allocators into
+        one globally ordered NCCL memory-pool allocation plan.
+        """
+        required_slot_sizes = self.materialization_requirements(bucket_specs)
+        requests = []
+        for buf_group_id in range(self.size):
+            for (dtype, bucket_offset), size in required_slot_sizes.items():
+                requests.append(
+                    (size, dtype, self._get_gbuf_name(buf_group_id, dtype, bucket_offset))
+                )
+        return requests
+
+    def record_materialized(self, size: int, dtype: torch.dtype, buffer_name: str) -> None:
+        """Record a backing tensor materialized by a shared allocation plan."""
+        self.allocation_tracker[(buffer_name, dtype)] = size
+
+    def materialize(
+        self,
+        bucket_specs: Dict[int, Tuple[int, torch.dtype]],
+        mem_alloc_context: Optional[Callable] = None,
+    ) -> None:
+        """Allocate every runtime-reachable pool slot in a deterministic order.
+
+        Manual NCCL memory-pool registration sorts segments by PyTorch's global
+        allocation counter. If the first allocation of a MaxPool slot happens
+        from overlapping FSDP streams, that order can differ across ranks even
+        when the final segment sizes are identical. Pre-materializing the slots
+        before training gives every rank the same registration order and keeps
+        the first 1F1B/CUDA-graph iteration allocation-free.
+
+        ``bucket_specs`` uses the exact padded ``DataParallelBuffer`` sizes,
+        rather than the unpadded parameter counts used for capacity planning.
+        """
+        total_bytes = 0
+        requests = self.materialization_requests(bucket_specs)
+        for size, dtype, buffer_name in sorted(
+            requests,
+            key=lambda item: (
+                item[0] * torch.empty((), dtype=item[1]).element_size(),
+                str(item[1]),
+                item[2],
+            ),
+        ):
+            materialized_buffer = get_global_memory_buffer().get_tensor(
+                [size], dtype=dtype, name=buffer_name, mem_alloc_context=mem_alloc_context
+            )
+            self.record_materialized(size, dtype, buffer_name)
+            total_bytes += size * materialized_buffer.element_size()
+
+        torch.cuda.synchronize()
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"[MaxPoolAllocator][{self.name}] Materialized {len(requests)} buffers "
+            f"({total_bytes} bytes) for manual NCCL registration.",
         )
 
     def allocate(
@@ -2373,6 +2473,78 @@ class ParamAndGradBuffer:
         torch.distributed.barrier(async_op=False)
         torch.cuda.synchronize()
 
+        # register_mem_pool performs one collective registration per pool
+        # segment. Validate that every communicator sees the same segment-size
+        # sequence first, otherwise a rank that has fewer or differently sized
+        # segments can leave its peers blocked inside ProcessGroupNCCL forever.
+        pool_signature = _mem_pool_registration_signature(NCCL_MEMORY_POOL)
+        registration_errors = []
+        for group in self.ubr_groups:
+            group_signatures = [None] * torch.distributed.get_world_size(group)
+            torch.distributed.all_gather_object(group_signatures, pool_signature, group=group)
+            reference_signature = group_signatures[0]
+            if any(signature != reference_signature for signature in group_signatures[1:]):
+                group_ranks = torch.distributed.get_process_group_ranks(group)
+                signature_groups = defaultdict(list)
+                for rank, signature in zip(group_ranks, group_signatures):
+                    signature_groups[signature].append(rank)
+                summary = []
+                for signature, ranks in signature_groups.items():
+                    first_difference = next(
+                        (
+                            index
+                            for index, (reference_size, size) in enumerate(
+                                zip(reference_signature, signature)
+                            )
+                            if reference_size != size
+                        ),
+                        None,
+                    )
+                    if first_difference is None and len(signature) != len(reference_signature):
+                        first_difference = min(len(signature), len(reference_signature))
+                    window_start = max(0, (first_difference or 0) - 2)
+                    window_end = min(len(signature), (first_difference or 0) + 3)
+                    signature_bytes = ",".join(map(str, signature)).encode()
+                    summary.append(
+                        {
+                            "rank_count": len(ranks),
+                            "first_ranks": ranks[:8],
+                            "segments": len(signature),
+                            "total_bytes": sum(signature),
+                            "sha256": hashlib.sha256(signature_bytes).hexdigest()[:12],
+                            "first_difference": first_difference,
+                            "sizes_near_difference": signature[window_start:window_end],
+                        }
+                    )
+                registration_errors.append(f"{group.group_desc} (size={group.size()}): {summary}")
+
+        # Synchronize the validation outcome globally so no rank enters NCCL
+        # registration while another rank is already raising an exception.
+        has_registration_error = torch.tensor(
+            [bool(registration_errors)], dtype=torch.int32, device=torch.cuda.current_device()
+        )
+        torch.distributed.all_reduce(has_registration_error, op=torch.distributed.ReduceOp.MAX)
+        if has_registration_error.item():
+            group_leader_ranks = {
+                torch.distributed.get_process_group_ranks(group)[0] for group in self.ubr_groups
+            }
+            if registration_errors and torch.distributed.get_rank() in group_leader_ranks:
+                logger.error(
+                    "[MCORE][FSDP][Manual REG] NCCL memory-pool layout mismatch: %s",
+                    " | ".join(registration_errors),
+                )
+            raise RuntimeError(
+                "NCCL memory-pool segment layout differs across an FSDP registration group. "
+                "See the rank-local mismatch log for segment details."
+            )
+
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"[MCORE][FSDP][Manual REG] Validated {len(pool_signature)} pool segments "
+            f"({sum(pool_signature)} bytes) across all registration groups.",
+        )
+
         for group in self.ubr_groups:
             log_single_rank(
                 logger,
@@ -2451,6 +2623,19 @@ class ParamAndGradBuffer:
         is_fp8 = isinstance(group.dtype, str) and group.dtype == "float8"
         # BF16 for FP8 parameters, otherwise grad.dtype == param.dtype.
         return torch.bfloat16 if is_fp8 else group.dtype
+
+    def _take_ubr_persistent_data(
+        self, buffer: DataParallelBuffer, size: int, dtype: torch.dtype
+    ) -> torch.Tensor:
+        """Consume canonically preallocated UBR storage, or allocate normally."""
+        persistent_data = getattr(self, "_ubr_persistent_data", None)
+        if persistent_data is None:
+            return torch.empty(size, dtype=dtype, device=self.device)
+
+        data = persistent_data.pop(id(buffer))
+        assert data.numel() == size, f"Preallocated UBR size mismatch: {data.numel()} != {size}"
+        assert data.dtype == dtype, f"Preallocated UBR dtype mismatch: {data.dtype} != {dtype}"
+        return data
 
     def _init_each_parameter_group_buffers(self, meta_device_init_fp8_params):
         """
@@ -2933,6 +3118,177 @@ class ParamAndGradBuffer:
                     **hfsdp_kwargs,
                 )
 
+        if self.ddp_config.nccl_ub and self.ddp_config.fsdp_manual_registration:
+            # Materialize every MaxPool tensor before initialization and training
+            # can first-touch the slots from rank-dependent CUDA stream timings.
+            weight_specs = {}
+            transpose_weight_specs = {}
+            main_grad_specs = {}
+            hsdp_grad_comm_specs = {}
+            for bucket_id, group in enumerate(self.parameter_groups):
+                weight_buffer = group.model_weight_buffer
+                if weight_buffer is not None and weight_buffer.is_data_distributed:
+                    weight_specs[bucket_id] = (weight_buffer.bucket_index.size, weight_buffer.dtype)
+
+                transpose_buffer = group.transpose_weight_buffer
+                if transpose_buffer is not None and transpose_buffer.is_data_distributed:
+                    transpose_weight_specs[bucket_id] = (
+                        transpose_buffer.bucket_index.size,
+                        transpose_buffer.dtype,
+                    )
+
+                grad_buffer = group.hfsdp_helper_gbuf or group.main_grad_buffer
+                if grad_buffer is not None and grad_buffer.is_data_distributed:
+                    main_grad_specs[bucket_id] = (
+                        grad_buffer.bucket_index.size,
+                        self.mp_policy.grad_comm_dtype or grad_buffer.dtype,
+                    )
+
+                custom_grad_comm_dtype = (
+                    group.main_grad_buffer is not None
+                    and self.mp_policy.grad_comm_dtype is not None
+                    and group.main_grad_buffer.dtype != self.mp_policy.grad_comm_dtype
+                )
+                if custom_grad_comm_dtype:
+                    hsdp_comm_buffer = group.hsdp_comm_gbuf
+                    assert hsdp_comm_buffer is not None
+                    hsdp_grad_comm_specs[bucket_id] = (
+                        hsdp_comm_buffer.bucket_index.size,
+                        self.mp_policy.grad_comm_dtype,
+                    )
+
+            allocator_specs = (
+                (self.weight_alloc, weight_specs),
+                (self.transpose_weight_alloc, transpose_weight_specs),
+                (self.main_grad_alloc, main_grad_specs),
+                (getattr(self, "hsdp_grad_comm_alloc", None), hsdp_grad_comm_specs),
+            )
+            persistent_buffers = []
+            for group in self.parameter_groups:
+                group_name_digest = hashlib.sha256(
+                    ",".join(sorted(self.param_to_name[param] for param in group.params)).encode()
+                ).hexdigest()[:16]
+                for buffer_role, buffer in (
+                    ("weight", group.hfsdp_helper_wbuf or group.model_weight_buffer),
+                    ("transpose_weight", group.hfsdp_helper_wtbuf or group.transpose_weight_buffer),
+                ):
+                    if buffer is not None:
+                        stable_name = (
+                            f"persistent:{buffer_role}:expert={group.is_expert_param}:"
+                            f"unit={group.fsdp_unit_id}:params={group_name_digest}"
+                        )
+                        persistent_buffers.append((buffer, stable_name))
+
+            # ProcessGroupNCCL registers memory-pool segments in allocator creation
+            # order.  Merge every known long-lived allocation into one global plan
+            # sorted by byte size so rank-local MoE parameter-group traversal cannot
+            # permute the registration sequence.  Unlike reserving a second pool-
+            # sized allocation, this creates only the storage training will consume.
+            allocation_plan = []
+            for allocator, bucket_specs in allocator_specs:
+                if isinstance(allocator, MaxPoolAllocator) and bucket_specs:
+                    for size, dtype, buffer_name in allocator.materialization_requests(
+                        bucket_specs
+                    ):
+                        allocation_plan.append(
+                            (
+                                size * torch.empty((), dtype=dtype).element_size(),
+                                "max_pool",
+                                allocator,
+                                size,
+                                dtype,
+                                buffer_name,
+                            )
+                        )
+
+            for buffer, stable_name in persistent_buffers:
+                allocation_plan.append(
+                    (
+                        buffer.data_size * torch.empty((), dtype=buffer.dtype).element_size(),
+                        "persistent",
+                        buffer,
+                        buffer.data_size,
+                        buffer.dtype,
+                        stable_name,
+                    )
+                )
+
+            for dtype, size in buffer_size.items():
+                if size == 0:
+                    continue
+                actual_dtype = torch.uint8 if dtype == "float8" else dtype
+                allocation_plan.append(
+                    (
+                        size * torch.empty((), dtype=actual_dtype).element_size(),
+                        "all_in_one",
+                        dtype,
+                        size,
+                        actual_dtype,
+                        f"all_in_one:{dtype}",
+                    )
+                )
+
+            ordered_allocation_plan = sorted(
+                allocation_plan, key=lambda item: (item[0], str(item[4]), item[1], item[5])
+            )
+            logical_plan_signature = tuple(
+                (num_bytes, request_kind, str(dtype), stable_name)
+                for num_bytes, request_kind, _, _, dtype, stable_name in ordered_allocation_plan
+            )
+            logical_plan_hash = hashlib.sha256(repr(logical_plan_signature).encode()).hexdigest()[
+                :12
+            ]
+            logical_plan_errors = []
+            for group in self.ubr_groups:
+                group_hashes = [None] * torch.distributed.get_world_size(group)
+                torch.distributed.all_gather_object(group_hashes, logical_plan_hash, group=group)
+                if any(plan_hash != group_hashes[0] for plan_hash in group_hashes[1:]):
+                    hash_rank_counts = defaultdict(int)
+                    for plan_hash in group_hashes:
+                        hash_rank_counts[plan_hash] += 1
+                    logical_plan_errors.append(
+                        f"{group.group_desc} (size={group.size()}): {dict(hash_rank_counts)}"
+                    )
+
+            has_logical_plan_error = torch.tensor(
+                [bool(logical_plan_errors)], dtype=torch.int32, device=self.device
+            )
+            torch.distributed.all_reduce(has_logical_plan_error, op=torch.distributed.ReduceOp.MAX)
+            if has_logical_plan_error.item():
+                if logical_plan_errors:
+                    logger.error(
+                        "[MCORE][FSDP][Manual REG] Logical allocation-plan mismatch: %s",
+                        " | ".join(logical_plan_errors),
+                    )
+                raise RuntimeError(
+                    "NCCL memory-pool logical allocation plan differs across an FSDP "
+                    "registration group. See the rank-local mismatch log for plan hashes."
+                )
+
+            self._ubr_persistent_data = {}
+            self._ubr_all_in_one_data = {}
+            with self.mem_alloc_context():
+                for _, request_kind, owner, size, dtype, buffer_name in ordered_allocation_plan:
+                    if request_kind == "max_pool":
+                        get_global_memory_buffer().get_tensor([size], dtype=dtype, name=buffer_name)
+                        owner.record_materialized(size, dtype, buffer_name)
+                    elif request_kind == "persistent":
+                        self._ubr_persistent_data[id(owner)] = torch.empty(
+                            size, dtype=dtype, device=self.device
+                        )
+                    else:
+                        self._ubr_all_in_one_data[owner] = torch.empty(
+                            size, dtype=dtype, device=self.device
+                        )
+            torch.cuda.synchronize()
+            log_single_rank(
+                logger,
+                logging.INFO,
+                f"[MCORE][FSDP][Manual REG] Materialized {len(allocation_plan)} buffers "
+                f"({sum(item[0] for item in allocation_plan)} requested bytes) in global order "
+                f"(logical plan {logical_plan_hash}).",
+            )
+
         reset_context_args = {"init_param_with_fp8": self.ddp_config.fp8_param_gather}
         module_reset_flag = {}
         if self.reset_parameters_for_meta_device_init_module:
@@ -2972,8 +3328,8 @@ class ParamAndGradBuffer:
                         _init_hfsdp_helper_and_dp_buffer_data(
                             group.hfsdp_helper_wbuf,
                             wbuf,
-                            mem_alloc=lambda size, dtype: torch.empty(
-                                size, dtype=dtype, device=self.device
+                            mem_alloc=lambda size, dtype, buffer=group.hfsdp_helper_wbuf: (
+                                self._take_ubr_persistent_data(buffer, size, dtype)
                             ),
                             outer_dp_group=self.dist_index.get_outer_fsdp_group(
                                 is_expert_parallel=group.is_expert_param
@@ -2982,7 +3338,7 @@ class ParamAndGradBuffer:
                     else:
                         # When not using HSDP, the main buffer shards across the FSDP group.
                         wbuf.init_data(
-                            torch.empty(wbuf.data_size, dtype=wbuf.dtype, device=self.device)
+                            self._take_ubr_persistent_data(wbuf, wbuf.data_size, wbuf.dtype)
                         )
                 # Allocate some memory to initialize the model.
                 bucket = wbuf.fetch_bucket(strict_assignments=False)
@@ -2994,8 +3350,8 @@ class ParamAndGradBuffer:
                         _init_hfsdp_helper_and_dp_buffer_data(
                             group.hfsdp_helper_wtbuf,
                             tbuf,
-                            mem_alloc=lambda size, dtype: torch.empty(
-                                size, dtype=dtype, device=self.device
+                            mem_alloc=lambda size, dtype, buffer=group.hfsdp_helper_wtbuf: (
+                                self._take_ubr_persistent_data(buffer, size, dtype)
                             ),
                             outer_dp_group=self.dist_index.get_outer_fsdp_group(
                                 is_expert_parallel=group.is_expert_param
@@ -3004,7 +3360,7 @@ class ParamAndGradBuffer:
                     else:
                         # Initialize the transpose buffer.
                         tbuf.init_data(
-                            torch.empty(tbuf.data_size, dtype=tbuf.dtype, device=self.device)
+                            self._take_ubr_persistent_data(tbuf, tbuf.data_size, tbuf.dtype)
                         )
                 # Allocate some memory to initialize the model.
                 transpose_bucket = tbuf.fetch_bucket(strict_assignments=False)
@@ -3169,21 +3525,23 @@ class ParamAndGradBuffer:
 
         # Allocate the main_weight buffer and main_grad buffer data in one buffer.
         if self.buffer_all_in_one:
+            preallocated_all_in_one = getattr(self, "_ubr_all_in_one_data", {})
             with self.mem_alloc_context():
-                self.buffer = {
-                    torch.float32: torch.empty(
-                        buffer_size[torch.float32], dtype=torch.float32, device=self.device
-                    ),
-                    torch.float16: torch.empty(
-                        buffer_size[torch.float16], dtype=torch.float16, device=self.device
-                    ),
-                    torch.bfloat16: torch.empty(
-                        buffer_size[torch.bfloat16], dtype=torch.bfloat16, device=self.device
-                    ),
-                    "float8": torch.empty(
-                        buffer_size["float8"], dtype=torch.uint8, device=self.device
-                    ),
-                }
+                self.buffer = {}
+                for dtype, size in buffer_size.items():
+                    actual_dtype = torch.uint8 if dtype == "float8" else dtype
+                    self.buffer[dtype] = preallocated_all_in_one.pop(
+                        dtype,
+                        (
+                            torch.empty(size, dtype=actual_dtype, device=self.device)
+                            if size == 0
+                            else None
+                        ),
+                    )
+                    if self.buffer[dtype] is None:
+                        self.buffer[dtype] = torch.empty(
+                            size, dtype=actual_dtype, device=self.device
+                        )
             offset = {torch.float32: 0, torch.float16: 0, torch.bfloat16: 0, "float8": 0}
 
         def _alloc(dtype, size):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -522,6 +522,12 @@ class TemporaryBucketAllocator:
             _free_storage(self.buckets[bucket_id].data)
             del self.buckets[bucket_id]
 
+    def can_allocate(
+        self, bucket_ids: List[int], releasable_bucket_ids: Optional[set[int]] = None
+    ) -> bool:
+        """Return whether ``bucket_ids`` fit after releasing the supplied buckets."""
+        return True
+
 
 class StorageResizeBasedBucketAllocator(TemporaryBucketAllocator):
     """
@@ -751,6 +757,33 @@ class FixedPoolAllocator(TemporaryBucketAllocator):
             if self.dtype_fn(pg_a) != self.dtype_fn(pg_b) or a_size != b_size:
                 return False
         return True
+
+    def can_allocate(
+        self, bucket_ids: List[int], releasable_bucket_ids: Optional[set[int]] = None
+    ) -> bool:
+        """Return whether the requested buckets fit in the fixed pool."""
+        releasable_bucket_ids = releasable_bucket_ids or set()
+        available_by_offset = defaultdict(int)
+        for _, bucket_offset in self.idle_buffer:
+            available_by_offset[bucket_offset] += 1
+        for bucket_id in releasable_bucket_ids:
+            if bucket_id in self.using_buffer:
+                _, bucket_offset = self.using_buffer[bucket_id]
+                available_by_offset[bucket_offset] += 1
+
+        required_by_offset = defaultdict(int)
+        for bucket_id in set(bucket_ids):
+            fsdp_unit_id = self.fsdp_param_groups[bucket_id].fsdp_unit_id
+            if fsdp_unit_id not in self.fsdp_double_buffer_units or (
+                bucket_id in self.using_buffer and bucket_id not in releasable_bucket_ids
+            ):
+                continue
+            _, bucket_offset = self.fsdp_unit_buckets[fsdp_unit_id][bucket_id]
+            required_by_offset[bucket_offset] += 1
+        return all(
+            required <= available_by_offset[bucket_offset]
+            for bucket_offset, required in required_by_offset.items()
+        )
 
     def allocate(
         self,
@@ -1030,6 +1063,35 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
                     f"\tBucket Sizes: {bucket_sizes} / Max (Unit, Bucket): {max_bucket_ids}"
                 ),
             )
+
+    def can_allocate(
+        self, bucket_ids: List[int], releasable_bucket_ids: Optional[set[int]] = None
+    ) -> bool:
+        """Return whether the requested buckets fit in the max-sized pool."""
+        releasable_bucket_ids = releasable_bucket_ids or set()
+        available_by_slot = defaultdict(int)
+        for _, dtype, bucket_offset in self.idle_buffer:
+            available_by_slot[(dtype, bucket_offset)] += 1
+        for bucket_id in releasable_bucket_ids:
+            if bucket_id in self.using_buffer:
+                _, dtype, bucket_offset = self.using_buffer[bucket_id]
+                available_by_slot[(dtype, bucket_offset)] += 1
+
+        required_by_slot = defaultdict(int)
+        for bucket_id in set(bucket_ids):
+            fsdp_unit_id = self.fsdp_param_groups[bucket_id].fsdp_unit_id
+            if fsdp_unit_id is None or (
+                bucket_id in self.using_buffer and bucket_id not in releasable_bucket_ids
+            ):
+                continue
+            _, bucket_offset = self.bucket_alloc_index[bucket_id]
+            dtype = self.dtype_fn(self.fsdp_param_groups[bucket_id])
+            if dtype == "float8":
+                dtype = torch.uint8
+            required_by_slot[(dtype, bucket_offset)] += 1
+        return all(
+            required <= available_by_slot[slot] for slot, required in required_by_slot.items()
+        )
 
     def allocate(
         self,
@@ -2591,8 +2653,9 @@ class ParamAndGradBuffer:
         for group in self.parameter_groups:
             group.grad_dtype = self._resolve_group_grad_dtype(group, meta_device_init_fp8_params)
         if self.ddp_config.fsdp_double_buffer and len(self.bucketing_policy.fsdp_unit_modules) > 0:
-            # Double Buffering
-            UB_BUFFER_NUM = 2
+            # Persistent communication-buffer pooling. The default pool size is two,
+            # while combined 1F1B overlap may require a third concurrently-live unit.
+            ub_buffer_num = self.ddp_config.fsdp_buffer_count
             # Double Buffer Allocator Choice
             FIXED_POOL_ALLOC_TYPE = (
                 MaxPoolAllocator
@@ -2602,13 +2665,13 @@ class ParamAndGradBuffer:
             self.weight_alloc = FIXED_POOL_ALLOC_TYPE(
                 name="fsdp_params",
                 fsdp_param_groups=self.parameter_groups,
-                size=UB_BUFFER_NUM,
+                size=ub_buffer_num,
                 fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
             )
             self.transpose_weight_alloc = FIXED_POOL_ALLOC_TYPE(
                 name="fsdp_fp8_transpose_params",
                 fsdp_param_groups=self.parameter_groups,
-                size=UB_BUFFER_NUM,
+                size=ub_buffer_num,
                 fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
             )
             # Resolve gradient bucket dtype used for MaxPoolAllocator bucket allocation
@@ -2622,7 +2685,7 @@ class ParamAndGradBuffer:
             self.main_grad_alloc = FIXED_POOL_ALLOC_TYPE(
                 name="fsdp_grads",
                 fsdp_param_groups=self.parameter_groups,
-                size=UB_BUFFER_NUM,
+                size=ub_buffer_num,
                 dtype_fn=grad_dtype_fn,
                 fallback_to_persistent_buffer=(
                     self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
@@ -2636,7 +2699,7 @@ class ParamAndGradBuffer:
                 self.hsdp_grad_comm_alloc = FIXED_POOL_ALLOC_TYPE(
                     name="hsdp_grad_comm",
                     fsdp_param_groups=self.parameter_groups,
-                    size=UB_BUFFER_NUM,
+                    size=ub_buffer_num,
                     dtype_fn=grad_dtype_fn,
                     fallback_to_persistent_buffer=(
                         self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
@@ -4031,21 +4094,23 @@ class GradReducePipeline:
         if not self.buffer.ddp_config.fsdp_double_buffer:
             return
 
+        buffer_count = self.buffer.ddp_config.fsdp_buffer_count
         param_groups = self.buffer.parameter_groups
         double_buf_units = set()
         for bucket_id in add_buckets:
             fsdp_unit_id = param_groups[bucket_id].fsdp_unit_id
             if fsdp_unit_id in self.buffer.double_buf_units:
                 double_buf_units.add(fsdp_unit_id)
-        assert (
-            len(double_buf_units) <= 2
-        ), f"Double buffer limit exceeded. Current double_buf_units: {double_buf_units}."
+        assert len(double_buf_units) <= buffer_count, (
+            f"FSDP buffer pool limit ({buffer_count}) exceeded. "
+            f"Current double_buf_units: {double_buf_units}."
+        )
 
         keep_n = len(self.grad_reduce_queue)
         for _, _, bucket_id in reversed(self.grad_reduce_queue):
             fsdp_unit_id = param_groups[bucket_id].fsdp_unit_id
             double_buf_units.add(fsdp_unit_id)
-            if len(double_buf_units) > 2:
+            if len(double_buf_units) > buffer_count:
                 keep_n -= 1
 
         with torch.cuda.stream(self.rs_stream):
@@ -4491,17 +4556,13 @@ class AllGatherPipeline:
         ag_buckets = [self.buffer.param_to_param_group[item] for item in params]
         ag_buckets = list(sorted(set(ag_buckets)))  # Sort in order of unique bucket ID.
         parameter_groups = self.buffer.parameter_groups
-        if self.buffer.ddp_config.fsdp_double_buffer:
-            double_buf_units = set()
-            for bucket_id in ag_buckets:
-                fsdp_unit_id = parameter_groups[bucket_id].fsdp_unit_id
-                if fsdp_unit_id in self.buffer.double_buf_units:
-                    double_buf_units.add(fsdp_unit_id)
-            if len(double_buf_units) > 2:
-                raise ValueError(
-                    f"{double_buf_units} FSDP units were requested, "
-                    "but double buffers can support no more than 2 FSDP units."
-                )
+        if self.buffer.ddp_config.fsdp_double_buffer and not self._persistent_allocators_can_fit(
+            ag_buckets, bwd
+        ):
+            raise ValueError(
+                f"FSDP buckets {ag_buckets} do not fit in the configured persistent "
+                f"buffer pools (fsdp_buffer_count={self.buffer.ddp_config.fsdp_buffer_count})."
+            )
 
         # Do not release the buckets that are being all-gathered.
         no_fsdp_units = True
@@ -4518,7 +4579,7 @@ class AllGatherPipeline:
             # Non-unit module pre-fetch can run inside other FSDP unit modules and
             # un-shard irrelevant model components that pointlessly steal buffer
             # allocations from the expected FSDP unit allocation and violating
-            # the maximum limit of 2 buffers allocated at any point in time.
+            # the configured persistent-buffer limit.
             self.buffer.ddp_config.fsdp_double_buffer
             and no_fsdp_units
         ):
@@ -4550,12 +4611,10 @@ class AllGatherPipeline:
                 # If use double buffer, we need to check if the next bucket
                 # is exceeding the coverage of the double buffer.
                 if self.buffer.ddp_config.fsdp_double_buffer:
-                    fsdp_unit_id = parameter_groups[bucket_id].fsdp_unit_id
-                    double_buf_units.add(fsdp_unit_id)
-                    if len(double_buf_units) > 2:
-                        # Prefetching the next bucket will exceed the coverage of
-                        # the double buffer, so we need to stop prefetching.
-                        return True
+                    candidate_buckets = self.buffer.bucket_to_bucket_group[bucket_id]
+                    return not self._persistent_allocators_can_fit(
+                        ag_buckets + candidate_buckets, bwd
+                    )
                 return False
 
             if suggested_AG_prefetch_size is None:
@@ -4764,6 +4823,27 @@ class AllGatherPipeline:
             return param_group.transpose_weight_buffer
         else:
             return param_group.model_weight_buffer
+
+    def _persistent_allocators_can_fit(self, bucket_ids: List[int], bwd: bool) -> bool:
+        """Check pool capacity, including allocations live before this all-gather call."""
+        allocator_buckets = defaultdict(list)
+        for bucket_id in set(bucket_ids):
+            allocator = self.get_fsdp_buffer(bucket_id, bwd=bwd).temporary_bucket_allocator
+            allocator_buckets[allocator].append(bucket_id)
+
+        allocator_releasable_buckets = defaultdict(set)
+        for bucket_key, can_be_released in self.bucket_can_be_released.items():
+            if not can_be_released:
+                continue
+            bucket_id, release_bwd = bucket_key
+            allocator = self.get_fsdp_buffer(bucket_id, bwd=release_bwd).temporary_bucket_allocator
+            if bucket_id not in allocator_buckets[allocator]:
+                allocator_releasable_buckets[allocator].add(bucket_id)
+
+        return all(
+            allocator.can_allocate(requested_buckets, allocator_releasable_buckets[allocator])
+            for allocator, requested_buckets in allocator_buckets.items()
+        )
 
     @torch.no_grad()
     def async_bucket_gather(self, bucket_id, bwd) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -16,7 +16,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from contextlib import ExitStack, nullcontext
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 import torch
 from torch.distributed import _coalescing_manager
@@ -106,6 +106,54 @@ except ImportError:
 NCCL_MEMORY_POOL = None
 
 
+def _get_ubr_registration_groups(
+    dist_index: FSDPDistributedIndex, registration_scope: str
+) -> List[torch.distributed.ProcessGroup]:
+    """Return the process groups that should register the FSDP NCCL memory pool.
+
+    ``dense_inner`` is intended for HSDP configurations where only dense inner-DP
+    parameter all-gathers are large enough to justify symmetric registration. Outer-DP
+    and expert collectives remain valid on tensors allocated from the pool without
+    registering that pool to their communicators; NCCL then selects its ordinary path.
+
+    HSDP parameter all-gathers use the dense helper buffer's base inner-FSDP group. In
+    non-HSDP configurations, prefer the independent dense all-gather group when present.
+    """
+    if registration_scope == "dense_inner":
+        if dist_index.use_hybrid_fsdp:
+            dense_param_ag_group = dist_index.get_fsdp_group(is_expert_parallel=False)
+        else:
+            dense_param_ag_group = dist_index.get_fsdp_group(
+                is_expert_parallel=False, independent_all_gather=True
+            ) or dist_index.get_fsdp_group(is_expert_parallel=False)
+        return [dense_param_ag_group] if dense_param_ag_group is not None else []
+
+    if registration_scope != "all":
+        raise ValueError(
+            f"Invalid FSDP UBR registration scope: {registration_scope}. "
+            "Expected one of: all, dense_inner."
+        )
+
+    groups = [dist_index.get_fsdp_group(is_expert_parallel=False)]
+    expert_group = dist_index.get_fsdp_group(is_expert_parallel=True)
+    if expert_group is not None:
+        groups.append(expert_group)
+    dense_ag_group = dist_index.get_fsdp_group(
+        is_expert_parallel=False, independent_all_gather=True
+    )
+    if dense_ag_group is not None:
+        groups.append(dense_ag_group)
+    expert_ag_group = dist_index.get_fsdp_group(
+        is_expert_parallel=True, independent_all_gather=True
+    )
+    if expert_ag_group is not None:
+        groups.append(expert_ag_group)
+    outer_group = dist_index.get_outer_fsdp_group()
+    if outer_group is not None:
+        groups.append(outer_group)
+    return groups
+
+
 def _mem_pool_registration_signature(pool) -> Tuple[int, ...]:
     """Return segment sizes in the order used by ProcessGroupNCCL registration.
 
@@ -125,6 +173,29 @@ def _mem_pool_registration_signature(pool) -> Tuple[int, ...]:
 
     ordered_segments = sorted(enumerate(snapshot), key=registration_order)
     return tuple(int(segment["total_size"]) for _, segment in ordered_segments)
+
+
+def _build_ubr_arena_layout(
+    ordered_allocation_plan: Sequence[tuple], alignment: int = 256
+) -> Tuple[List[Tuple[int, tuple]], int]:
+    """Assign deterministic byte offsets inside one registered UBR arena.
+
+    A PyTorch MemPool can expose the same live allocations as differently ordered
+    physical segments across ranks, even when their logical allocation plan is
+    identical. Packing all registered tensors into one backing allocation makes the
+    ProcessGroupNCCL registration sequence a single segment and also guarantees equal
+    tensor offsets across ranks.
+    """
+    assert alignment > 0 and alignment & (alignment - 1) == 0
+    layout = []
+    next_offset = 0
+    for request in ordered_allocation_plan:
+        num_bytes = request[0]
+        aligned_offset = (next_offset + alignment - 1) // alignment * alignment
+        layout.append((aligned_offset, request))
+        next_offset = aligned_offset + num_bytes
+    arena_size = (next_offset + alignment - 1) // alignment * alignment
+    return layout, arena_size
 
 
 def _p_assert(cond: Any, s: str, raise_assertion_error: bool = True) -> None:
@@ -957,6 +1028,7 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
         size: int = 2,
         dtype_fn: Callable[["ParameterGroup"], torch.dtype] = operator.attrgetter("dtype"),
         fallback_to_persistent_buffer: bool = False,
+        bucket_filter: Optional[Callable[[int, "ParameterGroup"], bool]] = None,
     ):
         self.name = name
         self.fsdp_param_groups = fsdp_param_groups
@@ -965,10 +1037,13 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
         self.bucket_alloc_index = {}  # map bucket ID to offset
         self.max_dtype_bucket_sizes = {}  # dtype -> [bucket sizes from smallest to largest]
         self.dtype_fn = dtype_fn
+        self.bucket_filter = bucket_filter
 
         # Build a mapping from FSDP unit id to its associated bucket ids.
         fsdp_unit_buckets = defaultdict(list)
         for bucket_id, param_group in enumerate(self.fsdp_param_groups):
+            if self.bucket_filter is not None and not self.bucket_filter(bucket_id, param_group):
+                continue
             # Filter out FSDP non-units. Only FSDP units can be double-buffered.
             if param_group.fsdp_unit_id is None:
                 continue
@@ -985,7 +1060,11 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
         assert (
             len(self.fsdp_double_buffer_units) > 0
         ), "Found no FSDP units to use max-sized buffering."
-        if any(pg.fsdp_unit_id is None for pg in self.fsdp_param_groups):
+        if any(
+            pg.fsdp_unit_id is None
+            for bucket_id, pg in enumerate(self.fsdp_param_groups)
+            if self.bucket_filter is None or self.bucket_filter(bucket_id, pg)
+        ):
             log_single_rank(
                 logger,
                 logging.INFO,
@@ -2302,41 +2381,20 @@ class ParamAndGradBuffer:
                 logging.INFO,
                 f"[Rank {torch.distributed.get_rank()}] FSDP double buffer is enabled.",
             )
-            # Select the communicator groups to register FSDP buffers.
-            self.ubr_groups = [self.dist_index.get_fsdp_group(is_expert_parallel=False)]
-            if self.dist_index.get_fsdp_group(is_expert_parallel=True) is not None:
-                # Expert-DP group when using EP
-                self.ubr_groups.append(self.dist_index.get_fsdp_group(is_expert_parallel=True))
-            if (
-                self.dist_index.get_fsdp_group(
-                    is_expert_parallel=False, independent_all_gather=True
-                )
-                is not None
-            ):
-                # All-gather group used when overlapping all-gather and gradient reduction.
-                self.ubr_groups.append(
-                    self.dist_index.get_fsdp_group(
-                        is_expert_parallel=False, independent_all_gather=True
-                    )
-                )
-            if (
-                self.dist_index.get_fsdp_group(is_expert_parallel=True, independent_all_gather=True)
-                is not None
-            ):
-                # Expert all-gather group used when overlapping all-gather and gradient reduction.
-                self.ubr_groups.append(
-                    self.dist_index.get_fsdp_group(
-                        is_expert_parallel=True, independent_all_gather=True
-                    )
-                )
-            if self.dist_index.get_outer_fsdp_group() is not None:
-                # Outer/Inter-FSDP group when using hybrid FSDP (IB domain, registered last).
-                self.ubr_groups.append(self.dist_index.get_outer_fsdp_group())
+            # Register only the communicators selected by the configured UBR scope. A
+            # dense-inner-only scope deliberately leaves expert and outer-DP collectives
+            # on NCCL's ordinary path; this avoids registration cost and the requirement
+            # that their physical pool segment layouts match across ranks.
+            self.ubr_groups = _get_ubr_registration_groups(
+                self.dist_index, self.ddp_config.fsdp_ubr_registration_scope
+            )
 
             log_single_rank(
                 logger,
                 logging.INFO,
-                f"[ParamAndGradBuffer] FSDP UBRegistration Groups ({len(self.ubr_groups)}):",
+                f"[ParamAndGradBuffer] FSDP UBRegistration Scope "
+                f"{self.ddp_config.fsdp_ubr_registration_scope}; "
+                f"Groups ({len(self.ubr_groups)}):",
             )
             # All ranks in each group must participate in the collective to avoid deadlock.
             for i, group in enumerate(self.ubr_groups):
@@ -2363,6 +2421,12 @@ class ParamAndGradBuffer:
         self.mem_alloc_context = self.get_mem_alloc_context(
             groups=self.ubr_groups, symmetric=not self.ddp_config.disable_symmetric_registration
         )
+        # Registered-buffer collectives require matching pool-relative offsets
+        # across ranks. FSDP reduce-scatter is in-place and intentionally writes
+        # each rank's output to ``rank * recvcount`` inside the input bucket.
+        # Keep gradient communication outside the registered pool until this
+        # path provides a same-offset staging output.
+        self.grad_mem_alloc_context = nullcontext
 
         # Mark FP8 params. If TransformerEngine is not installed, we can skip this.
         meta_device_init_fp8_params = {}
@@ -2632,7 +2696,13 @@ class ParamAndGradBuffer:
         if persistent_data is None:
             return torch.empty(size, dtype=dtype, device=self.device)
 
-        data = persistent_data.pop(id(buffer))
+        data = persistent_data.pop(id(buffer), None)
+        if data is None:
+            assert buffer.mem_alloc_context == nullcontext, (
+                "Registered FSDP parameter buffer was not included in the canonical "
+                "UBR allocation plan."
+            )
+            return torch.empty(size, dtype=dtype, device=self.device)
         assert data.numel() == size, f"Preallocated UBR size mismatch: {data.numel()} != {size}"
         assert data.dtype == dtype, f"Preallocated UBR dtype mismatch: {data.dtype} != {dtype}"
         return data
@@ -2847,18 +2917,81 @@ class ParamAndGradBuffer:
                 if self.ddp_config.megatron_fsdp_max_pool_double_buffer
                 else FixedPoolAllocator
             )
-            self.weight_alloc = FIXED_POOL_ALLOC_TYPE(
-                name="fsdp_params",
-                fsdp_param_groups=self.parameter_groups,
-                size=ub_buffer_num,
-                fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
+            dense_inner_ubr = (
+                self.ddp_config.nccl_ub
+                and self.ddp_config.fsdp_ubr_registration_scope == "dense_inner"
             )
-            self.transpose_weight_alloc = FIXED_POOL_ALLOC_TYPE(
-                name="fsdp_fp8_transpose_params",
-                fsdp_param_groups=self.parameter_groups,
-                size=ub_buffer_num,
-                fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
-            )
+            self.expert_weight_alloc = None
+            self.expert_transpose_weight_alloc = None
+            if dense_inner_ubr:
+                if FIXED_POOL_ALLOC_TYPE is not MaxPoolAllocator:
+                    raise ValueError(
+                        "Dense-inner-only FSDP UBR requires "
+                        "megatron_fsdp_max_pool_double_buffer=True."
+                    )
+
+                # Keep the registered dense inner-AG buffers in a pool that cannot be
+                # first-touched or resized by rank-dependent expert/outer-DP traffic.
+                # Expert collectives retain their own ordinary MaxPool allocator.
+                dense_bucket_filter = lambda _, pg: not pg.is_expert_param  # noqa: E731
+                expert_bucket_filter = lambda _, pg: pg.is_expert_param  # noqa: E731
+                self.weight_alloc = MaxPoolAllocator(
+                    name="fsdp_dense_params",
+                    fsdp_param_groups=self.parameter_groups,
+                    size=ub_buffer_num,
+                    fallback_to_persistent_buffer=(
+                        self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                    ),
+                    bucket_filter=dense_bucket_filter,
+                )
+                self.transpose_weight_alloc = MaxPoolAllocator(
+                    name="fsdp_dense_fp8_transpose_params",
+                    fsdp_param_groups=self.parameter_groups,
+                    size=ub_buffer_num,
+                    fallback_to_persistent_buffer=(
+                        self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                    ),
+                    bucket_filter=dense_bucket_filter,
+                )
+                if any(
+                    pg.is_expert_param and pg.fsdp_unit_id is not None
+                    for pg in self.parameter_groups
+                ):
+                    self.expert_weight_alloc = MaxPoolAllocator(
+                        name="fsdp_expert_params",
+                        fsdp_param_groups=self.parameter_groups,
+                        size=ub_buffer_num,
+                        fallback_to_persistent_buffer=(
+                            self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                        ),
+                        bucket_filter=expert_bucket_filter,
+                    )
+                    self.expert_transpose_weight_alloc = MaxPoolAllocator(
+                        name="fsdp_expert_fp8_transpose_params",
+                        fsdp_param_groups=self.parameter_groups,
+                        size=ub_buffer_num,
+                        fallback_to_persistent_buffer=(
+                            self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                        ),
+                        bucket_filter=expert_bucket_filter,
+                    )
+            else:
+                self.weight_alloc = FIXED_POOL_ALLOC_TYPE(
+                    name="fsdp_params",
+                    fsdp_param_groups=self.parameter_groups,
+                    size=ub_buffer_num,
+                    fallback_to_persistent_buffer=(
+                        self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                    ),
+                )
+                self.transpose_weight_alloc = FIXED_POOL_ALLOC_TYPE(
+                    name="fsdp_fp8_transpose_params",
+                    fsdp_param_groups=self.parameter_groups,
+                    size=ub_buffer_num,
+                    fallback_to_persistent_buffer=(
+                        self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+                    ),
+                )
             # Resolve gradient bucket dtype used for MaxPoolAllocator bucket allocation
             # planning and FixedPoolAllocator unit symmetries. Falls back to each
             # parameter group's main `grad_dtype` when no comm-dtype override is set.
@@ -2890,10 +3023,17 @@ class ParamAndGradBuffer:
                         self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
                     ),
                 )
-            self.double_buf_units = self.weight_alloc.fsdp_double_buffer_units
+            self.double_buf_units = list(self.weight_alloc.fsdp_double_buffer_units)
+            if self.expert_weight_alloc is not None:
+                self.double_buf_units = list(
+                    set(self.double_buf_units)
+                    | set(self.expert_weight_alloc.fsdp_double_buffer_units)
+                )
         else:
             self.weight_alloc = StorageResizeBasedBucketAllocator()
             self.transpose_weight_alloc = StorageResizeBasedBucketAllocator()
+            self.expert_weight_alloc = None
+            self.expert_transpose_weight_alloc = None
             self.main_grad_alloc = None
             if self.dist_index.use_hybrid_fsdp:
                 # Only required for custom communication dtype buffer allocation
@@ -2907,6 +3047,27 @@ class ParamAndGradBuffer:
 
         # For all bucket groups (partitioned parameter groups)...
         for group_id, group in enumerate(self.parameter_groups):
+            dense_inner_ubr = (
+                self.ddp_config.nccl_ub
+                and self.ddp_config.fsdp_ubr_registration_scope == "dense_inner"
+            )
+            param_mem_alloc_context = (
+                nullcontext if dense_inner_ubr and group.is_expert_param else self.mem_alloc_context
+            )
+            weight_alloc = (
+                self.expert_weight_alloc
+                if dense_inner_ubr and group.is_expert_param
+                else self.weight_alloc
+            )
+            transpose_weight_alloc = (
+                self.expert_transpose_weight_alloc
+                if dense_inner_ubr and group.is_expert_param
+                else self.transpose_weight_alloc
+            )
+            if dense_inner_ubr and group.is_expert_param:
+                assert weight_alloc is not None
+                assert transpose_weight_alloc is not None
+
             main_buf_extra_kwargs = {}
             if should_create_hfsdp_helper_buffers:
                 # DP-Outer + DP-Shard
@@ -2979,10 +3140,10 @@ class ParamAndGradBuffer:
                     # using basic HSDP or FSDP.
                     data_parallel_group=model_wbuf_dp_group,
                     is_transpose_buffer=False,
-                    temporary_bucket_allocator=self.weight_alloc,
+                    temporary_bucket_allocator=weight_alloc,
                     bucket_id=group_id,
                     chunk_size_factor=group.chunk_size_factor,
-                    mem_alloc_context=self.mem_alloc_context,
+                    mem_alloc_context=param_mem_alloc_context,
                     **main_buf_extra_kwargs,
                 )
                 if should_create_transpose_weight_buffer:
@@ -2995,10 +3156,10 @@ class ParamAndGradBuffer:
                         device=self.device,
                         data_parallel_group=main_buf_dp_group,
                         is_transpose_buffer=True,
-                        temporary_bucket_allocator=self.transpose_weight_alloc,
+                        temporary_bucket_allocator=transpose_weight_alloc,
                         bucket_id=group_id,
                         chunk_size_factor=group.chunk_size_factor,
-                        mem_alloc_context=self.mem_alloc_context,
+                        mem_alloc_context=param_mem_alloc_context,
                         **main_buf_extra_kwargs,
                     )
 
@@ -3018,7 +3179,7 @@ class ParamAndGradBuffer:
                     data_parallel_group=main_buf_dp_group,
                     bucket_id=group_id,
                     chunk_size_factor=group.chunk_size_factor,
-                    mem_alloc_context=self.mem_alloc_context,
+                    mem_alloc_context=param_mem_alloc_context,
                     **main_buf_extra_kwargs,
                 )
 
@@ -3044,7 +3205,7 @@ class ParamAndGradBuffer:
                     gradient_scaling_factor=gradient_scaling_factor,
                     bucket_id=group_id,
                     chunk_size_factor=group.chunk_size_factor,
-                    mem_alloc_context=self.mem_alloc_context,
+                    mem_alloc_context=self.grad_mem_alloc_context,
                     **main_buf_extra_kwargs,
                 )
 
@@ -3114,7 +3275,7 @@ class ParamAndGradBuffer:
                     temporary_bucket_allocator=self.hsdp_grad_comm_alloc,
                     bucket_id=group_id,
                     chunk_size_factor=group.chunk_size_factor,
-                    mem_alloc_context=self.mem_alloc_context,
+                    mem_alloc_context=self.grad_mem_alloc_context,
                     **hfsdp_kwargs,
                 )
 
@@ -3123,48 +3284,39 @@ class ParamAndGradBuffer:
             # can first-touch the slots from rank-dependent CUDA stream timings.
             weight_specs = {}
             transpose_weight_specs = {}
-            main_grad_specs = {}
-            hsdp_grad_comm_specs = {}
+            expert_weight_specs = {}
+            expert_transpose_weight_specs = {}
+            dense_inner_ubr = self.ddp_config.fsdp_ubr_registration_scope == "dense_inner"
             for bucket_id, group in enumerate(self.parameter_groups):
                 weight_buffer = group.model_weight_buffer
                 if weight_buffer is not None and weight_buffer.is_data_distributed:
-                    weight_specs[bucket_id] = (weight_buffer.bucket_index.size, weight_buffer.dtype)
+                    target_specs = (
+                        expert_weight_specs
+                        if dense_inner_ubr and group.is_expert_param
+                        else weight_specs
+                    )
+                    target_specs[bucket_id] = (weight_buffer.bucket_index.size, weight_buffer.dtype)
 
                 transpose_buffer = group.transpose_weight_buffer
                 if transpose_buffer is not None and transpose_buffer.is_data_distributed:
-                    transpose_weight_specs[bucket_id] = (
+                    target_specs = (
+                        expert_transpose_weight_specs
+                        if dense_inner_ubr and group.is_expert_param
+                        else transpose_weight_specs
+                    )
+                    target_specs[bucket_id] = (
                         transpose_buffer.bucket_index.size,
                         transpose_buffer.dtype,
-                    )
-
-                grad_buffer = group.hfsdp_helper_gbuf or group.main_grad_buffer
-                if grad_buffer is not None and grad_buffer.is_data_distributed:
-                    main_grad_specs[bucket_id] = (
-                        grad_buffer.bucket_index.size,
-                        self.mp_policy.grad_comm_dtype or grad_buffer.dtype,
-                    )
-
-                custom_grad_comm_dtype = (
-                    group.main_grad_buffer is not None
-                    and self.mp_policy.grad_comm_dtype is not None
-                    and group.main_grad_buffer.dtype != self.mp_policy.grad_comm_dtype
-                )
-                if custom_grad_comm_dtype:
-                    hsdp_comm_buffer = group.hsdp_comm_gbuf
-                    assert hsdp_comm_buffer is not None
-                    hsdp_grad_comm_specs[bucket_id] = (
-                        hsdp_comm_buffer.bucket_index.size,
-                        self.mp_policy.grad_comm_dtype,
                     )
 
             allocator_specs = (
                 (self.weight_alloc, weight_specs),
                 (self.transpose_weight_alloc, transpose_weight_specs),
-                (self.main_grad_alloc, main_grad_specs),
-                (getattr(self, "hsdp_grad_comm_alloc", None), hsdp_grad_comm_specs),
             )
             persistent_buffers = []
             for group in self.parameter_groups:
+                if dense_inner_ubr and group.is_expert_param:
+                    continue
                 group_name_digest = hashlib.sha256(
                     ",".join(sorted(self.param_to_name[param] for param in group.params)).encode()
                 ).hexdigest()[:16]
@@ -3213,21 +3365,6 @@ class ParamAndGradBuffer:
                     )
                 )
 
-            for dtype, size in buffer_size.items():
-                if size == 0:
-                    continue
-                actual_dtype = torch.uint8 if dtype == "float8" else dtype
-                allocation_plan.append(
-                    (
-                        size * torch.empty((), dtype=actual_dtype).element_size(),
-                        "all_in_one",
-                        dtype,
-                        size,
-                        actual_dtype,
-                        f"all_in_one:{dtype}",
-                    )
-                )
-
             ordered_allocation_plan = sorted(
                 allocation_plan, key=lambda item: (item[0], str(item[4]), item[1], item[5])
             )
@@ -3266,28 +3403,59 @@ class ParamAndGradBuffer:
                 )
 
             self._ubr_persistent_data = {}
-            self._ubr_all_in_one_data = {}
-            with self.mem_alloc_context():
-                for _, request_kind, owner, size, dtype, buffer_name in ordered_allocation_plan:
+            if dense_inner_ubr:
+                arena_layout, arena_size = _build_ubr_arena_layout(ordered_allocation_plan)
+                with self.mem_alloc_context():
+                    self._ubr_arena = torch.empty(
+                        arena_size, dtype=torch.uint8, device=self.device, requires_grad=False
+                    )
+                global_memory_buffer = get_global_memory_buffer()
+                for byte_offset, request in arena_layout:
+                    num_bytes, request_kind, owner, size, dtype, buffer_name = request
+                    data = self._ubr_arena.narrow(0, byte_offset, num_bytes).view(dtype)
+                    assert data.numel() == size
                     if request_kind == "max_pool":
-                        get_global_memory_buffer().get_tensor([size], dtype=dtype, name=buffer_name)
+                        global_memory_buffer.buffer[(buffer_name, dtype)] = data
                         owner.record_materialized(size, dtype, buffer_name)
                     elif request_kind == "persistent":
-                        self._ubr_persistent_data[id(owner)] = torch.empty(
-                            size, dtype=dtype, device=self.device
-                        )
+                        self._ubr_persistent_data[id(owner)] = data
                     else:
-                        self._ubr_all_in_one_data[owner] = torch.empty(
-                            size, dtype=dtype, device=self.device
-                        )
+                        raise AssertionError(f"Unexpected UBR allocation kind: {request_kind}")
+            else:
+                arena_size = None
+                with self.mem_alloc_context():
+                    for _, request_kind, owner, size, dtype, buffer_name in ordered_allocation_plan:
+                        if request_kind == "max_pool":
+                            get_global_memory_buffer().get_tensor(
+                                [size], dtype=dtype, name=buffer_name
+                            )
+                            owner.record_materialized(size, dtype, buffer_name)
+                        elif request_kind == "persistent":
+                            self._ubr_persistent_data[id(owner)] = torch.empty(
+                                size, dtype=dtype, device=self.device
+                            )
+                        else:
+                            raise AssertionError(f"Unexpected UBR allocation kind: {request_kind}")
             torch.cuda.synchronize()
             log_single_rank(
                 logger,
                 logging.INFO,
                 f"[MCORE][FSDP][Manual REG] Materialized {len(allocation_plan)} buffers "
                 f"({sum(item[0] for item in allocation_plan)} requested bytes) in global order "
-                f"(logical plan {logical_plan_hash}).",
+                f"(logical plan {logical_plan_hash}, arena bytes {arena_size}).",
             )
+
+            # Expert parameter AG uses an unregistered communicator in the dense-inner
+            # scope. Materialize its independent MaxPool outside the symmetric pool so
+            # expert/outer traffic cannot alter the registered physical segment order.
+            if dense_inner_ubr:
+                ordinary_allocator_specs = (
+                    (self.expert_weight_alloc, expert_weight_specs),
+                    (self.expert_transpose_weight_alloc, expert_transpose_weight_specs),
+                )
+                for allocator, bucket_specs in ordinary_allocator_specs:
+                    if isinstance(allocator, MaxPoolAllocator) and bucket_specs:
+                        allocator.materialize(bucket_specs, mem_alloc_context=nullcontext)
 
         reset_context_args = {"init_param_with_fp8": self.ddp_config.fp8_param_gather}
         module_reset_flag = {}
@@ -3323,7 +3491,7 @@ class ParamAndGradBuffer:
         for group in self.parameter_groups:
             wbuf = group.model_weight_buffer
             if wbuf:
-                with self.mem_alloc_context():
+                with wbuf.mem_alloc_context():
                     if group.hfsdp_helper_wbuf:
                         _init_hfsdp_helper_and_dp_buffer_data(
                             group.hfsdp_helper_wbuf,
@@ -3345,7 +3513,7 @@ class ParamAndGradBuffer:
 
             tbuf = group.transpose_weight_buffer
             if tbuf:
-                with self.mem_alloc_context():
+                with tbuf.mem_alloc_context():
                     if group.hfsdp_helper_wbuf:
                         _init_hfsdp_helper_and_dp_buffer_data(
                             group.hfsdp_helper_wtbuf,
@@ -3525,23 +3693,11 @@ class ParamAndGradBuffer:
 
         # Allocate the main_weight buffer and main_grad buffer data in one buffer.
         if self.buffer_all_in_one:
-            preallocated_all_in_one = getattr(self, "_ubr_all_in_one_data", {})
-            with self.mem_alloc_context():
+            with self.grad_mem_alloc_context():
                 self.buffer = {}
                 for dtype, size in buffer_size.items():
                     actual_dtype = torch.uint8 if dtype == "float8" else dtype
-                    self.buffer[dtype] = preallocated_all_in_one.pop(
-                        dtype,
-                        (
-                            torch.empty(size, dtype=actual_dtype, device=self.device)
-                            if size == 0
-                            else None
-                        ),
-                    )
-                    if self.buffer[dtype] is None:
-                        self.buffer[dtype] = torch.empty(
-                            size, dtype=actual_dtype, device=self.device
-                        )
+                    self.buffer[dtype] = torch.empty(size, dtype=actual_dtype, device=self.device)
             offset = {torch.float32: 0, torch.float16: 0, torch.bfloat16: 0, "float8": 0}
 
         def _alloc(dtype, size):
@@ -3567,7 +3723,7 @@ class ParamAndGradBuffer:
                 # No gradient sharding.
                 continue
             # Allocate the main grad buffer data, and attach it to the main grad buffer.
-            with self.mem_alloc_context():
+            with self.grad_mem_alloc_context():
                 if group.hfsdp_helper_gbuf:
                     _init_hfsdp_helper_and_dp_buffer_data(
                         group.hfsdp_helper_gbuf,

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -221,6 +221,7 @@ class TransformerLayerSchedulePlan:
         self.event = event
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
+        self._fsdp_prefetch_recompute_forward_parameters = None
 
         # Set by _build_recompute_segments(); None means this layer keeps its graph.
         self.recompute_segment = None
@@ -274,6 +275,7 @@ class TransformerLayerSchedulePlan:
             else:
                 self.layer._mhc_recompute_manager = None
             del self.layer
+        self._fsdp_prefetch_recompute_forward_parameters = None
 
     def _build_callable_nodes(self, event, comp_stream, comm_stream, extra_args):
         """
@@ -488,6 +490,30 @@ class TransformerLayerSchedulePlan:
         if dispatcher is not None:
             dispatcher.reset_transient_forward_state()
 
+    def set_fsdp_recompute_prefetch_hook(
+        self, prefetch_recompute_forward_parameters: Callable[[torch.nn.Module], None]
+    ) -> None:
+        """Wire selective-recompute weight prefetch for the overlap schedule.
+
+        Args:
+            prefetch_recompute_forward_parameters: Callable that starts an asynchronous
+                rowwise all-gather for marked selective-recompute weights in this layer.
+        """
+        from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+        from megatron.core.transformer.transformer_layer import TransformerLayer
+
+        assert isinstance(self.layer, (TransformerLayer, MultiTokenPredictionLayer)), (
+            f"Megatron FSDP with EP Overlap only supports TransformerLayer, "
+            f"but got {type(self.layer).__name__}."
+        )
+
+        hook_module = (
+            self.layer if isinstance(self.layer, TransformerLayer) else self.layer.mtp_model_layer
+        )
+        self._fsdp_prefetch_recompute_forward_parameters = lambda: (
+            prefetch_recompute_forward_parameters(hook_module)
+        )
+
     def get_fp8_context(self):
         """
         Get the fp8 context for the transformer layer.
@@ -541,6 +567,8 @@ class TransformerLayerSchedulePlan:
                 b_layer.mhc_recompute.forward()
             b_grad = b_layer.mhc_post.backward(b_grad)
             b_grad = b_layer.moe_combine.backward(b_grad)
+            if b_layer._fsdp_prefetch_recompute_forward_parameters is not None:
+                b_layer._fsdp_prefetch_recompute_forward_parameters()
 
         if f_layer is not None:
             # Full recompute: retain this segment's input for the backward-time replay.

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -222,6 +222,7 @@ class TransformerLayerSchedulePlan:
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
         self._fsdp_prefetch_recompute_forward_parameters = None
+        self._fsdp_prepare_forward_module = None
 
         # Set by _build_recompute_segments(); None means this layer keeps its graph.
         self.recompute_segment = None
@@ -276,6 +277,7 @@ class TransformerLayerSchedulePlan:
                 self.layer._mhc_recompute_manager = None
             del self.layer
         self._fsdp_prefetch_recompute_forward_parameters = None
+        self._fsdp_prepare_forward_module = None
 
     def _build_callable_nodes(self, event, comp_stream, comm_stream, extra_args):
         """
@@ -376,7 +378,9 @@ class TransformerLayerSchedulePlan:
         else:
             self.mtp_post_process = NoopScheduleNode()
 
-    def set_fsdp_reshard_hooks(self, post_forward_hook, post_backward_hook):
+    def set_fsdp_reshard_hooks(
+        self, post_forward_hook, post_backward_hook, prepare_forward_module=None
+    ):
         """Wire FSDP parameter release callbacks for the fine-grained overlap schedule.
 
         The EP overlap schedule bypasses the normal FSDP forward/backward hooks
@@ -390,6 +394,8 @@ class TransformerLayerSchedulePlan:
                 (bwd=False). Typically ``fsdp_wrapper.post_forward_release_module``.
             post_backward_hook: Callable(module) that releases backward-pass params
                 (bwd=True). Typically ``fsdp_wrapper.post_backward_release_module``.
+            prepare_forward_module: Optional callable that clears the root
+                ``PRE_BACKWARD`` marker for this genuine-forward layer.
         """
         from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
         from megatron.core.transformer.transformer_layer import TransformerLayer
@@ -403,6 +409,9 @@ class TransformerLayerSchedulePlan:
             hook_module = self.layer
         else:
             hook_module = self.layer.mtp_model_layer
+
+        if prepare_forward_module is not None:
+            self._fsdp_prepare_forward_module = lambda: prepare_forward_module(hook_module)
 
         # After the last backward op (attn), release backward-pass params.
         self.attn.set_post_backward_hook(lambda: post_backward_hook(hook_module))
@@ -574,6 +583,13 @@ class TransformerLayerSchedulePlan:
             # Full recompute: retain this segment's input for the backward-time replay.
             if f_layer.recompute_segment is not None:
                 f_layer.recompute_segment.capture(f_layer, f_input)
+
+            # With an odd layer count, the middle unit can schedule forward and
+            # backward on the same underlying layer. Keep PRE_BACKWARD there so
+            # recompute weights remain lazily resharded until backward uses them.
+            same_underlying_layer = b_layer is not None and f_layer.layer is b_layer.layer
+            if f_layer._fsdp_prepare_forward_module is not None and not same_underlying_layer:
+                f_layer._fsdp_prepare_forward_module()
             with f_layer.get_fp8_context():
                 f_input = f_layer.attn.forward(f_input)
 

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -420,6 +420,7 @@ def combined_forward_backward_step(
                 layer_plan.set_fsdp_reshard_hooks(
                     forward_fsdp_wrapper.post_forward_release_module,
                     forward_fsdp_wrapper.post_backward_release_module,
+                    forward_fsdp_wrapper.prepare_forward_module,
                 )
                 layer_plan.set_fsdp_recompute_prefetch_hook(
                     forward_fsdp_wrapper.prefetch_recompute_forward_parameters

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -421,6 +421,9 @@ def combined_forward_backward_step(
                     forward_fsdp_wrapper.post_forward_release_module,
                     forward_fsdp_wrapper.post_backward_release_module,
                 )
+                layer_plan.set_fsdp_recompute_prefetch_hook(
+                    forward_fsdp_wrapper.prefetch_recompute_forward_parameters
+                )
 
     # backward preprocess, the same as the backward_step()
     unwrap_input_tensor_grad = False

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -630,6 +630,18 @@ class MLASelfAttention(MultiLatentAttention):
             name=(name + ".linear_kv_up_proj") if name is not None else None,
         )
 
+        if self.recompute_up_proj:
+            # These are the only parameterized modules replayed by the
+            # ``mla_up_proj`` selective-recompute region. Megatron-FSDP uses
+            # this marker to launch their rowwise weight all-gather early in
+            # the 1F1B EP-overlap schedule, then waits at the regular
+            # pre-forward hook immediately before the replay consumes them.
+            if self.config.q_lora_rank is not None:
+                self.linear_q_up_proj._fsdp_recompute_forward_weight = True
+            else:
+                self.linear_q_proj._fsdp_recompute_forward_weight = True
+            self.linear_kv_up_proj._fsdp_recompute_forward_weight = True
+
         if self.config.q_lora_rank is not None:
             self.q_layernorm = submodules.q_layernorm(
                 hidden_size=self.config.q_lora_rank,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -4236,6 +4236,15 @@ def _add_distributed_args(parser):
         'This option will force to use conventional (local) userbuffer registration when use-nccl-ub is set.',
     )
     group.add_argument(
+        '--fsdp-ubr-registration-scope',
+        type=str,
+        choices=['all', 'dense_inner'],
+        default='all',
+        help='Select FSDP communicators registered with the NCCL memory pool. '
+        '"all" preserves the default behavior; "dense_inner" registers only the '
+        'dense inner-FSDP parameter all-gather communicator.',
+    )
+    group.add_argument(
         '--fsdp-manual-registration',
         action='store_true',
         dest='fsdp_manual_registration',

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -4282,6 +4282,14 @@ def _add_distributed_args(parser):
         "This is required for user buffer registration and is enabled by default when using NCCL user buffers.",
     )
     group.add_argument(
+        '--fsdp-buffer-count',
+        type=int,
+        default=2,
+        help="Number of persistent buffers in each Megatron FSDP communication pool. "
+        "The default of two provides conventional double buffering; combined 1F1B "
+        "overlap with forward prefetch requires at least three.",
+    )
+    group.add_argument(
         '--suggested-communication-unit-size',
         type=int,
         default=None,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Megatron arguments."""
 
@@ -1256,14 +1256,30 @@ def validate_args(args, defaults={}):
                 "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
                 'with --data-parallel-sharding-strategy optim_grads_params.'
             )
-            assert args.recompute_granularity == "full", (
-                "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
-                "with full activation recomputation."
-            )
-            assert not args.overlap_moe_expert_parallel_comm, (
-                "--megatron-fsdp-prefetch-recompute-forward-weights is not supported "
-                "with --overlap-moe-expert-parallel-comm."
-            )
+            if args.recompute_granularity == "full":
+                assert not args.overlap_moe_expert_parallel_comm, (
+                    "--megatron-fsdp-prefetch-recompute-forward-weights with full "
+                    "activation recomputation is not supported with "
+                    "--overlap-moe-expert-parallel-comm."
+                )
+            else:
+                assert args.recompute_granularity == "selective", (
+                    "--megatron-fsdp-prefetch-recompute-forward-weights requires "
+                    "full activation recomputation, or selective recomputation of "
+                    "mla_up_proj."
+                )
+                assert "mla_up_proj" in (args.recompute_modules or []), (
+                    "Selective --megatron-fsdp-prefetch-recompute-forward-weights "
+                    "requires mla_up_proj in --recompute-modules."
+                )
+                assert (
+                    args.cuda_graph_impl != "full_iteration"
+                    or args.overlap_moe_expert_parallel_comm
+                ), (
+                    "Selective --megatron-fsdp-prefetch-recompute-forward-weights with "
+                    "full-iteration CUDA graphs requires "
+                    "--overlap-moe-expert-parallel-comm."
+                )
 
         if args.nccl_ub:
             # In Megatron-LM, required implementation for manual registration is already provided.

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -195,6 +195,17 @@ class TestFSDP1F1BOverlap:
             gc.collect()
             torch.cuda.empty_cache()
 
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    def test_fsdp_1f1b_mtp_multi_microbatch(self):
+        """MTP shared root parameters must be finalized once per microbatch."""
+        self._run_test_helper(
+            dispatcher_type="alltoall",
+            sharding_strategy="optim_grads_params",
+            mtp_num_layers=1,
+            mtp_loss_scaling_factor=0.1,
+            num_microbatches=2,
+        )
+
     def _run_test_helper(
         self,
         dispatcher_type="alltoall",
@@ -204,6 +215,9 @@ class TestFSDP1F1BOverlap:
         recompute_modules=None,
         offload_modules=None,
         flex_backend=None,
+        num_microbatches=1,
+        mtp_num_layers=None,
+        mtp_loss_scaling_factor=None,
     ):
         """Verify multi-step FSDP training with overlap produces identical
         per-step loss and final weights as standard FSDP training.
@@ -226,6 +240,9 @@ class TestFSDP1F1BOverlap:
         if offload_modules:
             extra_kwargs["fine_grained_activation_offloading"] = True
             extra_kwargs["offload_modules"] = offload_modules
+        if mtp_num_layers is not None:
+            extra_kwargs["mtp_num_layers"] = mtp_num_layers
+            extra_kwargs["mtp_loss_scaling_factor"] = mtp_loss_scaling_factor
 
         def _make_ddp_config():
             return DistributedDataParallelConfig(
@@ -295,8 +312,12 @@ class TestFSDP1F1BOverlap:
             for step in range(NUM_STEPS):
                 if hasattr(ref_fsdp, 'set_is_first_microbatch'):
                     ref_fsdp.set_is_first_microbatch()
-                ref_loss = fsdp_train_step(ref_fsdp, ref_opt, data)
-                test_loss = overlap_train_step(test_fsdp, test_opt, test_config, data)
+                ref_loss = fsdp_train_step(
+                    ref_fsdp, ref_opt, data, num_microbatches=num_microbatches
+                )
+                test_loss = overlap_train_step(
+                    test_fsdp, test_opt, test_config, data, num_microbatches=num_microbatches
+                )
 
                 assert torch.equal(ref_loss, test_loss), (
                     f"[rank {rank}] Loss mismatch at step {step}: "

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.distributed.fsdp.src.megatron_fsdp.fully_shard import fully_shard_optimizer
+from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import TrainingState
 from megatron.core.pipeline_parallel.utils import set_streams
 from megatron.core.transformer import TransformerLayer
 from megatron.core.utils import is_te_min_version
@@ -89,6 +90,110 @@ class TestFSDP1F1BOverlap:
             recompute_modules=recompute_modules,
             offload_modules=offload_modules,
         )
+
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    def test_fsdp_1f1b_genuine_forward_state(self):
+        """A genuine forward must leave PRE_BACKWARD without changing its peer layer."""
+        num_layers = 2
+        num_microbatches = 2
+        extra_kwargs = {"overlap_moe_expert_parallel_comm": True}
+        apply_flex_backend_kwargs(extra_kwargs, "alltoall", None)
+
+        def _make_ddp_config():
+            return DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                data_parallel_sharding_strategy="optim_grads_params",
+                overlap_grad_reduce=True,
+                overlap_param_gather=True,
+                megatron_fsdp_main_params_dtype=None,
+            )
+
+        with deterministic_mode():
+            data = build_input_data(seq_len=SEQ_LEN, vocab_size=VOCAB_SIZE)
+
+            control_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            control_model = build_gpt_model(control_config, vocab_size=VOCAB_SIZE)
+            init_params = reset_model(control_model)
+            control_fsdp = FullyShardedDataParallel(
+                config=control_config,
+                ddp_config=_make_ddp_config(),
+                module=control_model,
+                fsdp_unit_modules=[TransformerLayer],
+            )
+            # Reproduce the old behavior: genuine forwards inherit the root
+            # PRE_BACKWARD marker and therefore disable forward-order prefetch.
+            control_fsdp.module.prepare_forward_module = lambda module: None
+            control_opt = fully_shard_optimizer(
+                optimizer=torch.optim.SGD(control_fsdp.parameters(), lr=LR)
+            )
+
+            test_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            test_model = build_gpt_model(test_config, vocab_size=VOCAB_SIZE)
+            reset_model(test_model, init_params)
+            test_fsdp = FullyShardedDataParallel(
+                config=test_config,
+                ddp_config=_make_ddp_config(),
+                module=test_model,
+                fsdp_unit_modules=[TransformerLayer],
+            )
+            genuine_forward_state_transitions = []
+            original_prepare_forward = test_fsdp.module.prepare_forward_module
+
+            def _track_prepare_forward(module):
+                before = tuple(submodule._training_state for submodule in module.modules())
+                peer_layers = [layer for layer in test_model.decoder.layers if layer is not module]
+                peer_states_before = tuple(
+                    tuple(submodule._training_state for submodule in layer.modules())
+                    for layer in peer_layers
+                )
+                result = original_prepare_forward(module)
+                after = tuple(submodule._training_state for submodule in module.modules())
+                peer_states_after = tuple(
+                    tuple(submodule._training_state for submodule in layer.modules())
+                    for layer in peer_layers
+                )
+                assert peer_states_after == peer_states_before
+                genuine_forward_state_transitions.append((before, after))
+                return result
+
+            test_fsdp.module.prepare_forward_module = _track_prepare_forward
+            test_opt = fully_shard_optimizer(
+                optimizer=torch.optim.SGD(test_fsdp.parameters(), lr=LR)
+            )
+
+            rank = torch.distributed.get_rank()
+            for step in range(NUM_STEPS):
+                control_loss = overlap_train_step(
+                    control_fsdp,
+                    control_opt,
+                    control_config,
+                    data,
+                    num_microbatches=num_microbatches,
+                )
+                test_loss = overlap_train_step(
+                    test_fsdp, test_opt, test_config, data, num_microbatches=num_microbatches
+                )
+                assert torch.equal(control_loss, test_loss), (
+                    f"[rank {rank}] Loss mismatch at step {step}: "
+                    f"control={control_loss.item()}, test={test_loss.item()}"
+                )
+
+            assert_models_equal(control_fsdp, test_fsdp)
+            assert len(genuine_forward_state_transitions) == (
+                NUM_STEPS * num_microbatches * num_layers
+            )
+            assert any(
+                TrainingState.PRE_BACKWARD in before
+                for before, _ in genuine_forward_state_transitions
+            )
+            assert all(
+                TrainingState.PRE_BACKWARD not in after
+                for _, after in genuine_forward_state_transitions
+            )
+
+            del control_fsdp, test_fsdp, control_opt, test_opt
+            gc.collect()
+            torch.cuda.empty_cache()
 
     def _run_test_helper(
         self,

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import gc
 
@@ -129,6 +129,9 @@ class TestFSDP1F1BOverlap:
                 overlap_grad_reduce=True,
                 overlap_param_gather=True,
                 megatron_fsdp_main_params_dtype=None,
+                megatron_fsdp_prefetch_recompute_forward_weights=bool(
+                    recompute_modules and "mla_up_proj" in recompute_modules
+                ),
             )
 
         with deterministic_mode():
@@ -145,6 +148,17 @@ class TestFSDP1F1BOverlap:
                 module=ref_model,
                 fsdp_unit_modules=[TransformerLayer],
             )
+            reference_selective_prefetch_calls = []
+            if ref_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                original_reference_prefetch = ref_fsdp.module.prefetch_recompute_forward_parameters
+
+                def _track_reference_selective_prefetch(module, **kwargs):
+                    reference_selective_prefetch_calls.append(module)
+                    return original_reference_prefetch(module, **kwargs)
+
+                ref_fsdp.module.prefetch_recompute_forward_parameters = (
+                    _track_reference_selective_prefetch
+                )
             ref_opt = torch.optim.SGD(ref_fsdp.parameters(), lr=LR)
             ref_opt = fully_shard_optimizer(optimizer=ref_opt)
 
@@ -160,6 +174,15 @@ class TestFSDP1F1BOverlap:
                 module=test_model,
                 fsdp_unit_modules=[TransformerLayer],
             )
+            selective_prefetch_calls = []
+            if test_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                original_prefetch = test_fsdp.module.prefetch_recompute_forward_parameters
+
+                def _track_selective_prefetch(module):
+                    selective_prefetch_calls.append(module)
+                    return original_prefetch(module)
+
+                test_fsdp.module.prefetch_recompute_forward_parameters = _track_selective_prefetch
             test_opt = torch.optim.SGD(test_fsdp.parameters(), lr=LR)
             test_opt = fully_shard_optimizer(optimizer=test_opt)
 
@@ -176,6 +199,9 @@ class TestFSDP1F1BOverlap:
                 )
 
             assert_models_equal(ref_fsdp, test_fsdp)
+            if test_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                assert len(reference_selective_prefetch_calls) == NUM_STEPS * num_layers
+                assert len(selective_prefetch_calls) == NUM_STEPS * num_layers
 
             del ref_fsdp, test_fsdp, ref_opt, test_opt
             gc.collect()

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -383,14 +383,17 @@ def overlap_train_step(model, optimizer, config, data, num_microbatches=1):
     return loss
 
 
-def fsdp_train_step(model, optimizer, data):
+def fsdp_train_step(model, optimizer, data, num_microbatches=1):
     """One standard forward-backward-optimizer step through FSDP. Return scalar loss."""
     from megatron.core.transformer.module import float16_to_fp32
 
     optimizer.zero_grad()
-    loss = model(**data)
-    loss = float16_to_fp32(loss).sum()
-    loss.backward()
+    loss = torch.zeros([], dtype=torch.float32, device="cuda")
+    for _ in range(num_microbatches):
+        microbatch_loss = model(**data)
+        microbatch_loss = float16_to_fp32(microbatch_loss).sum()
+        (microbatch_loss / num_microbatches).backward()
+        loss += microbatch_loss.detach() / num_microbatches
     optimizer.step()
     return loss.detach().clone()
 

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -352,10 +352,8 @@ def forward_step_func(data_iterator, model, return_schedule_plan=False):
     return output, loss_func
 
 
-def overlap_train_step(model, optimizer, config, data):
+def overlap_train_step(model, optimizer, config, data, num_microbatches=1):
     """One overlap forward-backward-optimizer step. Return scalar loss."""
-    from contextlib import nullcontext
-
     from megatron.core.pipeline_parallel.combined_1f1b import (
         combined_1f1b_schedule_for_no_pipelining,
     )
@@ -364,9 +362,9 @@ def overlap_train_step(model, optimizer, config, data):
     forward_data_store = []
     combined_1f1b_schedule_for_no_pipelining(
         forward_step_func=forward_step_func,
-        data_iterator=iter([data]),
+        data_iterator=iter([data] * num_microbatches),
         model=model,
-        num_microbatches=1,
+        num_microbatches=num_microbatches,
         input_tensor=None,
         output_tensor_grad=None,
         forward_data_store=forward_data_store,
@@ -374,12 +372,13 @@ def overlap_train_step(model, optimizer, config, data):
         collect_non_loss_data=False,
         first_val_step=None,
         forward_only=False,
-        no_sync_func=nullcontext,
+        no_sync_func=model.no_sync,
         total_num_tokens=torch.zeros([], dtype=torch.int, device="cuda"),
         check_first_val_step=lambda cond: cond,
     )
     torch.cuda.synchronize()
-    loss = forward_data_store[0]['lm loss'].detach().clone()
+    loss = sum(entry['lm loss'].detach().clone() for entry in forward_data_store)
+    loss /= num_microbatches
     optimizer.step()
     return loss
 

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
@@ -4,12 +4,14 @@ import math
 
 import torch
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp import param_and_grad_buffer as pgb_module
 from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
     BucketingPolicy,
     FixedPoolAllocator,
     MaxPoolAllocator,
     ParameterGroup,
     _get_parameter_groups,
+    _mem_pool_registration_signature,
 )
 
 
@@ -71,6 +73,77 @@ def test_max_pool_capacity_includes_live_and_releasable_buffers():
     assert allocator.can_allocate([0])
     assert not allocator.can_allocate([2])
     assert allocator.can_allocate([2], releasable_bucket_ids={0})
+
+
+class _TestMemoryPool:
+    def __init__(self, segments):
+        self.segments = segments
+
+    def snapshot(self):
+        return self.segments
+
+
+def test_mem_pool_registration_signature_uses_registration_order():
+    """Signature order must match ProcessGroupNCCL's registration order."""
+    pool = _TestMemoryPool(
+        [
+            {"total_size": 4096, "registration_counter": 7, "address": 0x1000},
+            {"total_size": 1024, "registration_counter": 3, "address": 0x2000},
+            {"total_size": 2048, "registration_counter": 5, "address": 0x3000},
+        ]
+    )
+
+    assert _mem_pool_registration_signature(pool) == (1024, 2048, 4096)
+
+
+def test_mem_pool_registration_signature_ignores_local_addresses():
+    """Different rank-local addresses do not change the collective layout."""
+    first = _TestMemoryPool([{"total_size": 1024, "address": 0x1000}])
+    second = _TestMemoryPool([{"total_size": 1024, "address": 0x9000}])
+
+    assert _mem_pool_registration_signature(first) == _mem_pool_registration_signature(second)
+
+
+def test_max_pool_materialize_uses_exact_largest_padded_bucket(monkeypatch):
+    """Eager materialization uses exact runtime sizes in deterministic slot order."""
+    parameter_groups = [
+        ParameterGroup(
+            [torch.nn.Parameter(torch.empty(4, dtype=torch.bfloat16))],
+            dtype=torch.bfloat16,
+            fsdp_unit_id=0,
+        ),
+        ParameterGroup(
+            [torch.nn.Parameter(torch.empty(8, dtype=torch.bfloat16))],
+            dtype=torch.bfloat16,
+            fsdp_unit_id=1,
+        ),
+    ]
+    allocator = MaxPoolAllocator("test_pool", parameter_groups, size=2)
+
+    allocations = []
+
+    class _TestGlobalMemoryBuffer:
+        def get_tensor(self, tensor_shape, dtype, name, mem_alloc_context=None):
+            allocations.append((tuple(tensor_shape), dtype, name, mem_alloc_context))
+            return torch.empty(tensor_shape, dtype=dtype)
+
+    monkeypatch.setattr(pgb_module, "get_global_memory_buffer", _TestGlobalMemoryBuffer)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    allocator.materialize({0: (64, torch.uint8), 1: (8, torch.float32)})
+
+    assert allocations == [
+        ((8,), torch.float32, "test_pool_0_torch.float32_0", None),
+        ((8,), torch.float32, "test_pool_1_torch.float32_0", None),
+        ((64,), torch.uint8, "test_pool_0_torch.uint8_0", None),
+        ((64,), torch.uint8, "test_pool_1_torch.uint8_0", None),
+    ]
+    assert allocator.allocation_tracker == {
+        ("test_pool_0_torch.float32_0", torch.float32): 8,
+        ("test_pool_0_torch.uint8_0", torch.uint8): 64,
+        ("test_pool_1_torch.float32_0", torch.float32): 8,
+        ("test_pool_1_torch.uint8_0", torch.uint8): 64,
+    }
 
 
 def test_grouped_expert_weights_split_when_chunk_size_factors_differ():

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
@@ -2,6 +2,7 @@
 
 import math
 
+import pytest
 import torch
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp import param_and_grad_buffer as pgb_module
@@ -10,7 +11,9 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer impo
     FixedPoolAllocator,
     MaxPoolAllocator,
     ParameterGroup,
+    _build_ubr_arena_layout,
     _get_parameter_groups,
+    _get_ubr_registration_groups,
     _mem_pool_registration_signature,
 )
 
@@ -83,6 +86,58 @@ class _TestMemoryPool:
         return self.segments
 
 
+class _TestDistIndex:
+    def __init__(self, use_hybrid_fsdp):
+        self.use_hybrid_fsdp = use_hybrid_fsdp
+        self.dense = object()
+        self.expert = object()
+        self.dense_ag = object()
+        self.expert_ag = object()
+        self.outer = object()
+
+    def get_fsdp_group(self, is_expert_parallel=False, independent_all_gather=False):
+        if is_expert_parallel:
+            return self.expert_ag if independent_all_gather else self.expert
+        return self.dense_ag if independent_all_gather else self.dense
+
+    def get_outer_fsdp_group(self):
+        return self.outer
+
+
+def test_dense_inner_ubr_scope_selects_hsdp_dense_helper_group_only():
+    """HSDP inner parameter AG uses the base dense FSDP group, not outer/expert groups."""
+    dist_index = _TestDistIndex(use_hybrid_fsdp=True)
+
+    assert _get_ubr_registration_groups(dist_index, "dense_inner") == [dist_index.dense]
+
+
+def test_dense_inner_ubr_scope_prefers_independent_ag_without_hsdp():
+    """Non-HSDP parameter AG uses its independent communicator when one is provided."""
+    dist_index = _TestDistIndex(use_hybrid_fsdp=False)
+
+    assert _get_ubr_registration_groups(dist_index, "dense_inner") == [dist_index.dense_ag]
+
+
+def test_all_ubr_scope_preserves_every_registration_group():
+    """The default scope remains backward compatible with the previous group list."""
+    dist_index = _TestDistIndex(use_hybrid_fsdp=True)
+
+    assert _get_ubr_registration_groups(dist_index, "all") == [
+        dist_index.dense,
+        dist_index.expert,
+        dist_index.dense_ag,
+        dist_index.expert_ag,
+        dist_index.outer,
+    ]
+
+
+def test_ubr_scope_rejects_unknown_value():
+    dist_index = _TestDistIndex(use_hybrid_fsdp=True)
+
+    with pytest.raises(ValueError, match="Invalid FSDP UBR registration scope"):
+        _get_ubr_registration_groups(dist_index, "outer")
+
+
 def test_mem_pool_registration_signature_uses_registration_order():
     """Signature order must match ProcessGroupNCCL's registration order."""
     pool = _TestMemoryPool(
@@ -102,6 +157,20 @@ def test_mem_pool_registration_signature_ignores_local_addresses():
     second = _TestMemoryPool([{"total_size": 1024, "address": 0x9000}])
 
     assert _mem_pool_registration_signature(first) == _mem_pool_registration_signature(second)
+
+
+def test_ubr_arena_layout_aligns_requests_in_logical_order():
+    requests = [
+        (17, "max_pool", object(), 17, torch.uint8, "first"),
+        (512, "persistent", object(), 128, torch.float32, "second"),
+        (33, "max_pool", object(), 33, torch.uint8, "third"),
+    ]
+
+    layout, arena_size = _build_ubr_arena_layout(requests, alignment=256)
+
+    assert [offset for offset, _ in layout] == [0, 256, 768]
+    assert [request[-1] for _, request in layout] == ["first", "second", "third"]
+    assert arena_size == 1024
 
 
 def test_max_pool_materialize_uses_exact_largest_padded_bucket(monkeypatch):
@@ -144,6 +213,40 @@ def test_max_pool_materialize_uses_exact_largest_padded_bucket(monkeypatch):
         ("test_pool_1_torch.float32_0", torch.float32): 8,
         ("test_pool_1_torch.uint8_0", torch.uint8): 64,
     }
+
+
+def test_max_pool_bucket_filter_keeps_dense_and_expert_slots_disjoint():
+    """Dense-inner UBR cannot share registered MaxPool slots with expert traffic."""
+    dense_param = torch.nn.Parameter(torch.empty(4, dtype=torch.bfloat16))
+    expert_param = torch.nn.Parameter(torch.empty(8, dtype=torch.bfloat16))
+    parameter_groups = [
+        ParameterGroup([dense_param], dtype=torch.bfloat16, fsdp_unit_id=0),
+        ParameterGroup([expert_param], dtype=torch.bfloat16, is_expert_param=True, fsdp_unit_id=0),
+    ]
+
+    dense_allocator = MaxPoolAllocator(
+        "dense_pool",
+        parameter_groups,
+        size=2,
+        bucket_filter=lambda _, group: not group.is_expert_param,
+    )
+    expert_allocator = MaxPoolAllocator(
+        "expert_pool",
+        parameter_groups,
+        size=2,
+        bucket_filter=lambda _, group: group.is_expert_param,
+    )
+
+    assert set(dense_allocator.bucket_alloc_index) == {0}
+    assert set(expert_allocator.bucket_alloc_index) == {1}
+    assert dense_allocator.materialization_requests({0: (16, torch.bfloat16)}) == [
+        (16, torch.bfloat16, "dense_pool_0_torch.bfloat16_0"),
+        (16, torch.bfloat16, "dense_pool_1_torch.bfloat16_0"),
+    ]
+    assert expert_allocator.materialization_requests({1: (32, torch.bfloat16)}) == [
+        (32, torch.bfloat16, "expert_pool_0_torch.bfloat16_0"),
+        (32, torch.bfloat16, "expert_pool_1_torch.bfloat16_0"),
+    ]
 
 
 def test_grouped_expert_weights_split_when_chunk_size_factors_differ():

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_param_and_grad_buffer.py
@@ -6,6 +6,9 @@ import torch
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
     BucketingPolicy,
+    FixedPoolAllocator,
+    MaxPoolAllocator,
+    ParameterGroup,
     _get_parameter_groups,
 )
 
@@ -37,6 +40,37 @@ def _get_bucket_signatures(module):
         }
         for group in bucket_groups
     ]
+
+
+def _make_uniform_parameter_groups(count=4):
+    return [
+        ParameterGroup(
+            [torch.nn.Parameter(torch.empty(8, dtype=torch.bfloat16))],
+            dtype=torch.bfloat16,
+            fsdp_unit_id=unit_id,
+        )
+        for unit_id in range(count)
+    ]
+
+
+def test_fixed_pool_capacity_includes_live_and_releasable_buffers():
+    allocator = FixedPoolAllocator("fixed", _make_uniform_parameter_groups(), size=2)
+    allocator.idle_buffer = []
+    allocator.using_buffer = {0: (0, 0), 1: (1, 0)}
+
+    assert allocator.can_allocate([0])
+    assert not allocator.can_allocate([2])
+    assert allocator.can_allocate([2], releasable_bucket_ids={0})
+
+
+def test_max_pool_capacity_includes_live_and_releasable_buffers():
+    allocator = MaxPoolAllocator("max", _make_uniform_parameter_groups(), size=2)
+    allocator.idle_buffer = []
+    allocator.using_buffer = {0: (0, torch.bfloat16, 0), 1: (1, torch.bfloat16, 0)}
+
+    assert allocator.can_allocate([0])
+    assert not allocator.can_allocate([2])
+    assert allocator.can_allocate([2], releasable_bucket_ids={0})
 
 
 def test_grouped_expert_weights_split_when_chunk_size_factors_differ():


### PR DESCRIPTION
## Summary

This draft integration PR provides one public, conflict-resolved code endpoint for the DeepSeek-V3 GB200 combined-1F1B/full-iteration-CUDA-Graph FSDP recipe.

It composes the production changes from:

- #6174: genuine-forward FSDP prefetch in combined 1F1B
- #6176: selective-recompute weight prefetch
- #6316: configurable persistent communication buffers and lifetime gates
- #6317: deterministic manual UBR registration
- #6318: dense-inner-only symmetric UBR arena
- #6605: MTP root finalization

The integration is rebased onto official `dev@1ea5c3472e2c762f8f5b32682c19d367e03e3c35`. The only runtime conflict with current dev was in `TransformerLayerSchedulePlan.run`: this branch preserves both the newer full-recompute segment input capture and the genuine-forward FSDP state preparation.

This branch intentionally excludes historical UBR tracing/debugging and workarounds that are superseded by the scoped production implementation or inactive for the A2A-overlap recipe.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev bash tools/autoformat.sh` with Black 26.3.0: passed Black, isort, pylint, and ruff
- `python tools/check_copyright.py <changed Python files>`: passed
- GPU correctness/performance validation remains pending; keep this PR in draft until the combined 1F1B/full-CG proxy and 256-GPU recipe gates complete

## Related validated reference

The historical DeepSeek-V3 GB200 run used `8c2ac747c5515cd063026c033fa17b158c40646c`. This PR is the public clean integration endpoint, not a byte-for-byte replay of historical debug commits.