### PR TITLE
Allow precomputed token positions in MIMO embedding alignment

### DIFF
--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -146,6 +146,7 @@ class MimoModel(MegatronModule):
         modality_embeddings: Dict[str, torch.Tensor],  # [num_embeddings, hidden_dim]
         input_ids: torch.Tensor,  # [bs, seq_len]
         special_token_ids: Dict[str, int],
+        modality_token_indices: Optional[Dict[str, torch.Tensor]] = None,
     ) -> torch.Tensor:
         """Align embeddings from different modalities based on special token positions in input_ids.
 
@@ -158,6 +159,7 @@ class MimoModel(MegatronModule):
                 The number of special tokens for each modality should exactly match the number
                 of embeddings for that modality.
             special_token_ids: Dictionary mapping modality names to their special token IDs
+            modality_token_indices: Optional mapping from modality names to flat token indices.
 
         Returns:
             Combined embeddings tensor. Shape: (S, B, H)
@@ -184,9 +186,20 @@ class MimoModel(MegatronModule):
         combined_embeddings = torch.zeros(
             (batch_size, seq_length, hidden_dim), dtype=dtype, device=device
         )
+        flat_combined_embeddings = combined_embeddings.view(-1, hidden_dim)
 
         # Process each modality in modality_embeddings
         for modality_name, modality_emb in modality_embeddings.items():
+            token_indices = (modality_token_indices or {}).get(modality_name)
+            if token_indices is not None:
+                if token_indices.ndim != 1 or token_indices.numel() != modality_emb.size(0):
+                    raise ValueError(
+                        f"Number of {modality_name} token indices ({token_indices.numel()}) "
+                        f"does not match number of embeddings ({modality_emb.size(0)})"
+                    )
+                flat_combined_embeddings.index_copy_(0, token_indices, modality_emb)
+                continue
+
             if modality_name == "text":
                 mask = torch.ones_like(input_ids, dtype=torch.bool, device=input_ids.device)
                 for token_id in special_token_ids.values():
@@ -344,7 +357,11 @@ class MimoModel(MegatronModule):
             module.zero_grad_buffer()
 
     def get_text_embeddings(
-        self, input_ids: torch.Tensor, position_ids: torch.Tensor, special_token_ids: Dict[str, int]
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        special_token_ids: Dict[str, int],
+        text_token_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Get embeddings for text tokens in the input.
         Args:
@@ -354,26 +371,36 @@ class MimoModel(MegatronModule):
                 Shape: (B, S)
             special_token_ids: Dictionary mapping modality names to their special token IDs.
                 Used to identify non-text tokens in the input_ids.
+            text_token_indices: Optional flat indices of text tokens in ``input_ids``.
 
         Returns:
             torch.Tensor: Embeddings for text tokens.
             Shape: (N, H), where N is the number of text tokens.
         """
-        text_mask = torch.ones_like(input_ids, dtype=torch.bool)  # [b, s]
-        for special_token_id in special_token_ids.values():
-            text_mask &= input_ids != special_token_id
+        if text_token_indices is None:
+            text_mask = torch.ones_like(input_ids, dtype=torch.bool)  # [b, s]
+            for special_token_id in special_token_ids.values():
+                text_mask &= input_ids != special_token_id
 
-        batch_idx, seq_idx = text_mask.nonzero(as_tuple=True)
-        input_ids_text = input_ids[batch_idx, seq_idx].unsqueeze(0)
+            batch_idx, seq_idx = text_mask.nonzero(as_tuple=True)
+            text_token_indices = batch_idx * input_ids.size(1) + seq_idx
+        elif text_token_indices.ndim != 1:
+            raise ValueError("Text token indices must be a flat one-dimensional tensor")
+
+        input_ids_text = input_ids.reshape(-1).index_select(0, text_token_indices).unsqueeze(0)
 
         if position_ids is None:
             position_ids_text = None
         elif position_ids.dim() == 3:
             # Multimodal RoPE can carry [rope_dim, batch, seq] ids. Text
             # embedding lookup only needs a single absolute position channel.
-            position_ids_text = position_ids[0, batch_idx, seq_idx].unsqueeze(0)
+            position_ids_text = (
+                position_ids[0].reshape(-1).index_select(0, text_token_indices).unsqueeze(0)
+            )
         else:
-            position_ids_text = position_ids[batch_idx, seq_idx].unsqueeze(0)
+            position_ids_text = (
+                position_ids.reshape(-1).index_select(0, text_token_indices).unsqueeze(0)
+            )
 
         embedding_layer = unwrap_model(self.language_model).embedding
         # Combined embeddings are SP-scattered later in PartitionAdapter; a second scatter
@@ -405,6 +432,7 @@ class MimoModel(MegatronModule):
         labels: Optional[torch.Tensor] = None,
         modality_inputs: Optional[Dict[str, Dict[str, Any]]] = None,
         packing_kwargs: Optional[dict] = None,
+        modality_token_indices: Optional[Dict[str, torch.Tensor]] = None,
     ):
         """Forward pass through the multimodal model.
 
@@ -438,6 +466,7 @@ class MimoModel(MegatronModule):
                                         max(seqlens_padded), dtype=torch.int32
                                     ),
                                 }
+            modality_token_indices: Optional mapping from modality names to flat token indices.
 
         Returns:
             tuple: (output, loss_mask) where output semantics depend on role:
@@ -457,6 +486,7 @@ class MimoModel(MegatronModule):
                 labels,
                 modality_inputs,
                 packing_kwargs,
+                modality_token_indices,
             )
 
         if self.role.mode == ModuleLayout.NON_COLOCATED:
@@ -472,6 +502,7 @@ class MimoModel(MegatronModule):
                     labels,
                     input_tensors,
                     packing_kwargs,
+                    modality_token_indices,
                 )
 
             raise RuntimeError(f"Rank has no modules assigned in role: {self.role}")
@@ -631,6 +662,7 @@ class MimoModel(MegatronModule):
         labels: Optional[torch.Tensor],
         input_tensors: Optional[Dict[str, torch.Tensor]],
         packing_kwargs: Optional[dict] = None,
+        modality_token_indices: Optional[Dict[str, torch.Tensor]] = None,
     ) -> Tuple[Any, Optional[torch.Tensor]]:
         """Forward pass for language module on this rank.
 
