### PR TITLE
[Dev] Add SiTU-GLU through Transformer Engine

### DIFF
--- a/megatron/core/activations.py
+++ b/megatron/core/activations.py
@@ -21,3 +21,20 @@ def quick_gelu(x: torch.Tensor) -> torch.Tensor:
 def fast_gelu(x: torch.Tensor) -> torch.Tensor:
     """Fast GELU activation"""
     return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
+
+
+@jit_fuser
+def situlu(x: torch.Tensor, beta1: float = 4.0, beta2: float = 25.0) -> torch.Tensor:
+    """Apply SiTU-GLU to contiguous gate/up halves of an FC1 output.
+
+    This is the slow PyTorch reference and config marker until PyTorch provides
+    a dedicated ``torch.nn.functional.situlu``-style operation. Unary
+    ``F.silu`` is not equivalent because SiTU-GLU transforms both branches.
+    """
+    input_dtype = x.dtype
+    gate, up = torch.chunk(x, 2, dim=-1)
+    gate = gate.float()
+    up = up.float()
+    gate = beta1 * torch.tanh(gate / beta1) * torch.sigmoid(gate)
+    up = beta2 * torch.tanh(up / beta2)
+    return (gate * up).to(input_dtype)

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -19,6 +19,7 @@ from torch import Tensor
 from torch.nn.parameter import Parameter
 from typing_extensions import override
 
+from megatron.core.activations import situlu
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp4Recipe, Fp8Recipe
@@ -483,6 +484,13 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                     layer_type = te.pytorch.ops.GEGLU
                 elif config.activation_func == F.silu:
                     layer_type = te.pytorch.ops.ReGLU
+                elif config.activation_func is situlu:
+                    layer_type = getattr(te.pytorch.ops, "SiTUGLU", None)
+                    if layer_type is None:
+                        raise RuntimeError(
+                            "SiTU-GLU requires Transformer Engine with "
+                            "pytorch.ops.SiTUGLU support."
+                        )
             else:
                 if config.activation_func == F.gelu:
                     layer_type = te.pytorch.ops.GELU
@@ -490,10 +498,14 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                     layer_type = te.pytorch.ops.ReLU
             if layer_type is None:
                 raise Exception(
-                    'Only SwiGLU, GEGLU, ReGLU, GELU, ReLU are supported by '
+                    'Only SwiGLU, SiTU-GLU, GEGLU, ReGLU, GELU, ReLU are supported by '
                     'transformer engine. Please set use_te_activation_func=False'
                 )
             activation_func_kwargs = {}
+            if config.activation_func is situlu:
+                activation_func_kwargs.update(
+                    beta1=config.situ_glu_beta1, beta2=config.situ_glu_beta2
+                )
             if config.activation_func_fp8_input_store:
                 activation_func_kwargs["cache_quantized_input"] = True
             layer = layer_type(**activation_func_kwargs)
@@ -2880,6 +2892,12 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                 op_type = te.pytorch.ops.ReLU
             elif (activation_func, gated_linear_unit) == (F.relu, True):
                 op_type = te.pytorch.ops.ReGLU
+            elif (activation_func, gated_linear_unit) == (situlu, True):
+                op_type = getattr(te.pytorch.ops, "SiTUGLU", None)
+                if op_type is None:
+                    raise RuntimeError(
+                        "SiTU-GLU requires Transformer Engine with " "pytorch.ops.SiTUGLU support."
+                    )
 
             # Could not find corresponding activation op
             if op_type is None:
@@ -2891,6 +2909,8 @@ if HAVE_TE and is_te_min_version("1.13.0"):
 
             # Construct op
             kwargs = {}
+            if activation_func is situlu:
+                kwargs.update(beta1=self.config.situ_glu_beta1, beta2=self.config.situ_glu_beta2)
             if is_te_min_version("2.3"):
                 kwargs["cache_quantized_input"] = cache_quantized_input
             return op_type(**kwargs)
@@ -3059,14 +3079,23 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                     f"{self.__class__.__name__} does not support add_bias_linear=True; "
                     "the CuTeGEMM fused kernel requires bias-free linear layers."
                 )
-            if self.config.activation_func != F.silu or not self.config.gated_linear_unit:
+            if not self.config.gated_linear_unit or self.config.activation_func not in (
+                F.silu,
+                situlu,
+            ):
                 raise ValueError(
-                    f"{self.__class__.__name__} requires SwiGLU activation "
-                    "(activation_func=F.silu, gated_linear_unit=True) "
+                    f"{self.__class__.__name__} requires SwiGLU or SiTU-GLU activation "
+                    "with gated_linear_unit=True "
                     "for the CuTeGEMM fused kernel, but got "
                     f"activation_func={self.config.activation_func}, "
                     f"gated_linear_unit={self.config.gated_linear_unit}."
                 )
+            if self.config.activation_func is situlu:
+                if not hasattr(te.pytorch.ops, "ScaledSiTUGLU"):
+                    raise RuntimeError(
+                        "SiTU-GLU requires Transformer Engine with "
+                        "pytorch.ops.ScaledSiTUGLU support."
+                    )
 
         def _make_fused_impl(self) -> te.pytorch.ops.Sequential:
             """Construct fused module with GroupedLinear(num_groups=1) + ScaledSwiGLU."""
@@ -3143,9 +3172,19 @@ if HAVE_TE and is_te_min_version("1.13.0"):
             op._glu_interleave_size = _GLU_INTERLEAVE_SIZE  # signals fuser_forward to interleave
             fused_impl.append(op)
 
