### PR TITLE
[dev] Fix mock data, hybrid recompute, CUDA graph reuse, and Hash MoE selection

### DIFF
--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -139,9 +139,9 @@ class StaticBufferLoader:
                     StaticBufferLoader.static_buffers[stage][microbatch], inputs
                 )
         torch.cuda.current_stream().wait_stream(self.stream)
-        # Callers may tailor the batch structure for their pipeline stage by
-        # replacing or removing entries. Keep those mutations from corrupting
-        # the cached structure while continuing to share its static tensors.
+        # Shallow-copy so callers may replace or remove top-level entries to tailor the
+        # batch to their pipeline stage without mutating the cached static buffer. Nested
+        # containers and the tensors themselves are still shared with the buffer.
         return StaticBufferLoader.static_buffers[stage][microbatch].copy()
 
 

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -139,7 +139,10 @@ class StaticBufferLoader:
                     StaticBufferLoader.static_buffers[stage][microbatch], inputs
                 )
         torch.cuda.current_stream().wait_stream(self.stream)
-        return StaticBufferLoader.static_buffers[stage][microbatch]
+        # Callers may tailor the batch structure for their pipeline stage by
+        # replacing or removing entries. Keep those mutations from corrupting
+        # the cached structure while continuing to share its static tensors.
+        return StaticBufferLoader.static_buffers[stage][microbatch].copy()
 
 
 class FullCudaGraphWrapper:

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -455,9 +455,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         if layer.recompute_pre_mlp_layernorm or (
             mhc_recompute_manager is not None and layer.mhc_checkpoint_pre_mlp_layernorm
         ):
-            layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(
-                output_with_bias[0]
-            )
+            layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(output_with_bias[0])
         if layer.mlp_norm_manager is not None:
             output_with_bias = layer._group_offload_output_with_bias(
                 output_with_bias, layer.mlp_norm_manager, forced_released_tensors=[residual]

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -400,7 +400,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         packed_seq_params: Optional[PackedSeqParams],
         padding_mask: Optional[Tensor],
         input_ids: Optional[Tensor] = None,
-        mhc_recompute_manager: Optional[CheckpointManager] = None,
+        mhc_recompute_manager: Optional[MHCCheckpointManager] = None,
     ) -> Optional[Tuple[Tuple[Tensor, Optional[Tensor]], Optional[Tensor], float, bool]]:
         """Return a raw TransformerLayer branch output when the wrapped layer is split.
 

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -450,6 +450,14 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             packed_seq_params=packed_seq_params,
             mhc_recompute_manager=mhc_recompute_manager,
         )
+        # This fast path bypasses TransformerLayer._forward_post_mlp(), which normally
+        # discards the selective pre-MLP layernorm checkpoint before MLP backward.
+        if layer.recompute_pre_mlp_layernorm or (
+            mhc_recompute_manager is not None and layer.mhc_checkpoint_pre_mlp_layernorm
+        ):
+            layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(
+                output_with_bias[0]
+            )
         if layer.mlp_norm_manager is not None:
             output_with_bias = layer._group_offload_output_with_bias(
                 output_with_bias, layer.mlp_norm_manager, forced_released_tensors=[residual]

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -118,6 +118,8 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
     + the inner router/preprocess submodules for partial MoE capture (experts stay eager).
     """
 
+    supports_hybrid_recompute_kwargs = True
+
     def __init__(self, config: TransformerConfig, layer: MegatronModule) -> None:
         super().__init__(config=config)
         if (
@@ -569,7 +571,7 @@ class HybridStack(MegatronModule):
             Defaults to True.
         layer_type_list (list, optional): pre-computed list of layer type symbols for
             this pipeline segment. When provided (by HybridModel), pipeline stage
-            selection has already been done via '|' separators in the pattern.
+            selection has already been done by the hybrid layer allocation helper.
         pp_layer_offset (int, optional): the global layer offset for this pipeline
             segment. Defaults to 0.
         post_layer_norm (bool, optional): whether to include a final layer norm.
@@ -582,6 +584,8 @@ class HybridStack(MegatronModule):
             process groups to use.
         is_mtp_layer (bool, optional): whether this is an MTP layer. Defaults to False.
         mtp_layer_number (int, optional): enclosing MTP depth for logging nested MTP metrics.
+        hash_moe_layer_threshold (int, optional): global Hybrid layer-number threshold used
+            to select hash-routed MoE layers. Defaults to the standard config semantics.
     """
 
     def __init__(
@@ -598,6 +602,7 @@ class HybridStack(MegatronModule):
         pg_collection: ProcessGroupCollection = None,
         is_mtp_layer: bool = False,
         mtp_layer_number: Optional[int] = None,
+        hash_moe_layer_threshold: Optional[int] = None,
         name: str | None = None,
     ) -> None:
         """
@@ -737,6 +742,7 @@ class HybridStack(MegatronModule):
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
                         add_layer_offset=False,
+                        hash_moe_layer_threshold=hash_moe_layer_threshold,
                         name=(name + f".layers.{i}") if name is not None else None,
                     )
                 elif layer_type == LayerSymbols.GDN:

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -400,6 +400,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         packed_seq_params: Optional[PackedSeqParams],
         padding_mask: Optional[Tensor],
         input_ids: Optional[Tensor] = None,
+        mhc_recompute_manager: Optional[CheckpointManager] = None,
     ) -> Optional[Tuple[Tuple[Tensor, Optional[Tensor]], Optional[Tensor], float, bool]]:
         """Return a raw TransformerLayer branch output when the wrapped layer is split.
 
@@ -431,6 +432,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
                     rotary_pos_emb=rotary_pos_emb,
                     packed_seq_params=packed_seq_params,
                     sequence_len_offset=sequence_len_offset,
+                    mhc_recompute_manager=mhc_recompute_manager,
                 )
             )
             output_with_bias = layer._group_offload_output_with_bias(
@@ -444,6 +446,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             padding_mask=padding_mask,
             input_ids=input_ids,
             packed_seq_params=packed_seq_params,
+            mhc_recompute_manager=mhc_recompute_manager,
         )
         if layer.mlp_norm_manager is not None:
             output_with_bias = layer._group_offload_output_with_bias(
@@ -487,6 +490,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             packed_seq_params,
             padding_mask,
             input_ids,
+            mhc_recompute_manager=mhc_recompute_manager,
         )
 
         if fast_path_result is None:

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -75,27 +75,29 @@ def _get_hash_moe_layer_threshold(main_pattern: str | None, n_hash_layers: int) 
 
 
 def _validate_hash_moe_pipeline_placement(
-    main_pattern: str | None,
-    n_hash_layers: int,
-    pipeline_model_parallel_size: int,
+    layer_type_list: list[str],
+    layer_offset: int,
+    hash_moe_layer_threshold: int,
+    pre_process: bool,
 ) -> None:
-    """Require all hybrid hash-MoE layers to share the embedding pipeline stage."""
-    if n_hash_layers <= 0 or pipeline_model_parallel_size <= 1:
+    """Reject local hash-MoE layers on a stage that does not own the token IDs."""
+    if hash_moe_layer_threshold <= 0 or pre_process:
         return
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 
-    assert main_pattern is not None and Symbols.PIPE in main_pattern, (
-        "hybrid_layer_pattern must contain pipe ('|') separators when using hash MoE layers "
-        "with pipeline parallelism (PP > 1)."
-    )
-    embedding_stage_pattern = main_pattern.split(Symbols.PIPE, 1)[0]
-    n_moe_layers_with_embedding = embedding_stage_pattern.count(Symbols.MOE)
-    assert n_hash_layers <= n_moe_layers_with_embedding, (
-        "Currently, all hash MoE layers must be in the same virtual pipeline stage as the "
-        f"embedding. The embedding stage has {n_moe_layers_with_embedding} MoE layers, but "
-        f"moe_n_hash_layers={n_hash_layers}."
-    )
+    local_hash_layer_numbers = [
+        layer_offset + local_layer_number
+        for local_layer_number, layer_type in enumerate(layer_type_list, start=1)
+        if layer_type == Symbols.MOE
+        and layer_offset + local_layer_number <= hash_moe_layer_threshold
+    ]
+    if local_hash_layer_numbers:
+        raise ValueError(
+            "Currently, all hash MoE layers must be in the same pipeline/virtual-pipeline "
+            "stage as the embedding because only that stage owns input_ids. This "
+            f"non-embedding stage contains hash MoE layer(s) {local_hash_layer_numbers}."
+        )
 
 
 class HybridModel(LanguageModule, GraphableMegatronModule):
@@ -250,11 +252,6 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         hash_layer_threshold = _get_hash_moe_layer_threshold(
             parsed.main_pattern, configured_n_hash_layers
         )
-        _validate_hash_moe_pipeline_placement(
-            parsed.main_pattern,
-            configured_n_hash_layers,
-            self.config.pipeline_model_parallel_size,
-        )
 
         logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
 
@@ -265,6 +262,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
             last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
             **logging_pg_kwargs,
+        )
+        _validate_hash_moe_pipeline_placement(
+            layer_type_list,
+            layer_offset,
+            hash_layer_threshold,
+            self.pre_process,
         )
 
         # Determine if MTP is needed (based on pattern parsing)
@@ -328,23 +331,20 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 use_cpu_initialization=self.config.use_cpu_initialization,
                 cp_group=self.pg_collection.cp,
             )
-        # TopKRouter allocates all hash-specific state during construction. Temporarily expose
-        # the global Hybrid layer threshold, then restore the user-facing MoE count.
-        self.config.moe_n_hash_layers = hash_layer_threshold
-        try:
-            self.decoder = build_module(
-                hybrid_stack_spec,
-                self.config,
-                pre_process=self.pre_process,
-                layer_type_list=layer_type_list,
-                pp_layer_offset=layer_offset,
-                post_process=self.post_process,
-                dtype=config.params_dtype,
-                pg_collection=self.pg_collection,
-                name="decoder",
-            )
-        finally:
-            self.config.moe_n_hash_layers = configured_n_hash_layers
+        self.decoder = build_module(
+            hybrid_stack_spec,
+            self.config,
+            pre_process=self.pre_process,
+            layer_type_list=layer_type_list,
+            pp_layer_offset=layer_offset,
+            post_process=self.post_process,
+            dtype=config.params_dtype,
+            pg_collection=self.pg_collection,
+            hash_moe_layer_threshold=(
+                hash_layer_threshold if configured_n_hash_layers > 0 else None
+            ),
+            name="decoder",
+        )
 
         # MTP block - uses mtp_block_spec from hybrid_stack_spec.submodules
         if self.mtp_process:

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -74,6 +74,30 @@ def _get_hash_moe_layer_threshold(main_pattern: str | None, n_hash_layers: int) 
     return moe_layer_numbers[n_hash_layers - 1]
 
 
+def _validate_hash_moe_pipeline_placement(
+    main_pattern: str | None,
+    n_hash_layers: int,
+    pipeline_model_parallel_size: int,
+) -> None:
+    """Require all hybrid hash-MoE layers to share the embedding pipeline stage."""
+    if n_hash_layers <= 0 or pipeline_model_parallel_size <= 1:
+        return
+
+    from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+
+    assert main_pattern is not None and Symbols.PIPE in main_pattern, (
+        "hybrid_layer_pattern must contain pipe ('|') separators when using hash MoE layers "
+        "with pipeline parallelism (PP > 1)."
+    )
+    embedding_stage_pattern = main_pattern.split(Symbols.PIPE, 1)[0]
+    n_moe_layers_with_embedding = embedding_stage_pattern.count(Symbols.MOE)
+    assert n_hash_layers <= n_moe_layers_with_embedding, (
+        "Currently, all hash MoE layers must be in the same virtual pipeline stage as the "
+        f"embedding. The embedding stage has {n_moe_layers_with_embedding} MoE layers, but "
+        f"moe_n_hash_layers={n_hash_layers}."
+    )
+
+
 class HybridModel(LanguageModule, GraphableMegatronModule):
     """Hybrid language model.
 