@@ -644,6 +676,7 @@ class MimoModel(MegatronModule):
             labels: Labels for loss computation
             input_tensors: Hidden states or embeddings from previous stage
             packing_kwargs: Optional kwargs to construct packed (THD) sequence params.
+            modality_token_indices: Optional mapping from modality names to flat token indices.
 
         Returns:
             Tuple of (language model output, possibly CP-sharded loss mask). The
@@ -675,7 +708,10 @@ class MimoModel(MegatronModule):
 
             # Get text embeddings
             text_embeddings = self.get_text_embeddings(
-                input_ids, position_ids, self.special_token_ids
+                input_ids,
+                position_ids,
+                self.special_token_ids,
+                text_token_indices=(modality_token_indices or {}).get("text"),
             )
             modality_embeddings["text"] = text_embeddings
 
@@ -684,6 +720,7 @@ class MimoModel(MegatronModule):
                 modality_embeddings=modality_embeddings,
                 input_ids=input_ids,
                 special_token_ids=self.special_token_ids,
+                modality_token_indices=modality_token_indices,
             )
 
             # Apply CP/SP sharding; combined_embeddings returns in [S/(cp*tp), B, H].
@@ -793,6 +830,7 @@ class MimoModel(MegatronModule):
         labels: Optional[torch.Tensor],
         modality_inputs: Optional[Dict[str, Dict[str, Any]]],
         packing_kwargs: Optional[dict] = None,
