### PR TITLE
fix: synchronize ZMQ subscribers before the first broadcast

### DIFF
--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -3,6 +3,7 @@
 import asyncio
 import socket
 import struct
+import time
 
 import torch.distributed as dist
 
@@ -25,6 +26,12 @@ class AsyncZMQCommunicator:
     Only to be used with small amounts of data (e.g., 1 integer)
     on the CPU.
     """
+
+    # Handshake tokens. Every token is 3 bytes so it can never be confused with a
+    # payload, which is always a whole number of 4-byte ints.
+    _SYNC = b"SYN"
+    _SYNC_DONE = b"FIN"
+    _SYNC_ACK = b"ACK"
 
     def __init__(
         self,
@@ -83,6 +90,60 @@ class AsyncZMQCommunicator:
             self.bcast_sock = zmq_context.socket(zmq.SUB)
             self.bcast_sock.connect(bcast_socket_addr)
             self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        self._bcast_socket_addr = bcast_socket_addr
+        self._synchronize_subscribers()
+
+    def _synchronize_subscribers(self, timeout: float = 300.0) -> None:
+        """Block until every subscriber is guaranteed to receive broadcasts.
+
+        A ZMQ subscription only takes effect once it has propagated to the
+        publisher, and anything published before then is dropped without error.
+        The leader therefore republishes _SYNC until every peer has acknowledged
+        one over the reliable gather channel, then publishes _SYNC_DONE to mark
+        the end of handshake traffic. Subscriptions from another node take long
+        enough to establish that, without this, the first broadcast is routinely
+        lost and every rank that misses it waits for it forever.
+
+        Args:
+            timeout (float): Seconds to wait for the handshake before failing.
+        """
+        if self.world_size <= 1:
+            return
+
+        deadline = time.monotonic() + timeout
+
+        if self.is_leader:
+            unacked = self.world_size - 1
+            while unacked > 0:
+                self.bcast_sock.send(self._SYNC)
+                while unacked > 0 and self.gather_sock.poll(timeout=10):
+                    if self.gather_sock.recv() == self._SYNC_ACK:
+                        unacked -= 1
+                if unacked > 0 and time.monotonic() > deadline:
+                    raise RuntimeError(
+                        f"Rank {self.rank} timed out after {timeout}s waiting for {unacked} "
+                        f"of {self.world_size - 1} peers to subscribe to "
+                        f"{self._bcast_socket_addr}"
+                    )
+            self.bcast_sock.send(self._SYNC_DONE)
+        else:
+            acked = False
+            while True:
+                if not self.bcast_sock.poll(timeout=100):
+                    if time.monotonic() > deadline:
+                        raise RuntimeError(
+                            f"Rank {self.rank} timed out after {timeout}s waiting for the "
+                            f"subscription handshake from {self._bcast_socket_addr}"
+                        )
+                    continue
+                message = self.bcast_sock.recv()
+                if message == self._SYNC_DONE:
+                    return
+                if not acked:
+                    # Receiving _SYNC proves this subscription reached the publisher.
+                    self.gather_sock.send(self._SYNC_ACK)
+                    acked = True
 
     async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.

--- a/tests/unit_tests/inference/engines/test_async_zmq_communicator.py
+++ b/tests/unit_tests/inference/engines/test_async_zmq_communicator.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import struct
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -116,6 +117,94 @@ async def test_all_reduce_max_async_handles_zmq_again_retries(rank, world_size, 
 
     result = await comm.all_reduce_max(7, async_op=True)
     assert result == 9
+
+
+def _make_socket_comm(context, rank, world_size, addresses):
+    """Build a communicator over real loopback sockets, skipping the PG rendezvous.
+
+    Mirrors what __init__ does once the socket addresses are known, so the
+    handshake can be exercised without a torch.distributed process group.
+    """
+    import zmq
+
+    comm = AsyncZMQCommunicator.__new__(AsyncZMQCommunicator)
+    comm.rank = rank
+    comm.world_size = world_size
+    comm.is_leader = rank == 0
+
+    if comm.is_leader:
+        comm.gather_sock = context.socket(zmq.PULL)
+        comm.gather_sock.bind_to_random_port("tcp://127.0.0.1")
+        addresses["gather"] = comm.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
+
+        comm.bcast_sock = context.socket(zmq.PUB)
+        comm.bcast_sock.bind_to_random_port("tcp://127.0.0.1")
+        addresses["bcast"] = comm.bcast_sock.getsockopt_string(zmq.LAST_ENDPOINT)
+    else:
+        comm.gather_sock = context.socket(zmq.PUSH)
+        comm.gather_sock.connect(addresses["gather"])
+        comm.bcast_sock = context.socket(zmq.SUB)
+        comm.bcast_sock.connect(addresses["bcast"])
+        comm.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+
+    comm._bcast_socket_addr = addresses["bcast"]
+    return comm
+
+
+@pytest.mark.parametrize("follower_connect_delay", [0.0, 0.5])
+async def test_handshake_keeps_late_subscribers_from_missing_broadcasts(follower_connect_delay):
+    """A reduction issued as soon as the leader is ready must reach every follower.
+
+    ZMQ discards published messages for any subscriber whose subscription has
+    not yet reached the publisher, and nothing in the PUB/SUB pattern reports
+    that. A leader that publishes the moment it is ready therefore loses the
+    reduced value for every follower still connecting, and those followers then
+    wait for it forever. `_synchronize_subscribers` closes that window by
+    republishing until each follower acknowledges over the reliable gather
+    channel, so subscribers connecting late (as they do from another node) still
+    see the first broadcast.
+    """
+    import zmq
+
+    world_size = 4
+    context = zmq.Context()
+    addresses = {}
+    leader_ready = threading.Event()
+    results: dict[int, object] = {}
+    errors: dict[int, BaseException] = {}
+
+    def run_rank(rank):
+        try:
+            if rank == 0:
+                comm = _make_socket_comm(context, rank, world_size, addresses)
+                leader_ready.set()
+            else:
+                assert leader_ready.wait(30)
+                # Connect after the leader is already ready to publish, which is
+                # the window where an unsynchronized broadcast gets dropped.
+                if follower_connect_delay:
+                    threading.Event().wait(follower_connect_delay)
+                comm = _make_socket_comm(context, rank, world_size, addresses)
+
+            comm._synchronize_subscribers(timeout=60.0)
+            results[rank] = comm.sync_all_reduce_max(rank, rank * 3)
+            comm.close()
+        except BaseException as error:  # surface failures instead of hanging the suite
+            errors[rank] = error
+            leader_ready.set()
+
+    threads = [threading.Thread(target=run_rank, args=(rank,)) for rank in range(world_size)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        # A dropped broadcast shows up as a thread that never finishes.
+        thread.join(timeout=90)
+        assert not thread.is_alive(), "a rank never completed its reduction"
+
+    context.term()
+    assert not errors, f"ranks raised: {errors}"
+    expected = (world_size - 1, (world_size - 1) * 3)
+    assert results == {rank: expected for rank in range(world_size)}
 
 
 @pytest.mark.parametrize("method_name", ["all_reduce_max", "sync_all_reduce_max"])


### PR DESCRIPTION
## Problem

`AsyncZMQCommunicator` shares the reduced value of a collective over a PUB
socket. ZMQ silently discards messages published before a subscriber's
subscription has propagated to the publisher, and the leader publishes as soon
as it has collected every peer's value over the (reliable) PUSH/PULL gather
channel. A subscriber that is still establishing its connection therefore misses
the broadcast, and since `all_reduce_max` loops on `recv` with no timeout, that
rank waits for the message forever.

The race is narrow within a node but wide enough to hit reliably when subscribers
connect from another node. A two-node expert-parallel inference instance (EP=8
across 2x4 GB200s) deadlocked during startup with one EP rank blocked here:

```
run_engine_with_coordinator -> _ep_establish_consensus
  -> AsyncZMQCommunicator.all_reduce_max
     msg = self.bcast_sock.recv()      # never returns
```

while the leader had already published the reduced value and moved on. Every
other rank progressed, so the engine never reached `RUNNING` and the whole job
hung with idle GPUs holding memory.

## Fix

Add a subscription handshake at the end of `__init__`. The leader republishes a
token until every peer has acknowledged one over the gather channel, then
publishes a terminator to mark the end of handshake traffic. An acknowledgement
proves the peer's subscription is registered with the publisher, so every later
broadcast is delivered. Handshake tokens are 3 bytes and payloads are whole
4-byte ints, so the two can never be confused. A timeout turns a genuinely
broken rendezvous into an error naming the rank and endpoint instead of another
silent hang.

Cost is one round trip during construction (0.04s for 8 ranks on loopback).

## Validation

- New unit test drives real loopback sockets across 4 ranks with a subscriber
  that connects after the leader is ready. It passes with the handshake and hangs
  without it, which is the regression it guards.
- 8-rank and 16-rank runs of the same harness pass repeatedly, including the
  single-rank short-circuit.
- End to end: the previously hanging 4-node GB200 GRPO job (NeMo-RL, 2 generation
  nodes at EP=8 plus 2 training nodes) now completes all 10 steps, three runs in
  a row.

Draft: raised by an agent, needs a human review before merge.