### PR TITLE
Integrate MIMO MTP conditioning metadata with current main

### DIFF
--- a/megatron/core/models/common/fine_grained_callables.py
+++ b/megatron/core/models/common/fine_grained_callables.py
@@ -36,7 +36,7 @@ def build_mtp_layer_callables(layer):
 
     forward_funcs, backward_dw = build_layer_callables(layer.mtp_model_layer)
     is_moe, _ = get_layer_moe_metadata(layer.mtp_model_layer)
-    (pre_dispatch_forward, dispatch_forward, mlp_forward, combine_forward, _) = forward_funcs
+    pre_dispatch_forward, dispatch_forward, mlp_forward, combine_forward, _ = forward_funcs
     assert is_moe, "MTP layer in a2a overlap only supports MoE layer for now."
 
     def submodule_mtp_pre_dispatch_forward(node, hidden_states):
@@ -67,17 +67,21 @@ def build_mtp_layer_callables(layer):
             node.chunk_state.mtp_hidden_states = list(torch.chunk(hidden_states, 1 + offset, dim=0))
             hidden_states = node.chunk_state.mtp_hidden_states[offset]
 
-        input_ids, position_ids, padding_mask, decoder_input, hidden_states = layer._get_embeddings(
-            input_ids=node.chunk_state.input_ids,
-            position_ids=node.chunk_state.position_ids,
-            embedding=node.chunk_state.model.embedding,
-            hidden_states=hidden_states,
-            packed_seq_params=node.chunk_state.packed_seq_params,
-            padding_mask=node.chunk_state.padding_mask,
+        input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states = (
+            layer._get_embeddings(
+                input_ids=node.chunk_state.input_ids,
+                position_ids=node.chunk_state.position_ids,
+                embedding=node.chunk_state.model.embedding,
+                hidden_states=hidden_states,
+                packed_seq_params=node.chunk_state.packed_seq_params,
+                padding_mask=node.chunk_state.padding_mask,
+                mtp_input_mask=getattr(node.chunk_state, 'mtp_input_mask', None),
+            )
         )
         node.chunk_state.input_ids = input_ids
         node.chunk_state.position_ids = position_ids
         node.chunk_state.padding_mask = padding_mask
+        node.chunk_state.mtp_input_mask = mtp_input_mask
 
         # MTP Layer Preprocess
         # norm, linear projection and transformer

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -351,6 +351,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         loss_mask: Optional[Tensor] = None,
         padding_mask=None,
         *,
+        mtp_input_mask: Optional[Tensor] = None,
         output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
     ):
@@ -370,6 +371,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             extra_block_kwargs: Additional keyword arguments for blocks.
             runtime_gather_output: Whether to gather output at runtime.
             loss_mask (torch.Tensor): Used to mask out some portions of the loss
+            mtp_input_mask (torch.Tensor): Mask of valid MTP conditioning tokens.
             output_processor (Callable): Custom postprocess hook to run instead of the
                 default logits/loss path.
             output_processor_context (Any): User-defined context object forwarded to
@@ -398,6 +400,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self._model_chunk_state.labels = labels
         self._model_chunk_state.mtp_hidden_states = None
         self._model_chunk_state.loss_mask = loss_mask
+        self._model_chunk_state.mtp_input_mask = mtp_input_mask  # type: ignore[attr-defined]
         self._model_chunk_state.packed_seq_params = packed_seq_params
         self._model_chunk_state.padding_mask = padding_mask
         self._model_chunk_state.extra_block_kwargs = extra_block_kwargs

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -203,6 +203,7 @@ class PostProcessNode(ScheduleNode):
             rotary_pos_sin=self.chunk_state.rotary_pos_sin,
             mtp_in_postprocess=False,
             loss_mask=self.chunk_state.loss_mask,
+            mtp_input_mask=self.chunk_state.mtp_input_mask,
             attention_mask=self.chunk_state.attention_mask,
             packed_seq_params=self.chunk_state.packed_seq_params,
             sequence_len_offset=self.chunk_state.sequence_len_offset,

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -168,6 +168,9 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             mtp_num_layers=self.config.mtp_num_layers,
             ignore_virtual=False,
             vp_stage=vp_stage,
+            pp_rank=self.pg_collection.pp.rank(),
+            pp_size=self.pg_collection.pp.size(),
+            vp_size=self.config.virtual_pipeline_model_parallel_size,
         )
 
         if self.pre_process or self.mtp_process:
@@ -763,6 +766,10 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
                     mtp_input_mask=mtp_input_mask,
+                    metric_avg_group=(
+                        getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
+                        or self.pg_collection.dp_cp
+                    ),
                 )
         sequence_parallel_override = False
 

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -575,6 +575,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
+        mtp_input_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
         output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
@@ -649,6 +650,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             rotary_pos_sin=rotary_pos_sin,
             mtp_in_postprocess=self.mtp_process,
             loss_mask=loss_mask,
+            mtp_input_mask=mtp_input_mask,
             decoder_input=decoder_input,
             attention_mask=attention_mask,
             padding_mask=padding_mask,
@@ -673,6 +675,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         rotary_pos_sin,
         mtp_in_postprocess=None,
         loss_mask=None,
+        mtp_input_mask=None,
         decoder_input=None,
         attention_mask=None,
         padding_mask=None,
@@ -722,6 +725,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 sequence_len_offset=sequence_len_offset,
                 padding_mask=padding_mask,
                 embedding=self.embedding,
+                mtp_input_mask=mtp_input_mask,
                 **(extra_block_kwargs or {}),
             )
 
@@ -758,6 +762,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     packed_seq_params=packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
+                    mtp_input_mask=mtp_input_mask,
                 )
         sequence_parallel_override = False
 
@@ -855,6 +860,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         loss_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
         *,
+        mtp_input_mask: Optional[Tensor] = None,
         output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
     ):
@@ -883,6 +889,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 Parameters for inference. Defaults to None.
             loss_mask (Optional[Tensor], optional): Loss mask. Defaults to None.
             padding_mask (Optional[Tensor], optional): Padding mask. Defaults to None.
+            mtp_input_mask (Optional[Tensor], optional): Mask of valid MTP conditioning tokens.
             output_processor (Callable, optional): Custom postprocess hook to run in the
                 schedule-plan postprocess node instead of the default logits/loss path.
             output_processor_context (Any, optional): User-defined context object forwarded to
@@ -911,6 +918,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             runtime_gather_output,
             loss_mask,
             padding_mask,
+            mtp_input_mask=mtp_input_mask,
             output_processor=output_processor,
             output_processor_context=output_processor_context,
         )

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -229,6 +229,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 mtp_num_layers=self.config.mtp_num_layers,
                 ignore_virtual=False,
                 vp_stage=self.vp_stage,
+                pp_rank=self.pg_collection.pp.rank(),
+                pp_size=self.pg_collection.pp.size(),
+                vp_size=self.config.virtual_pipeline_model_parallel_size,
             )
         )
 
@@ -606,6 +609,10 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
                     mtp_input_mask=mtp_input_mask,
+                    metric_avg_group=(
+                        getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
+                        or self.pg_collection.dp_cp
+                    ),
                 )
         sequence_parallel_override = False
         if (

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -432,6 +432,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
+        mtp_input_mask: Optional[Tensor] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[Tensor] = None,
         compute_mtp_loss: bool = True,
@@ -564,6 +565,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 rotary_pos_emb=rotary_pos_emb,
                 packed_seq_params=packed_seq_params,
                 embedding=self.embedding,
+                mtp_input_mask=mtp_input_mask,
             )
 
         if not self.post_process:
@@ -603,6 +605,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     packed_seq_params=packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
+                    mtp_input_mask=mtp_input_mask,
                 )
         sequence_parallel_override = False
         if (

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -715,6 +715,92 @@ class MimoModel(MegatronModule):
             packed_seq_params=packed_seq_params,
         )
 
