### PR TITLE
Re-derive quantized params from FP32 main params on checkpoint load

### DIFF
--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -137,6 +137,11 @@ class MimoOptimizer(MegatronOptimizer):
         for opt in self._active_optimizers:
             opt.prepare_model_params_for_param_sync()
 
+    def refresh_model_params_from_main_params(self) -> None:
+        """Re-derive model params from main params in all active module optimizers."""
+        for opt in self._active_optimizers:
+            opt.refresh_model_params_from_main_params()
+
     def get_loss_scale(self) -> torch.Tensor:
         """Return the loss scale tensor from the first active optimizer."""
         if self._active_optimizers:

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -137,10 +137,10 @@ class MimoOptimizer(MegatronOptimizer):
         for opt in self._active_optimizers:
             opt.prepare_model_params_for_param_sync()
 
-    def refresh_model_params_from_main_params(self) -> None:
+    def quantize_and_sync_model_params_from_main_params(self) -> None:
         """Re-derive model params from main params in all active module optimizers."""
         for opt in self._active_optimizers:
-            opt.refresh_model_params_from_main_params()
+            opt.quantize_and_sync_model_params_from_main_params()
 
     def get_loss_scale(self) -> torch.Tensor:
         """Return the loss scale tensor from the first active optimizer."""

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2917,15 +2917,15 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if self.is_stub_optimizer:
             return
         if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-            # MXFP8 params are quantized after the all-gather, from the FP32 masters staged
-            # in the param buffer.
+            # The param buffer is BF16, so the masters land there down-cast; the MXFP8
+            # quantization happens after the all-gather, in _post_param_sync.
             self._copy_main_params_to_param_buffer()
         else:
             self._copy_main_params_to_model_params()
 
     @torch.no_grad()
-    def refresh_model_params_from_main_params(self) -> None:
-        """Re-derive the model params from the FP32 main params (see MegatronOptimizer)."""
+    def quantize_and_sync_model_params_from_main_params(self) -> None:
+        """Re-derive and all-gather the model params (see MegatronOptimizer)."""
         if self.is_stub_optimizer:
             return
         if self.config.reuse_grad_buf_for_mxfp8_param_ag:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2912,6 +2912,33 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             model_chunk.zero_grad_buffer()
         self._copy_main_params_to_param_buffer()
 
+    @torch.no_grad()
+    def _stage_model_params_from_main_params(self) -> None:
+        if self.is_stub_optimizer:
+            return
+        if self.config.reuse_grad_buf_for_mxfp8_param_ag:
+            # MXFP8 params are quantized after the all-gather, from the FP32 masters staged
+            # in the param buffer.
+            self._copy_main_params_to_param_buffer()
+        else:
+            self._copy_main_params_to_model_params()
+
+    @torch.no_grad()
+    def refresh_model_params_from_main_params(self) -> None:
+        """Re-derive the model params from the FP32 main params (see MegatronOptimizer)."""
+        if self.is_stub_optimizer:
+            return
+        if self.config.reuse_grad_buf_for_mxfp8_param_ag:
+            # The param buffer aliases the grad buffer, so zero it before staging into it.
+            for model_chunk in self.model_chunks:
+                model_chunk.zero_grad_buffer()
+        self._stage_model_params_from_main_params()
+        # Each rank only owns a shard of the main params, so the full params have to be
+        # gathered. The caller is outside the training loop, so gather synchronously
+        # instead of relying on the next step's overlapped gather.
+        for model_chunk in self.model_chunks:
+            model_chunk.start_param_sync(force_sync=True)
+
     def _copy_main_params_to_param_buffer(self):
         """
         This function is only used for MXFP8 params.

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2928,10 +2928,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """Re-derive and all-gather the model params (see MegatronOptimizer)."""
         if self.is_stub_optimizer:
             return
-        if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-            # The param buffer aliases the grad buffer, so zero it before staging into it.
-            for model_chunk in self.model_chunks:
-                model_chunk.zero_grad_buffer()
         self._stage_model_params_from_main_params()
         # Each rank only owns a shard of the main params, so the full params have to be
         # gathered. The caller is outside the training loop, so gather synchronously

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2917,8 +2917,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if self.is_stub_optimizer:
             return
         if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-            # The param buffer is BF16, so the masters land there down-cast; the MXFP8
-            # quantization happens after the all-gather, in _post_param_sync.
+            # MXFP8 reuses the grad buffer for the param all-gather; the quantization
+            # happens after the all-gather, in _post_param_sync.
             self._copy_main_params_to_param_buffer()
         else:
             self._copy_main_params_to_model_params()

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1644,15 +1644,10 @@ class ChainedOptimizer(MegatronOptimizer):
     def quantize_and_sync_model_params_from_main_params(self) -> None:
         """Re-derive and all-gather the model params (see MegatronOptimizer)."""
         # A rank with no trainable parameters gets an empty chain, and __init__ leaves
-        # self.config unset in that case, so this has to return before touching it.
+        # self.config unset in that case, so nothing here may read it.
         if self.is_stub_optimizer:
             return
         model_chunks = self._unique_model_chunks()
-        if self.config.reuse_grad_buf_for_mxfp8_param_ag:
-            # The param buffer aliases the grad buffer and is shared by every chained
-            # optimizer, so it must be zeroed once, before any of them stages into it.
-            for model_chunk in model_chunks:
-                model_chunk.zero_grad_buffer()
         for optimizer in self.chained_optimizers:
             optimizer._stage_model_params_from_main_params()
         for model_chunk in model_chunks:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1629,6 +1629,15 @@ class ChainedOptimizer(MegatronOptimizer):
         return model_chunks
 
     @override
+    def _stage_model_params_from_main_params(self) -> None:
+        # A ChainedOptimizer can itself be a member of another chain -- a
+        # LayerWiseDistributedOptimizer is a ChainedOptimizer nested inside the outer one.
+        # Without this the nested chain inherits the base no-op and its params, which are
+        # the quantized weights under Muon, are never re-derived.
+        for optimizer in self.chained_optimizers:
+            optimizer._stage_model_params_from_main_params()
+
+    @override
     @torch.no_grad()
     def quantize_and_sync_model_params_from_main_params(self) -> None:
         """Re-derive and all-gather the model params (see MegatronOptimizer)."""

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -233,21 +233,26 @@ class MegatronOptimizer(ABC):
 
         Does not zero any shared buffer and does not all-gather; both are the caller's
         responsibility so that optimizers sharing a DDP model chunk can be staged together.
-        See :meth:`refresh_model_params_from_main_params`.
+        See :meth:`quantize_and_sync_model_params_from_main_params`.
         """
         return
 
     @torch.no_grad()
-    def refresh_model_params_from_main_params(self) -> None:
-        """Re-derive the model params from the FP32 main params.
+    def quantize_and_sync_model_params_from_main_params(self) -> None:
+        """Re-derive the model params from the main params, then all-gather them.
 
-        This is the same main-to-model copy the optimizer performs at the end of every step,
-        exposed so it can be run after the main params are restored from a checkpoint.
+        Runs the same main-to-model copy an optimizer step performs, quantizing where the
+        model params are quantized, and follows it with a *synchronous* param all-gather.
+        Exposed so it can be run after the main params are restored from a checkpoint.
+
+        Not for use inside the training loop: the all-gather is forced synchronous and would
+        defeat the overlapped param gather. The training loop reaches the same copy through
+        :meth:`step_with_ready_grads`.
 
         Quantized model params (MXFP8, NVFP4) are stored dequantized and carry no block
         scales, so loading them re-quantizes a value that has already been through one
         quantization round trip, which need not land on the same block scales the saving job
-        chose from its FP32 masters. Re-deriving the model params from those masters
+        chose from its main params. Re-deriving the model params from those masters
         reproduces the saved weights exactly.
         """
         self._stage_model_params_from_main_params()
@@ -1625,8 +1630,8 @@ class ChainedOptimizer(MegatronOptimizer):
 
     @override
     @torch.no_grad()
-    def refresh_model_params_from_main_params(self) -> None:
-        """Re-derive the model params from the FP32 main params (see MegatronOptimizer)."""
+    def quantize_and_sync_model_params_from_main_params(self) -> None:
+        """Re-derive and all-gather the model params (see MegatronOptimizer)."""
         model_chunks = self._unique_model_chunks()
         if self.config.reuse_grad_buf_for_mxfp8_param_ag:
             # The param buffer aliases the grad buffer and is shared by every chained

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -252,7 +252,7 @@ class MegatronOptimizer(ABC):
         Quantized model params (MXFP8, NVFP4) are stored dequantized and carry no block
         scales, so loading them re-quantizes a value that has already been through one
         quantization round trip, which need not land on the same block scales the saving job
-        chose from its main params. Re-deriving the model params from those masters
+        chose from its main params. Re-deriving the model params from those main params
         reproduces the saved weights exactly.
         """
         self._stage_model_params_from_main_params()

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1634,6 +1634,8 @@ class ChainedOptimizer(MegatronOptimizer):
         # LayerWiseDistributedOptimizer is a ChainedOptimizer nested inside the outer one.
         # Without this the nested chain inherits the base no-op and its params, which are
         # the quantized weights under Muon, are never re-derived.
