### PR TITLE
fix(num_zeros logging with gtp padding): exclude GTP alignment padding from num_zeros accounting

### DIFF
--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -246,7 +246,7 @@ The table below covers every GTP-related CLI flag and Python knob. "Required" me
 
 | Knob | Default | Purpose |
 |---|---|---|
-| `pad_for_alignment` | auto (16 NVFP4, 32 MXFP8, 16 BF16) | Shard alignment; auto-set by `training.py` based on quantization recipe. |
+| `pad_for_alignment` | auto (16 NVFP4, 32 MXFP8, 1 BF16) | Shard alignment; auto-set by `training.py` based on quantization recipe. BF16 has no tile-size requirement, so it pads only to `gtp_remat_size` — the minimum needed for equal-sized AG/RS shards. |
 | `weight_prefetch` | `True` | Disable only to debug the synchronous cold-start path. |
 | `async_reduction` | `True` | Async wgrad reduce-scatter; disable for easier debugging. |
 | `calculate_per_token_loss` | `False` | Must mirror `config.calculate_per_token_loss` (SUM vs MEAN RS). |
@@ -317,10 +317,13 @@ torchrun --nproc-per-node 4 pretrain_gpt.py \
 At iter-0 you'll see one rank-0 log line confirming the active config:
 
 ```
-GTP_remat enabled. GTPRematConfig(pad_for_alignment=16, check_param_states=False,
+GTP_remat enabled. GTPRematConfig(pad_for_alignment=1, check_param_states=False,
   weight_prefetch=True, async_reduction=True, calculate_per_token_loss=False,
   reduce_scatter_with_fp32_accumulation=False, graph_wgrad_ring_size=2)
 ```
+
+(`pad_for_alignment=1` here because this example is BF16 with no quantization-tile
+requirement — see the table above.)
 
 ### 2.5 Tuning knobs
 
