### PR TITLE
Add megatron/core/ops: an implementation home for kernel backends

### DIFF
--- a/megatron/core/inference/ops/__init__.py
+++ b/megatron/core/inference/ops/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Inference-optimized operation backends.
+
+These fill the same slots as any other backend and are selected the same way, by
+``--transformer-impl inference_optimized`` or ``--op-backend``. They live here rather than
+under ``megatron/core/ops`` so the inference-only implementations stay with the rest of the
+inference subsystem; ``megatron.core.ops.<family>.BACKENDS`` points at them by name.
+"""
+
+from megatron.core.inference.ops.backends import LinearInference, MoeInference, NormInference
+
+__all__ = ["LinearInference", "MoeInference", "NormInference"]

--- a/megatron/core/inference/ops/backends.py
+++ b/megatron/core/inference/ops/backends.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The inference-optimized backend for each operation family."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.mlp import TEActivationFunctionBuilder
+    from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
+
+__all__ = ["LinearInference", "MoeInference", "NormInference"]
+
+
+class NormInference:
+    """Transformer Engine's norm, never fusing the residual.
+
+    Inference layers manage the residual themselves, so folding it into the norm would apply
+    it twice. Composed rather than subclassed, and imported inside the method, so this module
+    has no import-time dependency on ``megatron.core.ops`` -- which would be a cycle, since
+    ``ops.norm`` names this class in its backend table.
+    """
+
+    #: Defers to the Transformer Engine norm, which is not audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def layer_norm(self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False):
+        """Transformer Engine's choice, with residual fusion always declined."""
+        from megatron.core.ops.norm.backends import NormTE
+
+        del has_residual
+        return NormTE().layer_norm(rms_norm=rms_norm, for_qk=for_qk, has_residual=False)
+
+
+class LinearInference:
+    """The inference-optimized linear layers."""
+
+    #: Not audited.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def linear(self) -> type:
+        """Inference reuses the Transformer Engine non-parallel linear."""
+        from megatron.core.extensions.transformer_engine import TELinear
+
+        return TELinear
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.inference_layers import InferenceColumnParallelLinear
+
+        return InferenceColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.inference_layers import InferenceRowParallelLinear
+
+        return InferenceRowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Which module fuses layernorm and column parallel linear."""
+        from megatron.core.tensor_parallel.inference_layers import (
+            InferenceLayerNormColumnParallelLinear,
+        )
+
+        return InferenceLayerNormColumnParallelLinear
+
+
+class MoeInference:
+    """The inference-optimized experts and router."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Inference always uses grouped experts."""
+        del moe_use_grouped_gemm
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelGroupedLinear,
+            TERowParallelGroupedLinear,
+        )
+        from megatron.core.transformer.moe.experts import GroupedMLPSubmodules, InferenceGroupedMLP
+
+        return partial(
+            InferenceGroupedMLP,
+            submodules=GroupedMLPSubmodules(
+                linear_fc1=TEColumnParallelGroupedLinear,
+                linear_fc2=TERowParallelGroupedLinear,
+                activation_func=self.activation_func(),
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Which module to use for activation function."""
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        return cast("TEActivationFunctionBuilder", TEActivationOp)
+
+    def moe_router(self) -> Optional[type]:
+        """Inference needs compact [tokens, topk] index routing rather than a dense map."""
+        from megatron.core.transformer.moe.router import InferenceTopKRouter
+
+        return InferenceTopKRouter

--- a/megatron/core/ops/README.md
+++ b/megatron/core/ops/README.md
@@ -1,0 +1,83 @@
+# `megatron/core/ops`
+
+Where the implementation of every operation lives, organized by operation.
+
+This is an implementation home, **not** a selection layer. There is no registry and no
+resolver here, and nothing in this package decides which backend a run gets. That decision
+belongs to the `BackendSpecProvider` implementations:
+
+| provider | lives in |
+| --- | --- |
+| `LocalSpecProvider`, `InferenceSpecProvider` | `megatron/core/models/backends.py` |
+| `TESpecProvider`, `KitchenSpecProvider` | `megatron/core/extensions/transformer_engine_spec_provider.py` |
+
+## Layout
+
+Two files per family:
+
+```
+<family>/__init__.py    the contract every backend for this family must meet
+<family>/backends.py    the backends themselves, side by side
+```
+
+Backends are named for the family and the implementation — `NormTE`, `NormApex`, `NormTorch`,
+`LinearTE`, `MoeLocal` — so the class name alone says what it is.
+
+They sit side by side in one file on purpose: a family's backends answer the same question and
+are read by comparison. Splitting them one-per-file would also mean importing one imports its
+optional package, which is the thing this package exists to avoid.
+
+## The one rule
+
+**Every optional-package import goes inside the method that returns its target**, never at
+module scope:
+
+```python
+class NormTE:
+    REQUIRES = "transformer_engine"
+    DETERMINISM = "unknown"
+
+    def layer_norm(self, rms_norm=False, for_qk=False, has_residual=False):
+        from megatron.core.extensions.transformer_engine import TENorm   # here, not above
+        return TENorm
+```
+
+So importing `megatron.core.ops` pulls in no optional dependency and no backend nobody
+selected. `tests/unit_tests/ops/test_import_hygiene.py` pins it.
+
+That is what lets a provider name a backend without the *call site* having to guard on whether
+it is installed — which is what the scattered `HAVE_TE` / `HAVE_APEX` flags were doing.
+
+## Tracing which implementation a run gets
+
+Open the provider. `TESpecProvider.layer_norm` names `NormTE`; `NormTE.layer_norm` names
+`TENorm`. Two hops, no globals, no dependence on import order or on what happens to be
+installed.
+
+## Adding a backend
+
+Say you want Liger's RMSNorm.
+
+1. Add a class to `norm/backends.py`, meeting the contract in `norm/__init__.py`:
+
+   ```python
+   class NormLiger:
+       """Liger's fused RMSNorm."""
+
+       REQUIRES = "liger_kernel"
+       DETERMINISM = "unknown"
+
+       def layer_norm(self, rms_norm=False, for_qk=False, has_residual=False):
+           if not rms_norm:
+               raise ValueError("The liger backend implements RMSNorm only")
+           from liger_kernel.ops.rms_norm import LigerRMSNorm
+
+           return LigerRMSNorm
+   ```
+
+2. Have a provider return it — either a new provider, or an existing one under a flag.
+
+`REQUIRES` and `DETERMINISM` are declarations a provider can check at construction:
+`REQUIRES` names the optional package, optionally with a version (`"transformer_engine>=1.13"`);
+`DETERMINISM` is `deterministic`, `nondeterministic`, or `unknown`, so that "nobody audited
+this" cannot read as "safe" under `--deterministic-mode`.

--- a/megatron/core/ops/__init__.py
+++ b/megatron/core/ops/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Where the implementation of every operation lives, organized by operation.
+
+This package is an implementation home, not a selection layer. It holds no registry and no
+resolver, and nothing here decides which backend a run gets -- that is the job of the
+``BackendSpecProvider`` implementations in :mod:`megatron.core.models.backends` and
+:mod:`megatron.core.extensions.transformer_engine_spec_provider`, which import their targets
+from here.
+
+Two files per family::
+
+    <family>/__init__.py    the contract every backend for this family must meet
+    <family>/backends.py    the backends themselves, side by side
+
+Every optional-package import lives *inside* the method that returns its target, so importing
+this package pulls in no optional dependency and no backend that nobody selected. That is what
+lets a provider name a backend without the call site having to guard on whether it is
+installed, which is what the scattered ``HAVE_*`` flags used to do.
+
+See ``megatron/core/ops/README.md``.
+"""
+
+from megatron.core.ops._availability import installed_version, is_installed, require
+
+__all__ = ["installed_version", "is_installed", "require"]

--- a/megatron/core/ops/_availability.py
+++ b/megatron/core/ops/_availability.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Optional-dependency checks for operation backends.
+
+Backends state their requirements here instead of setting a module-level ``HAVE_*`` flag.
+Two rules keep the failure modes distinct:
+
+* An optional dependency that is *not installed* is a normal, silent absence. Only a backend
+  that was explicitly selected turns that into an error, and it does so while the model is
+  being built, not at import time.
+* An optional dependency that is installed but *broken* (a missing transitive library, a
+  failed native loader) is always reported. Treating it as "not installed" is how a broken
+  install silently becomes a slow fallback.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+from functools import lru_cache
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+
+@lru_cache(maxsize=None)
+def _import_outcome(module_name: str) -> tuple[ModuleType | None, BaseException | None, bool]:
+    """Import ``module_name`` once. Returns (module, error, is_absent)."""
+    try:
+        return importlib.import_module(module_name), None, False
+    except ModuleNotFoundError as error:
+        # `error.name` distinguishes "this package is absent" from "this package is present
+        # but one of its own imports is not".
+        absent = error.name in {module_name, module_name.split(".", maxsplit=1)[0]}
+        return None, error, absent
+    except Exception as error:  # pylint: disable=broad-except
+        return None, error, False
+
+
+def is_installed(module_name: str) -> bool:
+    """Whether an optional dependency is importable, without raising if it is absent."""
+    module, _, absent = _import_outcome(module_name)
+    if module is not None:
+        return True
+    if absent:
+        return False
+    raise ImportError(f"Optional dependency '{module_name}' is installed but failed to import.")
+
+
+def require(module_name: str) -> ModuleType:
+    """Return a selected dependency, or explain what is wrong with it.
+
+    Callers that know which backend asked should catch this and add that context;
+    :mod:`megatron.core.ops.resolve` does exactly that, from its backend table.
+    """
+    module, error, absent = _import_outcome(module_name)
+    if module is not None:
+        return module
+    reason = "is not installed" if absent else "failed to import"
+    raise ImportError(f"'{module_name}' {reason}.") from error
+
+
+def installed_version(module_name: str) -> "Version | None":
+    """The installed version of an optional dependency, or None if it cannot be determined.
+
+    Transformer Engine is asked through Megatron's own resolver, which already handles its
+    module-versus-distribution naming and its dev suffixes; duplicating that here is how the
+    two would drift. Anything else comes from package metadata.
+    """
+    from packaging.version import Version
+
+    if module_name == "transformer_engine":
+        from megatron.core.utils import get_te_version
+
+        return get_te_version()
+    try:
+        return Version(importlib.metadata.version(module_name))
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def reset_cache() -> None:
+    """Clear cached import outcomes. Intended for tests only."""
+    _import_outcome.cache_clear()

--- a/megatron/core/ops/attention/__init__.py
+++ b/megatron/core/ops/attention/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Core attention: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract**
+
+* **Target**: a class the attention module constructs with Megatron's core-attention
+  signature, taking the layer number, attention mask type, and CP communication type.
+* **State**: none beyond what the target itself allocates. Q/K/V projections and the output
+  projection stay with the attention module, not with this target.
+* **Process groups**: the target owns context-parallel communication using the CP group and
+  communication type the attention module passes in. Tensor-parallel splitting of heads is
+  done by the projections, not here.
+* **Modes**: backends differ on packed and variable-length input, decode, and quantization.
+  Transformer Engine selects flash, fused, or unfused internally; Megatron does not add a
+  second attention dispatcher on top of it.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.attention.backends import AttentionLocal, AttentionTE
+
+__all__ = ["AttentionLocal", "AttentionTE"]

--- a/megatron/core/ops/attention/backends.py
+++ b/megatron/core/ops/attention/backends.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every core-attention backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["AttentionLocal", "AttentionTE"]
+
+
+class AttentionLocal:
+    """Megatron Core's own dot-product attention."""
+
+    #: Not audited.
+    DETERMINISM = "unknown"
+
+    def core_attention(self) -> type:
+        """Which module to use for attention."""
+        from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+        return DotProductAttention
+
+
+class AttentionTE:
+    """Transformer Engine's fused attention.
+
+    TE chooses flash, fused, or unfused internally from the shapes and environment it is
+    given. Megatron does not copy that decision here.
+    """
+
+    #: TE refuses to run under deterministic_mode unless NVTE_ALLOW_NONDETERMINISTIC_ALGO=0,
+    #: which is one of the env defaults that mode sets. See extensions/transformer_engine.py.
+    DETERMINISM = "deterministic"
+
+    REQUIRES = "transformer_engine"
+
+    def core_attention(self) -> type:
+        """Which module to use for attention."""
+        from megatron.core.extensions.transformer_engine import TEDotProductAttention
+
+        return TEDotProductAttention

--- a/megatron/core/ops/linear/__init__.py
+++ b/megatron/core/ops/linear/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Linear layers: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract**
+
+* **Targets**: classes the owning module constructs with Megatron's linear signature.
+  ``column_parallel_layer_norm_linear`` returns ``None`` when the backend does not fuse the
+  preceding norm into the projection.
+* **State**: each target owns its weight and optional bias; the fused variant additionally owns
+  the norm weight under ``layer_norm_weight``. Fused and unfused targets therefore have
+  different state dicts, which is why the layer spec, not the backend, decides which is used.
+* **Process groups**: the target owns the tensor-parallel collectives for its own weights,
+  using the group the owning module passes in. Nothing here creates a group.
+* **Modes**: every backend supports training, backward, and inference. Only Transformer Engine
+  and Kitchen support quantized execution.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.linear.backends import LinearLocal, LinearTE
+
+__all__ = ["LinearLocal", "LinearTE"]

--- a/megatron/core/ops/linear/backends.py
+++ b/megatron/core/ops/linear/backends.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every linear backend, side by side. The contract they meet is in this package's ``__init__``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["LinearLocal", "LinearTE"]
+
+
+class LinearLocal:
+    """The tensor-parallel linear layers in ``megatron.core.tensor_parallel``."""
+
+    #: Not audited; the TP collectives depend on NCCL_ALGO.
+    DETERMINISM = "unknown"
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+        return ColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.tensor_parallel.layers import RowParallelLinear
+
+        return RowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Megatron Core has no fused layernorm plus linear module."""
+        return None
+
+
+class LinearTE:
+    """Transformer Engine's linear layers."""
+
+    #: Not audited; the TP collectives depend on NCCL_ALGO.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def linear(self) -> type:
+        """Which non-parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TELinear
+
+        return TELinear
+
+    def column_parallel_linear(self) -> type:
+        """Which column parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TEColumnParallelLinear
+
+        return TEColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        from megatron.core.extensions.transformer_engine import TERowParallelLinear
+
+        return TERowParallelLinear
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        """Which module fuses layernorm and column parallel linear."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        return TELayerNormColumnParallelLinear

--- a/megatron/core/ops/loss/__init__.py
+++ b/megatron/core/ops/loss/__init__.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Loss: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract for vocab-parallel cross entropy**
+
+* **Target**: ``loss = target(logits, labels, tp_group)``.
+* **Layout**: ``logits`` are ``[s, b, vocab / tp]`` and ``labels`` are ``[s, b]``, already
+  transposed by the caller. The returned loss is ``[s, b]``.
+* **State**: none. The target holds no parameters and no cache. It does, however, *consume*
+  ``logits``: every target subtracts the row max and exponentiates in place to save memory,
+  and the up-cast that would otherwise copy is a no-op when ``logits`` is already float32. A
+  caller that needs ``logits`` afterwards has to pass a clone.
+* **Process groups**: the target owns every reduction over ``tp_group``. The caller performs
+  no collectives, so backends are free to fuse the reduction into their kernel. ``tp_group``
+  may be ``None``, meaning the default tensor-parallel group; targets whose kernel cannot take
+  ``None`` fill it in themselves rather than pushing that onto the caller.
+* **Modes**: every backend supports training and backward. Only the Transformer Engine target
+  supports capture under a full-iteration CUDA graph, and only from TE 2.7.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.loss.backends import (
+    LossMegatron,
+    LossMegatronFused,
+    LossTEFused,
+    fused_vocab_parallel_cross_entropy,
+    vocab_parallel_cross_entropy,
+)
+
+__all__ = [
+    "LossMegatron",
+    "LossMegatronFused",
+    "LossTEFused",
+    "fused_vocab_parallel_cross_entropy",
+    "vocab_parallel_cross_entropy",
+]

--- a/megatron/core/ops/loss/backends.py
+++ b/megatron/core/ops/loss/backends.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every vocab-parallel cross entropy backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import torch
+
+from megatron.core.fusions.fused_cross_entropy import (
+    fused_vocab_parallel_cross_entropy as _megatron_fused_kernel,
+)
+from megatron.core.tensor_parallel.cross_entropy import (
+    vocab_parallel_cross_entropy as _megatron_kernel,
+)
+
+__all__ = [
+    "LossMegatron",
+    "LossMegatronFused",
+    "LossTEFused",
+    "fused_vocab_parallel_cross_entropy",
+    "vocab_parallel_cross_entropy",
+]
+
+
+def _default_tp_group(tp_group):
+    """Fill in the default tensor-parallel group for kernels that cannot take ``None``."""
+    if tp_group is not None:
+        return tp_group
+    from megatron.core.parallel_state import get_tensor_model_parallel_group
+
+    return get_tensor_model_parallel_group()
+
+
+def vocab_parallel_cross_entropy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Megatron's custom-autograd cross entropy, in family contract order."""
+    return _megatron_kernel(logits, labels, tp_group=tp_group)
+
+
+def fused_vocab_parallel_cross_entropy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Megatron's compiled cross entropy, in family contract order.
+
+    The kernel reads rank and size straight off the group, so unlike the reference target it
+    cannot take ``None``. Filling that in is this adapter's job, not the caller's.
+    """
+    return _megatron_fused_kernel(logits, labels, _default_tp_group(tp_group))
+
+
+def _te_cross_entropy(logits, labels, tp_group=None, *, target, cuda_graph_capturable):
+    """Adapt TE's kernel to the family contract, including its label-stride requirement."""
+    labels = torch.as_strided(labels, labels.size(), (labels.size()[1], 1))
+    return target(logits, labels, _default_tp_group(tp_group), cuda_graph_capturable)
+
+
+class LossMegatron:
+    """Megatron's unfused implementation."""
+
+    #: The target that already runs under --deterministic-mode today, since the rule in
+    #: megatron/training/determinism.py requires cross entropy fusion to be off.
+    DETERMINISM = "deterministic"
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the reference target."""
+        return vocab_parallel_cross_entropy
+
+
+class LossMegatronFused:
+    """Megatron's compiled reductions and custom backward."""
+
+    #: megatron/training/determinism.py has always required cross_entropy_loss_fusion=False.
+    DETERMINISM = "nondeterministic"
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the fused target."""
+        return fused_vocab_parallel_cross_entropy
+
+
+class LossTEFused:
+    """Transformer Engine's fused kernel.
+
+    Both the TE version check and the CUDA-graph capture mode are resolved here, once, so the
+    forward pass has no version branch left.
+    """
+
+    #: Covered by the same cross_entropy_loss_fusion=False rule; not separately audited.
+    DETERMINISM = "nondeterministic"
+
+    REQUIRES = "transformer_engine"
+
+    @classmethod
+    def from_options(cls, options) -> "LossTEFused":
+        """Read the one setting this backend must bind up front."""
+        return cls(cuda_graph_capturable=options.cuda_graph_impl == "full_iteration")
+
+    def __init__(self, *, cuda_graph_capturable: bool = False) -> None:
+        from megatron.core.extensions.transformer_engine import te_parallel_cross_entropy
+
+        if te_parallel_cross_entropy is None:
+            raise ImportError(
+                "Transformer Engine is installed but does not expose a parallel cross entropy. "
+                "Use --cross-entropy-fusion-impl native instead."
+            )
+        if cuda_graph_capturable:
+            from megatron.core.utils import get_te_version, is_te_min_version
+
+            if not is_te_min_version("2.7.0"):
+                raise ValueError(
+                    "CUDA graph compatible cross entropy requires TransformerEngine >= 2.7.0, "
+                    f"but found version {get_te_version()}. Please upgrade TransformerEngine "
+                    "or set cuda_graph_impl to a value other than 'full_iteration'."
+                )
+        self._target = te_parallel_cross_entropy
+        self._cuda_graph_capturable = cuda_graph_capturable
+
+    def vocab_parallel_cross_entropy(self):
+        """Return the TE target with its construction-time choices already bound."""
+        return partial(
+            _te_cross_entropy,
+            target=self._target,
+            cuda_graph_capturable=self._cuda_graph_capturable,
+        )

--- a/megatron/core/ops/mlp/__init__.py
+++ b/megatron/core/ops/mlp/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The dense MLP block: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract**
+
+* **Target**: a class exposing ``as_mlp_submodule``, which the transformer layer calls with
+  the MLP submodules to build the block. The block owns its own linears and activation; which
+  linears it gets come from the ``linear`` family, not from here.
+* **Selection input**: ``grouped`` says the dense MLP should use grouped GEMM, which is known
+  while the model is built. A backend without a grouped form ignores it.
+* **State**: the block owns the weights of the linears it builds. Its state dict must match
+  the unfused MLP's, since the two are interchangeable at the spec level.
+* **Process groups**: none of its own; the linears it builds own their tensor-parallel
+  collectives, using the group the owning module passes in.
+* **Modes**: only Transformer Engine fuses, and only from TE 1.13. The fused form does not
+  support mixture-of-experts, which is why the MoE path uses ``moe.grouped_mlp_modules``.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.mlp.backends import MlpMegatron, MlpTEOpFuser
+
+__all__ = ["MlpMegatron", "MlpTEOpFuser"]

--- a/megatron/core/ops/mlp/backends.py
+++ b/megatron/core/ops/mlp/backends.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every dense MLP backend, side by side. The contract they meet is in this package's
+``__init__``."""
+
+from __future__ import annotations
+
+__all__ = ["MlpMegatron", "MlpTEOpFuser"]
+
+
+class MlpMegatron:
+    """Megatron Core's MLP block, built from whatever linear backend was selected."""
+
+    #: Not audited; it is the linear and activation backends underneath that would decide.
+    DETERMINISM = "unknown"
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Megatron Core has one MLP block; grouped GEMM is a Transformer Engine feature."""
+        del grouped
+        from megatron.core.transformer.mlp import MLP
+
+        return MLP
+
+
+class MlpTEOpFuser:
+    """Transformer Engine's operation-fused MLP.
+
+    Selected by ``--use-transformer-engine-op-fuser``. The version it needs is declared rather
+    than checked in code, so it is visible in the class header and enforced while arguments are
+    parsed.
+    """
+
+    REQUIRES = "transformer_engine>=1.13.0"
+
+    #: Not audited; the fused operations have not been checked for bit-exactness.
+    DETERMINISM = "unknown"
+
+    #: The block folds the linears it is handed into Transformer Engine operations and can
+    #: only convert Transformer Engine ones -- TEFusedMLP raises on anything else. So this
+    #: backend is only valid alongside LinearTE, which is why only TESpecProvider offers it.
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """The fused MLP, in its grouped-linear form when the dense MLP uses grouped GEMM."""
+        from megatron.core.extensions.transformer_engine import (
+            TEFusedMLP,
+            TEFusedMLPWithGroupedLinear,
+        )
+
+        target = TEFusedMLPWithGroupedLinear if grouped else TEFusedMLP
+        if target is None:
+            raise ImportError(
+                "Transformer Engine is installed but does not expose the operation-fused MLP."
+            )
+        return target

--- a/megatron/core/ops/moe/__init__.py
+++ b/megatron/core/ops/moe/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Mixture of experts: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract**
+
+* **Targets**: ``grouped_mlp_modules`` returns an experts builder called with the local expert
+  count and config; ``activation_func`` returns a builder for an activation *module*, or
+  ``None`` to fall back to ``config.activation_func``; ``moe_router`` returns a router class,
+  or ``None`` to keep the ``MoESubmodules`` default.
+* **State**: the experts own their own weights. The router owns its gate. Neither owns the
+  dispatcher's buffers.
+* **Process groups**: the dispatcher, not these targets, owns expert- and tensor-parallel
+  communication; it receives its groups from the MoE layer.
+* **Modes**: ``moe_use_grouped_gemm`` is a construction-time input, so a backend picks its
+  grouped or sequential experts once rather than branching per step. The inference backend
+  needs compact ``[tokens, topk]`` index routing, which is why the router is a slot at all.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.moe.backends import MoeLocal, MoeTE
+
+__all__ = ["MoeLocal", "MoeTE"]

--- a/megatron/core/ops/moe/backends.py
+++ b/megatron/core/ops/moe/backends.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every mixture-of-experts backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from functools import partial
+from typing import TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.mlp import TEActivationFunctionBuilder
+    from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
+
+__all__ = ["MoeLocal", "MoeTE"]
+
+
+class MoeLocal:
+    """Sequential experts made of Megatron Core linears."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Megatron Core has no grouped GEMM, so experts are always sequential."""
+        del moe_use_grouped_gemm
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+        from megatron.core.transformer.mlp import MLPSubmodules
+        from megatron.core.transformer.moe.experts import SequentialMLP
+
+        return partial(
+            SequentialMLP,
+            submodules=MLPSubmodules(
+                linear_fc1=ColumnParallelLinear,
+                linear_fc2=RowParallelLinear,
+                activation_func=self.activation_func(),
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Megatron Core reads config.activation_func rather than building a module."""
+        return None
+
+    def moe_router(self) -> Optional[type]:
+        """Keep the MoESubmodules default (the training TopKRouter)."""
+        return None
+
+
+class MoeTE:
+    """Transformer Engine grouped linears."""
+
+    #: Not audited; routing and permutation are unexamined.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+
+    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> "ExpertsBuilder":
+        """Grouped experts when TE offers them, sequential otherwise."""
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelGroupedLinear,
+            TEColumnParallelLinear,
+            TERowParallelGroupedLinear,
+            TERowParallelLinear,
+        )
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+        from megatron.core.transformer.mlp import MLPSubmodules
+        from megatron.core.transformer.moe.experts import (
+            GroupedMLPSubmodules,
+            SequentialMLP,
+            TEGroupedMLP,
+        )
+        from megatron.core.utils import get_te_version, is_te_min_version
+
+        if moe_use_grouped_gemm and TEColumnParallelGroupedLinear is not None:
+            return partial(
+                TEGroupedMLP,
+                submodules=GroupedMLPSubmodules(
+                    linear_fc1=TEColumnParallelGroupedLinear,
+                    linear_fc2=TERowParallelGroupedLinear,
+                    activation_func=self.activation_func(),
+                ),
+            )
+        if not is_te_min_version("1.7.0.dev0"):
+            warnings.warn(
+                "Only transformer-engine>=1.7.0 supports MoE experts, "
+                f"but your version is {get_te_version()}. "
+                "Use local linear implementation instead."
+            )
+            linear_fc1, linear_fc2 = ColumnParallelLinear, RowParallelLinear
+        else:
+            linear_fc1, linear_fc2 = TEColumnParallelLinear, TERowParallelLinear
+        return partial(
+            SequentialMLP,
+            submodules=MLPSubmodules(
+                linear_fc1=linear_fc1, linear_fc2=linear_fc2, activation_func=self.activation_func()
+            ),
+        )
+
+    def activation_func(self) -> Optional["TEActivationFunctionBuilder"]:
+        """Which module to use for activation function."""
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
+        # design these classes always meet the interface.
+        return cast("TEActivationFunctionBuilder", TEActivationOp)
+
+    def moe_router(self) -> Optional[type]:
+        """Keep the MoESubmodules default (the training TopKRouter)."""
+        return None

--- a/megatron/core/ops/norm/__init__.py
+++ b/megatron/core/ops/norm/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Normalization: what a backend must provide, and which ones exist.
+
+The implementations are in :mod:`.backends`; a provider in
+``megatron.core.models.backends`` or ``megatron.core.extensions`` picks between them.
+
+**Contract**
+
+* **Target**: a builder called as ``target(config=..., hidden_size=..., eps=...)`` returning a
+  module whose ``forward(x) -> Tensor`` preserves shape and dtype.
+* **Selection inputs**: ``rms_norm`` (RMSNorm vs LayerNorm), ``for_qk`` (query/key norm, which
+  some backends implement differently), ``has_residual`` (this norm is followed by a residual
+  add, which some backends can fuse). All three are known while the model is built.
+* **State**: the norm owns its own weight, and its bias for LayerNorm. Backends must agree on
+  the parameter names so a checkpoint stays loadable across backends.
+* **Process groups**: none. Sequence-parallel marking is read from ``config`` by the target
+  itself; the owning module keeps any surrounding communication.
+* **Modes**: every backend supports training, backward, and inference. Only Transformer Engine
+  fuses a residual, and only for RMSNorm. Apex implements LayerNorm only.
+"""
+
+from __future__ import annotations
+
+from megatron.core.ops.norm.backends import NormApex, NormTE, NormTorch, TENormWithResidual
+from megatron.core.transformer.torch_norm import L2Norm, WrappedTorchNorm
+
+__all__ = ["L2Norm", "NormApex", "NormTE", "NormTorch", "TENormWithResidual", "WrappedTorchNorm"]

--- a/megatron/core/ops/norm/backends.py
+++ b/megatron/core/ops/norm/backends.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every normalization backend, side by side.
+
+The contract they meet is in this package's ``__init__``.
+
+Each class is named for the backend key that selects it, so ``--op-backend layer_norm=apex``
+and ``NormApex`` are the same word. Targets are imported inside the method that returns them,
+never at module scope, so importing this file pulls in no optional package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from megatron.core.transformer.torch_norm import WrappedTorchNorm
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.torch_norm import LayerNormBuilder
+
+__all__ = ["NormApex", "NormTE", "NormTorch", "TENormWithResidual"]
+
+
+class TENormWithResidual:
+    """Class adapter for TENorm with residual fusion enabled.
+
+    Defined at module scope on purpose: spec building compares and copies these targets, so a
+    class created per provider would make two identically configured models compare unequal.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        return TENorm(*args, has_residual=True, **kwargs)
+
+
+#: Config options Torch's norm cannot honour, and the attribute each one lives under.
+_TORCH_NORM_CANNOT_DO = (
+    ("sequence_parallel", "sequence parallelism"),
+    ("persist_layer_norm", "persistent layer norm"),
+    ("layernorm_zero_centered_gamma", "zero-centered gamma"),
+    ("memory_efficient_layer_norm", "the memory-efficient path"),
+)
+
+
+class NormTorch:
+    """PyTorch's own LayerNorm and RMSNorm.
+
+    Always available and needs no optional package, which is why it is what ``local`` selects.
+    It cannot do sequence parallelism, persistent norm, zero-centered gamma, or the
+    memory-efficient path; a config asking for one of those is refused here, while the model is
+    being built, rather than by an assertion inside ``WrappedTorchNorm`` later.
+    """
+
+    @classmethod
+    def from_options(cls, options) -> "NormTorch":
+        """Refuse early, naming the option and the backend that can honour it."""
+        unsupported = [
+            label
+            for attribute, label in _TORCH_NORM_CANNOT_DO
+            if getattr(options, attribute, False)
+        ]
+        if unsupported:
+            raise ValueError(
+                f"Torch's norm cannot do {', '.join(unsupported)}. Select a norm that can, "
+                "with --op-backend layer_norm=apex, or turn the option off."
+            )
+        return cls()
+
+    #: Torch's norm backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """WrappedTorchNorm reads config.normalization, so one target covers every variant."""
+        del rms_norm, for_qk, has_residual
+        return WrappedTorchNorm
+
+
+class NormApex:
+    """Apex's fused LayerNorm.
+
+    Apex implements LayerNorm only, so RMSNorm falls through to the Torch target. This mirrors
+    what Megatron has always done rather than failing a model that mixes the two.
+    """
+
+    #: Apex's fused backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "apex"
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """Apex LayerNorm, or the Torch target when RMSNorm is requested."""
+        del for_qk, has_residual
+        if rms_norm:
+            return WrappedTorchNorm
+        from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+        return FusedLayerNorm
+
+
+class NormTE:
+    """Transformer Engine's norm.
+
+    Two backend-internal details stay here rather than at the call site: TE below 1.9 harms
+    convergence for query/key norm, and residual fusion needs a distinct target.
+    """
+
+    #: TE's norm backward has not been audited here.
+    DETERMINISM = "unknown"
+
+    REQUIRES = "transformer_engine"
+    FUSES_RESIDUAL = True
+
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
+    ) -> "LayerNormBuilder":
+        """TENorm, or Apex for query/key norm on TE versions that regress convergence."""
+        del rms_norm  # TENorm reads config.normalization.
+        from megatron.core.utils import is_te_min_version
+
+        if for_qk and not is_te_min_version("1.9.0"):
+            # TENorm significantly harms convergence when used for QKLayerNorm if
+            # TE version < 1.9; we instead use the Apex implementation.
+            from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+            return FusedLayerNorm
+        if has_residual and self.FUSES_RESIDUAL:
+            return TENormWithResidual
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        return TENorm

--- a/tests/unit_tests/ops/__init__.py
+++ b/tests/unit_tests/ops/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/tests/unit_tests/ops/test_backend_targets.py
+++ b/tests/unit_tests/ops/test_backend_targets.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Every backend returns the exact target it returned before the implementations moved.
+
+These are the equivalence tests the migration turns on: they name the concrete class each
+backend resolves to, so relocating an implementation cannot quietly change what a model is
+built from. Selection is not exercised here -- these classes are what a provider picks
+between, and the providers are tested where they live.
+"""
+
+import pytest
+
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.ops import is_installed
+from megatron.core.ops.attention import AttentionLocal, AttentionTE
+from megatron.core.ops.linear import LinearLocal, LinearTE
+from megatron.core.ops.mlp import MlpMegatron
+from megatron.core.ops.moe import MoeLocal, MoeTE
+from megatron.core.ops.norm import NormApex, NormTE, NormTorch, WrappedTorchNorm
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+_needs_te = pytest.mark.skipif(not HAVE_TE, reason="Transformer Engine is required")
+
+
+class TestLocalBackends:
+    def test_linear_targets(self):
+        backend = LinearLocal()
+        assert backend.column_parallel_linear() is ColumnParallelLinear
+        assert backend.row_parallel_linear() is RowParallelLinear
+        assert backend.column_parallel_layer_norm_linear() is None
+        assert backend.fuse_layernorm_and_linear() is False
+
+    def test_core_attention_target(self):
+        assert AttentionLocal().core_attention() is DotProductAttention
+
+    def test_torch_norm_is_torch_regardless_of_what_is_installed(self):
+        """Installing an optional package must not change which kernel this backend gives."""
+        assert NormTorch().layer_norm(rms_norm=False) is WrappedTorchNorm
+        assert NormTorch().layer_norm(rms_norm=True) is WrappedTorchNorm
+
+    def test_apex_is_a_separate_backend(self):
+        """Apex is its own class, so choosing it is a decision rather than an accident."""
+        if not is_installed("apex"):
+            pytest.skip("Apex is not installed")
+        from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
+
+        assert NormApex().layer_norm(rms_norm=False) is FusedLayerNorm
+
+    def test_layer_norm_choice_does_not_leak_between_calls(self):
+        """Asking for an RMSNorm must not change what a later LayerNorm request returns.
+
+        The implementation this replaces mutated a module-level global to do this.
+        """
+        backend = NormTorch()
+        first = backend.layer_norm(rms_norm=False)
+        backend.layer_norm(rms_norm=True)
+        assert backend.layer_norm(rms_norm=False) is first
+
+    def test_no_router_override(self):
+        assert MoeLocal().moe_router() is None
+
+    def test_megatron_mlp_target(self):
+        from megatron.core.transformer.mlp import MLP
+
+        assert MlpMegatron().mlp_module() is MLP
+
+
+@_needs_te
+class TestTransformerEngineBackends:
+    def test_linear_targets(self):
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelLinear,
+            TELayerNormColumnParallelLinear,
+            TELinear,
+            TERowParallelLinear,
+        )
+
+        backend = LinearTE()
+        assert backend.linear() is TELinear
+        assert backend.column_parallel_linear() is TEColumnParallelLinear
+        assert backend.row_parallel_linear() is TERowParallelLinear
+        assert backend.column_parallel_layer_norm_linear() is TELayerNormColumnParallelLinear
+        assert backend.fuse_layernorm_and_linear() is True
+
+    def test_core_attention_target(self):
+        from megatron.core.extensions.transformer_engine import TEDotProductAttention
+
+        assert AttentionTE().core_attention() is TEDotProductAttention
+
+    def test_norm_targets(self):
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        assert NormTE().layer_norm() is TENorm
+
+    def test_residual_fusion_target_is_stable(self):
+        """The residual-fused norm must be one class, not a new one per call, or a spec
+        built twice stops comparing equal."""
+        assert NormTE().layer_norm(has_residual=True) is NormTE().layer_norm(has_residual=True)
+
+    def test_activation_target(self):
+        from megatron.core.extensions.transformer_engine import TEActivationOp
+
+        assert MoeTE().activation_func() is TEActivationOp

--- a/tests/unit_tests/ops/test_cross_entropy_backend.py
+++ b/tests/unit_tests/ops/test_cross_entropy_backend.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The vocab-parallel cross entropy backends, against each other and against Torch.
+
+Which of them a run gets is a provider's decision and is tested where the providers live.
+What is tested here is that they are interchangeable, which is what makes that decision safe.
+"""
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.ops.loss import (
+    LossMegatron,
+    LossMegatronFused,
+    fused_vocab_parallel_cross_entropy,
+    vocab_parallel_cross_entropy,
+)
+from tests.unit_tests.test_utilities import Utils
+
+BACKENDS = [("megatron", LossMegatron), ("megatron_fused", LossMegatronFused)]
+
+
+class TestTargets:
+    def test_each_backend_returns_its_own_kernel(self):
+        assert LossMegatron().vocab_parallel_cross_entropy() is vocab_parallel_cross_entropy
+        assert (
+            LossMegatronFused().vocab_parallel_cross_entropy() is fused_vocab_parallel_cross_entropy
+        )
+
+    def test_the_fused_backend_declares_it_is_not_bit_exact(self):
+        """--deterministic-mode has to be able to tell these apart."""
+        assert LossMegatron().DETERMINISM == "deterministic"
+        assert LossMegatronFused().DETERMINISM == "nondeterministic"
+
+
+class TestDistributedContract:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(("name", "backend"), BACKENDS)
+    def test_target_accepts_a_default_tensor_parallel_group(self, name, backend):
+        """tp_group=None means the default group, whatever the underlying kernel needs."""
+        del name
+        torch.manual_seed(0)
+        logits = torch.randn(4, 2, 8).cuda()
+        labels = torch.randint(0, 8, (4, 2)).cuda()
+
+        target = backend().vocab_parallel_cross_entropy()
+        assert target(logits, labels, None).shape == labels.shape
+
+
+class TestCrossEntropyParity:
+    """Every backend has to agree on the same inputs, or swapping one changes the model."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_every_target_matches_torch_cross_entropy(self, dtype):
+        """Each target gets its own copy: the family contract says they consume logits."""
+        torch.manual_seed(1234)
+        logits = torch.randn(6, 2, 16).cuda().to(dtype)
+        labels = torch.randint(0, 16, (6, 2)).cuda()
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+
+        expected = torch.nn.functional.cross_entropy(
+            logits.float().reshape(-1, 16), labels.reshape(-1), reduction="none"
+        ).reshape(6, 2)
+
+        for name, backend in BACKENDS:
+            target = backend().vocab_parallel_cross_entropy()
+            loss = target(logits.clone(), labels, tp_group)
+            torch.testing.assert_close(
+                loss.float(), expected, rtol=1e-2, atol=1e-2, msg=lambda m: f"{name}: {m}"
+            )

--- a/tests/unit_tests/ops/test_import_hygiene.py
+++ b/tests/unit_tests/ops/test_import_hygiene.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Importing the ops package must not pull in a backend nobody selected."""
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_MIGRATED_MODULES = ("megatron.core.ops",)
+
+
+def test_importing_ops_does_not_import_an_optional_backend():
+    """Measured against a bare ``import megatron.core``, so this only blames core.ops.
+
+    Runs in a fresh interpreter because sys.modules here is already populated by other tests.
+    """
+    script = textwrap.dedent("""
+        import sys
+
+        optional = {"transformer_engine", "apex", "nvidia_kitchen"}
+        import megatron.core
+
+        before = {name for name in optional if name in sys.modules}
+        import megatron.core.ops
+
+        after = {name for name in optional if name in sys.modules}
+        print(",".join(sorted(after - before)))
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    added = result.stdout.strip()
+    assert added == "", f"importing megatron.core.ops additionally imported: {added}"
+
+
+@pytest.mark.parametrize("module_name", _MIGRATED_MODULES)
+def test_migrated_modules_define_no_availability_flags(module_name):
+    """Backends state their requirements in core.ops instead of exporting a HAVE_* global."""
+    module = importlib.import_module(module_name)
+    flags = sorted(name for name in vars(module) if name.startswith(("HAVE_", "_HAVE_")))
+    assert not flags, f"{module_name} still defines {flags}"


### PR DESCRIPTION
## What

Adds `megatron/core/ops` and `megatron/core/inference/ops`: one package per operation family, holding the backends for that operation side by side, plus the contract they meet.

**This is an implementation home, not a selection layer.** There is no registry and no resolver; nothing here decides which backend a run gets. That stays with the `BackendSpecProvider` implementations, which import their targets from here.

**Nothing calls it yet** — 21 files, +1266, **−0**. It cannot change behaviour and can be reviewed on its own. #6763 switches the callers over.

## Shape

| file | holds |
|---|---|
| `<family>/__init__.py` | the contract every backend for this family must meet |
| `<family>/backends.py` | every implementation, side by side |

Backends are named for the family and the implementation — `NormTE`, `NormApex`, `NormTorch`, `LinearTE`, `MoeLocal` — so the class name alone says what it is. They sit together on purpose: a family's backends answer the same question and are read by comparison.

## The one rule

Every optional-package import lives **inside the method that returns its target**, never at module scope:

```python
class NormTE:
    REQUIRES = "transformer_engine"
    DETERMINISM = "unknown"

    def layer_norm(self, rms_norm=False, for_qk=False, has_residual=False):
        from megatron.core.extensions.transformer_engine import TENorm   # here, not above
        return TENorm
```

So importing `megatron.core.ops` pulls in no optional dependency and no backend nobody selected — pinned by `tests/unit_tests/ops/test_import_hygiene.py`.

That is what lets a provider name a backend without the **call site** having to guard on whether it is installed, which is what the scattered `HAVE_TE` / `HAVE_APEX` flags were doing. Removing those is #6763.

## Tracing which implementation a run gets

Open the provider. `TESpecProvider.layer_norm` names `NormTE`; `NormTE.layer_norm` names `TENorm`. Two hops, no globals, no dependence on import order or on what happens to be installed.

For comparison, the same question on `main` takes five hops and still depends on whether Apex imported and whether an earlier call mutated `LNImpl` — a module-level global that eight files each define their own copy of.

## Testing

`tests/unit_tests/ops/` — 8×GPU, 20 passed. Backend targets (each backend returns the exact class it did before the move), cross-entropy parity against `F.cross_entropy`, and import hygiene.

See `megatron/core/ops/README.md`.
