### PR TITLE
RL: add per-step rollout bank metrics

### DIFF
--- a/megatron/rl/agent/rollout_pipeline.py
+++ b/megatron/rl/agent/rollout_pipeline.py
@@ -253,6 +253,7 @@ class RolloutPipeline:
         self._assemble_pending: dict[int, list[_InferredItem]] = {}
         self._consume_pending: dict[int, list[RolloutGroup]] = {}
         self._output_enqueued_at: dict[tuple[int, int], float] = {}
+        self._restored_output_keys: set[tuple[int, int]] = set()
 
         # Observability accumulators.
         self.infer_queue_dwell: list[float] = []
@@ -270,6 +271,7 @@ class RolloutPipeline:
         self.yielded_count = 0
         self.prepared_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
         self.assembled_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
+        self.restored_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
         self.yielded_groups_per_env = [0] * len(self.gran_policy.num_groups_per_env)
         self.refill_failure_reasons: dict[str, int] = {}
         self._lifetime_refilled_groups = 0
@@ -388,9 +390,10 @@ class RolloutPipeline:
                         )
                         restored.batch_id = batch_id
                         restored.index_in_batch = index_in_batch
-                        self._output_enqueued_at[(batch_id, index_in_batch)] = time.monotonic()
+                        output_key = (batch_id, index_in_batch)
+                        self._output_enqueued_at[output_key] = time.monotonic()
+                        self._restored_output_keys.add(output_key)
                         await self.output_queue.put(restored)
-                        self.restored_count += 1
                         self._groups_in_flight -= 1
                         self._maybe_close_intake()
                         group_id += 1
@@ -551,13 +554,22 @@ class RolloutPipeline:
             raise
 
     def _record_output_dwell(self, group: RolloutGroup) -> None:
-        """Record how long a group sat in output_queue before being yielded."""
+        """Record how long a group sat in output_queue before being dequeued."""
         key = (group.batch_id, group.index_in_batch)
         enqueued_at = self._output_enqueued_at.pop(key, 0.0)
         if enqueued_at:
             self.output_queue_dwell.append(time.monotonic() - enqueued_at)
+
+    def _record_yield(self, group: RolloutGroup) -> None:
+        """Record a group handed to the trainer, including whether it was restored."""
+        key = (group.batch_id, group.index_in_batch)
+        env_index = self.gran_policy.env_of_index(group.index_in_batch)
+        if key in self._restored_output_keys:
+            self._restored_output_keys.remove(key)
+            self.restored_count += 1
+            self.restored_groups_per_env[env_index] += 1
         self.yielded_count += 1
-        self.yielded_groups_per_env[self.gran_policy.env_of_index(group.index_in_batch)] += 1
+        self.yielded_groups_per_env[env_index] += 1
 
     async def _next_complete_group(self) -> RolloutGroup | None:
         """Pop the next group off output_queue and record its dwell."""
@@ -575,6 +587,7 @@ class RolloutPipeline:
             "B": self._consume_batch_order,
         }[self.gran_policy.consumption]
         async for group in consume():
+            self._record_yield(group)
             yield group
 
     async def _consume_completion_order(self) -> AsyncIterator[RolloutGroup]:

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -1823,18 +1823,24 @@ def _collect_rollout_pipeline_metrics() -> dict:
     # Per-env metrics, in env layout order (the pipeline arrays are env-indexed;
     # weighted env_ids are unique by construction).
     for env_index, allocation in enumerate(pipeline.allocations):
+        restored_groups = pipeline.restored_groups_per_env[env_index]
+        yielded_groups = pipeline.yielded_groups_per_env[env_index]
+        if yielded_groups:
+            restored_groups_percentage = 100.0 * restored_groups / yielded_groups
+            fresh_groups_percentage = 100.0 - restored_groups_percentage
+        else:
+            restored_groups_percentage = 0.0
+            fresh_groups_percentage = 0.0
         metrics[f"{allocation.env_id}_prepared_groups"] = (
             pipeline.prepared_groups_per_env[env_index]
         )
         metrics[f"{allocation.env_id}_assembled_groups"] = (
             pipeline.assembled_groups_per_env[env_index]
         )
