### PR TITLE
Integrate MFSDP v2 with fine-grained 1F1B scheduling

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -14,6 +14,7 @@
 
 import logging
 import random
+from contextlib import contextmanager
 from typing import Dict, List, NamedTuple, Optional, Tuple, Type
 
 __all__ = ["FullyShardedDataParallel"]
@@ -648,6 +649,11 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             forward_prefetch_size=ddp_config.suggested_communication_unit_size,
             backward_prefetch_size=ddp_config.suggested_communication_unit_size,
         )
+        common_fully_shard_kwargs = dict(
+            mixed_precision_policy=self.mp_policy,
+            schedule_policy=schedule_policy,
+            register_hooks=not config.overlap_moe_expert_parallel_comm,
+        )
         with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
@@ -661,9 +667,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                             submodule.experts,
                             mesh=expert_dp_mesh,
                             placements=expert_placements,
-                            mixed_precision_policy=self.mp_policy,
                             grad_divisor=config.expert_model_parallel_size,
-                            schedule_policy=schedule_policy,
+                            **common_fully_shard_kwargs,
                         )
             for submodule in reversed(list(module.modules())):
                 if submodule is module:
@@ -677,8 +682,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                         submodule,
                         mesh=dp_mesh,
                         placements=dense_placements,
-                        mixed_precision_policy=self.mp_policy,
-                        schedule_policy=schedule_policy,
+                        **common_fully_shard_kwargs,
                     )
             if config.init_model_with_meta_device:
                 _materialize_owned_meta_modules(module, device)
@@ -686,10 +690,21 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 module,
                 mesh=dp_mesh,
                 placements=dense_placements,
-                mixed_precision_policy=self.mp_policy,
-                schedule_policy=schedule_policy,
+                **common_fully_shard_kwargs,
             )
         super().__init__(config=config, module=module)
