### PR TITLE
Enforce BackendSpecProvider: select every kernel backend through megatron/core/ops

### DIFF
--- a/megatron/core/extensions/transformer_engine_spec_provider.py
+++ b/megatron/core/extensions/transformer_engine_spec_provider.py
@@ -1,114 +1,17 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-from __future__ import annotations
 
-import warnings
-from functools import partial
-from typing import Optional, cast
+"""Compatibility import for the Transformer Engine backend.
 
-from megatron.core.extensions.transformer_engine import (
-    TEActivationOp,
-    TEColumnParallelGroupedLinear,
-    TEColumnParallelLinear,
-    TEDotProductAttention,
-    TELayerNormColumnParallelLinear,
-    TELinear,
-    TENorm,
-    TERowParallelGroupedLinear,
-    TERowParallelLinear,
-)
-from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-from megatron.core.models.backends import BackendSpecProvider
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
-from megatron.core.transformer.mlp import MLPSubmodules, TEActivationFunctionBuilder
-from megatron.core.transformer.moe.experts import GroupedMLPSubmodules, SequentialMLP, TEGroupedMLP
-from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
-from megatron.core.transformer.torch_norm import LayerNormBuilder
-from megatron.core.utils import get_te_version, is_te_min_version
+Selection moved to :mod:`megatron.core.ops`. ``TESpecProvider`` is now a factory rather than a
+class: there is one provider type, assembled from the per-operation backends the Transformer
+Engine preset selects. Calling it still returns something with the same methods.
+"""
+
+from megatron.core.ops import BackendSpecProvider, get_backend
+
+__all__ = ["TESpecProvider"]
 
 
-class _TENormWithResidual:
-    """Class adapter for TENorm with residual fusion enabled."""
-
-    def __new__(cls, *args, **kwargs):
-        return TENorm(*args, has_residual=True, **kwargs)
-
-
-class TESpecProvider(BackendSpecProvider):
-    """A protocol for providing the submodules used in Spec building."""
-
-    def linear(self) -> type:
-        """Which linear module TE backend uses"""
-        return TELinear
-
-    def column_parallel_linear(self) -> type:
-        """Which column parallel linear module TE backend uses"""
-        return TEColumnParallelLinear
-
-    def row_parallel_linear(self) -> type[TERowParallelLinear]:
-        """Which row parallel linear module TE backend uses"""
-        return TERowParallelLinear
-
-    def fuse_layernorm_and_linear(self) -> bool:
-        """TE backend chooses a single module for layernorm and linear"""
-        return True
-
-    def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
-        return TELayerNormColumnParallelLinear
-
-    def layer_norm(
-        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
-    ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if for_qk and not is_te_min_version("1.9.0"):
-            # TENorm significantly harms convergence when used
-            # for QKLayerNorm if TE Version < 1.9;
-            # we instead use the Apex implementation.
-            return FusedLayerNorm
-        # Keep returning a class so this path stays aligned with build_module's class handling.
-        return _TENormWithResidual if has_residual else TENorm
-
-    def core_attention(self) -> type:
-        """Which module to use for attention"""
-        return TEDotProductAttention
-
-    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        if moe_use_grouped_gemm and TEColumnParallelGroupedLinear is not None:
-            return partial(
-                TEGroupedMLP,
-                submodules=GroupedMLPSubmodules(
-                    linear_fc1=TEColumnParallelGroupedLinear,
-                    linear_fc2=TERowParallelGroupedLinear,
-                    activation_func=self.activation_func(),
-                ),
-            )
-        else:
-            if not is_te_min_version("1.7.0.dev0"):
-                warnings.warn(
-                    "Only transformer-engine>=1.7.0 supports MoE experts, "
-                    f"but your version is {get_te_version()}. "
-                    "Use local linear implementation instead."
-                )
-                return partial(
-                    SequentialMLP,
-                    submodules=MLPSubmodules(
-                        linear_fc1=ColumnParallelLinear,
-                        linear_fc2=RowParallelLinear,
-                        activation_func=self.activation_func(),
-                    ),
-                )
-            return partial(
-                SequentialMLP,
-                submodules=MLPSubmodules(
-                    linear_fc1=TEColumnParallelLinear,
-                    linear_fc2=TERowParallelLinear,
-                    activation_func=self.activation_func(),
-                ),
-            )
-
-    def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
-        # design these classes always meet the interface.
-        return cast(TEActivationFunctionBuilder, TEActivationOp)
+def TESpecProvider() -> BackendSpecProvider:  # pylint: disable=invalid-name
+    """Deprecated: use ``get_backend("transformer_engine")``."""
+    return get_backend("transformer_engine")

--- a/megatron/core/models/backends.py
+++ b/megatron/core/models/backends.py
@@ -1,218 +1,39 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-from __future__ import annotations
 
-import warnings
-from abc import abstractmethod
-from functools import partial
-from typing import Literal, Optional, Protocol, cast
+"""Compatibility imports for backend selection.
 
-from megatron.core.extensions.transformer_engine import (
-    TEColumnParallelGroupedLinear,
-    TERowParallelGroupedLinear,
+Backend selection lives in :mod:`megatron.core.ops`. This module keeps the names it used to
+define working. The three ``*SpecProvider`` names are now factories rather than classes: there
+is one provider type, and a preset selects which backend fills each operation. Calling them
+still returns something with the same methods, so ``TESpecProvider().layer_norm()`` is
+unchanged, but ``isinstance`` against them no longer makes sense.
+"""
+
+from megatron.core.ops import (
+    BackendOptions,
+    BackendSpecProvider,
+    Operation,
+    get_backend,
+    get_backend_spec_provider,
 )
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
-from megatron.core.transformer.dot_product_attention import DotProductAttention
-from megatron.core.transformer.mlp import MLPSubmodules, TEActivationFunctionBuilder
-from megatron.core.transformer.moe.experts import (
-    GroupedMLPSubmodules,
-    InferenceGroupedMLP,
-    SequentialMLP,
-)
-from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
-from megatron.core.transformer.torch_norm import LayerNormBuilder, WrappedTorchNorm
-from megatron.core.typed_torch import not_none
-from megatron.core.utils import is_te_min_version
-
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    FusedLayerNorm = None
-    HAVE_APEX = False
-    LNImpl = WrappedTorchNorm
-
-from megatron.core.extensions.transformer_engine import (
-    TEActivationOp,
-    TEDotProductAttention,
-    TELinear,
-    TENorm,
-)
-from megatron.core.tensor_parallel.inference_layers import (
-    InferenceColumnParallelLinear,
-    InferenceLayerNormColumnParallelLinear,
-    InferenceRowParallelLinear,
-)
-from megatron.core.utils import is_te_min_version
 
 
-class BackendSpecProvider(Protocol):
-    """A protocol for providing the submodules used in Spec building."""
-
-    @abstractmethod
-    def column_parallel_linear(self) -> type:
-        """Which column parallel linear module the backend uses"""
-        ...
-
-    @abstractmethod
-    def row_parallel_linear(self) -> type:
-        """Which row parallel linear module the backend uses"""
-        ...
-
-    @abstractmethod
-    def fuse_layernorm_and_linear(self) -> bool:
-        """Does the backend support a single module for layernorm and linear"""
-        ...
-
-    @abstractmethod
-    def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
-        ...
-
-    @abstractmethod
-    def layer_norm(
-        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
-    ) -> LayerNormBuilder:
-        """Which module for layernorm"""
-        ...
-
-    @abstractmethod
-    def core_attention(self) -> type:
-        """Which module to use for attention"""
-        ...
-
-    @abstractmethod
-    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        ...
-
-    @abstractmethod
-    def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        ...
+def LocalSpecProvider() -> BackendSpecProvider:  # pylint: disable=invalid-name
+    """Deprecated: use ``get_backend("local")``."""
+    return get_backend("local")
 
 
-class LocalSpecProvider(BackendSpecProvider):
-    """A protocol for providing Local submodules used in Spec building."""
-
-    def column_parallel_linear(self) -> type:
-        """Which column parallel linear module the backend uses"""
-        return ColumnParallelLinear
-
-    def row_parallel_linear(self) -> type[RowParallelLinear]:
-        """Which row parallel linear module the backend uses"""
-        return RowParallelLinear
-
-    def fuse_layernorm_and_linear(self) -> bool:
-        """Does the backend choose a single module for layernorm and linear"""
-        return False
-
-    def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
-        return None
-
-    def layer_norm(
-        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
-    ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if rms_norm:
-            # Matching get_gpt_layer_local_spec.
-            # Why does the global need to be updated?
-            global LNImpl
-            LNImpl = WrappedTorchNorm
-        return LNImpl
-
-    def core_attention(self) -> type:
-        """Which module to use for attention"""
-        return DotProductAttention
-
-    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        return partial(
-            SequentialMLP,
-            submodules=MLPSubmodules(
-                linear_fc1=ColumnParallelLinear,
-                linear_fc2=RowParallelLinear,
-                activation_func=self.activation_func(),
-            ),
-        )
-
-    def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        return None
+def InferenceSpecProvider() -> BackendSpecProvider:  # pylint: disable=invalid-name
+    """Deprecated: use ``get_backend("inference_optimized")``."""
+    return get_backend("inference_optimized")
 
 
-class InferenceSpecProvider(BackendSpecProvider):
-    """A protocol for providing the submodules used in Spec building."""
-
-    def linear(self) -> type:
-        """Which linear module TE backend uses"""
-        return TELinear
-
-    def column_parallel_linear(self) -> type:
-        """Which column parallel linear module TE backend uses"""
-        return InferenceColumnParallelLinear
-
-    def row_parallel_linear(self) -> type[InferenceRowParallelLinear]:
-        """Which row parallel linear module Inference backend uses"""
-        return InferenceRowParallelLinear
-
-    def fuse_layernorm_and_linear(self) -> bool:
-        """TE backend chooses a single module for layernorm and linear"""
-        return True
-
-    def column_parallel_layer_norm_linear(self) -> type[InferenceLayerNormColumnParallelLinear]:
-        """Which module for sequential layernorm and linear"""
-        return InferenceLayerNormColumnParallelLinear
-
-    def layer_norm(
-        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
-    ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if for_qk and not is_te_min_version("1.9.0"):
-            # TENorm significantly harms convergence when used
-            # for QKLayerNorm if TE Version < 1.9;
-            # we instead use the Apex implementation.
-            return not_none(FusedLayerNorm)
-        return TENorm
-
-    def core_attention(self) -> type[TEDotProductAttention]:
-        """Which module to use for attention"""
-        return TEDotProductAttention
-
-    def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
-        # design these classes always meet the interface.
-        return cast(TEActivationFunctionBuilder, TEActivationOp)
-
-    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        return partial(
-            InferenceGroupedMLP,
-            submodules=GroupedMLPSubmodules(
-                linear_fc1=TEColumnParallelGroupedLinear,
-                linear_fc2=TERowParallelGroupedLinear,
-                activation_func=self.activation_func(),
-            ),
-        )
-
-
-def get_backend(
-    transformer_impl: Literal["local", "transformer_engine", "inference_optimized"]
-) -> BackendSpecProvider:
-    """Return the backend that's selected with the given `transformer_impl`."""
-    if transformer_impl == "transformer_engine":
-        from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-
-        return TESpecProvider()
-    elif transformer_impl == "inference_optimized":
-        return InferenceSpecProvider()
-    elif transformer_impl == "local":
-        return LocalSpecProvider()
-    else:
-        raise ValueError(f"unknown transformer_impl='{transformer_impl}'")
+__all__ = [
+    "BackendOptions",
+    "BackendSpecProvider",
+    "InferenceSpecProvider",
+    "LocalSpecProvider",
+    "Operation",
+    "get_backend",
+    "get_backend_spec_provider",
+]

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -6,15 +6,9 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 
-from megatron.core import parallel_state, tensor_parallel
+from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
-from megatron.core.transformer.cuda_graphs import CudaGraphManager
-
-try:
-    from megatron.core.extensions.transformer_engine import te_parallel_cross_entropy
-except:
-    te_parallel_cross_entropy = None
-from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+from megatron.core.ops import get_backend_spec_provider
 from megatron.core.pipeline_parallel.utils import (
     is_pp_first_stage,
     is_pp_last_stage,
@@ -22,6 +16,7 @@ from megatron.core.pipeline_parallel.utils import (
     is_vp_last_stage,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.cuda_graphs import CudaGraphManager
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.multi_token_prediction import tie_word_embeddings_state_dict
@@ -29,7 +24,6 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import ensure_metadata_has_dp_cp_group
 from megatron.core.utils import (
     get_tensor_model_parallel_group_if_none,
-    is_te_min_version,
     make_tp_sharded_tensor_for_checkpoint,
 )
 
@@ -63,6 +57,12 @@ class LanguageModule(MegatronModule):
         self.embd_group = pg_collection.embd
         self.vp_stage = None
         self.vp_size = self.config.virtual_pipeline_model_parallel_size
+        # Choose the cross entropy implementation once, here, rather than on every forward.
+        # Fusion settings, the Transformer Engine version check, and CUDA graph capture are
+        # all resolved inside the backend before the first step runs.
+        self.vocab_parallel_cross_entropy = get_backend_spec_provider(
+            config
+        ).vocab_parallel_cross_entropy()
 
     def _setup_mtp_cuda_graphs(self):
         """Wrap `compute_mtp_single_step` with a CudaGraphManager.
@@ -170,40 +170,9 @@ class LanguageModule(MegatronModule):
         """
         # [b s] => [s b]
         labels = labels.transpose(0, 1).contiguous()
-        if self.config.cross_entropy_loss_fusion:
-            if self.config.cross_entropy_fusion_impl == 'te':
-                if te_parallel_cross_entropy is not None:
-                    labels = torch.as_strided(labels, labels.size(), (labels.size()[1], 1))
-                    # Use is_cg_capturable=True for full iteration CUDA graphs to avoid torch.equal checks
-                    is_cg_capturable = (
-                        hasattr(self.config, 'cuda_graph_impl')
-                        and self.config.cuda_graph_impl == "full_iteration"
-                    )
-                    if is_cg_capturable and not is_te_min_version("2.7.0"):
-                        from megatron.core.utils import get_te_version
-
-                        current_version = get_te_version()
-                        raise AssertionError(
-                            f"CUDA graph compatible cross entropy requires TransformerEngine >= 2.7.0, "
-                            f"but found version {current_version}. Please upgrade TransformerEngine "
-                            f"or set cuda_graph_impl to a value other than 'full_iteration'."
-                        )
-
-                    loss = te_parallel_cross_entropy(
-                        logits, labels, self.pg_collection.tp, is_cg_capturable
-                    )
-                else:
-                    raise RuntimeError("Trying to use a TE block when it's not present.")
-            elif self.config.cross_entropy_fusion_impl == 'native':
-                loss = fused_vocab_parallel_cross_entropy(logits, labels, self.pg_collection.tp)
-        else:
-            loss = tensor_parallel.vocab_parallel_cross_entropy(
-                logits, labels, tp_group=self.tp_group
-            )
-
+        loss = self.vocab_parallel_cross_entropy(logits, labels, self.tp_group)
         # [s b] => [b, s]
-        loss = loss.transpose(0, 1).contiguous()
-        return loss
+        return loss.transpose(0, 1).contiguous()
 
     def setup_embeddings_and_output_layer(self) -> None:
         """Sets up embedding layer in first stage and output layer in last stage.

--- a/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
+++ b/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
@@ -4,7 +4,7 @@ import warnings
 from typing import List, Optional
 
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.models.backends import BackendSpecProvider
+from megatron.core.ops import BackendSpecProvider, get_backend_spec_provider
 from megatron.core.ssm.gated_delta_net import GatedDeltaNet, GatedDeltaNet2, GatedDeltaNetSubmodules
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
@@ -33,25 +33,6 @@ from megatron.core.transformer.transformer_layer import (
     get_transformer_layer_offset,
 )
 from megatron.core.typed_torch import not_none
-
-try:
-    import transformer_engine as te  # type: ignore[import-untyped]  # pylint: disable=unused-import
-
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-
-    HAVE_TE = True
-except ImportError:
-    HAVE_TE = False
-
-try:
-    import nvidia_kitchen  # type: ignore[import-not-found]  # pylint: disable=unused-import
-
-    from megatron.core.extensions.kitchen import KitchenSpecProvider
-
-    HAVE_KITCHEN = True
-except ImportError:
-    HAVE_KITCHEN = False
-
 
 ##########
 # Experimental Attention Variant Names
@@ -499,16 +480,7 @@ def _get_backend_spec_provider(config: TransformerConfig) -> BackendSpecProvider
         "Experimental GPT decoder block spec only supports "
         "transformer engine implementation for now."
     )
-    backend: BackendSpecProvider = (
-        KitchenSpecProvider(
-            fallback=TESpecProvider(),
-            use_kitchen_attention=config.use_kitchen_attention,
-            kitchen_attention_backend=config.kitchen_attention_backend,
-        )
-        if config.use_kitchen
-        else TESpecProvider()
-    )
-    return backend
+    return get_backend_spec_provider(config, transformer_impl="transformer_engine")
 
 
 ##########

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -3,18 +3,13 @@ import warnings
 from functools import partial
 from typing import Optional, Union
 
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.models.backends import (
-    BackendSpecProvider,
-    InferenceSpecProvider,
-    LocalSpecProvider,
-)
 from megatron.core.models.gpt.moe_module_specs import get_moe_module_spec_for_backend
+from megatron.core.ops import BackendSpecProvider, get_backend, get_backend_spec_provider
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.multi_latent_attention import (
     FusedMLASelfAttention,
     MLASelfAttention,
@@ -40,40 +35,16 @@ from megatron.core.transformer.transformer_layer import (
     TransformerLayerSubmodules,
     get_transformer_layer_offset,
 )
-from megatron.core.typed_torch import copy_signature, not_none
-from megatron.core.utils import is_te_min_version
+from megatron.core.typed_torch import copy_signature
 
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import (
-        TEFusedMLP,
-        TEFusedMLPWithGroupedLinear,
-        TENorm,
-    )
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-else:
-    TEFusedMLPWithGroupedLinear, TEFusedMLP, TENorm, TESpecProvider = None, None, None, None
 
-try:
-    from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
-
-except ImportError:
-    HAVE_KITCHEN = False
-
-try:
-    import apex  # type: ignore[import-untyped]  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
+def _base_backend_name(config: TransformerConfig, use_transformer_engine: bool) -> str:
+    """Which complete backend a GPT spec builds on."""
+    if use_transformer_engine:
+        return "transformer_engine"
+    if config.transformer_impl == "inference_optimized":
+        return "inference_optimized"
+    return "local"
 
 
 def get_gpt_layer_with_inference_submodules(
@@ -90,14 +61,12 @@ def get_gpt_layer_with_inference_submodules(
         multi_latent_attention (bool, optional): To use MLA. Defaults to False.
         qk_l2_norm (bool, optional): To use l2 norm for queries/keys. Defaults to False.
     """
-    assert HAVE_TE, "--transformer-impl inference_optimized requires transformer engine"
-    backend = InferenceSpecProvider()
+    backend = get_backend("inference_optimized")
 
     mlp = get_mlp_module_spec_for_backend(
         backend=backend,
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=False,
         use_te_activation_func=False,
     )
 
@@ -219,24 +188,22 @@ def get_gpt_layer_with_transformer_engine_submodules(
         )
 
     if use_kitchen:
-        assert HAVE_KITCHEN
-        backend: BackendSpecProvider = KitchenSpecProvider(
-            fallback=TESpecProvider(),
-            use_kitchen_attention=use_kitchen_attention,
-            kitchen_attention_backend=kitchen_attention_backend,
-        )
         if use_te_op_fuser:
             raise AssertionError("use_te_op_fuser not compatible with using kitchen in mlp.")
         if use_te_activation_func:
             raise AssertionError("use_te_activation_func not compatible with using kitchen.")
-    else:
-        backend = TESpecProvider()
+    backend: BackendSpecProvider = get_backend(
+        "transformer_engine",
+        use_te_op_fuser=bool(use_te_op_fuser),
+        use_kitchen=use_kitchen,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
 
     mlp = get_mlp_module_spec_for_backend(
         backend=backend,
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=use_te_op_fuser,
         use_te_activation_func=use_te_activation_func,
         use_grouped_gemm_for_dense_mlp=use_grouped_gemm_for_dense_mlp,
     )
@@ -383,15 +350,12 @@ def get_gpt_layer_local_submodules(
         TransformerLayerSubmodules: Megatron-Core modules to construct a TransformerLayer
     """
 
-    if use_kitchen:
-        assert HAVE_KITCHEN
-        backend = KitchenSpecProvider(
-            fallback=LocalSpecProvider(),
-            use_kitchen_attention=use_kitchen_attention,
-            kitchen_attention_backend=kitchen_attention_backend,
-        )
-    else:
-        backend = LocalSpecProvider()
+    backend = get_backend(
+        "local",
+        use_kitchen=use_kitchen,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
     # Adjust for RMS norm.
     if normalization == "RMSNorm":
         layer_norm = backend.layer_norm(rms_norm=True, for_qk=False, has_residual=True)
@@ -501,20 +465,17 @@ def get_mlp_module_spec(
             " and will be removed soon. Please update your code accordingly."
         )
     if use_te_op_fuser:
-        if not is_te_min_version("1.13.0"):
-            raise ValueError(
-                "Transformer Engine operation-based API requires Transformer Engine 1.13+"
-            )
         if num_experts is not None:
             raise ValueError(
                 "Transformer Engine operation-based API does not support mixture-of-experts"
             )
 
     return get_mlp_module_spec_for_backend(
-        backend=TESpecProvider() if use_te else LocalSpecProvider(),
+        backend=get_backend(
+            "transformer_engine" if use_te else "local", use_te_op_fuser=bool(use_te_op_fuser)
+        ),
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=use_te_op_fuser,
     )
 
 
@@ -522,7 +483,6 @@ def get_mlp_module_spec_for_backend(
     backend: BackendSpecProvider,
     num_experts: Optional[int] = None,
     moe_grouped_gemm: Optional[bool] = False,
-    use_te_op_fuser: Optional[bool] = False,
     use_te_activation_func: bool = False,
     use_grouped_gemm_for_dense_mlp: bool = False,
 ) -> MlpBuilder:
@@ -532,13 +492,8 @@ def get_mlp_module_spec_for_backend(
     activation_func = backend.activation_func() if use_te_activation_func else None
 
     if num_experts is None:
-        # Dense MLP w/ or w/o TE modules.
-        if use_grouped_gemm_for_dense_mlp and use_te_op_fuser:
-            module = not_none(TEFusedMLPWithGroupedLinear).as_mlp_submodule
-        elif use_te_op_fuser:
-            module = not_none(TEFusedMLP).as_mlp_submodule
-        else:
-            module = MLP.as_mlp_submodule
+        # Dense MLP; which block is a construction-time choice the backend already made.
+        module = backend.mlp_module(grouped=bool(use_grouped_gemm_for_dense_mlp)).as_mlp_submodule
         if backend.fuse_layernorm_and_linear():
             linear_fc1 = backend.column_parallel_layer_norm_linear()
             assert linear_fc1 is not None
@@ -560,6 +515,15 @@ def get_mlp_module_spec_for_backend(
         )
 
 
+def _fused_layer_spec(fused: Optional[type], spec: ModuleSpec) -> ModuleSpec:
+    """Swap in a fusion's layer, keeping the submodules the ordinary layer would have got.
+
+    Those are specs rather than modules, so whatever the fusion performs itself is simply
+    never built.
+    """
+    return spec if fused is None else ModuleSpec(module=fused, submodules=spec.submodules)
+
+
 def get_gpt_decoder_layer_specs(
     config: TransformerConfig,
     use_transformer_engine: bool,
@@ -575,7 +539,6 @@ def get_gpt_decoder_layer_specs(
     )
 
     if use_transformer_engine:
-        layer_norm_impl = TENorm
         dense_layer_spec = get_gpt_layer_with_transformer_engine_spec(
             num_experts=None,
             moe_grouped_gemm=False,
@@ -601,7 +564,6 @@ def get_gpt_decoder_layer_specs(
             mla_down_proj_fusion=getattr(config, "mla_down_proj_fusion", False),
         )
     elif config.transformer_impl == "inference_optimized":
-        layer_norm_impl = TENorm
         dense_layer_spec = get_gpt_layer_with_inference_spec(
             qk_layernorm=config.qk_layernorm,
             multi_latent_attention=config.multi_latent_attention,
@@ -616,7 +578,6 @@ def get_gpt_decoder_layer_specs(
             moe_use_legacy_grouped_gemm=getattr(config, "moe_use_legacy_grouped_gemm", False),
         )
     else:
-        layer_norm_impl = LNImpl
         dense_layer_spec = get_gpt_layer_local_spec(
             num_experts=None,
             moe_grouped_gemm=False,
@@ -639,6 +600,15 @@ def get_gpt_decoder_layer_specs(
             use_kitchen_attention=config.use_kitchen_attention,
             kitchen_attention_backend=config.kitchen_attention_backend,
         )
+
+    # A fusion replaces the layer that runs everything it spans, so it is asked here -- the
+    # one place a dense layer and an MoE layer are told apart. Without one selected the answer
+    # is None and the ordinary layer is kept.
+    backend = get_backend_spec_provider(
+        config, transformer_impl=_base_backend_name(config, use_transformer_engine)
+    )
+    dense_layer_spec = _fused_layer_spec(backend.fused_dense_layer(), dense_layer_spec)
+    moe_layer_spec = _fused_layer_spec(backend.fused_moe_layer(), moe_layer_spec)
 
     # Parse config.moe_layer_freq to determine the pattern of expert/dense layers.
     # 0 stands for dense layers, 1 stands for expert layers.
@@ -705,12 +675,14 @@ def get_gpt_decoder_block_spec(
         offset = get_transformer_layer_offset(config, vp_stage=vp_stage, pp_rank=pp_rank)
         local_layer_specs = layer_specs[offset : offset + num_layers_to_build]
 
-    if use_transformer_engine:
-        layer_norm_impl = TENorm
-    elif config.transformer_impl == "inference_optimized":
-        layer_norm_impl = TENorm
-    else:
-        layer_norm_impl = LNImpl
+    # The final norm is the same operation as every other norm in the block, so it comes
+    # from the same backend rather than from a second selection path.
+    backend = get_backend_spec_provider(
+        config, transformer_impl=_base_backend_name(config, use_transformer_engine)
+    )
+    layer_norm_impl = backend.layer_norm(
+        rms_norm=(normalization or config.normalization) == "RMSNorm"
+    )
     # Block spec.
     block_spec = TransformerBlockSubmodules(
         layer_specs=local_layer_specs, layer_norm=layer_norm_impl
@@ -727,26 +699,11 @@ def get_gpt_mtp_block_spec(
     pp_rank: Optional[int] = None,
 ) -> MultiTokenPredictionBlockSubmodules:
     """GPT Multi-Token Prediction (MTP) block spec."""
-    if use_transformer_engine:
-        backend: BackendSpecProvider = (
-            KitchenSpecProvider(
-                fallback=TESpecProvider(),
-                use_kitchen_attention=config.use_kitchen_attention,
-                kitchen_attention_backend=config.kitchen_attention_backend,
-            )
-            if config.use_kitchen
-            else TESpecProvider()
-        )
-    else:
-        backend = (
-            KitchenSpecProvider(
-                fallback=LocalSpecProvider(),
-                use_kitchen_attention=config.use_kitchen_attention,
-                kitchen_attention_backend=config.kitchen_attention_backend,
-            )
-            if config.use_kitchen
-            else LocalSpecProvider()
-        )
+    # MTP has only ever used the Transformer Engine or the local backend, never the
+    # inference one, so it does not go through _base_backend_name().
+    backend: BackendSpecProvider = get_backend_spec_provider(
+        config, transformer_impl="transformer_engine" if use_transformer_engine else "local"
+    )
     return get_gpt_mtp_block_spec_for_backend(
         config=config, spec=spec, backend=backend, vp_stage=vp_stage, pp_rank=pp_rank
     )

--- a/megatron/core/models/gpt/moe_module_specs.py
+++ b/megatron/core/models/gpt/moe_module_specs.py
@@ -3,19 +3,14 @@
 from functools import partial
 from typing import Optional
 
-from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-from megatron.core.models.backends import (
-    BackendSpecProvider,
-    InferenceSpecProvider,
-    LocalSpecProvider,
-)
+from megatron.core.ops import BackendSpecProvider, get_backend
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import ProcessGroupCollection
-from megatron.core.transformer.moe.router import InferenceTopKRouter
 from megatron.core.transformer.moe.shared_experts import FusedSharedExpertMLP, SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import MlpBuilder
+from megatron.core.typed_torch import not_none
 
 
 def _build_shared_experts(
@@ -53,10 +48,7 @@ def get_moe_module_spec(
         moe_grouped_gemm: Whether to use grouped GEMM.
         moe_use_legacy_grouped_gemm: Whether to use legacy grouped GEMM.
     """
-    if use_te is not None and use_te:
-        backend: BackendSpecProvider = TESpecProvider()
-    else:
-        backend = LocalSpecProvider()
+    backend = get_backend("transformer_engine" if use_te else "local")
     return get_moe_module_spec_for_backend(
         backend=backend, num_experts=num_experts, moe_grouped_gemm=moe_grouped_gemm
     )
@@ -83,10 +75,10 @@ def get_moe_module_spec_for_backend(
     # shared experts spec
     shared_experts = partial(_build_shared_experts, submodules=mlp)
 
-    # The inference-optimized backend needs InferenceTopKRouter (compact [tokens, topk]
-    # index routing); other backends keep the MoESubmodules default (training TopKRouter,
-    # dense [tokens, num_experts] map). Mirrors get_inference_optimized_moe_spec().
-    router = InferenceTopKRouter if isinstance(backend, InferenceSpecProvider) else None
+    # The router is an operation the backend owns: the inference backend needs compact
+    # [tokens, topk] index routing, and every other backend keeps the MoESubmodules default
+    # (training TopKRouter, dense [tokens, num_experts] map).
+    router = backend.moe_router()
     submodule_kwargs = {"router": router} if router is not None else {}
 
     # MoE module spec
@@ -101,14 +93,15 @@ def get_moe_module_spec_for_backend(
 def get_inference_optimized_moe_spec() -> MlpBuilder:
     """MoE module spec for inference-optimized transformer impl.
 
-    Uses InferenceSpecProvider to select inference-optimized modules:
+    Uses the inference backend to select inference-optimized modules:
     InferenceTopKRouter, InferenceGroupedMLP. MoELayer detects inference mode
     via config.transformer_impl and sets up the inference dispatcher internally.
 
     Called by hybrid_layer_specs.py and gpt_layer_specs.py.
     """
-    backend = InferenceSpecProvider()
+    backend = get_backend("inference_optimized")
     activation_func = backend.activation_func()
+    router = not_none(backend.moe_router())
 
     experts = backend.grouped_mlp_modules(True)
     shared_experts = partial(
@@ -122,7 +115,5 @@ def get_inference_optimized_moe_spec() -> MlpBuilder:
 
     return partial(
         MoELayer,
-        submodules=MoESubmodules(
-            router=InferenceTopKRouter, experts=experts, shared_experts=shared_experts
-        ),
+        submodules=MoESubmodules(router=router, experts=experts, shared_experts=shared_experts),
     )

--- a/megatron/core/transformer/mla_qk_norm_config.py
+++ b/megatron/core/transformer/mla_qk_norm_config.py
@@ -6,7 +6,7 @@ Resolve MLA and DSA Q/KV norm configuration from a layer specification.
 
 from typing import NoReturn
 
-from megatron.core.models.backends import get_backend
+from megatron.core.ops import get_backend
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.torch_norm import LayerNormBuilder

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -13,10 +13,9 @@ from megatron.core import InferenceParams, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.utils import InferenceMode
-from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
+from megatron.core.ops import BackendSpecProvider, get_backend
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -56,11 +55,6 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
-
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-else:
-    TESpecProvider = None
 
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
@@ -587,7 +581,7 @@ def get_mtp_layer_spec(
     """
     return get_mtp_layer_spec_for_backend(
         mtp_model_layer_spec,
-        backend=TESpecProvider() if use_transformer_engine else LocalSpecProvider(),
+        backend=get_backend("transformer_engine" if use_transformer_engine else "local"),
     )
 
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1288,6 +1288,15 @@ class TransformerConfig(ModelParallelConfig):
     """Transformer implementation to use.
     Options are 'transformer_engine' for Transformer Engine and 'local' for MCore."""
 
+    op_backend_overrides: dict[str, str] = field(default_factory=dict)
+    """Per-operation backend choices layered on top of ``transformer_impl``.
+
+    Maps an operation name to a backend name, for example
+    ``{"layer_norm": "apex", "vocab_parallel_cross_entropy": "te_fused"}``. Backend names are
+    scoped to the operation's family, so ``megatron.core.ops.backends_for(operation)`` lists
+    the valid choices. Selecting the same operation both here and through an older setting is
+    an error."""
+
     #####################################
     # Fine-grained Activation Offloading
     #####################################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -387,6 +387,9 @@ def tuple_type(x):
 
 def validate_args(args, defaults={}):
 
+    # Operation backend choices, so a bad name fails before the model is built.
+    _resolve_op_backend_overrides(args)
+
     # Prep for checkpoint conversion.
     if args.ckpt_convert_format is not None:
         assert args.ckpt_convert_save is not None
@@ -2225,6 +2228,46 @@ def _add_inference_args(parser):
     return parser
 
 
+def _op_backend_override(value):
+    """Parse one OPERATION=BACKEND pair from --op-backend."""
+    from megatron.core.ops import find_operation, validate_backend
+
+    name, separator, backend = value.partition("=")
+    if not separator:
+        raise argparse.ArgumentTypeError(f"expected OPERATION=BACKEND, got '{value}'")
+    try:
+        operation = find_operation(name.strip())
+        validate_backend(operation, backend.strip())
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+    return operation.method, backend.strip()
+
+
+def _load_op_backend_config(path):
+    """Read an operation-to-backend mapping from a JSON or YAML file."""
+    text = Path(path).read_text()
+    if path.endswith((".yaml", ".yml")):
+        import yaml
+
+        contents = yaml.safe_load(text)
+    else:
+        contents = json.loads(text)
+    if not isinstance(contents, dict):
+        raise ValueError(f"{path} must contain a mapping of operation name to backend name")
+    return dict(
+        _op_backend_override(f"{operation}={backend}") for operation, backend in contents.items()
+    )
+
+
+def _resolve_op_backend_overrides(args):
+    """Merge --op-backend-config and --op-backend into one mapping, command line last."""
+    overrides = {}
+    if getattr(args, "op_backend_config", None) is not None:
+        overrides.update(_load_op_backend_config(args.op_backend_config))
+    overrides.update(dict(getattr(args, "op_backend", []) or []))
+    args.op_backend_overrides = overrides
+
+
 def _add_network_size_args(parser):
     exclude = [
         # cannot provide callables over CLI
@@ -2319,9 +2362,22 @@ def _add_network_size_args(parser):
         "gtp_weight_remat_size",
         # internal/derived: controlled only via --expert-tensor-parallel-num-weight-shards
         "expert_gtp_weight_remat_size",
+        # a mapping; built from --op-backend and --op-backend-config
+        "op_backend_overrides",
     ]
     transformer_factory = ArgumentGroupFactory(TransformerConfig, exclude=exclude)
     transformer_group = transformer_factory.build_group(parser, "transformer configuration")
+
+    transformer_group.add_argument(
+        '--op-backend', nargs='+', type=_op_backend_override, default=[],
+        metavar='OPERATION=BACKEND',
+        help='Choose the backend for individual operations on top of --transformer-impl, '
+             'e.g. --op-backend layer_norm=apex vocab_parallel_cross_entropy=te_cross_entropy. '
+             'Run with an invalid value to list the operations and backends available.')
+    transformer_group.add_argument(
+        '--op-backend-config', type=str, default=None, metavar='FILE',
+        help='JSON or YAML file mapping operation names to backend names, applied the same '
+             'way as --op-backend. Values given on the command line win over the file.')
 
     group = parser.add_argument_group(title='network size')
 

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -21,7 +21,12 @@ import torch
 
 # Maps each arg name to the value it must hold for bit-exact execution;
 # verified by :func:`apply_determinism_to_args`.
-ARG_VALUES_REQUIRED_FOR_DETERMINISM = {"cross_entropy_loss_fusion": False, "tp_comm_overlap": False}
+#
+# Cross entropy is no longer listed here. Its backends declare DETERMINISM themselves and
+# megatron.core.ops.resolve rejects a non-deterministic one, which is both closer to the code
+# and finer grained: this table could only ban the whole fusion flag, not the specific
+# implementation that is not bit-exact.
+ARG_VALUES_REQUIRED_FOR_DETERMINISM = {"tp_comm_overlap": False}
 
 # Env-var defaults required for bit-exact reproducibility.
 DETERMINISM_ENV_VAR_DEFAULTS: dict[str, str] = {

--- a/tests/unit_tests/ops/test_fusions.py
+++ b/tests/unit_tests/ops/test_fusions.py
@@ -1,24 +1,53 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Selecting a fusion that spans several families.
+"""A fusion spanning several families, from selection through a forward pass.
 
 Exercises the in-tree reference fusion, which declares everything a real megakernel declares
--- so the mechanism is covered before any kernel exists, and a vendor can see what their own
-file has to do. What the layer spec builders then do with it is covered alongside them.
+and then runs the ordinary layer -- so the mechanism is covered before any kernel exists, and
+a vendor can see what their own file has to do.
 """
 
 import pytest
+import torch
 
 import megatron.core.ops.fusions as fusions
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.ops import PRESETS, BackendOptions, build_spec_provider, get_backend
 from megatron.core.ops.attention import CORE_ATTENTION
 from megatron.core.ops.fusions.attn_moe import ReferenceFusedAttentionMoELayer
 from megatron.core.ops.mlp import MLP_MODULE
 from megatron.core.ops.moe import GROUPED_MLP_MODULES
 from megatron.core.ops.norm import LAYER_NORM
+from megatron.core.transformer.transformer_block import TransformerBlock
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.training.initialize import _set_random_seed
+from tests.unit_tests.test_utilities import Utils
 
 #: What selects the reference fusion, wherever a test needs it.
 FUSION = {"fused_moe_layer": "attn_moe_reference"}
+
+
+def _config(**overrides):
+    """A two-layer model whose first layer is MoE and whose second is dense."""
+    settings = dict(
+        num_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=2,
+        moe_layer_freq=[1, 0],
+        moe_router_topk=2,
+        moe_ffn_hidden_size=32,
+        moe_token_dispatcher_type="alltoall",
+        moe_aux_loss_coeff=0.01,
+        add_bias_linear=False,
+        use_cpu_initialization=True,
+        # Off so the parity check below compares arithmetic, not two draws from the RNG.
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+    )
+    settings.update(overrides)
+    return TransformerConfig(**settings)
 
 
 class TestSelectingAFusion:
@@ -156,3 +185,81 @@ class TestASecondFusionAtAnotherHandoverPoint:
                     transformer_impl="local", operation_backends={**both, "mlp_module": "megatron"}
                 )
             )
+
+    def test_both_layer_kinds_are_replaced_in_the_block_spec(self, both):
+        Utils.initialize_model_parallel(1, 1)
+        try:
+            block = get_gpt_decoder_block_spec(
+                _config(op_backend_overrides=both), use_transformer_engine=False
+            )
+            assert [spec.module for spec in block.layer_specs] == [
+                ReferenceFusedAttentionMoELayer,
+                ReferenceFusedAttentionMoELayer,
+            ]
+        finally:
+            Utils.destroy_model_parallel()
+
+
+class TestFusionInTheBlockSpec:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _layer_modules(self, **overrides):
+        config = _config(**overrides)
+        block = get_gpt_decoder_block_spec(config, use_transformer_engine=False)
+        return [spec.module for spec in block.layer_specs]
+
+    def test_moe_layers_are_replaced_and_dense_layers_are_not(self):
+        assert self._layer_modules(op_backend_overrides=FUSION) == [
+            ReferenceFusedAttentionMoELayer,
+            TransformerLayer,
+        ]
+
+    def test_without_the_fusion_every_layer_is_ordinary(self):
+        assert self._layer_modules() == [TransformerLayer, TransformerLayer]
+
+    def test_the_fused_layer_keeps_the_submodules_it_replaced(self):
+        """A fusion is handed the ordinary submodules and ignores what it performs itself.
+
+        They are specs, not modules, so the ones its kernel carries out are never built.
+        """
+        config = _config(op_backend_overrides=FUSION)
+        fused = get_gpt_decoder_block_spec(config, use_transformer_engine=False).layer_specs[0]
+        plain = get_gpt_decoder_block_spec(_config(), use_transformer_engine=False).layer_specs[0]
+        assert fused.submodules.self_attention.module is plain.submodules.self_attention.module
+        assert fused.submodules.mlp is not None
+
+
+class TestFusedLayerRuns:
+    """The reference runs the ordinary path, so selecting it must change nothing but the class."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _forward(self, config):
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        block = TransformerBlock(
+            config, get_gpt_decoder_block_spec(config, use_transformer_engine=False)
+        ).cuda()
+        hidden_states = torch.ones((8, 2, config.hidden_size), device="cuda")
+        attention_mask = torch.ones((2, 1, 8, 8), dtype=bool, device="cuda")
+        output = block(hidden_states=hidden_states, attention_mask=attention_mask)
+        return block, output
+
+    def test_the_fused_layer_is_the_one_that_ran(self):
+        block, _ = self._forward(_config(op_backend_overrides=FUSION))
+        fused = block.layers[0]
+        assert isinstance(fused, ReferenceFusedAttentionMoELayer)
+        assert fused.fused_steps == 1
+        assert not isinstance(block.layers[1], ReferenceFusedAttentionMoELayer)
+
+    def test_selecting_the_reference_fusion_does_not_change_the_result(self):
+        _, plain = self._forward(_config())
+        _, fused = self._forward(_config(op_backend_overrides=FUSION))
+        torch.testing.assert_close(fused, plain, rtol=0, atol=0)

--- a/tests/unit_tests/ops/test_import_hygiene.py
+++ b/tests/unit_tests/ops/test_import_hygiene.py
@@ -9,7 +9,14 @@ import textwrap
 
 import pytest
 
-_MIGRATED_MODULES = ("megatron.core.ops",)
+_MIGRATED_MODULES = (
+    "megatron.core.ops",
+    "megatron.core.models.gpt.gpt_layer_specs",
+    "megatron.core.models.gpt.moe_module_specs",
+    "megatron.core.models.gpt.experimental_attention_variant_module_specs",
+    "megatron.core.transformer.multi_token_prediction",
+    "megatron.core.models.common.language_module.language_module",
+)
 
 
 def test_importing_ops_does_not_import_an_optional_backend():

--- a/tests/unit_tests/tensor_parallel/test_cross_entropy.py
+++ b/tests/unit_tests/tensor_parallel/test_cross_entropy.py
@@ -47,25 +47,21 @@ def test_vocab_parallel_cross_entropy_uses_explicit_tp_group(monkeypatch):
     assert all_reduce_groups == [tp_group, tp_group, tp_group]
 
 
-def test_language_module_unfused_loss_passes_tp_group(monkeypatch):
+def test_language_module_loss_calls_the_selected_cross_entropy():
+    """The loss uses the target the backend picked at construction, with no branch left here."""
     tp_group = _FakeTPGroup()
     captured = {}
 
-    def fake_vocab_parallel_cross_entropy(logits, labels, label_smoothing=0.0, tp_group=None):
+    def fake_vocab_parallel_cross_entropy(logits, labels, tp_group=None):
         captured["logits"] = logits
         captured["labels"] = labels
-        captured["label_smoothing"] = label_smoothing
         captured["tp_group"] = tp_group
         return torch.zeros_like(labels, dtype=logits.dtype)
 
-    monkeypatch.setattr(
-        language_module_module.tensor_parallel,
-        "vocab_parallel_cross_entropy",
-        fake_vocab_parallel_cross_entropy,
-    )
-
     module = SimpleNamespace(
-        config=SimpleNamespace(cross_entropy_loss_fusion=False), tp_group=tp_group
+        config=SimpleNamespace(cross_entropy_loss_fusion=False),
+        tp_group=tp_group,
+        vocab_parallel_cross_entropy=fake_vocab_parallel_cross_entropy,
     )
     labels = torch.tensor([[0, 1, 2], [2, 1, 0]])
     logits = torch.randn(3, 2, 4)
@@ -76,7 +72,6 @@ def test_language_module_unfused_loss_passes_tp_group(monkeypatch):
 
     assert captured["logits"] is logits
     assert captured["tp_group"] is tp_group
-    assert captured["label_smoothing"] == 0.0
     torch.testing.assert_close(captured["labels"], labels.transpose(0, 1).contiguous())
     assert loss.shape == labels.shape
 

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -15,6 +15,7 @@ from megatron.core.extensions.transformer_engine import (
     TERowParallelLinear,
 )
 from megatron.core.models.gpt import gpt_layer_specs
+from megatron.core.ops import get_backend
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -296,19 +297,15 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
 
     def test_dense_grouped_spec_selected_only_with_te_op_fuser(self):
         grouped_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=True,
+            backend=get_backend("transformer_engine", use_te_op_fuser=True),
             use_grouped_gemm_for_dense_mlp=True,
         )
         fused_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=True,
+            backend=get_backend("transformer_engine", use_te_op_fuser=True),
             use_grouped_gemm_for_dense_mlp=False,
         )
         unfused_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=False,
-            use_grouped_gemm_for_dense_mlp=True,
+            backend=get_backend("transformer_engine"), use_grouped_gemm_for_dense_mlp=True
         )
 
         assert grouped_spec.func.__self__ is TEFusedMLPWithGroupedLinear


### PR DESCRIPTION
## What

Switches every caller from `megatron.core.models.backends` and the scattered `HAVE_*` probes to the `ops` packages added in #6689, and adds `--op-backend OPERATION=BACKEND` / `--op-backend-config FILE` so a backend can be chosen per operation rather than only through `--transformer-impl`.

**Stacked on #6689 — review that one first.** This PR's own change is 15 files, net −217 lines.

`models/backends.py` and `extensions/transformer_engine_spec_provider.py` become compatibility shims: `LocalSpecProvider()`, `InferenceSpecProvider()` and `TESpecProvider()` are now factories returning an assembled provider, so out-of-tree callers keep working.

## This is not a mechanical import swap

Five behaviours change, and each is deliberate:

- **`--transformer-impl local --normalization RMSNorm` stops crashing.** `get_gpt_decoder_block_spec` now passes `normalization` through to the final norm, which previously asserted inside Apex's `FusedLayerNorm`.
- **Cross entropy is selected through the provider**, replacing a 30-line branch in `language_module` that had an `UnboundLocalError` on one path and passed a `None` tensor-parallel group on another.
- **`TEFusedMLP` misconfiguration is refused at selection.** It requires Transformer Engine linears; `FUSES` now catches that instead of failing partway through model construction.
- **Transformer Engine cross entropy stays refused.** `te_fused` is deliberately absent from the loss table, so `--op-backend` cannot route around the stability block in `arguments.py`, and the legacy flag path gives the same refusal.
- **The `local` norm backend is Torch, not Apex-if-installed.** Installing an optional package no longer silently changes which kernel a run gets; Apex is selected explicitly with `--op-backend layer_norm=apex`.

## Golden values

The last item moves golden values for the local functional tests that keep Apex — `gpt3_mcore_tp1_pp2`, `tp1_pp4`, `tp1_pp1_dist_optimizer_*`. This needs a **Run functional tests** round trip before it is ready for review.

## Testing

- `tests/unit_tests/ops/`, `models/test_moe_module_specs.py`, `models/test_experimental_attention_variant_module_specs.py`, `models/test_gpt_model.py`, `transformer/moe/test_moe_layer.py`, `transformer/test_transformer_block.py`, `tensor_parallel/test_cross_entropy.py`, `transformer/test_te_fused_mlp_with_grouped_linear_spec.py` — 8×GPU, all green.
- 8 end-to-end training configurations (dense, MoE, MLA, MTP, inference preset, TE and local presets) run against this branch and against the base commit: **loss identical in every case**.