+        modality_token_indices: Optional[Dict[str, torch.Tensor]] = None,
     ):
         """Forward pass when all modules are on all ranks (no multi-module PP).
 
@@ -822,7 +860,12 @@ class MimoModel(MegatronModule):
             modality_embeddings = self._apply_colocated_comms(modality_embeddings)
 
         # Get text embeddings
-        text_embeddings = self.get_text_embeddings(input_ids, position_ids, self.special_token_ids)
+        text_embeddings = self.get_text_embeddings(
+            input_ids,
+            position_ids,
+            self.special_token_ids,
+            text_token_indices=(modality_token_indices or {}).get("text"),
+        )
         logger.debug(f"Generated text embeddings with shape {text_embeddings.shape}")
 
         modality_embeddings["text"] = text_embeddings
@@ -833,6 +876,7 @@ class MimoModel(MegatronModule):
             modality_embeddings=modality_embeddings,
             input_ids=input_ids,
             special_token_ids=self.special_token_ids,
+            modality_token_indices=modality_token_indices,
         )
         logger.debug(f"Combined embeddings shape: {combined_embeddings.shape}")
 

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -159,7 +159,15 @@ class MimoModel(MegatronModule):
                 The number of special tokens for each modality should exactly match the number
                 of embeddings for that modality.
             special_token_ids: Dictionary mapping modality names to their special token IDs
-            modality_token_indices: Optional mapping from modality names to flat token indices.
+            modality_token_indices: Optional complete mapping from modality names to flat,
+                batch-major ``torch.long`` token indices on the embedding device. Each tensor must
+                contain the same positions, in the same order, that the corresponding
+                ``special_token_ids`` mask would select; ``text`` contains the complement of all
+                special-token positions. When provided, the keys must exactly match
+                ``modality_embeddings`` and their lengths must sum to ``B * S``. Index values are a
+                trusted producer contract and are not revalidated because doing so would add device
+                reductions and host synchronization to the forward hot path. Pass ``None`` to use
+                the mask-based path for every modality.
 
         Returns:
             Combined embeddings tensor. Shape: (S, B, H)
@@ -188,15 +196,57 @@ class MimoModel(MegatronModule):
         )
         flat_combined_embeddings = combined_embeddings.view(-1, hidden_dim)
 
-        # Process each modality in modality_embeddings
-        for modality_name, modality_emb in modality_embeddings.items():
-            token_indices = (modality_token_indices or {}).get(modality_name)
-            if token_indices is not None:
-                if token_indices.ndim != 1 or token_indices.numel() != modality_emb.size(0):
+        precomputed_indices = modality_token_indices
+        if precomputed_indices is not None:
+            expected_modalities = set(modality_embeddings)
+            supplied_modalities = set(precomputed_indices)
+            if supplied_modalities != expected_modalities:
+                missing = sorted(expected_modalities - supplied_modalities)
+                unexpected = sorted(supplied_modalities - expected_modalities)
+                raise ValueError(
+                    "Precomputed modality token indices must be provided for every modality "
+                    f"(missing={missing}, unexpected={unexpected})"
+                )
+
+            total_indices = 0
+            for modality_name, modality_emb in modality_embeddings.items():
+                if modality_name != "text" and modality_name not in special_token_ids:
+                    raise ValueError(f"No special token ID defined for modality {modality_name}")
+
+                token_indices = precomputed_indices[modality_name]
+                if token_indices.ndim != 1:
+                    raise ValueError(
+                        f"{modality_name} token indices must be a flat one-dimensional tensor, "
+                        f"got shape {tuple(token_indices.shape)}"
+                    )
+                if token_indices.dtype != torch.long:
+                    raise ValueError(
+                        f"{modality_name} token indices must have dtype torch.long, "
+                        f"got {token_indices.dtype}"
+                    )
+                if token_indices.device != device:
+                    raise ValueError(
+                        f"{modality_name} token indices must be on device {device}, "
+                        f"got {token_indices.device}"
+                    )
+                if token_indices.numel() != modality_emb.size(0):
                     raise ValueError(
                         f"Number of {modality_name} token indices ({token_indices.numel()}) "
                         f"does not match number of embeddings ({modality_emb.size(0)})"
                     )
+                total_indices += token_indices.numel()
+
+            num_positions = batch_size * seq_length
+            if total_indices != num_positions:
+                raise ValueError(
+                    "Precomputed modality token indices must cover the complete flattened "
+                    f"[B, S] grid ({num_positions} positions), got {total_indices} indices"
+                )
+
+        # Process each modality in modality_embeddings
+        for modality_name, modality_emb in modality_embeddings.items():
+            if precomputed_indices is not None:
+                token_indices = precomputed_indices[modality_name]
                 flat_combined_embeddings.index_copy_(0, token_indices, modality_emb)
                 continue
 
@@ -371,7 +421,8 @@ class MimoModel(MegatronModule):
                 Shape: (B, S)
             special_token_ids: Dictionary mapping modality names to their special token IDs.
                 Used to identify non-text tokens in the input_ids.
-            text_token_indices: Optional flat indices of text tokens in ``input_ids``.
+            text_token_indices: Optional flat, logical row-major ``torch.long`` indices of text
+                tokens in the ``[B, S]`` input grid.
 
         Returns:
             torch.Tensor: Embeddings for text tokens.
@@ -384,8 +435,18 @@ class MimoModel(MegatronModule):
 
             batch_idx, seq_idx = text_mask.nonzero(as_tuple=True)
             text_token_indices = batch_idx * input_ids.size(1) + seq_idx
-        elif text_token_indices.ndim != 1:
-            raise ValueError("Text token indices must be a flat one-dimensional tensor")
+        else:
+            if text_token_indices.ndim != 1:
+                raise ValueError("Text token indices must be a flat one-dimensional tensor")
+            if text_token_indices.dtype != torch.long:
+                raise ValueError(
+                    f"Text token indices must have dtype torch.long, got {text_token_indices.dtype}"
+                )
+            if text_token_indices.device != input_ids.device:
+                raise ValueError(
+                    f"Text token indices must be on device {input_ids.device}, "
+                    f"got {text_token_indices.device}"
+                )
 
         input_ids_text = input_ids.reshape(-1).index_select(0, text_token_indices).unsqueeze(0)
 
@@ -466,7 +527,11 @@ class MimoModel(MegatronModule):
                                         max(seqlens_padded), dtype=torch.int32
                                     ),
                                 }
-            modality_token_indices: Optional mapping from modality names to flat token indices.
+            modality_token_indices: Optional complete mapping from every active modality name,
+                including ``text``, to flat logical row-major ``torch.long`` indices in the
+                ``[B, S]`` input grid. Encoder-only ranks ignore this argument. Pass ``None`` to
+                derive every position from ``input_ids``. See
+                ``align_embeddings_by_token_positions`` for the trusted-producer contract.
 
         Returns:
             tuple: (output, loss_mask) where output semantics depend on role:
@@ -485,12 +550,13 @@ class MimoModel(MegatronModule):
                 loss_mask,
                 labels,
                 modality_inputs,
-                packing_kwargs,
-                modality_token_indices,
+                packing_kwargs=packing_kwargs,
+                modality_token_indices=modality_token_indices,
             )
 
         if self.role.mode == ModuleLayout.NON_COLOCATED:
             if self.role.has_modality_modules:
+                # Token indices are consumed only when language embeddings are assembled.
                 return self._forward_encoders(input_ids, modality_inputs, input_tensors), loss_mask
 
             if self.role.has_language_module:
@@ -501,8 +567,8 @@ class MimoModel(MegatronModule):
                     loss_mask,
                     labels,
                     input_tensors,
-                    packing_kwargs,
-                    modality_token_indices,
+                    packing_kwargs=packing_kwargs,
+                    modality_token_indices=modality_token_indices,
                 )
 
             raise RuntimeError(f"Rank has no modules assigned in role: {self.role}")
@@ -676,7 +742,8 @@ class MimoModel(MegatronModule):
             labels: Labels for loss computation
             input_tensors: Hidden states or embeddings from previous stage
             packing_kwargs: Optional kwargs to construct packed (THD) sequence params.
-            modality_token_indices: Optional mapping from modality names to flat token indices.
+            modality_token_indices: Optional complete mapping of trusted flat logical row-major
+                token indices. See ``align_embeddings_by_token_positions``.
 
         Returns:
             Tuple of (language model output, possibly CP-sharded loss mask). The

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -141,6 +141,36 @@ class MimoModel(MegatronModule):
                 )
         return sharded_sd
 
+    @staticmethod
+    def _validate_precomputed_token_indices(
+        modality_embeddings: Dict[str, torch.Tensor],
+        modality_token_indices: Dict[str, torch.Tensor],
+        num_positions: int,
+    ) -> None:
+        """Validate the metadata-only contract for precomputed token positions."""
+        if modality_token_indices.keys() != modality_embeddings.keys():
+            raise ValueError(
+                "Precomputed token indices must have the same modalities as the embeddings"
+            )
+
+        total_indices = 0
+        for name, embeddings in modality_embeddings.items():
+            indices = modality_token_indices[name]
+            if indices.ndim != 1:
+                raise ValueError(f"{name} token indices must be one-dimensional")
+            if indices.numel() != embeddings.size(0):
+                raise ValueError(
+                    f"Number of {name} token indices ({indices.numel()}) does not match "
+                    f"number of embeddings ({embeddings.size(0)})"
+                )
+            total_indices += indices.numel()
+
+        if total_indices != num_positions:
+            raise ValueError(
+                f"Precomputed token indices must cover {num_positions} positions, "
+                f"got {total_indices}"
+            )
+
     def align_embeddings_by_token_positions(
         self,
         modality_embeddings: Dict[str, torch.Tensor],  # [num_embeddings, hidden_dim]
@@ -196,60 +226,18 @@ class MimoModel(MegatronModule):
         )
         flat_combined_embeddings = combined_embeddings.view(-1, hidden_dim)
 
-        precomputed_indices = modality_token_indices
-        if precomputed_indices is not None:
-            expected_modalities = set(modality_embeddings)
-            supplied_modalities = set(precomputed_indices)
-            if supplied_modalities != expected_modalities:
-                missing = sorted(expected_modalities - supplied_modalities)
-                unexpected = sorted(supplied_modalities - expected_modalities)
-                raise ValueError(
-                    "Precomputed modality token indices must be provided for every modality "
-                    f"(missing={missing}, unexpected={unexpected})"
-                )
-
-            total_indices = 0
+        if modality_token_indices is not None:
+            self._validate_precomputed_token_indices(
+                modality_embeddings, modality_token_indices, batch_size * seq_length
+            )
             for modality_name, modality_emb in modality_embeddings.items():
-                if modality_name != "text" and modality_name not in special_token_ids:
-                    raise ValueError(f"No special token ID defined for modality {modality_name}")
-
-                token_indices = precomputed_indices[modality_name]
-                if token_indices.ndim != 1:
-                    raise ValueError(
-                        f"{modality_name} token indices must be a flat one-dimensional tensor, "
-                        f"got shape {tuple(token_indices.shape)}"
-                    )
-                if token_indices.dtype != torch.long:
-                    raise ValueError(
-                        f"{modality_name} token indices must have dtype torch.long, "
-                        f"got {token_indices.dtype}"
-                    )
-                if token_indices.device != device:
-                    raise ValueError(
-                        f"{modality_name} token indices must be on device {device}, "
-                        f"got {token_indices.device}"
-                    )
-                if token_indices.numel() != modality_emb.size(0):
-                    raise ValueError(
-                        f"Number of {modality_name} token indices ({token_indices.numel()}) "
-                        f"does not match number of embeddings ({modality_emb.size(0)})"
-                    )
-                total_indices += token_indices.numel()
-
-            num_positions = batch_size * seq_length
-            if total_indices != num_positions:
-                raise ValueError(
-                    "Precomputed modality token indices must cover the complete flattened "
-                    f"[B, S] grid ({num_positions} positions), got {total_indices} indices"
+                flat_combined_embeddings.index_copy_(
+                    0, modality_token_indices[modality_name], modality_emb
                 )
+            return combined_embeddings.transpose(0, 1).contiguous()
 
         # Process each modality in modality_embeddings
         for modality_name, modality_emb in modality_embeddings.items():
-            if precomputed_indices is not None:
-                token_indices = precomputed_indices[modality_name]
-                flat_combined_embeddings.index_copy_(0, token_indices, modality_emb)
-                continue
-
             if modality_name == "text":
                 mask = torch.ones_like(input_ids, dtype=torch.bool, device=input_ids.device)
                 for token_id in special_token_ids.values():
@@ -438,15 +426,6 @@ class MimoModel(MegatronModule):
         else:
             if text_token_indices.ndim != 1:
                 raise ValueError("Text token indices must be a flat one-dimensional tensor")
-            if text_token_indices.dtype != torch.long:
-                raise ValueError(
-                    f"Text token indices must have dtype torch.long, got {text_token_indices.dtype}"
-                )
-            if text_token_indices.device != input_ids.device:
-                raise ValueError(
-                    f"Text token indices must be on device {input_ids.device}, "
-                    f"got {text_token_indices.device}"
-                )
 
         input_ids_text = input_ids.reshape(-1).index_select(0, text_token_indices).unsqueeze(0)
 

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -525,6 +525,13 @@ class DataIterator:
         )
         loss_mask[input_ids == self.image_token_id] = 0.0
 
+        flat_input_ids = input_ids.reshape(-1)
+        image_mask = flat_input_ids == self.image_token_id
+        modality_token_indices = {
+            self.encoder_name: image_mask.nonzero(as_tuple=False).flatten(),
+            "text": (~image_mask).nonzero(as_tuple=False).flatten(),
+        }
+
         return {
             "input_ids": input_ids,
             "labels": labels,
@@ -538,6 +545,7 @@ class DataIterator:
                     "clip_encoder": {'hidden_states': encoder_hidden_states, 'attention_mask': None}
                 }
             },
+            "modality_token_indices": modality_token_indices,
         }
 
 

--- a/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
+++ b/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
@@ -499,7 +499,7 @@ class TestEmbeddingAlignment:
                 },
             )
 
-        with pytest.raises(ValueError, match="flat one-dimensional tensor"):
+        with pytest.raises(ValueError, match="must be one-dimensional"):
             self.model.align_embeddings_by_token_positions(
                 modality_embeddings=indexed_modality_embeddings,
                 input_ids=input_ids,
@@ -510,23 +510,12 @@ class TestEmbeddingAlignment:
                 },
             )
 
-        with pytest.raises(ValueError, match="must be provided for every modality"):
+        with pytest.raises(ValueError, match="same modalities as the embeddings"):
             self.model.align_embeddings_by_token_positions(
                 modality_embeddings=indexed_modality_embeddings,
                 input_ids=input_ids,
                 special_token_ids=special_token_ids,
                 modality_token_indices={"text": valid_text_indices},
-            )
-
-        with pytest.raises(ValueError, match="must have dtype torch.long"):
-            self.model.align_embeddings_by_token_positions(
-                modality_embeddings=indexed_modality_embeddings,
-                input_ids=input_ids,
-                special_token_ids=special_token_ids,
-                modality_token_indices={
-                    "text": valid_text_indices,
-                    "vision": valid_vision_indices.to(dtype=torch.int32),
-                },
             )
 
         incomplete_text_indices = valid_text_indices[:-1]
@@ -536,7 +525,7 @@ class TestEmbeddingAlignment:
                 (incomplete_text_indices.numel(), hidden_dim), 0.01, device=self.device
             ),
         }
-        with pytest.raises(ValueError, match="must cover the complete flattened"):
+        with pytest.raises(ValueError, match="must cover .* positions"):
             self.model.align_embeddings_by_token_positions(
                 modality_embeddings=incomplete_modality_embeddings,
                 input_ids=input_ids,

--- a/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
+++ b/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
@@ -480,61 +480,44 @@ class TestEmbeddingAlignment:
                 special_token_ids=special_token_ids,
             )
 
-        # The precomputed path validates its complete-map contract using tensor
-        # metadata only; none of these checks synchronize with the device.
         valid_text_indices = (input_ids.reshape(-1) != vision_token_id).nonzero().flatten()
         valid_vision_indices = (input_ids.reshape(-1) == vision_token_id).nonzero().flatten()
         indexed_modality_embeddings = {
             "vision": vision_embeddings,
             "text": torch.full((valid_text_indices.numel(), hidden_dim), 0.01, device=self.device),
         }
-        with pytest.raises(ValueError, match="Number of vision token indices.*does not match"):
-            self.model.align_embeddings_by_token_positions(
-                modality_embeddings=indexed_modality_embeddings,
-                input_ids=input_ids,
-                special_token_ids=special_token_ids,
-                modality_token_indices={
-                    "text": valid_text_indices,
-                    "vision": torch.tensor([1], dtype=torch.long, device=self.device),
-                },
-            )
-
-        with pytest.raises(ValueError, match="must be one-dimensional"):
-            self.model.align_embeddings_by_token_positions(
-                modality_embeddings=indexed_modality_embeddings,
-                input_ids=input_ids,
-                special_token_ids=special_token_ids,
-                modality_token_indices={
-                    "text": valid_text_indices,
-                    "vision": torch.tensor([[1, 7]], dtype=torch.long, device=self.device),
-                },
-            )
-
-        with pytest.raises(ValueError, match="same modalities as the embeddings"):
-            self.model.align_embeddings_by_token_positions(
-                modality_embeddings=indexed_modality_embeddings,
-                input_ids=input_ids,
-                special_token_ids=special_token_ids,
-                modality_token_indices={"text": valid_text_indices},
-            )
-
         incomplete_text_indices = valid_text_indices[:-1]
         incomplete_modality_embeddings = {
             "vision": vision_embeddings,
-            "text": torch.full(
-                (incomplete_text_indices.numel(), hidden_dim), 0.01, device=self.device
-            ),
+            "text": indexed_modality_embeddings["text"][:-1],
         }
-        with pytest.raises(ValueError, match="must cover .* positions"):
-            self.model.align_embeddings_by_token_positions(
-                modality_embeddings=incomplete_modality_embeddings,
-                input_ids=input_ids,
-                special_token_ids=special_token_ids,
-                modality_token_indices={
-                    "text": incomplete_text_indices,
-                    "vision": valid_vision_indices,
-                },
-            )
+        invalid_cases = (
+            (
+                indexed_modality_embeddings,
+                {"text": valid_text_indices, "vision": valid_vision_indices[:1]},
+                "Number of vision token indices.*does not match",
+            ),
+            (
+                indexed_modality_embeddings,
+                {"text": valid_text_indices, "vision": valid_vision_indices.unsqueeze(0)},
+                "must be one-dimensional",
+            ),
+            (
+                indexed_modality_embeddings,
+                {"text": valid_text_indices},
+                "same modalities as the embeddings",
+            ),
+            (
+                incomplete_modality_embeddings,
+                {"text": incomplete_text_indices, "vision": valid_vision_indices},
+                "must cover .* positions",
+            ),
+        )
+        for embeddings, indices, error in invalid_cases:
+            with pytest.raises(ValueError, match=error):
+                self.model._validate_precomputed_token_indices(
+                    embeddings, indices, batch_size * seq_length
+                )
 
     def test_missing_special_token_id(self):
         """Test error when a modality is missing from special_token_ids."""

--- a/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
+++ b/tests/unit_tests/models/mimo/test_mimo_embedding_alignment.py
@@ -237,6 +237,66 @@ class TestEmbeddingAlignment:
         assert torch.all(combined[5, 1, :1] == 0.0), "Non-zero values found before marker"
         assert torch.all(combined[5, 1, 2:] == 0.0), "Non-zero values found after marker"
 
+    def test_precomputed_indices_match_mask_path_outputs_and_gradients(self):
+        """Precomputed positions must be equivalent to the topology-independent mask path."""
+        input_ids = torch.tensor(
+            [
+                [1, 50, 50, 2, 51, 3, 4, 5],
+                [50, 6, 7, 51, 51, 8, 9, 10],
+                [11, 12, 51, 13, 14, 15, 16, 17],
+            ],
+            dtype=torch.long,
+            device=self.device,
+        )
+        special_token_ids = {"vision": 50, "audio": 51}
+        flat_input_ids = input_ids.reshape(-1)
+        text_mask = torch.ones_like(flat_input_ids, dtype=torch.bool)
+        modality_token_indices = {}
+        for modality_name, token_id in special_token_ids.items():
+            modality_mask = flat_input_ids == token_id
+            modality_token_indices[modality_name] = modality_mask.nonzero(as_tuple=False).flatten()
+            text_mask &= ~modality_mask
+        modality_token_indices["text"] = text_mask.nonzero(as_tuple=False).flatten()
+
+        torch.manual_seed(1234)
+        source_embeddings = {
+            modality_name: torch.randn(token_indices.numel(), self.hidden_dim, device=self.device)
+            for modality_name, token_indices in modality_token_indices.items()
+        }
+        mask_embeddings = {
+            name: embeddings.detach().clone().requires_grad_()
+            for name, embeddings in source_embeddings.items()
+        }
+        indexed_embeddings = {
+            name: embeddings.detach().clone().requires_grad_()
+            for name, embeddings in source_embeddings.items()
+        }
+
+        mask_output = self.model.align_embeddings_by_token_positions(
+            modality_embeddings=mask_embeddings,
+            input_ids=input_ids,
+            special_token_ids=special_token_ids,
+        )
+        indexed_output = self.model.align_embeddings_by_token_positions(
+            modality_embeddings=indexed_embeddings,
+            input_ids=input_ids,
+            special_token_ids=special_token_ids,
+            modality_token_indices=modality_token_indices,
+        )
+
+        torch.testing.assert_close(indexed_output, mask_output, rtol=0, atol=0)
+
+        output_gradient = torch.randn_like(mask_output)
+        mask_output.backward(output_gradient)
+        indexed_output.backward(output_gradient)
+        for modality_name in source_embeddings:
+            torch.testing.assert_close(
+                indexed_embeddings[modality_name].grad,
+                mask_embeddings[modality_name].grad,
+                rtol=0,
+                atol=0,
+            )
+
     def test_multiple_images_with_variable_length(self):
         """Test handling multiple images per sample with variable sequence lengths.
 
