### PR TITLE
Defer initial embedding synchronization during VPP model construction

### DIFF
--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import logging
 import os
-from typing import Optional, Tuple
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -32,6 +34,33 @@ from megatron.core.utils import (
     is_te_min_version,
     make_tp_sharded_tensor_for_checkpoint,
 )
+
+_DEFER_INITIAL_EMBEDDING_SYNC: ContextVar[bool] = ContextVar(
+    "defer_initial_embedding_sync", default=False
+)
+
+
+@contextmanager
+def defer_initial_embedding_sync() -> Iterator[None]:
+    """Defer tied embedding synchronization within a model-construction scope."""
+
+    token = _DEFER_INITIAL_EMBEDDING_SYNC.set(True)
+    try:
+        yield
+    finally:
+        _DEFER_INITIAL_EMBEDDING_SYNC.reset(token)
+
+
+def sync_initial_embeddings_and_output_layers(model: list[torch.nn.Module]) -> None:
+    """Synchronize deferred tied embeddings in nested model chunks."""
+
+    for model_module in model:
+        for module in model_module.modules():
+            sync_initial_embeddings = getattr(
+                module, 'sync_initial_embeddings_and_output_layer', None
+            )
+            if callable(sync_initial_embeddings):
+                sync_initial_embeddings()
 
 
 class LanguageModule(MegatronModule):
@@ -307,6 +336,22 @@ class LanguageModule(MegatronModule):
 
         # Ensure that first and last stages have the same initial parameter
         # values.
+        # Under VPP, defer synchronization until all local model chunks are built.
+        if not _DEFER_INITIAL_EMBEDDING_SYNC.get():
+            self.sync_initial_embeddings_and_output_layer()
+
+    def sync_initial_embeddings_and_output_layer(self) -> None:
+        """Synchronize tied embedding weights between pipeline stages."""
+
+        if not self.share_embeddings_and_output_weights and not getattr(
+            self.config, 'mtp_num_layers', 0
+        ):
+            return
+        if self.config.pipeline_model_parallel_size == 1:
+            return
+        if not (self.pre_process or self.post_process or getattr(self, 'mtp_process', False)):
+            return
+
         if torch.distributed.is_initialized():
             if self._is_in_embd_group() and not self.config.init_model_with_meta_device:
                 weight = self.shared_embedding_or_output_weight()

--- a/megatron/training/models/dist_utils.py
+++ b/megatron/training/models/dist_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import logging
+from contextlib import nullcontext
 from typing import Any, Callable
 
 import torch
@@ -12,6 +13,10 @@ from megatron.core.distributed import (
     FullyShardedDataParallel,
 )
 from megatron.core.full_cuda_graph import get_shared_capture_stream