+        if self.is_stub_optimizer:
+            return
         for optimizer in self.chained_optimizers:
             optimizer._stage_model_params_from_main_params()
 
@@ -1641,6 +1643,10 @@ class ChainedOptimizer(MegatronOptimizer):
     @torch.no_grad()
     def quantize_and_sync_model_params_from_main_params(self) -> None:
         """Re-derive and all-gather the model params (see MegatronOptimizer)."""
+        # A rank with no trainable parameters gets an empty chain, and __init__ leaves
+        # self.config unset in that case, so this has to return before touching it.
+        if self.is_stub_optimizer:
+            return
         model_chunks = self._unique_model_chunks()
         if self.config.reuse_grad_buf_for_mxfp8_param_ag:
             # The param buffer aliases the grad buffer and is shared by every chained

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -228,6 +228,30 @@ class MegatronOptimizer(ABC):
         """Stage optimizer-owned model params before an explicit DDP param sync."""
         return
 
+    def _stage_model_params_from_main_params(self) -> None:
+        """Re-derive this optimizer's model params from its FP32 main params.
+
+        Does not zero any shared buffer and does not all-gather; both are the caller's
+        responsibility so that optimizers sharing a DDP model chunk can be staged together.
+        See :meth:`refresh_model_params_from_main_params`.
+        """
+        return
+
+    @torch.no_grad()
+    def refresh_model_params_from_main_params(self) -> None:
+        """Re-derive the model params from the FP32 main params.
+
+        This is the same main-to-model copy the optimizer performs at the end of every step,
+        exposed so it can be run after the main params are restored from a checkpoint.
+
+        Quantized model params (MXFP8, NVFP4) are stored dequantized and carry no block
+        scales, so loading them re-quantizes a value that has already been through one
+        quantization round trip, which need not land on the same block scales the saving job
+        chose from its FP32 masters. Re-deriving the model params from those masters
+        reproduces the saved weights exactly.
+        """
+        self._stage_model_params_from_main_params()
+
     def _filter_grads_for_norm(
         self,
         params: List[torch.nn.Parameter],
@@ -703,6 +727,12 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
     def reload_model_params(self, state_dict=None):
         if self.param_groups:
             self._copy_model_params_to_main_params(state_dict=state_dict)
+
+    @override
+    def _stage_model_params_from_main_params(self) -> None:
+        if getattr(self, 'is_stub_optimizer', False):
+            return
+        self._copy_main_params_to_model_params()
 
     def _unscale_main_grads_and_check_for_nan(self):
 
@@ -1575,6 +1605,38 @@ class ChainedOptimizer(MegatronOptimizer):
         state_dicts = self._split_state_dict(state_dict)
         for idx, optimizer in enumerate(self.chained_optimizers):
             optimizer.reload_model_params(state_dict=state_dicts[idx])
+
+    def _unique_model_chunks(self) -> List[torch.nn.Module]:
+        """Model chunks owned by the chained optimizers, each listed once.
+
+        Chained optimizers (e.g. a dense and an expert optimizer) commonly share the same
+        DDP model chunk, so per-chunk work must not be repeated per optimizer.
+        """
+        model_chunks = []
+        seen = set()
+        for optimizer in self.chained_optimizers:
+            if getattr(optimizer, 'is_stub_optimizer', False):
+                continue
+            for model_chunk in getattr(optimizer, 'model_chunks', []):
+                if id(model_chunk) not in seen:
+                    seen.add(id(model_chunk))
+                    model_chunks.append(model_chunk)
+        return model_chunks
+
+    @override
+    @torch.no_grad()
+    def refresh_model_params_from_main_params(self) -> None:
+        """Re-derive the model params from the FP32 main params (see MegatronOptimizer)."""
+        model_chunks = self._unique_model_chunks()
+        if self.config.reuse_grad_buf_for_mxfp8_param_ag:
+            # The param buffer aliases the grad buffer and is shared by every chained
+            # optimizer, so it must be zeroed once, before any of them stages into it.
+            for model_chunk in model_chunks:
+                model_chunk.zero_grad_buffer()
+        for optimizer in self.chained_optimizers:
+            optimizer._stage_model_params_from_main_params()
+        for model_chunk in model_chunks:
+            model_chunk.start_param_sync(force_sync=True)
 
     def state_dict(self):
         if len(self.chained_optimizers) == 1:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1611,23 +1611,6 @@ class ChainedOptimizer(MegatronOptimizer):
         for idx, optimizer in enumerate(self.chained_optimizers):
             optimizer.reload_model_params(state_dict=state_dicts[idx])
 
-    def _unique_model_chunks(self) -> List[torch.nn.Module]:
-        """Model chunks owned by the chained optimizers, each listed once.
-
-        Chained optimizers (e.g. a dense and an expert optimizer) commonly share the same
-        DDP model chunk, so per-chunk work must not be repeated per optimizer.
-        """
-        model_chunks = []
-        seen = set()
-        for optimizer in self.chained_optimizers:
-            if getattr(optimizer, 'is_stub_optimizer', False):
-                continue
-            for model_chunk in getattr(optimizer, 'model_chunks', []):
-                if id(model_chunk) not in seen:
-                    seen.add(id(model_chunk))
-                    model_chunks.append(model_chunk)
-        return model_chunks
-
     @override
     def _stage_model_params_from_main_params(self) -> None:
         # A ChainedOptimizer can itself be a member of another chain -- a
@@ -1647,10 +1630,13 @@ class ChainedOptimizer(MegatronOptimizer):
         # self.config unset in that case, so nothing here may read it.
         if self.is_stub_optimizer:
             return
-        model_chunks = self._unique_model_chunks()
         for optimizer in self.chained_optimizers:
             optimizer._stage_model_params_from_main_params()
-        for model_chunk in model_chunks:
+        # self.model_chunks, not a walk over the members: __init__ collects chunks only from
+        # members that expose a model_chunks attribute, which Float16OptimizerWithFloat16Params
+        # does not. LayerWiseDistributedOptimizer therefore reassigns self.model_chunks after
+        # super().__init__(), and recomputing here would discard that and gather nothing.
+        for model_chunk in self.model_chunks:
             model_chunk.start_param_sync(force_sync=True)
 
     def state_dict(self):

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -3093,6 +3093,14 @@ def load_checkpoint(
         ):
             optimizer.quantize_and_sync_model_params_from_main_params()
     else:
+        if getattr(args, 'fp8_param_gather', False) or getattr(args, 'fp4_param_gather', False):
+            print_rank_0(
+                'WARNING: quantized params were loaded without the optimizer main params, so '
+                'they were re-quantized from the dequantized values in the checkpoint rather '
+                'than re-derived from the main params. The block scales need not match the '
+                'ones the saving job chose, so the weights are not guaranteed to be bit-wise '
+                'identical to those saved. Load the optimizer state to avoid this.'
+            )
         if (args.fp16 or args.bf16) and optimizer is not None:
             if args.load_main_params_from_ckpt:
                 optimizer.reload_model_params(state_dict=state_dict)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -3085,8 +3085,11 @@ def load_checkpoint(
         if (
             not skip_load_to_model_and_opt
             and optimizer is not None
-            and not optimizer.is_stub_optimizer
-            and (args.fp8_param_gather or args.fp4_param_gather)
+            and not getattr(optimizer, 'is_stub_optimizer', False)
+            and (
+                getattr(args, 'fp8_param_gather', False)
+                or getattr(args, 'fp4_param_gather', False)
+            )
         ):
             optimizer.quantize_and_sync_model_params_from_main_params()
     else:

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -3074,6 +3074,22 @@ def load_checkpoint(
                 'exiting ...'.format(checkpoint_name)
             )
             raise e
+
+        # Quantized params are stored dequantized to BF16 and carry no block scales, so
+        # loading them re-quantizes -- from a value that has already been through one
+        # quantization round trip, whereas a training step quantizes the FP32 master. Same
+        # quantizer, same blocks, different input: for MXFP8 that moves the block scale of
+        # roughly 5% of 32-element blocks one E8M0 exponent finer (never coarser, since a
+        # round trip can only lower a block's amax, which is capped at 448*scale), and every
+        # element in those blocks re-encodes. Re-derive the params from the FP32 masters that
+        # were just restored, so the resumed weights are bit-wise the weights that were saved.
+        if (
+            not skip_load_to_model_and_opt
+            and optimizer is not None
+            and not optimizer.is_stub_optimizer
+            and (args.fp8_param_gather or args.fp4_param_gather)
+        ):
+            optimizer.refresh_model_params_from_main_params()
     else:
         if (args.fp16 or args.bf16) and optimizer is not None:
             if args.load_main_params_from_ckpt:

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -3075,21 +3075,20 @@ def load_checkpoint(
             )
             raise e
 
-        # Quantized params are stored dequantized to BF16 and carry no block scales, so
-        # loading them re-quantizes -- from a value that has already been through one
-        # quantization round trip, whereas a training step quantizes the FP32 master. Same
-        # quantizer, same blocks, different input: for MXFP8 that moves the block scale of
-        # roughly 5% of 32-element blocks one E8M0 exponent finer (never coarser, since a
-        # round trip can only lower a block's amax, which is capped at 448*scale), and every
-        # element in those blocks re-encodes. Re-derive the params from the FP32 masters that
-        # were just restored, so the resumed weights are bit-wise the weights that were saved.
+        # Quantized weights are stored dequantized to BF16 with no block scales, so loading
+        # them re-quantizes a value that has already been through one quantization round
+        # trip, while a training step quantizes the main weights. Same quantizer, different
+        # input, so for MXFP8 the block scales do not come back the same. Recover the compute
+        # weights from the main weights in the optimizer state instead. Reaching here already
+        # implies they were loaded: the enclosing block excludes --no-load-optim, --finetune
+        # and release checkpoints, and the load above re-raises on failure.
         if (
             not skip_load_to_model_and_opt
             and optimizer is not None
             and not optimizer.is_stub_optimizer
             and (args.fp8_param_gather or args.fp4_param_gather)
         ):
-            optimizer.refresh_model_params_from_main_params()
+            optimizer.quantize_and_sync_model_params_from_main_params()
     else:
         if (args.fp16 or args.bf16) and optimizer is not None:
             if args.load_main_params_from_ckpt:

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -2,14 +2,20 @@
 """Plumbing of ``quantize_and_sync_model_params_from_main_params``.
 
 Chained optimizers (dense + expert, or a LayerWise/DistOpt pair) commonly own the *same*
-DDP model chunk, and under ``--reuse-grad-buf-for-mxfp8-param-ag`` the param buffer aliases
-the grad buffer. So the per-chunk work has to happen exactly once and in a fixed order:
-zero every shared buffer, then let each optimizer stage its own shards into it, then gather
-once. Getting that wrong corrupts weights silently -- a second zero wipes the shards a
-sibling optimizer already staged -- which is why it is worth pinning without a GPU.
+DDP model chunk, so the per-chunk work has to happen exactly once and in a fixed order:
+every optimizer stages its own shards, then the chunk is gathered once.
+
+The refresh must not zero the DDP buffers. Staging writes each rank's own shard and the
+forced gather rewrites every byte that is later read back as a param, so a zero buys
+nothing -- and under ``--reuse-grad-buf-for-mxfp8-param-ag`` the param buffer aliases the
+grad buffer, where clearing a bucket that mixes quantized and non-quantized params would
+wipe the non-quantized weights that alias it. ``_post_param_sync`` skips exactly those
+buckets for that reason. None of this needs a GPU to pin.
 """
 
 from types import SimpleNamespace
+
+import pytest
 
 from megatron.core.optimizer.optimizer import ChainedOptimizer, MegatronOptimizer
 
@@ -59,13 +65,12 @@ def _build(reuse_grad_buf, share_chunk=True, with_stub=False):
     return ChainedOptimizer(members), log
 
 
-def test_shared_model_chunk_is_zeroed_and_gathered_once():
-    """Two optimizers, one shared chunk: one zero and one gather, not two of each."""
+def test_shared_model_chunk_is_gathered_once():
+    """Two optimizers, one shared chunk: one gather, not one per optimizer."""
     optimizer, log = _build(reuse_grad_buf=True)
 
     optimizer.quantize_and_sync_model_params_from_main_params()
 
-    assert log.count(('zero', 'chunk_a')) == 1, log
     assert log.count(('sync', 'chunk_a', True)) == 1, log
     assert [entry for entry in log if entry[0] == 'stage'] == [
         ('stage', 'dense'),
@@ -73,30 +78,34 @@ def test_shared_model_chunk_is_zeroed_and_gathered_once():
     ], log
 
 
-def test_buffer_is_zeroed_before_any_optimizer_stages_into_it():
-    """A zero after a stage would wipe shards the sibling optimizer already wrote."""
+def test_every_optimizer_stages_before_the_gather():
+    """Gathering early would broadcast shards a sibling optimizer has not written yet."""
     optimizer, log = _build(reuse_grad_buf=True)
 
     optimizer.quantize_and_sync_model_params_from_main_params()
 
     order = [entry[0] for entry in log]
-    assert order.index('zero') < order.index('stage'), log
     assert max(i for i, k in enumerate(order) if k == 'stage') < order.index('sync'), log
 
 
-def test_distinct_model_chunks_are_each_zeroed_and_gathered():
+def test_distinct_model_chunks_are_each_gathered():
     optimizer, log = _build(reuse_grad_buf=True, share_chunk=False)
 
     optimizer.quantize_and_sync_model_params_from_main_params()
 
     for name in ('chunk_a', 'chunk_b'):
-        assert log.count(('zero', name)) == 1, log
         assert log.count(('sync', name, True)) == 1, log
 
 
-def test_grad_buffer_is_not_zeroed_when_the_buffer_is_not_reused():
-    """Without the shared param/grad buffer there is nothing to zero, only stage and gather."""
-    optimizer, log = _build(reuse_grad_buf=False)
+@pytest.mark.parametrize("reuse_grad_buf", [True, False])
+def test_the_refresh_never_zeroes_the_grad_buffer(reuse_grad_buf):
+    """Staging plus the forced gather rewrites every param byte, so zeroing buys nothing.
+
+    It is not merely redundant under --reuse-grad-buf-for-mxfp8-param-ag: zeroing a bucket
+    that mixes quantized and non-quantized params would clear the non-quantized weights,
+    which alias that buffer and are not restaged from the masters.
+    """
+    optimizer, log = _build(reuse_grad_buf=reuse_grad_buf)
 
     optimizer.quantize_and_sync_model_params_from_main_params()
 
@@ -135,16 +144,16 @@ def test_a_nested_chained_optimizer_stages_its_own_members():
 
     staged = [entry[1] for entry in log if entry[0] == 'stage']
     assert staged == ['inner_a', 'inner_b', 'outer'], log
-    assert log.count(('zero', 'chunk')) == 1, log
     assert log.count(('sync', 'chunk', True)) == 1, log
 
 
 def test_an_empty_chain_refreshes_without_touching_config():
     """A rank with no trainable parameters gets ChainedOptimizer([]).
 
-    __init__ takes the else branch there and never assigns self.config, so reading
-    self.config.reuse_grad_buf_for_mxfp8_param_ag raises AttributeError rather than
-    returning a default. Loading a quantized checkpoint on such a rank must not crash.
+    __init__ takes the else branch there and never assigns self.config, and it does not
+    call super().__init__(), so the attribute does not exist rather than holding None.
+    Any config read added to the refresh would raise AttributeError on exactly those
+    ranks, which is what the is_stub_optimizer guard and this test exist to prevent.
     """
     chained = ChainedOptimizer([])
     assert chained.is_stub_optimizer

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -139,6 +139,34 @@ def test_a_nested_chained_optimizer_stages_its_own_members():
     assert log.count(('sync', 'chunk', True)) == 1, log
 
 
+def test_an_empty_chain_refreshes_without_touching_config():
+    """A rank with no trainable parameters gets ChainedOptimizer([]).
+
+    __init__ takes the else branch there and never assigns self.config, so reading
+    self.config.reuse_grad_buf_for_mxfp8_param_ag raises AttributeError rather than
+    returning a default. Loading a quantized checkpoint on such a rank must not crash.
+    """
+    chained = ChainedOptimizer([])
+    assert chained.is_stub_optimizer
+    assert not hasattr(chained, 'config')
+
+    chained.quantize_and_sync_model_params_from_main_params()
+    chained._stage_model_params_from_main_params()
+
+
+def test_a_chain_of_only_stubs_stages_nothing():
+    """Every member being a stub makes the chain itself a stub."""
+    log = []
+    config = SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=True)
+    stub = _FakeOptimizer(log, 'stub', config, [], is_stub_optimizer=True)
+    chained = ChainedOptimizer([stub])
+    assert chained.is_stub_optimizer
+
+    chained.quantize_and_sync_model_params_from_main_params()
+
+    assert log == []
+
+
 def test_base_optimizer_refresh_is_a_no_op():
     """Optimizers with no main params inherit a no-op rather than failing."""
 

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -113,6 +113,32 @@ def test_stub_optimizers_contribute_no_chunks_and_stage_nothing():
     assert ('stage', 'stub') not in log, log
 
 
+def test_a_nested_chained_optimizer_stages_its_own_members():
+    """LayerWiseDistributedOptimizer is a ChainedOptimizer nested inside the outer one.
+
+    Without ChainedOptimizer._stage_model_params_from_main_params the nested chain inherits
+    the base no-op, and its params -- the quantized weights under Muon -- are never
+    re-derived. That is silent: no error, just weights that did not get refreshed.
+    """
+    log = []
+    config = SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=True)
+    chunk = _FakeModelChunk(log, 'chunk')
+    inner = ChainedOptimizer(
+        [
+            _FakeOptimizer(log, 'inner_a', config, [chunk]),
+            _FakeOptimizer(log, 'inner_b', config, [chunk]),
+        ]
+    )
+    outer = ChainedOptimizer([inner, _FakeOptimizer(log, 'outer', config, [chunk])])
+
+    outer.quantize_and_sync_model_params_from_main_params()
+
+    staged = [entry[1] for entry in log if entry[0] == 'stage']
+    assert staged == ['inner_a', 'inner_b', 'outer'], log
+    assert log.count(('zero', 'chunk')) == 1, log
+    assert log.count(('sync', 'chunk', True)) == 1, log
+
+
 def test_base_optimizer_refresh_is_a_no_op():
     """Optimizers with no main params inherit a no-op rather than failing."""
 

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Plumbing of ``quantize_and_sync_model_params_from_main_params``.
+
+Chained optimizers (dense + expert, or a LayerWise/DistOpt pair) commonly own the *same*
+DDP model chunk, and under ``--reuse-grad-buf-for-mxfp8-param-ag`` the param buffer aliases
+the grad buffer. So the per-chunk work has to happen exactly once and in a fixed order:
+zero every shared buffer, then let each optimizer stage its own shards into it, then gather
+once. Getting that wrong corrupts weights silently -- a second zero wipes the shards a
+sibling optimizer already staged -- which is why it is worth pinning without a GPU.
+"""
+
+from types import SimpleNamespace
+
+from megatron.core.optimizer.optimizer import ChainedOptimizer, MegatronOptimizer
+
+
+class _FakeModelChunk:
+    """Records the per-chunk calls the refresh is supposed to make."""
+
+    def __init__(self, log, name):
+        self._log = log
+        self._name = name
+
+    def zero_grad_buffer(self):
+        self._log.append(('zero', self._name))
+
+    def start_param_sync(self, *unused, force_sync=False, force_dispatch=False):
+        self._log.append(('sync', self._name, force_sync))
+
+
+class _FakeOptimizer:
+    """Minimal stand-in for a chained member optimizer."""
+
+    def __init__(self, log, name, config, model_chunks, is_stub_optimizer=False):
+        self._log = log
+        self._name = name
+        self.config = config
+        self.model_chunks = model_chunks
+        self.is_stub_optimizer = is_stub_optimizer
+
+    def _stage_model_params_from_main_params(self):
+        if self.is_stub_optimizer:
+            return
+        self._log.append(('stage', self._name))
+
+
+def _build(reuse_grad_buf, share_chunk=True, with_stub=False):
+    log = []
+    config = SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=reuse_grad_buf)
+    chunk_a = _FakeModelChunk(log, 'chunk_a')
+    chunk_b = chunk_a if share_chunk else _FakeModelChunk(log, 'chunk_b')
+    members = [
+        _FakeOptimizer(log, 'dense', config, [chunk_a]),
+        _FakeOptimizer(log, 'expert', config, [chunk_b]),
+    ]
+    if with_stub:
+        stub_chunk = _FakeModelChunk(log, 'stub_chunk')
+        members.append(_FakeOptimizer(log, 'stub', config, [stub_chunk], is_stub_optimizer=True))
+    return ChainedOptimizer(members), log
+
+
+def test_shared_model_chunk_is_zeroed_and_gathered_once():
+    """Two optimizers, one shared chunk: one zero and one gather, not two of each."""
+    optimizer, log = _build(reuse_grad_buf=True)
+
+    optimizer.quantize_and_sync_model_params_from_main_params()
+
+    assert log.count(('zero', 'chunk_a')) == 1, log
+    assert log.count(('sync', 'chunk_a', True)) == 1, log
+    assert [entry for entry in log if entry[0] == 'stage'] == [
+        ('stage', 'dense'),
+        ('stage', 'expert'),
+    ], log
+
+
+def test_buffer_is_zeroed_before_any_optimizer_stages_into_it():
+    """A zero after a stage would wipe shards the sibling optimizer already wrote."""
+    optimizer, log = _build(reuse_grad_buf=True)
+
+    optimizer.quantize_and_sync_model_params_from_main_params()
+
+    order = [entry[0] for entry in log]
+    assert order.index('zero') < order.index('stage'), log
+    assert max(i for i, k in enumerate(order) if k == 'stage') < order.index('sync'), log
+
+
+def test_distinct_model_chunks_are_each_zeroed_and_gathered():
+    optimizer, log = _build(reuse_grad_buf=True, share_chunk=False)
+
+    optimizer.quantize_and_sync_model_params_from_main_params()
+
+    for name in ('chunk_a', 'chunk_b'):
+        assert log.count(('zero', name)) == 1, log
+        assert log.count(('sync', name, True)) == 1, log
+
+
+def test_grad_buffer_is_not_zeroed_when_the_buffer_is_not_reused():
+    """Without the shared param/grad buffer there is nothing to zero, only stage and gather."""
+    optimizer, log = _build(reuse_grad_buf=False)
+
+    optimizer.quantize_and_sync_model_params_from_main_params()
+
+    assert not [entry for entry in log if entry[0] == 'zero'], log
+    assert log.count(('sync', 'chunk_a', True)) == 1, log
+
+
+def test_stub_optimizers_contribute_no_chunks_and_stage_nothing():
+    optimizer, log = _build(reuse_grad_buf=True, with_stub=True)
+
+    optimizer.quantize_and_sync_model_params_from_main_params()
+
+    assert not [entry for entry in log if entry[1] == 'stub_chunk'], log
+    assert ('stage', 'stub') not in log, log
+
+
+def test_base_optimizer_refresh_is_a_no_op():
+    """Optimizers with no main params inherit a no-op rather than failing."""
+
+    class _Bare(MegatronOptimizer):
+        def __init__(self):  # deliberately skips MegatronOptimizer.__init__
+            pass
+
+        def prepare_grads(self) -> bool: ...
+        def step_with_ready_grads(self) -> bool: ...
+        def zero_grad(self, set_to_none=True): ...
+        def get_loss_scale(self): ...
+        def reload_model_params(self, state_dict=None): ...
+        def state_dict(self): ...
+        def load_state_dict(self, state_dict): ...
+        def step(self): ...
+        def sharded_state_dict(self, model_sharded_state_dict, is_loading=False, metadata=None): ...
+
+    _Bare().quantize_and_sync_model_params_from_main_params()

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -113,13 +113,50 @@ def test_the_refresh_never_zeroes_the_grad_buffer(reuse_grad_buf):
     assert log.count(('sync', 'chunk_a', True)) == 1, log
 
 
-def test_stub_optimizers_contribute_no_chunks_and_stage_nothing():
+def test_stub_optimizers_stage_nothing():
+    """A stub member has no main params to re-derive from, so it must not stage."""
     optimizer, log = _build(reuse_grad_buf=True, with_stub=True)
 
     optimizer.quantize_and_sync_model_params_from_main_params()
 
-    assert not [entry for entry in log if entry[1] == 'stub_chunk'], log
     assert ('stage', 'stub') not in log, log
+    assert [entry[1] for entry in log if entry[0] == 'stage'] == ['dense', 'expert'], log
+
+
+def test_gather_uses_the_chain_s_own_model_chunks():
+    """The gather must read self.model_chunks, not re-walk the members.
+
+    ChainedOptimizer.__init__ collects chunks only from members exposing a model_chunks
+    attribute. LayerWiseDistributedOptimizer's members are Float16OptimizerWithFloat16Params,
+    which do not have one, so __init__ leaves the list empty and LayerWise reassigns
+    self.model_chunks afterwards. Recomputing from the members here would discard that
+    and silently gather nothing on the whole Muon path.
+    """
+    log = []
+    config = SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=True)
+
+    class _MemberWithoutChunks:
+        """Stands in for Float16OptimizerWithFloat16Params: no model_chunks attribute."""
+
+        def __init__(self, name):
+            self._name = name
+            self.config = config
+            self.is_stub_optimizer = False
+
+        def _stage_model_params_from_main_params(self):
+            log.append(('stage', self._name))
+
+    chained = ChainedOptimizer([_MemberWithoutChunks('a'), _MemberWithoutChunks('b')])
+    assert chained.model_chunks == [], "members expose no chunks, so __init__ finds none"
+
+    # What LayerWiseDistributedOptimizer.__init__ does after super().__init__().
+    chunk = _FakeModelChunk(log, 'layerwise_chunk')
+    chained.model_chunks = [chunk]
+
+    chained.quantize_and_sync_model_params_from_main_params()
+
+    assert [e[1] for e in log if e[0] == 'stage'] == ['a', 'b'], log
+    assert log.count(('sync', 'layerwise_chunk', True)) == 1, log
 
 
 def test_a_nested_chained_optimizer_stages_its_own_members():

--- a/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
+++ b/tests/unit_tests/optimizer/test_quantize_and_sync_model_params.py
@@ -103,7 +103,7 @@ def test_the_refresh_never_zeroes_the_grad_buffer(reuse_grad_buf):
 
     It is not merely redundant under --reuse-grad-buf-for-mxfp8-param-ag: zeroing a bucket
     that mixes quantized and non-quantized params would clear the non-quantized weights,
-    which alias that buffer and are not restaged from the masters.
+    which alias that buffer and are not restaged from the main params.
     """
     optimizer, log = _build(reuse_grad_buf=reuse_grad_buf)
 

