### PR TITLE
[GTP] Preserve forward-prefetch dependencies across local CUDA graphs

### DIFF
--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1490,13 +1490,13 @@ class GTPShardedParam(torch.nn.Parameter):
                 )
         _was_drained = getattr(self, "_already_ag_drained", False)
         if _was_drained:
-            # Producer already drained via wait_async_comms; skip the captured cross-graph
-            # wait (a CUDA no-op anyway). Correctness comes from the eager main_stream sync.
+            # The producer consumed the Work handle and recorded ag_event. Clear the host-side
+            # handoff marker, but retain the event wait that orders this consumer after the AG.
             self._already_ag_drained = False
         else:
             # Intra-graph or eager consume: drain inline.
             self._wait_param_gather()
-            self.ag_event.wait()
+        self.ag_event.wait()
 
         # Retrieve prefetched results from cache
         result = []
@@ -2341,12 +2341,14 @@ def wait_async_comms(
     finalize_after_drain: bool = False,
     params: Optional[List[GTPShardedParam]] = None,
 ):
-    """Drain in-flight GTP async AG / RS handles.
+    """Drain in-flight GTP asynchronous communication.
 
-    Inside CUDA graph capture the drains are captured into the graph — the producer-side hook
-    for cross-graph overlap. A captured cudaStreamWaitEvent on another capture session's event is
-    a CUDA no-op, so consumers can't wait cross-graph; instead the producer drains here and flags
-    the param, and the consumer skips its captured wait.
+    This drains AG and recompute-AG handles and, unless ``skip_rs`` is set, wgrad RS handles.
+    During CUDA graph capture, draining a handle materializes its wait in the producer graph and
+    records the corresponding external event. An AG handoff marker prevents a consumer from
+    draining the same Work handle again; the consumer still waits on the event to preserve the
+    producer-to-consumer dependency across local CUDA graphs. When requested, an RS result is also
+    accumulated into ``main_grad`` before its graph completes.
 
     Args:
         chain_id: If specified, only drain params on this chain.
