### PR TITLE
[Dev] Support THD CUDA graph capture for GatedDeltaNet with fla kernels

### DIFF
--- a/megatron/core/ssm/gated_delta_net/common.py
+++ b/megatron/core/ssm/gated_delta_net/common.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Protocol, Union
@@ -26,6 +27,7 @@ from megatron.core.ssm.mamba_context_parallel import (
 from megatron.core.ssm.utils import _split_tensor_factory
 from megatron.core.tensor_parallel import get_cuda_rng_tracker
 from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -49,6 +51,28 @@ except ImportError:
     chunk_gated_delta_rule = None
 
     HAVE_FLA = False
+
+try:
+    from fla.utils import FLA_DISABLE_TENSOR_CACHE
+except ImportError:
+    # Guarded separately from the block above: an fla build without this symbol is
+    # still a usable fla, and folding the import into that try would downgrade it to
+    # "FLA is not installed". Assume the cache is disabled so we never block a capture
+    # we cannot actually verify - but say so, because that assumption is exactly what
+    # _GDNBase._check_fla_tensor_cache_disabled exists to avoid making silently.
+    FLA_DISABLE_TENSOR_CACHE = True
+    warnings.warn(
+        "fla.utils.FLA_DISABLE_TENSOR_CACHE not found; GDN cannot verify that fla's "
+        "tensor cache is disabled before capturing THD CUDA graphs. Set "
+        "FLA_DISABLE_TENSOR_CACHE=1 manually if you intend to capture.",
+        stacklevel=2,
+    )
+
+# Chunk size fla's varlen kernels decompose sequences with. Must track both
+# ``fla.ops.gated_delta_rule.chunk_gated_delta_rule``'s ``chunk_size`` default and
+# ``fla.modules.conv``'s ``BT`` default; the chunk_indices tables we build below are
+# consumed by both.
+_FLA_CHUNK_SIZE = 64
 
 __all__ = [
     "HAVE_FLA",
@@ -164,6 +188,17 @@ class _GDNBase(MegatronModule):
             )
 
         super().__init__(config)
+
+        self._check_fla_tensor_cache_disabled(config)
+
+        # Single-entry ``(cu_seqlens, cpu_mirror)`` cache for static
+        # (CUDA-graph-capturable) cu_seqlens buffers - see _cu_seqlens_cpu_mirror.
+        # The source tensor is kept alive by this reference so ``is`` can never
+        # alias a freed tensor that happens to be reallocated at the same address.
+        self._cu_seqlens_cpu_cache: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+        # Config-derived constants for _fixed_shape_chunk_indices, materialized lazily
+        # once the device is known: {(nt_max, device): slot_arange}.
+        self._chunk_slot_cache: dict[tuple, torch.Tensor] = {}
 
         # Attributes from arguments
         self.layer_number = layer_number
@@ -478,30 +513,334 @@ class _GDNBase(MegatronModule):
         raise NotImplementedError
 
     def _resolve_cu_seqlens(
-        self, cu_seqlens_padded, cu_seqlens_actual, total_seq_len, name, cp_size: int = 1
+        self,
+        cu_seqlens_padded,
+        cu_seqlens_actual,
+        total_seq_len,
+        name,
+        cp_size: int = 1,
+        validate: bool = True,
     ) -> torch.Tensor:
-        """Resolve cu_seqlens for packed sequence all-to-all, handling alignment padding."""
+        """Resolve cu_seqlens for packed sequence all-to-all, handling alignment padding.
+
+        Args:
+            validate: Whether to run the consistency checks. They read cu_seqlens
+                *values* on the host, so the caller must pass ``False`` while a CUDA
+                graph is being captured. Kept as an explicit argument rather than
+                probing the stream here so the policy lives with the caller and this
+                stays a pure metadata resolver.
+        """
         if cu_seqlens_padded is not None:
             cu_seqlens = cu_seqlens_padded
         else:
             cu_seqlens = cu_seqlens_actual
 
-        total_cu = cu_seqlens[-1].cpu().item()
-        if total_cu != total_seq_len:
-            raise ValueError(
-                f"GDN: {name}[-1]={total_cu} does not match "
-                f"total_sequence_length={total_seq_len}. "
-                f"({cu_seqlens_padded=}, {cu_seqlens_actual=})."
-            )
+        if validate:
+            total_cu = cu_seqlens[-1].cpu().item()
+            if total_cu != total_seq_len:
+                raise ValueError(
+                    f"GDN: {name}[-1]={total_cu} does not match "
+                    f"total_sequence_length={total_seq_len}. "
+                    f"({cu_seqlens_padded=}, {cu_seqlens_actual=})."
+                )
 
-        seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-        if (seq_lengths % cp_size != 0).any():
-            raise ValueError(
-                f"All per-sequence lengths in cu_seqlens must be divisible by cp_size={cp_size}, "
-                f"but got lengths: {seq_lengths.tolist()}"
-            )
+            seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+            if (seq_lengths % cp_size != 0).any():
+                raise ValueError(
+                    f"All per-sequence lengths in cu_seqlens must be divisible by "
+                    f"cp_size={cp_size}, but got lengths: {seq_lengths.tolist()}"
+                )
 
         return cu_seqlens
+
+    def _fla_varlen_kwargs(
+        self,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_context=None,
+        extra_tokens: int = 0,
+        cu_seqlens_unpadded: Optional[torch.Tensor] = None,
+    ) -> dict:
+        """Capture-safe varlen metadata to forward to fla's chunked kernels.
+
+        fla's varlen kernels need a ``[NT, 2]`` ``chunk_indices`` table mapping each
+        chunk slot to ``(sequence index, chunk index within that sequence)``. Left to
+        itself fla builds that table on the host from the *contents* of ``cu_seqlens``
+        (``prepare_chunk_indices``), which CUDA graph capture forbids. This returns
+        whichever of fla's two escape hatches applies:
+
+        * ``chunk_indices``: a device-built, fixed-shape table (see
+          :meth:`_fixed_shape_chunk_indices`). This is the capture-safe path.
+        * ``cu_seqlens_cpu``: a cached CPU mirror, which only removes the D2H half of
+          fla's host build. Eager-only fallback, used when the static THD bounds
+          needed to fix the table's shape are not configured.
+
+        The two are mutually exclusive by fla's own contract: ``cu_seqlens_cpu`` is
+        read only when ``chunk_indices is None`` (``fla/ops/gated_delta_rule/chunk.py``
+        and ``fla/modules/conv/triton/ops.py``), so computing the mirror when a static
+        table exists would be dead work that can additionally fail capture.
+
+        Args:
+            cu_seqlens: The cu_seqlens actually passed to the fla call, i.e. after any
+                caller-side padding. ``None`` (SBHD) returns an empty dict.
+            cp_context: The ``FLACPContext`` passed to the same fla call, if any.
+            extra_tokens: Tokens the caller appended to ``cu_seqlens``'s last sequence
+                beyond the configured static buffer size (conv alignment padding).
+            cu_seqlens_unpadded: The tensor ``cu_seqlens`` was derived from, before those
+                ``extra_tokens`` were added. Required whenever ``extra_tokens`` is
+                non-zero. Passing it lets the CPU mirror be taken from the buffer both
+                call sites share, so the padded variant is host-side arithmetic on a cache
+                hit instead of a second D2H sync that evicts the unpadded entry.
+        """
+        assert extra_tokens == 0 or cu_seqlens_unpadded is not None, (
+            "cu_seqlens_unpadded is required when extra_tokens is non-zero, otherwise the "
+            "CPU mirror would double-count the padding."
+        )
+        if cu_seqlens is None:
+            return {}
+
+        # --- CP > 1 is deliberately not handled here. ---------------------------
+        # When a cp_context is supplied, fla overrides cu_seqlens with the *rank-local*
+        # partition (fla/ops/gated_delta_rule/chunk.py: `cu_seqlens = cp_context.cu_seqlens`;
+        # fla/modules/conv/cp/ops.py builds its table from cp_context.cu_seqlens), but it
+        # does *not* override a caller-supplied chunk_indices - it is consumed verbatim.
+        # Any table we build here is derived from the global cu_seqlens and would
+        # therefore describe the wrong tensor. GDN chunkwise CP is out of scope for CUDA
+        # graph capture today, so we simply hand the job back to fla, which derives the
+        # table from the CP-local cu_seqlens correctly (at the cost of a host round trip
+        # that only matters under capture).
+        #
+        # To lift this later: build the table from ``cp_context.cu_seqlens`` and derive
+        # nt_max from the CP-local token count (``max_seqlen_per_dp_cp_rank`` without the
+        # ``context_parallel_size`` factor in :meth:`_fixed_shape_chunk_indices`). The
+        # ``cp_context`` argument exists so that change is local to this method.
+        if cp_context is not None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "GDN: CUDA graph capture is not supported with GDN chunkwise context "
+                    "parallelism. fla ignores a caller-supplied chunk_indices override "
+                    "for the CP-local cu_seqlens, so no capture-safe table can be built."
+                )
+            return {}
+
+        chunk_indices = self._fixed_shape_chunk_indices(cu_seqlens, extra_tokens=extra_tokens)
+        if chunk_indices is not None:
+            return {"chunk_indices": chunk_indices}
+        if cu_seqlens_unpadded is None:
+            return {"cu_seqlens_cpu": self._cu_seqlens_cpu_mirror(cu_seqlens)}
+        return {
+            "cu_seqlens_cpu": self._cu_seqlens_cpu_mirror(
+                cu_seqlens_unpadded, extra_tokens=extra_tokens
+            )
+        }
+
+    @staticmethod
+    def _check_fla_tensor_cache_disabled(config) -> None:
+        """Reject CUDA graph capture of GDN while fla's tensor cache is live.
+
+        ``fla.ops.utils.prepare_chunk_offsets`` is ``@tensor_cache``'d on argument
+        identity, and it produces the ``chunk_offsets`` that fla's ``h``/``dh`` writer
+        kernels index with. Static THD packing reuses one ``cu_seqlens`` tensor object
+        across warmup/capture/replay, which is exactly the cache-hit condition: the hit
+        elides those device kernels from the graph and freezes ``chunk_offsets`` at the
+        warmup packing, while the ``chunk_indices`` table supplied by
+        :meth:`_fla_varlen_kwargs` is recomputed from the real packing on every replay.
+        The two then disagree and fla's ``row == chunk_offsets[seq] + intra`` invariant -
+        which the reader kernels rely on to index ``h`` - silently breaks.
+
+        This has to be an error rather than a documentation note: the failure mode is a
+        slowly diverging loss, with no crash and no warning. It is checked at construction
+        rather than at capture time because everything it reads is known before the model
+        is built, and because raising inside a live ``cudaStreamBeginCapture`` region
+        aborts the capture and surfaces as an unrelated downstream error.
+
+        Both predicates mirror ``TransformerConfig.__post_init__``: the THD one guards the
+        sibling ``--thd-max-packed-sequences`` requirement, and the capture one is its
+        ``cuda_graph_captures_attention``. Reusing them keeps the two checks from drifting.
+        """
+        if FLA_DISABLE_TENSOR_CACHE:
+            return
+
+        # SBHD is unaffected. fla only calls the @tensor_cache'd prepare_chunk_offsets on
+        # the varlen branch (``cu_seqlens is None`` -> ``chunk_offsets = None`` in
+        # fla/ops/common/chunk_delta_h.py), and with cu_seqlens None it never builds a
+        # chunk_indices table for those offsets to desynchronize from. So there is nothing
+        # to freeze, and SBHD capture must keep working without the environment variable.
+        is_thd = config.sequence_packing_scheduler is not None or config.dynamic_context_parallel
+        if not is_thd:
+            return
+
+        captures_attention = config.cuda_graph_impl == "full_iteration" or (
+            config.cuda_graph_impl in ("local", "transformer_engine")
+            and (not config.cuda_graph_modules or CudaGraphModule.attn in config.cuda_graph_modules)
+        )
+        if not captures_attention:
+            return
+
+        raise RuntimeError(
+            "GDN: capturing attention into a THD CUDA graph requires "
+            "FLA_DISABLE_TENSOR_CACHE=1. fla's @tensor_cache on prepare_chunk_offsets would "
+            "freeze chunk_offsets at the warmup packing and silently desynchronize it from "
+            "the chunk_indices recomputed on each replay, diverging the loss with no crash. "
+            "Set the environment variable before starting training, or drop attn from "
+            "--cuda-graph-modules."
+        )
+
+    def _cu_seqlens_cpu_mirror(
+        self, cu_seqlens: torch.Tensor, extra_tokens: int = 0
+    ) -> torch.Tensor:
+        """Return a CPU mirror of ``cu_seqlens``, without syncing during capture.
+
+        Eager-only fallback used by :meth:`_fla_varlen_kwargs` when the static THD
+        bounds are not configured. It removes the D2H half of fla's host-side
+        ``prepare_chunk_indices`` build, but not the H2D copy of the resulting table, so
+        it is *not* sufficient for CUDA graph capture.
+
+        Precondition: never called while capturing. :meth:`_fla_varlen_kwargs` only
+        reaches this fallback when :meth:`_fixed_shape_chunk_indices` returned ``None``,
+        and that raises under capture rather than returning ``None``. The ``.cpu()``
+        below would otherwise be an illegal D2H sync.
+
+        The cache holds a strong reference to the source tensor and compares with ``is``,
+        mirroring the contract of fla's own ``@tensor_cache``. Keying on bare ``id()``
+        would be unsafe: nothing keeps the source alive, so a freed tensor's address can
+        be reused by a new one and return a stale mirror.
+
+        Args:
+            cu_seqlens: Tensor to mirror. Callers pass the *unpadded* buffer so repeated
+                calls within a forward hit the same cache entry.
+            extra_tokens: Tokens the caller appended to the last sequence. Applied to a
+                copy of the cached mirror with host-side arithmetic, so a padded variant
+                costs no extra D2H sync and does not evict the unpadded entry.
+        """
+        cached = self._cu_seqlens_cpu_cache
+        if cached is not None and cached[0] is cu_seqlens:
+            cpu_mirror = cached[1]
+        else:
+            cpu_mirror = cu_seqlens.cpu()
+            self._cu_seqlens_cpu_cache = (cu_seqlens, cpu_mirror)
+        if extra_tokens:
+            cpu_mirror = cpu_mirror.clone()
+            cpu_mirror[-1] += extra_tokens
+        return cpu_mirror
+
+    def _fixed_shape_chunk_indices(
+        self, cu_seqlens: torch.Tensor, extra_tokens: int = 0, chunk_size: int = _FLA_CHUNK_SIZE
+    ) -> Optional[torch.Tensor]:
+        """Device-side, fixed-shape ``chunk_indices`` for fla's varlen kernels.
+
+        fla's chunked varlen kernels need a ``[NT, 2]`` table mapping each chunk slot to
+        ``(sequence index, chunk index within that sequence)``. fla builds it on the host
+        from the *contents* of ``cu_seqlens`` (``prepare_chunk_indices``), which is fatal
+        for CUDA graphs twice over:
+
+        1. the build itself is a host<->device round trip that capture forbids
+           (supplying ``cu_seqlens_cpu`` only removes the D2H half; the result is still
+           H2D-copied back);
+        2. even if it were capture-safe, ``NT`` and the table contents would be frozen at
+           capture time, while the static ``cu_seqlens`` buffer is refilled with a
+           *different* packing on every replay - so the graph would silently compute the
+           wrong chunk decomposition.
+
+        This builds the same table entirely with device ops and at a fixed ``NT_max``
+        upper bound, so the shape (and therefore the Triton grid) is a capture-time
+        constant while the *values* are recomputed by the replayed kernels from whatever
+        ``cu_seqlens`` holds. Note the name: only the *shape* is fixed, not the contents.
+
+        Slots past the real chunk count are pointed at sequence 0 with an intra-chunk
+        index beyond any possible sequence length, so every masked load/store in fla's
+        kernels (all gated on ``o_t < T``) turns them into no-ops. Real rows stay packed
+        contiguously from row 0 in sequence order, preserving fla's
+        ``row == chunk_offsets[seq] + intra`` invariant and keeping the padding rows
+        trailing (which ``chunk_o``'s unmasked ``h``/``dh`` loads rely on to stay in
+        bounds).
+
+        This is only needed for THD/varlen. In SBHD ``cu_seqlens`` is ``None``, fla never
+        builds the table at all, and ``NT`` is ``cdiv(T, BT)`` - a pure function of the
+        static tensor shape - so SBHD capture was always safe. The one exception is SBHD
+        with GDN chunkwise CP, which synthesizes a non-``None`` ``cu_seqlens``; that case
+        is filtered out by the CP guard in :meth:`_fla_varlen_kwargs` before reaching here.
+
+        Args:
+            cu_seqlens: The cu_seqlens the fla call will run on.
+            extra_tokens: Tokens the caller appended beyond the configured static buffer
+                size (conv alignment padding). Folded into the ``NT_max`` bound, since
+                under-sizing it silently drops chunks: ``NT`` is the Triton grid, so
+                surplus chunks are simply never launched.
+            chunk_size: Must match the chunk size the consuming fla kernel uses.
+
+        Returns:
+            The ``[NT_max, 2]`` table, or ``None`` when the static THD bounds are unknown,
+            in which case the caller lets fla build the table itself (eager-only path).
+        """
+        max_num_seqs = getattr(self.config, 'thd_max_packed_sequences', None)
+        max_seqlen = getattr(self.config, 'max_seqlen_per_dp_cp_rank', None)
+        if max_num_seqs is None or max_seqlen is None:
+            if torch.cuda.is_current_stream_capturing():
+                # TransformerConfig.__post_init__ already refuses this at startup for the
+                # supported launch paths ("THD CUDA Graph requires
+                # --thd-max-packed-sequences to be set"). This backstop only fires for
+                # callers that capture with cuda_graph_impl="none", e.g. an external or
+                # hand-rolled graph around the module.
+                raise RuntimeError(
+                    "GDN: cannot build a capture-safe chunk_indices table without "
+                    "thd_max_packed_sequences and max_seqlen_per_dp_cp_rank; see the "
+                    "THD CUDA Graph requirements validated in "
+                    "TransformerConfig.__post_init__."
+                )
+            return None
+
+        # Chunkwise CP never reaches here (see the CP guard in _fla_varlen_kwargs), so
+        # cu_seqlens still spans the full global sequence. Under dynamic CP the runtime
+        # group can be smaller than context_parallel_size, which makes this an
+        # overestimate: NT_max is only an upper bound, so the table stays correct and
+        # merely carries unused trailing slots. Threading the runtime cp size down from
+        # forward() would tighten it; dynamic CP cannot be captured anyway, so this only
+        # costs eager runs. Once chunkwise CP is supported, this becomes the CP-local
+        # token count.
+        total_t = int(max_seqlen) * int(self.config.context_parallel_size) + int(extra_tokens)
+        # Each sequence wastes at most one partial chunk, so the total chunk
+        # count never exceeds ceil(total_t / chunk_size) + num_sequences.
+        nt_max = (total_t + chunk_size - 1) // chunk_size + int(max_num_seqs)
+
+        lens = cu_seqlens[1:] - cu_seqlens[:-1]
+        n_seq = lens.shape[0]
+        n_chunks = (lens + (chunk_size - 1)).div(chunk_size, rounding_mode='floor').to(torch.int64)
+        # offsets[i] = first chunk slot owned by sequence i; offsets[-1] = total.
+        # Bit-identical to fla's prepare_chunk_offsets, which the h/dh writer kernels
+        # index with - this is what keeps `row == chunk_offsets[seq] + intra` true.
+        offsets = torch.nn.functional.pad(n_chunks.cumsum(0), (1, 0))
+        slot = self._chunk_slot_arange(nt_max, cu_seqlens.device)
+        # searchsorted over offsets[1:] maps a slot to its owning sequence; slots
+        # past the last boundary come back as n_seq, which flags them unused.
+        seg_id = torch.searchsorted(offsets[1:].contiguous(), slot, right=True)
+        valid = seg_id < n_seq
+        seg_id = seg_id.clamp(max=n_seq - 1)
+        intra = slot - offsets[seg_id]
+        zero = torch.zeros((), device=cu_seqlens.device, dtype=torch.int64)
+        beyond = torch.full((), nt_max, device=cu_seqlens.device, dtype=torch.int64)
+        seg_id = torch.where(valid, seg_id, zero)
+        intra = torch.where(valid, intra, beyond)
+        return torch.stack([seg_id, intra], 1).to(cu_seqlens)
+
+    def _chunk_slot_arange(self, nt_max: int, device: torch.device) -> torch.Tensor:
+        """Cached ``arange(nt_max)`` used as the chunk-slot axis.
+
+        ``nt_max`` is a config-derived constant, so this tensor is identical on every
+        forward of every microbatch. Only *shape*-invariant state is cached here - the
+        table itself is deliberately never cached, because its values depend on the
+        contents of a ``cu_seqlens`` buffer that is refilled every microbatch.
+        """
+        key = (nt_max, device)
+        slot = self._chunk_slot_cache.get(key)
+        if slot is not None:
+            return slot
+        slot = torch.arange(nt_max, device=device, dtype=torch.int64)
+        if not torch.cuda.is_current_stream_capturing():
+            # Do not cache an allocation made inside a graph's private memory pool:
+            # that storage is not valid for use outside the graph. A cold cache during
+            # capture just means one extra (capturable) arange per replay.
+            self._chunk_slot_cache[key] = slot
+        return slot
 
     def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None, tp_group=None):
         """Provide a sharded state dictionary for distributed checkpointing."""

