### PR TITLE
ci: isolate tokenizer metadata writes

### DIFF
--- a/tests/unit_tests/tokenizers/test_tokenizer.py
+++ b/tests/unit_tests/tokenizers/test_tokenizer.py
@@ -341,8 +341,10 @@ def test_bytelevel_tokenizer():
     assert tokenizer.detokenize([72, 101, 108, 108, 111]) == "Hello"
 
 
-def test_write_metadata_hf():
-    tokenizer_path = "/opt/data/tokenizers/huggingface"
+def test_write_metadata_hf(tmp_path):
+    tokenizer_dir = tmp_path / "huggingface"
+    tokenizer_dir.mkdir()
+    tokenizer_path = str(tokenizer_dir)
     metadata_path = f"{tokenizer_path}/tokenizer_metadata.json"
     chat_template = "test chat template"
     tokenizer_library = "huggingface"
@@ -376,7 +378,7 @@ def test_write_metadata_hf():
     assert metadata['class_name'] == "CustomTokenizerClass"
 
     # Save metadata to specific path
-    metadata_path = f"{tokenizer_path}/test_metadata.json"
+    metadata_path = str(tmp_path / "test_metadata.json")
     MegatronTokenizer.write_metadata(
         tokenizer_path=tokenizer_path,
         metadata_path=metadata_path,
@@ -389,10 +391,10 @@ def test_write_metadata_hf():
     assert metadata['class_name'] == "MegatronTokenizerText"
 
 
-def test_write_metadata_sp():
+def test_write_metadata_sp(tmp_path):
     path = "/opt/data/tokenizers/sentencepiece"
     tokenizer_path = f"{path}/tokenizer.model"
-    metadata_path = f"{path}/test_metadata.json"
+    metadata_path = str(tmp_path / "test_metadata.json")
     tokenizer_library = "sentencepiece"
     MegatronTokenizer.write_metadata(
         tokenizer_path=tokenizer_path,
@@ -407,9 +409,9 @@ def test_write_metadata_sp():
     assert metadata['class_name'] == "MegatronTokenizerText"
 
 
-def test_write_metadata_vision():
+def test_write_metadata_vision(tmp_path):
     tokenizer_path = "/opt/data/tokenizers/multimodal"
-    metadata_path = f"{tokenizer_path}/test_metadata.json"
+    metadata_path = str(tmp_path / "test_metadata.json")
     MegatronTokenizer.write_metadata(
         tokenizer_path=tokenizer_path,
         metadata_path=metadata_path,
@@ -420,12 +422,12 @@ def test_write_metadata_vision():
         assert json.load(f)["class_name"] == "MegatronTokenizerVision"
 
 
-def test_own_metadata_class():
+def test_own_metadata_class(tmp_path):
     tokenizer_path = "/opt/data/tokenizers/huggingface"
     chat_template = "test chat template"
     tokenizer_library = "huggingface"
 
-    metadata_path = f"{tokenizer_path}/test_metadata.json"
+    metadata_path = str(tmp_path / "test_metadata.json")
     MegatronTokenizer.write_metadata(
         tokenizer_path=tokenizer_path,
         metadata_path=metadata_path,


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Prevent multi-rank tokenizer metadata tests from racing on shared files under `/opt/data`.

## Issue tracking

Related CI failure: https://github.com/NVIDIA/Megatron-LM/actions/runs/32414216122/job/96585431264

## Why

The unit-test bucket launches the same pytest suite on eight distributed ranks. The metadata tests previously wrote to shared paths under `/opt/data`. Because `write_metadata` opens its output with mode `w`, one rank could truncate a metadata file while another rank was reading it.

In the linked failure, rank 6 failed in `test_write_metadata_hf` with `JSONDecodeError` after reading an empty `tokenizer_metadata.json`; the other seven ranks passed all 1,807 tests.

## Changes

- Create a rank-local temporary tokenizer directory for the Hugging Face default-metadata-path test.
- Write SentencePiece, vision, and custom-class metadata into pytest temporary directories.
- Preserve coverage of both default and explicitly supplied metadata paths.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not applicable; test-only race fix)
- [ ] I have added proper typing to my code (not applicable; no production API changes)
- [ ] I have added relevant documentation (not applicable; no user-facing behavior changes)
- [x] I have run the autoformatter checks on my PR

## Validation

- `uvx --from black==26.3.0 black --skip-magic-trailing-comma --skip-string-normalization --check --diff tests/unit_tests/tokenizers/test_tokenizer.py`
- `ruff check tests/unit_tests/tokenizers/test_tokenizer.py`
- `python3 -m py_compile tests/unit_tests/tokenizers/test_tokenizer.py`
- `git diff --check`

The prescribed eight-rank GPU pytest invocation was not run locally because this macOS host has no GPU runtime. The `Run tests` label is attached for CI validation.