+        # With fine-grained EP-overlap the automatic FSDP hooks are disabled at
+        # construction (register_hooks=False). Install the submodule demand-unshard
+        # hooks here so the model also has a working parameter lifecycle in
+        # forward_only (eval) paths that never build a schedule plan. In training the
+        # schedule-plan path re-invokes setup_combined_1f1b_hooks (idempotent) to add
+        # the per-layer release hooks.
+        if config.overlap_moe_expert_parallel_comm:
+            from megatron.core.models.common.fine_grained_mfsdp_scheduler import (
+                setup_combined_1f1b_hooks,
+            )
+
+            setup_combined_1f1b_hooks(self.module)
 
     @staticmethod
     def _validate_config(
@@ -799,8 +814,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise ValueError("MFSDP v2 requires symmetric registration when nccl_ub is enabled.")
         if ddp_config.fsdp_manual_registration:
             raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
-        if ddp_config.delay_wgrad_compute:
-            raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
         if ddp_config.num_buckets is not None:
             raise ValueError("MFSDP v2 does not support num_buckets.")
         if ddp_config.megatron_fsdp_use_decoupled_grad:
@@ -820,6 +833,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
     def finish_grad_sync(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 gradient reduction is complete when backward returns."""
+        # Under the custom schedule like 1F1B, post_backward_final_callback is not invoked.
+        # Synchronize gradients here to ensure it is safe to call optimizer.step().
+        context = self.module.context
+        context.current_stream().wait_stream(context.reduce_scatter_stream)
 
     def synchronize_param_gather(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 parameter gathers complete inside module hooks."""
@@ -832,6 +849,19 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
     def stop_communication(self) -> None:
         """MFSDP v2 communication is complete when backward returns."""
+
+    @contextmanager
+    def no_sync(self):
+        """
+        Context manager that turns off gradient synchronization.
+        For grads shard mode there will actually always be gradient sync happening.
+        """
+        context = self.module.context
+        context.is_last_microbatch = False
+        try:
+            yield
+        finally:
+            context.is_last_microbatch = True
 
 
 def FullyShardedDataParallel(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -160,7 +160,7 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
-    _post_backward_hook_registered: bool
+    _grad_reduction_callback_registered: bool
     _is_root: bool
     _num_trainable_parameters: int
     _schedule_policy: SchedulePolicy
@@ -194,7 +194,7 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         self._schedule_policy = schedule_policy
-        self._post_backward_hook_registered = False
+        self._grad_reduction_callback_registered = False
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -290,7 +290,7 @@ class FsdpModule:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
-        if self._post_backward_hook_registered:
+        if self._grad_reduction_callback_registered:
             raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
 
         module = cast(nn.Module, self)
@@ -300,7 +300,7 @@ class FsdpModule:
                     cast(FsdpModule, hooked_module)
                 )
             )
-            self._post_backward_hook_registered = True
+            self._grad_reduction_callback_registered = True
             return
 
         # Gradient reduction for trainable parameters is parameter-completion
@@ -336,7 +336,7 @@ class FsdpModule:
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )
-        self._post_backward_hook_registered = True
+        self._grad_reduction_callback_registered = True
 
     @staticmethod
     def _pre_load_state_dict(
@@ -381,7 +381,15 @@ class FsdpModule:
         self.unshard(prefetch="forward" if not is_recomputing else "none")
 
     def unshard(self, prefetch: Literal["forward", "backward", "none"] = "none") -> None:
-        """Unshard this FsdpModule's parameter groups immediately."""
+        """Unshard this FsdpModule's parameter groups immediately.
+
+        External schedulers invoking this directly (rather than through the
+        automatic ``pre_forward`` hook) must first synchronize the all-gather
+        stream on the root by calling
+        ``context.allgather_stream.wait_stream(context.current_stream())``
+        before this when ``self.is_root()``; the automatic forward path
+        performs that root sync in ``pre_forward()`` immediately before this.
+        """
         torch.cuda.nvtx.range_push(self._nvtx_label("unshard"))
         self._unshard_parameter_groups()
         assert self._unshard_event is not None

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -15,7 +15,8 @@
 """Module mixin for the minimal Megatron-FSDP path."""
 
 import enum
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Literal, cast
 from weakref import ref
 
@@ -375,6 +376,9 @@ class FsdpModule:
         is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
+        # forward/backward each span multiple lifecycle methods (pre_forward ->
+        # post_forward and pre_backward -> post_backward), so they keep explicit
+        # push/pop instead of a single context scope.
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
 
         if self.is_root():
@@ -392,23 +396,22 @@ class FsdpModule:
         before this when ``self.is_root()``; the automatic forward path
         performs that root sync in ``pre_forward()`` immediately before this.
         """
-        torch.cuda.nvtx.range_push(self._nvtx_label("unshard"))
-        self._unshard_parameter_groups()
-        assert self._unshard_event is not None
-        # Compute waits only for this FsdpModule's all-gather (the prefetch below is
-        # issued afterwards, so it is free to run concurrently with this FsdpModule).
-        self.context.current_stream().wait_event(self._unshard_event)
+        with self._nvtx_range("unshard"):
+            self._unshard_parameter_groups()
+            assert self._unshard_event is not None
+            # Compute waits only for this FsdpModule's all-gather (the prefetch below is
+            # issued afterwards, so it is free to run concurrently with this FsdpModule).
+            self.context.current_stream().wait_event(self._unshard_event)
 
-        context = self.context
-        if prefetch == "forward":
-            self._prefetch_parameter_groups(
-                context.forward_order, self._schedule_policy.forward_prefetch_size
-            )
-        elif prefetch == "backward":
-            self._prefetch_parameter_groups(
-                context.backward_order, self._schedule_policy.backward_prefetch_size
-            )
-        torch.cuda.nvtx.range_pop()
+            context = self.context
+            if prefetch == "forward":
+                self._prefetch_parameter_groups(
+                    context.forward_order, self._schedule_policy.forward_prefetch_size
+                )
+            elif prefetch == "backward":
+                self._prefetch_parameter_groups(
+                    context.backward_order, self._schedule_policy.backward_prefetch_size
+                )
 
     def _prefetch_parameter_groups(
         self, order: IndexedOrder["FsdpModule"], prefetch_size: int | None
@@ -457,9 +460,8 @@ class FsdpModule:
 
     def reshard(self) -> None:
         """Reshard this FsdpModule's parameter groups."""
-        torch.cuda.nvtx.range_push(self._nvtx_label("reshard"))
-        self._reshard_parameter_groups()
-        torch.cuda.nvtx.range_pop()
+        with self._nvtx_range("reshard"):
+            self._reshard_parameter_groups()
 
     def _reshard_parameter_groups(self) -> None:
         """Reshard parameter groups and release unsharded storage after compute.
@@ -507,25 +509,26 @@ class FsdpModule:
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""
-        torch.cuda.nvtx.range_push(self._nvtx_label("gradient_reduce"))
-        context = self.context
-        reduce_scatter_stream = context.reduce_scatter_stream
-        current_stream = context.current_stream()
+        with self._nvtx_range("gradient_reduce"):
+            context = self.context
+            reduce_scatter_stream = context.reduce_scatter_stream
+            current_stream = context.current_stream()
 
-        for group in self._parameter_groups:
-            if not group.requires_grad:
-                continue
+            for group in self._parameter_groups:
+                if not group.requires_grad:
+                    continue
 
-            with torch.cuda.stream(reduce_scatter_stream):
-                partial_grad = group.allocate_partial_grad_buffer()
+                with torch.cuda.stream(reduce_scatter_stream):
+                    partial_grad = group.allocate_partial_grad_buffer()
 
-            current_stream.wait_stream(reduce_scatter_stream)
-            group.copy_gradients_to_partial_buffer(partial_grad)
+                current_stream.wait_stream(reduce_scatter_stream)
+                group.copy_gradients_to_partial_buffer(partial_grad)
 
-            reduce_scatter_stream.wait_stream(current_stream)
-            with torch.cuda.stream(reduce_scatter_stream):
-                group.reduce_partial_gradients(partial_grad, self.context.is_last_microbatch)
-        torch.cuda.nvtx.range_pop()
+                reduce_scatter_stream.wait_stream(current_stream)
+                with torch.cuda.stream(reduce_scatter_stream):
+                    group.reduce_partial_gradients(
+                        partial_grad, self.context.is_last_microbatch
+                    )
 
     @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
@@ -544,6 +547,15 @@ class FsdpModule:
     def _nvtx_label(self, operation: str) -> str:
         module_name = self.name or "<root>"
         return f"MFSDP {module_name} {operation}"
+
+    @contextmanager
+    def _nvtx_range(self, operation: str) -> Iterator[None]:
+        """Scope an nvtx range to this context so an early return still pops it."""
+        torch.cuda.nvtx.range_push(self._nvtx_label(operation))
+        try:
+            yield
+        finally:
+            torch.cuda.nvtx.range_pop()
 
 
 def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -472,8 +472,8 @@ class FsdpModule:
     def pre_backward(self) -> None:
         """Prepare full parameters and prefetch the next FsdpModule in backward order."""
         self.phase = FsdpModule.Phase.BACKWARD
-        context = self.context
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
+        context = self.context
         current_stream = context.current_stream()
         if self.is_root():
             context.register_post_backward_final_callback()

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -160,7 +160,6 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
-    _grad_reduction_callback_registered: bool
     _is_root: bool
     _num_trainable_parameters: int
     _schedule_policy: SchedulePolicy
@@ -194,7 +193,6 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         self._schedule_policy = schedule_policy
-        self._grad_reduction_callback_registered = False
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -226,6 +224,10 @@ class FsdpModule:
                 if group.requires_grad
             )
         )
+        # The state-dict safety hook is registered unconditionally. It is still
+        # required to keep loading a state dict safe when ``register_hooks`` is
+        # False (i.e. execution hooks are disabled), so it must not be turned off
+        # together with the auto-execution hooks below.
         self.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
         if register_hooks:
             self._register_hooks()
@@ -279,20 +281,22 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
-        self.register_grad_reduction_callback(FsdpModule.post_backward)
+        self.register_post_backward_hook(FsdpModule.post_backward)
 
-    def register_grad_reduction_callback(
+    def register_post_backward_hook(
         self, post_backward_hook: Callable[["FsdpModule"], None]
     ) -> None:
-        """Register a callback to run gradient reduction when this module's backward is complete.
+        """Register a post-backward hook to run after this module's backward completes.
+
+        The hook runs when this module's backward is complete, so it can reshard
+        this module's parameters and reduce their gradients. It is invoked once
+        all of this module's trainable parameters have accumulated gradients, or
+        via a full-backward hook when the module owns no trainable parameters.
 
         Args:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
-        if self._grad_reduction_callback_registered:
-            raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
-
         module = cast(nn.Module, self)
         if self._trainable_parameter_countdown.initial_value == 0:
             module.register_full_backward_hook(
@@ -300,7 +304,6 @@ class FsdpModule:
                     cast(FsdpModule, hooked_module)
                 )
             )
-            self._grad_reduction_callback_registered = True
             return
 
         # Gradient reduction for trainable parameters is parameter-completion
@@ -336,7 +339,6 @@ class FsdpModule:
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )
-        self._grad_reduction_callback_registered = True
 
     @staticmethod
     def _pre_load_state_dict(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -279,19 +279,19 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
-        self.register_post_backward_hook(FsdpModule.post_backward)
+        self.register_grad_reduction_callback(FsdpModule.post_backward)
 
-    def register_post_backward_hook(
+    def register_grad_reduction_callback(
         self, post_backward_hook: Callable[["FsdpModule"], None]
     ) -> None:
-        """Register a callback to run when this module's backward is complete.
+        """Register a callback to run gradient reduction when this module's backward is complete.
 
         Args:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
         if self._post_backward_hook_registered:
-            raise RuntimeError("This FSDP module already has a post-backward hook registered.")
+            raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
 
         module = cast(nn.Module, self)
         if self._trainable_parameter_countdown.initial_value == 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -469,22 +469,14 @@ class FsdpModule:
                 group.release_unsharded_storage()
             self._unshard_event = None
 
-    def pre_backward(self, register_final_callback: bool = True) -> None:
-        """Prepare full parameters and prefetch the next FsdpModule in backward order.
-
-        Args:
-            register_final_callback: Whether to finalize through the autograd engine.
-                Manual backward schedules (e.g. 1F1B EP overlap schedule) finalize
-                explicitly in ``post_backward()``, so they pass False to avoid
-                installing an autograd callback outside the backward pass.
-        """
+    def pre_backward(self) -> None:
+        """Prepare full parameters and prefetch the next FsdpModule in backward order."""
         self.phase = FsdpModule.Phase.BACKWARD
         context = self.context
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         current_stream = context.current_stream()
         if self.is_root():
-            if register_final_callback:
-                context.register_post_backward_final_callback()
+            context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
             # part of any active CUDA-graph capture. A stream only joins the

--- a/megatron/core/models/common/fine_grained_mfsdp_scheduler.py
+++ b/megatron/core/models/common/fine_grained_mfsdp_scheduler.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from weakref import ref
+
+from torch import nn
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+
+_MFSDP_PARENT_MODULE_REF_ATTR = "_fsdp_parent_module_ref"
+_MFSDP_SCHEDULER_ATTR = "_fsdp_scheduler"
+
+
+def _get_owning_fsdp_module(submodule: nn.Module) -> FsdpModule | None:
+    """Return the FsdpModule that owns a fine-grained schedule submodule."""
+    if isinstance(submodule, FsdpModule):
+        return submodule
+    parent_ref = getattr(submodule, _MFSDP_PARENT_MODULE_REF_ATTR, None)
+    return parent_ref() if parent_ref is not None else None
+
+
+def _unshard_before_submodule_forward(submodule: nn.Module, _args, _kwargs) -> None:
+    """Materialize the owning FSDP unit before a schedule sub-module runs."""
+    fsdp_module = _get_owning_fsdp_module(submodule)
+    assert fsdp_module is not None, "FSDP module not found for submodule."
+    if fsdp_module.is_root():
+        context = fsdp_module.context
+        context.allgather_stream.wait_stream(context.current_stream())
+
+    fsdp_module.unshard()
+
+
+def _unshard_before_submodule_backward(submodule: nn.Module, _grad_output) -> None:
+    """Enter the owning FSDP unit's backward lifecycle before sub-module backward."""
+    fsdp_module = _get_owning_fsdp_module(submodule)
+    assert fsdp_module is not None, "FSDP module not found for submodule."
+    fsdp_module.unshard()
+    if fsdp_module.is_root():
+        context = fsdp_module.context
+        context.reduce_scatter_stream.wait_stream(context.current_stream())
+
+
+def _set_owning_fsdp_module_refs(module: FsdpModule) -> None:
+    """Recursively set the nearest FsdpModule reference on all sub-modules.
+
+    This is used by fine-grained schedules to find the owning FSDP unit for a
+    sub-module without traversing the module tree.
+    """
+
+    def register_refs(submodule: nn.Module, owner: FsdpModule) -> None:
+        """Register references recursively while preserving the nearest FSDP owner."""
+        if isinstance(submodule, FsdpModule):
+            owner = submodule
+        object.__setattr__(submodule, _MFSDP_PARENT_MODULE_REF_ATTR, ref(owner))
+        for child in submodule.children():
+            register_refs(child, owner)
+
+    register_refs(module, module)
+
+
+def _register_combined_1f1b_hooks(module: FsdpModule) -> None:
+    """Install the sub-module hooks required by MCore combined 1F1B."""
+
+    for submodule in module.modules():
+        submodule.register_forward_pre_hook(
+            _unshard_before_submodule_forward, prepend=True, with_kwargs=True
+        )
+        submodule.register_full_backward_pre_hook(_unshard_before_submodule_backward)
+
+
+def reshard_fsdp_module(module: FsdpModule) -> None:
+    """Reshard the FSDP module after fine-grained computation."""
+    assert isinstance(module, FsdpModule), "Expected an FsdpModule."
+    module.reshard()
+
+
+def setup_combined_1f1b_hooks(module: nn.Module) -> None:
+    """Install the parameter lifecycle hooks used by combined 1F1B."""
+    # The scheduler is driven by the submodule hooks below; it must not rely on
+    # the static prefetch/lifecycle assumptions of the automatic FSDP hooks. The
+    # FSDP unit's own idempotent ``unshard()``/``reshard()`` are used directly so
+    # the scheduler works on the generic MFSDP v2 lifecycle.
+    root_modules = [
+        submodule
+        for submodule in module.modules()
+        if isinstance(submodule, FsdpModule) and submodule.is_root()
+    ]
+    assert root_modules, "Root FSDP module not found."
+
+    for root_module in root_modules:
+        if hasattr(root_module, _MFSDP_SCHEDULER_ATTR):
+            continue
+        _set_owning_fsdp_module_refs(root_module)
+        _register_combined_1f1b_hooks(root_module)
+        object.__setattr__(root_module, _MFSDP_SCHEDULER_ATTR, True)

--- a/megatron/core/models/common/fine_grained_mfsdp_scheduler.py
+++ b/megatron/core/models/common/fine_grained_mfsdp_scheduler.py
@@ -57,6 +57,17 @@ def _set_owning_fsdp_module_refs(module: FsdpModule) -> None:
     register_refs(module, module)
 
 
+def reshard_fsdp_module(module: FsdpModule) -> None:
+    """Reshard the FSDP module after fine-grained computation."""
+    assert isinstance(module, FsdpModule), "Expected an FsdpModule."
+    module.reshard()
+
+
+def module_post_backward_hook(module: FsdpModule) -> None:
+    reshard_fsdp_module(module)
+    module._reduce_gradient_groups()
+
+
 def _register_combined_1f1b_hooks(module: FsdpModule) -> None:
     """Install the sub-module hooks required by MCore combined 1F1B."""
 
@@ -65,12 +76,8 @@ def _register_combined_1f1b_hooks(module: FsdpModule) -> None:
             _unshard_before_submodule_forward, prepend=True, with_kwargs=True
         )
         submodule.register_full_backward_pre_hook(_unshard_before_submodule_backward)
