### PR TITLE
[Main] Fix Numerical issue for GTP + Muon + MXFP8 param gather + use layerwise optimizer layout 

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -249,6 +249,34 @@ class DistributedDataParallelConfig:
     FSDP units, such as models with hybrid architectures (e.g. Mamba and MoE).
     """
 
+    @property
+    def param_sync_via_bucket_group(self) -> bool:
+        """Whether DP parameter synchronization is dispatched through DDP bucket groups.
+
+        ``True``:
+        ``_ParamAndGradBucketGroup.start_param_sync()`` is the collective entry point. This is
+        the standard DistributedOptimizer path. LayerWise also uses it when overlap needs
+        bucket-level prefetch, or when MXFP8 reuse needs ``bucket.grad_data`` as the gather
+        buffer. With overlap, the current bucket's forward pre-hook waits for its gather and
+        dispatches the next bucket's gather before computation starts, allowing communication
+        for the next bucket to overlap with the current computation.
+
+        ``False``:
+        DDP bucket groups do not launch parameter all-gather. Then either:
+
+        - No gather is needed because every DP rank runs the same optimizer update.
+        - Another component performs the gather. With ``LayerWiseDistributedOptimizer``, this
+          happens when ``use_layer_wise_param_layout=False``, parameter-gather overlap is disabled,
+          and MXFP8 grad-buffer reuse is disabled. Each rank updates only its assigned parameters,
+          then the optimizer calls ``allgather_params()`` synchronously after the step.
+        """
+        if self.use_distributed_optimizer:
+            return True
+
+        # When standard DistOpt is disabled, these flags select the legacy LayerWise
+        # bucket-group path: forward-scheduled overlap or synchronous grad-buffer reuse.
+        return self.overlap_param_gather or self.reuse_grad_buf_for_mxfp8_param_ag
+
     def __post_init__(self):
         import os
 

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -247,11 +247,7 @@ class _ParamAndGradBucketGroup:
         # LayerWise parameter sync can use this collective group without the distributed
         # optimizer: asynchronously when overlap is enabled, or synchronously when MXFP8 reuses
         # grad_data as its BF16 all-gather transport.
-        if (
-            self.ddp_config.use_distributed_optimizer
-            or self.ddp_config.overlap_param_gather
-            or self.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
-        ):
+        if self.ddp_config.param_sync_via_bucket_group:
             self.intra_distributed_optimizer_instance_group = collective_group
             self.intra_distributed_optimizer_instance_size = collective_group_size
             self.intra_distributed_optimizer_instance_rank = collective_group.rank()
@@ -440,13 +436,7 @@ class _ParamAndGradBucketGroup:
             force_sync (bool, optional): force synchronous collective regardless of
                 other settings if true.
         """
-        # overlap_param_gather covers the layer-wise optimizer case, which sets
-        # overlap_param_gather=True without use_distributed_optimizer.
-        assert (
-            self.ddp_config.use_distributed_optimizer
-            or self.ddp_config.overlap_param_gather
-            or self.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
-        )
+        assert self.ddp_config.param_sync_via_bucket_group
 
         if force_sync:
             if self.param_gather_handle is not None:

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -145,6 +145,49 @@ class _ParamAndGradBucket:
         self.layerwise_param_flat_sizes = None
         self.layerwise_gather_list = None
 
+    @torch.no_grad()
+    def _stage_layerwise_mxfp8_params(self, local_data_view: torch.Tensor, local_rank: int) -> None:
+        """Stage owner-rank LayerWise MXFP8 masters into the BF16 all-gather input.
+
+        LayerWise layouts keep each parameter wholly inside one data-parallel shard.
+        Unlike regular BF16 parameters, MXFP8 parameters retain TE-owned storage, so
+        updating ``param.data`` does not update this bucket's parameter buffer.
+        """
+        if not self.params_list or not getattr(
+            self.params_list[0], 'is_managed_by_layer_wise_optimizer', False
+        ):
+            return
+
+        local_shard_start = local_rank * local_data_view.numel()
+        local_shard_end = local_shard_start + local_data_view.numel()
+        for param in self.params_list:
+            if not (is_mxfp8tensor(param) or is_grouped_mxfp8tensor(param)):
+                continue
+
+            param_start, param_end = self.param_to_index[param]
+            if param_end <= local_shard_start or local_shard_end <= param_start:
+                continue
+            if not (local_shard_start <= param_start and param_end <= local_shard_end):
+                raise RuntimeError(
+                    "LayerWise MXFP8 parameter must be entirely inside its owner's DDP shard."
+                )
+
+            main_param = getattr(param, 'main_param', None)
+            if main_param is None:
+                raise RuntimeError(
+                    "The owner of a LayerWise MXFP8 parameter must have its FP32 main parameter."
+                )
+
+            param_slot = local_data_view[
+                param_start - local_shard_start : param_end - local_shard_start
+            ]
+            if param_slot.numel() != main_param.numel():
+                raise RuntimeError(
+                    "LayerWise MXFP8 master and DDP parameter slot must have equal size: "
+                    f"master={main_param.numel()}, slot={param_slot.numel()}."
+                )
+            param_slot.copy_(main_param.detach().reshape(-1))
+
     def set_layerwise_params_list(self, layerwise_params_list: List[List[torch.nn.Parameter]]):
         """Set per-rank parameter lists for layer-wise async all-gather.
 
@@ -201,9 +244,14 @@ class _ParamAndGradBucketGroup:
         self.buckets = buckets
         self.ddp_config = ddp_config
 
-        # overlap_param_gather covers the layer-wise optimizer case, which sets
-        # overlap_param_gather=True without use_distributed_optimizer.
-        if self.ddp_config.use_distributed_optimizer or self.ddp_config.overlap_param_gather:
+        # LayerWise parameter sync can use this collective group without the distributed
+        # optimizer: asynchronously when overlap is enabled, or synchronously when MXFP8 reuses
+        # grad_data as its BF16 all-gather transport.
+        if (
+            self.ddp_config.use_distributed_optimizer
+            or self.ddp_config.overlap_param_gather
+            or self.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
+        ):
             self.intra_distributed_optimizer_instance_group = collective_group
             self.intra_distributed_optimizer_instance_size = collective_group_size
             self.intra_distributed_optimizer_instance_rank = collective_group.rank()
@@ -394,7 +442,11 @@ class _ParamAndGradBucketGroup:
         """
         # overlap_param_gather covers the layer-wise optimizer case, which sets
         # overlap_param_gather=True without use_distributed_optimizer.
-        assert self.ddp_config.use_distributed_optimizer or self.ddp_config.overlap_param_gather
+        assert (
+            self.ddp_config.use_distributed_optimizer
+            or self.ddp_config.overlap_param_gather
+            or self.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
+        )
 
         if force_sync:
             if self.param_gather_handle is not None:
@@ -518,6 +570,10 @@ class _ParamAndGradBucketGroup:
                     local_data_view = self.cached_param_buffer_shard_list[idx][
                         self.intra_distributed_optimizer_instance_rank
                     ]
