### PR TITLE
Use DTensor placements for DBuffer

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -18,15 +18,12 @@ from .checkpoint import load_checkpoint, save_checkpoint
 from .dbuffer import DBuffer
 from .fully_shard import fully_shard, fully_shard_context, microbatch
 from .optimizer import fully_shard_optimizer
-from .placement import Flat, Partial, Placement, Placements, Replicate
+from .placement import Flat, Placements
 
 __all__ = [
     "DBuffer",
     "Flat",
-    "Partial",
-    "Placement",
     "Placements",
-    "Replicate",
     "fully_shard",
     "fully_shard_context",
     "fully_shard_optimizer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -20,12 +20,12 @@ from collections.abc import Iterable
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
-import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Partial, Replicate
+from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate, changed_mesh_axis
+from .placement import Flat, changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -48,6 +48,12 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
                 "Flat placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
+
+
+def _get_reduce_op(partial_placement: Partial) -> dist.ReduceOp.RedOpType:
+    """Convert a DTensor Partial reduction name to a torch.distributed op."""
+    reduce_ops = {"sum": dist.ReduceOp.SUM, "avg": dist.ReduceOp.AVG}
+    return reduce_ops[partial_placement.reduce_op]
 
 
 class DBuffer:
@@ -350,7 +356,7 @@ class DBuffer:
             # buffer without communication. Value-preserving for AVG only -- the
             # mean of identical per-rank locals is that value; SUM would need a
             # 1/axis_size rescale, which no caller needs.
-            if new_placement.reduce_op != dist.ReduceOp.AVG:
+            if new_placement.reduce_op != "avg":
                 raise NotImplementedError(
                     "Replicate -> Partial redistribute supports AVG only, got "
                     f"{new_placement.reduce_op!r}."
@@ -405,7 +411,7 @@ class DBuffer:
         out = self._create_or_validate_out(out, placements=placements)
         out.local_buffer.copy_(self.local_buffer)
         dist.all_reduce(
-            out.local_buffer, op=partial_placement.reduce_op, group=self.mesh.get_group(axis)
+            out.local_buffer, op=_get_reduce_op(partial_placement), group=self.mesh.get_group(axis)
         )
         return out
 
@@ -424,7 +430,7 @@ class DBuffer:
         placements[axis] = new_placement
         _validate_placements(placements)
         out = self._create_or_validate_out(out, placements=placements)
-        reduce_op = partial_placement.reduce_op
+        reduce_op = _get_reduce_op(partial_placement)
         # Symmetric-memory MFSDP requires this detector, but ordinary DBuffer
         # reductions remain supported on older PyTorch versions that lack it.
         if self.is_symmetric_memory:
@@ -440,7 +446,7 @@ class DBuffer:
             op=reduce_op,
             group=self.mesh.get_group(axis),
         )
-        if self.is_symmetric_memory and partial_placement.reduce_op == dist.ReduceOp.AVG:
+        if self.is_symmetric_memory and partial_placement.reduce_op == "avg":
             out.local_buffer.div_(self.mesh.size(axis))
         return out
 
@@ -511,27 +517,6 @@ class DBuffer:
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""
-        torch_placements = []
-        for placement in self.placements:
-            if isinstance(placement, Replicate):
-                torch_placements.append(dist_tensor.Replicate())
-            elif isinstance(placement, Flat):
-                torch_placements.append(dist_tensor.Shard(0))
-            elif isinstance(placement, Partial):
-                # main_grad backs .grad while it rests DP-outer-Partial between
-                # microbatches, so a Partial placement must round-trip to a DTensor.
-                if placement.reduce_op == dist.ReduceOp.AVG:
-                    reduce_op = "avg"
-                elif placement.reduce_op == dist.ReduceOp.SUM:
-                    reduce_op = "sum"
-                else:
-                    raise ValueError(
-                        f"Unsupported Partial reduce op for DTensor: {placement.reduce_op!r}."
-                    )
-                torch_placements.append(dist_tensor.Partial(reduce_op))
-            else:
-                raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
-
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
         # DBuffer uses contiguous flat storage, and Flat only shards dim 0, so
@@ -539,7 +524,7 @@ class DBuffer:
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,
-            placements=tuple(torch_placements),
+            placements=self.placements,
             run_check=False,
             shape=tensor_shape,
             stride=local_tensor.stride(),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -21,8 +21,9 @@ from typing import TypeAlias
 
 import torch
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor.placement_types import Placement
 
-from .placement import Flat, Placement
+from .placement import Flat
 
 Shape: TypeAlias = torch.Size | Iterable[int]
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -20,14 +20,14 @@ from dataclasses import dataclass
 from weakref import ReferenceType, ref
 
 import torch
-import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import Partial, Replicate
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Partial, Placements, Replicate, changed_mesh_axis
+from .placement import Placements, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -335,7 +335,7 @@ class FsdpParameterGroup:
         with self._symmetric_memory_context():
             return DBuffer(
                 mesh=self.mesh,
-                placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim,
+                placements=[Partial("avg")] * self.mesh.ndim,
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -14,10 +14,9 @@
 
 """DBuffer placement definitions.
 
-These placement concepts are borrowed from PyTorch DTensor placements:
-``Replicate`` and ``Partial`` mirror DTensor's placements. ``Flat`` is the
-only sharded DBuffer placement implemented so far; it stores dim-0 shards in a
-flattened local buffer.
+DBuffer uses PyTorch DTensor's ``Placement``, ``Replicate``, and ``Partial``
+types directly. ``Flat`` is the only DBuffer-specific placement: a dim-0
+``Shard`` whose local storage is part of one flattened buffer.
 
 =============  =============  ====================
 Source         Destination    DBuffer operation
@@ -32,31 +31,19 @@ sharded        ``Replicate``  ``allgather()``
 import dataclasses
 from collections.abc import Iterable, Sequence
 
-import torch.distributed as dist
+from torch.distributed.tensor import Shard
+from torch.distributed.tensor.placement_types import Placement
 
-
-class Placement:
-    """Base class for DBuffer placements."""
-
+__all__ = ["Flat", "Placements", "changed_mesh_axis"]
 
 MeshAxis = int | str
 
 
-@dataclasses.dataclass(frozen=True)
-class Replicate(Placement):
-    """Replicated local buffer placement."""
+class Flat(Shard):
+    """DBuffer-specific flattened dim-0 shard placement."""
 
-
-@dataclasses.dataclass(frozen=True)
-class Partial(Placement):
-    """Unreduced replicated local buffer placement."""
-
-    reduce_op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM
-
-
-@dataclasses.dataclass(frozen=True)
-class Flat(Placement):
-    """Flat dim-0 sharded local buffer placement."""
+    def __init__(self) -> None:
+        super().__init__(0)
 
 
 def changed_mesh_axis(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -9,13 +9,9 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Partial, Replicate
 
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import (
-    DBuffer,
-    Flat,
-    Partial,
-    Replicate,
-)
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer, Flat
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -396,9 +392,7 @@ def test_partial_allreduce_average(distributed_setup):
         torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
-    partial_buffer = DBuffer.distribute_tensors(
-        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
-    )
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("avg")])
 
     destination = DBuffer(
         mesh=mesh,
@@ -459,9 +453,7 @@ def test_partial_reduce_scatter_to_flat_average(distributed_setup):
         torch.full((5, 3), rank_scale, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), rank_scale * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
-    partial_buffer = DBuffer.distribute_tensors(
-        tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
-    )
+    partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("avg")])
     layout = partial_buffer.layout
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
@@ -487,9 +479,7 @@ def test_partial_reduce_scatter_to_flat_average_without_symm_mem_detector(
     monkeypatch.delattr(symm_mem, "is_symm_mem_tensor")
     rank_scale = float(distributed_setup.rank + 1)
     partial_buffer = DBuffer.distribute_tensors(
-        [torch.full((5, 3), rank_scale, dtype=torch.float32, device=device)],
-        mesh,
-        [Partial(reduce_op=dist.ReduceOp.AVG)],
+        [torch.full((5, 3), rank_scale, dtype=torch.float32, device=device)], mesh, [Partial("avg")]
     )
 
     replicated_buffer = partial_buffer.reduce_scatter(0, Flat()).allgather(0)
@@ -510,9 +500,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_average(distributed_set
     ]
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
-        partial_buffer = DBuffer.distribute_tensors(
-            tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
-        )
+        partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("avg")])
     assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
@@ -538,9 +526,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_sum(distributed_setup):
     ]
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
-        partial_buffer = DBuffer.distribute_tensors(
-            tensors, mesh, [Partial(reduce_op=dist.ReduceOp.SUM)]
-        )
+        partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("sum")])
     assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
@@ -566,6 +552,7 @@ def test_get_dtensor_from_sharded_buffer(distributed_setup):
         dtensor.to_local(), sharded_buffer.get_local_tensor(0), rtol=0, atol=0
     )
     assert dtensor.shape == tensors[0].shape
+    assert dtensor.placements == (Flat(),)
 
 
 def test_2d_mesh_replicate_flat_round_trip(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -9,15 +9,13 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Partial, Replicate
 from torch.profiler import ProfilerActivity, profile
 from torch.utils.checkpoint import checkpoint
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
-    Partial,
     Placements,
-    Replicate,
     fully_shard,
     fully_shard_context,
     fully_shard_optimizer,
@@ -137,19 +135,13 @@ def _flat_placements() -> Placements:
 
 def _no_shard_placements() -> Placements:
     return Placements(
-        dp_axes=[0],
-        parameter=[Replicate()],
-        gradient=[Partial(dist.ReduceOp.AVG)],
-        optimizer=[Replicate()],
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Replicate()]
     )
 
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0],
-        parameter=[Replicate()],
-        gradient=[Partial(dist.ReduceOp.AVG)],
-        optimizer=[Flat()],
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
     )
 
 
@@ -164,7 +156,7 @@ def _hsdp_placements() -> Placements:
     return Placements(
         dp_axes=[0, 1],
         parameter=[Replicate(), Flat()],
-        gradient=[Partial(dist.ReduceOp.AVG), Flat()],
+        gradient=[Partial("avg"), Flat()],
         optimizer=[Replicate(), Flat()],
     )
 
@@ -177,7 +169,7 @@ def _hfsdp_placements() -> Placements:
     return Placements(
         dp_axes=[0, 1],
         parameter=[Replicate(), Flat()],
-        gradient=[Partial(dist.ReduceOp.AVG), Flat()],
+        gradient=[Partial("avg"), Flat()],
         optimizer=[Flat(), Flat()],
     )
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -9,12 +9,11 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Partial, Replicate
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
-    Partial,
     Placements,
-    Replicate,
     fully_shard,
     fully_shard_context,
     fully_shard_optimizer,
@@ -58,10 +57,7 @@ def _flat_placements() -> Placements:
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0],
-        parameter=[Replicate()],
-        gradient=[Partial(dist.ReduceOp.AVG)],
-        optimizer=[Flat()],
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
     )
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -7,13 +7,12 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Partial, Replicate
 from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
-    Partial,
     Placements,
-    Replicate,
     fully_shard,
     fully_shard_context,
     fully_shard_optimizer,
@@ -48,10 +47,7 @@ def _flat_placements() -> Placements:
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0],
-        parameter=[Replicate()],
-        gradient=[Partial(dist.ReduceOp.AVG)],
-        optimizer=[Flat()],
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
     )
 
 


### PR DESCRIPTION
## Summary

DBuffer currently maintains local `Placement`, `Replicate`, and `Partial` types that duplicate PyTorch DTensor placement semantics. That parallel class system is not worth the duplication: it requires manual translation when materializing DTensors and lets reduction semantics drift between the two representations.

Use PyTorch DTensor placements directly instead. `Flat` remains the DBuffer-specific concept as a `Shard(0)` subclass, while the shared placements retain their native Torch identity. This also makes migration from Torch FSDP2 to MFSDP-v2 simpler: existing placement descriptions carry over without an extra translation layer.

- remove the duplicate placement hierarchy and DTensor conversion
- represent `Flat` as a dim-0 Torch shard
- use native `"avg"` Partial placements in the production gradient path; retain sum coverage in DBuffer tests

Related: #5615

## Testing

- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_memory.py tests/unit_tests/distributed/mfsdp_v2/test_overlap.py`
- Black and isort on the CI file set
