### PR TITLE
Fix premature termination of persistent ckpt worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ onelogger.err
 runs/
 /test_cases/
 **/dist/
+.mypy_cache/
 
 # Sphinx documentation
 docs/_build

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4981,13 +4981,14 @@ def train(
         disable_forward_pre_hook(model, optimizer=optimizer)
 
     ft_integration.on_checkpointing_start()
-    # This will finalize all unfinalized async request and terminate a persistent
-    # async worker if persistent ckpt worker is enabled. Exposed TERMINATE cost:
-    # the trainer BLOCKS here until the final async checkpoint is durably written
-    # (the worker drains) -- a defense cost on the exit path that otherwise reads
-    # as dark/unobserved time (it runs after the last iteration, before shutdown).
+    # This will finalize all unfinalized async request and terminate a
+    # persistent async worker if the code exits and doesn't return from this
+    # function. Exposed TERMINATE cost: the trainer BLOCKS here until the final
+    # async checkpoint is durably written (the worker drains) -- a defense cost
+    # on the exit path that otherwise reads as dark/unobserved time (it runs
+    # after the last iteration, before shutdown).
     with _otel_managed_span('checkpoint', 'megatron.checkpoint.exit_finalize', is_goodput_span=True):
-        maybe_finalize_async_save(blocking=True, terminate=True)
+        maybe_finalize_async_save(blocking=True, terminate=should_exit)
     ft_integration.on_checkpointing_end(is_async_finalization=True)
 
     if args.log_energy:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4981,12 +4981,9 @@ def train(
         disable_forward_pre_hook(model, optimizer=optimizer)
 
     ft_integration.on_checkpointing_start()
-    # This will finalize all unfinalized async request and terminate a
-    # persistent async worker if the code exits and doesn't return from this
-    # function. Exposed TERMINATE cost: the trainer BLOCKS here until the final
-    # async checkpoint is durably written (the worker drains) -- a defense cost
-    # on the exit path that otherwise reads as dark/unobserved time (it runs
-    # after the last iteration, before shutdown).
+    # Finalize all unfinished async requests and terminate the persistent
+    # async worker (if enabled) if the code is meant to exit and not return from this
+    # function.
     with _otel_managed_span('checkpoint', 'megatron.checkpoint.exit_finalize', is_goodput_span=True):
         maybe_finalize_async_save(blocking=True, terminate=should_exit)
     ft_integration.on_checkpointing_end(is_async_finalization=True)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Fixes a bug where the checkpoint worker process would be killed at the
end of the training loop, even in the case where the process was not
supposed to terminate (i.e., not reach sys.exit(), but just the end of
the train() function). This returned the control to pretrain(), which
would then respawn the worker process to save one additional checkpoint.

The fix only terminates the worker process if exit() is requested.