+                    if self.ddp_config.reuse_grad_buf_for_mxfp8_param_ag:
+                        bucket._stage_layerwise_mxfp8_params(
+                            local_data_view, self.intra_distributed_optimizer_instance_rank
+                        )
                     dist_all_gather_func(
                         bucket.param_data,
                         local_data_view,
@@ -1672,7 +1728,11 @@ def partition_buckets(
     CUDA_DEVICE_MAX_CONNECTIONS=1, having multiple back-to-back communications will prevent the
     overlap of communication kernels with computation kernels.
 
-    The grouping strategy is:
+    Before applying a grouping strategy that could merge buckets, buffers are partitioned by
+    optimizer ownership so a bucket group never mixes LayerWise-managed and
+    DistributedOptimizer-managed parameters.
+
+    The grouping strategy within each optimizer ownership partition is:
     1. If force_single_bucket_group is True, put all buckets across all buffers into a single
        bucket group.
     2. If force_single_bucket_group is False, when there is no fp8 buffer in the input buffers,
@@ -1691,18 +1751,56 @@ def partition_buckets(
 
     Args:
         buffers (list): list of input buffers.
-        single_bucket_group_per_buffer (bool, optional): force group all buckets in each buffer
-            into a single bucket group.
+        force_single_bucket_group (bool, optional): force all buckets with the same optimizer
+            ownership into a single bucket group.
+        reduce_scatter_with_fp32_accumulation (bool, optional): keep buckets separate when the
+            FP32-accumulating reduce-scatter implementation requires singleton groups.
     """
 
     if len(buffers) == 0:
         return []
 
+    # LayerWiseDistributedOptimizer and DistributedOptimizer classify a whole bucket group from
+    # its first bucket when synchronizing their subsets. Partition only when the policy below may
+    # merge owners (or when multiple owners each have an FP8 buffer); singleton paths retain their
+    # existing global bucket order for overlap linkage.
+    buffers_by_optimizer_owner = {}
+    num_fp8_buffers = 0
+    for buffer in buffers:
+        assert buffer.params
+        is_layerwise_owned = getattr(buffer.params[0], 'is_managed_by_layer_wise_optimizer', False)
+        assert all(
+            getattr(param, 'is_managed_by_layer_wise_optimizer', False) == is_layerwise_owned
+            for param in buffer.params
+        )
+        buffers_by_optimizer_owner.setdefault(is_layerwise_owned, []).append(buffer)
+        num_fp8_buffers += int(buffer.param_dtype == torch.uint8)
+
+    should_partition_by_owner = len(buffers_by_optimizer_owner) > 1 and (
+        force_single_bucket_group
+        or num_fp8_buffers > 1
+        or (num_fp8_buffers == 1 and not reduce_scatter_with_fp32_accumulation)
+    )
+    if should_partition_by_owner:
+        owner_buffer_partitions = list(buffers_by_optimizer_owner.values())
+        owner_buffer_partitions.sort(
+            key=lambda owner_buffers: not any(
+                buffer.param_dtype == torch.uint8 for buffer in owner_buffers
+            )
+        )
+        return [
+            bucket_group
+            for owner_buffers in owner_buffer_partitions
+            for bucket_group in partition_buckets(
+                owner_buffers,
+                force_single_bucket_group=force_single_bucket_group,
+                reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
+            )
+        ]
+
     # At most one fp8 (uint8) buffer is allowed; Cases 2 and 3 below branch on
     # whether one is present. Non-uint8 dtypes can legitimately appear in
-    # multiple buffers (e.g. LayerWise-managed bf16 weights + Adam-managed bf16
-    # biases share the bf16 ``param_dtype`` but live in separate buffers), so
-    # the uniqueness check is restricted to uint8.
+    # multiple buffers, so the uniqueness check is restricted to uint8.
     fp8_buffer = None
     for buffer in buffers:
         if buffer.param_dtype == torch.uint8:

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -585,13 +585,15 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
             if self.ddp_config is not None
             else config.overlap_param_gather
         )
-        if self.overlap_param_gather and not self.use_buffer_param_sync:
-            # Legacy path: set up per-bucket param lists for variable-size all-gather.
-            # When use_buffer_param_sync is True, the standard distributed optimizer
-            # all-gather path is used and this setup is not needed.
+        if not self.use_buffer_param_sync and (
+            self.overlap_param_gather or config.reuse_grad_buf_for_mxfp8_param_ag
+        ):
+            # Legacy bucket path: set up per-bucket param lists for variable-size all-gather.
+            # Overlap uses this from forward pre-hooks; synchronous MXFP8 reuse uses the same
+            # path during optimizer step so both modes stage FP32 masters into BF16 grad_data.
             assert (
                 model_chunks is not None
-            ), "model_chunks must be provided if overlap_param_gather is True"
+            ), "model_chunks must be provided for bucket-based LayerWise parameter sync"
             self.set_bucket_layerwise_params_list(model_chunks)
 
         if init_state_fn_list:
@@ -1005,14 +1007,10 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # All-gather updated params. If overlap_param_gather is True, the all-gather
         # is deferred to the forward pre-hooks via DDP bucket infrastructure.
         if not self.overlap_param_gather:
-            if self.use_buffer_param_sync:
-                # Model params are views into the DDP param buffer
-                # (ddp_config.use_distributed_optimizer=True). The optimizer step
-                # already copied updated fp32 main params → bf16 model params (=
-                # buffer views), so the buffer is up-to-date. Trigger the standard
-                # buffer all-gather, but only for LayerWise-managed bucket groups
-                # so a sibling DistributedOptimizer's own ``start_param_sync`` call
-                # is not duplicated for the same buckets.
+            if self.use_buffer_param_sync or self.config.reuse_grad_buf_for_mxfp8_param_ag:
+                # Full layouts use the standard DDP buffer all-gather. Legacy MXFP8 reuse uses
+                # the variable-size bucket path, which stages FP32 masters into BF16 grad_data.
+                # Both cases sync only the LayerWise-owned bucket groups.
                 self.start_param_sync_for_bucket_group_subset()
             else:
                 self.allgather_params()

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -585,10 +585,22 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
             if self.ddp_config is not None
             else config.overlap_param_gather
         )
-        if not self.use_buffer_param_sync and (
-            self.overlap_param_gather or config.reuse_grad_buf_for_mxfp8_param_ag
-        ):
-            # Legacy bucket path: set up per-bucket param lists for variable-size all-gather.
+        # Selects who executes LayerWise parameter synchronization. True means DDP bucket groups
+        # launch it: a full layout uses the fixed-size parameter buffer, while the variable-size
+        # path without a full layout uses grad_data. False means the optimizer calls
+        # allgather_params() synchronously after its step, using temporary flatten/receive buffers.
+        self.layerwise_param_sync_via_bucket_group = (
+            self.ddp_config.param_sync_via_bucket_group
+            if self.ddp_config is not None
+            else self.overlap_param_gather or config.reuse_grad_buf_for_mxfp8_param_ag
+        )
+
+        needs_variable_size_bucket_metadata = (
+            not self.use_buffer_param_sync and self.layerwise_param_sync_via_bucket_group
+        )
+        if needs_variable_size_bucket_metadata:
+            # With use_layer_wise_param_layout=False, set up per-bucket param lists for
+            # variable-size all-gather.
             # Overlap uses this from forward pre-hooks; synchronous MXFP8 reuse uses the same
             # path during optimizer step so both modes stage FP32 masters into BF16 grad_data.
             assert (
@@ -1007,9 +1019,9 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # All-gather updated params. If overlap_param_gather is True, the all-gather
         # is deferred to the forward pre-hooks via DDP bucket infrastructure.
         if not self.overlap_param_gather:
-            if self.use_buffer_param_sync or self.config.reuse_grad_buf_for_mxfp8_param_ag:
-                # Full layouts use the standard DDP buffer all-gather. Legacy MXFP8 reuse uses
-                # the variable-size bucket path, which stages FP32 masters into BF16 grad_data.
+            if self.layerwise_param_sync_via_bucket_group:
+                # Full layouts use the standard DDP buffer all-gather. With
+                # use_layer_wise_param_layout=False, the variable-size path uses grad_data.
                 # Both cases sync only the LayerWise-owned bucket groups.
                 self.start_param_sync_for_bucket_group_subset()
             else:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1008,8 +1008,30 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                         # float16 params:
                         if param.type() in ['torch.cuda.HalfTensor', 'torch.cuda.BFloat16Tensor']:
                             float16_params_this_group.append(param)
-                            # Create a copy
-                            main_param = param.detach().clone().float()
+                            # Native quantized parameters may retain their pre-quantization
+                            # BF16/FP16 initializer on CPU. Build the FP32 master from that value
+                            # so primary-weight and non-primary-weight runs start identically.
+                            # Falling back to the model parameter is correct for ordinary
+                            # BF16/FP16 parameters and older quantized-tensor implementations.
+                            get_high_precision_init_val = getattr(
+                                param, 'get_high_precision_init_val', None
+                            )
+                            high_precision_init_val = (
+                                get_high_precision_init_val()
+                                if get_high_precision_init_val is not None
+                                else None
+                            )
+                            if high_precision_init_val is not None:
+                                main_param = high_precision_init_val.to(
+                                    device=param.device, dtype=torch.float32, copy=True
+                                )
+                                clear_high_precision_init_val = getattr(
+                                    param, 'clear_high_precision_init_val', None
+                                )
+                                if clear_high_precision_init_val is not None:
+                                    clear_high_precision_init_val()
+                            else:
+                                main_param = param.detach().clone().float()
                             # Copy tensor model parallel attributes.
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
                             tensor_parallel.copy_gtp_attributes(main_param, param)

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1025,11 +1025,7 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                                 main_param = high_precision_init_val.to(
                                     device=param.device, dtype=torch.float32, copy=True
                                 )
-                                clear_high_precision_init_val = getattr(
-                                    param, 'clear_high_precision_init_val', None
-                                )
-                                if clear_high_precision_init_val is not None:
-                                    clear_high_precision_init_val()
+                                param.clear_high_precision_init_val()
                             else:
                                 main_param = param.detach().clone().float()
                             # Copy tensor model parallel attributes.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1743,6 +1743,13 @@ def validate_args(args, defaults={}):
         assert not args.use_megatron_fsdp, "Emerging optimizer does not support Megatron-FSDP for now."
         assert args.ckpt_format in ["torch", "torch_dist"], "Emerging optimizer supports torch and torch_dist checkpoint format."
 
+    assert not (
+        args.use_layer_wise_distributed_optimizer and args.moe_single_grouped_weight
+    ), (
+        "The LayerWise distributed optimizer does not support --moe-single-grouped-weight: "
+        "Muon semantics for a single grouped [E, N, K] expert weight are not defined. "
+        "Disable --moe-single-grouped-weight or use Adam/DistributedOptimizer."
+    )
 
     # Make sure all functionality that requires Gloo process groups is disabled.
     if not args.use_gloo_process_groups:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
@@ -9,6 +9,8 @@ under a non-``Test*`` alias so pytest doesn't re-collect it), flipping GTP on vi
 ``tensor_parallel_num_weight_shards`` (= tp x gtp_weight_remat_size).
 """
 
+import math
+
 import pytest
 import torch
 
@@ -17,6 +19,7 @@ from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
 if not HAVE_GTP:
     pytest.skip("GTP requires TransformerEngine >= 2.19", allow_module_level=True)
 
+from megatron.core.optimizer import HAVE_EMERGING_OPTIMIZERS
 from megatron.core.utils import is_te_min_version
 from megatron.training.utils import get_device_arch_version
 
@@ -24,6 +27,7 @@ from megatron.training.utils import get_device_arch_version
 # world/DP config + global-state pollution); reused by composition only.
 from tests.unit_tests.test_fp8_param import TestFP8Param as _FP8ParamHarness
 from tests.unit_tests.test_fp8_param import fp8_available, reason_for_no_fp8
+from tests.unit_tests.test_utilities import Utils
 
 
 class TestGTPFp8ParamGather:
@@ -133,6 +137,89 @@ class TestGTPFp8ParamGather:
                 f"GTP+mxfp8 MoE fp8-param-gather loss diverges from pure-BF16 GTP baseline "
                 f"(max per-step |diff|={diff:.4f}; fp8: {loss_fp8[0]:.3f}->{loss_fp8[-1]:.3f}, "
                 f"bf16: {loss_bf16[0]:.3f}->{loss_bf16[-1]:.3f})."
+            )
+        finally:
+            harness.teardown_method(None)
+            from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+                update_gtp_config,
+            )
+
+            update_gtp_config(pad_for_alignment=16, calculate_per_token_loss=False)
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.skipif(
+        get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
+    )
+    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
+    )
+    @pytest.mark.parametrize("overlap", [False, True])
+    def test_muon_layout_and_mxfp8_param_gather_parity(self, overlap):
+        """Padded LayerWise MXFP8 sync must match the legacy LayerWise path.
+
+        Both runs are configured with Muon, GTP2 x DP2, MXFP8 primary weights,
+        FP8 parameter gather, and grad-buffer reuse. The legacy LayerWise gather
+        is the oracle; the padded-layout run exercises the reused DDP grad buffer
+        and is the regression target. Overlap selects synchronous step-time gather
+        or asynchronous dispatch from the next forward pre-hook.
+        """
+        if Utils.world_size != 4:
+            pytest.skip("Requires exactly 4 torchrun ranks for GTP2 x DP2")
+
+        harness = _FP8ParamHarness()
+        harness.setup_method(None)
+        harness.seq_length = 64
+        harness.micro_batch_size = 1
+        try:
+            common = dict(
+                num_steps=12,
+                num_layers=1,
+                padded_vocab_size=512,
+                ffn_hidden_size=256,
+                global_batch_size=4,
+                optimizer="muon",
+                muon_scalar_optimizer="adam",
+                muon_momentum=0.9,
+                muon_scale_mode="spectral",
+                muon_num_ns_steps=5,
+                muon_coefficient_type="quintic",
+                muon_tp_mode="duplicated",
+                lr=1e-3,
+                clip_grad=0.0,
+                hidden_dropout=0.0,
+                attention_dropout=0.0,
+                tensor_parallel_num_weight_shards=2,
+                untie_embeddings_and_output_weights=True,
+                overlap_param_gather=overlap,
+                overlap_grad_reduce=overlap,
+            )
+
+            loss_legacy = harness._run_test_helper(
+                tp_size=1,
+                recipe="mxfp8",
+                fp8_param_gather=True,
+                use_layer_wise_param_layout=False,
+                **common,
+            )
+            loss_padded = harness._run_test_helper(
+                tp_size=1,
+                recipe="mxfp8",
+                fp8_param_gather=True,
+                use_layer_wise_param_layout=True,
+                **common,
+            )
+
+            max_diff = torch.tensor(float((loss_legacy - loss_padded).abs().max()), device="cuda")
+            # Compare the worst local GTP/DP trajectory, rather than rank 0 alone.
+            # Map local non-finite values before MAX so NCCL cannot hide a NaN from one rank.
+            max_diff.nan_to_num_(nan=float('inf'), posinf=float('inf'), neginf=float('inf'))
+            torch.distributed.all_reduce(max_diff, op=torch.distributed.ReduceOp.MAX)
+            diff = max_diff.item()
+            tolerance = 2e-3
+            assert math.isfinite(diff) and diff < tolerance, (
+                f"Padded LayerWise MXFP8 loss diverges from the legacy path "
+                f"(overlap={overlap}, max per-step |diff|={diff:.6f}, tolerance={tolerance})."
             )
         finally:
             harness.teardown_method(None)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