@@ -222,6 +246,16 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         self.mtp_pattern = parsed.mtp_pattern
         self.mtp_num_depths = parsed.mtp_num_depths
 
+        configured_n_hash_layers = self.config.moe_n_hash_layers
+        hash_layer_threshold = _get_hash_moe_layer_threshold(
+            parsed.main_pattern, configured_n_hash_layers
+        )
+        _validate_hash_moe_pipeline_placement(
+            parsed.main_pattern,
+            configured_n_hash_layers,
+            self.config.pipeline_model_parallel_size,
+        )
+
         logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
 
         layer_type_list, layer_offset = select_pipeline_segment(
@@ -294,10 +328,6 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 use_cpu_initialization=self.config.use_cpu_initialization,
                 cp_group=self.pg_collection.cp,
             )
-        configured_n_hash_layers = self.config.moe_n_hash_layers
-        hash_layer_threshold = _get_hash_moe_layer_threshold(
-            parsed.main_pattern, configured_n_hash_layers
-        )
         # TopKRouter allocates all hash-specific state during construction. Temporarily expose
         # the global Hybrid layer threshold, then restore the user-facing MoE count.
         self.config.moe_n_hash_layers = hash_layer_threshold

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -56,7 +56,7 @@ def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
 def _get_hash_moe_layer_threshold(main_pattern: str | None, n_hash_layers: int) -> int:
     """Convert a leading hash-MoE count to a global hybrid layer-number threshold."""
     if n_hash_layers <= 0:
-        return n_hash_layers
+        return 0
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 
@@ -247,10 +247,14 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
         self.mtp_pattern = parsed.mtp_pattern
         self.mtp_num_depths = parsed.mtp_num_depths
+        if self.mtp_pattern is not None and self.config.overlap_moe_expert_parallel_comm:
+            raise ValueError(
+                "Hybrid MTP does not support overlap_moe_expert_parallel_comm because the "
+                "overlap scheduler does not expand the nested HybridStack."
+            )
 
-        configured_n_hash_layers = self.config.moe_n_hash_layers
         hash_layer_threshold = _get_hash_moe_layer_threshold(
-            parsed.main_pattern, configured_n_hash_layers
+            parsed.main_pattern, self.config.moe_n_hash_layers
         )
 
         logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
@@ -340,9 +344,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             post_process=self.post_process,
             dtype=config.params_dtype,
             pg_collection=self.pg_collection,
-            hash_moe_layer_threshold=(
-                hash_layer_threshold if configured_n_hash_layers > 0 else None
-            ),
+            hash_moe_layer_threshold=hash_layer_threshold or None,
             name="decoder",
         )
 
@@ -363,6 +365,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 mtp_layer_pattern=self.mtp_pattern,
                 mtp_num_depths=self.mtp_num_depths,
                 hybrid_submodules=hybrid_submodules,
+                hash_moe_layer_threshold=hash_layer_threshold or None,
                 name="mtp",
             )
             self._setup_mtp_cuda_graphs()

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -75,10 +75,7 @@ def _get_hash_moe_layer_threshold(main_pattern: str | None, n_hash_layers: int) 
 
 
 def _validate_hash_moe_pipeline_placement(
-    layer_type_list: list[str],
-    layer_offset: int,
-    hash_moe_layer_threshold: int,
-    pre_process: bool,
+    layer_type_list: list[str], layer_offset: int, hash_moe_layer_threshold: int, pre_process: bool
 ) -> None:
     """Reject local hash-MoE layers on a stage that does not own the token IDs."""
     if hash_moe_layer_threshold <= 0 or pre_process:
@@ -268,10 +265,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             **logging_pg_kwargs,
         )
         _validate_hash_moe_pipeline_placement(
-            layer_type_list,
-            layer_offset,
-            hash_layer_threshold,
-            self.pre_process,
+            layer_type_list, layer_offset, hash_layer_threshold, self.pre_process
         )
 
         # Determine if MTP is needed (based on pattern parsing)

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -53,6 +53,27 @@ def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
     return {'tp_group': tp_group, 'dp_cp_group': dp_cp_group}
 
 
+def _get_hash_moe_layer_threshold(main_pattern: str | None, n_hash_layers: int) -> int:
+    """Convert a leading hash-MoE count to a global hybrid layer-number threshold."""
+    if n_hash_layers <= 0:
+        return n_hash_layers
+
+    from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+
+    global_layer_pattern = (main_pattern or '').replace(Symbols.PIPE, '')
+    moe_layer_numbers = [
+        layer_number
+        for layer_number, layer_type in enumerate(global_layer_pattern, start=1)
+        if layer_type == Symbols.MOE
+    ]
+    if n_hash_layers > len(moe_layer_numbers):
+        raise ValueError(
+            f"moe_n_hash_layers={n_hash_layers} exceeds the {len(moe_layer_numbers)} "
+            "MoE layers in the main hybrid layer pattern."
+        )
+    return moe_layer_numbers[n_hash_layers - 1]
+
+
 class HybridModel(LanguageModule, GraphableMegatronModule):
     """Hybrid language model.
 
@@ -273,17 +294,27 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 use_cpu_initialization=self.config.use_cpu_initialization,
                 cp_group=self.pg_collection.cp,
             )
-        self.decoder = build_module(
-            hybrid_stack_spec,
-            self.config,
-            pre_process=self.pre_process,
-            layer_type_list=layer_type_list,
-            pp_layer_offset=layer_offset,
-            post_process=self.post_process,
-            dtype=config.params_dtype,
-            pg_collection=self.pg_collection,
-            name="decoder",
+        configured_n_hash_layers = self.config.moe_n_hash_layers
+        hash_layer_threshold = _get_hash_moe_layer_threshold(
+            parsed.main_pattern, configured_n_hash_layers
         )
+        # TopKRouter allocates all hash-specific state during construction. Temporarily expose
+        # the global Hybrid layer threshold, then restore the user-facing MoE count.
+        self.config.moe_n_hash_layers = hash_layer_threshold
+        try:
+            self.decoder = build_module(
+                hybrid_stack_spec,
+                self.config,
+                pre_process=self.pre_process,
+                layer_type_list=layer_type_list,
+                pp_layer_offset=layer_offset,
+                post_process=self.post_process,
+                dtype=config.params_dtype,
+                pg_collection=self.pg_collection,
+                name="decoder",
+            )
+        finally:
+            self.config.moe_n_hash_layers = configured_n_hash_layers
 
         # MTP block - uses mtp_block_spec from hybrid_stack_spec.submodules
         if self.mtp_process:

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -76,9 +76,10 @@ def checkpointed_forward(
                 else:
                     inner_quantization_context = nullcontext()
 
-                # Build the full TransformerLayer kwarg set; for non-TL
-                # layers (currently MambaLayer in HybridStack) pop the kwargs
-                # they don't accept and treat the return as a single tensor.
+                # Build the full TransformerLayer kwarg set. Hybrid mHC wraps
+                # TransformerLayer instead of subclassing it, so detect that
+                # case through inner_layer without importing hybrid_block here
+                # (which would create a circular import).
                 layer_kwargs = dict(
                     hidden_states=hidden_states,
                     attention_mask=attention_mask,
@@ -93,6 +94,13 @@ def checkpointed_forward(
                 )
                 with inner_quantization_context:
                     if isinstance(layer, TransformerLayer):
+                        hidden_states, context = layer(**layer_kwargs)
+                    elif isinstance(getattr(layer, "inner_layer", None), TransformerLayer):
+                        # HyperConnectionHybridLayer accepts the routing metadata
+                        # needed by its wrapped MoE layer, but not cross-attention
+                        # kwargs from the TransformerLayer interface.
+                        for k in ("context", "context_mask", "attention_bias"):
+                            layer_kwargs.pop(k, None)
                         hidden_states, context = layer(**layer_kwargs)
                     else:  # MambaLayer (HybridStack `M` slot)
                         for k in (

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -76,10 +76,9 @@ def checkpointed_forward(
                 else:
                     inner_quantization_context = nullcontext()
 
-                # Build the full TransformerLayer kwarg set. Hybrid mHC wraps
-                # TransformerLayer instead of subclassing it, so detect that
-                # case through inner_layer without importing hybrid_block here
-                # (which would create a circular import).
+                # Build the full TransformerLayer kwarg set. Hybrid mHC wrappers expose
+                # an explicit capability flag so this module does not need to import
+                # hybrid_block (which would create a circular import).
                 layer_kwargs = dict(
                     hidden_states=hidden_states,
                     attention_mask=attention_mask,
@@ -95,14 +94,15 @@ def checkpointed_forward(
                 with inner_quantization_context:
                     if isinstance(layer, TransformerLayer):
                         hidden_states, context = layer(**layer_kwargs)
-                    elif isinstance(getattr(layer, "inner_layer", None), TransformerLayer):
+                    elif getattr(layer, "supports_hybrid_recompute_kwargs", False):
                         # HyperConnectionHybridLayer accepts the routing metadata
-                        # needed by its wrapped MoE layer, but not cross-attention
-                        # kwargs from the TransformerLayer interface.
+                        # consumed by wrapped MoE layers, but not cross-attention kwargs
+                        # from the TransformerLayer interface. This also covers a wrapper
+                        # around a MambaLayer; the wrapper narrows kwargs for its inner layer.
                         for k in ("context", "context_mask", "attention_bias"):
                             layer_kwargs.pop(k, None)
                         hidden_states, context = layer(**layer_kwargs)
-                    else:  # MambaLayer (HybridStack `M` slot)
+                    else:  # An unwrapped layer with a narrower interface, e.g. MambaLayer.
                         for k in (
                             "context",
                             "context_mask",

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -148,7 +148,14 @@ class RouterBuilder(Protocol):
     """Protocol for building a Router."""
 
     def __call__(
-        self, /, *, config: TransformerConfig, pg_collection: ProcessGroupCollection | None
+        self,
+        /,
+        *,
+        config: TransformerConfig,
+        pg_collection: ProcessGroupCollection | None,
+        is_mtp_layer: bool = False,
+        layer_number: int | None = None,
+        hash_moe_layer_threshold: int | None = None,
     ) -> RouterInterface: ...
 
 
@@ -229,10 +236,13 @@ class MoELayer(BaseMoELayer):
         layer_number: Optional[int] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
         is_mtp_layer: bool = False,
+        hash_moe_layer_threshold: Optional[int] = None,
         name: str | None = None,
     ):
         """
         Args:
+            hash_moe_layer_threshold (int, optional): Explicit layer-number threshold for
+                selecting hash-routed MoE layers.
             name (str | None): module instance name passed top-down from its paranet module
         """
         self.submodules = not_none(submodules)
@@ -261,12 +271,21 @@ class MoELayer(BaseMoELayer):
         self.tp_ep_group = pg_collection.tp_ep
 
         # Initialize router.
-        self.router = self.submodules.router(
-            config=self.config,
-            pg_collection=pg_collection,
-            is_mtp_layer=is_mtp_layer,
-            layer_number=layer_number,
-        )
+        if hash_moe_layer_threshold is None:
+            self.router = self.submodules.router(
+                config=self.config,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                layer_number=layer_number,
+            )
+        else:
+            self.router = self.submodules.router(
+                config=self.config,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                layer_number=layer_number,
+                hash_moe_layer_threshold=hash_moe_layer_threshold,
+            )
         self.tp_group = pg_collection.tp
 
         # Initialize latent projections.

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -271,21 +271,15 @@ class MoELayer(BaseMoELayer):
         self.tp_ep_group = pg_collection.tp_ep
 
         # Initialize router.
-        if hash_moe_layer_threshold is None:
-            self.router = self.submodules.router(
-                config=self.config,
-                pg_collection=pg_collection,
-                is_mtp_layer=is_mtp_layer,
-                layer_number=layer_number,
-            )
-        else:
-            self.router = self.submodules.router(
-                config=self.config,
-                pg_collection=pg_collection,
-                is_mtp_layer=is_mtp_layer,
-                layer_number=layer_number,
-                hash_moe_layer_threshold=hash_moe_layer_threshold,
-            )
+        router_kwargs = {
+            "config": self.config,
+            "pg_collection": pg_collection,
+            "is_mtp_layer": is_mtp_layer,
+            "layer_number": layer_number,
+        }
+        if hash_moe_layer_threshold is not None:
+            router_kwargs["hash_moe_layer_threshold"] = hash_moe_layer_threshold
+        self.router = self.submodules.router(**router_kwargs)
         self.tp_group = pg_collection.tp
 
         # Initialize latent projections.

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -52,6 +52,7 @@ class Router(ABC, MegatronModule):
         pg_collection: Optional[ProcessGroupCollection] = None,
         is_mtp_layer: bool = False,
         layer_number: Optional[int] = None,
+        hash_moe_layer_threshold: Optional[int] = None,
     ) -> None:
         """
         Initialize the Router module.