--- a/megatron/core/ssm/gated_delta_net/gdn.py
+++ b/megatron/core/ssm/gated_delta_net/gdn.py
@@ -191,6 +191,11 @@ class GatedDeltaNet(_GDNBase):
                 not self.config.deterministic_mode
             ), "Packed sequence does not support deterministic mode."
 
+            # cu_seqlens *values* only exist on the device, so every check below is a
+            # D2H sync. They are skipped while a CUDA graph is being captured; the
+            # warmup iterations that must precede capture run them on the same buffers.
+            validate_cu_seqlens = not torch.cuda.is_current_stream_capturing()
+
             # Resolve cu_seqlens with alignment padding handling.
             cu_seqlens_q = self._resolve_cu_seqlens(
                 packed_seq_params.cu_seqlens_q_padded,
@@ -198,6 +203,7 @@ class GatedDeltaNet(_GDNBase):
                 seq_len_global,
                 "cu_seqlens_q",
                 cp_size=cp_size_runtime,
+                validate=validate_cu_seqlens,
             )
             cu_seqlens_kv = self._resolve_cu_seqlens(
                 packed_seq_params.cu_seqlens_kv_padded,
@@ -205,11 +211,13 @@ class GatedDeltaNet(_GDNBase):
                 seq_len_global,
                 "cu_seqlens_kv",
                 cp_size=cp_size_runtime,
+                validate=validate_cu_seqlens,
             )