@@ -19,8 +19,27 @@ from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
 if not HAVE_GTP:
     pytest.skip("GTP requires TransformerEngine >= 2.19", allow_module_level=True)
 
+from megatron.core.fp8_utils import dequantize_fp8_tensor, is_mxfp8tensor
 from megatron.core.optimizer import HAVE_EMERGING_OPTIMIZERS
-from megatron.core.utils import is_te_min_version
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.optimizer.emerging_optimizers import _is_muon_excluded
+from megatron.core.optimizer.layer_wise_optimizer import (
+    LayerWiseDistributedOptimizer,
+    is_managed_by_layer_wise_optimizer,
+)
+from megatron.core.ssm.gated_delta_product import (
+    HAVE_EINOPS,
+    HAVE_FLA,
+    HAVE_MAMBA_SSM,
+    GatedDeltaProductMixer,
+    causal_conv1d_fn,
+    check_fla_sequence_packing_support,
+)
+from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+    dequantize_gtp_native_fp8,
+    is_gtp_param,
+)
+from megatron.core.utils import is_te_min_version, unwrap_model
 from megatron.training.utils import get_device_arch_version
 
 # Non-"Test*" alias so pytest does not re-collect the whole TestFP8Param suite here (wrong
@@ -29,9 +48,290 @@ from tests.unit_tests.test_fp8_param import TestFP8Param as _FP8ParamHarness
 from tests.unit_tests.test_fp8_param import fp8_available, reason_for_no_fp8
 from tests.unit_tests.test_utilities import Utils
 