-
-
-def reshard_fsdp_module(module: FsdpModule) -> None:
-    """Reshard the FSDP module after fine-grained computation."""
-    assert isinstance(module, FsdpModule), "Expected an FsdpModule."
-    module.reshard()
+        if isinstance(submodule, FsdpModule):
+            submodule.register_post_backward_hook(module_post_backward_hook)
 
 
 def setup_combined_1f1b_hooks(module: nn.Module) -> None:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -6,8 +6,13 @@ from typing import Any, Callable, Optional
 import torch
 from torch import Tensor
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.enums import Fp8Recipe
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.models.common.fine_grained_mfsdp_scheduler import (
+    reshard_fsdp_module,
+    setup_combined_1f1b_hooks,
+)
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     NoopScheduleNode,
@@ -434,6 +439,15 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             self.post_process = post_process_cls(
                 model, self._model_chunk_state, self._event, get_comp_stream
             )
+
+        # setup FSDP hooks
+        has_fsdp_module = any(isinstance(submodule, FsdpModule) for submodule in model.modules())
+        if has_fsdp_module:
+            setup_combined_1f1b_hooks(model)
+            for layer_plan in self._transformer_layers:
+                # Forward resharding follows the schedule. Backward resharding and
+                # reduction are triggered by each FsdpModule's gradient countdown.
+                layer_plan.set_fsdp_reshard_hooks(reshard_fsdp_module, lambda _: None)
 
     def _build_layer_schedule_plan(self, module, comp_stream, comm_stream):
         if module is None:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -9,10 +9,7 @@ from torch import Tensor
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.enums import Fp8Recipe
 from megatron.core.fp8_utils import get_fp8_context
