### PR TITLE
[Inference] Fix deadlock when initializing ZMQ communication between inference engine ranks.

### DIFF
--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -26,6 +26,13 @@ class AsyncZMQCommunicator:
     on the CPU.
     """
 
+    _READINESS_TOPIC_PREFIX = b"\x00megatron-ready:"
+
+    @classmethod
+    def _readiness_topic(cls, rank: int) -> bytes:
+        """Return the exact XPUB subscription topic identifying one group rank."""
+        return cls._READINESS_TOPIC_PREFIX + struct.pack("!I", rank)
+
     def __init__(
         self,
         zmq_context: zmq.Context,
@@ -51,13 +58,7 @@ class AsyncZMQCommunicator:
         self.world_size = dist.get_world_size(process_group)
         self.is_leader = self.rank == 0
         # Get the global rank of the leader (first rank in the process group).
-        # `process_group=None` is torch's idiom for the default world group;
-        # its leader is always global rank 0, and dist.get_process_group_ranks
-        # does not accept None.
-        if process_group is None:
-            src_rank = 0
-        else:
-            src_rank = dist.get_process_group_ranks(process_group)[0]
+        src_rank = dist.get_process_group_ranks(process_group)[0]
 
         if self.is_leader:
             local_ip = hostname or socket.gethostname()
@@ -65,10 +66,8 @@ class AsyncZMQCommunicator:
             self.gather_sock.bind_to_random_port(f"tcp://{local_ip}")
             gather_socket_addr = self.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
-            # XPUB exposes subscription notifications. Needed to ensure that all
-            # inference engine ranks have (asynchronously) subscribed to the ZMQ
-            # leader rank. Helps prevent deadlock when the leader rank begins
-            # publishing before all ranks have subscribed.
+            # XPUB exposes rank-specific subscription notifications so startup
+            # readiness can be tracked by peer identity rather than frame count.
             self.bcast_sock = zmq_context.socket(zmq.XPUB)
             self.bcast_sock.setsockopt(zmq.XPUB_VERBOSE, 1)
             self.bcast_sock.bind_to_random_port(f"tcp://{local_ip}")
@@ -87,25 +86,36 @@ class AsyncZMQCommunicator:
             self.gather_sock.connect(gather_socket_addr)
             self.bcast_sock = zmq_context.socket(zmq.SUB)
             self.bcast_sock.connect(bcast_socket_addr)
+            # Subscribe to the rank-specific readiness topic before the empty
+            # collective topic so XPUB receives an explicit identity command.
+            self.bcast_sock.setsockopt(zmq.SUBSCRIBE, self._readiness_topic(self.rank))
             self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
 
-        # Wait until all ProcessGroup peers have subscribed to the ZMQ leader.
-        # Otherwise, ranks that fail to subscribe in time will deadlock.
+        # Wait until every ProcessGroup peer has subscribed to the leader.
+        # Rank-specific topics make duplicate reconnect notifications idempotent.
         if self.is_leader:
-            # XPUB subscription messages are one byte for an empty-topic
-            # subscription: b"\x01". XPUB_VERBOSE is required so identical
-            # subs from every peer are reported rather than coalesced.
-            subscribed_peers = 0
+            expected_topics = {self._readiness_topic(rank) for rank in range(1, self.world_size)}
+            subscribed_topics = set()
             self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
             try:
-                while subscribed_peers < self.world_size - 1:
-                    subscription = self.bcast_sock.recv()
-                    if subscription == b"\x01":
-                        subscribed_peers += 1
+                while subscribed_topics != expected_topics:
+                    notification = self.bcast_sock.recv()
+                    event, topic = notification[:1], notification[1:]
+                    if topic not in expected_topics:
+                        continue
+                    if event == b"\x01":
+                        subscribed_topics.add(topic)
+                    elif event == b"\x00":
+                        subscribed_topics.discard(topic)
             except zmq.Again as exc:
+                missing_ranks = [
+                    rank
+                    for rank in range(1, self.world_size)
+                    if self._readiness_topic(rank) not in subscribed_topics
+                ]
                 raise RuntimeError(
-                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers: "
-                    f"{subscribed_peers}/{self.world_size - 1} connected"
+                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers; "
+                    f"missing process-group ranks: {missing_ranks}"
                 ) from exc
             finally:
                 self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -65,7 +65,12 @@ class AsyncZMQCommunicator:
             self.gather_sock.bind_to_random_port(f"tcp://{local_ip}")
             gather_socket_addr = self.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
-            self.bcast_sock = zmq_context.socket(zmq.PUB)
+            # XPUB exposes subscription notifications. Needed to ensure that all
+            # inference engine ranks have (asynchronously) subscribed to the ZMQ
+            # leader rank. Helps prevent deadlock when the leader rank begins
+            # publishing before all ranks have subscribed.
+            self.bcast_sock = zmq_context.socket(zmq.XPUB)
+            self.bcast_sock.setsockopt(zmq.XPUB_VERBOSE, 1)
             self.bcast_sock.bind_to_random_port(f"tcp://{local_ip}")
             bcast_socket_addr = self.bcast_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
@@ -83,6 +88,27 @@ class AsyncZMQCommunicator:
             self.bcast_sock = zmq_context.socket(zmq.SUB)
             self.bcast_sock.connect(bcast_socket_addr)
             self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        # Wait until all ProcessGroup peers have subscribed to the ZMQ leader.
+        # Otherwise, ranks that fail to subscribe in time will deadlock.
+        if self.is_leader:
+            # XPUB subscription messages are one byte for an empty-topic
+            # subscription: b"\x01". XPUB_VERBOSE is required so identical
+            # subs from every peer are reported rather than coalesced.
+            subscribed_peers = 0
+            self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
+            try:
+                while subscribed_peers < self.world_size - 1:
+                    subscription = self.bcast_sock.recv()
+                    if subscription == b"\x01":
+                        subscribed_peers += 1
+            except zmq.Again as exc:
+                raise RuntimeError(
+                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers: "
+                    f"{subscribed_peers}/{self.world_size - 1} connected"
+                ) from exc
+            finally:
+                self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)
 
     async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -3,6 +3,7 @@
 import asyncio
 import socket
 import struct
+from collections.abc import Iterable
 
 import torch.distributed as dist
 
@@ -17,6 +18,62 @@ except ImportError:
     HAVE_ZMQ = False
 
 
+class RankedPubSub:
+    """Create PUB/SUB sockets with rank-identified subscription readiness."""
+
+    def __init__(self, readiness_topic_prefix: bytes):
+        self.readiness_topic_prefix = readiness_topic_prefix
+
+    def _readiness_topic(self, rank: int) -> bytes:
+        return self.readiness_topic_prefix + struct.pack("!I", rank)
+
+    @staticmethod
+    def create_publisher(zmq_context: zmq.Context) -> zmq.Socket:
+        """Create an XPUB socket that exposes every subscription notification."""
+        publisher_socket = zmq_context.socket(zmq.XPUB)
+        publisher_socket.setsockopt(zmq.XPUB_VERBOSE, 1)
+        return publisher_socket
+
+    def create_subscriber(self, zmq_context: zmq.Context, address: str, rank: int) -> zmq.Socket:
+        """Create a connected SUB socket with a rank-specific readiness topic."""
+        subscriber_socket = zmq_context.socket(zmq.SUB)
+        subscriber_socket.connect(address)
+        # Subscribe to readiness before the empty collective topic so XPUB
+        # receives an explicit identity command for this rank.
+        subscriber_socket.setsockopt(zmq.SUBSCRIBE, self._readiness_topic(rank))
+        subscriber_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+        return subscriber_socket
+
+    def wait_for_subscribers(
+        self, publisher_socket: zmq.Socket, ranks: Iterable[int], *, timeout_ms: int = 60_000
+    ) -> None:
+        """Wait until the XPUB socket reports every distinct rank as subscribed."""
+        topics_by_rank = {rank: self._readiness_topic(rank) for rank in ranks}
+        expected_topics = set(topics_by_rank.values())
+        subscribed_topics = set()
+        publisher_socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
+        try:
+            while subscribed_topics != expected_topics:
+                notification = publisher_socket.recv()
+                event, topic = notification[:1], notification[1:]
+                if topic not in expected_topics:
+                    continue
+                if event == b"\x01":
+                    subscribed_topics.add(topic)
+                elif event == b"\x00":
+                    subscribed_topics.discard(topic)
+        except zmq.Again as exc:
+            missing_ranks = [
+                rank for rank, topic in topics_by_rank.items() if topic not in subscribed_topics
+            ]
+            raise RuntimeError(
+                f"Timed out waiting for ZMQ subscribers for prefix "
+                f"{self.readiness_topic_prefix!r}; missing ranks: {missing_ranks}"
+            ) from exc
+        finally:
+            publisher_socket.setsockopt(zmq.RCVTIMEO, -1)
+
+
 class AsyncZMQCommunicator:
     """
     An asyncio-friendly communicator abstraction using ZMQ.
