### PR TITLE
rl: persist incomplete rollout groups and replay them

### DIFF
--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -42,10 +42,16 @@ class GroupRolloutParams(NamedTuple):
     One instance is created per group call and reused for all rollouts in that group.
     Every rollout is an episode: run_episode generates it (one or more turns), while
     build_rollout turns the completed episode into a Rollout.
+
+    Args:
+        run_episode: A callable that returns an EpisodeResult.
+        build_rollout: A callable that returns a Rollout.
+        problem_state: A dictionary of problem state used to restore the group.
     """
 
     run_episode: Callable[[], Awaitable[EpisodeResult]]
     build_rollout: Callable[[EpisodeResult], Awaitable[Rollout]]
+    problem_state: dict | None = None
 
 
 class ContrastiveRollout(AgentBaseModel):
@@ -144,8 +150,19 @@ class GroupedRolloutGenerator(Agent, ABC):
     """Agent contract consumed by RolloutPipeline to generate grouped rollouts (e.g. GRPO)."""
 
     @abstractmethod
-    async def prepare_group_rollout(self, request: GroupedRolloutRequest) -> GroupRolloutParams:
-        """Return the params for one group's rollouts."""
+    async def prepare_group_rollout(
+        self, request: GroupedRolloutRequest, *, problem_state: dict | None = None
+    ) -> GroupRolloutParams:
+        """Return the params for one group's rollouts.
+
+        Args:
+            request: The grouped rollout request being served.
+            problem_state: When None, draw a fresh problem as usual. When given, it
+                is a state this agent previously returned on ``GroupRolloutParams``;
+                prepare for that same problem instead of drawing a new one, so a
+                restored group's missing members are regenerated against the prompt
+                its existing members already answered.
+        """
         ...
 
     def rollout_allocations(self, num_groups: int) -> list[EnvAllocation]:

--- a/megatron/rl/agent/reward_only_agent.py
+++ b/megatron/rl/agent/reward_only_agent.py
@@ -233,16 +233,24 @@ class RewardOnlyAgent(RolloutGenerator, GroupedRolloutGenerator, PassAtEvaluatio
         )
 
     async def prepare_group_rollout(
-        self,
-        request: GroupedRolloutRequest,
+        self, request: GroupedRolloutRequest, *, problem_state: dict | None = None
     ) -> GroupRolloutParams:
+        """Prepare one group, either from a fresh draw or from a restored problem.
 
-        prompt, golden = await self.get_prompt(validation=request.validation)
+        Implemented once here so every env deriving from ``RewardOnlyAgent`` becomes
+        completable after a crash without per-env work. Envs whose ``golden`` is not
+        JSON-serializable should override this and return ``problem_state=None``.
+        """
+        if problem_state is None:
+            prompt, golden = await self.get_prompt(validation=request.validation)
+        else:
+            prompt, golden = problem_state["prompt"], problem_state["golden"]
 
         # Every rollout runs as a (possibly multi-turn) episode over the group's shared prompt.
         return GroupRolloutParams(
             run_episode=functools.partial(self._run_episode, request, prompt=prompt, golden=golden),
             build_rollout=functools.partial(self._rollout_from_episode, request, golden=golden),
+            problem_state={"prompt": prompt, "golden": golden},
         )
 
     async def _evaluation(

--- a/megatron/rl/agent/rollout_pipeline.py
+++ b/megatron/rl/agent/rollout_pipeline.py
@@ -4,9 +4,11 @@
 
 import asyncio
 import logging
+import queue as thread_queue
+import threading
 import time
 from collections import deque
-from typing import TYPE_CHECKING, AsyncIterator, NamedTuple
+from typing import TYPE_CHECKING, AsyncIterator, Iterable, NamedTuple
 
 import numpy as np
 
@@ -14,14 +16,29 @@ from megatron.core.inference.utils import asyncio_Queue, asyncio_QueueShutDown
 from megatron.core.utils import trace_async_exceptions
 
 from ..inference import ReturnsRaw
+from ..rollout_bank import _PendingProblem, _PendingRollout
 from ..rollout_granularity import GRANULARITY_RANK, ConsumptionGranularity, SubmissionGranularity
 from .api import EpisodeResult, GroupedRolloutRequest, GroupRolloutParams, RolloutGroup
+
+logger = logging.getLogger(__name__)
+
+BANK_WRITE_MAX_RECORDS = 64
+
+
+class _PendingConsumedMarkers(NamedTuple):
+    """A consumption-marker batch riding the bank queue behind its records.
+
+    FIFO order through the single writer thread is what guarantees the marker
+    reaches disk only after every record enqueued before it — the invariant a
+    blocking ``drain_bank`` used to provide at the inference-to-training switch.
+    """
+
+    uids: tuple[str, ...]
+    iteration: int
 
 if TYPE_CHECKING:
     from ..rollout_bank import RolloutBank
     from .api import GroupedRolloutGenerator, Rollout, TokenRollout
-
-logger = logging.getLogger(__name__)
 
 
 class _GranularityConfig(NamedTuple):
@@ -171,6 +188,11 @@ class _InferWorkItem(NamedTuple):
     Timestamps are wall-clock monotonic seconds: `prepared_at` is stamped at
     construction and `infer_dequeued_at` is filled in via `_replace` when an
     infer worker dequeues the item. Zero means "not yet reached".
+
+    `bank_uid` is the owning group's durable bank identity, reserved before any
+    member exists and None whenever the durable rollout bank is disabled. It is
+    distinct from `group_id`, which is the pipeline-local assemble-bucket key and
+    is always present.
     """
 
     group_id: int
@@ -179,6 +201,7 @@ class _InferWorkItem(NamedTuple):
     index_in_batch: int
     params: GroupRolloutParams
     env_index: int = 0
+    bank_uid: str | None = None
     prepared_at: float = 0.0
     infer_dequeued_at: float = 0.0
 
@@ -242,6 +265,17 @@ class RolloutPipeline:
         self.infer_queue = asyncio_Queue()
         self.assemble_queue = asyncio_Queue()
         self.output_queue = asyncio_Queue()
+        # The bank queue is a plain thread queue, not an asyncio queue: its
+        # consumer must keep writing while the trainer holds the loop thread
+        # inside a training step and nothing pumps the event loop.
+        self.bank_queue: thread_queue.Queue = thread_queue.Queue()
+        self._bank_error: Exception | None = None
+        self._bank_writer: threading.Thread | None = None
+        if bank is not None:
+            self._bank_writer = threading.Thread(
+                target=self._bank_writer_loop, name="rollout-bank-writer", daemon=True
+            )
+            self._bank_writer.start()
 
         # Track regenerated groups and tasks for proper shutdown.
         self._next_regen_group_id = -1
@@ -250,7 +284,7 @@ class RolloutPipeline:
         self._regen_tasks: set[asyncio.Task] = set()
 
         # Buffers of partial results.
-        self._assemble_pending: dict[int, list[_InferredItem]] = {}
+        self._assemble_pending: dict[int, dict[int, RolloutGroup]] = {}
         self._consume_pending: dict[int, list[RolloutGroup]] = {}
         self._output_enqueued_at: dict[tuple[int, int], float] = {}
 
@@ -267,6 +301,7 @@ class RolloutPipeline:
         self.filtered_count = 0
         self.refilled_placeholder_groups = 0
         self.restored_count = 0
+        self.restored_rollout_count = 0
         self.yielded_count = 0
         self.prepared_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
         self.assembled_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
@@ -280,11 +315,11 @@ class RolloutPipeline:
         Yields:
             RolloutGroup: Groups in consumption-granularity order.
         """
-        tasks = (
+        tasks = [
             asyncio.create_task(self.stage_prepare()),
             asyncio.create_task(self.stage_infer()),
             asyncio.create_task(self.stage_assemble()),
-        )
+        ]
         try:
             async for group in self.stage_consume():
                 yield group
@@ -311,15 +346,44 @@ class RolloutPipeline:
             await asyncio.gather(*tasks, *regen_tasks, return_exceptions=True)
 
     async def _submit_group_to_infer_queue(
-        self, *, group_id: int, batch_id: int, index_in_batch: int
+        self,
+        *,
+        group_id: int,
+        batch_id: int,
+        index_in_batch: int,
+        restored: RolloutGroup | None = None,
     ) -> None:
-        """Enqueue one group's inference items, acquiring per-rollout gate slots."""
+        """Enqueue one group's inference items, acquiring per-rollout gate slots.
+
+        Args:
+            group_id: Pipeline-local key for this group's assemble bucket.
+            batch_id: Trainer batch this group belongs to.
+            index_in_batch: Slot within that batch.
+            restored: An incomplete group recovered from the bank. Its members seed
+                the assemble bucket and only its missing slots are generated, using
+                the persisted problem state so they answer the same prompt.
+        """
         env_index = self.gran_policy.env_of_index(index_in_batch)
         agent = self.allocations[env_index].agent
-        params: GroupRolloutParams = await agent.prepare_group_rollout(self.request)
+        params: GroupRolloutParams = await agent.prepare_group_rollout(
+            self.request, problem_state=restored.problem_state if restored else None
+        )
         self.prepared_groups_per_env[env_index] += 1
 
-        for rollout_idx in range(self.request.rollouts_per_group):
+        if restored is not None:
+            bank_uid = restored.uid
+            indices = restored.missing_indices(self.request.rollouts_per_group)
+            self._assemble_pending[group_id] = dict(
+                zip(restored.member_indices, restored.rollouts, strict=True)
+            )
+            self.restored_rollout_count += len(restored.rollouts)
+        else:
+            bank_uid = self.bank.reserve_group_uid() if self.bank is not None else None
+            indices = list(range(self.request.rollouts_per_group))
+            if self.bank is not None and params.problem_state is not None:
+                self.bank_queue.put_nowait(_PendingProblem(bank_uid, params.problem_state))
+
+        for rollout_idx in indices:
             await self.gate.acquire_for("R")
             item = _InferWorkItem(
                 group_id=group_id,
@@ -328,6 +392,7 @@ class RolloutPipeline:
                 index_in_batch=index_in_batch,
                 params=params,
                 env_index=env_index,
+                bank_uid=bank_uid,
                 prepared_at=time.monotonic(),
             )
             await self.infer_queue.put(item)
@@ -339,7 +404,12 @@ class RolloutPipeline:
             self.infer_queue.shutdown()
 
     def assert_no_inflight_rollouts(self) -> None:
-        """Verify no rollouts are buffered or in-flight at an iteration boundary for lag=0."""
+        """Verify no rollouts are buffered or in-flight at an iteration boundary for lag=0.
+
+        Counts rollouts rather than groups: dropped groups consume prepared
+        rollouts without ever being yielded, and a partially restored group is
+        yielded having consumed only some of its members from the gate.
+        """
         buffered = {
             "infer_queue": self.infer_queue.qsize(),
             "assemble_queue": self.assemble_queue.qsize(),
@@ -352,16 +422,16 @@ class RolloutPipeline:
             f"The rollout pipeline has buffered rollouts at iteration boundary: {buffered}. "
             "The generator has run ahead under a stale policy."
         )
-        # Dropped groups consume prepared rollouts without ever being yielded;
-        # restored groups are yielded without being freshly prepared.
-        fresh_yielded_count = self.yielded_count - self.restored_count
+        yielded_rollouts = (
+            self.yielded_count * self.request.rollouts_per_group - self.restored_rollout_count
+        )
         in_flight = self.prepared_count - (
-            (fresh_yielded_count + self.dropped_count) * self.request.rollouts_per_group
+            yielded_rollouts + self.dropped_count * self.request.rollouts_per_group
         )
         assert in_flight == 0, (
             f"The rollout pipeline prepared {self.prepared_count} rollout(s) but yielded "
-            f"{self.yielded_count} ({self.restored_count} restored) and dropped "
-            f"{self.dropped_count} group(s) of {self.request.rollouts_per_group} "
+            f"{self.yielded_count} group(s) ({self.restored_rollout_count} restored member(s)) "
+            f"and dropped {self.dropped_count} group(s) of {self.request.rollouts_per_group} "
             f"({self.filtered_count} same-reward-filtered, "
             f"{self.refilled_placeholder_groups} placeholder-refilled); "
             f"{in_flight} rollout(s) in flight at iteration boundary."
@@ -380,19 +450,29 @@ class RolloutPipeline:
                     self._groups_in_flight += 1
                     env_index = self.gran_policy.env_of_index(index_in_batch)
                     allocation = self.allocations[env_index]
-                    restored = self.agent.take_restored_group(allocation.env_id)
+                    restored: RolloutGroup | None = self.agent.take_restored_group(allocation.env_id)
                     if restored is not None:
                         assert all(rollout.env_id == allocation.env_id for rollout in restored), (
                             f"Restored rollout group routed to env {allocation.env_id!r} contains "
                             f"members for {[rollout.env_id for rollout in restored]}"
                         )
-                        restored.batch_id = batch_id
-                        restored.index_in_batch = index_in_batch
-                        self._output_enqueued_at[(batch_id, index_in_batch)] = time.monotonic()
-                        await self.output_queue.put(restored)
-                        self.restored_count += 1
-                        self._groups_in_flight -= 1
-                        self._maybe_close_intake()
+                        if restored.is_complete(self.request.rollouts_per_group):
+                            restored.batch_id = batch_id
+                            restored.index_in_batch = index_in_batch
+                            self._output_enqueued_at[(batch_id, index_in_batch)] = time.monotonic()
+                            await self.output_queue.put(restored)
+                            self.restored_count += 1
+                            self.restored_rollout_count += len(restored.rollouts)
+                            self._groups_in_flight -= 1
+                            self._maybe_close_intake()
+                            group_id += 1
+                            continue
+                        await self._submit_group_to_infer_queue(
+                            group_id=group_id,
+                            batch_id=batch_id,
+                            index_in_batch=index_in_batch,
+                            restored=restored,
+                        )
                         group_id += 1
                         continue
                     await self._submit_group_to_infer_queue(
@@ -406,6 +486,134 @@ class RolloutPipeline:
         finally:
             self._prepare_done = True
             self._maybe_close_intake()
+
+    def _bank_writer_loop(self) -> None:
+        """Consume the bank queue on a dedicated thread, for the pipeline's lifetime.
+
+        The trainer only runs the asyncio loop while collecting rollouts, so a
+        loop-driven consumer would freeze for the whole training step and force
+        the inference-to-training switch to drain the backlog with the GPUs
+        idle. This thread keeps writing regardless of what the loop is doing.
+
+        A single consumer means only one write is ever in flight, which is what
+        lets the bank keep its running sidecar offsets without a lock. All
+        failures are latched, never raised, so the thread cannot die and a
+        ``bank_queue.join()`` cannot deadlock.
+        """
+        while True:
+            items = [self.bank_queue.get()]
+            while len(items) < BANK_WRITE_MAX_RECORDS:
+                try:
+                    items.append(self.bank_queue.get_nowait())
+                except thread_queue.Empty:
+                    break
+            try:
+                self._process_bank_items(items)
+            finally:
+                for _ in items:
+                    self.bank_queue.task_done()
+
+    def _process_bank_items(self, items: list) -> None:
+        """Apply queued items in FIFO order: coalesced record writes, markers in place.
+
+        A marker batch flushes the records queued before it first, so a marker
+        can never reach disk ahead of a record it names.
+        """
+        records: list = []
+        for item in items:
+            if isinstance(item, _PendingConsumedMarkers):
+                self._write_records_latching(records)
+                records = []
+                self._mark_consumed_latching(item)
+            else:
+                records.append(item)
+        self._write_records_latching(records)
+
+    def _write_records_latching(self, records: list) -> None:
+        """Write one set of records, recording any failure instead of raising.
+
+        Latching keeps the writer thread alive through a bad write; the failure
+        surfaces at the next durability barrier or marker enqueue instead.
+        """
+        if not records:
+            return
+        try:
+            self.bank.write_records(records)
+        except Exception as exc:
+            self._bank_error = exc
+            logger.exception("Rollout bank write failed; %d record(s) lost", len(records))
+
+    def _mark_consumed_latching(self, markers: _PendingConsumedMarkers) -> None:
+        """Apply one consumption-marker batch, recording any failure instead of raising."""
+        try:
+            self.bank.mark_consumed_many(markers.uids, markers.iteration)
+        except Exception as exc:
+            self._bank_error = exc
+            logger.exception(
+                "Rollout bank consumption-marker write failed; %d marker(s) lost",
+                len(markers.uids),
+            )
+
+    def _raise_latched_bank_error(self) -> None:
+        """Raise the last latched bank failure once, then clear it."""
+        if self._bank_error is not None:
+            error, self._bank_error = self._bank_error, None
+            raise error
+
+    def enqueue_consumed_markers(self, uids: Iterable[str | None], iteration: int) -> None:
+        """Queue consumption markers behind the records they name, without blocking.
+
+        The single FIFO writer guarantees the markers reach disk only after
+        every record enqueued before them — the same records-before-marker
+        invariant a blocking drain used to enforce at the inference-to-training
+        switch, minus the idle GPUs. A crash mid-queue loses the tail records
+        and their marker together, which recovery already treats as "never
+        generated": the groups regenerate.
+
+        Raises any bank failure latched since the last barrier, so a broken
+        disk surfaces within one training iteration.
+        """
+        if self.bank is None:
+            return
+        self._raise_latched_bank_error()
+        markers = _PendingConsumedMarkers(
+            uids=tuple(uid for uid in uids if uid), iteration=iteration
+        )
+        if not markers.uids:
+            return
+        self.bank_queue.put(markers)
+        if self._bank_writer is None or not self._bank_writer.is_alive():
+            self.drain_bank()
+
+    def drain_bank(self) -> None:
+        """Block until every queued bank record and marker is durable.
+
+        The barrier before segment switches and compaction, both of which
+        rewrite state that queued items would be written against. Needs no
+        event loop: the writer runs on its own thread, and has had the whole
+        training step to work through the backlog, so this is normally instant.
+
+        If the writer thread is unavailable (it never started, or the
+        interpreter is tearing it down), the remaining items are applied inline
+        instead of dropped.
+        """
+        if self.bank is None:
+            return
+        if self._bank_writer is not None and self._bank_writer.is_alive():
+            self.bank_queue.join()
+        else:
+            pending = []
+            while True:
+                try:
+                    pending.append(self.bank_queue.get_nowait())
+                except thread_queue.Empty:
+                    break
+            try:
+                self._process_bank_items(pending)
+            finally:
+                for _ in pending:
+                    self.bank_queue.task_done()
+        self._raise_latched_bank_error()
 
     async def stage_infer(self) -> None:
         """Run a persistent pool of inference workers, spawned once per pipeline."""
@@ -448,7 +656,18 @@ class RolloutPipeline:
         )
 
     async def stage_assemble(self) -> None:
-        """Build complete rollout groups, and regenerate dropped groups."""
+        """Grade each rollout as it arrives, emit groups once they fill, and
+        regenerate dropped ones.
+
+        Grading moved here from group completion so a member can be persisted the
+        moment it is durable-worthy. It does not run more often: every rollout is
+        graded either way, because the drop decision needs the rewards.
+
+        Placeholders are not persisted. A failed episode has an empty trajectory
+        and no decode work to save, and banking one would let a restored group
+        carry a placeholder past the refill path in ``_decide_drop``; leaving the
+        slot empty means restore regenerates it instead.
+        """
         pending = self._assemble_pending
         try:
             while True:
@@ -459,22 +678,33 @@ class RolloutPipeline:
                 dequeued_at = time.monotonic()
                 if inferred.inferred_at:
                     self.assemble_queue_dwell.append(dequeued_at - inferred.inferred_at)
-                bucket = pending.setdefault(inferred.item.group_id, [])
-                bucket.append(inferred)
+
+                item = inferred.item
+                rollout = await item.params.build_rollout(inferred.episode)
+                if (
+                    self.bank is not None
+                    and item.bank_uid is not None
+                    and not rollout.is_placeholder
+                ):
+                    self.bank_queue.put_nowait(
+                        _PendingRollout(item.bank_uid, item.rollout_idx, rollout)
+                    )
+
+                bucket = pending.setdefault(item.group_id, {})
+                bucket[item.rollout_idx] = rollout
                 if len(bucket) < self.request.rollouts_per_group:
                     continue
-                completed = pending.pop(inferred.item.group_id)
-                completed.sort(key=lambda item: item.item.rollout_idx)
-                rollouts = await asyncio.gather(
-                    *[item.item.params.build_rollout(item.episode) for item in completed]
-                )
-                first = completed[0]
+
+                pending.pop(item.group_id)
+                indices = sorted(bucket)
                 self.assembled_count += 1
-                self.assembled_groups_per_env[first.item.env_index] += 1
+                self.assembled_groups_per_env[item.env_index] += 1
                 group = RolloutGroup(
-                    rollouts=rollouts,
-                    batch_id=first.item.batch_id,
-                    index_in_batch=first.item.index_in_batch,
+                    rollouts=[bucket[index] for index in indices],
+                    batch_id=item.batch_id,
+                    index_in_batch=item.index_in_batch,
+                    uid=item.bank_uid,
+                    member_indices=indices,
                 )
                 if self._decide_drop(group):
                     self.dropped_count += 1
@@ -484,8 +714,6 @@ class RolloutPipeline:
                     self._regen_tasks.add(task)
                     task.add_done_callback(self._regen_tasks.discard)
                     continue
-                if self.bank is not None:
-                    group.uid = self.bank.append(group)
                 self._output_enqueued_at[(group.batch_id, group.index_in_batch)] = (
                     time.monotonic()
                 )

--- a/megatron/rl/agent/weighted_multi_task.py
+++ b/megatron/rl/agent/weighted_multi_task.py
@@ -252,8 +252,7 @@ class WeightedMultiTask(
         ]
 
     async def prepare_group_rollout(
-        self,
-        request: GroupedRolloutRequest,
+        self, request: GroupedRolloutRequest, *, problem_state: dict | None = None
     ) -> GroupRolloutParams:
         raise NotImplementedError(
             "WeightedMultiTask only routes; the pipeline prepares each group via the "

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -684,7 +684,12 @@ def maybe_get_rollout_bank(args):
         from megatron.rl.rollout_bank import RolloutBank
 
         bank_dir = args.rl_rollout_bank_dir or os.path.join(args.save or ".", "rollout_bank")
-        _ROLLOUT_BANK = RolloutBank(bank_dir, max_bytes=args.rl_rollout_bank_max_bytes)
+        _ROLLOUT_BANK = RolloutBank(
+            bank_dir,
+            max_bytes=args.rl_rollout_bank_max_bytes,
+            rollouts_per_group=args.grpo_group_size,
+            drop_zero_variance=args.grpo_filter_groups_with_same_reward,
+        )
         get_rl_runtime_state().rollout_bank = _ROLLOUT_BANK
         log_single_rank(logger, logging.INFO, f"Durable rollout bank enabled at {bank_dir}")
     return _ROLLOUT_BANK
@@ -696,10 +701,21 @@ def get_rollout_bank():
 
 
 def maybe_compact_rollout_bank(iteration):
-    """Compact the bank at a durable-checkpoint boundary."""
+    """Compact the bank at a durable-checkpoint boundary.
+
+    Compaction rewrites and reclaims segments, so queued records must reach disk
+    first or they would be written against a segment that no longer exists. The
+    drain is a plain thread-queue barrier — the bank writer runs on its own
+    thread, independent of the asyncio loop — and it also flushes any queued
+    consumption markers, so a checkpoint that includes a training update can
+    never land before that update's markers do.
+    """
     bank = get_rollout_bank()
-    if bank is not None:
-        bank.checkpoint(iteration)
+    if bank is None:
+        return
+    if _ROLLOUT_PIPELINE is not None:
+        _ROLLOUT_PIPELINE.drain_bank()
+    bank.checkpoint(iteration)
 
 
 def _get_or_create_rollout_agent(env_config_path):
@@ -833,6 +849,12 @@ def get_environment_rollouts(
                             f"RolloutBank restored {total_restored_groups} completed groups from "
                             f"disk at resume iteration {args.iteration}",
                         )
+                if _ROLLOUT_PIPELINE is not None:
+                    # Sidecar offsets are per-segment: queued records must land
+                    # in their own segment before appends move to the new one.
+                    # The writer thread has had the whole training step to work
+                    # through the backlog, so this barrier is normally instant.
+                    _ROLLOUT_PIPELINE.drain_bank()
                 bank.set_collection(args.curr_iteration)
 
             with nvtx_range("rl/inference-setup", time=True):
@@ -876,8 +898,12 @@ def get_environment_rollouts(
                     # Record consumption for every group handed to the trainer. On a
                     # rollback (restart before this update) the marker > T rule restores
                     # these; once a checkpoint includes the update they are pruned.
+                    # The markers ride the bank's FIFO queue behind the records they
+                    # name, so this returns immediately instead of idling the GPUs
+                    # on a full backlog drain; the writer thread keeps flushing
+                    # while the training step runs.
                     if bank is not None:
-                        bank.mark_consumed_many(
+                        _ROLLOUT_PIPELINE.enqueue_consumed_markers(
                             (group.uid for group in rollouts), args.curr_iteration + 1
                         )
                 else:
@@ -1456,7 +1482,7 @@ def _bounded_artifact_key(key, limit=100):
 
     keys containing characters outside [a-zA-Z0-9_.-] (env ids contain ':') are given
     a 7-char CRC suffix by wandb's sanitizer.
-    
+
     Worst-case key budget: 128 - 13 - 6 - 7 = 102 ~= 100.
     """
     if len(key) <= limit:

--- a/megatron/rl/rollout_bank.py
+++ b/megatron/rl/rollout_bank.py
@@ -1,13 +1,23 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Durable rollout bank — the queued-rollout (completed-group) path.
+"""Durable rollout bank — rollout-granular persistence with incomplete-group replay.
 
-Persists completed ``RolloutGroup``s the instant they assemble, so a SIGKILL (the
-4h SLURM limit) does not destroy work that is already on disk. This is PR #1 of
-the durable rollout bank: it covers only the *queued* path — groups sitting in
-the pipeline's ``output_queue`` (assembled, not yet trained-in) plus groups
-consumed at a training step that a restart rolls back. In-flight decode state and
-partial-group snapshots (design phases B/C) are out of scope here.
+Persists each rollout the instant it is graded, so a SIGKILL (the 4h SLURM limit)
+does not destroy finished decode work. A group whose members were only partly
+persisted reads back as an *incomplete* group carrying the problem state needed to
+regenerate the rest against the same prompt. In-flight decode state (a rollout
+killed mid-generation) is still lost.
+
+The ledger has exactly two record kinds:
+
+    problem  {group_uid, problem_state}   one per group, written at prepare
+    rollout  {group_uid, rollout_idx, ..} one per graded member
+
+There is deliberately no seal record and no tombstone. A group is complete iff it
+has ``rollouts_per_group`` distinct members, which is config (asserted against the
+manifest on load). A zero-variance group is re-filtered from its persisted rewards
+rather than marked; re-deriving has no crash window between the last member's write
+and a marker's, which a tombstone would.
 
 Layout (single-writer, rank-0 only, on Lustre)::
 
@@ -34,11 +44,24 @@ sidecar format in ``megatron/core/transformer/moe/router_trace.py`` (see
 hooks and hardcodes bf16/filenames, so it is not importable here. Unifying the two
 onto a shared parameterized primitive is a tracked follow-up.
 
-Recovery guarantees: append is write-through with ``fsync`` per group, so a kill can
-damage only the final record, which its checksum drops on read. A checkpoint writes
-a complete new generation, including a compacted marker log, before atomically
-flipping the manifest. ``restore`` replays the active generation and returns every
-group that is not already trained through checkpoint step ``T``:
+This module is a passive, synchronous store: ``write_records`` encodes them and
+fsyncs before returning. It owns no thread and no queue. Batching lives in the
+``RolloutPipeline``'s dedicated writer thread, which coalesces records and keeps
+writing even while a training step holds the loop thread — the trainer never has
+to idle on a backlog at the inference-to-training switch. That single consumer is
+also what serializes access: exactly one write is in flight at a time, consumption
+markers ride the same FIFO queue behind the records they name, and the pipeline
+drains the queue before any segment switch or compaction.
+
+Because writes are queued in the pipeline, a kill can lose one un-drained set of
+freshly graded rollout records, which then regenerate. It cannot corrupt: a torn record is
+dropped by the tail truncation and per-record checksum, and a missing member only
+makes a group look *less* complete — precisely the incomplete-group case this module
+already handles.
+
+A checkpoint writes a complete new generation, including a compacted marker log, before
+atomically flipping the manifest. ``restore`` replays the active generation and returns
+every group that is not already trained through checkpoint step ``T``:
 
     marker <= T -> discard (training already in the loaded weights)
     marker  > T -> restore (that training step was erased by the kill)
@@ -54,6 +77,7 @@ import hashlib
 import json
 import logging
 import os
+import pathlib
 import threading
 import uuid
 from typing import Iterable, Iterator, Literal, NamedTuple, NotRequired, Optional, TypedDict
@@ -74,7 +98,8 @@ _MASK_DTYPE = np.uint8
 
 # Bump whenever the manifest/ledger schema or any sidecar dtype/layout changes.
 # Readers intentionally fail closed; cross-version migration must be explicit.
-_FORMAT_VERSION = 2
+_FORMAT_VERSION = 3
+_ZERO_VARIANCE_TOLERANCE = 1e-6
 _MANIFEST = "MANIFEST.json"
 _GENERATIONS = "generations"
 _LEDGER = "ledger.log"
@@ -101,30 +126,59 @@ class SidecarMeta(TypedDict):
 
 class LedgerRecord(TypedDict):
     """
-    One self-describing JSONL index record for a completed group.
+    One self-describing JSONL index record for a single graded rollout.
 
     Args:
         format_version: The persisted schema and sidecar-layout version.
-        uid: The unique identifier of the group.
+        kind: Always ``"rollout"``.
+        uid: The rollout's unique identifier, ``"<group_uid>#<rollout_idx>"``.
+        group_uid: The owning group's unique identifier.
+        rollout_idx: Which slot in the group this member occupies.
         collection_iter: The iteration number of the collection.
-        member_type: The type of the member. This is the type of the rollouts in the group.
-        kind: How the group is stored. "inline" if the group is not token-typed, "token" if the group is token-typed.
-        group: The group of rollouts.
-        tok: The token meta. This is only present if the group is token-typed.
-        lp: The logprob meta. This is only present if the group is token-typed and logprobs are present.
-        mask: The mask meta. This is only present if the group is token-typed and generation_mask is present.
-        checksum: The checksum of the group.
+        member_type: Whether the member is a ``Rollout`` or a ``TokenRollout``.
+        member: The rollout, with bulk per-token arrays stripped into sidecars.
+        tok: Token-id sidecar slice. Present only for token-typed members.
+        lp: Logprob sidecar slice. Present only when logprobs were provided.
+        mask: Generation-mask sidecar slice. Present only when a mask was provided.
+        checksum: Digest over the record and its raw sidecar slices.
     """
 
     format_version: int
+    kind: Literal["rollout"]
     uid: str
+    group_uid: str
+    rollout_idx: int
     collection_iter: int
     member_type: Literal["Rollout", "TokenRollout"]
-    kind: Literal["inline", "token"]
-    group: dict
+    member: dict
     tok: NotRequired[SidecarMeta]
     lp: NotRequired[SidecarMeta]
     mask: NotRequired[SidecarMeta]
+    checksum: NotRequired[str]
+
+
+class ProblemRecord(TypedDict):
+    """
+    One JSONL record carrying the state needed to regenerate a group's members.
+
+    Written once per group, at prepare time, before any of its members exist. The
+    writer is FIFO and a member cannot be enqueued until its inference finishes, so
+    this record always precedes its members on disk without an explicit barrier.
+
+    Args:
+        format_version: The persisted schema and sidecar-layout version.
+        kind: Always ``"problem"``.
+        group_uid: The owning group's unique identifier.
+        collection_iter: The iteration number of the collection.
+        problem_state: Agent-owned opaque payload; the bank never inspects it.
+        checksum: Digest over the record.
+    """
+
+    format_version: int
+    kind: Literal["problem"]
+    group_uid: str
+    collection_iter: int
+    problem_state: dict
     checksum: NotRequired[str]
 
 
@@ -139,6 +193,9 @@ class Manifest(TypedDict):
         trained_through: The iteration number of the last checkpoint.
         segments: The list of segment names (e.g. ["gen-000000", "gen-000001"]).
         compacted_at: The iteration number of the last compaction.
+        rollouts_per_group: Group size this bank's records were written under.
+            Completeness is inferred from the member count, so a resume that
+            changes it cannot read these records correctly and is rejected.
     """
 
     format_version: int
@@ -147,6 +204,7 @@ class Manifest(TypedDict):
     trained_through: int
     segments: list[str]
     compacted_at: int
+    rollouts_per_group: int
 
 
 class ConsumedMarker(TypedDict):
@@ -156,13 +214,28 @@ class ConsumedMarker(TypedDict):
     iter: int
 
 
-class EncodedGroup(NamedTuple):
-    """Ledger record and packed sidecar payloads for one rollout group."""
+class EncodedRecord(NamedTuple):
+    """Ledger record and packed sidecar payloads for one rollout."""
 
     record: LedgerRecord
     tok_bytes: bytes
     lp_bytes: bytes
     mask_bytes: bytes
+
+
+class _PendingProblem(NamedTuple):
+    """Queued ``problem`` record awaiting the writer thread."""
+
+    group_uid: str
+    problem_state: dict
+
+
+class _PendingRollout(NamedTuple):
+    """Queued ``rollout`` record awaiting the writer thread."""
+
+    group_uid: str
+    rollout_idx: int
+    rollout: "Rollout | TokenRollout"
 
 
 def _segment_name(iteration: int) -> str:
@@ -204,15 +277,34 @@ def _fsync_directory(path: str) -> None:
 
 
 class RolloutBank:
-    """Single-writer durable store for completed rollout groups (rank-0 only)."""
+    """Single-writer durable store for graded rollouts (rank-0 only).
 
-    def __init__(self, bank_dir: str, *, max_bytes: int = 0) -> None:
+    Args:
+        bank_dir: Directory owning the manifest, generations, and segments.
+        max_bytes: Soft cap on live sidecar payload; exceeding it warns.
+        rollouts_per_group: Group size. Completeness is inferred from the member
+            count, so this is written to the manifest and asserted on load.
+        drop_zero_variance: Whether a fully persisted group whose members all
+            scored the same is discarded at restore and reclaimed at compaction.
+    """
+
+    def __init__(
+        self,
+        bank_dir: str,
+        *,
+        max_bytes: int = 0,
+        rollouts_per_group: int = 1,
+        drop_zero_variance: bool = False,
+    ) -> None:
         self.bank_dir = bank_dir
         self.max_bytes = max_bytes
+        self.rollouts_per_group = rollouts_per_group
+        self.drop_zero_variance = drop_zero_variance
         os.makedirs(bank_dir, exist_ok=True)
         self._lock = threading.RLock()
         self._collection_iter: Optional[int] = None
         self._seg_dir: Optional[str] = None
+        self._run_nonce = uuid.uuid4().hex[:12]
         self._seq = 0
         # Open sidecar/ledger handles for the active segment, with running offsets.
         self._ledger_f = None
@@ -242,6 +334,7 @@ class RolloutBank:
                     "trained_through": 0,
                     "segments": [],
                     "compacted_at": 0,
+                    "rollouts_per_group": rollouts_per_group,
                 }
             )
         manifest = self._read_manifest()
@@ -250,6 +343,11 @@ class RolloutBank:
         # live-size accounting and to fail closed on malformed existing state.
         self._bytes_written = self._manifest_sidecar_bytes(manifest)
         self._maybe_warn_over_cap()
+
+    def active_segment_path(self, name: str) -> pathlib.Path:
+        """Path to a file in the segment currently being appended to."""
+        assert self._seg_dir is not None, "set_collection() must be called first"
+        return pathlib.Path(self._seg_dir) / name
 
     # ------------------------------------------------------------------ paths
     @property
@@ -324,6 +422,15 @@ class RolloutBank:
                 f"Active rollout-bank generation {active!r} does not exist in "
                 f"{self._generations_dir}"
             )
+        persisted_group_size = manifest.get("rollouts_per_group")
+        if persisted_group_size != self.rollouts_per_group:
+            raise ValueError(
+                f"RolloutBank at {self.bank_dir} was written with rollouts_per_group="
+                f"{persisted_group_size!r} but this run uses {self.rollouts_per_group!r}. "
+                "Group completeness is inferred from the member count, so these records "
+                "cannot be read correctly. Resume with a matching config or clear the "
+                "rollout-bank directory."
+            )
         return manifest
 
     def _write_manifest_atomic(self, manifest: Manifest) -> None:
@@ -340,41 +447,45 @@ class RolloutBank:
 
     # ------------------------------------------------------------- lifecycle
     def set_collection(self, iteration: int) -> None:
-        """Point subsequent appends at the ``gen-<iteration>/`` segment."""
-        with self._lock:
-            if self._collection_iter == iteration and self._seg_dir is not None:
-                return
-            self._close_handles()
-            self._collection_iter = iteration
-            seg = _segment_name(iteration)
-            manifest = self._read_manifest()
-            generation_dir = self._generation_dir(manifest)
-            self._seg_dir = os.path.join(generation_dir, seg)
-            segment_created = not os.path.exists(self._seg_dir)
-            os.makedirs(self._seg_dir, exist_ok=True)
-            if segment_created:
-                _fsync_directory(generation_dir)
-            self._truncate_torn_ledger_tail(self._seg_dir)
-            self._seq = self._next_sequence(self._seg_dir, seg)
-            self._tok_off = self._file_size(_TOKENS_BIN)
-            self._lp_off = self._file_size(_LOGPROBS_BIN)
-            self._mask_off = self._file_size(_MASKS_BIN)
-            if seg not in manifest["segments"]:
-                manifest["segments"].append(seg)
-                self._write_manifest_atomic(manifest)
-                # A directory left behind before manifest publication was not live
-                # at startup, but becomes live when this segment is published.
-                self._bytes_written += self._segment_sidecar_bytes(self._seg_dir)
-                self._maybe_warn_over_cap()
+        """Point subsequent appends at the ``gen-<iteration>/`` segment.
 
-    def _next_sequence(self, seg_dir: str, seg: str) -> int:
-        """Return the next unused sequence number in ``seg``."""
-        next_seq = 0
-        for record in self._read_ledger(seg_dir):
-            uid_seg, separator, uid_seq = record.get("uid", "").partition("/")
-            if separator and uid_seg == seg and uid_seq.isdigit():
-                next_seq = max(next_seq, int(uid_seq) + 1)
-        return next_seq
+        Sidecar offsets are per-segment, so callers must drain queued records first:
+        a record written after this returns would use offsets from the old segment.
+        """
+        if self._collection_iter == iteration and self._seg_dir is not None:
+            return
+        self._close_handles()
+        self._collection_iter = iteration
+        seg = _segment_name(iteration)
+        manifest = self._read_manifest()
+        generation_dir = self._generation_dir(manifest)
+        self._seg_dir = os.path.join(generation_dir, seg)
+        segment_created = not os.path.exists(self._seg_dir)
+        os.makedirs(self._seg_dir, exist_ok=True)
+        if segment_created:
+            _fsync_directory(generation_dir)
+        self._truncate_torn_ledger_tail(self._seg_dir)
+        self._tok_off = self._file_size(_TOKENS_BIN)
+        self._lp_off = self._file_size(_LOGPROBS_BIN)
+        self._mask_off = self._file_size(_MASKS_BIN)
+        if seg not in manifest["segments"]:
+            manifest["segments"].append(seg)
+            self._write_manifest_atomic(manifest)
+            # A directory left behind before manifest publication was not live
+            # at startup, but becomes live when this segment is published.
+            self._bytes_written += self._segment_sidecar_bytes(self._seg_dir)
+            self._maybe_warn_over_cap()
+
+    def reserve_group_uid(self) -> str:
+        """Reserve a group's durable identity before any of its members exist.
+
+        Called at prepare time: the first member to finish must already be able
+        to name its group, and a regenerated group must not reuse a slot's uid.
+        """
+        with self._lock:
+            uid = f"{self._run_nonce}/{self._seq}"
+            self._seq += 1
+            return uid
 
     def _truncate_torn_ledger_tail(self, seg_dir: str) -> None:
         """Remove an incomplete final JSONL line before resuming appends."""
@@ -433,47 +544,88 @@ class RolloutBank:
         self._ledger_f = self._tok_f = self._lp_f = self._mask_f = None
 
     def close(self) -> None:
-        with self._lock:
-            self._close_handles()
+        """Release the segment's file handles."""
+        self._close_handles()
 
     # ---------------------------------------------------------------- append
-    def append(self, group: "RolloutGroup", uid: str | None = None) -> str:
-        """Write-through one completed group; return its stable uid.
+    def append_problem(self, group_uid: str, problem_state: dict) -> None:
+        """Write this group's regeneration state immediately.
 
-        A uid is assigned for a new group or preserved when rewriting an
-        existing group during compaction.
+        Batching is the caller's job: the pipeline queues records and writes them
+        coalesced from its bank writer thread. This one-record path exists for
+        compaction and for direct use in tests.
         """
-        with self._lock:
-            assert self._seg_dir is not None, "set_collection() must be called before append()"
-            current_seg = _segment_name(self._collection_iter)
-            if uid is None:
-                uid = f"{current_seg}/{self._seq}"
-                self._seq += 1
-            else:
-                uid_seg, separator, uid_seq = uid.partition("/")
-                if separator and uid_seg == current_seg and uid_seq.isdigit():
-                    self._seq = max(self._seq, int(uid_seq) + 1)
+        self.write_records([_PendingProblem(group_uid, problem_state)])
 
-            record, tok_bytes, lp_bytes, mask_bytes = self._encode(group, uid)
-            # Write sidecar slices first, then the index record that points at them,
-            # so a torn write can only ever lose the trailing index line.
-            if tok_bytes:
-                self._write_sidecar("_tok_f", _TOKENS_BIN, tok_bytes)
-            if lp_bytes:
-                self._write_sidecar("_lp_f", _LOGPROBS_BIN, lp_bytes)
-            if mask_bytes:
-                self._write_sidecar("_mask_f", _MASKS_BIN, mask_bytes)
-            record["checksum"] = _checksum(
-                {k: v for k, v in record.items() if k != "checksum"},
-                tok_bytes,
-                lp_bytes,
-                mask_bytes,
+    def append_rollout(
+        self, group_uid: str, rollout_idx: int, rollout: "Rollout | TokenRollout"
+    ) -> None:
+        """Write one graded member of ``group_uid`` immediately."""
+        self.write_records([_PendingRollout(group_uid, rollout_idx, rollout)])
+
+    def append(
+        self,
+        group: "RolloutGroup",
+        uid: str | None = None,
+        *,
+        problem_state: dict | None = None,
+    ) -> str:
+        """Write a whole group as its individual member records; return its uid.
+
+        A uid is assigned for a new group or preserved when rewriting an existing
+        group during compaction. Member slots come from ``group.member_indices``
+        when present, so a restored incomplete group keeps its original slots.
+        """
+        if uid is None:
+            uid = group.uid or self.reserve_group_uid()
+        state = problem_state if problem_state is not None else group.problem_state
+        if state is not None:
+            self.append_problem(uid, state)
+        for rollout_idx, rollout in zip(group.member_indices, group.rollouts, strict=True):
+            self.append_rollout(uid, rollout_idx, rollout)
+        return uid
+
+    # --------------------------------------------------------- writer thread
+    def write_records(self, pending: list) -> None:
+        """Encode and durably write one set of ledger records.
+
+        Sidecar slices are written before the index records that point at them, so
+        a torn write can only ever lose trailing index lines. One fsync per touched
+        file per write, rather than per record.
+
+        Blocking. The pipeline calls this through ``asyncio.to_thread`` so the fsync
+        never runs on the event loop. Serialization is the caller's responsibility:
+        exactly one ``write_records`` may be in flight, and no segment mutation may
+        overlap one.
+        """
+        assert self._seg_dir is not None, "set_collection() must be called before appending"
+        records: list[dict] = []
+        payload_bytes = 0
+        for item in pending:
+            if isinstance(item, _PendingProblem):
+                records.append(self._encode_problem(item))
+                continue
+            encoded = self._encode_rollout(item)
+            for data, handle, name in (
+                (encoded.tok_bytes, "_tok_f", _TOKENS_BIN),
+                (encoded.lp_bytes, "_lp_f", _LOGPROBS_BIN),
+                (encoded.mask_bytes, "_mask_f", _MASKS_BIN),
+            ):
+                if data:
+                    self._write_sidecar(handle, name, data)
+            records.append(encoded.record)
+            payload_bytes += (
+                len(encoded.tok_bytes) + len(encoded.lp_bytes) + len(encoded.mask_bytes)
             )
-            self._append_ledger(record)
 
-            self._bytes_written += len(tok_bytes) + len(lp_bytes) + len(mask_bytes)
-            self._maybe_warn_over_cap()
-            return uid
+        for handle in (self._tok_f, self._lp_f, self._mask_f):
+            if handle is not None:
+                handle.flush()
+                os.fsync(handle.fileno())
+        self._append_ledger(records)
+
+        self._bytes_written += payload_bytes
+        self._maybe_warn_over_cap()
 
     def _write_sidecar(self, handle_attr: str, name: str, data: bytes) -> None:
         f = getattr(self, handle_attr)
@@ -484,97 +636,97 @@ class RolloutBank:
             f = open(path, "ab")
             setattr(self, handle_attr, f)
         f.write(data)
-        f.flush()
-        os.fsync(f.fileno())
         if created:
             _fsync_directory(self._seg_dir)
 
-    def _append_ledger(self, record: LedgerRecord) -> None:
+    def _append_ledger(self, records: list[dict]) -> None:
+        """Append index records with a single fsync."""
+        if not records:
+            return
         created = False
         if self._ledger_f is None:
             path = os.path.join(self._seg_dir, _LEDGER)
             created = not os.path.exists(path)
             self._ledger_f = open(path, "a")
-        self._ledger_f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        self._ledger_f.write(
+            "".join(json.dumps(record, separators=(",", ":")) + "\n" for record in records)
+        )
         self._ledger_f.flush()
         os.fsync(self._ledger_f.fileno())
         if created:
             _fsync_directory(self._seg_dir)
 
-    def _encode(self, group: "RolloutGroup", uid: str) -> EncodedGroup:
-        """Build the JSONL index record + packed sidecar bytes for one group."""
-        assert self._collection_iter is not None, "set_collection() must be called before _encode()"
-        dumped = group.model_dump()
-        dumped.pop("uid", None)  # uid lives at the top level of the record
-        members = dumped.get("rollouts", [])
-        token_members = [isinstance(member, TokenRollout) for member in group.rollouts]
-        if token_members and any(token_members) and not all(token_members):
-            raise ValueError("RolloutGroup must not mix TokenRollout and Rollout members")
-        token_typed = bool(token_members) and all(token_members)
+    def _encode_problem(self, pending: _PendingProblem) -> dict:
+        """Build the JSONL record carrying one group's regeneration state."""
+        assert self._collection_iter is not None, "set_collection() must precede encoding"
+        record: ProblemRecord = {
+            "format_version": _FORMAT_VERSION,
+            "kind": "problem",
+            "group_uid": pending.group_uid,
+            "collection_iter": self._collection_iter,
+            "problem_state": pending.problem_state,
+        }
+        record["checksum"] = _checksum(dict(record))
+        return dict(record)
+
+    def _encode_rollout(self, pending: _PendingRollout) -> EncodedRecord:
+        """Build the JSONL index record + packed sidecar bytes for one rollout."""
+        assert self._collection_iter is not None, "set_collection() must precede encoding"
+        rollout = pending.rollout
+        dumped = rollout.model_dump()
+        token_typed = isinstance(rollout, TokenRollout)
         member_type: Literal["Rollout", "TokenRollout"] = (
             "TokenRollout" if token_typed else "Rollout"
         )
-
-        if not token_typed:
-            record: LedgerRecord = {
-                "format_version": _FORMAT_VERSION,
-                "uid": uid,
-                "collection_iter": self._collection_iter,
-                "member_type": member_type,
-                "kind": "inline",
-                "group": dumped,
-            }
-            return EncodedGroup(record, b"", b"", b"")
-
-        tok_flat, tok_lengths = [], []
-        lp_flat, lp_lengths = [], []
-        mask_flat, mask_lengths = [], []
-        for m in members:
-            traj = m.pop("trajectory")
-            tok_lengths.append([len(turn) for turn in traj])
-            for turn in traj:
-                tok_flat.extend(turn)
-
-            lp = m.pop("logprobs", None)
-            if lp is not None:
-                lp_lengths.append([len(turn) for turn in lp])
-                for turn in lp:
-                    lp_flat.extend(turn)
-
-            mask = m.pop("generation_mask", None)
-            if mask is not None:
-                mask_lengths.append([len(turn) for turn in mask])
-                for turn in mask:
-                    mask_flat.extend(turn)
-
-        for field, lengths in (("logprobs", lp_lengths), ("generation_mask", mask_lengths)):
-            if lengths and len(lengths) != len(members):
-                raise ValueError(f"{field} must be present for all or no rollouts in a group")
-
-        tok_bytes = np.asarray(tok_flat, dtype=_TOKEN_DTYPE).tobytes()
         record: LedgerRecord = {
             "format_version": _FORMAT_VERSION,
-            "uid": uid,
+            "kind": "rollout",
+            "uid": f"{pending.group_uid}#{pending.rollout_idx}",
+            "group_uid": pending.group_uid,
+            "rollout_idx": pending.rollout_idx,
             "collection_iter": self._collection_iter,
             "member_type": member_type,
-            "kind": "token",
-            "group": dumped,  # dumped members are now array-stripped
-            "tok": {"offset": self._tok_off, "bytes": len(tok_bytes), "lengths": tok_lengths},
+            "member": dumped,
+        }
+
+        if not token_typed:
+            record["checksum"] = _checksum(dict(record))
+            return EncodedRecord(record, b"", b"", b"")
+
+        trajectory = dumped.pop("trajectory")
+        tok_bytes = np.asarray(
+            [token for turn in trajectory for token in turn], dtype=_TOKEN_DTYPE
+        ).tobytes()
+        record["tok"] = {
+            "offset": self._tok_off,
+            "bytes": len(tok_bytes),
+            "lengths": [len(turn) for turn in trajectory],
         }
 
         lp_bytes = b""
-        if lp_lengths:
-            lp_bytes = np.asarray(lp_flat, dtype=_LOGPROB_DTYPE).tobytes()
-            record["lp"] = {"offset": self._lp_off, "bytes": len(lp_bytes), "lengths": lp_lengths}
+        logprobs = dumped.pop("logprobs", None)
+        if logprobs is not None:
+            lp_bytes = np.asarray(
+                [value for turn in logprobs for value in turn], dtype=_LOGPROB_DTYPE
+            ).tobytes()
+            record["lp"] = {
+                "offset": self._lp_off,
+                "bytes": len(lp_bytes),
+                "lengths": [len(turn) for turn in logprobs],
+            }
 
         mask_bytes = b""
-        if mask_lengths:
-            mask_arr = np.asarray(mask_flat, dtype=bool).astype(_MASK_DTYPE)
-            mask_bytes = mask_arr.tobytes()
+        mask = dumped.pop("generation_mask", None)
+        if mask is not None:
+            mask_bytes = (
+                np.asarray([value for turn in mask for value in turn], dtype=bool)
+                .astype(_MASK_DTYPE)
+                .tobytes()
+            )
             record["mask"] = {
                 "offset": self._mask_off,
                 "bytes": len(mask_bytes),
-                "lengths": mask_lengths,
+                "lengths": [len(turn) for turn in mask],
             }
 
         # Advance running offsets now that this record's slices are placed.
@@ -582,7 +734,8 @@ class RolloutBank:
         self._lp_off += len(lp_bytes)
         self._mask_off += len(mask_bytes)
 
-        return EncodedGroup(record, tok_bytes, lp_bytes, mask_bytes)
+        record["checksum"] = _checksum(dict(record), tok_bytes, lp_bytes, mask_bytes)
+        return EncodedRecord(record, tok_bytes, lp_bytes, mask_bytes)
 
     def mark_consumed(self, uid: str | None, iteration: int) -> None:
         """Record that ``uid`` was pulled by the trainer at ``iteration``.
@@ -610,7 +763,7 @@ class RolloutBank:
         """Durably record one trainer collection's consumption markers.
 
         All non-empty ``uids`` are appended with one file open and one ``fsync``.
-        The batch is therefore durable before this method returns without paying
+        They are therefore durable before this method returns without paying
         one filesystem synchronization per rollout group.
 
         Args:
@@ -638,30 +791,96 @@ class RolloutBank:
 
     def restore(self, trained_through: int) -> list["RolloutGroup"]:
         """Replay the ledger and return groups not yet trained through ``T``."""
-        with self._lock:
-            restored, _ = self._restore_state(trained_through)
-            return restored
+        return self._restore_state(trained_through)[0]
 
     def _restore_state(self, trained_through: int) -> tuple[list["RolloutGroup"], dict[str, int]]:
-        """Return survivors and the active generation's collapsed markers."""
-        self._close_handles()  # flush any active writer before reading
+        """Return survivors and the active generation's collapsed markers.
+
+        Folds the rollout-granular ledger back into groups:
+
+            members == rollouts_per_group -> complete; drop if zero-variance
+            0 < members < that            -> incomplete; needs a problem record
+            no members                    -> nothing worth restoring
+
+        Callers must have drained any queued records first, so everything appended
+        so far is already durable and no write can land mid-read.
+        """
+        self._close_handles()
         manifest = self._read_manifest()
         generation_dir = self._generation_dir(manifest)
-        restored: list["RolloutGroup"] = []
         markers = self._read_markers(generation_dir)
+        problems: dict[str, dict] = {}
+        members: dict[str, dict[int, "Rollout | TokenRollout"]] = {}
+        order: list[str] = []
+
         for seg in manifest["segments"]:
             seg_dir = os.path.join(generation_dir, seg)
             for uid, iteration in self._read_markers(seg_dir).items():
                 markers[uid] = max(markers.get(uid, iteration), iteration)
             for record in self._read_ledger(seg_dir):
-                uid = record["uid"]
-                marker_iter = markers.get(uid)
+                group_uid = record.get("group_uid")
+                if group_uid is None:
+                    logger.debug(f"Ledger record without a group_uid — dropping: {record}")
+                    continue
+                marker_iter = markers.get(group_uid)
                 if marker_iter is not None and marker_iter <= trained_through:
                     continue  # trained into the loaded weights; drop
-                group = self._decode(record, seg_dir)
-                if group is not None:
-                    restored.append(group)
+                if group_uid not in members:
+                    members[group_uid] = {}
+                    order.append(group_uid)
+                if record["kind"] == "problem":
+                    if self._problem_is_intact(record):
+                        problems[group_uid] = record["problem_state"]
+                    continue
+                rollout = self._decode_rollout(record, seg_dir)
+                if rollout is not None:
+                    members[group_uid][record["rollout_idx"]] = rollout
+
+        restored: list["RolloutGroup"] = []
+        for group_uid in order:
+            group = self._assemble_restored(group_uid, members[group_uid], problems.get(group_uid))
+            if group is not None:
+                restored.append(group)
         return restored, markers
+
+    def _assemble_restored(
+        self,
+        group_uid: str,
+        members: dict[int, "Rollout | TokenRollout"],
+        problem_state: Optional[dict],
+    ) -> Optional["RolloutGroup"]:
+        """Turn one group's decoded members into a restorable group, or drop it."""
+        if not members:
+            return None
+        indices = sorted(members)
+        rollouts = [members[index] for index in indices]
+
+        if len(indices) >= self.rollouts_per_group:
+            if self.drop_zero_variance and _is_zero_variance(rollouts):
+                logger.debug(f"Dropping zero-variance restored group {group_uid}")
+                return None
+        elif problem_state is None:
+            logger.debug(
+                f"Dropping incomplete restored group {group_uid} "
+                f"({len(indices)}/{self.rollouts_per_group} members, no problem state)"
+            )
+            return None
+
+        return RolloutGroup(
+            rollouts=rollouts,
+            uid=group_uid,
+            member_indices=indices,
+            problem_state=problem_state,
+        )
+
+    @staticmethod
+    def _problem_is_intact(record: dict) -> bool:
+        """Verify a problem record's checksum before trusting its payload."""
+        expected = _checksum({k: v for k, v in record.items() if k != "checksum"})
+        if expected != record.get("checksum"):
+            logger.debug(f"Checksum mismatch — dropping problem record: {record}")
+            return False
+        return True
 
     def _read_markers(self, seg_dir: str) -> dict:
         """
@@ -734,15 +953,18 @@ class RolloutBank:
                 _validate_format_version(record, path)
                 yield record
 
-    def _decode(self, record: LedgerRecord, seg_dir: str) -> Optional["RolloutGroup"]:
+    def _decode_rollout(
+        self, record: LedgerRecord, seg_dir: str
+    ) -> "Optional[Rollout | TokenRollout]":
         """
-        Decode a ledger record into a RolloutGroup.
+        Decode one ledger record into a single rollout.
+
         Args:
             record: The ledger record to decode.
             seg_dir: The directory of the segment.
 
         Returns:
-            A RolloutGroup or None if the record is corrupted or truncated.
+            A Rollout/TokenRollout, or None if the record is corrupted or truncated.
         """
         tok_bytes = self._read_slice(seg_dir, _TOKENS_BIN, record.get("tok"))
         lp_bytes = self._read_slice(seg_dir, _LOGPROBS_BIN, record.get("lp"))
@@ -758,49 +980,33 @@ class RolloutBank:
             logger.debug(f"Checksum mismatch — dropping record: {record}")
             return None
 
-        group_dict = record["group"]
-        uid = record["uid"]
-        if record["kind"] == "inline":
-            cls = TokenRollout if record["member_type"] == "TokenRollout" else Rollout
-            members = [cls.model_validate(m) for m in group_dict["rollouts"]]
-            group = RolloutGroup(
-                rollouts=members,
-                batch_id=group_dict.get("batch_id", 0),
-                index_in_batch=group_dict.get("index_in_batch", 0),
+        member = dict(record["member"])
+        if record["member_type"] != "TokenRollout":
+            return Rollout.model_validate(member)
+
+        tokens = np.frombuffer(tok_bytes, dtype=_TOKEN_DTYPE).tolist()
+        member["trajectory"] = self._unflatten(tokens, record["tok"]["lengths"])
+        member["logprobs"] = (
+            self._unflatten(
+                np.frombuffer(lp_bytes, dtype=_LOGPROB_DTYPE).astype(np.float32).tolist(),
+                record["lp"]["lengths"],
             )
-            group.uid = uid
-            return group
-
-        # token kind: re-split flat sidecar arrays back into jagged per-turn lists
-        tok = np.frombuffer(tok_bytes, dtype=_TOKEN_DTYPE)
-        traj_per_member = self._unflatten(tok.tolist(), record["tok"]["lengths"])
-        lp_per_member = None
-        if "lp" in record:
-            lp = np.frombuffer(lp_bytes, dtype=_LOGPROB_DTYPE).astype(np.float32)
-            lp_per_member = self._unflatten(lp.tolist(), record["lp"]["lengths"])
-        mask_per_member = None
-        if "mask" in record:
-            mask = np.frombuffer(mask_bytes, dtype=_MASK_DTYPE).astype(bool)
-            mask_per_member = self._unflatten(mask.tolist(), record["mask"]["lengths"])
-
-        members = []
-        for i, m in enumerate(group_dict["rollouts"]):
-            m = dict(m)
-            m["trajectory"] = traj_per_member[i]
-            m["logprobs"] = lp_per_member[i] if lp_per_member is not None else None
-            m["generation_mask"] = mask_per_member[i] if mask_per_member is not None else None
-            # Completion IDs point into the inference engine's process-local
-            # metadata ledger. That ledger does not survive a crash, so recovered
-            # rollouts must not attempt to join against stale IDs.
-            m["completion_ids"] = []
-            members.append(TokenRollout.model_validate(m))
-        group = RolloutGroup(
-            rollouts=members,
-            batch_id=group_dict.get("batch_id", 0),
-            index_in_batch=group_dict.get("index_in_batch", 0),
+            if "lp" in record
+            else None
         )
-        group.uid = uid
-        return group
+        member["generation_mask"] = (
+            self._unflatten(
+                np.frombuffer(mask_bytes, dtype=_MASK_DTYPE).astype(bool).tolist(),
+                record["mask"]["lengths"],
+            )
+            if "mask" in record
+            else None
+        )
+        # Completion IDs point into the inference engine's process-local metadata
+        # ledger. That ledger does not survive a crash, so recovered rollouts must
+        # not attempt to join against stale IDs.
+        member["completion_ids"] = []
+        return TokenRollout.model_validate(member)
 
     @staticmethod
     def _read_slice(seg_dir: str, name: str, meta: Optional[SidecarMeta]) -> Optional[bytes]:
@@ -817,14 +1023,11 @@ class RolloutBank:
 
     @staticmethod
     def _unflatten(flat: list, lengths: list) -> list:
-        """Split a flat list back into [member][turn] jagged nesting."""
+        """Split one rollout's flat array back into per-turn nesting."""
         out, pos = [], 0
-        for member_lengths in lengths:
-            turns = []
-            for n in member_lengths:
-                turns.append(flat[pos : pos + n])
-                pos += n
-            out.append(turns)
+        for length in lengths:
+            out.append(flat[pos : pos + length])
+            pos += length
         return out
 
     def checkpoint(self, iteration: int) -> None:
@@ -837,25 +1040,23 @@ class RolloutBank:
         writer remains closed until the next ``set_collection()`` call selects the
         current rollout collection.
         """
-        with self._lock:
-            survivors, markers = self._restore_state(iteration)
-            survivor_uids = {group.uid for group in survivors}
-            retained_markers = {
-                uid: marker_iter
-                for uid, marker_iter in markers.items()
-                if uid in survivor_uids and marker_iter > iteration
-            }
-            manifest = self._read_manifest()
-            self._publish_generation(
-                iteration, survivors, retained_markers, timeline=manifest["timeline"]
-            )
+        survivors, markers = self._restore_state(iteration)
+        survivor_uids = {group.uid for group in survivors}
+        retained_markers = {
+            uid: marker_iter
+            for uid, marker_iter in markers.items()
+            if uid in survivor_uids and marker_iter > iteration
+        }
+        manifest = self._read_manifest()
+        self._publish_generation(
+            iteration, survivors, retained_markers, timeline=manifest["timeline"]
+        )
 
     def recover(self, trained_through: int) -> list["RolloutGroup"]:
         """Rebase survivors at ``T`` into a new timeline with no old markers."""
-        with self._lock:
-            survivors, _ = self._restore_state(trained_through)
-            self._publish_generation(trained_through, survivors, {}, timeline=uuid.uuid4().hex)
-            return survivors
+        survivors, _ = self._restore_state(trained_through)
+        self._publish_generation(trained_through, survivors, {}, timeline=uuid.uuid4().hex)
+        return survivors
 
     def _publish_generation(
         self,
@@ -893,6 +1094,7 @@ class RolloutBank:
                 "trained_through": iteration,
                 "segments": [new_seg],
                 "compacted_at": iteration,
+                "rollouts_per_group": self.rollouts_per_group,
             }
         )
 
@@ -925,13 +1127,24 @@ class RolloutBank:
         _fsync_directory(generation_dir)
 
     def _rewrite_segment(self, seg_dir: str, iteration: int, groups: list["RolloutGroup"]) -> None:
-        """Write ``groups`` into ``seg_dir`` as a fresh ledger + sidecars."""
+        """Write ``groups`` into ``seg_dir`` as a fresh ledger + sidecars.
+
+        Group uids and member slots are preserved, so a group that survives
+        several compactions keeps the identity its records were written under.
+        """
+        pending: list = []
+        for group in groups:
+            uid = group.uid or self.reserve_group_uid()
+            if group.problem_state is not None:
+                pending.append(_PendingProblem(uid, group.problem_state))
+            for rollout_idx, rollout in zip(group.member_indices, group.rollouts, strict=True):
+                pending.append(_PendingRollout(uid, rollout_idx, rollout))
+
         live_bytes = self._bytes_written
         warned_over_cap = self._warned_over_cap
         saved = (
             self._seg_dir,
             self._collection_iter,
-            self._seq,
             self._tok_off,
             self._lp_off,
             self._mask_off,
@@ -940,14 +1153,14 @@ class RolloutBank:
             self._lp_f,
             self._mask_f,
         )
-        self._seg_dir, self._collection_iter, self._seq = seg_dir, iteration, 0
+        self._seg_dir, self._collection_iter = seg_dir, iteration
         self._tok_off = self._lp_off = self._mask_off = 0
         self._ledger_f = self._tok_f = self._lp_f = self._mask_f = None
         self._bytes_written = 0
         self._warned_over_cap = True  # staging data is not live yet
         try:
-            for group in groups:
-                self.append(group, uid=group.uid)  # reuses the write-through encoder + fsync
+            if pending:
+                self.write_records(pending)
         finally:
             self._close_handles()
             self._bytes_written = live_bytes
@@ -955,7 +1168,6 @@ class RolloutBank:
             (
                 self._seg_dir,
                 self._collection_iter,
-                self._seq,
                 self._tok_off,
                 self._lp_off,
                 self._mask_off,
@@ -976,6 +1188,28 @@ class RolloutBank:
                 self.max_bytes,
             )
             self._warned_over_cap = True
+
+
+def _is_zero_variance(rollouts: list) -> bool:
+    """Whether every member scored the same, leaving no learning signal.
+
+    Mirrors the same-reward half of ``RolloutPipeline._decide_drop``. Re-deriving
+    this from the persisted rewards, rather than persisting a tombstone when the
+    pipeline filters a group, removes the crash window between a group's last
+    member write and its marker.
+
+    ``_decide_drop`` also drops all-placeholder groups so they can be refilled.
+    That half needs no mirror: ``stage_assemble`` never persists a placeholder, so
+    a restored group cannot contain one.
+
+    A ``TokenRollout`` reward may be per-turn, so each is collapsed to its
+    trajectory total before comparison.
+    """
+    rewards = [rollout.reward for rollout in rollouts]
+    if any(reward is None for reward in rewards):
+        return False
+    scalars = [float(np.sum(reward)) for reward in rewards]
+    return bool(np.std(scalars) <= _ZERO_VARIANCE_TOLERANCE)
 
 
 def _rmtree(path: str) -> None:

--- a/megatron/rl/server/agent/fastapi_env_server.py
+++ b/megatron/rl/server/agent/fastapi_env_server.py
@@ -15,7 +15,6 @@ from uvicorn.config import LOGGING_CONFIG
 LOGGING_CONFIG['root'] = {"handlers": ["default"], "level": "INFO"}
 
 from ... import inference
-from ...agent.registry import get_agent_class
 from ...agent.api import (
     Agent,
     ContrastiveRollout,
@@ -30,6 +29,7 @@ from ...agent.api import (
     RolloutRequest,
     TokenRollout,
 )
+from ...agent.registry import get_agent_class
 from ...server.api import (
     EnvironmentServer,
     InferenceServer,
@@ -119,8 +119,7 @@ class FastAPIEnvServer(EnvironmentServer):
         return rollouts
 
     async def prepare_group_rollout(
-        self,
-        request: GroupedRolloutRequest,
+        self, request: GroupedRolloutRequest, *, problem_state: dict | None = None
     ) -> GroupRolloutParams:
         raise NotImplementedError(
             "FastAPIEnvServer overrides get_grouped_rollouts; prepare_group_rollout is not used."

--- a/megatron/rl/types/rollout.py
+++ b/megatron/rl/types/rollout.py
@@ -3,7 +3,7 @@
 from collections import deque
 from typing import TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 #: An environment identifier, as reported by an agent's ``env_id`` attribute
 #: (see ``WeightedMultiTask._env_ids``).
@@ -57,12 +57,60 @@ Rollouts = list[TokenRollout | Rollout]
 
 
 class RolloutGroup(AgentBaseModel):
-    """A group of rollouts (e.g. multiple completions for one prompt) with batch metadata."""
+    """A group of rollouts (e.g. multiple completions for one prompt) with batch metadata.
+
+    A group restored from the rollout bank may be *incomplete*: a kill can land
+    after some members were persisted but before the group filled. Such a group
+    carries ``problem_state`` (what the agent needs to regenerate the rest against
+    the same prompt) and ``member_indices`` (the slots its members occupy, so the
+    complement can be regenerated).
+
+    Args:
+        rollouts: The rollouts in this group.
+        batch_id: The batch ID of this group.
+        index_in_batch: The index of this group in the batch.
+        uid: The UID of this group.
+        problem_state: What the agent needs to regenerate this group's remaining
+            members against the same prompt. Present on restored incomplete groups.
+        member_indices: The slot each member occupies, parallel to ``rollouts``.
+            Defaults to the positional slots, so there is one source of truth about
+            which slots are filled rather than a fallback at each read site.
+    """
 
     rollouts: Rollouts
     batch_id: int = 0
     index_in_batch: int = 0
     uid: str | None = None
+    problem_state: dict | None = None
+    member_indices: list[int] | None = None
+
+    @model_validator(mode="after")
+    def _fill_member_indices(self) -> "RolloutGroup":
+        """Default the slots to positional, and reject a list that disagrees."""
+        if self.member_indices is None:
+            self.member_indices = list(range(len(self.rollouts)))
+        elif len(self.member_indices) != len(self.rollouts):
+            raise ValueError(
+                f"member_indices has {len(self.member_indices)} slot(s) but the group has "
+                f"{len(self.rollouts)} rollout(s); they must correspond one-to-one."
+            )
+        return self
+
+    def is_complete(self, rollouts_per_group: int) -> bool:
+        """Whether this group has every member it needs to be trained on."""
+        return len(self.rollouts) >= rollouts_per_group
+
+    def missing_indices(self, rollouts_per_group: int) -> list[int]:
+        """
+        Slots that still need to be generated, in ascending order.
+
+        Example:
+        >>> group = RolloutGroup(rollouts=[r0, r2], member_indices=[0, 2])
+        >>> group.missing_indices(4)
+        [1, 3]
+        """
+        occupied = set(self.member_indices)
+        return [index for index in range(rollouts_per_group) if index not in occupied]
 
     def __iter__(self):
         return iter(self.rollouts)

--- a/tests/unit_tests/rl/test_pipeline.py
+++ b/tests/unit_tests/rl/test_pipeline.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import itertools
+import time
+from collections import Counter
 from contextlib import aclosing
 from unittest.mock import MagicMock
 
@@ -9,6 +11,7 @@ import numpy as np
 import pytest
 from pydantic import Field, ValidationError
 
+from megatron.rl.agent import rollout_pipeline as rollout_pipeline_module
 from megatron.rl.agent.api import (
     EpisodeResult,
     GroupedRolloutGenerator,
@@ -23,6 +26,8 @@ from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.rollout_pipeline import RolloutPipeline, _SubmissionGate
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw, ReturnsTokens
+from megatron.rl.rollout_bank import RolloutBank
+from megatron.rl.types import RolloutGroup
 
 
 class MockInferenceInterface(ReturnsRaw):
@@ -68,8 +73,8 @@ class MockGenerator(RolloutGenerator, GroupedRolloutGenerator):
         self.get_rollout_response_calls += 1
         return await request.inference_interface.agenerate(inference_request)
 
-    async def prepare_group_rollout(self, request):
-        idx = self._call_count
+    async def prepare_group_rollout(self, request, *, problem_state=None):
+        idx = problem_state["idx"] if problem_state else self._call_count
         self._call_count += 1
         self.prepare_group_rollout_calls += 1
 
@@ -100,8 +105,8 @@ class FilteringMockGenerator(MockGenerator):
         super().__init__(**kwargs)
         self.num_degenerate = num_degenerate
 
-    async def prepare_group_rollout(self, request):
-        idx = self._call_count
+    async def prepare_group_rollout(self, request, *, problem_state=None):
+        idx = problem_state["idx"] if problem_state else self._call_count
         params = await super().prepare_group_rollout(request)
         degenerate = idx < self.num_degenerate
         rollout_counter = itertools.count()
@@ -112,7 +117,11 @@ class FilteringMockGenerator(MockGenerator):
             rollout.reward = 0.0 if degenerate else float(next(rollout_counter))
             return rollout
 
-        return GroupRolloutParams(run_episode=params.run_episode, build_rollout=build_rollout)
+        return GroupRolloutParams(
+            run_episode=params.run_episode,
+            build_rollout=build_rollout,
+            problem_state=params.problem_state,
+        )
 
 
 class PlaceholderMockGenerator(MockGenerator):
@@ -139,9 +148,9 @@ class PlaceholderMockGenerator(MockGenerator):
         self.placeholder_status = placeholder_status
         self.placeholder_reason = placeholder_reason
 
-    async def prepare_group_rollout(self, request):
+    async def prepare_group_rollout(self, request, *, problem_state=None):
         idx = self._call_count
-        params = await super().prepare_group_rollout(request)
+        params = await super().prepare_group_rollout(request, problem_state=problem_state)
         make_placeholder = idx < self.num_placeholder
         member_counter = itertools.count()
         base_build = params.build_rollout
@@ -295,7 +304,7 @@ class TestStageFailurePropagation:
     @pytest.mark.asyncio
     async def test_prepare_failure_raises_out_of_run(self):
         class BrokenPrepareGenerator(MockGenerator):
-            async def prepare_group_rollout(self, request):
+            async def prepare_group_rollout(self, request, *, problem_state=None):
                 raise TypeError("agent/pipeline interface mismatch")
 
         request = GroupedRolloutRequest(
@@ -318,7 +327,7 @@ class TestStageFailurePropagation:
         class BrokenBuildGenerator(MockGenerator):
             """First group builds normally; every later group's build_rollout raises."""
 
-            async def prepare_group_rollout(self, request):
+            async def prepare_group_rollout(self, request, *, problem_state=None):
                 idx = self._call_count
                 params = await super().prepare_group_rollout(request)
                 if idx < 1:
@@ -672,9 +681,9 @@ class TestGroupedRollouts:
             """Group 0: member 0 fails, real members share one reward; later
             groups carry distinct member rewards."""
 
-            async def prepare_group_rollout(self, request):
+            async def prepare_group_rollout(self, request, *, problem_state=None):
                 idx = self._call_count
-                params = await super().prepare_group_rollout(request)
+                params = await super().prepare_group_rollout(request, problem_state=problem_state)
                 affected = idx < 1
                 member_counter = itertools.count()
                 base_build = params.build_rollout
@@ -1176,3 +1185,551 @@ class TestMultiTurnEpisode:
         assert agent.observation_turns == expected["observation_turns"]
         # get_trajectory_reward sees the full dialogue, ending on the final reply exactly once.
         assert [(m.role, m.content) for m in agent.reward_conversation] == expected["reward_conv"]
+
+
+class _RestoringGenerator(MockGenerator):
+    """MockGenerator that hands back preloaded groups before generating fresh ones."""
+
+    def __init__(self, restored=None, **kwargs):
+        super().__init__(**kwargs)
+        self._restored = list(restored or [])
+        self.resumed_states = []
+
+    def take_restored_group(self, env_id):
+        return self._restored.pop(0) if self._restored else None
+
+    async def prepare_group_rollout(self, request, *, problem_state=None):
+        if problem_state is not None:
+            self.resumed_states.append(problem_state)
+        params = await super().prepare_group_rollout(request, problem_state=problem_state)
+        # Incomplete groups are only banked for envs that can regenerate them.
+        return params._replace(problem_state=problem_state or {"idx": self._call_count})
+
+
+class _StallingGenerator(_RestoringGenerator):
+    """Generator whose episodes past `stall_after` never return, so a group never fills."""
+
+    def __init__(self, stall_after=1, **kwargs):
+        super().__init__(**kwargs)
+        self.stall_after = stall_after
+        self.started = 0
+        self._never = asyncio.Event()
+
+    async def prepare_group_rollout(self, request, *, problem_state=None):
+        params = await super().prepare_group_rollout(request, problem_state=problem_state)
+        base_run = params.run_episode
+
+        async def run_episode():
+            self.started += 1
+            if self.started > self.stall_after:
+                await self._never.wait()
+            return await base_run()
+
+        return params._replace(run_episode=run_episode)
+
+
+class TestProblemStateContract:
+    """problem_state is handed out so the bank can store it, and taken back to replay."""
+
+    @staticmethod
+    def _request():
+        return GroupedRolloutRequest(
+            num_groups=1,
+            rollouts_per_group=2,
+            inference_interface=MockInferenceInterface(),
+            generation_args={},
+        )
+
+    def test_params_default_to_no_problem_state(self):
+        """Agents that opt out keep working; the field is optional."""
+        params = GroupRolloutParams(run_episode=lambda: None, build_rollout=lambda e: None)
+        assert params.problem_state is None
+
+    @pytest.mark.asyncio
+    async def test_agent_exposes_the_problem_it_drew(self):
+        agent = CountingRewardAgent()
+        params = await agent.prepare_group_rollout(self._request())
+        assert params.problem_state == {"prompt": "t0", "golden": {"idx": 0}}
+
+    @pytest.mark.asyncio
+    async def test_replaying_a_state_does_not_advance_the_dataset(self):
+        """Completing a restored group must reuse its prompt, not draw a new one."""
+        agent = CountingRewardAgent()
+        first = await agent.prepare_group_rollout(self._request())
+        await agent.prepare_group_rollout(self._request())  # dataset moves on
+
+        resumed = await agent.prepare_group_rollout(
+            self._request(), problem_state=first.problem_state
+        )
+        assert agent._prompt_count == 2, "no third draw"
+        assert resumed.problem_state == first.problem_state
+        episode = await resumed.run_episode()
+        assert episode.conversation[0].content == "t0"
+
+
+class TestDurableBank:
+    """The pipeline's half of incomplete-group durability."""
+
+    ROLLOUTS_PER_GROUP = 4
+
+    @classmethod
+    def _request(cls, **kwargs):
+        kwargs.setdefault("num_groups", 1)
+        kwargs.setdefault("rollouts_per_group", cls.ROLLOUTS_PER_GROUP)
+        kwargs.setdefault("inference_interface", MockInferenceInterface())
+        kwargs.setdefault("submission_granularity", "R")
+        kwargs.setdefault("consumption_granularity", "G")
+        return GroupedRolloutRequest(**kwargs)
+
+    @classmethod
+    def _bank(cls, tmp_path, **kwargs):
+        bank = RolloutBank(str(tmp_path), rollouts_per_group=cls.ROLLOUTS_PER_GROUP, **kwargs)
+        bank.set_collection(1)
+        return bank
+
+    @staticmethod
+    async def _take(pipeline, count):
+        async with aclosing(pipeline.run()) as stream:
+            return [await asyncio.wait_for(anext(stream), timeout=10) for _ in range(count)]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stall, expected_members",
+        [
+            pytest.param(False, ROLLOUTS_PER_GROUP, id="complete-group-fully-persisted"),
+            pytest.param(True, ROLLOUTS_PER_GROUP - 1, id="stalled-group-persists-what-it-has"),
+        ],
+    )
+    async def test_members_persist_as_they_are_graded(self, tmp_path, stall, expected_members):
+        """Members are durable without waiting for the group.
+
+        Under append-at-assembly the stalled case would leave nothing on disk,
+        because that group is one member short forever.
+        """
+        bank = self._bank(tmp_path)
+        agent = (
+            _StallingGenerator(stall_after=self.ROLLOUTS_PER_GROUP - 1)
+            if stall
+            else _RestoringGenerator()
+        )
+        try:
+            pipeline = RolloutPipeline(
+                agent, self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            if stall:
+                async with aclosing(pipeline.run()) as stream:
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(anext(stream), timeout=1.0)
+            else:
+                await self._take(pipeline, 1)
+                pipeline.drain_bank()
+            restored = bank.restore(0)
+        finally:
+            bank.close()
+
+        assert len(restored) == 1
+        assert len(restored[0].rollouts) == expected_members
+
+    @pytest.mark.asyncio
+    async def test_restored_group_regenerates_only_its_missing_members(self, tmp_path):
+        """Persisted members are reused; only the gaps are generated, same prompt."""
+        incomplete = RolloutGroup(
+            rollouts=[
+                Rollout(trajectory=["kept-0"], reward=1.0, env_id="test"),
+                Rollout(trajectory=["kept-2"], reward=0.0, env_id="test"),
+            ],
+            uid="nonce/7",
+            member_indices=[0, 2],
+            problem_state={"idx": 0},
+        )
+        agent = _RestoringGenerator(restored=[incomplete])
+        bank = self._bank(tmp_path)
+        try:
+            pipeline = RolloutPipeline(
+                agent, self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            group = (await self._take(pipeline, 1))[0]
+        finally:
+            bank.close()
+
+        assert len(group.rollouts) == self.ROLLOUTS_PER_GROUP
+        assert group.uid == "nonce/7", "completion must not mint a new identity"
+        assert group.member_indices == [0, 1, 2, 3]
+        assert agent.resumed_states == [{"idx": 0}]
+        kept = [r.trajectory[0] for r in group.rollouts if r.trajectory[0].startswith("kept")]
+        assert sorted(kept) == ["kept-0", "kept-2"], "persisted members are not regenerated"
+
+    @pytest.mark.asyncio
+    async def test_writes_are_coalesced_and_run_off_the_event_loop(self, tmp_path):
+        """fsync is blocking, so it must batch and must not run on the loop thread."""
+        import threading
+
+        loop_thread = threading.get_ident()
+        writes, threads = [], set()
+
+        class RecordingBank(RolloutBank):
+            def write_records(self, pending):
+                writes.append(len(pending))
+                threads.add(threading.get_ident())
+                super().write_records(pending)
+
+        bank = RecordingBank(str(tmp_path), rollouts_per_group=self.ROLLOUTS_PER_GROUP)
+        bank.set_collection(1)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(),
+                self._request(num_groups=2),
+                parallel_generation_tasks=2,
+                bank=bank,
+            )
+            await self._take(pipeline, 2)
+            pipeline.drain_bank()
+        finally:
+            bank.close()
+
+        assert threads and loop_thread not in threads, "a blocking fsync ran on the event loop"
+        assert len(writes) < sum(writes), "records must coalesce, not fsync one at a time"
+
+    @pytest.mark.asyncio
+    async def test_write_failure_surfaces_at_the_durability_barrier(self, tmp_path):
+        """Persistence is best-effort mid-stream, but a failure cannot be swallowed."""
+
+        class BrokenBank(RolloutBank):
+            def write_records(self, pending):
+                raise RuntimeError("disk exploded")
+
+        bank = BrokenBank(str(tmp_path), rollouts_per_group=self.ROLLOUTS_PER_GROUP)
+        bank.set_collection(1)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            groups = await self._take(pipeline, 1)
+            assert len(groups) == 1, "a bank failure must not stop rollout generation"
+            with pytest.raises(RuntimeError, match="disk exploded"):
+                pipeline.drain_bank()
+            pipeline.drain_bank()  # latched errors report once, then clear
+        finally:
+            bank.close()
+
+    @pytest.mark.asyncio
+    async def test_placeholders_are_not_persisted(self, tmp_path):
+        """A failed episode has no decode work to save, and must not be restored.
+
+        main drops all-placeholder groups so they can be refilled. Persisting a
+        placeholder would let a restored group carry one past that policy; leaving
+        the slot empty means restore regenerates it, which is the same outcome.
+        """
+        # One member of the first group comes back empty; the rest are real.
+        agent = PlaceholderMockGenerator(num_placeholder=1, placeholder_members=1)
+        bank = self._bank(tmp_path)
+        try:
+            pipeline = RolloutPipeline(
+                agent, self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            await self._take(pipeline, 1)
+            pipeline.drain_bank()
+            restored = bank.restore(0)
+        finally:
+            bank.close()
+
+        for group in restored:
+            assert all(not r.is_placeholder for r in group.rollouts), "placeholder persisted"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_without_a_bank_is_unaffected(self, tmp_path):
+        """Persistence is opt-in."""
+        pipeline = RolloutPipeline(
+            _RestoringGenerator(), self._request(), parallel_generation_tasks=1
+        )
+        group = (await self._take(pipeline, 1))[0]
+        assert len(group.rollouts) == self.ROLLOUTS_PER_GROUP
+        assert group.uid is None
+
+
+class TestBackgroundBankWriter:
+    """Bank writes progress during training, without anyone pumping the event loop.
+
+    The trainer only runs the asyncio loop while collecting rollouts. If bank
+    writes could only progress on the loop, the whole backlog would have to be
+    fsynced inside the inference-to-training switch with the GPUs idle. These
+    tests pin the fix: a dedicated writer thread drains the queue on its own,
+    and consumption markers ride the same FIFO queue behind the records they
+    name instead of waiting for a drain.
+    """
+
+    ROLLOUTS_PER_GROUP = 4
+    # One problem record plus one record per member.
+    RECORDS_PER_GROUP = ROLLOUTS_PER_GROUP + 1
+
+    @classmethod
+    def _request(cls, **kwargs):
+        kwargs.setdefault("num_groups", 1)
+        kwargs.setdefault("rollouts_per_group", cls.ROLLOUTS_PER_GROUP)
+        kwargs.setdefault("inference_interface", MockInferenceInterface())
+        kwargs.setdefault("submission_granularity", "R")
+        kwargs.setdefault("consumption_granularity", "G")
+        return GroupedRolloutRequest(**kwargs)
+
+    @classmethod
+    def _recording_bank(cls, tmp_path, write_delay=0.0):
+        """A bank that logs ("w", n)/("m", n) ops, optionally slowing writes."""
+        ops = []
+
+        class RecordingBank(RolloutBank):
+            def write_records(self, pending):
+                if write_delay:
+                    time.sleep(write_delay)
+                super().write_records(pending)
+                ops.append(("w", len(pending)))
+
+            def mark_consumed_many(self, uids, iteration):
+                uids = [uid for uid in uids if uid]
+                super().mark_consumed_many(uids, iteration)
+                ops.append(("m", len(uids)))
+
+        bank = RecordingBank(str(tmp_path), rollouts_per_group=cls.ROLLOUTS_PER_GROUP)
+        bank.set_collection(1)
+        return bank, ops
+
+    @staticmethod
+    def _written(ops):
+        return sum(n for kind, n in ops if kind == "w")
+
+    @staticmethod
+    def _marked(ops):
+        return sum(n for kind, n in ops if kind == "m")
+
+    @staticmethod
+    def _poll_blocking(condition, timeout=10.0):
+        """Busy-wait on the loop thread, so nothing can pump the event loop."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and not condition():
+            time.sleep(0.01)
+
+    @pytest.mark.asyncio
+    async def test_writes_progress_while_the_loop_is_blocked(self, tmp_path, monkeypatch):
+        """A training step blocks the loop thread; queued records must still land."""
+        monkeypatch.setattr(rollout_pipeline_module, "BANK_WRITE_MAX_RECORDS", 1)
+        bank, ops = self._recording_bank(tmp_path, write_delay=0.05)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            async with aclosing(pipeline.run()) as stream:
+                await asyncio.wait_for(anext(stream), timeout=10)
+                # Run-ahead may bank records beyond the consumed group, so the
+                # bar is "at least the consumed group's records", not equality.
+                self._poll_blocking(lambda: self._written(ops) >= self.RECORDS_PER_GROUP)
+            assert (
+                self._written(ops) >= self.RECORDS_PER_GROUP
+            ), "bank writes stalled while the event loop was blocked (training)"
+        finally:
+            bank.close()
+
+    @pytest.mark.asyncio
+    async def test_consumed_markers_apply_without_a_drain(self, tmp_path):
+        """The switch enqueues markers and returns; no drain, no marker loss."""
+        bank, ops = self._recording_bank(tmp_path)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            async with aclosing(pipeline.run()) as stream:
+                group = await asyncio.wait_for(anext(stream), timeout=10)
+                pipeline.enqueue_consumed_markers([group.uid], iteration=5)
+                self._poll_blocking(lambda: self._marked(ops) == 1)
+            pipeline.drain_bank()
+            assert self._marked(ops) == 1
+            marked_uids = {group.uid for group in bank.restore(trained_through=5)}
+            assert group.uid not in marked_uids, "marker was not applied"
+            unmarked_uids = {group.uid for group in bank.restore(trained_through=0)}
+            assert group.uid in unmarked_uids, "records were lost"
+        finally:
+            bank.close()
+
+    @pytest.mark.asyncio
+    async def test_markers_are_written_behind_every_queued_record(self, tmp_path, monkeypatch):
+        """FIFO ordering is the safety rule: records durable before their marker."""
+        monkeypatch.setattr(rollout_pipeline_module, "BANK_WRITE_MAX_RECORDS", 1)
+        bank, ops = self._recording_bank(tmp_path, write_delay=0.05)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            async with aclosing(pipeline.run()) as stream:
+                group = await asyncio.wait_for(anext(stream), timeout=10)
+                pipeline.enqueue_consumed_markers([group.uid], iteration=5)
+                assert (
+                    self._marked(ops) == 0
+                ), "enqueue_consumed_markers blocked on the backlog instead of queueing"
+                pipeline.drain_bank()
+            kinds = [kind for kind, _ in ops]
+            assert kinds.count("m") == 1
+            # Every record queued before the marker (the consumed group's full
+            # set) must be on disk before the marker is; run-ahead records for
+            # the next batch may legitimately land after it.
+            marker_index = kinds.index("m")
+            written_before_marker = sum(n for kind, n in ops[:marker_index] if kind == "w")
+            assert (
+                written_before_marker >= self.RECORDS_PER_GROUP
+            ), f"marker overtook queued records, got {ops}"
+        finally:
+            bank.close()
+
+    @pytest.mark.asyncio
+    async def test_drain_is_synchronous_and_needs_no_loop(self, tmp_path):
+        """Compaction runs from sync checkpoint code; drain must not need the loop."""
+        bank, ops = self._recording_bank(tmp_path)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            async with aclosing(pipeline.run()) as stream:
+                await asyncio.wait_for(anext(stream), timeout=10)
+            result = pipeline.drain_bank()
+            assert result is None, "drain_bank must be a plain synchronous barrier"
+            assert self._written(ops) >= self.RECORDS_PER_GROUP
+        finally:
+            bank.close()
+
+    @pytest.mark.asyncio
+    async def test_marker_enqueue_surfaces_a_latched_write_failure(self, tmp_path):
+        """A write failure from the previous backlog cannot be swallowed forever."""
+
+        class BrokenBank(RolloutBank):
+            def write_records(self, pending):
+                raise RuntimeError("disk exploded")
+
+        bank = BrokenBank(str(tmp_path), rollouts_per_group=self.ROLLOUTS_PER_GROUP)
+        bank.set_collection(1)
+        try:
+            pipeline = RolloutPipeline(
+                _RestoringGenerator(), self._request(), parallel_generation_tasks=1, bank=bank
+            )
+            async with aclosing(pipeline.run()) as stream:
+                group = await asyncio.wait_for(anext(stream), timeout=10)
+                self._poll_blocking(lambda: pipeline._bank_error is not None)
+                with pytest.raises(RuntimeError, match="disk exploded"):
+                    pipeline.enqueue_consumed_markers([group.uid], iteration=5)
+        finally:
+            bank.close()
+
+
+class TestRestoredGroupRouting:
+    """Recovered groups keep their per-env weighting and drain before fresh work."""
+
+    @staticmethod
+    def _env_group(env_id, problem_id):
+        return RolloutGroup(
+            rollouts=[
+                Rollout(trajectory=["cached"], reward=1.0, env_id=env_id, problem_id=problem_id)
+            ]
+        )
+
+    @staticmethod
+    def _weighted_agent(env_weights):
+        return WeightedMultiTask(
+            [
+                AgentConfig(agent_type=MockGenerator, agent_args={"env_id": env_id}, weight=weight)
+                for env_id, weight in env_weights
+            ]
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "env_weights, restored_env, restored_count, request_groups, take_count, "
+        "expected_envs, expected_fresh_calls, write_through",
+        [
+            pytest.param(
+                [("a", 1.0), ("b", 1.0)],
+                "a",
+                2,
+                4,
+                4,
+                {"a": 2, "b": 2},
+                [0, 2],
+                False,
+                id="restored-groups-replace-fresh",
+            ),
+            pytest.param(
+                [("a", 1.0), ("b", 1.0)],
+                "a",
+                4,
+                4,
+                12,
+                {"a": 6, "b": 6},
+                [2, 6],
+                False,
+                id="streaming-backlog-drains-before-fresh",
+            ),
+            pytest.param(
+                [("", 1.0)], "", 1, 2, 2, {"": 2}, [1], False, id="single-env-without-env-id"
+            ),
+            pytest.param(
+                [("a", 1.0)], "a", 0, 4, 4, {"a": 4}, [4], True, id="fresh-groups-write-through"
+            ),
+        ],
+    )
+    async def test_restored_groups_are_consumed_before_fresh_generation(
+        self,
+        tmp_path,
+        env_weights,
+        restored_env,
+        restored_count,
+        request_groups,
+        take_count,
+        expected_envs,
+        expected_fresh_calls,
+        write_through,
+    ):
+        agent = self._weighted_agent(env_weights)
+        restored = [self._env_group(restored_env, f"cached-{i}") for i in range(restored_count)]
+        assert agent.set_restored_groups(restored) == restored_count
+
+        if len(env_weights) > 1:
+            with pytest.raises(ValueError, match="not in the current"):
+                agent.set_restored_groups([self._env_group("unknown", "drift")])
+            assert agent.set_restored_groups(restored) == restored_count
+
+        bank = RolloutBank(str(tmp_path), rollouts_per_group=1) if write_through else None
+        if bank is not None:
+            bank.set_collection(0)
+        request = GroupedRolloutRequest(
+            num_groups=request_groups,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+        )
+        pipeline = RolloutPipeline(
+            agent, request, parallel_generation_tasks=1, initial_batch_id=20, bank=bank
+        )
+
+        async with aclosing(pipeline.run()) as groups:
+            produced = [
+                await asyncio.wait_for(anext(groups), timeout=10) for _ in range(take_count)
+            ]
+            if bank is not None:
+                pipeline.drain_bank()
+
+        assert Counter(group[0].env_id for group in produced) == expected_envs
+        assert [g.prepare_group_rollout_calls for g in agent.agents] == expected_fresh_calls
+        assert {f"cached-{i}" for i in range(restored_count)} <= {
+            group[0].problem_id for group in produced
+        }
+        assert not agent._restored_groups.get(restored_env)
+        assert [group.batch_id for group in produced] == [
+            20 + i // request_groups for i in range(take_count)
+        ]
+        assert [group.index_in_batch for group in produced] == [
+            i % request_groups for i in range(take_count)
+        ]
+
+        if bank is not None:
+            bank.close()
+            persisted = RolloutBank(str(tmp_path), rollouts_per_group=1).restore(trained_through=0)
+            assert {group.uid for group in persisted} == {group.uid for group in produced}
+
+    def test_multiple_envs_require_env_ids_for_restore_routing(self):
+        agent = self._weighted_agent([("", 1.0), ("b", 1.0)])
+        with pytest.raises(ValueError, match="configuring multiple active agents"):
+            agent.set_restored_groups([])

--- a/tests/unit_tests/rl/test_rl_utils.py
+++ b/tests/unit_tests/rl/test_rl_utils.py
@@ -2173,3 +2173,48 @@ def _ledger_record(epoch, num_evictions=0):
     return FinishedRequestRecord(
         policy_epoch=[(0, epoch)], kv_cache_epoch=[(0, epoch)], num_evictions=num_evictions
     )
+
+
+class TestDurableBankBarriers:
+    """The rollout bank's durability barriers on the production path.
+
+    Nothing else exercises rl_utils with a bank attached, so a rename in the bank
+    or pipeline can silently orphan these call sites. That already happened once:
+    a stale ``bank.flush()`` survived a refactor that deleted the method.
+    """
+
+    def test_consumption_marks_ride_the_bank_queue(self):
+        """Markers queue behind the records they name instead of forcing a drain.
+
+        A blocking drain at the inference-to-training switch idles the GPUs on
+        the whole write backlog; FIFO order through the pipeline's writer thread
+        provides the same records-before-marker guarantee without the wait. A
+        direct ``mark_consumed_many`` call here would silently drop that
+        ordering, so its absence is asserted too.
+        """
+        import inspect
+
+        from megatron.rl import rl_utils
+        from megatron.rl.agent.rollout_pipeline import RolloutPipeline
+        from megatron.rl.rollout_bank import RolloutBank
+
+        source = inspect.getsource(rl_utils.get_environment_rollouts)
+        assert "enqueue_consumed_markers" in source, "consumption markers are not recorded"
+        assert (
+            "mark_consumed_many" not in source
+        ), "a direct marker write bypasses the FIFO records-before-marker ordering"
+        assert "drain_bank" in source, "no bank drain before set_collection's segment switch"
+        assert hasattr(RolloutPipeline, "enqueue_consumed_markers")
+        assert hasattr(RolloutPipeline, "drain_bank")
+        assert not hasattr(
+            RolloutBank, "flush"
+        ), "a stale bank.flush() call site would AttributeError at runtime"
+
+    def test_compaction_drains_before_reclaiming_segments(self):
+        """Compaction rewrites segments; queued records must land first."""
+        import inspect
+
+        from megatron.rl import rl_utils
+
+        source = inspect.getsource(rl_utils.maybe_compact_rollout_bank)
+        assert "drain_bank" in source, "compaction does not drain queued records first"

--- a/tests/unit_tests/rl/test_rollout_bank.py
+++ b/tests/unit_tests/rl/test_rollout_bank.py
@@ -1,18 +1,19 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Parameterized coverage for durable rollout-bank persistence and replay."""
+"""Durable rollout-bank persistence, recovery, and compaction.
 
-import asyncio
+Format v3 stores one ledger record per rollout, so a group exists on disk only
+through its members. Completeness is inferred from the member count rather than a
+seal record, and a group that lost members to a kill reads back as *incomplete*,
+carrying the problem state needed to regenerate the rest.
+"""
+
 import json
-from collections import Counter
-from contextlib import aclosing
 
 import numpy as np
 import pytest
 
-from megatron.rl.agent.api import GroupedRolloutRequest, Rollout, RolloutGroup, TokenRollout
-from megatron.rl.agent.rollout_pipeline import RolloutPipeline
-from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
+from megatron.rl.agent.api import Rollout, RolloutGroup, TokenRollout
 from megatron.rl.rollout_bank import (
     _CONSUMED,
     _FORMAT_VERSION,
@@ -26,88 +27,57 @@ from megatron.rl.rollout_bank import (
 from megatron.rl.types import Rollout as SharedRollout
 from megatron.rl.types import RolloutGroup as SharedRolloutGroup
 from megatron.rl.types import TokenRollout as SharedTokenRollout
-from tests.unit_tests.rl.test_rollout_generation import MockGenerator, MockInferenceInterface
+
+PROBLEM = {"prompt": "Natalia sold clips to 48 friends", "golden": {"answer": "72"}}
+ITER = 3
 
 
-def _token_group(batch_id=0, *, empty=False):
-    members = (
-        [([], [], [])]
-        if empty
-        else [
-            (
-                [[1, 2, 3], [4, 5]],
-                [[-0.1, -0.2, -0.3], [-0.4, -0.5]],
-                [[False, True, True], [True, True]],
-            ),
-            ([[7, 8]], [[-1.5, -2.5]], [[True, True]]),
-        ]
-    )
-    return RolloutGroup(
-        rollouts=[
-            TokenRollout(
-                trajectory=tokens,
-                reward=1.0,
-                logprobs=logprobs,
-                generation_mask=mask,
-                env_id="test",
-                problem_id="p",
-                completion_ids=[f"completion-{index}" for index in range(len(tokens))],
-            )
-            for tokens, logprobs, mask in members
-        ],
-        batch_id=batch_id,
+def _token(reward=1.0, tokens=((1, 2, 3), (4, 5))):
+    trajectory = [list(turn) for turn in tokens]
+    return TokenRollout(
+        trajectory=trajectory,
+        reward=reward,
+        logprobs=[[-0.1 * (i + 1) for i in range(len(turn))] for turn in trajectory],
+        generation_mask=[[True] * len(turn) for turn in trajectory],
+        env_id="gsm8k",
+        problem_id="p0",
     )
 
 
-def _text_group():
-    return RolloutGroup(rollouts=[Rollout(trajectory=["hello world"], reward=0.5, env_id="text")])
+def _text(reward=0.5):
+    return Rollout(trajectory=["hello world"], reward=reward, env_id="text")
 
 
-def _empty_group():
-    return RolloutGroup(rollouts=[])
+def _bank(path, group_size=2, **kwargs):
+    return RolloutBank(str(path), rollouts_per_group=group_size, **kwargs)
 
 
-def _empty_token_group():
-    return _token_group(empty=True)
-
-
-def _active_generation(bank_dir):
+def _generation(bank_dir):
     manifest = json.loads((bank_dir / _MANIFEST).read_text())
     return bank_dir / _GENERATIONS / manifest["active_generation"]
 
 
-def _segment_dir(bank_dir, iteration=3):
-    return _active_generation(bank_dir) / _segment_name(iteration)
+def _segment(bank_dir, iteration=ITER):
+    return _generation(bank_dir) / _segment_name(iteration)
 
 
-def _assert_group_matches(actual, expected):
-    assert actual.batch_id == expected.batch_id
-    assert len(actual.rollouts) == len(expected.rollouts)
-    for actual_rollout, expected_rollout in zip(actual.rollouts, expected.rollouts, strict=True):
-        assert type(actual_rollout) is type(expected_rollout)
-        assert actual_rollout.trajectory == expected_rollout.trajectory
-        assert actual_rollout.reward == expected_rollout.reward
-        assert actual_rollout.env_id == expected_rollout.env_id
-        if isinstance(expected_rollout, TokenRollout):
-            assert actual_rollout.generation_mask == expected_rollout.generation_mask
-            assert len(actual_rollout.logprobs) == len(expected_rollout.logprobs)
-            for actual_turn, expected_turn in zip(
-                actual_rollout.logprobs, expected_rollout.logprobs, strict=True
-            ):
-                assert np.allclose(actual_turn, expected_turn, atol=1e-3)
+def _records(bank_dir, iteration=ITER):
+    ledger = _segment(bank_dir, iteration) / _LEDGER
+    return [json.loads(line) for line in ledger.read_text().splitlines() if line.strip()]
 
 
-@pytest.mark.parametrize(
-    "group_factory",
-    [
-        pytest.param(_token_group, id="ragged-token-sidecars"),
-        pytest.param(_text_group, id="inline-text"),
-        pytest.param(_empty_group, id="empty-group"),
-        pytest.param(_empty_token_group, id="empty-token-trajectory"),
-    ],
-)
-def test_rollout_bank_round_trip(tmp_path, group_factory):
-    """All supported payload shapes survive a close/restart round trip."""
+def _write(bank, members, uid=None, problem_state=None, indices=None):
+    """Persist one group's members, optionally at explicit slots."""
+    uid = uid or bank.reserve_group_uid()
+    if problem_state is not None:
+        bank.append_problem(uid, problem_state)
+    for slot, member in zip(indices or range(len(members)), members, strict=True):
+        bank.append_rollout(uid, slot, member)
+    return uid
+
+
+def test_shared_types_are_the_same_objects_as_the_agent_api_re_exports():
+    """api.py re-exports the megatron.rl.types models; drift would split the schema."""
     assert (SharedRollout, SharedRolloutGroup, SharedTokenRollout) == (
         Rollout,
         RolloutGroup,
@@ -115,79 +85,218 @@ def test_rollout_bank_round_trip(tmp_path, group_factory):
     )
     assert Rollout(trajectory=["prompt"], reward=None).reward is None
 
-    expected = group_factory()
-    bank = RolloutBank(str(tmp_path))
-    bank.set_collection(3)
-    uid = bank.append(expected)
+
+@pytest.mark.parametrize(
+    "members, group_size",
+    [
+        pytest.param([_token(), _token(reward=0.0, tokens=((7, 8),))], 2, id="ragged-token"),
+        pytest.param([_text()], 1, id="inline-text"),
+        pytest.param([_token(tokens=())], 1, id="empty-trajectory"),
+    ],
+)
+def test_payload_shapes_survive_a_restart(tmp_path, members, group_size):
+    """Every supported member shape decodes back to what was written."""
+    bank = _bank(tmp_path, group_size)
+    bank.set_collection(ITER)
+    uid = _write(bank, members)
     bank.close()
 
-    manifest = json.loads((tmp_path / _MANIFEST).read_text())
-    generation = _active_generation(tmp_path)
-    record = json.loads((generation / _segment_name(3) / _LEDGER).read_text())
-    assert manifest["format_version"] == record["format_version"] == _FORMAT_VERSION
-    assert manifest["timeline"]
-    assert (generation / _CONSUMED).exists()
+    records = _records(tmp_path)
+    assert len(records) == group_size, "one record per member; no group record"
+    assert {record["format_version"] for record in records} == {_FORMAT_VERSION}
+    assert (_generation(tmp_path) / _CONSUMED).exists()
 
-    restored = RolloutBank(str(tmp_path)).restore(trained_through=0)
+    restored = _bank(tmp_path, group_size).restore(trained_through=0)
     assert [group.uid for group in restored] == [uid]
-    _assert_group_matches(restored[0], expected)
+    for actual, expected in zip(restored[0].rollouts, members, strict=True):
+        assert type(actual) is type(expected)
+        assert actual.trajectory == expected.trajectory
+        assert actual.reward == expected.reward
+        if isinstance(expected, TokenRollout):
+            assert actual.generation_mask == expected.generation_mask
+            for got, want in zip(actual.logprobs, expected.logprobs, strict=True):
+                assert np.allclose(got, want, atol=1e-3)
 
-    if group_factory is _empty_token_group:
-        assert record["kind"] == "token"
-        assert record["tok"]["bytes"] == 0
-        assert not (generation / _segment_name(3) / _TOKENS_BIN).exists()
+
+@pytest.mark.parametrize(
+    "members, indices, problem_state, drop_zero_variance, expect",
+    [
+        pytest.param([_token(0.0), _token(1.0)], None, PROBLEM, False, "complete", id="complete"),
+        pytest.param([_token()], [0], PROBLEM, False, "incomplete", id="incomplete-restores"),
+        pytest.param([_token()], [0], None, False, "dropped", id="incomplete-without-problem"),
+        pytest.param([_token(1.0), _token(1.0)], None, None, True, "dropped", id="zero-variance"),
+        pytest.param(
+            [_token(1.0), _token(1.0)], None, None, False, "complete", id="zero-variance-allowed"
+        ),
+    ],
+)
+def test_restore_fold(tmp_path, members, indices, problem_state, drop_zero_variance, expect):
+    """Completeness comes from the member count; there is no seal and no tombstone."""
+    bank = _bank(tmp_path, 2, drop_zero_variance=drop_zero_variance)
+    try:
+        bank.set_collection(ITER)
+        uid = _write(bank, members, problem_state=problem_state, indices=indices)
+        restored = bank.restore(0)
+    finally:
+        bank.close()
+
+    if expect == "dropped":
+        assert restored == []
+        return
+    assert [group.uid for group in restored] == [uid]
+    group = restored[0]
+    assert group.is_complete(2) is (expect == "complete")
+    if expect == "incomplete":
+        assert group.problem_state == PROBLEM
+        assert group.missing_indices(2) == [1]
 
 
-def test_restore_drops_torn_final_ledger_record(tmp_path):
-    """A partial final JSONL append is truncated and does not hide durable records."""
-    bank = RolloutBank(str(tmp_path))
-    bank.set_collection(3)
-    durable_uid = bank.append(_token_group())
-    bank.append(_token_group())
-    bank.close()
+def test_members_restore_in_slot_order_with_gaps_preserved(tmp_path):
+    """Records interleave on disk, so restore must order by slot, not arrival."""
+    bank = _bank(tmp_path, 4)
+    try:
+        bank.set_collection(ITER)
+        uid = bank.reserve_group_uid()
+        bank.append_problem(uid, PROBLEM)
+        bank.append_rollout(uid, 2, _token(reward=1.0))
+        bank.append_rollout(uid, 0, _token(reward=0.0))
+        restored = bank.restore(0)
+    finally:
+        bank.close()
 
-    ledger = _segment_dir(tmp_path) / _LEDGER
+    assert restored[0].member_indices == [0, 2]
+    assert [rollout.reward for rollout in restored[0].rollouts] == [0.0, 1.0]
+    assert restored[0].missing_indices(4) == [1, 3]
+
+
+def test_ledger_holds_only_problem_and_rollout_records(tmp_path):
+    """Format v3 has exactly two record kinds."""
+    bank = _bank(tmp_path, 2)
+    try:
+        bank.set_collection(ITER)
+        uid = _write(bank, [_token(), _token()], problem_state=PROBLEM)
+    finally:
+        bank.close()
+
+    records = _records(tmp_path)
+    assert [record["kind"] for record in records] == ["problem", "rollout", "rollout"]
+    assert records[1]["uid"] == f"{uid}#0"
+
+
+def _tear_ledger(bank_dir):
+    ledger = _segment(bank_dir) / _LEDGER
     lines = ledger.read_bytes().splitlines(keepends=True)
-    ledger.write_bytes(lines[0] + lines[1][: len(lines[1]) // 2])
-
-    restarted = RolloutBank(str(tmp_path))
-    restarted.set_collection(3)
-    assert ledger.read_bytes() == lines[0]
-    assert [group.uid for group in restarted.restore(trained_through=0)] == [durable_uid]
+    ledger.write_bytes(b"".join(lines[:3]) + lines[3][: len(lines[3]) // 2])
 
 
-def test_restore_drops_record_with_bad_checksum(tmp_path):
-    """Checksum corruption drops only the affected record during recovery."""
-    bank = RolloutBank(str(tmp_path))
-    bank.set_collection(3)
-    durable_uid = bank.append(_token_group())
-    bank.append(_token_group())
-    bank.close()
-
-    ledger = _segment_dir(tmp_path) / _LEDGER
+def _corrupt_checksum(bank_dir):
+    ledger = _segment(bank_dir) / _LEDGER
     records = [json.loads(line) for line in ledger.read_text().splitlines()]
     records[-1]["checksum"] = "0" * 32
     ledger.write_text("".join(json.dumps(record) + "\n" for record in records))
 
-    assert [group.uid for group in RolloutBank(str(tmp_path)).restore(trained_through=0)] == [
-        durable_uid
-    ]
 
-
-def test_restore_drops_record_with_truncated_sidecar(tmp_path):
-    """A short sidecar slice drops its ledger record instead of failing resume."""
-    bank = RolloutBank(str(tmp_path))
-    bank.set_collection(3)
-    durable_uid = bank.append(_token_group())
-    bank.append(_token_group())
-    bank.close()
-
-    tokens = _segment_dir(tmp_path) / _TOKENS_BIN
+def _truncate_sidecar(bank_dir):
+    tokens = _segment(bank_dir) / _TOKENS_BIN
     tokens.write_bytes(tokens.read_bytes()[:-1])
 
-    assert [group.uid for group in RolloutBank(str(tmp_path)).restore(trained_through=0)] == [
-        durable_uid
-    ]
+
+@pytest.mark.parametrize(
+    "damage",
+    [
+        pytest.param(_tear_ledger, id="torn-final-record"),
+        pytest.param(_corrupt_checksum, id="bad-checksum"),
+        pytest.param(_truncate_sidecar, id="truncated-sidecar"),
+    ],
+)
+def test_damage_drops_only_the_affected_group(tmp_path, damage):
+    """A damaged record leaves its group short, which is then unrestorable.
+
+    Losing a member can only make a group look *less* complete, never more, so
+    corruption degrades into the incomplete-group case rather than corrupting.
+    """
+    bank = _bank(tmp_path, 2)
+    bank.set_collection(ITER)
+    durable = _write(bank, [_token(), _token()])
+    _write(bank, [_token(), _token()])
+    bank.close()
+
+    damage(tmp_path)
+
+    restarted = _bank(tmp_path, 2)
+    restarted.set_collection(ITER)
+    assert [group.uid for group in restarted.restore(trained_through=0)] == [durable]
+
+
+def test_empty_group_persists_nothing(tmp_path):
+    """A group exists on disk only through its members, so a memberless one cannot."""
+    bank = _bank(tmp_path, 1)
+    try:
+        bank.set_collection(ITER)
+        bank.append(RolloutGroup(rollouts=[]))
+        assert (_segment(tmp_path) / _LEDGER).exists() is False
+        assert bank.restore(trained_through=0) == []
+    finally:
+        bank.close()
+
+
+def test_append_group_writes_each_member_and_keeps_its_uid(tmp_path):
+    """The whole-group convenience path is the per-member path underneath."""
+    bank = _bank(tmp_path, 2)
+    try:
+        bank.set_collection(ITER)
+        group = RolloutGroup(rollouts=[_token(0.0), _token(1.0)])
+        uid = bank.append(group, problem_state=PROBLEM)
+        restored = bank.restore(0)
+    finally:
+        bank.close()
+
+    assert [group.uid for group in restored] == [uid]
+    assert restored[0].member_indices == [0, 1]
+    assert restored[0].problem_state == PROBLEM
+
+
+def test_uids_do_not_collide_across_bank_instances(tmp_path):
+    """Uids carry a per-run nonce, so a restart cannot reuse one."""
+    first, second = _bank(tmp_path / "a"), _bank(tmp_path / "b")
+    try:
+        uids = {first.reserve_group_uid() for _ in range(5)}
+        uids |= {second.reserve_group_uid() for _ in range(5)}
+        assert len(uids) == 10
+    finally:
+        first.close()
+        second.close()
+
+
+def test_rollouts_per_group_change_across_resume_is_rejected(tmp_path):
+    """Completeness is inferred from the count, so the count must not shift."""
+    bank = _bank(tmp_path, 4)
+    try:
+        bank.set_collection(ITER)
+        _write(bank, [_token()], indices=[0])
+    finally:
+        bank.close()
+
+    with pytest.raises(ValueError, match="rollouts_per_group"):
+        _bank(tmp_path, 8)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        pytest.param({}, [0, 1], id="defaults-to-positional"),
+        pytest.param({"member_indices": [0, 2]}, [0, 2], id="explicit-slots-preserved"),
+    ],
+)
+def test_member_indices_are_always_populated(kwargs, expected):
+    """One source of truth: readers never fall back to positional slots."""
+    assert RolloutGroup(rollouts=[_token(), _token()], **kwargs).member_indices == expected
+
+
+def test_member_indices_must_match_the_member_count():
+    """A slot list that disagrees with the members is a bug, not a fallback."""
+    with pytest.raises(ValueError, match="member_indices"):
+        RolloutGroup(rollouts=[_token()], member_indices=[0, 1])
 
 
 @pytest.mark.parametrize(
@@ -198,162 +307,31 @@ def test_restore_drops_record_with_truncated_sidecar(tmp_path):
         pytest.param(1, True, id="consumed-after-checkpoint"),
     ],
 )
-def test_checkpoint_compacts_at_consumption_boundary(tmp_path, consumed_offset, should_restore):
-    """Checkpoint compaction prunes trained groups and preserves future markers."""
-    checkpoint_iteration = 10
-    bank = RolloutBank(str(tmp_path))
+def test_checkpoint_compacts_at_the_consumption_boundary(tmp_path, consumed_offset, should_restore):
+    """Compaction prunes trained groups and carries forward future markers."""
+    checkpoint = 10
+    bank = _bank(tmp_path, 2)
     bank.set_collection(5)
-    consumed = bank.append(_token_group())
-    never_consumed = bank.append(_token_group())
-    bank.mark_consumed(consumed, checkpoint_iteration + consumed_offset)
-    old_generation = _active_generation(tmp_path)
+    consumed = _write(bank, [_token(0.0), _token(1.0)])
+    kept = _write(bank, [_token(0.0), _token(1.0)])
+    bank.mark_consumed(consumed, checkpoint + consumed_offset)
+    old_generation = _generation(tmp_path)
 
-    before_checkpoint = {group.uid for group in bank.restore(checkpoint_iteration)}
-    assert (consumed in before_checkpoint) is should_restore
-    assert never_consumed in before_checkpoint
+    before = {group.uid for group in bank.restore(checkpoint)}
+    assert (consumed in before) is should_restore
+    assert kept in before
 
-    bank.checkpoint(checkpoint_iteration)
+    bank.checkpoint(checkpoint)
     manifest = json.loads((tmp_path / _MANIFEST).read_text())
-    assert manifest["trained_through"] == checkpoint_iteration
-    assert manifest["segments"] == [_segment_name(checkpoint_iteration)]
+    assert manifest["trained_through"] == checkpoint
+    assert manifest["segments"] == [_segment_name(checkpoint)]
     assert not old_generation.exists()
 
-    restarted = RolloutBank(str(tmp_path))
-    restored = restarted.restore(checkpoint_iteration)
-    restored_uids = {group.uid for group in restored}
-    assert restored_uids == ({consumed, never_consumed} if should_restore else {never_consumed})
-    for group in restored:
-        _assert_group_matches(group, _token_group())
+    restarted = _bank(tmp_path, 2)
+    restored = {group.uid for group in restarted.restore(checkpoint)}
+    assert restored == ({consumed, kept} if should_restore else {kept})
 
     markers = [
-        json.loads(line)
-        for line in (_active_generation(tmp_path) / _CONSUMED).read_text().splitlines()
+        json.loads(line) for line in (_generation(tmp_path) / _CONSUMED).read_text().splitlines()
     ]
-    expected_markers = (
-        [{"uid": consumed, "iter": checkpoint_iteration + 1}] if should_restore else []
-    )
-    assert markers == expected_markers
-
-    if should_restore:
-        restarted.checkpoint(checkpoint_iteration + 1)
-        assert {group.uid for group in restarted.restore(checkpoint_iteration + 1)} == {
-            never_consumed
-        }
-
-
-def _env_group(env_id, problem_id):
-    return RolloutGroup(
-        rollouts=[Rollout(trajectory=["cached"], reward=1.0, env_id=env_id, problem_id=problem_id)]
-    )
-
-
-def _weighted_agent(env_weights):
-    return WeightedMultiTask(
-        [
-            AgentConfig(agent_type=MockGenerator, agent_args={"env_id": env_id}, weight=weight)
-            for env_id, weight in env_weights
-        ]
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "env_weights, restored_env, restored_count, request_groups, take_count, "
-    "expected_envs, expected_fresh_calls, write_through",
-    [
-        pytest.param(
-            [("a", 1.0), ("b", 1.0)],
-            "a",
-            2,
-            4,
-            4,
-            {"a": 2, "b": 2},
-            [0, 2],
-            False,
-            id="restored-groups-replace-fresh",
-        ),
-        pytest.param(
-            [("a", 1.0), ("b", 1.0)],
-            "a",
-            4,
-            4,
-            12,
-            {"a": 6, "b": 6},
-            [2, 6],
-            False,
-            id="streaming-backlog-drains-before-fresh",
-        ),
-        pytest.param(
-            [("", 1.0)], "", 1, 2, 2, {"": 2}, [1], False, id="single-environment-without-env-id"
-        ),
-        pytest.param(
-            [("a", 1.0)], "a", 0, 4, 4, {"a": 4}, [4], True, id="fresh-groups-write-through"
-        ),
-    ],
-)
-async def test_pipeline_uses_restored_groups_before_fresh_generation(
-    tmp_path,
-    env_weights,
-    restored_env,
-    restored_count,
-    request_groups,
-    take_count,
-    expected_envs,
-    expected_fresh_calls,
-    write_through,
-):
-    """Restored groups retain weighted routing; fresh groups remain durable."""
-    agent = _weighted_agent(env_weights)
-    restored = [
-        _env_group(restored_env, problem_id=f"cached-{index}") for index in range(restored_count)
-    ]
-    assert agent.set_restored_groups(restored) == restored_count
-
-    if len(env_weights) > 1:
-        with pytest.raises(ValueError, match="not in the current"):
-            agent.set_restored_groups([_env_group("unknown", "drift")])
-        assert agent.set_restored_groups(restored) == restored_count
-
-    bank = RolloutBank(str(tmp_path)) if write_through else None
-    if bank is not None:
-        bank.set_collection(0)
-    request = GroupedRolloutRequest(
-        num_groups=request_groups,
-        rollouts_per_group=1,
-        inference_interface=MockInferenceInterface(),
-    )
-    pipeline = RolloutPipeline(
-        agent, request, parallel_generation_tasks=1, initial_batch_id=20, bank=bank
-    )
-
-    async with aclosing(pipeline.run()) as groups:
-        produced = [await asyncio.wait_for(anext(groups), timeout=10) for _ in range(take_count)]
-
-    assert len(produced) == take_count
-    assert Counter(group[0].env_id for group in produced) == expected_envs
-    assert [generator.prepare_group_rollout_calls for generator in agent.agents] == (
-        expected_fresh_calls
-    )
-    cached_problem_ids = {f"cached-{index}" for index in range(restored_count)}
-    assert cached_problem_ids <= {group[0].problem_id for group in produced}
-    assert not agent._restored_groups.get(restored_env)
-
-    assert [group.batch_id for group in produced] == [
-        20 + index // request_groups for index in range(take_count)
-    ]
-    assert [group.index_in_batch for group in produced] == [
-        index % request_groups for index in range(take_count)
-    ]
-
-    if bank is not None:
-        bank.close()
-        persisted = RolloutBank(str(tmp_path)).restore(trained_through=0)
-        assert len(persisted) == take_count
-        assert {group.uid for group in persisted} == {group.uid for group in produced}
-
-
-def test_multiple_envs_require_env_ids_for_restore_routing():
-    agent = _weighted_agent([("", 1.0), ("b", 1.0)])
-
-    with pytest.raises(ValueError, match="configuring multiple active agents"):
-        agent.set_restored_groups([])
+    assert markers == ([{"uid": consumed, "iter": checkpoint + 1}] if should_restore else [])


### PR DESCRIPTION
Builds on #6352, which persists a `RolloutGroup` once it assembles. That covers only whole groups: every rollout that finished inference but whose group never filled is still lost. With `rollouts_per_group = G`, each in-flight group can lose up to `G - 1` finished rollouts, and `gate.capacity` groups are in flight.

This persists each rollout the instant it is graded, and restores a partially persisted group with what it needs to regenerate the rest.

## What changed

- **`rollout_bank.py`** — format v3 stores one ledger record per rollout (`problem` + `rollout` kinds). Completeness is inferred from the member count rather than a seal record, and the zero-variance filter is re-derived from persisted rewards rather than tombstoned, which removes the crash window between a group's last member write and its marker. Group uids carry a per-run nonce so a restart cannot collide with records it is about to read.
- **`rollout_pipeline.py`** — each rollout is graded on arrival and queued to a new `stage_bank`, which coalesces records and writes them via `asyncio.to_thread` so the blocking `fsync` never stalls the event loop. `stage_prepare` completes a restored incomplete group by generating only its missing slots.
- **`api.py` / `reward_only_agent.py`** — `GroupRolloutParams.problem_state` plus a `problem_state` keyword on `prepare_group_rollout`, implemented once so every `RewardOnlyAgent` subclass is completion-capable with no per-env work.
- **`rl_utils.py`** — drain the bank queue before consumption markers and before compaction, so a marker never names a record still sitting in the queue.

No new flag: this is automatic with `--rl-durable-rollout-bank`. An agent that returns no `problem_state` keeps today's behavior, so degradation is per-env rather than a global switch.

## Why no seal record and no tombstone

A group is complete iff it has `rollouts_per_group` distinct members, which is config; the manifest records it and asserts on load, following the precedent in `weighted_multi_task.py` that hard-errors on a changed env set. A zero-variance group is re-derived from its persisted rewards rather than marked, which is strictly more correct than a tombstone: a tombstone has a crash window between the last member's write and the marker, and a resurrected zero-variance group is exactly what breaks a divide-by-std in the advantage computation.

## Interaction with #6480

`_decide_drop` drops all-placeholder groups so they can be refilled. Placeholders are therefore not persisted: a failed episode has an empty trajectory and no decode work to save, and persisting one would let a restored group carry a placeholder past that policy. Leaving the slot empty means restore regenerates it, which reaches the same outcome.

## Tests

`tests/unit_tests/rl/` — 139 pass locally. `test_rollout_generation.py` is renamed to `test_pipeline.py` and absorbs the incomplete-group, problem-state, and restored-routing coverage; bank tests are consolidated and parameterized into `test_rollout_bank.py`.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Persists rollouts that finish inference but whose group never completes, so a SIGKILL no longer discards them, and regenerates only the missing members at resume.

## Issue tracking

Linked issue: follows #6352.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)