@@ -2360,8 +2362,9 @@ def wait_async_comms(
                 capture, the process-global in-flight set remains the default.
 
     Per-param side effects:
-        * _already_ag_drained = True   (if an AG handle was drained)
-        * _already_finalized  = True   (if finalize_after_drain=True)
+        * _already_ag_drained = True          (if an AG handle was drained)
+        * _recompute_already_drained = True   (if a recompute AG handle was drained)
+        * _already_finalized = True           (if an RS result was finalized)
     """
     comm_params = list(_inflight_comm_params) if params is None else params
     for param in comm_params:

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1488,6 +1488,9 @@ class GTPShardedParam(torch.nn.Parameter):
                     "cache.get() would return stale data. Check the chain's "
                     "_need_weight_prefetch flag and issuer's prefetch logic."
                 )
+        # This handoff marker is specific to CUDA graphs: capture-side wait_async_comms drains
+        # the producer's Work handle and sets it. In eager execution, the consumer drains the
+        # handle directly instead.
         _was_drained = getattr(self, "_already_ag_drained", False)
         if _was_drained:
             # The producer consumed the Work handle and recorded ag_event. Clear the host-side
@@ -1534,13 +1537,14 @@ class GTPShardedParam(torch.nn.Parameter):
     def _get_recompute_prefetched_weight(self):
         # Recompute-chain analogue of _get_prefetched_weight (state-neutral; reads the
         # rowwise gather via the _recompute_* slot).
+        # CUDA-graph handoff marker equivalent to _already_ag_drained for recompute AGs.
         if self._recompute_already_drained:
-            # Producer already drained via wait_async_comms (CG capture); skip the
-            # captured cross-graph wait (CUDA no-op anyway).
+            # The producer consumed the Work handle and recorded _recompute_ag_event. Clear the
+            # host-side handoff marker, but retain the event wait that orders this consumer.
             self._recompute_already_drained = False
         else:
             self._wait_recompute_param_gather()
-            self._recompute_ag_event.wait()
+        self._recompute_ag_event.wait()
 
         result = []
         cache = get_global_GTP_cache()
@@ -2345,10 +2349,12 @@ def wait_async_comms(
 
     This drains AG and recompute-AG handles and, unless ``skip_rs`` is set, wgrad RS handles.
     During CUDA graph capture, draining a handle materializes its wait in the producer graph and
-    records the corresponding external event. An AG handoff marker prevents a consumer from
-    draining the same Work handle again; the consumer still waits on the event to preserve the
-    producer-to-consumer dependency across local CUDA graphs. When requested, an RS result is also
-    accumulated into ``main_grad`` before its graph completes.
+    records the corresponding external event. Because the event was constructed with
+    ``external=True``, capture emits event-record and event-wait nodes that preserve the dependency
+    between separately captured graphs at replay. The host must launch the producer graph before
+    the consumer graph so its record is the one observed by the wait. An AG handoff marker prevents
+    the consumer from draining the same Work handle again; the consumer still waits on the event.
+    When requested, an RS result is also accumulated into ``main_grad`` before graph completion.
 
     Args:
         chain_id: If specified, only drain params on this chain.
@@ -2358,8 +2364,8 @@ def wait_async_comms(
                  NCCL RS) so it starts during AG drain rather than after,
                  avoiding SM-saturation that blocks cross-graph overlap.
                  Falls back to caller-stream accumulation if no RS handle.
-        params: If specified, drain only async work issued by the owning CUDA graph. Outside graph
-                capture, the process-global in-flight set remains the default.
+        params: If specified, drain only the listed parameters' async work instead of the
+                process-global in-flight set.
 
     Per-param side effects:
         * _already_ag_drained = True          (if an AG handle was drained)
@@ -2377,8 +2383,8 @@ def wait_async_comms(
         param._wait_param_gather()
         if had_ag:
             param._already_ag_drained = True
-        # Recompute-forward chain: drain its separate in-flight rowwise AG so the
-        # captured recompute consumer skips its cross-graph wait (full-iteration CG).
+        # Recompute-forward chain: drain its separate in-flight rowwise AG and mark the handoff.
+        # The consumer skips re-draining the Work handle but still waits on the external event.
         if param._recompute_prefetch_handle is not None:
             param._wait_recompute_param_gather()
             param._recompute_already_drained = True

--- a/megatron/core/tensor_parallel/gtp_api.py
+++ b/megatron/core/tensor_parallel/gtp_api.py
@@ -31,6 +31,7 @@ try:
         wrap_module_params_gtp,
     )
     from megatron.core.tensor_parallel.gtp_cuda_graphs import (
+        preserve_gtp_prefetch_state,
         set_cuda_graph_mempool,
         track_gtp_capture_comms,
     )
@@ -58,6 +59,7 @@ __all__ = [
     "is_gtp_param",
     "initialize_graph_wgrad_rings",
     "make_sharded_tensors_for_checkpoint_with_gtp_remat",
+    "preserve_gtp_prefetch_state",
     "set_cuda_graph_mempool",
     "track_gtp_capture_comms",
     "wait_async_comms",

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -25,31 +25,43 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def _preserve_gtp_forward_prefetch_state(params: Iterable):
-    """Preserve cross-graph forward-AG handoffs while a local graph warms up.
+def preserve_gtp_prefetch_state(params: Iterable[torch.nn.Parameter]):
+    """Preserve cross-graph AG handoffs while a local graph warms up.
 
-    A local graph's first GTP weight can be prefetched and drained by the preceding graph.
-    Runner-local warmup consumes that readiness without rerunning the producer, and can create
-    outgoing readiness of its own. Capture must therefore see the same ``_already_ag_drained``
-    state that existed before warmup. Completed Work handles are intentionally not restored; the
-    producer's external ``ag_event`` carries the device-side dependency into the consumer graph.
+    A local graph's first GTP weight can be prefetched and drained by the preceding forward or
+    backward graph. Runner-local warmup consumes that readiness without rerunning the producer,
+    and can create outgoing readiness of its own. Capture must therefore see the same forward and
+    recompute-forward handoff state that existed before each warmup pass. Completed Work handles
+    are intentionally not restored; the producer's external event carries the device dependency.
     """
     prefetch_state = tuple(
-        (param, getattr(param, "_already_ag_drained", False))
+        (
+            param,
+            getattr(param, "_already_ag_drained", False),
+            getattr(param, "_recompute_already_drained", False),
+        )
         for param in params
         if getattr(param, "is_gtp_weight_remat", False)
     )
+    completed = False
     try:
         yield
+        completed = True
     finally:
-        for param, already_drained in prefetch_state:
-            # Warmup must consume every forward AG it issues. Restoring a completed Work handle
-            # would be invalid; restore only the host flag describing the cross-graph handoff.
-            assert getattr(param, "_prefetch_handle", None) is None, (
-                "GTP warmup left an undrained forward AG for "
-                f"{getattr(param, '_debug_name', '') or id(param)}"
-            )
+        leaked_params = []
+        for param, already_drained, recompute_already_drained in prefetch_state:
+            if (
+                getattr(param, "_prefetch_handle", None) is not None
+                or getattr(param, "_recompute_prefetch_handle", None) is not None
+            ):
+                leaked_params.append(getattr(param, "_debug_name", "") or f"id={id(param):#x}")
             param._already_ag_drained = already_drained
+            param._recompute_already_drained = recompute_already_drained
+
+        # Do not replace an exception from the warmup body with a cleanup failure. On successful
+        # warmup, however, a live Work handle would make the restored host handoff state invalid.
+        if completed and leaked_params:
+            raise RuntimeError("GTP warmup left undrained AG work for: " + ", ".join(leaked_params))
 
 
 @dataclass
@@ -64,7 +76,7 @@ class GraphWgradRingSlot:
 
 @dataclass
 class GTPCaptureCommState:
-    """GTP work and parameter-readiness dependencies issued while capturing one CUDA graph."""
+    """GTP work and parameter-readiness dependencies owned by one capture or warmup pass."""
 
     params: list = field(default_factory=list)
     params_to_ensure_ready: list = field(default_factory=list)
@@ -76,9 +88,11 @@ class GTPCaptureCommState:
     _ag_stream_ids: set = field(default_factory=set)
     _rs_stream_ids: set = field(default_factory=set)
     _wgrad_ring_slot_params: dict = field(default_factory=dict)
+    _comm_records: list[tuple[object, torch.cuda.Stream, bool]] = field(default_factory=list)
 
     def register_comm(self, param, stream: torch.cuda.Stream, *, reduce_scatter: bool) -> None:
-        """Record a parameter and side stream owned by this graph capture."""
+        """Record a parameter and side stream owned by the active capture tracker."""
+        self._comm_records.append((param, stream, reduce_scatter))
         param_id = id(param)
         if param_id not in self._param_ids:
             self._param_ids.add(param_id)
@@ -98,6 +112,30 @@ class GTPCaptureCommState:
             if param_id not in self._param_ids_to_ensure_ready:
                 self._param_ids_to_ensure_ready.add(param_id)
                 self.params_to_ensure_ready.append(param)
+
+    def get_comms_for_chain(self, chain_id: str) -> tuple[list, list, list]:
+        """Return owned parameters, AG streams, and RS streams for one GTP chain."""
+        params = []
+        ag_streams = []
+        rs_streams = []
+        param_ids = set()
+        ag_stream_ids = set()
+        rs_stream_ids = set()
+
+        for param, stream, reduce_scatter in self._comm_records:
+            if getattr(param, "chain_id", None) != chain_id:
+                continue
+            if id(param) not in param_ids:
+                param_ids.add(id(param))
+                params.append(param)
+
+            streams = rs_streams if reduce_scatter else ag_streams
+            stream_ids = rs_stream_ids if reduce_scatter else ag_stream_ids
+            if id(stream) not in stream_ids:
+                stream_ids.add(id(stream))
+                streams.append(stream)
+
+        return params, ag_streams, rs_streams
 
     def register_wgrad_ring_slot(self, slot: GraphWgradRingSlot, param) -> None:
         """Track slots used by this graph and reject unsafe intra-graph aliasing."""
@@ -137,7 +175,12 @@ def register_capture_wgrad_ring_slot(slot: GraphWgradRingSlot, param) -> None:
 
 @contextmanager
 def track_gtp_capture_comms():
-    """Track asynchronous GTP work owned by one CUDA-graph capture."""
+    """Track asynchronous GTP work issued during one capture or warmup pass.
+
+    This context tracks ownership, not graph-chain membership. Nested modules can issue work for
+    ``UNGRAPHED`` parameters while the context is active, so callers implementing the cross-graph
+    handoff must explicitly select the ``GRAPHED`` parameters and their corresponding streams.
+    """
     global _ACTIVE_CAPTURE_COMM_STATE
 
     if _ACTIVE_CAPTURE_COMM_STATE is not None:

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -24,6 +24,34 @@ from megatron.core.utils import log_single_rank
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
+def _preserve_gtp_forward_prefetch_state(params: Iterable):
+    """Preserve cross-graph forward-AG handoffs while a local graph warms up.
+
+    A local graph's first GTP weight can be prefetched and drained by the preceding graph.
+    Runner-local warmup consumes that readiness without rerunning the producer, and can create
+    outgoing readiness of its own. Capture must therefore see the same ``_already_ag_drained``
+    state that existed before warmup. Completed Work handles are intentionally not restored; the
+    producer's external ``ag_event`` carries the device-side dependency into the consumer graph.
+    """
+    prefetch_state = tuple(
+        (param, getattr(param, "_already_ag_drained", False))
+        for param in params
+        if getattr(param, "is_gtp_weight_remat", False)
+    )
+    try:
+        yield
+    finally:
+        for param, already_drained in prefetch_state:
+            # Warmup must consume every forward AG it issues. Restoring a completed Work handle
+            # would be invalid; restore only the host flag describing the cross-graph handoff.
+            assert getattr(param, "_prefetch_handle", None) is None, (
+                "GTP warmup left an undrained forward AG for "
+                f"{getattr(param, '_debug_name', '') or id(param)}"
+            )
+            param._already_ag_drained = already_drained
+
+
 @dataclass
 class GraphWgradRingSlot:
     """One persistent wgrad slot guarded by its reduce-scatter completion event."""

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -22,6 +22,7 @@ from torch.utils._pytree import tree_map as tree_map_pyt
 
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.gtp_cuda_graphs import _preserve_gtp_forward_prefetch_state
 from megatron.core.tensor_parallel.random import (
     CudaRNGStatesTracker,
     get_all_rng_states,
@@ -69,7 +70,6 @@ if HAVE_GTP:
     from megatron.core.tensor_parallel.gtp_api import (
         GTP_CONFIG,
         GTPChain,
-        get_ag_stream,
         get_rs_stream,
         initialize_graph_wgrad_rings,
         set_cuda_graph_mempool,
@@ -82,7 +82,6 @@ else:
     # gtp_remat at runtime.
     GTPChain = None
     GTP_CONFIG = None
-    get_ag_stream = None
     get_rs_stream = None
     initialize_graph_wgrad_rings = None
     set_cuda_graph_mempool = None
@@ -989,8 +988,6 @@ class _CudaGraphRunner(torch.nn.Module):
         self.needs_recompute_param_discovery = False
         self.use_stream = False
         self.gtp_remat = False
-        self.fwd_side_streams = []
-        self.bwd_side_streams = []
         # Populated by create_bwd_graph: GTP params whose main_grad.add_ was captured in THIS
         # graph.  Used in Graphed.backward's post-replay hook loop to fire DDP hooks only in the
         # graph whose replay populates main_grad.
@@ -1038,18 +1035,6 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.stream = _get_cuda_graph_stream()
                 self.fwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
                 self.bwd_completion_event = torch.cuda.Event(external=True, interprocess=True)
-                # Register (chain, group) side streams before the first forward.
-                # Dense for mamba/attn/shared_experts; expert (below) for routed
-                # experts captured when "moe" is in cuda_graph_modules.
-                pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                    required_pgs=["gtp_remat", "expt_gtp_remat"]
-                )
-                self._register_gtp_side_streams(pg_collection.gtp_remat)
-                # EGTP_remat streams: required so _wait/_sync_side_streams drain EGTP_remat
-                # NCCL into runner_stream before bwd_completion_event fires.
-                egtp_remat_group = pg_collection.expt_gtp_remat
-                if egtp_remat_group is not None and egtp_remat_group.size() > 1:
-                    self._register_gtp_side_streams(egtp_remat_group)
                 # Registered for finalize_model_grads to wait on (Phase 2 fence).
                 _GTP_RUNNER_STREAMS.append(self.stream)
 
@@ -1063,29 +1048,8 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.fp4_recipe = get_fp4_recipe(self.base_module.config)
                 _set_skip_fp8_weight_update_tensor(False)
 
-    def _register_gtp_side_streams(self, group):
-        """Register static streams used by forward capture and GTP warmup.
-
-        Backward capture dynamically discovers exact owned streams via track_gtp_capture_comms().
-        """
-        ag = get_ag_stream(GTPChain.GRAPHED.value, group)
-        rs = get_rs_stream(GTPChain.GRAPHED.value, group)
-        self.fwd_side_streams.append(ag)
-        self.bwd_side_streams.append(ag)
-        self.bwd_side_streams.append(rs)
-
-    def _sync_against_side_streams(self, side_streams):
-        """Make registered side streams wait for the current stream.
-        Also injects a dummy kernel into each stream to ensure it is non-empty,
-        which is required for CUDA graph capture (joining an empty captured
-        stream is a CUDA error)."""
-        for s in side_streams:
-            s.wait_stream(torch.cuda.current_stream())
-            with torch.cuda.stream(s):
-                torch.cuda._sleep(1)
-
     def _wait_side_streams(self, side_streams):
-        """Make the current stream wait for all registered side streams."""
+        """Make the current stream wait for all side streams discovered."""
         for s in side_streams:
             torch.cuda.current_stream().wait_stream(s)
 
@@ -1335,9 +1299,15 @@ class _CudaGraphRunner(torch.nn.Module):
             self.fwd_graph_input_args, self.fwd_graph_input_kwargs
         )
 
-        ctx = torch.no_grad() if not self.grad_enabled else nullcontext()
-        with ctx:
-            # warmup again as case graph capture mode may execute a different codepath
+        grad_context = torch.no_grad() if not self.grad_enabled else nullcontext()
+        preserve_prefetch_context = (
+            _preserve_gtp_forward_prefetch_state(self.base_module.parameters())
+            if self.gtp_remat
+            else nullcontext()
+        )
+        warmup_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext()
+        with grad_context, preserve_prefetch_context, warmup_comm_context as warmup_comms:
+            # Warm up again because CUDA graph capture mode may execute a different codepath
             _set_warmup_start()
 
             # Recompute parameter discovery needs one warmup output: graph warmup bypasses
@@ -1369,11 +1339,15 @@ class _CudaGraphRunner(torch.nn.Module):
                     )
 
                 if self.gtp_remat:
