### PR TITLE
Add megatron/core/ops: one place a kernel backend is selected

### DIFF
--- a/megatron/core/inference/ops/__init__.py
+++ b/megatron/core/inference/ops/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Inference-optimized operation backends.
+
+These fill the same slots as any other backend and are selected the same way, by
+``--transformer-impl inference_optimized`` or ``--op-backend``. They live here rather than
+under ``megatron/core/ops`` so the inference-only implementations stay with the rest of the
+inference subsystem; ``megatron.core.ops.<family>.BACKENDS`` points at them by name.
+"""
+
+from megatron.core.inference.ops.backends import LinearInference, MoeInference, NormInference
+
+__all__ = ["LinearInference", "MoeInference", "NormInference"]

--- a/megatron/core/inference/ops/backends.py
+++ b/megatron/core/inference/ops/backends.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The inference-optimized backend for each operation family."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.mlp import TEActivationFunctionBuilder
+    from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
+
+__all__ = ["LinearInference", "MoeInference", "NormInference"]
+
+
+class NormInference:
+    """Transformer Engine's norm, never fusing the residual.
+
+    Inference layers manage the residual themselves, so folding it into the norm would apply
+    it twice. Composed rather than subclassed, and imported inside the method, so this module
+    has no import-time dependency on ``megatron.core.ops`` -- which would be a cycle, since
+    ``ops.norm`` names this class in its backend table.
+    """
+
+    #: Defers to the Transformer Engine norm, which is not audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def layer_norm(self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False):
+        """Transformer Engine's choice, with residual fusion always declined."""
+        from megatron.core.ops.norm.backends import NormTE
+
+        del has_residual
+        return NormTE().layer_norm(rms_norm=rms_norm, for_qk=for_qk, has_residual=False)
+
+
+class LinearInference:
+    """The inference-optimized linear layers."""
+
+    #: Not audited.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def linear(self) -> type:
+        """Inference reuses the Transformer Engine non-parallel linear."""
+        from megatron.core.extensions.transformer_engine import TELinear
+
+        return TELinear
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.inference_layers import InferenceColumnParallelLinear
+
+        return InferenceColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.inference_layers import InferenceRowParallelLinear
+
+        return InferenceRowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Which module fuses layernorm and column parallel linear."""
+        from megatron.core.tensor_parallel.inference_layers import (
+            InferenceLayerNormColumnParallelLinear,
+        )
+
+        return InferenceLayerNormColumnParallelLinear
+
+
+class MoeInference:
+    """The inference-optimized experts and router."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Inference always uses grouped experts."""
+        del moe_use_grouped_gemm
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelGroupedLinear,
+            TERowParallelGroupedLinear,
+        )
+        from megatron.core.transformer.moe.experts import GroupedMLPSubmodules, InferenceGroupedMLP
+
+        return partial(
+            InferenceGroupedMLP,
+            submodules=GroupedMLPSubmodules(
+                linear_fc1=TEColumnParallelGroupedLinear,
+                linear_fc2=TERowParallelGroupedLinear,
+                activation_func=self.activation_func(),
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Which module to use for activation function."""
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        return cast("TEActivationFunctionBuilder", TEActivationOp)
+
+    def moe_router(self) -> Optional[type]:
+        """Inference needs compact [tokens, topk] index routing rather than a dense map."""
+        from megatron.core.transformer.moe.router import InferenceTopKRouter
+
+        return InferenceTopKRouter

--- a/megatron/core/ops/README.md
+++ b/megatron/core/ops/README.md
@@ -1,0 +1,245 @@
+# Operation backends
+
+Model code asks for an implementation once, while it builds a spec, and calls the result
+directly from then on:
+
+```python
+provider = get_backend_spec_provider(config)
+norm_cls = provider.layer_norm(rms_norm=True)   # returns the class; nothing else happens
+self.input_layernorm = norm_cls(config=config, hidden_size=..., eps=...)
+```
+
+There is no registry lookup, no resolver, and no dispatch in the forward path.
+
+## Two layers
+
+**Central, and it stops changing.** `operations.py` defines what an operation *is*.
+`spec_provider.py` defines `BackendSpecProvider`, the one type model code ever holds.
+`options.py` lists every setting that can change which implementation you get. `resolve.py`
+builds a provider and names no individual backend.
+
+**Per family, and it grows.** Each `megatron/core/ops/<family>/` declares its own operations,
+its contract, its backend table, and its default. Adding a backend touches one family;
+adding a family is a milestone.
+
+```
+megatron/core/ops/norm/
+  __init__.py               # the contract, the operations, the slots, BACKENDS, DEFAULT
+  backends.py               # every implementation, side by side
+```
+
+Two files per family, split by who reads them: `__init__.py` is what a *caller* needs — what
+this family promises and which backends exist — and `backends.py` is what a *maintainer* of an
+implementation needs. A family becomes a package with sub-packages when its operations have
+disjoint backend sets, which is how `attention/dsa/` will work. Each backend class is named for the family and the key that
+selects it — `NormApex`, `NormTE`, `LinearLocal`, `MoeTE` — so `--op-backend layer_norm=apex`
+and `NormApex` are the same word, and nothing collides with the target classes themselves
+(`TENorm` and `TELinear` are real modules in `extensions/transformer_engine.py`).
+
+Backends whose implementations belong to another subsystem live there and are referenced by
+name: the inference-optimized ones are in `megatron/core/inference/ops/backends.py`.
+
+A family can split into sub-folders when its operations have disjoint backend sets, which is
+how `attention.dsa` will work: `FAMILY = "attention.dsa"` is the module path, so the resolver
+finds it with no extra machinery, and DSA can offer `tilelang` without offering it for
+`core_attention`.
+
+## How selection works
+
+Three steps, in this order:
+
+1. `--transformer-impl` names a preset. Each family uses its entry for that name, or its own
+   `DEFAULT` if it has none.
+2. Settings that predate `--op-backend` take over the operations they name.
+3. `--op-backend` takes over last.
+
+Two settings claiming the same operation is an error, not a silent win for one of them.
+
+Backend names are scoped to the operation, so the same word means "that vendor's
+implementation of whatever you named":
+
+```bash
+--op-backend layer_norm=transformer_engine core_attention=transformer_engine
+--op-backend layer_norm=apex                       # Apex norm on a Transformer Engine model
+--op-backend-config backends.yaml                  # same thing from a file
+```
+
+`BackendSpecProvider` binds the owning backend's method onto itself while the model is being
+built, so combining backends costs one attribute lookup then and nothing afterwards. A slot no
+backend owns raises and says how to select one.
+
+## Where a choice is made
+
+One selection, end to end, so the hops are written down rather than discovered:
+
+```
+--transformer-impl transformer_engine --op-backend layer_norm=apex
+  |
+  options.py      BackendOptions          every selector, each with its valid values
+  resolve.py      _preset_owners          preset -> each family's entry, or its DEFAULT
+  resolve.py      _override_owners        legacy flags, then --op-backend, last word
+  norm/__init__   BACKENDS["apex"]        -> NormApex
+  norm/backends   NormApex.layer_norm     -> megatron.core.fusions.fused_layer_norm
+
+and at runtime, repr(provider) names the backend that won every slot:
+
+  BackendSpecProvider(activation_func=MoeTE, column_parallel_linear=LinearTE,
+                      layer_norm=NormApex, ...)
+```
+
+Two rules make that traceable:
+
+- **`resolve.py` names no family and no backend.** It asks each family for its table, its
+  default, and its `legacy_backends`. Grepping a backend name never lands there.
+- **A family's `__init__.py` is the whole story for its operations** — which backends exist,
+  which is the default, and how any older flag maps onto them. The cross entropy flags
+  (`--cross-entropy-fusion-impl native`) turn into backend names in
+  `loss/__init__.py:legacy_backends`, next to the `BACKENDS` table they refer to.
+
+## Adding a backend
+
+Say you want Liger's RMSNorm.
+
+1. Add a class to `megatron/core/ops/norm/backends.py`. Meet the contract in
+   `norm/contract.py`, and keep the target import inside the method that returns it — nothing
+   in that file may import an optional package at module scope:
+
+   ```python
+   class NormLiger:
+       """Liger's fused RMSNorm."""
+
+       REQUIRES = "liger_kernel"
+
+       def layer_norm(self, rms_norm=False, for_qk=False, has_residual=False):
+           if not rms_norm:
+               raise ValueError("The liger backend implements RMSNorm only")
+           from liger_kernel.ops.rms_norm import LigerRMSNorm
+
+           return LigerRMSNorm
+   ```
+
+   `REQUIRES` is the whole dependency story. The resolver checks it once, in one place, while
+   arguments are parsed — so `--op-backend layer_norm=liger` on a machine without Liger fails
+   before anything is built. A backend that needs more than "is the package importable", such
+   as a version check, does that in its own constructor.
+
+2. Add one entry to `BACKENDS` in `norm/__init__.py`:
+
+   ```python
+   "liger": NormLiger,
+   ```
+
+That is the whole change. Nothing central moves, no call site changes, and
+`--op-backend layer_norm=liger` works immediately. `tests/unit_tests/ops/test_conformance.py`
+is parametrized off `BACKENDS`, so the new backend is covered the moment it is registered — if
+it misses a slot its family declares, that test fails by name.
+
+Backends that need a setting bound up front expose `from_options(options)` instead of a bare
+constructor; the loss family's `LossTEFused` does this for CUDA-graph capture.
+
+## Fusing across operations
+
+A backend may fuse whatever it likes. What it may not do is fuse silently: it has to say which
+operations it reaches across, and what it needs from each.
+
+`MlpTEOpFuser` is the worked example. It fills `mlp_module`, but folds the linears it is handed
+into Transformer Engine operations, and `TEFusedMLP` raises on anything that is not a TE
+linear. So it declares:
+
+```python
+FUSES = {
+    COLUMN_PARALLEL_LAYER_NORM_LINEAR: "transformer_engine",
+    ROW_PARALLEL_LINEAR: "transformer_engine",
+}
+```
+
+`resolve.py` then refuses a configuration the fusion cannot serve — including
+`--transformer-impl local --use-transformer-engine-op-fuser`, and
+`--op-backend column_parallel_layer_norm_linear=local` alongside the fuser. Both used to build
+a spec that died with a type error partway through model construction.
+
+A backend that *replaces* a slot rather than consuming it names itself as the backend for it.
+
+`FUSES` is for a backend that stays inside one family and is picky about its neighbours. A
+kernel that swallows operations from *several* families is the next section.
+
+## Megakernels: `ops/fusions/`
+
+A megakernel cannot be a backend in any single family, because it does not answer any single
+family's question. It gets a family of its own, one file per fusion — so two vendors adding two
+kernels never touch the same file, and neither has to reorganise anything that already exists.
+
+`fusions/attn_moe.py` is a complete worked example, `ReferenceFusedAttentionMoELayer`. It runs
+Megatron Core's ordinary attention and experts rather than a kernel, so the mechanism is
+testable before any kernel exists and a vendor can see exactly what their own file owes:
+
+```python
+class AttnMoeReference:
+    REQUIRES = None            # a vendor: "vendor_kernels>=0.4", checked while args are parsed
+    DETERMINISM = "unknown"    # a vendor: "nondeterministic", refused by --deterministic-mode
+    SPANS = (CORE_ATTENTION, GROUPED_MLP_MODULES)
+
+    def fused_moe_layer(self):
+        return ReferenceFusedAttentionMoELayer
+```
+
+Selected the same way as anything else, with no new flag:
+
+```
+--op-backend fused_moe_layer=attn_moe_reference
+```
+
+Three things make an arbitrary span safe to accept:
+
+- **`SPANS` is the whole rule.** Fuse across whatever you like, but list the operations your
+  kernel performs itself. `resolve.py:_check_spans` then refuses `--op-backend
+  core_attention=...` alongside the fusion, because that backend would never be built — the run
+  would look configured and be nothing of the sort. Everything the fusion did *not* swallow
+  stays selectable.
+- **The target is a `TransformerLayer` subclass**, handed the same `TransformerLayerSubmodules`
+  the ordinary layer would have got. Those are specs, not modules, so the parts the kernel
+  performs itself are simply never built. Its state dict still has to load a checkpoint the
+  ordinary layer wrote, or it is a different model rather than a faster one.
+- **`REQUIRES`, `DETERMINISM` and `FUSES` mean what they always mean.** A fusion is a backend
+  in a table; it gets the version check, the `--deterministic-mode` refusal, and the
+  conformance tests for free.
+
+### One slot per handover point, not per kernel
+
+The slots are named for **where the layer hands over control**, not for what any one kernel
+swallows. There are two, matching the two layer specs `get_gpt_decoder_layer_specs` already
+builds:
+
+```python
+def fused_dense_layer(self) -> Optional[type]   # a dense layer, as one kernel
+def fused_moe_layer(self) -> Optional[type]     # an MoE layer, as one kernel
+```
+
+That split is what keeps the family from growing per contributor:
+
+- **A kernel that reaches wider needs no new slot.** One that also eats the input norm still
+  fills `fused_moe_layer` and just lists `LAYER_NORM` in `SPANS`. The layer hands it the full
+  `TransformerLayerSubmodules`; the norm it ignores is never built.
+- **An attention-plus-dense-MLP kernel is a new *file*, not a new slot.** It fills
+  `fused_dense_layer`, declares `SPANS = (CORE_ATTENTION, MLP_MODULE)`, and can be selected
+  *alongside* an attention-plus-MoE kernel from someone else, because the two are separate
+  operations. One generic `fusion(*ops)` slot could not do that — `--op-backend` binds one
+  backend per operation, so only one fusion could ever be enabled.
+- **What does force a new slot** is a kernel needing control somewhere the layer does not hand
+  it over — spanning the residual into the *next* layer, say, which is a block-level handover.
+  That needs a call site beside these two, which is a milestone rather than a drive-by.
+
+Which is the trade on offer: the kernel is yours to write, the handover point is ours to name.
+
+## Adding a family
+
+Create `megatron/core/ops/<family>/` with an `__init__.py` carrying the contract, the
+`Operation` constants, a `*Slots` class whose methods raise `unowned(...)`, `BACKENDS` and
+`DEFAULT`, plus a `backends.py` with the implementations. Then list the family in
+`resolve.py:_FAMILIES` and add its `*Slots` to the bases of `BackendSpecProvider`. If any
+older setting selects one of its operations, give it a `legacy_backends(options)` so that
+mapping lives beside the table it refers to.
+
+Declare an operation only when an existing class, callable, or builder already owns that
+boundary at construction time. An implementation that has to branch on shape, phase, or
+communication keeps its current owner and exposes a target through `ops` instead.

--- a/megatron/core/ops/__init__.py
+++ b/megatron/core/ops/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Operation implementations and the construction-time API that selects between them.
+
+Model code asks a :class:`BackendSpecProvider` for the implementation of an operation while it
+builds a spec, and calls the returned target directly afterwards. There is no registry lookup
+and no dispatch in the forward path::
+
+    provider = get_backend_spec_provider(config)   # honours --transformer-impl and --op-backend
+    norm_cls = provider.layer_norm(rms_norm=True)  # returns the class, nothing else happens
+
+A *backend* is any object implementing one or more provider methods. Each operation family
+under ``megatron/core/ops/<family>/`` declares its own operations, contract, and backend table,
+so adding a backend touches one family and nothing central. See ``README.md``.
+"""
+
+from megatron.core.ops.operations import Operation
+from megatron.core.ops.options import BackendOptions
+from megatron.core.ops.resolve import (
+    PRESETS,
+    backends_for,
+    build_spec_provider,
+    find_operation,
+    get_backend,
+    get_backend_spec_provider,
+    operations,
+    validate_backend,
+)
+from megatron.core.ops.spec_provider import BackendSpecProvider
+
+__all__ = [
+    "PRESETS",
+    "BackendOptions",
+    "BackendSpecProvider",
+    "Operation",
+    "backends_for",
+    "build_spec_provider",
+    "find_operation",
+    "get_backend",
+    "get_backend_spec_provider",
+    "operations",
+    "validate_backend",
+]

--- a/megatron/core/ops/_availability.py
+++ b/megatron/core/ops/_availability.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Optional-dependency checks for operation backends.
+
+Backends state their requirements here instead of setting a module-level ``HAVE_*`` flag.
+Two rules keep the failure modes distinct:
+
+* An optional dependency that is *not installed* is a normal, silent absence. Only a backend
+  that was explicitly selected turns that into an error, and it does so while the model is
+  being built, not at import time.
+* An optional dependency that is installed but *broken* (a missing transitive library, a
+  failed native loader) is always reported. Treating it as "not installed" is how a broken
+  install silently becomes a slow fallback.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+from functools import lru_cache
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+
+@lru_cache(maxsize=None)
+def _import_outcome(module_name: str) -> tuple[ModuleType | None, BaseException | None, bool]:
+    """Import ``module_name`` once. Returns (module, error, is_absent)."""
+    try:
+        return importlib.import_module(module_name), None, False
+    except ModuleNotFoundError as error:
+        # `error.name` distinguishes "this package is absent" from "this package is present
+        # but one of its own imports is not".
+        absent = error.name in {module_name, module_name.split(".", maxsplit=1)[0]}
+        return None, error, absent
+    except Exception as error:  # pylint: disable=broad-except
+        return None, error, False
+
+
+def is_installed(module_name: str) -> bool:
+    """Whether an optional dependency is importable, without raising if it is absent."""
+    module, _, absent = _import_outcome(module_name)
+    if module is not None:
+        return True
+    if absent:
+        return False
+    raise ImportError(f"Optional dependency '{module_name}' is installed but failed to import.")
+
+
+def require(module_name: str) -> ModuleType:
+    """Return a selected dependency, or explain what is wrong with it.
+
+    Callers that know which backend asked should catch this and add that context;
+    :mod:`megatron.core.ops.resolve` does exactly that, from its backend table.
+    """
+    module, error, absent = _import_outcome(module_name)
+    if module is not None:
+        return module
+    reason = "is not installed" if absent else "failed to import"
+    raise ImportError(f"'{module_name}' {reason}.") from error
+
+
+def installed_version(module_name: str) -> "Version | None":
+    """The installed version of an optional dependency, or None if it cannot be determined.
+
+    Transformer Engine is asked through Megatron's own resolver, which already handles its
+    module-versus-distribution naming and its dev suffixes; duplicating that here is how the
+    two would drift. Anything else comes from package metadata.
+    """
+    from packaging.version import Version
+
+    if module_name == "transformer_engine":
+        from megatron.core.utils import get_te_version
+
+        return get_te_version()
+    try:
+        return Version(importlib.metadata.version(module_name))
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def reset_cache() -> None:
+    """Clear cached import outcomes. Intended for tests only."""
+    _import_outcome.cache_clear()

--- a/megatron/core/ops/attention/__init__.py
+++ b/megatron/core/ops/attention/__init__.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Core attention: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract**
+
+* **Target**: a class the attention module constructs with Megatron's core-attention
+  signature, taking the layer number, attention mask type, and CP communication type.
+* **State**: none beyond what the target itself allocates. Q/K/V projections and the output
+  projection stay with the attention module, not with this target.
+* **Process groups**: the target owns context-parallel communication using the CP group and
+  communication type the attention module passes in. Tensor-parallel splitting of heads is
+  done by the projections, not here.
+* **Modes**: backends differ on packed and variable-length input, decode, and quantization.
+  Transformer Engine selects flash, fused, or unfused internally; Megatron does not add a
+  second attention dispatcher on top of it.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.attention.backends import AttentionLocal, AttentionTE
+from megatron.core.ops.operations import Operation, unowned
+
+FAMILY = "attention"
+
+CORE_ATTENTION = Operation(FAMILY, "core_attention")
+
+OPERATIONS = (CORE_ATTENTION,)
+
+
+class AttentionSlots:
+    """The attention slots."""
+
+    def core_attention(self) -> type:
+        """Which module to use for attention."""
+        raise unowned(CORE_ATTENTION)
+
+
+#: Backend name -> the class that owns this family's slots. Add a backend by adding its class
+#: to backends.py and one entry here; one that needs an optional package declares ``REQUIRES``.
+BACKENDS = {
+    "local": AttentionLocal,
+    "transformer_engine": AttentionTE,
+    # Inference reuses TE attention; the inference gains are in the linear and MoE layers.
+    "inference_optimized": AttentionTE,
+}
+
+#: Used when the selected preset has no entry above.
+DEFAULT = "local"
+
+__all__ = ["BACKENDS", "CORE_ATTENTION", "DEFAULT", "FAMILY", "OPERATIONS", "AttentionSlots"]

--- a/megatron/core/ops/attention/backends.py
+++ b/megatron/core/ops/attention/backends.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every core-attention backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["AttentionLocal", "AttentionTE"]
+
+
+class AttentionLocal:
+    """Megatron Core's own dot-product attention."""
+
+    #: Not audited.
+    DETERMINISM = "unknown"
+
+    def core_attention(self) -> type:
+        """Which module to use for attention."""
+        from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+        return DotProductAttention
+
+
+class AttentionTE:
+    """Transformer Engine's fused attention.
+
+    TE chooses flash, fused, or unfused internally from the shapes and environment it is
+    given. Megatron does not copy that decision here.
+    """
+
+    #: TE refuses to run under deterministic_mode unless NVTE_ALLOW_NONDETERMINISTIC_ALGO=0,
+    #: which is one of the env defaults that mode sets. See extensions/transformer_engine.py.
+    DETERMINISM = "deterministic"
+
+    REQUIRES = "transformer_engine"
+
+    def core_attention(self) -> type:
+        """Which module to use for attention."""
+        from megatron.core.extensions.transformer_engine import TEDotProductAttention
+
+        return TEDotProductAttention

--- a/megatron/core/ops/determinism.py
+++ b/megatron/core/ops/determinism.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Whether a backend produces bit-exact results run to run.
+
+Every backend declares ``DETERMINISM``. Three values, because "nobody has checked" is a
+different statement from "verified safe" and should not be able to masquerade as it:
+
+``DETERMINISTIC``
+    Bit-exact under ``--deterministic-mode``, given the environment that mode sets up.
+``NONDETERMINISTIC``
+    Known not to be. Selecting it under ``--deterministic-mode`` is an error.
+``UNKNOWN``
+    Nobody has established either way. Usable, but ``--deterministic-mode`` warns, because
+    the guarantee it advertises does not hold for that operation.
+
+Declared as plain strings rather than an enum so that a backend module needs no import to
+state it -- which is what keeps ``megatron/core/inference/ops/backends.py`` free of any
+module-scope ``megatron.core.ops`` import, the invariant that stops the two packages forming
+an import cycle.
+"""
+
+DETERMINISTIC = "deterministic"
+NONDETERMINISTIC = "nondeterministic"
+UNKNOWN = "unknown"
+
+VALUES = frozenset({DETERMINISTIC, NONDETERMINISTIC, UNKNOWN})
+
+__all__ = ["DETERMINISTIC", "NONDETERMINISTIC", "UNKNOWN", "VALUES"]

--- a/megatron/core/ops/fusions/__init__.py
+++ b/megatron/core/ops/fusions/__init__.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Fusions that span several families: what one must declare, and which ones exist.
+
+Every other family under ``megatron.core.ops`` owns one boundary, and its backends are
+interchangeable -- ``NormTE`` and ``NormApex`` answer the same question, so they are read side
+by side in one ``backends.py``. A fusion owns a *larger* boundary than any single family, and
+two fusions are not alternatives to each other: each defines its own span. So this family keeps
+one file per fusion, and two vendors adding two megakernels never touch the same file.
+
+**Contract**
+
+* **Target**: a ``TransformerLayer`` subclass, or ``None`` to keep the ordinary layer. It is
+  handed the same ``TransformerLayerSubmodules`` the ordinary layer would have received, and
+  ignores the ones it performs itself -- those are specs, so an ignored one is never built.
+* **Slots**: one per point where the layer hands over control, *not* one per kernel. The two
+  here are the two layer specs the builder already makes, dense and MoE, so a kernel spanning
+  attention and the dense MLP and a kernel spanning attention and the experts are separate
+  choices that can both be made. Both are optional: a fusion fills the one it covers.
+
+**When a new slot is *not* the answer**
+This class stays short only if the rule is held to, so it is written down. A new slot is
+warranted when the layer hands over control somewhere it currently does not -- a span reaching
+into the next layer, for instance, which is a block-level handover. It is **not** warranted for:
+
+* **A wider footprint.** A kernel that also eats the input norm fills ``fused_moe_layer`` and
+  lists ``LAYER_NORM`` in ``SPANS``. The handover point did not move.
+* **Different internals.** An MLA-plus-MoE kernel and a GQA-plus-MoE kernel hand over at the
+  same point, so they share ``fused_moe_layer`` and each refuses the configuration it cannot
+  serve from ``from_options`` -- the same thing ``NormTorch`` does.
+* **Another vendor.** Two kernels at one handover point are two entries in ``BACKENDS``.
+
+``tests/unit_tests/ops/test_fusions.py:test_one_slot_per_handover_point`` pins the list, so
+adding one is a deliberate, reviewed change rather than something that accumulates.
+* **State**: the fusion is a transformer layer, so it owns what a transformer layer owns. Its
+  state dict has to load a checkpoint the ordinary layer wrote, or it is a different model
+  rather than a faster one.
+* **Process groups**: whatever the layer it replaces owned, received the same way.
+* **Declarations**: ``SPANS`` lists the operations it performs itself, so that selecting a
+  backend for one of them is refused instead of silently ignored. ``REQUIRES``, ``DETERMINISM``
+  and ``FUSES`` mean exactly what they mean on any other backend.
+
+The freedom is real and the rule is short: fuse across whatever you like, but say which
+operations you swallowed, what you need, and whether you are deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from megatron.core.ops.fusions.attn_moe import AttnMoeReference
+from megatron.core.ops.operations import Operation, unowned
+
+FAMILY = "fusions"
+
+#: Named for where control is handed over, not for what any one kernel swallows -- a kernel
+#: reaching wider says so in SPANS rather than needing a slot of its own.
+FUSED_DENSE_LAYER = Operation(FAMILY, "fused_dense_layer", optional=True)
+FUSED_MOE_LAYER = Operation(FAMILY, "fused_moe_layer", optional=True)
+
+OPERATIONS = (FUSED_DENSE_LAYER, FUSED_MOE_LAYER)
+
+
+class FusionSlots:
+    """The fusion slots: one per handover point, not one per fusion."""
+
+    def fused_dense_layer(self) -> Optional[type]:
+        """Which layer runs a dense layer as one kernel, or None to build it from parts."""
+        raise unowned(FUSED_DENSE_LAYER)
+
+    def fused_moe_layer(self) -> Optional[type]:
+        """Which layer runs an MoE layer as one kernel, or None to build it from parts."""
+        raise unowned(FUSED_MOE_LAYER)
+
+
+class FusionNone:
+    """No fusion: every operation keeps the backend its own family selected.
+
+    Returning ``None`` to mean "keep the default" is the same shape ``moe_router`` already
+    uses, so an unfused build asks the question and gets an answer rather than taking a
+    different path through the spec builder.
+    """
+
+    #: It selects nothing, so it cannot make anything nondeterministic.
+    DETERMINISM = "deterministic"
+
+    def fused_dense_layer(self) -> None:
+        """No fused layer; a dense layer is built from its parts."""
+        return None
+
+    def fused_moe_layer(self) -> None:
+        """No fused layer; an MoE layer is built from its parts."""
+        return None
+
+
+#: Backend name -> the class that owns this family's slots. Add a fusion by adding its own
+#: file beside attn_moe.py and one entry here.
+BACKENDS = {"none": FusionNone, "attn_moe_reference": AttnMoeReference}
+
+#: Used when the selected preset has no entry above, which for this family is always: a fusion
+#: is never implied by --transformer-impl, only ever asked for by name.
+DEFAULT = "none"
+
+__all__ = [
+    "BACKENDS",
+    "DEFAULT",
+    "FAMILY",
+    "FUSED_DENSE_LAYER",
+    "FUSED_MOE_LAYER",
+    "OPERATIONS",
+    "FusionNone",
+    "FusionSlots",
+]

--- a/megatron/core/ops/fusions/attn_moe.py
+++ b/megatron/core/ops/fusions/attn_moe.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Attention fused with the expert MLPs.
+
+One file, one fusion. This is the file a vendor copies to contribute a megakernel: nothing
+outside it has to change, and no other vendor's file is touched. The contract it meets is in
+this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.attention import CORE_ATTENTION
+from megatron.core.ops.moe import GROUPED_MLP_MODULES
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+__all__ = ["AttnMoeReference", "ReferenceFusedAttentionMoELayer"]
+
+
+class ReferenceFusedAttentionMoELayer(TransformerLayer):
+    """Where the kernel goes.
+
+    A fused layer is handed the same :class:`TransformerLayerSubmodules` the ordinary layer
+    would have received, and is free to ignore the ones it performs itself -- those are specs,
+    not modules, so ignoring one means it is simply never built.
+
+    This reference ignores none of them and calls the ordinary path, so a run with it selected
+    trains identically to a run without. That is the point: the wiring can be tested on its
+    own, before anyone writes a kernel.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #: Counts calls, so a test can tell the fused layer is the one that ran.
+        self.fused_steps = 0
+
+    def forward(self, *args, **kwargs):
+        """One entry point for attention through the experts.
+
+        A real kernel does here, in one call into its own library, what
+        ``TransformerLayer.forward`` does across attention, the residual, and the experts.
+        """
+        self.fused_steps += 1
+        return super().forward(*args, **kwargs)
+
+
+class AttnMoeReference:
+    """A worked attention-plus-MoE fusion, selected like any other backend::
+
+        --op-backend fused_moe_layer=attn_moe_reference
+
+    It fills the MoE handover point and leaves the dense one alone, so an attention-plus-dense
+    -MLP kernel from somewhere else can be selected alongside it.
+
+    A vendor's version differs in three places and nowhere else::
+
+        REQUIRES = "vendor_kernels>=0.4"       # checked once, while arguments are parsed
+        DETERMINISM = "nondeterministic"       # refused under --deterministic-mode
+
+        def fused_moe_layer(self):
+            from vendor_kernels.megatron import FusedAttentionMoELayer   # here, never at
+            return FusedAttentionMoELayer                                # module scope
+    """
+
+    #: In tree, so there is nothing to require. An optional package is named here instead of
+    #: being checked in code, so the dependency is visible in the class header.
+    REQUIRES = None
+
+    #: It delegates to the ordinary layer, which has not been audited for bit-exactness.
+    DETERMINISM = "unknown"
+
+    #: The operations this fusion performs itself. Selecting a backend for one of them is
+    #: refused rather than silently ignored -- see ``resolve.py:_check_spans``. This is the
+    #: declaration that makes an arbitrary span checkable: fuse what you like, but say what
+    #: you swallowed.
+    SPANS = (CORE_ATTENTION, GROUPED_MLP_MODULES)
+
+    #: A kernel that can only accept particular *neighbours* -- slots it does not perform but
+    #: is handed -- declares them the way any backend does, and would say, for example::
+    #:
+    #:     FUSES = {COLUMN_PARALLEL_LAYER_NORM_LINEAR: "transformer_engine"}
+    #:
+    #: The reference accepts anything, so it declares nothing.
+
+    def fused_moe_layer(self) -> type:
+        """The layer that runs an MoE layer as one kernel."""
+        return ReferenceFusedAttentionMoELayer

--- a/megatron/core/ops/kitchen.py
+++ b/megatron/core/ops/kitchen.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The Kitchen quantization backend.
+
+Kitchen ships outside this repository as a partial backend: it takes over its quantized
+linear, attention, and expert modules and forwards everything else to a fallback. That is
+already the composition shape used here, so it is layered over an assembled provider rather
+than split across the operation families, and core never has to know which slots it claims.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from megatron.core.ops.options import BackendOptions
+
+__all__ = ["kitchen_backend"]
+
+
+def kitchen_backend(fallback: object, options: "BackendOptions") -> object:
+    """Return a backend that owns Kitchen's operations and defers the rest to ``fallback``.
+
+    The dependency check lives in :mod:`megatron.core.ops.resolve` with every other one.
+    """
+    from megatron.core.extensions.kitchen import KitchenSpecProvider
+
+    return KitchenSpecProvider(
+        fallback=fallback,
+        use_kitchen_attention=options.use_kitchen_attention,
+        kitchen_attention_backend=options.kitchen_attention_backend,
+    )

--- a/megatron/core/ops/linear/__init__.py
+++ b/megatron/core/ops/linear/__init__.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Linear layers: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract**
+
+* **Targets**: classes the owning module constructs with Megatron's linear signature.
+  ``column_parallel_layer_norm_linear`` returns ``None`` when the backend does not fuse the
+  preceding norm into the projection.
+* **State**: each target owns its weight and optional bias; the fused variant additionally owns
+  the norm weight under ``layer_norm_weight``. Fused and unfused targets therefore have
+  different state dicts, which is why the layer spec, not the backend, decides which is used.
+* **Process groups**: the target owns the tensor-parallel collectives for its own weights,
+  using the group the owning module passes in. Nothing here creates a group.
+* **Modes**: every backend supports training, backward, and inference. Only Transformer Engine
+  and Kitchen support quantized execution.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from megatron.core.inference.ops.backends import LinearInference
+from megatron.core.ops.linear.backends import LinearLocal, LinearTE
+from megatron.core.ops.operations import Operation, unowned
+
+FAMILY = "linear"
+
+# Megatron Core has no non-tensor-parallel linear, so a backend may leave this one alone.
+LINEAR = Operation(FAMILY, "linear", optional=True)
+COLUMN_PARALLEL_LINEAR = Operation(FAMILY, "column_parallel_linear")
+ROW_PARALLEL_LINEAR = Operation(FAMILY, "row_parallel_linear")
+COLUMN_PARALLEL_LAYER_NORM_LINEAR = Operation(FAMILY, "column_parallel_layer_norm_linear")
+
+OPERATIONS = (
+    LINEAR,
+    COLUMN_PARALLEL_LINEAR,
+    ROW_PARALLEL_LINEAR,
+    COLUMN_PARALLEL_LAYER_NORM_LINEAR,
+)
+
+
+class LinearSlots:
+    """The linear slots, plus the one query derived from them."""
+
+    def linear(self) -> type:
+        """Which non-parallel linear module the backend uses."""
+        raise unowned(LINEAR)
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        raise unowned(COLUMN_PARALLEL_LINEAR)
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        raise unowned(ROW_PARALLEL_LINEAR)
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Which module fuses layernorm and column parallel linear, or None if unfused."""
+        raise unowned(COLUMN_PARALLEL_LAYER_NORM_LINEAR)
+
+    def fuse_layernorm_and_linear(self) -> bool:
+        """Whether the backend fuses layernorm into the column parallel linear.
+
+        Derived, never owned: asking the slot keeps this answer and the target it describes
+        from disagreeing.
+        """
+        return self.column_parallel_layer_norm_linear() is not None
+
+
+#: Backend name -> the class that owns this family's slots. Add a backend by adding its class
+#: to backends.py and one entry here; one that needs an optional package declares ``REQUIRES``.
+BACKENDS = {
+    "local": LinearLocal,
+    "transformer_engine": LinearTE,
+    "inference_optimized": LinearInference,
+}
+
+#: Used when the selected preset has no entry above.
+DEFAULT = "local"
+
+__all__ = [
+    "BACKENDS",
+    "COLUMN_PARALLEL_LAYER_NORM_LINEAR",
+    "COLUMN_PARALLEL_LINEAR",
+    "DEFAULT",
+    "FAMILY",
+    "LINEAR",
+    "OPERATIONS",
+    "ROW_PARALLEL_LINEAR",
+    "LinearSlots",
+]

--- a/megatron/core/ops/linear/backends.py
+++ b/megatron/core/ops/linear/backends.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every linear backend, side by side. The contract they meet is in this package's ``__init__``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["LinearLocal", "LinearTE"]
+
+
+class LinearLocal:
+    """The tensor-parallel linear layers in ``megatron.core.tensor_parallel``."""
+
+    #: Not audited; the TP collectives depend on NCCL_ALGO.
+    DETERMINISM = "unknown"
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+        return ColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.layers import RowParallelLinear
+
+        return RowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Megatron Core has no fused layernorm plus linear module."""
+        return None
+
+
+class LinearTE:
+    """Transformer Engine's linear layers."""
+
+    #: Not audited; the TP collectives depend on NCCL_ALGO.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def linear(self) -> type:
+        """Which non-parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TELinear
+
+        return TELinear
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TEColumnParallelLinear
+
+        return TEColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TERowParallelLinear
+
+        return TERowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Which module fuses layernorm and column parallel linear."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        return TELayerNormColumnParallelLinear

--- a/megatron/core/ops/loss/__init__.py
+++ b/megatron/core/ops/loss/__init__.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Loss: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract for vocab-parallel cross entropy**
+
+* **Target**: ``loss = target(logits, labels, tp_group)``.
+* **Layout**: ``logits`` are ``[s, b, vocab / tp]`` and ``labels`` are ``[s, b]``, already
+  transposed by the caller. The returned loss is ``[s, b]``.
+* **State**: none. The target holds no parameters and no cache. It does, however, *consume*
+  ``logits``: every target subtracts the row max and exponentiates in place to save memory,
+  and the up-cast that would otherwise copy is a no-op when ``logits`` is already float32. A
+  caller that needs ``logits`` afterwards has to pass a clone.
+* **Process groups**: the target owns every reduction over ``tp_group``. The caller performs
+  no collectives, so backends are free to fuse the reduction into their kernel. ``tp_group``
+  may be ``None``, meaning the default tensor-parallel group; targets whose kernel cannot take
+  ``None`` fill it in themselves rather than pushing that onto the caller.
+* **Modes**: every backend supports training and backward. Only the Transformer Engine target
+  supports capture under a full-iteration CUDA graph, and only from TE 2.7.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import torch
+
+from megatron.core.ops.loss.backends import (
+    LossMegatron,
+    LossMegatronFused,
+    LossTEFused,
+    fused_vocab_parallel_cross_entropy,
+    vocab_parallel_cross_entropy,
+)
+from megatron.core.ops.operations import Operation, unowned
+
+FAMILY = "loss"
+
+VOCAB_PARALLEL_CROSS_ENTROPY = Operation(FAMILY, "vocab_parallel_cross_entropy")
+
+OPERATIONS = (VOCAB_PARALLEL_CROSS_ENTROPY,)
+
+VocabParallelCrossEntropy = Callable[
+    [torch.Tensor, torch.Tensor, Optional[torch.distributed.ProcessGroup]], torch.Tensor
+]
+"""The callable shape this family's targets have."""
+
+
+class LossSlots:
+    """The loss slots."""
+
+    def vocab_parallel_cross_entropy(self) -> VocabParallelCrossEntropy:
+        """Which vocab-parallel cross entropy to use."""
+        raise unowned(VOCAB_PARALLEL_CROSS_ENTROPY)
+
+
+#: Backend name -> the class that owns this family's slots.
+#:
+#: Deliberately no "transformer_engine" key: a Transformer Engine run defaults to the reference
+#: cross entropy rather than having the --transformer-impl preset claim this slot.
+BACKENDS = {
+    "megatron": LossMegatron,
+    "megatron_fused": LossMegatronFused,
+    # "te_fused": LossTEFused is deliberately absent. megatron/training/arguments.py disables
+    # Transformer Engine cross entropy outright for stability, and registering it here would
+    # let --op-backend reach it and route around that. LossTEFused stays for when it is
+    # re-enabled; adding this entry back is the whole change.
+}
+
+#: Used when the selected preset has no entry above, which for this family is always.
+DEFAULT = "megatron"
+
+
+def legacy_backends(options) -> dict:
+    """Which backend the cross entropy flags that predate --op-backend select.
+
+    ``--cross-entropy-loss-fusion`` and ``--cross-entropy-fusion-impl`` are older than
+    ``--op-backend``, so their values are a second vocabulary for the same choice. The
+    translation lives here, next to BACKENDS, so both vocabularies are visible together:
+
+    =======================================  =========================
+    flags                                    backend
+    =======================================  =========================
+    (no fusion)                              ``megatron``  (DEFAULT)
+    ``--cross-entropy-fusion-impl native``   ``megatron_fused``
+    ``--cross-entropy-fusion-impl te``       refused, see below
+    =======================================  =========================
+    """
+    if not options.cross_entropy_loss_fusion:
+        return {}
+    impl = options.cross_entropy_fusion_impl
+    if impl == "te":
+        # The same refusal megatron/training/arguments.py gives; te_fused is not registered
+        # above either, so neither path can reach it.
+        raise ValueError(
+            "Transformer Engine cross entropy loss fusion is disabled due to stability "
+            "issues. Use --cross-entropy-fusion-impl native, or omit "
+            "--cross-entropy-loss-fusion."
+        )
+    if impl != "native":
+        raise ValueError(f"Unknown cross_entropy_fusion_impl='{impl}'. Valid choices: native, te")
+    return {VOCAB_PARALLEL_CROSS_ENTROPY: "megatron_fused"}
+
+
+__all__ = [
+    "BACKENDS",
+    "DEFAULT",
+    "FAMILY",
+    "OPERATIONS",
+    "VOCAB_PARALLEL_CROSS_ENTROPY",
+    "LossSlots",
+    "VocabParallelCrossEntropy",
+    "fused_vocab_parallel_cross_entropy",
+    "legacy_backends",
+    "vocab_parallel_cross_entropy",
+]

--- a/megatron/core/ops/loss/backends.py
+++ b/megatron/core/ops/loss/backends.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every vocab-parallel cross entropy backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import torch
+
+from megatron.core.fusions.fused_cross_entropy import (
+    fused_vocab_parallel_cross_entropy as _megatron_fused_kernel,
+)
+from megatron.core.tensor_parallel.cross_entropy import (
+    vocab_parallel_cross_entropy as _megatron_kernel,
+)
+
+__all__ = [
+    "LossMegatron",
+    "LossMegatronFused",
+    "LossTEFused",
+    "fused_vocab_parallel_cross_entropy",
+    "vocab_parallel_cross_entropy",
+]
+
+
+def _default_tp_group(tp_group):
+    """Fill in the default tensor-parallel group for kernels that cannot take ``None``."""
+    if tp_group is not None:
+        return tp_group
+    from megatron.core.parallel_state import get_tensor_model_parallel_group
+
+    return get_tensor_model_parallel_group()
+
+
+def vocab_parallel_cross_entropy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Megatron's custom-autograd cross entropy, in family contract order."""
+    return _megatron_kernel(logits, labels, tp_group=tp_group)
+
+
+def fused_vocab_parallel_cross_entropy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Megatron's compiled cross entropy, in family contract order.
+
+    The kernel reads rank and size straight off the group, so unlike the reference target it
+    cannot take ``None``. Filling that in is this adapter's job, not the caller's.
+    """
+    return _megatron_fused_kernel(logits, labels, _default_tp_group(tp_group))
+
+
+def _te_cross_entropy(logits, labels, tp_group=None, *, target, cuda_graph_capturable):
+    """Adapt TE's kernel to the family contract, including its label-stride requirement."""
+    labels = torch.as_strided(labels, labels.size(), (labels.size()[1], 1))
+    return target(logits, labels, _default_tp_group(tp_group), cuda_graph_capturable)
+
+
+class LossMegatron:
+    """Megatron's unfused implementation."""
+
+    #: The target that already runs under --deterministic-mode today, since the rule in
+    #: megatron/training/determinism.py requires cross entropy fusion to be off.
+    DETERMINISM = "deterministic"
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the reference target."""
+        return vocab_parallel_cross_entropy
+
+
+class LossMegatronFused:
+    """Megatron's compiled reductions and custom backward."""
+
+    #: megatron/training/determinism.py has always required cross_entropy_loss_fusion=False.
+    DETERMINISM = "nondeterministic"
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the fused target."""
+        return fused_vocab_parallel_cross_entropy
+
+
+class LossTEFused:
+    """Transformer Engine's fused kernel.
+
+    Both the TE version check and the CUDA-graph capture mode are resolved here, once, so the
+    forward pass has no version branch left.
+    """
+
+    #: Covered by the same cross_entropy_loss_fusion=False rule; not separately audited.
+    DETERMINISM = "nondeterministic"
+
+    REQUIRES = "transformer_engine"
+
+    @classmethod
+    def from_options(cls, options) -> "LossTEFused":
+        """Read the one setting this backend must bind up front."""
+        return cls(cuda_graph_capturable=options.cuda_graph_impl == "full_iteration")
+
+    def __init__(self, *, cuda_graph_capturable: bool = False) -> None:
+        from megatron.core.extensions.transformer_engine import te_parallel_cross_entropy
+
+        if te_parallel_cross_entropy is None:
+            raise ImportError(
+                "Transformer Engine is installed but does not expose a parallel cross entropy. "
+                "Use --cross-entropy-fusion-impl native instead."
+            )
+        if cuda_graph_capturable:
+            from megatron.core.utils import get_te_version, is_te_min_version
+
+            if not is_te_min_version("2.7.0"):
+                raise ValueError(
+                    "CUDA graph compatible cross entropy requires TransformerEngine >= 2.7.0, "
+                    f"but found version {get_te_version()}. Please upgrade TransformerEngine "
+                    "or set cuda_graph_impl to a value other than 'full_iteration'."
+                )
+        self._target = te_parallel_cross_entropy
+        self._cuda_graph_capturable = cuda_graph_capturable
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the TE target with its construction-time choices already bound."""
+        return partial(
+            _te_cross_entropy,
+            target=self._target,
+            cuda_graph_capturable=self._cuda_graph_capturable,
+        )

--- a/megatron/core/ops/mlp/__init__.py
+++ b/megatron/core/ops/mlp/__init__.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The dense MLP block: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract**
+
+* **Target**: a class exposing ``as_mlp_submodule``, which the transformer layer calls with
+  the MLP submodules to build the block. The block owns its own linears and activation; which
+  linears it gets come from the ``linear`` family, not from here.
+* **Selection input**: ``grouped`` says the dense MLP should use grouped GEMM, which is known
+  while the model is built. A backend without a grouped form ignores it.
+* **State**: the block owns the weights of the linears it builds. Its state dict must match
+  the unfused MLP's, since the two are interchangeable at the spec level.
+* **Process groups**: none of its own; the linears it builds own their tensor-parallel
+  collectives, using the group the owning module passes in.
+* **Modes**: only Transformer Engine fuses, and only from TE 1.13. The fused form does not
+  support mixture-of-experts, which is why the MoE path uses ``moe.grouped_mlp_modules``.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.mlp.backends import MlpMegatron, MlpTEOpFuser
+from megatron.core.ops.operations import Operation, unowned
+
+FAMILY = "mlp"
+
+MLP_MODULE = Operation(FAMILY, "mlp_module")
+
+OPERATIONS = (MLP_MODULE,)
+
+
+class MlpSlots:
+    """The dense MLP slots."""
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Which module to use for the dense MLP block."""
+        raise unowned(MLP_MODULE)
+
+
+#: Backend name -> the class that owns this family's slots. Add a backend by adding its class
+#: to backends.py and one entry here; one that needs an optional package declares ``REQUIRES``.
+#:
+#: Deliberately no "transformer_engine" key: a Transformer Engine run uses the plain MLP unless
+#: --use-transformer-engine-op-fuser asks for the fused one.
+BACKENDS = {"megatron": MlpMegatron, "te_op_fuser": MlpTEOpFuser}
+
+#: Used when the selected preset has no entry above, which for this family is always.
+DEFAULT = "megatron"
+
+
+def legacy_backends(options) -> dict:
+    """Which backend ``--use-transformer-engine-op-fuser`` selects.
+
+    That flag predates ``--op-backend``, so it is a second vocabulary for this slot. The
+    translation lives here, beside BACKENDS, rather than in the resolver.
+    """
+    if not options.use_te_op_fuser:
+        return {}
+    return {MLP_MODULE: "te_op_fuser"}
+
+
+__all__ = [
+    "BACKENDS",
+    "DEFAULT",
+    "FAMILY",
+    "MLP_MODULE",
+    "OPERATIONS",
+    "MlpSlots",
+    "legacy_backends",
+]

--- a/megatron/core/ops/mlp/backends.py
+++ b/megatron/core/ops/mlp/backends.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every dense MLP backend, side by side. The contract they meet is in this package's
+``__init__``."""
+
+from __future__ import annotations
+
+from megatron.core.ops.linear import COLUMN_PARALLEL_LAYER_NORM_LINEAR, ROW_PARALLEL_LINEAR
+
+__all__ = ["MlpMegatron", "MlpTEOpFuser"]
+
+
+class MlpMegatron:
+    """Megatron Core's MLP block, built from whatever linear backend was selected."""
+
+    #: Not audited; it is the linear and activation backends underneath that would decide.
+    DETERMINISM = "unknown"
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Megatron Core has one MLP block; grouped GEMM is a Transformer Engine feature."""
+        del grouped
+        from megatron.core.transformer.mlp import MLP
+
+        return MLP
+
+
+class MlpTEOpFuser:
+    """Transformer Engine's operation-fused MLP.
+
+    Selected by ``--use-transformer-engine-op-fuser``. The version it needs is declared rather
+    than checked in code, so it is visible in the class header and enforced while arguments are
+    parsed.
+    """
+
+    REQUIRES = "transformer_engine>=1.13.0"
+
+    #: Not audited; the fused operations have not been checked for bit-exactness.
+    DETERMINISM = "unknown"
+
+    #: The block folds the linears it is handed into Transformer Engine operations, and can
+    #: only convert Transformer Engine ones -- TEFusedMLP raises on anything else. Declaring
+    #: that here turns a failure during model construction into a refusal at selection.
+    FUSES = {
+        COLUMN_PARALLEL_LAYER_NORM_LINEAR: "transformer_engine",
+        ROW_PARALLEL_LINEAR: "transformer_engine",
+    }
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """The fused MLP, in its grouped-linear form when the dense MLP uses grouped GEMM."""
+        from megatron.core.extensions.transformer_engine import (
+            TEFusedMLP,
+            TEFusedMLPWithGroupedLinear,
+        )
+
+        target = TEFusedMLPWithGroupedLinear if grouped else TEFusedMLP
+        if target is None:
+            raise ImportError(
+                "Transformer Engine is installed but does not expose the operation-fused MLP."
+            )
+        return target

--- a/megatron/core/ops/moe/__init__.py
+++ b/megatron/core/ops/moe/__init__.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Mixture of experts: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract**
+
+* **Targets**: ``grouped_mlp_modules`` returns an experts builder called with the local expert
+  count and config; ``activation_func`` returns a builder for an activation *module*, or
+  ``None`` to fall back to ``config.activation_func``; ``moe_router`` returns a router class,
+  or ``None`` to keep the ``MoESubmodules`` default.
+* **State**: the experts own their own weights. The router owns its gate. Neither owns the
+  dispatcher's buffers.
+* **Process groups**: the dispatcher, not these targets, owns expert- and tensor-parallel
+  communication; it receives its groups from the MoE layer.
+* **Modes**: ``moe_use_grouped_gemm`` is a construction-time input, so a backend picks its
+  grouped or sequential experts once rather than branching per step. The inference backend
+  needs compact ``[tokens, topk]`` index routing, which is why the router is a slot at all.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from megatron.core.inference.ops.backends import MoeInference
+from megatron.core.ops.moe.backends import MoeLocal, MoeTE
+from megatron.core.ops.operations import Operation, unowned
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.mlp import TEActivationFunctionBuilder
+    from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
+
+FAMILY = "moe"
+
+GROUPED_MLP_MODULES = Operation(FAMILY, "grouped_mlp_modules")
+ACTIVATION_FUNC = Operation(FAMILY, "activation_func")
+MOE_ROUTER = Operation(FAMILY, "moe_router")
+
+OPERATIONS = (GROUPED_MLP_MODULES, ACTIVATION_FUNC, MOE_ROUTER)
+
+
+class MoeSlots:
+    """The mixture-of-experts slots."""
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Which module and submodules to use for grouped mlp."""
+        raise unowned(GROUPED_MLP_MODULES)
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Which module to use for the activation function, or None for config.activation_func."""
+        raise unowned(ACTIVATION_FUNC)
+
+    def moe_router(self) -> Optional[type]:
+        """Which MoE router to use, or None to keep the MoESubmodules default."""
+        raise unowned(MOE_ROUTER)
+
+
+#: Backend name -> the class that owns this family's slots. Add a backend by adding its class
+#: to backends.py and one entry here; one that needs an optional package declares ``REQUIRES``.
+BACKENDS = {"local": MoeLocal, "transformer_engine": MoeTE, "inference_optimized": MoeInference}
+
+#: Used when the selected preset has no entry above.
+DEFAULT = "local"
+
+__all__ = [
+    "ACTIVATION_FUNC",
+    "BACKENDS",
+    "DEFAULT",
+    "FAMILY",
+    "GROUPED_MLP_MODULES",
+    "MOE_ROUTER",
+    "OPERATIONS",
+    "MoeSlots",
+]

--- a/megatron/core/ops/moe/backends.py
+++ b/megatron/core/ops/moe/backends.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every mixture-of-experts backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from functools import partial
+from typing import TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.mlp import TEActivationFunctionBuilder
+    from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
+
+__all__ = ["MoeLocal", "MoeTE"]
+
+
+class MoeLocal:
+    """Sequential experts made of Megatron Core linears."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Megatron Core has no grouped GEMM, so experts are always sequential."""
+        del moe_use_grouped_gemm
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+        from megatron.core.transformer.mlp import MLPSubmodules
+        from megatron.core.transformer.moe.experts import SequentialMLP
+
+        return partial(
+            SequentialMLP,
+            submodules=MLPSubmodules(
+                linear_fc1=ColumnParallelLinear,
+                linear_fc2=RowParallelLinear,
+                activation_func=self.activation_func(),
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Megatron Core reads config.activation_func rather than building a module."""
+        return None
+
+    def moe_router(self) -> Optional[type]:
+        """Keep the MoESubmodules default (the training TopKRouter)."""
+        return None
+
+
+class MoeTE:
+    """Transformer Engine grouped linears."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Grouped experts when TE offers them, sequential otherwise."""
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelGroupedLinear,
+            TEColumnParallelLinear,
+            TERowParallelGroupedLinear,
+            TERowParallelLinear,
+        )
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+        from megatron.core.transformer.mlp import MLPSubmodules
+        from megatron.core.transformer.moe.experts import (
+            GroupedMLPSubmodules,
+            SequentialMLP,
+            TEGroupedMLP,
+        )
+        from megatron.core.utils import get_te_version, is_te_min_version
+
+        if moe_use_grouped_gemm and TEColumnParallelGroupedLinear is not None:
+            return partial(
+                TEGroupedMLP,
+                submodules=GroupedMLPSubmodules(
+                    linear_fc1=TEColumnParallelGroupedLinear,
+                    linear_fc2=TERowParallelGroupedLinear,
+                    activation_func=self.activation_func(),
+                ),
+            )
+        if not is_te_min_version("1.7.0.dev0"):
+            warnings.warn(
+                "Only transformer-engine>=1.7.0 supports MoE experts, "
+                f"but your version is {get_te_version()}. "
+                "Use local linear implementation instead."
+            )
+            linear_fc1, linear_fc2 = ColumnParallelLinear, RowParallelLinear
+        else:
+            linear_fc1, linear_fc2 = TEColumnParallelLinear, TERowParallelLinear
+        return partial(
+            SequentialMLP,
+            submodules=MLPSubmodules(
+                linear_fc1=linear_fc1, linear_fc2=linear_fc2, activation_func=self.activation_func()
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Which module to use for activation function."""
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
+        # design these classes always meet the interface.
+        return cast("TEActivationFunctionBuilder", TEActivationOp)
+
+    def moe_router(self) -> Optional[type]:
+        """Keep the MoESubmodules default (the training TopKRouter)."""
+        return None

--- a/megatron/core/ops/norm/__init__.py
+++ b/megatron/core/ops/norm/__init__.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Normalization: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`.
+
+**Contract**
+
+* **Target**: a builder called as ``target(config=..., hidden_size=..., eps=...)`` returning a
+  module whose ``forward(x) -> Tensor`` preserves shape and dtype.
+* **Selection inputs**: ``rms_norm`` (RMSNorm vs LayerNorm), ``for_qk`` (query/key norm, which
+  some backends implement differently), ``has_residual`` (this norm is followed by a residual
+  add, which some backends can fuse). All three are known while the model is built.
+* **State**: the norm owns its own weight, and its bias for LayerNorm. Backends must agree on
+  the parameter names so a checkpoint stays loadable across backends.
+* **Process groups**: none. Sequence-parallel marking is read from ``config`` by the target
+  itself; the owning module keeps any surrounding communication.
+* **Modes**: every backend supports training, backward, and inference. Only Transformer Engine
+  fuses a residual, and only for RMSNorm. Apex implements LayerNorm only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from megatron.core.inference.ops.backends import NormInference
+from megatron.core.ops.norm.backends import NormApex, NormTE, NormTorch
+from megatron.core.ops.operations import Operation, unowned
+from megatron.core.transformer.torch_norm import L2Norm, WrappedTorchNorm
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.torch_norm import LayerNormBuilder
+
+FAMILY = "norm"
+
+LAYER_NORM = Operation(FAMILY, "layer_norm")
+
+OPERATIONS = (LAYER_NORM,)
+
+
+class NormSlots:
+    """The normalization slots, with the error a slot gives when no backend owns it."""
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """Which module to use for layernorm."""
+        raise unowned(LAYER_NORM)
+
+
+#: Backend name -> the class that owns this family's slots. Add a backend by adding its class
+#: to backends.py and one entry here; one that needs an optional package declares ``REQUIRES``.
+BACKENDS = {
+    # Torch, not Apex: installing an optional package must not silently change which kernel a
+    # run gets. Apex is selected explicitly, with --op-backend layer_norm=apex.
+    "local": NormTorch,
+    "transformer_engine": NormTE,
+    "inference_optimized": NormInference,
+    "torch": NormTorch,
+    "apex": NormApex,
+}
+
+#: Used when the selected preset has no entry above.
+DEFAULT = "local"
+
+__all__ = [
+    "BACKENDS",
+    "DEFAULT",
+    "FAMILY",
+    "LAYER_NORM",
+    "OPERATIONS",
+    "L2Norm",
+    "NormSlots",
+    "WrappedTorchNorm",
+]

--- a/megatron/core/ops/norm/backends.py
+++ b/megatron/core/ops/norm/backends.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every normalization backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+
+Each class is named for the backend key that selects it, so ``--op-backend layer_norm=apex``
+and ``NormApex`` are the same word. Targets are imported inside the method that returns them,
+never at module scope, so importing this file pulls in no optional package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from megatron.core.transformer.torch_norm import WrappedTorchNorm
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.torch_norm import LayerNormBuilder
+
+__all__ = ["NormApex", "NormTE", "NormTorch", "TENormWithResidual"]
+
+
+class TENormWithResidual:
+    """Class adapter for TENorm with residual fusion enabled.
+
+    Defined at module scope on purpose: spec building compares and copies these targets, so a
+    class created per provider would make two identically configured models compare unequal.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        return TENorm(*args, has_residual=True, **kwargs)
+
+
+#: Config options Torch's norm cannot honour, and the attribute each one lives under.
+_TORCH_NORM_CANNOT_DO = (
+    ("sequence_parallel", "sequence parallelism"),
+    ("persist_layer_norm", "persistent layer norm"),
+    ("layernorm_zero_centered_gamma", "zero-centered gamma"),
+    ("memory_efficient_layer_norm", "the memory-efficient path"),
+)
+
+
+class NormTorch:
+    """PyTorch's own LayerNorm and RMSNorm.
+
+    Always available and needs no optional package, which is why it is what ``local`` selects.
+    It cannot do sequence parallelism, persistent norm, zero-centered gamma, or the
+    memory-efficient path; a config asking for one of those is refused here, while the model is
+    being built, rather than by an assertion inside ``WrappedTorchNorm`` later.
+    """
+
+    @classmethod
+    def from_options(cls, options) -> "NormTorch":
+        """Refuse early, naming the option and the backend that can honour it."""
+        unsupported = [
+            label
+            for attribute, label in _TORCH_NORM_CANNOT_DO
+            if getattr(options, attribute, False)
+        ]
+        if unsupported:
+            raise ValueError(
+                f"Torch's norm cannot do {', '.join(unsupported)}. Select a norm that can, "
+                "with --op-backend layer_norm=apex, or turn the option off."
+            )
+        return cls()
+
+    #: Torch's norm backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """WrappedTorchNorm reads config.normalization, so one target covers every variant."""
+        del rms_norm, for_qk, has_residual
+        return WrappedTorchNorm
+
+
+class NormApex:
+    """Apex's fused LayerNorm.
+
+    Apex implements LayerNorm only, so RMSNorm falls through to the Torch target. This mirrors
+    what Megatron has always done rather than failing a model that mixes the two.
+    """
+
+    #: Apex's fused backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "apex"
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """Apex LayerNorm, or the Torch target when RMSNorm is requested."""
+        del for_qk, has_residual
+        if rms_norm:
+            return WrappedTorchNorm
+        from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+        return FusedLayerNorm
+
+
+class NormTE:
+    """Transformer Engine's norm.
+
+    Two backend-internal details stay here rather than at the call site: TE below 1.9 harms
+    convergence for query/key norm, and residual fusion needs a distinct target.
+    """
+
+    #: TE's norm backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+    FUSES_RESIDUAL = True
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """TENorm, or Apex for query/key norm on TE versions that regress convergence."""
+        del rms_norm  # TENorm reads config.normalization.
+        from megatron.core.utils import is_te_min_version
+
+        if for_qk and not is_te_min_version("1.9.0"):
+            # TENorm significantly harms convergence when used for QKLayerNorm if
+            # TE version < 1.9; we instead use the Apex implementation.
+            from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+            return FusedLayerNorm
+        if has_residual and self.FUSES_RESIDUAL:
+            return TENormWithResidual
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        return TENorm

--- a/megatron/core/ops/operations.py
+++ b/megatron/core/ops/operations.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""What an operation is. The operations themselves are declared by their family."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["Operation", "unowned"]
+
+
+@dataclass(frozen=True)
+class Operation:
+    """One :class:`~megatron.core.ops.BackendSpecProvider` method a backend can own.
+
+    ``family`` names the package under ``megatron.core.ops`` that declares this operation and
+    the backends able to fill it. ``method`` is the provider method name, so an operation and
+    the method implementing it cannot drift apart.
+
+    Operations are declared by their family, next to their contract, rather than in one central
+    list. Declare one only when an existing class, callable, or builder already owns that
+    boundary at construction time; an implementation that has to branch on shape, phase, or
+    communication keeps its current owner and exposes a target through ``ops`` instead.
+    """
+
+    family: str
+    method: str
+    optional: bool = False
+    """True when a backend may leave this slot alone, because not every backend has one.
+
+    An optional slot that nobody owns raises :func:`unowned` when it is called, rather than
+    silently returning something wrong.
+    """
+
+    def __str__(self) -> str:
+        return self.method
+
+    @property
+    def qualified_name(self) -> str:
+        """``family.method``, for error messages and for disambiguating on the command line."""
+        return f"{self.family}.{self.method}"
+
+
+def unowned(operation: Operation) -> NotImplementedError:
+    """The error a slot raises when no selected backend fills it."""
+    return NotImplementedError(
+        f"No backend owns '{operation.qualified_name}' for this configuration. "
+        f"Select one with --op-backend {operation.method}=<backend>."
+    )

--- a/megatron/core/ops/options.py
+++ b/megatron/core/ops/options.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every input that influences backend selection, in one value."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Mapping
+
+__all__ = ["BackendOptions"]
+
+
+TransformerImpl = Literal["local", "transformer_engine", "inference_optimized"]
+"""What --transformer-impl accepts. ``resolve.PRESETS`` is derived from this, so the values
+cannot drift apart."""
+
+
+@dataclass(frozen=True)
+class BackendOptions:
+    """The complete set of selectors read while a provider is built.
+
+    Adding a selector means adding a field here and one line to :meth:`from_config`. That is
+    deliberately the only place to look for "what can change which implementation I get".
+    Names are left as strings; :mod:`megatron.core.ops.resolve` is what turns them into
+    operations and backends, so this stays plain data.
+    """
+
+    transformer_impl: TransformerImpl = "transformer_engine"
+    """Chooses the backend each family should prefer for every operation it declares."""
+
+    use_kitchen: bool = False
+    use_kitchen_attention: bool = False
+    kitchen_attention_backend: Literal["sdpa", "fa"] = "sdpa"
+
+    use_te_op_fuser: bool = False
+
+    # Options Torch's norm cannot honour, so they decide whether it can fill the norm slot.
+    sequence_parallel: bool = False
+    persist_layer_norm: bool = False
+    layernorm_zero_centered_gamma: bool = False
+    memory_efficient_layer_norm: bool = False
+
+    cross_entropy_loss_fusion: bool = False
+    cross_entropy_fusion_impl: Literal["native", "te"] = "native"
+    """Which fused cross entropy, when ``cross_entropy_loss_fusion`` is on.
+
+    ``megatron.core.ops.loss.legacy_backends`` is where these values turn into backend names.
+    """
+
+    cuda_graph_impl: Literal["none", "local", "transformer_engine", "full_iteration"] | None = None
+    deterministic_mode: bool = False
+
+    operation_backends: Mapping[str, str] = field(default_factory=dict)
+    """Explicit per-operation choices, applied last and never silently ignored.
+
+    Keys are operation names (``megatron.core.ops.operations()``); values are backend names
+    for that operation (``megatron.core.ops.backends_for(operation)``).
+    """
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "operation_backends", dict(self.operation_backends))
+
+    @classmethod
+    def from_config(
+        cls, config: object, *, transformer_impl: TransformerImpl | None = None
+    ) -> "BackendOptions":
+        """Read the selectors a TransformerConfig already carries.
+
+        Args:
+            config: a TransformerConfig, or anything exposing the same attributes.
+            transformer_impl: overrides ``config.transformer_impl``, for the callers that build
+                a Transformer Engine spec regardless of what the config says.
+        """
+        return cls(
+            transformer_impl=transformer_impl or getattr(config, "transformer_impl"),
+            use_kitchen=getattr(config, "use_kitchen", False),
+            use_te_op_fuser=getattr(config, "use_transformer_engine_op_fuser", False),
+            sequence_parallel=getattr(config, "sequence_parallel", False),
+            persist_layer_norm=getattr(config, "persist_layer_norm", False),
+            layernorm_zero_centered_gamma=getattr(config, "layernorm_zero_centered_gamma", False),
+            memory_efficient_layer_norm=getattr(config, "memory_efficient_layer_norm", False),
+            use_kitchen_attention=getattr(config, "use_kitchen_attention", False),
+            kitchen_attention_backend=getattr(config, "kitchen_attention_backend", "sdpa"),
+            cross_entropy_loss_fusion=getattr(config, "cross_entropy_loss_fusion", False),
+            cross_entropy_fusion_impl=getattr(config, "cross_entropy_fusion_impl", "native"),
+            cuda_graph_impl=getattr(config, "cuda_graph_impl", None),
+            deterministic_mode=getattr(config, "deterministic_mode", False),
+            operation_backends=getattr(config, "op_backend_overrides", None) or {},
+        )

--- a/megatron/core/ops/resolve.py
+++ b/megatron/core/ops/resolve.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The one place a BackendSpecProvider is built.
+
+Nothing here names an individual backend. Each family under ``megatron.core.ops`` declares its
+own operations, its own backend table, and its own default, so adding a backend touches that
+family and nothing else.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from functools import lru_cache
+from types import ModuleType
+from typing import Mapping, get_args
+
+from packaging.requirements import Requirement
+
+from megatron.core.ops import determinism
+from megatron.core.ops._availability import installed_version, is_installed, require
+from megatron.core.ops.operations import Operation
+from megatron.core.ops.options import BackendOptions, TransformerImpl
+from megatron.core.ops.spec_provider import BackendSpecProvider
+
+__all__ = [
+    "PRESETS",
+    "backends_for",
+    "build_spec_provider",
+    "find_operation",
+    "get_backend",
+    "get_backend_spec_provider",
+    "operations",
+    "validate_backend",
+]
+
+#: The families that declare operations. Adding one is a milestone; adding a backend is not.
+_FAMILIES = ("norm", "linear", "attention", "mlp", "moe", "loss", "fusions")
+
+#: What --transformer-impl accepts. A preset names the backend each family should prefer;
+#: a family that does not offer that name keeps its own default.
+PRESETS = get_args(TransformerImpl)
+
+
+@lru_cache(maxsize=None)
+def _families() -> tuple[ModuleType, ...]:
+    return tuple(importlib.import_module(f"megatron.core.ops.{name}") for name in _FAMILIES)
+
+
+@lru_cache(maxsize=None)
+def _family_of(operation: Operation) -> ModuleType:
+    for family in _families():
+        if family.FAMILY == operation.family:
+            return family
+    raise ValueError(f"No family declares '{operation.qualified_name}'")
+
+
+def operations() -> tuple[Operation, ...]:
+    """Every operation, in family order."""
+    return tuple(op for family in _families() for op in family.OPERATIONS)
+
+
+def find_operation(name: str) -> Operation:
+    """Return the operation called ``name``, accepting ``method`` or ``family.method``."""
+    matches = [op for op in operations() if name in (op.method, op.qualified_name)]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        choices = ", ".join(op.method for op in operations())
+        raise ValueError(f"Unknown operation '{name}'. Valid operations: {choices}")
+    choices = ", ".join(op.qualified_name for op in matches)
+    raise ValueError(f"Operation '{name}' is ambiguous. Use one of: {choices}")
+
+
+def backends_for(operation: Operation) -> tuple[str, ...]:
+    """Every backend name that can fill one operation."""
+    return tuple(_family_of(operation).BACKENDS)
+
+
+def _instantiate(backend: object, options: BackendOptions) -> object:
+    """Build one backend, giving it the options only if it asked for them."""
+    from_options = getattr(backend, "from_options", None)
+    if from_options is None:
+        return backend()  # type: ignore[operator]
+    return from_options(options)
+
+
+def _check_dependency(backend: object, backend_name: str, wanted_by: str) -> None:
+    """Check a backend's declared ``REQUIRES``, which may carry a version constraint.
+
+    ``REQUIRES = "transformer_engine"`` asks only that the package be importable;
+    ``REQUIRES = "transformer_engine>=1.13"`` also pins a minimum. A requirement that depends
+    on another setting cannot be declared this way and stays in the backend's constructor.
+    """
+    requires = getattr(backend, "REQUIRES", None)
+    if requires is None:
+        return
+    requirement = Requirement(requires)
+    module_name = requirement.name
+    if not is_installed(module_name):
+        raise ValueError(
+            f"Backend '{backend_name}' for {wanted_by} requires '{module_name}', "
+            "which is not installed."
+        )
+    if not requirement.specifier:
+        return
+    version = installed_version(module_name)
+    if version is None:
+        warnings.warn(
+            f"Backend '{backend_name}' for {wanted_by} requires "
+            f"'{requires}', and the installed version could not be determined."
+        )
+    elif version not in requirement.specifier:
+        raise ValueError(
+            f"Backend '{backend_name}' for {wanted_by} requires '{requires}'; " f"found {version}."
+        )
+
+
+def _check_backend(
+    family: ModuleType, backend_name: str, wanted_by: str, *, deterministic_mode: bool = False
+) -> None:
+    """The one place a backend name, its dependency, and its determinism are checked."""
+    if backend_name not in family.BACKENDS:
+        raise ValueError(
+            f"Unknown backend '{backend_name}' for {wanted_by}. "
+            f"Available backends: {', '.join(family.BACKENDS)}"
+        )
+    backend = family.BACKENDS[backend_name]
+
+    _check_dependency(backend, backend_name, wanted_by)
+
+    if not deterministic_mode:
+        return
+    declared = getattr(backend, "DETERMINISM", None)
+    if declared == determinism.NONDETERMINISTIC:
+        raise ValueError(
+            f"Backend '{backend_name}' for {wanted_by} is not deterministic, and "
+            "--deterministic-mode is on. Select a different backend or drop the flag."
+        )
+    if declared not in determinism.VALUES:
+        raise ValueError(
+            f"Backend '{backend_name}' for {wanted_by} does not declare DETERMINISM. "
+            f"Declare one of: {', '.join(sorted(determinism.VALUES))}."
+        )
+    if declared == determinism.UNKNOWN:
+        warnings.warn(
+            f"Backend '{backend_name}' for {wanted_by} has not been established as "
+            "deterministic, so --deterministic-mode cannot guarantee bit-exact results "
+            "for that operation."
+        )
+
+
+def validate_backend(
+    operation: Operation, backend_name: str, *, deterministic_mode: bool = False
+) -> None:
+    """Raise if ``backend_name`` cannot fill ``operation`` here.
+
+    A backend declares what it needs as ``REQUIRES``, so no family repeats the check. Public
+    so the command line can reject a bad ``--op-backend`` while it parses, rather than leaving
+    it to fail at model build time.
+    """
+    _check_backend(
+        _family_of(operation),
+        backend_name,
+        f"operation '{operation.method}'",
+        deterministic_mode=deterministic_mode,
+    )
+
+
+def _owner_for(operation: Operation, backend_name: str, options: BackendOptions) -> object:
+    validate_backend(operation, backend_name, deterministic_mode=options.deterministic_mode)
+    return _instantiate(_family_of(operation).BACKENDS[backend_name], options)
+
+
+def _preset_owners(options: BackendOptions) -> dict[Operation, object]:
+    """Assign every operation from one preset: the family's entry for it, or its default."""
+    if options.transformer_impl not in PRESETS:
+        raise ValueError(
+            f"unknown transformer_impl='{options.transformer_impl}'. "
+            f"Valid choices: {', '.join(PRESETS)}"
+        )
+    owners: dict[Operation, object] = {}
+    for family in _families():
+        name = (
+            options.transformer_impl
+            if options.transformer_impl in family.BACKENDS
+            else family.DEFAULT
+        )
+        # A named preset fails clearly when its backend cannot be used here.
+        _check_backend(
+            family,
+            name,
+            f"--transformer-impl {options.transformer_impl}",
+            deterministic_mode=options.deterministic_mode,
+        )
+        backend = _instantiate(family.BACKENDS[name], options)
+        owners.update(
+            {
+                operation: backend
+                for operation in family.OPERATIONS
+                if not operation.optional or callable(getattr(backend, operation.method, None))
+            }
+        )
+    return owners
+
+
+def _legacy_overrides(options: BackendOptions) -> dict[Operation, str]:
+    """Ask each family what the settings older than --op-backend select for it.
+
+    A family that has such settings exposes ``legacy_backends(options)``; the mapping lives
+    with the family so its flag values and its backend names can be read together. Nothing
+    about any particular family is known here.
+    """
+    overrides: dict[Operation, str] = {}
+    for family in _families():
+        translate = getattr(family, "legacy_backends", None)
+        if translate is not None:
+            overrides.update(translate(options))
+    return overrides
+
+
+def _selected_backends(options: BackendOptions) -> dict[Operation, str]:
+    """Every operation an explicit selector claims, rejecting two claims on one slot."""
+    legacy = _legacy_overrides(options)
+    explicit = {
+        find_operation(name): backend for name, backend in options.operation_backends.items()
+    }
+
+    contested = sorted(op.method for op in set(legacy) & set(explicit))
+    if contested:
+        raise ValueError(
+            "Two settings select a backend for the same operation: "
+            + ", ".join(
+                f"'{name}' (from an existing setting and from --op-backend)" for name in contested
+            )
+            + ". Keep only one of them."
+        )
+    return {**legacy, **explicit}
+
+
+def _override_owners(
+    options: BackendOptions, selected: Mapping[Operation, str]
+) -> dict[Operation, object]:
+    """Build the backend each explicit selector named."""
+    return {operation: _owner_for(operation, name, options) for operation, name in selected.items()}
+
+
+def _layered_owners(overlay: object, owners: dict[Operation, object]) -> dict[Operation, object]:
+    """Give ``overlay`` the slots it implements, and leave the rest where they are.
+
+    A partial backend layered over an assembled provider -- Kitchen is the one in tree --
+    forwards the operations it does not own to a fallback. It cannot forward a slot that did
+    not exist when it was written, so anything it does not define itself stays with the
+    backend that already had it, rather than reaching an unowned stub.
+    """
+    return {
+        operation: (
+            overlay
+            if getattr(type(overlay), operation.method, None)
+            not in (None, getattr(BackendSpecProvider, operation.method, None))
+            else owner
+        )
+        for operation, owner in owners.items()
+    }
+
+
+def _check_fusions(owners: dict[Operation, object]) -> None:
+    """Refuse a fusion whose neighbouring slots are not what it can work with.
+
+    A backend that reaches across operations declares ``FUSES``: the operations it spans, and
+    the backend each one has to be filled by. Without that, a mismatch only shows up as a type
+    error while the model is built. See megatron/core/ops/README.md.
+    """
+    for operation, owner in owners.items():
+        for spanned, expected in getattr(owner, "FUSES", {}).items():
+            wanted = _family_of(spanned).BACKENDS[expected]
+            actual = owners.get(spanned)
+            if isinstance(actual, wanted):
+                continue
+            found = type(actual).__name__ if actual is not None else "nothing"
+            raise ValueError(
+                f"Backend '{type(owner).__name__}' fills '{operation.method}' and spans "
+                f"'{spanned.method}', which it needs the '{expected}' backend to fill; "
+                f"{found} fills it instead."
+            )
+
+
+def _check_spans(owners: dict[Operation, object], selected: Mapping[Operation, str]) -> None:
+    """Refuse a backend chosen for an operation a fusion performs itself.
+
+    A fusion spanning several families declares ``SPANS``: the operations its own kernel
+    carries out. Those slots are never consulted on a fused layer, so a backend selected for
+    one of them would be quietly discarded -- the run would look configured and be nothing of
+    the sort. Saying so is the price of an arbitrary span, and the only rule a fusion has to
+    follow. See megatron/core/ops/README.md.
+    """
+    for operation, owner in owners.items():
+        for spanned in getattr(owner, "SPANS", ()):
+            if spanned in selected:
+                raise ValueError(
+                    f"Backend '{type(owner).__name__}' fills '{operation.method}' and performs "
+                    f"'{spanned.method}' itself, so the '{selected[spanned]}' backend selected "
+                    f"for '{spanned.method}' would never be built. Drop one of the two."
+                )
+
+
+def build_spec_provider(options: BackendOptions) -> BackendSpecProvider:
+    """Build the provider for ``options``.
+
+    Selection order is fixed and total: the preset assigns every operation, Kitchen layers over
+    that when enabled, and --op-backend wins last. Every optional dependency a selected backend
+    needs is checked here, while the model is being built.
+    """
+    selected = _selected_backends(options)
+    owners = _preset_owners(options)
+    if options.use_kitchen:
+        from megatron.core.ops.kitchen import kitchen_backend
+
+        require("nvidia_kitchen")
+        owners = _layered_owners(kitchen_backend(BackendSpecProvider(owners), options), owners)
+    owners.update(_override_owners(options, selected))
+    _check_fusions(owners)
+    _check_spans(owners, selected)
+    return BackendSpecProvider(owners)
+
+
+def get_backend_spec_provider(
+    config: object, *, transformer_impl: TransformerImpl | None = None
+) -> BackendSpecProvider:
+    """Build the provider a TransformerConfig asks for."""
+    return build_spec_provider(
+        BackendOptions.from_config(config, transformer_impl=transformer_impl)
+    )
+
+
+def get_backend(transformer_impl: TransformerImpl, **options) -> BackendSpecProvider:
+    """Build the provider for a preset name, with no config to read."""
+    return build_spec_provider(BackendOptions(transformer_impl=transformer_impl, **options))

--- a/megatron/core/ops/spec_provider.py
+++ b/megatron/core/ops/spec_provider.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The one type model code holds, and how it is assembled."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from megatron.core.ops.attention import AttentionSlots
+from megatron.core.ops.fusions import FusionSlots
+from megatron.core.ops.linear import LinearSlots
+from megatron.core.ops.loss import LossSlots
+from megatron.core.ops.mlp import MlpSlots
+from megatron.core.ops.moe import MoeSlots
+from megatron.core.ops.norm import NormSlots
+from megatron.core.ops.operations import Operation
+
+__all__ = ["BackendSpecProvider"]
+
+
+def _backend_name(owner: object) -> str:
+    """How a backend identifies itself in a message.
+
+    Each class is named for the family and the backend key that selects it -- ``NormApex``,
+    ``LinearTE`` -- so the class name alone is enough.
+    """
+    return type(owner).__name__
+
+
+class BackendSpecProvider(
+    NormSlots, LinearSlots, AttentionSlots, MlpSlots, MoeSlots, LossSlots, FusionSlots
+):
+    """Provides the implementation of every operation, for one configuration.
+
+    This is the only type model code holds, so nothing downstream can branch on which backend
+    it got. Its slots come from the per-family ``*Slots`` classes, each of which sits next to
+    the contract it describes; inherited slots raise until a backend takes them over.
+
+    A *backend* is any object implementing one or more of those slot methods. Assembling binds
+    the owning backend's method onto this object, so a call costs one attribute lookup while
+    the model is built and nothing at all afterwards.
+    """
+
+    def __init__(self, owners: Mapping[Operation, object] | None = None) -> None:
+        # Defaulted so a subclass that does not call up, such as the out-of-tree Kitchen
+        # provider, still gets a usable object.
+        owners = dict(owners or {})
+        self._owners = owners
+        for operation, owner in owners.items():
+            method = getattr(owner, operation.method, None)
+            if not callable(method):
+                raise ValueError(
+                    f"Backend '{_backend_name(owner)}' was selected for operation "
+                    f"'{operation.qualified_name}' but does not implement {operation.method}()."
+                )
+            # Shadow the inherited slot with the owner's bound method.
+            setattr(self, operation.method, method)  # type: ignore[method-assign]
+
+    def __repr__(self) -> str:
+        owners = ", ".join(
+            f"{operation.method}={_backend_name(owner)}"
+            for operation, owner in sorted(
+                getattr(self, "_owners", {}).items(), key=lambda item: str(item[0])
+            )
+        )
+        return f"BackendSpecProvider({owners})"

--- a/tests/unit_tests/ops/__init__.py
+++ b/tests/unit_tests/ops/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/tests/unit_tests/ops/test_assembly.py
+++ b/tests/unit_tests/ops/test_assembly.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""One provider type, assembled from per-operation owners."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.ops import (
+    BackendOptions,
+    BackendSpecProvider,
+    build_spec_provider,
+    find_operation,
+    get_backend,
+    operations,
+)
+from megatron.core.ops.linear import COLUMN_PARALLEL_LAYER_NORM_LINEAR
+from megatron.core.ops.norm import LAYER_NORM, WrappedTorchNorm
+from megatron.core.ops.norm.backends import NormTorch
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+_needs_te = pytest.mark.skipif(not HAVE_TE, reason="Transformer Engine is required")
+
+
+def _options(**kwargs):
+    return BackendOptions(transformer_impl="local", **kwargs)
+
+
+class TestOneProviderType:
+    def test_every_preset_returns_the_same_type(self):
+        """Nothing downstream can branch on which backend it got."""
+        assert type(get_backend("local")) is BackendSpecProvider
+
+    def test_overrides_do_not_change_the_type(self):
+        provider = build_spec_provider(_options(operation_backends={"layer_norm": "torch"}))
+        assert type(provider) is BackendSpecProvider
+
+    def test_an_unowned_slot_names_itself(self):
+        """A slot with no owner explains how to select one instead of returning nonsense."""
+        provider = BackendSpecProvider({})
+        with pytest.raises(NotImplementedError, match="norm.layer_norm"):
+            provider.layer_norm()
+
+
+class TestAssembly:
+    def test_owner_takes_over_only_its_operation(self):
+        provider = build_spec_provider(_options(operation_backends={"layer_norm": "torch"}))
+        assert provider.layer_norm(rms_norm=False) is WrappedTorchNorm
+        assert provider.column_parallel_linear() is ColumnParallelLinear
+
+    def test_assembly_costs_nothing_at_call_time(self):
+        """The owner's bound method is attached directly, with no forwarding wrapper."""
+        owner = NormTorch()
+        provider = BackendSpecProvider({LAYER_NORM: owner})
+        assert provider.layer_norm.__func__ is NormTorch.layer_norm
+        assert provider.layer_norm.__self__ is owner
+
+    def test_derived_query_follows_the_override(self):
+        """fuse_layernorm_and_linear() is derived, so it must see the new owner's answer."""
+
+        class _FusedNormLinear:
+            def column_parallel_layer_norm_linear(self):
+                return _FusedNormLinear
+
+        assert get_backend("local").fuse_layernorm_and_linear() is False
+
+        provider = BackendSpecProvider({COLUMN_PARALLEL_LAYER_NORM_LINEAR: _FusedNormLinear()})
+        assert provider.fuse_layernorm_and_linear() is True
+
+    def test_owner_without_the_operation_is_rejected(self):
+        with pytest.raises(ValueError, match="NormTorch.*does not implement core_attention"):
+            BackendSpecProvider({find_operation("core_attention"): NormTorch()})
+
+    def test_repr_shows_who_owns_what(self):
+        provider = BackendSpecProvider({LAYER_NORM: NormTorch()})
+        assert "layer_norm=NormTorch" in repr(provider)
+
+
+class TestBackendNamesAreScopedToTheirOperation:
+    def test_the_same_name_means_different_things_per_operation(self):
+        """'transformer_engine' resolves within the operation's family, not globally."""
+        from megatron.core.ops import backends_for
+
+        assert "apex" in backends_for(find_operation("layer_norm"))
+        assert "apex" not in backends_for(find_operation("core_attention"))
+
+    def test_unknown_backend_lists_only_the_relevant_choices(self):
+        with pytest.raises(ValueError, match="Unknown backend 'liger' for operation 'layer_norm'"):
+            build_spec_provider(_options(operation_backends={"layer_norm": "liger"}))
+
+    def test_a_backend_from_another_family_is_rejected(self):
+        with pytest.raises(ValueError, match="Unknown backend 'apex'"):
+            build_spec_provider(_options(operation_backends={"core_attention": "apex"}))
+
+    def test_unknown_operation_lists_the_valid_ones(self):
+        with pytest.raises(ValueError, match="Unknown operation 'norm'"):
+            build_spec_provider(_options(operation_backends={"norm": "torch"}))
+
+    def test_operations_can_be_named_by_family(self):
+        assert find_operation("norm.layer_norm") is LAYER_NORM
+
+    def test_unknown_preset_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown transformer_impl='nope'"):
+            get_backend("nope")
+
+
+class TestOptions:
+    def test_overrides_are_copied_from_the_caller(self):
+        overrides = {"layer_norm": "torch"}
+        options = _options(operation_backends=overrides)
+        overrides["layer_norm"] = "apex"
+        assert options.operation_backends["layer_norm"] == "torch"
+
+    def test_config_field_is_read(self):
+        config = SimpleNamespace(
+            transformer_impl="local", op_backend_overrides={"layer_norm": "torch"}
+        )
+        options = BackendOptions.from_config(config)
+        assert options.operation_backends["layer_norm"] == "torch"
+
+    @_needs_te
+    def test_transformer_impl_override_wins_over_the_config(self):
+        from megatron.core.extensions.transformer_engine import TEColumnParallelLinear
+        from megatron.core.ops import get_backend_spec_provider
+
+        config = SimpleNamespace(transformer_impl="local")
+        provider = get_backend_spec_provider(config, transformer_impl="transformer_engine")
+        assert provider.column_parallel_linear() is TEColumnParallelLinear
+
+
+class TestConflictingSelectors:
+    def test_two_settings_claiming_one_operation_is_an_error(self):
+        options = _options(
+            cross_entropy_loss_fusion=True,
+            cross_entropy_fusion_impl="native",
+            operation_backends={"vocab_parallel_cross_entropy": "megatron"},
+        )
+        with pytest.raises(ValueError, match="vocab_parallel_cross_entropy"):
+            build_spec_provider(options)
+
+    def test_unrelated_settings_do_not_conflict(self):
+        options = _options(
+            cross_entropy_loss_fusion=True,
+            cross_entropy_fusion_impl="native",
+            operation_backends={"layer_norm": "torch"},
+        )
+        assert build_spec_provider(options).layer_norm(rms_norm=False) is WrappedTorchNorm
+
+
+def test_every_operation_is_declared_by_exactly_one_family():
+    """Derived from the registry, so adding a family does not mean editing this test."""
+    from megatron.core.ops.resolve import _FAMILIES
+
+    assert {op.family for op in operations()} == set(_FAMILIES)
+
+
+class _OverlayLinear:
+    """Stand-in for a quantized linear target."""
+
+
+class _PartialOverlay(BackendSpecProvider):
+    """Stands in for Kitchen: owns a couple of slots and inherits the rest.
+
+    Kitchen was written against a protocol that declared eight methods, so it cannot forward
+    the slots added since. Subclassing without overriding those is exactly its shape.
+    """
+
+    def __init__(self, fallback):
+        self._fallback = fallback
+
+    def column_parallel_linear(self):
+        return _OverlayLinear
+
+
+class TestLayeredBackend:
+    """A partial backend layered over an assembled provider, which is how Kitchen works."""
+
+    @staticmethod
+    def _build(monkeypatch):
+        from megatron.core.ops import kitchen, resolve
+
+        monkeypatch.setattr(
+            kitchen, "kitchen_backend", lambda fallback, options: _PartialOverlay(fallback)
+        )
+        monkeypatch.setattr(resolve, "require", lambda module_name: None)
+        return build_spec_provider(BackendOptions(transformer_impl="local", use_kitchen=True))
+
+    def test_overlay_takes_the_slots_it_implements(self, monkeypatch):
+        assert self._build(monkeypatch).column_parallel_linear() is _OverlayLinear
+
+    def test_slots_the_overlay_predates_stay_with_the_base(self, monkeypatch):
+        """It inherits raising stubs for these, so handing them over would break the model."""
+        provider = self._build(monkeypatch)
+        assert provider.moe_router() is None
+        assert provider.vocab_parallel_cross_entropy() is not None
+        assert provider.layer_norm(rms_norm=True) is WrappedTorchNorm
+
+    def test_an_explicit_override_still_wins_over_the_overlay(self, monkeypatch):
+        from megatron.core.ops import kitchen, resolve
+
+        monkeypatch.setattr(
+            kitchen, "kitchen_backend", lambda fallback, options: _PartialOverlay(fallback)
+        )
+        monkeypatch.setattr(resolve, "require", lambda module_name: None)
+        provider = build_spec_provider(
+            BackendOptions(
+                transformer_impl="local",
+                use_kitchen=True,
+                operation_backends={"layer_norm": "torch"},
+            )
+        )
+        assert provider.column_parallel_linear() is _OverlayLinear
+        assert provider.layer_norm(rms_norm=False) is WrappedTorchNorm
+
+
+class TestDenseMlpSlot:
+    """--use-transformer-engine-op-fuser selects a backend like any other flag."""
+
+    def test_default_is_the_plain_megatron_block(self):
+        from megatron.core.transformer.mlp import MLP
+
+        assert get_backend("local").mlp_module() is MLP
+        assert get_backend("transformer_engine").mlp_module() is MLP
+
+    @_needs_te
+    def test_the_op_fuser_flag_selects_the_fused_block(self):
+        from megatron.core.extensions.transformer_engine import (
+            TEFusedMLP,
+            TEFusedMLPWithGroupedLinear,
+        )
+
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="transformer_engine", use_te_op_fuser=True)
+        )
+        assert provider.mlp_module(grouped=False) is TEFusedMLP
+        assert provider.mlp_module(grouped=True) is TEFusedMLPWithGroupedLinear
+
+    def test_the_flag_and_op_backend_cannot_both_claim_the_slot(self):
+        options = BackendOptions(
+            transformer_impl="transformer_engine",
+            use_te_op_fuser=True,
+            operation_backends={"mlp_module": "megatron"},
+        )
+        with pytest.raises(ValueError, match="mlp_module"):
+            build_spec_provider(options)

