### PR TITLE
[Dev] Reuse caller-owned HybridEP dispatch and expert output buffers

### DIFF
--- a/megatron/core/pipeline_parallel/reusable_buffers.py
+++ b/megatron/core/pipeline_parallel/reusable_buffers.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Caller-owned CUDA output buffers with schedule-aware lifetime tracking."""
+
+from dataclasses import dataclass
+
+import torch
+
+StorageKey = tuple[int, int]
+
+
+def _storage_key(tensor: torch.Tensor) -> StorageKey:
+    """Return a device-qualified key shared by every view of a CUDA storage."""
+    return (tensor.device.index, tensor.untyped_storage().data_ptr())
+
+
+@dataclass
+class _BufferSlot:
+    tensor: torch.Tensor
+    event: torch.cuda.Event | None = None
+    in_use: bool = False
+
+
+_buffer_owners: dict[StorageKey, tuple["ReusableOutputBufferPool", int]] = {}
+
+
+class ReusableOutputBufferPool:
+    """A fixed-size CUDA tensor ring whose slots are released by schedule consumers.
+
+    The pool is intended for external kernels that can write into caller-provided output
+    tensors. A slot is reused only after the stream consuming its previous contents records
+    a completion event. Unlike ``Tensor.record_stream``, the storage stays persistent and
+    does not enter the caching allocator's pending-free queue.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        self.num_slots = 0
+        self._slots: list[_BufferSlot] = []
+        self._signature = None
+        self._cursor = 0
+
+    def configure(self, num_slots: int) -> None:
+        """Configure the ring before its first allocation.
+
+        Args:
+            num_slots: Number of persistent tensors in the ring. Zero disables the pool.
+        """
+        if num_slots < 0:
+            raise ValueError(f"{self.name} buffer count must be non-negative, got {num_slots}")
+        if self._slots and num_slots != self.num_slots:
+            raise RuntimeError(
+                f"Cannot resize initialized {self.name} pool from {self.num_slots} to {num_slots}"
+            )
+        self.num_slots = num_slots
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the pool should provide caller-owned output tensors."""
+        return self.num_slots > 0
+
+    def acquire(
+        self, shape: tuple[int, ...], dtype: torch.dtype, device: torch.device
+    ) -> torch.Tensor | None:
+        """Acquire an alias of the next persistent slot on the current CUDA stream.
+
+        Args:
+            shape: Static output shape shared by every pool use.
+            dtype: Output data type.
+            device: CUDA device on which to allocate the pool.
+
+        Returns:
+            A fresh tensor alias of a persistent slot, or ``None`` when disabled.
+        """
+        if not self.enabled:
+            return None
+
+        signature = (tuple(shape), dtype, torch.device(device))
+        if self._signature is None:
+            self._signature = signature
+            for index in range(self.num_slots):
+                tensor = torch.empty(shape, dtype=dtype, device=device)
+                self._slots.append(_BufferSlot(tensor=tensor))
+                _buffer_owners[_storage_key(tensor)] = (self, index)
+        elif signature != self._signature:
+            raise RuntimeError(
+                f"{self.name} requires a static output signature; expected {self._signature}, "
+                f"got {signature}"
+            )
+
+        slot_index = self._cursor % self.num_slots
+        self._cursor += 1
+        slot = self._slots[slot_index]
+        if slot.in_use:
+            raise RuntimeError(
+                f"{self.name} slot {slot_index} was reused before its consumer released it; "
+                "increase the configured buffer count"
+            )
+        if slot.event is not None:
+            torch.cuda.current_stream(device).wait_event(slot.event)
+        slot.in_use = True
+        # A fresh TensorImpl prevents autograd metadata from one dispatch from being reused by
+        # another dispatch while retaining the same persistent storage.
+        return slot.tensor.detach()
+
+    def _release(self, slot_index: int, stream: torch.cuda.Stream) -> None:
+        slot = self._slots[slot_index]
+        if not slot.in_use:
+            raise RuntimeError(f"{self.name} slot {slot_index} was released more than once")
+        if slot.event is None:
+            # External events become explicit CUDA graph event nodes. This is required when
+            # capture begins after eager warmup: an internal event wait would otherwise create
+            # a forbidden dependency on uncaptured work from the warmup stream.
+            slot.event = torch.cuda.Event(enable_timing=False, external=True)
+        slot.event.record(stream)
+        slot.in_use = False
+
+    def reset(self) -> None:
+        """Drop persistent tensors and their storage-owner registrations."""
+        for slot in self._slots:
+            _buffer_owners.pop(_storage_key(slot.tensor), None)
+        self.num_slots = 0
+        self._slots.clear()
+        self._signature = None
+        self._cursor = 0
+
+
+def release_reusable_output_buffer(tensor: torch.Tensor, stream: torch.cuda.Stream) -> bool:
+    """Release a registered persistent output after its last scheduled consumer.
+
+    Args:
+        tensor: Tensor whose storage may belong to a reusable output pool.
+        stream: CUDA stream containing the tensor's final consumer.
+
+    Returns:
+        ``True`` when the tensor belongs to a reusable pool. The caller must then avoid
+        resizing its storage or calling ``record_stream``, because the pool owns the storage
+        and records the precise consumer completion event itself.
+    """
+    owner = _buffer_owners.get(_storage_key(tensor))
+    if owner is None:
+        return False
+    pool, slot_index = owner
+    pool._release(slot_index, stream)
+    return True

--- a/megatron/core/pipeline_parallel/reusable_buffers.py
+++ b/megatron/core/pipeline_parallel/reusable_buffers.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 
 import torch
 
-StorageKey = tuple[int, int]
+StorageKey = tuple[int | None, int]
+BufferSignature = tuple[tuple[int, ...], torch.dtype, torch.device]
 
 
 def _storage_key(tensor: torch.Tensor) -> StorageKey:
@@ -37,7 +38,7 @@ class ReusableOutputBufferPool:
         self.name = name
         self.num_slots = 0
         self._slots: list[_BufferSlot] = []
-        self._signature = None
+        self._signature: BufferSignature | None = None
         self._cursor = 0
 
     def configure(self, num_slots: int) -> None:
@@ -106,11 +107,7 @@ class ReusableOutputBufferPool:
     def _release(self, slot_index: int, stream: torch.cuda.Stream) -> None:
         slot = self._slots[slot_index]
         if not slot.in_use:
-            # Some final consumers own their lifetime and release immediately after enqueueing
-            # work, while ScheduleNode subsequently visits the same input in its generic
-            # free-input path. Treat that second visit as an ownership query: the persistent
-            # storage is already safe and must not be resized or record_stream'ed.
-            return
+            raise RuntimeError(f"{self.name} slot {slot_index} was released more than once")
         if slot.event is None:
             # External events become explicit CUDA graph event nodes. This is required when
             # capture begins after eager warmup: an internal event wait would otherwise create
@@ -129,6 +126,16 @@ class ReusableOutputBufferPool:
         self._cursor = 0
 
 
+def is_reusable_output_buffer(tensor: torch.Tensor) -> bool:
+    """Return whether ``tensor`` storage belongs to a reusable output pool.
+
+    This ownership probe does not change slot lifetime state. Generic cleanup paths should use
+    it to avoid resizing or recording persistent storage, leaving the actual release to the
+    component that knows the tensor's final scheduled consumer.
+    """
+    return _storage_key(tensor) in _buffer_owners
+
+
 def release_reusable_output_buffer(tensor: torch.Tensor, stream: torch.cuda.Stream) -> bool:
     """Release a registered persistent output after its last scheduled consumer.
 
