### PR TITLE
[Dev] Fix DS4 lite train/inference consistency: mHC combine transpose and hash-route weights

### DIFF
--- a/experimental/lite/megatron/lite/primitive/modules/attention/hca.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/hca.py
@@ -62,5 +62,5 @@ class HyperConnection(nn.Module):
     ) -> torch.Tensor:
         dtype = x.dtype
         placed = post.to(dtype).unsqueeze(-1) * x.unsqueeze(-2)
-        mixed = torch.matmul(comb.to(dtype), residual.to(dtype))
+        mixed = torch.matmul(comb.to(dtype).transpose(-1, -2), residual.to(dtype))
         return placed + mixed

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -296,7 +296,9 @@ class TokenDispatcher:
         num_out = int(routing_map.sum().item())
 
         probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
-        probs_2d.scatter_(1, topk_indices, topk_scores)
+        # Hash routing may repeat an expert across top-k slots. The bool routing
+        # map deduplicates its compute, so preserve multiplicity by summing weights.
+        probs_2d.scatter_add_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
             hidden_states,
@@ -338,7 +340,7 @@ class TokenDispatcher:
         num_out = int(routing_map.sum().item())
 
         probs_2d = torch.zeros(t, e, dtype=topk_scores.dtype, device=hidden_states.device)
-        probs_2d.scatter_(1, topk_indices, topk_scores)
+        probs_2d.scatter_add_(1, topk_indices, topk_scores)
 
         permuted, permuted_probs, sorted_indices = permute(
             hidden_states,

--- a/experimental/lite/tests/unit/primitive/modules/attention/test_hca.py
+++ b/experimental/lite/tests/unit/primitive/modules/attention/test_hca.py
@@ -1,0 +1,15 @@
+import torch
+
+
+def test_post_consumes_comb_transposed(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.attention.hca import HyperConnection
+
+    x = torch.zeros(1, 2)
+    residual = torch.eye(2).unsqueeze(0)
+    post = torch.zeros(1, 2)
+    comb = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+
+    actual = HyperConnection.post(x, residual, post, comb)
+
+    torch.testing.assert_close(actual, comb.transpose(-1, -2))

--- a/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
+++ b/experimental/lite/tests/unit/primitive/parallel/test_parallel_dimensions_independent_unit.py
@@ -127,3 +127,26 @@ def test_ep_token_dispatcher_local_roundtrip_is_independent_of_deepep():
 
     combined.sum().backward()
     torch.testing.assert_close(hidden.grad, torch.ones_like(hidden))
+
+
+def test_ep_token_dispatcher_local_sums_duplicate_route_weights(
+    transformer_engine_import_stub,
+):
+    transformer_engine_import_stub()
+    from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+
+    ps = ParallelState(ep_size=1, ep_rank=0)
+    dispatcher = TokenDispatcher(num_experts=3, hidden_size=2, ps=ps, use_deepep=False)
+    hidden = torch.tensor([[2.0, 4.0]])
+    topk_indices = torch.tensor([[1, 1, 1]])
+    topk_scores = torch.tensor([[0.2, 0.3, 0.4]])
+
+    dispatched, tokens_per_expert, dispatched_probs = dispatcher.dispatch(
+        hidden, topk_scores, topk_indices
+    )
+    combined = dispatcher.combine(dispatched * dispatched_probs.unsqueeze(-1))
+
+    torch.testing.assert_close(tokens_per_expert, torch.tensor([0, 1, 0]))
+    torch.testing.assert_close(dispatched, hidden)
+    torch.testing.assert_close(dispatched_probs, torch.tensor([0.9]))
+    torch.testing.assert_close(combined, hidden * 0.9)


### PR DESCRIPTION
## What does this PR do?

Fix two DeepSeek-V4 Lite correctness issues:

1. Fix mHC residual mixing combine matrix orientation.
2. Fix MoE routing probability accumulation for duplicate expert assignments.

These mismatches can cause train/inference numerical divergence.

---

## Issue 1: mHC combine matrix orientation mismatch

The DeepSeek-V4 reference implementation applies mHC residual mixing with the transposed combine matrix.

For the Lite residual layout, this corresponds to:

```python
mixed = combine_matrix.transpose(-1, -2) @ residual
```

The previous implementation used:

```python
mixed = combine_matrix @ residual
```

These operations are not equivalent because the Sinkhorn-normalized combine matrix is not guaranteed to be symmetric.

Fix:

```diff
- mixed = combine_matrix @ residual
+ mixed = combine_matrix.transpose(-1, -2) @ residual
```

This restores the intended mHC residual mixing behavior.

---

## Issue 2: Duplicate expert assignment handling in MoE routing

DeepSeek-V4 hash routing may produce duplicate expert indices for the same token.

The previous implementation used:

```python
probs_2d.scatter_(1, topk_indices, topk_scores)
```

which overwrites previous values when indices are duplicated.

Example:

```text
expert_ids: [5, 5, 12]
scores:     [0.2, 0.3, 0.5]
```

The reference behavior accumulates duplicate assignments:

```text
expert 5  -> 0.2 + 0.3
expert 12 -> 0.5
```

Fix:

```diff
- probs_2d.scatter_(1, topk_indices, topk_scores)
+ probs_2d.scatter_add_(1, topk_indices, topk_scores)
```

This preserves routing probability aggregation for duplicate expert assignments.

---
## Validation

Tested with:

- Hardware: NVIDIA H20
- Model: DeepSeek-V4-Flash
- Rollout: vLLM 0.25.1
- RL framework: verl
- Training backend: Megatron-Lite

The fixes eliminate the deep-layer residual magnitude blow-up and restore
train/inference consistency on the same prompt and response.

| Metric | Before | After |
|---|---:|---:|
| L24 Actor / Rollout RMS | 15.75 / 2.46 | 2.40 / 2.46 |
| L32 Actor / Rollout RMS | 84.40 / 2.14 | 2.11 / 2.14 |
| L42 Actor / Rollout RMS | 159.71 / 3.46 | 3.45 / 3.46 |
| Mean absolute log-prob difference | 2.008 | 0.006 |
| K3 KL | 1.661 | 0.0003 |
| Log-prob Pearson correlation | 0.003 | 0.996 |

On a larger step-0 validation run with an 80K context length and 128 rollout
trajectories, the K3 KL was 0.00472.

## Impact

This PR does not change the model architecture.

It fixes DeepSeek-V4 Lite implementation mismatches and restores:

- mHC residual mixing consistency;
- MoE routing correctness;
- train/inference numerical alignment.

## Not a duplicate

Verified against the current upstream branch, and no other open PR was found
for either fix.