+from megatron.core.models.common.language_module.language_module import (
+    defer_initial_embedding_sync,
+    sync_initial_embeddings_and_output_layers,
+)
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.optimizer.layer_wise_optimizer import (
     LayerWiseDistributedOptimizer,
@@ -30,7 +35,6 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import get_model_config, get_pg_rank
-
 
 try:
     from megatron.core.fp8_utils import correct_amax_history_if_needed
@@ -96,11 +100,23 @@ def unimodal_build_distributed_models(
 
     vp_size = transformer_config.virtual_pipeline_model_parallel_size
     init_model_with_meta_device = transformer_config.init_model_with_meta_device
-    if init_model_with_meta_device:
-        with torch.device("meta"):
-            model_list = build_virtual_pipeline_stages(build_model_func, pg_collection, vp_size, model_type)
-    else:
-        model_list = build_virtual_pipeline_stages(build_model_func, pg_collection, vp_size, model_type)
+    should_defer_embedding_sync = pg_collection.pp.size() > 1 and vp_size is not None
+    embedding_sync_context = (
+        defer_initial_embedding_sync() if should_defer_embedding_sync else nullcontext()
+    )
+    with embedding_sync_context:
+        if init_model_with_meta_device:
+            with torch.device("meta"):
+                model_list = build_virtual_pipeline_stages(
+                    build_model_func, pg_collection, vp_size, model_type
+                )
+        else:
+            model_list = build_virtual_pipeline_stages(
+                build_model_func, pg_collection, vp_size, model_type
+            )
+
+    if should_defer_embedding_sync:
+        sync_initial_embeddings_and_output_layers(model_list)
 
     # Apply pre wrap hooks
     if pre_wrap_hook is not None:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -60,6 +60,10 @@ from megatron.core.fp8_utils import correct_amax_history_if_needed
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper, get_shared_capture_stream
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.inference.unified_memory import create_unified_mempool
+from megatron.core.models.common.language_module.language_module import (
+    defer_initial_embedding_sync,
+    sync_initial_embeddings_and_output_layers,
+)
 from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
     is_gated_delta_net_variant,
     is_linear_attention_variant,
@@ -2371,12 +2375,14 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     if has_nvidia_modelopt:
         maybe_enable_modelopt(args)
 
+    should_defer_embedding_sync = (
+        get_pg_size(pg_collection.pp) > 1
+        and args.virtual_pipeline_model_parallel_size is not None
+    )
+
     # Build model.
     def build_model():
-        if (
-            get_pg_size(pg_collection.pp) > 1
-            and args.virtual_pipeline_model_parallel_size is not None
-        ):
+        if should_defer_embedding_sync:
             model = []
             vp_size = args.virtual_pipeline_model_parallel_size
             for i in range(vp_size):
@@ -2410,14 +2416,23 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         return model
 
 
-    if args.init_model_with_meta_device:
-        with torch.device('meta'):
+    embedding_sync_context = (
+        defer_initial_embedding_sync()
+        if should_defer_embedding_sync
+        else nullcontext()
+    )
+    with embedding_sync_context:
+        if args.init_model_with_meta_device:
+            with torch.device('meta'):
+                model = build_model()
+        else:
             model = build_model()
-    else:
-        model = build_model()
 
     if not isinstance(model, list):
         model = [model]
+
+    if should_defer_embedding_sync:
+        sync_initial_embeddings_and_output_layers(model)
 
     # For rare operations like post-training logits saving
     if args.freeze_all_layers:

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -1,11 +1,21 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from collections import defaultdict
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 import torch
 
+import megatron.core.models.common.language_module.language_module as language_module
+import megatron.core.pipeline_parallel.utils as pipeline_utils
+import megatron.training.models.dist_utils as dist_utils
+import megatron.training.training as training
+from megatron.core.models.common.language_module.language_module import (
+    LanguageModule,
+    defer_initial_embedding_sync,
+)
 from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding
 from megatron.training.checkpointing import save_grads
 from megatron.training.global_vars import set_args
@@ -56,6 +66,164 @@ def create_test_args():
     args.phase_transition_iterations = None
 
     return args
+
+
+def _make_mtp_language_module():
+    module = LanguageModule.__new__(LanguageModule)
+    torch.nn.Module.__init__(module)
+    module.config = SimpleNamespace(
+        init_model_with_meta_device=False,
+        mtp_num_layers=1,
+        pipeline_model_parallel_size=2,
+        use_mup=False,
+    )
+    module.share_embeddings_and_output_weights = False
+    module.mtp_process = True
+    module.pre_process = False
+    module.post_process = False
+    module.vp_stage = 1
+    module.vp_size = 2
+    module.pp_group = None
+    module.embd_group = object()
+    module.embedding = torch.nn.Module()
+    module.embedding.word_embeddings = torch.nn.Embedding(4, 2)
+    return module
+
+
+def _model_construction_config():
+    return SimpleNamespace(
+        bf16=False,
+        fp16=False,
+        freeze_all_layers=False,
+        init_model_with_meta_device=False,
+        use_cpu_initialization=True,
+        use_megatron_fsdp=False,
+        use_torch_fsdp2=True,
+        virtual_pipeline_model_parallel_size=3,
+    )
+
+
+def _model_construction_pg_collection():
+    pp_group = mock.Mock()
+    pp_group.size.return_value = 2
+    return SimpleNamespace(cp=object(), dp=object(), gtp_remat=object(), pp=pp_group, tp=object())
+
+
+def _record_deferred_scope(event_log):
+    @contextmanager
+    def context():
+        event_log.append("enter-defer")
+        try:
+            yield
+        finally:
+            event_log.append("exit-defer")
+
+    return context
+
+
+def _make_sync_recording_model(event_log, vp_stage):
+    model = torch.nn.Module()
+
+    def record_sync():
+        event_log.append(f"sync-{vp_stage}")
+
+    setattr(model, "sync_initial_embeddings_and_output_layer", record_sync)
+    return model
+
+
+def test_mtp_embedding_sync_is_deferred_until_explicit_sync(monkeypatch):
+    module = _make_mtp_language_module()
+    shared_weight = mock.Mock()
+    shared_weight.data.cuda.return_value = shared_weight.data
+    module.shared_embedding_or_output_weight = mock.Mock(return_value=shared_weight)
+    module._is_in_embd_group = mock.Mock(return_value=True)
+    all_reduce = mock.Mock()
+    monkeypatch.setattr(
+        language_module, "is_vp_first_stage", lambda vp_stage, _vp_size: vp_stage == 0
+    )
+    monkeypatch.setattr(language_module, "is_pp_first_stage", lambda _group: False)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+
+    with defer_initial_embedding_sync():
+        module.setup_embeddings_and_output_layer()
+
+    all_reduce.assert_not_called()
+    module.sync_initial_embeddings_and_output_layer()
+    all_reduce.assert_called_once_with(shared_weight.data, group=module.embd_group)
+
+    all_reduce.reset_mock()
+    module.setup_embeddings_and_output_layer()
+    all_reduce.assert_called_once_with(shared_weight.data, group=module.embd_group)
+
+
+def test_vpp_builders_sync_embeddings_after_all_chunks_are_built(monkeypatch):
+    expected_events = [
+        "enter-defer",
+        "build-0",
+        "build-1",
+        "build-2",
+        "exit-defer",
+        "sync-0",
+        "sync-1",
+        "sync-2",
+    ]
+
+    legacy_events = []
+    legacy_args = _model_construction_config()
+    legacy_pg = _model_construction_pg_collection()
+    monkeypatch.setattr(training, "get_args", lambda: legacy_args)
+    monkeypatch.setattr(training, "get_pg_size", lambda group: 2 if group is legacy_pg.pp else 1)
+    monkeypatch.setattr(training, "get_pg_rank", lambda _group: 1)
+    monkeypatch.setattr(training, "is_pp_first_stage", lambda _group: True)
+    monkeypatch.setattr(training, "is_pp_last_stage", lambda _group: False)
+    monkeypatch.setattr(training, "correct_amax_history_if_needed", lambda _model: None)
+    monkeypatch.setattr(training, "has_nvidia_modelopt", False)
+    monkeypatch.setattr(
+        training, "defer_initial_embedding_sync", _record_deferred_scope(legacy_events)
+    )
+
+    def legacy_model_provider(**kwargs):
+        legacy_events.append(f"build-{kwargs['vp_stage']}")
+        return _make_sync_recording_model(legacy_events, kwargs["vp_stage"])
+
+    legacy_model = training.get_model(
+        legacy_model_provider, wrap_with_ddp=False, pg_collection=legacy_pg
+    )
+
+    assert len(legacy_model) == 3
+    assert legacy_events == expected_events
+
+    builder_events = []
+    builder_config = _model_construction_config()
+    builder_pg = _model_construction_pg_collection()
+    monkeypatch.setattr(pipeline_utils, "is_pp_first_stage", lambda _group: True)
+    monkeypatch.setattr(pipeline_utils, "is_pp_last_stage", lambda _group: False)
+    monkeypatch.setattr(
+        pipeline_utils, "is_vp_first_stage", lambda vp_stage, vp_size: vp_stage == 0
+    )
+    monkeypatch.setattr(
+        pipeline_utils, "is_vp_last_stage", lambda vp_stage, vp_size: vp_stage == vp_size - 1
+    )
+    monkeypatch.setattr(
+        dist_utils, "defer_initial_embedding_sync", _record_deferred_scope(builder_events)
+    )
+    monkeypatch.setattr(
+        dist_utils,
+        "prepare_existing_model_chunks_for_distributed_training",
+        lambda model, *_args, **_kwargs: model,
+    )
+
+    def build_model(_pg_collection, *, vp_stage, **_kwargs):
+        builder_events.append(f"build-{vp_stage}")
+        return _make_sync_recording_model(builder_events, vp_stage)
+
+    builder_model = dist_utils.unimodal_build_distributed_models(
+        build_model, builder_config, builder_pg, wrap_with_ddp=False
+    )
+
+    assert len(builder_model) == 3
+    assert builder_events == expected_events
 
 
 class TestTraining:


### PR DESCRIPTION
Defers the blocking initial embedding synchronization until all local VPP model chunks have been built, preventing it from blocking subsequent VP construction.

 Fixes #6747