### PR TITLE
Handle Transformer Engine delayed gradients in MFSDP

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -27,6 +27,7 @@ from torch.distributed.tensor.placement_types import Placement
 from ..mixed_precision import MixedPrecisionPolicy
 from .countdown import Countdown
 from .indexed_order import IndexedOrder
+from .module_utils import get_parameter_owner
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Flat
 
@@ -299,9 +300,13 @@ class FsdpModule:
                 if not getattr(parameter, "skip_backward_post_hook", False):
                     parameter.register_post_accumulate_grad_hook(grad_hook)
                     continue
-
-                module_fqn, _, _ = fsdp_parameter.fqns[0].rpartition(".")
-                parameter_module = module.get_submodule(module_fqn) if module_fqn else module
+                if len(fsdp_parameter.fqns) > 1:
+                    raise ValueError(
+                        "Tied parameters with delayed wgrad are not supported because "
+                        "Transformer Engine does not accumulate their gradients. See "
+                        "https://github.com/NVIDIA/TransformerEngine/issues/3437"
+                    )
+                parameter_module, _ = get_parameter_owner(module, fsdp_parameter.fqns[0])
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -293,7 +293,18 @@ class FsdpModule:
             if not group.requires_grad:
                 continue
             for fsdp_parameter in group.fsdp_parameters:
-                fsdp_parameter.unsharded.register_post_accumulate_grad_hook(grad_hook)
+                parameter = fsdp_parameter.unsharded
+                # ``skip_backward_post_hook`` is TE's delayed-wgrad contract: these
+                # gradients are materialized by ``backward_dw()``, not autograd.
+                if not getattr(parameter, "skip_backward_post_hook", False):
+                    parameter.register_post_accumulate_grad_hook(grad_hook)
+                    continue
+
+                module_fqn, _, _ = fsdp_parameter.fqns[0].rpartition(".")
+                parameter_module = module.get_submodule(module_fqn) if module_fqn else module
+                parameter_module.register_wgrad_accumulation_and_reduce_hooks(
+                    lambda parameter=parameter: grad_hook(parameter)
+                )
 
     @staticmethod
     def _pre_load_state_dict(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for resolving parameters within FSDP modules."""
+
+from torch import nn
+
+
+def get_parameter_owner(root_module: nn.Module, parameter_fqn: str) -> tuple[nn.Module, str]:
+    """Resolve a root-module-relative parameter FQN to its direct owner."""
+    module_name, separator, parameter_name = parameter_fqn.rpartition(".")
+    owner = root_module.get_submodule(module_name) if separator else root_module
+    return owner, parameter_name

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,6 +28,7 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
+from .module_utils import get_parameter_owner
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -265,7 +266,7 @@ class FsdpParameterGroup:
         if owning_module is None:
             raise RuntimeError("FSDP parameter group outlived its owning module.")
         for fqn in fqns:
-            module, parameter_name = _get_parameter_owner(owning_module, fqn)
+            module, parameter_name = get_parameter_owner(owning_module, fqn)
             module._parameters[parameter_name] = parameter
 
     def _switch_to_sharded_parameters(self) -> None:
@@ -429,10 +430,3 @@ class FsdpParameterGroup:
             # sharded.grad is only read by the optimizer. However, for consistency and
             # debugging, keep sharded.grad valid even between microbatches.
             install_sharded_grads(self.main_grad)
-
-
-def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:
-    """Resolve a root-module-relative parameter FQN to its direct owner."""
-    module_name, separator, parameter_name = name.rpartition(".")
-    owner = module.get_submodule(module_name) if separator else module
-    return owner, parameter_name

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -279,6 +279,33 @@ def test_fully_shard_waits_for_delayed_te_weight_gradient(distributed_setup):
     assert model.phase is FsdpModule.Phase.RESTING
 
 
+def test_fully_shard_rejects_tied_delayed_weight_gradients(distributed_setup):
+    """Tied delayed weights are unsupported until TE accumulates their gradients."""
+    device = distributed_setup.device
+    model = nn.Sequential(
+        *(
+            te.Linear(
+                16,
+                16,
+                bias=False,
+                params_dtype=torch.bfloat16,
+                device=device,
+                delay_wgrad_compute=True,
+                fuse_wgrad_accumulation=False,
+            )
+            for _ in range(2)
+        )
+    )
+    model[1].weight = model[0].weight
+
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    with (
+        fully_shard_context(device=device),
+        pytest.raises(ValueError, match="Transformer Engine does not accumulate their gradients"),
+    ):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+
 @pytest.mark.parametrize("use_reentrant", [False, True], ids=["non_reentrant", "reentrant"])
 def test_fully_shard_activation_recompute_reshards_parameters(distributed_setup, use_reentrant):
     """Activation recomputation should leave every FSDP module resharded.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -7,6 +7,7 @@ import logging
 import pytest
 import torch
 import torch.distributed as dist
+import transformer_engine.pytorch as te
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
@@ -246,6 +247,36 @@ def test_fully_shard_sgd_losses_match_baseline(
         torch.stack(baseline_losses),
         msg="Sharded losses did not match baseline losses.",
     )
+
+
+def test_fully_shard_waits_for_delayed_te_weight_gradient(distributed_setup):
+    """TE's callback, not AccumulateGrad, completes MFSDP backward."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = te.Linear(
+        16,
+        16,
+        bias=False,
+        params_dtype=torch.bfloat16,
+        device=device,
+        delay_wgrad_compute=True,
+        fuse_wgrad_accumulation=False,
+    )
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    x = torch.randn(4, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
+    model(x).float().square().mean().backward()
+    assert model.weight.grad is None
+    assert model.phase is FsdpModule.Phase.BACKWARD
+
+    model.backward_dw()
+    torch.cuda.synchronize(device)
+
+    assert model.weight.grad is not None
+    assert model.phase is FsdpModule.Phase.RESTING
 
 
 @pytest.mark.parametrize("use_reentrant", [False, True], ids=["non_reentrant", "reentrant"])

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -273,7 +273,6 @@ def test_fully_shard_waits_for_delayed_te_weight_gradient(distributed_setup):
     assert model.phase is FsdpModule.Phase.BACKWARD
 
     model.backward_dw()
-    torch.cuda.synchronize(device)
 
     assert model.weight.grad is not None
     assert model.phase is FsdpModule.Phase.RESTING


### PR DESCRIPTION
## Summary

MFSDP normally treats PyTorch post-accumulate-grad hooks as the gradient-ready signal. Transformer Engine delayed-wgrad parameters instead materialize their gradients in `backward_dw()`.

Register MFSDP’s existing gradient-completion hook through TE’s `register_wgrad_accumulation_and_reduce_hooks()` for parameters marked with TE’s `skip_backward_post_hook` contract. Ordinary parameters retain the normal PyTorch hook.

Add a direct, single-rank TE `Linear` test that verifies MFSDP remains in backward after autograd and completes only after `backward_dw()`.

## Dependency

Depends on #6695, which shares the MFSDP gradient-completion hook used here. This branch is based on that PR’s head.

## Tests

- `python -m torch.distributed.run --nproc-per-node 1 -m pytest -q --capture=fd tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_fully_shard_waits_for_delayed_te_weight_gradient`
- `ruff check megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py`
