### PR TITLE
Reduce redundant MIMO optimizer synchronization

### DIFF
--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -40,6 +40,8 @@ class MimoOptimizer(MegatronOptimizer):
     across all modules via all_reduce MAX.
     """
 
+    step_stats_are_global = True
+
     def __init__(self, module_infos: Dict[str, ModuleOptimizerInfo], config: OptimizerConfig):
         self.module_infos = module_infos
         self.config = config
@@ -50,6 +52,7 @@ class MimoOptimizer(MegatronOptimizer):
         ]
         self.is_stub_optimizer = len(self._active_optimizers) == 0
         self.optimizer = None  # Base class compat
+        self._has_loss_scaler = bool(config.fp16 or config.loss_scale)
 
     @torch.no_grad()
     def prepare_grads(self) -> bool:
@@ -67,8 +70,12 @@ class MimoOptimizer(MegatronOptimizer):
 
         for i, (name, info) in enumerate(sorted(self.module_infos.items())):
             if info.is_active and info.optimizer:
-                module_norm = info.optimizer.get_grad_norm() or 0.0
-                norm_sq[i] = module_norm**2
+                module_norm = info.optimizer.get_grad_norm()
+                if module_norm is not None:
+                    module_norm = torch.as_tensor(
+                        module_norm, device=norm_sq.device, dtype=norm_sq.dtype
+                    ).reshape(())
+                    norm_sq[i].copy_(module_norm.square())
 
         torch.distributed.all_reduce(norm_sq, op=torch.distributed.ReduceOp.MAX)
         return torch.sqrt(norm_sq.sum()).item()
@@ -77,12 +84,11 @@ class MimoOptimizer(MegatronOptimizer):
     def step(self) -> Tuple[bool, Optional[float], Optional[int]]:
         """Run one optimizer step across all active module optimizers."""
         found_inf = self.prepare_grads()
-        # Synchronize found_inf across all ranks to prevent deadlock:
-        # if encoder ranks detect inf but LLM ranks don't, the early return
-        # would skip the all_reduce in get_grad_norm(), causing a hang.
-        found_inf_tensor = torch.tensor([found_inf], dtype=torch.float32, device="cuda")
-        torch.distributed.all_reduce(found_inf_tensor, op=torch.distributed.ReduceOp.MAX)
-        found_inf = found_inf_tensor.item() > 0
+        if self._has_loss_scaler:
+            # All module grids must agree on overflow before any rank returns early.
+            found_inf_tensor = torch.tensor([found_inf], dtype=torch.float32, device="cuda")
+            torch.distributed.all_reduce(found_inf_tensor, op=torch.distributed.ReduceOp.MAX)
+            found_inf = found_inf_tensor.item() > 0
         if found_inf:
             return False, None, None
 
@@ -104,10 +110,11 @@ class MimoOptimizer(MegatronOptimizer):
         num_zeros = self.count_zeros() if self.config.log_num_zeros_in_grad else None
         success = self.step_with_ready_grads()
 
-        # Reduce update success across the world (MIN) so disjoint-grid ranks agree.
-        success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device="cuda")
-        torch.distributed.all_reduce(success_tensor, op=torch.distributed.ReduceOp.MIN)
-        success = bool(success_tensor.item())
+        if self._has_loss_scaler:
+            # Scaled optimizers can skip an update independently, so disjoint grids must agree.
+            success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device="cuda")
+            torch.distributed.all_reduce(success_tensor, op=torch.distributed.ReduceOp.MIN)
+            success = bool(success_tensor.item())
 
         return success, grad_norm, num_zeros
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3177,16 +3177,19 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     # tokens (replicate dp_cp would report a 1/gtp_remat subsample -> per-step noisy). Display-only.
     dp_cp_group = getattr(pg_collection, 'dp_cp_gtp_remat', None) or pg_collection.dp_cp
     is_last_stage = is_pp_last_stage(pg_collection.pp)
-    # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
-    # so we must gather across mp ranks
-    update_successful = logical_and_across_model_parallel_group(update_successful, group=mp_group)
-    # grad_norm and num_zeros_in_grad will be None on ranks without trainable params,
-    # so we must gather across mp ranks
-    grad_norm = reduce_max_stat_across_model_parallel_group(grad_norm, group=mp_group)
-    if args.log_num_zeros_in_grad:
-        num_zeros_in_grad = reduce_max_stat_across_model_parallel_group(
-            num_zeros_in_grad, group=mp_group
+    if not getattr(optimizer, "step_stats_are_global", False):
+        # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
+        # so we must gather across mp ranks
+        update_successful = logical_and_across_model_parallel_group(
+            update_successful, group=mp_group
         )
+        # grad_norm and num_zeros_in_grad will be None on ranks without trainable params,
+        # so we must gather across mp ranks
+        grad_norm = reduce_max_stat_across_model_parallel_group(grad_norm, group=mp_group)
+        if args.log_num_zeros_in_grad:
+            num_zeros_in_grad = reduce_max_stat_across_model_parallel_group(
+                num_zeros_in_grad, group=mp_group
+            )
 
     # Vision momentum.
     if args.vision_pretraining and args.vision_pretraining_type == "dino":

--- a/tests/unit_tests/models/mimo/test_mimo_optimizer_consensus.py
+++ b/tests/unit_tests/models/mimo/test_mimo_optimizer_consensus.py
@@ -15,7 +15,9 @@ def test_step_success_is_world_min():
     """One rank's failed update must propagate to every rank via the MIN reduction."""
     Utils.initialize_distributed()
     try:
-        opt = MimoOptimizer(module_infos={}, config=OptimizerConfig(log_num_zeros_in_grad=False))
+        opt = MimoOptimizer(
+            module_infos={}, config=OptimizerConfig(fp16=True, log_num_zeros_in_grad=False)
+        )
         last_rank = torch.distributed.get_world_size() - 1
         opt.step_with_ready_grads = lambda: torch.distributed.get_rank() != last_rank
         success, _, _ = opt.step()


### PR DESCRIPTION
## Summary

- gate MIMO cross-grid overflow and update-success consensus on loss scaling
- mark MIMO step statistics as world-global to skip redundant model-parallel reductions
- avoid Tensor truth-value conversion while assembling module gradient norms

FP16 and explicit fixed-loss-scale consensus are unchanged. Stock optimizers retain the existing training-loop reductions.

## Validation

- `git diff --check`
- `python3 -m py_compile` on the three changed files
- Black 26.3.0, isort 5.13.2, Ruff 0.9.10, and Pylint 3.2.6 in the narrow changed-file scope

Tests were not run for this focused synchronization cleanup.
