### PR TITLE
Select kernel backends through BackendSpecProvider, not HAVE_* flags

### DIFF
--- a/megatron/core/extensions/transformer_engine_spec_provider.py
+++ b/megatron/core/extensions/transformer_engine_spec_provider.py
@@ -1,114 +1,91 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Which backend a Transformer Engine run uses for each operation.
+
+Every entry is one line naming a class in :mod:`megatron.core.ops`, so this file is the whole
+answer to "which implementation does a TE run get". The choices themselves -- when TE cannot
+serve query/key norm, when a residual can be fused -- belong to those classes, not here.
+"""
+
 from __future__ import annotations
 
-import warnings
-from functools import partial
-from typing import Optional, cast
+from typing import Optional
 
-from megatron.core.extensions.transformer_engine import (
-    TEActivationOp,
-    TEColumnParallelGroupedLinear,
-    TEColumnParallelLinear,
-    TEDotProductAttention,
-    TELayerNormColumnParallelLinear,
-    TELinear,
-    TENorm,
-    TERowParallelGroupedLinear,
-    TERowParallelLinear,
-)
-from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
 from megatron.core.models.backends import BackendSpecProvider
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
-from megatron.core.transformer.mlp import MLPSubmodules, TEActivationFunctionBuilder
-from megatron.core.transformer.moe.experts import GroupedMLPSubmodules, SequentialMLP, TEGroupedMLP
+from megatron.core.ops import require
+from megatron.core.ops.attention import AttentionTE
+from megatron.core.ops.linear import LinearTE
+from megatron.core.ops.loss import LossMegatron, LossMegatronFused, VocabParallelCrossEntropy
+from megatron.core.ops.mlp import MlpMegatron, MlpTEOpFuser
+from megatron.core.ops.moe import MoeTE
+from megatron.core.ops.norm import NormTE
+from megatron.core.transformer.mlp import TEActivationFunctionBuilder
 from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
 from megatron.core.transformer.torch_norm import LayerNormBuilder
-from megatron.core.utils import get_te_version, is_te_min_version
-
-
-class _TENormWithResidual:
-    """Class adapter for TENorm with residual fusion enabled."""
-
-    def __new__(cls, *args, **kwargs):
-        return TENorm(*args, has_residual=True, **kwargs)
 
 
 class TESpecProvider(BackendSpecProvider):
-    """A protocol for providing the submodules used in Spec building."""
+    """Every backend a Transformer Engine run uses."""
+
+    def __init__(
+        self, use_te_op_fuser: bool = False, cross_entropy_loss_fusion: bool = False
+    ) -> None:
+        require("transformer_engine")
+        self._norm = NormTE()
+        self._linear = LinearTE()
+        self._attention = AttentionTE()
+        # The operation fuser folds the linears it is handed into TE operations and can only
+        # convert TE ones, which is why it is offered here and not by the local provider.
+        self._mlp = MlpTEOpFuser() if use_te_op_fuser else MlpMegatron()
+        self._moe = MoeTE()
+        self._loss = LossMegatronFused() if cross_entropy_loss_fusion else LossMegatron()
 
     def linear(self) -> type:
-        """Which linear module TE backend uses"""
-        return TELinear
+        """Which non-parallel linear module the backend uses."""
+        return self._linear.linear()
 
     def column_parallel_linear(self) -> type:
-        """Which column parallel linear module TE backend uses"""
-        return TEColumnParallelLinear
+        """Which column parallel linear module the backend uses."""
+        return self._linear.column_parallel_linear()
 
-    def row_parallel_linear(self) -> type[TERowParallelLinear]:
-        """Which row parallel linear module TE backend uses"""
-        return TERowParallelLinear
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        return self._linear.row_parallel_linear()
 
     def fuse_layernorm_and_linear(self) -> bool:
-        """TE backend chooses a single module for layernorm and linear"""
+        """Transformer Engine chooses a single module for layernorm and linear."""
         return True
 
     def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
-        return TELayerNormColumnParallelLinear
+        """Which module for sequential layernorm and linear."""
+        return self._linear.column_parallel_layer_norm_linear()
 
     def layer_norm(
         self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
     ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if for_qk and not is_te_min_version("1.9.0"):
-            # TENorm significantly harms convergence when used
-            # for QKLayerNorm if TE Version < 1.9;
-            # we instead use the Apex implementation.
-            return FusedLayerNorm
-        # Keep returning a class so this path stays aligned with build_module's class handling.
-        return _TENormWithResidual if has_residual else TENorm
+        """Which module to use for layer norm."""
+        return self._norm.layer_norm(rms_norm=rms_norm, for_qk=for_qk, has_residual=has_residual)
 
     def core_attention(self) -> type:
-        """Which module to use for attention"""
-        return TEDotProductAttention
+        """Which module to use for attention."""
+        return self._attention.core_attention()
 
     def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        if moe_use_grouped_gemm and TEColumnParallelGroupedLinear is not None:
-            return partial(
-                TEGroupedMLP,
-                submodules=GroupedMLPSubmodules(
-                    linear_fc1=TEColumnParallelGroupedLinear,
-                    linear_fc2=TERowParallelGroupedLinear,
-                    activation_func=self.activation_func(),
-                ),
-            )
-        else:
-            if not is_te_min_version("1.7.0.dev0"):
-                warnings.warn(
-                    "Only transformer-engine>=1.7.0 supports MoE experts, "
-                    f"but your version is {get_te_version()}. "
-                    "Use local linear implementation instead."
-                )
-                return partial(
-                    SequentialMLP,
-                    submodules=MLPSubmodules(
-                        linear_fc1=ColumnParallelLinear,
-                        linear_fc2=RowParallelLinear,
-                        activation_func=self.activation_func(),
-                    ),
-                )
-            return partial(
-                SequentialMLP,
-                submodules=MLPSubmodules(
-                    linear_fc1=TEColumnParallelLinear,
-                    linear_fc2=TERowParallelLinear,
-                    activation_func=self.activation_func(),
-                ),
-            )
+        """Which module and submodules to use for grouped mlp."""
+        return self._moe.grouped_mlp_modules(moe_use_grouped_gemm)
 
     def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
-        # design these classes always meet the interface.
-        return cast(TEActivationFunctionBuilder, TEActivationOp)
+        """Which module to use for activation function."""
+        return self._moe.activation_func()
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Which module to use for the dense MLP block."""
+        return self._mlp.mlp_module(grouped=grouped)
+
+    def moe_router(self) -> Optional[type]:
+        """Which MoE router to use, or None to keep the MoESubmodules default."""
+        return self._moe.moe_router()
+
+    def vocab_parallel_cross_entropy(self) -> VocabParallelCrossEntropy:
+        """Which vocab-parallel cross entropy to use."""
+        return self._loss.vocab_parallel_cross_entropy()

--- a/megatron/core/inference/ops/__init__.py
+++ b/megatron/core/inference/ops/__init__.py
@@ -5,7 +5,7 @@
 These fill the same slots as any other backend and are selected the same way, by
 ``--transformer-impl inference_optimized`` or ``--op-backend``. They live here rather than
 under ``megatron/core/ops`` so the inference-only implementations stay with the rest of the
