### PR TITLE
Docs: add parallel_state to the curated Core APIs guide

### DIFF
--- a/docs/api-guide/core/index.md
+++ b/docs/api-guide/core/index.md
@@ -19,6 +19,7 @@ tensor_parallel
 pipeline_parallel
 fusions
 distributed
+parallel_state
 datasets
 dist_checkpointing
 dist_checkpointing.strategies

--- a/docs/api-guide/core/parallel_state.md
+++ b/docs/api-guide/core/parallel_state.md
@@ -1,0 +1,17 @@
+<!---
+   Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
+   NVIDIA CORPORATION and its licensors retain all intellectual property
+   and proprietary rights in and to this software, related documentation
+   and any modifications thereto. Any use, reproduction, disclosure or
+   distribution of this software and related documentation without an express
+   license agreement from NVIDIA CORPORATION is strictly prohibited.
+-->
+
+# parallel_state module
+
+This module manages model parallelism and data parallelism process groups in distributed training. It provides initialization and query functions for tensor parallelism (TP), pipeline parallelism (PP), data parallelism (DP), context parallelism (CP), and expert parallelism (EP) groups.
+
+The key entry point is `initialize_model_parallel()`, which creates all necessary process groups based on the specified parallelism configuration. Once initialized, the module provides getter functions to retrieve the initialized groups and query rank information within each group.
+
+See the [auto-generated API reference](https://nvidia.github.io/Megatron-LM/apidocs/core/core.parallel_state.html) for detailed function signatures and documentation.
+


### PR DESCRIPTION
## Description
Addresses issue #6175 by adding documentation for the \parallel_state\ module to the curated Core APIs guide.

## Changes
- Add \docs/api-guide/core/parallel_state.md\ with an overview of the parallel_state module
- Document the key entry point \initialize_model_parallel()\ and process group getter functions
- Add \parallel_state\ to the toctree in \docs/api-guide/core/index.md\`n- Include link to the auto-generated API reference

## Related Issue
Closes #6175