+HAVE_FLA_SEQUENCE_PACKING, FLA_SEQUENCE_PACKING_REASON = check_fla_sequence_packing_support()
+HAVE_GDP_DEPS = all(
+    (HAVE_MAMBA_SSM, HAVE_EINOPS, HAVE_FLA, causal_conv1d_fn is not None, HAVE_FLA_SEQUENCE_PACKING)
+)
+
+
+def _gdp_moe_test_args(overlap, *, num_weight_shards):
+    """Return the shared real-GDP + grouped-MoE training configuration."""
+
+    return dict(
+        tp_size=1,
+        num_steps=4,
+        num_layers=2,
+        hybrid_layer_pattern="ME",
+        spec=["megatron.core.models.hybrid.hybrid_layer_specs", "gated_delta_product_stack_spec"],
+        position_embedding_type="none",
+        padded_vocab_size=512,
+        hidden_size=256,
+        num_attention_heads=8,
+        ffn_hidden_size=256,
+        normalization="RMSNorm",
+        # Keep d_inner=256 while making GDP's logical in-proj/dgrad K
+        # 4 * (d_inner + groups * state_dim + heads) = 2080, which is
+        # divisible by the MXFP8 block size (32). GTP storage remains padded when enabled.
+        mamba_num_heads=8,
+        mamba_head_dim=32,
+        mamba_num_groups=2,
+        mamba_state_dim=128,
+        gdp_num_householder=3,
+        gdp_cutedsl_kernel=False,
+        num_experts=2,
+        moe_grouped_gemm=True,
+        moe_single_grouped_weight=False,
+        moe_ffn_hidden_size=256,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        expert_tensor_parallel_num_weight_shards=1,
+        moe_token_dispatcher_type="alltoall",
+        moe_router_topk=2,
+        moe_router_pre_softmax=True,
+        moe_router_load_balancing_type="none",
+        moe_aux_loss_coeff=0.0,
+        add_bias_linear=False,
+        optimizer="muon",
+        muon_scalar_optimizer="adam",
+        muon_momentum=0.9,
+        muon_scale_mode="spectral",
+        muon_num_ns_steps=5,
+        muon_coefficient_type="quintic",
+        muon_tp_mode="duplicated",
+        lr=1e-3,
+        clip_grad=0.0,
+        global_batch_size=4,
+        tensor_parallel_num_weight_shards=num_weight_shards,
+        use_layer_wise_param_layout=True,
+        untie_embeddings_and_output_weights=True,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        overlap_param_gather=overlap,
+        overlap_grad_reduce=overlap,
+    )
+
+
+class _GDPAdamWMuonHarness(_FP8ParamHarness):
+    """Validate the real GDP-AdamW + MoE-Muon ownership and sync paths."""
+
+    @staticmethod
+    def _dequantize(param):
+        with torch.no_grad():
+            if is_mxfp8tensor(param):
+                if is_gtp_param(param):
+                    value = dequantize_gtp_native_fp8(param)
+                else:
+                    value = dequantize_fp8_tensor(param)
+            else:
+                value = param.float()
+            return value.detach().clone()
+
+    @staticmethod
+    def _find_buffer(model, param):
+        matches = [
+            buffer
+            for buffer in model.buffers + model.expert_parallel_buffers
+            if any(buffer_param is param for buffer_param in buffer.params)
+        ]
+        assert len(matches) == 1, f"Expected one DDP buffer for parameter, found {len(matches)}"
+        return matches[0]
+
+    def _on_model_built(self, model_chunks, optimizer, args):
+        assert args.use_layer_wise_param_layout
+        assert args.expert_gtp_weight_remat_size == 1
+        gtp_enabled = args.gtp_weight_remat_size > 1
+        native_mxfp8 = args.fp8_param_gather
+        assert args.fp8_recipe == "mxfp8"
+        assert args.fp8 is not None
+        if gtp_enabled:
+            assert native_mxfp8, "GTP with the MXFP8 recipe requires FP8 parameter gather"
+        if native_mxfp8:
+            assert args.reuse_grad_buf_for_mxfp8_param_ag
+        else:
+            assert not args.reuse_grad_buf_for_mxfp8_param_ag
+        assert args.muon_scalar_optimizer == "adam"
+        assert optimizer.config.decoupled_weight_decay, "Scalar Adam must use AdamW semantics"
+
+        model = model_chunks[0]
+        core_model = unwrap_model(model)
+        assert core_model.decoder.layer_type_list == ["M", "E"]
+
+        gdp_mixers = [
+            module for module in core_model.modules() if isinstance(module, GatedDeltaProductMixer)
+        ]
+        assert len(gdp_mixers) == 1, f"Expected one GDP mixer, found {len(gdp_mixers)}"
+        gdp = gdp_mixers[0]
+        in_proj_width = (1 + gdp.num_householder) * (
+            gdp.d_inner + gdp.ngroups * gdp.d_state + gdp.nheads
+        )
+        assert (
+            in_proj_width % 32 == 0
+        ), f"GDP in-proj width {in_proj_width} is incompatible with MXFP8's 32-element blocks"
+        in_proj = gdp.in_proj.weight
+        out_proj = gdp.out_proj.weight
+
+        named_params = dict(core_model.named_parameters())
+        expert_name = "decoder.layers.1.mlp.experts.linear_fc1.weight0"
+        assert expert_name in named_params, f"Missing grouped-MoE parameter {expert_name}"
+        expert_weight = named_params[expert_name]
+
+        # These are production attributes: the test does not inject optimizer routing.
+        assert getattr(in_proj, "use_muon", True) is False
+        assert _is_muon_excluded(in_proj)
+        assert not is_managed_by_layer_wise_optimizer(in_proj)
+        assert getattr(in_proj, "is_managed_by_layer_wise_optimizer", None) is False
+
+        for label, param in (("GDP out_proj", out_proj), ("MoE expert", expert_weight)):
+            assert not _is_muon_excluded(param), f"{label} must remain on Muon"
+            assert is_managed_by_layer_wise_optimizer(param)
+            assert getattr(param, "is_managed_by_layer_wise_optimizer", None) is True
+
+        assert is_gtp_param(in_proj) == gtp_enabled
+        assert is_gtp_param(out_proj) == gtp_enabled
+        assert not is_gtp_param(expert_weight)
+        assert getattr(expert_weight, "allreduce", True) is False
+        for label, param in (
+            ("GDP in_proj", in_proj),
+            ("GDP out_proj", out_proj),
+            ("MoE expert", expert_weight),
+        ):
+            assert (
+                is_mxfp8tensor(param) == native_mxfp8
+            ), f"{label} storage does not match fp8_param_gather={args.fp8_param_gather}"
+
+        layerwise_optimizers = [
+            child
+            for child in optimizer.chained_optimizers
+            if isinstance(child, LayerWiseDistributedOptimizer)
+        ]
+        distributed_optimizers = [
+            child
+            for child in optimizer.chained_optimizers
+            if isinstance(child, DistributedOptimizer)
+        ]
+        assert len(layerwise_optimizers) == 1
+        assert len(distributed_optimizers) == 1
+        layerwise_optimizer = layerwise_optimizers[0]
+        distributed_optimizer = distributed_optimizers[0]
+
+        assert any(
+            param is in_proj
+            for group in distributed_optimizer.model_float16_groups
+            for param in group
+        ), "GDP in_proj must be owned by the scalar AdamW DistributedOptimizer"
+        assert any(
+            param is out_proj
+            for owner_params in (layerwise_optimizer.dp_cp_params_list or [])
+            for param in owner_params
+        ), "GDP out_proj must be owned by LayerWise/Muon"
+        assert any(
+            param is expert_weight
+            for owner_params in (layerwise_optimizer.expt_dp_params_list or [])
+            for param in owner_params
+        ), "MoE expert weight must be owned by LayerWise/Muon"
+
+        in_proj_buffer = self._find_buffer(model, in_proj)
+        out_proj_buffer = self._find_buffer(model, out_proj)
+        expert_buffer = self._find_buffer(model, expert_weight)
+        expected_buffer_dtype = torch.uint8 if native_mxfp8 else torch.bfloat16
+        assert in_proj_buffer.param_dtype == expected_buffer_dtype
+        assert out_proj_buffer.param_dtype == expected_buffer_dtype
+        assert expert_buffer.param_dtype == expected_buffer_dtype
+        assert (
+            in_proj_buffer is not out_proj_buffer
+        ), "AdamW GDP in_proj and Muon GDP out_proj require distinct DDP buffers"
+        assert in_proj_buffer.data_parallel_group.size() == args.data_parallel_size
+        assert out_proj_buffer.data_parallel_group.size() == args.data_parallel_size
+        assert expert_buffer.data_parallel_group.size() == 2
+
+        # Subset sync classifies a whole bucket group from its first bucket, so mixed ownership is
+        # never legal. This is the invariant guarded by the partition_buckets change.
+        for bucket_group in model.bucket_groups + model.expert_parallel_bucket_groups:
+            owners = {
+                getattr(param, "is_managed_by_layer_wise_optimizer", False)
+                for bucket in bucket_group.buckets
+                for param in bucket.params
+            }
+            assert len(owners) == 1, f"Bucket group mixes optimizer ownership: {owners}"
+
+        in_proj_group_index, in_proj_group_order = (
+            distributed_optimizer.model_param_group_index_map[in_proj]
+        )
+        in_proj_main = distributed_optimizer.optimizer.param_groups[in_proj_group_index]["params"][
+            in_proj_group_order
+        ]
+
+        tracked = [
+            ("GDP in_proj", in_proj, in_proj_buffer),
+            ("GDP out_proj", out_proj, out_proj_buffer),
+            ("MoE expert", expert_weight, expert_buffer),
+        ]
+        self._tracked_params = [
+            (label, param, buffer, self._dequantize(param)) for label, param, buffer in tracked
+        ]
+        self._tracked_masters = [
+            ("GDP in_proj AdamW master", in_proj_main, in_proj_main.detach().clone())
+        ]
+        for label, param, _ in tracked[1:]:
+            main_param = getattr(param, "main_param", None)
+            if main_param is not None:
+                self._tracked_masters.append(
+                    (f"{label} Muon master", main_param, main_param.detach().clone())
+                )
+        self._runtime_validation_ran = False
+
+    def _on_forward_complete(self, model_chunks, optimizer, args, step, num_steps):
+        if args.overlap_param_gather:
+            hooks_enabled = bool(model_chunks[0].remove_forward_pre_hook_handles)
+            assert hooks_enabled == (step > 0), (
+                "Parameter-gather pre-hook lifecycle differs from production: "
+                f"step={step}, hooks_enabled={hooks_enabled}"
+            )
+
+        if step != num_steps - 1:
+            return
+
+        failures = []
+        for label, main_param, initial_main in self._tracked_masters:
+            if torch.equal(main_param, initial_main):
+                failures.append(f"{label} did not update")
+
+        for label, param, buffer, initial_value in self._tracked_params:
+            current_value = self._dequantize(param)
+            if not torch.isfinite(current_value).all():
+                failures.append(f"{label} contains NaN/Inf")
+            if torch.equal(current_value, initial_value):
+                failures.append(f"{label} forward weight did not update")
+
+            initial_norm = initial_value.float().norm()
+            current_norm = current_value.float().norm()
+            if not (current_norm > initial_norm * 0.1 and current_norm < initial_norm * 10.0):
+                failures.append(
+                    f"{label} norm changed implausibly: {initial_norm.item():.4f} -> "
+                    f"{current_norm.item():.4f}"
+                )
+
+            replicas = [
+                torch.empty_like(current_value) for _ in range(buffer.data_parallel_group.size())
+            ]
+            torch.distributed.all_gather(
+                replicas, current_value.contiguous(), group=buffer.data_parallel_group
+            )
+            if any(not torch.equal(replicas[0], replica) for replica in replicas[1:]):
+                failures.append(f"{label} differs across its data-parallel replicas")
+
+        # Make every rank fail together so teardown barriers cannot hang on a rank-local error.
+        failure_flag = torch.tensor(bool(failures), dtype=torch.int32, device="cuda")
+        torch.distributed.all_reduce(failure_flag, op=torch.distributed.ReduceOp.MAX)
+        if failure_flag.item():
+            if not failures:
+                failures.append("runtime validation failed on another rank")
+            raise AssertionError("; ".join(failures))
+        self._runtime_validation_ran = True
+
 
 class TestGTPFp8ParamGather:
