### PR TITLE
Reduce eval loss over the GTP-remat-inclusive data-parallel group

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -707,9 +707,15 @@ def validate_args(args, defaults={}):
         args.eval_global_batch_size = args.global_batch_size
     if args.eval_micro_batch_size is None:
         args.eval_micro_batch_size = args.micro_batch_size
-    assert args.eval_global_batch_size % (args.eval_micro_batch_size * args.data_parallel_size) == 0, \
+    # data_parallel_size is the replicate degree, so multiply the GTP-remat axis back in: evaluate()
+    # divides eval_global_batch_size by the same product to get its microbatch count, and without
+    # gtp_weight_remat_size here that division can silently floor (down to zero microbatches).
+    assert args.eval_global_batch_size % (
+        args.eval_micro_batch_size * args.data_parallel_size * args.gtp_weight_remat_size
+    ) == 0, \
         f"eval_global_batch_size ({args.eval_global_batch_size}) must be divisible by " \
-        f"eval_micro_batch_size ({args.eval_micro_batch_size}) * data_parallel_size ({args.data_parallel_size})"
+        f"eval_micro_batch_size ({args.eval_micro_batch_size}) * data_parallel_size ({args.data_parallel_size})" \
+        f" * gtp_weight_remat_size ({args.gtp_weight_remat_size})"
 
     if args.perform_rl_step:
         num_generated_samples_per_inference_iteration = (

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -5085,6 +5085,11 @@ def evaluate(
     eval_pgc = get_attr_wrapped_model(model[0], "pg_collection")
     if eval_pgc is None:
         eval_pgc = ProcessGroupCollection.use_mpu_process_groups()
+    # gtp_remat-inclusive, mirroring train_step: gtp_remat peers hold distinct micro-batches, so
+    # the reduction must cover every distinct-data rank. Reducing over the replicate dp_cp would
+    # average a 1/gtp_remat subsample of the eval batch (768 sequences read, 12 averaged at
+    # dp=6/gtp_remat=64) while consumed_valid_samples still books the full eval_batch_size.
+    eval_dp_cp_group = getattr(eval_pgc, 'dp_cp_gtp_remat', None) or eval_pgc.dp_cp
     if args.cuda_graph_impl == "full_iteration":
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,
@@ -5163,13 +5168,13 @@ def evaluate(
                             val = torch.vstack(val)
                             val = val[:, 0] / val[:, 1].clamp(min=1)
                             val = val.mean()
-                            torch.distributed.all_reduce(val, group=eval_pgc.dp_cp)
-                            val /= torch.distributed.get_world_size(group=eval_pgc.dp_cp)
+                            torch.distributed.all_reduce(val, group=eval_dp_cp_group)
+                            val /= torch.distributed.get_world_size(group=eval_dp_cp_group)
                             total_loss_dict[key][0] += val
                             total_loss_dict[key][1] += 1
                         else :
                             val = torch.vstack(val).sum(dim=0)
-                            torch.distributed.all_reduce(val, group=eval_pgc.dp_cp)
+                            torch.distributed.all_reduce(val, group=eval_dp_cp_group)
                             total_loss_dict[key] += val
                     elif val[0].numel() == 1:
                         val = torch.cat(val).sum()

--- a/tests/unit_tests/test_eval_batch_size.py
+++ b/tests/unit_tests/test_eval_batch_size.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import sys
 from argparse import ArgumentParser
 from types import SimpleNamespace
 
 import pytest
 
 from megatron.training.argument_utils import ArgumentGroupFactory
+from megatron.training.arguments import parse_args, validate_args
 from megatron.training.config import ValidationConfig
 from megatron.training.global_vars import set_args
 from megatron.training.training import get_train_valid_test_num_samples
@@ -154,6 +156,61 @@ class TestEvalBatchSizeDivisibility:
         )
         assert args.eval_global_batch_size == 32
         assert args.eval_micro_batch_size == 2
+
+
+class TestEvalBatchSizeDivisibilityWithGTP:
+    """Test that the GTP weight-remat axis is factored into the eval divisibility check.
+
+    Unlike TestEvalBatchSizeDivisibility above, these call the real validate_args instead of
+    re-implementing its expression, so a future change to that expression is actually caught.
+    """
+
+    @staticmethod
+    def _build_args(
+        monkeypatch, num_weight_shards, eval_global_batch_size, eval_micro_batch_size=1
+    ):
+        """Build a minimal GTP config: world_size 8 = gtp_weight_remat_size x data_parallel_size."""
+        monkeypatch.setattr(sys, 'argv', ['test_eval_batch_size.py'])
+        args = parse_args()
+        # parse_args reads WORLD_SIZE from the environment. Pin it, since data_parallel_size is
+        # derived from it and the test must not depend on how the job was launched.
+        args.world_size = 8
+        args.num_layers = 2
+        args.hidden_size = 128
+        args.num_attention_heads = 4
+        args.max_position_embeddings = 1024
+        args.seq_length = 1024
+        args.micro_batch_size = 1
+        args.global_batch_size = 8
+        args.train_iters = 1
+        args.lr = 1e-4
+        args.tokenizer_type = 'NullTokenizer'
+        args.vocab_size = 1024
+        args.tensor_parallel_num_weight_shards = num_weight_shards
+        args.eval_global_batch_size = eval_global_batch_size
+        args.eval_micro_batch_size = eval_micro_batch_size
+        return args
+
+    def test_gtp_remat_factored_into_divisibility(self, monkeypatch):
+        """Divisible by eval_micro_batch_size * data_parallel_size, but not by the GTP axis."""
+        args = self._build_args(monkeypatch, num_weight_shards=8, eval_global_batch_size=4)
+        # 4 % (1 * 1) == 0 satisfies the two-factor check, but evaluate() divides by
+        # eval_micro_batch_size * data_parallel_size * gtp_weight_remat_size, which floors to
+        # 4 // 8 == 0 microbatches: evaluation would silently do nothing.
+        with pytest.raises(AssertionError, match="gtp_weight_remat_size"):
+            validate_args(args)
+
+    def test_gtp_remat_divisible_config_passes(self, monkeypatch):
+        """A config divisible by the full data-distribution breadth validates."""
+        args = self._build_args(monkeypatch, num_weight_shards=8, eval_global_batch_size=8)
+        validate_args(args)
+        assert args.gtp_weight_remat_size == 8
+        assert args.data_parallel_size == 1
+        # The division evaluate() performs; it must leave at least one microbatch.
+        num_microbatches = args.eval_global_batch_size // (
+            args.eval_micro_batch_size * args.data_parallel_size * args.gtp_weight_remat_size
+        )
+        assert num_microbatches == 1
 
 
 class TestGetTrainValidTestNumSamples:


### PR DESCRIPTION
## What

`evaluate()` all-reduced its loss over `pg_collection.dp_cp`, which is the **replicate** data-parallel group and excludes the GTP weight-remat axis (`use_mpu_process_groups()` builds it with `with_gtp_remat=False`, `megatron/core/process_groups_config.py:261`). But `gtp_remat` peers hold **distinct** micro-batches: the eval sampler uses `mpu.get_data_parallel_rank()` / `get_data_parallel_world_size()`, both of which default to `with_gtp_remat=True`.

See figure demonstrating the issue:
<img width="2700" height="1050" alt="gtp_validation_loss" src="https://github.com/user-attachments/assets/1d73d89b-7a2d-41a6-8d15-4ad2c4f73b08" />


So the full eval batch was read and forwarded, and then only a `1/gtp_remat` slice of it was averaged into the reported number. On a run with `dp=6`, `gtp_remat=64`, `eval_global_batch_size=768`: all 384 distinct-data ranks read their micro-batches (768 sequences per eval iteration), the all-reduce covered 6 of those ranks (12 sequences), and `consumed_valid_samples` still incremented by the full 768. Over `--eval-iters 14` that is ~168 sequences behind each reported validation loss instead of 10,752. The estimate stays unbiased, but its standard error is ~8x larger, which shows up as visible scatter between evaluations.

`train_step` already handles this correctly and picks `dp_cp_gtp_remat` with a comment explaining exactly this hazard (`megatron/training/training.py:3178`). `evaluate()` was missed in that migration. This change makes it consistent.

## Also

`validate_args` asserted `eval_global_batch_size % (eval_micro_batch_size * data_parallel_size) == 0`, but `evaluate()` divides by `eval_micro_batch_size * data_parallel_size * gtp_weight_remat_size` to derive its micro-batch count. With GTP active the assert can pass while the division floors to a smaller count, or to zero micro-batches, silently evaluating nothing. The assert now includes `gtp_weight_remat_size`.

`megatron/training/yaml_arguments.py` carries the same assert, but that path never factors GTP into `data_parallel_size` at all, so it needs a broader change and is left alone here.

## Impact

No behavior change when `gtp_weight_remat_size == 1`: `dp_cp_gtp_remat` aliases `dp_cp` in that case, and the added assert factor is 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)