@@ -139,9 +146,11 @@ def release_reusable_output_buffer(tensor: torch.Tensor, stream: torch.cuda.Stre
     Returns:
         ``True`` when the tensor belongs to a reusable pool. The caller must then avoid
         resizing its storage or calling ``record_stream``, because the pool owns the storage
-        and records the precise consumer completion event itself. Releasing an already-released
-        registered storage is an idempotent ownership query, so a final consumer may release it
-        before ``ScheduleNode`` reaches its generic free-input path.
+        and records the precise consumer completion event itself.
+
+    Raises:
+        RuntimeError: If the registered slot is not currently in use, including a repeated
+            release of the same acquisition.
     """
     owner = _buffer_owners.get(_storage_key(tensor))
     if owner is None:

--- a/megatron/core/pipeline_parallel/reusable_buffers.py
+++ b/megatron/core/pipeline_parallel/reusable_buffers.py
@@ -106,7 +106,11 @@ class ReusableOutputBufferPool:
     def _release(self, slot_index: int, stream: torch.cuda.Stream) -> None:
         slot = self._slots[slot_index]
         if not slot.in_use:
-            raise RuntimeError(f"{self.name} slot {slot_index} was released more than once")
+            # Some final consumers own their lifetime and release immediately after enqueueing
+            # work, while ScheduleNode subsequently visits the same input in its generic
+            # free-input path. Treat that second visit as an ownership query: the persistent
+            # storage is already safe and must not be resized or record_stream'ed.
+            return
         if slot.event is None:
             # External events become explicit CUDA graph event nodes. This is required when
             # capture begins after eager warmup: an internal event wait would otherwise create
@@ -135,7 +139,9 @@ def release_reusable_output_buffer(tensor: torch.Tensor, stream: torch.cuda.Stre
     Returns:
         ``True`` when the tensor belongs to a reusable pool. The caller must then avoid
         resizing its storage or calling ``record_stream``, because the pool owns the storage
-        and records the precise consumer completion event itself.
+        and records the precise consumer completion event itself. Releasing an already-released
+        registered storage is an idempotent ownership query, so a final consumer may release it
+        before ``ScheduleNode`` reaches its generic free-input path.
     """
     owner = _buffer_owners.get(_storage_key(tensor))
     if owner is None:

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -8,7 +8,10 @@ from typing import Callable, Optional
 import torch
 from torch.autograd import Variable
 
-from megatron.core.pipeline_parallel.reusable_buffers import release_reusable_output_buffer
+from megatron.core.pipeline_parallel.reusable_buffers import (
+    is_reusable_output_buffer,
+    release_reusable_output_buffer,
+)
 from megatron.core.utils import (
     get_pg_rank,
     get_pg_size,
@@ -242,7 +245,7 @@ class ScheduleNode:
         if self.free_input:
             for input in inputs:
                 if input is not None:
-                    if not release_reusable_output_buffer(input, self.stream):
+                    if not is_reusable_output_buffer(input):
                         input.record_stream(self.stream)
                         input.untyped_storage().resize_(0)
 

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -8,6 +8,7 @@ from typing import Callable, Optional
 import torch
 from torch.autograd import Variable
 
+from megatron.core.pipeline_parallel.reusable_buffers import release_reusable_output_buffer
 from megatron.core.utils import (
     get_pg_rank,
     get_pg_size,
@@ -241,8 +242,9 @@ class ScheduleNode:
         if self.free_input:
             for input in inputs:
                 if input is not None:
-                    input.record_stream(self.stream)
-                    input.untyped_storage().resize_(0)
+                    if not release_reusable_output_buffer(input, self.stream):
+                        input.record_stream(self.stream)
+                        input.untyped_storage().resize_(0)
 
         return self.output
 
@@ -274,7 +276,8 @@ class ScheduleNode:
         if output_grad:
             for g in output_grad:
                 if g is not None:
-                    g.record_stream(self.stream)
+                    if not release_reusable_output_buffer(g, self.stream):
+                        g.record_stream(self.stream)
 
         grads = self.get_grad()
         self._release_state()

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -322,6 +322,12 @@ trade-off for DeepSeek-V3 MBS2. This requires
 `--moe-expert-rank-capacity-factor` or `--moe-pad-expert-input-to-capacity`. The installed DeepEP
 must expose the caller-provided `output_token` argument; Megatron fails early otherwise.
 
+Setting `--moe-hybridep-num-expert-output-buffers N` additionally makes the fused grouped MLP
+write FC2 results directly into an `N`-slot persistent ring. HybridEP combine records the final
+consumer event before releasing each slot, so this works with both combined-1F1B overlap and the
+regular layer-by-layer schedule. It requires the same static HybridEP output bound, the Transformer
+Engine op fuser, and a Transformer Engine build with GroupedLinear caller-output support.
+
 ### Upcycling
 Use `--moe-use-upcycling` to enable upcycling, which loads the dense model from the `--load` directory, converts it to an MoE model at runtime, and starts training. The converted model is saved to the `--save` path before training begins. Upcycling is built on distributed checkpointing, supporting parallel modes different from existing dense checkpoints, such as arbitrary expert parallelism during upcycling.
 
@@ -569,6 +575,7 @@ For MoE models, certain configurations may prevent CUDA Graph capture of MoE lay
 | --moe-permute-fusion | Fuse permutation ops | False |
 | --moe-hybridep-reuse-dispatch-output-buffers | Reuse caller-owned HybridEP token outputs | False |
 | --moe-hybridep-num-dispatch-output-buffers | Persistent HybridEP token output ring size | 4 |
+| --moe-hybridep-num-expert-output-buffers | Persistent caller-owned HybridEP FC2 output ring | 0 |
 
 ### Performance Optimization
 | Argument | Description | Default |

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -311,6 +311,15 @@ After routing, tokens are **dispatched** to the GPU hosting the assigned expert.
 | **FlexDispatcher with [HybridEP](https://github.com/deepseek-ai/DeepEP/tree/hybrid-ep) backend** | NVIDIA's optimized dispatcher using TMA and IBGDA, fewer SMs, native MNNVL support | GB200 NVL72, Multi-Node NVLink | `--moe-token-dispatcher-type flex --moe-flex-dispatcher-backend hybridep` |
 | **allgather** | Gathers all tokens to each GPU, no inter-GPU token movement | TP-only setups, small EP, large Top-K | `--moe-token-dispatcher-type allgather` |
 
+For combined-1F1B HybridEP training with static dispatch shapes, setting
+`--moe-hybridep-num-dispatch-output-buffers 2` reuses two persistent token-output tensors
+instead of allocating one for every dispatch. The schedule records each expert consumer's CUDA
+completion event before returning a slot to the ring, which avoids caching-allocator pending-free
+accumulation without removing forward/backward overlap. This requires
+`--overlap-moe-expert-parallel-comm`, FP8 or FP4 expert GEMMs, and a static output bound from
+`--moe-expert-rank-capacity-factor` or `--moe-pad-expert-input-to-capacity`. The installed DeepEP
+must expose the caller-provided `output_token` argument; Megatron fails early otherwise.
+
 ### Upcycling
 Use `--moe-use-upcycling` to enable upcycling, which loads the dense model from the `--load` directory, converts it to an MoE model at runtime, and starts training. The converted model is saved to the `--save` path before training begins. Upcycling is built on distributed checkpointing, supporting parallel modes different from existing dense checkpoints, such as arbitrary expert parallelism during upcycling.
 
@@ -556,6 +565,7 @@ For MoE models, certain configurations may prevent CUDA Graph capture of MoE lay
 | --moe-pad-expert-input-to-capacity | Pad to capacity | False |
 | --moe-token-drop-policy | Drop policy: probs, position | probs |
 | --moe-permute-fusion | Fuse permutation ops | False |
+| --moe-hybridep-num-dispatch-output-buffers | Persistent caller-owned HybridEP token output ring | 0 |
 
 ### Performance Optimization
 | Argument | Description | Default |

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -326,9 +326,10 @@ offload path releases the grouped-MLP input storage.
 
 Setting `--moe-hybridep-num-expert-output-buffers N` additionally makes the fused grouped MLP
 write FC2 results directly into an `N`-slot persistent ring. HybridEP combine records the final
-consumer event before releasing each slot, so this works with both combined-1F1B overlap and the
-regular layer-by-layer schedule. It requires the same static HybridEP output bound, the Transformer
-Engine op fuser, and a Transformer Engine build with GroupedLinear caller-output support.
+consumer event before releasing each slot. It requires combined-1F1B HybridEP overlap, the same
+static HybridEP output bound, the Transformer Engine op fuser, and a Transformer Engine build with
+GroupedLinear caller-output support. The regular schedule currently has no backend API that exposes
+a safe bound for its consumer-command depth, so expert-output reuse fails fast in that mode.
 
 ### Upcycling
 Use `--moe-use-upcycling` to enable upcycling, which loads the dense model from the `--load` directory, converts it to an MoE model at runtime, and starts training. The converted model is saved to the `--save` path before training begins. Upcycling is built on distributed checkpointing, supporting parallel modes different from existing dense checkpoints, such as arbitrary expert parallelism during upcycling.

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -320,7 +320,9 @@ accumulation without consumer-event backpressure. The ring size can be overridde
 trade-off for DeepSeek-V3 MBS2. This requires
 `--overlap-moe-expert-parallel-comm`, FP8 or FP4 expert GEMMs, and a static output bound from
 `--moe-expert-rank-capacity-factor` or `--moe-pad-expert-input-to-capacity`. The installed DeepEP
-must expose the caller-provided `output_token` argument; Megatron fails early otherwise.
+must expose the caller-provided `output_token` argument; Megatron fails early otherwise. Dispatch
+output reuse is incompatible with fine-grained `fused_group_mlp` activation offload because that
+offload path releases the grouped-MLP input storage.
 
 Setting `--moe-hybridep-num-expert-output-buffers N` additionally makes the fused grouped MLP
 write FC2 results directly into an `N`-slot persistent ring. HybridEP combine records the final

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -312,10 +312,12 @@ After routing, tokens are **dispatched** to the GPU hosting the assigned expert.
 | **allgather** | Gathers all tokens to each GPU, no inter-GPU token movement | TP-only setups, small EP, large Top-K | `--moe-token-dispatcher-type allgather` |
 
 For combined-1F1B HybridEP training with static dispatch shapes, setting
-`--moe-hybridep-num-dispatch-output-buffers 2` reuses two persistent token-output tensors
+`--moe-hybridep-reuse-dispatch-output-buffers` reuses four persistent token-output tensors
 instead of allocating one for every dispatch. The schedule records each expert consumer's CUDA
 completion event before returning a slot to the ring, which avoids caching-allocator pending-free
-accumulation without removing forward/backward overlap. This requires
+accumulation without consumer-event backpressure. The ring size can be overridden with
+`--moe-hybridep-num-dispatch-output-buffers`; four is the measured best throughput/memory
+trade-off for DeepSeek-V3 MBS2. This requires
 `--overlap-moe-expert-parallel-comm`, FP8 or FP4 expert GEMMs, and a static output bound from
 `--moe-expert-rank-capacity-factor` or `--moe-pad-expert-input-to-capacity`. The installed DeepEP
 must expose the caller-provided `output_token` argument; Megatron fails early otherwise.
@@ -565,7 +567,8 @@ For MoE models, certain configurations may prevent CUDA Graph capture of MoE lay
 | --moe-pad-expert-input-to-capacity | Pad to capacity | False |
 | --moe-token-drop-policy | Drop policy: probs, position | probs |
 | --moe-permute-fusion | Fuse permutation ops | False |
-| --moe-hybridep-num-dispatch-output-buffers | Persistent caller-owned HybridEP token output ring | 0 |
+| --moe-hybridep-reuse-dispatch-output-buffers | Reuse caller-owned HybridEP token outputs | False |
+| --moe-hybridep-num-dispatch-output-buffers | Persistent HybridEP token output ring size | 4 |
 
 ### Performance Optimization
 | Argument | Description | Default |

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -61,9 +61,15 @@ if HAVE_TE:
     import transformer_engine as te
 
     from megatron.core.extensions.transformer_engine import Fp8Padding, Fp8Unpadding
+
+    try:
+        from transformer_engine.pytorch.ops.basic.grouped_linear import OUTPUT_BUFFER_KEY
+    except ImportError:
+        OUTPUT_BUFFER_KEY = None
 else:
     te = None  # type: ignore[assignment, misc]
     Fp8Padding, Fp8Unpadding = None, None
+    OUTPUT_BUFFER_KEY = None
 
 try:
     import flashinfer.fused_moe as fused_moe
@@ -645,6 +651,7 @@ class TEGroupedMLP(MegatronModule):
         permuted_local_hidden_states: torch.Tensor,
         tokens_per_expert: torch.Tensor,
         permuted_probs: torch.Tensor,
+        output_buffer: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass using Transformer Engine operation fuser API."""
 
@@ -700,6 +707,16 @@ class TEGroupedMLP(MegatronModule):
         fused_group_mlp_manager = off_interface(
             fine_grained_activation_offloading, permuted_local_hidden_states, offload_name
         )
+        op_kwargs = None
+        if output_buffer is not None:
+            if OUTPUT_BUFFER_KEY is None:
+                raise RuntimeError(
+                    "HybridEP caller-provided expert output buffers require a Transformer "
+                    "Engine build with GroupedLinear output-buffer support (PR #3161)."
+                )
+            # The fused Sequential contains [FC1, activation, FC2]. Route the persistent
+            # output only to FC2, which writes into it directly without a copy.
+            op_kwargs = {-1: {OUTPUT_BUFFER_KEY: output_buffer}}
         with fused_group_mlp_manager as permuted_local_hidden_states:
             forced_released_tensors = (
                 [permuted_local_hidden_states] if fine_grained_activation_offloading else []
@@ -711,6 +728,7 @@ class TEGroupedMLP(MegatronModule):
                     tokens_per_expert,  # FC1
                     permuted_probs,  # Scaled activation
                     tokens_per_expert,  # FC2
+                    **({"op_kwargs": op_kwargs} if op_kwargs is not None else {}),
                 )
         output = fused_group_mlp_manager.group_offload(
             output,
@@ -738,6 +756,7 @@ class TEGroupedMLP(MegatronModule):
         permuted_local_hidden_states: torch.Tensor,
         tokens_per_expert: torch.Tensor,
         permuted_probs: torch.Tensor,
+        output_buffer: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Forward of TEGroupedMLP
 
@@ -746,6 +765,7 @@ class TEGroupedMLP(MegatronModule):
             local experts.
             tokens_per_expert (torch.Tensor): The number of tokens per expert.
             permuted_probs (torch.Tensor): The permuted probs of each token produced by the router.
+            output_buffer (torch.Tensor, optional): Preallocated buffer for the fused FC2 output.
 
         Return:
             output (torch.Tensor): The output of the local experts.
@@ -754,10 +774,11 @@ class TEGroupedMLP(MegatronModule):
         # Call fused impl if enabled
         if self._with_fused_impl:
             output = self._fused_forward(
-                permuted_local_hidden_states, tokens_per_expert, permuted_probs
+                permuted_local_hidden_states, tokens_per_expert, permuted_probs, output_buffer
             )
             output_bias = None
             return output, output_bias
+        assert output_buffer is None, "output_buffer requires the TE op-fuser (fused) path"
 
         # Apply padding if needed
         unpadded_tokens_per_expert = None

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Portions of this code are from DeepSeek DeepEP project
 # Copyright (c) 2025 DeepSeek
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
@@ -31,6 +31,8 @@ except ImportError:
     HAVE_DEEP_EP_V2 = False
 
 import torch
+
+from megatron.core.pipeline_parallel.reusable_buffers import ReusableOutputBufferPool
 
 _buffer = None
 _elastic_buffer = None
@@ -498,6 +500,7 @@ except ImportError:
     HAVE_HYBRIDEP = False
 
 _hybrid_ep_buffer = None
+_hybrid_ep_dispatch_output_pool = ReusableOutputBufferPool("HybridEP dispatch output")
 
 # HybridEP dispatch/combine kernels use 64-token chunks for their public APIs.
 HYBRIDEP_TOKEN_ALIGNMENT = 64
@@ -574,6 +577,7 @@ def reset_hybrid_ep_buffer():
     '''
     global _hybrid_ep_buffer
     _hybrid_ep_buffer = None
+    _hybrid_ep_dispatch_output_pool.reset()
 
 
 class HybridEPDispatch(torch.autograd.Function):
@@ -597,11 +601,17 @@ class HybridEPDispatch(torch.autograd.Function):
         num_permuted_tokens=None,
         pad_multiple=None,
         num_sms_preprocessing_api=108,
+        num_dispatch_output_buffers=0,
     ):
         '''
         Forward pass of fused dispatch of the HybridEP backend
         '''
-        if fused or num_blocks_permute is not None or num_blocks_unpermute is not None:
+        if (
+            fused
+            or num_blocks_permute is not None
+            or num_blocks_unpermute is not None
+            or num_dispatch_output_buffers > 0
+        ):
             import inspect
             import warnings
 
@@ -618,6 +628,13 @@ class HybridEPDispatch(torch.autograd.Function):
                 num_blocks_permute = None
                 num_blocks_unpermute = None
 
+            if num_dispatch_output_buffers > 0 and 'output_token' not in sig.parameters:
+                raise RuntimeError(
+                    "HybridEP caller-provided dispatch buffers require a DeepEP build whose "
+                    "dispatch_with_permute API accepts output_token; loaded "
+                    f"{inspect.getfile(HybridEPBuffer)} with signature {sig}"
+                )
+
         if _hybrid_ep_buffer is None:
             num_tokens, hidden_dim = x.shape[-2:]
             fp8_dispatch = False  # Currently, we do not support fp8 dispatch
@@ -633,6 +650,18 @@ class HybridEPDispatch(torch.autograd.Function):
                 fp8_dispatch,
                 num_sms_preprocessing_api,
             )
+        _hybrid_ep_dispatch_output_pool.configure(num_dispatch_output_buffers)
+        output_token = None
+        if _hybrid_ep_dispatch_output_pool.enabled:
+            if num_permuted_tokens is None:
+                raise RuntimeError(
+                    "HybridEP caller-provided dispatch buffers require a static "
+                    "num_permuted_tokens"
+                )
+            output_token = _hybrid_ep_dispatch_output_pool.acquire(
+                (num_permuted_tokens, x.shape[-1]), x.dtype, x.device
+            )
+
         # If we provide the num_permuted_tokens, we do not need to use sync to
         # wait for the data in pinned memory ready
         non_blocking = num_permuted_tokens is not None
@@ -652,6 +681,7 @@ class HybridEPDispatch(torch.autograd.Function):
             pad_multiple=pad_multiple,
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=non_blocking,
+            **({"output_token": output_token} if output_token is not None else {}),
             **({"fuse_permute_dispatch": fused} if fused else {}),
         )
 
@@ -683,6 +713,7 @@ class HybridEPDispatch(torch.autograd.Function):
             combined_hidden,
             None,
             combined_probs,
+            None,
             None,
             None,
             None,
@@ -731,6 +762,15 @@ class HybridEPCombine(torch.autograd.Function):
             handle=handle,
             pad_multiple=ctx.pad_multiple,
             num_permuted_tokens=ctx.num_permuted_tokens,
+            **(
+                {
+                    "output_token": _hybrid_ep_dispatch_output_pool.acquire(
+                        (ctx.num_permuted_tokens, grad_x.shape[-1]), grad_x.dtype, grad_x.device
+                    )
+                }
+                if _hybrid_ep_dispatch_output_pool.enabled
+                else {}
+            ),
             **({"fuse_permute_dispatch": ctx.fused} if ctx.fused else {}),
         )
         return dispatched_hidden, None, None, None, None
@@ -753,6 +793,7 @@ if HAVE_HYBRIDEP:
         num_permuted_tokens=None,
         pad_multiple=None,
         num_sms_preprocessing_api=108,
+        num_dispatch_output_buffers=0,
     ):
         '''
         Perform fused dispatch for "permute + dispatch a2a + permute" using the
@@ -801,6 +842,7 @@ if HAVE_HYBRIDEP:
             num_permuted_tokens,
             pad_multiple,
             num_sms_preprocessing_api,
+            num_dispatch_output_buffers,
         )
 
     @internal_api

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -501,6 +501,7 @@ except ImportError:
 
 _hybrid_ep_buffer = None
 _hybrid_ep_dispatch_output_pool = ReusableOutputBufferPool("HybridEP dispatch output")
+_hybrid_ep_expert_output_pool = ReusableOutputBufferPool("HybridEP expert output")
 
 # HybridEP dispatch/combine kernels use 64-token chunks for their public APIs.
 HYBRIDEP_TOKEN_ALIGNMENT = 64
@@ -578,6 +579,19 @@ def reset_hybrid_ep_buffer():
     global _hybrid_ep_buffer
     _hybrid_ep_buffer = None
     _hybrid_ep_dispatch_output_pool.reset()
+    _hybrid_ep_expert_output_pool.reset()
+
+
+def acquire_hybrid_ep_expert_output_buffer(
+    like: torch.Tensor, num_expert_output_buffers: int
+) -> torch.Tensor | None:
+    """Acquire a persistent buffer for the fused expert FC2 output.
+
+    HybridEP's expert output has the same static shape and dtype as its dispatched token input.
+    The buffer is released after HybridEP combine enqueues its final read.
+    """
+    _hybrid_ep_expert_output_pool.configure(num_expert_output_buffers)
+    return _hybrid_ep_expert_output_pool.acquire(tuple(like.shape), like.dtype, like.device)
 
 
 class HybridEPDispatch(torch.autograd.Function):

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -616,8 +616,12 @@ class MoELayer(BaseMoELayer):
                 dispatched_input, tokens_per_expert, permuted_probs, routing_map=routing_map
             )
         else:
+            # HybridEP can provide a persistent buffer that fused FC2 writes directly into.
+            # The dispatcher releases it after combine enqueues the final read.
+            output_buffer = self.token_dispatcher.get_expert_output_buffer(dispatched_input)
+            expert_kwargs = {"output_buffer": output_buffer} if output_buffer is not None else {}
             expert_output, mlp_bias = apply_module(self.experts)(
-                dispatched_input, tokens_per_expert, permuted_probs
+                dispatched_input, tokens_per_expert, permuted_probs, **expert_kwargs
             )
         assert mlp_bias is None, f"mlp_bias is not supported for {type(self.token_dispatcher)}"
         output = self.token_dispatcher.combine_preprocess(expert_output)

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from megatron.core import tensor_parallel, utils
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.pipeline_parallel.reusable_buffers import release_reusable_output_buffer
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.moe_logging import get_moe_overload_factor_tracker
@@ -623,6 +624,10 @@ class MoELayer(BaseMoELayer):
             expert_output, mlp_bias = apply_module(self.experts)(
                 dispatched_input, tokens_per_expert, permuted_probs, **expert_kwargs
             )
+        # Expert compute is the final consumer of a caller-owned HybridEP dispatch output.
+        # Release it here rather than in ScheduleNode's generic free-input cleanup, which may
+        # encounter an old alias after the slot has already been acquired for a later dispatch.
+        release_reusable_output_buffer(hidden_states, torch.cuda.current_stream())
         assert mlp_bias is None, f"mlp_bias is not supported for {type(self.token_dispatcher)}"
         output = self.token_dispatcher.combine_preprocess(expert_output)
 

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -12,6 +12,7 @@ from megatron.core.config import is_experimental_enabled
 from megatron.core.fusions.fused_indices_converter import fused_indices_to_multihot
 from megatron.core.fusions.fused_pad_routing_map import fused_pad_routing_map
 from megatron.core.jit import jit_fuser
+from megatron.core.pipeline_parallel.reusable_buffers import release_reusable_output_buffer
 from megatron.core.tensor_parallel import (
     all_to_all,
     gather_from_sequence_parallel_region,
@@ -20,6 +21,7 @@ from megatron.core.tensor_parallel import (
 from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.fused_a2a import (
     HYBRIDEP_TOKEN_ALIGNMENT,
+    acquire_hybrid_ep_expert_output_buffer,
     deepepv2_combine,
     deepepv2_dispatch,
     ensure_nccl_ep_bootstrapped,
@@ -243,6 +245,10 @@ class MoETokenDispatcher:
         assert self.config.moe_shared_expert_overlap
         self.shared_experts = shared_experts
         self.use_nccl_stream = True
+
+    def get_expert_output_buffer(self, dispatched_input: torch.Tensor) -> torch.Tensor | None:
+        """Return a caller-provided expert FC2 output buffer when supported."""
+        return None
 
 
 class MoEAllGatherTokenDispatcher(MoETokenDispatcher):
@@ -1249,13 +1255,18 @@ class _HybridEPManager(_DispatchManager):
         async_finish: bool = True,
         allocate_on_comm_stream: bool = True,
     ) -> torch.Tensor:
+        expert_output = hidden_states
         hidden_states = hybrid_ep_combine(
-            x=hidden_states,
+            x=expert_output,
             handle=self.handle,
             num_permuted_tokens=self.num_permuted_tokens,
             pad_multiple=self.pad_multiple,
             fused=self.config.moe_permute_fusion_into_hybridep,
         )
+        # HybridEP combine is the final reader of the persistent FC2 output. Record its
+        # completion on the launch stream so both the fine-grained overlap schedule and the
+        # regular layer-by-layer schedule can safely reuse the slot.
+        release_reusable_output_buffer(expert_output, torch.cuda.current_stream())
         if (
             self._padded_num_tokens is not None
             and self._original_num_tokens is not None
@@ -1935,6 +1946,14 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         """Delegate to the active communication manager to free its transient
         per-forward routing metadata (see _DispatchManager.reset_transient_forward_state)."""
         self._comm_manager.reset_transient_forward_state()
+
+    def get_expert_output_buffer(self, dispatched_input: torch.Tensor) -> torch.Tensor | None:
+        """Acquire the HybridEP FC2 output slot for this expert invocation."""
+        if self.config.moe_flex_dispatcher_backend != "hybridep":
+            return None
+        return acquire_hybrid_ep_expert_output_buffer(
+            dispatched_input, self.config.moe_hybridep_num_expert_output_buffers
+        )
 
     def _initialize_metadata(self, routing_map: torch.Tensor, probs: torch.Tensor) -> torch.Tensor:
         """

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1220,7 +1220,11 @@ class _HybridEPManager(_DispatchManager):
                 pad_multiple=self.pad_multiple,
                 fused=self.config.moe_permute_fusion_into_hybridep,
                 num_sms_preprocessing_api=self.config.moe_hybridep_num_sms_preprocessing,
-                num_dispatch_output_buffers=(self.config.moe_hybridep_num_dispatch_output_buffers),
+                num_dispatch_output_buffers=(
+                    self.config.moe_hybridep_num_dispatch_output_buffers
+                    if self.config.moe_hybridep_reuse_dispatch_output_buffers
+                    else 0
+                ),
             )
         )
         if self.moe_expert_rank_capacity_factor is not None:

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1220,6 +1220,7 @@ class _HybridEPManager(_DispatchManager):
                 pad_multiple=self.pad_multiple,
                 fused=self.config.moe_permute_fusion_into_hybridep,
                 num_sms_preprocessing_api=self.config.moe_hybridep_num_sms_preprocessing,
+                num_dispatch_output_buffers=(self.config.moe_hybridep_num_dispatch_output_buffers),
             )
         )
         if self.moe_expert_rank_capacity_factor is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2160,6 +2160,16 @@ class TransformerConfig(ModelParallelConfig):
                     "moe_hybridep_num_dispatch_output_buffers requires FP8 or FP4 expert "
                     "GEMMs so the BF16 dispatch input is not saved for backward"
                 )