@@ -328,7 +331,7 @@ Set via `from megatron.core.tensor_parallel.generalized_tensor_parallelism impor
 
 ```python
 update_gtp_config(
-    pad_for_alignment=16,         # NVFP4: 16, MXFP8: 32, BF16: any; auto-set in training.py
+    pad_for_alignment=1,          # NVFP4: 16, MXFP8: 32, BF16: 1 (min for AG/RS); auto-set in training.py
     weight_prefetch=True,         # Disable to debug the cold-start path
     async_reduction=True,         # Whether to perform GTP_remat gradient reduction asynchronously
     calculate_per_token_loss=False,  # Mirror config.calculate_per_token_loss (SUM vs MEAN RS)
@@ -337,7 +340,7 @@ update_gtp_config(
 )
 ```
 
-`training.py` auto-tunes `pad_for_alignment` based on the quantization recipe (`--fp4`, `--fp8-recipe=mxfp8`, etc.) before model construction. The other knobs are usually left at defaults.
+`training.py` auto-tunes `pad_for_alignment` based on the quantization recipe (`--fp4`, `--fp8-recipe=mxfp8`, etc.) before model construction, defaulting to `1` (the minimum needed for equal-sized AG/RS shards) when no low-precision tile size applies. The other knobs are usually left at defaults.
 
 GTP backward reduce-scatter overlap across local CUDA-graph boundaries is enabled automatically. The ownership and ordering protocol is described in [§3.6](#cross-graph-backward-reduce-scatter-overlap).
 
@@ -787,7 +790,7 @@ The feature applies only to **local/partial CUDA graphs** and is enabled automat
 
 ### 3.7 Per-parameter alignment padding
 
-Low-precision tiling formats need each rank's local shard aligned to their tile size (MXFP8: 32, NVFP4: 16) — plain equal-sized AG/RS shards only need `dim0` divisible by `gtp_remat_size`, which padding is not required for (`_gtp_slice_one_param` skips it and just asserts that divisibility when `pad_for_alignment == 0`). A weight's real `dim0` is rarely already a multiple of `pad_for_alignment × gtp_remat_size`, so `_gtp_slice_one_param` pads the *logical* tensor up to the next multiple before slicing it evenly across `gtp_remat_group` (§1.3) — the padding lands as a contiguous suffix of that padded buffer. It is real, allocated storage, but the wgrad GEMM only ever writes the logical prefix (§3.6), so it stays exact `0.0` for the life of the run: a permanent structural zero, not a value that merely happens to be zero.
+Low-precision tiling formats need each rank's local shard aligned to their tile size (MXFP8: 32, NVFP4: 16) — plain equal-sized AG/RS shards only need `dim0` divisible by `gtp_remat_size`, which padding is not required for (`_gtp_slice_one_param` skips it and just asserts that divisibility when `pad_for_alignment == 0`). BF16 has no tile-size requirement, so `training.py` sets `pad_for_alignment=1` for it — `dim0` still isn't guaranteed divisible by `gtp_remat_size` on its own, so padding stays on, just bounded to `gtp_remat_size - 1` rows instead of a 16/32-row tile margin. A weight's real `dim0` is rarely already a multiple of `pad_for_alignment × gtp_remat_size`, so `_gtp_slice_one_param` pads the *logical* tensor up to the next multiple before slicing it evenly across `gtp_remat_group` (§1.3) — the padding lands as a contiguous suffix of that padded buffer. It is real, allocated storage, but the wgrad GEMM only ever writes the logical prefix (§3.6), so it stays exact `0.0` for the life of the run: a permanent structural zero, not a value that merely happens to be zero.
 
 #### Where padding lands
 
@@ -832,7 +835,7 @@ Case A is what §1.3's "tail slice" framing describes for the reassembled tensor
 #### Why pad this way
 
 - **Uniform shard sizes without runtime coordination.** `pad_length` is a pure function of `dim0`, `pad_for_alignment`, and `gtp_remat_size` — computed once, locally, at shard-construction time. No cross-rank negotiation is needed to agree on a shard size before the first AG/RS.
-- **Equal-sized AG/RS shards fall out for free.** `pad_for_alignment` is set to the precision format's tile size (MXFP8/NVFP4); the same pass that satisfies tiling also leaves every rank with an equal-sized shard, so AG/RS needs no separate padding step of its own.
+- **Equal-sized AG/RS shards fall out for free.** For MXFP8/NVFP4, `pad_for_alignment` is set to the precision format's tile size, so the same pass that satisfies tiling also leaves every rank with an equal-sized shard. For BF16, `pad_for_alignment=1` rounds `dim0` up to the next multiple of `gtp_remat_size` directly — no tile size to satisfy, so padding is only the minimum AG/RS itself requires.
 - **A contiguous tail keeps stripping (and resharding) cheap.** Padding is always appended as a suffix *before* slicing, never interleaved with real data, so recovering the logical tensor is a single trailing slice (`tensor[:-pad_length]`) — simple enough to stay correct even when a checkpoint reload changes `gtp_remat_size` and thus the padded size (§3.3's `allow_shape_mismatch`).
 - **A predictable invariant other systems can build on.** "Padding is always an exact structural zero, never written" is safe for any consumer that needs to distinguish real elements from padding — DCP's cross-topology reshard tolerance (§3.3) and the wgrad-ring's fixed-address buffers (§3.6) both lean on it, and it's what lets `count_zeros_fp32` exclude these permanent zeros from `num_zeros` instead of miscounting them as converged-to-zero gradients.
 

--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -70,6 +70,10 @@ Both `GTP_remat` collectives are prefetched one step ahead, so they overlap the 
       - [Configuration traps](#configuration-traps)
     - [3.6 CUDA graph integration](#36-cuda-graph-integration)
       - [Cross-graph backward reduce-scatter overlap](#cross-graph-backward-reduce-scatter-overlap)
+    - [3.7 Per-parameter alignment padding](#37-per-parameter-alignment-padding)
+      - [Where padding lands](#where-padding-lands)
+      - [Why pad this way](#why-pad-this-way)
+      - [Trade-off](#trade-off)
   - [4. Testing](#4-testing)
 
 ---
@@ -111,7 +115,7 @@ Wire bandwidth scales with the **quantized** size, not BF16 size — GTP_remat c
 - **Native NVFP4 param — `--fp4-param-gather` (required).** Same shape as MXFP8: the shard **is** a native `NVFP4Tensor`, all-gathered as packed 4-bit (`kFloat4E2M1`) and optimizer-maintained, no per-microbatch quantize. See the *GTP + NVFP4* subsection below.
 - **BF16 (no FP8/NVFP4 params).** The BF16 shard is all-gathered as-is.
 - **Coalesced NCCL**: `grouped_gather_along_first_dim` uses `torch.distributed._coalescing_manager` to batch E experts' AGs into a single NCCL op.
-- **Padding**: shards are allocated **already padded** so each rank's dim0 stays `pad_for_alignment`-divisible (MXFP8: 32). Column-parallel pads the per-TP slice (`out_features / tp_size`) to a multiple of `pad_for_alignment × gtp_remat_size` so it survives TE's TP split aligned; row-parallel / Megatron-local pad the TP-local tensor directly (§3.1). Padding lands contiguous at the tail, so stripping is one trailing slice (`tensor[:-pad_length]`).
+- **Padding**: shards are allocated **already padded** so each rank's dim0 stays `pad_for_alignment`-divisible (MXFP8: 32). Column-parallel pads the per-TP slice (`out_features / tp_size`) to a multiple of `pad_for_alignment × gtp_remat_size` so it survives TE's TP split aligned; row-parallel / Megatron-local pad the TP-local tensor directly (§3.1). Padding lands contiguous at the tail, so stripping is one trailing slice (`tensor[:-pad_length]`). For how that tail maps onto individual per-rank shards, and why `num_zeros` accounting has to account for it, see §3.7.
 
 #### Per-microbatch schedule
 
@@ -601,7 +605,7 @@ Because the offsets reconstruct the global shape, the checkpoint is independent 
 
 **`_extra_state`.** This is TransformerEngine's per-module **FP8 calibration state** — for delayed-scaling recipes it holds the `recipe`, the forward/backward `scale` tensors and `amax_history` buffers, plus picklable `extra_fp8_variables`; for BF16 (non-FP8) runs it is an empty tensor. Because it is a pickled byte blob rather than a tensor with a meaningful shape, it is emitted as a `ShardedObject` (via `make_sharded_object_for_checkpoint`), not a `ShardedTensor`. Its amax/scale statistics are *per-tensor globals* for the **full** weight (amax is reduced across the FP8 group), so every GTP_remat peer carries an identical copy — which is exactly why it takes the replicated path above, with `gtp_rank` folded into its `replica_id`.
 
-**Alignment padding & cross-topology reshard.** When `_gtp_slice_one_param` pads `out_features` to a multiple of `gtp_remat_size · pad_for_alignment`, the saved global describes the *padded* shape, so the helper sets `allow_shape_mismatch=True`. DCP then tolerates a load-side topology whose alignment yields a different padded size — the unpadded data overlaps and the tail pad rows are zeros GTP_remat recomputes.
+**Alignment padding & cross-topology reshard.** When `_gtp_slice_one_param` pads `out_features` to a multiple of `gtp_remat_size · pad_for_alignment`, the saved global describes the *padded* shape, so the helper sets `allow_shape_mismatch=True`. DCP then tolerates a load-side topology whose alignment yields a different padded size — the unpadded data overlaps and the tail pad rows are zeros GTP_remat recomputes (§3.7 covers how that padding is laid out per rank).
 
 > Note: the SSM `in_proj` weights — Mamba's (`mamba_mixer.py`, split `[z|x|B|C|dt]`) and gated-delta-product's (`gated_delta_product.py`, split householder-major into `z|V*|K*|Q|b*|a`) — are a special case: each **all-gathers its GTP_remat shards** back to the logical TP-local size and strips the pad *before* saving, so its global is topology-independent and needs no `allow_shape_mismatch`. This is required, not just tidier: the split-chunk boundaries do not line up with the GTP_remat slice boundaries, so a raw shard cannot be split at all. The checkpoint therefore matches a non-GTP_remat run byte-for-byte.
 >
@@ -777,9 +781,67 @@ The two modes differ only in release timing and the storage required to make ear
 5. **Replay fencing.** Before replay writes a slot, the graph runner waits for its `ready_event`. The RS stream publishes that event only after NCCL has stopped reading the slot. Different slots may remain live concurrently; reuse of an occupied slot waits.
 6. **Final gradient fence.** `wait_for_gtp_grad_reduction_on_current_stream()` joins GTP side streams and graph-runner streams before DDP or the optimizer consumes `main_grad`.
 
-*Result and cost.* The ring owns the padded RS input. The wgrad GEMM writes the logical prefix, the alignment tail remains zero, and a non-ring producer is copied into the logical view before reduce-scatter. The bounded memory cost is up to `graph_wgrad_ring_size` full unsharded wgrad buffers for each matching scheduling/shape domain, rather than one buffer per layer. The default ring size of two is sufficient when each graph has one same-key writer: one slot may remain an in-flight RS input while the next graph writes the other, and reuse waits on the older slot's `ready_event`. A larger ring is needed only when one graph contains multiple same-key writers whose reduce-scatter inputs can be live together. Capture rejects unsafe same-slot reuse instead of silently aliasing it.
+*Result and cost.* The ring owns the padded RS input. The wgrad GEMM writes the logical prefix, the alignment tail remains zero (§3.7 covers why that permanent zero has to be excluded from `num_zeros`), and a non-ring producer is copied into the logical view before reduce-scatter. The bounded memory cost is up to `graph_wgrad_ring_size` full unsharded wgrad buffers for each matching scheduling/shape domain, rather than one buffer per layer. The default ring size of two is sufficient when each graph has one same-key writer: one slot may remain an in-flight RS input while the next graph writes the other, and reuse waits on the older slot's `ready_event`. A larger ring is needed only when one graph contains multiple same-key writers whose reduce-scatter inputs can be live together. Capture rejects unsafe same-slot reuse instead of silently aliasing it.
 
 The feature applies only to **local/partial CUDA graphs** and is enabled automatically. Full-iteration CUDA graphs do not use this feature because their backward execution has no local graph boundary.
+
+### 3.7 Per-parameter alignment padding
+
+Low-precision tiling formats need each rank's local shard aligned to their tile size (MXFP8: 32, NVFP4: 16) — plain equal-sized AG/RS shards only need `dim0` divisible by `gtp_remat_size`, which padding is not required for (`_gtp_slice_one_param` skips it and just asserts that divisibility when `pad_for_alignment == 0`). A weight's real `dim0` is rarely already a multiple of `pad_for_alignment × gtp_remat_size`, so `_gtp_slice_one_param` pads the *logical* tensor up to the next multiple before slicing it evenly across `gtp_remat_group` (§1.3) — the padding lands as a contiguous suffix of that padded buffer. It is real, allocated storage, but the wgrad GEMM only ever writes the logical prefix (§3.6), so it stays exact `0.0` for the life of the run: a permanent structural zero, not a value that merely happens to be zero.
+
+#### Where padding lands
+
+```text
+alignment = pad_for_alignment × gtp_remat_size
+pad_length = amount needed to round dim0 up to a multiple of alignment
+shard_size = (dim0 + pad_length) / gtp_remat_size   -- same for every rank
+```
+
+**Case A — padding fits in the tail shard (the common case).**
+
+```text
+dim0 = 48, gtp_remat_size = 2, pad_for_alignment = 16
+  -> alignment = 32, pad_length = 16, shard_size = 32 rows
+
+row:        0                          32                        48          63
+            |---------- rank 0 ----------|---------- rank 1 ----------------|
+            |<-------------- real (48 rows) -------------->|<-- pad (16) -->|
+
+rank 0 (32 rows):  [ real real real real ................ real ]        pad rows = 0
+rank 1 (32 rows):  [ real ............ real | pad pad .......... pad ]  pad rows = 16  <- tail rank
+```
+
+**Case B — small `dim0` makes padding spill backward from the tail rank into lower-numbered ranks' shards too.**
+
+```text
+dim0 = 1, gtp_remat_size = 4, pad_for_alignment = 16
+  -> alignment = 64, pad_length = 63, shard_size = 16 rows
+
+row:  0  1                                                                    63
+      |---rank 0---|------ rank 1 ------|------ rank 2 ------|------ rank 3 ------|
+      |r|<------------------------- pad (63 rows) -------------------------------->|
+
+rank 0 (16 rows):  [ real | pad pad pad ........ pad ]              pad rows = 15
+rank 1 (16 rows):  [ pad pad pad ...................... pad ]       pad rows = 16  (fully padding)
+rank 2 (16 rows):  [ pad pad pad ...................... pad ]       pad rows = 16  (fully padding)
+rank 3 (16 rows):  [ pad pad pad ...................... pad ]       pad rows = 16  <- tail rank
+```
+
+Case A is what §1.3's "tail slice" framing describes for the reassembled tensor — true per-shard too, whenever `pad_length` is smaller than one shard's own row count. Case B is why any per-rank consumer of this layout (e.g. `gtp_local_pad_zero_count` in `tensor_parallel/layers.py`) has to compute padding from each rank's **row offset in the unsharded padded buffer**, rather than assuming only the tail rank ever holds it.
+
+#### Why pad this way
+
+- **Uniform shard sizes without runtime coordination.** `pad_length` is a pure function of `dim0`, `pad_for_alignment`, and `gtp_remat_size` — computed once, locally, at shard-construction time. No cross-rank negotiation is needed to agree on a shard size before the first AG/RS.
+- **Equal-sized AG/RS shards fall out for free.** `pad_for_alignment` is set to the precision format's tile size (MXFP8/NVFP4); the same pass that satisfies tiling also leaves every rank with an equal-sized shard, so AG/RS needs no separate padding step of its own.
+- **A contiguous tail keeps stripping (and resharding) cheap.** Padding is always appended as a suffix *before* slicing, never interleaved with real data, so recovering the logical tensor is a single trailing slice (`tensor[:-pad_length]`) — simple enough to stay correct even when a checkpoint reload changes `gtp_remat_size` and thus the padded size (§3.3's `allow_shape_mismatch`).
+- **A predictable invariant other systems can build on.** "Padding is always an exact structural zero, never written" is safe for any consumer that needs to distinguish real elements from padding — DCP's cross-topology reshard tolerance (§3.3) and the wgrad-ring's fixed-address buffers (§3.6) both lean on it, and it's what lets `count_zeros_fp32` exclude these permanent zeros from `num_zeros` instead of miscounting them as converged-to-zero gradients.
+
+#### Trade-off
+
+- **Wasted memory and bandwidth.** Every padded row is allocated in the weight, gradient, and optimizer-state buffers, and travels over the wire on every gather/reduce-scatter — pure overhead, `pad_length / (dim0 + pad_length)` of the padded tensor.
+- **Negligible in the common case, severe in the small-`dim0` one.** That fraction is ~0 when `dim0 ≫ pad_for_alignment × gtp_remat_size`, but Case B's `dim0 = 1` weight pads to 64 rows — **98% (63/64) padding**, with 3 of its 4 per-rank shards pure padding and contributing nothing.
+- **No automatic mitigation.** Choosing `gtp_remat_size` to divide (or nearly divide) a weight's real `dim0` avoids this, but GTP does not warn when it doesn't — it's on the caller to notice.
+- **A bookkeeping tax on every raw-buffer consumer.** Checkpointing, `num_zeros`, and the wgrad ring all have to explicitly account for padding rather than assume a shard's buffer is fully real.
 
 ## 4. Testing
 
@@ -792,7 +854,7 @@ torchrun --nproc-per-node 4 -m pytest tests/unit_tests/generalized_tensor_parall
 
 | Test file | What it guards |
 |-----------|----------------|
-| `test_gtp_basics.py` | Core GTP_remat shard/gather, cache ownership, wgrad ring, and DDP bucket alignment. Also pins TE's recompute-phase flag as dtype-agnostic (true under BF16, not just FP8), which the forward-only readiness gate in §3.2 relies on. |
+| `test_gtp_basics.py` | Core GTP_remat shard/gather, cache ownership, wgrad ring, DDP bucket alignment, the `num_zeros` padding correction (§3.7), and TE's recompute-phase flag (dtype-agnostic, relied on by the readiness gate in §3.2). |
 | `test_attention_gtp.py` | GTP_remat on attention linears, loss parity vs no-GTP_remat. |
 | `test_mamba_gtp.py` | GTP_remat on Mamba projection weights. |
 | `test_tp_gtp.py` | GTP_remat composed with tensor parallelism (`tp_group × gtp_remat_group`). |
@@ -812,5 +874,7 @@ torchrun --nproc-per-node 4 -m pytest tests/unit_tests/generalized_tensor_parall
 The fp32-accumulation primitive itself is covered outside this suite, by `tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py`, which does not require GTP_remat.
 
 The parameter-readiness contract itself (§3.2) is likewise covered outside this suite, by `tests/unit_tests/distributed/test_param_readiness.py` — CPU-only, no GPU or GTP_remat required. It pins the branches the 4-GPU test does not exercise: `align_param_gather`, pre-hooks removed mid-sequence, and a collected DDP or bucket group.
+
+The `num_zeros` padding correction (§3.7) has two more layers of coverage outside this suite, both CPU-only: `tests/unit_tests/tensor_parallel/test_layers.py::TestGtpLocalPadZeroCount` unit-tests `gtp_local_pad_zero_count`'s row-offset math directly (no padding, tail-only, DP-fragment overlap variants, and the small-`dim0` spillover case), and `tests/unit_tests/optimizer/test_clip_grads.py::TestCountZerosFp32GtpPadding` checks `count_zeros_fp32`'s subtraction with and without an explicit `.gtp_pad_zeros` stamp.
 
 All tests require ≥ 4 GPUs and TransformerEngine >= 2.19; they self-skip when those are unavailable. A green run (skips for unmet hardware/config are acceptable) is the minimum bar for any GTP_remat change.

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -47,7 +47,11 @@ except ImportError:
         multi_tensor_scale_tensor_impl = None
 
 
-from ..tensor_parallel import param_is_not_gtp_duplicate, param_is_not_tensor_parallel_duplicate
+from ..tensor_parallel import (
+    gtp_local_pad_zero_count,
+    param_is_not_gtp_duplicate,
+    param_is_not_tensor_parallel_duplicate,
+)
 from ..transformer.module import param_is_not_shared
 from ..utils import get_data_parallel_group_if_dtensor, to_local_if_dtensor
 
@@ -192,6 +196,28 @@ def clip_grad_by_total_norm_fp32(
         )
 
 
+def _gtp_pad_zero_count(param: torch.Tensor, grad: torch.Tensor) -> int:
+    """Structural GTP alignment-padding zeros to exclude from ``grad``'s raw zero count.
+
+    Padding rows are permanent zeros (never written by the wgrad GEMM), not real zero
+    gradients, so counting them would inflate GTP's num_zeros relative to non-GTP runs.
+
+    - :class:`~megatron.core.optimizer.distrib_optimizer.DistributedOptimizer`, when it
+      byte-slices a GTP shard into DP-optimizer-state fragments, stamps the correction
+      explicitly as ``.gtp_pad_zeros``: a fragment alone can't tell whether it overlaps the
+      padding tail without the slice offset, which only that optimizer has.
+    - Everyone else (``LayerWiseDistributedOptimizer``, which assigns whole params per rank; or
+      ``DistributedOptimizer`` at data-parallel size 1) registers the param's own unsliced GTP
+      shard directly, which already carries ``.pad_length``/``.group``, so the correction is
+      computed here and cached onto ``.gtp_pad_zeros`` -- it's invariant for the param's
+      lifetime, so this only runs once.
+    """
+    pad_zeros = getattr(param, "gtp_pad_zeros", None)
+    if pad_zeros is None and grad.numel() == param.numel():
+        pad_zeros = param.gtp_pad_zeros = gtp_local_pad_zero_count(param, 0, grad.numel())
+    return pad_zeros or 0
+
+
 def count_zeros_fp32(
     parameters: Union[List[torch.Tensor], torch.Tensor],
     grad_stats_parallel_group: torch.distributed.ProcessGroup,
@@ -252,6 +278,7 @@ def count_zeros_fp32(
             data_parallel_group = get_data_parallel_group_if_dtensor(grad_obj, data_parallel_group)
             grad = to_local_if_dtensor(grad_obj).detach()
             num_zeros = grad.numel() - torch.count_nonzero(grad)
+            num_zeros -= _gtp_pad_zero_count(param, grad)  # exclude structural GTP padding
             total_num_zeros = num_zeros + total_num_zeros
 
     if use_megatron_fsdp and data_parallel_group is not None:

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -214,6 +214,8 @@ def _gtp_pad_zero_count(param: torch.Tensor, grad: torch.Tensor) -> int:
     """
     pad_zeros = getattr(param, "gtp_pad_zeros", None)
     if pad_zeros is None and grad.numel() == param.numel():
+        # Not stamped yet (DistributedOptimizer does this explicitly) -- compute and cache it
+        # here so later calls for this param skip straight to the getattr above.
         pad_zeros = param.gtp_pad_zeros = gtp_local_pad_zero_count(param, 0, grad.numel())
     return pad_zeros or 0
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -417,6 +417,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         tensor_parallel.copy_gtp_attributes(shard_model_param, model_param)
                         copy_optimizer_param_metadata(shard_model_param, model_param)
+                        shard_model_param.gtp_pad_zeros = tensor_parallel.gtp_local_pad_zero_count(
+                            model_param, param_range.start, param_range.end
+                        )
 
                     # Generate main param.
                     if not config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -449,6 +452,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         )
                         tensor_parallel.copy_gtp_attributes(shard_main_param, model_param)
                         copy_optimizer_param_metadata(shard_main_param, model_param)
+                        shard_main_param.gtp_pad_zeros = tensor_parallel.gtp_local_pad_zero_count(
+                            model_param, param_range.start, param_range.end
+                        )
                     else:
                         # When using precision-aware optimizer, main params are held by FusedAdam.
                         shard_main_param = None
@@ -472,6 +478,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     )
                     tensor_parallel.copy_gtp_attributes(shard_model_param, model_param)
                     copy_optimizer_param_metadata(shard_model_param, model_param)
+                    shard_model_param.gtp_pad_zeros = tensor_parallel.gtp_local_pad_zero_count(
+                        model_param, param_range.start, param_range.end
+                    )
 
                 else:
                     raise TypeError(

--- a/megatron/core/tensor_parallel/__init__.py
+++ b/megatron/core/tensor_parallel/__init__.py
@@ -12,6 +12,7 @@ from .layers import (
     VocabParallelEmbedding,
     copy_gtp_attributes,
     copy_tensor_model_parallel_attributes,
+    gtp_local_pad_zero_count,
     linear_with_grad_accumulation_and_async_allreduce,
     param_is_not_gtp_duplicate,
     param_is_not_tensor_parallel_duplicate,
@@ -63,6 +64,7 @@ __all__ = [
     "copy_gtp_attributes",
     "param_is_not_tensor_parallel_duplicate",
     "param_is_not_gtp_duplicate",
+    "gtp_local_pad_zero_count",
     "linear_with_grad_accumulation_and_async_allreduce",
     # mappings.py
     "copy_to_tensor_model_parallel_region",

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -502,6 +502,10 @@ def configure_gtp_remat_from_recipe(
         update_gtp_config(pad_for_alignment=32)
     elif fp8:
         update_gtp_config(pad_for_alignment=16)
+    else:
+        # No MXFP8/NVFP4 tile-size requirement in this recipe -- pad only to the minimum
+        # gtp_remat_size needed for even AG/RS sharding, not a fixed quantization tile size.
+        update_gtp_config(pad_for_alignment=1)
 
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         logger.info("> GTP_remat enabled. %s", GTP_CONFIG)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -135,6 +135,33 @@ def param_is_not_gtp_duplicate(param):
     return get_gtp_weight_remat_rank() == 0
 
 
+def gtp_local_pad_zero_count(gtp_shard, range_start, range_end):
+    """Count structural GTP alignment-padding elements in
+    ``gtp_shard.view(-1)[range_start:range_end]`` (see ``_gtp_slice_one_param``).
+
+    Padding is a contiguous suffix of the *unsharded* padded buffer (``shard_dim0 *
+    group.size()`` rows), sliced evenly across the GTP group. It usually lands entirely in the
+    last rank's shard, but when ``pad_length`` exceeds one shard's own row count (small ``dim0``
+    relative to ``pad_for_alignment * gtp_remat_size``) it spills backward from the tail into
+    lower-numbered ranks' shards too. Computed via each rank's row offset in the unsharded
+    buffer -- not special-cased to the last rank -- so both cases come out correct.
+    """
+    pad_length = getattr(gtp_shard, "pad_length", 0)
+    if not pad_length:
+        return 0
+    group = getattr(gtp_shard, "group", None)
+    if group is None:
+        return 0
+    shard_dim0 = gtp_shard.shape[0]
+    unsharded_padded_dim0 = shard_dim0 * group.size()
+    unsharded_real_dim0 = unsharded_padded_dim0 - pad_length
+    trailing_numel = gtp_shard.numel() // shard_dim0
+    shard_row_start = group.rank() * shard_dim0
+    pad_start_in_shard = max(0, unsharded_real_dim0 - shard_row_start) * trailing_numel
+    overlap_start = max(range_start, pad_start_in_shard)
+    return max(0, range_end - overlap_start)
+
+
 def set_tensor_model_parallel_attributes(tensor, is_parallel, dim, stride):
     """Sets tp attributes to tensor"""
     # Make sure the attributes are not set.

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -145,19 +145,46 @@ def gtp_local_pad_zero_count(gtp_shard, range_start, range_end):
     relative to ``pad_for_alignment * gtp_remat_size``) it spills backward from the tail into
     lower-numbered ranks' shards too. Computed via each rank's row offset in the unsharded
     buffer -- not special-cased to the last rank -- so both cases come out correct.
+
+    Args:
+        gtp_shard: This rank's local GTP shard (carries ``pad_length``/``group``).
+        range_start: Start offset, in ``gtp_shard.view(-1)`` flat-index units, of the
+            fragment being queried.
+        range_end: End offset (exclusive) of that fragment. Pass ``0, gtp_shard.numel()``
+            for the whole shard (e.g. ``LayerWiseDistributedOptimizer``, which never
+            byte-slices); ``DistributedOptimizer`` passes the DP-optimizer-state
+            fragment's own ``[param_range.start, param_range.end)`` instead, since a
+            fragment only covers part of the shard.
     """
+    # No padding on this weight at all -> nothing to exclude.
     pad_length = getattr(gtp_shard, "pad_length", 0)
     if not pad_length:
         return 0
+    # Not a GTP shard (or GTP off) -> no group to compute a row offset against.
     group = getattr(gtp_shard, "group", None)
     if group is None:
         return 0
+
+    # Reconstruct the *unsharded* padded buffer this shard came from, and where in it
+    # the real (non-padding) data ends. Padding is always a contiguous suffix of this
+    # buffer (see _gtp_slice_one_param), so everything from unsharded_real_dim0 onward
+    # is padding.
     shard_dim0 = gtp_shard.shape[0]
     unsharded_padded_dim0 = shard_dim0 * group.size()
     unsharded_real_dim0 = unsharded_padded_dim0 - pad_length
-    trailing_numel = gtp_shard.numel() // shard_dim0
+
+    # Locate this rank's shard within that unsharded buffer, and convert the row-based
+    # padding boundary into flat-index units (one row = elems_per_row elements) so it's
+    # comparable against range_start/range_end.
+    elems_per_row = gtp_shard.numel() // shard_dim0
     shard_row_start = group.rank() * shard_dim0
-    pad_start_in_shard = max(0, unsharded_real_dim0 - shard_row_start) * trailing_numel
+    pad_start_in_shard = max(0, unsharded_real_dim0 - shard_row_start) * elems_per_row
+
+    # Overlap of the queried [range_start, range_end) fragment with [pad_start_in_shard, end).
+    # A whole-shard query only needs "does this shard have padding", but DistributedOptimizer's
+    # DP-wide bucket split doesn't respect shard boundaries, so a fragment can start/end
+    # anywhere -- entirely before the padding, straddling it, or entirely inside it.
+    # max(0, ...) at the end handles a fragment that ends before padding starts.
     overlap_start = max(range_start, pad_start_in_shard)
     return max(0, range_end - overlap_start)
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -111,11 +111,11 @@ def param_is_not_tensor_parallel_duplicate(param, tp_group=None, expert_tp_group
 
 
 def copy_gtp_attributes(destination, source):
-    """Copy GTP metadata onto a param view/copy, so the optimizer's master shards stay
-    classifiable by param_is_not_gtp_duplicate (is_gtp_weight_remat, allreduce), keep
-    electing their checkpoint writer off the caller's own groups (gtp_replica_group), and
-    stay reconstructable by GTP_remat-aware orthogonalization (pad_length)."""
-    for attr in ("is_gtp_weight_remat", "allreduce", "gtp_replica_group", "pad_length"):
+    """Copy GTP metadata onto a param view/copy (e.g. an optimizer's master or shard param):
+    dedup tags for ``param_is_not_gtp_duplicate``, the checkpoint replica group, and
+    ``pad_length``/``group`` for ``gtp_local_pad_zero_count``. The latter two must both be
+    present or padding exclusion silently returns 0."""
+    for attr in ("is_gtp_weight_remat", "allreduce", "gtp_replica_group", "pad_length", "group"):
         if hasattr(source, attr):
             setattr(destination, attr, getattr(source, attr))
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1789,6 +1789,7 @@ class TestGTPCaptureParamReadiness:
         assert ag_streams == [graphed_ag_stream]
         assert rs_streams == [graphed_rs_stream]
 
+
 # ---------------------------------------------------------------------------
 # count_zeros_fp32 must exclude GTP alignment padding, end-to-end through the
 # real distributed optimizer (build_model_and_main_param_groups stamps

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -25,6 +25,8 @@ Test groups
 - TestGTPDDPGradReadyWiring  - GTP params drive DDP grad-ready via the manual hook, not autograd
 - TestGTPWeightCacheSchedulingDomain - cache reuse stays within one chain/process-group domain
 - TestGTPGraphWgradRing       - partial-CG wgrad ring ownership and RS-input correctness
+- TestGTPCountZerosExcludesPadding - real distributed optimizer: count_zeros_fp32 must not
+                                count structural alignment-padding rows as zero gradient
 
 Multi-GPU tests skip when ``torch.distributed.get_world_size()`` != the required world size (4).
 """
@@ -1786,3 +1788,135 @@ class TestGTPCaptureParamReadiness:
         assert params == [graphed_param]
         assert ag_streams == [graphed_ag_stream]
         assert rs_streams == [graphed_rs_stream]
+
+# ---------------------------------------------------------------------------
+# count_zeros_fp32 must exclude GTP alignment padding, end-to-end through the
+# real distributed optimizer (build_model_and_main_param_groups stamps
+# .gtp_pad_zeros; count_zeros_fp32 subtracts it).
+# ---------------------------------------------------------------------------
+
+
+def _worker_count_zeros_excludes_gtp_padding(rank, world_size, port):
+    """GTP alignment padding is a permanent structural zero (never written by the wgrad GEMM),
+    not a real zero gradient. Left uncorrected, count_zeros_fp32 over-counts by exactly the
+    padding-element count on whichever (GTP-rank, DP-sub-shard) fragment physically owns it.
+
+    OUT_F=48 with gtp_remat_size=2 forces real padding (48 is not a multiple of
+    pad_for_alignment(16) * gtp_remat_size(2) = 32). With real random bf16 gradients, no element
+    is coincidentally exactly zero, so:
+      - the FIXED count_zeros() must report 0 (padding correctly excluded)
+      - artificially zeroing the .gtp_pad_zeros correction (simulating the pre-fix code) must
+        make count_zeros() jump by exactly pad_length * IN_F -- the total padding this weight
+        carries, summed over however the distributed optimizer's DP-bucket slicing split it
+        across ranks.
+    """
+    from megatron.core import parallel_state as ps
+    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.distributed.finalize_model_grads import (
+        _allreduce_replicated_grads_over_gtp_remat_group,
+    )
+    from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    IN_F, OUT_F = 64, 48  # OUT_F not a multiple of pad_for_alignment * gtp_remat_size(2) -> pads.
+
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=2
+    )
+    try:
+        model_parallel_cuda_manual_seed(42)
+        gtp_remat_group = ps.get_gtp_weight_remat_group()
+        assert gtp_remat_group.size() == 2, f"expected gtp_remat=2, got {gtp_remat_group.size()}"
+
+        layer = _make_gtp_linear(IN_F, OUT_F, gtp_remat_group)
+        w = layer.weight
+        assert isinstance(w, GTPShardedParam)
+        alignment = gtp_module.GTP_CONFIG.pad_for_alignment * gtp_remat_group.size()
+        expected_pad_length = (alignment - OUT_F % alignment) % alignment
+        assert (
+            w.pad_length == expected_pad_length > 0
+        ), f"test needs real padding to exercise the fix, got pad_length={w.pad_length}"
+        pad_elems = w.pad_length * IN_F
+
+        tconfig = TransformerConfig(
+            num_attention_heads=1, num_layers=1, hidden_size=IN_F, tensor_model_parallel_size=1
+        )
+        ddp_config = DistributedDataParallelConfig(
+            use_distributed_optimizer=True, overlap_grad_reduce=False
+        )
+        module = torch.nn.Sequential(layer)
+        ddp_model = DistributedDataParallel(tconfig, ddp_config, module)
+
+        opt_config = OptimizerConfig(
+            optimizer='adam',
+            lr=0.01,
+            bf16=True,
+            use_distributed_optimizer=True,
+            use_precision_aware_optimizer=False,
+            main_params_dtype=torch.float32,
+            main_grads_dtype=torch.float32,
+            exp_avg_dtype=torch.float32,
+            exp_avg_sq_dtype=torch.float32,
+            log_num_zeros_in_grad=True,
+        )
+        optim = get_megatron_optimizer(opt_config, [ddp_model])
+
+        optim.zero_grad()
+        ddp_model.zero_grad_buffer()
+        torch.manual_seed(1000 + rank)
+        x = torch.randn(8, IN_F, dtype=torch.bfloat16, device='cuda')
+        out = ddp_model.module(x)
+        loss = out.float().mean()
+        loss.backward()
+        ddp_model.finish_grad_sync()
+        _allreduce_replicated_grads_over_gtp_remat_group(
+            [ddp_model],
+            ps.get_gtp_weight_remat_group(check_initialized=False),
+            ps.get_expert_gtp_weight_remat_group(check_initialized=False),
+        )
+        # count_zeros() reads the master-shard .grad, which optim.step() normally populates as
+        # its first internal step. Do that copy explicitly so count_zeros() can be exercised
+        # standalone, without running (and being coupled to) the rest of step()'s update logic.
+        for sub_optimizer in getattr(optim, 'chained_optimizers', [optim]):
+            sub_optimizer._copy_model_grads_to_main_grads()
+
+        num_zeros_fixed = optim.count_zeros()
+        assert num_zeros_fixed == 0, (
+            f"expected 0 zeros with real random gradients (padding correctly excluded), "
+            f"got {num_zeros_fixed}"
+        )
+
+        # Simulate the pre-fix code: zero out this rank's own .gtp_pad_zeros correction(s) --
+        # whatever fraction of the padding the distributed optimizer's DP-bucket slicing handed
+        # to this rank -- then restore it.
+        params = optim.get_parameters()
+        pad_attrs = [(p, getattr(p, "gtp_pad_zeros", 0)) for p in params]
+        for p, saved in pad_attrs:
+            if saved:
+                p.gtp_pad_zeros = 0
+        try:
+            num_zeros_unfixed = optim.count_zeros()
+        finally:
+            for p, saved in pad_attrs:
+                if saved:
+                    p.gtp_pad_zeros = saved
+
+        assert num_zeros_unfixed - num_zeros_fixed == pad_elems, (
+            f"expected the pre-fix simulation to over-count by exactly pad_elems={pad_elems}, "
+            f"got delta={num_zeros_unfixed - num_zeros_fixed} "
+            f"(fixed={num_zeros_fixed}, unfixed={num_zeros_unfixed})"
+        )
+    finally:
+        ps.destroy_model_parallel()
+        GTPShardedParam._chain_state = {}
+
+
+class TestGTPCountZerosExcludesPadding:
+    def test_count_zeros_excludes_gtp_padding_end_to_end(self):
+        """Real DistributedOptimizer + count_zeros_fp32: GTP alignment padding must not be
+        counted as zero gradient. Regression test for the count_zeros_fp32 + distrib_optimizer
+        .gtp_pad_zeros wiring."""
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_count_zeros_excludes_gtp_padding, 4)

--- a/tests/unit_tests/optimizer/test_clip_grads.py
+++ b/tests/unit_tests/optimizer/test_clip_grads.py
@@ -1,9 +1,61 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.optimizer.clip_grads import count_zeros_fp32
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from tests.unit_tests.test_utilities import Utils
 
 
 def test_grad_norm_skip_threshold_config():
     """Test that grad_norm_skip_threshold config has correct default."""
     config = OptimizerConfig()
     assert config.grad_norm_skip_threshold == float('inf')
+
+
+class TestCountZerosFp32GtpPadding:
+    """count_zeros_fp32 must exclude GTP alignment-padding rows: they are structural zeros
+    (never written by the wgrad GEMM, see generalized_tensor_parallelism), not real zero
+    gradients, so counting them inflates GTP's num_zeros relative to 3D. The distributed
+    optimizer stamps the per-shard pad-element count onto `.gtp_pad_zeros`
+    (tensor_parallel.gtp_local_pad_zero_count) for count_zeros_fp32 to subtract."""
+
+    def setup_method(self):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def _make_param(self, grad, gtp_pad_zeros=0):
+        param = torch.nn.Parameter(torch.zeros_like(grad))
+        param.grad = grad
+        if gtp_pad_zeros:
+            param.gtp_pad_zeros = gtp_pad_zeros
+        return param
+
+    def test_padding_elements_excluded_from_zero_count(self):
+        grad = torch.zeros(8, 4, device='cuda')
+        grad[0, 0] = 1.0
+        # Last 3 rows (12 elements) are structural GTP padding, not real zero gradient.
+        param = self._make_param(grad, gtp_pad_zeros=12)
+
+        num_zeros = count_zeros_fp32(
+            [param], grad_stats_parallel_group=parallel_state.get_model_parallel_group()
+        )
+
+        assert num_zeros == grad.numel() - 1 - 12
+
+    def test_no_gtp_pad_zeros_attribute_counts_all_zeros(self):
+        """Non-GTP params (no .gtp_pad_zeros stamped) are unaffected by the correction."""
+        grad = torch.zeros(8, 4, device='cuda')
+        grad[0, 0] = 1.0
+        param = self._make_param(grad)
+
+        num_zeros = count_zeros_fp32(
+            [param], grad_stats_parallel_group=parallel_state.get_model_parallel_group()
+        )
+
+        assert num_zeros == grad.numel() - 1

--- a/tests/unit_tests/tensor_parallel/test_layers.py
+++ b/tests/unit_tests/tensor_parallel/test_layers.py
@@ -102,7 +102,9 @@ class TestCopyGtpAttributes:
     def test_padding_exclusion_survives_the_copy(self):
         """End-to-end: gtp_local_pad_zero_count on a copy must match the original -- this is
         exactly the check that would have caught the pad_length/group-dropping bug directly."""
-        source = TestGtpLocalPadZeroCount._shard(8, 4, pad_length=3, group=_FakeGroup(size=4, rank=3))
+        source = TestGtpLocalPadZeroCount._shard(
+            8, 4, pad_length=3, group=_FakeGroup(size=4, rank=3)
+        )
 
         destination = torch.zeros(8, 4)
         copy_gtp_attributes(destination, source)

--- a/tests/unit_tests/tensor_parallel/test_layers.py
+++ b/tests/unit_tests/tensor_parallel/test_layers.py
@@ -4,11 +4,92 @@ import torch
 
 from megatron.core.extensions.transformer_engine import te_general_gemm
 from megatron.core.tensor_parallel.layers import (
+    gtp_local_pad_zero_count,
     linear_with_frozen_weight,
     linear_with_grad_accumulation_and_async_allreduce,
 )
 from megatron.core.tensor_parallel.mappings import gather_from_tensor_model_parallel_region
 from tests.unit_tests.test_utilities import Utils
+
+
+class _FakeGroup:
+    """Minimal mock for a dist process group — used in single-process unit tests."""
+
+    def __init__(self, size, rank):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+class TestGtpLocalPadZeroCount:
+    """gtp_local_pad_zero_count: how many elements of a [range_start, range_end) fragment of a
+    GTP shard's flattened buffer are structural alignment padding (see
+    generalized_tensor_parallelism._gtp_slice_one_param). Padding is a contiguous suffix of the
+    *unsharded* padded buffer, sliced evenly across the GTP group -- usually it lands entirely on
+    the last rank, but when pad_length exceeds one shard's own row count (small dim0 relative to
+    pad_for_alignment * gtp_remat_size) it spills backward from the tail into lower-numbered
+    ranks' shards too."""
+
+    @staticmethod
+    def _shard(dim0, dim1, pad_length, group):
+        shard = torch.zeros(dim0, dim1)
+        shard.pad_length = pad_length
+        shard.group = group
+        return shard
+
+    @pytest.mark.parametrize(
+        "pad_length,rank",
+        [
+            (0, 3),  # no padding at all (tail rank)
+            # pad_length is stamped identically on every rank's shard object
+            # (_gtp_slice_one_param), but when padding is smaller than one shard, only the
+            # tail shard physically contains it -- rank 0 here has none.
+            (3, 0),
+        ],
+        ids=["no_padding", "non_tail_rank_padding_fits_in_tail_shard"],
+    )
+    def test_returns_zero_when_this_rank_has_no_local_padding(self, pad_length, rank):
+        shard = self._shard(8, 4, pad_length, group=_FakeGroup(size=4, rank=rank))
+        assert gtp_local_pad_zero_count(shard, 0, shard.numel()) == 0
+
+    def test_padding_spills_into_earlier_ranks_when_larger_than_one_shard(self):
+        # dim0=1, pad_for_alignment=16, gtp_remat_size=4 -> alignment=64, pad_length=63,
+        # shard_dim0=16: padding (63 rows) exceeds one shard's own row count (16), so every rank
+        # except rank 0 is entirely padding, and rank 0 is 1 real row + 15 padding rows.
+        dim0, pad_length, trailing = 16, 63, 8
+        group_size = 4
+        totals = []
+        for rank in range(group_size):
+            shard = self._shard(dim0, trailing, pad_length, group=_FakeGroup(group_size, rank))
+            totals.append(gtp_local_pad_zero_count(shard, 0, shard.numel()))
+        assert totals == [15 * trailing, 16 * trailing, 16 * trailing, 16 * trailing]
+        assert sum(totals) == pad_length * trailing
+
+    # dim0=8, dim1=4, pad_length=3 -> shard.numel()=32, pad_start=32-3*4=20. DP-optimizer bucket
+    # slicing can hand count_zeros_fp32 any [range_start, range_end) fragment of this shard.
+    @pytest.mark.parametrize(
+        "range_start,range_end,expected",
+        [
+            (0, 32, 12),  # whole range: all 12 pad elements
+            (0, 20, 0),  # fragment strictly before the pad region
+            (18, 32, 12),  # fragment straddling the boundary: only the pad portion counts
+            (21, 31, 10),  # fragment entirely inside padding: every element counts
+        ],
+        ids=["whole_range", "strictly_before_pad", "straddles_pad_boundary", "entirely_inside_pad"],
+    )
+    def test_tail_rank_fragment_ranges(self, range_start, range_end, expected):
+        shard = self._shard(8, 4, pad_length=3, group=_FakeGroup(size=4, rank=3))
+        assert gtp_local_pad_zero_count(shard, range_start, range_end) == expected
+
+    def test_no_gtp_group_returns_zero(self):
+        shard = torch.zeros(8, 4)
+        shard.pad_length = 3
+        assert gtp_local_pad_zero_count(shard, 0, shard.numel()) == 0
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])

--- a/tests/unit_tests/tensor_parallel/test_layers.py
+++ b/tests/unit_tests/tensor_parallel/test_layers.py
@@ -4,6 +4,7 @@ import torch
 
 from megatron.core.extensions.transformer_engine import te_general_gemm
 from megatron.core.tensor_parallel.layers import (
+    copy_gtp_attributes,
     gtp_local_pad_zero_count,
     linear_with_frozen_weight,
     linear_with_grad_accumulation_and_async_allreduce,
@@ -90,6 +91,25 @@ class TestGtpLocalPadZeroCount:
         shard = torch.zeros(8, 4)
         shard.pad_length = 3
         assert gtp_local_pad_zero_count(shard, 0, shard.numel()) == 0
+
+
+class TestCopyGtpAttributes:
+    """copy_gtp_attributes(destination, source) must carry pad_length/group onto any param
+    view/copy (e.g. an optimizer's master param) -- regression coverage for a real bug where
+    a prior version dropped one of the two, which silently disabled GTP padding exclusion for
+    optimizers relying on this fallback (e.g. LayerWiseDistributedOptimizer/Muon)."""
+
+    def test_padding_exclusion_survives_the_copy(self):
+        """End-to-end: gtp_local_pad_zero_count on a copy must match the original -- this is
+        exactly the check that would have caught the pad_length/group-dropping bug directly."""
+        source = TestGtpLocalPadZeroCount._shard(8, 4, pad_length=3, group=_FakeGroup(size=4, rank=3))
+
+        destination = torch.zeros(8, 4)
+        copy_gtp_attributes(destination, source)
+
+        expected = gtp_local_pad_zero_count(source, 0, source.numel())
+        assert expected > 0, "test setup must exercise real padding"
+        assert gtp_local_pad_zero_count(destination, 0, destination.numel()) == expected
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
fix(num_zeros logging with GTP padding): exclude GTP alignment padding from `num_zeros` accounting, for both `DistributedOptimizer` (Adam) and `LayerWiseDistributedOptimizer` (Muon).

**Problem description**: GTP pads a weight's `dim0` so each rank's local shard satisfies MXFP8/NVFP4 tile alignment. Those padding rows are permanent structural zeros — never written by the wgrad GEMM — but `count_zeros_fp32` counted them as real zero gradients, inflating GTP's `num_zeros` relative to an equivalent non-GTP run. 

Here is a simple example for how GTP padding works:
```
dim0 = 48, gtp_remat_size = 2, pad_for_alignment = 16 -> pad_length = 16, shard_size = 32

rank 0 (32 rows):  [ real real real real ................       real ]        pad rows = 0
rank 1 (32 rows):  [ real ............ real | pad pad .......... pad ]        pad rows = 16
```
## What's changed
**1. Exclude GTP padding from `num_zeros` (Adam).** 
- `gtp_local_pad_zero_count` (`tensor_parallel/layers.py`) computes each fragment's padding count from its row offset in the unsharded buffer — correct even when a small `dim0` spills padding across multiple ranks. 
- `DistributedOptimizer` stamps the correction explicitly at shard-construction time; 
- Every other optimizer gets it via a cached fallback in `count_zeros_fp32` (`optimizer/clip_grads.py`, `optimizer/distrib_optimizer.py`) — no GTP-specific code needed in `layer_wise_optimizer.py`.

**2. Fix the fallback for Muon.** The fallback needs `pad_length`/`group` still on the param object. `LayerWiseDistributedOptimizer` clones every bf16 param via `Float16OptimizerWithFloat16Params`, using `copy_gtp_attributes` to carry attributes onto the clone — but that function wasn't copying `pad_length`/`group`, so the fallback silently returned 0 exclusion for every Muon-managed GTP param.

<img width="727" height="148" alt="image" src="https://github.com/user-attachments/assets/cb7d4f11-83c3-41fb-82f3-ece207c2ad8e" />

Fix — one line added to the copied-attribute list:

```python
for attr in (..., "pad_length", "group"):   # <- added
    if hasattr(source, attr):
        setattr(destination, attr, getattr(source, attr))
```
Added a regression test that fails against the old implementation.

3. **Don't pad bf16 to a quantization-tile alignment**. configure_gtp_remat_from_recipe only set pad_for_alignment for fp4/mxfp8/fp8; plain bf16 fell through to the default of 16, a tile margin it doesn't need. Now pads to gtp_remat_size — the AG/RS minimum. Independent improvement, kept alongside the real fix above.

4. **Update the GTP user guide accordingly**.

# Experiment results
**Model**: Hybrid model, L52E512, w/ Muon, worldSize=128, mb1gb128
**Parallel configs**:
- 3D baseline: TP2_EP64
- GTP: GTP64_EP64EGTP2

## GTP+Muon

<img width="1089" height="1026" alt="image" src="https://github.com/user-attachments/assets/660c92a0-8de3-42ac-8fb7-0337286a56e2" />


## GTP+Adam
<img width="1084" height="1024" alt="image" src="https://github.com/user-attachments/assets/9360a20f-68b9-44e7-8580-3b72df7e7b62" />


### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

