### PR TITLE
Move stacked PR merge checks to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ test` can verify the pushed commit without manually specifying the SHA.
 Megatron Core engineers at NVIDIA should sign using their NVIDIA emails so they
 are automatically added to the right user groups on the internal Slack
 workspace.
+- For stacked PRs, use `pull-request/<base PR number>` as a dependent PR's
+  GitHub base/diffbase while the stack is under review. Before merging any base
+  PR, retarget every dependent PR to `main` and refresh its branch against
+  `origin/main`; otherwise GitHub may close dependents and discard their review
+  discussion or approvals.
 - Read @docs/developer/contribute.md for the full contribution policy, including code style, commit message conventions, and issue guidelines.
 
 ### Code Quality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,10 @@ test` can verify the pushed commit without manually specifying the SHA.
 Megatron Core engineers at NVIDIA should sign using their NVIDIA emails so they
 are automatically added to the right user groups on the internal Slack
 workspace.
-- For stacked PRs, use `pull-request/<base PR number>` as a dependent PR's
-  GitHub base/diffbase while the stack is under review. Before merging any base
-  PR, retarget every dependent PR to `main`; otherwise GitHub may close
-  dependents and discard their review discussion or approvals.
+- Before merging any PR, check for open PRs whose GitHub base/diffbase is
+  `pull-request/<this PR number>`. Retarget every such dependent PR to `main`
+  before merging; otherwise GitHub may close it and discard review discussion
+  or approvals.
 - Read @docs/developer/contribute.md for the full contribution policy, including code style, commit message conventions, and issue guidelines.
 
 ### Code Quality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,8 @@ are automatically added to the right user groups on the internal Slack
 workspace.
 - For stacked PRs, use `pull-request/<base PR number>` as a dependent PR's
   GitHub base/diffbase while the stack is under review. Before merging any base
-  PR, retarget every dependent PR to `main` and refresh its branch against
-  `origin/main`; otherwise GitHub may close dependents and discard their review
-  discussion or approvals.
+  PR, retarget every dependent PR to `main`; otherwise GitHub may close
+  dependents and discard their review discussion or approvals.
 - Read @docs/developer/contribute.md for the full contribution policy, including code style, commit message conventions, and issue guidelines.
 
 ### Code Quality

--- a/skills/mcore-split-pr/SKILL.md
+++ b/skills/mcore-split-pr/SKILL.md
@@ -28,6 +28,19 @@ workflow:
   separate PR just to reduce reviewer groups.
 - If PR B depends on symbols renamed in PR A, call out the dependency and put
   backward-compatible aliases, re-exports, or shims in PR A when needed.
+- [GitHub's standard stacked-PR flow](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/creating-stacked-pull-requests)
+  — push each branch to the upstream repo and base each PR on the previous
+  branch — does not work here: contributors cannot push branches to
+  `NVIDIA/Megatron-LM`, and a PR's base must be an upstream branch. The only
+  upstream refs containing a fork PR's commits are the `pull-request/<N>`
+  mirrors that copy-pr-bot creates, so stacking goes through them.
+- Create every PR with base `main`; the `pull-request/<N>` mirror refs do not
+  exist until a vetter comments `/ok to test <head-sha>` (copy-pr-bot). Once
+  the mirror exists, stack a dependent PR with
+  `gh pr edit <child> --base pull-request/<base PR number>`.
+- Never merge a PR while its base is a `pull-request/*` ref: the squash lands
+  in the bot's scratch ref, not `main`, and the PR ends up MERGED and
+  unreopenable. Retarget to `main` first.
 - Wait for user approval before execution.
 - Execution creates draft PRs from the right base, applies file-scoped diffs
   with `git diff upstream/main..<source-branch> -- <paths> | git apply`, pushes

--- a/skills/mcore-split-pr/SKILL.md
+++ b/skills/mcore-split-pr/SKILL.md
@@ -28,24 +28,6 @@ workflow:
   separate PR just to reduce reviewer groups.
 - If PR B depends on symbols renamed in PR A, call out the dependency and put
   backward-compatible aliases, re-exports, or shims in PR A when needed.
-- [GitHub's standard stacked-PR flow](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/creating-stacked-pull-requests)
-  — push each branch to the upstream repo and base each PR on the previous
-  branch — does not work here: contributors cannot push branches to
-  `NVIDIA/Megatron-LM`, and a PR's base must be an upstream branch. The only
-  upstream refs containing a fork PR's commits are the `pull-request/<N>`
-  mirrors that copy-pr-bot creates, so stacking goes through them.
-- Create every PR with base `main`; the `pull-request/<N>` mirror refs do not
-  exist until a vetter comments `/ok to test <head-sha>` (copy-pr-bot). Once
-  the mirror exists, stack a dependent PR with
-  `gh pr edit <child> --base pull-request/<base PR number>`.
-- Never merge a PR while its base is a `pull-request/*` ref: the squash lands
-  in the bot's scratch ref, not `main`, and the PR ends up MERGED and
-  unreopenable. Retarget to `main` first.
-- Retarget each dependent PR back to `main` as soon as its base PR is
-  approved: copy-pr-bot deletes `pull-request/<N>` when PR N merges or
-  closes, and GitHub then auto-closes (unreopenably) every PR based on that
-  ref. After the base PR squash-merges, rebase dependents onto the new `main`
-  and force-push.
 - Wait for user approval before execution.
 - Execution creates draft PRs from the right base, applies file-scoped diffs
   with `git diff upstream/main..<source-branch> -- <paths> | git apply`, pushes
@@ -86,7 +68,7 @@ For each new PR:
 1. Create a new branch from the appropriate local base (`main`, or a dependency PR's branch).
 2. Extract the relevant changes: `git diff upstream/main..<source-branch> -- <file paths> | git apply`.
 3. Stage, commit with a clear message, and push to the user's fork.
-4. Create the PR as a **draft** with base `main` (per repo contributing guidelines). Retarget dependent PRs to `pull-request/<base PR number>` only after a vetter's `/ok to test` has created that mirror ref.
+4. Create the PR as a **draft** (per repo contributing guidelines).
 5. If the original PR needs to be narrowed in scope, confirm with the user before force-pushing.
 6. Report all PR URLs when done.
 

--- a/skills/mcore-split-pr/SKILL.md
+++ b/skills/mcore-split-pr/SKILL.md
@@ -81,7 +81,7 @@ For each new PR:
 1. Create a new branch from the appropriate local base (`main`, or a dependency PR's branch).
 2. Extract the relevant changes: `git diff upstream/main..<source-branch> -- <file paths> | git apply`.
 3. Stage, commit with a clear message, and push to the user's fork.
-4. Create the PR as a **draft** (per repo contributing guidelines).
+4. Create the PR as a **draft** with base `main` (per repo contributing guidelines). Retarget dependent PRs to `pull-request/<base PR number>` only after a vetter's `/ok to test` has created that mirror ref.
 5. If the original PR needs to be narrowed in scope, confirm with the user before force-pushing.
 6. Report all PR URLs when done.
 


### PR DESCRIPTION
## What

Add the stacked-PR merge-time dependency check to always-loaded `AGENTS.md`. Keep the split-specific construction details in `mcore-split-pr`.

## Why

The split-PR skill is not necessarily loaded when merging an ordinary PR. Before merging any PR, agents must check for dependents whose diffbase is `pull-request/<this PR number>` and retarget them to `main` first, preventing GitHub from closing the dependents and losing review discussion or approvals.

## Validation

- `git diff --check`