### PR TITLE
ci: prioritize baseline cache for merge groups

### DIFF
--- a/.github/workflows/_build_ci_container.yml
+++ b/.github/workflows/_build_ci_container.yml
@@ -206,16 +206,23 @@ jobs:
         shell: bash
         env:
           BASELINE_CACHE: ${{ matrix.registry }}/megatron-lm:${{ steps.cache_keys.outputs.baseline }}-buildcache-${{ matrix.cloud }}
+          EVENT_NAME: ${{ github.event_name }}
           LEGACY_CACHE: ${{ matrix.registry }}/megatron-lm:0-buildcache-${{ matrix.cloud }}
           RUN_CACHE: ${{ matrix.registry }}/megatron-lm:${{ steps.cache_keys.outputs.key }}-buildcache-${{ matrix.cloud }}
         run: |
-          DONOR_CACHE="$RUN_CACHE"
-          if ! docker buildx imagetools inspect "$DONOR_CACHE" >/dev/null 2>&1; then
-            DONOR_CACHE="$BASELINE_CACHE"
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            CANDIDATES=("$BASELINE_CACHE" "$RUN_CACHE" "$LEGACY_CACHE")
+          else
+            CANDIDATES=("$RUN_CACHE" "$BASELINE_CACHE" "$LEGACY_CACHE")
           fi
-          if ! docker buildx imagetools inspect "$DONOR_CACHE" >/dev/null 2>&1; then
-            DONOR_CACHE="$LEGACY_CACHE"
-          fi
+
+          DONOR_CACHE="$LEGACY_CACHE"
+          for candidate in "${CANDIDATES[@]}"; do
+            if docker buildx imagetools inspect "$candidate" >/dev/null 2>&1; then
+              DONOR_CACHE="$candidate"
+              break
+            fi
+          done
           echo "donor=$DONOR_CACHE" | tee -a "$GITHUB_OUTPUT"
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- prefer the target-branch baseline cache for merge-group builds
- fall back to the run/PR cache, then the legacy cache
- preserve the existing run-first priority for all other events
- continue passing exactly one cache donor to BuildKit

## Validation

- exercised merge-group baseline, PR-cache, and legacy fallback cases with a temporary Bash harness
- exercised the existing non-merge-group run-cache priority with the same harness
- ran .github/scripts/test_cache_keys.sh
- parsed .github/workflows/_build_ci_container.yml with Ruby YAML
- checked the extracted cache donor script with bash -n
- ran git diff --check