@@ -60,6 +61,8 @@ class Router(ABC, MegatronModule):
             config (TransformerConfig): Configuration object for the Transformer model.
             pg_collection (ProcessGroupCollection, optional): Process groups for MoE operations.
             is_mtp_layer (bool): Flag indicating if this router is part of an MTP layer.
+            hash_moe_layer_threshold (int, optional): Explicit layer-number threshold for
+                hash routing. When omitted, use config.moe_n_hash_layers.
         """
         super().__init__(config)
         self.config = config
@@ -67,6 +70,11 @@ class Router(ABC, MegatronModule):
         self.moe_aux_loss_func = None
         self.layer_number = layer_number
         self.is_mtp_layer = is_mtp_layer
+        self.hash_moe_layer_threshold = (
+            self.config.moe_n_hash_layers
+            if hash_moe_layer_threshold is None
+            else hash_moe_layer_threshold
+        )
         self.tp_group = pg_collection.tp
         self.cp_group = pg_collection.cp
         self.tp_cp_group = pg_collection.tp_cp
@@ -176,6 +184,7 @@ class TopKRouter(Router):
         pg_collection: Optional[ProcessGroupCollection] = None,
         is_mtp_layer: bool = False,
         layer_number: Optional[int] = None,
+        hash_moe_layer_threshold: Optional[int] = None,
     ) -> None:
         """Initialize the zero token dropping router.
 
@@ -183,12 +192,15 @@ class TopKRouter(Router):
             config (TransformerConfig): The configuration for the transformer model.
             pg_collection (ProcessGroupCollection, optional): Process groups for MoE operations.
             is_mtp_layer (bool): Flag indicating if this router is part of an MTP layer.
+            hash_moe_layer_threshold (int, optional): Explicit layer-number threshold for
+                hash routing. Hybrid models use this to translate a MoE-position count.
         """
         super().__init__(
             config=config,
             pg_collection=pg_collection,
             is_mtp_layer=is_mtp_layer,
             layer_number=layer_number,
+            hash_moe_layer_threshold=hash_moe_layer_threshold,
         )
         self.topk = self.config.moe_router_topk
         self.routing_type = self.config.moe_router_load_balancing_type
@@ -197,12 +209,12 @@ class TopKRouter(Router):
         self.mtp_layer_number: Optional[int] = None
         self.frozen_expert_bias = False
 
-        if self.config.moe_n_hash_layers > 0:
+        if self.hash_moe_layer_threshold > 0:
             assert layer_number is not None, "layer_number is required for the hash-based router."
         self.is_hash_layer = (
             not self.is_mtp_layer
-            and self.config.moe_n_hash_layers > 0
-            and layer_number <= self.config.moe_n_hash_layers
+            and self.hash_moe_layer_threshold > 0
+            and layer_number <= self.hash_moe_layer_threshold
         )
         if self.is_hash_layer:
             # DSv4-Pro ships a pre-trained tid2eid table in its inference checkpoint;
@@ -964,6 +976,7 @@ class InferenceTopKRouter(TopKRouter):
         pg_collection: Optional[ProcessGroupCollection] = None,
         is_mtp_layer: bool = False,
         layer_number: Optional[int] = None,
+        hash_moe_layer_threshold: Optional[int] = None,
     ) -> None:
         """Initialize the specialized inference top-k router.
 
@@ -986,6 +999,7 @@ class InferenceTopKRouter(TopKRouter):
             pg_collection=pg_collection,
             is_mtp_layer=is_mtp_layer,
             layer_number=layer_number,
+            hash_moe_layer_threshold=hash_moe_layer_threshold,
         )
 
     @staticmethod

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2934,7 +2934,7 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
+            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2492,6 +2492,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                 )
 
         if self.config.recompute_method == 'uniform':
+            # This is the standard non-EP-overlap checkpoint path. Hybrid MTP with
+            # overlap_moe_expert_parallel_comm is not currently supported because the
+            # overlap scheduler does not expand the nested HybridStack.
             # A legacy GPT MTP layer is already a single Transformer-layer recompute unit.
             # Hybrid MTP instead owns a nested HybridStack, which consumes the global
             # recompute_num_layers setting to chunk its layer pattern. The outer MTP layer

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1892,10 +1892,13 @@ class MultiTokenPredictionLayer(MegatronModule):
         mtp_layer_pattern: Optional[str] = None,
         hybrid_submodules: Optional[HybridStackSubmodules] = None,
         mamba_submodules: Optional[HybridStackSubmodules] = None,
+        hash_moe_layer_threshold: int | None = None,
         name: str | None = None,
     ):
         """
         Args:
+            hash_moe_layer_threshold (int, optional): Global Hybrid layer-number threshold used
+                to select hash-routed MoE layers in the nested HybridStack.
             name (str | None): module instance name passed top-down from its paranet module
         """
         super().__init__(config=config)
@@ -1918,11 +1921,6 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
-        if self.mtp_layer_pattern is not None and self.config.overlap_moe_expert_parallel_comm:
-            raise ValueError(
-                "Hybrid MTP does not support overlap_moe_expert_parallel_comm because the "
-                "overlap scheduler does not expand the nested HybridStack."
-            )
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -2040,6 +2038,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 pg_collection=pg_collection,
                 is_mtp_layer=True,
                 mtp_layer_number=self.layer_number,
+                hash_moe_layer_threshold=hash_moe_layer_threshold,
                 name=(name + ".mtp_model_layer") if name is not None else None,
             )
         elif self.config.mtp_num_layers is not None:
@@ -2379,8 +2378,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
     ):
-        """Forward through ``_proj_and_transformer_layer`` with activation
-        recomputation.
+        """Forward a legacy GPT MTP layer with activation recomputation.
 
         Mirrors ``transformer_block._checkpointed_forward``:
 
@@ -2399,6 +2397,9 @@ class MultiTokenPredictionLayer(MegatronModule):
           context entered before ``te_checkpoint``; see the
           ``outer_quantization_context`` block below.
         """
+        assert (
+            self.mtp_layer_pattern is None
+        ), "Hybrid MTP delegates full activation recomputation to its nested HybridStack."
 
         def custom_forward(
             hidden_states,
@@ -2498,13 +2499,9 @@ class MultiTokenPredictionLayer(MegatronModule):
 
         if self.config.recompute_method == 'uniform':
             # A legacy GPT MTP layer is already a single Transformer-layer recompute unit.
-            # Hybrid MTP instead owns a nested HybridStack, which consumes the global
-            # recompute_num_layers setting to chunk its layer pattern. The outer MTP layer
-            # remains one checkpoint unit in either case.
-            if self.mtp_layer_pattern is None:
-                assert (
-                    self.config.recompute_num_layers == 1
-                ), "recompute_num_layers must be 1 for MTP recompute"
+            assert (
+                self.config.recompute_num_layers == 1
+            ), "recompute_num_layers must be 1 for MTP recompute"
             with outer_quantization_context:
                 outputs = checkpoint_handler()
         elif self.config.recompute_method == 'block':
@@ -2593,7 +2590,15 @@ class MultiTokenPredictionLayer(MegatronModule):
             roll_depth=roll_depth,
         )
 
-        if self.config.recompute_granularity == 'full' and self.training:
+        # Legacy GPT MTP owns one outer checkpoint around its projection and Transformer
+        # layer. Hybrid MTP instead delegates full recompute to the nested HybridStack so
+        # that ``recompute_num_layers`` controls its layer chunks without nesting checkpoints.
+        use_outer_recompute = (
+            self.config.recompute_granularity == 'full'
+            and self.training
+            and self.mtp_layer_pattern is None
+        )
+        if use_outer_recompute:
             hidden_states = self._checkpointed_forward(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
@@ -2740,10 +2745,13 @@ class MultiTokenPredictionBlock(MegatronModule):
         mtp_num_depths: int = 0,
         hybrid_submodules: Optional["HybridStackSubmodules"] = None,
         mamba_submodules: Optional["HybridStackSubmodules"] = None,
+        hash_moe_layer_threshold: int | None = None,
         name: str | None = None,
     ):
         """
         Args:
+            hash_moe_layer_threshold (int, optional): Global Hybrid layer-number threshold passed
+                to each nested MTP HybridStack.
             name (str | None): module instance name passed top-down from its paranet module
         """
         super().__init__(config=config)
@@ -2765,6 +2773,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         self.mtp_layer_pattern = mtp_layer_pattern
         self.mtp_num_depths = mtp_num_depths
         self.hybrid_submodules = hybrid_submodules
+        self.hash_moe_layer_threshold = hash_moe_layer_threshold
         self.mtp_use_repeated_layer = self.config.mtp_use_repeated_layer
         self.name = name
 
@@ -2832,6 +2841,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                     pg_collection=pg_collection,
                     mtp_layer_pattern=mtp_layer_pattern,
                     hybrid_submodules=hybrid_submodules,
+                    hash_moe_layer_threshold=self.hash_moe_layer_threshold,
                     name=(self.name + f".layers.{layer_number}") if self.name is not None else None,
                 )
             return module

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2949,7 +2949,7 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
+            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1918,6 +1918,11 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if self.mtp_layer_pattern is not None and self.config.overlap_moe_expert_parallel_comm:
+            raise ValueError(
+                "Hybrid MTP does not support overlap_moe_expert_parallel_comm because the "
+                "overlap scheduler does not expand the nested HybridStack."
+            )
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -2492,9 +2497,6 @@ class MultiTokenPredictionLayer(MegatronModule):
                 )
 
         if self.config.recompute_method == 'uniform':
-            # This is the standard non-EP-overlap checkpoint path. Hybrid MTP with
-            # overlap_moe_expert_parallel_comm is not currently supported because the
-            # overlap scheduler does not expand the nested HybridStack.
             # A legacy GPT MTP layer is already a single Transformer-layer recompute unit.
             # Hybrid MTP instead owns a nested HybridStack, which consumes the global
             # recompute_num_layers setting to chunk its layer pattern. The outer MTP layer
@@ -2937,7 +2939,7 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
+            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2492,12 +2492,14 @@ class MultiTokenPredictionLayer(MegatronModule):
                 )
 
         if self.config.recompute_method == 'uniform':
-            # Uniformly divide the total number of Transformer layers and checkpoint
-            # the input activation of each divided chunk.
-            # A method to further reduce memory usage reducing checkpoints.
-            assert (
-                self.config.recompute_num_layers == 1
-            ), "recompute_num_layers must be 1 for MTP recompute"
+            # A legacy GPT MTP layer is already a single Transformer-layer recompute unit.
+            # Hybrid MTP instead owns a nested HybridStack, which consumes the global
+            # recompute_num_layers setting to chunk its layer pattern. The outer MTP layer
+            # remains one checkpoint unit in either case.
+            if self.mtp_layer_pattern is None:
+                assert (
+                    self.config.recompute_num_layers == 1
+                ), "recompute_num_layers must be 1 for MTP recompute"
             with outer_quantization_context:
                 outputs = checkpoint_handler()
         elif self.config.recompute_method == 'block':

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -891,9 +891,10 @@ class TransformerConfig(ModelParallelConfig):
     This is an experimental feature for benchmarking purposes."""
 
     moe_n_hash_layers: int = 0
