### PR TITLE
fix: avoid requiring GTP for CUDA graph stream warning

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -134,7 +134,7 @@ def _get_cuda_graph_stream() -> torch.cuda.Stream:
                 if max_connections_value < 16:
                     warning_reason = f"is {max_connections_value}"
 
-        if warning_reason is not None and GTP_CONFIG.is_active():
+        if warning_reason is not None:
             logger.warning(
                 "CUDA_DEVICE_MAX_CONNECTIONS %s. For GTP workloads, consider setting it to "
                 "16 or 32 before process startup to avoid implicit stream aliasing.",


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Remove the is_active() check of GTP_CONFIG, as GTP_CONFIG doesn't have such a field.

Resolve the bug introduced by https://github.com/NVIDIA/Megatron-LM/pull/6643

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
