### PR TITLE
Integrate MFSDP v2 with 1F1B overlap

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -14,6 +14,8 @@
 
 import logging
 import random
+from contextlib import contextmanager
+from functools import partial
 from typing import Dict, List, Optional, Tuple, Type
 
 __all__ = ["FullyShardedDataParallel"]
@@ -60,6 +62,7 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -578,6 +581,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         # without symmetric memory: it uses ncclCommRegister rather than the more performant
         # ncclCommWindowRegister:
         # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#window-registration
+        fine_grained = config.overlap_moe_expert_parallel_comm
+        skip_backward_cb = fine_grained and ddp_config.delay_wgrad_compute
         with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
@@ -591,6 +596,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                             placements=placements,
                             mixed_precision_policy=self.mp_policy,
                             grad_divisor=config.expert_model_parallel_size,
+                            fine_grained=fine_grained,
+                            skip_backward_callback=skip_backward_cb,
                         )
             for submodule in reversed(list(module.modules())):
                 if submodule is module:
@@ -603,11 +610,59 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                         mesh=dp_mesh,
                         placements=placements,
                         mixed_precision_policy=self.mp_policy,
+                        fine_grained=fine_grained,
+                        skip_backward_callback=skip_backward_cb,
                     )
             fully_shard(
-                module, mesh=dp_mesh, placements=placements, mixed_precision_policy=self.mp_policy
+                module,
+                mesh=dp_mesh,
+                placements=placements,
+                mixed_precision_policy=self.mp_policy,
+                fine_grained=fine_grained,
+                skip_backward_callback=skip_backward_cb,
             )
         super().__init__(config=config, module=module)
+        if fine_grained:
+            self._setup_1f1b_overlap_interface()
+
+    def _setup_1f1b_overlap_interface(self) -> None:
+        """Expose the parameter lifecycle callbacks used by combined 1F1B.
+
+        All callbacks live on the adapter rather than on ``FsdpModule`` so the
+        experimental module API stays schedule-agnostic; the schedule-facing
+        surface is assembled here.
+        """
+
+        def _require_fsdp_module(module: torch.nn.Module) -> FsdpModule:
+            if not isinstance(module, FsdpModule):
+                raise TypeError(
+                    "MFSDP v2 combined 1F1B callbacks require an experimental FsdpModule, "
+                    f"got {type(module).__name__}."
+                )
+            return module
+
+        def release_module(module: torch.nn.Module, *, reduce_grad: bool) -> None:
+            module = _require_fsdp_module(module)
+            if reduce_grad:
+                module.post_backward()
+            else:
+                module._reshard_parameter_groups()
+
+        def _replace_param_with_raw_if_needed() -> None:
+            """Initialize the root context before a fine-grained schedule runs.
+
+            The experimental API stores raw tensors backed by DBuffer at all
+            times, so no parameter swap is needed, but finalizing the context
+            here ensures a child FSDP unit cannot mistake itself for the root
+            when it executes first.
+            """
+            self.module.context.ensure_finalized()
+
+        self._replace_param_with_raw_if_needed = _replace_param_with_raw_if_needed
+        self.post_forward_release_module = partial(release_module, reduce_grad=False)
+        self.post_backward_release_module = partial(release_module, reduce_grad=True)
+        self.pre_backward = partial(self.module.pre_backward, register_final_callback=False)
+        self.post_backward = self.module.post_backward
 
     @staticmethod
     def _validate_config(
@@ -699,8 +754,11 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise ValueError("MFSDP v2 requires symmetric registration when nccl_ub is enabled.")
         if ddp_config.fsdp_manual_registration:
             raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
-        if ddp_config.delay_wgrad_compute:
-            raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
+        if ddp_config.delay_wgrad_compute and not config.overlap_moe_expert_parallel_comm:
+            raise ValueError(
+                "MFSDP v2 only supports delay_wgrad_compute with "
+                "overlap_moe_expert_parallel_comm."
+            )
         if ddp_config.suggested_communication_unit_size is not None:
             raise ValueError("MFSDP v2 does not support suggested_communication_unit_size.")
         if ddp_config.num_buckets is not None:
@@ -713,6 +771,24 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             )
         if ddp_config.megatron_fsdp_max_pool_double_buffer:
             raise ValueError("MFSDP v2 does not support megatron_fsdp_max_pool_double_buffer.")