--- a/tests/unit_tests/ops/test_backend_targets.py
+++ b/tests/unit_tests/ops/test_backend_targets.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every backend returns the exact target it returned before selection was unified.
+
+These are the equivalence tests the migration turns on: they name the concrete class each
+operation resolves to, so moving selection around cannot quietly change what a model is
+built from.
+"""
+
+import pytest
+
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.ops import BackendOptions, build_spec_provider, get_backend
+from megatron.core.ops._availability import is_installed
+from megatron.core.ops.norm import WrappedTorchNorm
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+_needs_te = pytest.mark.skipif(not HAVE_TE, reason="Transformer Engine is required")
+
+
+class TestLocalBackend:
+    def test_linear_targets(self):
+        backend = get_backend("local")
+        assert backend.column_parallel_linear() is ColumnParallelLinear
+        assert backend.row_parallel_linear() is RowParallelLinear
+        assert backend.column_parallel_layer_norm_linear() is None
+        assert backend.fuse_layernorm_and_linear() is False
+
+    def test_core_attention_target(self):
+        assert get_backend("local").core_attention() is DotProductAttention
+
+    def test_local_is_torch_regardless_of_what_is_installed(self):
+        """Installing an optional package must not change which kernel a local run gets."""
+        assert get_backend("local").layer_norm(rms_norm=False) is WrappedTorchNorm
+        assert get_backend("local").layer_norm(rms_norm=True) is WrappedTorchNorm
+
+    def test_apex_is_selected_explicitly(self):
+        if not is_installed("apex"):
+            pytest.skip("Apex is not installed")
+        from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="local", operation_backends={"layer_norm": "apex"})
+        )
+        assert provider.layer_norm(rms_norm=False) is FusedLayerNorm
+
+    def test_a_config_torch_norm_cannot_serve_is_refused_with_the_fix(self):
+        """Better than WrappedTorchNorm asserting deep inside construction."""
+        with pytest.raises(ValueError, match="sequence parallelism.*--op-backend layer_norm=apex"):
+            build_spec_provider(BackendOptions(transformer_impl="local", sequence_parallel=True))
+
+    def test_layer_norm_choice_does_not_leak_between_calls(self):
+        """Asking for an RMSNorm must not change what a later LayerNorm request returns."""
+        backend = get_backend("local")
+        first = backend.layer_norm(rms_norm=False)
+        backend.layer_norm(rms_norm=True)
+        assert backend.layer_norm(rms_norm=False) is first
+
+    def test_no_router_override(self):
+        assert get_backend("local").moe_router() is None
+
+    def test_unowned_linear_says_how_to_select_one(self):
+        """Megatron Core has no non-parallel linear, and the slot says so."""
+        with pytest.raises(NotImplementedError, match="linear.linear"):
+            get_backend("local").linear()
+
+
+@_needs_te
+class TestTransformerEngineBackend:
+    def test_linear_targets(self):
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelLinear,
+            TELayerNormColumnParallelLinear,
+            TELinear,
+            TERowParallelLinear,
+        )
+
+        backend = get_backend("transformer_engine")
+        assert backend.linear() is TELinear
+        assert backend.column_parallel_linear() is TEColumnParallelLinear
+        assert backend.row_parallel_linear() is TERowParallelLinear
+        assert backend.column_parallel_layer_norm_linear() is TELayerNormColumnParallelLinear
+        assert backend.fuse_layernorm_and_linear() is True
+
+    def test_core_attention_target(self):
+        from megatron.core.extensions.transformer_engine import TEDotProductAttention
+
+        assert get_backend("transformer_engine").core_attention() is TEDotProductAttention
+
+    def test_norm_targets(self):
+        from megatron.core.extensions.transformer_engine import TENorm
+        from megatron.core.ops.norm.backends import TENormWithResidual
+
+        backend = get_backend("transformer_engine")
+        assert backend.layer_norm() is TENorm
+        assert backend.layer_norm(has_residual=True) is TENormWithResidual
+
+    def test_residual_norm_target_is_stable_across_providers(self):
+        """Two providers built the same way must produce equal specs."""
+        first = get_backend("transformer_engine").layer_norm(has_residual=True)
+        second = get_backend("transformer_engine").layer_norm(has_residual=True)
+        assert first is second
+
+    def test_activation_func_target(self):
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        assert get_backend("transformer_engine").activation_func() is TEActivationOp
+
+
+@_needs_te
+class TestInferenceBackend:
+    def test_linear_targets(self):
+        from megatron.core.tensor_parallel.inference_layers import (
+            InferenceColumnParallelLinear,
+            InferenceLayerNormColumnParallelLinear,
+            InferenceRowParallelLinear,
+        )
+
+        backend = get_backend("inference_optimized")
+        assert backend.column_parallel_linear() is InferenceColumnParallelLinear
+        assert backend.row_parallel_linear() is InferenceRowParallelLinear
+        assert backend.column_parallel_layer_norm_linear() is InferenceLayerNormColumnParallelLinear
+
+    def test_router_target(self):
+        from megatron.core.transformer.moe.router import InferenceTopKRouter
+
+        assert get_backend("inference_optimized").moe_router() is InferenceTopKRouter
+
+    def test_norm_never_fuses_a_residual(self):
+        """Inference layers own the residual themselves, so the norm must not absorb it."""
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        assert get_backend("inference_optimized").layer_norm(has_residual=True) is TENorm

--- a/tests/unit_tests/ops/test_conformance.py
+++ b/tests/unit_tests/ops/test_conformance.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every registered backend meets its family's contract.
+
+Parametrized off the real family tables, so a backend cannot be added without being covered.
+"""
+
+import importlib
+
+import pytest
+
+from megatron.core.ops import PRESETS, BackendOptions, build_spec_provider, operations
+from megatron.core.ops.resolve import _FAMILIES, _instantiate
+
+_OPTIONS = BackendOptions(transformer_impl="local")
+
+_REGISTERED = [
+    (family_name, backend_name)
+    for family_name in _FAMILIES
+    for backend_name in importlib.import_module(f"megatron.core.ops.{family_name}").BACKENDS
+]
+
+
+def _family(name):
+    return importlib.import_module(f"megatron.core.ops.{name}")
+
+
+def _build_or_skip(family, backend_name):
+    from packaging.requirements import Requirement
+
+    from megatron.core.ops._availability import is_installed
+
+    backend = family.BACKENDS[backend_name]
+    requires = getattr(backend, "REQUIRES", None)
+    if requires is not None and not is_installed(Requirement(requires).name):
+        pytest.skip(f"{requires} is not installed")
+    try:
+        return _instantiate(backend, _OPTIONS)
+    except ImportError as error:
+        pytest.skip(str(error))
+
+
+@pytest.mark.parametrize(("family_name", "backend_name"), _REGISTERED)
+def test_backend_fills_every_slot_its_family_declares(family_name, backend_name):
+    """A backend registered in a family has to answer that family's whole contract."""
+    family = _family(family_name)
+    backend = _build_or_skip(family, backend_name)
+
+    missing = [
+        op.method
+        for op in family.OPERATIONS
+        if not op.optional and not callable(getattr(backend, op.method, None))
+    ]
+    assert not missing, f"{family_name}.{backend_name} does not implement {missing}"
+
+
+@pytest.mark.parametrize(("family_name", "backend_name"), _REGISTERED)
+def test_backend_is_selectable_by_name(family_name, backend_name):
+    """Every table entry is reachable through --op-backend, and owns its family's slots."""
+    family = _family(family_name)
+    backend = _build_or_skip(family, backend_name)
+    # An optional slot may legitimately be unimplemented -- a fusion fills only the handover
+    # point it covers -- so pick one this backend actually fills.
+    operation = next(op for op in family.OPERATIONS if callable(getattr(backend, op.method, None)))
+    # A fusion is only selectable where the operations it spans can be served, so build it on
+    # a preset that can serve them.
+    spans = getattr(family.BACKENDS[backend_name], "FUSES", {})
+    preset = next((name for name in spans.values() if name in PRESETS), "local")
+
+    provider = build_spec_provider(
+        BackendOptions(transformer_impl=preset, operation_backends={operation.method: backend_name})
+    )
+
+    owner = provider._owners[operation]
+    assert (
+        type(owner).__name__ == type(_instantiate(family.BACKENDS[backend_name], _OPTIONS)).__name__
+    )
+
+
+def test_every_family_declares_its_defaults_and_operations():
+    """The resolver relies on these three names; a new family must supply all of them."""
+    for family_name in _FAMILIES:
+        family = _family(family_name)
+        assert family.OPERATIONS, f"{family_name} declares no operations"
+        assert family.BACKENDS, f"{family_name} declares no backends"
+        assert family.DEFAULT in family.BACKENDS, f"{family_name}.DEFAULT is not in BACKENDS"
+        assert all(op.family == family.FAMILY for op in family.OPERATIONS)
+
+
+def test_operation_names_are_unique_across_families():
+    """--op-backend takes a bare method name, so two families must not both claim one."""
+    names = [operation.method for operation in operations()]
+    assert len(names) == len(set(names)), f"duplicate operation names: {names}"
+
+
+def test_a_family_may_live_in_a_subfolder():
+    """Sub-families like ``attention.dsa`` resolve by their dotted module path.
+
+    Pins the mechanism that lets one family split into sub-folders with disjoint backend
+    tables, so DSA cannot be offered a backend that only core attention has.
+    """
+    from megatron.core.ops.operations import Operation
+    from megatron.core.ops.resolve import _family_of
+
+    for family_name in _FAMILIES:
+        family = _family(family_name)
+        assert family.FAMILY == family_name, "FAMILY must be the module path under ops"
+        probe = Operation(family_name, family.OPERATIONS[0].method)
+        assert _family_of(probe) is family
+
+    dotted = [name for name in _FAMILIES if "." in name]
+    for name in dotted:
+        assert importlib.import_module(f"megatron.core.ops.{name}") is _family(name)
+
+
+@pytest.mark.parametrize(("family_name", "backend_name"), _REGISTERED)
+def test_backend_declares_its_determinism(family_name, backend_name):
+    """Every backend states whether it is bit-exact, so 'nobody checked' cannot look like 'safe'."""
+    from megatron.core.ops import determinism
+
+    backend = _family(family_name).BACKENDS[backend_name]
+    declared = getattr(backend, "DETERMINISM", None)
+    assert declared in determinism.VALUES, (
+        f"{family_name}.{backend_name} declares DETERMINISM={declared!r}; "
+        f"expected one of {sorted(determinism.VALUES)}"
+    )
+
+
+def test_deterministic_mode_rejects_a_nondeterministic_backend():
+    """--deterministic-mode must not silently select a backend known not to be bit-exact."""
+    from megatron.core.ops import determinism
+
+    options = BackendOptions(
+        transformer_impl="local",
+        deterministic_mode=True,
+        operation_backends={"vocab_parallel_cross_entropy": "megatron_fused"},
+    )
+    assert _family("loss").BACKENDS["megatron_fused"].DETERMINISM == determinism.NONDETERMINISTIC
+    with pytest.raises(ValueError, match="not deterministic"):
+        build_spec_provider(options)
+
+
+def test_deterministic_mode_allows_a_deterministic_backend():
+    options = BackendOptions(
+        transformer_impl="local",
+        deterministic_mode=True,
+        operation_backends={"vocab_parallel_cross_entropy": "megatron"},
+    )
+    assert build_spec_provider(options).vocab_parallel_cross_entropy() is not None
+
+
+def test_a_version_constraint_in_requires_is_enforced(monkeypatch):
+    """REQUIRES may pin a minimum, and the check happens before anything is built."""
+    from megatron.core.ops import resolve
+    from megatron.core.ops.mlp import BACKENDS as MLP_BACKENDS
+
+    assert MLP_BACKENDS["te_op_fuser"].REQUIRES == "transformer_engine>=1.13.0"
+
+    from packaging.version import Version
+
+    monkeypatch.setattr(resolve, "is_installed", lambda name: True)
+    monkeypatch.setattr(resolve, "installed_version", lambda name: Version("1.12.0"))
+    with pytest.raises(ValueError, match="requires 'transformer_engine>=1.13.0'; found 1.12"):
+        build_spec_provider(
+            BackendOptions(
+                transformer_impl="local", operation_backends={"mlp_module": "te_op_fuser"}
+            )
+        )
+
+
+class TestFusionDeclarations:
+    """A backend that reaches across operations says so, and the resolver holds it to that."""
+
+    @staticmethod
+    def _op_fuser(**kwargs):
+        return BackendOptions(transformer_impl="transformer_engine", use_te_op_fuser=True, **kwargs)
+
+    def test_a_fusion_declares_the_operations_it_spans(self):
+        from megatron.core.ops.linear import COLUMN_PARALLEL_LAYER_NORM_LINEAR
+        from megatron.core.ops.mlp import BACKENDS as MLP_BACKENDS
+
+        spans = MLP_BACKENDS["te_op_fuser"].FUSES
+        assert spans[COLUMN_PARALLEL_LAYER_NORM_LINEAR] == "transformer_engine"
+
+    def test_a_neighbouring_slot_it_cannot_work_with_is_refused(self):
+        """Previously this built a spec that died with a type error during construction."""
+        with pytest.raises(ValueError, match="spans 'column_parallel_layer_norm_linear'"):
+            build_spec_provider(
+                self._op_fuser(operation_backends={"column_parallel_layer_norm_linear": "local"})
+            )
+
+    def test_a_preset_that_cannot_serve_the_fusion_is_refused(self):
+        with pytest.raises(ValueError, match="spans"):
+            build_spec_provider(BackendOptions(transformer_impl="local", use_te_op_fuser=True))
+
+    def test_the_matching_preset_is_accepted(self):
+        from megatron.core.extensions.transformer_engine import HAVE_TE
+
+        if not HAVE_TE:
+            pytest.skip("Transformer Engine is required")
+        assert build_spec_provider(self._op_fuser()).mlp_module() is not None