-        metrics[f"{allocation.env_id}_restored_groups"] = (
-            pipeline.restored_groups_per_env[env_index]
-        )
-        metrics[f"{allocation.env_id}_yielded_groups"] = (
-            pipeline.yielded_groups_per_env[env_index]
-        )
+        metrics[f"{allocation.env_id}_restored_groups"] = restored_groups
+        metrics[f"{allocation.env_id}_restored_groups_percentage"] = restored_groups_percentage
+        metrics[f"{allocation.env_id}_fresh_groups_percentage"] = fresh_groups_percentage
+        metrics[f"{allocation.env_id}_yielded_groups"] = yielded_groups
         metrics[f"{allocation.env_id}_agent_groups"] = allocation.num_groups
         # The realized weight: the constant share of each batch the env actually owns.
         metrics[f"{allocation.env_id}_weight"] = (

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -1800,6 +1800,7 @@ def _collect_rollout_pipeline_metrics() -> dict:
         "rollout_pipeline_assembled_count": pipeline.assembled_count,
         "rollout_pipeline_filtered_count": pipeline.filtered_count,
         "rollout_pipeline_refilled_placeholder_groups": pipeline.refilled_placeholder_groups,
+        "rollout_pipeline_restored_count": pipeline.restored_count,
         "rollout_pipeline_yielded_count": pipeline.yielded_count,
     })
     # Refilled groups never reach the trainer-side failure accounting,
@@ -1828,6 +1829,9 @@ def _collect_rollout_pipeline_metrics() -> dict:
         metrics[f"{allocation.env_id}_assembled_groups"] = (
             pipeline.assembled_groups_per_env[env_index]
         )
+        metrics[f"{allocation.env_id}_restored_groups"] = (
+            pipeline.restored_groups_per_env[env_index]
+        )
         metrics[f"{allocation.env_id}_yielded_groups"] = (
             pipeline.yielded_groups_per_env[env_index]
         )
@@ -1853,6 +1857,7 @@ def _collect_rollout_pipeline_metrics() -> dict:
     num_envs = len(pipeline.gran_policy.num_groups_per_env)
     pipeline.prepared_groups_per_env = [0] * num_envs
     pipeline.assembled_groups_per_env = [0] * num_envs
+    pipeline.restored_groups_per_env = [0] * num_envs
     pipeline.yielded_groups_per_env = [0] * num_envs
     gate.prepare_blocked_seconds = 0.0
     gate.acquire_calls = 0

--- a/tests/unit_tests/rl/test_rollout_bank.py
+++ b/tests/unit_tests/rl/test_rollout_bank.py
@@ -373,6 +373,10 @@ async def test_restored_group_metrics_are_reported_per_step_and_env(monkeypatch)
     pipeline = RolloutPipeline(agent, request, parallel_generation_tasks=2)
     monkeypatch.setattr(rl_utils, "_ROLLOUT_PIPELINE", pipeline)
 
+    empty_metrics = rl_utils._collect_rollout_pipeline_metrics()
+    assert empty_metrics["a_restored_groups_percentage"] == 0.0
+    assert empty_metrics["a_fresh_groups_percentage"] == 0.0
+
     async with aclosing(pipeline.run()) as groups:
         [await anext(groups) for _ in range(4)]
         first_step_metrics = rl_utils._collect_rollout_pipeline_metrics()
@@ -381,6 +385,10 @@ async def test_restored_group_metrics_are_reported_per_step_and_env(monkeypatch)
         assert first_step_metrics["rollout_pipeline_yielded_count"] == 4
         assert first_step_metrics["a_restored_groups"] == 2
         assert first_step_metrics["b_restored_groups"] == 1
+        assert first_step_metrics["a_restored_groups_percentage"] == 100.0
+        assert first_step_metrics["a_fresh_groups_percentage"] == 0.0
+        assert first_step_metrics["b_restored_groups_percentage"] == 50.0
+        assert first_step_metrics["b_fresh_groups_percentage"] == 50.0
 
         [await anext(groups) for _ in range(4)]
         second_step_metrics = rl_utils._collect_rollout_pipeline_metrics()
@@ -389,6 +397,10 @@ async def test_restored_group_metrics_are_reported_per_step_and_env(monkeypatch)
         assert second_step_metrics["rollout_pipeline_yielded_count"] == 4
         assert second_step_metrics["a_restored_groups"] == 1
         assert second_step_metrics["b_restored_groups"] == 0