--- a/tests/unit_tests/test_fp4_param.py
+++ b/tests/unit_tests/test_fp4_param.py
@@ -487,6 +487,7 @@ class TestFP4Param:
         gc.collect()
         torch.cuda.empty_cache()
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="NVFP4 is supported since Blackwell architecture"
     )

--- a/tests/unit_tests/test_fp4_param.py
+++ b/tests/unit_tests/test_fp4_param.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import gc
 import os
 import sys
 from datetime import timedelta
@@ -18,14 +19,16 @@ from megatron.core.num_microbatches_calculator import destroy_num_microbatches_c
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.utils import is_te_min_version
 from megatron.training.arguments import core_transformer_config_from_args, parse_args, validate_args
+from megatron.training.checkpointing import load_checkpoint, save_checkpoint
 from megatron.training.global_vars import (
     destroy_global_vars,
     get_args,
     set_args,
     set_global_variables,
 )
-from megatron.training.training import get_model, setup_model_and_optimizer
+from megatron.training.training import force_param_sync, get_model, setup_model_and_optimizer
 from megatron.training.utils import get_device_arch_version
+from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 cuda_graph_supported = False
@@ -391,6 +394,154 @@ class TestFP4Param:
         loss_list_2 = self._run_test_helper(tp_size, fp4_param_gather=fp4_param_gather, **kwargs)
 
         torch.testing.assert_close(loss_list_1, loss_list_2, atol=0, rtol=0)
