### PR TITLE
Keep MIMO gradient normalization on device

### DIFF
--- a/examples/mimo/training/grad_sync.py
+++ b/examples/mimo/training/grad_sync.py
@@ -55,15 +55,6 @@ def _vision_participation_count(submodule, vision_dp_group) -> torch.Tensor:
     return indicator
 
 
-def _vision_participation_scale(participation: torch.Tensor, vision_dp_size: int) -> torch.Tensor:
-    """Correct gradients when only part of the vision-DP group processed input."""
-    return torch.where(
-        (participation > 0) & (participation < vision_dp_size),
-        vision_dp_size * participation.reciprocal(),
-        torch.ones_like(participation),
-    )
-
-
 def _token_normalization_scale(num_tokens: torch.Tensor) -> torch.Tensor:
     """Return a device-side reciprocal, leaving zero-token gradients unscaled."""
     return num_tokens.clamp_min(1).reciprocal()
@@ -193,8 +184,10 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
                     vision_dp_size = dist.get_world_size(vision_dp_group)
                     if vision_dp_size > 1:
                         participation = _vision_participation_count(submodule, vision_dp_group)
-                        participation_scale = _vision_participation_scale(
-                            participation, vision_dp_size
+                        participation_scale = torch.where(
+                            (participation > 0) & (participation < vision_dp_size),
+                            vision_dp_size * participation.reciprocal(),
+                            torch.ones_like(participation),
                         )
                         vision_scale = vision_scale * participation_scale
 

--- a/examples/mimo/training/grad_sync.py
+++ b/examples/mimo/training/grad_sync.py
@@ -48,11 +48,25 @@ def reset_modality_participation(mimo_model: MimoModel) -> None:
 
 
 def _vision_participation_count(submodule, vision_dp_group) -> torch.Tensor:
-    """Number of vision-DP ranks that processed image input this step."""
+    """Scalar count of vision-DP ranks that processed image input this step."""
     val = 1.0 if getattr(submodule, _PARTICIPATED_ATTR, False) else 0.0
-    indicator = torch.tensor([val], dtype=torch.float32, device="cuda")
+    indicator = torch.tensor(val, dtype=torch.float32, device="cuda")
     dist.all_reduce(indicator, op=dist.ReduceOp.SUM, group=vision_dp_group)
     return indicator
+
+
+def _vision_participation_scale(participation: torch.Tensor, vision_dp_size: int) -> torch.Tensor:
+    """Correct gradients when only part of the vision-DP group processed input."""
+    return torch.where(
+        (participation > 0) & (participation < vision_dp_size),
+        vision_dp_size * participation.reciprocal(),
+        torch.ones_like(participation),
+    )
+
+
+def _token_normalization_scale(num_tokens: torch.Tensor) -> torch.Tensor:
+    """Return a device-side reciprocal, leaving zero-token gradients unscaled."""
+    return num_tokens.clamp_min(1).reciprocal()
 
 
 def _is_pg_member(pg) -> bool:
@@ -106,10 +120,10 @@ def _global_token_count(num_tokens, language_pg, src_global_rank) -> torch.Tenso
     world (including the non-colocated encoder grid, where ``language_pg`` is None) so
     both modules divide by the same per-token mean.
     """
-    global_num_tokens = torch.zeros(1, dtype=torch.float32, device="cuda")
+    global_num_tokens = torch.zeros((), dtype=torch.float32, device="cuda")
     if _is_token_source_rank(language_pg):
         data_group = language_pg.dp_cp_gtp_remat or language_pg.dp_cp
-        token_count = num_tokens.to(dtype=torch.float32).sum().view(1)
+        token_count = num_tokens.to(dtype=torch.float32).sum()
         dist.all_reduce(token_count, group=data_group, op=dist.ReduceOp.SUM)
         if dist.get_rank(group=data_group) == 0:
             global_num_tokens.copy_(token_count)
@@ -150,7 +164,7 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
         # N_global is the global token count, published to every rank (including the
         # non-colocated encoder grid) so both modules divide by the same per-token mean.
         n_global = _global_token_count(num_tokens, language_pg, src_global_rank)
-        inv = torch.where(n_global > 0, n_global.reciprocal(), torch.zeros_like(n_global))
+        inv = _token_normalization_scale(n_global)
 
         if mimo_model.language_model is not None:
             finalize_model_grads(
@@ -179,10 +193,8 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
                     vision_dp_size = dist.get_world_size(vision_dp_group)
                     if vision_dp_size > 1:
                         participation = _vision_participation_count(submodule, vision_dp_group)
-                        participation_scale = torch.where(
-                            (participation > 0) & (participation < vision_dp_size),
-                            vision_dp_size * participation.reciprocal(),
-                            torch.ones_like(participation),
+                        participation_scale = _vision_participation_scale(
+                            participation, vision_dp_size
                         )
                         vision_scale = vision_scale * participation_scale
 

--- a/examples/mimo/training/grad_sync.py
+++ b/examples/mimo/training/grad_sync.py
@@ -47,12 +47,12 @@ def reset_modality_participation(mimo_model: MimoModel) -> None:
             setattr(submodule, _PARTICIPATED_ATTR, False)
 
 
-def _vision_participation_count(submodule, vision_dp_group) -> float:
+def _vision_participation_count(submodule, vision_dp_group) -> torch.Tensor:
     """Number of vision-DP ranks that processed image input this step."""
     val = 1.0 if getattr(submodule, _PARTICIPATED_ATTR, False) else 0.0
     indicator = torch.tensor([val], dtype=torch.float32, device="cuda")
     dist.all_reduce(indicator, op=dist.ReduceOp.SUM, group=vision_dp_group)
-    return float(indicator.item())
+    return indicator
 
 
 def _is_pg_member(pg) -> bool:
@@ -98,7 +98,7 @@ def _token_source_global_rank(language_grid) -> int:
     )
 
 
-def _global_token_count(num_tokens, language_pg, src_global_rank) -> float:
+def _global_token_count(num_tokens, language_pg, src_global_rank) -> torch.Tensor:
     """Total non-padded tokens in the global batch, visible on every rank.
 
     Only the LLM token-source ranks compute the count by summing over all LLM data lanes;
@@ -114,7 +114,7 @@ def _global_token_count(num_tokens, language_pg, src_global_rank) -> float:
         if dist.get_rank(group=data_group) == 0:
             global_num_tokens.copy_(token_count)
     dist.broadcast(global_num_tokens, src=src_global_rank)
-    return float(global_num_tokens.item())
+    return global_num_tokens
 
 
 def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -> None:
@@ -150,7 +150,7 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
         # N_global is the global token count, published to every rank (including the
         # non-colocated encoder grid) so both modules divide by the same per-token mean.
         n_global = _global_token_count(num_tokens, language_pg, src_global_rank)
-        inv = 1.0 / n_global if n_global > 0 else 0.0
+        inv = torch.where(n_global > 0, n_global.reciprocal(), torch.zeros_like(n_global))
 
         if mimo_model.language_model is not None:
             finalize_model_grads(
@@ -159,8 +159,7 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
                 pg_collection=language_pg,
                 force_all_reduce=force_all_reduce,
             )
-            if inv != 0.0:
-                mimo_model.language_model.scale_gradients(inv)
+            mimo_model.language_model.scale_gradients(inv)
 
         for name, submodule in mimo_model.modality_submodules.items():
             if submodule is None:
@@ -180,11 +179,14 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
                     vision_dp_size = dist.get_world_size(vision_dp_group)
                     if vision_dp_size > 1:
                         participation = _vision_participation_count(submodule, vision_dp_group)
-                        if 0.0 < participation < vision_dp_size:
-                            vision_scale *= vision_dp_size / participation
+                        participation_scale = torch.where(
+                            (participation > 0) & (participation < vision_dp_size),
+                            vision_dp_size * participation.reciprocal(),
+                            torch.ones_like(participation),
+                        )
+                        vision_scale = vision_scale * participation_scale
 
-            if vision_scale != 0.0:
-                submodule.scale_gradients(vision_scale)
+            submodule.scale_gradients(vision_scale)
 
     mimo_model.config.finalize_model_grads_func = finalize_grads_func
     # The schedule always calls grad_scale_func with a Tensor loss; the per-token

--- a/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
+++ b/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
@@ -15,7 +15,9 @@ import torch
 import torch.distributed as dist
 
 from examples.mimo.training.grad_sync import (
+    _token_normalization_scale,
     _vision_participation_count,
+    _vision_participation_scale,
     configure_grad_sync,
     mark_modality_participation,
     reset_modality_participation,
@@ -26,6 +28,22 @@ from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
     destroy_all_grids,
 )
 from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize(("num_tokens", "expected"), [(0.0, 1.0), (4.0, 0.25)])
+def test_token_normalization_scale(num_tokens, expected):
+    scale = _token_normalization_scale(torch.tensor(num_tokens))
+
+    assert scale.ndim == 0
+    torch.testing.assert_close(scale, torch.tensor(expected))
+
+
+@pytest.mark.parametrize(("participation", "expected"), [(0.0, 1.0), (4.0, 2.0), (8.0, 1.0)])
+def test_vision_participation_scale(participation, expected):
+    scale = _vision_participation_scale(torch.tensor(participation), vision_dp_size=8)
+
+    assert scale.ndim == 0
+    torch.testing.assert_close(scale, torch.tensor(expected))
 
 
 def test_configure_grad_sync_installs_production_overlap_hooks():
@@ -67,6 +85,15 @@ class TestVisionParticipation:
     def teardown_method(self):
         destroy_all_grids()
 
+    def test_scalar_fp32_scale_applies_to_bf16_gradients(self):
+        grad = torch.ones(4, dtype=torch.bfloat16, device="cuda")
+        scale = _token_normalization_scale(torch.tensor(2.0, dtype=torch.float32, device="cuda"))
+
+        grad.mul_(scale)
+
+        assert scale.ndim == 0
+        torch.testing.assert_close(grad, torch.full_like(grad, 0.5))
+
     def test_vision_participation_correction(self):
         """Partial participation: text-only ranks upscale present ranks.
 
@@ -94,9 +121,14 @@ class TestVisionParticipation:
         mark_modality_participation(fake_model, batch)
 
         count = _vision_participation_count(submodule, vision_dp)
-        assert count == float(dp_size // 2)
+        assert count.ndim == 0
+        torch.testing.assert_close(
+            count, torch.tensor(float(dp_size // 2), dtype=count.dtype, device=count.device)
+        )
         factor = dp_size / count
-        assert factor == pytest.approx(2.0)
+        torch.testing.assert_close(
+            factor, torch.tensor(2.0, dtype=factor.dtype, device=factor.device)
+        )
 
         reset_modality_participation(fake_model)
         assert getattr(submodule, "_mimo_rank_processed_input") is False

--- a/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
+++ b/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
@@ -17,7 +17,6 @@ import torch.distributed as dist
 from examples.mimo.training.grad_sync import (
     _token_normalization_scale,
     _vision_participation_count,
-    _vision_participation_scale,
     configure_grad_sync,
     mark_modality_participation,
     reset_modality_participation,
@@ -33,14 +32,6 @@ from tests.unit_tests.test_utilities import Utils
 @pytest.mark.parametrize(("num_tokens", "expected"), [(0.0, 1.0), (4.0, 0.25)])
 def test_token_normalization_scale(num_tokens, expected):
     scale = _token_normalization_scale(torch.tensor(num_tokens))
-
-    assert scale.ndim == 0
-    torch.testing.assert_close(scale, torch.tensor(expected))
-
-
-@pytest.mark.parametrize(("participation", "expected"), [(0.0, 1.0), (4.0, 2.0), (8.0, 1.0)])
-def test_vision_participation_scale(participation, expected):
-    scale = _vision_participation_scale(torch.tensor(participation), vision_dp_size=8)
 
     assert scale.ndim == 0
     torch.testing.assert_close(scale, torch.tensor(expected))


### PR DESCRIPTION
## What

- Keep global token and vision-participation counts as 0-D CUDA tensors after their collectives.
- Clamp the global token count to one before taking its reciprocal, matching Megatron Core and leaving zero-token gradients unscaled.
- Compute participation correction with tensor operations and pass tensor scales directly to gradient buffers without `.item()` or Python tensor conditions.
- Keep vision scaling out of place so one modality cannot mutate the shared token-normalization tensor used by another.
- Add regression coverage for zero-token normalization, scalar shape, and fp32-scale/bf16-gradient compatibility.

This removes device-to-host scalar extraction from MIMO gradient normalization while preserving supported lower-precision gradient buffers.

## Validation

- `git diff --check`
- `python3 -m py_compile examples/mimo/training/grad_sync.py tests/unit_tests/models/mimo/test_mimo_grad_sync.py`
- Repository-pinned isort, Black, Ruff, and Pylint on both changed files
- Cog on CW-DFW, job `16286460`: 1 node, 8 GPUs, Slurm exit `0:0`
  - `tests/unit_tests/models/mimo/test_mimo_grad_sync.py`
  - `tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py`
  - `tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py`
  - All 8 ranks: `18 passed, 2 skipped`; skips are the expected 2-GPU and 4-GPU cases
  - All five 8-GPU non-colocated 1F1B configurations passed, including heterogeneous fan-in and fan-out