-from megatron.core.models.common.fine_grained_mfsdp_scheduler import (
-    reshard_fsdp_module,
-    setup_combined_1f1b_hooks,
-)
+from megatron.core.models.common.fine_grained_mfsdp_scheduler import reshard_fsdp_module
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     NoopScheduleNode,
@@ -443,7 +440,6 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         # setup FSDP hooks
         has_fsdp_module = any(isinstance(submodule, FsdpModule) for submodule in model.modules())
         if has_fsdp_module:
-            setup_combined_1f1b_hooks(model)
             for layer_plan in self._transformer_layers:
                 # Forward resharding follows the schedule. Backward resharding and
                 # reduction are triggered by each FsdpModule's gradient countdown.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -88,7 +88,7 @@ def _setup_nvtx_recording(monkeypatch: pytest.MonkeyPatch, events: list[NvtxEven
     monkeypatch.setattr(torch.cuda.nvtx, "range_pop", record_pop)
 
 
-def _lifecycle_events(events: list[NvtxEvent]) -> list[NvtxEvent]:
+def _forward_backward_events(events: list[NvtxEvent]) -> list[NvtxEvent]:
     """Return the forward/backward ranges asserted by the lifecycle tests."""
     return [event for event in events if event.operation in ("forward", "backward")]
 
