### PR TITLE
Only build single-sequence packed_seq_params when RL CUDA graphs are on

### DIFF
--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -1009,11 +1009,12 @@ def get_logprobs(model, tokens, position_ids, no_grad=False, sequence_packing=Fa
     """
 
     args = get_args()
-    # Ensure packed_seq_params is always provided for CUDA graph signature consistency.
-    # When sequence_packing is enabled, construct from packing config (max_sequences_per_bin).
-    # When sequence_packing is disabled, construct a single-sequence default so the CUDA
-    # graph signature matches the training forward_step in train_rl.py.
-    # This is necessary because reference logprobs steps will reuse the training forward graph.
+    # packed_seq_params is only needed for CUDA graph signature consistency: with
+    # sequence packing the reference logprobs reuse the packed training forward graph,
+    # and without packing a single-sequence thd (== dense) matches the graph signature
+    # when RL training CUDA graphs are enabled. When they are disabled, leave it None
+    # so the non-TE (unfused) DotProductAttention path is used -- that path rejects
+    # packed_seq_params.
     if packed_seq_params is None:
         if sequence_packing:
             packed_seq_params = get_default_packed_seq_params(
@@ -1021,7 +1022,7 @@ def get_logprobs(model, tokens, position_ids, no_grad=False, sequence_packing=Fa
                 max_sequences_per_bin=args.rl_sequence_packing_max_sequences_per_bin,
                 device=tokens.device,
             )
-        else:
+        elif args.rl_training_cuda_graphs:
             cu_seqlens = torch.tensor([0, tokens.shape[1]], dtype=torch.int32, device=tokens.device)
             # Make sure to omit `total_tokens` to prevent `seq_idx` from being auto-computed.
             # That would cause a sequence packing kernel to be incorrectly used.

--- a/train_rl.py
+++ b/train_rl.py
@@ -262,7 +262,9 @@ def forward_step(data_iterator, model: GPTModel, loss_only: bool = False):
                 max_sequences_per_bin=args.rl_sequence_packing_max_sequences_per_bin,
                 device=tokens.device,
             )
-        else:
+        elif args.rl_training_cuda_graphs:
+            # Single-sequence thd == dense; only needed so the CUDA graph signature
+            # matches between the training forward and the reference logprobs.
             cu_seqlens = torch.tensor([0, tokens.shape[1]], dtype=torch.int32, device=tokens.device)
             # Make sure to omit `total_tokens` to prevent `seq_idx` from being auto-computed.
             # That would cause a sequence packing kernel to be incorrectly used.


### PR DESCRIPTION
# What does this PR do?

Fixes RL (GRPO) training crashes on non-TE (local) transformer implementations when RL training CUDA graphs are disabled.

`get_logprobs()` and the GRPO `forward_step` in `train_rl.py` unconditionally build a single-sequence thd `PackedSeqParams` whenever sequence packing is disabled, for CUDA graph signature consistency. The non-TE `DotProductAttention` (`--transformer-impl local`) asserts `packed_seq_params is None` and has no packed/thd path, so the reference-logprobs pass crashes with `AssertionError: Packed sequence is not supported by DotProductAttention` even though CUDA graphs are not in use.

A single-sequence thd is identical to dense. The construction is now gated on `args.rl_training_cuda_graphs`, and `packed_seq_params` is left as `None` otherwise, which is what the non-TE (unfused) attention path expects. No behavior change for the default path (TE / flash-attn, CUDA graphs on).

## Issue tracking

Fixes #6708

## Checks / tests

- E2E: GRPO RL training (rollout → reference logprobs → training step) completes cleanly on an Ascend 910B NPU with `--transformer-impl local --attention-backend unfused`, exit 0
- Default path unchanged: with `rl_training_cuda_graphs` set, the single-sequence thd is still constructed
- Changed files are outside the `megatron/core` + `tests` scope scanned by `tools/autoformat.sh`; edits are black-clean by construction (gated branch + 100-col comments)

This PR was written in part with the assistance of generative AI.