-                    wait_async_comms(GTPChain.GRAPHED.value)
-                    self._sync_against_side_streams(self.bwd_side_streams)
-
+                    # Join only communication issued during this runner's warmup. The tracker
+                    # is discarded before capture, so warmup ownership cannot leak into the
+                    # captured graph's communication set.
+                    wait_async_comms(params=warmup_comms.params)
+                    self._wait_side_streams(warmup_comms.ag_streams)
+                    self._wait_side_streams(warmup_comms.rs_streams)
             _set_warmup_end()
 
+        with grad_context:
             with self.get_quantization_context():
                 torch.cuda.synchronize()
                 # Register default CUDA generators ourselves (fixed in-place to have normal tensors)
@@ -1399,21 +1373,20 @@ class _CudaGraphRunner(torch.nn.Module):
                     ),
                 ):
 
-                    self._sync_against_side_streams(self.fwd_side_streams)
-
                     fwd_graph_outputs = self.func(
                         *self.fwd_graph_input_args, **self.fwd_graph_input_kwargs
                     )
 
-                    if self.gtp_remat:
-                        # Forward only issues AG prefetches (no wgrad RS), so drain AG and skip RS.
-                        wait_async_comms(GTPChain.GRAPHED.value, skip_rs=True)
-
-                    if self.fwd_side_streams:
-                        self._wait_side_streams(self.fwd_side_streams)
-
                     if self.use_stream:
