### PR TITLE
Pass process groups to param norm logging and support multiple modules

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4889,7 +4889,7 @@ def train(
                 # (~1.5s cold on the first iteration, ~10ms steady). Kept as a real
                 # cost span (it stalls the critical path), unlike passive monitors.
                 with _otel_managed_span('step', 'megatron.train.params_norm', is_goodput_span=True):
-                    params_norm = calc_params_l2_norm(model)
+                    params_norm = calc_params_l2_norm(model, pg_collection=pg_collection)
             if optimizer is not None:
                 learning_rate = get_canonical_lr_for_logging(optimizer.param_groups)
             else:

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -37,6 +37,10 @@ except ImportError:
 
 from megatron.core import mpu
 from megatron.core.datasets.utils import get_blend_from_list
+from megatron.core.process_groups_config import (
+    MultiModuleProcessGroupCollection,
+    ProcessGroupCollection,
+)
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
 from megatron.core.transformer.module import param_is_not_shared
 from megatron.core.utils import (
@@ -77,11 +81,26 @@ def _get_param_data(param, force_create_fp32_copy, bf16):
     return param.data, False
 
 
-def calc_params_l2_norm(model, force_create_fp32_copy=False):
-    """Calculate l2 norm of parameters"""
-    args = get_args()
+def calc_params_l2_norm(
+    model,
+    force_create_fp32_copy=False,
+    *,
+    pg_collection: ProcessGroupCollection | MultiModuleProcessGroupCollection | None = None,
+    return_squared_tensor=False,
+):
+    """Calculate the parameter L2 norm using global, single-model, or multi-module groups."""
     if not isinstance(model, list):
         model = [model]
+
+    if isinstance(pg_collection, MultiModuleProcessGroupCollection):
+        return _calc_multi_module_params_l2_norm(
+            model,
+            pg_collection,
+            force_create_fp32_copy=force_create_fp32_copy,
+            return_squared_tensor=return_squared_tensor,
+        )
+
+    args = get_args()
 
     if getattr(args, 'use_megatron_fsdp', False):
         # All Megatron FSDP parameters are expected to be PyTorch DTensor.
@@ -97,7 +116,9 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
                     )
                 params.append(param)
 
-        return calc_dtensor_params_l2_norm(params)
+        return calc_dtensor_params_l2_norm(
+            params, return_squared_tensor=return_squared_tensor
+        )
 
     # 8 buckets: 4 categories × (non-sharded, sharded optimizer main_param).
     # Each category needs different reduction groups.
@@ -110,10 +131,28 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
     moe_gtp_params_data = []        # MoE-GTP_remat, non-sharded
     moe_gtp_sharded_params_data = []  # MoE-GTP_remat sharded → expert_dp
 
-    gtp_rank = mpu.get_gtp_weight_remat_rank()
-    egtp_rank = mpu.get_expert_gtp_weight_remat_rank()
-    tp_group = mpu.get_tensor_model_parallel_group()
-    expert_tp_group = mpu.get_expert_tensor_parallel_group()
+    if pg_collection is None:
+        gtp_rank = mpu.get_gtp_weight_remat_rank()
+        egtp_rank = mpu.get_expert_gtp_weight_remat_rank()
+        tp_group = mpu.get_tensor_model_parallel_group()
+        expert_tp_group = mpu.get_expert_tensor_parallel_group()
+        dp_cp_group = mpu.get_data_parallel_group(
+            with_context_parallel=True, with_gtp_remat=False
+        )
+        expert_dp_group = mpu.get_expert_data_parallel_group(with_gtp_remat=False)
+        expert_gtp_group = mpu.get_expert_gtp_weight_remat_group()
+        dense_reduce_group = mpu.get_model_parallel_group()
+        expert_reduce_group = mpu.get_expert_tensor_model_pipeline_parallel_group()
+    else:
+        gtp_rank = get_pg_rank(pg_collection.gtp_remat)
+        egtp_rank = get_pg_rank(pg_collection.expt_gtp_remat)
+        tp_group = pg_collection.tp
+        expert_tp_group = pg_collection.expt_tp
+        dp_cp_group = pg_collection.dp_cp
+        expert_dp_group = pg_collection.expt_dp
+        expert_gtp_group = pg_collection.expt_gtp_remat
+        dense_reduce_group = pg_collection.mp
+        expert_reduce_group = pg_collection.tp_ep_pp
 
     for model_chunk in model:
         for param in model_chunk.parameters():
@@ -176,14 +215,14 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
     # over-count by gtp_remat. No-op for non-GTP_remat runs.
     _sum_reduce(
         sharded_norm_2,
-        mpu.get_data_parallel_group(with_context_parallel=True, with_gtp_remat=False),
+        dp_cp_group,
     )
     _sum_reduce(
         gtp_sharded_norm_2,
-        mpu.get_data_parallel_group(with_context_parallel=True, with_gtp_remat=False),
+        dp_cp_group,
     )
-    _sum_reduce(moe_sharded_norm_2, mpu.get_expert_data_parallel_group(with_gtp_remat=False))
-    _sum_reduce(moe_gtp_sharded_norm_2, mpu.get_expert_data_parallel_group(with_gtp_remat=False))
+    _sum_reduce(moe_sharded_norm_2, expert_dp_group)
+    _sum_reduce(moe_gtp_sharded_norm_2, expert_dp_group)
 
     # --- Combine dense + GTP_remat norms ---
     # model_parallel group = TP×GTP_remat×PP, so GTP_remat reduction is implicit.
@@ -193,12 +232,10 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
     # expert_model_parallel = TP×EP×PP (does NOT include EGTP_remat), so we need
     # an explicit EGTP_remat reduction for MoE-GTP_remat before the model-parallel reduce.
     moe_gtp_combined_norm_2 = moe_gtp_norm_2 + moe_gtp_sharded_norm_2
-    _sum_reduce(moe_gtp_combined_norm_2, mpu.get_expert_gtp_weight_remat_group())
+    _sum_reduce(moe_gtp_combined_norm_2, expert_gtp_group)
     moe_total_norm_2 = moe_norm_2 + moe_sharded_norm_2 + moe_gtp_combined_norm_2
 
     # --- Model-parallel reductions ---
-    dense_reduce_group = mpu.get_model_parallel_group()
-    expert_reduce_group = mpu.get_expert_tensor_model_pipeline_parallel_group()
     ranks_in_dense_reduce_group = torch.distributed.get_process_group_ranks(dense_reduce_group)
     ranks_in_expert_reduce_group = torch.distributed.get_process_group_ranks(expert_reduce_group)
 
@@ -210,10 +247,63 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
         _sum_reduce(moe_total_norm_2, expert_reduce_group)
         norm_2 += moe_total_norm_2
 
+    if return_squared_tensor:
+        return norm_2
     return norm_2.item() ** 0.5
 
 
-def calc_dtensor_params_l2_norm(params):
+@torch.no_grad()
+def _calc_multi_module_params_l2_norm(
+    model,
+    pg_collection: MultiModuleProcessGroupCollection,
+    *,
+    force_create_fp32_copy=False,
+    return_squared_tensor=False,
+):
+    """Calculate a combined parameter L2 norm across multi-module model grids."""
+    mimo_models = [unwrap_model(model_chunk) for model_chunk in model]
+    grid_map = getattr(getattr(mimo_models[0], 'mimo_config', None), 'module_to_grid_map', None)
+    if not grid_map:
+        raise RuntimeError("Multi-module parameter norm requires a model module_to_grid_map")
+
+    module_names = sorted(grid_map)
+    module_indices = {name: index for index, name in enumerate(module_names)}
+    norm_sq = torch.zeros(len(module_names), device='cuda', dtype=torch.float32)
+
+    for name, module_pg_collection in pg_collection.items():
+        if name not in module_indices:
+            raise RuntimeError(f"Process groups provided for unknown model module '{name}'")
+
+        module_chunks = []
+        for mimo_model in mimo_models:
+            if name == pg_collection.language_model_module_name:
+                module = mimo_model.language_model
+            elif name in mimo_model.modality_submodules:
+                module = mimo_model.modality_submodules[name]
+            else:
+                module = None
+            if module is not None:
+                module_chunks.append(module)
+
+        if not module_chunks:
+            raise RuntimeError(f"No local model found for active module '{name}'")
+
+        module_norm_sq = calc_params_l2_norm(
+            module_chunks,
+            force_create_fp32_copy,
+            pg_collection=module_pg_collection,
+            return_squared_tensor=True,
+        )
+        norm_sq[module_indices[name]].copy_(module_norm_sq.reshape(()))
+
+    torch.distributed.all_reduce(norm_sq, op=torch.distributed.ReduceOp.MAX)
+    total_norm_sq = norm_sq.sum()
+    if return_squared_tensor:
+        return total_norm_sq
+    return torch.sqrt(total_norm_sq).item()
+
+
+def calc_dtensor_params_l2_norm(params, return_squared_tensor=False):
     """Calculate l2 norm of DTensor parameters."""
     params_data = defaultdict(list)
     for param in params:
@@ -247,6 +337,8 @@ def calc_dtensor_params_l2_norm(params):
                 )
         total_norm_2 += norm_2
 
