### PR TITLE
fix(ssm): refresh the mamba decode cache after a refit

### DIFF
--- a/megatron/core/resharding/refit.py
+++ b/megatron/core/resharding/refit.py
@@ -407,6 +407,26 @@ def swap_model_weights(
             pool_index=pool,
         )
 
+        if target is not None:
+            _refresh_inference_weight_caches(target)
+
+
+def _refresh_inference_weight_caches(target_model) -> None:
+    """Recompute any values a module derives from weights and caches for decode.
+
+    A refit updates weights in place while the target stays in eval mode, so the
+    ``train()`` transition that normally invalidates such caches never happens.
+    Modules that keep one expose ``refresh_inference_weight_caches``; without
+    this call they would keep decoding from values derived from the weights the
+    target held before the refit.
+    """
+    chunks = target_model if isinstance(target_model, (list, tuple)) else [target_model]
+    for chunk in chunks:
+        for module in chunk.modules():
+            refresh = getattr(module, "refresh_inference_weight_caches", None)
+            if refresh is not None:
+                refresh()
+
 
 def _harmonize_buffer_dtypes(plan, src_core, tgt_core, group=None):
     """Bring destination persistent-buffer dtypes into agreement with source.

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1054,6 +1054,24 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
             self._A_neg_exp_cache_stale = True
         return super().train(mode)
 
+    def refresh_inference_weight_caches(self) -> None:
+        """Refill weight-derived decode caches from the current weights.
+
+        Call after ``A_log`` is updated without a ``train()`` transition, as an
+        RL refit does: the model stays in eval mode throughout, so nothing else
+        marks the decode cache stale and inference would keep using the value
+        derived from the pre-refit weights.
+
+        Refills in place rather than only marking the cache stale. Once decode
+        graphs are captured, a replay does not re-execute the staleness check in
+        ``_get_decode_A_neg_exp``, so the captured buffer itself must be
+        updated -- which is safe precisely because that buffer is allocated
+        outside graph capture and keeps its address for the model's lifetime.
+        """
+        with torch.no_grad():
+            self._A_neg_exp_cache.copy_(-torch.exp(self.A_log.float()))
+        self._A_neg_exp_cache_stale = False
+
     def ssm_decode(
         self,
         zxBCdt: torch.Tensor,


### PR DESCRIPTION
Found while validating NeMo-RL's Megatron-generation functional suite on
nemotron-nano-3.5 (30B-A3B, mamba-hybrid MoE) on GB200.

## Failure

`grpo_megatron_generation_async_prefix_caching` reported a maximum
`token_mult_prob_error` of `1.59e12` (and `gen_kl_error` ~0.5): the generation
engine's logprobs bore no relation to the training policy's, even though refit
had delivered every parameter correctly.

## Root cause

`MambaMixer._get_decode_A_neg_exp` decodes from a cached `-exp(A_log)` held in
`self._A_neg_exp_cache`, and the only thing that marks it stale is
`train(True)`:

https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/ssm/mamba_mixer.py#L1049-L1055

An RL refit updates `A_log` in place while the inference model stays in eval
mode for its entire lifetime, so that transition never happens. The cache is
filled during decode CUDA-graph capture, which precedes the first refit, and is
never refreshed again. Generation therefore decodes with the SSM decay derived
from whatever `A_log` held before the first refit:

- when the inference model loads a checkpoint, the cache is seeded with step-0
  weights, so it is correct at step 1 and drifts as `A_log` trains (small but
  growing error);
- when the caller skips that load and relies on refit — which is a sound
  optimization otherwise, since refit does deliver every parameter — the cache
  holds *randomly initialized* values for the whole run, which is the 1e12 above.

Disabling inference CUDA graphs also hides the bug, because the first cache fill
then happens on a real decode after the refit.

Because the cache is a plain attribute rather than a registered buffer, it is
invisible to `named_parameters()`, `named_buffers()`, and `state_dict()`: a
post-refit fingerprint of all three shows the inference model as byte-identical
to a correctly loaded one.

## Fix

`swap_model_weights` now refreshes weight-derived decode caches on the target
after writeback, through a `refresh_inference_weight_caches` hook that
`MambaMixer` implements. The hook refills in place rather than only marking the
cache stale, because once decode graphs are captured a replay never re-executes
the staleness check — the captured buffer itself has to be updated, which is
safe precisely because that buffer is deliberately allocated outside graph
capture and keeps its address for the model's lifetime.

The hook keeps refit from reaching into mixer internals and gives any future
weight-derived inference cache one place to hang off.

## Validation

Re-ran `grpo_megatron_generation_async_prefix_caching` (2 nodes, GB200, mamba
-hybrid MoE with EP=4, inference CUDA graphs on, non-colocated refit over NCCL)
with this patch cherry-picked onto the megatron-lm revision the failing run
used, `14346b65a`, and with the NeMo-RL side unchanged:

| run | max `token_mult_prob_error` over 5 steps |
|---|---|
| unpatched | 1.59e12 (fail) |
| unpatched, inference model loads the checkpoint | 1.05 (pass) |
| this patch | **1.0263** (pass) |

## Scope of the improvement

Caller-side reordering reaches the same numbers on this test. If the inference
engine is constructed only after the first refit — so decode graphs capture
weights that refit has already delivered — the cache is seeded correctly and the
test passes without this patch: 1.0266 unpatched versus 1.0269 with it, over
five steps, on otherwise identical code (NVIDIA-NeMo/RL#3731 makes exactly that
change). An earlier version of this description claimed the patch also removed
residual drift; that is not supported by the per-step measurements and has been
withdrawn.

What the patch still buys is not conditional on caller ordering: any refit into
`A_log` after the cache has been filled leaves the cache wrong, so the error
grows with how far the weights travel after capture. Five steps of a functional
test barely moves `A_log`; a real RL run does. It also removes the requirement
that every caller know to construct its engine after a refit in order to get
correct decode math.

Draft: raised by an agent, needs a human review before merge.