@@ -418,6 +478,73 @@ class TestEmbeddingAlignment:
                 modality_embeddings=modality_embeddings,
                 input_ids=input_ids,
                 special_token_ids=special_token_ids,
+            )
+
+        # The precomputed path validates its complete-map contract using tensor
+        # metadata only; none of these checks synchronize with the device.
+        valid_text_indices = (input_ids.reshape(-1) != vision_token_id).nonzero().flatten()
+        valid_vision_indices = (input_ids.reshape(-1) == vision_token_id).nonzero().flatten()
+        indexed_modality_embeddings = {
+            "vision": vision_embeddings,
+            "text": torch.full((valid_text_indices.numel(), hidden_dim), 0.01, device=self.device),
+        }
+        with pytest.raises(ValueError, match="Number of vision token indices.*does not match"):
+            self.model.align_embeddings_by_token_positions(
+                modality_embeddings=indexed_modality_embeddings,
+                input_ids=input_ids,
+                special_token_ids=special_token_ids,
+                modality_token_indices={
+                    "text": valid_text_indices,
+                    "vision": torch.tensor([1], dtype=torch.long, device=self.device),
+                },
+            )
+
+        with pytest.raises(ValueError, match="flat one-dimensional tensor"):
+            self.model.align_embeddings_by_token_positions(
+                modality_embeddings=indexed_modality_embeddings,
+                input_ids=input_ids,
+                special_token_ids=special_token_ids,
+                modality_token_indices={
+                    "text": valid_text_indices,
+                    "vision": torch.tensor([[1, 7]], dtype=torch.long, device=self.device),
+                },
+            )
+
+        with pytest.raises(ValueError, match="must be provided for every modality"):
+            self.model.align_embeddings_by_token_positions(
+                modality_embeddings=indexed_modality_embeddings,
+                input_ids=input_ids,
+                special_token_ids=special_token_ids,
+                modality_token_indices={"text": valid_text_indices},
+            )
+
+        with pytest.raises(ValueError, match="must have dtype torch.long"):
+            self.model.align_embeddings_by_token_positions(
+                modality_embeddings=indexed_modality_embeddings,
+                input_ids=input_ids,
+                special_token_ids=special_token_ids,
+                modality_token_indices={
+                    "text": valid_text_indices,
+                    "vision": valid_vision_indices.to(dtype=torch.int32),
+                },
+            )
+
+        incomplete_text_indices = valid_text_indices[:-1]
+        incomplete_modality_embeddings = {
+            "vision": vision_embeddings,
+            "text": torch.full(
+                (incomplete_text_indices.numel(), hidden_dim), 0.01, device=self.device
+            ),
+        }
+        with pytest.raises(ValueError, match="must cover the complete flattened"):
+            self.model.align_embeddings_by_token_positions(
+                modality_embeddings=incomplete_modality_embeddings,
+                input_ids=input_ids,
+                special_token_ids=special_token_ids,
+                modality_token_indices={
+                    "text": incomplete_text_indices,
+                    "vision": valid_vision_indices,
+                },
             )
 
     def test_missing_special_token_id(self):

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -234,74 +234,6 @@ class TestMimoModel:
         assert indexed_embeddings.shape == (expected_text_tokens, self.hidden_size)
         torch.testing.assert_close(indexed_embeddings, mask_embeddings, rtol=0, atol=0)
 