-    """Number of leading transformer layers that use hash-based MoE routing.
-    Layers with layer_number <= moe_n_hash_layers use a pre-computed tid2eid
-    lookup table for expert selection instead of learned top-k routing."""
+    """Number of leading layers that use hash-based MoE routing. Standard transformer
+    stacks compare this value with layer_number; hybrid stacks count only MoE positions
+    in the hybrid layer pattern. Hash layers use a pre-computed tid2eid lookup table for
+    expert selection instead of learned top-k routing."""
 
     actual_vocab_size: Optional[int] = None
     """Padded actual vocabulary size. Required when moe_n_hash_layers > 0 for the

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -617,7 +617,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         inference_context: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
-        mhc_recompute_manager: Optional['CheckpointManager'] = None,
+        mhc_recompute_manager: Optional['MHCCheckpointManager'] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -874,7 +874,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         return output, context
 
     def _forward_pre_mlp_layernorm(
-        self, hidden_states: Tensor, mhc_recompute_manager: Optional['CheckpointManager'] = None
+        self, hidden_states: Tensor, mhc_recompute_manager: Optional['MHCCheckpointManager'] = None
     ):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         checkpoint_pre_mlp_layernorm = self.recompute_pre_mlp_layernorm or (
@@ -940,7 +940,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         padding_mask: Tensor | None = None,
         input_ids: Optional[Tensor] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
-        mhc_recompute_manager: Optional['CheckpointManager'] = None,
+        mhc_recompute_manager: Optional['MHCCheckpointManager'] = None,
     ) -> tuple[tuple[Tensor, Tensor | None], Tensor]:
         """Run pre-MLP norm + MLP/MoE and return the raw output before BDA."""
         pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -617,6 +617,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         inference_context: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
+        mhc_recompute_manager: Optional['CheckpointManager'] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -624,8 +625,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
-        if self.recompute_input_layernorm:
-            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+        checkpoint_input_layernorm = self.recompute_input_layernorm or (
+            mhc_recompute_manager is not None and not isinstance(self.input_layernorm, IdentityOp)
+        )
+        if checkpoint_input_layernorm:
+            self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                ckpt_manager=mhc_recompute_manager
+            )
             with attn_norm_manager as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
                     apply_module(self.input_layernorm), hidden_states
@@ -669,7 +675,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         nvtx_range_pop(suffix="self_attention")
 
-        if self.recompute_input_layernorm:
+        if checkpoint_input_layernorm:
             self.input_layernorm_checkpoint.discard_output_and_register_recompute(
                 attention_output_with_bias[0]
             )
@@ -867,10 +873,17 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         return output, context
 
-    def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
+    def _forward_pre_mlp_layernorm(
+        self, hidden_states: Tensor, mhc_recompute_manager: Optional['CheckpointManager'] = None
+    ):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
-        if self.recompute_pre_mlp_layernorm:
-            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+        checkpoint_pre_mlp_layernorm = self.recompute_pre_mlp_layernorm or (
+            mhc_recompute_manager is not None and not isinstance(self.pre_mlp_layernorm, IdentityOp)
+        )
+        if checkpoint_pre_mlp_layernorm:
+            self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                ckpt_manager=mhc_recompute_manager
+            )
             with self.mlp_norm_manager as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(
                     apply_module(self.pre_mlp_layernorm), hidden_states
@@ -927,9 +940,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         padding_mask: Tensor | None = None,
         input_ids: Optional[Tensor] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
+        mhc_recompute_manager: Optional['CheckpointManager'] = None,
     ) -> tuple[tuple[Tensor, Tensor | None], Tensor]:
         """Run pre-MLP norm + MLP/MoE and return the raw output before BDA."""
-        pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
+        pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(
+            hidden_states, mhc_recompute_manager=mhc_recompute_manager
+        )
 
         if isinstance(pre_mlp_layernorm_output, tuple):
             if len(pre_mlp_layernorm_output) != 2:

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -329,10 +329,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         is_mtp_layer: bool = False,
         add_layer_offset: bool = True,
         pp_layer_offset: Optional[int] = None,
+        hash_moe_layer_threshold: Optional[int] = None,
         name: str | None = None,
     ):
         """
         Args:
+            hash_moe_layer_threshold (int, optional): Explicit layer-number threshold passed
+                to an MoE router when constructing a HybridStack layer.
             name (str | None): module instance name passed top-down from its paranet module
         """
         self.submodules_config = submodules
@@ -420,6 +423,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        # Cache these predicates because the split hybrid mHC path consults them on every
+        # forward. The sibling HyperConnectionTransformerLayer uses the same attributes.
+        self.mhc_checkpoint_input_layernorm = not isinstance(self.input_layernorm, IdentityOp)
+        self.mhc_checkpoint_pre_mlp_layernorm = not isinstance(
+            self.pre_mlp_layernorm, IdentityOp
+        )
         # [Module 8: MLP block]
         # import here to avoid circular import
         from megatron.core.extensions.transformer_engine import TEFusedMLP
@@ -442,15 +451,20 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 "Consider migrating the `mlp` submodule spec to a direct call of the "
                 "`as_mlp_submodule` classmethod instead.",
             )
+        mlp_kwargs: Dict[str, Any] = {
+            "config": self.config,
+            "pg_collection": pg_collection,
+            "is_mtp_layer": self.is_mtp_layer,
+            "layer_number": self.layer_number,
+            "name": (name + ".mlp") if name is not None else None,
+        }
+        if hash_moe_layer_threshold is not None:
+            mlp_kwargs["hash_moe_layer_threshold"] = hash_moe_layer_threshold
         try:
-            self.mlp = submodules.mlp(
-                config=self.config,
-                pg_collection=pg_collection,
-                is_mtp_layer=self.is_mtp_layer,
-                layer_number=self.layer_number,
-                name=(name + ".mlp") if name is not None else None,
-            )
+            self.mlp = submodules.mlp(**mlp_kwargs)
         except TypeError:
+            if hash_moe_layer_threshold is not None:
+                raise
             # Fallback for MLP builders that don't accept layer_number (dense MLP, TEFusedMLP).
             self.mlp = submodules.mlp(
                 config=self.config,
@@ -626,7 +640,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         checkpoint_input_layernorm = self.recompute_input_layernorm or (
-            mhc_recompute_manager is not None and not isinstance(self.input_layernorm, IdentityOp)
+            mhc_recompute_manager is not None and self.mhc_checkpoint_input_layernorm
         )
         if checkpoint_input_layernorm:
             self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput(
@@ -878,7 +892,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     ):
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         checkpoint_pre_mlp_layernorm = self.recompute_pre_mlp_layernorm or (
-            mhc_recompute_manager is not None and not isinstance(self.pre_mlp_layernorm, IdentityOp)
+            mhc_recompute_manager is not None and self.mhc_checkpoint_pre_mlp_layernorm
         )
         if checkpoint_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -423,12 +423,6 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
-        # Cache these predicates because the split hybrid mHC path consults them on every
-        # forward. The sibling HyperConnectionTransformerLayer uses the same attributes.
-        self.mhc_checkpoint_input_layernorm = not isinstance(self.input_layernorm, IdentityOp)
-        self.mhc_checkpoint_pre_mlp_layernorm = not isinstance(
-            self.pre_mlp_layernorm, IdentityOp
-        )
         # [Module 8: MLP block]
         # import here to avoid circular import
         from megatron.core.extensions.transformer_engine import TEFusedMLP
@@ -479,6 +473,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         self.mlp_bda = build_module(submodules.mlp_bda)
 
         self.is_moe_layer = isinstance(self.mlp, MoELayer)
+
+        # Cache whether these optional layernorms are materialized. The split hybrid mHC
+        # recompute and fine-grained activation-offloading paths share these predicates.
+        self.mhc_checkpoint_input_layernorm = not isinstance(self.input_layernorm, IdentityOp)
+        self.mhc_checkpoint_pre_mlp_layernorm = not isinstance(self.pre_mlp_layernorm, IdentityOp)
 
         self.recompute_input_layernorm = False
         self.recompute_pre_mlp_layernorm = False
@@ -1825,14 +1824,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     def _set_offload_modules(self):
         """Set the offload modules for the transformer layer."""
         if self.config.fine_grained_activation_offloading:
-            self.offload_attn_norm = "attn_norm" in self.config.offload_modules and not isinstance(
-                self.input_layernorm, IdentityOp
+            self.offload_attn_norm = (
+                "attn_norm" in self.config.offload_modules and self.mhc_checkpoint_input_layernorm
             )
             self.offload_qkv_linear = "qkv_linear" in self.config.offload_modules
             self.offload_core_attn = "core_attn" in self.config.offload_modules
             self.offload_attn_proj = "attn_proj" in self.config.offload_modules
-            self.offload_mlp_norm = "mlp_norm" in self.config.offload_modules and not isinstance(
-                self.pre_mlp_layernorm, IdentityOp
+            self.offload_mlp_norm = (
+                "mlp_norm" in self.config.offload_modules and self.mhc_checkpoint_pre_mlp_layernorm
             )
             self.offload_expert_fc1 = "expert_fc1" in self.config.offload_modules
             self.offload_moe_act = "moe_act" in self.config.offload_modules
@@ -1966,11 +1965,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         self.mlp_hyper_connection = build_module(
             submodules.mlp_hyper_connection, config=self.config, layer_number=self.layer_number
         )
-
-        # When mHC recompute is active, skip checkpointing if the layernorm
-        # is IdentityOp (fused into TE linear) — there is nothing to recompute.
-        self.mhc_checkpoint_input_layernorm = not isinstance(self.input_layernorm, IdentityOp)
-        self.mhc_checkpoint_pre_mlp_layernorm = not isinstance(self.pre_mlp_layernorm, IdentityOp)
 
         self._validate_mhc_recompute_attn_cuda_graph_split()
 

--- a/megatron/training/datasets/sft_dataset.py
+++ b/megatron/training/datasets/sft_dataset.py
@@ -227,6 +227,8 @@ class MockSFTLowLevelDataset:
 
     Args:
         mode (str): One of 'file', 'distribution', or 'verification'.
+        vocab_size (Optional[int]): Tokenizer vocabulary size. Required for the generated
+            'file' and 'distribution' modes and ignored by 'verification' mode.
         **kwargs: Additional arguments depending on mode.
             For mode='file': path (str) - path to a CSV file with sequence lengths.
             For mode='distribution': type (str), min_seq_len (int), max_seq_len (int),
@@ -245,9 +247,15 @@ class MockSFTLowLevelDataset:
     size: int = 1000000
     """The hard-coded number of sequence to generate"""
 
-    def __init__(self, mode: str, **kwargs) -> None:
+    def __init__(self, mode: str, vocab_size: Optional[int] = None, **kwargs) -> None:
         np.random.seed(self.seed)
         self.format = kwargs.get("format", "thd")
+        self.vocab_size = vocab_size
+
+        if mode in ("file", "distribution") and (vocab_size is None or vocab_size <= 0):
+            raise ValueError(
+                f"vocab_size must be a positive integer for generated mock data, got {vocab_size}"
+            )
 
         if mode == "file":
             import pandas as pd
@@ -317,7 +325,11 @@ class MockSFTLowLevelDataset:
             assert len(sample) == target
             return sample.astype(np.int64)
         else:
-            return np.arange(1, length, dtype=np.int64)
+            if self.vocab_size is None:
+                raise RuntimeError("Generated mock data requires a configured vocabulary size")
+            sample = np.arange(1, length, dtype=np.int64)
+            sample %= self.vocab_size
+            return sample
 
 
 class MockSFTDataset(SFTDataset):
@@ -347,6 +359,7 @@ class MockSFTDataset(SFTDataset):
             }
         else:
             mock_config = load_json_arg(config.sft_mock_dataset_config_json)
+        mock_config["vocab_size"] = config.tokenizer.vocab_size
         return MockSFTLowLevelDataset(**mock_config)
 
     def __len__(self) -> int:

--- a/megatron/training/datasets/sft_dataset.py
+++ b/megatron/training/datasets/sft_dataset.py
@@ -252,9 +252,11 @@ class MockSFTLowLevelDataset:
         self.format = kwargs.get("format", "thd")
         self.vocab_size = vocab_size
 
-        if mode in ("file", "distribution") and (vocab_size is None or vocab_size <= 0):
+        if mode in ("file", "distribution") and (vocab_size is None or vocab_size < 2):
             raise ValueError(
-                f"vocab_size must be a positive integer for generated mock data, got {vocab_size}"
+                "Generated mock data requires vocab_size >= 2. If tokenizer.vocab_size is "
+                "unavailable, set vocab_size in the mock dataset config JSON; "
+                f"got {vocab_size}."
             )
 
         if mode == "file":
@@ -328,7 +330,10 @@ class MockSFTLowLevelDataset:
             if self.vocab_size is None:
                 raise RuntimeError("Generated mock data requires a configured vocabulary size")
             sample = np.arange(1, length, dtype=np.int64)
-            sample %= self.vocab_size
+            # Preserve the original positive-token invariant while bounding IDs to the
+            # tokenizer vocabulary. In particular, do not synthesize token 0, which is
+            # commonly used as EOD/padding and therefore masked out of the loss.
+            sample = (sample - 1) % (self.vocab_size - 1) + 1
             return sample
 
 
@@ -359,7 +364,7 @@ class MockSFTDataset(SFTDataset):
             }
         else:
             mock_config = load_json_arg(config.sft_mock_dataset_config_json)
-        mock_config["vocab_size"] = config.tokenizer.vocab_size
+        mock_config.setdefault("vocab_size", getattr(config.tokenizer, "vocab_size", None))
         return MockSFTLowLevelDataset(**mock_config)
 
     def __len__(self) -> int:

--- a/megatron/training/datasets/sft_dataset.py
+++ b/megatron/training/datasets/sft_dataset.py
@@ -327,8 +327,7 @@ class MockSFTLowLevelDataset:
             assert len(sample) == target
             return sample.astype(np.int64)
         else:
-            if self.vocab_size is None:
-                raise RuntimeError("Generated mock data requires a configured vocabulary size")
+            assert self.vocab_size is not None and self.vocab_size >= 2
             sample = np.arange(1, length, dtype=np.int64)
             # Preserve the original positive-token invariant while bounding IDs to the
             # tokenizer vocabulary. In particular, do not synthesize token 0, which is

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -486,6 +486,7 @@ class MockVarlenDataset(MockSFTDataset):
             }
         else:
             mock_config = load_json_arg(config.varlen_mock_dataset_config_json)
+        mock_config["vocab_size"] = config.tokenizer.vocab_size
         return MockSFTLowLevelDataset(**mock_config)
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -486,7 +486,7 @@ class MockVarlenDataset(MockSFTDataset):
             }
         else:
             mock_config = load_json_arg(config.varlen_mock_dataset_config_json)
-        mock_config["vocab_size"] = config.tokenizer.vocab_size
+        mock_config.setdefault("vocab_size", getattr(config.tokenizer, "vocab_size", None))
         return MockSFTLowLevelDataset(**mock_config)
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -440,7 +440,7 @@ class _FakeTokenizer:
     with ``IGNORE_INDEX`` in the targets.
     """
 