-    """GTP weight-remat=2 loss-trajectory parity for the MXFP8 param-gather knobs."""
+    """MXFP8 parameter-gather tests, including GTP and exact same-recipe parity."""
 
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
@@ -154,6 +454,51 @@ class TestGTPFp8ParamGather:
     @pytest.mark.skipif(
         not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
     )
+    @pytest.mark.skipif(
+        not HAVE_GDP_DEPS,
+        reason=(
+            FLA_SEQUENCE_PACKING_REASON or "GDP requires mamba-ssm, einops, FLA, and causal-conv1d"
+        ),
+    )
+    @pytest.mark.parametrize("overlap", [False, True])
+    def test_gtp_gdp_adamw_moe_muon_mxfp8_sync(self, overlap):
+        """GTP2 GDP-AdamW + MoE-Muon MXFP8 weights must update and stay synchronized."""
+        if Utils.world_size != 4:
+            pytest.skip("Requires exactly 4 torchrun ranks for GTP2 x DP2 and EP2 x EDP2")
+
+        harness = _GDPAdamWMuonHarness()
+        harness.setup_method(None)
+        harness.seq_length = 128
+        harness.micro_batch_size = 1
+        try:
+            losses = harness._run_test_helper(
+                recipe="mxfp8",
+                fp8_param_gather=True,
+                **_gdp_moe_test_args(overlap, num_weight_shards=2),
+            )
+            assert harness._runtime_validation_ran
+
+            all_ranks_finite = torch.tensor(
+                int(torch.isfinite(losses).all().item()), dtype=torch.int32, device="cuda"
+            )
+            torch.distributed.all_reduce(all_ranks_finite, op=torch.distributed.ReduceOp.MIN)
+            assert all_ranks_finite.item(), f"GTP GDP+MoE loss contains NaN/Inf: {losses}"
+        finally:
+            harness.teardown_method(None)
+            from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+                update_gtp_config,
+            )
+
+            update_gtp_config(pad_for_alignment=16, calculate_per_token_loss=False)
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.skipif(
+        get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
+    )
+    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
+    )
     @pytest.mark.parametrize("overlap", [False, True])
     def test_muon_layout_and_mxfp8_param_gather_parity(self, overlap):
         """Padded LayerWise MXFP8 sync must match the legacy LayerWise path.
@@ -228,6 +573,97 @@ class TestGTPFp8ParamGather:
             )
 
             update_gtp_config(pad_for_alignment=16, calculate_per_token_loss=False)
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.skipif(
+        get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
+    )
+    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
+    )
+    @pytest.mark.skipif(
+        not HAVE_GDP_DEPS,
+        reason=(
+            FLA_SEQUENCE_PACKING_REASON or "GDP requires mamba-ssm, einops, FLA, and causal-conv1d"
+        ),
+    )
+    @pytest.mark.parametrize("overlap", [False, True])
+    def test_gdp_adamw_moe_muon_mxfp8_param_gather(self, overlap, monkeypatch):
+        """GDP-AdamW + MoE-Muon must agree with MXFP8 parameter gather ON and OFF.
+
+        ``ME`` builds a GDP mixer followed by a grouped-MoE layer. GDP itself marks its
+        ``in_proj.weight`` ``use_muon=False``, which routes it to scalar AdamW; GDP ``out_proj``
+        and the two-dimensional expert weights remain on LayerWise/Muon. The padded layout then
+        creates separate AdamW-owned and Muon-owned buffers. For each overlap mode, the native
+        MXFP8 parameter-gather/reuse trajectory must remain close to the same model using BF16
+        primary weights, while both runs use the same MXFP8 compute recipe. In particular, the
+        first post-update loss verifies that LayerWise/Muon initialized its FP32 masters from
+        TE's preserved high-precision values instead of dequantized MXFP8 weights.
+
+        Weight rematerialization is intentionally disabled: active GTP requires MXFP8 parameter
+        gather and cannot form this exact ON/OFF comparison. The original reused-grad-buffer bug
+        does not require GTP, and remains exercised by the ON leg's LayerWise DP all-gather.
+        """
+        if Utils.world_size != 4:
+            pytest.skip("Requires exactly 4 torchrun ranks for DP4 and EP2 x EDP2")
+
+        # GDP's channels-last causal-conv backward normally accumulates dweight with atomicAdd.
+        # Its launch-order-dependent rounding becomes visible when gradient reduce is overlapped,
+        # even between two otherwise identical BF16 runs. causal-conv1d 1.6.2 reads this switch on
+        # every backward and uses a deterministic workspace reduction, keeping this test focused
+        # on fp8-param-gather/reuse instead of an unrelated convolution-kernel scheduling effect.
+        monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
+
+        harness = _GDPAdamWMuonHarness()
+        harness.setup_method(None)
+        harness.seq_length = 128
+        harness.micro_batch_size = 1
+        try:
+            common = _gdp_moe_test_args(overlap, num_weight_shards=1)
+
+            loss_fp8_param_gather_on = harness._run_test_helper(
+                recipe="mxfp8", fp8_param_gather=True, **common
+            )
+            assert harness._runtime_validation_ran
+
+            loss_fp8_param_gather_off = harness._run_test_helper(
+                recipe="mxfp8", fp8_param_gather=False, **common
+            )
+            assert harness._runtime_validation_ran
+
+            local_trajectories = torch.stack(
+                (loss_fp8_param_gather_on, loss_fp8_param_gather_off)
+            ).cuda()
+            gathered_trajectories = [
+                torch.empty_like(local_trajectories)
+                for _ in range(torch.distributed.get_world_size())
+            ]
+            torch.distributed.all_gather(gathered_trajectories, local_trajectories)
+            trajectories = torch.stack(gathered_trajectories)
+            per_rank_step_diff = (trajectories[:, 0] - trajectories[:, 1]).abs()
+            per_rank_step_diff.nan_to_num_(
+                nan=float("inf"), posinf=float("inf"), neginf=float("inf")
+            )
+            atol = 1e-4
+            rtol = 1e-3
+            allowed_diff = atol + rtol * trajectories[:, 1].abs()
+            error_ratio = per_rank_step_diff / allowed_diff
+            error_ratio.nan_to_num_(nan=float("inf"), posinf=float("inf"), neginf=float("inf"))
+            worst_index = int(error_ratio.argmax().item())
+            worst_rank, worst_step = divmod(worst_index, per_rank_step_diff.shape[1])
+            diff = per_rank_step_diff[worst_rank, worst_step].item()
+            tolerance = allowed_diff[worst_rank, worst_step].item()
+            assert torch.isfinite(trajectories).all() and diff <= tolerance, (
+                "GDP-AdamW + MoE-Muon loss differs with MXFP8 parameter gather ON versus OFF "
+                f"(overlap={overlap}, |diff|={diff:.6f}, allowed={tolerance:.6f}, "
+                f"atol={atol}, rtol={rtol}, worst_rank={worst_rank}, "
+                f"worst_step={worst_step}; fp8-param-gather-ON: "
+                f"{trajectories[worst_rank, 0].tolist()}, fp8-param-gather-OFF: "
+                f"{trajectories[worst_rank, 1].tolist()})."
+            )
+        finally:
+            harness.teardown_method(None)
 
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
@@ -582,6 +582,104 @@ class TestGTPFp8ParamGather:
     @pytest.mark.skipif(
         not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
     )
+    def test_moe_grouped_tensor_op_fuser_layerwise_mxfp8_sync_parity(self, monkeypatch):
+        """Grouped-tensor op fuser must match regular TEGroupedMLP with LayerWise MXFP8 sync.
+
+        The reference disables grouped-tensor execution and the TE op fuser; the target enables
+        both. Everything else is identical: MXFP8 primary weights, parameter gather, grad-buffer
+        reuse, padded LayerWise layout, and overlap. The target therefore reaches
+        ``_stage_layerwise_mxfp8_params`` through the fused implementation's forwarded pre-hooks.
+        """
+        if Utils.world_size != 4:
+            pytest.skip("Requires exactly 4 torchrun ranks for EP2 x EDP2")
+
+        monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
+
+        harness = _FP8ParamHarness()
+        harness.setup_method(None)
+        harness.seq_length = 128
+        harness.micro_batch_size = 1
+        try:
+            common = dict(
+                tp_size=1,
+                num_steps=6,
+                num_layers=1,
+                padded_vocab_size=512,
+                hidden_size=256,
+                num_attention_heads=8,
+                ffn_hidden_size=256,
+                global_batch_size=4,
+                num_experts=2,
+                moe_grouped_gemm=True,
+                moe_single_grouped_weight=False,
+                moe_ffn_hidden_size=256,
+                expert_model_parallel_size=2,
+                expert_tensor_parallel_size=1,
+                expert_tensor_parallel_num_weight_shards=1,
+                moe_token_dispatcher_type="alltoall",
+                moe_router_topk=2,
+                moe_router_pre_softmax=True,
+                moe_router_load_balancing_type="none",
+                moe_aux_loss_coeff=0.0,
+                add_bias_linear=False,
+                optimizer="muon",
+                muon_scalar_optimizer="adam",
+                muon_momentum=0.9,
+                muon_scale_mode="spectral",
+                muon_num_ns_steps=5,
+                muon_coefficient_type="quintic",
+                muon_tp_mode="duplicated",
+                lr=1e-3,
+                clip_grad=0.0,
+                tensor_parallel_num_weight_shards=1,
+                use_layer_wise_param_layout=True,
+                untie_embeddings_and_output_weights=True,
+                hidden_dropout=0.0,
+                attention_dropout=0.0,
+                overlap_param_gather=True,
+                overlap_grad_reduce=True,
+            )
+
+            loss_reference = harness._run_test_helper(
+                recipe="mxfp8",
+                fp8_param_gather=True,
+                moe_use_grouped_tensor=False,
+                use_transformer_engine_op_fuser=False,
+                **common,
+            )
+
+            loss_target = harness._run_test_helper(
+                recipe="mxfp8",
+                fp8_param_gather=True,
+                moe_use_grouped_tensor=True,
+                use_transformer_engine_op_fuser=True,
+                **common,
+            )
+
+            local_trajectories = torch.stack((loss_target, loss_reference)).cuda()
+            gathered_trajectories = [
+                torch.empty_like(local_trajectories)
+                for _ in range(torch.distributed.get_world_size())
+            ]
+            torch.distributed.all_gather(gathered_trajectories, local_trajectories)
+            trajectories = torch.stack(gathered_trajectories)
+            torch.testing.assert_close(
+                trajectories[:, 0],
+                trajectories[:, 1],
+                atol=1e-4,
+                rtol=1e-3,
+            )
+        finally:
+            harness.teardown_method(None)
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.skipif(
+        get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
+    )
+    @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+    @pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="emerging-optimizers package is required"
+    )
     @pytest.mark.skipif(
         not HAVE_GDP_DEPS,
         reason=(

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
@@ -663,12 +663,7 @@ class TestGTPFp8ParamGather:
             ]
             torch.distributed.all_gather(gathered_trajectories, local_trajectories)
             trajectories = torch.stack(gathered_trajectories)
-            torch.testing.assert_close(
-                trajectories[:, 0],
-                trajectories[:, 1],
-                atol=1e-4,
-                rtol=1e-3,
-            )
+            torch.testing.assert_close(trajectories[:, 0], trajectories[:, 1], atol=1e-4, rtol=1e-3)
         finally:
             harness.teardown_method(None)
 

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -26,7 +26,12 @@ from megatron.training.global_vars import (
     set_args,
     set_global_variables,
 )
-from megatron.training.training import force_param_sync, get_model, setup_model_and_optimizer
+from megatron.training.training import (
+    force_param_sync,
+    get_model,
+    setup_model_and_optimizer,
+    should_disable_forward_pre_hook,
+)
 from megatron.training.utils import get_device_arch_version
 from tests.unit_tests.test_utilities import Utils
 
@@ -56,13 +61,6 @@ def disable_forward_pre_hook(model_chunks, param_sync=True):
     for model_chunk in model_chunks:
         assert isinstance(model_chunk, DDP)
         model_chunk.disable_forward_pre_hook(param_sync=param_sync)
-
-
-def should_disable_forward_pre_hook(args):
-    """Block forward pre-hook for certain configurations."""
-    return (
-        not args.use_megatron_fsdp and args.use_distributed_optimizer and args.overlap_param_gather
-    )
 
 
 class TestFP8Param:
@@ -108,6 +106,12 @@ class TestFP8Param:
             position_embedding_type=args.position_embedding_type,
             rotary_percent=args.rotary_percent,
         )
+
+    def _on_model_built(self, model_chunks, optimizer, args):
+        """Optional test hook after distributed model and optimizer construction."""
+
+    def _on_forward_complete(self, model_chunks, optimizer, args, step, num_steps):
+        """Optional test hook after a forward has consumed synchronized parameters."""
 
     def create_test_args(
         self,
@@ -248,9 +252,11 @@ class TestFP8Param:
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=tp_size,
             expert_model_parallel_size=args.expert_model_parallel_size,
+            expert_tensor_parallel_size=args.expert_tensor_parallel_size,
             # Enable GTP weight-remat when the test requested it (default 1 => no GTP, so
             # non-GTP fp8 tests are unaffected).
             gtp_remat_size=getattr(args, "gtp_weight_remat_size", 1),
+            expert_gtp_remat_size=getattr(args, "expert_gtp_weight_remat_size", 1),
         )
 
         input_ids, labels, position_ids, attention_mask, loss_mask = self.get_batch(
@@ -266,7 +272,8 @@ class TestFP8Param:
             use_cudagraphable_rng=args.cuda_graph_impl != "none",
             force_reset_rng=True,
         )
-        cfg_container = Utils.pretrain_config_from_global_args(args, "gpt")
+        model_class = "hybrid" if args.hybrid_layer_pattern is not None else "gpt"
+        cfg_container = Utils.pretrain_config_from_global_args(args, model_class)
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         if inference:
             model_cfg = cfg_container.model
@@ -291,6 +298,7 @@ class TestFP8Param:
                 "LayerWise test did not enter the requested parameter-layout path: "
                 f"requested={args.use_layer_wise_param_layout}, actual={has_param_layout}"
             )
+        self._on_model_built(gpt_model, optimizer, args)
 
         # Hard coded to use cuda_graph_impl="transformer_engine"
         cuda_graph_impl = "transformer_engine"
@@ -354,6 +362,17 @@ class TestFP8Param:
         loss_list = []
         eval_loss_list = []
 
+        # Production starts overlapped training with parameter-gather pre-hooks disabled: model
+        # initialization/checkpoint loading has already populated the forward weights, and the
+        # reused grad buffer must stay empty for the first backward. Enable the hooks only after
+        # the first successful optimizer step. CUDA-graph tests retain their existing capture-time
+        # hook lifecycle, which handles this transition separately.
+        first_iteration_pre_hook_disabled = (
+            not inference and not use_cuda_graph and should_disable_forward_pre_hook(args)
+        )
+        if first_iteration_pre_hook_disabled:
+            disable_forward_pre_hook(gpt_model, param_sync=False)
+
         # Optional: generate the sharded_state_dict (the checkpoint-save metadata path) at these
         # steps to catch save side-effects on the live weights — a correct save must not perturb
         # the subsequent training step (regression guard for GTP native-FP8 save corruption).
@@ -389,7 +408,14 @@ class TestFP8Param:
             # For the mxfp8_param with reuse_grad_buf_for_mxfp8_param_ag and dp_ag_overlap,
             # we need to call the _copy_main_params_to_param_buffer() after the grad buffer
             # is zeroed by zero_grad_buffer() because param and grad buffer are shared.
-            if args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather:
+            forward_pre_hook_enabled = bool(
+                getattr(gpt_model[0], 'remove_forward_pre_hook_handles', {})
+            )
+            if (
+                args.reuse_grad_buf_for_mxfp8_param_ag
+                and args.overlap_param_gather
+                and forward_pre_hook_enabled
+            ):
                 self.copy_main_params_to_param_buffer(gpt_model, optimizer)
 
             gpt_model[0].set_is_first_microbatch()
@@ -400,6 +426,7 @@ class TestFP8Param:
                 labels=labels,
                 loss_mask=loss_mask,
             )
+            self._on_forward_complete(gpt_model, optimizer, args, i, num_steps)
 
             # Check output shapes
             assert output.shape[0] == self.micro_batch_size
@@ -420,6 +447,10 @@ class TestFP8Param:
 
             update_successful, _, _ = optimizer.step()
             assert update_successful
+
+            if first_iteration_pre_hook_disabled:
+                enable_forward_pre_hook(gpt_model)
+                first_iteration_pre_hook_disabled = False
 
             loss_list.append(loss.item())
 

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -226,6 +226,7 @@ class TestFP8Param:
         # Test-only knob: not a model arg, so pop before create_test_args (which asserts every
         # kwarg is a real arg attribute).
         save_at_steps_kw = kwargs.pop("save_at_steps", ())
+        num_steps = kwargs.pop("num_steps", 100)
         args = self.create_test_args(
             tp_size,
             recipe,
@@ -275,6 +276,12 @@ class TestFP8Param:
                 pg_collection=pg_collection,
             )
         assert len(gpt_model) == 1  # Assume only one model in the model provider.
+        if getattr(args, "use_layer_wise_distributed_optimizer", False):
+            has_param_layout = getattr(gpt_model[0], "full_param_layout", None) is not None
+            assert has_param_layout == args.use_layer_wise_param_layout, (
+                "LayerWise test did not enter the requested parameter-layout path: "
+                f"requested={args.use_layer_wise_param_layout}, actual={has_param_layout}"
+            )
 
         # Hard coded to use cuda_graph_impl="transformer_engine"
         cuda_graph_impl = "transformer_engine"
@@ -343,7 +350,7 @@ class TestFP8Param:
         # the subsequent training step (regression guard for GTP native-FP8 save corruption).
         save_at_steps = set(save_at_steps_kw or ())
 
-        for i in range(100):
+        for i in range(num_steps):
             if not inference:
                 gpt_model[0].zero_grad_buffer()
                 optimizer.zero_grad()
@@ -532,6 +539,7 @@ class TestFP8Param:
         kwargs = {"overlap_param_gather": dp_overlap[0], "overlap_grad_reduce": dp_overlap[1]}
         self.run_test_with_cuda_graph(tp_size, "blockwise", **kwargs)
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
     )
@@ -546,6 +554,7 @@ class TestFP8Param:
         kwargs = {"overlap_param_gather": dp_overlap[0], "overlap_grad_reduce": dp_overlap[1]}
         self.run_test(tp_size=tp_size, recipe="mxfp8", **kwargs)
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
     )
@@ -561,7 +570,7 @@ class TestFP8Param:
             "overlap_param_gather": dp_overlap[0],
             "overlap_grad_reduce": dp_overlap[1],
             "num_layers": 4,
-            "vocal_size": 128800,
+            "padded_vocab_size": 128800,
             "hidden_size": 128,
             "num_attention_heads": 8,
             "expert_model_parallel_size": 2,
@@ -576,6 +585,7 @@ class TestFP8Param:
         }
         self.run_test(tp_size=tp_size, recipe="mxfp8", **kwargs)
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
     )
@@ -586,6 +596,7 @@ class TestFP8Param:
         kwargs = {"overlap_param_gather": True, "overlap_grad_reduce": True}
         self.run_test_with_eval_transition(tp_size=tp_size, recipe="mxfp8", **kwargs)
 
+    @pytest.mark.launch_on_gb200
     @pytest.mark.skipif(
         get_device_arch_version() < 10, reason="MXFP8 is supported since Blackwell architecture"
     )

--- a/tests/unit_tests/test_fp8_param.py
+++ b/tests/unit_tests/test_fp8_param.py
@@ -256,7 +256,16 @@ class TestFP8Param:
         input_ids, labels, position_ids, attention_mask, loss_mask = self.get_batch(
             self.seq_length, self.micro_batch_size
         )
-        model_parallel_cuda_manual_seed(_SEED)
+        # Mirror production RNG initialization. CUDA-graph validation enables the TE RNG
+        # tracker, whose graph-safe states must be torch.Generator objects rather than the
+        # Tensor states produced by the default MCore tracker. Each helper invocation may
+        # follow a test using a different tracker, so replace the process-global tracker.
+        model_parallel_cuda_manual_seed(
+            _SEED,
+            te_rng_tracker=args.te_rng_tracker,
+            use_cudagraphable_rng=args.cuda_graph_impl != "none",
+            force_reset_rng=True,
+        )
         cfg_container = Utils.pretrain_config_from_global_args(args, "gpt")
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         if inference:

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -547,6 +547,29 @@ class TestLayerWiseOptimizer:
 
         assert update_successful, "Optimizer step should be successful"
 
+    def test_bf16_wrapper_uses_preserved_high_precision_initializer(self):
+        """FP32 masters must not be initialized from an already-quantized model weight."""
+        model_param = torch.nn.Parameter(
+            torch.full((2, 2), -1.0, dtype=torch.bfloat16, device='cuda')
+        )
+        preserved_init = torch.full((2, 2), 1.25, dtype=torch.bfloat16)
+        init_state = {'value': preserved_init}
+        model_param.get_high_precision_init_val = lambda: init_state['value']
+        model_param.clear_high_precision_init_val = lambda: init_state.update(value=None)
+
+        base_optimizer = torch.optim.SGD([model_param], lr=0.1)
+        wrapped_optimizer = Float16OptimizerWithFloat16Params(
+            base_optimizer,
+            OptimizerConfig(optimizer='sgd', lr=0.1, bf16=True),
+            None,
+            lambda opt, config: None,
+        )
+
+        main_param = wrapped_optimizer.fp32_from_float16_groups[0][0]
+        torch.testing.assert_close(main_param, preserved_init.cuda().float(), rtol=0, atol=0)
+        assert init_state['value'] is None
+        assert model_param.main_param is main_param
+
     def test_bf16_error(self):
         """Test LayerWiseDistributedOptimizer raises error when receiving pre-wrapped Float16 optimizer."""
         model = SimpleModel().bfloat16().cuda()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

This PR fixed a numerical issue under the specific combination as shown in the title: GTP + Muon + MXFP8 param gather + use layerwise optimizer layout

The fix is simple, let `use_layer_wise_param_layout` for Muon layerwise optimizer respect `reuse_grad_buf_for_mxfp8_param_ag` and choose not to remap parameters into the flat DDP buffer and reuse the gradient buffer for AG. 

This bug also fixed the corner case where Muon + layerwise optimizer + mxfp8 primary weight used to only work with `--overlap-param-gather`, so we need to make sure overlap False also just works. 

**How `_stage_layerwise_mxfp8_params` works for distributed layerwise optimizer for muon**

```
1. Overlap ON

Optimizer step
└─ Update locally owned FP32 masters
   └─ Do not synchronize parameters yet                 # step_with_ready_grads

Next forward:

Bucket group N becomes needed                           # DDP forward pre-hook
├─ If not already dispatched:
│  ├─ Stage every bucket in group N                     # _stage_layerwise_mxfp8_params
│  └─ Launch asynchronous all-gather                    # dist_all_gather_func
├─ Wait for group N                                     # finish_param_sync
├─ Stage and launch group N+1
├─ Publish group N into TE MXFP8 storage                # _post_param_sync
└─ Compute with group N
       └─ overlaps with group N+1 all-gather
Forward pre-hooks and the next-group link progressively synchronize all bucket groups.


2. Overlap OFF

Optimizer step
├─ Update locally owned FP32 masters
└─ Iterate over every LayerWise-owned bucket group      # start_param_sync_for_bucket_group_subset
   ├─ Stage every bucket in the current group           # _stage_layerwise_mxfp8_params
   ├─ Run synchronous all-gather                        # dist_all_gather_func
   ├─ Publish gathered values into TE MXFP8 storage     # _post_param_sync
   └─ Continue with the next bucket group

All groups complete
└─ Optimizer step returns

Both modes synchronize every bucket group; 

overlap ON lets forward pre-hooks drive them incrementally, 

while overlap OFF must traverse all groups eagerly before the next forward begins.
```

Unit test:
```
torchrun --standalone --nproc-per-node=4 \
  --log-dir /tmp/gtp-test-logs \
  --redirects 3 --tee 0:3 \
  -m pytest -q --capture=fd \
  tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py
```

```
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_fp8_param_gather[tp_case0-dp_overlap0]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_fp8_param_gather[tp_case0-dp_overlap1]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_fp8_param_gather[tp_case1-dp_overlap0]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_fp8_param_gather[tp_case1-dp_overlap1]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_moe_fp8_param_gather
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_gdp_adamw_moe_muon_mxfp8_sync[False]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_gdp_adamw_moe_muon_mxfp8_sync[True]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_muon_layout_and_mxfp8_param_gather_parity[False]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_muon_layout_and_mxfp8_param_gather_parity[True]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_moe_grouped_tensor_op_fuser_layerwise_mxfp8_sync_parity
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gdp_adamw_moe_muon_mxfp8_param_gather[False]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gdp_adamw_moe_muon_mxfp8_param_gather[True]
[default0]:PASSED tests/unit_tests/generalized_tensor_parallel/test_gtp_fp8_param_gather.py::TestGTPFp8ParamGather::test_gtp_mxfp8_save_does_not_perturb_training
```

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