-            assert torch.equal(cu_seqlens_q, cu_seqlens_kv), (
-                "Currently only support cu_seqlens_q equals to cu_seqlens_kv, "
-                f"but got {cu_seqlens_q=} and {cu_seqlens_kv=}"
-            )
+            if validate_cu_seqlens:
+                assert torch.equal(cu_seqlens_q, cu_seqlens_kv), (
+                    "Currently only support cu_seqlens_q equals to cu_seqlens_kv, "
+                    f"but got {cu_seqlens_q=} and {cu_seqlens_kv=}"
+                )
             num_packed_seqs = cu_seqlens_q.shape[0] - 1
             assert num_packed_seqs > 0, (
                 "Number of packed sequences must be greater than 0, "
@@ -376,6 +384,14 @@ class GatedDeltaNet(_GDNBase):
             nvtx_range_pop(suffix="pre_gated_delta_rule")
 
         nvtx_range_push(suffix="gated_delta_rule")
+        # torch_chunk_gated_delta_rule (the deterministic_mode path) accepts neither
+        # chunk_indices nor cu_seqlens_cpu, and asserts cu_seqlens is None outright,
+        # so the capture-safe varlen metadata is only threaded on the fla path.
+        gdr_varlen_kwargs = (
+            {}
+            if self.config.deterministic_mode
+            else self._fla_varlen_kwargs(cu_seqlens_q, cp_context=chunkwise_cp_context)
+        )
         core_attn_out, _ = self.gated_delta_rule(
             **kernel_inputs,
             initial_state=None,
@@ -383,6 +399,7 @@ class GatedDeltaNet(_GDNBase):
             use_qk_l2norm_in_kernel=False,
             cu_seqlens=cu_seqlens_q,
             cp_context=chunkwise_cp_context,
+            **gdr_varlen_kwargs,
         )
         nvtx_range_pop(suffix="gated_delta_rule")
 
@@ -529,6 +546,16 @@ class GatedDeltaNet(_GDNBase):
                 conv_input = torch.nn.functional.pad(conv_input, (0, 0, 0, pad_n))
                 conv_cu_seqlens = cu_seqlens_q.clone()
                 conv_cu_seqlens[-1] += pad_n
+            # causal_conv1d host-builds chunk_indices from cu_seqlens contents just like
+            # chunk_gated_delta_rule does. Derived from conv_cu_seqlens (post conv
+            # padding); pad_n is passed separately because it grows the last sequence
+            # past the configured static buffer size and so widens the NT_max bound.
+            conv_varlen_kwargs = self._fla_varlen_kwargs(
+                conv_cu_seqlens,
+                cp_context=conv_cp_context,
+                extra_tokens=pad_n,
+                cu_seqlens_unpadded=cu_seqlens_q if pad_n > 0 else None,
+            )
             qkv, _ = causal_conv1d(
                 x=conv_input,
                 weight=conv1d_weight.squeeze(1),
@@ -538,6 +565,7 @@ class GatedDeltaNet(_GDNBase):
                 output_final_state=False,
                 cu_seqlens=conv_cu_seqlens,
                 cp_context=conv_cp_context,
+                **conv_varlen_kwargs,
             )
             if pad_n > 0:
                 qkv = qkv[:, :orig_seq, :]

--- a/tests/unit_tests/ssm/gated_delta_net/test_gdn_chunk_indices.py
+++ b/tests/unit_tests/ssm/gated_delta_net/test_gdn_chunk_indices.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for the fixed-shape ``chunk_indices`` table used for THD CUDA graph capture.
+
+The table is what makes fla's varlen kernels capturable: only its *shape* is a
+capture-time constant, its values are recomputed on every replay. It must agree
+element-for-element with fla's own host-built table, and it must preserve fla's
+``row == chunk_offsets[seq] + intra`` invariant, which the ``h``/``dh`` reader
+kernels rely on to index into the chunk-state buffer.
+"""
+
+import copy
+
+import pytest
+import torch
+
+import megatron.core.ssm.gated_delta_net.common as common
+from megatron.core.ssm.gated_delta_net.common import _FLA_CHUNK_SIZE, _GDNBase
+from megatron.core.transformer.enums import CudaGraphModule
+
+try:
+    from fla.ops.utils.index import prepare_chunk_indices, prepare_chunk_offsets
+
+    HAVE_FLA = True
+except ImportError:
+    HAVE_FLA = False
+
+
+class _Config:
+    thd_max_packed_sequences = 8
+    max_seqlen_per_dp_cp_rank = 4096
+    context_parallel_size = 1
+
+
+class _Stub:
+    """Minimal stand-in exposing just the pure table builder off ``_GDNBase``."""
+
+    _fixed_shape_chunk_indices = _GDNBase._fixed_shape_chunk_indices
+    _chunk_slot_arange = _GDNBase._chunk_slot_arange
+
+    def __init__(self):
+        self.config = _Config()
+        self._chunk_slot_cache = {}
+
+
+def _make_cu_seqlens(lens, extra_tokens=0):
+    """Build a statically-shaped cu_seqlens, padded with zero-length sequences."""
+    cu = [0]
+    for length in lens:
+        cu.append(cu[-1] + length)
+    cu[-1] += extra_tokens
+    while len(cu) < _Config.thd_max_packed_sequences + 1:
+        cu.append(cu[-1])
+    return torch.tensor(cu, device="cuda", dtype=torch.int32)
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "lens",
+    [
+        [4096],
+        [2048, 2048],
+        [1024, 512, 1536, 1024],
+        [64, 64, 3968],
+        [100, 200, 300, 3496],  # every sequence ends mid-chunk
+        [512] * 8,  # cu_seqlens fully occupied, no padding sequences
+        [_FLA_CHUNK_SIZE * 7 + 1] * 8,  # worst case for the NT_max bound
+    ],
+)
+@pytest.mark.parametrize("extra_tokens", [0, 16, 63, 127])
+def test_matches_fla_prepare_chunk_indices(lens, extra_tokens):
+    stub = _Stub()
+    cu_seqlens = _make_cu_seqlens(lens, extra_tokens=extra_tokens)
+
+    table = stub._fixed_shape_chunk_indices(cu_seqlens, extra_tokens=extra_tokens)
+    reference = prepare_chunk_indices(cu_seqlens, _FLA_CHUNK_SIZE)
+    num_real = reference.shape[0]
+
+    # The shape is a fixed upper bound; under-sizing it would silently drop chunks,
+    # since NT is the Triton grid dimension.
+    assert table.shape[0] >= num_real
+    assert table.dtype == cu_seqlens.dtype
+    # Real rows are bit-identical to fla's own table, and stay contiguous from row 0.
+    assert torch.equal(table[:num_real], reference)
+
+    # fla's h/dh reader kernels index by row, the writer by chunk_offsets[seq] + intra.
+    chunk_offsets = prepare_chunk_offsets(cu_seqlens, _FLA_CHUNK_SIZE)
+    rows = torch.arange(num_real, device=cu_seqlens.device, dtype=torch.int64)
+    assert torch.equal(chunk_offsets[table[:num_real, 0].long()] + table[:num_real, 1], rows)
+
+    # Trailing pad rows point at sequence 0 with an out-of-range intra index, so every
+    # masked load/store in fla's kernels (all gated on o_t < T) no-ops.
+    assert torch.all(table[num_real:, 0] == 0)
+    assert torch.all(table[num_real:, 1] >= table.shape[0])
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_shape_is_constant_across_packings():
+    """The whole point: shape frozen at capture, values recomputed on replay."""
+    stub = _Stub()
+    shapes = {
+        stub._fixed_shape_chunk_indices(_make_cu_seqlens(lens)).shape
+        for lens in ([4096], [2048, 2048], [100, 200, 300, 3496], [512] * 8)
+    }
+    assert len(shapes) == 1
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_returns_none_without_static_bounds():
+    """Eager fallback: without the static bounds the caller lets fla build the table."""
+    stub = _Stub()
+    stub.config.thd_max_packed_sequences = None
+    assert stub._fixed_shape_chunk_indices(_make_cu_seqlens([2048, 2048])) is None
+
+
+class _KwargsStub(_Stub):
+    _fla_varlen_kwargs = _GDNBase._fla_varlen_kwargs
+    _cu_seqlens_cpu_mirror = _GDNBase._cu_seqlens_cpu_mirror
+
+    def __init__(self):
+        super().__init__()
+        self._cu_seqlens_cpu_cache = None
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_varlen_kwargs_selects_static_table_or_cpu_mirror():
+    stub = _KwargsStub()
+    cu_seqlens = _make_cu_seqlens([2048, 2048])
+
+    # Static bounds configured: the capture-safe table, and no redundant CPU mirror
+    # (fla ignores cu_seqlens_cpu whenever chunk_indices is supplied).
+    kwargs = stub._fla_varlen_kwargs(cu_seqlens)
+    assert set(kwargs) == {"chunk_indices"}
+
+    # Without them, fall back to the eager-only CPU mirror.
+    stub.config.thd_max_packed_sequences = None
+    kwargs = stub._fla_varlen_kwargs(cu_seqlens)
+    assert set(kwargs) == {"cu_seqlens_cpu"}
+    assert torch.equal(kwargs["cu_seqlens_cpu"], cu_seqlens.cpu())
+
+    # SBHD supplies no cu_seqlens at all; fla never builds the table.
+    assert stub._fla_varlen_kwargs(None) == {}
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_conv_padding_reuses_the_unpadded_mirror():
+    """The padded mirror is host arithmetic on a cache hit, not a second D2H sync."""
+    stub = _KwargsStub()
+    stub.config.thd_max_packed_sequences = None  # force the cu_seqlens_cpu fallback
+    unpadded = _make_cu_seqlens([1024, 512, 1536, 1024])
+    padded = unpadded.clone()
+    padded[-1] += 64
+
+    conv = stub._fla_varlen_kwargs(padded, extra_tokens=64, cu_seqlens_unpadded=unpadded)
+    # The cache now holds the *unpadded* buffer, so the second call site hits it.
+    assert stub._cu_seqlens_cpu_cache[0] is unpadded
+    gdr = stub._fla_varlen_kwargs(unpadded)
+    assert stub._cu_seqlens_cpu_cache[0] is unpadded
+
+    assert torch.equal(conv["cu_seqlens_cpu"], padded.cpu())
+    assert torch.equal(gdr["cu_seqlens_cpu"], unpadded.cpu())
+    # The cached mirror must not have been mutated by the padded variant.
+    assert gdr["cu_seqlens_cpu"] is stub._cu_seqlens_cpu_cache[1]
+
+    with pytest.raises(AssertionError):
+        stub._fla_varlen_kwargs(padded, extra_tokens=64)
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_varlen_kwargs_defers_to_fla_under_chunkwise_cp():
+    """fla overrides cu_seqlens with the CP-local partition but not chunk_indices.
+
+    A table built here from the global cu_seqlens would describe the wrong tensor, so
+    the CP path must hand the job back to fla entirely.
+    """
+    stub = _KwargsStub()
+    cu_seqlens = _make_cu_seqlens([2048, 2048])
+    assert stub._fla_varlen_kwargs(cu_seqlens, cp_context=object()) == {}
+
+
+@pytest.mark.skipif(not HAVE_FLA, reason="fla is not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cpu_mirror_cache_holds_a_reference_to_its_source():
+    """Keying on bare id() would let a freed tensor's address alias a new one."""
+    stub = _KwargsStub()
+    first = _make_cu_seqlens([2048, 2048])
+    mirror = stub._cu_seqlens_cpu_mirror(first)
+    assert stub._cu_seqlens_cpu_mirror(first) is mirror
+    assert stub._cu_seqlens_cpu_cache[0] is first
+
+    second = _make_cu_seqlens([1024, 512, 1536, 1024])
+    assert not torch.equal(stub._cu_seqlens_cpu_mirror(second), mirror)
+
+
+class _CGConfig:
+    def __init__(
+        self, impl="none", modules=None, packing_scheduler="dp_balanced", dynamic_cp=False
+    ):
+        self.cuda_graph_impl = impl
+        self.cuda_graph_modules = modules
+        self.sequence_packing_scheduler = packing_scheduler
+        self.dynamic_context_parallel = dynamic_cp
+
+
+@pytest.mark.parametrize(
+    "impl,modules,should_raise",
+    [
+        ("none", None, False),
+        ("none", [CudaGraphModule.attn], False),
+        ("transformer_engine", [CudaGraphModule.attn], True),
+        ("transformer_engine", [CudaGraphModule.moe_router], False),
+        ("transformer_engine", None, True),  # unset == every module
+        ("full_iteration", None, True),
+        ("local", [CudaGraphModule.attn], True),
+    ],
+)
+def test_tensor_cache_check_fires_only_when_thd_attention_is_captured(
+    monkeypatch, impl, modules, should_raise
+):
+    """fla's @tensor_cache freezes chunk_offsets across replays; GDN must refuse capture.
+
+    The failure it guards against is a silently diverging loss, so the check must be an
+    error, and it must fire at construction rather than inside a live capture region.
+    """
+    monkeypatch.setattr(common, "FLA_DISABLE_TENSOR_CACHE", False)
+    config = _CGConfig(impl, modules)
+    if should_raise:
+        with pytest.raises(RuntimeError, match="FLA_DISABLE_TENSOR_CACHE"):
+            _GDNBase._check_fla_tensor_cache_disabled(config)
+    else:
+        _GDNBase._check_fla_tensor_cache_disabled(config)
+
+    # With the cache disabled the check is a no-op for every configuration.
+    monkeypatch.setattr(common, "FLA_DISABLE_TENSOR_CACHE", True)
+    _GDNBase._check_fla_tensor_cache_disabled(config)
+
+
+@pytest.mark.parametrize("impl", ["transformer_engine", "local", "full_iteration"])
+def test_sbhd_capture_does_not_need_the_env_var(monkeypatch, impl):
+    """SBHD capture was always safe and must not be blocked.
+
+    With cu_seqlens None, fla takes the ``chunk_offsets = None`` branch in
+    ``chunk_delta_h.py`` and never calls the ``@tensor_cache``'d
+    ``prepare_chunk_offsets``, so there is nothing for a stale cache to freeze and no
+    ``chunk_indices`` table to desynchronize from. Requiring FLA_DISABLE_TENSOR_CACHE
+    here would break configurations that work today.
+    """
+    monkeypatch.setattr(common, "FLA_DISABLE_TENSOR_CACHE", False)
+    config = _CGConfig(impl, [CudaGraphModule.attn], packing_scheduler=None, dynamic_cp=False)
+    _GDNBase._check_fla_tensor_cache_disabled(config)
+
+
+@pytest.mark.parametrize(
+    "packing_scheduler,dynamic_cp",
+    [("dp_balanced", False), ("default_dynamic_cp", False), (None, True)],
+)
+def test_thd_is_detected_by_either_packing_signal(monkeypatch, packing_scheduler, dynamic_cp):
+    """Mirrors TransformerConfig.__post_init__'s THD-CUDA-graph predicate."""
+    monkeypatch.setattr(common, "FLA_DISABLE_TENSOR_CACHE", False)
+    config = _CGConfig(
+        "transformer_engine",
+        [CudaGraphModule.attn],
+        packing_scheduler=packing_scheduler,
+        dynamic_cp=dynamic_cp,
+    )
+    with pytest.raises(RuntimeError, match="FLA_DISABLE_TENSOR_CACHE"):
+        _GDNBase._check_fla_tensor_cache_disabled(config)


### PR DESCRIPTION
## Summary

GatedDeltaNet layers could not be captured into a CUDA graph in THD (varlen) mode. Three separate host-side dependencies on `cu_seqlens` had to be removed. SBHD was never affected and is untouched.

**1. Unconditional D2H syncs in `_resolve_cu_seqlens`.** `cu_seqlens[-1].cpu().item()` for the total-length check, and the `(seq_lengths % cp_size != 0).any()` device→host bool in an `if`, ran on every forward. The caller now passes `validate=False` while capturing; the warmup iterations that must precede capture run the same checks on the same buffers.

**2. fla host-builds `chunk_indices` from `cu_seqlens` contents.** fla's varlen kernels need a `[NT, 2]` table mapping each chunk slot to `(sequence, chunk-within-sequence)`, built by `prepare_chunk_indices` via a `.tolist()` on the CUDA `cu_seqlens`. Supplying fla's `cu_seqlens_cpu` parameter removes only the D2H half — the table is still assembled on the host and H2D-copied back, which capture also forbids.

**3. `chunk_indices`' shape and contents are data-dependent.** This is the deeper problem, and `cu_seqlens_cpu` does not address it. `NT` is read at Python level as a Triton grid dim and as the `h`/`dh` chunk-state allocation size, and the table's contents depend on `cu_seqlens` *values*. Under THD static packing only shapes are static; the `cu_seqlens` buffer is refilled with the real packing every microbatch. A table baked at capture time describes one full-length sequence and would be replayed against every real multi-sequence pack, silently computing the wrong chunk decomposition.

`_fixed_shape_chunk_indices` builds the table with device ops only (cumsum + searchsorted + where) at a fixed `NT_max = ceil(total_T / chunk_size) + thd_max_packed_sequences`. Only the *shape* is fixed — it becomes a capture-time constant for the grid and allocations — while the values are recomputed by the replayed kernels from whatever the static `cu_seqlens` buffer holds. Real rows stay contiguous from row 0 in sequence order, preserving fla's `row == chunk_offsets[seq] + intra` invariant, which its `chunk_o` kernels rely on to index `h`/`dh`; trailing pad rows point at sequence 0 with an out-of-range intra index so every masked load/store no-ops.

`_fla_varlen_kwargs` is the single place that decides what varlen metadata to hand fla: the device-built table when the static THD bounds are configured, otherwise a cached CPU mirror of `cu_seqlens` (eager-only, and enough to remove fla's D2H). The two are mutually exclusive by fla's own contract — `cu_seqlens_cpu` is read only when `chunk_indices is None`.

### Requirements

**This needs an `fla` build that includes [fla-org/flash-linear-attention#1132](https://github.com/fla-org/flash-linear-attention/pull/1132)** ("[GDN] Allow passing pre-computed `chunk_indices` to `chunk_gated_delta_rule`", merged 2026-08-17, `033b19e81`). That PR is what makes `chunk_gated_delta_rule` accept the `chunk_indices` override this change depends on. The `causal_conv1d` side needs [#641](https://github.com/fla-org/flash-linear-attention/pull/641) (merged 2025-11-14), which is old enough to be in any recent build.

No PyPI release carries #1132 yet: the newest, `0.5.2`, was published 2026-07-27, and `pyproject.toml` currently pins `flash-linear-attention[tilelang]==0.5.1` (2026-06-18). Verified here against fla at git `27967b970eaaf982a6960abf6cba8add9c34c7cc`, which is 18 commits after #1132 and reports version `0.5.2`.

An older `fla` fails **loudly**, not silently. Verified by simulating one (forcing our varlen metadata to be dropped, as `**kwargs` would) on the same 4×GB300 setup — capture aborts on the third iteration:

```
torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
  fla/modules/conv/triton/ops.py:386   prepare_chunk_indices(...)
  fla/ops/utils/index.py:128           torch.repeat_interleave(...)
```

Ignoring `chunk_indices` forces fla to build the table itself, and building it means reading `cu_seqlens` values on the host — a D2H sync that capture forbids. It dies there rather than producing a frozen table.

There is no silent path. An old `fla` gives one of two loud failures:

- `FLA_DISABLE_TENSOR_CACHE` unset → `_GDNBase` refuses at construction (the guard described below).
- `FLA_DISABLE_TENSOR_CACHE=1` → fla cannot reuse a table cached during warmup, so it recomputes and hits the sync above.

The second case is worth naming explicitly: requiring the variable also removes fla's ability to replay a stale cached table, which is what would otherwise make an old `fla` dangerous rather than merely broken.

A capability check (inspecting the two entry points for `chunk_indices`) would therefore only improve the error message — turning a CUDA capture error raised deep inside fla into "your fla is too old". Happy to add it if maintainers want the better diagnostic, and/or to bump the `pyproject.toml` pin, though no PyPI release currently satisfies it so the pin would have to point at a git ref.

### Scope and known limitations

- **GDN chunkwise context parallelism is explicitly out of scope.** fla overrides `cu_seqlens` with the rank-local partition when a `cp_context` is supplied but consumes a caller-supplied `chunk_indices` verbatim, so a table derived from the global `cu_seqlens` would describe the wrong tensor. That path hands the build back to fla, which derives the table from the CP-local `cu_seqlens` correctly. `TransformerConfig` already rejects attention capture with GDN under any form of CP. The `cp_context` argument is threaded through so lifting this later stays local to one method.
- **Why SBHD was always fine:** every fla call site is gated on `cu_seqlens` being non-`None`, and `NT` falls back to `cdiv(T, BT)` — a pure function of the static tensor shape. With `cu_seqlens=None`, fla never builds the table at all.
- **`FLA_DISABLE_TENSOR_CACHE=1` is required.** fla's `prepare_chunk_offsets` is `@tensor_cache`'d on tensor identity, and it produces the `chunk_offsets` that fla's `h`/`dh` writer kernels index with. Because the static path reuses one `cu_seqlens` object across warmup/capture/replay, a cache hit at capture time elides its device kernels from the graph and freezes `chunk_offsets`, desynchronizing it from the `chunk_indices` recomputed on every replay. `_GDNBase` therefore refuses to construct under a THD attention-capturing config unless the variable is set — at construction rather than mid-capture, because the failure mode is a silently diverging loss rather than a crash.

## Test plan

- `tests/unit_tests/ssm/gated_delta_net/test_gdn_chunk_indices.py` (new, 47 cases): checks the device-built table element-wise against fla's own `prepare_chunk_indices` across 7 packing layouts × 4 padding amounts, re-derives the `row == chunk_offsets[seq] + intra` invariant against `prepare_chunk_offsets`, asserts the pad-row placement and that the shape is constant across packings, and covers the capture-refusal predicate and the CPU-mirror cache contract.
- Existing `tests/unit_tests/ssm/gated_delta_net/` suites pass unchanged.
- End-to-end on 4×GB300 (TP1 PP1 EP4 CP1, 4-layer Qwen3.5-GDN proxy, THD static packing, mock varlen data so each microbatch packs a different number of sequences): `--cuda-graph-modules attn` trains without NaN, and an nsys trace taken with `--cuda-graph-trace=node` shows every fla GDN kernel (`chunk_gated_delta_rule` fwd/bwd, `causal_conv1d`, `l2norm`, chunk cumsum) executing as a CUDA graph node with zero eager launches. The loss trajectory stays within the spread of two identical CUDA-graph runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