+                        # Release the caller before joining outgoing GTP prefetches. The next local
+                        # graph can launch while this graph's tail AG runs, then wait on that AG's
+                        # external event before reading the prefetched weight.
                         self.fwd_completion_event.record()
+
+                    if self.gtp_remat:
+                        # Forward only issues AG prefetches. Drain the operations directly.
+                        wait_async_comms(skip_rs=True, params=capture_comms.params)
+                        self._wait_side_streams(capture_comms.ag_streams)
 
                 if self.gtp_remat:
                     self._gtp_fwd_params_to_ensure_ready = tuple(

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -22,7 +22,6 @@ from torch.utils._pytree import tree_map as tree_map_pyt
 
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.tensor_parallel.gtp_cuda_graphs import _preserve_gtp_forward_prefetch_state
 from megatron.core.tensor_parallel.random import (
     CudaRNGStatesTracker,
     get_all_rng_states,
@@ -72,6 +71,7 @@ if HAVE_GTP:
         GTPChain,
         get_rs_stream,
         initialize_graph_wgrad_rings,
+        preserve_gtp_prefetch_state,
         set_cuda_graph_mempool,
         track_gtp_capture_comms,
         wait_async_comms,
@@ -84,6 +84,7 @@ else:
     GTP_CONFIG = None
     get_rs_stream = None
     initialize_graph_wgrad_rings = None
+    preserve_gtp_prefetch_state = None
     set_cuda_graph_mempool = None
     track_gtp_capture_comms = None
     wait_async_comms = None
@@ -1049,7 +1050,11 @@ class _CudaGraphRunner(torch.nn.Module):
                 _set_skip_fp8_weight_update_tensor(False)
 
     def _wait_side_streams(self, side_streams):
-        """Make the current stream wait for all side streams discovered."""
+        """Wait for side streams that carried work owned by one capture tracker.
+
+        Joining only streams discovered by ``track_gtp_capture_comms`` avoids waiting on an empty
+        captured stream.
+        """
         for s in side_streams:
             torch.cuda.current_stream().wait_stream(s)
 
@@ -1300,13 +1305,8 @@ class _CudaGraphRunner(torch.nn.Module):
         )
 
         grad_context = torch.no_grad() if not self.grad_enabled else nullcontext()
-        preserve_prefetch_context = (
-            _preserve_gtp_forward_prefetch_state(self.base_module.parameters())
-            if self.gtp_remat
-            else nullcontext()
-        )
         warmup_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext()
-        with grad_context, preserve_prefetch_context, warmup_comm_context as warmup_comms:
+        with grad_context, warmup_comm_context as warmup_comms:
             # Warm up again because CUDA graph capture mode may execute a different codepath
             _set_warmup_start()
 
@@ -1315,36 +1315,45 @@ class _CudaGraphRunner(torch.nn.Module):
             # from that output's autograd graph. Force this pass even when configured warmup is 0.
             num_warmup_steps = max(self.num_warmup_steps, int(self.needs_recompute_param_discovery))
             for _ in range(num_warmup_steps):
-                with self.get_quantization_context():
+                preserve_prefetch_context = (
+                    preserve_gtp_prefetch_state(self.base_module.parameters())
+                    if self.gtp_remat
+                    else nullcontext()
+                )
+                with preserve_prefetch_context:
+                    with self.get_quantization_context():
 
-                    def clone_ten(ten):
-                        if not torch.is_tensor(ten):
-                            return ten
-                        return torch.clone(ten).detach().requires_grad_(ten.requires_grad)
+                        def clone_ten(ten):
+                            if not torch.is_tensor(ten):
+                                return ten
+                            return torch.clone(ten).detach().requires_grad_(ten.requires_grad)
 
-                    warmup_args = tree_map(clone_ten, self.fwd_graph_input_args)
-                    warmup_kwargs = tree_map(clone_ten, self.fwd_graph_input_kwargs)
-                    warmup_outputs = self.func(*warmup_args, **warmup_kwargs)
+                        warmup_args = tree_map(clone_ten, self.fwd_graph_input_args)
+                        warmup_kwargs = tree_map(clone_ten, self.fwd_graph_input_kwargs)
+                        warmup_outputs = self.func(*warmup_args, **warmup_kwargs)
 
-                if self.grad_enabled:
-                    warmup_outputs = self.get_tensors(warmup_outputs)
-                    warmup_outputs = tuple(o for o in warmup_outputs if o.requires_grad)
-                    input_tensors = self.get_tensors(warmup_args, warmup_kwargs)
-                    torch.autograd.grad(
-                        outputs=warmup_outputs,
-                        inputs=tuple(i for i in input_tensors if i.requires_grad),
-                        grad_outputs=tuple(torch.zeros_like(o) for o in warmup_outputs),
-                        only_inputs=True,
-                        allow_unused=True,
-                    )
+                    if self.grad_enabled:
+                        warmup_outputs = self.get_tensors(warmup_outputs)
+                        warmup_outputs = tuple(o for o in warmup_outputs if o.requires_grad)
+                        input_tensors = self.get_tensors(warmup_args, warmup_kwargs)
+                        torch.autograd.grad(
+                            outputs=warmup_outputs,
+                            inputs=tuple(i for i in input_tensors if i.requires_grad),
+                            grad_outputs=tuple(torch.zeros_like(o) for o in warmup_outputs),
+                            only_inputs=True,
+                            allow_unused=True,
+                        )
 
-                if self.gtp_remat:
-                    # Join only communication issued during this runner's warmup. The tracker
-                    # is discarded before capture, so warmup ownership cannot leak into the
-                    # captured graph's communication set.
-                    wait_async_comms(params=warmup_comms.params)
-                    self._wait_side_streams(warmup_comms.ag_streams)
-                    self._wait_side_streams(warmup_comms.rs_streams)
+                    if self.gtp_remat:
+                        # Join only GRAPHED-chain communication issued by this runner. Selecting
+                        # by both capture ownership and chain keeps UNGRAPHED work on its eager
+                        # lifecycle instead of turning it into a cross-graph handoff.
+                        warmup_params, warmup_ag_streams, warmup_rs_streams = (
+                            warmup_comms.get_comms_for_chain(GTPChain.GRAPHED.value)
+                        )
+                        wait_async_comms(GTPChain.GRAPHED.value, params=warmup_params)
+                        self._wait_side_streams(warmup_ag_streams)
+                        self._wait_side_streams(warmup_rs_streams)
             _set_warmup_end()
 
         with grad_context:
@@ -1385,8 +1394,13 @@ class _CudaGraphRunner(torch.nn.Module):
 
                     if self.gtp_remat:
                         # Forward only issues AG prefetches. Drain the operations directly.
-                        wait_async_comms(skip_rs=True, params=capture_comms.params)
-                        self._wait_side_streams(capture_comms.ag_streams)
+                        captured_params, captured_ag_streams, _ = capture_comms.get_comms_for_chain(
+                            GTPChain.GRAPHED.value
+                        )
+                        wait_async_comms(
+                            GTPChain.GRAPHED.value, skip_rs=True, params=captured_params
+                        )
+                        self._wait_side_streams(captured_ag_streams)
 
                 if self.gtp_remat:
                     self._gtp_fwd_params_to_ensure_ready = tuple(
@@ -1536,18 +1550,21 @@ class _CudaGraphRunner(torch.nn.Module):
             #             consumer's cascade; for within-graph tails both
             #             happen here (see wait_async_comms).
             if self.gtp_remat:
+                captured_params, captured_ag_streams, captured_rs_streams = (
+                    capture_comms.get_comms_for_chain(GTPChain.GRAPHED.value)
+                )
                 # Phase 1: drain AG
-                wait_async_comms(GTPChain.GRAPHED.value, skip_rs=True, params=capture_comms.params)
-                self._wait_side_streams(capture_comms.ag_streams)
+                wait_async_comms(GTPChain.GRAPHED.value, skip_rs=True, params=captured_params)
+                self._wait_side_streams(captured_ag_streams)
 
                 # Release the next runner after AG drain but before RS drain.
                 self.bwd_completion_event.record()
 
                 # Phase 2: in-graph RS drain + finalize.
                 wait_async_comms(
-                    GTPChain.GRAPHED.value, finalize_after_drain=True, params=capture_comms.params
+                    GTPChain.GRAPHED.value, finalize_after_drain=True, params=captured_params
                 )
-                self._wait_side_streams(capture_comms.rs_streams)
+                self._wait_side_streams(captured_rs_streams)
 
             if self.use_stream and not self.gtp_remat:
                 # Non-GTP path: record after the side-stream join.

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -53,6 +53,7 @@ from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     GTPWeightCache,
     wrap_module_params_gtp,
 )
+from megatron.core.tensor_parallel.gtp_cuda_graphs import _preserve_gtp_forward_prefetch_state
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
     _make_gtp_linear,
     _make_gtp_remat_grouped_linear,
@@ -1628,3 +1629,52 @@ class TestGTPCaptureParamReadiness:
             gtp_cuda_graphs.register_capture_params_to_ensure_ready((second,))
 
         assert capture.params_to_ensure_ready == [first, second]
+
+    def test_warmup_preserves_cross_graph_prefetch_state(self):
+        class FakeParam:
+            is_gtp_weight_remat = True
+            _prefetch_handle = None
+
+            def __init__(self, already_drained):
+                self._already_ag_drained = already_drained
+
+        incoming = FakeParam(already_drained=True)
+        ordinary = FakeParam(already_drained=False)
+
+        with _preserve_gtp_forward_prefetch_state(iter((incoming, ordinary))):
+            # Warmup consumes the incoming handoff and produces unrelated outgoing readiness.
+            incoming._already_ag_drained = False
+            ordinary._already_ag_drained = True
+
+        assert incoming._already_ag_drained is True
+        assert ordinary._already_ag_drained is False
+        assert incoming._prefetch_handle is None
+
+    def test_drained_cross_graph_prefetch_still_waits_on_ag_event(self, monkeypatch):
+        class ExpectedEventWait(Exception):
+            pass
+
+        calls = []
+
+        class FakeEvent:
+            def wait(self):
+                calls.append("event_wait")
+                raise ExpectedEventWait
+
+        param = type(
+            "Param",
+            (),
+            {
+                "_already_ag_drained": True,
+                "_weights": (),
+                "ag_event": FakeEvent(),
+                "_wait_param_gather": lambda self: calls.append("handle_wait"),
+            },
+        )()
+        monkeypatch.setattr(gtp_module.GTP_CONFIG, "check_param_states", False)
+
+        with pytest.raises(ExpectedEventWait):
+            GTPShardedParam._get_prefetched_weight(param, fwd=True)
+
+        assert calls == ["event_wait"]
+        assert param._already_ag_drained is False

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -53,7 +53,7 @@ from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     GTPWeightCache,
     wrap_module_params_gtp,
 )