-inference subsystem; ``megatron.core.ops.<family>.BACKENDS`` points at them by name.
+inference subsystem; ``InferenceSpecProvider`` is what selects them.
 """
 
 from megatron.core.inference.ops.backends import LinearInference, MoeInference, NormInference

--- a/megatron/core/models/T5/t5_spec.py
+++ b/megatron/core/models/T5/t5_spec.py
@@ -1,56 +1,24 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from functools import partial
 
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.models.backends import get_backend
 from megatron.core.transformer.attention import (
     CrossAttention,
     CrossAttentionSubmodules,
     SelfAttention,
     SelfAttentionSubmodules,
 )
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
-from megatron.core.typed_torch import not_none
 
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import (
-        TEColumnParallelLinear,
-        TEDotProductAttention,
-        TELayerNormColumnParallelLinear,
-        TENorm,
-        TERowParallelLinear,
-    )
-else:
-    (
-        TEColumnParallelLinear,
-        TEDotProductAttention,
-        TELayerNormColumnParallelLinear,
-        TENorm,
-        TERowParallelLinear,
-    ) = (None, None, None, None, None)
-
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn(f"Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
+# One provider per backend, so every choice below names a class in megatron.core.ops.
+_te = get_backend("transformer_engine")
+_local = get_backend("local")
 
 
 def encoder_model_with_transformer_engine_default_spec() -> ModuleSpec:
@@ -63,9 +31,9 @@ def encoder_model_with_transformer_engine_default_spec() -> ModuleSpec:
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.padding},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=not_none(TELayerNormColumnParallelLinear),
-                    core_attention=not_none(TEDotProductAttention),
-                    linear_proj=not_none(TERowParallelLinear),
+                    linear_qkv=_te.column_parallel_layer_norm_linear(),
+                    core_attention=_te.core_attention(),
+                    linear_proj=_te.row_parallel_linear(),
                     q_layernorm=IdentityOp,
                     k_layernorm=IdentityOp,
                 ),
@@ -74,8 +42,8 @@ def encoder_model_with_transformer_engine_default_spec() -> ModuleSpec:
             mlp=partial(
                 MLP.as_mlp_submodule,
                 submodules=MLPSubmodules(
-                    linear_fc1=not_none(TELayerNormColumnParallelLinear),
-                    linear_fc2=not_none(TERowParallelLinear),
+                    linear_fc1=_te.column_parallel_layer_norm_linear(),
+                    linear_fc2=_te.row_parallel_linear(),
                 ),
             ),
             mlp_bda=get_bias_dropout_add,
@@ -93,31 +61,31 @@ def decoder_model_with_transformer_engine_default_spec() -> ModuleSpec:
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.causal},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=not_none(TELayerNormColumnParallelLinear),
-                    core_attention=not_none(TEDotProductAttention),
-                    linear_proj=not_none(TERowParallelLinear),
+                    linear_qkv=_te.column_parallel_layer_norm_linear(),
+                    core_attention=_te.core_attention(),
+                    linear_proj=_te.row_parallel_linear(),
                     q_layernorm=IdentityOp,
                     k_layernorm=IdentityOp,
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
-            pre_cross_attn_layernorm=not_none(TENorm),
+            pre_cross_attn_layernorm=_te.layer_norm(),
             cross_attention=ModuleSpec(
                 module=CrossAttention,
                 params={"attn_mask_type": AttnMaskType.padding},
                 submodules=CrossAttentionSubmodules(
-                    linear_q=not_none(TEColumnParallelLinear),
-                    linear_kv=not_none(TEColumnParallelLinear),
-                    core_attention=not_none(TEDotProductAttention),
-                    linear_proj=not_none(TERowParallelLinear),
+                    linear_q=_te.column_parallel_linear(),
+                    linear_kv=_te.column_parallel_linear(),
+                    core_attention=_te.core_attention(),
+                    linear_proj=_te.row_parallel_linear(),
                 ),
             ),
             cross_attn_bda=get_bias_dropout_add,
             mlp=partial(
                 MLP.as_mlp_submodule,
                 submodules=MLPSubmodules(
-                    linear_fc1=not_none(TELayerNormColumnParallelLinear),
-                    linear_fc2=not_none(TERowParallelLinear),
+                    linear_fc1=_te.column_parallel_layer_norm_linear(),
+                    linear_fc2=_te.row_parallel_linear(),
                 ),
             ),
             mlp_bda=get_bias_dropout_add,
@@ -131,24 +99,25 @@ def encoder_model_with_local_spec() -> ModuleSpec:
     return ModuleSpec(
         module=TransformerLayer,
         submodules=TransformerLayerSubmodules(
-            input_layernorm=LNImpl,
+            input_layernorm=_local.layer_norm(),
             self_attention=ModuleSpec(
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.arbitrary},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=ColumnParallelLinear,
-                    core_attention=DotProductAttention,
-                    linear_proj=RowParallelLinear,
+                    linear_qkv=_local.column_parallel_linear(),
+                    core_attention=_local.core_attention(),
+                    linear_proj=_local.row_parallel_linear(),
                     q_layernorm=IdentityOp,
                     k_layernorm=IdentityOp,
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
-            pre_mlp_layernorm=LNImpl,
+            pre_mlp_layernorm=_local.layer_norm(),
             mlp=partial(
                 MLP.as_mlp_submodule,
                 submodules=MLPSubmodules(
-                    linear_fc1=ColumnParallelLinear, linear_fc2=RowParallelLinear
+                    linear_fc1=_local.column_parallel_linear(),
+                    linear_fc2=_local.row_parallel_linear(),
                 ),
             ),
             mlp_bda=get_bias_dropout_add,
@@ -166,36 +135,37 @@ def decoder_model_with_local_spec() -> ModuleSpec:
     return ModuleSpec(
         module=TransformerLayer,
         submodules=TransformerLayerSubmodules(
-            input_layernorm=LNImpl,
+            input_layernorm=_local.layer_norm(),
             self_attention=ModuleSpec(
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.causal},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=ColumnParallelLinear,
-                    core_attention=DotProductAttention,
-                    linear_proj=RowParallelLinear,
+                    linear_qkv=_local.column_parallel_linear(),
+                    core_attention=_local.core_attention(),
+                    linear_proj=_local.row_parallel_linear(),
                     q_layernorm=IdentityOp,
                     k_layernorm=IdentityOp,
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
-            pre_cross_attn_layernorm=LNImpl,
+            pre_cross_attn_layernorm=_local.layer_norm(),
             cross_attention=ModuleSpec(
                 module=CrossAttention,
                 params={"attn_mask_type": AttnMaskType.arbitrary},
                 submodules=CrossAttentionSubmodules(
-                    linear_q=ColumnParallelLinear,
-                    linear_kv=ColumnParallelLinear,
-                    core_attention=DotProductAttention,
-                    linear_proj=RowParallelLinear,
+                    linear_q=_local.column_parallel_linear(),
+                    linear_kv=_local.column_parallel_linear(),
+                    core_attention=_local.core_attention(),
+                    linear_proj=_local.row_parallel_linear(),
                 ),
             ),
             cross_attn_bda=get_bias_dropout_add,
-            pre_mlp_layernorm=LNImpl,
+            pre_mlp_layernorm=_local.layer_norm(),
             mlp=partial(
                 MLP.as_mlp_submodule,
                 submodules=MLPSubmodules(
-                    linear_fc1=ColumnParallelLinear, linear_fc2=RowParallelLinear
+                    linear_fc1=_local.column_parallel_linear(),
+                    linear_fc2=_local.row_parallel_linear(),
                 ),
             ),
             mlp_bda=get_bias_dropout_add,
@@ -217,7 +187,7 @@ def get_t5_encoder_with_transformer_engine_block_spec(
     """
 
     layer_spec = encoder_model_with_transformer_engine_default_spec()
-    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=TENorm)
+    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=_te.layer_norm())
     return block_spec
 
 
@@ -231,7 +201,7 @@ def get_t5_decoder_with_transformer_engine_block_spec(
     """
 
     layer_spec = decoder_model_with_transformer_engine_default_spec()
-    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=TENorm)
+    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=_te.layer_norm())
     return block_spec
 
 
@@ -243,7 +213,7 @@ def get_t5_encoder_with_local_block_spec(num_layers: int) -> TransformerBlockSub
     """
 
     layer_spec = encoder_model_with_local_spec()
-    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=TENorm)
+    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=_te.layer_norm())
     return block_spec
 
 
@@ -255,5 +225,5 @@ def get_t5_decoder_with_local_block_spec(num_layers: int) -> TransformerBlockSub
     """
 
     layer_spec = decoder_model_with_local_spec()
-    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=TENorm)
+    block_spec = TransformerBlockSubmodules([layer_spec] * num_layers, layer_norm=_te.layer_norm())
     return block_spec

--- a/megatron/core/models/backends.py
+++ b/megatron/core/models/backends.py
@@ -1,218 +1,247 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""The construction-time API for choosing a kernel backend.
+
+A provider answers, once while the model is built, which implementation each operation
+should use. Model code asks the provider and never branches on what it got back, so a spec
+builder needs no ``HAVE_*`` flag and no import guard of its own.
+
+The implementations themselves live in :mod:`megatron.core.ops`, one package per operation
+family. A provider is the short, readable list of which of them this configuration uses --
+reading :class:`LocalSpecProvider` tells you every backend a local run gets.
+"""
+
 from __future__ import annotations
 
-import warnings
-from abc import abstractmethod
-from functools import partial
-from typing import Literal, Optional, Protocol, cast
+from typing import Optional, Protocol
 
-from megatron.core.extensions.transformer_engine import (
-    TEColumnParallelGroupedLinear,
-    TERowParallelGroupedLinear,
-)
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
-from megatron.core.transformer.dot_product_attention import DotProductAttention
-from megatron.core.transformer.mlp import MLPSubmodules, TEActivationFunctionBuilder
-from megatron.core.transformer.moe.experts import (
-    GroupedMLPSubmodules,
-    InferenceGroupedMLP,
-    SequentialMLP,
-)
+from megatron.core.ops.attention import AttentionLocal
+from megatron.core.ops.linear import LinearLocal
+from megatron.core.ops.loss import LossMegatron, LossMegatronFused, VocabParallelCrossEntropy
+from megatron.core.ops.mlp import MlpMegatron
+from megatron.core.ops.moe import MoeLocal
+from megatron.core.transformer.mlp import TEActivationFunctionBuilder
 from megatron.core.transformer.moe.moe_layer import ExpertsBuilder
-from megatron.core.transformer.torch_norm import LayerNormBuilder, WrappedTorchNorm
-from megatron.core.typed_torch import not_none
-from megatron.core.utils import is_te_min_version
-
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    FusedLayerNorm = None
-    HAVE_APEX = False
-    LNImpl = WrappedTorchNorm
-
-from megatron.core.extensions.transformer_engine import (
-    TEActivationOp,
-    TEDotProductAttention,
-    TELinear,
-    TENorm,
-)
-from megatron.core.tensor_parallel.inference_layers import (
-    InferenceColumnParallelLinear,
-    InferenceLayerNormColumnParallelLinear,
-    InferenceRowParallelLinear,
-)
-from megatron.core.utils import is_te_min_version
+from megatron.core.transformer.torch_norm import LayerNormBuilder
 
 
 class BackendSpecProvider(Protocol):
-    """A protocol for providing the submodules used in Spec building."""
+    """A protocol for providing the submodules used in spec building."""
 
-    @abstractmethod
+    def linear(self) -> type:
+        """Which linear module the backend uses."""
+        ...
+
     def column_parallel_linear(self) -> type:
-        """Which column parallel linear module the backend uses"""
+        """Which column parallel linear module the backend uses."""
         ...
 
-    @abstractmethod
     def row_parallel_linear(self) -> type:
-        """Which row parallel linear module the backend uses"""
+        """Which row parallel linear module the backend uses."""
         ...
 
-    @abstractmethod
     def fuse_layernorm_and_linear(self) -> bool:
-        """Does the backend support a single module for layernorm and linear"""
+        """Does the backend choose a single module for layernorm and linear."""
         ...
 
-    @abstractmethod
     def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
+        """Which module for sequential layernorm and linear."""
         ...
 
-    @abstractmethod
     def layer_norm(
         self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
     ) -> LayerNormBuilder:
-        """Which module for layernorm"""
+        """Which module to use for layer norm."""
         ...
 
-    @abstractmethod
     def core_attention(self) -> type:
-        """Which module to use for attention"""
+        """Which module to use for attention."""
         ...
 
-    @abstractmethod
     def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
+        """Which module and submodules to use for grouped mlp."""
         ...
 
-    @abstractmethod
     def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
+        """Which module to use for activation function."""
+        ...
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Which module to use for the dense MLP block."""
+        ...
+
+    def moe_router(self) -> Optional[type]:
+        """Which MoE router to use, or None to keep the MoESubmodules default."""
+        ...
+
+    def vocab_parallel_cross_entropy(self) -> VocabParallelCrossEntropy:
+        """Which vocab-parallel cross entropy to use."""
         ...
 
 
 class LocalSpecProvider(BackendSpecProvider):
-    """A protocol for providing Local submodules used in Spec building."""
+    """Every backend a Megatron-Core-only run uses.
+
+    Norm is Torch rather than Apex-if-installed: whether an optional package happens to be
+    present must not silently change which kernel a run gets. Apex is a deliberate choice,
+    made by passing ``use_apex_norm=True``.
+    """
+
+    def __init__(
+        self, use_apex_norm: bool = False, cross_entropy_loss_fusion: bool = False
+    ) -> None:
+        # Imported here so that selecting Apex is what pulls Apex in.
+        if use_apex_norm:
+            from megatron.core.ops.norm import NormApex
+
+            self._norm = NormApex()
+        else:
+            from megatron.core.ops.norm import NormTorch
+
+            self._norm = NormTorch()
+        self._linear = LinearLocal()
+        self._attention = AttentionLocal()
+        self._mlp = MlpMegatron()
+        self._moe = MoeLocal()
+        self._loss = LossMegatronFused() if cross_entropy_loss_fusion else LossMegatron()
+
+    def linear(self) -> type:
+        """Megatron Core has no non-parallel linear; Transformer Engine is the one that does."""
+        raise NotImplementedError(
+            "This backend has no non-parallel linear. Use --transformer-impl transformer_engine."
+        )
 
     def column_parallel_linear(self) -> type:
-        """Which column parallel linear module the backend uses"""
-        return ColumnParallelLinear
+        """Which column parallel linear module the backend uses."""
+        return self._linear.column_parallel_linear()
 
-    def row_parallel_linear(self) -> type[RowParallelLinear]:
-        """Which row parallel linear module the backend uses"""
-        return RowParallelLinear
+    def row_parallel_linear(self) -> type:
+        """Which row parallel linear module the backend uses."""
+        return self._linear.row_parallel_linear()
 
     def fuse_layernorm_and_linear(self) -> bool:
-        """Does the backend choose a single module for layernorm and linear"""
+        """Does the backend choose a single module for layernorm and linear."""
         return False
 
     def column_parallel_layer_norm_linear(self) -> Optional[type]:
-        """Which module for sequential layernorm and linear"""
-        return None
+        """Which module for sequential layernorm and linear."""
+        return self._linear.column_parallel_layer_norm_linear()
 
     def layer_norm(
         self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
     ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if rms_norm:
-            # Matching get_gpt_layer_local_spec.
-            # Why does the global need to be updated?
-            global LNImpl
-            LNImpl = WrappedTorchNorm
-        return LNImpl
+        """Which module to use for layer norm."""
+        return self._norm.layer_norm(rms_norm=rms_norm, for_qk=for_qk, has_residual=has_residual)
 
     def core_attention(self) -> type:
-        """Which module to use for attention"""
-        return DotProductAttention
+        """Which module to use for attention."""
+        return self._attention.core_attention()
 
     def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        return partial(
-            SequentialMLP,
-            submodules=MLPSubmodules(
-                linear_fc1=ColumnParallelLinear,
-                linear_fc2=RowParallelLinear,
-                activation_func=self.activation_func(),
-            ),
-        )
+        """Which module and submodules to use for grouped mlp."""
+        return self._moe.grouped_mlp_modules(moe_use_grouped_gemm)
 
     def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        return None
+        """Which module to use for activation function."""
+        return self._moe.activation_func()
+
+    def mlp_module(self, grouped: bool = False) -> type:
+        """Which module to use for the dense MLP block."""
+        return self._mlp.mlp_module(grouped=grouped)
+
+    def moe_router(self) -> Optional[type]:
+        """Which MoE router to use, or None to keep the MoESubmodules default."""
+        return self._moe.moe_router()
+
+    def vocab_parallel_cross_entropy(self) -> VocabParallelCrossEntropy:
+        """Which vocab-parallel cross entropy to use."""
+        return self._loss.vocab_parallel_cross_entropy()
 
 
-class InferenceSpecProvider(BackendSpecProvider):
-    """A protocol for providing the submodules used in Spec building."""
+class InferenceSpecProvider(LocalSpecProvider):
+    """Every backend an inference-optimized run uses.
+
+    Attention comes from Transformer Engine; the inference-specific gains are in the linear
+    and mixture-of-experts layers.
+    """
+
+    def __init__(self, cross_entropy_loss_fusion: bool = False) -> None:
+        super().__init__(cross_entropy_loss_fusion=cross_entropy_loss_fusion)
+        from megatron.core.inference.ops import LinearInference, MoeInference, NormInference
+        from megatron.core.ops.attention import AttentionTE
+
+        self._norm = NormInference()
+        self._linear = LinearInference()
+        self._attention = AttentionTE()
+        self._moe = MoeInference()
 
     def linear(self) -> type:
-        """Which linear module TE backend uses"""
-        return TELinear
-
-    def column_parallel_linear(self) -> type:
-        """Which column parallel linear module TE backend uses"""
-        return InferenceColumnParallelLinear
-
-    def row_parallel_linear(self) -> type[InferenceRowParallelLinear]:
-        """Which row parallel linear module Inference backend uses"""
-        return InferenceRowParallelLinear
+        """Which non-parallel linear module the backend uses."""
+        return self._linear.linear()
 
     def fuse_layernorm_and_linear(self) -> bool:
-        """TE backend chooses a single module for layernorm and linear"""
+        """The inference linear fuses layernorm into the column-parallel linear."""
         return True
-
-    def column_parallel_layer_norm_linear(self) -> type[InferenceLayerNormColumnParallelLinear]:
-        """Which module for sequential layernorm and linear"""
-        return InferenceLayerNormColumnParallelLinear
-
-    def layer_norm(
-        self, rms_norm: bool = False, for_qk: bool = False, has_residual: bool = False
-    ) -> LayerNormBuilder:
-        """Which module to use for layer norm"""
-        if for_qk and not is_te_min_version("1.9.0"):
-            # TENorm significantly harms convergence when used
-            # for QKLayerNorm if TE Version < 1.9;
-            # we instead use the Apex implementation.
-            return not_none(FusedLayerNorm)
-        return TENorm
-
-    def core_attention(self) -> type[TEDotProductAttention]:
-        """Which module to use for attention"""
-        return TEDotProductAttention
-
-    def activation_func(self) -> TEActivationFunctionBuilder | None:
-        """Which module to use for activation function"""
-        # transformer_engine.BasicOperation.forward has an overly permissive return type, but by
-        # design these classes always meet the interface.
-        return cast(TEActivationFunctionBuilder, TEActivationOp)
-
-    def grouped_mlp_modules(self, moe_use_grouped_gemm: bool) -> ExpertsBuilder:
-        """Which module and submodules to use for grouped mlp"""
-        return partial(
-            InferenceGroupedMLP,
-            submodules=GroupedMLPSubmodules(
-                linear_fc1=TEColumnParallelGroupedLinear,
-                linear_fc2=TERowParallelGroupedLinear,
-                activation_func=self.activation_func(),
-            ),
-        )
 
 
 def get_backend(
-    transformer_impl: Literal["local", "transformer_engine", "inference_optimized"]
+    transformer_impl: str,
+    *,
+    use_kitchen: bool = False,
+    use_kitchen_attention: bool = False,
+    kitchen_attention_backend: str = "sdpa",
+    **settings,
 ) -> BackendSpecProvider:
-    """Return the backend that's selected with the given `transformer_impl`."""
+    """Build the provider for a named backend.
+
+    The whole of backend selection is here: three names, three providers, plus Kitchen layered
+    over whichever was chosen. A caller that has a ``TransformerConfig`` should use
+    :func:`get_backend_spec_provider` instead, which reads the settings off it.
+    """
+    base = _base_backend(transformer_impl, **settings)
+    if not use_kitchen:
+        return base
+    # Kitchen takes the operations it implements and forwards the rest to the provider that
+    # would otherwise have owned them.
+    from megatron.core.extensions.kitchen import KitchenSpecProvider
+
+    return KitchenSpecProvider(
+        fallback=base,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
+
+
+def _base_backend(transformer_impl: str, **settings) -> BackendSpecProvider:
     if transformer_impl == "transformer_engine":
         from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
 
-        return TESpecProvider()
-    elif transformer_impl == "inference_optimized":
-        return InferenceSpecProvider()
-    elif transformer_impl == "local":
-        return LocalSpecProvider()
-    else:
-        raise ValueError(f"unknown transformer_impl='{transformer_impl}'")
+        return TESpecProvider(**settings)
+    if transformer_impl == "inference_optimized":
+        settings.pop("use_te_op_fuser", None)
+        return InferenceSpecProvider(**settings)
+    if transformer_impl == "local":
+        settings.pop("use_te_op_fuser", None)
+        return LocalSpecProvider(**settings)
+    raise ValueError(
+        f"unknown transformer_impl='{transformer_impl}'. "
+        "Valid choices: local, transformer_engine, inference_optimized"
+    )
+
+
+def get_backend_spec_provider(
+    config: object, *, transformer_impl: Optional[str] = None
+) -> BackendSpecProvider:
+    """Build the provider a TransformerConfig asks for.
+
+    ``transformer_impl`` overrides ``config.transformer_impl``, for the callers that build a
+    Transformer Engine spec regardless of what the config says.
+    """
+    return get_backend(
+        transformer_impl or getattr(config, "transformer_impl", "local"),
+        use_kitchen=getattr(config, "use_kitchen", False),
+        use_kitchen_attention=getattr(config, "use_kitchen_attention", False),
+        kitchen_attention_backend=getattr(config, "kitchen_attention_backend", "sdpa"),
+        use_te_op_fuser=getattr(config, "use_transformer_engine_op_fuser", False),
+        cross_entropy_loss_fusion=getattr(config, "cross_entropy_loss_fusion", False),
+    )

--- a/megatron/core/models/bert/bert_layer_specs.py
+++ b/megatron/core/models/bert/bert_layer_specs.py
@@ -2,44 +2,14 @@
 import warnings
 from functools import partial
 
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.models.backends import get_backend
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
-from megatron.core.typed_torch import not_none
-
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import (
-        TEDotProductAttention,
-        TELayerNormColumnParallelLinear,
-        TERowParallelLinear,
-    )
-else:
-    (TEDotProductAttention, TELayerNormColumnParallelLinear, TERowParallelLinear) = (
-        None,
-        None,
-        None,
-    )
-
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
 
 
 def get_bert_layer_with_transformer_engine_submodules() -> TransformerLayerSubmodules:
@@ -49,19 +19,16 @@ def get_bert_layer_with_transformer_engine_submodules() -> TransformerLayerSubmo
     Returns:
         TransformerLayerSubmodules: Submodules with TE modules.
     """
-    if not HAVE_TE:
-        raise ImportError(
-            "Transformer Engine is not installed. Please use local Bert layer spec instead."
-        )
+    backend = get_backend("transformer_engine")
 
     return TransformerLayerSubmodules(
         self_attention=ModuleSpec(
             module=SelfAttention,
             params={"attn_mask_type": AttnMaskType.padding},
             submodules=SelfAttentionSubmodules(
-                linear_qkv=not_none(TELayerNormColumnParallelLinear),
-                core_attention=not_none(TEDotProductAttention),
-                linear_proj=not_none(TERowParallelLinear),
+                linear_qkv=backend.column_parallel_layer_norm_linear(),
+                core_attention=backend.core_attention(),
+                linear_proj=backend.row_parallel_linear(),
                 # Leave q_layernorm/k_layernorm unset (None) rather than IdentityOp so that
                 # TransformerConfig.qk_layernorm can select the default TENorm through the
                 # shared SelfAttention fallback (`submodules.q_layernorm or TENorm`).
@@ -73,8 +40,8 @@ def get_bert_layer_with_transformer_engine_submodules() -> TransformerLayerSubmo
         mlp=partial(
             MLP.as_mlp_submodule,
             submodules=MLPSubmodules(
-                linear_fc1=not_none(TELayerNormColumnParallelLinear),
-                linear_fc2=not_none(TERowParallelLinear),
+                linear_fc1=backend.column_parallel_layer_norm_linear(),
+                linear_fc2=backend.row_parallel_linear(),
             ),
         ),
         mlp_bda=get_bias_dropout_add,
@@ -94,36 +61,39 @@ def get_bert_layer_with_transformer_engine_spec():
 
 def __getattr__(name):
     if name == "bert_layer_with_transformer_engine_spec":
-        warnings.warn(
-            """Attribute bert_layer_specs.bert_layer_with_transformer_engine_spec is on a
+        warnings.warn("""Attribute bert_layer_specs.bert_layer_with_transformer_engine_spec is on a
             deprecation track and will be removed in future releases. Please migrate to
-            bert_layer_specs.get_bert_layer_with_transformer_engine_spec()."""
-        )
+            bert_layer_specs.get_bert_layer_with_transformer_engine_spec().""")
 
         return get_bert_layer_with_transformer_engine_spec()
 
+
+_local_backend = get_backend("local")
 
 # Use this spec for an implementation using only modules in megatron core
 bert_layer_local_spec = ModuleSpec(
     module=TransformerLayer,
     submodules=TransformerLayerSubmodules(
-        input_layernorm=LNImpl,
+        input_layernorm=_local_backend.layer_norm(),
         self_attention=ModuleSpec(
             module=SelfAttention,
             params={"attn_mask_type": AttnMaskType.padding},
             submodules=SelfAttentionSubmodules(
-                linear_qkv=ColumnParallelLinear,
-                core_attention=DotProductAttention,
-                linear_proj=RowParallelLinear,
+                linear_qkv=_local_backend.column_parallel_linear(),
+                core_attention=_local_backend.core_attention(),
+                linear_proj=_local_backend.row_parallel_linear(),
                 q_layernorm=IdentityOp,
                 k_layernorm=IdentityOp,
             ),
         ),
         self_attn_bda=get_bias_dropout_add,
-        pre_mlp_layernorm=LNImpl,
+        pre_mlp_layernorm=_local_backend.layer_norm(),
         mlp=partial(
             MLP.as_mlp_submodule,
-            submodules=MLPSubmodules(linear_fc1=ColumnParallelLinear, linear_fc2=RowParallelLinear),
+            submodules=MLPSubmodules(
+                linear_fc1=_local_backend.column_parallel_linear(),
+                linear_fc2=_local_backend.row_parallel_linear(),
+            ),
         ),
         mlp_bda=get_bias_dropout_add,
         sharded_state_dict_keys_map={

--- a/megatron/core/models/bert/bert_lm_head.py
+++ b/megatron/core/models/bert/bert_lm_head.py
@@ -2,18 +2,10 @@
 import torch
 from torch import Tensor
 
-from megatron.core.fusions.fused_layer_norm import HAVE_FUSED_LAYER_NORM, FusedLayerNorm
+from megatron.core.models.backends import get_backend_spec_provider
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import get_linear_layer
-
-if HAVE_FUSED_LAYER_NORM:
-    LNImpl = FusedLayerNorm
-else:
-    import warnings
-
-    warnings.warn(f'Apex is not installed. Falling back to Torch Norm')
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm as LNImpl
 
 
 class BertLMHead(MegatronModule):
@@ -35,7 +27,7 @@ class BertLMHead(MegatronModule):
         setattr(self.dense.weight, 'sequence_parallel', config.sequence_parallel)
         setattr(self.dense.bias, 'sequence_parallel', config.sequence_parallel)
 
-        self.layer_norm = LNImpl(
+        self.layer_norm = get_backend_spec_provider(config).layer_norm()(
             config=config, hidden_size=hidden_size, eps=config.layernorm_epsilon
         )
 

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -6,15 +6,9 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 
-from megatron.core import parallel_state, tensor_parallel
+from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
-from megatron.core.transformer.cuda_graphs import CudaGraphManager
-
-try:
-    from megatron.core.extensions.transformer_engine import te_parallel_cross_entropy
-except:
-    te_parallel_cross_entropy = None
-from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+from megatron.core.models.backends import get_backend_spec_provider
 from megatron.core.pipeline_parallel.utils import (
     is_pp_first_stage,
     is_pp_last_stage,
@@ -22,6 +16,7 @@ from megatron.core.pipeline_parallel.utils import (
     is_vp_last_stage,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.cuda_graphs import CudaGraphManager
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.multi_token_prediction import tie_word_embeddings_state_dict
@@ -29,7 +24,6 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import ensure_metadata_has_dp_cp_group
 from megatron.core.utils import (
     get_tensor_model_parallel_group_if_none,
-    is_te_min_version,
     make_tp_sharded_tensor_for_checkpoint,
 )
 
@@ -63,6 +57,12 @@ class LanguageModule(MegatronModule):
         self.embd_group = pg_collection.embd
         self.vp_stage = None
         self.vp_size = self.config.virtual_pipeline_model_parallel_size
+        # Choose the cross entropy implementation once, here, rather than on every forward.
+        # Fusion settings, the Transformer Engine version check, and CUDA graph capture are
+        # all resolved inside the backend before the first step runs.
+        self.vocab_parallel_cross_entropy = get_backend_spec_provider(
+            config
+        ).vocab_parallel_cross_entropy()
 
     def _setup_mtp_cuda_graphs(self):
         """Wrap `compute_mtp_single_step` with a CudaGraphManager.
@@ -170,40 +170,9 @@ class LanguageModule(MegatronModule):
         """
         # [b s] => [s b]
         labels = labels.transpose(0, 1).contiguous()
-        if self.config.cross_entropy_loss_fusion:
-            if self.config.cross_entropy_fusion_impl == 'te':
-                if te_parallel_cross_entropy is not None:
-                    labels = torch.as_strided(labels, labels.size(), (labels.size()[1], 1))
-                    # Use is_cg_capturable=True for full iteration CUDA graphs to avoid torch.equal checks
-                    is_cg_capturable = (
-                        hasattr(self.config, 'cuda_graph_impl')
-                        and self.config.cuda_graph_impl == "full_iteration"
-                    )
-                    if is_cg_capturable and not is_te_min_version("2.7.0"):
-                        from megatron.core.utils import get_te_version
-
-                        current_version = get_te_version()
-                        raise AssertionError(
-                            f"CUDA graph compatible cross entropy requires TransformerEngine >= 2.7.0, "
-                            f"but found version {current_version}. Please upgrade TransformerEngine "
-                            f"or set cuda_graph_impl to a value other than 'full_iteration'."
-                        )
-
-                    loss = te_parallel_cross_entropy(
-                        logits, labels, self.pg_collection.tp, is_cg_capturable
-                    )
-                else:
-                    raise RuntimeError("Trying to use a TE block when it's not present.")
-            elif self.config.cross_entropy_fusion_impl == 'native':
-                loss = fused_vocab_parallel_cross_entropy(logits, labels, self.pg_collection.tp)
-        else:
-            loss = tensor_parallel.vocab_parallel_cross_entropy(
-                logits, labels, tp_group=self.tp_group
-            )
-
+        loss = self.vocab_parallel_cross_entropy(logits, labels, self.tp_group)
         # [s b] => [b, s]
-        loss = loss.transpose(0, 1).contiguous()
-        return loss
+        return loss.transpose(0, 1).contiguous()
 
     def setup_embeddings_and_output_layer(self) -> None:
         """Sets up embedding layer in first stage and output layer in last stage.

--- a/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
+++ b/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
@@ -4,7 +4,7 @@ import warnings
 from typing import List, Optional
 
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.models.backends import BackendSpecProvider
+from megatron.core.models.backends import BackendSpecProvider, get_backend_spec_provider
 from megatron.core.ssm.gated_delta_net import GatedDeltaNet, GatedDeltaNet2, GatedDeltaNetSubmodules
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
@@ -33,25 +33,6 @@ from megatron.core.transformer.transformer_layer import (
     get_transformer_layer_offset,
 )
 from megatron.core.typed_torch import not_none
-
-try:
-    import transformer_engine as te  # type: ignore[import-untyped]  # pylint: disable=unused-import
-
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-
-    HAVE_TE = True
-except ImportError:
-    HAVE_TE = False
-
-try:
-    import nvidia_kitchen  # type: ignore[import-not-found]  # pylint: disable=unused-import
-
-    from megatron.core.extensions.kitchen import KitchenSpecProvider
-
-    HAVE_KITCHEN = True
-except ImportError:
-    HAVE_KITCHEN = False
-
 
 ##########
 # Experimental Attention Variant Names
@@ -499,16 +480,7 @@ def _get_backend_spec_provider(config: TransformerConfig) -> BackendSpecProvider
         "Experimental GPT decoder block spec only supports "
         "transformer engine implementation for now."
     )