-    def __init__(self, eod: int = 0, pad=None, vocab_size: int = 128):
+    def __init__(self, eod: int = 0, pad=None, vocab_size: int | None = 128):
         self._eod = eod
         self._pad = pad
         self._vocab_size = vocab_size
@@ -534,9 +534,66 @@ def test_generated_mock_tokens_stay_within_tokenizer_vocab(
     tokens = low_level_dataset[0]
 
     assert tokens.size == 19
-    assert tokens.min() >= 0
+    assert tokens.min() >= 1
     assert tokens.max() < tokenizer.vocab_size
-    assert tokens[:9].tolist() == [1, 2, 3, 4, 5, 6, 7, 0, 1]
+    assert tokens[:9].tolist() == [1, 2, 3, 4, 5, 6, 7, 1, 2]
+
+
+@pytest.mark.parametrize(
+    ("dataset_cls", "mock_config_attr"),
+    [
+        (MockSFTDataset, "sft_mock_dataset_config_json"),
+        (MockVarlenDataset, "varlen_mock_dataset_config_json"),
+    ],
+)
+@pytest.mark.parametrize("tokenizer_vocab_size", [None, 32])
+def test_mock_config_vocab_size_takes_precedence(
+    monkeypatch, dataset_cls, mock_config_attr, tokenizer_vocab_size
+):
+    """An explicit JSON vocabulary works without, and overrides, the tokenizer value."""
+    monkeypatch.setattr(MockSFTLowLevelDataset, "size", 1)
+    tokenizer = _FakeTokenizer(eod=0, pad=None, vocab_size=tokenizer_vocab_size)
+    config = _make_config(tokenizer, seq_length=20)
+    setattr(
+        config,
+        mock_config_attr,
+        json.dumps(
+            {
+                "mode": "distribution",
+                "type": "lognormal",
+                "min_seq_len": 20,
+                "max_seq_len": 20,
+                "mean_seq_len": 20,
+                "lognormal_sigma": 1.1,
+                "vocab_size": 8,
+            }
+        ),
+    )
+
+    tokens = dataset_cls.build_low_level_dataset("", config)[0]
+
+    assert tokens.min() >= 1
+    assert tokens.max() < 8
+    assert tokens[:9].tolist() == [1, 2, 3, 4, 5, 6, 7, 1, 2]
+
+
+def test_generated_mock_data_requires_available_vocab_size():
+    """Missing tokenizer and JSON vocabulary values produce an actionable error."""
+    tokenizer = _FakeTokenizer(eod=0, pad=None, vocab_size=None)
+    config = _make_config(tokenizer, seq_length=20)
+    config.sft_mock_dataset_config_json = json.dumps(
+        {
+            "mode": "distribution",
+            "type": "lognormal",
+            "min_seq_len": 20,
+            "max_seq_len": 20,
+            "mean_seq_len": 20,
+            "lognormal_sigma": 1.1,
+        }
+    )
+
+    with pytest.raises(ValueError, match="set vocab_size in the mock dataset config JSON"):
+        MockSFTDataset.build_low_level_dataset("", config)
 
 
 def test_getitem_thd_pretrain_text_keys_and_shapes():

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -20,7 +20,11 @@ import torch
 # Import via the public module path so this test gets discovered through the
 # regular pytest entry point. The functions under test are pure Python and do
 # not require torch.distributed.
-from megatron.training.datasets.sft_dataset import IGNORE_INDEX
+from megatron.training.datasets.sft_dataset import (
+    IGNORE_INDEX,
+    MockSFTDataset,
+    MockSFTLowLevelDataset,
+)
 from megatron.training.datasets.varlen_dataset import (
     MockVarlenDataset,
     VarlenDataset,
@@ -436,9 +440,10 @@ class _FakeTokenizer:
     with ``IGNORE_INDEX`` in the targets.
     """
 
-    def __init__(self, eod: int = 0, pad=None):
+    def __init__(self, eod: int = 0, pad=None, vocab_size: int = 128):
         self._eod = eod
         self._pad = pad
+        self._vocab_size = vocab_size
 
     @property
     def eod(self):
@@ -447,6 +452,10 @@ class _FakeTokenizer:
     @property
     def pad(self):
         return self._pad
+
+    @property
+    def vocab_size(self):
+        return self._vocab_size
 
     def tokenize(self, text):
         return [ord(c) % 100 + 1 for c in text]  # always >= 1, never eod (0)
@@ -490,6 +499,44 @@ def _make_mock_varlen(token_arrays, config):
     ds.dataset = token_arrays  # each item exposes .tolist()
     ds.indices = np.arange(len(token_arrays))
     return ds
+
+
+@pytest.mark.parametrize(
+    ("dataset_cls", "mock_config_attr"),
+    [
+        (MockSFTDataset, "sft_mock_dataset_config_json"),
+        (MockVarlenDataset, "varlen_mock_dataset_config_json"),
+    ],
+)
+def test_generated_mock_tokens_stay_within_tokenizer_vocab(
+    monkeypatch, dataset_cls, mock_config_attr
+):
+    """Long generated mock sequences must wrap before exceeding the tokenizer vocabulary."""
+    monkeypatch.setattr(MockSFTLowLevelDataset, "size", 1)
+    tokenizer = _FakeTokenizer(eod=0, pad=None, vocab_size=8)
+    config = _make_config(tokenizer, seq_length=20)
+    setattr(
+        config,
+        mock_config_attr,
+        json.dumps(
+            {
+                "mode": "distribution",
+                "type": "lognormal",
+                "min_seq_len": 20,
+                "max_seq_len": 20,
+                "mean_seq_len": 20,
+                "lognormal_sigma": 1.1,
+            }
+        ),
+    )
+
+    low_level_dataset = dataset_cls.build_low_level_dataset("", config)
+    tokens = low_level_dataset[0]
+
+    assert tokens.size == 19
+    assert tokens.min() >= 0
+    assert tokens.max() < tokenizer.vocab_size
+    assert tokens[:9].tolist() == [1, 2, 3, 4, 5, 6, 7, 0, 1]
 
 
 def test_getitem_thd_pretrain_text_keys_and_shapes():

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -332,6 +332,7 @@ class TestHybridModel:
         manager = type("_FakeManager", (), {})()
         manager.is_last_layer_in_recompute_block = True
         seen_bda_managers = []
+        seen_inner_managers = []
 
         def fake_hyper_connection_forward(hidden_states, mhc_recompute_manager=None):
             assert mhc_recompute_manager is manager
@@ -356,18 +357,27 @@ class TestHybridModel:
             seen_bda_managers.append(manager)
             return original_residual
 
+        def fake_inner_fast_path(*_args, mhc_recompute_manager=None, **_kwargs):
+            seen_inner_managers.append(mhc_recompute_manager)
+            return None
+
         monkeypatch.setattr(layer.hyper_connection, "forward", fake_hyper_connection_forward)
         monkeypatch.setattr(
             layer.hyper_connection, "fused_h_res_h_post_bda", fake_fused_h_res_h_post_bda
+        )
+        monkeypatch.setattr(
+            layer, "_call_inner_transformer_layer_without_local_bda", fake_inner_fast_path
         )
 
         output, _ = layer(hidden_states, attention_mask=None, mhc_recompute_manager=manager)
         assert output is hidden_states
         assert seen_bda_managers == [None]
+        assert seen_inner_managers == [manager]
 
         manager.is_last_layer_in_recompute_block = False
         layer(hidden_states, attention_mask=None, mhc_recompute_manager=manager)
         assert seen_bda_managers[-1] is manager
+        assert seen_inner_managers[-1] is manager
 
     def test_forward_with_hyper_connections(self):
         model_config = TransformerConfig(

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -256,6 +256,52 @@ class TestHybridBlock:
             gb, gr = base_grads[name], rec_grads[name]
             assert torch.equal(gr, gb), f"Grad should be bitwise matched for {name}"
 
+    @pytest.mark.timeout(60)
+    def test_hash_moe_hyper_connection_full_recompute(self):
+        """Full recompute preserves input IDs through the hybrid mHC wrapper."""
+        block = self.get_hybrid_block(
+            Symbols.MOE,
+            enable_hyper_connections=True,
+            hidden_dropout=0.0,
+            mhc_sinkhorn_iterations=5,
+            recompute_granularity="full",
+            recompute_method="uniform",
+            recompute_num_layers=1,
+            num_moe_experts=4,
+            moe_ffn_hidden_size=64,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_aux_loss_coeff=0.0,
+            moe_router_dtype="fp32",
+            moe_n_hash_layers=1,
+            actual_vocab_size=128,
+            add_bias_linear=False,
+        ).cuda()
+        block.train()
+
+        sequence_length, micro_batch_size = 8, 2
+        hidden_states = torch.randn(
+            sequence_length,
+            micro_batch_size,
+            block.config.hidden_size,
+            device="cuda",
+            requires_grad=True,
+        )
+        input_ids = torch.randint(
+            0, block.config.actual_vocab_size, (micro_batch_size, sequence_length), device="cuda"
+        )
+
+        assert isinstance(block.layers[0], HyperConnectionHybridLayer)
+        assert block.layers[0].inner_layer.mlp.router.is_hash_layer
+
+        output = block(hidden_states, attention_mask=None, input_ids=input_ids)
+        assert output.shape == hidden_states.shape
+        assert torch.isfinite(output).all()
+
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+        assert torch.isfinite(hidden_states.grad).all()
+
     def test_layer_types(self):
         """
         Make sure that the layer types specified with layer_pattern

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -7,7 +7,7 @@ from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
-from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.hybrid_model import HybridModel, _validate_hash_moe_pipeline_placement
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.gated_delta_net import HAVE_FLA_KDA, GatedDeltaNet, KimiDeltaAttention
 from megatron.core.ssm.mamba_layer import MambaLayer
@@ -327,6 +327,7 @@ class TestHybridBlock:
             vocab_size=128,
             max_sequence_length=8,
             hybrid_layer_pattern=layer_pattern,
+            pg_collection=self.get_pg_collection(),
         )
         block = model.decoder
 
@@ -339,30 +340,17 @@ class TestHybridBlock:
 
         assert [layer.layer_number for layer in moe_layers] == [2, 4, 6, 8]
         assert [router.is_hash_layer for router in routers] == [True, True, True, False]
+        assert [router.hash_moe_layer_threshold for router in routers] == [6, 6, 6, 6]
         assert model.config.moe_n_hash_layers == 3
 
-    @pytest.mark.parametrize(
-        ("layer_pattern", "error_match"),
-        [
-            (
-                Symbols.MAMBA + Symbols.PIPE + Symbols.MOE,
-                "same virtual pipeline stage as the embedding",
-            ),
-            (
-                Symbols.MAMBA + Symbols.MOE,
-                "must contain pipe",
-            ),
-        ],
-    )
-    def test_hash_moe_pipeline_placement_validation(self, layer_pattern, error_match):
-        """Hash MoE layers must remain on the embedding stage under pipeline parallelism."""
+    def test_hash_moe_pipeline_placement_validation(self):
+        """A stage without the embedding cannot own a hash-routed MoE layer."""
+        layer_pattern = Symbols.MAMBA + Symbols.MOE
         config = TransformerConfig(
             hidden_size=256,
-            num_layers=len(layer_pattern.replace(Symbols.PIPE, '')),
+            num_layers=len(layer_pattern),
             num_attention_heads=4,
             use_cpu_initialization=True,
-            pipeline_model_parallel_size=2,
-            pipeline_dtype=torch.float32,
             is_hybrid_model=True,
             num_moe_experts=4,
             moe_ffn_hidden_size=64,
@@ -375,14 +363,25 @@ class TestHybridBlock:
             add_bias_linear=False,
         )
 
-        with pytest.raises(AssertionError, match=error_match):
+        with pytest.raises(ValueError, match="same pipeline/virtual-pipeline stage"):
             HybridModel(
                 config=config,
                 hybrid_stack_spec=hybrid_stack_spec,
                 vocab_size=128,
                 max_sequence_length=8,
                 hybrid_layer_pattern=layer_pattern,
+                pre_process=False,
+                pg_collection=self.get_pg_collection(),
             )
+
+    def test_hash_moe_pipeline_placement_allows_non_hash_stage(self):
+        """A later stage from a pipe-free split is valid when its MoE is not hash-routed."""
+        _validate_hash_moe_pipeline_placement(
+            [Symbols.MAMBA, Symbols.MOE],
+            layer_offset=2,
+            hash_moe_layer_threshold=2,
+            pre_process=False,
+        )
 
     def test_layer_types(self):
         """

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -7,6 +7,7 @@ from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.gated_delta_net import HAVE_FLA_KDA, GatedDeltaNet, KimiDeltaAttention
 from megatron.core.ssm.mamba_layer import MambaLayer
@@ -301,6 +302,44 @@ class TestHybridBlock:
         output.float().sum().backward()
         assert hidden_states.grad is not None
         assert torch.isfinite(hidden_states.grad).all()
+
+    def test_hash_moe_counts_only_moe_layers(self):
+        """Hash routing derives a global layer threshold from the MoE positions."""
+        layer_pattern = (Symbols.MLP + Symbols.MOE) * 4
+        config = TransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_pattern),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            num_moe_experts=4,
+            moe_ffn_hidden_size=64,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_aux_loss_coeff=0.0,
+            moe_router_dtype="fp32",
+            moe_n_hash_layers=3,
+            actual_vocab_size=128,
+            add_bias_linear=False,
+        )
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=128,
+            max_sequence_length=8,
+            hybrid_layer_pattern=layer_pattern,
+        )
+        block = model.decoder
+
+        moe_layers = [
+            layer
+            for layer_type, layer in zip(block.layer_type_list, block.layers)
+            if layer_type == Symbols.MOE
+        ]
+        routers = [layer.mlp.router for layer in moe_layers]
+
+        assert [layer.layer_number for layer in moe_layers] == [2, 4, 6, 8]
+        assert [router.is_hash_layer for router in routers] == [True, True, True, False]
+        assert model.config.moe_n_hash_layers == 3
 
     def test_layer_types(self):
         """

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -53,6 +53,7 @@ class TestHybridBlock:
             required_pgs=[
                 'tp',
                 'pp',
+                'embd',
                 'cp',
                 'ep',
                 'expt_tp',

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -55,6 +55,7 @@ class TestHybridBlock:
                 'pp',
                 'embd',
                 'cp',
+                'dp_cp',
                 'ep',
                 'expt_tp',
                 'expt_dp',

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -7,7 +7,11 @@ from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
-from megatron.core.models.hybrid.hybrid_model import HybridModel, _validate_hash_moe_pipeline_placement
+from megatron.core.models.hybrid.hybrid_model import (
+    HybridModel,
+    _get_hash_moe_layer_threshold,
+    _validate_hash_moe_pipeline_placement,
+)
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.gated_delta_net import HAVE_FLA_KDA, GatedDeltaNet, KimiDeltaAttention
 from megatron.core.ssm.mamba_layer import MambaLayer
@@ -23,6 +27,12 @@ from megatron.core.transformer.multi_latent_attention import MLASelfAttention
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize("n_hash_layers", [-3, -1, 0])
+def test_non_positive_hash_moe_count_has_disabled_threshold(n_hash_layers):
+    """Non-positive hash-MoE counts normalize to the disabled threshold."""
+    assert _get_hash_moe_layer_threshold(Symbols.MOE, n_hash_layers) == 0
 
 
 @pytest.mark.internal
@@ -306,9 +316,11 @@ class TestHybridBlock:
     def test_hash_moe_counts_only_moe_layers(self):
         """Hash routing derives a global layer threshold from the MoE positions."""
         layer_pattern = (Symbols.MLP + Symbols.MOE) * 4
+        mtp_pattern = Symbols.MOE
         config = TransformerConfig(
             hidden_size=256,
             num_layers=len(layer_pattern),
+            mtp_num_layers=1,
             num_attention_heads=4,
             use_cpu_initialization=True,
             num_moe_experts=4,
@@ -326,7 +338,7 @@ class TestHybridBlock:
             hybrid_stack_spec=hybrid_stack_spec,
             vocab_size=128,
             max_sequence_length=8,
-            hybrid_layer_pattern=layer_pattern,
+            hybrid_layer_pattern=f"{layer_pattern}/{mtp_pattern}",
             pg_collection=self.get_pg_collection(),
         )
         block = model.decoder
@@ -341,6 +353,9 @@ class TestHybridBlock:
         assert [layer.layer_number for layer in moe_layers] == [2, 4, 6, 8]
         assert [router.is_hash_layer for router in routers] == [True, True, True, False]
         assert [router.hash_moe_layer_threshold for router in routers] == [6, 6, 6, 6]
+        mtp_router = model.mtp.layers[0].mtp_model_layer.layers[0].mlp.router
+        assert mtp_router.hash_moe_layer_threshold == 6
+        assert not mtp_router.is_hash_layer
         assert model.config.moe_n_hash_layers == 3
 
     def test_hash_moe_pipeline_placement_validation(self):
@@ -382,6 +397,29 @@ class TestHybridBlock:
             hash_moe_layer_threshold=2,
             pre_process=False,
         )
+
+    def test_hybrid_mtp_rejects_expert_parallel_overlap_before_build(self, monkeypatch):
+        """Reject overlap before constructing any HybridModel submodule."""
+        config = TransformerConfig(
+            hidden_size=256, num_layers=1, num_attention_heads=4, use_cpu_initialization=True
+        )
+        # Mutate after generic config validation to exercise the pattern-specific guard.
+        config.overlap_moe_expert_parallel_comm = True
+
+        def fail_build(*args, **kwargs):
+            pytest.fail("HybridModel submodule construction must not begin")
+
+        monkeypatch.setattr("megatron.core.models.hybrid.hybrid_model.build_module", fail_build)
+
+        with pytest.raises(ValueError, match="Hybrid MTP does not support"):
+            HybridModel(
+                config=config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                vocab_size=128,
+                max_sequence_length=8,
+                hybrid_layer_pattern=f"{Symbols.MAMBA}/{Symbols.MAMBA}",
+                pg_collection=self.get_pg_collection(),
+            )
 
     def test_layer_types(self):
         """

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -341,6 +341,49 @@ class TestHybridBlock:
         assert [router.is_hash_layer for router in routers] == [True, True, True, False]
         assert model.config.moe_n_hash_layers == 3
 
+    @pytest.mark.parametrize(
+        ("layer_pattern", "error_match"),
+        [
+            (
+                Symbols.MAMBA + Symbols.PIPE + Symbols.MOE,
+                "same virtual pipeline stage as the embedding",
+            ),
+            (
+                Symbols.MAMBA + Symbols.MOE,
+                "must contain pipe",
+            ),
+        ],
+    )
+    def test_hash_moe_pipeline_placement_validation(self, layer_pattern, error_match):
+        """Hash MoE layers must remain on the embedding stage under pipeline parallelism."""
+        config = TransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_pattern.replace(Symbols.PIPE, '')),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            pipeline_model_parallel_size=2,
+            pipeline_dtype=torch.float32,
+            is_hybrid_model=True,
+            num_moe_experts=4,
+            moe_ffn_hidden_size=64,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="aux_loss",
+            moe_aux_loss_coeff=0.0,
+            moe_router_dtype="fp32",
+            moe_n_hash_layers=1,
+            actual_vocab_size=128,
+            add_bias_linear=False,
+        )
+
+        with pytest.raises(AssertionError, match=error_match):
+            HybridModel(
+                config=config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                vocab_size=128,
+                max_sequence_length=8,
+                hybrid_layer_pattern=layer_pattern,
+            )
+
     def test_layer_types(self):
         """
         Make sure that the layer types specified with layer_pattern

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -1,9 +1,15 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+from copy import deepcopy
+
 import pytest
 import torch
 
-from megatron.core.extensions.transformer_engine import TEDotProductAttention
+from megatron.core.extensions.transformer_engine import (
+    TEColumnParallelLinear,
+    TEDotProductAttention,
+    TENorm,
+)
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
@@ -44,6 +50,22 @@ class TestHybridBlock:
 
     def get_pg_collection(self):
         return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
+
+    @staticmethod
+    def _non_fused_norm_submodules():
+        """Un-fuse the TE layernorm+linear pairs so the explicit norm modules exist.
+
+        The default dense hybrid spec folds each norm into the following TE linear,
+        leaving IdentityOp placeholders that cannot exercise the norm checkpoints.
+        """
+        submodules = deepcopy(hybrid_stack_spec.submodules)
+        attention_submodules = submodules.attention_layer.submodules
+        attention_submodules.input_layernorm = TENorm
+        attention_submodules.self_attention.submodules.linear_qkv = TEColumnParallelLinear
+        mlp_submodules = submodules.mlp_layer.submodules
+        mlp_submodules.pre_mlp_layernorm = TENorm
+        mlp_submodules.mlp.keywords["submodules"].linear_fc1 = TEColumnParallelLinear
+        return submodules
 
     def get_mamba_block(self, layer_pattern, enable_hyper_connections=False):
         layer_type_list = validate_segment_layers(layer_pattern)
@@ -475,6 +497,124 @@ class TestHybridBlock:
         assert len(managers) == len(block.layers)
         assert all(manager is not None for manager in managers)
         assert block_ends[-1] is True
+
+    @pytest.mark.timeout(60)
+    def test_hyper_connection_mhc_recompute_bitwise(self):
+        """mHC selective recompute is bitwise identical to the eager path."""
+        seed = 123
+        layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLP
+        layer_type_list = validate_segment_layers(layer_pattern)
+        arch_kwargs = dict(
+            enable_hyper_connections=True,
+            hidden_dropout=0.0,
+            mhc_sinkhorn_iterations=5,
+            add_bias_linear=False,
+        )
+
+        def build_block(**recompute_kwargs):
+            model_parallel_cuda_manual_seed(seed)
+            torch.manual_seed(seed)
+            config = TransformerConfig(
+                hidden_size=256,
+                num_layers=len(layer_type_list),
+                num_attention_heads=4,
+                use_cpu_initialization=True,
+                **arch_kwargs,
+                **recompute_kwargs,
+            )
+            return HybridStack(
+                config,
+                self._non_fused_norm_submodules(),
+                layer_type_list=layer_type_list,
+                pp_layer_offset=0,
+                pg_collection=self.get_pg_collection(),
+            ).cuda()
+
+        torch.manual_seed(seed)
+        hidden_states = torch.randn(32, 2, 256, device="cuda")
+        attention_mask = torch.ones((2, 1, 32, 32), dtype=bool, device="cuda")
+
+        def run(block, inputs):
+            block.train()
+            output = block(inputs, attention_mask=attention_mask)
+            output.float().sum().backward()
+            grads = {
+                name: param.grad.detach().float().cpu()
+                for name, param in block.named_parameters()
+                if param.grad is not None
+            }
+            return output.detach().float().cpu(), grads
+
+        baseline = build_block()
+        baseline_output, baseline_grads = run(
+            baseline, hidden_states.detach().clone().requires_grad_()
+        )
+        del baseline
+        torch.cuda.empty_cache()
+
+        recomputed = build_block(recompute_granularity="selective", recompute_modules=["mhc"])
+        attention_layer = recomputed.layers[1].inner_layer
+        mlp_layer = recomputed.layers[2].inner_layer
+        assert attention_layer.mhc_checkpoint_input_layernorm
+        assert mlp_layer.mhc_checkpoint_pre_mlp_layernorm
+
+        recomputed_output, recomputed_grads = run(
+            recomputed, hidden_states.detach().clone().requires_grad_()
+        )
+
+        assert torch.equal(recomputed_output, baseline_output)
+        assert set(recomputed_grads) == set(baseline_grads)
+        for name, baseline_grad in baseline_grads.items():
+            assert torch.equal(recomputed_grads[name], baseline_grad), name
+
+        for checkpoint in (
+            attention_layer.input_layernorm_checkpoint,
+            mlp_layer.pre_mlp_norm_checkpoint,
+        ):
+            assert checkpoint in checkpoint.ckpt_manager.checkpoints
+            assert checkpoint.ctx is None
+            assert checkpoint.outputs is None
+
+    @pytest.mark.timeout(60)
+    def test_hyper_connection_mlp_fast_path_discards_layernorm_checkpoint(self):
+        """The hybrid mHC MLP fast path releases selective layernorm activations."""
+        layer_type_list = validate_segment_layers(Symbols.MLP)
+        config = TransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_type_list),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            enable_hyper_connections=True,
+            hidden_dropout=0.0,
+            mhc_sinkhorn_iterations=5,
+            recompute_granularity="selective",
+            recompute_modules=["layernorm"],
+        )
+        block = HybridStack(
+            config,
+            self._non_fused_norm_submodules(),
+            layer_type_list=layer_type_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        ).cuda()
+        block.train()
+
+        hidden_states = torch.randn(
+            8, 2, block.config.hidden_size, device="cuda", requires_grad=True
+        )
+        output = block(hidden_states, attention_mask=None)
+
+        layer = block.layers[0]
+        assert isinstance(layer, HyperConnectionHybridLayer)
+        inner_layer = layer.inner_layer
+        assert inner_layer.recompute_pre_mlp_layernorm
+        checkpoint = inner_layer.pre_mlp_norm_checkpoint
+        assert checkpoint.ckpt_manager is None
+        assert checkpoint.outputs[0].untyped_storage().nbytes() == 0
+
+        output.sum().backward()
+        assert checkpoint.ctx is None
+        assert checkpoint.outputs is None
 
     def test_hyper_connection_gpu_forward(self):
         """mHC-enabled HybridStack expands internally and contracts back at the output."""

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -49,7 +49,19 @@ class TestHybridBlock:
         model_parallel_cuda_manual_seed(123)
 
     def get_pg_collection(self):