-from megatron.core.tensor_parallel.gtp_cuda_graphs import _preserve_gtp_forward_prefetch_state
+from megatron.core.tensor_parallel.gtp_cuda_graphs import preserve_gtp_prefetch_state
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
     _make_gtp_linear,
     _make_gtp_remat_grouped_linear,
@@ -1634,20 +1634,30 @@ class TestGTPCaptureParamReadiness:
         class FakeParam:
             is_gtp_weight_remat = True
             _prefetch_handle = None
+            _recompute_prefetch_handle = None
 
-            def __init__(self, already_drained):
+            def __init__(self, already_drained, recompute_already_drained):
                 self._already_ag_drained = already_drained
+                self._recompute_already_drained = recompute_already_drained
 
-        incoming = FakeParam(already_drained=True)
-        ordinary = FakeParam(already_drained=False)
+        incoming = FakeParam(already_drained=True, recompute_already_drained=True)
+        ordinary = FakeParam(already_drained=False, recompute_already_drained=False)
 
-        with _preserve_gtp_forward_prefetch_state(iter((incoming, ordinary))):
-            # Warmup consumes the incoming handoff and produces unrelated outgoing readiness.
-            incoming._already_ag_drained = False
-            ordinary._already_ag_drained = True
+        observed = []
+        for _ in range(2):
+            with preserve_gtp_prefetch_state(iter((incoming, ordinary))):
+                observed.append((incoming._already_ag_drained, incoming._recompute_already_drained))
+                # Each warmup consumes the incoming handoff and creates outgoing readiness.
+                incoming._already_ag_drained = False
+                incoming._recompute_already_drained = False
+                ordinary._already_ag_drained = True
+                ordinary._recompute_already_drained = True
 