@@ -136,7 +136,7 @@ def test_fsdp_sibling_roots_emit_root_nvtx_ranges_after_training_step(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "forward"),
@@ -161,7 +161,7 @@ def test_fsdp_training_hooks_emit_stacked_nvtx_ranges(distributed_setup, monkeyp
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -191,7 +191,7 @@ def test_fsdp_frozen_parameters_emit_balanced_backward_nvtx_range(distributed_se
     x = torch.ones(2, 4, device=distributed_setup.device, requires_grad=True)
     model(x).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),
@@ -216,7 +216,7 @@ def test_fsdp_frozen_child_without_grad_inputs_skips_backward_nvtx_range(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -244,7 +244,7 @@ def test_tied_child_parameters_complete_backward_once_per_cycle(distributed_setu
         model.zero_grad(set_to_none=True)
         model(token_ids).backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -179,7 +179,7 @@ def test_fully_shard_can_disable_execution_hooks(distributed_setup):
                 assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
 
 
-def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
+def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(distributed_setup):
     """An external scheduler callback should run once all owned gradients are ready."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -196,7 +196,7 @@ def test_register_post_backward_hook_waits_for_all_parameter_gradients(distribut
     ]
     assert len(parameters) == 2
     callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
+    model.register_grad_reduction_callback(callback_modules.append)
 
     parameter_hooks = []
     for parameter in parameters:
@@ -212,7 +212,7 @@ def test_register_post_backward_hook_waits_for_all_parameter_gradients(distribut
     assert callback_modules == [model]
 
 
-def test_register_post_backward_hook_rejects_duplicate_registration(distributed_setup):
+def test_register_grad_reduction_callback_rejects_duplicate_registration(distributed_setup):
     """An FSDP unit should accept only one post-backward callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -221,12 +221,12 @@ def test_register_post_backward_hook_rejects_duplicate_registration(distributed_
     with fully_shard_context(device=device):
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
-    model.register_post_backward_hook(lambda _module: None)
-    with pytest.raises(RuntimeError, match="already has a post-backward hook registered"):
-        model.register_post_backward_hook(lambda _module: None)
+    model.register_grad_reduction_callback(lambda _module: None)
+    with pytest.raises(RuntimeError, match="already has a grad-reduction callback registered"):
+        model.register_grad_reduction_callback(lambda _module: None)
 
 
-def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
+def test_register_grad_reduction_callback_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -236,7 +236,7 @@ def test_register_post_backward_hook_handles_parameterless_module(distributed_se
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
     callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
+    model.register_grad_reduction_callback(callback_modules.append)
     model(torch.ones(2, 4, device=device, requires_grad=True)).sum().backward()
 
     assert callback_modules == [model]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -158,60 +158,6 @@ def test_nested_prefetch_orders_use_dfs(distributed_setup):
     assert list(context.backward_order) == [model, model.right, model.left, model.left.inner]
 
 
-def test_fully_shard_can_disable_execution_hooks(distributed_setup):
-    """An external scheduler can disable execution hooks without disabling load safety."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = NestedModel().to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model.inner, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    for fsdp_module in (model, model.inner):
-        assert not fsdp_module._forward_pre_hooks
-        assert not fsdp_module._forward_hooks
-        assert not fsdp_module._backward_pre_hooks
-        assert not fsdp_module._backward_hooks
-        assert len(fsdp_module._load_state_dict_pre_hooks) == 1
-        for group in fsdp_module.parameter_groups:
-            for fsdp_parameter in group.fsdp_parameters:
-                assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
-
-
-def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
-    """An external scheduler callback should run once all owned gradients are ready."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    parameters = [
-        fsdp_parameter.unsharded
-        for group in model.parameter_groups
-        if group.requires_grad
-        for fsdp_parameter in group.fsdp_parameters
-    ]
-    assert len(parameters) == 2
-    callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
-
-    parameter_hooks = []
-    for parameter in parameters:
-        hooks = getattr(parameter, "_post_accumulate_grad_hooks", None)
-        assert hooks is not None and len(hooks) == 1
-        parameter_hooks.append(next(iter(hooks.values())))
-
-    for parameter, hook in zip(parameters[:-1], parameter_hooks[:-1]):
-        hook(parameter)
-    assert callback_modules == []
-
-    parameter_hooks[-1](parameters[-1])
-    assert callback_modules == [model]
-
-
 def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
@@ -304,33 +250,3 @@ def test_fully_shard_rejects_child_from_another_context(distributed_setup):
             fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     assert model.inner.context is first_context
-
-
-def test_multiple_forwards_before_backwards_reset_gradient_readiness(
-    distributed_setup, monkeypatch
-):
-    """Consecutive pipeline backwards should each finalize gradient reduction."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements())
-
-    reduce_calls = []
-    original_reduce_gradient_groups = model._reduce_gradient_groups
-
-    def record_reduce_gradient_groups() -> None:
-        reduce_calls.append(None)
-        original_reduce_gradient_groups()
-
-    monkeypatch.setattr(model, "_reduce_gradient_groups", record_reduce_gradient_groups)
-
-    # Pipeline warmup may run multiple forwards before cooldown runs consecutive
-    # backwards. Each backward must reset the parameter-completion counter.
-    losses = [model(torch.ones(2, 4, device=device)).sum() for _ in range(2)]
-    for loss in reversed(losses):
-        loss.backward()
-
-    assert len(reduce_calls) == 2
-    assert model.phase is model.Phase.RESTING

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -179,7 +179,7 @@ def test_fully_shard_can_disable_execution_hooks(distributed_setup):
                 assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
 
 
-def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(distributed_setup):
+def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
     """An external scheduler callback should run once all owned gradients are ready."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -196,7 +196,7 @@ def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(dist
     ]
     assert len(parameters) == 2
     callback_modules = []
-    model.register_grad_reduction_callback(callback_modules.append)
+    model.register_post_backward_hook(callback_modules.append)
 
     parameter_hooks = []
     for parameter in parameters:
@@ -212,21 +212,7 @@ def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(dist
     assert callback_modules == [model]
 
 
-def test_register_grad_reduction_callback_rejects_duplicate_registration(distributed_setup):
-    """An FSDP unit should accept only one post-backward callback."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    model.register_grad_reduction_callback(lambda _module: None)
-    with pytest.raises(RuntimeError, match="already has a grad-reduction callback registered"):
-        model.register_grad_reduction_callback(lambda _module: None)
-
-
-def test_register_grad_reduction_callback_handles_parameterless_module(distributed_setup):
+def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -236,7 +222,7 @@ def test_register_grad_reduction_callback_handles_parameterless_module(distribut
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
     callback_modules = []
-    model.register_grad_reduction_callback(callback_modules.append)
+    model.register_post_backward_hook(callback_modules.append)
     model(torch.ones(2, 4, device=device, requires_grad=True)).sum().backward()
 
     assert callback_modules == [model]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
@@ -1,0 +1,425 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""End-to-end EP 1F1B-overlap parity for MFSDP v2.
+
+Train the same small GPT model under MFSDP v2 and the distributed-optimizer
+reference, then compare per-step losses and parameter snapshots.  The helpers
+are local to this test because the MFSDP v1 test utilities now build only
+HybridModel.
+"""
+
+import os
+import sys
+from functools import partial
+
+import pytest
+import torch
+from torch.distributed.tensor import DTensor
+from torch.testing import assert_close
+
+import megatron.core.parallel_state as mpu
+from gpt_builders import gpt_builder
+from megatron.core.distributed import finalize_model_grads
+from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+    gather_and_compute_chunk_metadata,
+    uneven_dtensor_to_full_tensor,
+)
+from megatron.core.enums import ModelType
+from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.utils import is_te_min_version, is_torch_min_version
+from megatron.training.arguments import parse_args, validate_args
+from megatron.training.global_vars import destroy_global_vars, set_global_variables
+from megatron.training.training import setup_model_and_optimizer
+from model_provider import model_provider
+from tests.unit_tests.test_utilities import Utils
+
+
+def _set_manual_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    model_parallel_cuda_manual_seed(seed)
+
+
+def _make_mock_data_iterator(
+    *,
+    dp_group: torch.distributed.ProcessGroup,
+    num_batches: int,
+    batch_size: int,
+    sequence_length: int,
+    vocab_size: int,
+    seed: int,
+):
+    """Yield deterministic, rank-local GPT batches for both training runs."""
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed + 1009 * dp_group.rank())
+    position_ids = torch.arange(sequence_length, dtype=torch.int64).unsqueeze(0)
+    attention_mask = torch.triu(
+        torch.ones((1, sequence_length, sequence_length), dtype=torch.bool), diagonal=1
+    )
+
+    for _ in range(num_batches):
+        tokens = torch.randint(
+            vocab_size, (batch_size, sequence_length), dtype=torch.int64, generator=generator
+        )
+        yield {
+            "tokens": tokens,
+            "labels": (tokens + 1) % vocab_size,
+            "loss_mask": torch.ones((batch_size, sequence_length), dtype=torch.float32),
+            "attention_mask": attention_mask.expand(batch_size, -1, -1, -1),
+            "position_ids": position_ids.expand(batch_size, -1),
+        }
+
+
+def _forward_step_func(data_iterator, model, return_schedule_plan: bool = False):
+    """Run eager forward or build the plan required by combined 1F1B."""
+    data = next(data_iterator)
+    tokens = data["tokens"].cuda(non_blocking=True)
+    labels = data["labels"].cuda(non_blocking=True)
+    loss_mask = data["loss_mask"].cuda(non_blocking=True)
+    attention_mask = data["attention_mask"].cuda(non_blocking=True)
+    position_ids = data["position_ids"].cuda(non_blocking=True)
+
+    def loss_func(output_tensor):
+        losses = output_tensor.float().view(-1)
+        flat_loss_mask = loss_mask.view(-1).float()
+        loss = torch.sum(losses * flat_loss_mask) / flat_loss_mask.sum()
+        # The overlap schedule releases the loss node after backward.  Retain a
+        # standalone value for the end-to-end comparison.
+        return loss, {"lm loss": loss.detach().clone()}
+
+    if return_schedule_plan:
+        schedule_plan = model.build_schedule_plan(
+            tokens, position_ids, attention_mask, labels=labels, loss_mask=loss_mask
+        )
+        return schedule_plan, loss_func
+
+    output_tensor = model(tokens, position_ids, attention_mask, labels=labels)
+    return output_tensor, loss_func
+
+
+def _pretrain_forward_backward(
+    *, model, data_iterator, sequence_length: int, micro_batch_size: int, num_micro_batches: int
+):
+    forward_backward_func = get_forward_backward_func()
+    return forward_backward_func(
+        forward_step_func=_forward_step_func,
+        data_iterator=data_iterator,
+        model=model,
+        num_microbatches=num_micro_batches,
+        seq_length=sequence_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+    )
+
+
+def _make_model_and_optimizer(*, use_mfsdp_v2: bool, overrides: dict):
+    """Build a small MoE GPT through the current pretrain configuration API."""
+    base_args = {
+        "num_layers": 4,
+        "hidden_size": 128,
+        "num_attention_heads": 2,
+        "max_position_embeddings": 128,
+        "bf16": False,
+        "add_bias_linear": False,
+        "swiglu": True,
+        "position_embedding_type": "rope",
+        "rotary_percent": 1.0,
+        "hidden_dropout": 0.0,
+        "attention_dropout": 0.0,
+        "num_experts": 4,
+        "moe_shared_expert_intermediate_size": 256,
+        "moe_layer_freq": [0, 0, 1, 1],
+        "moe_permute_fusion": True,
+        "moe_router_fusion": True,
+        "moe_router_topk": 2,
+        "moe_router_dtype": "fp32",
+        "create_attention_mask_in_dataloader": True,
+        "lr": 3e-5,
+        "min_lr": 3e-5,
+        "use_distributed_optimizer": not use_mfsdp_v2,
+        "use_megatron_fsdp": use_mfsdp_v2,
+        "megatron_fsdp_version": 2,
+        "ckpt_format": "fsdp_dtensor" if use_mfsdp_v2 else "torch_dist",
+        "gradient_accumulation_fusion": False,
+        "finalize_model_grads_func": finalize_model_grads,
+        "spec": None,
+        "mtp_num_layers": None,
+    }
+    base_args.update(overrides)
+
+    original_argv = sys.argv
+    try:
+        sys.argv = [__file__]
+        args = parse_args()
+    finally:
+        sys.argv = original_argv
+    for key, value in base_args.items():
+        setattr(args, key, value)
+    validate_args(args)
+
+    destroy_global_vars()
+    destroy_num_microbatches_calculator()
+    set_global_variables(args, build_tokenizer=False)
+
+    cfg_container = Utils.pretrain_config_from_global_args(args, "gpt")
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    model, optimizer, _ = setup_model_and_optimizer(
+        model_type=ModelType.encoder_or_decoder,
+        model_provider_func=partial(model_provider, gpt_builder),
+        cfg_container=cfg_container,
+        pg_collection=pg_collection,
+    )
+    return model, optimizer
+
+
+class TestMfsdpV2OverlapParity:
+    NUM_STEPS = 20
+    SEQUENCE_LENGTH = 64
+    MICRO_BATCH_SIZE = 1
+    GLOBAL_BATCH_SIZE = 8
+    VOCAB_SIZE = 100
+
+    def teardown_method(self):
+        destroy_global_vars()
+        destroy_num_microbatches_calculator()
+
+    @staticmethod
+    def _normalize_parameter_name(name: str) -> str:
+        while name.startswith("module."):
+            name = name[len("module.") :]
+        return name
+
+    @classmethod
+    def _capture_parameters(cls, model):
+        parameters = {}
+        for chunk_index, model_chunk in enumerate(model):
+            for name, parameter in model_chunk.named_parameters():
+                tensor = parameter.detach()
+                if isinstance(tensor, DTensor):
+                    tensor = uneven_dtensor_to_full_tensor(tensor)
+                name = cls._normalize_parameter_name(name)
+                parameters[f"{chunk_index}.{name}"] = tensor.float().cpu()
+        return parameters
+
+    @classmethod
+    def _load_parameters(cls, model, reference_parameters):
+        with torch.no_grad():
+            for chunk_index, model_chunk in enumerate(model):
+                for name, parameter in model_chunk.named_parameters():
+                    name = cls._normalize_parameter_name(name)
+                    reference = reference_parameters[f"{chunk_index}.{name}"].to(
+                        device=parameter.device, dtype=parameter.dtype
+                    )
+                    tensor = parameter.detach()
+                    if isinstance(tensor, DTensor):
+                        chunk = gather_and_compute_chunk_metadata(tensor)
+                        local_slice = tuple(
+                            slice(offset, offset + size)
+                            for offset, size in zip(chunk.offsets, chunk.sizes)
+                        )
+                        tensor._local_tensor.copy_(reference[local_slice])
+                    else:
+                        tensor.copy_(reference)
+
+    @classmethod
+    def _run_training(cls, *, use_mfsdp_v2: bool, initial_parameters=None):
+        Utils.initialize_model_parallel(expert_model_parallel_size=2)
+        data_parallel_group = mpu.get_data_parallel_group()
+        _set_manual_seed(42)
+
+        try:
+            model, optimizer = _make_model_and_optimizer(
+                use_mfsdp_v2=use_mfsdp_v2,
+                overrides={
+                    "micro_batch_size": cls.MICRO_BATCH_SIZE,
+                    "global_batch_size": cls.GLOBAL_BATCH_SIZE,
+                    "vocab_size": cls.VOCAB_SIZE,
+                    "padded_vocab_size": cls.VOCAB_SIZE,
+                    "untie_embeddings_and_output_weights": True,
+                    "seq_length": cls.SEQUENCE_LENGTH,
+                    "train_iters": cls.NUM_STEPS,
+                    "expert_model_parallel_size": 2,
+                    "bf16": True,
+                    "data_parallel_sharding_strategy": "optim_grads_params",
+                    "clip_grad": 0.0,
+                    "megatron_fsdp_main_grads_dtype": torch.float32,
+                    "moe_grouped_gemm": True,
+                    "moe_token_dispatcher_type": "alltoall",
+                    "overlap_moe_expert_parallel_comm": True,
+                    "delay_wgrad_compute": True,
+                },
+            )
+            if use_mfsdp_v2 and os.environ.get("MFSDP_PARITY_DEBUG"):
+                for model_chunk in model:
+                    adapter = model_chunk
+                    while not hasattr(adapter, "post_backward"):
+                        adapter = adapter.module
+                    root = adapter.module
+                    source_model = root
+                    while not hasattr(source_model, "decoder"):
+                        source_model = source_model.module
+                    final_layernorm = source_model.decoder.final_layernorm
+                    final_layernorm.register_forward_hook(
+                        lambda _module, _inputs, _output: print(
+                            f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
+                            "final_layernorm forward",
+                            flush=True,
+                        )
+                    )
+                    for group in root.parameter_groups:
+                        for fsdp_parameter in group.fsdp_parameters:
+                            if not any(
+                                fqn.endswith("decoder.final_layernorm.weight")
+                                for fqn in fsdp_parameter.fqns
+                            ):
+                                continue
+                            fsdp_parameter.unsharded.register_post_accumulate_grad_hook(
+                                lambda parameter: print(
+                                    f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
+                                    "final_layernorm grad ready "
+                                    f"none={parameter.grad is None}",
+                                    flush=True,
+                                )
+                            )
+
+                    original_reduce_gradient_groups = root._reduce_gradient_groups
+
+                    def debug_reduce_gradient_groups(
+                        *, root=root, original=original_reduce_gradient_groups
+                    ):
+                        missing = [
+                            fsdp_parameter.fqns
+                            for group in root.parameter_groups
+                            for fsdp_parameter in group.fsdp_parameters
+                            if group.requires_grad and fsdp_parameter.unsharded.grad is None
+                        ]
+                        countdown = root._trainable_parameter_countdown
+                        print(
+                            f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
+                            f"root reduce phase={root.phase} "
+                            f"countdown={countdown._value}/{countdown.initial_value} "
+                            f"missing={missing}",
+                            flush=True,
+                        )
+                        return original()
+
+                    root._reduce_gradient_groups = debug_reduce_gradient_groups
+            if initial_parameters is not None:
+                cls._load_parameters(model, initial_parameters)
+                for sub_optimizer in getattr(optimizer, "chained_optimizers", [optimizer]):
+                    sub_optimizer._copy_main_params_to_model_params()
+
+            captured_initial_parameters = cls._capture_parameters(model)
+            num_micro_batches = (
+                cls.GLOBAL_BATCH_SIZE // cls.MICRO_BATCH_SIZE // data_parallel_group.size()
+            )
+            data_iterator = _make_mock_data_iterator(
+                dp_group=data_parallel_group,
+                num_batches=cls.NUM_STEPS * num_micro_batches,
+                batch_size=cls.MICRO_BATCH_SIZE,
+                sequence_length=cls.SEQUENCE_LENGTH,
+                vocab_size=cls.VOCAB_SIZE,
+                seed=42,
+            )
+            losses = []
+            parameter_snapshots = []
+            run_name = "MFSDP v2" if use_mfsdp_v2 else "DistOpt"
+
+            for step in range(cls.NUM_STEPS):
+                for model_chunk in model:
+                    model_chunk.zero_grad_buffer()
+                optimizer.zero_grad()
+                output = _pretrain_forward_backward(
+                    model=model,
+                    data_iterator=data_iterator,
+                    sequence_length=cls.SEQUENCE_LENGTH,
+                    micro_batch_size=cls.MICRO_BATCH_SIZE,
+                    num_micro_batches=num_micro_batches,
+                )
+                loss = (
+                    torch.stack(
+                        [microbatch_output["lm loss"].detach() for microbatch_output in output]
+                    )
+                    .mean()
+                    .cpu()
+                )
+                update_successful, grad_norm, _ = optimizer.step()
+                losses.append(loss)
+                if torch.distributed.get_rank() == 0:
+                    grad_norm_text = "None" if grad_norm is None else f"{float(grad_norm):.8f}"
+                    print(
+                        f"[{run_name}] step={step + 1}/{cls.NUM_STEPS} "
+                        f"loss={loss.item():.8f} grad_norm={grad_norm_text} "
+                        f"update_successful={update_successful}",
+                        flush=True,
+                    )
+                parameter_snapshots.append(cls._capture_parameters(model))
+
+            return {
+                "initial_parameters": captured_initial_parameters,
+                "losses": losses,
+                "parameters": parameter_snapshots,
+            }
+        finally:
+            Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6.0"),
+        reason="Combined expert-parallel overlap requires PyTorch 2.6.0 or newer.",
+    )
+    @pytest.mark.skipif(
+        not is_te_min_version("2.7.0"),
+        reason="Delayed wgrad without gradient-accumulation fusion requires TE 2.7 or newer.",
+    )
+    def test_compatible_with_nd_parallel(self, distributed_setup):
+        """MFSDP v2 EP delayed-wgrad overlap matches DistOpt without static prefetch."""
+        if (
+            distributed_setup.world_size < 2
+            or distributed_setup.world_size % 2
+            or distributed_setup.world_size > self.GLOBAL_BATCH_SIZE
+        ):
+            pytest.skip("Requires an even world size between two and the global batch size.")
+
+        reference = self._run_training(use_mfsdp_v2=False)
+        if torch.distributed.get_rank() == 0:
+            print("DistOpt reference run completed successfully.", flush=True)
+
+        actual = self._run_training(
+            use_mfsdp_v2=True, initial_parameters=reference["initial_parameters"]
+        )
+        if torch.distributed.get_rank() == 0:
+            print("MFSDP v2 run completed successfully.", flush=True)
+
+        for run_name, run in (("DistOpt", reference), ("MFSDP v2", actual)):
+            changed_parameters = [
+                name
+                for name, initial_parameter in run["initial_parameters"].items()
+                if not torch.equal(initial_parameter, run["parameters"][-1][name])
+            ]
+            assert changed_parameters, f"{run_name} did not update any parameters."
+
+        assert len(actual["losses"]) == len(reference["losses"])
+        for step, (loss, reference_loss) in enumerate(zip(actual["losses"], reference["losses"])):
+            assert_close(
+                loss,
+                reference_loss,
+                atol=0,
+                rtol=0.05,
+                msg=lambda msg: f"Loss mismatch at step {step}: {msg}",
+            )
+
+        assert len(actual["parameters"]) == len(reference["parameters"])
+        for step, (parameters, reference_parameters) in enumerate(
+            zip(actual["parameters"], reference["parameters"])
+        ):
+            assert parameters.keys() == reference_parameters.keys()
+            for name in parameters:
+                assert_close(
+                    parameters[name],
+                    reference_parameters[name],
+                    atol=5e-3,
+                    rtol=1e-3,
+                    msg=lambda msg: f"Parameter {name!r} mismatch at step {step}: {msg}",
+                )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
@@ -8,22 +8,16 @@ are local to this test because the MFSDP v1 test utilities now build only
 HybridModel.
 """
 
-import os
-import sys
 from functools import partial
 
 import pytest
 import torch
-from torch.distributed.tensor import DTensor
 from torch.testing import assert_close
 
 import megatron.core.parallel_state as mpu
 from gpt_builders import gpt_builder
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.distributed import finalize_model_grads
-from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
-    gather_and_compute_chunk_metadata,
-    uneven_dtensor_to_full_tensor,
-)
 from megatron.core.enums import ModelType
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
@@ -149,12 +143,7 @@ def _make_model_and_optimizer(*, use_mfsdp_v2: bool, overrides: dict):
     }
     base_args.update(overrides)
 
-    original_argv = sys.argv
-    try:
-        sys.argv = [__file__]
-        args = parse_args()
-    finally:
-        sys.argv = original_argv
+    args = parse_args(ignore_unknown_args=True)
     for key, value in base_args.items():
         setattr(args, key, value)
     validate_args(args)
@@ -181,50 +170,27 @@ class TestMfsdpV2OverlapParity:
     GLOBAL_BATCH_SIZE = 8
     VOCAB_SIZE = 100
 
-    def teardown_method(self):
-        destroy_global_vars()
-        destroy_num_microbatches_calculator()
+    @classmethod
+    def _capture_parameters(cls, model_chunks):
+        if isinstance(model_chunks, torch.nn.Module):
+            model_chunks = [model_chunks]
 
-    @staticmethod
-    def _normalize_parameter_name(name: str) -> str:
-        while name.startswith("module."):
-            name = name[len("module.") :]
-        return name
+        for module in model_chunks:
+            for submodule in module.modules():
+                if isinstance(submodule, FsdpModule):
+                    submodule.unshard()
+        captured_parameters = {}
+        for module in model_chunks:
+            for name, param in module.named_parameters():
+                captured_parameters[name] = param.detach().clone().cpu()
+        for module in model_chunks:
+            for submodule in module.modules():
+                if isinstance(submodule, FsdpModule):
+                    submodule.reshard()
+        return captured_parameters
 
     @classmethod
-    def _capture_parameters(cls, model):
-        parameters = {}
-        for chunk_index, model_chunk in enumerate(model):
-            for name, parameter in model_chunk.named_parameters():
-                tensor = parameter.detach()
-                if isinstance(tensor, DTensor):
-                    tensor = uneven_dtensor_to_full_tensor(tensor)
-                name = cls._normalize_parameter_name(name)
-                parameters[f"{chunk_index}.{name}"] = tensor.float().cpu()
-        return parameters
-
-    @classmethod
-    def _load_parameters(cls, model, reference_parameters):
-        with torch.no_grad():
-            for chunk_index, model_chunk in enumerate(model):
-                for name, parameter in model_chunk.named_parameters():
-                    name = cls._normalize_parameter_name(name)
-                    reference = reference_parameters[f"{chunk_index}.{name}"].to(
-                        device=parameter.device, dtype=parameter.dtype
-                    )
-                    tensor = parameter.detach()
-                    if isinstance(tensor, DTensor):
-                        chunk = gather_and_compute_chunk_metadata(tensor)
-                        local_slice = tuple(
-                            slice(offset, offset + size)
-                            for offset, size in zip(chunk.offsets, chunk.sizes)
-                        )
-                        tensor._local_tensor.copy_(reference[local_slice])
-                    else:
-                        tensor.copy_(reference)
-
-    @classmethod
-    def _run_training(cls, *, use_mfsdp_v2: bool, initial_parameters=None):
+    def _run_training(cls, *, use_mfsdp_v2: bool):
         Utils.initialize_model_parallel(expert_model_parallel_size=2)
         data_parallel_group = mpu.get_data_parallel_group()
         _set_manual_seed(42)
@@ -243,7 +209,7 @@ class TestMfsdpV2OverlapParity:
                     "expert_model_parallel_size": 2,
                     "bf16": True,
                     "data_parallel_sharding_strategy": "optim_grads_params",
-                    "clip_grad": 0.0,
+                    "clip_grad": 1.0,
                     "megatron_fsdp_main_grads_dtype": torch.float32,
                     "moe_grouped_gemm": True,
                     "moe_token_dispatcher_type": "alltoall",
@@ -251,67 +217,7 @@ class TestMfsdpV2OverlapParity:
                     "delay_wgrad_compute": True,
                 },
             )
-            if use_mfsdp_v2 and os.environ.get("MFSDP_PARITY_DEBUG"):
-                for model_chunk in model:
-                    adapter = model_chunk
-                    while not hasattr(adapter, "post_backward"):
-                        adapter = adapter.module
-                    root = adapter.module
-                    source_model = root
-                    while not hasattr(source_model, "decoder"):
-                        source_model = source_model.module
-                    final_layernorm = source_model.decoder.final_layernorm
-                    final_layernorm.register_forward_hook(
-                        lambda _module, _inputs, _output: print(
-                            f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
-                            "final_layernorm forward",
-                            flush=True,
-                        )
-                    )
-                    for group in root.parameter_groups:
-                        for fsdp_parameter in group.fsdp_parameters:
-                            if not any(
-                                fqn.endswith("decoder.final_layernorm.weight")
-                                for fqn in fsdp_parameter.fqns
-                            ):
-                                continue
-                            fsdp_parameter.unsharded.register_post_accumulate_grad_hook(
-                                lambda parameter: print(
-                                    f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
-                                    "final_layernorm grad ready "
-                                    f"none={parameter.grad is None}",
-                                    flush=True,
-                                )
-                            )
 
-                    original_reduce_gradient_groups = root._reduce_gradient_groups
-
-                    def debug_reduce_gradient_groups(
-                        *, root=root, original=original_reduce_gradient_groups
-                    ):
-                        missing = [
-                            fsdp_parameter.fqns
-                            for group in root.parameter_groups
-                            for fsdp_parameter in group.fsdp_parameters
-                            if group.requires_grad and fsdp_parameter.unsharded.grad is None
-                        ]
-                        countdown = root._trainable_parameter_countdown
-                        print(
-                            f"[MFSDP parity debug][rank={torch.distributed.get_rank()}] "
-                            f"root reduce phase={root.phase} "
-                            f"countdown={countdown._value}/{countdown.initial_value} "
-                            f"missing={missing}",
-                            flush=True,
-                        )
-                        return original()
-
-                    root._reduce_gradient_groups = debug_reduce_gradient_groups
-            if initial_parameters is not None:
-                cls._load_parameters(model, initial_parameters)
-                for sub_optimizer in getattr(optimizer, "chained_optimizers", [optimizer]):
-                    sub_optimizer._copy_main_params_to_model_params()
-
-            captured_initial_parameters = cls._capture_parameters(model)
             num_micro_batches = (
                 cls.GLOBAL_BATCH_SIZE // cls.MICRO_BATCH_SIZE // data_parallel_group.size()
             )
@@ -328,8 +234,6 @@ class TestMfsdpV2OverlapParity:
             run_name = "MFSDP v2" if use_mfsdp_v2 else "DistOpt"
 
             for step in range(cls.NUM_STEPS):
-                for model_chunk in model:
-                    model_chunk.zero_grad_buffer()
                 optimizer.zero_grad()
                 output = _pretrain_forward_backward(
                     model=model,
@@ -358,12 +262,13 @@ class TestMfsdpV2OverlapParity:
                 parameter_snapshots.append(cls._capture_parameters(model))
 
             return {
-                "initial_parameters": captured_initial_parameters,
                 "losses": losses,
                 "parameters": parameter_snapshots,
             }
         finally:
             Utils.destroy_model_parallel()
+            destroy_global_vars()
+            destroy_num_microbatches_calculator()
 
     @pytest.mark.skipif(
         not is_torch_min_version("2.6.0"),
@@ -386,19 +291,9 @@ class TestMfsdpV2OverlapParity:
         if torch.distributed.get_rank() == 0:
             print("DistOpt reference run completed successfully.", flush=True)
 
-        actual = self._run_training(
-            use_mfsdp_v2=True, initial_parameters=reference["initial_parameters"]
-        )
+        actual = self._run_training(use_mfsdp_v2=True)
         if torch.distributed.get_rank() == 0:
             print("MFSDP v2 run completed successfully.", flush=True)
-
-        for run_name, run in (("DistOpt", reference), ("MFSDP v2", actual)):
-            changed_parameters = [
-                name
-                for name, initial_parameter in run["initial_parameters"].items()
-                if not torch.equal(initial_parameter, run["parameters"][-1][name])
-            ]
-            assert changed_parameters, f"{run_name} did not update any parameters."
 
         assert len(actual["losses"]) == len(reference["losses"])
         for step, (loss, reference_loss) in enumerate(zip(actual["losses"], reference["losses"])):


### PR DESCRIPTION
## Summary

Part 2 of the MFSDP v2 combined-1F1B split. This PR contains the MCore adapter and `models/common` schedule integration; the generic experimental lifecycle remains in #6484.

- infer MFSDP custom scheduling from `overlap_moe_expert_parallel_comm`
- install fine-grained demand-unshard hooks with nearest-FSDP-owner tracking and idempotent setup
- keep forward resharding explicit and let the parameter countdown finalize backward reduction
- add MFSDP v2 `no_sync()` handling and wait for the final reduce-scatter before gradient consumers
- add focused adapter tests and 20-step MFSDP-v2/DistOpt overlap parity coverage

## Dependency

Depends on #6484 and is based on its verified `pull-request/6484` mirror. Retarget this PR to `main` before merging; merging while based on the mirror would land into the bot scratch branch instead of `main`.

## Validation

- Black 26.3.0: passed
- isort 5.13.2: passed
- Ruff 0.9.10, including explicit undefined/unused-symbol checks: passed
- `git diff --check`: passed
- pre-split 20-step, 2-GPU MFSDP-v2/DistOpt parity: passed; final LM loss 4.30552197 vs. 4.30558395
- GPU rerun on current `main`: pending cluster MFA availability