-        return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
+        return ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=[
+                'tp',
+                'pp',
+                'cp',
+                'ep',
+                'expt_tp',
+                'expt_dp',
+                'tp_ep',
+                'tp_cp',
+                'tp_dp_cp',
+            ]
+        )
 
     @staticmethod
     def _non_fused_norm_submodules():

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -50,6 +50,41 @@ def reset_full_cuda_graph_state():
     gc.collect()
 
 
+def test_static_buffer_loader_isolates_cached_batch_structure():
+    loader = StaticBufferLoader()
+    first_inputs = {
+        'tokens': torch.ones(2, 4),
+        'labels': torch.ones(2, 4),
+        'loss_mask': torch.ones(2, 4),
+    }
+
+    first_batch = loader(first_inputs, 'training', 0)
+    cached_batch = StaticBufferLoader.static_buffers['training'][0]
+
+    assert first_batch is not cached_batch
+    assert first_batch['labels'] is cached_batch['labels']
+    assert first_batch['loss_mask'] is cached_batch['loss_mask']
+
+    # Pipeline stages replace unused fields in place. This must not replace the
+    # corresponding tensors in the loader's static buffer.
+    first_batch['labels'] = None
+    first_batch['loss_mask'] = None
+
+    second_inputs = {
+        'tokens': torch.full((2, 4), 2.0),
+        'labels': torch.full((2, 4), 3.0),
+        'loss_mask': torch.full((2, 4), 4.0),
+    }
+    second_batch = loader(second_inputs, 'training', 0)
+
+    assert second_batch is not cached_batch
+    assert second_batch['labels'] is cached_batch['labels']
+    assert second_batch['loss_mask'] is cached_batch['loss_mask']
+    torch.testing.assert_close(second_batch['tokens'], second_inputs['tokens'].cuda())
+    torch.testing.assert_close(second_batch['labels'], second_inputs['labels'].cuda())
+    torch.testing.assert_close(second_batch['loss_mask'], second_inputs['loss_mask'].cuda())
+
+
 @pytest.mark.skipif(
     not (HAVE_TE and is_te_min_version("1.5.0")),
     reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -50,6 +50,9 @@ def reset_full_cuda_graph_state():
     gc.collect()
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="StaticBufferLoader stages inputs on the GPU"
+)
 def test_static_buffer_loader_isolates_cached_batch_structure():
     loader = StaticBufferLoader()
     first_inputs = {

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -2244,6 +2244,47 @@ class TestMultiTokenPredictionHybrid:
                 assert param.main_grad is not None
 
     @pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
+    def test_full_recompute_with_multi_layer_chunks_mamba(self):
+        """Hybrid MTP accepts decoder-sized uniform recompute chunks."""
+        args = self.create_test_args(
+            tp=1,
+            cp=1,
+            sequence_length=self.seq_length,
+            micro_batch_size=self.micro_batch_size,
+            full_recompute=True,
+        )
+        # The main pattern has four symbols and each MTP pattern has two. A chunk
+        # size larger than both should checkpoint each nested HybridStack once.
+        args.recompute_num_layers = 8
+        set_args(args)
+
+        torch.manual_seed(_SEED)
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+        batch = self.get_batch(self.seq_length, self.micro_batch_size)
+
+        model_parallel_cuda_manual_seed(_SEED)
+        cfg_container = Utils.pretrain_config_from_global_args(args, "hybrid")
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        model, _, _ = setup_model_and_optimizer(
+            ModelType.encoder_or_decoder,
+            self.model_provider,
+            cfg_container=cfg_container,
+            pg_collection=pg_collection,
+        )
+
+        output = model[0].forward(
+            input_ids=batch['tokens'],
+            position_ids=batch['position_ids'],
+            attention_mask=batch['attention_mask'],
+            labels=batch['labels'],
+            loss_mask=batch['loss_mask'],
+        )
+        output.mean().backward()
+
+        for name, param in model[0].named_parameters():
+            assert param.main_grad is not None, f"Gradient missing for {name}"
+
+    @pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
     def test_attention_mask_validation_mamba(self):
         """Test that attention mask type validation works for Mamba hybrid models."""
         tp = 1

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -99,22 +99,6 @@ class TestMultiTokenPredictionLayer:
         )
         assert config.mtp_detach_heads is False
 
