### PR TITLE
ci: grant cache workflow permissions

### DIFF
--- a/.github/workflows/populate-build-cache.yml
+++ b/.github/workflows/populate-build-cache.yml
@@ -56,6 +56,10 @@ jobs:
     name: Populate build caches
     needs: validate-source
     if: github.repository == 'NVIDIA/Megatron-LM'
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
     uses: ./.github/workflows/_build_ci_container.yml
     with:
       is-maintainer: true


### PR DESCRIPTION
## Summary

- grant the cache population caller the permissions requested by the reusable container-build workflow
- restore push, scheduled, and manual cache population runs after #6774

## Root cause

The reusable `build-container` job requests `contents: read`, `id-token: write`, and `pull-requests: read`. The `cicd-main.yml` caller grants all three, but `populate-build-cache.yml` did not grant `pull-requests: read`, so GitHub rejected the workflow at startup before any jobs ran.

## Validation

- `git diff --check`
- parsed `.github/workflows/populate-build-cache.yml` with Ruby YAML
- verified the caller permission set matches the reusable `build-container` job

Related startup failures:
- https://github.com/NVIDIA/Megatron-LM/actions/runs/32574416537
- https://github.com/NVIDIA/Megatron-LM/actions/runs/32622234936