+        assert observed == [(True, True), (True, True)]
         assert incoming._already_ag_drained is True
+        assert incoming._recompute_already_drained is True
         assert ordinary._already_ag_drained is False
+        assert ordinary._recompute_already_drained is False
         assert incoming._prefetch_handle is None
 
     def test_drained_cross_graph_prefetch_still_waits_on_ag_event(self, monkeypatch):
@@ -1678,3 +1688,96 @@ class TestGTPCaptureParamReadiness:
 
         assert calls == ["event_wait"]
         assert param._already_ag_drained is False
+
+    def test_drained_recompute_prefetch_still_waits_on_ag_event(self):
+        class ExpectedEventWait(Exception):
+            pass
+
+        calls = []
+
+        class FakeEvent:
+            def wait(self):
+                calls.append("event_wait")
+                raise ExpectedEventWait
+
+        param = type(
+            "Param",
+            (),
+            {
+                "_recompute_already_drained": True,
+                "_weights": (),
+                "_recompute_ag_event": FakeEvent(),
+                "_wait_recompute_param_gather": lambda self: calls.append("handle_wait"),
+            },
+        )()
+
+        with pytest.raises(ExpectedEventWait):
+            GTPShardedParam._get_recompute_prefetched_weight(param)
+
+        assert calls == ["event_wait"]
+        assert param._recompute_already_drained is False
+
+    def test_warmup_exception_is_not_masked_by_leaked_handle(self):
+        class WarmupError(Exception):
+            pass
+
+        param = type(
+            "Param",
+            (),
+            {
+                "is_gtp_weight_remat": True,
+                "_already_ag_drained": True,
+                "_recompute_already_drained": True,
+                "_prefetch_handle": None,
+                "_recompute_prefetch_handle": None,
+            },
+        )()
+
+        with pytest.raises(WarmupError):
+            with preserve_gtp_prefetch_state((param,)):
+                param._already_ag_drained = False
+                param._prefetch_handle = object()
+                raise WarmupError
+
+        assert param._already_ag_drained is True
+        assert param._recompute_already_drained is True
+
+    def test_successful_warmup_rejects_leaked_handle_after_restoring_state(self):
+        param = type(
+            "Param",
+            (),
+            {
+                "is_gtp_weight_remat": True,
+                "_already_ag_drained": True,
+                "_recompute_already_drained": False,
+                "_prefetch_handle": None,
+                "_recompute_prefetch_handle": None,
+            },
+        )()
+
+        with pytest.raises(RuntimeError, match="undrained AG work"):
+            with preserve_gtp_prefetch_state((param,)):
+                param._already_ag_drained = False
+                param._prefetch_handle = object()
+
+        assert param._already_ag_drained is True
+        assert param._recompute_already_drained is False
+
+    def test_capture_comm_selection_keeps_chain_and_ownership_scoped(self):
+        state = gtp_cuda_graphs.GTPCaptureCommState()
+        graphed_param = type("Param", (), {"chain_id": GTPChain.GRAPHED.value})()
+        ungraphed_param = type("Param", (), {"chain_id": GTPChain.UNGRAPHED.value})()
+        graphed_ag_stream = object()
+        graphed_rs_stream = object()
+        ungraphed_ag_stream = object()
+
+        state.register_comm(graphed_param, graphed_ag_stream, reduce_scatter=False)
+        state.register_comm(graphed_param, graphed_ag_stream, reduce_scatter=False)
+        state.register_comm(graphed_param, graphed_rs_stream, reduce_scatter=True)
+        state.register_comm(ungraphed_param, ungraphed_ag_stream, reduce_scatter=False)
+
+        params, ag_streams, rs_streams = state.get_comms_for_chain(GTPChain.GRAPHED.value)
+
+        assert params == [graphed_param]
+        assert ag_streams == [graphed_ag_stream]
+        assert rs_streams == [graphed_rs_stream]


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