--- a/tests/unit_tests/ops/test_cross_entropy_backend.py
+++ b/tests/unit_tests/ops/test_cross_entropy_backend.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Cross entropy is chosen while the model is built, not on every forward."""
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.ops import BackendOptions, build_spec_provider
+from megatron.core.ops.loss import fused_vocab_parallel_cross_entropy, vocab_parallel_cross_entropy
+from tests.unit_tests.test_utilities import Utils
+
+_needs_te = pytest.mark.skipif(not HAVE_TE, reason="Transformer Engine is required")
+
+
+def _provider(**kwargs):
+    return build_spec_provider(BackendOptions(transformer_impl="local", **kwargs))
+
+
+class TestCrossEntropySelection:
+    def test_default_is_the_reference_implementation(self):
+        assert _provider().vocab_parallel_cross_entropy() is vocab_parallel_cross_entropy
+
+    def test_fusion_off_ignores_the_implementation_setting(self):
+        provider = _provider(cross_entropy_loss_fusion=False, cross_entropy_fusion_impl="te")
+        assert provider.vocab_parallel_cross_entropy() is vocab_parallel_cross_entropy
+
+    def test_native_fusion_selects_the_megatron_kernel(self):
+        provider = _provider(cross_entropy_loss_fusion=True, cross_entropy_fusion_impl="native")
+        assert provider.vocab_parallel_cross_entropy() is fused_vocab_parallel_cross_entropy
+
+    def test_unknown_fusion_implementation_is_rejected(self):
+        """This used to fall through the branch and raise UnboundLocalError mid-forward."""
+        with pytest.raises(ValueError, match="Unknown cross_entropy_fusion_impl='jax'"):
+            _provider(cross_entropy_loss_fusion=True, cross_entropy_fusion_impl="jax")
+
+    def test_explicit_override_selects_the_same_kernel(self):
+        provider = _provider(operation_backends={"vocab_parallel_cross_entropy": "megatron_fused"})
+        assert provider.vocab_parallel_cross_entropy() is fused_vocab_parallel_cross_entropy
+
+    def test_te_fusion_is_refused_the_same_way_the_flag_check_refuses_it(self):
+        """--op-backend must not route around the stability block in arguments.py."""
+        with pytest.raises(ValueError, match="disabled due to stability issues"):
+            _provider(cross_entropy_loss_fusion=True, cross_entropy_fusion_impl="te")
+        with pytest.raises(ValueError, match="Unknown backend 'te_fused'"):
+            _provider(operation_backends={"vocab_parallel_cross_entropy": "te_fused"})
+
+
+class TestCrossEntropyContract:
+    """Every target in the family has to be callable the same way."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("backend_name", ["megatron", "megatron_fused"])
+    def test_target_accepts_a_default_tensor_parallel_group(self, backend_name):
+        """tp_group=None means the default group, whatever the underlying kernel needs."""
+        torch.manual_seed(0)
+        logits = torch.randn(4, 2, 8).cuda()
+        labels = torch.randint(0, 8, (4, 2)).cuda()
+
+        target = _provider(
+            operation_backends={"vocab_parallel_cross_entropy": backend_name}
+        ).vocab_parallel_cross_entropy()
+
+        assert target(logits, labels, None).shape == labels.shape
+
+
+class TestCrossEntropyParity:
+    """Every selectable target has to agree on the same inputs."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_every_target_matches_torch_cross_entropy(self, dtype):
+        """Each target gets its own copy: the family contract says they consume logits."""
+        torch.manual_seed(1234)
+        logits = torch.randn(6, 2, 16).cuda().to(dtype)
+        labels = torch.randint(0, 16, (6, 2)).cuda()
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+
+        expected = torch.nn.functional.cross_entropy(
+            logits.float().reshape(-1, 16), labels.reshape(-1), reduction="none"
+        ).reshape(6, 2)
+
+        names = ["megatron", "megatron_fused"]
+        for name in names:
+            target = _provider(
+                operation_backends={"vocab_parallel_cross_entropy": name}
+            ).vocab_parallel_cross_entropy()
+            loss = target(logits.clone(), labels, tp_group)
+            torch.testing.assert_close(
+                loss.float(), expected, rtol=1e-2, atol=1e-2, msg=lambda m: f"{name}: {m}"
+            )

--- a/tests/unit_tests/ops/test_fusions.py
+++ b/tests/unit_tests/ops/test_fusions.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Selecting a fusion that spans several families.
+
+Exercises the in-tree reference fusion, which declares everything a real megakernel declares
+-- so the mechanism is covered before any kernel exists, and a vendor can see what their own
+file has to do. What the layer spec builders then do with it is covered alongside them.
+"""
+
+import pytest
+
+import megatron.core.ops.fusions as fusions
+from megatron.core.ops import PRESETS, BackendOptions, build_spec_provider, get_backend
+from megatron.core.ops.attention import CORE_ATTENTION
+from megatron.core.ops.fusions.attn_moe import ReferenceFusedAttentionMoELayer
+from megatron.core.ops.mlp import MLP_MODULE
+from megatron.core.ops.moe import GROUPED_MLP_MODULES
+from megatron.core.ops.norm import LAYER_NORM
+
+#: What selects the reference fusion, wherever a test needs it.
+FUSION = {"fused_moe_layer": "attn_moe_reference"}
+
+
+class TestSelectingAFusion:
+    @pytest.mark.parametrize("preset", PRESETS)
+    def test_no_fusion_unless_asked_for(self, preset):
+        """No --transformer-impl implies a fusion; the answer is None and the layer is ordinary."""
+        assert get_backend(preset).fused_moe_layer() is None
+
+    def test_a_fusion_is_selected_like_any_other_backend(self):
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="local", operation_backends=FUSION)
+        )
+        assert provider.fused_moe_layer() is ReferenceFusedAttentionMoELayer
+
+    def test_a_fusion_leaves_the_handover_point_it_does_not_cover(self):
+        """An attention-plus-MoE kernel has nothing to fuse on a dense layer, so that slot
+        stays with FusionNone and the ordinary layer is kept."""
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="local", operation_backends=FUSION)
+        )
+        assert provider.fused_dense_layer() is None
+
+    def test_a_backend_for_a_spanned_operation_is_refused(self):
+        """The rule a fusion has to follow: say what you swallowed, and it gets checked.
+
+        The fusion performs attention itself, so a backend selected for ``core_attention``
+        would never be built. Refusing beats a run that looks configured and is not.
+        """
+        options = BackendOptions(
+            transformer_impl="local", operation_backends={**FUSION, "core_attention": "local"}
+        )
+        with pytest.raises(ValueError, match="performs 'core_attention' itself"):
+            build_spec_provider(options)
+
+    def test_an_unspanned_operation_is_still_selectable(self):
+        """SPANS refuses only what the fusion swallowed; everything else stays configurable."""
+        provider = build_spec_provider(
+            BackendOptions(
+                transformer_impl="local", operation_backends={**FUSION, "layer_norm": "torch"}
+            )
+        )
+        assert provider.fused_moe_layer() is ReferenceFusedAttentionMoELayer
+
+
+class TestASlotIsAHandoverPointNotAKernel:
+    """What makes the family scale: SPANS is per kernel, the slot is per handover point.
+
+    A kernel that swallows more than the slot is named for does not need a new slot -- it
+    fills the same one and says so in SPANS. So two vendors whose kernels cover different
+    footprints still share ``fused_moe_layer``, and ``FusionSlots`` does not grow.
+    """
+
+    class WideAttnMoe:
+        """The same handover point, a larger footprint: it eats the input norm too."""
+
+        REQUIRES = None
+        DETERMINISM = "unknown"
+        SPANS = (CORE_ATTENTION, GROUPED_MLP_MODULES, LAYER_NORM)
+
+        def fused_moe_layer(self):
+            return ReferenceFusedAttentionMoELayer
+
+    @pytest.fixture()
+    def wide(self, monkeypatch):
+        monkeypatch.setitem(fusions.BACKENDS, "wide_attn_moe", self.WideAttnMoe)
+        return {"fused_moe_layer": "wide_attn_moe"}
+
+    def test_a_wider_kernel_needs_no_new_slot(self, wide):
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="local", operation_backends=wide)
+        )
+        assert provider.fused_moe_layer() is ReferenceFusedAttentionMoELayer
+
+    def test_the_wider_footprint_is_what_gets_checked(self, wide):
+        """LAYER_NORM is refused for this kernel and not for the narrower one, same slot."""
+        with pytest.raises(ValueError, match="performs 'layer_norm' itself"):
+            build_spec_provider(
+                BackendOptions(
+                    transformer_impl="local", operation_backends={**wide, "layer_norm": "torch"}
+                )
+            )
+        # The narrower kernel, at the very same slot, still allows it.
+        build_spec_provider(
+            BackendOptions(
+                transformer_impl="local", operation_backends={**FUSION, "layer_norm": "torch"}
+            )
+        )
+
+    def test_one_slot_per_handover_point(self):
+        """Pins the slot list, so FusionSlots cannot quietly accumulate a method per kernel.
+
+        Every fusion operation is a place the layer hands over control, and each one needs a
+        call site in the spec builders. Adding to this list is meant to be a reviewed decision;
+        a wider footprint, different internals, or another vendor are none of them reasons to.
+        See the rule in megatron/core/ops/fusions/__init__.py.
+        """
+        assert [op.method for op in fusions.OPERATIONS] == ["fused_dense_layer", "fused_moe_layer"]
+
+
+class TestASecondFusionAtAnotherHandoverPoint:
+    """What adding an attention-plus-dense-MLP kernel costs: one file, and no new slot.
+
+    Stands in for a future ``fusions/attn_mlp.py``. It fills the dense handover point, so it
+    coexists with the attention-plus-MoE kernel rather than competing with it -- the two are
+    separate operations, each independently selectable.
+    """
+
+    class AttnMlp:
+        """Attention fused with the dense MLP."""
+
+        REQUIRES = None
+        DETERMINISM = "unknown"
+        SPANS = (CORE_ATTENTION, MLP_MODULE)
+
+        def fused_dense_layer(self):
+            return ReferenceFusedAttentionMoELayer
+
+    @pytest.fixture()
+    def both(self, monkeypatch):
+        monkeypatch.setitem(fusions.BACKENDS, "attn_mlp", self.AttnMlp)
+        return {**FUSION, "fused_dense_layer": "attn_mlp"}
+
+    def test_two_fusions_can_be_selected_at_once(self, both):
+        provider = build_spec_provider(
+            BackendOptions(transformer_impl="local", operation_backends=both)
+        )
+        assert provider.fused_dense_layer() is ReferenceFusedAttentionMoELayer
+        assert provider.fused_moe_layer() is ReferenceFusedAttentionMoELayer
+
+    def test_each_fusion_is_checked_against_its_own_span(self, both):
+        """The dense kernel eats mlp_module; the MoE one does not. Both spans are enforced."""
+        with pytest.raises(ValueError, match="performs 'mlp_module' itself"):
+            build_spec_provider(
+                BackendOptions(
+                    transformer_impl="local", operation_backends={**both, "mlp_module": "megatron"}
+                )
+            )