-            # ScaledSwiGLU with glu_interleave_size=32
-            # Required by ForwardGroupedMLP_CuTeGEMMSwiGLU_MXFP8
-            fused_impl.append(te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=32))
+            if self.config.activation_func is situlu:
+                # ScaledSiTUGLU with glu_interleave_size=32.
+                fused_impl.append(
+                    te.pytorch.ops.ScaledSiTUGLU(
+                        glu_interleave_size=32,
+                        beta1=self.config.situ_glu_beta1,
+                        beta2=self.config.situ_glu_beta2,
+                    )
+                )
+            else:
+                # ScaledSwiGLU with glu_interleave_size=32
+                # Required by ForwardGroupedMLP_CuTeGEMMSwiGLU_MXFP8
+                fused_impl.append(te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=32))
 
             # FC2: GroupedLinear(num_groups=1) instead of BasicLinear
             weight = self.linear_fc2.weight

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from megatron.core.activations import situlu
 from megatron.core.dist_checkpointing import ShardedTensor
 from megatron.core.dist_checkpointing.mapping import (
     ReplicaId,
@@ -187,12 +188,8 @@ class MLP(MegatronModule):
         if ffn_hidden_size is None:
             if is_expert:
                 raise ValueError("MoE MLP requires `ffn_hidden_size`, but it was not provided.")
-            warnings.warn(
-                "MLP requires ffn_hidden_size, but it was not provided. Using \
-                    config.ffn_hidden_size by default.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warnings.warn("MLP requires ffn_hidden_size, but it was not provided. Using \
+                    config.ffn_hidden_size by default.", DeprecationWarning, stacklevel=2)
             ffn_hidden_size = not_none(self.config.ffn_hidden_size)
 
         # If this is a gated linear unit we double the output width
@@ -262,7 +259,12 @@ class MLP(MegatronModule):
         if self.config.use_te_activation_func:
             if bias_parallel is not None:
                 intermediate_parallel = intermediate_parallel + bias_parallel
-            intermediate_parallel = self.activation_func(intermediate_parallel)
+            if self.activation_func is situlu:
+                intermediate_parallel = situlu(
+                    intermediate_parallel, self.config.situ_glu_beta1, self.config.situ_glu_beta2
+                )
+            else:
+                intermediate_parallel = self.activation_func(intermediate_parallel)
             if per_token_scale is not None:
                 original_dtype = intermediate_parallel.dtype
                 intermediate_parallel = intermediate_parallel * per_token_scale.unsqueeze(-1)
@@ -317,6 +319,8 @@ class MLP(MegatronModule):
             if self.config.gated_linear_unit:
 
                 def glu(x):
+                    if self.config.activation_func is situlu:
+                        return situlu(x, self.config.situ_glu_beta1, self.config.situ_glu_beta2)
                     x_glu, x_linear = torch.chunk(x, 2, dim=-1)
                     if (val := self.config.activation_func_clamp_value) is not None:
                         x_glu = x_glu.clamp(min=None, max=val)

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -434,9 +434,9 @@ class TEGroupedMLP(MegatronModule):
                 f"(gated_linear_unit={self.config.gated_linear_unit}, "
                 f"use_fused_weighted_squared_relu={self.config.use_fused_weighted_squared_relu})"
             )
-        if self.config.activation_func is situlu and self.activation_recompute:
+        if use_glu_fusion and self.activation_recompute:
             return _unsupported(
-                "Transformer Engine ScaledSiTUGLU does not support activation recompute"
+                "Transformer Engine scaled GLU ops do not support activation recompute"
             )
         if self.config.activation_func == situlu:
             if not hasattr(te_ops, "ScaledSiTUGLU"):

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn.functional as F
 
 from megatron.core import tensor_parallel
-from megatron.core.activations import squared_relu
+from megatron.core.activations import situlu, squared_relu
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp4Recipe, Fp8Recipe
@@ -413,13 +413,14 @@ class TEGroupedMLP(MegatronModule):
         if not isinstance(self.linear_fc2, te.pytorch.GroupedLinear):
             return _unsupported(f"linear_fc2 is {type(self.linear_fc2).__name__}")
 
-        # Check activation: SwiGLU, quick GEGLU, or weighted squared ReLU.
+        # Check activation: SwiGLU, SiTU-GLU, quick GEGLU, or weighted squared ReLU.
         # Clamped SwiGLU (e.g. DSv4) routes through ScaledClampedQGeGLU with
         # alpha=1.0, since the cuDNN geglu kernel is a superset of swiglu.
         # Use config.activation_func instead of self.activation_func because when
         # use_te_activation_func is True, self.activation_func is a TE module, not the raw function.
         use_glu_fusion = self.config.gated_linear_unit and self.config.activation_func in (
             F.silu,
+            situlu,
             quick_gelu,
         )
         use_srelu_fusion = (
@@ -433,7 +434,14 @@ class TEGroupedMLP(MegatronModule):
                 f"(gated_linear_unit={self.config.gated_linear_unit}, "
                 f"use_fused_weighted_squared_relu={self.config.use_fused_weighted_squared_relu})"
             )
-        if self.config.activation_func == F.silu:
+        if self.config.activation_func is situlu and self.activation_recompute:
+            return _unsupported(
+                "Transformer Engine ScaledSiTUGLU does not support activation recompute"
+            )
+        if self.config.activation_func == situlu:
+            if not hasattr(te_ops, "ScaledSiTUGLU"):
+                return _unsupported("SiTU-GLU needs ScaledSiTUGLU")
+        elif self.config.activation_func == F.silu:
             if self.config.activation_func_clamp_value is not None:
                 if not is_te_min_version("2.17.0.dev0"):
                     return _unsupported("clamped SwiGLU needs TE >= 2.17.0.dev0")
@@ -536,14 +544,20 @@ class TEGroupedMLP(MegatronModule):
         )
         ops.append(op)
 
-        # Activation and post-multiply probs (SwiGLU, clamped GeGLU, or SReLU).
+        # Activation and post-multiply probs (SwiGLU, SiTU-GLU, clamped GeGLU, or SReLU).
         # TE's ScaledClampedQGeGLU computes sigmoid(alpha * x) * x, so
         # alpha=1.702 gives quick_gelu and alpha=1.0 gives silu/swiglu.
         # With cuDNN FE >= 1.24.0 the alpha, limit and offset are
         # forwarded as runtime params to the cuDNN kernel.
         glu_interleave = self.config.moe_mlp_glu_interleave_size
         activation_recompute_in_mlp = bool(getattr(self, "activation_recompute", False))
-        if self.config.activation_func == F.silu and self.config.gated_linear_unit:
+        if self.config.activation_func is situlu and self.config.gated_linear_unit:
+            op = te.pytorch.ops.ScaledSiTUGLU(
+                glu_interleave_size=glu_interleave,
+                beta1=self.config.situ_glu_beta1,
+                beta2=self.config.situ_glu_beta2,
+            )
+        elif self.config.activation_func == F.silu and self.config.gated_linear_unit:
             clamp = self.config.activation_func_clamp_value
             if clamp is not None:
                 qgeglu_kwargs = {
@@ -611,7 +625,8 @@ class TEGroupedMLP(MegatronModule):
                 op = te.pytorch.ops.ScaledSReLU()
         else:
             raise RuntimeError(
-                "_make_fused_ops expected SwiGLU, quick_gelu, or weighted squared_relu; "
+                "_make_fused_ops expected SwiGLU, SiTU-GLU, quick_gelu, or weighted "
+                "squared_relu; "
                 "call _is_fused_impl_supported() before constructing fused ops."
             )
         ops.append(op)
@@ -914,7 +929,14 @@ class TEGroupedMLP(MegatronModule):
                     intermediate_parallel = self._remove_glu_interleaving(
                         intermediate_parallel, self.config.moe_mlp_glu_interleave_size
                     )
-                intermediate_parallel = self.activation_func(intermediate_parallel)
+                if self.activation_func is situlu:
+                    intermediate_parallel = situlu(
+                        intermediate_parallel,
+                        self.config.situ_glu_beta1,
+                        self.config.situ_glu_beta2,
+                    )
+                else:
+                    intermediate_parallel = self.activation_func(intermediate_parallel)
                 if permuted_probs is not None:
                     original_dtype = intermediate_parallel.dtype
                     intermediate_parallel = intermediate_parallel * permuted_probs
@@ -959,6 +981,8 @@ class TEGroupedMLP(MegatronModule):
                             x = self._remove_glu_interleaving(
                                 x, self.config.moe_mlp_glu_interleave_size
                             )
+                        if self.config.activation_func is situlu:
+                            return situlu(x, self.config.situ_glu_beta1, self.config.situ_glu_beta2)
                         x_glu, x_linear = torch.chunk(x, 2, dim=-1)
                         if (val := self.config.activation_func_clamp_value) is not None:
                             x_glu = x_glu.clamp(min=None, max=val)

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -9,6 +9,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 
+from megatron.core.activations import situlu
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_geglu import bias_geglu_impl
@@ -276,7 +277,14 @@ class SharedExpertMLP(MLP):
             if self.config.use_te_activation_func:
                 if bias_parallel is not None:
                     intermediate_parallel = intermediate_parallel + bias_parallel
-                intermediate_parallel = self.activation_func(intermediate_parallel)
+                if self.activation_func is situlu:
+                    intermediate_parallel = situlu(
+                        intermediate_parallel,
+                        self.config.situ_glu_beta1,
+                        self.config.situ_glu_beta2,
+                    )
+                else:
+                    intermediate_parallel = self.activation_func(intermediate_parallel)
             elif self.config.bias_activation_fusion:
                 if self.activation_func == F.gelu:
                     if self.config.gated_linear_unit:
@@ -301,6 +309,8 @@ class SharedExpertMLP(MLP):
                 if self.config.gated_linear_unit:
 
                     def glu(x):
+                        if self.config.activation_func is situlu:
+                            return situlu(x, self.config.situ_glu_beta1, self.config.situ_glu_beta2)
                         x_glu, x_linear = torch.chunk(x, 2, dim=-1)
                         if (val := self.config.activation_func_clamp_value) is not None:
                             x_glu = x_glu.clamp(min=None, max=val)
@@ -417,12 +427,17 @@ class FusedSharedExpertMLP(SharedExpertMLP):
                 f"{self.__class__.__name__} does not support add_bias_linear=True; "
                 "the CuTeGEMM fused kernel requires bias-free linear layers."
             )