+
+    @contextmanager
+    def no_sync(self):
+        """Suppress gradient finalization for non-final microbatches.
+
+        Toggles ``is_last_microbatch`` on this model's ``FsdpContext`` so gradient
+        reduce-scatters accumulate between microbatches rather than finalizing
+        on every backward. Called by the training loop via
+        ``config.no_sync_func`` and the 1F1B overlap schedule.
+        """
+        self.module.context.ensure_finalized()
+        context = self.module.context
+        previous_state = context.is_last_microbatch
+        context.is_last_microbatch = False
+        try:
+            yield
+        finally:
+            context.is_last_microbatch = previous_state
 
     def start_param_sync(self, *unused, **unused_kwargs) -> None:
         """No-op: MFSDP v2 gathers parameters from its forward pre-hooks."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
@@ -107,19 +107,30 @@ def is_submodule(module, parent_module, strict=True):
 
 
 def find_megatron_fsdp(model):
-    """Walk the model wrapper chain to find a MegatronFSDP instance, if any."""
+    """Walk the model wrapper chain to find a Megatron-FSDP wrapper or module, if any."""
     # Lazy import to avoid a circular import: megatron_fsdp.py transitively imports
     # this module during its own initialization, so a top-level import of
     # MegatronFSDP here would fail with a partially-initialized module error.
     try:
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
     except (ImportError, ModuleNotFoundError):
-        return None
+        MegatronFSDP = None
+    try:
+        from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+    except (ImportError, ModuleNotFoundError):
+        FsdpModule = None
     m = model
     while m is not None:
-        if isinstance(m, MegatronFSDP):
+        if MegatronFSDP is not None and isinstance(m, MegatronFSDP):
             return m
-        m = getattr(m, 'module', None)
+        wrapped_module = getattr(m, 'module', None)
+        if (
+            FsdpModule is not None
+            and isinstance(wrapped_module, FsdpModule)
+            and hasattr(m, "ddp_config")
+        ):
+            return m
+        m = wrapped_module
     return None
 
 

--- a/tests/unit_tests/distributed/mfsdp_v1/utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/utils.py
@@ -7,6 +7,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 
+from gpt_builders import gpt_builder
 from hybrid_builders import hybrid_builder
 from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
@@ -52,18 +53,13 @@ def make_gpt_mock_data_iterator(
         yield batch
 
 
-def make_moe_args_model_and_optimizer(ut_filename, **overrides):
+def make_moe_args_model_and_optimizer(ut_filename, model_family="hybrid", **overrides):
     sys.argv = [ut_filename]
     base_args = dict(
-        hybrid_layer_pattern="MEME/ME",
-        spec=["megatron.core.models.hybrid.hybrid_layer_specs", "hybrid_stack_spec"],
         num_layers=4,
-        mtp_num_layers=1,
         hidden_size=128,
         num_attention_heads=2,
         max_position_embeddings=128,
-        mamba_num_groups=4,
-        mamba_num_heads=16,
         bf16=False,
         add_bias_linear=False,
         swiglu=True,
@@ -84,6 +80,20 @@ def make_moe_args_model_and_optimizer(ut_filename, **overrides):
         use_distributed_optimizer=True,
         finalize_model_grads_func=finalize_model_grads,
     )
+    if model_family == "hybrid":
+        base_args.update(
+            hybrid_layer_pattern="MEME/ME",
+            spec=["megatron.core.models.hybrid.hybrid_layer_specs", "hybrid_stack_spec"],
+            mtp_num_layers=1,
+            mamba_num_groups=4,
+            mamba_num_heads=16,
+        )
+        model_builder = hybrid_builder
+    elif model_family == "gpt":
+        base_args.update(hybrid_layer_pattern=None, spec=None, mtp_num_layers=None)
+        model_builder = gpt_builder
+    else:
+        raise ValueError(f"Unsupported model family: {model_family}")
 
     base_args.update(overrides)
     args = parse_args()
@@ -96,11 +106,11 @@ def make_moe_args_model_and_optimizer(ut_filename, **overrides):
     destroy_num_microbatches_calculator()
     set_global_variables(args, build_tokenizer=False)
 
-    cfg_container = Utils.pretrain_config_from_global_args(args, "hybrid")
+    cfg_container = Utils.pretrain_config_from_global_args(args, model_family)
     pg_collection = ProcessGroupCollection.use_mpu_process_groups()
     model, optimizer, _ = setup_model_and_optimizer(
         model_type=ModelType.encoder_or_decoder,
-        model_provider_func=partial(model_provider, hybrid_builder),
+        model_provider_func=partial(model_provider, model_builder),
         cfg_container=cfg_container,
         pg_collection=pg_collection,
     )
@@ -173,7 +183,7 @@ class GPTMockDataset(Dataset):
         }
 
 
-def _forward_step_func(data_iterator, model, device="cuda"):
+def _forward_step_func(data_iterator, model, device="cuda", return_schedule_plan=False):
 
     def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor):
 
@@ -183,7 +193,7 @@ def _forward_step_func(data_iterator, model, device="cuda"):
         # If you have data parallel reduce loss across data parallel groups.
         # If pipeline parallel, loss computation is done only in last stage.
 
-        return loss, {'lm loss': loss}
+        return loss, {'lm loss': loss.detach().clone()}
 
     vp_stage = get_attr_wrapped_model(model, "vp_stage")
 
@@ -201,6 +211,11 @@ def _forward_step_func(data_iterator, model, device="cuda"):
         )
         position_ids = data["position_ids"].to(device, non_blocking=True)
 
-    output_tensor = model(tokens, position_ids, attention_mask, labels=labels)
+    if return_schedule_plan:
+        schedule_plan = model.build_schedule_plan(
+            tokens, position_ids, attention_mask, labels=labels, loss_mask=loss_mask
+        )
+        return schedule_plan, partial(loss_func, loss_mask)
 
+    output_tensor = model(tokens, position_ids, attention_mask, labels=labels)
     return output_tensor, partial(loss_func, loss_mask)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_nd_parallel.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""End-to-end EP 1F1B-overlap parity for M-FSDP v2.
+
+Train the same small GPT model under M-FSDP v2 and the distributed-optimizer
+reference, then compare per-step losses and parameter snapshots.
+"""
+
+import pytest
+import torch
+from torch.distributed.tensor import DTensor
+from torch.testing import assert_close
+
+import megatron.core.parallel_state as mpu
+from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+    gather_and_compute_chunk_metadata,
+    uneven_dtensor_to_full_tensor,
+)
+from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.core.utils import is_te_min_version, is_torch_min_version
+from megatron.training.global_vars import destroy_global_vars
+from tests.unit_tests.distributed.mfsdp_v1.utils import (
+    make_gpt_mock_data_iterator,
+    make_moe_args_model_and_optimizer,
+    pretrain_forward_backward,
+    set_manual_seed,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestMfsdpV2OverlapParity:
+    NUM_STEPS = 20
+    SEQUENCE_LENGTH = 64
+    MICRO_BATCH_SIZE = 1
+    GLOBAL_BATCH_SIZE = 8
+    VOCAB_SIZE = 100
+
+    def teardown_method(self):
+        destroy_global_vars()
+        destroy_num_microbatches_calculator()
+
+    @staticmethod
+    def _normalize_parameter_name(name):
+        while name.startswith("module."):
+            name = name[len("module.") :]
+        return name
+
+    @classmethod
+    def _capture_parameters(cls, model):
+        parameters = {}
+        for chunk_index, model_chunk in enumerate(model):
+            for name, parameter in model_chunk.named_parameters():
+                tensor = parameter.detach()
+                if isinstance(tensor, DTensor):
+                    tensor = uneven_dtensor_to_full_tensor(tensor)
+                name = cls._normalize_parameter_name(name)
+                parameters[f"{chunk_index}.{name}"] = tensor.float().cpu()
+        return parameters
+
+    @classmethod
+    def _load_parameters(cls, model, reference_parameters):
+        with torch.no_grad():
+            for chunk_index, model_chunk in enumerate(model):
+                for name, parameter in model_chunk.named_parameters():
+                    name = cls._normalize_parameter_name(name)
+                    reference = reference_parameters[f"{chunk_index}.{name}"].to(
+                        device=parameter.device, dtype=parameter.dtype
+                    )
+                    tensor = parameter.detach()
+                    if isinstance(tensor, DTensor):
+                        chunk = gather_and_compute_chunk_metadata(tensor)
+                        local_slice = tuple(
+                            slice(offset, offset + size)
+                            for offset, size in zip(chunk.offsets, chunk.sizes)
+                        )
+                        tensor._local_tensor.copy_(reference[local_slice])
+                    else:
+                        tensor.copy_(reference)
+
+    @classmethod
+    def _run_training(cls, use_mfsdp_v2, case, initial_parameters=None):
+        model_parallel_config = case["model_parallel_config"]
+        Utils.initialize_model_parallel(**model_parallel_config)
+        data_parallel_group = mpu.get_data_parallel_group()
+        set_manual_seed(42)
+
+        fsdp_args = {}
+        if use_mfsdp_v2:
+            fsdp_args = {
+                "use_megatron_fsdp": True,
+                "megatron_fsdp_version": 2,
+                "ckpt_format": "fsdp_dtensor",
+            }
+
+        try:
+            model, optimizer = make_moe_args_model_and_optimizer(
+                ut_filename=__file__,
+                model_family=case["model_family"],
+                micro_batch_size=cls.MICRO_BATCH_SIZE,
+                global_batch_size=cls.GLOBAL_BATCH_SIZE,
+                vocab_size=cls.VOCAB_SIZE,
+                padded_vocab_size=cls.VOCAB_SIZE,
+                seq_length=cls.SEQUENCE_LENGTH,
+                train_iters=cls.NUM_STEPS,
+                gradient_accumulation_fusion=False,
+                use_distributed_optimizer=not use_mfsdp_v2,
+                **model_parallel_config,
+                **case["model_config"],
+                **fsdp_args,
+            )
+            if initial_parameters is not None:
+                cls._load_parameters(model, initial_parameters)
+                for sub_optimizer in getattr(optimizer, "chained_optimizers", [optimizer]):
+                    sub_optimizer._copy_main_params_to_model_params()
+
+            captured_initial_parameters = cls._capture_parameters(model)
+            data_iterator = make_gpt_mock_data_iterator(
+                dp_group=data_parallel_group,
+                num_samples=cls.GLOBAL_BATCH_SIZE * cls.NUM_STEPS,
+                vocab_size=cls.VOCAB_SIZE,
+                sequence_length=cls.SEQUENCE_LENGTH,
+                batch_size=cls.MICRO_BATCH_SIZE,
+                seed=42,
+            )
+            losses = []
+            parameter_snapshots = []
+            run_name = "MFSDP v2" if use_mfsdp_v2 else "Reference"
+
+            for step in range(cls.NUM_STEPS):
+                optimizer.zero_grad()
+                output = pretrain_forward_backward(
+                    model=model,
+                    data_iterator=data_iterator,
+                    sequence_length=cls.SEQUENCE_LENGTH,
+                    micro_batch_size=cls.MICRO_BATCH_SIZE,
+                    num_micro_batches=cls.GLOBAL_BATCH_SIZE
+                    // cls.MICRO_BATCH_SIZE
+                    // data_parallel_group.size(),
+                )
+                loss = output[-1]["lm loss"].detach().cpu()
+                update_successful, grad_norm, _ = optimizer.step()
+                losses.append(loss)
+                if torch.distributed.get_rank() == 0:
+                    grad_norm_text = "None" if grad_norm is None else f"{float(grad_norm):.8f}"
+                    print(
+                        f"[{case['name']}][{run_name}] "
+                        f"step={step + 1}/{cls.NUM_STEPS} "
+                        f"loss={loss.item():.8f} grad_norm={grad_norm_text} "
+                        f"update_successful={update_successful}",
+                        flush=True,
+                    )
+                parameter_snapshots.append(cls._capture_parameters(model))
+
+            return {
+                "initial_parameters": captured_initial_parameters,
+                "losses": losses,
+                "parameters": parameter_snapshots,
+            }
+        finally:
+            Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.4.0"), reason="Requires PyTorch 2.4.0 or newer."
+    )
+    def test_compatible_with_nd_parallel(self):
+        """MFSDP v2 EP overlap matches a distributed-optimizer reference."""
+        if not is_te_min_version("2.3.0"):
+            pytest.skip("1F1B expert-parallel overlap requires Transformer Engine 2.3.0 or newer.")
+
+        case = {
+            "name": "EP2 optim_grads_params 1F1B overlap",
+            "model_family": "gpt",
+            "model_parallel_config": {"expert_model_parallel_size": 2},
+            "model_config": {
+                "bf16": True,
+                "data_parallel_sharding_strategy": "optim_grads_params",
+                "clip_grad": 0.0,
+                "megatron_fsdp_main_grads_dtype": torch.float32,
+                "moe_grouped_gemm": True,
+                "moe_token_dispatcher_type": "alltoall",
+                "overlap_moe_expert_parallel_comm": True,
+                "delay_wgrad_compute": True,
+            },
+            "loss_tolerance": {"atol": 0, "rtol": 0.05},
+            "parameter_tolerance": {"atol": 5e-3, "rtol": 1e-3},
+        }
+
+        reference = self._run_training(use_mfsdp_v2=False, case=case)
+        if torch.distributed.get_rank() == 0:
+            print(f"[{case['name']}] Reference run completed successfully.", flush=True)
+
+        actual = self._run_training(
+            use_mfsdp_v2=True, case=case, initial_parameters=reference["initial_parameters"]
+        )
+        if torch.distributed.get_rank() == 0:
+            print(f"[{case['name']}] MFSDP v2 run completed successfully.", flush=True)
+
+        assert len(actual["losses"]) == len(reference["losses"])
+        for step, (loss, reference_loss) in enumerate(zip(actual["losses"], reference["losses"])):
+            assert_close(
+                loss,
+                reference_loss,
+                **case["loss_tolerance"],
+                msg=lambda msg: f"Loss mismatch at step {step}: {msg}",
+            )
+
+        assert len(actual["parameters"]) == len(reference["parameters"])
+        for step, (parameters, reference_parameters) in enumerate(
+            zip(actual["parameters"], reference["parameters"])
+        ):
+            assert parameters.keys() == reference_parameters.keys()
+            for name in parameters:
+                assert_close(
+                    parameters[name],
+                    reference_parameters[name],
+                    **case["parameter_tolerance"],
+                    msg=lambda msg: f"Parameter {name!r} mismatch at step {step}: {msg}",
+                )