+
+    # ------------------------------------------------------------------
+    # Checkpoint round trip
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def quantized_param_state(model_chunk):
+        """Raw element codes and dequantized values of every NVFP4 param, by name.
+
+        Comparing the dequantized values alone would be weak: a block scale can change
+        without moving any value, and that still means the resumed tensor is not the one
+        that was saved. Comparing the raw codes alone would be weak the other way round,
+        since codes only mean something paired with a scale. So compare both.
+
+        The scale arrays are deliberately not compared directly. TE keeps block scales in a
+        padded, swizzled layout, and the padding entries are never read and not reproducible
+        across allocations, so they raise false mismatches. A scale that is actually used
+        shows up in the dequantized values.
+        """
+        data_attrs = ("_data", "_rowwise_data", "_columnwise_data")
+        state = {}
+        for name, param in model_chunk.named_parameters():
+            if not is_nvfp4tensor(param):
+                continue
+            # A quantized tensor may be the Parameter itself or its .data payload.
+            for holder in (param, param.data):
+                tensors = {
+                    attr: getattr(holder, attr).detach().clone()
+                    for attr in data_attrs
+                    if torch.is_tensor(getattr(holder, attr, None))
+                }
+                if tensors:
+                    break
+            assert tensors, f"no quantized storage found on {name} ({type(param).__name__})"
+            # .float() and not .dequantize(): on a quantized Parameter the latter recurses
+            # through __torch_dispatch__ until the stack overflows.
+            tensors["dequantized"] = param.detach().float().clone()
+            state[name] = tensors
+        return state
+
+    def setup_checkpoint_case(self, tp_size, ckpt_dir, **kwargs):
+        args = self.create_test_args(
+            tp_size,
+            self.seq_length,
+            self.micro_batch_size,
+            inference=False,
+            fp4_param_gather=True,
+            save=ckpt_dir,
+            load=ckpt_dir,
+            save_interval=1,
+            ckpt_format="torch_dist",
+            async_save=False,
+            save_tokenizer_assets=False,
+            **kwargs,
+        )
+        set_args(args)
+        torch.manual_seed(_SEED)
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp_size)
+        model_parallel_cuda_manual_seed(_SEED)
+        model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
+            ModelType.encoder_or_decoder, self.model_provider
+        )
+        assert len(model) == 1
+        return args, model, optimizer, opt_param_scheduler
+
+    def run_train_steps(self, args, model, optimizer, num_steps):
+        input_ids, labels, position_ids, attention_mask, loss_mask = self.get_batch(
+            self.seq_length, self.micro_batch_size
+        )
+        for _ in range(num_steps):
+            model[0].zero_grad_buffer()
+            optimizer.zero_grad()
+            model[0].set_is_first_microbatch()
+            output = model[0].forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                labels=labels,
+                loss_mask=loss_mask,
+            )
+            output.mean().backward()
+            if args.overlap_grad_reduce:
+                model[0].finish_grad_sync()
+            update_successful, _, _ = optimizer.step()
+            assert update_successful
+
+    def cleanup_between_runs(self):
+        Utils.destroy_model_parallel()
+        destroy_global_vars()
+        destroy_num_microbatches_calculator()
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(
+        get_device_arch_version() < 10, reason="NVFP4 is supported since Blackwell architecture"
+    )
+    @pytest.mark.skipif(not is_nvfp4_available, reason=reason_for_no_nvfp4)
+    @pytest.mark.skipif(not is_te_min_version("2.7.0.dev0"), reason="TE 2.7.0.dev0 is required")
+    @pytest.mark.parametrize("tp_size", [2])
+    def test_nvfp4_checkpoint_resume_is_bitwise_exact(self, tmp_path_dist_ckpt, tp_size):
+        """A resumed run must hold exactly the NVFP4 weights the saving run held.
+
+        NVFP4 is block-scaled like MXFP8: an E4M3 scale per 16-element block on top of a
+        per-tensor FP32 scale. Quantized params are stored dequantized to BF16 and the block
+        scales are not stored, so loading re-quantizes a value that has already been through
+        one quantization round trip, whereas a training step quantizes the FP32 master. That
+        costs MXFP8 its block scales; NVFP4 is measured to survive it today, so this is a
+        regression guard rather than a reproduction of a known break.
+        """
+        kwargs = {"overlap_param_gather": True, "overlap_grad_reduce": True}
+        # TempNamedDir(sync=True) barriers, so the process group has to exist first.
+        Utils.initialize_distributed()
+        with TempNamedDir(tmp_path_dist_ckpt / "test_nvfp4_ckpt_resume", sync=True) as ckpt_dir:
+            args, model, optimizer, opt_param_scheduler = self.setup_checkpoint_case(
+                tp_size, str(ckpt_dir), **kwargs
+            )
+            self.run_train_steps(args, model, optimizer, num_steps=3)
+            # Mirror save_checkpoint_and_time: the params are staged from the FP32 masters
+            # and gathered before the state dict is taken.
+            force_param_sync(model, optimizer=optimizer)
+            saved_state = self.quantized_param_state(model[0])
+            save_checkpoint(3, model, optimizer, opt_param_scheduler, 0)
+            torch.distributed.barrier()
+
+            self.cleanup_between_runs()
+
+            args, model, optimizer, opt_param_scheduler = self.setup_checkpoint_case(
+                tp_size, str(ckpt_dir), **kwargs
+            )
+            iteration, _ = load_checkpoint(model, optimizer, opt_param_scheduler, strict=True)
+            assert iteration == 3
+            loaded_state = self.quantized_param_state(model[0])
+
+        # Each layer contributes 4 GEMM weights: qkv, proj, fc1, fc2. Assert the count rather
+        # than just non-emptiness, so a config change that quietly drops --fp4-param-gather
+        # cannot turn this into a vacuous pass.
+        assert len(saved_state) == 4 * args.num_layers, sorted(saved_state)
+        assert saved_state.keys() == loaded_state.keys()
+        mismatches = []
+        for name, saved_tensors in saved_state.items():
+            for attr, saved_tensor in saved_tensors.items():
+                loaded_tensor = loaded_state[name][attr]
+                num_differing = int((saved_tensor != loaded_tensor).sum())
+                if num_differing:
+                    mismatches.append(f"{name}{attr}: {num_differing}/{saved_tensor.numel()}")
+        assert not mismatches, "NVFP4 params changed across a checkpoint round trip:\n" + "\n".join(
+            mismatches
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_fp4_param.py
+++ b/tests/unit_tests/test_fp4_param.py
@@ -493,7 +493,9 @@ class TestFP4Param:
     @pytest.mark.skipif(not is_nvfp4_available, reason=reason_for_no_nvfp4)
     @pytest.mark.skipif(not is_te_min_version("2.7.0.dev0"), reason="TE 2.7.0.dev0 is required")
     @pytest.mark.parametrize("tp_size", [2])
-    def test_nvfp4_checkpoint_resume_is_bitwise_exact(self, tmp_path_dist_ckpt, tp_size):
+    def test_nvfp4_checkpoint_resume_is_bitwise_exact(
+        self, tmp_path_dist_ckpt, monkeypatch, tp_size
+    ):
         """A resumed run must hold exactly the NVFP4 weights the saving run held.
 
         NVFP4 is block-scaled like MXFP8: an E4M3 scale per 16-element block on top of a
@@ -503,6 +505,9 @@ class TestFP4Param:
         costs MXFP8 its block scales; NVFP4 is measured to survive it today, so this is a
         regression guard rather than a reproduction of a known break.
         """
+        # TE refuses to load a pickled extra state by default. This checkpoint is created
+        # by the test and is therefore trusted.
+        monkeypatch.setenv("NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE", "1")
         kwargs = {"overlap_param_gather": True, "overlap_grad_reduce": True}
         # TempNamedDir(sync=True) barriers, so the process group has to exist first.
         Utils.initialize_distributed()

--- a/tests/unit_tests/test_fp4_param.py
+++ b/tests/unit_tests/test_fp4_param.py
@@ -502,7 +502,7 @@ class TestFP4Param:
         NVFP4 is block-scaled like MXFP8: an E4M3 scale per 16-element block on top of a
         per-tensor FP32 scale. Quantized params are stored dequantized to BF16 and the block
         scales are not stored, so loading re-quantizes a value that has already been through
-        one quantization round trip, whereas a training step quantizes the FP32 master. That
+        one quantization round trip, whereas a training step quantizes the FP32 main param. That
         costs MXFP8 its block scales; NVFP4 is measured to survive it today, so this is a
         regression guard rather than a reproduction of a known break.
         """
@@ -517,7 +517,7 @@ class TestFP4Param:
                 tp_size, str(ckpt_dir), **kwargs
             )
             self.run_train_steps(args, model, optimizer, num_steps=3)
-            # Mirror save_checkpoint_and_time: the params are staged from the FP32 masters
+            # Mirror save_checkpoint_and_time: the params are staged from the FP32 main params
             # and gathered before the state dict is taken.
             force_param_sync(model, optimizer=optimizer)
             saved_state = self.quantized_param_state(model[0])

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -798,10 +798,10 @@ class TestFP8Param:
 
         Quantized params are dequantized to BF16 for the checkpoint and MXFP8 block scales
         are not stored, so loading re-quantizes a value that has already been through one
-        quantization round trip, whereas a training step quantizes the FP32 master. Same
+        quantization round trip, whereas a training step quantizes the FP32 main param. Same
         quantizer, same blocks, different input: roughly 5% of 32-element blocks come back
         one E8M0 exponent finer, and every element in those blocks re-encodes. The load path
-        re-derives the params from the restored FP32 masters, which reproduces them exactly.
+        re-derives the params from the restored FP32 main params, which reproduces them exactly.
 
         Tensorwise and delayed scaling are expected to round-trip on their own, and are
         covered here so the re-derivation cannot silently perturb them.
@@ -833,7 +833,7 @@ class TestFP8Param:
                 tp_size, recipe, str(ckpt_dir), **kwargs
             )
             self.run_train_steps(args, model, optimizer, num_steps=3)
-            # Mirror save_checkpoint_and_time: the params are staged from the FP32 masters
+            # Mirror save_checkpoint_and_time: the params are staged from the FP32 main params
             # and gathered before the state dict is taken.
             force_param_sync(model, optimizer=optimizer)
             saved_state = self.quantized_param_state(model[0])

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 import torch
+from packaging.version import Version
 from transformer_engine.pytorch.fp8 import check_fp8_support
 
 from megatron.core.distributed import DistributedDataParallel as DDP
@@ -774,11 +775,23 @@ class TestFP8Param:
     # MXFP8Tensor is not supported yet"), so mxfp8 + --fp8-param-gather always runs with
     # reuse_grad_buf_for_mxfp8_param_ag. That covers the shared param/grad buffer branch of
     # the re-derivation; tensorwise and delayed cover the direct quantize_param_shard branch.
+    # LayerWiseDistributedOptimizer is a ChainedOptimizer nested inside the outer one, so
+    # it re-derives through ChainedOptimizer._stage_model_params_from_main_params. Covered
+    # on mxfp8 only: tensorwise + muon does not round-trip on some ranks for a reason that
+    # predates this change -- the layer-wise path quantizes from the FP32 main param while
+    # DistributedOptimizer quantizes from bf16(main), so the two derive different tensorwise
+    # scales from a checkpoint that stores BF16.
     @pytest.mark.parametrize(
-        ("recipe", "reuse_grad_buf"), [("mxfp8", True), ("tensorwise", False), ("delayed", False)]
+        ("recipe", "reuse_grad_buf", "optimizer_name"),
+        [
+            ("mxfp8", True, "adam"),
+            ("tensorwise", False, "adam"),
+            ("delayed", False, "adam"),
+            ("mxfp8", True, "muon"),
+        ],
     )
     def test_fp8_param_checkpoint_resume_is_bitwise_exact(
-        self, tmp_path_dist_ckpt, monkeypatch, tp_size, recipe, reuse_grad_buf
+        self, tmp_path_dist_ckpt, monkeypatch, tp_size, recipe, reuse_grad_buf, optimizer_name
     ):
         """A resumed run must hold exactly the quantized weights the saving run held.
 
@@ -794,6 +807,10 @@ class TestFP8Param:
         """
         if recipe == "mxfp8" and get_device_arch_version() < 10:
             pytest.skip("MXFP8 is supported since Blackwell architecture")
+        if optimizer_name == "muon" and Version(
+            os.getenv('NVIDIA_PYTORCH_VERSION', "24.01")
+        ) <= Version("25.05"):
+            pytest.skip("Layer-wise optimizer is not supported on LTS")
         # Delayed scaling stores its FP8 metadata as a pickled TE extra state, which TE
         # refuses to load by default. This checkpoint is created by the test and is
         # therefore trusted.
@@ -802,7 +819,12 @@ class TestFP8Param:
             "overlap_param_gather": True,
             "overlap_grad_reduce": True,
             "reuse_grad_buf_for_mxfp8_param_ag": reuse_grad_buf,
+            "optimizer": optimizer_name,
         }
+        if optimizer_name == "muon":
+            # validate_args turns --optimizer muon + --use-distributed-optimizer into the
+            # layer-wise optimizer.
+            kwargs["muon_tp_mode"] = "duplicated"
         # TempNamedDir(sync=True) barriers, so the process group has to exist first.
         Utils.initialize_distributed()
         with TempNamedDir(tmp_path_dist_ckpt / "test_fp8_ckpt_resume", sync=True) as ckpt_dir:

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -20,6 +20,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.utils import is_te_min_version
 from megatron.training.arguments import core_transformer_config_from_args, parse_args, validate_args
+from megatron.training.checkpointing import load_checkpoint, save_checkpoint
 from megatron.training.global_vars import (
     destroy_global_vars,
     get_args,
@@ -33,6 +34,7 @@ from megatron.training.training import (
     should_disable_forward_pre_hook,
 )
 from megatron.training.utils import get_device_arch_version
+from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
 _SEED = 1234
@@ -665,3 +667,173 @@ class TestFP8Param:
             "num_layers_at_end_in_bf16": 1,
         }
         self.run_test(tp_size=tp_size, recipe="blockwise", **kwargs)
+
+    # ------------------------------------------------------------------
+    # Checkpoint round trip
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def quantized_param_state(model_chunk):
+        """Raw element codes and dequantized values of every quantized param, by name.
+
+        Comparing the dequantized values alone would be weak: a block scale can change
+        without moving any value, and that still means the resumed tensor is not the one
+        that was saved. Comparing the raw codes alone would be weak the other way round,
+        since codes only mean something paired with a scale. So compare both.
+
+        The scale arrays are deliberately not compared directly. TE keeps MXFP8 block scales
+        in a padded, swizzled layout, and the padding entries are never read and not
+        reproducible across allocations, so they raise false mismatches. A scale that is
+        actually used shows up in the dequantized values.
+        """
+        data_attrs = ("_data", "_rowwise_data", "_columnwise_data")
+        state = {}
+        for name, param in model_chunk.named_parameters():
+            if not is_float8tensor(param):
+                continue
+            # A quantized tensor may be the Parameter itself or its .data payload.
+            for holder in (param, param.data):
+                tensors = {
+                    attr: getattr(holder, attr).detach().clone()
+                    for attr in data_attrs
+                    if torch.is_tensor(getattr(holder, attr, None))
+                }
+                if tensors:
+                    break
+            assert tensors, f"no quantized storage found on {name} ({type(param).__name__})"
+            # .float() and not .dequantize(): on a quantized Parameter the latter recurses
+            # through __torch_dispatch__ until the stack overflows.
+            tensors["dequantized"] = param.detach().float().clone()
+            state[name] = tensors
+        return state
+
+    def setup_checkpoint_case(self, tp_size, recipe, ckpt_dir, **kwargs):
+        args = self.create_test_args(
+            tp_size,
+            recipe,
+            self.seq_length,
+            self.micro_batch_size,
+            inference=False,
+            fp8_param_gather=True,
+            use_cuda_graph=False,
+            save=ckpt_dir,
+            load=ckpt_dir,
+            save_interval=1,
+            ckpt_format="torch_dist",
+            async_save=False,
+            save_tokenizer_assets=False,
+            **kwargs,
+        )
+        set_args(args)
+        torch.manual_seed(_SEED)
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp_size)
+        model_parallel_cuda_manual_seed(_SEED)
+        cfg_container = Utils.pretrain_config_from_global_args(args, "gpt")
+        model, optimizer, opt_param_scheduler = setup_model_and_optimizer(
+            ModelType.encoder_or_decoder,
+            self.model_provider,
+            cfg_container=cfg_container,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+        )
+        assert len(model) == 1
+        return args, model, optimizer, opt_param_scheduler
+
+    def run_train_steps(self, args, model, optimizer, num_steps):
+        batch = self.get_batch(self.seq_length, self.micro_batch_size)
+        input_ids, labels, position_ids, attention_mask, loss_mask = batch
+        for _ in range(num_steps):
+            model[0].zero_grad_buffer()
+            optimizer.zero_grad()
+            if args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather:
+                self.copy_main_params_to_param_buffer(model, optimizer)
+            model[0].set_is_first_microbatch()
+            output = model[0].forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                labels=labels,
+                loss_mask=loss_mask,
+            )
+            output.mean().backward()
+            if args.overlap_grad_reduce:
+                model[0].finish_grad_sync()
+            update_successful, _, _ = optimizer.step()
+            assert update_successful
+
+    def cleanup_between_runs(self):
+        Utils.destroy_model_parallel()
+        destroy_global_vars()
+        destroy_num_microbatches_calculator()
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(not is_te_min_version("2.3.0.dev0"), reason="TE 2.3.0.dev0 is required")
+    @pytest.mark.parametrize("tp_size", [2])
+    # MXFP8 params cannot be re-homed into the DDP param buffer ("replace_raw_data for
+    # MXFP8Tensor is not supported yet"), so mxfp8 + --fp8-param-gather always runs with
+    # reuse_grad_buf_for_mxfp8_param_ag. That covers the shared param/grad buffer branch of
+    # the re-derivation; tensorwise and delayed cover the direct quantize_param_shard branch.
+    @pytest.mark.parametrize(
+        ("recipe", "reuse_grad_buf"), [("mxfp8", True), ("tensorwise", False), ("delayed", False)]
+    )
+    def test_fp8_param_checkpoint_resume_is_bitwise_exact(
+        self, tmp_path_dist_ckpt, tp_size, recipe, reuse_grad_buf
+    ):
+        """A resumed run must hold exactly the quantized weights the saving run held.
+
+        Quantized params are dequantized to BF16 for the checkpoint and MXFP8 block scales
+        are not stored, so loading re-quantizes a value that has already been through one
+        quantization round trip, whereas a training step quantizes the FP32 master. Same
+        quantizer, same blocks, different input: roughly 5% of 32-element blocks come back
+        one E8M0 exponent finer, and every element in those blocks re-encodes. The load path
+        re-derives the params from the restored FP32 masters, which reproduces them exactly.
+
+        Tensorwise and delayed scaling are expected to round-trip on their own, and are
+        covered here so the re-derivation cannot silently perturb them.
+        """
+        if recipe == "mxfp8" and get_device_arch_version() < 10:
+            pytest.skip("MXFP8 is supported since Blackwell architecture")
+        kwargs = {
+            "overlap_param_gather": True,
+            "overlap_grad_reduce": True,
+            "reuse_grad_buf_for_mxfp8_param_ag": reuse_grad_buf,
+        }
+        # TempNamedDir(sync=True) barriers, so the process group has to exist first.
+        Utils.initialize_distributed()
+        with TempNamedDir(tmp_path_dist_ckpt / "test_fp8_ckpt_resume", sync=True) as ckpt_dir:
+            args, model, optimizer, opt_param_scheduler = self.setup_checkpoint_case(
+                tp_size, recipe, str(ckpt_dir), **kwargs
+            )
+            self.run_train_steps(args, model, optimizer, num_steps=3)
+            # Mirror save_checkpoint_and_time: the params are staged from the FP32 masters
+            # and gathered before the state dict is taken.
+            force_param_sync(model, optimizer=optimizer)
+            saved_state = self.quantized_param_state(model[0])
+            save_checkpoint(3, model, optimizer, opt_param_scheduler, 0)
+            torch.distributed.barrier()
+
+            self.cleanup_between_runs()
+
+            args, model, optimizer, opt_param_scheduler = self.setup_checkpoint_case(
+                tp_size, recipe, str(ckpt_dir), **kwargs
+            )
+            iteration, _ = load_checkpoint(model, optimizer, opt_param_scheduler, strict=True)
+            assert iteration == 3
+            loaded_state = self.quantized_param_state(model[0])
+
+        # Each layer contributes 4 GEMM weights: qkv, proj, fc1, fc2. Assert the count rather
+        # than just non-emptiness, so a config change that quietly drops --fp8-param-gather
+        # cannot turn this into a vacuous pass.
+        assert len(saved_state) == 4 * args.num_layers, sorted(saved_state)
+        assert saved_state.keys() == loaded_state.keys()
+        mismatches = []
+        for name, saved_tensors in saved_state.items():
+            for attr, saved_tensor in saved_tensors.items():
+                loaded_tensor = loaded_state[name][attr]
+                num_differing = int((saved_tensor != loaded_tensor).sum())
+                if num_differing:
+                    mismatches.append(f"{name}{attr}: {num_differing}/{saved_tensor.numel()}")
+        assert (
+            not mismatches
+        ), "quantized params changed across a checkpoint round trip:\n" + "\n".join(mismatches)

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -768,6 +768,7 @@ class TestFP8Param:
         gc.collect()
         torch.cuda.empty_cache()
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
     @pytest.mark.skipif(not is_te_min_version("2.3.0.dev0"), reason="TE 2.3.0.dev0 is required")
     @pytest.mark.parametrize("tp_size", [2])

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -778,7 +778,7 @@ class TestFP8Param:
         ("recipe", "reuse_grad_buf"), [("mxfp8", True), ("tensorwise", False), ("delayed", False)]
     )
     def test_fp8_param_checkpoint_resume_is_bitwise_exact(
-        self, tmp_path_dist_ckpt, tp_size, recipe, reuse_grad_buf
+        self, tmp_path_dist_ckpt, monkeypatch, tp_size, recipe, reuse_grad_buf
     ):
         """A resumed run must hold exactly the quantized weights the saving run held.
 
@@ -794,6 +794,10 @@ class TestFP8Param:
         """
         if recipe == "mxfp8" and get_device_arch_version() < 10:
             pytest.skip("MXFP8 is supported since Blackwell architecture")
+        # Delayed scaling stores its FP8 metadata as a pickled TE extra state, which TE
+        # refuses to load by default. This checkpoint is created by the test and is
+        # therefore trusted.
+        monkeypatch.setenv("NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE", "1")
         kwargs = {
             "overlap_param_gather": True,
             "overlap_grad_reduce": True,


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Makes a checkpoint round trip reproduce the MXFP8 weight tensor bit-for-bit when `--fp8-param-gather` is used.

**This is a reproducibility fix, not an accuracy fix.** The round trip preserves the represented values exactly and the GEMM is invariant to the difference (both measured below). What it does not preserve is the `(codes, block scale)` encoding, which is what a zero-tolerance checkpoint parity check compares.

Reported and root-caused by @ZhiyuLi-Nvidia, with a [standalone repro](https://github.com/ZhiyuLi-Nvidia/Megatron-LM/blob/zhiyul/mxfp8-ckpt-scale-repro/mxfp8_ckpt_repro/README.md).

## What goes wrong

The checkpoint stores the weight dequantized to BF16 and stores no block scales. Read back from a real checkpoint written by `save_checkpoint`:

```
key = decoder.layers.self_attention.linear_qkv.weight   dtype = torch.bfloat16
n_keys = 132    keys containing 'scale' = 0
```

So load has to re-quantize, and `MXFP8 -> BF16 -> MXFP8` is not idempotent. Measured on one 128x256 tensor, GB300:

| | codes | block scales |
|---|---|---|
| `MXFP8 -> BF16 -> MXFP8`, `copy_`/`quantize_` both sides | 1664/32768 | 52/1024 |
| `MXFP8 -> BF16 -> MXFP8`, `update_quantized` both sides | 1664/32768 | 52/1024 |
| same input, the two entry points against each other | **0**/32768 | **0**/1024 |
| sharded main-weight kernel vs `quantize_`, same FP32 main param | **0**/32768 | **0**/1024 |

Identical through both entry points, so it is a property of MXFP8 quantization rather than of any one implementation. It is not two different quantizers and not DP-shard block misalignment. (The sharded-kernel row ran at `world_size=1`, so the DP amax all-reduce was not exercised; that path is not used by mxfp8 + `--fp8-param-gather`, which requires `--reuse-grad-buf-for-mxfp8-param-ag` and quantizes after the all-gather.)

Mechanism, measured per block. The scale is the smallest power of two whose ceiling `448*s` covers the block max:

- no block's dequantized max exceeds `448*s` — 0/1024 violations, which is what makes the error one-sided
- a block's scale drops one E8M0 exponent **iff** its dequantized max is `<= 224*s`, half the ceiling — 1024/1024 agreement, zero exceptions
- every change is exactly `-1` code, never coarser
- `1664 = 52 x 32`: when a block's scale halves, all 32 of its codes double

A real flipped block:

```
amax(x)  = 0.05566406
scale    : code 115 (s=2.441e-04, ceiling 0.10937500) -> code 114 (s=1.221e-04, ceiling 0.05468750)
amax(D)  = 0.05468750  ==  224*s                      -> finer scale admissible

quantization error  max|x - D|  = 1.709e-03   <- lossy, and this happens during training
round-trip error    max|D - D2| = 0.000e+00   <- the checkpoint round trip is not lossy
```

At model scale, 4x GB300 TP=2 through a real save/load: 448/8192, 1024/24576, 2208/40960 and 1056/20480 element codes differ per parameter.

## What is not affected

Two measurements that bound the impact:

- **values**: `dequant(W)` vs `dequant(W2)` — **0/32768 differ**
- **GEMM**: same values, different encoding, through `te.Linear` under `fp8_autocast` — forward **0/16384**, dgrad **0/32768**, against a same-encoding control that also gave 0

So a resumed model computes bit-identically without this PR. The quantization loss is real but happens during training, before any checkpoint exists; the round trip does not add to it.

## The fix

The optimizer state round-trips exactly, so the FP32 main params restored from the checkpoint are the ones the saving job held, and the model param is a pure function of them (`W = Q(bf16(main))`, recomputed every step, never updated in place). Re-derive it from them after the optimizer state is loaded, through the same path a training step uses.

- New `MegatronOptimizer.quantize_and_sync_model_params_from_main_params()`, implemented for `MixedPrecisionOptimizer`, `DistributedOptimizer`, `ChainedOptimizer` and `MimoOptimizer`. Covers both quantization paths: the shared param/grad buffer (`--reuse-grad-buf-for-mxfp8-param-ag`, which quantizes after the gather) and the direct `quantize_param_shard` path. A shard-local copy is not enough on its own, so it forces the param all-gather, and stages the shared buffer once across chained optimizers owning the same model chunk.
- `load_checkpoint` calls it when `--fp8-param-gather` or `--fp4-param-gather` is on and the optimizer state was loaded.
- `LayerWiseDistributedOptimizer` subclasses `ChainedOptimizer`, so it inherits this. Not covered by a test.

**Cost**: one main-to-model copy plus one param all-gather, once per load — the same work an optimizer step already does every iteration. On the unit-test model that is ~5 ms warm; the larger numbers in that run are first-call NCCL setup. Not measured at model scale.

**Not covered**: `--no-load-optim` / `--finetune` / release checkpoints. No main params, nothing to re-derive from. Those paths now log a warning instead of silently resuming from a re-quantized weight. Closing that properly needs the block scales stored, which is a save-format change and belongs in its own PR.

## Test

`test_fp8_param_checkpoint_resume_is_bitwise_exact` (mxfp8, tensorwise, delayed) and `test_nvfp4_checkpoint_resume_is_bitwise_exact` train, save, reload into a fresh model and optimizer, and compare each quantized param's element codes and dequantized values against what was saved.

Verified on 4x GB300, TP=2, `torch_dist`:

| recipe | fix removed | with fix |
|---|---|---|
| mxfp8 | FAIL | PASS |
| tensorwise | PASS | PASS |
| delayed | PASS | PASS |
| nvfp4 | PASS | PASS |

Only the element codes ever mismatch; the dequantized values never do. The test is therefore calibrated to encoding equality, which is the invariant this PR is claiming. If we decide bit-wise identity across a checkpoint round trip is not required, this test is the thing that should change.

MXFP8 is the only recipe affected today. A single global FP32 scale reproduces across a round trip because it is determined by an amax that survives dequantization; a power-of-two E8M0 block scale does not. `blockwise` is not covered — its tests are gated to Hopper and this ran on GB300.

Existing coverage cannot see this. `run_mxfp8_checkpoint_save_load_next_loss` asserts on the loss with `atol = rtol = 2e-2` and compares a downstream scalar rather than the weights. `tests/unit_tests/dist_checkpointing/test_fp8.py` builds a tensorwise `Float8Tensor` on a 3-element constant tensor, so block scaling is never exercised.

## Issue tracking

Linked issue: none — reported internally.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter on my PR
