### PR TITLE
Use Shard for MFSDP public placements

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -30,6 +30,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import Shard
 
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
@@ -49,7 +50,6 @@ try:
         MixedPrecisionPolicy,
     )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-        Flat,
         Placements,
         fully_shard,
         fully_shard_context,
@@ -560,7 +560,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 pg_collection.expt_dp, device_type=device_type, mesh_dim_names=("expert_dp",)
             )
         placements = Placements(
-            dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
+            dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)]
         )
         # NCCL symmetric memory requires UB. MFSDP v2 intentionally does not support UB
         # without symmetric memory: it uses ncclCommRegister rather than the more performant

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -18,11 +18,9 @@ from .checkpoint import load_checkpoint, save_checkpoint
 from .dbuffer import DBuffer
 from .fully_shard import Placements, fully_shard, fully_shard_context, microbatch
 from .optimizer import fully_shard_optimizer
-from .placement import Flat
 
 __all__ = [
     "DBuffer",
-    "Flat",
     "Placements",
     "fully_shard",
     "fully_shard_context",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -37,7 +37,8 @@ class Placements:
     """Per-data-parallel-axis placements for MFSDP buffers.
 
     ``dp_axes`` identifies the parent-mesh axes that form MFSDP's data-parallel
-    mesh. Placement sequences are ordered to match those axes.
+    mesh. Placement sequences are ordered to match those axes. Use Torch's
+    ``Shard(0)`` for public parameter, gradient, and optimizer sharding.
     """
 
     dp_axes: Sequence[MeshAxis]
@@ -198,7 +199,7 @@ def microbatch(context: FsdpContext, is_last: bool) -> Iterator[None]:
     """Mark an FSDP microbatch as the last accumulation microbatch.
 
     At present, this is only needed for HSDP/HFSDP gradient accumulation, so
-    FSDP finalizes gradients only on the last backward. Plain all-Flat data
+    FSDP finalizes gradients only on the last backward. Plain all-``Shard(0)`` data
     parallelism finalizes gradients on every backward and does not need it.
 
     Args:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -21,11 +21,13 @@ from weakref import ref
 import torch
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
+from .placement import Flat
 
 
 def _is_in_backward() -> bool:
@@ -186,22 +188,28 @@ class FsdpModule:
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
-        parameter_groups = [
-            FsdpParameterGroup(
-                owning_module=self,
-                parameters=group_parameters,
-                mesh=mesh,
-                model_weight_placements=model_weight_placements,
-                main_grad_placements=main_grad_placements,
-                main_weight_placements=main_weight_placements,
-                mixed_precision_policy=mixed_precision_policy,
-                allgather_stream=context.allgather_stream,
-                reduce_scatter_stream=context.reduce_scatter_stream,
-                grad_divisor=grad_divisor,
-                use_symmetric_memory=use_symmetric_memory,
+        parameter_groups = []
+        for group_parameters in _group_parameters(owned_parameters):
+            group_dtype = next(iter(group_parameters.values())).dtype
+            parameter_groups.append(
+                FsdpParameterGroup(
+                    owning_module=self,
+                    parameters=group_parameters,
+                    mesh=mesh,
+                    model_weight_placements=_specialize_placements(
+                        model_weight_placements, group_dtype
+                    ),
+                    main_grad_placements=_specialize_placements(main_grad_placements, group_dtype),
+                    main_weight_placements=_specialize_placements(
+                        main_weight_placements, group_dtype
+                    ),
+                    mixed_precision_policy=mixed_precision_policy,
+                    allgather_stream=context.allgather_stream,
+                    reduce_scatter_stream=context.reduce_scatter_stream,
+                    grad_divisor=grad_divisor,
+                    use_symmetric_memory=use_symmetric_memory,
+                )
             )
-            for group_parameters in _group_parameters(owned_parameters)
-        ]
         self._parameter_groups = tuple(parameter_groups)
         self._num_ready_grad_parameters = 0
         self._num_trainable_parameters = sum(
@@ -503,3 +511,22 @@ def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.
         key = (parameter.dtype, parameter.requires_grad)
         grouped.setdefault(key, {})[name] = parameter
     return [grouped[key] for key in grouped]
+
+
+def _specialize_placements(
+    placements: tuple[Placement, ...], dtype: torch.dtype
+) -> tuple[Placement, ...]:
+    """Specialize public placements for one homogeneous parameter group.
+
+    Today every parameter group maps Torch's user-facing ``Shard(0)`` to the
+    DBuffer-specific ``Flat`` format. This dtype-homogeneous group boundary is
+    where MXFP8 groups will instead select ``BlockAtomic``.
+    """
+    if dtype not in (torch.float32, torch.bfloat16, torch.float16):
+        raise NotImplementedError(f"Unsupported dtype: {dtype}.")
+    for placement in placements:
+        if type(placement) is Shard and placement.dim != 0:
+            raise NotImplementedError(
+                "MFSDP currently supports only dim-0 Shard placements, " f"got {placement!r}."
+            )
+    return tuple(Flat() if type(placement) is Shard else placement for placement in placements)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -9,9 +9,9 @@ import pytest
 import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -64,7 +64,7 @@ class TiedLM(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def _setup_nvtx_recording(monkeypatch: pytest.MonkeyPatch, events: list[NvtxEvent]) -> None:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_checkpoint.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_checkpoint.py
@@ -9,10 +9,9 @@ import torch
 from torch import nn
 from torch.distributed.checkpoint import FileSystemReader
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -36,7 +35,7 @@ class _TinyModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def test_post_wrap_assign_true_load_raises(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -6,9 +6,9 @@ import pytest
 import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -72,7 +72,7 @@ class NestedSiblingModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def test_child_then_parent_share_one_context(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py
@@ -9,9 +9,9 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -41,7 +41,7 @@ class NestedModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 # CUDA graph capture without symmetric memory is supported and runs by default. The symmetric

--- a/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel.py
@@ -23,9 +23,9 @@ import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -37,7 +37,9 @@ from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import MoETransformerLayer
 
-_FLAT_SHARD = Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+_FLAT_SHARD = Placements(
+    dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)]
+)
 
 
 def _transformer_config(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -9,12 +9,11 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import DTensor, Partial, Replicate
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.profiler import ProfilerActivity, profile
 from torch.utils.checkpoint import checkpoint
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -130,7 +129,7 @@ class NonLeafViewModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def _no_shard_placements() -> Placements:
@@ -141,36 +140,38 @@ def _no_shard_placements() -> Placements:
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Shard(0)]
     )
 
 
 def _zero2_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Replicate()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(
+        dp_axes=[0], parameter=[Replicate()], gradient=[Shard(0)], optimizer=[Shard(0)]
+    )
 
 
 def _hsdp_placements() -> Placements:
     """HSDP: params/optimizer replicated across DP-outer (axis 0), sharded within
-    DP-inner (axis 1). main_grad rests [Partial, Flat] between microbatches and is
-    all-reduced to [Replicate, Flat] on the last microbatch."""
+    DP-inner (axis 1). main_grad rests [Partial, Shard(0)] between microbatches and is
+    all-reduced to [Replicate, Shard(0)] on the last microbatch."""
     return Placements(
         dp_axes=[0, 1],
-        parameter=[Replicate(), Flat()],
-        gradient=[Partial("avg"), Flat()],
-        optimizer=[Replicate(), Flat()],
+        parameter=[Replicate(), Shard(0)],
+        gradient=[Partial("avg"), Shard(0)],
+        optimizer=[Replicate(), Shard(0)],
     )
 
 
 def _hfsdp_placements() -> Placements:
     """HFSDP: params replicated across DP-outer (axis 0) for compute but the
     optimizer sharded across it, all sharded within DP-inner (axis 1). main_grad
-    rests [Partial, Flat] between microbatches and is reduce-scattered to
-    [Flat, Flat] (the optimizer placement) on the last microbatch."""
+    rests [Partial, Shard(0)] between microbatches and is reduce-scattered to
+    [Shard(0), Shard(0)] (the optimizer placement) on the last microbatch."""
     return Placements(
         dp_axes=[0, 1],
-        parameter=[Replicate(), Flat()],
-        gradient=[Partial("avg"), Flat()],
-        optimizer=[Flat(), Flat()],
+        parameter=[Replicate(), Shard(0)],
+        gradient=[Partial("avg"), Shard(0)],
+        optimizer=[Shard(0), Shard(0)],
     )
 
 
@@ -371,8 +372,8 @@ def test_hfsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to
     Like HSDP, gradients reduce-scatter within DP-inner every backward and
     accumulate into main_grad. Unlike HSDP, the last-microbatch DP-outer reduction
     is a reduce-scatter (not an all-reduce) that finalizes main_grad to the
-    optimizer's [Flat, Flat] placement, shrinking the buffer; the next step's reset
-    therefore allocates a fresh [Partial, Flat] accumulation buffer. Every rank
+    optimizer's [Shard(0), Shard(0)] placement, shrinking the buffer; the next step's reset
+    therefore allocates a fresh [Partial, Shard(0)] accumulation buffer. Every rank
     sees identical data, so the averaged gradient equals the single-rank gradient
     and losses must match. Both ``zero_grad`` modes are covered.
     """
@@ -403,8 +404,8 @@ def test_hfsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to
         fully_shard(model, mesh=mesh, placements=_hfsdp_placements())
     baseline_optimizer = torch.optim.SGD(baseline.parameters(), lr=0.05)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
-    # HFSDP's optimizer placement [Flat, Flat] differs from the parameter placement
-    # [Replicate, Flat], so main_weight and model_weight are distinct buffers and the
+    # HFSDP's optimizer placement [Shard(0), Shard(0)] differs from the parameter placement
+    # [Replicate, Shard(0)], so main_weight and model_weight are distinct buffers and the
     # compute weight is stale until the step post-hook registered here refreshes it.
     # HSDP needs no wrapper: its two placements match, so the buffers alias.
     fully_shard_optimizer(optimizer)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -9,15 +9,15 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor import Partial, Replicate, Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
     fully_shard_optimizer,
 )
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import Flat
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
 logger = logging.getLogger(__name__)
