### PR TITLE
Support EP-sharded DTensor expert weights in Megatron-FSDP v2

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -239,6 +239,16 @@ class DBuffer:
             A DBuffer whose real local storage matches ``placements``. Ranges
             corresponding to meta tensors are left uninitialized.
         """
+        # A DBuffer holds plain data-parallel-local storage: its mesh is the DP submesh and
+        # its layout is expressed in local elements. A parameter already sharded on another
+        # mesh axis (expert parallelism) arrives as a DTensor, whose .shape is the *global*
+        # extent and which cannot be the source of a plain copy_. Reduce it to its local
+        # shard so the layout math and the copy below both operate on ordinary tensors.
+        # Preserving the DTensor's mesh and placements is the caller's job --
+        # FsdpParameterGroup.get_dtensor lifts the result back onto the parent mesh.
+        tensors = tuple(
+            tensor.to_local() if isinstance(tensor, DTensor) else tensor for tensor in tensors
+        )
         tensors = tuple(tensor.detach().contiguous() for tensor in tensors)
         if not tensors:
             raise ValueError("DBuffer.distribute_tensors() requires at least one tensor.")

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -144,7 +144,8 @@ def fully_shard(
                 "fully_shard_context."
             )
 
-    _validate_dp_axes(mesh, placements.dp_axes)
+    dp_axes = _normalize_dp_axes(mesh, placements.dp_axes)
+    dp_mesh = _select_dp_mesh(mesh, dp_axes)
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
     original_cls = module.__class__
     _attach_mixin(module)
@@ -153,7 +154,9 @@ def fully_shard(
         FsdpModule.__init__(
             module,
             context=context,
-            mesh=mesh,
+            mesh=dp_mesh,
+            parent_mesh=mesh,
+            dp_axes=dp_axes,
             model_weight_placements=tuple(placements.parameter),
             main_grad_placements=tuple(placements.gradient),
             main_weight_placements=tuple(placements.optimizer),
@@ -166,17 +169,35 @@ def fully_shard(
         raise
 
 
-def _validate_dp_axes(mesh: DeviceMesh, dp_axes: Sequence[MeshAxis]) -> None:
-    """Validate the parent mesh's data-parallel axes."""
+def _normalize_dp_axes(mesh: DeviceMesh, dp_axes: Sequence[MeshAxis]) -> tuple[int, ...]:
+    """Resolve ``dp_axes`` to distinct parent-mesh axis indices in mesh-axis order."""
     normalized_dp_axes = tuple(_axis_index(mesh, axis) for axis in dp_axes)
+    if not normalized_dp_axes:
+        raise ValueError("MFSDP requires at least one data-parallel mesh axis.")
     if len(set(normalized_dp_axes)) != len(normalized_dp_axes):
         raise ValueError(f"Data-parallel axes must be distinct, got {dp_axes!r}.")
     if normalized_dp_axes != tuple(sorted(normalized_dp_axes)):
         raise ValueError(f"Data-parallel axes must be in mesh-axis order, got {dp_axes!r}.")
-    if normalized_dp_axes != tuple(range(mesh.ndim)):
-        raise NotImplementedError(
-            "MFSDP currently requires dp_axes to match every mesh axis in mesh order."
+    return normalized_dp_axes
+
+
+def _select_dp_mesh(mesh: DeviceMesh, dp_axes: Sequence[int]) -> DeviceMesh:
+    """Select the data-parallel submesh MFSDP shards over.
+
+    Axes not named by ``dp_axes`` belong to other parallelisms; MFSDP does not shard
+    over them, and what they mean is the caller's concern rather than this function's.
+    """
+    if tuple(dp_axes) == tuple(range(mesh.ndim)):
+        return mesh
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None:
+        raise ValueError(
+            "A mesh with non-data-parallel axes must have dim names so the "
+            "data-parallel submesh can be selected by name."
         )
+    dp_names = tuple(dim_names[axis] for axis in dp_axes)
+    return mesh[dp_names[0]] if len(dp_names) == 1 else mesh[dp_names]
 
 
 def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -15,6 +15,7 @@
 """Module mixin for the minimal Megatron-FSDP path."""
 
 import enum
+from collections.abc import Sequence
 from typing import Literal, cast
 from weakref import ref
 
@@ -178,8 +179,16 @@ class FsdpModule:
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
+        parent_mesh: DeviceMesh | None = None,
+        dp_axes: Sequence[int] | None = None,
     ) -> None:
-        """Initialize FSDP runtime state on an already-constructed module."""
+        """Initialize FSDP runtime state on an already-constructed module.
+
+        ``mesh`` is the data-parallel submesh MFSDP shards over. ``parent_mesh`` is the
+        mesh the caller passed to ``fully_shard`` and ``dp_axes`` names which of its axes
+        ``mesh`` was selected from, so the sharded DTensors can be expressed on the parent
+        mesh and any sharding a parameter already carried on the other axes survives.
+        """
         self._context = context
         self._is_root = False
         self._name = None
@@ -196,6 +205,8 @@ class FsdpModule:
                     owning_module=self,
                     parameters=group_parameters,
                     mesh=mesh,
+                    parent_mesh=parent_mesh if parent_mesh is not None else mesh,
+                    dp_axes=dp_axes,
                     model_weight_placements=_specialize_placements(
                         model_weight_placements, group_dtype
                     ),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,7 +14,7 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from weakref import ReferenceType, ref
@@ -23,7 +23,7 @@ import torch
 import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
@@ -57,6 +57,18 @@ def sync_model_weights_from_main_weights(parameters: Iterable[nn.Parameter]) -> 
             continue
         seen_parameter_groups.add(parameter_group)
         parameter_group.sync_model_weight_from_main_weight()
+
+
+@dataclass(frozen=True)
+class _ExpertSpec:
+    """The expert-parallel sharding an input parameter already carried.
+
+    Captured before ``DBuffer`` reduces the parameter to its local shard, so the sharded
+    parameter MFSDP installs can be re-expressed on the parent mesh.
+    """
+
+    global_shape: torch.Size
+    placement: Shard
 
 
 @dataclass(frozen=True, eq=False)
@@ -100,6 +112,8 @@ class FsdpParameterGroup:
         reduce_scatter_stream: torch.cuda.Stream,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
+        parent_mesh: DeviceMesh | None = None,
+        dp_axes: Sequence[int] | None = None,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -117,6 +131,9 @@ class FsdpParameterGroup:
                 NCCL symmetric-memory pool.
             grad_divisor: Additional divisor applied on top of the mesh-size
                 averaging. See ``fully_shard``.
+            parent_mesh: Mesh the caller passed to ``fully_shard``. Defaults to ``mesh``.
+            dp_axes: Indices of ``parent_mesh``'s data-parallel axes, in mesh-axis order.
+                Defaults to every axis of ``mesh``.
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
@@ -127,6 +144,22 @@ class FsdpParameterGroup:
         for fqn, parameter in parameters.items():
             parameter_to_fqns.setdefault(parameter, []).append(fqn)
 
+        # The group owns the parent mesh because it builds the optimizer- and
+        # checkpoint-facing DTensors; the DBuffers below own only the data-parallel submesh.
+        self.parent_mesh = parent_mesh if parent_mesh is not None else mesh
+        self._dp_axes = tuple(dp_axes) if dp_axes is not None else tuple(range(mesh.ndim))
+        # Axes of the parent mesh that MFSDP does not shard over. A parameter may already
+        # be sharded on one of them; today only expert parallelism is supported, and
+        # _expert_spec is where that restriction lives.
+        self._non_dp_axes = tuple(
+            axis for axis in range(self.parent_mesh.ndim) if axis not in set(self._dp_axes)
+        )
+        # Captured before DBuffer reduces each parameter to its local shard. None for
+        # parameters that are not expert-parallel DTensors, which keep the existing path;
+        # dense and expert parameters can share a (dtype, requires_grad) group.
+        self._expert_specs: tuple[_ExpertSpec | None, ...] = tuple(
+            self._expert_spec(fqns, parameter) for parameter, fqns in parameter_to_fqns.items()
+        )
         self._model_weight_placements = model_weight_placements
         # main_grad rests here (DP-outer-Partial for HSDP) between microbatches and
         # is finalized to main_weight's placements after the last microbatch.
@@ -152,7 +185,12 @@ class FsdpParameterGroup:
                     f"got {parameter.requires_grad}."
                 )
 