This PR removes the redundant on-demand AG in forward cudagraph and 
restores overlap between one local graph's tail AG and the beginning of 
the next local graph.

## Problem
Partial CUDA graph execution had two related forward GTP prefetch problems.

  ### 1. Redundant on-demand all-gather

  The first GTP parameter consumed by a local CUDA graph can be prefetched by the
  preceding graph. The producer drains the AG work handle and sets
  `_already_ag_drained` to tell the consumer that the prefetched weight is
  available through `ag_event`.

  However, runner-local warmup executes the consumer without replaying its
  producer. Warmup consumes and clears `_already_ag_drained`, so the subsequent
  capture no longer sees the incoming prefetch.

  Because both `_prefetch_handle` and `_already_ag_drained` appear unset during
  capture, `_prefetch_available()` returns false and the consumer captures a
  synchronous on-demand AG for the same parameter. This introduces a redundant
  all-gather and loses the intended prefetched path.

  ```text
  Expected:
  previous graph:  async AG(param X) -------------------+
  next graph:                              wait event -> use X

  Before this fix:
  warmup:                                  consumes prefetch state
  captured graph:                          on-demand AG(X) -> use X
```
### 2. Tail AG could not overlap the next local graph

  A local graph may launch an AG near the end of its forward computation to
  prefetch the first parameter required by the next graph.

  Previously, the graph joined its AG side stream before recording
  fwd_completion_event:

  local graph N:    compute -> launch tail AG -> wait for tail AG -> completion
  local graph N+1:                                                -> launch

  The caller therefore could not launch graph N+1 until graph N's tail AG had
  finished. Even computation at the beginning of graph N+1 that did not depend on
  the prefetched weight, such as RMSNorm, could not overlap with the tail AG.

  The desired execution is:
```test
  local graph N:    compute -> launch tail AG --------------------+
                               completion                         |
  local graph N+1:              launch -> independent compute -> wait event -> use weight
```
  To make this safe, the consumer must retain an explicit wait on the producer's
  AG event before reading the prefetched weight.

## Solution

  This PR fixes both issues by preserving the cross-graph prefetch state and
  dependency:

  - Preserve _already_ag_drained across runner-local warmup so capture sees the
    same incoming prefetch state as real replay.

  - Do not restore a completed _prefetch_handle; it has already been drained by
    the producer. The external ag_event represents the remaining device-side
    dependency.

  - When _already_ag_drained is set, skip draining the completed work handle but
    still wait on ag_event before consuming the weight.

  - Record fwd_completion_event before joining outgoing tail AGs. This allows
    the next local graph to launch and execute independent work while the tail AG
    is running.

## Convergence
1/4 Nemotron-Next train and val loss curve match with eager, and with the codebase before the fix.
<img width="1678" height="929" alt="Screenshot 2026-08-20 at 9 30 34 AM" src="https://github.com/user-attachments/assets/dca3b3cb-1faf-4491-9235-441f305d3cc5" />
<img width="1661" height="931" alt="Screenshot 2026-08-20 at 9 30 48 AM" src="https://github.com/user-attachments/assets/6d65e5aa-151b-4148-bcc2-e8cac96e8f3b" />


## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