+    if return_squared_tensor:
+        return total_norm_2
     return total_norm_2.item() ** 0.5
 
 

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -12,10 +12,10 @@ from typing import Optional
 
 import torch
 
-from megatron.core.msc_utils import maybe_msc
 from megatron.core._rank_utils import safe_get_rank as _safe_get_rank
 from megatron.core._slurm_utils import resolve_slurm_local_rank
 from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
+from megatron.core.msc_utils import maybe_msc
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_l2norm
@@ -37,6 +37,7 @@ except ImportError:
 
 from megatron.core import mpu
 from megatron.core.datasets.utils import get_blend_from_list
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from megatron.core.process_groups_config import (
     MultiModuleProcessGroupCollection,
     ProcessGroupCollection,
@@ -50,7 +51,6 @@ from megatron.core.utils import (
     unwrap_model,
 )
 from megatron.training import get_adlr_autoresume, get_args, get_timers
-
 
 
 def _compute_norm_2(params_list):
@@ -93,7 +93,7 @@ def calc_params_l2_norm(
         model = [model]
 
     if isinstance(pg_collection, MultiModuleProcessGroupCollection):
-        return _calc_multi_module_params_l2_norm(
+        return _calc_mimo_params_l2_norm(
             model,
             pg_collection,
             force_create_fp32_copy=force_create_fp32_copy,
@@ -252,55 +252,41 @@ def calc_params_l2_norm(
     return norm_2.item() ** 0.5
 
 
+def _get_mimo_module(model_chunk, module_name):
+    """Get a MIMO module by its topology name."""
+    if module_name == MIMO_LANGUAGE_MODULE_KEY:
+        return model_chunk.language_model
+    return model_chunk.modality_submodules[module_name]
+
+
 @torch.no_grad()
-def _calc_multi_module_params_l2_norm(
+def _calc_mimo_params_l2_norm(
     model,
     pg_collection: MultiModuleProcessGroupCollection,
     *,
     force_create_fp32_copy=False,
     return_squared_tensor=False,
 ):
-    """Calculate a combined parameter L2 norm across multi-module model grids."""
-    mimo_models = [unwrap_model(model_chunk) for model_chunk in model]
-    grid_map = getattr(getattr(mimo_models[0], 'mimo_config', None), 'module_to_grid_map', None)
-    if not grid_map:
-        raise RuntimeError("Multi-module parameter norm requires a model module_to_grid_map")
-
-    module_names = sorted(grid_map)
-    module_indices = {name: index for index, name in enumerate(module_names)}
+    """Calculate a combined parameter L2 norm across MIMO model grids."""
+    model_chunks = [unwrap_model(model_chunk) for model_chunk in model]
+    module_names = sorted(model_chunks[0].mimo_config.module_to_grid_map)
     norm_sq = torch.zeros(len(module_names), device='cuda', dtype=torch.float32)
 
-    for name, module_pg_collection in pg_collection.items():
-        if name not in module_indices:
-            raise RuntimeError(f"Process groups provided for unknown model module '{name}'")
-
-        module_chunks = []
-        for mimo_model in mimo_models:
-            if name == pg_collection.language_model_module_name:
-                module = mimo_model.language_model
-            elif name in mimo_model.modality_submodules:
-                module = mimo_model.modality_submodules[name]
-            else:
-                module = None
-            if module is not None:
-                module_chunks.append(module)
-
-        if not module_chunks:
-            raise RuntimeError(f"No local model found for active module '{name}'")
+    for index, name in enumerate(module_names):
+        if name not in pg_collection.keys():
+            continue
 
         module_norm_sq = calc_params_l2_norm(
-            module_chunks,
+            [_get_mimo_module(model_chunk, name) for model_chunk in model_chunks],
             force_create_fp32_copy,
-            pg_collection=module_pg_collection,
+            pg_collection=pg_collection[name],
             return_squared_tensor=True,
         )
-        norm_sq[module_indices[name]].copy_(module_norm_sq.reshape(()))
+        norm_sq[index].copy_(module_norm_sq.reshape(()))
 
     torch.distributed.all_reduce(norm_sq, op=torch.distributed.ReduceOp.MAX)
     total_norm_sq = norm_sq.sum()
-    if return_squared_tensor:
-        return total_norm_sq
-    return torch.sqrt(total_norm_sq).item()
+    return total_norm_sq if return_squared_tensor else total_norm_sq.sqrt().item()
 
 
 def calc_dtensor_params_l2_norm(params, return_squared_tensor=False):

--- a/tests/unit_tests/models/mimo/test_mimo_optimizer_consensus.py
+++ b/tests/unit_tests/models/mimo/test_mimo_optimizer_consensus.py
@@ -2,9 +2,12 @@
 
 """Distributed test for MimoOptimizer cross-grid step-success consensus."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from megatron.core.models.mimo.optimizer import MimoOptimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -21,4 +24,57 @@ def test_step_success_is_world_min():
         success, _, _ = opt.step()
         assert success is False
     finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires >= 2 ranks.")
+def test_param_norm_combines_disjoint_module_grids(monkeypatch):
+    """Parameter logging sums module norms without reading global model-parallel state."""
+    from examples.mimo.training.topology import ModuleGridSpec, create_topology
+    from megatron.training.utils import common_utils
+
+    Utils.initialize_distributed()
+    topology = None
+    try:
+        world_size = torch.distributed.get_world_size()
+        if world_size < 2 or world_size % 2:
+            pytest.skip("Requires an even distributed world size >= 2")
+        module_size = world_size // 2
+        encoder_name = "encoder"
+        topology = create_topology(
+            [
+                ModuleGridSpec(name=encoder_name, num_ranks=module_size, tp=module_size),
+                ModuleGridSpec(
+                    name=MIMO_LANGUAGE_MODULE_KEY,
+                    num_ranks=module_size,
+                    tp=module_size,
+                    rank_offset=module_size,
+                ),
+            ]
+        )
+
+        model = torch.nn.Module()
+        model.mimo_config = SimpleNamespace(module_to_grid_map=topology.grids)
+        model.language_model = None
+        model.modality_submodules = torch.nn.ModuleDict()
+
+        active_names = list(topology.schedule_pg_collection.keys())
+        assert len(active_names) == 1
+        active_name = active_names[0]
+        active_module = torch.nn.Linear(2, 2, bias=False, device="cuda")
+        active_module.weight.data.fill_(1.0 if active_name == encoder_name else 2.0)
+        if active_name == MIMO_LANGUAGE_MODULE_KEY:
+            model.language_model = active_module
+        else:
+            model.modality_submodules[active_name] = active_module
+
+        monkeypatch.setattr(
+            common_utils, "get_args", lambda: SimpleNamespace(bf16=False, use_megatron_fsdp=False)
+        )
+        assert common_utils.calc_params_l2_norm(
+            model, pg_collection=topology.schedule_pg_collection
+        ) == pytest.approx(20**0.5)
+    finally:
+        if topology is not None:
+            topology.destroy()
         Utils.destroy_model_parallel()


### PR DESCRIPTION
## What changed

- Support `--log-params-norm` by extending the existing parameter-norm utility to accept either a single process-group collection or a MIMO multi-module collection.
- Compute each active MIMO module norm with that module's own process groups, then combine the squared module norms once across the world.
- Keep MIMO module-name resolution local to the parameter-norm utility and preserve the existing non-MIMO path.

## Validation

- CW-DFW focused 8-rank test, job `16684038`: `2 passed`, including the disjoint-grid parameter-norm test.
- CW-DFW heterogeneous 20-layer MIMO training, job `16684906`: completed 2 iterations on all 8 ranks with finite `params norm` values `1810.402` and `1810.554`; no hard failures were present in rank-local or Slurm logs.
- CW-DFW static checks: scoped Black, isort, and Ruff passed in job `16684571`; Pylint with only existing whole-file warning categories excluded plus compileall passed in job `16684626`.