--- a/tests/unit_tests/ops/test_import_hygiene.py
+++ b/tests/unit_tests/ops/test_import_hygiene.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Importing the ops package must not pull in a backend nobody selected."""
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_MIGRATED_MODULES = ("megatron.core.ops",)
+
+
+def test_importing_ops_does_not_import_an_optional_backend():
+    """Measured against a bare ``import megatron.core``, so this only blames core.ops.
+
+    Runs in a fresh interpreter because sys.modules here is already populated by other tests.
+    """
+    script = textwrap.dedent("""
+        import sys
+
+        optional = {"transformer_engine", "apex", "nvidia_kitchen"}
+        import megatron.core
+
+        before = {name for name in optional if name in sys.modules}
+        import megatron.core.ops
+
+        after = {name for name in optional if name in sys.modules}
+        print(",".join(sorted(after - before)))
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    added = result.stdout.strip()
+    assert added == "", f"importing megatron.core.ops additionally imported: {added}"
+
+
+@pytest.mark.parametrize("module_name", _MIGRATED_MODULES)
+def test_migrated_modules_define_no_availability_flags(module_name):
+    """Backends state their requirements in core.ops instead of exporting a HAVE_* global."""
+    module = importlib.import_module(module_name)
+    flags = sorted(name for name in vars(module) if name.startswith(("HAVE_", "_HAVE_")))
+    assert not flags, f"{module_name} still defines {flags}"