+            if (
+                self.fine_grained_activation_offloading
+                and "fused_group_mlp" in (self.offload_modules or [])
+            ):
+                raise ValueError(
+                    "moe_hybridep_reuse_dispatch_output_buffers is incompatible with "
+                    "fine-grained activation offloading of fused_group_mlp because that "
+                    "offload path releases the dispatch input storage; disable dispatch "
+                    "output reuse or remove fused_group_mlp from offload_modules"
+                )
 
         if self.moe_hybridep_num_expert_output_buffers < 0:
             raise ValueError("moe_hybridep_num_expert_output_buffers must be non-negative")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1063,9 +1063,9 @@ class TransformerConfig(ModelParallelConfig):
     """Number of persistent caller-provided buffers for HybridEP expert FC2 outputs.
 
     The fused grouped MLP writes directly into these buffers and HybridEP combine releases each
-    slot after enqueueing its final read. This avoids allocator pending-free accumulation in both
-    combined-1F1B and regular schedules. Requires static HybridEP output shapes and Transformer
-    Engine GroupedLinear caller-output support. Zero disables reuse.
+    slot after enqueueing its final read. This avoids allocator pending-free accumulation in the
+    combined-1F1B overlap schedule. Requires static HybridEP output shapes and Transformer Engine
+    GroupedLinear caller-output support. Zero disables reuse.
     """
 
     moe_ncclep_static_shape: bool = False