@@ -52,17 +52,19 @@ class ElementwiseModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Shard(0)]
     )
 
 
 def _zero2_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Replicate()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(
+        dp_axes=[0], parameter=[Replicate()], gradient=[Shard(0)], optimizer=[Shard(0)]
+    )
 
 
 def _mb(num_bytes: int) -> str:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
@@ -6,10 +6,10 @@ import pytest
 import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
 from transformer_engine.pytorch.optimizers import FusedAdam
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -33,7 +33,7 @@ class TinyModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def test_adam_without_adapter_raises_precision_error(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -7,11 +7,10 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor import Partial, Replicate, Shard
 from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -42,17 +41,19 @@ class MultiChildModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 def _zero1_placements() -> Placements:
     return Placements(
-        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Flat()]
+        dp_axes=[0], parameter=[Replicate()], gradient=[Partial("avg")], optimizer=[Shard(0)]
     )
 
 
 def _zero2_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Replicate()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(
+        dp_axes=[0], parameter=[Replicate()], gradient=[Shard(0)], optimizer=[Shard(0)]
+    )
 
 
 # CPU ops that a device event chains up to via cpu_parent, used to attribute the device

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -7,11 +7,11 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.tensor import Shard
 from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp import MixedPrecisionPolicy
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
-    Flat,
     Placements,
     fully_shard,
     fully_shard_context,
@@ -43,7 +43,7 @@ class TinyModel(nn.Module):
 
 
 def _flat_placements() -> Placements:
-    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
 
 
 @pytest.mark.parametrize("num_microbatches", [1, 3])


### PR DESCRIPTION
## Summary

Make Torch `Shard(0)` the user-facing MFSDP sharding format. `FsdpParameterGroup` translates exact Torch `Shard(0)` placements to its internal `Flat` DBuffer representation, so DBuffer-specific storage semantics do not leak into the public API.

- remove `Flat` from the experimental package exports
- update MFSDP callers and tests to configure `Shard(0)` directly
- retain specialized shard subclasses for future per-parameter-group formats, including MXFP8 `BlockAtomic`

Related: #5615

## Testing

- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_memory.py` — 36 passed, 6 topology-dependent skips
- Black, isort, and `python -m compileall -q megatron/core/distributed/fsdp`
