### PR TITLE
Pass process groups to GDP projections

### DIFF
--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -304,6 +304,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             is_expert=False,
             tp_comm_buffer_name="fc1",
             tp_group=self.pg_collection.tp,
+            pg_collection=self.pg_collection,
             name=(name + f".in_proj") if name is not None else None,
         )
         setattr(self.in_proj.weight, "use_muon", False)
@@ -422,6 +423,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             is_expert=False,
             tp_comm_buffer_name="fc2",
             tp_group=self.pg_collection.tp,
+            pg_collection=self.pg_collection,
             name=(name + f".out_proj") if name is not None else None,
         )
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_custom_pgs.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_custom_pgs.py
@@ -279,6 +279,56 @@ def _worker_partial_pgs_fall_back_to_mpu(rank, world_size, port):
     ps.initialize_model_parallel()
 
 
+def _worker_gdp_uses_custom_gtp_group(rank, world_size, port):
+    """GDP projections must use the caller-owned GTP group when MPU owns another topology."""
+    from megatron.core import parallel_state as ps
+    from megatron.core.models.hybrid.hybrid_layer_specs import gdp_stack_spec
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.ssm.gated_delta_product import GatedDeltaProductMixer
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=GTP_SIZE
+    )
+    mpu_pgs = ProcessGroupCollection.use_mpu_process_groups(
+        required_pgs=['tp', 'cp', 'gtp_remat', 'expt_gtp_remat']
+    )
+    mpu_ranks = sorted(dist.get_process_group_ranks(mpu_pgs.gtp_remat))
+    custom_gtp_group = _pick_permuted_gtp_group(rank, mpu_ranks)
+    custom_pgs = ProcessGroupCollection(
+        tp=mpu_pgs.tp,
+        cp=mpu_pgs.cp,
+        gtp_remat=custom_gtp_group,
+        expt_gtp_remat=mpu_pgs.expt_gtp_remat,
+    )
+    model_parallel_cuda_manual_seed(
+        42, gtp_remat_rank=custom_gtp_group.rank(), egtp_remat_rank=0, force_reset_rng=True
+    )
+
+    config = _make_config()
+    config.mamba_num_heads = 4
+    config.mamba_head_dim = 64
+    config.mamba_num_groups = 2
+    config.mamba_state_dim = 128
+    mixer = GatedDeltaProductMixer(
+        config,
+        gdp_stack_spec.submodules.mamba_layer.submodules.mixer.submodules,
+        config.hidden_size,
+        layer_number=1,
+        pg_collection=custom_pgs,
+    ).cuda()
+
+    for name, param in (("in_proj", mixer.in_proj.weight), ("out_proj", mixer.out_proj.weight)):
+        assert isinstance(param, GTPShardedParam), f"GDP {name} was not GTP-sharded"
+        assert (
+            param.group is custom_gtp_group
+        ), f"GDP {name} used the MPU-global GTP group instead of the caller-owned group"
+
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel()
+
+
 def _worker_seed_custom_gtp_groups_without_mpu(rank, world_size, port):
     """Explicit GTP groups must seed their trackers without MPU groups."""
     from megatron.core import parallel_state as ps
@@ -330,6 +380,11 @@ class TestGTPCustomProcessGroups:
         """Omitting gtp_remat must fall back to the MPU group, not silently disable sharding."""
         _requires_multi_gpu(WORLD)
         _run_distributed(_worker_partial_pgs_fall_back_to_mpu, WORLD)
+
+    def test_gdp_projections_use_custom_gtp_group(self):
+        """GDP leaf linears must honor a MIMO-owned GTP group instead of MPU globals."""
+        _requires_multi_gpu(WORLD)
+        _run_distributed(_worker_gdp_uses_custom_gtp_group, WORLD)
 
     def test_custom_gtp_groups_seed_without_mpu(self):
         """Explicit GTP groups must not depend on MPU rank or world-size state."""


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Pass the caller-owned process-group collection to the gated delta product input and output projections.

Without the collection, the projection linears resolve their GTP rematerialization group through the MPU-global fallback. A model using a custom `ProcessGroupCollection` can therefore shard the GDP projection weights over a different group than the one owned by the caller.

This change threads the existing collection into both projections and adds a regression test that keeps one GTP topology in MPU globals while constructing the GDP mixer with a different, caller-owned topology. The test verifies both projection weights are GTP-sharded over the caller-owned group.

## Issue tracking

Linked issue: N/A — standalone bug fix.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests — not applicable to this constructor-level process-group fix
- [ ] I have added proper typing to my code — no public API or type surface changed
- [ ] I have added relevant documentation — no user-facing behavior or configuration changed
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Validation

- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
  - Black 26.3.0: passed
  - isort: passed
  - Pylint: 10.00/10
  - Ruff: passed
- `python3 -m py_compile megatron/core/ssm/gated_delta_product.py tests/unit_tests/generalized_tensor_parallel/test_gtp_custom_pgs.py`
- `git diff --check origin/main...HEAD`

The new distributed regression requires four GPUs and was not run locally.