@@ -2160,9 +2160,8 @@ class TransformerConfig(ModelParallelConfig):
                     "moe_hybridep_num_dispatch_output_buffers requires FP8 or FP4 expert "
                     "GEMMs so the BF16 dispatch input is not saved for backward"
                 )
-            if (
-                self.fine_grained_activation_offloading
-                and "fused_group_mlp" in (self.offload_modules or [])
+            if self.fine_grained_activation_offloading and "fused_group_mlp" in (
+                self.offload_modules or []
             ):
                 raise ValueError(
                     "moe_hybridep_reuse_dispatch_output_buffers is incompatible with "
@@ -2181,6 +2180,12 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "moe_hybridep_num_expert_output_buffers requires the HybridEP flex "
                     "dispatcher"
+                )
+            if not self.overlap_moe_expert_parallel_comm:
+                raise ValueError(
+                    "moe_hybridep_num_expert_output_buffers requires "
+                    "overlap_moe_expert_parallel_comm; the regular schedule does not expose "
+                    "a safe bound for the HybridEP consumer-command depth"
                 )
             if not self.use_transformer_engine_op_fuser:
                 raise ValueError(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1059,6 +1059,15 @@ class TransformerConfig(ModelParallelConfig):
     ``moe_hybridep_reuse_dispatch_output_buffers``.
     """
 
+    moe_hybridep_num_expert_output_buffers: int = 0
+    """Number of persistent caller-provided buffers for HybridEP expert FC2 outputs.
+
+    The fused grouped MLP writes directly into these buffers and HybridEP combine releases each
+    slot after enqueueing its final read. This avoids allocator pending-free accumulation in both
+    combined-1F1B and regular schedules. Requires static HybridEP output shapes and Transformer
+    Engine GroupedLinear caller-output support. Zero disables reuse.
+    """
+
     moe_ncclep_static_shape: bool = False
     """For the 'ncclep' flex dispatcher: feed the experts the full fixed-size receive buffer
     instead of narrowing to the (data-dependent) number of received tokens, removing the D2H sync
@@ -2150,6 +2159,34 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "moe_hybridep_num_dispatch_output_buffers requires FP8 or FP4 expert "
                     "GEMMs so the BF16 dispatch input is not saved for backward"
+                )
+
+        if self.moe_hybridep_num_expert_output_buffers < 0:
+            raise ValueError("moe_hybridep_num_expert_output_buffers must be non-negative")
+        if self.moe_hybridep_num_expert_output_buffers > 0:
+            if (
+                self.moe_token_dispatcher_type != "flex"
+                or self.moe_flex_dispatcher_backend != "hybridep"
+            ):
+                raise ValueError(
+                    "moe_hybridep_num_expert_output_buffers requires the HybridEP flex "
+                    "dispatcher"
+                )
+            if not self.use_transformer_engine_op_fuser:
+                raise ValueError(
+                    "moe_hybridep_num_expert_output_buffers requires "
+                    "use_transformer_engine_op_fuser"
+                )
+            if not self.moe_grouped_gemm:
+                raise ValueError("moe_hybridep_num_expert_output_buffers requires moe_grouped_gemm")
+            if (
+                self.moe_expert_rank_capacity_factor is None
+                and not self.moe_pad_expert_input_to_capacity
+            ):
+                raise ValueError(
+                    "moe_hybridep_num_expert_output_buffers requires a static HybridEP "
+                    "output size from moe_expert_rank_capacity_factor or "
+                    "moe_pad_expert_input_to_capacity"
                 )
 
         # moe_deepep_num_sms / moe_hybridep_num_sms are deprecated and unified into

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1047,12 +1047,16 @@ class TransformerConfig(ModelParallelConfig):
     moe_hybridep_num_sms_preprocessing: int = 108
     """Number of SMs to use for HybridEP preprocessing (metadata scan kernel)."""
 
-    moe_hybridep_num_dispatch_output_buffers: int = 0
+    moe_hybridep_reuse_dispatch_output_buffers: bool = False
+    """Reuse persistent caller-provided buffers for HybridEP permuted token outputs."""
+
+    moe_hybridep_num_dispatch_output_buffers: int = 4
     """Number of persistent caller-provided buffers for HybridEP permuted token outputs.
 
-    A positive value avoids caching-allocator pending-free accumulation in the combined-1F1B
-    schedule. Two buffers preserve overlap between forward and backward expert computation.
-    Requires static HybridEP output shapes and low-precision expert GEMMs. Zero disables reuse.
+    Four buffers avoid caching-allocator pending-free accumulation without consumer-event
+    backpressure in the combined-1F1B schedule. Requires static HybridEP output shapes and
+    low-precision expert GEMMs. Reuse remains opt-in through
+    ``moe_hybridep_reuse_dispatch_output_buffers``.
     """
 
     moe_ncclep_static_shape: bool = False
@@ -2114,7 +2118,12 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.moe_hybridep_num_dispatch_output_buffers < 0:
             raise ValueError("moe_hybridep_num_dispatch_output_buffers must be non-negative")
-        if self.moe_hybridep_num_dispatch_output_buffers > 0:
+        if self.moe_hybridep_reuse_dispatch_output_buffers:
+            if self.moe_hybridep_num_dispatch_output_buffers == 0:
+                raise ValueError(
+                    "moe_hybridep_num_dispatch_output_buffers must be positive when "
+                    "moe_hybridep_reuse_dispatch_output_buffers is enabled"
+                )
             if (
                 self.moe_token_dispatcher_type != "flex"
                 or self.moe_flex_dispatcher_backend != "hybridep"

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1047,6 +1047,14 @@ class TransformerConfig(ModelParallelConfig):
     moe_hybridep_num_sms_preprocessing: int = 108
     """Number of SMs to use for HybridEP preprocessing (metadata scan kernel)."""
 
+    moe_hybridep_num_dispatch_output_buffers: int = 0
+    """Number of persistent caller-provided buffers for HybridEP permuted token outputs.
+
+    A positive value avoids caching-allocator pending-free accumulation in the combined-1F1B
+    schedule. Two buffers preserve overlap between forward and backward expert computation.
+    Requires static HybridEP output shapes and low-precision expert GEMMs. Zero disables reuse.
+    """
+
     moe_ncclep_static_shape: bool = False
     """For the 'ncclep' flex dispatcher: feed the experts the full fixed-size receive buffer
     instead of narrowing to the (data-dependent) number of received tokens, removing the D2H sync
@@ -2102,6 +2110,37 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "moe_flex_dispatcher_backend='ncclep' requires "
                     "moe_token_dispatcher_type='flex'."
+                )
+
+        if self.moe_hybridep_num_dispatch_output_buffers < 0:
+            raise ValueError("moe_hybridep_num_dispatch_output_buffers must be non-negative")
+        if self.moe_hybridep_num_dispatch_output_buffers > 0:
+            if (
+                self.moe_token_dispatcher_type != "flex"
+                or self.moe_flex_dispatcher_backend != "hybridep"
+            ):
+                raise ValueError(
+                    "moe_hybridep_num_dispatch_output_buffers requires the HybridEP flex "
+                    "dispatcher"
+                )
+            if not self.overlap_moe_expert_parallel_comm:
+                raise ValueError(
+                    "moe_hybridep_num_dispatch_output_buffers requires "
+                    "overlap_moe_expert_parallel_comm"
+                )
+            if (
+                self.moe_expert_rank_capacity_factor is None
+                and not self.moe_pad_expert_input_to_capacity
+            ):
+                raise ValueError(
+                    "moe_hybridep_num_dispatch_output_buffers requires a static HybridEP "
+                    "output size from moe_expert_rank_capacity_factor or "
+                    "moe_pad_expert_input_to_capacity"
+                )
+            if self.fp8 is None and self.fp4 is None:
+                raise ValueError(
+                    "moe_hybridep_num_dispatch_output_buffers requires FP8 or FP4 expert "
+                    "GEMMs so the BF16 dispatch input is not saved for backward"
                 )
 
         # moe_deepep_num_sms / moe_hybridep_num_sms are deprecated and unified into

--- a/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
+++ b/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.pipeline_parallel.reusable_buffers import (
+    ReusableOutputBufferPool,
+    release_reusable_output_buffer,
+)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_reusable_output_buffer_pool_rotates_and_reuses_storage():
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(2)
+    stream = torch.cuda.current_stream()
+
+    first = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    second = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    assert first.data_ptr() != second.data_ptr()
+    assert release_reusable_output_buffer(first, stream)
+    assert release_reusable_output_buffer(second, stream)
+
+    reused = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    assert reused.data_ptr() == first.data_ptr()
+    assert release_reusable_output_buffer(reused, stream)
+    pool.reset()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_reusable_output_buffer_pool_rejects_early_reuse():
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(1)
+    pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+
+    with pytest.raises(RuntimeError, match="before its consumer released it"):
+        pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    pool.reset()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_reusable_output_buffer_pool_requires_static_signature():
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(1)
+    tensor = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    assert release_reusable_output_buffer(tensor, torch.cuda.current_stream())
+
+    with pytest.raises(RuntimeError, match="requires a static output signature"):
+        pool.acquire((8, 8), torch.bfloat16, torch.device("cuda"))
+    pool.reset()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_reusable_output_buffer_pool_crosses_eager_warmup_into_cuda_graph():
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(1)
+    stream = torch.cuda.current_stream()
+
+    warmup = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+    warmup.fill_(1)
+    assert release_reusable_output_buffer(warmup, stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = pool.acquire((4, 8), torch.bfloat16, torch.device("cuda"))
+        captured.fill_(2)
+        assert release_reusable_output_buffer(captured, torch.cuda.current_stream())
+
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.all(captured == 2)
+    pool.reset()

--- a/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
+++ b/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
@@ -5,11 +5,12 @@ import torch
 
 from megatron.core.pipeline_parallel.reusable_buffers import (
     ReusableOutputBufferPool,
+    is_reusable_output_buffer,
     release_reusable_output_buffer,
 )
 
 
-def test_reusable_output_buffer_release_is_idempotent_for_final_consumer(monkeypatch):
+def test_reusable_output_buffer_ownership_probe_does_not_release(monkeypatch):
     events = []
 
     class FakeEvent:
@@ -26,11 +27,31 @@ def test_reusable_output_buffer_release_is_idempotent_for_final_consumer(monkeyp
     tensor = pool.acquire((4, 8), torch.bfloat16, torch.device("cpu"))
     stream = object()
 
-    # The dispatcher releases at the true final consumer. ScheduleNode then sees the same
-    # persistent storage in its generic free-input path and must skip resize without failing.
-    assert release_reusable_output_buffer(tensor, stream)
+    assert is_reusable_output_buffer(tensor)
+    assert is_reusable_output_buffer(tensor.detach())
+    assert not events
     assert release_reusable_output_buffer(tensor, stream)
     assert events[0].recorded_streams == [stream]
+    pool.reset()
+    assert not is_reusable_output_buffer(tensor)
+
+
+def test_reusable_output_buffer_rejects_double_release(monkeypatch):
+    class FakeEvent:
+        def __init__(self, **_):
+            pass
+
+        def record(self, _stream):
+            pass
+
+    monkeypatch.setattr(torch.cuda, "Event", FakeEvent)
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(1)
+    tensor = pool.acquire((4, 8), torch.bfloat16, torch.device("cpu"))
+
+    assert release_reusable_output_buffer(tensor, object())
+    with pytest.raises(RuntimeError, match="released more than once"):
+        release_reusable_output_buffer(tensor, object())
     pool.reset()
 
 

--- a/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
+++ b/tests/unit_tests/pipeline_parallel/test_reusable_buffers.py
@@ -9,6 +9,31 @@ from megatron.core.pipeline_parallel.reusable_buffers import (
 )
 
 
+def test_reusable_output_buffer_release_is_idempotent_for_final_consumer(monkeypatch):
+    events = []
+
+    class FakeEvent:
+        def __init__(self, **_):
+            self.recorded_streams = []
+            events.append(self)
+
+        def record(self, stream):
+            self.recorded_streams.append(stream)
+
+    monkeypatch.setattr(torch.cuda, "Event", FakeEvent)
+    pool = ReusableOutputBufferPool("test")
+    pool.configure(1)
+    tensor = pool.acquire((4, 8), torch.bfloat16, torch.device("cpu"))
+    stream = object()
+
+    # The dispatcher releases at the true final consumer. ScheduleNode then sees the same
+    # persistent storage in its generic free-input path and must skip resize without failing.
+    assert release_reusable_output_buffer(tensor, stream)
+    assert release_reusable_output_buffer(tensor, stream)
+    assert events[0].recorded_streams == [stream]
+    pool.reset()
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_reusable_output_buffer_pool_rotates_and_reuses_storage():
     pool = ReusableOutputBufferPool("test")

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -190,6 +190,36 @@ def test_fused_forward_caches_ops_and_forwards_expected_arguments():
     assert fused_ops.args[3] is tokens_per_expert
 
 
+def test_fused_forward_routes_caller_output_to_fc2(monkeypatch):
+    output_buffer = torch.empty(2, 4)
+
+    class FakeFusedOps:
+        def __call__(self, hidden_states, fc1_tokens, probs, fc2_tokens, *, op_kwargs=None):
+            self.op_kwargs = op_kwargs
+            return op_kwargs[-1]["output"]
+
+    module = TEGroupedMLP.__new__(TEGroupedMLP)
+    module.config = SimpleNamespace(
+        fp8=False,
+        fp4=False,
+        moe_router_padding_for_quantization=False,
+        moe_token_dispatcher_type="flex",
+        moe_flex_dispatcher_backend="hybridep",
+        moe_paged_stash=False,
+        delay_offload_until_cuda_graph=False,
+    )
+    fused_ops = FakeFusedOps()
+    module._fused_ops = (fused_ops,)
+    monkeypatch.setattr(experts_module, "OUTPUT_BUFFER_KEY", "output")
+
+    output = module._fused_forward(
+        torch.zeros(2, 4), torch.tensor([1, 1]), torch.ones(2), output_buffer
+    )
+
+    assert output is output_buffer
+    assert fused_ops.op_kwargs == {-1: {"output": output_buffer}}
+
+
 def test_apply_bias_returns_input_unchanged_when_bias_is_none():
     intermediate = torch.arange(6, dtype=torch.float32).view(3, 2)
 

--- a/tests/unit_tests/transformer/moe/test_hybridep_dispatch_output_buffers.py
+++ b/tests/unit_tests/transformer/moe/test_hybridep_dispatch_output_buffers.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _config(**kwargs):
+    return TransformerConfig(num_layers=1, hidden_size=64, num_attention_heads=4, **kwargs)
+
+
+def test_dispatch_output_buffer_reuse_is_opt_in_with_four_slots_by_default():
+    config = _config()
+
+    assert config.moe_hybridep_reuse_dispatch_output_buffers is False
+    assert config.moe_hybridep_num_dispatch_output_buffers == 4
+
+
+def test_disabled_dispatch_output_buffer_reuse_accepts_custom_slot_count():
+    config = _config(moe_hybridep_num_dispatch_output_buffers=2)
+
+    assert config.moe_hybridep_reuse_dispatch_output_buffers is False
+    assert config.moe_hybridep_num_dispatch_output_buffers == 2
+
+
+def test_enabled_dispatch_output_buffer_reuse_requires_a_positive_slot_count():
+    with pytest.raises(ValueError, match="must be positive"):
+        _config(
+            moe_hybridep_reuse_dispatch_output_buffers=True,
+            moe_hybridep_num_dispatch_output_buffers=0,
+        )

--- a/tests/unit_tests/transformer/moe/test_hybridep_dispatch_output_buffers.py
+++ b/tests/unit_tests/transformer/moe/test_hybridep_dispatch_output_buffers.py
@@ -29,3 +29,19 @@ def test_enabled_dispatch_output_buffer_reuse_requires_a_positive_slot_count():
             moe_hybridep_reuse_dispatch_output_buffers=True,
             moe_hybridep_num_dispatch_output_buffers=0,
         )
+
+
+def test_dispatch_output_buffer_reuse_rejects_fused_group_mlp_offload():
+    with pytest.raises(ValueError, match="incompatible.*fused_group_mlp"):
+        _config(
+            num_moe_experts=2,
+            moe_hybridep_reuse_dispatch_output_buffers=True,
+            moe_hybridep_num_dispatch_output_buffers=4,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            overlap_moe_expert_parallel_comm=True,
+            moe_expert_rank_capacity_factor=1.0,
+            fp8="hybrid",
+            fine_grained_activation_offloading=True,
+            offload_modules=["fused_group_mlp"],
+        )

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import dataclasses
 from types import SimpleNamespace
@@ -282,7 +282,7 @@ class MoEModelTestContainer:
         probs, indices = apply_module(moe_layer.router)(hidden_states)
         probs = torch.ones_like(probs) / moe_layer.router.topk
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -325,7 +325,7 @@ class MoEModelTestContainer:
         restored_hidden_states_answer = hidden_states * local_probss.sum(dim=1).unsqueeze(1)
         restored_hidden_states_answer = restored_hidden_states_answer.to(dtype=self.test_dtype)
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -376,7 +376,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -394,7 +394,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         permuted_input_2 = permuted_input_2 * permuted_probs_2.unsqueeze(-1)
@@ -447,7 +447,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert_1, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert_1, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -464,7 +464,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert_2, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert_2, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         assert (

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -161,23 +161,22 @@ def test_hybridep_dispatcher_acquires_expert_output_buffer(monkeypatch):
     assert calls == [(dispatched_input, 4)]
 
 
-def test_hybridep_expert_output_buffers_allow_regular_schedule():
-    transformer_config = TransformerConfig(
-        num_layers=1,
-        hidden_size=16,
-        num_attention_heads=4,
-        num_moe_experts=2,
-        moe_ffn_hidden_size=16,
-        moe_grouped_gemm=True,
-        use_transformer_engine_op_fuser=True,
-        moe_token_dispatcher_type="flex",
-        moe_flex_dispatcher_backend="hybridep",
-        moe_expert_rank_capacity_factor=1.0,
-        moe_hybridep_num_expert_output_buffers=2,
-        overlap_moe_expert_parallel_comm=False,
-    )
-
-    assert transformer_config.moe_hybridep_num_expert_output_buffers == 2
+def test_hybridep_expert_output_buffers_reject_regular_schedule():
+    with pytest.raises(ValueError, match="requires overlap_moe_expert_parallel_comm"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=2,
+            moe_ffn_hidden_size=16,
+            moe_grouped_gemm=True,
+            use_transformer_engine_op_fuser=True,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_expert_rank_capacity_factor=1.0,
+            moe_hybridep_num_expert_output_buffers=2,
+            overlap_moe_expert_parallel_comm=False,
+        )
 
 
 class MoEModelTestContainer:

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -6,12 +6,17 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import megatron.core.transformer.moe.token_dispatcher as token_dispatcher_module
 from megatron.core import config, parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.transformer.moe.fused_a2a import HYBRIDEP_TOKEN_ALIGNMENT, reset_hybrid_ep_buffer
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import get_capacity
-from megatron.core.transformer.moe.token_dispatcher import MoETokenDispatcher, _HybridEPManager
+from megatron.core.transformer.moe.token_dispatcher import (
+    MoEFlexTokenDispatcher,
+    MoETokenDispatcher,
+    _HybridEPManager,
+)
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
@@ -106,6 +111,73 @@ def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     assert manager.token_probs.shape == (expected_num_tokens, manager.num_experts)
     assert not manager.routing_map[local_num_tokens:].any()
     assert not manager.token_probs[local_num_tokens:].any()
+
+
+def test_hybridep_combine_releases_expert_output_at_final_consumer(monkeypatch):
+    manager = object.__new__(_HybridEPManager)
+    manager.handle = object()
+    manager.num_permuted_tokens = 8
+    manager.pad_multiple = 4
+    manager.config = SimpleNamespace(moe_permute_fusion_into_hybridep=False)
+    manager._padded_num_tokens = None
+    manager._original_num_tokens = None
+    manager.drop_and_pad = False
+    expert_output = torch.empty(8, 4)
+    combined_output = torch.empty(2, 4)
+    stream = object()
+    releases = []
+
+    monkeypatch.setattr(token_dispatcher_module, "hybrid_ep_combine", lambda **_: combined_output)
+    monkeypatch.setattr(
+        token_dispatcher_module,
+        "release_reusable_output_buffer",
+        lambda tensor, release_stream: releases.append((tensor, release_stream)) or True,
+    )
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: stream)
+
+    output = manager.combine(expert_output)
+
+    assert output is combined_output
+    assert releases == [(expert_output, stream)]
+
+
+def test_hybridep_dispatcher_acquires_expert_output_buffer(monkeypatch):
+    dispatcher = object.__new__(MoEFlexTokenDispatcher)
+    dispatcher.config = SimpleNamespace(
+        moe_flex_dispatcher_backend="hybridep", moe_hybridep_num_expert_output_buffers=4
+    )
+    dispatched_input = torch.empty(8, 4)
+    expected = torch.empty_like(dispatched_input)
+    calls = []
+    monkeypatch.setattr(
+        token_dispatcher_module,
+        "acquire_hybrid_ep_expert_output_buffer",
+        lambda tensor, slots: calls.append((tensor, slots)) or expected,
+    )
+
+    output = dispatcher.get_expert_output_buffer(dispatched_input)
+
+    assert output is expected
+    assert calls == [(dispatched_input, 4)]
+
+
+def test_hybridep_expert_output_buffers_allow_regular_schedule():
+    transformer_config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=2,
+        moe_ffn_hidden_size=16,
+        moe_grouped_gemm=True,
+        use_transformer_engine_op_fuser=True,
+        moe_token_dispatcher_type="flex",
+        moe_flex_dispatcher_backend="hybridep",
+        moe_expert_rank_capacity_factor=1.0,
+        moe_hybridep_num_expert_output_buffers=2,
+        overlap_moe_expert_parallel_comm=False,
+    )
+
+    assert transformer_config.moe_hybridep_num_expert_output_buffers == 2
 
 
 class MoEModelTestContainer:


### PR DESCRIPTION
## Summary

This draft bounds two HybridEP cross-stream allocation patterns with caller-owned persistent buffer rings:

- **dispatch output**: HybridEP writes permuted tokens into a reusable buffer; the expert consumer records the final-read event;
- **expert FC2 output**: Transformer Engine fused grouped MLP writes FC2 directly into a reusable buffer; HybridEP combine records the final-read event;
- provide a shared schedule-aware buffer pool that keeps storage persistent, returns a fresh TensorImpl per acquisition, and uses external CUDA events for eager warmup → full-iteration CUDA Graph capture/replay;
- keep both optimizations opt-in, validate static shapes and required backends, and fail explicitly on early reuse or double release.

The final-consumer release points are intentional. A generic `ScheduleNode.free_input` ownership probe must not mutate ring state because an old alias can be encountered after the same storage has already been acquired by a later operation.

## Configuration

```yaml
# Dispatch-output reuse (independent)
moe_hybridep_reuse_dispatch_output_buffers: true
moe_hybridep_num_dispatch_output_buffers: 4

# Expert FC2-output reuse (independent; zero disables)
moe_hybridep_num_expert_output_buffers: 4
```

Both paths require a static HybridEP output bound from `moe_expert_rank_capacity_factor` or `moe_pad_expert_input_to_capacity`.

Dispatch-output reuse additionally requires HybridEP flex dispatch, EP communication overlap, FP8/FP4 expert GEMMs, and a DeepEP `dispatch_with_permute(..., output_token=...)` API.

Expert-output reuse requires the Transformer Engine op fuser and grouped MLP. It depends on [Transformer Engine PR #3161](https://github.com/NVIDIA/TransformerEngine/pull/3161) (GroupedLinear caller-provided output), plus a cuDNN frontend wrapper that forwards the caller output pointer. Megatron fails early if the TE API is unavailable.

## Motivation

A 64-GPU DeepSeek-V3 MBS2 allocator snapshot showed **9 HybridEP dispatch outputs × 1,078 MiB = 9.47 GiB** in the caching allocator pending-free queue at the max-active point. Those buffers are logically dead after grouped-MLP consumption, but the generic allocator cannot infer the higher-level producer/consumer ordering across streams.

FC2/grouped-GEMM outputs have the analogous lifetime:

```text
grouped FC2 on compute stream writes expert_output
    -> HybridEP combine on communication stream performs the final read
    -> caching allocator waits for cross-stream retirement
```

The application-owned rings make these final-consumer dependencies explicit without a CPU or stream-wide synchronization and bound the amount of persistent output storage.

## Validation

- Megatron autoformat against current `dev`: Black, isort, pylint (10.00/10), and ruff passed.
- Copyright check passed for all changed Python files.
- Unit coverage includes ring rotation, ownership probes, early/double release, eager-warmup-to-CUDA-Graph transition, FC2 output routing, and combine final-consumer release.
- Existing dispatch-output validation:
  - 8-GPU full-iteration CUDA Graph control/feature runs completed 10/10;
  - four 64-GPU, 30-step slot-sweep runs completed 30/30;
  - 4 slots matched control throughput and reduced max reserved from 169,326 to 159,026 MiB on the measured MBS2 proxy.
- Expert FC2-output validation:
  - 64-GPU GB200 proxy completed full-CG replay with combined-1F1B and with the regular schedule, including dense-inner symmetric UBR;
  - 256-GPU DeepSeek-V3, MBS1, combined-1F1B/full-CG/UBR completed 30/30 (SLURM 2796654): mean/median **1112.34/1115.00 TFLOP/s/GPU**, peak allocated/reserved/device-used **154701/175300/189420 MiB**;
  - the comparable no-pool baseline was 1124.86/1128.10 TFLOP/s/GPU and 152545/175294/187430 MiB. This establishes compatibility and stability, but **does not show a throughput or reserved-memory benefit for MBS1**;
  - exploratory full-model regular-schedule one-step controls completed with 0 and 10 expert-output slots, while four slots spun before the first iteration at EP64. Because HybridEP does not expose a safe consumer-command depth bound, production configuration now rejects expert-output reuse without combined-1F1B overlap; the pending 30-step regular runs are characterization only.

## Known limitations

- Ring size is schedule- and pipeline-depth-dependent. Reuse before the prior consumer release fails explicitly.
- The current measured MBS1 expert FC2 output is about **539 MiB per slot**; persistent allocated memory therefore rises linearly with the configured slot count.
- Expert-output reuse intentionally requires combined-1F1B overlap. DeepEP's dispatch kernel stage-count environment variables are not a general cross-API lifetime bound, so regular-schedule reuse fails fast until the backend exposes one.
- Throughput measurements used different node sets. Small deltas are treated as parity/regression signals, not speedup claims.
- Dispatch-output reuse is rejected with fine-grained `fused_group_mlp` activation offload because that path releases the persistent dispatch input storage.
- This remains a draft until the final-code full-model replay and clean-dev GPU CI are complete.