-    def test_get_text_embeddings_handles_noncontiguous_inputs(self):
-        """Flat indices use logical ``[B, S]`` order for non-contiguous tensors."""
-        mimo_model = self._make_avlm().eval()
-
-        input_values = self._make_input_ids()
-        input_values[0, 3] = self.special_token_ids["images"]
-        input_values[1, 5] = self.special_token_ids["audio"]
-        input_storage = torch.empty(
-            self.batch_size, self.seq_len, 2, dtype=input_values.dtype, device=self.device
-        )
-        input_storage[..., 0] = input_values
-        input_ids = input_storage[..., 0]
-
-        position_values = self._make_position_ids()
-        position_storage = torch.empty(
-            self.batch_size, self.seq_len, 2, dtype=position_values.dtype, device=self.device
-        )
-        position_storage[..., 0] = position_values
-        position_ids_2d = position_storage[..., 0]
-
-        position_storage_3d = torch.empty(
-            3, self.batch_size, self.seq_len, 2, dtype=position_values.dtype, device=self.device
-        )
-        position_storage_3d[..., 0] = position_values.unsqueeze(0).expand(3, -1, -1)
-        position_ids_3d = position_storage_3d[..., 0]
-
-        assert not input_ids.is_contiguous()
-        assert not position_ids_2d.is_contiguous()
-        assert not position_ids_3d.is_contiguous()
-        assert not position_ids_3d[0].is_contiguous()
-
-        text_mask = torch.ones_like(input_ids, dtype=torch.bool)
-        for special_token_id in self.special_token_ids.values():
-            text_mask &= input_ids != special_token_id
-        text_token_indices = text_mask.reshape(-1).nonzero(as_tuple=False).flatten()
-
-        expected_2d = mimo_model.get_text_embeddings(
-            input_ids.contiguous(),
-            position_ids_2d.contiguous(),
-            self.special_token_ids,
-            text_token_indices=text_token_indices,
-        )
-        actual_2d = mimo_model.get_text_embeddings(
-            input_ids,
-            position_ids_2d,
-            self.special_token_ids,
-            text_token_indices=text_token_indices,
-        )
-        fallback_2d = mimo_model.get_text_embeddings(
-            input_ids, position_ids_2d, self.special_token_ids
-        )
-        expected_3d = mimo_model.get_text_embeddings(
-            input_ids.contiguous(),
-            position_ids_3d.contiguous(),
-            self.special_token_ids,
-            text_token_indices=text_token_indices,
-        )
-        actual_3d = mimo_model.get_text_embeddings(
-            input_ids,
-            position_ids_3d,
-            self.special_token_ids,
-            text_token_indices=text_token_indices,
-        )
-
-        torch.testing.assert_close(actual_2d, expected_2d, rtol=0, atol=0)
-        torch.testing.assert_close(fallback_2d, expected_2d, rtol=0, atol=0)
-        torch.testing.assert_close(actual_3d, expected_3d, rtol=0, atol=0)
-
     def test_get_text_embeddings_handles_3d_position_ids(self):
         """3D mRoPE position_ids ``[rope_dim, B, S]`` must produce the same text
         embeddings as the 2D ``[B, S]`` baseline.
@@ -834,7 +766,7 @@ class TestMimoModelNonColocated:
         assert "images" in outputs
 
     def test_forward_language_only(self):
-        """Test non-colocated language forward consumes precomputed token positions."""
+        """Test language-only forward returns tensor."""
         model = MimoModel(self._make_config(encoder_in_grid=False, language_in_grid=True))
         model = model.to(self.device)
 
@@ -854,13 +786,6 @@ class TestMimoModelNonColocated:
         )
         model.set_input_tensor({"images": encoder_embeddings})
 
-        flat_input_ids = input_ids.reshape(-1)
-        image_mask = flat_input_ids == 50257
-        modality_token_indices = {
-            "images": image_mask.nonzero(as_tuple=False).flatten(),
-            "text": (~image_mask).nonzero(as_tuple=False).flatten(),
-        }
-
         captured = {}
 
         def capture_language_inputs(module, args, kwargs):
@@ -869,36 +794,20 @@ class TestMimoModelNonColocated:
         hook = model.language_model.register_forward_pre_hook(
             capture_language_inputs, with_kwargs=True
         )
-        with (
-            patch.object(
-                model, 'get_text_embeddings', wraps=model.get_text_embeddings
-            ) as get_text_embeddings,
-            patch.object(
-                model,
-                'align_embeddings_by_token_positions',
-                wraps=model.align_embeddings_by_token_positions,
-            ) as align_embeddings,
-        ):
-            try:
-                outputs, out_loss_mask = model(
-                    input_ids=input_ids,
-                    position_ids=position_ids,
-                    loss_mask=loss_mask,
-                    modality_inputs=None,
-                    modality_token_indices=modality_token_indices,
-                )
-            finally:
-                hook.remove()
+        try:
+            outputs, out_loss_mask = model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                loss_mask=loss_mask,
+                modality_inputs=None,
+            )
+        finally:
+            hook.remove()
 
         assert isinstance(outputs, torch.Tensor)
         assert outputs.shape == (self.batch_size, self.seq_len, self.vocab_size)
         assert captured['loss_mask'] is loss_mask
         assert out_loss_mask is loss_mask
-        assert (
-            get_text_embeddings.call_args.kwargs['text_token_indices']
-            is modality_token_indices['text']
-        )
-        assert align_embeddings.call_args.kwargs['modality_token_indices'] is modality_token_indices
 
     def test_forward_language_module_non_first_stage_drops_input_ids(self):
         """Non-first PP stage in ``_forward_language_module`` must call the LM

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -211,15 +211,96 @@ class TestMimoModel:
         assert mimo_model.special_token_ids == self.special_token_ids
 
     def test_get_text_embeddings(self):