+        assert second_step_metrics["a_restored_groups_percentage"] == 50.0
+        assert second_step_metrics["a_fresh_groups_percentage"] == 50.0
+        assert second_step_metrics["b_restored_groups_percentage"] == 0.0
+        assert second_step_metrics["b_fresh_groups_percentage"] == 100.0
 
 
 def test_multiple_envs_require_env_ids_for_restore_routing():

--- a/tests/unit_tests/rl/test_rollout_bank.py
+++ b/tests/unit_tests/rl/test_rollout_bank.py
@@ -10,6 +10,7 @@ from contextlib import aclosing
 import numpy as np
 import pytest
 
+from megatron.rl import rl_utils
 from megatron.rl.agent.api import GroupedRolloutRequest, Rollout, RolloutGroup, TokenRollout
 from megatron.rl.agent.rollout_pipeline import RolloutPipeline
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
@@ -350,6 +351,44 @@ async def test_pipeline_uses_restored_groups_before_fresh_generation(
         persisted = RolloutBank(str(tmp_path)).restore(trained_through=0)
         assert len(persisted) == take_count
         assert {group.uid for group in persisted} == {group.uid for group in produced}
+
+
+@pytest.mark.asyncio
+async def test_restored_group_metrics_are_reported_per_step_and_env(monkeypatch):
+    agent = _weighted_agent([("a", 1.0), ("b", 1.0)])
+    agent.set_restored_groups(
+        [
+            *[_env_group("a", problem_id=f"a{index}") for index in range(3)],
+            _env_group("b", problem_id="b0"),
+        ]
+    )
+    request = GroupedRolloutRequest(
+        num_groups=4,
+        rollouts_per_group=1,
+        inference_interface=MockInferenceInterface(num_slow_calls=100),
+        streaming=True,
+        submission_granularity="B",
+        consumption_granularity="B",
+    )
+    pipeline = RolloutPipeline(agent, request, parallel_generation_tasks=2)
+    monkeypatch.setattr(rl_utils, "_ROLLOUT_PIPELINE", pipeline)
+
+    async with aclosing(pipeline.run()) as groups:
+        [await anext(groups) for _ in range(4)]
+        first_step_metrics = rl_utils._collect_rollout_pipeline_metrics()
+
+        assert first_step_metrics["rollout_pipeline_restored_count"] == 3
+        assert first_step_metrics["rollout_pipeline_yielded_count"] == 4
+        assert first_step_metrics["a_restored_groups"] == 2
+        assert first_step_metrics["b_restored_groups"] == 1
+
+        [await anext(groups) for _ in range(4)]
+        second_step_metrics = rl_utils._collect_rollout_pipeline_metrics()
+
+        assert second_step_metrics["rollout_pipeline_restored_count"] == 1
+        assert second_step_metrics["rollout_pipeline_yielded_count"] == 4
+        assert second_step_metrics["a_restored_groups"] == 1
+        assert second_step_metrics["b_restored_groups"] == 0
 
 
 def test_multiple_envs_require_env_ids_for_restore_routing():


### PR DESCRIPTION
## Summary

Follow-up to #6352 (durable rollout bank for completed groups). That PR added the bank
but reported restored groups only as a lifetime counter incremented at enqueue time, so
per-step W&B panels could not tell how much of a given step's batch came from the bank
versus fresh generation.

This moves the accounting to yield time and adds per-env breakdowns.

## Changes

`megatron/rl/agent/rollout_pipeline.py`
- Track restored groups by output key (`_restored_output_keys`) instead of bumping
  `restored_count` at enqueue. Counting at enqueue attributed a group to the step that
  restored it rather than the step that consumed it.
- Add `_record_yield()`, which increments `yielded_count` / `restored_count` and their
  per-env arrays when a group is actually handed to the trainer. `_record_output_dwell()`
  is now purely about dwell time.
- Add `restored_groups_per_env`, reset per step alongside the other per-env counters.

`megatron/rl/rl_utils.py`
- New scalar `rollout_pipeline_restored_count`.
- New per-env metrics: `{env_id}_restored_groups`, `{env_id}_restored_groups_percentage`,
  `{env_id}_fresh_groups_percentage`.
- `restored_groups_per_env` added to the per-step reset.

## Testing

`tests/unit_tests/rl/test_rollout_bank.py` — new
`test_restored_group_metrics_are_reported_per_step_and_env` covers the per-step and
per-env split. Full file passes locally (16 passed); wider `tests/unit_tests/rl/`
run is clean apart from pre-existing CUDA-only tests that cannot run on this host.