### PR TITLE
Relax CUDA-only device assert in triton KV append kernel

### DIFF
--- a/megatron/core/inference/contexts/fused_kv_append_kernel.py
+++ b/megatron/core/inference/contexts/fused_kv_append_kernel.py
@@ -115,10 +115,10 @@ def triton_append_key_value_cache(
     """
     # --- Input Validation and Preparation ---
     assert (
-        key.device.type == 'cuda'
-        and value.device.type == 'cuda'
-        and memory_buffer.device.type == 'cuda'
-    ), "All tensors must be on CUDA devices."
+        key.device.type not in ('cpu', 'meta')
+        and value.device.type not in ('cpu', 'meta')
+        and memory_buffer.device.type not in ('cpu', 'meta')
+    ), "All tensors must be on a device with a Triton backend (CUDA, NPU, ...)."
 
     assert (
         key.size(1) == 1 and value.size(1) == 1


### PR DESCRIPTION
# What does this PR do?

Relaxes the CUDA-only device assert in `triton_append_key_value_cache` (`megatron/core/inference/contexts/fused_kv_append_kernel.py`) so the dynamic-batching inference KV-append path also runs on Triton backends whose device type is not `cuda`.

The kernel is pure Triton and device-agnostic; the input-validation preamble is its only CUDA-ism. It currently asserts `key/value/memory_buffer.device.type == 'cuda'`, which blocks non-CUDA accelerators with a Triton backend (e.g. Ascend NPU, device type `npu`) at the first KV append. The assert's real intent is to reject tensors that cannot be launched on a Triton backend at all (CPU, meta); expressed that way (a blocklist of `('cpu', 'meta')`) it holds for every current and future Triton-backed accelerator instead of enumerating vendors. No behavior change on CUDA.

## Issue tracking

Fixes #6729

## Checks / tests

- Ascend 910B (torch_npu): dynamic-batching inference KV-append path exercised end-to-end; assert no longer fires and the kernel runs on the NPU Triton backend
- CUDA: assert still accepts `cuda` (not in the blocklist), no change
- Change is inside `megatron/core`, so `tools/autoformat.sh` (black + ruff) applies; the edit is a single boolean expression swap and is clean under both

This PR was written in part with the assistance of generative AI.