-    def test_hybrid_mtp_rejects_expert_parallel_overlap(self):
-        """Hybrid MTP must fail clearly before the unsupported overlap path is built."""
-        config = TransformerConfig(
-            num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
-        )
-        # Mutate after config validation to exercise the model-family-specific guard directly.
-        config.overlap_moe_expert_parallel_comm = True
-
-        with pytest.raises(ValueError, match="Hybrid MTP does not support"):
-            MultiTokenPredictionLayer(
-                config=config,
-                submodules=None,
-                pg_collection=types.SimpleNamespace(cp=None, tp=None),
-                mtp_layer_pattern="M",
-            )
-
     def test_constructor_with_detach_heads(self):
         """Test construction of MTP module with mtp_detach_heads=True."""
         torch.manual_seed(_SEED)
@@ -2262,7 +2246,7 @@ class TestMultiTokenPredictionHybrid:
 
     @pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
     def test_full_recompute_with_multi_layer_chunks_mamba(self):
-        """Hybrid MTP accepts decoder-sized uniform recompute chunks."""
+        """Hybrid MTP chunks are recomputed once without an outer MTP checkpoint."""
         args = self.create_test_args(
             tp=1,
             cp=1,
@@ -2289,14 +2273,41 @@ class TestMultiTokenPredictionHybrid:
             pg_collection=pg_collection,
         )
 
