### PR TITLE
Preserve observed golden values during extraction

### DIFF
--- a/tests/functional_tests/python_test_utils/common.py
+++ b/tests/functional_tests/python_test_utils/common.py
@@ -3,9 +3,10 @@ import enum
 import glob
 import json
 import logging
+import math
 import os
 import pathlib
-from typing import Callable, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pydantic
@@ -80,28 +81,18 @@ class GoldenValues(pydantic.RootModel):
     root: Dict[str, GoldenValueMetric]
 
 
-def _remove_leading_nan_iteration_times(
-    golden_values: Dict[str, GoldenValueMetric],
-) -> Dict[str, GoldenValueMetric]:
-    """Remove leading synthetic NaNs from iteration-time values.
+def _infer_step_interval(steps: List[int], start_idx: int, default: int) -> int:
+    """Infer the cadence of observed samples, ignoring the special start sample."""
+    cadence_steps = sorted(step for step in steps if step != start_idx)
+    if len(cadence_steps) < 2:
+        return default
 
-    Internal NaNs are preserved, and an all-NaN metric is left unchanged so
-    missing iteration-time telemetry remains visible.
-    """
-    iteration_time = golden_values.get("iteration-time")
-    if iteration_time is None:
-        return golden_values
-
-    values = list(iteration_time.values.items())
-    first_valid_index = next(
-        (index for index, (_, value) in enumerate(values) if value != "nan"), None
+    return math.gcd(
+        *(
+            current_step - previous_step
+            for previous_step, current_step in zip(cadence_steps, cadence_steps[1:])
+        )
     )
-    if first_valid_index in (None, 0):
-        return golden_values
-
-    iteration_time.values = dict(values[first_valid_index:])
-    iteration_time.start_step = values[first_valid_index][0]
-    return golden_values
 
 
 class MissingTensorboardLogsError(Exception):
@@ -155,6 +146,9 @@ def read_tb_logs_as_list(
     Returns:
         summary_list: list, the values in the read summary list, formatted as a list.
     """
+    if step_size <= 0:
+        raise ValueError(f"step_size must be positive, got {step_size}")
+
     files = glob.glob(f"{path}/events*tfevents*")
     files += glob.glob(f"{path}/results/events*tfevents*")
 
@@ -195,21 +189,30 @@ def read_tb_logs_as_list(
     golden_values = {}
 
     for metric, values in summaries.items():
-        # Add missing values
         values = {
-            k: (values[k] if k in values else "nan")
-            for k in range(1, train_iters + 1)
-            if k == start_idx or (k > start_idx and int(k) % step_size == 0)
+            step: values[step]
+            for step in sorted(values)
+            if 1 <= step <= train_iters
+            and (step == start_idx or (step > start_idx and step % step_size == 0))
         }
+        if not values:
+            logger.warning(
+                "Skipping metric %r because it has no observed values "
+                "on the requested sampling grid",
+                metric,
+            )
+            continue
+
+        steps = list(values)
 
         golden_values[metric] = GoldenValueMetric(
-            start_step=min(values.keys()),
-            end_step=max(values.keys()),
-            step_interval=step_size,
+            start_step=steps[0],
+            end_step=steps[-1],
+            step_interval=_infer_step_interval(steps, start_idx, step_size),
             values=values,
         )
 
-    return _remove_leading_nan_iteration_times(golden_values)
+    return golden_values
 
 
 def read_golden_values_from_json(
@@ -253,40 +256,69 @@ def pipeline(
 
             try:
                 golden_value = golden_values[metric_name]
+                if not golden_value.values:
+                    raise MissingTensorboardLogsError(
+                        f"Metric {metric_name} has no values in the golden file."
+                    )
+
                 golden_value_list = list(golden_value.values.values())
                 actual_value_list = [
-                    value
-                    for value_step, value in actual_values[metric_name].values.items()
-                    if value_step in golden_value.values.keys()
+                    actual_values[metric_name].values.get(value_step, "nan")
+                    for value_step in golden_value.values
                 ]
 
                 if metric_name == "iteration-time":
-                    max_golden_step = max(golden_value.values.keys()) if golden_value.values else 0
-                    steady_window = range(5, 21) if max_golden_step <= 25 else range(30, 46)
-                    actual_value_list = [
-                        value
-                        for value_step, value in actual_values[metric_name].values.items()
-                        if value_step in golden_value.values.keys() and value_step in steady_window
+                    finite_golden_steps = [
+                        value_step
+                        for value_step, value in sorted(golden_value.values.items())
+                        if not isinstance(value, str) and math.isfinite(value)
                     ]
-                    golden_value_list = [
-                        value
-                        for value_step, value in golden_value.values.items()
+                    if not finite_golden_steps:
+                        raise MissingTensorboardLogsError(
+                            "Metric iteration-time has no finite values."
+                        )
+
+                    max_golden_step = finite_golden_steps[-1]
+                    steady_window = range(5, 21) if max_golden_step <= 25 else range(30, 46)
+                    comparison_steps = [
+                        value_step
+                        for value_step in finite_golden_steps
                         if value_step in steady_window
                     ]
+                    if not comparison_steps:
+                        comparison_steps = [
+                            value_step
+                            for value_step in finite_golden_steps
+                            if value_step >= steady_window.start
+                        ][:4]
+                    if not comparison_steps:
+                        raise MissingTensorboardLogsError(
+                            "Metric iteration-time has no finite values after its warmup window."
+                        )
+
+                    golden_value_list = [
+                        golden_value.values[value_step] for value_step in comparison_steps
+                    ]
                     actual_value_list = [
-                        np.median([np.inf if type(v) is str else v for v in actual_value_list])
+                        actual_values[metric_name].values.get(value_step, "nan")
+                        for value_step in comparison_steps
                     ]
                     golden_value_list = [
-                        np.median([np.inf if type(v) is str else v for v in golden_value_list])
+                        np.median([np.inf if isinstance(v, str) else v for v in golden_value_list])
+                    ]
+                    actual_value_list = [
+                        np.median([np.inf if isinstance(v, str) else v for v in actual_value_list])
                     ]
                     total_steps_evaluated = 1
                 else:
-                    total_steps_evaluated = (
-                        golden_value.end_step - golden_value.start_step
-                    ) / golden_value.step_interval + 1
+                    total_steps_evaluated = len(golden_value.values)
 
-                    actual_value_list = [np.inf if type(v) is str else v for v in actual_value_list]
-                    golden_value_list = [np.inf if type(v) is str else v for v in golden_value_list]
+                    actual_value_list = [
+                        np.inf if isinstance(v, str) else v for v in actual_value_list
+                    ]
+                    golden_value_list = [
+                        np.inf if isinstance(v, str) else v for v in golden_value_list
+                    ]
 
                 actual = np.array(actual_value_list)
                 golden = np.array(golden_value_list)

--- a/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
+++ b/tests/functional_tests/python_test_utils/get_test_results_from_tensorboard_logs.py
@@ -56,15 +56,16 @@ def collect_train_test_metrics(
     }
 
     if output_path is not None:
+        serialized_summaries = json.dumps(
+            {
+                golden_value_key: golden_values.model_dump()
+                for golden_value_key, golden_values in summaries.items()
+            },
+            indent=4,
+            allow_nan=False,
+        )
         with open(output_path, "w") as fh:
-            json.dump(
-                {
-                    golden_value_key: golden_values.model_dump()
-                    for golden_value_key, golden_values in summaries.items()
-                },
-                fh,
-                indent=4,
-            )
+            fh.write(serialized_summaries)
 
 
 if __name__ == "__main__":

--- a/tests/functional_tests/python_test_utils/test_common.py
+++ b/tests/functional_tests/python_test_utils/test_common.py
@@ -14,7 +14,6 @@ from tests.functional_tests.python_test_utils.common import (
     NotDeterminsticError,
     TypeOfTestResult,
     _filter_checks,
-    _remove_leading_nan_iteration_times,
     pipeline,
     read_tb_logs_as_list,
 )
@@ -42,35 +41,51 @@ def run(golden, actual, checks, compare_approximate=False):
 
 
 class FakeEventAccumulator:
+    def __init__(self, values):
+        self.values = values
+
     def Tags(self):
-        return {"scalars": ["iteration-time", "lm loss"]}
+        return {"scalars": list(self.values)}
 
     def Scalars(self, metric):
-        values = {"iteration-time": [(2, 0.25)], "lm loss": [(2, 1.0)]}
-        return [SimpleNamespace(step=step, value=value) for step, value in values[metric]]
+        return [SimpleNamespace(step=step, value=value) for step, value in self.values[metric]]
 
 
-def test_read_tb_logs_removes_only_leading_iteration_time_nan(monkeypatch, tmp_path):
+def test_read_tb_logs_keeps_only_observed_samples(monkeypatch, tmp_path):
     (tmp_path / "events.out.tfevents.test").touch()
-    monkeypatch.setattr(
-        common, "_load_event_accumulators_with_scalars", lambda _: [FakeEventAccumulator()]
+    accumulator = FakeEventAccumulator(
+        {
+            "iteration-time": [(10, 0.25), (20, 0.26)],
+            "lm loss": [(1, 1.4), (5, 1.3), (10, 1.2), (15, 1.1), (20, 1.0)],
+        }
     )
+    monkeypatch.setattr(common, "_load_event_accumulators_with_scalars", lambda _: [accumulator])
 
-    result = read_tb_logs_as_list(str(tmp_path), train_iters=3, start_idx=1, step_size=1)
+    result = read_tb_logs_as_list(str(tmp_path), train_iters=20, start_idx=1, step_size=5)
 
-    assert result["iteration-time"].start_step == 2
-    assert result["iteration-time"].values == {2: 0.25, 3: "nan"}
+    assert result["iteration-time"].start_step == 10
+    assert result["iteration-time"].end_step == 20
+    assert result["iteration-time"].step_interval == 10
+    assert result["iteration-time"].values == {10: 0.25, 20: 0.26}
     assert result["lm loss"].start_step == 1
-    assert result["lm loss"].values == {1: "nan", 2: 1.0, 3: "nan"}
+    assert result["lm loss"].end_step == 20
+    assert result["lm loss"].step_interval == 5
+    assert result["lm loss"].values == {1: 1.4, 5: 1.3, 10: 1.2, 15: 1.1, 20: 1.0}
 
 
-def test_remove_leading_iteration_time_nan_preserves_all_nan_metric():
-    iteration_time = make_metric({1: "nan", 5: "nan"}, step_interval=5)
+def test_read_tb_logs_skips_metric_without_sampled_values(monkeypatch, tmp_path):
+    (tmp_path / "events.out.tfevents.test").touch()
+    accumulator = FakeEventAccumulator({"iteration-time": [(2, 0.25), (3, 0.26)]})
+    monkeypatch.setattr(common, "_load_event_accumulators_with_scalars", lambda _: [accumulator])
 
-    result = _remove_leading_nan_iteration_times({"iteration-time": iteration_time})
+    result = read_tb_logs_as_list(str(tmp_path), train_iters=10, start_idx=1, step_size=5)
 
-    assert result["iteration-time"] == iteration_time
-    assert result["iteration-time"].start_step == 1
+    assert result == {}
+
+
+def test_read_tb_logs_rejects_nonpositive_step_size():
+    with pytest.raises(ValueError, match="step_size must be positive"):
+        read_tb_logs_as_list("unused", step_size=0)
 
 
 # ── ApproximateTest ───────────────────────────────────────────────────────────
@@ -179,7 +194,7 @@ class TestPipelineApproximate:
             run({"loss": golden}, {"loss": actual}, {"loss": [ApproximateTest(atol=1, rtol=0)]})
 
     def test_single_bad_step_in_large_run_passes(self):
-        # With 1000 steps: total_steps_evaluated=1001, num_failing_allowed=10.
+        # With 1000 steps: total_steps_evaluated=1000, num_failing_allowed=10.
         # 1 bad step → mean(is_close) = 999/1000 = 0.999, well above threshold.
         n = 1000
         golden = {i: 1.0 for i in range(1, n + 1)}
@@ -201,6 +216,18 @@ class TestPipelineApproximate:
                 {"loss": [ApproximateTest(rtol=0.05)]},
             )
 
+    def test_sparse_failure_budget_uses_observed_value_count(self):
+        golden_values = {1 + index * 10: 1.0 for index in range(200)}
+        actual_values = dict(golden_values)
+        for step in list(actual_values)[:2]:
+            actual_values[step] = 2.0
+
+        run(
+            {"loss": make_metric(golden_values)},
+            {"loss": make_metric(actual_values)},
+            {"loss": [ApproximateTest(rtol=0.05)]},
+        )
+
 
 # ── pipeline — missing metric ─────────────────────────────────────────────────
 
@@ -218,9 +245,9 @@ class TestPipelineMissingMetric:
 class TestPipelineIterationTime:
     def test_uses_median_not_per_step_values(self):
         # Per-step values diverge but medians match — should pass.
-        golden = make_metric({1: 0.25, 2: 0.25, 3: 0.25, 4: 0.25})
+        golden = make_metric({5: 0.25, 10: 0.25, 15: 0.25, 20: 0.25})
         # median([0.10, 0.25, 0.26, 100.0]) = (0.25+0.26)/2 = 0.255 ≈ 0.25 ✓
-        actual = make_metric({1: 0.10, 2: 0.25, 3: 0.26, 4: 100.0})
+        actual = make_metric({5: 0.10, 10: 0.25, 15: 0.26, 20: 100.0})
         run(
             {"iteration-time": golden},
             {"iteration-time": actual},
@@ -228,8 +255,8 @@ class TestPipelineIterationTime:
         )
 
     def test_diverging_medians_fails(self):
-        golden = make_metric({1: 0.25, 2: 0.25, 3: 0.25})
-        actual = make_metric({1: 0.50, 2: 0.50, 3: 0.50})  # median 0.50, 100 % off
+        golden = make_metric({5: 0.25, 10: 0.25, 15: 0.25})
+        actual = make_metric({5: 0.50, 10: 0.50, 15: 0.50})  # median 0.50, 100 % off
         with pytest.raises(AssertionError, match="iteration-time"):
             run(
                 {"iteration-time": golden},
@@ -238,14 +265,52 @@ class TestPipelineIterationTime:
             )
 
     def test_nan_warmup_step_does_not_break_median(self):
-        # Step 1 is "nan" (warm-up). Median of [inf, 0.25, 0.25, 0.25] = 0.25.
-        golden = make_metric({1: "nan", 2: 0.25, 3: 0.25, 4: 0.25})
-        actual = make_metric({1: "nan", 2: 0.25, 3: 0.25, 4: 0.25})
+        # Legacy placeholders are ignored when selecting finite timing samples.
+        golden = make_metric({5: "nan", 10: 0.25, 15: 0.25, 20: 0.25})
+        actual = make_metric({5: "nan", 10: 0.25, 15: 0.25, 20: 0.25})
         run(
             {"iteration-time": golden},
             {"iteration-time": actual},
             {"iteration-time": [ApproximateTest(rtol=0.05)]},
         )
+
+    def test_sparse_values_match_on_observed_steps(self):
+        golden = make_metric({30: 0.25, 40: 0.25}, step_interval=10)
+        actual = make_metric({30: 0.25, 35: "nan", 40: 0.25, 45: "nan"}, step_interval=5)
+        run(
+            {"iteration-time": golden},
+            {"iteration-time": actual},
+            {"iteration-time": [ApproximateTest(rtol=0.05)]},
+        )
+
+    def test_falls_back_to_first_finite_values_after_warmup(self):
+        golden = make_metric({1: "nan", 100: 0.25, 200: 0.25}, step_interval=100)
+        actual = make_metric({100: 0.25, 200: 0.25}, step_interval=100)
+        run(
+            {"iteration-time": golden},
+            {"iteration-time": actual},
+            {"iteration-time": [ApproximateTest(rtol=0.05)]},
+        )
+
+    def test_trailing_legacy_placeholders_do_not_change_short_run_window(self):
+        golden = make_metric(
+            {**{step: 0.25 for step in range(2, 26)}, **{step: "nan" for step in range(26, 51)}}
+        )
+        actual = make_metric({step: 0.25 for step in range(2, 26)})
+        run(
+            {"iteration-time": golden},
+            {"iteration-time": actual},
+            {"iteration-time": [ApproximateTest(rtol=0.05)]},
+        )
+
+    def test_fails_when_no_finite_value_exists_after_warmup(self):
+        metric = make_metric({1: "nan", 5: "nan"}, step_interval=5)
+        with pytest.raises(AssertionError, match="iteration-time"):
+            run(
+                {"iteration-time": metric},
+                {"iteration-time": metric},
+                {"iteration-time": [ApproximateTest(rtol=0.05)]},
+            )
 
 
 # ── pipeline — "nan" string handling ─────────────────────────────────────────
@@ -262,6 +327,17 @@ class TestPipelineNanHandling:
     def test_nan_in_golden_but_not_actual_fails_deterministic(self):
         golden = make_metric({1: 1.0, 2: "nan"})
         actual = make_metric({1: 1.0, 2: 1.0})
+        with pytest.raises(AssertionError):
+            run({"loss": golden}, {"loss": actual}, {"loss": [DeterministicTest()]})
+
+    def test_missing_actual_value_matches_legacy_nan_placeholder(self):
+        golden = make_metric({1: "nan", 5: 1.0}, step_interval=5)
+        actual = make_metric({5: 1.0}, step_interval=5)
+        run({"loss": golden}, {"loss": actual}, {"loss": [DeterministicTest()]})
+
+    def test_missing_actual_value_fails_against_finite_golden(self):
+        golden = make_metric({1: 1.0, 5: 2.0}, step_interval=5)
+        actual = make_metric({5: 2.0}, step_interval=5)
         with pytest.raises(AssertionError):
             run({"loss": golden}, {"loss": actual}, {"loss": [DeterministicTest()]})
 

--- a/tests/functional_tests/python_test_utils/test_get_test_results_from_tensorboard_logs.py
+++ b/tests/functional_tests/python_test_utils/test_get_test_results_from_tensorboard_logs.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import json
+
+from click.testing import CliRunner
+
+from tests.functional_tests.python_test_utils import get_test_results_from_tensorboard_logs
+from tests.functional_tests.python_test_utils.common import GoldenValueMetric
+
+
+def test_non_finite_value_does_not_leave_partial_output(monkeypatch, tmp_path):
+    output_path = tmp_path / "golden_values.json"
+    non_finite_metric = GoldenValueMetric(
+        start_step=1, end_step=1, step_interval=1, values={1: float("nan")}
+    )
+    monkeypatch.setattr(
+        get_test_results_from_tensorboard_logs.common,
+        "read_tb_logs_as_list",
+        lambda *args, **kwargs: {"lm loss": non_finite_metric},
+    )
+
+    result = CliRunner().invoke(
+        get_test_results_from_tensorboard_logs.collect_train_test_metrics,
+        ["--logs-dir", str(tmp_path), "--train-iters", "1", "--output-path", str(output_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "Out of range float values are not JSON compliant" in str(result.exception)
+    assert not output_path.exists()
+
+
+def test_unselected_non_finite_metric_is_not_serialized(monkeypatch, tmp_path):
+    output_path = tmp_path / "golden_values.json"
+    finite_metric = GoldenValueMetric(start_step=1, end_step=1, step_interval=1, values={1: 1.0})
+    non_finite_metric = GoldenValueMetric(
+        start_step=1, end_step=1, step_interval=1, values={1: float("nan")}
+    )
+    monkeypatch.setattr(
+        get_test_results_from_tensorboard_logs.common,
+        "read_tb_logs_as_list",
+        lambda *args, **kwargs: {"lm loss": finite_metric, "learning-rate": non_finite_metric},
+    )
+
+    result = CliRunner().invoke(
+        get_test_results_from_tensorboard_logs.collect_train_test_metrics,
+        ["--logs-dir", str(tmp_path), "--train-iters", "1", "--output-path", str(output_path)],
+    )
+
+    assert result.exit_code == 0
+    assert set(json.loads(output_path.read_text())) == {"lm loss"}


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Stop the TensorBoard extractor from synthesizing `"nan"` placeholders for missing sampling-grid points.

This is a follow-up to #6539 and fixes the internal and trailing placeholder pattern exposed by #6644.

- Keep only observed TensorBoard samples and derive per-metric start, end, and cadence metadata.
- Align sparse actual values by golden step while remaining compatible with legacy placeholder goldens.
- Select iteration-time windows from finite samples and fall back to the first finite post-warmup samples when the preferred window is empty.
- Serialize selected metrics with `allow_nan=False` before opening the output file, preventing partial invalid artifacts.

## Issue tracking

Linked issue: Follow-up to #6539 and #6644.