-        """Test getting text embeddings."""
-        mimo_model = self._make_avlm()
+        """Precomputed text positions must match the mask-based embedding lookup."""
+        mimo_model = self._make_avlm().eval()
         input_ids = self._make_input_ids()
         position_ids = self._make_position_ids()
+        input_ids[0, 3] = self.special_token_ids["images"]
+        input_ids[1, 5] = self.special_token_ids["audio"]
 
-        text_embeddings = mimo_model.get_text_embeddings(
+        text_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in self.special_token_ids.values():
+            text_mask &= input_ids != special_token_id
+        text_token_indices = text_mask.reshape(-1).nonzero(as_tuple=False).flatten()
+
+        mask_embeddings = mimo_model.get_text_embeddings(
             input_ids, position_ids, self.special_token_ids
         )
-        assert text_embeddings.shape == (self.batch_size * self.seq_len, self.hidden_size)
+        indexed_embeddings = mimo_model.get_text_embeddings(
+            input_ids, position_ids, self.special_token_ids, text_token_indices=text_token_indices
+        )
+
+        expected_text_tokens = self.batch_size * self.seq_len - 2
+        assert indexed_embeddings.shape == (expected_text_tokens, self.hidden_size)
+        torch.testing.assert_close(indexed_embeddings, mask_embeddings, rtol=0, atol=0)
+
+    def test_get_text_embeddings_handles_noncontiguous_inputs(self):
+        """Flat indices use logical ``[B, S]`` order for non-contiguous tensors."""
+        mimo_model = self._make_avlm().eval()
+
+        input_values = self._make_input_ids()
+        input_values[0, 3] = self.special_token_ids["images"]
+        input_values[1, 5] = self.special_token_ids["audio"]
+        input_storage = torch.empty(
+            self.batch_size, self.seq_len, 2, dtype=input_values.dtype, device=self.device
+        )
+        input_storage[..., 0] = input_values
+        input_ids = input_storage[..., 0]
+
+        position_values = self._make_position_ids()
+        position_storage = torch.empty(
+            self.batch_size, self.seq_len, 2, dtype=position_values.dtype, device=self.device
+        )
+        position_storage[..., 0] = position_values
+        position_ids_2d = position_storage[..., 0]
+
+        position_storage_3d = torch.empty(
+            3, self.batch_size, self.seq_len, 2, dtype=position_values.dtype, device=self.device
+        )
+        position_storage_3d[..., 0] = position_values.unsqueeze(0).expand(3, -1, -1)
+        position_ids_3d = position_storage_3d[..., 0]
+
+        assert not input_ids.is_contiguous()
+        assert not position_ids_2d.is_contiguous()
+        assert not position_ids_3d.is_contiguous()
+        assert not position_ids_3d[0].is_contiguous()
+
+        text_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in self.special_token_ids.values():
+            text_mask &= input_ids != special_token_id
+        text_token_indices = text_mask.reshape(-1).nonzero(as_tuple=False).flatten()
+
+        expected_2d = mimo_model.get_text_embeddings(
+            input_ids.contiguous(),
+            position_ids_2d.contiguous(),
+            self.special_token_ids,
+            text_token_indices=text_token_indices,
+        )
+        actual_2d = mimo_model.get_text_embeddings(
+            input_ids,
+            position_ids_2d,
+            self.special_token_ids,
+            text_token_indices=text_token_indices,
+        )
+        fallback_2d = mimo_model.get_text_embeddings(
+            input_ids, position_ids_2d, self.special_token_ids
+        )
+        expected_3d = mimo_model.get_text_embeddings(
+            input_ids.contiguous(),
+            position_ids_3d.contiguous(),
+            self.special_token_ids,
+            text_token_indices=text_token_indices,
+        )
+        actual_3d = mimo_model.get_text_embeddings(
+            input_ids,
+            position_ids_3d,
+            self.special_token_ids,
+            text_token_indices=text_token_indices,
+        )
+
+        torch.testing.assert_close(actual_2d, expected_2d, rtol=0, atol=0)
+        torch.testing.assert_close(fallback_2d, expected_2d, rtol=0, atol=0)
+        torch.testing.assert_close(actual_3d, expected_3d, rtol=0, atol=0)
 
     def test_get_text_embeddings_handles_3d_position_ids(self):
         """3D mRoPE position_ids ``[rope_dim, B, S]`` must produce the same text
@@ -753,7 +834,7 @@ class TestMimoModelNonColocated:
         assert "images" in outputs
 
     def test_forward_language_only(self):
-        """Test language-only forward returns tensor."""
+        """Test non-colocated language forward consumes precomputed token positions."""
         model = MimoModel(self._make_config(encoder_in_grid=False, language_in_grid=True))
         model = model.to(self.device)
 
@@ -773,6 +854,13 @@ class TestMimoModelNonColocated:
         )
         model.set_input_tensor({"images": encoder_embeddings})
 
+        flat_input_ids = input_ids.reshape(-1)
+        image_mask = flat_input_ids == 50257
+        modality_token_indices = {
+            "images": image_mask.nonzero(as_tuple=False).flatten(),
+            "text": (~image_mask).nonzero(as_tuple=False).flatten(),
+        }
+
         captured = {}
 
         def capture_language_inputs(module, args, kwargs):
@@ -781,20 +869,36 @@ class TestMimoModelNonColocated:
         hook = model.language_model.register_forward_pre_hook(
             capture_language_inputs, with_kwargs=True
         )
-        try:
-            outputs, out_loss_mask = model(
-                input_ids=input_ids,
-                position_ids=position_ids,
-                loss_mask=loss_mask,
-                modality_inputs=None,
-            )
-        finally:
-            hook.remove()
+        with (
+            patch.object(
+                model, 'get_text_embeddings', wraps=model.get_text_embeddings
+            ) as get_text_embeddings,
+            patch.object(
+                model,
+                'align_embeddings_by_token_positions',
+                wraps=model.align_embeddings_by_token_positions,
+            ) as align_embeddings,
+        ):
+            try:
+                outputs, out_loss_mask = model(
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    loss_mask=loss_mask,
+                    modality_inputs=None,
+                    modality_token_indices=modality_token_indices,
+                )
+            finally:
+                hook.remove()
 
         assert isinstance(outputs, torch.Tensor)
         assert outputs.shape == (self.batch_size, self.seq_len, self.vocab_size)
         assert captured['loss_mask'] is loss_mask
         assert out_loss_mask is loss_mask
+        assert (
+            get_text_embeddings.call_args.kwargs['text_token_indices']
+            is modality_token_indices['text']
+        )
+        assert align_embeddings.call_args.kwargs['modality_token_indices'] is modality_token_indices
 
     def test_forward_language_module_non_first_stage_drops_input_ids(self):
         """Non-first PP stage in ``_forward_language_module`` must call the LM


### PR DESCRIPTION
## Summary

- Accept an optional complete mapping of flat, batch-major token positions for every active MIMO modality, including `text`.
- Reuse the supplied text positions for embedding lookup and use `index_copy_` for modality placement.
- Keep the existing mask-based behavior unchanged when indices are absent.
- Support the non-colocated communicator path: language ranks consume the indices while encoder-only ranks intentionally ignore them.

## Correctness and hot-path contract

- Precomputed indices are all-or-nothing, so a forward uses either the indexed path or the mask path; it cannot mix `index_copy_` and `masked_scatter_` writes.
- Validate the complete key set, one-dimensional shape, per-modality embedding count, and total `B * S` count in a small metadata-only helper. PyTorch's indexing operators enforce dtype and device requirements.
- Index values must contain the same positions, in the same order, as the corresponding masks. This remains a trusted producer contract: the forward path deliberately avoids value scans, device reductions, and host synchronization.
- Flat positions use the logical row-major `[B, S]` convention. Unit coverage includes actually non-contiguous input and 2-D/3-D position-ID tensors.

The MIMO training step already forwards batch keyword arguments, so no additional training-step plumbing is required.

## Validation

- CW DFW Cog job `16295718`: 1 node, 8 GPUs, 8 distributed ranks; Ruff and Black passed, then `13 passed, 2 skipped` on every rank. This covers output and gradient parity, malformed-index validation, non-contiguous inputs, non-colocated language-only forwarding, and MIMO 1F1B fan-in/fan-out/pipeline configurations.