+    def _language_model_owns_mtp(self) -> bool:
+        """Return whether this rank executes the language model's MTP block."""
+        if self.language_model is None:
+            return False
+        return bool(getattr(unwrap_model(self.language_model), 'mtp_process', False))
+
+    @staticmethod
+    def _materialize_mtp_input_mask(
+        input_ids: torch.Tensor,
+        special_token_ids: Dict[str, int],
+        text_token_indices: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Return positions backed by the language model's token embedding table."""
+        if text_token_indices is not None:
+            mtp_input_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+            mtp_input_mask.reshape(-1).index_fill_(0, text_token_indices, True)
+            return mtp_input_mask
+
+        mtp_input_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in special_token_ids.values():
+            mtp_input_mask &= input_ids != special_token_id
+        return mtp_input_mask
+
+    def _prepare_mtp_inputs(
+        self,
+        input_ids: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        owns_mtp: bool,
+        text_token_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Prepare CP-local position IDs and optional MTP token metadata.
+
+        MTP consumes token IDs only on the stage that owns its prediction block. Under
+        context parallelism, those IDs, their validity mask, and position IDs must all
+        use the same local sequence partition as the language-model hidden states.
+        """
+        if owns_mtp and input_ids is None:
+            raise RuntimeError("A language stage that owns MTP requires input_ids.")
+
+        mtp_input_ids = input_ids if owns_mtp else None
+        mtp_input_mask = None
+        if owns_mtp and self.special_token_ids:
+            assert input_ids is not None
+            mtp_input_mask = self._materialize_mtp_input_mask(
+                input_ids, self.special_token_ids, text_token_indices=text_token_indices
+            )
+
+        if self.partition_adapter is None or not self.partition_adapter.cfg.use_cp:
+            return mtp_input_ids, position_ids, mtp_input_mask
+
+        # PartitionAdapter shards batch-first [B, S, ...] metadata along dimension 1.
+        # Multidimensional RoPE positions arrive as [rope_dim, B, S], so expose their
+        # sequence dimension in the adapter's expected layout and restore it afterward.
+        is_multiaxis_position_ids = position_ids is not None and position_ids.dim() == 3
+        position_metadata = (
+            position_ids.movedim(0, -1).contiguous() if is_multiaxis_position_ids else position_ids
+        )
+
+        packed_mtp_metadata = mtp_input_ids
+        if mtp_input_mask is not None:
+            assert mtp_input_ids is not None
+            packed_mtp_metadata = torch.cat(
+                (mtp_input_ids, mtp_input_mask.to(dtype=mtp_input_ids.dtype)), dim=0
+            )
+
+        _, local_position_ids, packed_mtp_metadata, _ = self.partition_adapter.shard(
+            embeddings=None,
+            labels=position_metadata,
+            loss_mask=packed_mtp_metadata,
+            packed_seq_params=packed_seq_params,
+        )
+
+        if mtp_input_mask is not None:
+            assert packed_mtp_metadata is not None
+            mtp_input_ids, mtp_input_mask = packed_mtp_metadata.chunk(2, dim=0)
+            mtp_input_mask = mtp_input_mask.to(dtype=torch.bool)
+        else:
+            mtp_input_ids = packed_mtp_metadata
+
+        if is_multiaxis_position_ids:
+            assert local_position_ids is not None
+            local_position_ids = local_position_ids.movedim(-1, 0).contiguous()
+
+        return mtp_input_ids, local_position_ids, mtp_input_mask
+
     def _forward_language_module(
         self,
         input_ids: torch.Tensor,
@@ -759,6 +845,7 @@ class MimoModel(MegatronModule):
             )
 
         packed_seq_params = self._build_packed_seq_params(packing_kwargs)
+        owns_mtp = self._language_model_owns_mtp()
 
         if self.role.is_first_stage(lang_name):
             # First stage: receive encoder embeddings, combine with text, pass to LM
@@ -793,16 +880,23 @@ class MimoModel(MegatronModule):
                 loss_mask=loss_mask,
                 packed_seq_params=packed_seq_params,
             )
+            mtp_input_ids, position_ids, mtp_input_mask = self._prepare_mtp_inputs(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+                owns_mtp=owns_mtp,
+                text_token_indices=(modality_token_indices or {}).get("text"),
+            )
 
             lm_output = self.language_model(
-                # decoder_input replaces the embedding lookup, so input_ids is
-                # unused here; position_ids is still consumed by mRoPE in models
-                # such as Qwen3-VL.
-                input_ids=None,
+                # decoder_input replaces the main embedding lookup, but MTP still
+                # needs token IDs to construct its shifted-token embeddings.
+                input_ids=mtp_input_ids,
                 position_ids=position_ids,
                 decoder_input=combined_embeddings,
                 labels=labels,
                 loss_mask=loss_mask,
+                mtp_input_mask=mtp_input_mask,
                 attention_mask=attention_mask,
                 packed_seq_params=packed_seq_params,
             )
@@ -816,6 +910,13 @@ class MimoModel(MegatronModule):
                 loss_mask=loss_mask,
                 packed_seq_params=packed_seq_params,
             )
+            mtp_input_ids, position_ids, mtp_input_mask = self._prepare_mtp_inputs(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+                owns_mtp=owns_mtp,
+                text_token_indices=(modality_token_indices or {}).get("text"),
+            )
 
             hidden_states = input_tensors.get(lang_name) if input_tensors else None
 
@@ -828,11 +929,12 @@ class MimoModel(MegatronModule):
             lm_output = self.language_model(
                 # Hidden states arrive via set_input_tensor; position_ids is
                 # still consumed by mRoPE on non-first PP stages.
-                input_ids=None,
+                input_ids=mtp_input_ids,
                 position_ids=position_ids,
                 decoder_input=None,
                 labels=labels,
                 loss_mask=loss_mask,
+                mtp_input_mask=mtp_input_mask,
                 attention_mask=attention_mask,
                 packed_seq_params=packed_seq_params,
             )
@@ -900,6 +1002,7 @@ class MimoModel(MegatronModule):
         This is the original behavior, preserved for backward compatibility.
         """
         packed_seq_params = self._build_packed_seq_params(packing_kwargs)
+        owns_mtp = self._language_model_owns_mtp()
 
         # 1. Process each modality to get embeddings
         modality_embeddings = {}
@@ -951,17 +1054,24 @@ class MimoModel(MegatronModule):
             loss_mask=loss_mask,
             packed_seq_params=packed_seq_params,
         )
+        mtp_input_ids, position_ids, mtp_input_mask = self._prepare_mtp_inputs(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            owns_mtp=owns_mtp,
+            text_token_indices=(modality_token_indices or {}).get("text"),
+        )
 
         # 5. Forward pass through language model
         lm_output = self.language_model(
-            # decoder_input replaces the embedding lookup, so input_ids is
-            # unused here; position_ids is still consumed by mRoPE in models
-            # such as Qwen3-VL.
-            input_ids=None,
+            # decoder_input replaces the main embedding lookup, but MTP still
+            # needs token IDs to construct its shifted-token embeddings.
+            input_ids=mtp_input_ids,
             position_ids=position_ids,
             decoder_input=combined_embeddings,
             labels=labels,
             loss_mask=loss_mask,
+            mtp_input_mask=mtp_input_mask,
             attention_mask=None,
             packed_seq_params=packed_seq_params,
         )

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -944,6 +944,7 @@ def process_mtp_loss(
     packed_seq_params: Optional[PackedSeqParams] = None,
     scale_logits_fn: Optional[Callable[[Tensor], Tensor]] = None,
     input_ids: Optional[Tensor] = None,
+    mtp_input_mask: Optional[Tensor] = None,
 ) -> Tensor:
     """Process Multi-Token Prediction (MTP) loss computation.
 
@@ -969,6 +970,9 @@ def process_mtp_loss(
             ``labels`` is None (e.g. RL training), by rolling left to match the SFT
             label convention (``label[i] = input_id[i + 1]``). Ignored when ``labels``
             is provided.
+        mtp_input_mask (Optional[Tensor]): Boolean mask over tokens that are valid as
+            additional MTP conditioning inputs. The mask accumulates across prediction
+            steps so a path stays masked after it reaches an invalid token.
 
     Returns:
         Tensor: Updated hidden states after MTP loss processing (first chunk only).
@@ -1009,6 +1013,15 @@ def process_mtp_loss(
     # correctly scaled relative to the main loss gradients in finalize_model_grads.
     original_num_tokens = loss_mask.sum()
 
+    cumulative_mtp_input_mask = None
+    rolled_num_tokens = original_num_tokens
+    if mtp_input_mask is not None:
+        assert mtp_input_mask.shape == loss_mask.shape, (
+            f"mtp_input_mask shape {mtp_input_mask.shape} must match "
+            f"loss_mask shape {loss_mask.shape}"
+        )
+        mtp_input_mask = mtp_input_mask.to(dtype=torch.bool)
+
     for mtp_layer_number in range(config.mtp_num_layers):
         mtp_logits, _ = output_layer(
             hidden_states_list[mtp_layer_number + 1],
@@ -1020,20 +1033,47 @@ def process_mtp_loss(
         mtp_labels, _ = roll_tensor(
             mtp_labels, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
         )
-        loss_mask, num_tokens = roll_tensor(
+        loss_mask, rolled_num_tokens = roll_tensor(
             loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
         )
 
+        layer_loss_mask = loss_mask
+        if mtp_input_mask is not None:
+            # Each MTP step consumes one additional token. Accumulate validity so
+            # one invalid conditioning token also masks every later step on that path.
+            mtp_input_mask, _ = roll_tensor(
+                mtp_input_mask,
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            if cumulative_mtp_input_mask is None:
+                cumulative_mtp_input_mask = mtp_input_mask
+            else:
+                cumulative_mtp_input_mask = cumulative_mtp_input_mask & mtp_input_mask
+            layer_loss_mask = loss_mask * cumulative_mtp_input_mask
+            num_tokens = layer_loss_mask.sum()
+        else:
+            # roll_tensor already computed this reduction. Preserve the legacy
+            # no-mask fast path for all non-multimodal MTP callers.
+            num_tokens = rolled_num_tokens
+
         mtp_loss = compute_language_model_loss(mtp_labels, mtp_logits)
 
-        mtp_loss = loss_mask * mtp_loss
+        mtp_loss = layer_loss_mask * mtp_loss
 
         if is_training:
             mtp_loss_for_log = (
                 torch.sum(mtp_loss) * (num_tokens > 0).to(mtp_loss.dtype)
             ) / num_tokens.clamp(min=1)
             correct, total = _compute_mtp_acceptance_counts(
-                mtp_logits, mtp_labels, loss_mask, output_layer, runtime_gather_output, tp_group
+                mtp_logits,
+                mtp_labels,
+                layer_loss_mask,
+                output_layer,
+                runtime_gather_output,
+                tp_group,
             )
 
             MTPLossLoggingHelper.save_metrics_to_tracker(
@@ -1259,6 +1299,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         hidden_states: torch.Tensor,
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[torch.Tensor] = None,
+        mtp_input_mask: Optional[torch.Tensor] = None,
     ):
         """
         Preprocesses input data for the Multi-Token Prediction (MTP) layers.
@@ -1274,15 +1315,34 @@ class MultiTokenPredictionLayer(MegatronModule):
             hidden_states (torch.Tensor): hidden states tensor of shape [s, b, h] where s is the
                 sequence length, b is the batch size, and h is the hidden size.
             packed_seq_params (PackedSeqParams): Parameters for packed sequence processing.
+            mtp_input_mask (torch.Tensor, optional): Mask of conditioning tokens backed by
+                regular token embeddings. Shape: [b, s].
         """
         # Calc logits for the current Multi-Token Prediction (MTP) layers.
-        input_ids, _ = roll_tensor(
-            input_ids,
-            shifts=-1,
-            dims=-1,
-            cp_group=self.cp_group,
-            packed_seq_params=packed_seq_params,
-        )
+        if mtp_input_mask is None:
+            input_ids, _ = roll_tensor(
+                input_ids,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+        else:
+            assert mtp_input_mask.shape == input_ids.shape, (
+                f"mtp_input_mask shape {mtp_input_mask.shape} must match "
+                f"input_ids shape {input_ids.shape}"
+            )
+            # Roll IDs and validity together so CP performs one boundary exchange.
+            token_metadata = torch.cat((input_ids, mtp_input_mask.to(dtype=input_ids.dtype)), dim=0)
+            token_metadata, _ = roll_tensor(
+                token_metadata,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            input_ids, mtp_input_mask = token_metadata.chunk(2, dim=0)
+            mtp_input_mask = mtp_input_mask.to(dtype=torch.bool)
         position_ids, _ = roll_tensor(
             position_ids,
             shifts=-1,
@@ -1300,6 +1360,12 @@ class MultiTokenPredictionLayer(MegatronModule):
             )
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
+
+        if mtp_input_mask is not None:
+            # Keep invalid placeholder values in the forward pass, but prevent
+            # later causal positions from updating their shared embedding rows.
+            valid_decoder_input = mtp_input_mask.transpose(0, 1).unsqueeze(-1)
+            decoder_input = torch.where(valid_decoder_input, decoder_input, decoder_input.detach())
 
         # Mirror the scatter in the model's own forward (see hybrid_model.py:
         # "the embedding skips SP scatter for models whose outer wrapper
@@ -1326,7 +1392,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         if not hidden_states.requires_grad:
             hidden_states.requires_grad_(True)
 
-        return input_ids, position_ids, padding_mask, decoder_input, hidden_states
+        return (input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states)
 
     def _concat_embeddings(self, hidden_states: torch.Tensor, decoder_input: torch.Tensor):
         """
@@ -1669,6 +1735,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
+        mtp_input_mask: Optional[Tensor] = None,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -1687,19 +1754,23 @@ class MultiTokenPredictionLayer(MegatronModule):
             rotary_pos_sin (Tensor, optional): Sine component of rotary positional embeddings.
             sequence_len_offset (Tensor, optional): Offset for sequence length, if applicable.
             embedding (Callable): The embedding module from gpt model to compute the decoder input.
+            mtp_input_mask (Tensor, optional): Mask of valid MTP conditioning tokens.
 
         Returns:
             Union[Tensor, Tuple[Tensor, Tensor]]: The output hidden states tensor of shape
             [s, b, h], and optionally the updated context tensor if cross-attention is used.
         """
         assert context is None, "multi token prediction + cross attention is not yet supported."
-        input_ids, position_ids, padding_mask, decoder_input, hidden_states = self._get_embeddings(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            padding_mask=padding_mask,
-            embedding=embedding,
-            hidden_states=hidden_states,
-            packed_seq_params=packed_seq_params,
+        input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states = (
+            self._get_embeddings(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                padding_mask=padding_mask,
+                embedding=embedding,
+                hidden_states=hidden_states,
+                packed_seq_params=packed_seq_params,
+                mtp_input_mask=mtp_input_mask,
+            )
         )
 
         if self.config.recompute_granularity == 'full' and self.training:
@@ -1735,7 +1806,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 sequence_len_offset=sequence_len_offset,
             )
 
-        return hidden_states, input_ids, position_ids, padding_mask
+        return hidden_states, input_ids, position_ids, padding_mask, mtp_input_mask
 
     def sharded_state_dict(
         self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
@@ -2020,6 +2091,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
+        mtp_input_mask: Optional[Tensor] = None,
     ) -> Tensor:
         """
         Perform the forward pass through all of the MTP modules.
@@ -2029,6 +2101,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                 where s is the sequence length, b is the batch size, and h is the hidden size.
             attention_mask (Tensor): Boolean tensor of shape [1, 1, s, s] for masking
                 self-attention.
+            mtp_input_mask (Tensor, optional): Mask of valid MTP conditioning tokens.
 
         Returns:
             (Tensor): The mtp loss tensor of shape [b, s].
@@ -2112,7 +2185,9 @@ class MultiTokenPredictionBlock(MegatronModule):
             else:
                 hidden_states_input = hidden_states
 
-            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
+            hidden_states, input_ids, position_ids, padding_mask, mtp_input_mask = self.layers[
+                layer_idx
+            ](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states_input,
@@ -2125,6 +2200,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
+                mtp_input_mask=mtp_input_mask,
                 **(extra_block_kwargs or {}),
             )
 

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -790,6 +790,9 @@ def mtp_on_this_rank(
     mtp_num_layers: Optional[int] = None,
     ignore_virtual: Optional[bool] = True,
     vp_stage: Optional[int] = None,
+    pp_rank: Optional[int] = None,
+    pp_size: Optional[int] = None,
+    vp_size: Optional[int] = None,
 ) -> bool:
     """
     Check if there is MTP on the current rank.
@@ -804,13 +807,17 @@ def mtp_on_this_rank(
           pipeline stage. The function returns True only on the last pipeline stage.
     """
     mtp_on_this_rank = False
-    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    if pp_rank is None:
+        # Compatibility fallback for callers that have not migrated to explicit PP metadata.
+        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    if vp_size is None and layout is not None:
+        vp_size = layout.virtual_pipeline_model_parallel_size
+    elif vp_size is None and not ignore_virtual:
+        vp_size = parallel_state.get_virtual_pipeline_model_parallel_world_size()
+
     if layout is not None:
         # with custom PP layout, we support put MTP layers on any pipeline stage
-        if (
-            not ignore_virtual
-            and parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None
-        ):
+        if not ignore_virtual and vp_size not in (None, 1):
             assert vp_stage is not None, "vp_stage must be passed if virtual pipeline is enabled"
             num_layers_to_build = layout.layout[pp_rank][vp_stage].count(LayerType.mtp)
             mtp_on_this_rank = num_layers_to_build > 0
@@ -823,9 +830,15 @@ def mtp_on_this_rank(
     else:
         # without custom PP layout, we only support put all of MTP layers on the last pipeline stage
         if mtp_num_layers is not None:
-            mtp_on_this_rank = parallel_state.is_pipeline_last_stage(
-                ignore_virtual=ignore_virtual, vp_stage=vp_stage
-            )
+            if pp_size is None:
+                # Compatibility fallback for callers without explicit pipeline metadata.
+                pp_size = parallel_state.get_pipeline_model_parallel_world_size()
+            mtp_on_this_rank = pp_rank == pp_size - 1
+            if mtp_on_this_rank and not ignore_virtual and vp_size not in (None, 1):
+                assert (
+                    vp_stage is not None
+                ), "vp_stage must be passed if virtual pipeline is enabled"
+                mtp_on_this_rank = vp_stage == vp_size - 1
         else:
             mtp_on_this_rank = False
     return mtp_on_this_rank
@@ -865,21 +878,32 @@ def get_mtp_num_layers_to_build(
     config: TransformerConfig, vp_stage: Optional[int] = None, pp_rank: Optional[int] = None
 ) -> int:
     """Get the number of MTP layers to build."""
+    if pp_rank is None:
+        # Compatibility fallback for callers that have not migrated to explicit PP ranks.
+        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+
     if config.pipeline_model_parallel_layout is not None:
         # If we have a custom PP layout, get the number of mtp layers in the layout array.
-        num_layers_to_build = config.pipeline_model_parallel_layout.get_num_layers_to_build(
-            layer_type=LayerType.mtp, vp_stage=vp_stage
-        )
+        layout = config.pipeline_model_parallel_layout
+        if layout.virtual_pipeline_model_parallel_size > 1:
+            assert vp_stage is not None, "vp_stage must be passed if virtual pipeline is enabled"
+        else:
+            vp_stage = 0
+        num_layers_to_build = layout.layout[pp_rank][vp_stage].count(LayerType.mtp)
         assert num_layers_to_build == config.mtp_num_layers or num_layers_to_build == 0, (
             f"Currently, we only support put all of MTP layers on the last pipeline stage, "
             f"so the number of MTP layers to build ({num_layers_to_build}) must match "
             f"mtp_num_layers ({config.mtp_num_layers}) or be 0."
         )
     else:
-        if parallel_state.is_pipeline_last_stage(ignore_virtual=False, vp_stage=vp_stage):
-            num_layers_to_build = config.mtp_num_layers if config.mtp_num_layers else 0
-        else:
-            num_layers_to_build = 0
+        vp_size = config.virtual_pipeline_model_parallel_size
+        if vp_size not in (None, 1):
+            assert vp_stage is not None, "vp_stage must be passed if virtual pipeline is enabled"
+        is_last_vp_stage = vp_size in (None, 1) or vp_stage == vp_size - 1
+        is_last_pp_stage = pp_rank == config.pipeline_model_parallel_size - 1
+        num_layers_to_build = (
+            config.mtp_num_layers if is_last_pp_stage and is_last_vp_stage else 0
+        ) or 0
     return num_layers_to_build
 
 
@@ -945,6 +969,7 @@ def process_mtp_loss(
     scale_logits_fn: Optional[Callable[[Tensor], Tensor]] = None,
     input_ids: Optional[Tensor] = None,
     mtp_input_mask: Optional[Tensor] = None,
+    metric_avg_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> Tensor:
     """Process Multi-Token Prediction (MTP) loss computation.
 
@@ -973,6 +998,7 @@ def process_mtp_loss(
         mtp_input_mask (Optional[Tensor]): Boolean mask over tokens that are valid as
             additional MTP conditioning inputs. The mask accumulates across prediction
             steps so a path stays masked after it reaches an invalid token.
+        metric_avg_group (Optional[ProcessGroup]): Group used to average MTP logging metrics.
 
     Returns:
         Tensor: Updated hidden states after MTP loss processing (first chunk only).
@@ -1076,13 +1102,18 @@ def process_mtp_loss(
                 tp_group,
             )
 
+            if metric_avg_group is None:
+                # Compatibility fallback for callers that have not migrated to explicit groups.
+                metric_avg_group = parallel_state.get_data_parallel_group(
+                    with_context_parallel=True
+                )
             MTPLossLoggingHelper.save_metrics_to_tracker(
                 mtp_loss_for_log,
                 correct,
                 total,
                 mtp_layer_number,
                 config.mtp_num_layers,
-                avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
+                avg_group=metric_avg_group,
             )
         mtp_loss_scale = config.mtp_loss_scaling_factor / config.mtp_num_layers
         if config.calculate_per_token_loss:

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1013,7 +1013,12 @@ def process_mtp_loss(
         if input_ids is None:
             return hidden_states
         labels, _ = roll_tensor(
-            input_ids, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            input_ids,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
         )
         derived_labels_from_input_ids = True
 
@@ -1031,7 +1036,12 @@ def process_mtp_loss(
         # label is fabricated (zeroed). Roll loss_mask in lockstep with the
         # input_ids -> labels shift so that boundary position is masked.
         loss_mask, _ = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            loss_mask,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
         )
 
     # Store the original number of tokens before rolling for proper normalization
@@ -1057,23 +1067,28 @@ def process_mtp_loss(
         if scale_logits_fn is not None:
             mtp_logits = scale_logits_fn(mtp_logits)
         mtp_labels, _ = roll_tensor(
-            mtp_labels, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
-        )
-        loss_mask, rolled_num_tokens = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            mtp_labels,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
         )
 
-        layer_loss_mask = loss_mask
         if mtp_input_mask is not None:
             # Each MTP step consumes one additional token. Accumulate validity so
             # one invalid conditioning token also masks every later step on that path.
-            mtp_input_mask, _ = roll_tensor(
-                mtp_input_mask,
+            mask_metadata = torch.cat((loss_mask, mtp_input_mask.to(dtype=loss_mask.dtype)), dim=0)
+            mask_metadata, _ = roll_tensor(
+                mask_metadata,
                 shifts=-1,
                 dims=-1,
                 cp_group=cp_group,
                 packed_seq_params=packed_seq_params,
+                return_sum=False,
             )
+            loss_mask, mtp_input_mask = mask_metadata.chunk(2, dim=0)
+            mtp_input_mask = mtp_input_mask.to(dtype=torch.bool)
             if cumulative_mtp_input_mask is None:
                 cumulative_mtp_input_mask = mtp_input_mask
             else:
@@ -1081,6 +1096,14 @@ def process_mtp_loss(
             layer_loss_mask = loss_mask * cumulative_mtp_input_mask
             num_tokens = layer_loss_mask.sum()
         else:
+            loss_mask, rolled_num_tokens = roll_tensor(
+                loss_mask,
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            layer_loss_mask = loss_mask
             # roll_tensor already computed this reduction. Preserve the legacy
             # no-mask fast path for all non-multimodal MTP callers.
             num_tokens = rolled_num_tokens
@@ -1357,6 +1380,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 dims=-1,
                 cp_group=self.cp_group,
                 packed_seq_params=packed_seq_params,
+                return_sum=False,
             )
         else:
             assert mtp_input_mask.shape == input_ids.shape, (
@@ -1371,6 +1395,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 dims=-1,
                 cp_group=self.cp_group,
                 packed_seq_params=packed_seq_params,
+                return_sum=False,
             )
             input_ids, mtp_input_mask = token_metadata.chunk(2, dim=0)
             mtp_input_mask = mtp_input_mask.to(dtype=torch.bool)
@@ -1380,6 +1405,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             dims=-1,
             cp_group=self.cp_group,
             packed_seq_params=packed_seq_params,
+            return_sum=False,
         )
         if padding_mask is not None:
             padding_mask, _ = roll_tensor(
@@ -1388,6 +1414,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 dims=-1,
                 cp_group=self.cp_group,
                 packed_seq_params=packed_seq_params,
+                return_sum=False,
             )
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -672,7 +672,8 @@ class TestMimoModel:
             )
 
     @pytest.mark.parametrize(("tp", "cp"), [(1, 1), (2, 1), (1, 2), (2, 2)])
-    def test_mtp_forward_uses_parallel_local_token_metadata(self, tp, cp):
+    @pytest.mark.parametrize("position_dims", [2, 3])
+    def test_mtp_forward_uses_parallel_local_token_metadata(self, tp, cp, position_dims):
         """Run real MIMO+MTP for the supported TP/CP combinations.
 
         MIMO owns CP partitioning for its pre-combined decoder embeddings, so
@@ -687,7 +688,7 @@ class TestMimoModel:
 
         seq_len = 16
         vocab_size = 128
-        invalid_token_id = 127
+        special_token_ids = {"images": 126, "audio": 127}
         config = TransformerConfig(
             mtp_num_layers=1,
             num_layers=2,
@@ -723,7 +724,7 @@ class TestMimoModel:
             MimoModelConfig(
                 language_model_spec=language_model_spec,
                 modality_submodules_spec={},
-                special_token_ids={"images": invalid_token_id},
+                special_token_ids=special_token_ids,
             ),
             cp_group=pg_collection.cp,
             tp_group=pg_collection.tp,
@@ -753,12 +754,16 @@ class TestMimoModel:
             for mtp_layer in model.language_model.mtp.layers:
                 mtp_layer.mtp_model_layer = _IdentityMTPLayer()
 
-        input_ids = torch.randint(1, vocab_size - 1, (1, seq_len), device="cuda")
-        input_ids[0, 3] = invalid_token_id
+        input_ids = torch.randint(1, min(special_token_ids.values()), (1, seq_len), device="cuda")
+        input_ids[0, 3] = special_token_ids["images"]
+        input_ids[0, 12] = special_token_ids["audio"]
         position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
+        if position_dims == 3:
+            position_ids = position_ids.unsqueeze(0).expand(3, -1, -1).contiguous()
         labels = torch.roll(input_ids, shifts=-1, dims=-1)
         loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
-        loss_mask[input_ids == invalid_token_id] = 0
+        for special_token_id in special_token_ids.values():
+            loss_mask[input_ids == special_token_id] = 0
 
         output, local_loss_mask = model(
             input_ids=input_ids,
@@ -772,11 +777,18 @@ class TestMimoModel:
         assert output.shape == local_loss_mask.shape == (1, seq_len // cp)
         output.mean().backward()
 
-    def test_non_first_pipeline_stage_runs_real_mtp(self):
-        """Run real MIMO+MTP on the last stage of a two-stage LM pipeline."""
+    @pytest.mark.parametrize(("tp", "cp"), [(1, 1), (2, 1), (1, 2), (4, 1), (1, 4), (2, 2)])
+    def test_non_first_pipeline_stage_runs_real_mtp(self, tp, cp):
+        """Run real MIMO+MTP on the last stage with combined parallelism."""
+        required_world_size = 2 * tp * cp
+        if torch.distributed.get_world_size() < required_world_size:
+            pytest.skip(f"requires {required_world_size} distributed ranks")
+
         os.environ['CUDA_DEVICE_MAX_CONNECTIONS'] = '1'
         Utils.destroy_model_parallel()
-        Utils.initialize_model_parallel(pipeline_model_parallel_size=2)
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp, pipeline_model_parallel_size=2, context_parallel_size=cp
+        )
         model_parallel_cuda_manual_seed(123)
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         is_first_stage = parallel_state.is_pipeline_first_stage()
@@ -791,6 +803,9 @@ class TestMimoModel:
             hidden_size=32,
             num_attention_heads=4,
             use_cpu_initialization=True,
+            tensor_model_parallel_size=tp,
+            sequence_parallel=tp > 1,
+            context_parallel_size=cp,
             pipeline_model_parallel_size=2,
             pipeline_dtype=torch.float32,
             attention_dropout=0.0,
@@ -810,6 +825,7 @@ class TestMimoModel:
                 "pre_process": is_first_stage,
                 "post_process": is_last_stage,
                 "position_embedding_type": "rope",
+                "scatter_embedding_sequence_parallel": False,
                 "share_embeddings_and_output_weights": True,
                 "pg_collection": pg_collection,
             },
@@ -819,7 +835,9 @@ class TestMimoModel:
                 language_model_spec=language_model_spec,
                 modality_submodules_spec={},
                 special_token_ids={"images": invalid_token_id},
-            )
+            ),
+            cp_group=pg_collection.cp,
+            tp_group=pg_collection.tp,
         ).cuda()
         model.role = RankRole(
             modules={
@@ -833,13 +851,36 @@ class TestMimoModel:
         if not is_last_stage:
             return
 
+        if cp > 1:
+            # The validation image has no TE attention backend for CP. Preserve
+            # real PP/CP metadata partitioning and the MTP embedding/projection/loss
+            # path while replacing only the attention-bearing blocks.
+            class _IdentityDecoder(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.input_tensor = None
+
+                def set_input_tensor(self, input_tensor):
+                    self.input_tensor = input_tensor
+
+                def forward(self, hidden_states, **kwargs):
+                    return hidden_states if hidden_states is not None else self.input_tensor
+
+            class _IdentityMTPLayer(torch.nn.Module):
+                def forward(self, hidden_states, **kwargs):
+                    return hidden_states, None
+
+            model.language_model.decoder = _IdentityDecoder()
+            for mtp_layer in model.language_model.mtp.layers:
+                mtp_layer.mtp_model_layer = _IdentityMTPLayer()
+
         input_ids = torch.randint(1, vocab_size - 1, (1, seq_len), device="cuda")
         input_ids[0, 2] = invalid_token_id
         position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
         labels = torch.roll(input_ids, shifts=-1, dims=-1)
         loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
         loss_mask[input_ids == invalid_token_id] = 0
-        hidden_states = torch.randn(seq_len, 1, config.hidden_size, device="cuda")
+        hidden_states = torch.randn(seq_len // (tp * cp), 1, config.hidden_size, device="cuda")
 
         output, _ = model._forward_language_module(
             input_ids=input_ids,
@@ -850,7 +891,7 @@ class TestMimoModel:
             input_tensors={MIMO_LANGUAGE_MODULE_KEY: hidden_states},
         )
 
-        assert output.shape == loss_mask.shape
+        assert output.shape == (1, seq_len // cp)
         output.mean().backward()
 
 

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -5,6 +5,7 @@ WORLD_SIZE=1 LOCAL_RANK=0 python -m pytest tests/unit_tests/models/mimo/test_mim
 '''
 
 import math
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,14 +15,25 @@ import torch.distributed as dist
 import torch.nn as nn
 from transformers import WhisperConfig, WhisperModel
 
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_spec,
+    get_gpt_mtp_block_spec,
+)
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.models.mimo.config.base_configs import MimoModelConfig
-from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY, ModuleLayout
+from megatron.core.models.mimo.config.role import (
+    MIMO_LANGUAGE_MODULE_KEY,
+    ModuleLayout,
+    ModuleStageInfo,
+    RankRole,
+)
 from megatron.core.models.mimo.model.base import MimoModel
 from megatron.core.models.mimo.submodules.audio import AudioModalitySubmodules
 from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -270,18 +282,18 @@ class TestMimoModel:
         assert outputs.shape == (self.batch_size, self.seq_len, self.vocab_size)
 
     def test_forward_threads_position_ids_to_language_model(self):
-        """``MimoModel.forward`` must thread ``position_ids`` through to
-        ``self.language_model`` so multimodal RoPE can compute its rotary
-        embeddings.
+        """Thread token, position, and MTP-mask inputs to the language model.
 
         Multimodal RoPE (e.g. Qwen3-VL) consumes ``position_ids`` even when
-        the language model receives a pre-combined ``decoder_input`` (which
-        replaces the embedding lookup). ``input_ids`` is therefore unused on
-        this path and must not be forwarded — its shape would not match the
-        expanded ``decoder_input`` sequence.
+        the language model receives a pre-combined ``decoder_input``. The main
+        embedding lookup ignores ``input_ids`` on this path, but MTP still uses
+        them to build shifted-token embeddings and its conditioning mask.
         """
         mimo_model = self._make_vlm()
+        mimo_model.language_model.mtp_process = True
         input_ids = self._make_input_ids()
+        input_ids[0, 1] = self.special_token_ids['images']
+        input_ids[1, 2] = self.special_token_ids['audio']
         position_ids = self._make_position_ids()
         loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
 
@@ -292,6 +304,7 @@ class TestMimoModel:
             captured['position_ids'] = kwargs.get('position_ids')
             captured['decoder_input'] = kwargs.get('decoder_input')
             captured['loss_mask'] = kwargs.get('loss_mask')
+            captured['mtp_input_mask'] = kwargs.get('mtp_input_mask')
             return torch.zeros(self.batch_size, self.seq_len, self.vocab_size, device=self.device)
 
         with patch.object(mimo_model.language_model, 'forward', side_effect=capture_lm_forward):
@@ -306,13 +319,46 @@ class TestMimoModel:
             captured['decoder_input'] is not None
         ), "MimoModel.forward must pass a pre-combined decoder_input to the language model"
         assert (
-            captured['input_ids'] is None
-        ), "MimoModel.forward must not forward input_ids when decoder_input is pre-combined"
+            captured['input_ids'] is input_ids
+        ), "MimoModel.forward must preserve input_ids for MTP"
         assert (
             captured['position_ids'] is not None
         ), "MimoModel.forward must pass position_ids to the language model (got None)"
         torch.testing.assert_close(captured['position_ids'], position_ids)
         assert captured['loss_mask'] is loss_mask
+        expected_mtp_input_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in self.special_token_ids.values():
+            expected_mtp_input_mask &= input_ids != special_token_id
+        torch.testing.assert_close(captured['mtp_input_mask'], expected_mtp_input_mask)
+
+    def test_prepare_mtp_inputs_uses_optional_text_indices(self):
+        """Precomputed text positions and the fallback scan must produce the same MTP mask."""
+        mimo_model = self._make_vlm()
+        input_ids = self._make_input_ids()
+        input_ids[0, 1] = self.special_token_ids['images']
+        input_ids[1, 2] = self.special_token_ids['audio']
+        position_ids = self._make_position_ids()
+
+        expected_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in self.special_token_ids.values():
+            expected_mask &= input_ids != special_token_id
+        text_token_indices = expected_mask.reshape(-1).nonzero(as_tuple=False).flatten()
+
+        indexed_ids, indexed_positions, indexed_mask = mimo_model._prepare_mtp_inputs(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            packed_seq_params=None,
+            owns_mtp=True,
+            text_token_indices=text_token_indices,
+        )
+        fallback_ids, fallback_positions, fallback_mask = mimo_model._prepare_mtp_inputs(
+            input_ids=input_ids, position_ids=position_ids, packed_seq_params=None, owns_mtp=True
+        )
+
+        assert indexed_ids is fallback_ids is input_ids
+        assert indexed_positions is fallback_positions is position_ids
+        torch.testing.assert_close(indexed_mask, expected_mask)
+        torch.testing.assert_close(indexed_mask, fallback_mask)
 
     def test_forward_with_image_modality(self):
         """Test forward pass with text and image input."""
@@ -470,16 +516,24 @@ class TestMimoModel:
         assert packed_seq_params.cu_seqlens_kv.dtype == torch.int32
 
     def test_forward_with_partition_adapter(self):
-        """shard() receives sequence-first embeddings and returns LM-layout [S/cp, B, H].
+        """MTP token metadata must use the same CP-local sequence as hidden states.
 
         The caller no longer transposes around shard(): it passes the sequence-first
         ``(S, B, H)`` combined embeddings straight in, and shard()'s LM-layout output
-        flows straight into the language model as ``decoder_input``.
+        flows straight into the language model as ``decoder_input``. Token and position
+        IDs used by MTP must be partitioned to that same local sequence.
         """
         mimo_model = self._make_vlm()
+        mimo_model.language_model.mtp_process = True
         input_ids = self._make_input_ids()
+        input_ids[0, 1] = self.special_token_ids['images']
         position_ids = self._make_position_ids()
         loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
+        text_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for special_token_id in self.special_token_ids.values():
+            text_mask &= input_ids != special_token_id
+        text_token_indices = text_mask.reshape(-1).nonzero(as_tuple=False).flatten()
+        modality_token_indices = {"text": text_token_indices}
 
         sharded_seq_len = self.seq_len // 2
         # shard() returns LM-layout [S/cp, B, H] and a (CP-sharded) loss mask.
@@ -487,8 +541,16 @@ class TestMimoModel:
             sharded_seq_len, self.batch_size, self.hidden_size, device=self.device
         )
         sharded_loss_mask = torch.ones(self.batch_size, sharded_seq_len, device=self.device)
+        sharded_input_ids = input_ids[:, :sharded_seq_len].clone()
+        sharded_position_ids = position_ids[:, :sharded_seq_len].clone()
+        sharded_token_metadata = torch.cat(
+            (sharded_input_ids, text_mask[:, :sharded_seq_len].to(dtype=input_ids.dtype)), dim=0
+        )
         mock_adapter = MagicMock()
-        mock_adapter.shard.return_value = (sharded_emb, None, sharded_loss_mask, None)
+        mock_adapter.shard.side_effect = [
+            (sharded_emb, None, sharded_loss_mask, None),
+            (None, sharded_position_ids, sharded_token_metadata, None),
+        ]
         mimo_model.partition_adapter = mock_adapter
 
         text_emb = torch.zeros(self.batch_size * self.seq_len, self.hidden_size, device=self.device)
@@ -499,8 +561,11 @@ class TestMimoModel:
         captured = {}
 
         def capture_lm_forward(*args, **kwargs):
+            captured['input_ids'] = kwargs.get('input_ids')
+            captured['position_ids'] = kwargs.get('position_ids')
             captured['decoder_input'] = kwargs.get('decoder_input')
             captured['loss_mask'] = kwargs.get('loss_mask')
+            captured['mtp_input_mask'] = kwargs.get('mtp_input_mask')
             return torch.zeros(
                 self.batch_size, sharded_seq_len, self.vocab_size, device=self.device
             )
@@ -517,13 +582,19 @@ class TestMimoModel:
                 position_ids=position_ids,
                 loss_mask=loss_mask,
                 modality_inputs=None,
+                modality_token_indices=modality_token_indices,
             )
 
-        mock_adapter.shard.assert_called_once()
-        shard_kwargs = mock_adapter.shard.call_args[1]
+        assert mock_adapter.shard.call_count == 2
+        shard_kwargs = mock_adapter.shard.call_args_list[0].kwargs
         # The helper passes sequence-first [S, B, H] embeddings straight to shard().
         assert shard_kwargs['embeddings'].shape == (self.seq_len, self.batch_size, self.hidden_size)
         assert shard_kwargs['loss_mask'] is loss_mask
+        mtp_shard_kwargs = mock_adapter.shard.call_args_list[1].kwargs
+        assert mtp_shard_kwargs['embeddings'] is None
+        assert mtp_shard_kwargs['labels'] is position_ids
+        expected_token_metadata = torch.cat((input_ids, text_mask.to(dtype=input_ids.dtype)), dim=0)
+        torch.testing.assert_close(mtp_shard_kwargs['loss_mask'], expected_token_metadata)
         # shard()'s LM-layout output flows straight into the LM (no extra transpose).
         assert captured['decoder_input'].shape == (
             sharded_seq_len,
@@ -531,6 +602,10 @@ class TestMimoModel:
             self.hidden_size,
         )
         assert captured['loss_mask'] is sharded_loss_mask
+        assert captured['input_ids'] is sharded_input_ids
+        assert captured['position_ids'] is sharded_position_ids
+        assert captured['mtp_input_mask'].dtype == torch.bool
+        assert torch.equal(captured['mtp_input_mask'], text_mask[:, :sharded_seq_len])
         # forward() returns the (possibly sharded) loss mask from shard().
         assert out_loss_mask is sharded_loss_mask
 
@@ -595,6 +670,188 @@ class TestMimoModel:
                 labels=None,
                 input_tensors=None,
             )
+
+    @pytest.mark.parametrize(("tp", "cp"), [(1, 1), (2, 1), (1, 2), (2, 2)])
+    def test_mtp_forward_uses_parallel_local_token_metadata(self, tp, cp):
+        """Run real MIMO+MTP for the supported TP/CP combinations.
+
+        MIMO owns CP partitioning for its pre-combined decoder embeddings, so
+        the token and position IDs consumed by MTP must be partitioned to the
+        same CP-local sequence. TP additionally exercises MTP's SP scatter.
+        """
+        os.environ['CUDA_DEVICE_MAX_CONNECTIONS'] = '1'
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
+        model_parallel_cuda_manual_seed(123)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        seq_len = 16
+        vocab_size = 128
+        invalid_token_id = 127
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            tensor_model_parallel_size=tp,
+            sequence_parallel=tp > 1,
+            context_parallel_size=cp,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        language_model_spec = ModuleSpec(
+            module=GPTModel,
+            params={
+                "config": config,
+                "transformer_layer_spec": layer_spec,
+                "mtp_block_spec": get_gpt_mtp_block_spec(
+                    config=config, spec=layer_spec, use_transformer_engine=True
+                ),
+                "vocab_size": vocab_size,
+                "max_sequence_length": seq_len,
+                "pre_process": True,
+                "post_process": True,
+                "position_embedding_type": "rope",
+                "scatter_embedding_sequence_parallel": False,
+                "share_embeddings_and_output_weights": True,
+                "pg_collection": pg_collection,
+            },
+        )
+        model = MimoModel(
+            MimoModelConfig(
+                language_model_spec=language_model_spec,
+                modality_submodules_spec={},
+                special_token_ids={"images": invalid_token_id},
+            ),
+            cp_group=pg_collection.cp,
+            tp_group=pg_collection.tp,
+        ).cuda()
+
+        if cp > 1:
+            # The test container has no TE attention backend for CP. Keep the real
+            # MIMO partitioning and MTP embedding/projection/loss path, but replace
+            # the main decoder and the inner attention layer with identities so the
+            # test reaches the CP-local MTP concatenation this regression covers.
+            class _IdentityDecoder(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.input_tensor = None
+
+                def set_input_tensor(self, input_tensor):
+                    self.input_tensor = input_tensor
+
+                def forward(self, hidden_states, **kwargs):
+                    return hidden_states if hidden_states is not None else self.input_tensor
+
+            class _IdentityMTPLayer(torch.nn.Module):
+                def forward(self, hidden_states, **kwargs):
+                    return hidden_states, None
+
+            model.language_model.decoder = _IdentityDecoder()
+            for mtp_layer in model.language_model.mtp.layers:
+                mtp_layer.mtp_model_layer = _IdentityMTPLayer()
+
+        input_ids = torch.randint(1, vocab_size - 1, (1, seq_len), device="cuda")
+        input_ids[0, 3] = invalid_token_id
+        position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
+        labels = torch.roll(input_ids, shifts=-1, dims=-1)
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+        loss_mask[input_ids == invalid_token_id] = 0
+
+        output, local_loss_mask = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            labels=labels,
+            loss_mask=loss_mask,
+            attention_mask=None,
+            modality_inputs=None,
+        )
+
+        assert output.shape == local_loss_mask.shape == (1, seq_len // cp)
+        output.mean().backward()
+
+    def test_non_first_pipeline_stage_runs_real_mtp(self):
+        """Run real MIMO+MTP on the last stage of a two-stage LM pipeline."""
+        os.environ['CUDA_DEVICE_MAX_CONNECTIONS'] = '1'
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(pipeline_model_parallel_size=2)
+        model_parallel_cuda_manual_seed(123)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        is_first_stage = parallel_state.is_pipeline_first_stage()
+        is_last_stage = parallel_state.is_pipeline_last_stage()
+
+        seq_len = 8
+        vocab_size = 128
+        invalid_token_id = 127
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            num_layers=2,
+            hidden_size=32,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            pipeline_model_parallel_size=2,
+            pipeline_dtype=torch.float32,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec()
+        language_model_spec = ModuleSpec(
+            module=GPTModel,
+            params={
+                "config": config,
+                "transformer_layer_spec": layer_spec,
+                "mtp_block_spec": get_gpt_mtp_block_spec(
+                    config=config, spec=layer_spec, use_transformer_engine=True
+                ),
+                "vocab_size": vocab_size,
+                "max_sequence_length": seq_len,
+                "pre_process": is_first_stage,
+                "post_process": is_last_stage,
+                "position_embedding_type": "rope",
+                "share_embeddings_and_output_weights": True,
+                "pg_collection": pg_collection,
+            },
+        )
+        model = MimoModel(
+            MimoModelConfig(
+                language_model_spec=language_model_spec,
+                modality_submodules_spec={},
+                special_token_ids={"images": invalid_token_id},
+            )
+        ).cuda()
+        model.role = RankRole(
+            modules={
+                MIMO_LANGUAGE_MODULE_KEY: ModuleStageInfo(
+                    is_first_stage=is_first_stage, is_last_stage=is_last_stage
+                )
+            },
+            mode=ModuleLayout.NON_COLOCATED,
+        )
+
+        if not is_last_stage:
+            return
+
+        input_ids = torch.randint(1, vocab_size - 1, (1, seq_len), device="cuda")
+        input_ids[0, 2] = invalid_token_id
+        position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
+        labels = torch.roll(input_ids, shifts=-1, dims=-1)
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+        loss_mask[input_ids == invalid_token_id] = 0
+        hidden_states = torch.randn(seq_len, 1, config.hidden_size, device="cuda")
+
+        output, _ = model._forward_language_module(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            loss_mask=loss_mask,
+            labels=labels,
+            input_tensors={MIMO_LANGUAGE_MODULE_KEY: hidden_states},
+        )
+
+        assert output.shape == loss_mask.shape
+        output.mean().backward()
 
 
 class MockProcessGroup:
@@ -809,17 +1066,20 @@ class TestMimoModelNonColocated:
         assert captured['loss_mask'] is loss_mask
         assert out_loss_mask is loss_mask
 
-    def test_forward_language_module_non_first_stage_drops_input_ids(self):
-        """Non-first PP stage in ``_forward_language_module`` must call the LM
-        with ``input_ids=None`` (hidden states arrive via ``set_input_tensor``)
-        while still threading ``position_ids`` through for mRoPE.
+    def test_forward_language_module_non_first_stage_threads_mtp_mask(self):
+        """A non-first PP stage that owns MTP must preserve token IDs and its mask.
+
+        Hidden states arrive through ``set_input_tensor`` while the conditioning
+        token IDs remain available for MTP's shifted embedding lookup.
         """
         model = MimoModel(self._make_config(encoder_in_grid=False, language_in_grid=True))
         model = model.to(self.device)
+        model.language_model.mtp_process = True
 
         input_ids = torch.randint(
             0, self.vocab_size, (self.batch_size, self.seq_len), device=self.device
         )
+        input_ids[0, 1] = model.special_token_ids['images']
         position_ids = (
             torch.arange(self.seq_len, device=self.device).unsqueeze(0).expand(self.batch_size, -1)
         )
@@ -849,9 +1109,11 @@ class TestMimoModelNonColocated:
                 input_tensors={MIMO_LANGUAGE_MODULE_KEY: hidden_states},
             )
 
-        assert captured['input_ids'] is None
+        assert captured['input_ids'] is input_ids
         assert captured['decoder_input'] is None
         assert captured['loss_mask'] is loss_mask
+        assert captured['mtp_input_mask'][0, 1].item() is False
+        assert captured['mtp_input_mask'][0, 0].item() is True
         torch.testing.assert_close(captured['position_ids'], position_ids)
 
 

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -1152,6 +1152,50 @@ class TestMultiTokenPredictionLayer:
         assert second_step_grad[0] == 0  # The path that crossed the modality is masked.
         assert second_step_grad[1] != 0  # Its neighboring text-only path remains supervised.
 
+    @pytest.mark.parametrize("with_mtp_input_mask", [False, True])
+    def test_process_mtp_loss_co_rolls_conditioning_mask(self, monkeypatch, with_mtp_input_mask):
+        """Conditioning validity must not add a CP roll at each prediction depth."""
+        config = TransformerConfig(
+            mtp_num_layers=2,
+            mtp_loss_scaling_factor=1.0,
+            num_layers=2,
+            hidden_size=1,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+        )
+        seq_len = 5
+        rolled = []
+
+        def capture_roll(tensor, *args, **kwargs):
+            rolled.append((tensor.shape, kwargs.get("return_sum", True)))
+            return roll_tensor(tensor, *args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "roll_tensor", capture_roll)
+        process_mtp_loss(
+            hidden_states=torch.ones((1 + config.mtp_num_layers) * seq_len, 1, 1),
+            labels=torch.arange(seq_len).unsqueeze(0),
+            loss_mask=torch.ones(1, seq_len),
+            mtp_input_mask=(
+                torch.tensor([[True, False, True, True, True]]) if with_mtp_input_mask else None
+            ),
+            output_layer=lambda hidden, **kwargs: (hidden, None),
+            output_weight=None,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=lambda labels, logits: torch.ones_like(
+                labels, dtype=logits.dtype
+            ),
+            config=config,
+        )
+
+        assert len(rolled) == 2 * config.mtp_num_layers
+        if with_mtp_input_mask:
+            assert [shape[0] for shape, _ in rolled] == [1, 2, 1, 2]
+            assert all(not return_sum for _, return_sum in rolled)
+        else:
+            assert [shape[0] for shape, _ in rolled] == [1, 1, 1, 1]
+            assert [return_sum for _, return_sum in rolled] == [False, True, False, True]
+
 
 class TestMTPHiddenStateRollUnderParallelism:
     """Token-level checks on the HSM hidden-state roll for every sequence-sharding mode.

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -38,6 +38,8 @@ from megatron.core.transformer.multi_token_prediction import (
     _mix_hidden_state_history,
     _mtp_logits_are_vocab_sharded,
     _packed_seq_params_for_local_hsm_roll,
+    get_mtp_num_layers_to_build,
+    mtp_on_this_rank,
     process_mtp_loss,
     roll_tensor,
 )
@@ -116,6 +118,89 @@ class TestMultiTokenPredictionLayer:
             config=config, spec=transformer_layer_spec, use_transformer_engine=use_te
         )
         return config, mtp_block_spec
+
+    def test_mtp_placement_uses_explicit_pipeline_rank(self, monkeypatch):
+        """Explicit PP metadata must avoid global MPU reads during model construction."""
+
+        def unexpected_global_read(*args, **kwargs):
+            raise AssertionError("global pipeline state must not be read")
+
+        monkeypatch.setattr(
+            mtp_module.parallel_state, "get_pipeline_model_parallel_rank", unexpected_global_read
+        )
+        monkeypatch.setattr(
+            mtp_module.parallel_state,
+            "get_pipeline_model_parallel_world_size",
+            unexpected_global_read,
+        )
+        monkeypatch.setattr(
+            mtp_module.parallel_state,
+            "get_virtual_pipeline_model_parallel_world_size",
+            unexpected_global_read,
+        )
+
+        assert mtp_on_this_rank(
+            mtp_num_layers=1, ignore_virtual=False, vp_stage=0, pp_rank=1, pp_size=2, vp_size=1
+        )
+        assert not mtp_on_this_rank(
+            mtp_num_layers=1, ignore_virtual=False, vp_stage=0, pp_rank=0, pp_size=2, vp_size=1
+        )
+
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            mtp_loss_scaling_factor=1.0,
+            num_layers=2,
+            hidden_size=8,
+            num_attention_heads=1,
+            pipeline_model_parallel_size=2,
+            use_cpu_initialization=True,
+        )
+        assert get_mtp_num_layers_to_build(config, pp_rank=1) == 1
+        assert get_mtp_num_layers_to_build(config, pp_rank=0) == 0
+
+    def test_process_mtp_loss_uses_explicit_metric_group(self, monkeypatch):
+        """MTP metric reduction must use the language model's supplied data group."""
+        metric_avg_group = object()
+        captured = {}
+
+        def unexpected_global_read(*args, **kwargs):
+            raise AssertionError("global data-parallel state must not be read")
+
+        def capture_metrics(*args, **kwargs):
+            captured["avg_group"] = kwargs["avg_group"]
+
+        monkeypatch.setattr(
+            mtp_module.parallel_state, "get_data_parallel_group", unexpected_global_read
+        )
+        monkeypatch.setattr(MTPLossLoggingHelper, "save_metrics_to_tracker", capture_metrics)
+
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            mtp_loss_scaling_factor=1.0,
+            num_layers=2,
+            hidden_size=1,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+        )
+        seq_len = 4
+        hidden_states = torch.ones(2 * seq_len, 1, 1)
+
+        process_mtp_loss(
+            hidden_states=hidden_states,
+            labels=torch.zeros(1, seq_len, dtype=torch.long),
+            loss_mask=torch.ones(1, seq_len),
+            output_layer=lambda hidden, **kwargs: (hidden, None),
+            output_weight=None,
+            runtime_gather_output=None,
+            is_training=True,
+            compute_language_model_loss=lambda labels, logits: torch.ones_like(
+                labels, dtype=logits.dtype
+            ),
+            config=config,
+            metric_avg_group=metric_avg_group,
+        )
+
+        assert captured["avg_group"] is metric_avg_group
 
     def test_hsm_mix_preserves_dtype_and_gradients(self, monkeypatch):
         """HSM selects per-element history entries without changing dtype or gradients."""
@@ -3009,6 +3094,7 @@ class TestMultiTokenPredictionHybrid:
     def _make_forward_stub():
         hidden_states = torch.arange(4, dtype=torch.float32).reshape(2, 1, 2)
         call_counts = {"mtp": 0, "mtp_loss": 0, "main_loss": 0, "mtp_input_mask": None}
+        metric_avg_group = object()
 
         def decoder(**kwargs):
             decoder_hidden_states = kwargs["hidden_states"]
@@ -3051,11 +3137,11 @@ class TestMultiTokenPredictionHybrid:
             output_layer=output_layer,
             training=True,
             compute_language_model_loss=compute_language_model_loss,
-            pg_collection=types.SimpleNamespace(cp=None),
+            pg_collection=types.SimpleNamespace(cp=None, dp_cp=metric_avg_group),
             tp_group=None,
             _scale_logits=lambda logits: logits,
         )
-        return model, hidden_states, call_counts
+        return model, hidden_states, call_counts, metric_avg_group
 
     @pytest.mark.parametrize(
         (
@@ -3082,7 +3168,7 @@ class TestMultiTokenPredictionHybrid:
         expected_main_loss_calls,
     ):
         """Test that MTP execution and the main output contract are independent."""
-        model, hidden_states, call_counts = self._make_forward_stub()
+        model, hidden_states, call_counts, metric_avg_group = self._make_forward_stub()
         labels = torch.tensor([[3, 4]]) if provide_labels else None
         input_ids = torch.zeros(1, 2, dtype=torch.long)
         loss_mask = torch.ones(1, 2)
@@ -3094,6 +3180,7 @@ class TestMultiTokenPredictionHybrid:
             assert kwargs["input_ids"] is input_ids
             assert kwargs["loss_mask"] is loss_mask
             assert kwargs["mtp_input_mask"] is mtp_input_mask
+            assert kwargs["metric_avg_group"] is metric_avg_group
             return torch.chunk(kwargs["hidden_states"], 1 + kwargs["config"].mtp_num_layers, dim=0)[
                 0
             ]
@@ -3131,7 +3218,7 @@ class TestMultiTokenPredictionHybrid:
         self, monkeypatch, compute_mtp_loss
     ):
         """Test the auxiliary MTP switch does not disable speculative-decoding state capture."""
-        model, hidden_states, call_counts = self._make_forward_stub()
+        model, hidden_states, call_counts, _ = self._make_forward_stub()
         inference_context = types.SimpleNamespace(
             is_dynamic_batching=lambda: True,
             num_speculative_tokens=1,

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -504,7 +504,7 @@ class TestMultiTokenPredictionLayer:
         def fake_embedding(input_ids, position_ids):
             return torch.zeros(seq_len, batch_size, config.hidden_size, dtype=hidden_states.dtype)
 
-        rolled_input_ids, rolled_position_ids, rolled_padding_mask, _, _ = (
+        rolled_input_ids, rolled_position_ids, rolled_padding_mask, _, _, _ = (
             mtp_layer._get_embeddings(
                 input_ids=input_ids,
                 position_ids=position_ids,
@@ -567,7 +567,7 @@ class TestMultiTokenPredictionLayer:
             types.MethodType(fake_proj_and_transformer_layer, mtp_layer),
         )
 
-        _, _, _, returned_padding_mask = mtp_layer.forward(
+        _, _, _, returned_padding_mask, _ = mtp_layer.forward(
             input_ids=input_ids,
             position_ids=position_ids,
             hidden_states=hidden_states,
@@ -601,7 +601,7 @@ class TestMultiTokenPredictionLayer:
         def fake_embedding(input_ids, position_ids):
             return emb_weight.clone()
 
-        _, _, _, decoder_input, returned_hidden_states = mtp_layer._get_embeddings(
+        _, _, _, _, decoder_input, returned_hidden_states = mtp_layer._get_embeddings(
             input_ids=input_ids,
             position_ids=position_ids,
             embedding=fake_embedding,
@@ -741,6 +741,68 @@ class TestMultiTokenPredictionLayer:
             assert hidden_states.grad is not None
             assert emb_weight.grad is not None
 
+    def test_invalid_conditioning_embedding_has_no_input_gradient(self):
+        """A later causal loss must not update an invalid tied embedding row.
+
+        The selected output position can attend to the earlier invalid MTP input.
+        Its embedding value remains available in the forward pass, but its row in
+        the shared embedding table must be detached from the input-side gradient.
+        """
+        torch.manual_seed(_SEED)
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+        model_parallel_cuda_manual_seed(_SEED)
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            num_layers=2,
+            hidden_size=32,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        layer_spec = get_gpt_layer_local_spec()
+        mtp_block_spec = get_gpt_mtp_block_spec(
+            config=config, spec=layer_spec, use_transformer_engine=False
+        )
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
+
+        vocab_size = 16
+        invalid_token_id = 9
+
+        class SharedEmbedding(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(
+                    torch.randn(vocab_size, config.hidden_size, device="cuda")
+                )
+
+            def forward(self, input_ids, position_ids):
+                return torch.nn.functional.embedding(input_ids, self.weight).transpose(0, 1)
+
+        embedding = SharedEmbedding()
+        input_ids = torch.tensor([[4, invalid_token_id, 5, 6]], device="cuda")
+        position_ids = torch.arange(input_ids.size(1), device="cuda").unsqueeze(0)
+        mtp_input_mask = input_ids != invalid_token_id
+        hidden_states = torch.randn(
+            input_ids.size(1), 1, config.hidden_size, device="cuda", requires_grad=True
+        )
+
+        output = mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attention_mask=None,
+            embedding=embedding,
+            mtp_input_mask=mtp_input_mask,
+        )
+
+        # After the MTP shift, the invalid token is at position 0. A loss on
+        # position 2 can attend to it through causal self-attention.
+        output[input_ids.size(1) + 2].square().sum().backward()
+
+        assert torch.count_nonzero(embedding.weight.grad[invalid_token_id]) == 0
+        assert torch.count_nonzero(embedding.weight.grad[6]) > 0
+
     @pytest.mark.parametrize("detach_heads", [False, True])
     def test_process_mtp_loss_detaches_output_weight(self, detach_heads):
         """process_mtp_loss must detach the output-head weight when mtp_detach_heads=True
@@ -835,6 +897,50 @@ class TestMultiTokenPredictionLayer:
         assert torch.count_nonzero(hidden_states.grad[seq_len:]) == 0
         assert output_weight.grad is not None
         assert torch.count_nonzero(output_weight.grad) == 0
+
+    def test_process_mtp_loss_masks_later_steps_after_invalid_input(self):
+        """Mask an MTP prediction after its conditioning path reaches an invalid token."""
+        config = TransformerConfig(
+            mtp_num_layers=2,
+            mtp_loss_scaling_factor=1.0,
+            num_layers=2,
+            hidden_size=1,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+        )
+        seq_len = 5
+        hidden_states = torch.ones(
+            (1 + config.mtp_num_layers) * seq_len, 1, config.hidden_size, requires_grad=True
+        )
+
+        def output_layer(hidden, weight=None, runtime_gather_output=None):
+            return hidden, None
+
+        def compute_language_model_loss(labels, logits):
+            return logits.squeeze(-1).transpose(0, 1)
+
+        # Input validity: [text, modality, text, text, padding]. The first-step path
+        # starting at position 1 consumes only valid text at position 2. The second-step
+        # path starting at position 0 crosses the modality token at position 1.
+        process_mtp_loss(
+            hidden_states=hidden_states,
+            labels=torch.tensor([[10, 13, 100, 101, 0]]),
+            loss_mask=torch.tensor([[0.0, 0.0, 1.0, 1.0, 0.0]]),
+            mtp_input_mask=torch.tensor([[True, False, True, True, True]]),
+            output_layer=output_layer,
+            output_weight=None,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=compute_language_model_loss,
+            config=config,
+        ).sum().backward()
+
+        first_step_grad = hidden_states.grad[seq_len : 2 * seq_len, 0, 0]
+        second_step_grad = hidden_states.grad[2 * seq_len :, 0, 0]
+
+        assert first_step_grad[1] != 0  # The one-step text-only path remains supervised.
+        assert second_step_grad[0] == 0  # The path that crossed the modality is masked.
+        assert second_step_grad[1] != 0  # Its neighboring text-only path remains supervised.
 
 
 class TestMTPHiddenStateRollUnderParallelism:
@@ -2771,7 +2877,7 @@ class TestMultiTokenPredictionHybrid:
     @staticmethod
     def _make_forward_stub():
         hidden_states = torch.arange(4, dtype=torch.float32).reshape(2, 1, 2)
-        call_counts = {"mtp": 0, "mtp_loss": 0, "main_loss": 0}
+        call_counts = {"mtp": 0, "mtp_loss": 0, "main_loss": 0, "mtp_input_mask": None}
 
         def decoder(**kwargs):
             decoder_hidden_states = kwargs["hidden_states"]
@@ -2783,6 +2889,7 @@ class TestMultiTokenPredictionHybrid:
 
         def mtp(**kwargs):
             call_counts["mtp"] += 1
+            call_counts["mtp_input_mask"] = kwargs.get("mtp_input_mask")
             decoder_hidden_states = kwargs["hidden_states"]
             return torch.cat((decoder_hidden_states, decoder_hidden_states + 100.0), dim=0)
 
@@ -2848,12 +2955,14 @@ class TestMultiTokenPredictionHybrid:
         labels = torch.tensor([[3, 4]]) if provide_labels else None
         input_ids = torch.zeros(1, 2, dtype=torch.long)
         loss_mask = torch.ones(1, 2)
+        mtp_input_mask = torch.ones(1, 2, dtype=torch.bool)
 
         def process_mtp_loss_spy(**kwargs):
             call_counts["mtp_loss"] += 1
             assert kwargs["labels"] is labels
             assert kwargs["input_ids"] is input_ids
             assert kwargs["loss_mask"] is loss_mask
+            assert kwargs["mtp_input_mask"] is mtp_input_mask
             return torch.chunk(kwargs["hidden_states"], 1 + kwargs["config"].mtp_num_layers, dim=0)[
                 0
             ]
@@ -2870,9 +2979,12 @@ class TestMultiTokenPredictionHybrid:
             decoder_input=hidden_states,
             labels=labels,
             loss_mask=loss_mask,
+            mtp_input_mask=mtp_input_mask,
             compute_mtp_loss=compute_mtp_loss,
         )
 
+        expected_block_mask = mtp_input_mask if expected_mtp_calls else None
+        assert call_counts.pop("mtp_input_mask") is expected_block_mask
         assert call_counts == {
             "mtp": expected_mtp_calls,
             "mtp_loss": expected_mtp_loss_calls,
@@ -2918,6 +3030,7 @@ class TestMultiTokenPredictionHybrid:
 
         torch.testing.assert_close(output, hidden_states.transpose(0, 1).contiguous())
         torch.testing.assert_close(inference_context.mtp_decoder_hidden_states, hidden_states)
+        assert call_counts.pop("mtp_input_mask") is None
         assert call_counts == {"mtp": 0, "mtp_loss": 0, "main_loss": 0}
 
     @pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -295,11 +295,21 @@ class TestMultiTokenPredictionLayer:
             num_layers=2, hidden_size=4, num_attention_heads=1, mtp_num_layers=2, mtp_hsm=True
         )
         seen_inputs = []
+        seen_masks = []
 
         class _IncrementLayer:
-            def __call__(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
+            def __call__(
+                self,
+                hidden_states,
+                input_ids,
+                position_ids,
+                padding_mask,
+                mtp_input_mask=None,
+                **kwargs,
+            ):
                 seen_inputs.append(hidden_states.clone())
-                return hidden_states + 1, input_ids, position_ids, padding_mask
+                seen_masks.append(mtp_input_mask)
+                return hidden_states + 1, input_ids, position_ids, padding_mask, mtp_input_mask
 
         block = types.SimpleNamespace(
             config=config,
@@ -322,12 +332,14 @@ class TestMultiTokenPredictionLayer:
         )
 
         hidden_states = torch.ones(2, 1, config.hidden_size)
+        mtp_input_mask = torch.tensor([[True, False]])
         MultiTokenPredictionBlock.forward(
             block,
             input_ids=torch.zeros(1, 2, dtype=torch.long),
             position_ids=torch.zeros(1, 2, dtype=torch.long),
             hidden_states=hidden_states,
             attention_mask=torch.ones(1, 1, 2, 2, dtype=torch.bool),
+            mtp_input_mask=mtp_input_mask,
         )
 
         torch.testing.assert_close(seen_inputs[0], hidden_states)
@@ -335,6 +347,8 @@ class TestMultiTokenPredictionLayer:
             seen_inputs[1],
             torch.tensor(expected_second_input).view(2, 1, 1).expand_as(hidden_states),
         )
+        assert len(seen_masks) == 2
+        assert all(mask is mtp_input_mask for mask in seen_masks)
 
     @pytest.mark.parametrize("packed", [False, True])
     def test_hsm_aligns_history_with_target_tokens(self, monkeypatch, packed):
@@ -347,7 +361,13 @@ class TestMultiTokenPredictionLayer:
         class _IncrementLayer:
             def __call__(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
                 seen_inputs.append(hidden_states.clone())
-                return hidden_states + 10, input_ids, position_ids, padding_mask
+                return (
+                    hidden_states + 10,
+                    input_ids,
+                    position_ids,
+                    padding_mask,
+                    kwargs.get("mtp_input_mask"),
+                )
 
         block = types.SimpleNamespace(
             config=config,
@@ -522,6 +542,103 @@ class TestMultiTokenPredictionLayer:
         assert torch.equal(rolled_input_ids, expected_input_ids)
         assert torch.equal(rolled_position_ids, expected_position_ids)
         assert torch.equal(rolled_padding_mask, expected_padding_mask)
+
+    @pytest.mark.parametrize("with_mask", [False, True])
+    def test_get_embeddings_does_not_add_a_mask_roll(self, monkeypatch, with_mask):
+        """Conditioning validity shares the token-ID roll instead of adding an exchange."""
+        torch.manual_seed(_SEED)
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
+        mtp_layer = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).layers[0]
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.int64)
+        position_ids = torch.arange(input_ids.size(1), dtype=torch.int64).unsqueeze(0)
+        hidden_states = torch.randn(input_ids.size(1), 1, config.hidden_size)
+        mtp_input_mask = input_ids != 2 if with_mask else None
+        rolled_shapes = []
+
+        def capture_roll(tensor, *args, **kwargs):
+            rolled_shapes.append(tensor.shape)
+            return roll_tensor(tensor, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "megatron.core.transformer.multi_token_prediction.roll_tensor", capture_roll
+        )
+
+        mtp_layer._get_embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            embedding=lambda input_ids, position_ids: torch.zeros(
+                input_ids.size(1), input_ids.size(0), config.hidden_size
+            ),
+            hidden_states=hidden_states,
+            mtp_input_mask=mtp_input_mask,
+        )
+
+        assert len(rolled_shapes) == 2  # Token metadata and position IDs.
+        expected_metadata_batch = 2 * input_ids.size(0) if with_mask else input_ids.size(0)
+        assert rolled_shapes[0][0] == expected_metadata_batch
+
+    @pytest.mark.parametrize("cp", [1, 2])
+    def test_get_embeddings_rolls_packed_ids_and_validity_together(self, cp):
+        """Packed CP rolling keeps token IDs and their validity exactly aligned."""
+        torch.manual_seed(_SEED)
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=cp, use_te=cp > 1)
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp_layer = mtp.layers[0]
+        cp_group = get_context_parallel_group() if cp > 1 else None
+        cp_rank = torch.distributed.get_rank(group=cp_group) if cp_group is not None else 0
+
+        if cp == 1:
+            input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int64).cuda()
+            expected_ids = torch.tensor([[2, 3, 0, 5, 0]], dtype=torch.int64).cuda()
+            cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32).cuda()
+            max_seqlen = 3
+        elif cp_rank == 0:
+            input_ids = torch.tensor(
+                [[1, 2, 7, 8, 11, 12, 13, 20, 21, 22]], dtype=torch.int64
+            ).cuda()
+            expected_ids = torch.tensor(
+                [[2, 3, 8, 0, 12, 13, 14, 21, 22, 0]], dtype=torch.int64
+            ).cuda()
+            cu_seqlens = torch.tensor([0, 8, 20], dtype=torch.int32).cuda()
+            max_seqlen = 6
+        else:
+            input_ids = torch.tensor(
+                [[3, 4, 5, 6, 14, 15, 16, 17, 18, 19]], dtype=torch.int64
+            ).cuda()
+            expected_ids = torch.tensor(
+                [[4, 5, 6, 7, 15, 16, 17, 18, 19, 20]], dtype=torch.int64
+            ).cuda()
+            cu_seqlens = torch.tensor([0, 8, 20], dtype=torch.int32).cuda()
+            max_seqlen = 6
+
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            qkv_format='thd',
+        )
+        mtp_input_mask = (input_ids != 3) & (input_ids != 14)
+        position_ids = torch.arange(input_ids.size(1), device="cuda").unsqueeze(0)
+        hidden_states = torch.randn(input_ids.size(1), 1, config.hidden_size, device="cuda")
+
+        def fake_embedding(input_ids, position_ids):
+            return torch.zeros(
+                input_ids.size(1), input_ids.size(0), config.hidden_size, device="cuda"
+            )
+
+        rolled_ids, _, _, rolled_mask, _, _ = mtp_layer._get_embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            embedding=fake_embedding,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+            mtp_input_mask=mtp_input_mask,
+        )
+
+        expected_mask = (expected_ids != 0) & (expected_ids != 3) & (expected_ids != 14)
+        torch.testing.assert_close(rolled_ids, expected_ids)
+        torch.testing.assert_close(rolled_mask, expected_mask)
 
     def test_forward_propagates_rolled_padding_mask(self, monkeypatch):
         """Test forward passes rolled padding_mask to transformer path."""
@@ -741,7 +858,8 @@ class TestMultiTokenPredictionLayer:
             assert hidden_states.grad is not None
             assert emb_weight.grad is not None
 
-    def test_invalid_conditioning_embedding_has_no_input_gradient(self):
+    @pytest.mark.parametrize("mtp_num_layers", [1, 2])
+    def test_invalid_conditioning_embedding_has_no_input_gradient(self, mtp_num_layers):
         """A later causal loss must not update an invalid tied embedding row.
 
         The selected output position can attend to the earlier invalid MTP input.
@@ -752,7 +870,7 @@ class TestMultiTokenPredictionLayer:
         Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
         model_parallel_cuda_manual_seed(_SEED)
         config = TransformerConfig(
-            mtp_num_layers=1,
+            mtp_num_layers=mtp_num_layers,
             num_layers=2,
             hidden_size=32,
             num_attention_heads=4,
@@ -767,7 +885,7 @@ class TestMultiTokenPredictionLayer:
         mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
 
         vocab_size = 16
-        invalid_token_id = 9
+        invalid_token_ids = (9, 10)
 
         class SharedEmbedding(torch.nn.Module):
             def __init__(self):
@@ -780,9 +898,13 @@ class TestMultiTokenPredictionLayer:
                 return torch.nn.functional.embedding(input_ids, self.weight).transpose(0, 1)
 
         embedding = SharedEmbedding()
-        input_ids = torch.tensor([[4, invalid_token_id, 5, 6]], device="cuda")
+        input_ids = torch.tensor(
+            [[4, invalid_token_ids[0], 5, invalid_token_ids[1], 6, 7]], device="cuda"
+        )
         position_ids = torch.arange(input_ids.size(1), device="cuda").unsqueeze(0)
-        mtp_input_mask = input_ids != invalid_token_id
+        mtp_input_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for invalid_token_id in invalid_token_ids:
+            mtp_input_mask &= input_ids != invalid_token_id
         hidden_states = torch.randn(
             input_ids.size(1), 1, config.hidden_size, device="cuda", requires_grad=True
         )
@@ -796,11 +918,14 @@ class TestMultiTokenPredictionLayer:
             mtp_input_mask=mtp_input_mask,
         )
 
-        # After the MTP shift, the invalid token is at position 0. A loss on
-        # position 2 can attend to it through causal self-attention.
-        output[input_ids.size(1) + 2].square().sum().backward()
+        # Each MTP output at position 4 can causally attend to every invalid
+        # shifted embedding that remains in that prediction depth.
+        seq_len = input_ids.size(1)
+        mtp_outputs = output[seq_len:].reshape(mtp_num_layers, seq_len, 1, config.hidden_size)
+        mtp_outputs[:, 4].square().sum().backward()
 
-        assert torch.count_nonzero(embedding.weight.grad[invalid_token_id]) == 0
+        for invalid_token_id in invalid_token_ids:
+            assert torch.count_nonzero(embedding.weight.grad[invalid_token_id]) == 0
         assert torch.count_nonzero(embedding.weight.grad[6]) > 0
 
     @pytest.mark.parametrize("detach_heads", [False, True])
@@ -1130,7 +1255,13 @@ class TestMTPHiddenStateRollUnderParallelism:
 
             def __call__(self, hidden_states, input_ids, position_ids, padding_mask=None, **kwargs):
                 layer_inputs.append(hidden_states.detach().clone())
-                return hidden_states + 1, input_ids, position_ids, padding_mask
+                return (
+                    hidden_states + 1,
+                    input_ids,
+                    position_ids,
+                    padding_mask,
+                    kwargs.get("mtp_input_mask"),
+                )
 
         rolled_history = []
         mixed_states = []


### PR DESCRIPTION
## Context

Draft duplicate of #6770, rebased onto current main for focused iteration with Kevin. This is an integration workspace, not a competing replacement for the original PR.

## What changed

- Preserve latest main's optional modality_token_indices API and index_copy_ embedding-alignment fast path.
- Add a focused `_prepare_mtp_inputs` path in the MIMO base model:
  - derive MTP input IDs only on the MTP-owning stage;
  - build MTP validity from precomputed text indices when provided, with the special-token scan as the optional fallback;
  - CP-partition token IDs, validity, and 2-D/3-D position IDs consistently while preserving the language model's multidimensional RoPE layout;
  - avoid threading a text mask through the text-embedding and alignment APIs.
- Carry mtp_input_mask through GPT, Hybrid, fine-grained scheduling, and MTP loss processing.
- Preserve current-main MTP hidden-state mixing while threading the conditioning mask.
- Pass explicit language ProcessGroupCollection metadata for MTP PP placement and metric reduction, retaining documented MPU fallbacks for legacy callers.
- Co-roll IDs with validity and loss masks with conditioning validity, and disable unused roll reductions on the hot path.
- Preserve invalid-conditioning embedding values in forward while detaching their input-side gradient.

The commit stack keeps the original production change and parallelism tests separate from the explicit process-group plumbing and the optional roll/reduction optimization.

## Validation

- isort check on changed Python files
- black check on changed Python files
- ruff check on changed Python files
- Python bytecode compilation on changed Python files
- git diff --check

Distributed GPU tests have not been run from this local workspace because it does not have PyTorch or a GPU runtime. The draft includes focused PP/CP, packed-sequence, HSM, gradient, explicit-process-group, and roll-count regressions for the GPU CI pass.

## Follow-up validation

- Run the focused MIMO and MTP unit-test files through torch.distributed.run.
- Run a disjoint-rank MIMO + MTP smoke with PP > 1 and CP > 1 and inspect every rank.
- Compare masked and unmasked step timing after warmup at CP1/CP2 and multiple MTP depths.