-    backend: BackendSpecProvider = (
-        KitchenSpecProvider(
-            fallback=TESpecProvider(),
-            use_kitchen_attention=config.use_kitchen_attention,
-            kitchen_attention_backend=config.kitchen_attention_backend,
-        )
-        if config.use_kitchen
-        else TESpecProvider()
-    )
-    return backend
+    return get_backend_spec_provider(config, transformer_impl="transformer_engine")
 
 
 ##########

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -3,18 +3,17 @@ import warnings
 from functools import partial
 from typing import Optional, Union
 
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 from megatron.core.models.backends import (
     BackendSpecProvider,
-    InferenceSpecProvider,
-    LocalSpecProvider,
+    get_backend,
+    get_backend_spec_provider,
 )
 from megatron.core.models.gpt.moe_module_specs import get_moe_module_spec_for_backend
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.multi_latent_attention import (
     FusedMLASelfAttention,
     MLASelfAttention,
@@ -40,40 +39,16 @@ from megatron.core.transformer.transformer_layer import (
     TransformerLayerSubmodules,
     get_transformer_layer_offset,
 )
-from megatron.core.typed_torch import copy_signature, not_none
-from megatron.core.utils import is_te_min_version
+from megatron.core.typed_torch import copy_signature
 
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import (
-        TEFusedMLP,
-        TEFusedMLPWithGroupedLinear,
-        TENorm,
-    )
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-else:
-    TEFusedMLPWithGroupedLinear, TEFusedMLP, TENorm, TESpecProvider = None, None, None, None
 
-try:
-    from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
-
-except ImportError:
-    HAVE_KITCHEN = False
-
-try:
-    import apex  # type: ignore[import-untyped]  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
+def _base_backend_name(config: TransformerConfig, use_transformer_engine: bool) -> str:
+    """Which complete backend a GPT spec builds on."""
+    if use_transformer_engine:
+        return "transformer_engine"
+    if config.transformer_impl == "inference_optimized":
+        return "inference_optimized"
+    return "local"
 
 
 def get_gpt_layer_with_inference_submodules(
@@ -90,14 +65,12 @@ def get_gpt_layer_with_inference_submodules(
         multi_latent_attention (bool, optional): To use MLA. Defaults to False.
         qk_l2_norm (bool, optional): To use l2 norm for queries/keys. Defaults to False.
     """
-    assert HAVE_TE, "--transformer-impl inference_optimized requires transformer engine"
-    backend = InferenceSpecProvider()
+    backend = get_backend("inference_optimized")
 
     mlp = get_mlp_module_spec_for_backend(
         backend=backend,
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=False,
         use_te_activation_func=False,
     )
 
@@ -219,24 +192,22 @@ def get_gpt_layer_with_transformer_engine_submodules(
         )
 
     if use_kitchen:
-        assert HAVE_KITCHEN
-        backend: BackendSpecProvider = KitchenSpecProvider(
-            fallback=TESpecProvider(),
-            use_kitchen_attention=use_kitchen_attention,
-            kitchen_attention_backend=kitchen_attention_backend,
-        )
         if use_te_op_fuser:
             raise AssertionError("use_te_op_fuser not compatible with using kitchen in mlp.")
         if use_te_activation_func:
             raise AssertionError("use_te_activation_func not compatible with using kitchen.")
-    else:
-        backend = TESpecProvider()
+    backend: BackendSpecProvider = get_backend(
+        "transformer_engine",
+        use_te_op_fuser=bool(use_te_op_fuser),
+        use_kitchen=use_kitchen,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
 
     mlp = get_mlp_module_spec_for_backend(
         backend=backend,
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=use_te_op_fuser,
         use_te_activation_func=use_te_activation_func,
         use_grouped_gemm_for_dense_mlp=use_grouped_gemm_for_dense_mlp,
     )
@@ -383,15 +354,12 @@ def get_gpt_layer_local_submodules(
         TransformerLayerSubmodules: Megatron-Core modules to construct a TransformerLayer
     """
 
-    if use_kitchen:
-        assert HAVE_KITCHEN
-        backend = KitchenSpecProvider(
-            fallback=LocalSpecProvider(),
-            use_kitchen_attention=use_kitchen_attention,
-            kitchen_attention_backend=kitchen_attention_backend,
-        )
-    else:
-        backend = LocalSpecProvider()
+    backend = get_backend(
+        "local",
+        use_kitchen=use_kitchen,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
     # Adjust for RMS norm.
     if normalization == "RMSNorm":
         layer_norm = backend.layer_norm(rms_norm=True, for_qk=False, has_residual=True)
@@ -501,20 +469,17 @@ def get_mlp_module_spec(
             " and will be removed soon. Please update your code accordingly."
         )
     if use_te_op_fuser:
-        if not is_te_min_version("1.13.0"):
-            raise ValueError(
-                "Transformer Engine operation-based API requires Transformer Engine 1.13+"
-            )
         if num_experts is not None:
             raise ValueError(
                 "Transformer Engine operation-based API does not support mixture-of-experts"
             )
 
     return get_mlp_module_spec_for_backend(
-        backend=TESpecProvider() if use_te else LocalSpecProvider(),
+        backend=get_backend(
+            "transformer_engine" if use_te else "local", use_te_op_fuser=bool(use_te_op_fuser)
+        ),
         num_experts=num_experts,
         moe_grouped_gemm=moe_grouped_gemm,
-        use_te_op_fuser=use_te_op_fuser,
     )
 
 
@@ -522,7 +487,6 @@ def get_mlp_module_spec_for_backend(
     backend: BackendSpecProvider,
     num_experts: Optional[int] = None,
     moe_grouped_gemm: Optional[bool] = False,
-    use_te_op_fuser: Optional[bool] = False,
     use_te_activation_func: bool = False,
     use_grouped_gemm_for_dense_mlp: bool = False,
 ) -> MlpBuilder:
@@ -532,13 +496,8 @@ def get_mlp_module_spec_for_backend(
     activation_func = backend.activation_func() if use_te_activation_func else None
 
     if num_experts is None:
-        # Dense MLP w/ or w/o TE modules.
-        if use_grouped_gemm_for_dense_mlp and use_te_op_fuser:
-            module = not_none(TEFusedMLPWithGroupedLinear).as_mlp_submodule
-        elif use_te_op_fuser:
-            module = not_none(TEFusedMLP).as_mlp_submodule
-        else:
-            module = MLP.as_mlp_submodule
+        # Dense MLP; which block is a construction-time choice the backend already made.
+        module = backend.mlp_module(grouped=bool(use_grouped_gemm_for_dense_mlp)).as_mlp_submodule
         if backend.fuse_layernorm_and_linear():
             linear_fc1 = backend.column_parallel_layer_norm_linear()
             assert linear_fc1 is not None
@@ -575,7 +534,6 @@ def get_gpt_decoder_layer_specs(
     )
 
     if use_transformer_engine:
-        layer_norm_impl = TENorm
         dense_layer_spec = get_gpt_layer_with_transformer_engine_spec(
             num_experts=None,
             moe_grouped_gemm=False,
@@ -601,7 +559,6 @@ def get_gpt_decoder_layer_specs(
             mla_down_proj_fusion=getattr(config, "mla_down_proj_fusion", False),
         )
     elif config.transformer_impl == "inference_optimized":
-        layer_norm_impl = TENorm
         dense_layer_spec = get_gpt_layer_with_inference_spec(
             qk_layernorm=config.qk_layernorm,
             multi_latent_attention=config.multi_latent_attention,
@@ -616,7 +573,6 @@ def get_gpt_decoder_layer_specs(
             moe_use_legacy_grouped_gemm=getattr(config, "moe_use_legacy_grouped_gemm", False),
         )
     else:
-        layer_norm_impl = LNImpl
         dense_layer_spec = get_gpt_layer_local_spec(
             num_experts=None,
             moe_grouped_gemm=False,
@@ -705,12 +661,14 @@ def get_gpt_decoder_block_spec(
         offset = get_transformer_layer_offset(config, vp_stage=vp_stage, pp_rank=pp_rank)
         local_layer_specs = layer_specs[offset : offset + num_layers_to_build]
 
-    if use_transformer_engine:
-        layer_norm_impl = TENorm
-    elif config.transformer_impl == "inference_optimized":
-        layer_norm_impl = TENorm
-    else:
-        layer_norm_impl = LNImpl
+    # The final norm is the same operation as every other norm in the block, so it comes
+    # from the same backend rather than from a second selection path.
+    backend = get_backend_spec_provider(
+        config, transformer_impl=_base_backend_name(config, use_transformer_engine)
+    )
+    layer_norm_impl = backend.layer_norm(
+        rms_norm=(normalization or config.normalization) == "RMSNorm"
+    )
     # Block spec.
     block_spec = TransformerBlockSubmodules(
         layer_specs=local_layer_specs, layer_norm=layer_norm_impl
@@ -727,26 +685,11 @@ def get_gpt_mtp_block_spec(
     pp_rank: Optional[int] = None,
 ) -> MultiTokenPredictionBlockSubmodules:
     """GPT Multi-Token Prediction (MTP) block spec."""
-    if use_transformer_engine:
-        backend: BackendSpecProvider = (
-            KitchenSpecProvider(
-                fallback=TESpecProvider(),
-                use_kitchen_attention=config.use_kitchen_attention,
-                kitchen_attention_backend=config.kitchen_attention_backend,
-            )
-            if config.use_kitchen
-            else TESpecProvider()
-        )
-    else:
-        backend = (
-            KitchenSpecProvider(
-                fallback=LocalSpecProvider(),
-                use_kitchen_attention=config.use_kitchen_attention,
-                kitchen_attention_backend=config.kitchen_attention_backend,
-            )
-            if config.use_kitchen
-            else LocalSpecProvider()
-        )
+    # MTP has only ever used the Transformer Engine or the local backend, never the
+    # inference one, so it does not go through _base_backend_name().
+    backend: BackendSpecProvider = get_backend_spec_provider(
+        config, transformer_impl="transformer_engine" if use_transformer_engine else "local"
+    )
     return get_gpt_mtp_block_spec_for_backend(
         config=config, spec=spec, backend=backend, vp_stage=vp_stage, pp_rank=pp_rank
     )

--- a/megatron/core/models/gpt/heterogeneous/heterogeneous_layer_specs.py
+++ b/megatron/core/models/gpt/heterogeneous/heterogeneous_layer_specs.py
@@ -1,14 +1,11 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
-import warnings
 from functools import partial
 from typing import Optional
 
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.models.backends import get_backend
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.heterogeneous.heterogeneous_config import (
     AttentionConfig,
@@ -29,50 +26,28 @@ from megatron.core.transformer.transformer_layer import (
     TransformerLayerSubmodules,
     get_transformer_layer_offset,
 )
-from megatron.core.typed_torch import not_none
 from megatron.core.utils import is_te_min_version
 
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import (
-        TEDotProductAttention,
-        TELayerNormColumnParallelLinear,
-        TENorm,
-        TERowParallelLinear,
-    )
+# One provider per backend, so every choice below names a class in megatron.core.ops.
+_te = get_backend("transformer_engine")
+_local = get_backend("local")
+
+
+def _TE_LN_LINEAR_GATHERED():
+    """The heterogeneous-specific layernorm+linear, which is not a backend choice."""
     from megatron.core.transformer.heterogeneous.linear_replacements import (
         TELayerNormColumnParallelLinearGathered,
     )
-else:
-    (
-        TEDotProductAttention,
-        TELayerNormColumnParallelLinear,
-        TENorm,
-        TERowParallelLinear,
-        TELayerNormColumnParallelLinearGathered,
-    ) = (None, None, None, None, None)
+
+    return TELayerNormColumnParallelLinearGathered
+
 
 from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
 
 
 def _get_layer_norm(config: AttentionConfig | MLPConfig, use_te: bool, normalization: str):
     # RMSNorm is not supported in FusedLayerNorm
-    ln_impl = LNImpl if normalization == "LayerNorm" else WrappedTorchNorm
+    ln_impl = _local.layer_norm() if normalization == "LayerNorm" else WrappedTorchNorm
 
     # We don't use layernorm when the attention/mlp is no-op or
     # when we are using TE (the layernorm is fused with the first linear).
@@ -81,14 +56,14 @@ def _get_layer_norm(config: AttentionConfig | MLPConfig, use_te: bool, normaliza
 
 def _get_qk_layernorm(use_te: bool, normalization: str):
     # RMSNorm is not supported in FusedLayerNorm
-    ln_impl = LNImpl if normalization == "LayerNorm" else WrappedTorchNorm
+    ln_impl = _local.layer_norm() if normalization == "LayerNorm" else WrappedTorchNorm
 
     if use_te:
         if is_te_min_version("1.9.0"):
-            # TENorm significantly harms convergence when used
+            # _te.layer_norm() significantly harms convergence when used
             # for QKLayerNorm if TE Version < 1.9;
             # we instead use the Apex implementation.
-            qk_norm = TENorm
+            qk_norm = _te.layer_norm()
         else:
             qk_norm = ln_impl
     else:
@@ -104,9 +79,7 @@ def _get_heterogenous_attention_spec(
         self_attention = ModuleSpec(module=IdentityOp)
     elif attn_config.replace_with_linear:
         self_attention = ModuleSpec(
-            module=(
-                TELayerNormColumnParallelLinearGathered if use_te else ColumnParallelLinearGathered
-            ),
+            module=(_TE_LN_LINEAR_GATHERED() if use_te else ColumnParallelLinearGathered),
             params={"tp_comm_buffer_name": "linear_attn"},
         )
     else:
@@ -116,10 +89,12 @@ def _get_heterogenous_attention_spec(
             params={"attn_mask_type": AttnMaskType.causal},
             submodules=SelfAttentionSubmodules(
                 linear_qkv=(
-                    not_none(TELayerNormColumnParallelLinear) if use_te else ColumnParallelLinear
+                    _te.column_parallel_layer_norm_linear()
+                    if use_te
+                    else _local.column_parallel_linear()
                 ),
-                core_attention=not_none(TEDotProductAttention) if use_te else DotProductAttention,
-                linear_proj=not_none(TERowParallelLinear) if use_te else RowParallelLinear,
+                core_attention=_te.core_attention() if use_te else _local.core_attention(),
+                linear_proj=_te.row_parallel_linear() if use_te else _local.row_parallel_linear(),
                 q_layernorm=ln,
                 k_layernorm=ln,
             ),
@@ -132,11 +107,7 @@ def _get_heterogenous_mlp_spec(mlp_config: MLPConfig, use_te: bool):
         return IdentityOp
     elif mlp_config.replace_with_linear:
         return partial(
-            (
-                not_none(TELayerNormColumnParallelLinearGathered)
-                if use_te
-                else ColumnParallelLinearGathered
-            ),
+            (_TE_LN_LINEAR_GATHERED() if use_te else ColumnParallelLinearGathered),
             tp_comm_buffer_name="linear_mlp",
         )
     else:
@@ -144,9 +115,11 @@ def _get_heterogenous_mlp_spec(mlp_config: MLPConfig, use_te: bool):
             MLP.as_mlp_submodule,
             submodules=MLPSubmodules(
                 linear_fc1=(
-                    not_none(TELayerNormColumnParallelLinear) if use_te else ColumnParallelLinear
+                    _te.column_parallel_layer_norm_linear()
+                    if use_te
+                    else _local.column_parallel_linear()
                 ),
-                linear_fc2=not_none(TERowParallelLinear) if use_te else RowParallelLinear,
+                linear_fc2=_te.row_parallel_linear() if use_te else _local.row_parallel_linear(),
             ),
         )
 
@@ -224,7 +197,9 @@ def get_gpt_heterogeneous_layer_spec(
 
     # Submodules layer_norm determines the type of layernorm used in the last layernorm
     if use_te:
-        layer_norm = TENorm
+        layer_norm = _te.layer_norm()
     else:
-        layer_norm = LNImpl if config.normalization == "LayerNorm" else WrappedTorchNorm
+        layer_norm = (
+            _local.layer_norm() if config.normalization == "LayerNorm" else WrappedTorchNorm
+        )
     return TransformerBlockSubmodules(layer_specs, layer_norm=layer_norm)

--- a/megatron/core/models/gpt/moe_module_specs.py
+++ b/megatron/core/models/gpt/moe_module_specs.py
@@ -3,19 +3,14 @@
 from functools import partial
 from typing import Optional
 
-from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-from megatron.core.models.backends import (
-    BackendSpecProvider,
-    InferenceSpecProvider,
-    LocalSpecProvider,
-)
+from megatron.core.models.backends import BackendSpecProvider, get_backend
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import ProcessGroupCollection
-from megatron.core.transformer.moe.router import InferenceTopKRouter
 from megatron.core.transformer.moe.shared_experts import FusedSharedExpertMLP, SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import MlpBuilder
+from megatron.core.typed_torch import not_none
 
 
 def _build_shared_experts(
@@ -53,10 +48,7 @@ def get_moe_module_spec(
         moe_grouped_gemm: Whether to use grouped GEMM.
         moe_use_legacy_grouped_gemm: Whether to use legacy grouped GEMM.
     """
-    if use_te is not None and use_te:
-        backend: BackendSpecProvider = TESpecProvider()
-    else:
-        backend = LocalSpecProvider()
+    backend = get_backend("transformer_engine" if use_te else "local")
     return get_moe_module_spec_for_backend(
         backend=backend, num_experts=num_experts, moe_grouped_gemm=moe_grouped_gemm
     )
@@ -83,10 +75,10 @@ def get_moe_module_spec_for_backend(
     # shared experts spec
     shared_experts = partial(_build_shared_experts, submodules=mlp)
 
-    # The inference-optimized backend needs InferenceTopKRouter (compact [tokens, topk]
-    # index routing); other backends keep the MoESubmodules default (training TopKRouter,
-    # dense [tokens, num_experts] map). Mirrors get_inference_optimized_moe_spec().
-    router = InferenceTopKRouter if isinstance(backend, InferenceSpecProvider) else None
+    # The router is an operation the backend owns: the inference backend needs compact
+    # [tokens, topk] index routing, and every other backend keeps the MoESubmodules default
+    # (training TopKRouter, dense [tokens, num_experts] map).
+    router = backend.moe_router()
     submodule_kwargs = {"router": router} if router is not None else {}
 
     # MoE module spec
@@ -101,14 +93,15 @@ def get_moe_module_spec_for_backend(
 def get_inference_optimized_moe_spec() -> MlpBuilder:
     """MoE module spec for inference-optimized transformer impl.
 
-    Uses InferenceSpecProvider to select inference-optimized modules:
+    Uses the inference backend to select inference-optimized modules:
     InferenceTopKRouter, InferenceGroupedMLP. MoELayer detects inference mode
     via config.transformer_impl and sets up the inference dispatcher internally.
 
     Called by hybrid_layer_specs.py and gpt_layer_specs.py.
     """
-    backend = InferenceSpecProvider()
+    backend = get_backend("inference_optimized")
     activation_func = backend.activation_func()
+    router = not_none(backend.moe_router())
 
     experts = backend.grouped_mlp_modules(True)
     shared_experts = partial(
@@ -122,7 +115,5 @@ def get_inference_optimized_moe_spec() -> MlpBuilder:
 
     return partial(
         MoELayer,
-        submodules=MoESubmodules(
-            router=InferenceTopKRouter, experts=experts, shared_experts=shared_experts
-        ),
+        submodules=MoESubmodules(router=router, experts=experts, shared_experts=shared_experts),
     )

--- a/megatron/core/models/multimodal/llava_spec.py
+++ b/megatron/core/models/multimodal/llava_spec.py
@@ -1,37 +1,18 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from typing import Optional
 
-from megatron.core.extensions.transformer_engine import (
-    TEDotProductAttention,
-    TELayerNormColumnParallelLinear,
-    TENorm,
-    TERowParallelLinear,
-)
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
+from megatron.core.models.backends import get_backend
 from megatron.core.models.gpt.gpt_layer_specs import get_mlp_module_spec
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
 
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
+# One provider per backend, so every choice below names a class in megatron.core.ops.
+_te = get_backend("transformer_engine")
+_local = get_backend("local")
 
 
 def decoder_model_with_transformer_engine_default_spec(
@@ -48,11 +29,11 @@ def decoder_model_with_transformer_engine_default_spec(
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.causal},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=TELayerNormColumnParallelLinear,
-                    core_attention=TEDotProductAttention,
-                    linear_proj=TERowParallelLinear,
-                    q_layernorm=TENorm if qk_layernorm else IdentityOp,
-                    k_layernorm=TENorm if qk_layernorm else IdentityOp,
+                    linear_qkv=_te.column_parallel_layer_norm_linear(),
+                    core_attention=_te.core_attention(),
+                    linear_proj=_te.row_parallel_linear(),
+                    q_layernorm=_te.layer_norm() if qk_layernorm else IdentityOp,
+                    k_layernorm=_te.layer_norm() if qk_layernorm else IdentityOp,
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
@@ -72,18 +53,18 @@ def decoder_model_with_local_default_spec(
     return ModuleSpec(
         module=TransformerLayer,
         submodules=TransformerLayerSubmodules(
-            input_layernorm=LNImpl,
+            input_layernorm=_local.layer_norm(),
             self_attention=ModuleSpec(
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.causal},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=ColumnParallelLinear,
-                    core_attention=DotProductAttention,
-                    linear_proj=RowParallelLinear,
+                    linear_qkv=_local.column_parallel_linear(),
+                    core_attention=_local.core_attention(),
+                    linear_proj=_local.row_parallel_linear(),
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
-            pre_mlp_layernorm=LNImpl,
+            pre_mlp_layernorm=_local.layer_norm(),
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
         ),

--- a/megatron/core/models/vision/vit_layer_specs.py
+++ b/megatron/core/models/vision/vit_layer_specs.py
@@ -1,36 +1,18 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from functools import partial
 
-from megatron.core.extensions.transformer_engine import (
-    TEDotProductAttention,
-    TELayerNormColumnParallelLinear,
-    TERowParallelLinear,
-)
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.models.backends import get_backend
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
 
-try:
-    import apex  # pylint: disable=unused-import
-
-    from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
-
-    HAVE_APEX = True
-    LNImpl = FusedLayerNorm
-except ImportError:
-    import warnings
-
-    from megatron.core.transformer.torch_norm import WrappedTorchNorm
-
-    warnings.warn("Apex is not installed. Falling back to Torch Norm")
-    LNImpl = WrappedTorchNorm
-    HAVE_APEX = False
+# One provider per backend, so every choice below names a class in megatron.core.ops.
+_te = get_backend("transformer_engine")
+_local = get_backend("local")
 
 
 # Use this spec to use lower level Transformer Engine modules (required for fp8 training)
@@ -46,9 +28,9 @@ def get_vit_layer_with_transformer_engine_spec() -> ModuleSpec:
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.no_mask},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=TELayerNormColumnParallelLinear,
-                    core_attention=TEDotProductAttention,
-                    linear_proj=TERowParallelLinear,
+                    linear_qkv=_te.column_parallel_layer_norm_linear(),
+                    core_attention=_te.core_attention(),
+                    linear_proj=_te.row_parallel_linear(),
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
@@ -67,18 +49,18 @@ def get_vit_layer_with_local_spec() -> ModuleSpec:
     return ModuleSpec(
         module=TransformerLayer,
         submodules=TransformerLayerSubmodules(
-            input_layernorm=LNImpl,
+            input_layernorm=_local.layer_norm(),
             self_attention=ModuleSpec(
                 module=SelfAttention,
                 params={"attn_mask_type": AttnMaskType.no_mask},
                 submodules=SelfAttentionSubmodules(
-                    linear_qkv=ColumnParallelLinear,
-                    core_attention=DotProductAttention,
-                    linear_proj=RowParallelLinear,
+                    linear_qkv=_local.column_parallel_linear(),
+                    core_attention=_local.core_attention(),
+                    linear_proj=_local.row_parallel_linear(),
                 ),
             ),
             self_attn_bda=get_bias_dropout_add,
-            pre_mlp_layernorm=LNImpl,
+            pre_mlp_layernorm=_local.layer_norm(),
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
         ),

--- a/megatron/core/ops/_availability.py
+++ b/megatron/core/ops/_availability.py
@@ -53,7 +53,7 @@ def require(module_name: str) -> ModuleType:
     """Return a selected dependency, or explain what is wrong with it.
 
     Callers that know which backend asked should catch this and add that context;
-    :mod:`megatron.core.ops.resolve` does exactly that, from its backend table.
+    A provider does exactly that, from the ``REQUIRES`` its chosen backend declares.
     """
     module, error, absent = _import_outcome(module_name)
     if module is not None:

--- a/megatron/core/ops/loss/__init__.py
+++ b/megatron/core/ops/loss/__init__.py
@@ -24,6 +24,10 @@ The implementations are in :mod:`.backends`; a provider in
 
 from __future__ import annotations
 
+from typing import Callable, Optional
+
+import torch
+
 from megatron.core.ops.loss.backends import (
     LossMegatron,
     LossMegatronFused,
@@ -32,10 +36,16 @@ from megatron.core.ops.loss.backends import (
     vocab_parallel_cross_entropy,
 )
 
+VocabParallelCrossEntropy = Callable[
+    [torch.Tensor, torch.Tensor, Optional[torch.distributed.ProcessGroup]], torch.Tensor
+]
+"""The callable shape this family's targets have."""
+
 __all__ = [
     "LossMegatron",
     "LossMegatronFused",
     "LossTEFused",
     "fused_vocab_parallel_cross_entropy",
+    "VocabParallelCrossEntropy",
     "vocab_parallel_cross_entropy",
 ]

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -13,10 +13,9 @@ from megatron.core import InferenceParams, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
-from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.utils import InferenceMode
-from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
+from megatron.core.models.backends import BackendSpecProvider, get_backend
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -56,11 +55,6 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
-
-if HAVE_TE:
-    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
-else:
-    TESpecProvider = None
 
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
@@ -587,7 +581,7 @@ def get_mtp_layer_spec(
     """
     return get_mtp_layer_spec_for_backend(
         mtp_model_layer_spec,
-        backend=TESpecProvider() if use_transformer_engine else LocalSpecProvider(),
+        backend=get_backend("transformer_engine" if use_transformer_engine else "local"),
     )
 
 

--- a/tests/unit_tests/ops/test_backend_targets.py
+++ b/tests/unit_tests/ops/test_backend_targets.py
@@ -29,7 +29,6 @@ class TestLocalBackends:
         assert backend.column_parallel_linear() is ColumnParallelLinear
         assert backend.row_parallel_linear() is RowParallelLinear
         assert backend.column_parallel_layer_norm_linear() is None
-        assert backend.fuse_layernorm_and_linear() is False
 
     def test_core_attention_target(self):
         assert AttentionLocal().core_attention() is DotProductAttention
@@ -81,7 +80,6 @@ class TestTransformerEngineBackends:
         assert backend.column_parallel_linear() is TEColumnParallelLinear
         assert backend.row_parallel_linear() is TERowParallelLinear
         assert backend.column_parallel_layer_norm_linear() is TELayerNormColumnParallelLinear
-        assert backend.fuse_layernorm_and_linear() is True
 
     def test_core_attention_target(self):
         from megatron.core.extensions.transformer_engine import TEDotProductAttention

--- a/tests/unit_tests/tensor_parallel/test_cross_entropy.py
+++ b/tests/unit_tests/tensor_parallel/test_cross_entropy.py
@@ -47,25 +47,21 @@ def test_vocab_parallel_cross_entropy_uses_explicit_tp_group(monkeypatch):
     assert all_reduce_groups == [tp_group, tp_group, tp_group]
 
 
-def test_language_module_unfused_loss_passes_tp_group(monkeypatch):
+def test_language_module_loss_calls_the_selected_cross_entropy():
+    """The loss uses the target the backend picked at construction, with no branch left here."""
     tp_group = _FakeTPGroup()
     captured = {}
 
-    def fake_vocab_parallel_cross_entropy(logits, labels, label_smoothing=0.0, tp_group=None):
+    def fake_vocab_parallel_cross_entropy(logits, labels, tp_group=None):
         captured["logits"] = logits
         captured["labels"] = labels
-        captured["label_smoothing"] = label_smoothing
         captured["tp_group"] = tp_group
         return torch.zeros_like(labels, dtype=logits.dtype)
 
-    monkeypatch.setattr(
-        language_module_module.tensor_parallel,
-        "vocab_parallel_cross_entropy",
-        fake_vocab_parallel_cross_entropy,
-    )
-
     module = SimpleNamespace(
-        config=SimpleNamespace(cross_entropy_loss_fusion=False), tp_group=tp_group
+        config=SimpleNamespace(cross_entropy_loss_fusion=False),
+        tp_group=tp_group,
+        vocab_parallel_cross_entropy=fake_vocab_parallel_cross_entropy,
     )
     labels = torch.tensor([[0, 1, 2], [2, 1, 0]])
     logits = torch.randn(3, 2, 4)
@@ -76,7 +72,6 @@ def test_language_module_unfused_loss_passes_tp_group(monkeypatch):
 
     assert captured["logits"] is logits
     assert captured["tp_group"] is tp_group
-    assert captured["label_smoothing"] == 0.0
     torch.testing.assert_close(captured["labels"], labels.transpose(0, 1).contiguous())
     assert loss.shape == labels.shape
 

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -14,6 +14,7 @@ from megatron.core.extensions.transformer_engine import (
     TELayerNormColumnParallelLinear,
     TERowParallelLinear,
 )
+from megatron.core.models.backends import get_backend
 from megatron.core.models.gpt import gpt_layer_specs
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
@@ -296,19 +297,15 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
 
     def test_dense_grouped_spec_selected_only_with_te_op_fuser(self):
         grouped_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=True,
+            backend=get_backend("transformer_engine", use_te_op_fuser=True),
             use_grouped_gemm_for_dense_mlp=True,
         )
         fused_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=True,
+            backend=get_backend("transformer_engine", use_te_op_fuser=True),
             use_grouped_gemm_for_dense_mlp=False,
         )
         unfused_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(
-            backend=gpt_layer_specs.TESpecProvider(),
-            use_te_op_fuser=False,
-            use_grouped_gemm_for_dense_mlp=True,
+            backend=get_backend("transformer_engine"), use_grouped_gemm_for_dense_mlp=True
         )
 
         assert grouped_spec.func.__self__ is TEFusedMLPWithGroupedLinear


### PR DESCRIPTION
## What

Every spec builder now asks a provider which implementation to use, instead of carrying its own availability flags and import guards.

**Stacked on #6762 — review that one first.** This PR's own change is 19 files, +449 / **−704**.

## The number this is for

Across the thirteen files that build specs:

| | before | after |
|---|---|---|
| `HAVE_TE` / `HAVE_APEX` / `HAVE_FUSED_LAYER_NORM` / `LNImpl` references | **72** | **0** |
| direct `transformer_engine` imports | **9** | **0** |

The files: `gpt_layer_specs`, `moe_module_specs`, `experimental_attention_variant_module_specs`, `multi_token_prediction`, `mla_qk_norm_config`, `language_module`, `models/backends`, `t5_spec`, `bert_layer_specs`, `bert_lm_head`, `vit_layer_specs`, `llava_spec`, `heterogeneous_layer_specs`.

## What is deliberately left alone

There are two populations of `HAVE_TE`, and only one of them is backend selection:

- **Selection (13 files) — fixed here.** `HAVE_TE` used to pick which module goes into a spec.
- **Implementation guards (28 files) — untouched.** `HAVE_TE` guarding `try: from transformer_engine.pytorch.X import Y`, where `Y` differs per file: `Float8Tensor`, `TransformerEngineBaseModule`, `get_dummy_wgrad`, `TE_DType`. Those files *wrap* TE rather than choosing between backends, each needs its own symbols bound, and they belong to the milestone that moves the TE wrappers.

Conflating the two is what makes the problem look like 112 files instead of 13.

## Selection is a plain if-else

```python
def get_backend(transformer_impl, *, use_kitchen=False, ...):
    base = _base_backend(transformer_impl, **settings)
    if not use_kitchen:
        return base
    return KitchenSpecProvider(fallback=base, ...)
```

and each provider is a flat list naming a class in `megatron.core.ops`, so reading `TESpecProvider` is the whole answer to which implementation a TE run gets.

## Deliberate behaviour changes

- **The `local` norm is Torch, not Apex-if-installed.** Installing an optional package no longer silently changes which kernel a run gets; Apex is chosen explicitly. This moves golden values for the 2 BERT functional cases and the GPT cases using `--spec local` — T5 has none.
- **`get_gpt_decoder_block_spec` passes `normalization` through** to the final norm, so `--transformer-impl local --normalization RMSNorm` stops asserting inside Apex's `FusedLayerNorm`.
- **Vocab-parallel cross entropy is chosen by the provider** rather than by a branch in the forward path, dropping an `UnboundLocalError` on one route and a `None` tensor-parallel group on another.

## Testing

8×GPU, all green: `ops/` 20, `test_bert_model` 14, `test_t5_model` 13, `test_llava_model` 24, `test_heterogeneous_gpt_model` 20, `test_clip_vit_model` 8, `test_gpt_model` 16, `test_moe_module_specs` 4, `test_transformer_block` 53, `test_cross_entropy` 3. Plus an import check of every rewritten spec module.

Needs a **Run functional tests** round trip for the golden values noted above.