@@ -25,13 +82,6 @@ class AsyncZMQCommunicator:
     Only to be used with small amounts of data (e.g., 1 integer)
     on the CPU.
     """
-
-    _READINESS_TOPIC_PREFIX = b"\x00megatron-ready:"
-
-    @classmethod
-    def _readiness_topic(cls, rank: int) -> bytes:
-        """Return the exact XPUB subscription topic identifying one group rank."""
-        return cls._READINESS_TOPIC_PREFIX + struct.pack("!I", rank)
 
     def __init__(
         self,
@@ -57,6 +107,7 @@ class AsyncZMQCommunicator:
         self.rank = dist.get_rank(process_group)
         self.world_size = dist.get_world_size(process_group)
         self.is_leader = self.rank == 0
+        broadcast_pub_sub = RankedPubSub(b"AsyncZMQCommunicator.broadcast:")
         # Get the global rank of the leader (first rank in the process group).
         src_rank = dist.get_process_group_ranks(process_group)[0]
 
@@ -66,10 +117,7 @@ class AsyncZMQCommunicator:
             self.gather_sock.bind_to_random_port(f"tcp://{local_ip}")
             gather_socket_addr = self.gather_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
-            # XPUB exposes rank-specific subscription notifications so startup
-            # readiness can be tracked by peer identity rather than frame count.
-            self.bcast_sock = zmq_context.socket(zmq.XPUB)
-            self.bcast_sock.setsockopt(zmq.XPUB_VERBOSE, 1)
+            self.bcast_sock = broadcast_pub_sub.create_publisher(zmq_context)
             self.bcast_sock.bind_to_random_port(f"tcp://{local_ip}")
             bcast_socket_addr = self.bcast_sock.getsockopt_string(zmq.LAST_ENDPOINT)
 
@@ -84,41 +132,14 @@ class AsyncZMQCommunicator:
             gather_socket_addr, bcast_socket_addr = bcast_output
             self.gather_sock = zmq_context.socket(zmq.PUSH)
             self.gather_sock.connect(gather_socket_addr)
-            self.bcast_sock = zmq_context.socket(zmq.SUB)
-            self.bcast_sock.connect(bcast_socket_addr)
-            # Subscribe to the rank-specific readiness topic before the empty
-            # collective topic so XPUB receives an explicit identity command.
-            self.bcast_sock.setsockopt(zmq.SUBSCRIBE, self._readiness_topic(self.rank))
-            self.bcast_sock.setsockopt_string(zmq.SUBSCRIBE, "")
+            self.bcast_sock = broadcast_pub_sub.create_subscriber(
+                zmq_context, bcast_socket_addr, self.rank
+            )
 
         # Wait until every ProcessGroup peer has subscribed to the leader.
         # Rank-specific topics make duplicate reconnect notifications idempotent.
         if self.is_leader:
-            expected_topics = {self._readiness_topic(rank) for rank in range(1, self.world_size)}
-            subscribed_topics = set()
-            self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
-            try:
-                while subscribed_topics != expected_topics:
-                    notification = self.bcast_sock.recv()
-                    event, topic = notification[:1], notification[1:]
-                    if topic not in expected_topics:
-                        continue
-                    if event == b"\x01":
-                        subscribed_topics.add(topic)
-                    elif event == b"\x00":
-                        subscribed_topics.discard(topic)
-            except zmq.Again as exc:
-                missing_ranks = [
-                    rank
-                    for rank in range(1, self.world_size)
-                    if self._readiness_topic(rank) not in subscribed_topics
-                ]
-                raise RuntimeError(
-                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers; "
-                    f"missing process-group ranks: {missing_ranks}"
-                ) from exc
-            finally:
-                self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)
+            broadcast_pub_sub.wait_for_subscribers(self.bcast_sock, range(1, self.world_size))
 
     async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -71,7 +71,7 @@ from megatron.core.utils import (
     unwrap_model,
 )
 
-from .async_zmq_communicator import AsyncZMQCommunicator
+from .async_zmq_communicator import AsyncZMQCommunicator, RankedPubSub
 
 try:
     from tqdm import tqdm
@@ -747,6 +747,11 @@ class DynamicInferenceEngine(AbstractEngine):
 
         mp_group = self.pg_collection.mp
         mp_src = get_pg_src_rank(mp_group)
+        mp_size = get_pg_size(mp_group)
+        mp_rank = get_pg_rank(mp_group)
+        dp_replica_mp_request_broadcast = RankedPubSub(
+            b"DynamicInferenceEngine.mp_request_broadcast:"
+        )
         tp_rank = get_pg_rank(self.pg_collection.tp)
         pp_rank = get_pg_rank(self.pg_collection.pp)
 
@@ -799,10 +804,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Find available ports for MP and bind to them.
         if self.is_mp_coordinator:
-            mp_req_sock = self.zmq_context.socket(zmq.PUB)
+            mp_req_sock = dp_replica_mp_request_broadcast.create_publisher(self.zmq_context)
             mp_req_sock.bind_to_random_port(f"tcp://{local_ip}")
             mp_req_addr = mp_req_sock.getsockopt_string(zmq.LAST_ENDPOINT)
-
         else:
             mp_req_addr = None
 
@@ -834,11 +838,16 @@ class DynamicInferenceEngine(AbstractEngine):
                 self.model_parallel_publisher_socket,
             ]
         # All MP ranks subscribe to the publisher socket
-        self.model_parallel_subscriber_socket = self.zmq_context.socket(zmq.SUB)
-        self.model_parallel_subscriber_socket.connect(mp_req_addr)
-        self.model_parallel_subscriber_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+        self.model_parallel_subscriber_socket = dp_replica_mp_request_broadcast.create_subscriber(
+            self.zmq_context, mp_req_addr, mp_rank
+        )
 
         self.zmq_sockets += [self.model_parallel_subscriber_socket]
+
+        if self.is_mp_coordinator:
+            dp_replica_mp_request_broadcast.wait_for_subscribers(
+                self.model_parallel_publisher_socket, range(mp_size)
+            )
 
         self._setup_handoff_completion_tracking(hostname)
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- While testing Megatron Inference with CG (in NeMo-RL async non-colocated GRPO with video), I encountered an odd hang from a race condition during ZMQ communicator initialization that only appears when running my video script with CG on 8N.
  - After some `RAY_DEDUP` debug logging with Sol, one of the generation ranks was unable to subscribe to the ZMQ leader on Rank 0 before a ZMQ broadcast was queued, so the leader doesn't publish to it and the lagged rank waits for no response forever, blocking the rest of the model FWD.
  - I think the first `PUB` is in `_ep_establish_consensus`. So this is where the rank that missed the train blocks. Then the rest of the program blocks on some other collective that requires all ranks.
- To fix this, we add a topic to `SUB` such that `XPUB` that reports a subscription notification and byte-string to the publisher for each subscriber that connects. Then, the publisher can check to make sure that all subscribers have connected before publishing any messages and avoid orphaning subscribers that do not connect in time.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