### PR DESCRIPTION
## Summary

Dependent split from #6484. This PR wires the generic fine-grained MFSDP v2
hooks from #6692 into the MCore combined 1F1B schedule.

## Changes

- Enable fine-grained MFSDP v2 operation for expert-parallel communication
  overlap and expose the schedule-facing release/finalization callbacks.
- Support delayed Transformer Engine weight-gradient computation by deferring
  gradient reduction until the schedule's explicit post-`backward_dw()`
  release point.
- Add MFSDP v2 `no_sync()` behavior for gradient accumulation across
  microbatches.
- Teach the wrapper discovery helper to recognize the experimental MFSDP v2
  adapter.
- Generalize the existing MoE test fixture to build a GPT model as well as a
  Hybrid model.
- Add a focused 4-GPU EP2 end-to-end parity test against the
  distributed-optimizer reference.

## Split relationship

- Depends on generic fine-grained MFSDP hooks: #6692
- Design document: #6693
- Original combined PR and review history: #6484

This PR is intentionally stacked on `pull-request/6692`. It should be
retargeted to `main` after #6692 merges.

## Validation

- `isort` on all changed Python files
- `ruff check` on all changed Python files
- Python bytecode compilation for all changed Python files
- `git diff --check`
- GPU rerun for this rebased split: pending