-        tensor_shapes = tuple(parameter.shape for parameter in parameter_to_fqns)
+        # Local shapes: an expert-parallel DTensor's .shape is the global extent, while the
+        # DBuffer layout is expressed in this rank's local elements.
+        tensor_shapes = tuple(
+            (parameter.to_local() if isinstance(parameter.data, DTensor) else parameter).shape
+            for parameter in parameter_to_fqns
+        )
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
             (parameter.to(dtype=main_weight_dtype) for parameter in parameter_to_fqns),
@@ -216,7 +254,16 @@ class FsdpParameterGroup:
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
             unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
-            if parameter.is_meta:
+            if isinstance(parameter.data, DTensor):
+                # An expert-parallel DTensor Parameter can neither take a plain .data --
+                # the wrapper survives and autograd then demands gradients shaped like the
+                # *global* tensor instead of this rank's shard -- nor be swapped with a
+                # plain Parameter, because DTensor carries extra slots. Replace it with a
+                # plain Parameter over the same storage; the module entry is rewritten by
+                # _switch_to_sharded_parameters() either way, and the expert sharding was
+                # already captured in self._expert_specs.
+                parameter = nn.Parameter(unsharded_tensor, requires_grad=parameter.requires_grad)
+            elif parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
                 # This may be problematic if attributes from the original Parameter need
@@ -232,7 +279,7 @@ class FsdpParameterGroup:
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
-                self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
+                self.get_dtensor(self.main_weight, index), requires_grad=parameter.requires_grad
             )
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
@@ -244,6 +291,96 @@ class FsdpParameterGroup:
 
         self._unsharded_model_weight.release_storage()
         self._switch_to_sharded_parameters()
+
+    def _expert_spec(self, fqns: list[str], parameter: nn.Parameter) -> "_ExpertSpec | None":
+        """Validate and capture a parameter's pre-existing expert-parallel sharding.
+
+        Returns None for ordinary parameters, which keep the data-parallel-only path.
+        Rejects unsupported inputs before any buffer is allocated.
+        """
+        data = parameter.data
+        if not isinstance(data, DTensor):
+            return None
+        if not self._non_dp_axes:
+            raise ValueError(
+                f"Parameter {fqns!r} is an expert-parallel DTensor, but the mesh passed to "
+                "fully_shard has no non-data-parallel axis to place it on. Pass an (ep, dp) "
+                "mesh and name the data-parallel axis via Placements.dp_axes."
+            )
+        if len(self._non_dp_axes) != 1:
+            raise NotImplementedError(
+                f"MFSDP supports at most one non-data-parallel mesh axis alongside an "
+                f"expert-parallel parameter, got {len(self._non_dp_axes)}: axes "
+                f"{list(self._non_dp_axes)} of mesh dim names {self.parent_mesh.mesh_dim_names}."
+            )
+        (expert_axis,) = self._non_dp_axes
+        if expert_axis > min(self._dp_axes):
+            # DTensor applies placements outer-to-inner in mesh-axis order, so the expert
+            # axis must precede the data-parallel axes to describe the physical nesting:
+            # expert parallelism partitions the experts, and MFSDP shards the local ones
+            # underneath. A (dp, ep) mesh would need a strided placement to describe the
+            # same bytes, so reject it rather than emit placements that tile perfectly
+            # over the wrong rows.
+            raise NotImplementedError(
+                "The non-data-parallel mesh axis must precede the data-parallel axes, i.e. "
+                f"an (ep, dp) mesh. Got dim names {self.parent_mesh.mesh_dim_names} with "
+                f"data-parallel axes {list(self._dp_axes)}."
+            )
+        if data.device_mesh.ndim != 1:
+            raise NotImplementedError(
+                f"Only a 1-D expert-parallel mesh is supported, but parameter {fqns!r} has a "
+                f"{data.device_mesh.ndim}-D mesh {data.device_mesh.mesh_dim_names}."
+            )
+        (placement,) = data.placements
+        if not isinstance(placement, Shard) or placement.dim != 0:
+            raise NotImplementedError(
+                f"Only Shard(0) expert-parallel placement is supported, but parameter "
+                f"{fqns!r} has placement {placement!r}."
+            )
+        expert_mesh_size = self.parent_mesh.size(expert_axis)
+        if data.device_mesh.size() != expert_mesh_size:
+            raise ValueError(
+                f"Parameter {fqns!r} is sharded over an expert-parallel mesh of size "
+                f"{data.device_mesh.size()}, but axis {expert_axis} of the mesh passed "
+                f"to fully_shard has size {expert_mesh_size}."
+            )
+        return _ExpertSpec(global_shape=torch.Size(data.shape), placement=placement)
+
+    def get_dtensor(self, buffer: DBuffer, index: int) -> DTensor:
+        """Lift a DBuffer's data-parallel DTensor onto this group's parent mesh.
+
+        ``buffer.get_dtensor`` returns a DTensor on the data-parallel submesh. When the
+        parameter arrived already expert-parallel sharded, this re-wraps it on
+        ``self.parent_mesh``, putting the captured expert placement on the expert axis and
+        restoring the global dim-0 extent, so the global expert index survives into the
+        optimizer and checkpoints. Everything else is returned unchanged.
+
+        Mesh-axis order is the nesting order -- expert parallelism partitions the experts
+        and MFSDP shards the local ones underneath -- so both axes carry a plain
+        ``Shard(0)`` and no strided placement is needed. ``fully_shard`` rejects the
+        reverse (dp, ep) order for exactly that reason.
+        """
+        dp_dtensor = buffer.get_dtensor(index)
+        expert_spec = self._expert_specs[index]
+        if expert_spec is None:
+            return dp_dtensor
+
+        parent_mesh = self.parent_mesh
+        # Data-parallel placements go back on the parent axes they were selected from;
+        # the remaining axis carries the sharding the parameter already had.
+        placements: list[Placement] = [expert_spec.placement] * parent_mesh.ndim
+        for dp_index, parent_axis in enumerate(self._dp_axes):
+            placements[parent_axis] = dp_dtensor.placements[dp_index]
+
+        local_tensor = dp_dtensor.to_local()
+        return DTensor.from_local(
+            local_tensor=local_tensor,
+            device_mesh=parent_mesh,
+            placements=tuple(placements),
+            run_check=False,
+            shape=expert_spec.global_shape,
+            stride=local_tensor.stride(),
+        )
 
     def _symmetric_memory_context(self):
         if self._symm_mem_pool is None:
@@ -443,7 +580,7 @@ class FsdpParameterGroup:
 
         # Make each sharded parameter's .grad consistent with the final main_grad.
         for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            fsdp_parameter.sharded.grad = self.main_grad.get_dtensor(index)
+            fsdp_parameter.sharded.grad = self.get_dtensor(self.main_grad, index)
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel_dtensor.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel_dtensor.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Megatron-FSDP v2 composed with an already-EP-sharded grouped expert weight.
+
+Covers the representation NeMo AutoModel's EP parallelizer produces: a single contiguous
+3D expert weight ``[E, h_in, h_out]`` replaced by
+``nn.Parameter(distribute_tensor(param, ep_mesh, [Shard(0)]))``. mFSDP receives the full
+``(ep, dp)`` mesh, shards only the parameter's EP-local shard, and re-expresses the result
+on the full mesh so the global expert index survives into the optimizer and checkpoints.
+
+See https://github.com/NVIDIA/Megatron-LM/issues/6600.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed.checkpoint import FileSystemReader
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard, distribute_tensor
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Placements,
+    fully_shard,
+    fully_shard_context,
+    fully_shard_optimizer,
+    load_checkpoint,
+    save_checkpoint,
+)
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+
+_EP_SIZE = 2
+_NUM_EXPERTS = 4
+_H_IN = 8
+_H_OUT = 4
+
+# dp_axes names the FSDP axis inside the full (ep, dp) mesh; the leftover axis is EP.
+_FLAT_DP = Placements(
+    dp_axes=["dp"], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)]
+)
+
+
+class GroupedExperts(nn.Module):
+    """One contiguous 3D expert weight, consumed through ``to_local()`` like grouped GEMMs."""
+
+    def __init__(self, generator: torch.Generator, device: torch.device) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.randn(
+                _NUM_EXPERTS, _H_IN, _H_OUT, generator=generator, device=device, dtype=torch.float32
+            )
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply this rank's local experts to its local slice of the batch."""
+        weight = self.weight
+        local_weight = weight.to_local() if isinstance(weight, DTensor) else weight
+        return torch.bmm(x, local_weight)
+
+
+def _skip_unless_composable(world_size: int) -> int:
+    if world_size < _EP_SIZE * 2 or world_size % _EP_SIZE != 0:
+        pytest.skip(f"This test requires a multiple of {_EP_SIZE * 2} ranks.")
+    return world_size // _EP_SIZE
+
+
+def _build_ep_sharded_model(device: torch.device, mesh) -> GroupedExperts:
+    # Identical seed on every rank so the pre-EP global weight is identical, matching a
+    # real load-then-shard flow.
+    generator = torch.Generator(device=device).manual_seed(1234)
+    model = GroupedExperts(generator, device)
+    sharded = distribute_tensor(model.weight.data, mesh["ep"], [Shard(0)])
+    dist_param = nn.Parameter(sharded)
+    dist_param.requires_grad = model.weight.requires_grad
+    model.weight = dist_param
+    return model
+
+
+def test_ep_sharded_dtensor_expert_weight_shards_and_keeps_global_spec(distributed_setup):
+    """fully_shard accepts an EP-sharded DTensor and keeps the global expert extent."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    dp_size = _skip_unless_composable(world_size)
+
+    mesh = init_device_mesh("cuda", (_EP_SIZE, dp_size), mesh_dim_names=("ep", "dp"))
+    model = _build_ep_sharded_model(device, mesh)
+    assert isinstance(model.weight.data, DTensor)
+    assert tuple(model.weight.to_local().shape) == (_NUM_EXPERTS // _EP_SIZE, _H_IN, _H_OUT)
+
+    with fully_shard_context(device=device, use_symmetric_memory=False):
+        fully_shard(model, mesh=mesh, placements=_FLAT_DP)
+
+    sharded = model.weight
+    assert isinstance(sharded.data, DTensor), "Expected the sharded parameter to be a DTensor."
+    # The global expert extent must survive, or a checkpoint records only local experts.
+    assert tuple(sharded.shape) == (
+        _NUM_EXPERTS,
+        _H_IN,
+        _H_OUT,
+    ), f"Expected the global expert shape, got {tuple(sharded.shape)}."
+    assert sharded.device_mesh.mesh_dim_names == (
+        "ep",
+        "dp",
+    ), f"Expected the full (ep, dp) mesh, got {sharded.device_mesh.mesh_dim_names}."
+    # EP shards the expert axis; FSDP shards the EP-local experts underneath it. Mesh-axis
+    # order is the nesting order, so both are plain Shard(0) and neither is strided.
+    ep_placement, dp_placement = sharded.placements
+    assert isinstance(ep_placement, Shard) and ep_placement.dim == 0, ep_placement
+    assert isinstance(dp_placement, Shard) and dp_placement.dim == 0, dp_placement
+
+
+def test_ep_sharded_dtensor_expert_weight_trains(distributed_setup):
+    """A step through the sharded model updates the expert weights."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    dp_size = _skip_unless_composable(world_size)
+
+    mesh = init_device_mesh("cuda", (_EP_SIZE, dp_size), mesh_dim_names=("ep", "dp"))
+    model = _build_ep_sharded_model(device, mesh)
+    with fully_shard_context(device=device, use_symmetric_memory=False):
+        fully_shard(model, mesh=mesh, placements=_FLAT_DP)
+
+    before = model.weight.to_local().detach().clone()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1, foreach=False)
+
+    local_experts = _NUM_EXPERTS // _EP_SIZE
+    x = torch.randn(local_experts, 3, _H_IN, device=device, dtype=torch.float32)
+    optimizer.zero_grad()
+    model(x).sum().backward()
+    optimizer.step()
+
+    after = model.weight.to_local().detach()
+    if before.numel() > 0:
+        # This is what catches a silently-unwired buffer: losses can look fine while the
+        # optimizer updates storage the forward pass never reads.
+        assert not torch.equal(before, after), "Expert weights did not change after a step."
+
+
+def test_ep_sharded_dtensor_requires_an_expert_mesh_axis(distributed_setup):
+    """An EP-sharded parameter with no non-DP axis to place it on is rejected clearly."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    _skip_unless_composable(world_size)
+
+    mesh = init_device_mesh("cuda", (_EP_SIZE, world_size // _EP_SIZE), mesh_dim_names=("ep", "dp"))
+    model = _build_ep_sharded_model(device, mesh)
+
+    # A DP-only mesh has no axis left for the parameter's existing EP sharding.
+    dp_only = mesh["dp"]
+    flat_all_axes = Placements(
+        dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)]
+    )
+    with pytest.raises(ValueError, match="no non-data-parallel axis"):
+        with fully_shard_context(device=device, use_symmetric_memory=False):
+            fully_shard(model, mesh=dp_only, placements=flat_all_axes)
+
+
+def test_dp_before_ep_mesh_order_is_rejected(distributed_setup):
+    """A (dp, ep) mesh cannot be described without a strided placement, so reject it."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    dp_size = _skip_unless_composable(world_size)
+
+    # Axis order reversed: FSDP axis first. Plain Shard(0) on both axes would describe a
+    # different physical layout than EP-outer/FSDP-inner and would corrupt checkpoints.
+    mesh = init_device_mesh("cuda", (dp_size, _EP_SIZE), mesh_dim_names=("dp", "ep"))
+    model = _build_ep_sharded_model(device, mesh)
+    with pytest.raises(NotImplementedError, match="must precede the data-parallel axes"):
+        with fully_shard_context(device=device, use_symmetric_memory=False):
+            fully_shard(model, mesh=mesh, placements=_FLAT_DP)
+
+
+def test_ep_sharded_dtensor_checkpoint_records_global_expert_shape(
+    distributed_setup, tmp_path_dist_ckpt: Path
+):
+    """A DCP checkpoint must describe the assembled [E, ...] tensor, not local experts.
+
+    This is the assertion that catches a lost expert axis. Training and loss comparisons do
+    not: an FSDP-only spec is perfectly self-consistent within one topology and only shows up
+    as corruption when a reader reshards with a different EP degree.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    dp_size = _skip_unless_composable(world_size)
+
+    mesh = init_device_mesh("cuda", (_EP_SIZE, dp_size), mesh_dim_names=("ep", "dp"))
+    model = _build_ep_sharded_model(device, mesh)
+    with fully_shard_context(device=device, use_symmetric_memory=False):
+        fully_shard(model, mesh=mesh, placements=_FLAT_DP)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.02)
+    fully_shard_optimizer(optimizer)
+
+    # Train one step so the saved state is non-trivial.
+    local_experts = _NUM_EXPERTS // _EP_SIZE
+    x = torch.randn(local_experts, 3, _H_IN, device=device, dtype=torch.float32)
+    optimizer.zero_grad()
+    model(x).sum().backward()
+    optimizer.step()
+
+    saved = model.state_dict()["weight"]
+    assert tuple(saved.shape) == (_NUM_EXPERTS, _H_IN, _H_OUT)
+
+    with TempNamedDir(tmp_path_dist_ckpt / "ckpt_ep_dtensor", sync=True) as checkpoint_dir:
+        save_checkpoint(model, optimizer, checkpoint_dir)
+        dist.barrier(device_ids=[device.index])
+
+        metadata = FileSystemReader(checkpoint_dir).read_metadata()
+        entry = metadata.state_dict_metadata["model.weight"]
+        assert tuple(entry.size) == (_NUM_EXPERTS, _H_IN, _H_OUT), (
+            f"Checkpoint recorded {tuple(entry.size)} for the grouped expert weight; expected the "
+            f"global shape ({_NUM_EXPERTS}, {_H_IN}, {_H_OUT}). A local-experts shape means the "
+            "global expert index was lost and the checkpoint cannot be resharded."
+        )
+
+        # A correct load must overwrite an obviously-different destination.
+        before = model.weight.to_local().detach().clone()
+        with torch.no_grad():
+            model.weight.to_local().zero_()
+        load_checkpoint(model, optimizer, checkpoint_dir)
+        restored = model.weight.to_local().detach()
+        if before.numel() > 0:
+            torch.testing.assert_close(restored, before)


### PR DESCRIPTION
Closes #6600.

## What

MFSDP v2 cannot accept a grouped expert weight that is already sharded over an expert-parallel mesh — the representation NeMo AutoModel's EP parallelizer produces for models such as Qwen3.5-35B-A3B:

```python
# Automodel components/moe/parallelizer.py
dist_param = nn.Parameter(distribute_tensor(param, device_mesh, [Shard(0)]))
```

Construction fails on **every** rank in `DBuffer.distribute_tensors()`:

```
RuntimeError: aten.copy_.default got mixed torch.Tensor and DTensor,
need to convert all torch.Tensor to DTensor before calling distributed operators!
```

Measured on 8×H100 before the fix, `succeeded_ranks=0/N` in all three configurations:

| config | ranks | local shape |
|---|---|---|
| EP=2, FSDP=2 | 2 | `(2,3,2)` |
| EP=4 × DP=2 | 8 | `(1,3,2)` |
| EP=2 × DP=4 | 8 | `(2,3,2)` |

## The bug

Three defects, only the first of which the issue names.

1. `dbuffer.py` — the copy source stays a DTensor, because `tensor.detach().contiguous()` preserves the wrapper.
2. `dbuffer.py` — `tensor.shape` on a DTensor is the **global** extent, so the buffer would have been sized `ep_size`× too large even had the copy worked.
3. `parameter_group.py` — an EP DTensor parameter cannot receive the unsharded buffer through `.data`: the wrapper survives and autograd then demands globally-shaped gradients (`got [4,8,4] but expected [2,8,4]`). It cannot be `swap_tensors`'d with a plain Parameter either, because DTensor carries extra slots.

## The fix

`DBuffer` keeps owning only the data-parallel submesh — it reduces a DTensor input to its local shard, which is what upstream FSDP2 does (`_init_sharding_spec_dtensor` shards `param._local_tensor`). `FsdpParameterGroup` takes over the composed view: it captures each parameter's expert sharding *before* the reduction and re-expresses the sharded parameter on the parent mesh, so the global expert index survives into the optimizer and checkpoints.

`_validate_dp_axes` becomes `_resolve_dp_mesh`: rather than requiring `dp_axes` to cover every mesh axis, it splits the parent mesh into the data-parallel submesh MFSDP shards over plus at most one leftover expert axis. Callers pass the full `(ep, dp)` mesh and name the data-parallel axis via `Placements.dp_axes`, which is what `dp_axes` was always for.

Parameters that are not EP DTensors are untouched and take the existing path — dense and expert parameters can share a `(dtype, requires_grad)` group.

## Mesh-axis order

Mesh-axis order is the nesting order: expert parallelism partitions the experts, MFSDP shards the local ones underneath. So `(ep, dp)` with `(Shard(0), Shard(0))` describes the layout directly and needs **no** strided placement — unlike FSDP2, which requires `_StridedShard(0, split_factor=ep_size)` because it forces DP to axis 0 via `DeviceMesh._concatenate([dp_mesh, tp_mesh])`.

The reverse `(dp, ep)` order *would* need one, and is rejected rather than silently mislabeled: plain placements there tile the tensor perfectly while describing different rows, which corrupts checkpoints without raising anything.

## Tests

`tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel_dtensor.py` — the composed spec, a training step, a checkpoint round-trip asserting the global `[E, ...]` shape, and both rejected configurations.

The checkpoint assertion is the one that matters: an FSDP-only spec is self-consistent within a single topology and only surfaces as corruption when a reader reshards at a different EP degree, so neither the loss nor a single backward would catch it.

## Verification

8×H100 (`dgxh100`), EP=4/DP=2 and EP=2/DP=4:

- repro goes `0/8` → `8/8` ranks, with `global=(4,3,2) mesh=('ep','dp') placements=(Shard(dim=0), Shard(dim=0))`;
- the `mfsdp_v2` bucket goes from **105 passed + 1 skipped** to **111 passed, 0 failed** — exactly the 5 added tests.

## Known limitations

- `GlobalLayout` chunks at `LCM(non_leading_numel)`, so a grouped `[E_local, h_in, h_out]` weight shards at whole-expert granularity. With `E_local=1, dp=2` one rank holds the expert and the other holds zero rows — correct but unbalanced.
- Only `Shard(0)` over a 1-D expert mesh is accepted; other placements and multi-dim expert meshes are rejected explicitly rather than mis-handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