-        output = model[0].forward(
-            input_ids=batch['tokens'],
-            position_ids=batch['position_ids'],
-            attention_mask=batch['attention_mask'],
-            labels=batch['labels'],
-            loss_mask=batch['loss_mask'],
-        )
-        output.mean().backward()
+        mtp_layers = [
+            module
+            for module in unwrap_model(model[0]).modules()
+            if isinstance(module, MultiTokenPredictionLayer)
+        ]
+        assert len(mtp_layers) == args.mtp_num_layers
+
+        inner_layer_forward_counts = {}
+
+        def count_inner_layer_forward(module, _inputs, _output):
+            inner_layer_forward_counts[module] += 1
+
+        hook_handles = []
+        for mtp_layer in mtp_layers:
+            for inner_layer in mtp_layer.mtp_model_layer.layers:
+                inner_layer_forward_counts[inner_layer] = 0
+                hook_handles.append(inner_layer.register_forward_hook(count_inner_layer_forward))
+
+        try:
+            output = model[0].forward(
+                input_ids=batch['tokens'],
+                position_ids=batch['position_ids'],
+                attention_mask=batch['attention_mask'],
+                labels=batch['labels'],
+                loss_mask=batch['loss_mask'],
+            )
+            output.mean().backward()
+        finally:
+            for handle in hook_handles:
+                handle.remove()
+
+        # Each nested layer runs once in the original forward and once when its HybridStack
+        # chunk is recomputed in backward. An outer MTP checkpoint would add a third execution.
+        assert inner_layer_forward_counts
+        assert all(count == 2 for count in inner_layer_forward_counts.values())
 
         for name, param in model[0].named_parameters():
             assert param.main_grad is not None, f"Gradient missing for {name}"

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -30,6 +30,7 @@ from megatron.core.transformer.multi_token_prediction import (
     ContiguousPackedSeqRollPlan,
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
     _mtp_logits_are_vocab_sharded,
     prepare_mtp_sequence_roll_context,
     process_mtp_loss,
@@ -97,6 +98,22 @@ class TestMultiTokenPredictionLayer:
             num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
         )
         assert config.mtp_detach_heads is False
+
+    def test_hybrid_mtp_rejects_expert_parallel_overlap(self):
+        """Hybrid MTP must fail clearly before the unsupported overlap path is built."""
+        config = TransformerConfig(
+            num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
+        )
+        # Mutate after config validation to exercise the model-family-specific guard directly.
+        config.overlap_moe_expert_parallel_comm = True
+
+        with pytest.raises(ValueError, match="Hybrid MTP does not support"):
+            MultiTokenPredictionLayer(
+                config=config,
+                submodules=None,
+                pg_collection=types.SimpleNamespace(cp=None, tp=None),
+                mtp_layer_pattern="M",
+            )
 
     def test_constructor_with_detach_heads(self):
         """Test construction of MTP module with mtp_detach_heads=True."""

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -114,6 +114,8 @@ class TestParallelTransformerLayer:
         layer = self.parallel_transformer_layer
         layer.input_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
         layer.pre_mlp_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
+        layer.mhc_checkpoint_input_layernorm = True
+        layer.mhc_checkpoint_pre_mlp_layernorm = True
         layer.recompute_input_layernorm = False
         layer.recompute_pre_mlp_layernorm = False
         layer.off_interface = lambda _enabled, hidden_states, _name: nullcontext(hidden_states)
@@ -152,7 +154,7 @@ class TestParallelTransformerLayer:
         layer._forward_mlp_output_with_bias(hidden_states)
         assert seen_managers == []
 
-        manager = CheckpointManager()
+        manager = MHCCheckpointManager()
         attention_output, _, _ = layer._forward_self_attention_output_with_bias(
             hidden_states, mhc_recompute_manager=manager
         )

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -101,6 +101,10 @@ class TestParallelTransformerLayer:
         parallel_transformer_layer = self.parallel_transformer_layer
         assert isinstance(parallel_transformer_layer, TransformerLayer)
         assert parallel_transformer_layer.layer_number == 1
+        # The TE dense spec fuses both norms into their following linears, leaving
+        # IdentityOp placeholders that must not be checkpointed independently.
+        assert not parallel_transformer_layer.mhc_checkpoint_input_layernorm
+        assert not parallel_transformer_layer.mhc_checkpoint_pre_mlp_layernorm
 
         num_weights = sum([p.numel() for p in parallel_transformer_layer.parameters()])
         assert num_weights == 1884
@@ -111,13 +115,18 @@ class TestParallelTransformerLayer:
 
         import megatron.core.transformer.transformer_layer as transformer_layer_module
 
-        layer = self.parallel_transformer_layer
-        layer.input_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
-        layer.pre_mlp_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
-        layer.mhc_checkpoint_input_layernorm = True
-        layer.mhc_checkpoint_pre_mlp_layernorm = True
-        layer.recompute_input_layernorm = False
-        layer.recompute_pre_mlp_layernorm = False
+        def build_layernorm(config, hidden_size, eps):
+            del config
+            return torch.nn.LayerNorm(hidden_size, eps=eps)
+
+        submodules = transformer_layer_module.TransformerLayerSubmodules(
+            input_layernorm=build_layernorm, pre_mlp_layernorm=build_layernorm
+        )
+        layer = TransformerLayer(self.parallel_transformer_layer.config, submodules)
+        assert layer.mhc_checkpoint_input_layernorm
+        assert layer.mhc_checkpoint_pre_mlp_layernorm
+        assert not layer.recompute_input_layernorm
+        assert not layer.recompute_pre_mlp_layernorm
         layer.off_interface = lambda _enabled, hidden_states, _name: nullcontext(hidden_states)
 
         class IdentityBranch(torch.nn.Module):

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -105,6 +105,66 @@ class TestParallelTransformerLayer:
         num_weights = sum([p.numel() for p in parallel_transformer_layer.parameters()])
         assert num_weights == 1884
 
+    def test_split_branch_norms_join_mhc_recompute_manager(self, monkeypatch):
+        """Explicit norms in split hybrid branches use the unified mHC manager."""
+        from contextlib import nullcontext
+
+        import megatron.core.transformer.transformer_layer as transformer_layer_module
+
+        layer = self.parallel_transformer_layer
+        layer.input_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
+        layer.pre_mlp_layernorm = torch.nn.LayerNorm(layer.config.hidden_size)
+        layer.recompute_input_layernorm = False
+        layer.recompute_pre_mlp_layernorm = False
+        layer.off_interface = lambda _enabled, hidden_states, _name: nullcontext(hidden_states)
+
+        class IdentityBranch(torch.nn.Module):
+            def forward(self, hidden_states, **_kwargs):
+                return hidden_states, None
+
+        layer.self_attention = IdentityBranch()
+        layer.mlp = IdentityBranch()
+        layer.is_moe_layer = False
+
+        seen_managers = []
+        discarded_outputs = []
+
+        class RecordingCheckpoint:
+            def __init__(self, fp8=False, ckpt_manager=None):
+                del fp8
+                seen_managers.append(ckpt_manager)
+
+            def checkpoint(self, function, *args):
+                return function(*args)
+
+            def discard_output_and_register_recompute(self, hook_tensor):
+                discarded_outputs.append(hook_tensor)
+
+        monkeypatch.setattr(
+            transformer_layer_module.tensor_parallel, "CheckpointWithoutOutput", RecordingCheckpoint
+        )
+        monkeypatch.setattr(transformer_layer_module, "nvtx_range_push", lambda **_kwargs: None)
+        monkeypatch.setattr(transformer_layer_module, "nvtx_range_pop", lambda **_kwargs: None)
+
+        hidden_states = torch.randn(4, 2, layer.config.hidden_size)
+
+        layer._forward_self_attention_output_with_bias(hidden_states)
+        layer._forward_mlp_output_with_bias(hidden_states)
+        assert seen_managers == []
+
+        manager = CheckpointManager()
+        attention_output, _, _ = layer._forward_self_attention_output_with_bias(
+            hidden_states, mhc_recompute_manager=manager
+        )
+        mlp_output, _ = layer._forward_mlp_output_with_bias(
+            hidden_states, mhc_recompute_manager=manager
+        )
+
+        assert seen_managers == [manager, manager]
+        assert len(discarded_outputs) == 1
+        assert discarded_outputs[0] is attention_output[0]
+        assert mlp_output[0].shape == hidden_states.shape
+
     def test_gpu_forward(self):
         parallel_transformer_layer = self.parallel_transformer_layer
         config: TransformerConfig = parallel_transformer_layer.config


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fix correctness and activation-memory blockers exposed by long-sequence hybrid training, including vocabulary-safe mock data, hybrid activation recomputation, Hash MoE layer selection, and full CUDA graph batch reuse.

## Mock-data token bounds

`MockSFTLowLevelDataset` previously generated token IDs using an unbounded `np.arange`. When a generated sequence exceeded the tokenizer vocabulary size, invalid IDs reached `F.embedding` and triggered a CUDA device-side assertion.

This PR:

- Passes the tokenizer vocabulary size to SFT and variable-length mock datasets.
- Keeps generated token IDs within `[0, vocab_size)`.
- Validates the vocabulary size for generated mock-data modes.

## Hybrid activation recompute

The shared full-recompute path only recognized direct `TransformerLayer` instances. An mHC layer wrapping a `TransformerLayer` was therefore handled as a Mamba layer, causing `input_ids` required by hash-routed MoE layers to be removed.

Hybrid MTP also required `recompute_num_layers == 1`, even though its nested `HybridStack` uses the decoder-level value to divide its layer pattern into uniform recompute chunks.

For selective mHC recompute, split HybridModel attention and MLP branches did not pass the shared checkpoint manager into their explicit layer norms. Those norm outputs therefore remained outside the unified mHC recompute group instead of being discarded at recompute block boundaries.

This PR:

- Recognizes mHC-wrapped Transformer layers during full recomputation.
- Preserves routing metadata such as `input_ids` for hash-routed MoE layers.
- Removes unsupported cross-attention arguments before invoking the mHC wrapper.
- Allows hybrid MTP stacks to use uniform recompute chunk sizes larger than one.
- Retains the existing restriction for legacy GPT MTP layers.
- Passes the mHC checkpoint manager through split attention and MLP branches.
- Includes explicit input and pre-MLP layer norms in the unified mHC recompute group.
- Preserves the existing behavior when mHC recompute is disabled.

## Full CUDA graph batch isolation

`StaticBufferLoader` previously returned its cached batch dictionary directly. Pipeline stages may replace or remove entries for unused fields, which mutated the cached structure and corrupted later batch reuse.

The loader now returns a shallow copy of the batch dictionary. Callers can safely tailor the structure for their pipeline stage while the underlying static CUDA tensors remain shared.

## Hybrid Hash MoE layer selection

Hybrid models use global hybrid-layer numbers when constructing MoE routers, while `moe_n_hash_layers` specifies the number of MoE layers that should use hash routing. For interleaved hybrid patterns, comparing the global layer number directly against this count caused too few MoE layers to use hash routing. For example, with MoE layers at hybrid layers 2, 4, 6, and 8, `moe_n_hash_layers=3` enabled hash routing only for layer 2.

This PR:

- Maps the configured Hash MoE count to the hybrid-layer number of the corresponding MoE position.
- Applies hash routing to exactly the first `moe_n_hash_layers` MoE layers.
- Validates that the requested count does not exceed the number of MoE layers in the hybrid pattern.
- Restores the user-facing configuration after model construction.
- Preserves the existing layer-number semantics for non-hybrid transformer models.

## Testing

Added regression coverage for:

- Generated SFT and variable-length mock tokens staying within the tokenizer vocabulary.
- Forward and backward full recomputation through an mHC-wrapped hash-MoE layer.
- Hybrid MTP using a decoder-level recompute chunk size larger than its nested layer pattern.
- mHC checkpoint-manager plumbing through split HybridModel branches.
- Explicit attention and pre-MLP norms joining the unified mHC recompute manager, including unchanged behavior without that manager.
- Full CUDA graph batch dictionaries remaining isolated while reusing their cached tensors.
- Interleaved hybrid patterns applying hash routing to exactly the configured number of MoE layers.

Local validation:

- Ruff, Black 26.3, isort, and `git diff --check` pass for the changed files.
- A 1,048,576-length mock sample with a vocabulary size of 129,280 produces token IDs only in `[0, 129279]`.
- CUDA/distributed unit tests are left to PR CI because no GPU test allocation was available locally.

## Issue tracking

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [ ] I have run `tools/autoformat.sh` on my PR

### Code review

Only mark this PR ready for review once merge conflicts are resolved and CI is passing.