-        if not self.config.gated_linear_unit or self.config.activation_func != F.silu:
+        if not self.config.gated_linear_unit or self.config.activation_func not in (F.silu, situlu):
             raise ValueError(
-                f"{self.__class__.__name__} requires SwiGLU activation "
-                "(activation_func=F.silu, gated_linear_unit=True) for the CuTeGEMM "
+                f"{self.__class__.__name__} requires SwiGLU or SiTU-GLU activation "
+                "with gated_linear_unit=True for the CuTeGEMM "
                 f"fused kernel, but got activation_func={self.config.activation_func}, "
                 f"gated_linear_unit={self.config.gated_linear_unit}."
+            )
+        if self.config.activation_func is situlu and not hasattr(te.pytorch.ops, "ScaledSiTUGLU"):
+            raise RuntimeError(
+                f"{self.__class__.__name__} requires Transformer Engine with "
+                "pytorch.ops.ScaledSiTUGLU for SiTU-GLU."
             )
         if self.config.moe_shared_expert_glu_interleave_size is None:
             raise ValueError(
@@ -483,7 +498,16 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         op._glu_interleave_size = glu_interleave_size
         ops.append(op)
 
-        ops.append(te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size))
+        if self.config.activation_func is situlu:
+            ops.append(
+                te.pytorch.ops.ScaledSiTUGLU(
+                    glu_interleave_size=glu_interleave_size,
+                    beta1=self.config.situ_glu_beta1,
+                    beta2=self.config.situ_glu_beta2,
+                )
+            )
+        else:
+            ops.append(te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size))
 
         fc2_weight = self.linear_fc2.weight
         op = te.pytorch.ops.GroupedLinear(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -33,6 +33,7 @@ from megatron.core.transformer.pipeline_parallel_layer_layout import PipelinePar
 from megatron.core.utils import experimental_api
 
 from .._rank_utils import log_single_rank
+from ..activations import situlu
 from ..fusions.fused_bias_geglu import quick_gelu
 from ..model_parallel_config import ModelParallelConfig
 from ..utils import (
@@ -1354,6 +1355,12 @@ class TransformerConfig(ModelParallelConfig):
 
     use_te_activation_func: bool = False
     """Whether to use ffn activation functions implemented by TransformerEngine"""
+
+    situ_glu_beta1: float = 4.0
+    """SiTU-GLU gate tanh soft-cap."""
+
+    situ_glu_beta2: float = 25.0
+    """SiTU-GLU up-branch tanh soft-cap."""
 
     use_te_rng_tracker: bool = False
     """ Whether to use the TE or MCore version of the RNG tracker. """
@@ -2897,12 +2904,25 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.use_te_activation_func:
-            if self.activation_func not in (F.gelu, F.silu, F.relu):
+            if self.activation_func not in (F.gelu, F.silu, F.relu, situlu):
                 raise ValueError(
-                    "TransformerEngine only support gelu, geglu, silu, swiglu, relu, reglu. "
+                    "TransformerEngine only supports gelu, geglu, silu, swiglu, relu, reglu, "
+                    "and situ-glu. "
                     "If you don't want to use TransformerEngine activation function, set "
                     "use_te_activation_func to False"
                 )
+
+        if self.activation_func == situlu:
+            if not self.gated_linear_unit:
+                raise ValueError("SiTU-GLU requires gated_linear_unit=True.")
+            if self.activation_func_clamp_value is not None:
+                raise ValueError("SiTU-GLU does not use activation_func_clamp_value.")
+            if self.glu_linear_offset != 0.0:
+                raise ValueError("SiTU-GLU requires glu_linear_offset=0.0.")
+            if not math.isfinite(self.situ_glu_beta1) or self.situ_glu_beta1 <= 0:
+                raise ValueError("situ_glu_beta1 must be finite and positive.")
+            if not math.isfinite(self.situ_glu_beta2) or self.situ_glu_beta2 <= 0:
+                raise ValueError("situ_glu_beta2 must be finite and positive.")
 
         if self.activation_func_fp8_input_store:
             if self.activation_func != F.silu or not self.gated_linear_unit:

--- a/megatron/training/argument_utils.py
+++ b/megatron/training/argument_utils.py
@@ -388,7 +388,7 @@ def _resolve_dsa_kernel_backend_cli_default(args, kw_args):
 
 
 def core_transformer_config_from_args(args, config_class=None):
-    from megatron.core.activations import squared_relu
+    from megatron.core.activations import situlu, squared_relu
     from megatron.core.fusions.fused_bias_geglu import quick_gelu
     from megatron.core.quantization.utils import (
         kitchen_quantization_recipe_config,
@@ -427,17 +427,23 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['num_layers_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers
     kw_args['fp8_param'] = args.fp8_param_gather
     kw_args['fp4_param'] = args.fp4_param_gather
-    if args.swiglu:
+    use_situ_glu = getattr(args, 'situ_glu', False)
+    if use_situ_glu:
+        kw_args['activation_func'] = situlu
+        kw_args['gated_linear_unit'] = True
+        kw_args['use_te_activation_func'] = True
+        kw_args['bias_activation_fusion'] = False
+    elif args.swiglu:
         kw_args['activation_func'] = F.silu
         kw_args['gated_linear_unit'] = True
         kw_args['bias_activation_fusion'] = args.bias_swiglu_fusion
     else:
         kw_args['bias_activation_fusion'] = args.bias_gelu_fusion
     if args.squared_relu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['activation_func'] = squared_relu
     elif args.quick_geglu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['gated_linear_unit'] = True
         kw_args['activation_func'] = quick_gelu
     if args.init_method_xavier_uniform:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn.functional as F
 from packaging.version import Version as PkgVersion
 
-from megatron.core.activations import squared_relu
+from megatron.core.activations import situlu, squared_relu
 from megatron.core.dist_checkpointing.validation import StrictHandling
 from megatron.core.fusions.fused_bias_geglu import quick_gelu
 from megatron.core.model_parallel_config import _parse_pad_packed_seq_alignment
@@ -1412,8 +1412,16 @@ def validate_args(args, defaults={}):
         _check_arg_is_not_none(args, req_arg)
 
     # Checks.
+    use_situ_glu = getattr(args, 'situ_glu', False)
+    if use_situ_glu:
+        if args.swiglu or args.quick_geglu or args.squared_relu:
+            raise ValueError(
+                "--situ-glu is mutually exclusive with --swiglu, --quick-geglu, "
+                "and --squared-relu."
+            )
+
     if args.ffn_hidden_size is None:
-        if args.swiglu:
+        if args.swiglu or use_situ_glu:
             # reduce the dimnesion for MLP since projections happens on
             # two linear layers. this keeps the number of paramters in
             # the same ballpark as the counterpart with 4*h size
@@ -2243,17 +2251,23 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['num_layers_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers
     kw_args['fp8_param'] = args.fp8_param_gather
     kw_args['fp4_param'] = args.fp4_param_gather
-    if args.swiglu:
+    use_situ_glu = getattr(args, 'situ_glu', False)
+    if use_situ_glu:
+        kw_args['activation_func'] = situlu
+        kw_args['gated_linear_unit'] = True
+        kw_args['use_te_activation_func'] = True
+        kw_args['bias_activation_fusion'] = False
+    elif args.swiglu:
         kw_args['activation_func'] = F.silu
         kw_args['gated_linear_unit'] = True
         kw_args['bias_activation_fusion'] = args.bias_swiglu_fusion
     else:
         kw_args['bias_activation_fusion'] = args.bias_gelu_fusion
     if args.squared_relu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['activation_func'] = squared_relu
     elif args.quick_geglu:
-        assert not args.swiglu
+        assert not args.swiglu and not use_situ_glu
         kw_args['gated_linear_unit'] = True
         kw_args['activation_func'] = quick_gelu
     if args.init_method_xavier_uniform:
@@ -2995,6 +3009,15 @@ def _add_network_size_args(parser):
         '--swiglu',
         action='store_true',
         help='Use gated linear units and SiLU activation instead of default gelu',
+    )
+    group.add_argument(
+        '--situ-glu',
+        '--moe-use-situ-glu',
+        action='store_true',
+        help=(
+            'Use SiTU-GLU in all dense and MoE FFNs. TE-backed paths select SiTUGLU '
+            'or ScaledSiTUGLU; other paths use the PyTorch reference.'
+        ),
     )
     group.add_argument(
         '--quick-geglu',

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1369,7 +1369,7 @@ def generate_state_dict(
 def preprocess_fsdp_dtensor_state_dict(args, raw_state_dict, model):
     state_dict = raw_state_dict.copy()
     handle_fp8_extra_state_case(state_dict["model"])
-    if args.swiglu:
+    if args.swiglu or getattr(args, "situ_glu", False):
         if "optimizer" in state_dict:
             model_state_dict, optimizer_state_dict = handle_swiglu_in_state_dict(
                 model, state_dict["model"], state_dict["optimizer"]
@@ -1927,6 +1927,9 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
     _set_arg('add_qkv_bias', force=True)
     _set_arg('squared_relu', force=True)
     _set_arg('swiglu', force=True)
+    _set_arg('situ_glu', force=True)
+    _set_arg('situ_glu_beta1', force=True)
+    _set_arg('situ_glu_beta2', force=True)
     _set_arg('untie_embeddings_and_output_weights', force=True)
     _set_arg('apply_layernorm_1p', force=True)
     _set_arg('normalization', force=True)

--- a/megatron/training/theoretical_memory_usage.py
+++ b/megatron/training/theoretical_memory_usage.py
@@ -19,7 +19,7 @@ def compute_weight_and_optimizer_memory(args, verbose=False):
         args.num_query_groups = args.num_attention_heads
     # MoE.
     num_experts = 1 if args.num_experts is None else args.num_experts
-    gated_linear_multiplier = 3 / 2 if args.swiglu else 1
+    gated_linear_multiplier = 3 / 2 if (args.swiglu or getattr(args, "situ_glu", False)) else 1
 
     shared_expert_ffn_hidden_size = (
         0

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1077,9 +1077,9 @@ def num_floating_point_operations(
         forward_backward_expansion_factor = 3
         # - 2x: A GEMM of a m*n tensor with a n*k tensor requires 2mnk floating-point operations.
         fma_expansion_factor = 2
-        # - 3x (SwiGLU enabled): h->2*ffn_h GEMM and ffn_h->h GEMM are stacked.
-        # - 2x (SwiGLU disabled): h->ffn_h GEMM and ffn_h->h GEMM are stacked.
-        ffn_expansion_factor = 3 if args.swiglu else 2
+        # - 3x (gated GLU): h->2*ffn_h GEMM and ffn_h->h GEMM are stacked.
+        # - 2x (non-gated): h->ffn_h GEMM and ffn_h->h GEMM are stacked.
+        ffn_expansion_factor = 3 if (args.swiglu or getattr(args, "situ_glu", False)) else 2
 
         # self_attn is split into a token-linear part (projections, multiplied by
         # ``batch_size * args.seq_length`` like all other token-linear work) and a
@@ -1519,7 +1519,7 @@ def num_floating_point_operations(
             gqa_groups=args.num_query_groups,
             kv_channels=args.kv_channels,
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
-            swiglu=args.swiglu,
+            swiglu=(args.swiglu or getattr(args, "situ_glu", False)),
             moe_latent_size=args.moe_latent_size,
             moe_ffn_hidden_size=(
                 args.moe_ffn_hidden_size

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -307,6 +307,8 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "rotary_base_per_layer": None,
     "rotary_interleaved": False,
     "sequence_parallel": True,
+    "situ_glu_beta1": 4.0,
+    "situ_glu_beta2": 25.0,
     "softmax_scale": None,
     "softmax_type": "vanilla",
     "symmetric_ar_type": None,

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -130,6 +130,39 @@ def test_load_args_restores_latent_rmsnorm_from_checkpoint():
     assert restored_args.moe_latent_up_projection_rmsnorm is True
 
 
+@pytest.mark.parametrize(
+    "checkpoint_args",
+    [
+        SimpleNamespace(swiglu=True, situ_glu=False, situ_glu_beta1=4.0, situ_glu_beta2=25.0),
+        SimpleNamespace(swiglu=False, situ_glu=True, situ_glu_beta1=3.0, situ_glu_beta2=20.0),
+    ],
+)
+def test_load_args_restores_glu_activation_from_checkpoint(checkpoint_args):
+    """Checkpoint arguments select the saved gated activation and SiTU scaling."""
+    args = SimpleNamespace(
+        load="checkpoint",
+        iteration=0,
+        swiglu=not checkpoint_args.swiglu,
+        situ_glu=not checkpoint_args.situ_glu,
+        situ_glu_beta1=1.0,
+        situ_glu_beta2=1.0,
+        use_tokenizer_model_from_checkpoint_args=False,
+        use_mp_args_from_checkpoint_args=False,
+    )
+    state_dict = {"args": checkpoint_args, "iteration": 12}
+
+    with mock.patch(
+        "megatron.training.checkpointing._load_base_checkpoint",
+        return_value=(state_dict, "checkpoint", False, CheckpointType.LEGACY),
+    ):
+        restored_args, _ = load_args_from_checkpoint(args)
+
+    assert restored_args.swiglu is checkpoint_args.swiglu
+    assert restored_args.situ_glu is checkpoint_args.situ_glu
+    assert restored_args.situ_glu_beta1 == checkpoint_args.situ_glu_beta1
+    assert restored_args.situ_glu_beta2 == checkpoint_args.situ_glu_beta2
+
+
 def create_checkpoint(load_path, ckpt_format):
     """Setup a dummy checkpoint directory."""
     iteration = 123

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -126,6 +126,16 @@ def _make_mla_hybrid_args():
     return args
 
 
+def test_situ_glu_counts_the_same_ffn_gemms_as_swiglu():
+    swiglu_args = _make_gpt_args(swiglu=True)
+    situ_glu_args = _make_gpt_args(swiglu=False)
+    situ_glu_args.situ_glu = True
+
+    assert num_floating_point_operations(
+        situ_glu_args, batch_size=8
+    ) == num_floating_point_operations(swiglu_args, batch_size=8)
+
+
 class TestBSHDBackwardCompat:
     """For unpacked BSHD, the new optional arg must not change the result."""
 

--- a/tests/unit_tests/training/test_weight_and_optimizer_memory.py
+++ b/tests/unit_tests/training/test_weight_and_optimizer_memory.py
@@ -41,6 +41,15 @@ def _make_args(**overrides):
     return args
 
 
+def test_situ_glu_counts_the_same_ffn_parameters_as_swiglu():
+    swiglu_args = _make_args(swiglu=True)
+    situ_glu_args = _make_args(situ_glu=True)
+
+    assert compute_weight_and_optimizer_memory(
+        situ_glu_args
+    ) == compute_weight_and_optimizer_memory(swiglu_args)
+
+
 def test_weight_and_optimizer_memory_accounts_for_expert_parallelism():
     args = _make_args(pipeline_model_parallel_size=2, world_size=64)
 

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn.functional as F
 
 import megatron.core.transformer.moe.experts as experts_module
-from megatron.core.activations import squared_relu
+from megatron.core.activations import situlu, squared_relu
 from megatron.core.fusions.fused_bias_geglu import quick_gelu
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_submodules,
@@ -483,6 +483,13 @@ def _make_fake_te_namespace():
             self.glu_interleave_size = glu_interleave_size
             self.activation_recompute_in_mlp = activation_recompute_in_mlp
 
+    class FakeScaledSiTUGLU(torch.nn.Module):
+        def __init__(self, glu_interleave_size, *, beta1, beta2):
+            super().__init__()
+            self.glu_interleave_size = glu_interleave_size
+            self.beta1 = beta1
+            self.beta2 = beta2
+
     class FakeScaledClampedQGeGLU(torch.nn.Module):
         def __init__(
             self,
@@ -519,6 +526,7 @@ def _make_fake_te_namespace():
                 ops=SimpleNamespace(
                     GroupedLinear=FakeGroupedLinear,
                     ScaledSwiGLU=FakeScaledSwiGLU,
+                    ScaledSiTUGLU=FakeScaledSiTUGLU,
                     ScaledClampedQGeGLU=FakeScaledClampedQGeGLU,
                     ScaledSReLU=FakeScaledSReLU,
                     Sequential=FakeSequential,
@@ -631,7 +639,7 @@ def test_make_fused_ops_rejects_scaled_srelu_with_gated_linear_unit(monkeypatch)
     module.linear_fc2.weight0 = torch.nn.Parameter(torch.ones(4, 8))
     module.linear_fc2.weight1 = torch.nn.Parameter(torch.ones(4, 8))
 
-    with pytest.raises(RuntimeError, match="expected SwiGLU, quick_gelu"):
+    with pytest.raises(RuntimeError, match="expected SwiGLU, SiTU-GLU, quick_gelu"):
         module._make_fused_ops()
 
 
@@ -672,11 +680,15 @@ def _make_fused_impl_support_module(
         use_fused_weighted_squared_relu=use_fused_weighted_squared_relu,
         moe_mlp_glu_interleave_size=moe_mlp_glu_interleave_size,
         moe_apply_probs_on_input=False,
+        delay_wgrad_compute=False,
+        situ_glu_beta1=4.0,
+        situ_glu_beta2=25.0,
     )
     module.activation_func = object()
     module.tp_group = SimpleNamespace(size=lambda: 1)
     module.offload_expert_fc1 = False
     module.offload_moe_act = False
+    module.activation_recompute = False
     common = dict(
         device="cuda",
         dtype=torch.bfloat16,
@@ -688,7 +700,45 @@ def _make_fused_impl_support_module(
     return module
 
 
-def test_is_fused_impl_supported_uses_config_activation_for_swiglu(monkeypatch):
+def test_make_fused_ops_selects_scaled_situ_glu(monkeypatch):
+    """The routed-expert op-fuser passes SiTU betas to TE."""
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear, activation_func=situlu, gated_linear_unit=True
+    )
+    for linear in (module.linear_fc1, module.linear_fc2):
+        linear.weight0 = torch.nn.Parameter(torch.ones(linear.out_features, linear.in_features))
+        linear.weight1 = torch.nn.Parameter(torch.ones(linear.out_features, linear.in_features))
+
+    ops = module._make_fused_ops()
+
+    activation = ops[1]
+    assert type(activation).__name__ == "FakeScaledSiTUGLU"
+    assert activation.glu_interleave_size == 32
+    assert activation.beta1 == 4.0
+    assert activation.beta2 == 25.0
+
+
+def test_is_fused_impl_supported_rejects_situ_glu_activation_recompute(monkeypatch):
+    """ScaledSiTUGLU cannot honor selective MoE activation recompute."""
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
+    monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
+    _install_fake_te_ops_modules(monkeypatch, fake_te)
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear, activation_func=situlu, gated_linear_unit=True
+    )
+    module.activation_recompute = True
+
+    assert module._is_fused_impl_supported() is False
+
+
+@pytest.mark.parametrize("activation_func", [F.silu, quick_gelu], ids=("swiglu", "quick-geglu"))
+def test_is_fused_impl_supported_preserves_existing_glu_recompute(monkeypatch, activation_func):
+    """Existing scaled GLUs continue to forward activation recompute to TE."""
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
     monkeypatch.setattr(experts_module, "te", fake_te)
     monkeypatch.setattr(experts_module, "HAVE_TE", True)
@@ -697,8 +747,9 @@ def test_is_fused_impl_supported_uses_config_activation_for_swiglu(monkeypatch):
     _install_fake_te_ops_modules(monkeypatch, fake_te)
 
     module = _make_fused_impl_support_module(
-        FakeGroupedLinear, activation_func=F.silu, gated_linear_unit=True
+        FakeGroupedLinear, activation_func=activation_func, gated_linear_unit=True
     )
+    module.activation_recompute = True
 
     assert module._is_fused_impl_supported() is True
 

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -720,38 +720,31 @@ def test_make_fused_ops_selects_scaled_situ_glu(monkeypatch):
     assert activation.beta2 == 25.0
 
 
-def test_is_fused_impl_supported_rejects_situ_glu_activation_recompute(monkeypatch):
-    """ScaledSiTUGLU cannot honor selective MoE activation recompute."""
+@pytest.mark.parametrize(
+    ("activation_func", "activation_func_clamp_value"),
+    [(F.silu, None), (F.silu, 7.0), (situlu, None), (quick_gelu, None)],
+    ids=("swiglu", "clamped-swiglu", "situ-glu", "quick-geglu"),
+)
+def test_is_fused_impl_supported_rejects_scaled_glu_activation_recompute(
+    monkeypatch, activation_func, activation_func_clamp_value
+):
+    """TE scaled GLU ops cannot honor selective MoE activation recompute."""
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
     monkeypatch.setattr(experts_module, "te", fake_te)
     monkeypatch.setattr(experts_module, "HAVE_TE", True)
     monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
     monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
     _install_fake_te_ops_modules(monkeypatch, fake_te)
+
     module = _make_fused_impl_support_module(
-        FakeGroupedLinear, activation_func=situlu, gated_linear_unit=True
+        FakeGroupedLinear,
+        activation_func=activation_func,
+        activation_func_clamp_value=activation_func_clamp_value,
+        gated_linear_unit=True,
     )
     module.activation_recompute = True
 
     assert module._is_fused_impl_supported() is False
-
-
-@pytest.mark.parametrize("activation_func", [F.silu, quick_gelu], ids=("swiglu", "quick-geglu"))
-def test_is_fused_impl_supported_preserves_existing_glu_recompute(monkeypatch, activation_func):
-    """Existing scaled GLUs continue to forward activation recompute to TE."""
-    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
-    monkeypatch.setattr(experts_module, "te", fake_te)
-    monkeypatch.setattr(experts_module, "HAVE_TE", True)
-    monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
-    monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
-    _install_fake_te_ops_modules(monkeypatch, fake_te)
-
-    module = _make_fused_impl_support_module(
-        FakeGroupedLinear, activation_func=activation_func, gated_linear_unit=True
-    )
-    module.activation_recompute = True
-
-    assert module._is_fused_impl_supported() is True
 
 
 def test_is_fused_impl_supported_requires_cutedsl_env(monkeypatch):

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from megatron.core.activations import situlu
 from megatron.core.models.gpt import moe_module_specs
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.parallel_state import get_tensor_model_parallel_world_size
@@ -52,6 +53,14 @@ class _FakeTEScaledSwiGLU(torch.nn.Module):
         self.glu_interleave_size = glu_interleave_size
 
 
+class _FakeTEScaledSiTUGLU(torch.nn.Module):
+    def __init__(self, glu_interleave_size, *, beta1, beta2):
+        super().__init__()
+        self.glu_interleave_size = glu_interleave_size
+        self.beta1 = beta1
+        self.beta2 = beta2
+
+
 class _FakeTESequential(torch.nn.Module):
     def append(self, module):
         self.add_module(str(len(self._modules)), module)
@@ -90,6 +99,7 @@ def _fake_te_module(linear_cls=_FakeTELinear):
             ops=SimpleNamespace(
                 GroupedLinear=_FakeTEGroupedLinear,
                 ScaledSwiGLU=_FakeTEScaledSwiGLU,
+                ScaledSiTUGLU=_FakeTEScaledSiTUGLU,
                 Sequential=_FakeTESequential,
             ),
             fp8_autocast=_FakeFP8Autocast,
@@ -123,6 +133,10 @@ def _fake_shared_expert(**config_kwargs):
         add_bias_linear=False,
         gated_linear_unit=True,
         activation_func=F.silu,
+        activation_func_clamp_value=None,
+        situ_glu_beta1=4.0,
+        situ_glu_beta2=25.0,
+        use_fused_weighted_squared_relu=False,
         moe_shared_expert_glu_interleave_size=32,
         delay_wgrad_compute=False,
         sequence_parallel=False,
@@ -187,8 +201,8 @@ def test_validate_fused_grouped_swiglu_requires_te(monkeypatch):
     ("config_kwargs", "bad_linear", "match"),
     [
         ({"add_bias_linear": True}, None, "add_bias_linear"),
-        ({"activation_func": F.gelu}, None, "SwiGLU activation"),
-        ({"gated_linear_unit": False}, None, "SwiGLU activation"),
+        ({"activation_func": F.gelu}, None, "SwiGLU or SiTU-GLU activation"),
+        ({"gated_linear_unit": False}, None, "SwiGLU or SiTU-GLU activation"),
         ({"moe_shared_expert_glu_interleave_size": None}, None, "glu_interleave_size"),
         ({}, "linear_fc1", "FC1"),
         ({}, "linear_fc2", "FC2"),
@@ -236,6 +250,20 @@ def test_make_fused_grouped_swiglu_ops_builds_grouped_pipeline(monkeypatch):
     assert fc2_op.kwargs["bias"] is False
     assert fc2_op.kwargs["accumulate_into_main_grad"] is False
     assert fc2_op.weight0 is shared_expert.linear_fc2.weight
+
+
+def test_make_fused_grouped_swiglu_ops_selects_situ_glu(monkeypatch):
+    _patch_fake_shared_expert_te(monkeypatch)
+    shared_expert = _fake_shared_expert(activation_func=situlu)
+
+    shared_expert._validate_fused_grouped_swiglu()
+    ops = shared_expert._make_fused_grouped_swiglu_ops()
+
+    activation_op = list(ops.children())[1]
+    assert isinstance(activation_op, _FakeTEScaledSiTUGLU)
+    assert activation_op.glu_interleave_size == 32
+    assert activation_op.beta1 == 4.0
+    assert activation_op.beta2 == 25.0
 
 
 def test_fused_grouped_swiglu_ops_replay_linear_pre_forward_hooks(monkeypatch):
@@ -476,6 +504,9 @@ class TestSharedExperts:
             moe_shared_expert_overlap=False,
             moe_token_dispatcher_type="alltoall",
             activation_func_clamp_value=None,
+            situ_glu_beta1=4.0,
+            situ_glu_beta2=25.0,
+            use_fused_weighted_squared_relu=False,
             bias_activation_fusion=bias_activation_fusion,
         ).to(dtype=torch.bfloat16)
         moe_layer_unclamped.load_state_dict(moe_layer_overlap.state_dict())

--- a/tests/unit_tests/transformer/test_situ_glu.py
+++ b/tests/unit_tests/transformer/test_situ_glu.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.core.extensions.transformer_engine as te_extension
+from megatron.core.activations import situlu
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class _FakeActivation:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _patch_te_activation_ops(monkeypatch, *, include_situ=True):
+    ops = SimpleNamespace()
+    if include_situ:
+        ops.SiTUGLU = type("SiTUGLU", (_FakeActivation,), {})
+
+    monkeypatch.setattr(
+        te_extension, "te", SimpleNamespace(pytorch=SimpleNamespace(ops=ops)), raising=False
+    )
+    monkeypatch.setattr(te_extension, "HAVE_TE", True)
+    monkeypatch.setattr(te_extension, "is_te_min_version", lambda *_args, **_kwargs: True)
+    return ops
+
+
+def _config(activation_func, gated_linear_unit, **kwargs):
+    defaults = dict(
+        activation_func=activation_func,
+        gated_linear_unit=gated_linear_unit,
+        activation_func_fp8_input_store=False,
+        activation_func_clamp_value=None,
+        use_fused_weighted_squared_relu=False,
+        situ_glu_beta1=4.0,
+        situ_glu_beta2=25.0,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_ordinary_te_situ_glu_activation_selection(monkeypatch):
+    """The ordinary TE path selects SiTUGLU with the configured betas."""
+    _patch_te_activation_ops(monkeypatch)
+    op = te_extension.TEActivationOp(_config(situlu, True))
+
+    assert type(op).__name__ == "SiTUGLU"
+    assert op.kwargs == {"beta1": 4.0, "beta2": 25.0}
+
+
+def test_situ_glu_requires_te_operations(monkeypatch):
+    """An older TE cannot cause the SiTU marker to fall through to SwiGLU."""
+    _patch_te_activation_ops(monkeypatch, include_situ=False)
+
+    with pytest.raises(RuntimeError, match="pytorch.ops.SiTUGLU"):
+        te_extension.TEActivationOp(_config(situlu, True))
+
+
+def test_situlu_reference_matches_kimi_bf16_precision_and_backward():
+    """The fallback evaluates both branches in FP32 and returns the original dtype."""
+    x = torch.linspace(-20, 20, 30, device="cuda", dtype=torch.bfloat16).reshape(3, 10)
+    x = x.detach().requires_grad_(True)
+    reference_x = x.detach().clone().requires_grad_(True)
+    gate, up = reference_x.chunk(2, dim=-1)
+    gate = gate.float()
+    up = up.float()
+    expected = 3.0 * torch.tanh(gate / 3.0) * torch.sigmoid(gate)
+    expected = (expected * (7.0 * torch.tanh(up / 7.0))).to(reference_x.dtype)
+
+    actual = situlu(x, 3.0, 7.0)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    grad = torch.randn_like(actual)
+    actual.backward(grad)
+    expected.backward(grad)
+    torch.testing.assert_close(x.grad, reference_x.grad, rtol=0, atol=0)
+
+
+def test_situlu_reference_matches_fixed_values():
+    """Check independent values, including positive and negative saturation."""
+    x = torch.tensor(
+        [[0.0, 1.0, 0.0, 2.0], [-1.0, 4.0, -2.0, 25.0], [100.0, -100.0, 100.0, -100.0]],
+        device="cuda",
+    )
+    expected = torch.tensor(
+        [[0.0, 1.4293511], [0.5258289, 56.959320], [99.932930, 3.717581e-42]], device="cuda"
+    )
+
+    torch.testing.assert_close(situlu(x), expected, rtol=1e-6, atol=1e-5)
+
+
+def test_transformer_config_accepts_situ_glu_defaults():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        activation_func=situlu,
+        gated_linear_unit=True,
+        use_te_activation_func=True,
+    )
+
+    assert config.situ_glu_beta1 == 4.0
+    assert config.situ_glu_beta2 == 25.0
+
+
+def test_transformer_config_accepts_pytorch_situ_glu_fallback():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        activation_func=situlu,
+        gated_linear_unit=True,
+        use_te_activation_func=False,
+    )
+
+    assert config.activation_func is situlu
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"gated_linear_unit": False}, "gated_linear_unit=True"),
+        ({"activation_func_clamp_value": 1.0}, "does not use activation_func_clamp_value"),
+        ({"glu_linear_offset": 1.0}, "requires glu_linear_offset=0.0"),
+        ({"situ_glu_beta1": 0.0}, "situ_glu_beta1 must be finite and positive"),
+        ({"situ_glu_beta2": float("inf")}, "situ_glu_beta2 must be finite and positive"),
+    ],
+)
+def test_transformer_config_rejects_unsupported_situ_glu(overrides, match):
+    kwargs = dict(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        activation_func=situlu,
+        gated_linear_unit=True,
+        use_te_activation_func=True,
+    )
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=match):
+        TransformerConfig(**kwargs)

--- a/tests/unit_tests/transformer/test_te_fused_dense_mlp_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_dense_mlp_spec.py
@@ -54,12 +54,12 @@ class TestTEFusedDenseMLPSpec:
 
     def test_wrong_activation_raises(self):
         config = _make_config(activation_func=F.gelu, gated_linear_unit=False)
-        with pytest.raises(ValueError, match="SwiGLU activation"):
+        with pytest.raises(ValueError, match="SwiGLU or SiTU-GLU activation"):
             TEFusedDenseMLP(config, _make_submodules())
 
     def test_gated_linear_unit_false_raises(self):
         config = _make_config(gated_linear_unit=False)
-        with pytest.raises(ValueError, match="SwiGLU activation"):
+        with pytest.raises(ValueError, match="SwiGLU or SiTU-GLU activation"):
             TEFusedDenseMLP(config, _make_submodules())
 
     def test_add_bias_linear_raises(self):

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from megatron.core.activations import situlu
 from megatron.core.extensions.transformer_engine import (
     HAVE_TE,
     TEFusedMLP,
@@ -74,13 +75,18 @@ def _patch_fake_te_ops(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
+    class FakeScaledSiTUGLU(FakeScaledSwiGLU):
+        pass
+
     fake_ops = SimpleNamespace(
         Sequential=FakeSequential,
         LayerNorm=FakeNorm,
         RMSNorm=FakeNorm,
         GroupedLinear=FakeGroupedLinear,
         ScaledSwiGLU=FakeScaledSwiGLU,
+        ScaledSiTUGLU=FakeScaledSiTUGLU,
     )
+    monkeypatch.setattr(te_ext, "HAVE_TE", True)
     monkeypatch.setattr(te_ext.te.pytorch, "LayerNormLinear", FakeLayerNormLinear, raising=False)
     monkeypatch.setattr(te_ext.te.pytorch, "Linear", FakeLinear, raising=False)
     monkeypatch.setattr(te_ext.te.pytorch, "ops", fake_ops, raising=False)
@@ -95,11 +101,20 @@ def _patch_fake_te_ops(monkeypatch):
         Linear=FakeLinear,
         GroupedLinear=FakeGroupedLinear,
         ScaledSwiGLU=FakeScaledSwiGLU,
+        ScaledSiTUGLU=FakeScaledSiTUGLU,
     )
 
 
-def _make_fake_grouped_mlp(fake_te, normalization="LayerNorm"):
+def _make_fake_grouped_mlp(fake_te, normalization="LayerNorm", activation_func=F.silu):
     module = TEFusedMLPWithGroupedLinear.__new__(TEFusedMLPWithGroupedLinear)
+    module.config = SimpleNamespace(
+        activation_func=activation_func,
+        activation_func_clamp_value=None,
+        gated_linear_unit=True,
+        situ_glu_beta1=4.0,
+        situ_glu_beta2=25.0,
+        use_fused_weighted_squared_relu=False,
+    )
 
     fc1 = fake_te.LayerNormLinear()
     fc1.normalization = normalization
@@ -147,8 +162,8 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         ("config_overrides", "match"),
         [
             ({"add_bias_linear": True}, "add_bias_linear"),
-            ({"activation_func": F.gelu}, "SwiGLU activation"),
-            ({"gated_linear_unit": False}, "SwiGLU activation"),
+            ({"activation_func": F.gelu}, "SwiGLU or SiTU-GLU activation"),
+            ({"gated_linear_unit": False}, "SwiGLU or SiTU-GLU activation"),
         ],
     )
     def test_init_validates_supported_dense_swiglu_config(
@@ -207,6 +222,15 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         assert fc2_op.kwargs["out_features"] == 4
         assert fc2_op.kwargs["accumulate_into_main_grad"] is False
         assert fc2_op.weight0 is module.linear_fc2.weight
+
+    def test_make_fused_impl_selects_scaled_situ_glu(self, monkeypatch):
+        fake_te = _patch_fake_te_ops(monkeypatch)
+        module = _make_fake_grouped_mlp(fake_te, activation_func=situlu)
+
+        fused_impl = TEFusedMLPWithGroupedLinear._make_fused_impl(module)
+
+        assert isinstance(fused_impl[1], fake_te.ScaledSiTUGLU)
+        assert fused_impl[1].kwargs == {"glu_interleave_size": 32, "beta1": 4.0, "beta2": 25.0}
 
     @pytest.mark.parametrize(("bad_attr", "match"), [("linear_fc1", "FC1"), ("linear_fc2", "FC2")])
     def test_make_fused_impl_validates_te_linear_types(self, monkeypatch, bad_attr, match):
@@ -333,12 +357,12 @@ class TestTEFusedMLPWithGroupedLinearSpec:
 
     def test_wrong_activation_raises(self):
         config = _make_config(activation_func=F.gelu, gated_linear_unit=False)
-        with pytest.raises(ValueError, match="SwiGLU activation"):
+        with pytest.raises(ValueError, match="SwiGLU or SiTU-GLU activation"):
             TEFusedMLPWithGroupedLinear(config, _make_submodules())
 
     def test_gated_linear_unit_false_raises(self):
         config = _make_config(gated_linear_unit=False)
-        with pytest.raises(ValueError, match="SwiGLU activation"):
+        with pytest.raises(ValueError, match="SwiGLU or SiTU-GLU activation"):
             TEFusedMLPWithGroupedLinear(config, _make_submodules())
 
     def test_add_bias_linear_raises(self):

--- a/tools/checkpoint/loader_base.py
+++ b/tools/checkpoint/loader_base.py
@@ -443,7 +443,7 @@ class MegatronCheckpointLoaderBase:
         md.linear_bias = self.margs.add_bias_linear
         md.qkv_bias = self.margs.add_qkv_bias
         md.norm_has_bias = norm_has_bias
-        md.swiglu = self.margs.swiglu
+        md.swiglu = self.margs.swiglu or getattr(self.margs, "situ_glu", False)
         md.previous_tensor_parallel_size = self.margs.tensor_model_parallel_size
         md.previous_pipeline_parallel_size = self.margs.pipeline_model_parallel_size
         md.true_vocab_size = true_vocab_size


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Add Kimi K3 SiTU-GLU as a global FFN activation on `dev`.

Paired main-target PR: https://github.com/NVIDIA/Megatron-LM/pull/6674

## Activation

For gate projection `G`, up projection `U`, and K3 defaults `beta1=4`, `beta2=25`:

```text
T_g = beta1 * tanh(G / beta1) * sigmoid(G)
T_u = beta2 * tanh(U / beta2)
Y   = T_g * T_u
```

Reference: [Kimi K3 technical report, Figure 4 and Equation 12](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf).

## Design

- Add `--situ-glu`, with `--moe-use-situ-glu` as an alias, and apply it consistently to dense, routed-expert, and shared-expert FFNs.
- Add `situ_glu_beta1=4` and `situ_glu_beta2=25` to `TransformerConfig`, with validation that SiTU-GLU is gated, unclamped, uses zero GLU linear offset, and has finite positive beta values.
- Add `situlu` as the correct PyTorch pointwise reference and configuration marker. It serves non-TE/custom module paths until PyTorch provides a dedicated `torch.nn.functional.situlu`-style operation; unary `F.silu` is not equivalent.
- Use `transformer_engine.pytorch.ops.SiTUGLU` for ordinary dense, sequential-expert, and ordinary shared-expert paths.
- Use `transformer_engine.pytorch.ops.ScaledSiTUGLU` for fused grouped dense, routed-expert, and shared-expert paths.
- Fail clearly when a requested TE path does not expose the required SiTU-GLU operator. cuDNN frontend capability selection remains inside TE.
- Extend checkpoint conversion, default FFN sizing, FLOP accounting, and memory estimation to treat SiTU-GLU as a gated GLU.

The required TE interface is available in https://github.com/NVIDIA/TransformerEngine/pull/3402.

With that TE interface, an older cuDNN frontend without SiTU parameters uses TE's unfused `GroupedLinear -> ScaledSiTUGLU -> GroupedLinear` operation sequence. A SiTU-capable cuDNN frontend enables fused grouped GEMM + SiTU-GLU without an MCore-side backend check.

## Test results

Validated on NVIDIA B300 with https://github.com/NVIDIA/TransformerEngine/pull/3402 and cuDNN Frontend develop through https://github.com/NVIDIA/cudnn-frontend/pull/670, using CuTe DSL 4.6.2:

- final focused SiTU-GLU and grouped-MLP suite on the review-fixed tip: **41 passed**;
- broader selected dev suites: **114 passed, 11 skipped, 4 deselected**; the deselected cases are existing multi-rank shared-expert parameterizations that cannot run on one GPU;
- BF16 real MCore MoE routed forward/backward through `ScaledSiTUGLU`: **passed**;
- MXFP8 real MCore MoE forward/backward: routed and fused-shared `ScaledSiTUGLU`, with the fused cuDNN/CuTe grouped-MLP operation asserted: **passed**;
- NVFP4 routed-expert forward/backward through `ScaledSiTUGLU`, with the fused Hadamard forward operation asserted: **passed**;
- `git diff --check`, Python compilation, and Ruff on all changed source and test files: **passed**;
- SSH commit signature and DCO: **passed**.
- `--use-checkpoint-args` restoration passed two parametrized SwiGLU/SiTU-GLU cases, including the SiTU selector and non-default beta values.
- The hybrid-model golden-config comparator passed on the current rebased tip.

Fused-shared NVFP4 currently reaches an existing TE FC1 weight-scale reshape failure that reproduces with an equivalent SwiGLU control, so this PR does not claim that combination. MXFP8 dSiTU validation used the cuDNN frontend correction included in https://github.com/NVIDIA/cudnn-frontend/pull/670; the published cuDNN frontend 1.27.0 package tested here does not yet contain that correction.

## Scope and dependencies

This PR depends on https://github.com/NVIDIA/TransformerEngine/pull/3402 for TE-backed SiTU-GLU functionality. The cuDNN frontend support is optional for correctness and required only for fused block-scaled grouped execution. A functional test is deferred until that TE interface is available in Megatron-LM CI; the focused MCore unit and GPU suites cover the current integration boundary.

This PR is independent of Quantile Balancing and https://github.com/NVIDIA/Megatron-LM/pull/6637.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: TODO — link a Megatron-LM feature-request issue before marking this draft ready for review.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.


