### PR TITLE
Validate GQA query group counts in TransformerConfig

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1425,6 +1425,14 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.num_query_groups is None:
             self.num_query_groups = self.num_attention_heads
+        elif self.num_query_groups <= 0:
+            raise ValueError(f"num_query_groups ({self.num_query_groups}) must be positive.")
+
+        if self.num_query_groups > 0 and self.num_attention_heads % self.num_query_groups != 0:
+            raise ValueError(
+                f"num_attention_heads ({self.num_attention_heads}) must be a multiple of "
+                f"num_query_groups ({self.num_query_groups})."
+            )
 
         if (
             self.num_query_groups % self.tensor_model_parallel_size != 0

--- a/tests/unit_tests/export/trtllm/test_trtllm_single_device_converter.py
+++ b/tests/unit_tests/export/trtllm/test_trtllm_single_device_converter.py
@@ -25,7 +25,7 @@ class TestTRTLLMSingleDeviceConverter:
         model_config = TransformerConfig(
             num_layers=num_layers,
             num_attention_heads=num_attn_heads,
-            num_query_groups=0,
+            num_query_groups=num_attn_heads,
             hidden_size=hidden_dim,
             ffn_hidden_size=hidden_dim * 4,
         )

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -55,3 +55,18 @@ def test_gdp_num_householder_rejects_non_positive_values(num_householder: int):
             num_attention_heads=4,
             gdp_num_householder=num_householder,
         )
+
+
+def test_num_query_groups_must_divide_num_attention_heads():
+    with pytest.raises(
+        ValueError, match="num_attention_heads .* must be a multiple of num_query_groups"
+    ):
+        TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4, num_query_groups=3)
+
+
+@pytest.mark.parametrize("num_query_groups", [0, -1])
+def test_num_query_groups_must_be_positive(num_query_groups: int):
+    with pytest.raises(ValueError, match="num_query_groups .* must be positive"):
+        TransformerConfig(
+            num_layers=1, hidden_size=128, num_attention_heads=4, num_query_groups=num_query_groups
+        )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Validates grouped-query attention head counts in `TransformerConfig` before they reach attention shape logic.

Explicit `num_query_groups` values must now be positive and divide `num_attention_heads`. Minimal configs that omit `num_query_groups` keep the existing default behavior. The TRT-LLM converter test that used `num_query_groups=0` as a placeholder now uses the equivalent MHA value (`num_attn_heads`).

This is a small current-`main` alternative to #5756, which is currently conflicted. Unlike #5756, it does not normalize an explicit zero query-group count to MHA.

## Issue tracking

Linked issue: Fixes #5755

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not applicable; this is config validation)
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation (not applicable)
- [x] I have run the `tools/autoformat.sh` on my PR

Local verification:

```text
12 passed - tests/unit_tests/transformer/test_transformer_config.py
5 passed  - tests/unit_tests/export/trtllm/test_trtllm_single_device_converter.py
```

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.