### PR DESCRIPTION
## What

Adds `megatron/core/ops` and `megatron/core/inference/ops`: one package per operation family, each declaring its own contract, its own backend table and its own default, assembled into a single `BackendSpecProvider`.

**Nothing calls it yet.** Every existing selection path is untouched, so this PR is purely additive (+3200, −0) and cannot change behaviour. It can be reviewed as a design on its own. #6690 switches the callers over.

## Shape

Two files per family:

| file | holds |
|---|---|
| `<family>/__init__.py` | the contract, the `Operation` constants, the `*Slots` class, `BACKENDS`, `DEFAULT` |
| `<family>/backends.py` | the implementations side by side |

Every optional-package import lives inside the method that returns its target, so importing `megatron.core.ops` pulls in no backend nobody selected — pinned by `test_import_hygiene.py`.

Adding a backend is one class plus one table entry. `test_conformance.py` is parametrized off the tables, so a new backend is covered the moment it is registered, and fails by name if it misses a slot its family declares.

## What a backend declares

| | means | checked |
|---|---|---|
| `REQUIRES` | the optional package it needs, optionally with a version specifier | at selection |
| `DETERMINISM` | `deterministic` / `nondeterministic` / `unknown` | refused under `--deterministic-mode` |
| `FUSES` | the neighbouring slots it can accept | at selection |
| `SPANS` | the operations a fusion performs itself | at selection |

All four are resolved once, while the model is built. There is no dispatch on the forward path.

`resolve.py` names no family and no backend — it asks each family for its table, its default and its `legacy_backends`. Grepping a backend name never lands there.

## Fusions

`ops/fusions/` is a family for kernels spanning several others, one file per fusion, with `attn_moe.py` as a worked reference. The slots are named for where the layer hands over control (`fused_dense_layer`, `fused_moe_layer`), not for what any one kernel swallows — a wider footprint is a longer `SPANS`, not a new slot. The rule for when a new slot *is* warranted is written into `fusions/__init__.py` and pinned by `test_one_slot_per_handover_point`.

## Testing

`tests/unit_tests/ops/` — 8×GPU, all green. Assembly, per-backend targets, conformance parametrized off the real tables, cross-entropy parity against `F.cross_entropy`, import hygiene, and fusion selection.

See `megatron/core/ops/README.md`.
