### PR TITLE
[dev] Support arbitrary-size dynamic context parallelism

### DIFF
--- a/examples/dynamic_context_parallel/README.md
+++ b/examples/dynamic_context_parallel/README.md
@@ -107,13 +107,18 @@ only a tie-break. Payload size follows the existing `pad_packed_seq_alignment`
 setting (including full-capacity `max` padding), not just the valid tokens.
 The two default weights are a rounded H100/Qwen3 attention
 reference, not native-transport calibration; override them for a different
-model, payload or interconnect. Setting equal weights disables the adjustment.
+model, payload or interconnect. Equal weights or a single NVLink domain preserve
+the existing packing/filling policy, including its full-parent packing fallback.
 
 All integer CP sizes remain eligible, including groups that must cross a
-domain. Whole-group placement and capacity-checked filling avoid gratuitous
-crossings without leaving empty ranks; VPP-aligned groups are rechecked.
-The training path loads no predictor, runs no solver, and creates no process
-groups or topology-probing collectives. This heuristic does not guarantee an
+domain. Spare ranks are distributed across packs by a bounded dynamic program,
+instead of all being assigned to one pack. It minimizes the slowest group, then
+total rank-work and cross-domain traffic, exactly for each fixed pack order.
+Only two orders are tried for rank allocation (original and topology-greedy),
+so this is not a globally optimal packing solver. Each order costs O(groups × ranks²); VPP
+splits use the same allocator before committing an expansion.
+The training path loads no predictor, uses no external solver, and creates no
+process groups or topology-probing collectives. This heuristic does not guarantee an
 E2E improvement: EP imbalance, communication overlap and native timings still
 need offline prediction or measurement for the workload of interest.
 

--- a/examples/dynamic_context_parallel/README.md
+++ b/examples/dynamic_context_parallel/README.md
@@ -71,6 +71,52 @@ The baseline keeps the full fixed CP size for the packed workload. DCP can
 spread short samples over the DPxCP domain instead of making every sample occupy
 the full CP group.
 
+## NVLink-aware native DCP scheduling
+
+For a Cartesian rank layout with each consecutive eight global GPU ranks in
+one NVLink domain, add these arguments to a native DCP training command:
+
+```text
+--dynamic-context-parallel --use-native-cp-transport
+--dynamic-cp-nvlink-domain-size 8
+--dynamic-cp-communication-cost 1024 2304
+```
+
+The domain size is an explicit placement contract, **not** GPUs per Slurm host
+or automatic topology discovery. Use 72 only when consecutive 72-rank blocks
+really describe NVL72 domains. The scheduler maps global ranks to DP×CP
+positions and takes the common boundaries across TP/PP planes so all stages
+choose the same schedule. Custom non-Cartesian process-group layouts are not
+supported by this option. Omitting the domain size preserves compute-only
+scheduling; legacy multi-ProcessGroup DCP is unchanged.
+
+The lightweight score retains the padded compute proxy `Q = sum(L_i²) / CP`.
+For a group crossing a domain boundary, it adds only the extra exposed ring
+communication, using `CP - 1` overlapping exchanges:
+
+```text
+q = Q / CP
+u_local, u_cross = communication_cost * payload_tokens_per_rank
+score = Q + (CP - 1) * (max(q, u_cross) - max(q, u_local))
+```
+
+Both terms use the same token-squared units; the communication coefficients
+are equivalent-token weights, not milliseconds or bandwidths. They apply to
+the complete pack, not separately to each sequence. Fully hidden traffic is
+only a tie-break. Payload size follows the existing `pad_packed_seq_alignment`
+setting (including full-capacity `max` padding), not just the valid tokens.
+The two default weights are a rounded H100/Qwen3 attention
+reference, not native-transport calibration; override them for a different
+model, payload or interconnect. Setting equal weights disables the adjustment.
+
+All integer CP sizes remain eligible, including groups that must cross a
+domain. Whole-group placement and capacity-checked filling avoid gratuitous
+crossings without leaving empty ranks; VPP-aligned groups are rechecked.
+The training path loads no predictor, runs no solver, and creates no process
+groups or topology-probing collectives. This heuristic does not guarantee an
+E2E improvement: EP imbalance, communication overlap and native timings still
+need offline prediction or measurement for the workload of interest.
+
 ## Output
 
 At the end, the script prints:

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -6,6 +6,7 @@ import torch
 
 from megatron.core import parallel_state
 from megatron.core.datasets.data_schedule_utils import (
+    _validate_dcp_nvlink_cost,
     align_sample_id_groups,
     broadcast_scalars,
     broadcast_tensor,
@@ -479,25 +480,30 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
             self.microbatch_group_size_per_vp_stage is not None
             and self.microbatch_group_size_per_vp_stage > 1
         ):
+
+            def fill_group(group):
+                return reorder_dcp_groups(
+                    group,
+                    sample_lengths,
+                    self.nvlink_domains,
+                    self.communication_cost,
+                    self.sequence_parallel_size,
+                    self.max_seq_len_per_rank,
+                    self.padding_alignment,
+                )
+
             sample_id_groups = align_sample_id_groups(
                 sample_id_groups,
                 self.microbatch_group_size_per_vp_stage,
                 allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
-            )
-
-            if self.nvlink_domains is not None:
-                sample_id_groups = [
-                    reorder_dcp_groups(
-                        group,
-                        sample_lengths,
-                        self.nvlink_domains,
-                        self.communication_cost,
-                        self.sequence_parallel_size,
-                        self.max_seq_len_per_rank,
-                        self.padding_alignment,
+                fill_empty_ranks=(
+                    fill_group
+                    if _validate_dcp_nvlink_cost(
+                        self.nvlink_domains, self.communication_cost, self.total_hdp_gpus
                     )
-                    for group in sample_id_groups
-                ]
+                    else None
+                ),
+            )
 
         return sample_id_groups
 

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -14,6 +14,7 @@ from megatron.core.datasets.data_schedule_utils import (
     get_batch_and_global_seqlens,
     get_cp_slice_for_thd,
     next_hdp_group_packing_aware,
+    reorder_dcp_groups,
     reroute_samples_to_dcp_ranks,
 )
 from megatron.core.packed_seq_params import (
@@ -432,6 +433,9 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
         min_cp_size=1,
         allow_arbitrary_group_starts=False,
         sequence_parallel_size=1,
+        nvlink_domains=None,
+        communication_cost=(1024.0, 2304.0),
+        padding_alignment=None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -441,6 +445,9 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
         self.min_cp_size = min_cp_size
         self.allow_arbitrary_group_starts = allow_arbitrary_group_starts
         self.sequence_parallel_size = sequence_parallel_size
+        self.nvlink_domains = nvlink_domains
+        self.communication_cost = communication_cost
+        self.padding_alignment = padding_alignment
 
     def get_groups_and_subsamples(self, sample_id_seqlens):
         """
@@ -449,6 +456,7 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
         """
         mslpr = self.max_seq_len_per_rank
         min_cp = self.min_cp_size
+        sample_lengths = dict(sample_id_seqlens) if self.nvlink_domains is not None else None
 
         sample_id_groups = []
         sample_id_seqlens = sorted(sample_id_seqlens, key=lambda x: x[1], reverse=True)
@@ -461,6 +469,9 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
                 min_cp_size=min_cp,
                 allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
                 sequence_parallel_size=self.sequence_parallel_size,
+                nvlink_domains=self.nvlink_domains,
+                communication_cost=self.communication_cost,
+                padding_alignment=self.padding_alignment,
             )
             sample_id_groups.append(sample_ids)
 
@@ -473,6 +484,20 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
                 self.microbatch_group_size_per_vp_stage,
                 allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
             )
+
+            if self.nvlink_domains is not None:
+                sample_id_groups = [
+                    reorder_dcp_groups(
+                        group,
+                        sample_lengths,
+                        self.nvlink_domains,
+                        self.communication_cost,
+                        self.sequence_parallel_size,
+                        self.max_seq_len_per_rank,
+                        self.padding_alignment,
+                    )
+                    for group in sample_id_groups
+                ]
 
         return sample_id_groups
 
@@ -511,6 +536,48 @@ def _get_scheduler_max_real_num_seqs(config) -> Optional[int]:
         return max_num_seqs - 1
 
     return max_num_seqs
+
+
+def _get_dynamic_cp_nvlink_domains(
+    dp_cp_ranks: List[int],
+    tp_ranks: List[int],
+    pp_ranks: List[int],
+    rank: int,
+    world_size: int,
+    domain_size: int,
+) -> List[int]:
+    """Return a common contiguous NVLink partition for all Cartesian TP/PP planes.
+
+    Physical domains are declared consecutive global-rank blocks. Megatron's rank
+    generator uses additive Cartesian strides, so translating explicit group ranks
+    enumerates all planes without communication. A boundary in any plane becomes a
+    shared boundary, ensuring independently scheduled PP stages use the same costs.
+    """
+    if domain_size < 1 or any(
+        not ranks or ranks != sorted(set(ranks)) or rank not in ranks
+        for ranks in (dp_cp_ranks, tp_ranks, pp_ranks)
+    ):
+        raise ValueError(
+            "NVLink scheduling requires positive domain size and valid Cartesian rank lists."
+        )
+    boundaries = set()
+    visited = set()
+    for tp_rank in tp_ranks:
+        for pp_rank in pp_ranks:
+            plane = [r + tp_rank + pp_rank - 2 * rank for r in dp_cp_ranks]
+            if plane[0] < 0 or plane[-1] >= world_size or visited.intersection(plane):
+                raise ValueError(
+                    "NVLink scheduling requires disjoint Cartesian TP/PP rank planes within WORLD."
+                )
+            visited.update(plane)
+            domains = [r // domain_size for r in plane]
+            boundaries.update(i for i in range(1, len(domains)) if domains[i] != domains[i - 1])
+    domain = 0
+    result = []
+    for i in range(len(dp_cp_ranks)):
+        domain += i in boundaries
+        result.append(domain)
+    return result
 
 
 def wrap_data_iterator(
@@ -559,6 +626,31 @@ def wrap_data_iterator(
         )
         if scheduler_kwargs['allow_arbitrary_group_starts'] and config.sequence_parallel:
             scheduler_kwargs['sequence_parallel_size'] = config.tensor_model_parallel_size
+        domain_size = getattr(config, 'dynamic_cp_nvlink_domain_size', None)
+        if scheduler_kwargs['allow_arbitrary_group_starts'] and domain_size is not None:
+            ranks = torch.distributed.get_process_group_ranks
+            scheduler_kwargs['nvlink_domains'] = _get_dynamic_cp_nvlink_domains(
+                ranks(dp_cp_group),
+                ranks(tp_group),
+                ranks(pp_group),
+                torch.distributed.get_global_rank(dp_cp_group, dp_cp_group.rank()),
+                torch.distributed.get_world_size(),
+                domain_size,
+            )
+            scheduler_kwargs['communication_cost'] = getattr(
+                config, 'dynamic_cp_communication_cost', None
+            ) or (1024.0, 2304.0)
+            padding_alignment = getattr(config, 'pad_packed_seq_alignment', None)
+            if padding_alignment is not None:
+                alignment, target_len, _ = get_thd_padding_kwargs(
+                    padding_alignment,
+                    config.max_seqlen_per_dp_cp_rank,
+                    getattr(config, 'thd_max_packed_sequences', None),
+                    getattr(config, 'cuda_graph_impl', 'none') != 'none',
+                )
+                scheduler_kwargs['padding_alignment'] = (
+                    'max' if target_len is not None else alignment
+                )
 
     scheduler_max_num_seqs = (
         _get_scheduler_max_real_num_seqs(config)

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -51,11 +51,23 @@ def _build_thd_padding_mask(
     positions = torch.arange(
         total_tokens, dtype=cu_seqlens_padded.dtype, device=cu_seqlens_padded.device
     )
-    seq_indices = torch.searchsorted(cu_seqlens_padded[1:].contiguous(), positions, right=True)
+    seq_indices = _build_thd_sequence_indices(cu_seqlens_padded)
 
     valid_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).clamp(min=0)
     valid_ends = cu_seqlens_padded[:-1] + valid_lengths
     return positions >= valid_ends[seq_indices]
+
+
+def _build_thd_sequence_indices(cu_seqlens_padded: torch.Tensor) -> torch.Tensor:
+    """Map every physical THD row to its original packed sequence."""
+    assert cu_seqlens_padded.dim() == 1
+    total_tokens = int(cu_seqlens_padded[-1].item())
+    positions = torch.arange(
+        total_tokens, dtype=cu_seqlens_padded.dtype, device=cu_seqlens_padded.device
+    )
+    return torch.searchsorted(cu_seqlens_padded[1:].contiguous(), positions, right=True).to(
+        torch.int32
+    )
 
 
 def _sanitize_thd_padding_values(batch: Dict[str, Any], padding_mask: torch.Tensor) -> None:
@@ -409,12 +421,13 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
     Dynamic CP scheduler that balances workload across variable CP sizes.
     """
 
-    def __init__(self, *args, min_cp_size=1, **kwargs):
+    def __init__(self, *args, min_cp_size=1, allow_arbitrary_group_starts=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.is_dynamic_cp = True
         self.max_seq_len_per_rank = self.max_seqlen_per_dp_cp_rank
         self.total_hdp_gpus = self.dp_size * self.cp_size
         self.min_cp_size = min_cp_size
+        self.allow_arbitrary_group_starts = allow_arbitrary_group_starts
 
     def get_groups_and_subsamples(self, sample_id_seqlens):
         """
@@ -433,6 +446,7 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
                 self.total_hdp_gpus,
                 max_seq_len_per_rank=mslpr,
                 min_cp_size=min_cp,
+                allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
             )
             sample_id_groups.append(sample_ids)
 
@@ -524,6 +538,9 @@ def wrap_data_iterator(
     scheduler_kwargs = {}
     if scheduler_type == 'default_dynamic_cp':
         scheduler_kwargs['min_cp_size'] = config.min_dynamic_context_parallel_size
+        scheduler_kwargs['allow_arbitrary_group_starts'] = getattr(
+            config, 'use_native_cp_transport', False
+        )
 
     scheduler_max_num_seqs = (
         _get_scheduler_max_real_num_seqs(config)
@@ -602,11 +619,18 @@ def get_batch_on_this_rank_for_sequence_packing(
 
     is_first_or_last_stage = is_first_stage or is_last_stage
     dev = torch.cuda.current_device()
+    use_native_cp_transport = dynamic_cp and getattr(config, 'use_native_cp_transport', False)
+    router_loss_type = getattr(config, 'moe_router_load_balancing_type', None)
+    use_packed_seq_aux_loss = router_loss_type == 'seq_aux_loss' or (
+        isinstance(router_loss_type, (list, tuple)) and 'seq_aux_loss' in router_loss_type
+    )
 
     # data_iterator should return a batch including the following keys.
     batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen']
     if dynamic_cp:
         batch_keys.append('local_cp_size')
+        if use_native_cp_transport:
+            batch_keys.append('local_cp_group_start')
     if is_first_stage or mtp_on_this_rank:
         batch_keys.append('tokens')
         batch_keys.append('position_ids')
@@ -629,9 +653,13 @@ def get_batch_on_this_rank_for_sequence_packing(
         local_cp_size_val = batch['local_cp_size']
         if isinstance(local_cp_size_val, torch.Tensor):
             local_cp_size_val = local_cp_size_val.item()
-        cp_group = parallel_state.get_dynamic_data_context_parallel_groups(
-            group_size=local_cp_size_val
-        )
+        group_kwargs = {'group_size': local_cp_size_val}
+        if use_native_cp_transport:
+            local_cp_group_start_val = batch['local_cp_group_start']
+            if isinstance(local_cp_group_start_val, torch.Tensor):
+                local_cp_group_start_val = local_cp_group_start_val.item()
+            group_kwargs['group_start'] = local_cp_group_start_val
+        cp_group = parallel_state.get_dynamic_data_context_parallel_groups(**group_kwargs)
 
     cp_partition_mode = getattr(config, "cp_partition_mode", "zigzag")
     tail_padding_policy = resolve_thd_tail_padding_policy(config)
@@ -669,6 +697,8 @@ def get_batch_on_this_rank_for_sequence_packing(
         batch['padding_mask'] = _build_thd_padding_mask(
             batch['cu_seqlens'], batch['cu_seqlens_padded']
         )
+        if use_packed_seq_aux_loss:
+            batch['seq_idx'] = _build_thd_sequence_indices(batch['cu_seqlens_padded'])
         _sanitize_thd_padding_values(batch, batch['padding_mask'])
 
         # In extend_last mode, the padding tail belongs to the final real
@@ -692,6 +722,8 @@ def get_batch_on_this_rank_for_sequence_packing(
     # on every PP stage, while data tensors are only needed on first/last/MTP stages.
     if is_tp_rank_0:
         cp_slice_keys = ['padding_mask']
+        if use_packed_seq_aux_loss:
+            cp_slice_keys.append('seq_idx')
         if is_first_or_last_stage or mtp_on_this_rank:
             cp_slice_keys.extend(['tokens', 'position_ids', 'labels', 'loss_mask'])
         if non_dummy_global_target_len is not None:
@@ -770,8 +802,16 @@ def get_batch_on_this_rank_for_sequence_packing(
     if is_tp_rank_0:
         assert batch['padding_mask'].dtype == torch.bool
         batch['padding_mask'] = batch['padding_mask'].view(1, total_tokens)
+        if use_packed_seq_aux_loss:
+            assert batch['seq_idx'].dtype == torch.int32
+            batch['seq_idx'] = batch['seq_idx'].view(1, total_tokens)
     else:
         batch['padding_mask'] = torch.empty([1, total_tokens], dtype=torch.bool, device=dev)
+        if use_packed_seq_aux_loss:
+            batch['seq_idx'] = torch.empty([1, total_tokens], dtype=torch.int32, device=dev)
+
+    if not use_packed_seq_aux_loss:
+        batch['seq_idx'] = None
 
     # Step4: Prepare "cu_seqlens", "cu_seqlens_padded", "max_seqlen" on all ranks.
     if is_tp_rank_0:
@@ -804,16 +844,32 @@ def get_batch_on_this_rank_for_sequence_packing(
     else:
         batch['local_cp_size'] = None
 
+    if use_native_cp_transport:
+        if is_tp_rank_0:
+            if type(batch['local_cp_group_start']) == int:
+                batch['local_cp_group_start'] = torch.tensor(
+                    batch['local_cp_group_start'], dtype=torch.int32, device=dev
+                )
+            else:
+                assert batch['local_cp_group_start'].dtype == torch.int32
+                assert batch['local_cp_group_start'].numel() == 1
+        else:
+            batch['local_cp_group_start'] = torch.empty(1, dtype=torch.int32, device=dev)
+    else:
+        batch['local_cp_group_start'] = None
+
     # Broadcast batch inside TP group.
     broadcast_tensor(batch['tokens'], tp_src_rank, tp_group)
     broadcast_tensor(batch['position_ids'], tp_src_rank, tp_group)
     broadcast_tensor(batch['labels'], tp_src_rank, tp_group)
     broadcast_tensor(batch['loss_mask'], tp_src_rank, tp_group)
     broadcast_tensor(batch['padding_mask'], tp_src_rank, tp_group)
+    broadcast_tensor(batch['seq_idx'], tp_src_rank, tp_group)
     broadcast_tensor(batch['cu_seqlens'], tp_src_rank, tp_group)
     broadcast_tensor(batch['cu_seqlens_padded'], tp_src_rank, tp_group)
     broadcast_tensor(batch['max_seqlen'], tp_src_rank, tp_group)
     broadcast_tensor(batch['local_cp_size'], tp_src_rank, tp_group)
+    broadcast_tensor(batch['local_cp_group_start'], tp_src_rank, tp_group)
 
     # Extract the data from batch after broadcasting.
     tokens = batch['tokens']
@@ -821,15 +877,19 @@ def get_batch_on_this_rank_for_sequence_packing(
     labels = batch['labels']
     loss_mask = batch['loss_mask']
     padding_mask = batch['padding_mask']
+    seq_idx = batch['seq_idx']
     cu_seqlens = batch['cu_seqlens']
     cu_seqlens_padded = batch['cu_seqlens_padded']
     max_seqlen = batch['max_seqlen'].item()
     local_cp_size = batch['local_cp_size'].item() if dynamic_cp else None
-    cp_group = (
-        parallel_state.get_dynamic_data_context_parallel_groups(group_size=local_cp_size)
-        if dynamic_cp
-        else None
-    )
+    local_cp_group_start = batch['local_cp_group_start'].item() if use_native_cp_transport else None
+    if dynamic_cp:
+        group_kwargs = {'group_size': local_cp_size}
+        if use_native_cp_transport:
+            group_kwargs['group_start'] = local_cp_group_start
+        cp_group = parallel_state.get_dynamic_data_context_parallel_groups(**group_kwargs)
+    else:
+        cp_group = None
 
     # cu_seqlens_q/kv hold the original (unpadded) boundaries so downstream
     # loss paths (e.g. CSA indexer KL) can identify padding rows.
@@ -845,6 +905,7 @@ def get_batch_on_this_rank_for_sequence_packing(
         max_seqlen_kv=max_seqlen,
         local_cp_size=local_cp_size,
         cp_group=cp_group,
+        seq_idx=seq_idx,
         cp_partition_mode=cp_partition_mode,
         pad_between_seqs=True,
     )

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -373,7 +373,12 @@ class DpBalancedScheduler(BasePackingScheduler):
 
             # Step 6: Build packed microbatches
             new_samples = build_packed_microbatches(
-                samples_this_rank_with_id, sample_id_groups, dcp_rank, dev, self.is_dynamic_cp
+                samples_this_rank_with_id,
+                sample_id_groups,
+                dcp_rank,
+                dev,
+                self.is_dynamic_cp,
+                sequence_parallel_size=getattr(self, 'sequence_parallel_size', 1),
             )
 
             # Step 7: Calculate FLOPs info
@@ -421,13 +426,21 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
     Dynamic CP scheduler that balances workload across variable CP sizes.
     """
 
-    def __init__(self, *args, min_cp_size=1, allow_arbitrary_group_starts=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        min_cp_size=1,
+        allow_arbitrary_group_starts=False,
+        sequence_parallel_size=1,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.is_dynamic_cp = True
         self.max_seq_len_per_rank = self.max_seqlen_per_dp_cp_rank
         self.total_hdp_gpus = self.dp_size * self.cp_size
         self.min_cp_size = min_cp_size
         self.allow_arbitrary_group_starts = allow_arbitrary_group_starts
+        self.sequence_parallel_size = sequence_parallel_size
 
     def get_groups_and_subsamples(self, sample_id_seqlens):
         """
@@ -447,6 +460,7 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
                 max_seq_len_per_rank=mslpr,
                 min_cp_size=min_cp,
                 allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
+                sequence_parallel_size=self.sequence_parallel_size,
             )
             sample_id_groups.append(sample_ids)
 
@@ -455,7 +469,9 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
             and self.microbatch_group_size_per_vp_stage > 1
         ):
             sample_id_groups = align_sample_id_groups(
-                sample_id_groups, self.microbatch_group_size_per_vp_stage
+                sample_id_groups,
+                self.microbatch_group_size_per_vp_stage,
+                allow_arbitrary_group_starts=self.allow_arbitrary_group_starts,
             )
 
         return sample_id_groups
@@ -541,6 +557,8 @@ def wrap_data_iterator(
         scheduler_kwargs['allow_arbitrary_group_starts'] = getattr(
             config, 'use_native_cp_transport', False
         )
+        if scheduler_kwargs['allow_arbitrary_group_starts'] and config.sequence_parallel:
+            scheduler_kwargs['sequence_parallel_size'] = config.tensor_model_parallel_size
 
     scheduler_max_num_seqs = (
         _get_scheduler_max_real_num_seqs(config)

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 from math import ceil, isfinite, lcm
-from typing import Dict, List, Literal, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 import torch
 
@@ -683,8 +683,9 @@ def reorder_dcp_groups(
     """Compact/fill a rank layout, then greedily place whole packs within NVLink domains.
 
     CP sizes and sample membership are preserved except when absorbing unused
-    ranks. Compare complete layouts before accepting a reorder; no search solver
-    or measured-model dependency runs in the training path.
+    ranks. A bounded dynamic program allocates spare ranks across packs. Compare
+    complete layouts before accepting a reorder; no external solver or measured
+    model is needed in the training path.
     """
     if not _validate_dcp_nvlink_cost(nvlink_domains, communication_cost, len(sample_id_group)):
         return sample_id_group
@@ -698,6 +699,9 @@ def reorder_dcp_groups(
             groups.append((1, tuple(samples)))
     if not groups:
         return sample_id_group
+    boundaries_before = [0]
+    for a, b in zip(nvlink_domains, nvlink_domains[1:]):
+        boundaries_before.append(boundaries_before[-1] + (a != b))
 
     @lru_cache(maxsize=None)
     def pack_work(cp_size, samples):
@@ -705,12 +709,12 @@ def reorder_dcp_groups(
         local = [ceil(sample_lengths[sid] / alignment) * (alignment // cp_size) for sid in samples]
         return sum(length**2 * cp_size for length in local), sum(local)
 
+    @lru_cache(maxsize=None)
     def cost(group, start):
         cp_size, samples = group
         compute, tokens = pack_work(cp_size, samples)
         tokens = _dcp_communication_tokens(tokens, capacity, padding_alignment)
-        domains = nvlink_domains[start : start + cp_size]
-        boundaries = sum(a != b for a, b in zip(domains, domains[1:]))
+        boundaries = boundaries_before[start + cp_size - 1] - boundaries_before[start]
         extra = _dcp_communication_overhead(
             compute, tokens, cp_size, boundaries > 0, communication_cost
         )
@@ -742,22 +746,70 @@ def reorder_dcp_groups(
     capacity = max_seq_len_per_rank
     if capacity is None:
         capacity = max(pack_work(*group)[1] for group in groups)
-    missing = len(sample_id_group) - sum(cp for cp, _ in groups)
-    best, best_score = None, None
-    # Check CP1 -> CP>1 explicitly: zigzag alignment can grow very short sequences.
-    for expanded in range(len(groups)) if missing else (None,):
-        filled = [
-            (cp + (missing if i == expanded else 0), samples)
-            for i, (cp, samples) in enumerate(groups)
-        ]
-        if any(pack_work(*group)[1] > capacity for group in filled):
-            continue
-        candidate_score = score(filled)
-        if best is None or candidate_score < best_score:
-            best, best_score = filled, candidate_score
-    if best is None:
-        raise ValueError('Cannot fill DPxCP ranks without exceeding per-rank token capacity')
-    # Only one placement pass, not one per expansion candidate: O(number_of_groups * ranks).
+    total_ranks = len(sample_id_group)
+
+    def allocate(ordered, limit=None):
+        # State is the occupied rank prefix. First minimize the bottleneck;
+        # then minimize total rank-work/traffic under that exact bottleneck.
+        # Keeping only one (max, sum) label in a single pass loses optimal ties
+        # when a later group hides the earlier prefix's maximum.
+        states, parents = {0: (0.0, 0.0)}, []
+        reserved = sum(cp for cp, _ in ordered)
+        for minimum, samples in ordered:
+            reserved -= minimum
+            next_states, previous = {}, {}
+            for start, prefix in states.items():
+                ends = (
+                    range(start + minimum, total_ranks - reserved + 1)
+                    if reserved
+                    else (total_ranks,)
+                )
+                for end in ends:
+                    cp = end - start
+                    # CP1 -> CP>1 can increase zigzag padding; do not assume
+                    # every expansion fits or that feasibility is monotone.
+                    if pack_work(cp, samples)[1] > capacity:
+                        continue
+                    duration, _, traffic = cost((cp, samples), start)
+                    if limit is not None and duration > limit:
+                        continue
+                    candidate = (
+                        (max(prefix[0], duration), prefix[1] + cp * duration)
+                        if limit is None
+                        else (prefix[0] + cp * duration, prefix[1] + traffic)
+                    )
+                    if end not in next_states or candidate < next_states[end]:
+                        next_states[end], previous[end] = candidate, start
+            states = next_states
+            parents.append(previous)
+        if total_ranks not in states:
+            raise ValueError('Cannot fill DPxCP ranks without exceeding per-rank token capacity')
+        end, filled = total_ranks, []
+        for (_, samples), previous in zip(reversed(ordered), reversed(parents)):
+            start = previous[end]
+            filled.append((end - start, samples))
+            end = start
+        return states[total_ranks], list(reversed(filled))
+
+    if sum(cp for cp, _ in groups) == total_ranks:
+        best = groups
+        if any(pack_work(*group)[1] > capacity for group in best):
+            raise ValueError('Cannot fill DPxCP ranks without exceeding per-rank token capacity')
+        best_score = score(best)
+    else:
+        # Allocating first can lock in an avoidable crossing. Try the existing
+        # order and one topology-aware order of the minimum-size packs; do not
+        # enumerate permutations or run an unbounded local search.
+        placed = place(groups)
+        orders = [groups] if placed == groups else [groups, placed]
+        best, best_score = None, None
+        for ordered in orders:
+            optimum, _ = allocate(ordered)
+            _, filled = allocate(ordered, optimum[0])
+            candidate_score = score(filled)
+            if best is None or candidate_score < best_score:
+                best, best_score = filled, candidate_score
+    # At most two orders, each with O(groups * ranks**2) exact rank allocation.
     placed = place(best)
     if score(placed) < best_score:
         best = placed
@@ -1126,10 +1178,12 @@ def align_sample_id_groups(
     sample_id_groups: List,
     microbatch_group_size_per_vp_stage: int,
     allow_arbitrary_group_starts: bool = False,
+    fill_empty_ranks: Callable[[List], List] | None = None,
 ) -> List:
     """Align len(sample_id_groups) to microbatch_group_size_per_vp_stage when VPP is enabled.
 
-    Standalone version extracted from DefaultDynamicCPScheduler.
+    An optional fill callback assigns the spare ranks immediately after each
+    split, before the default expansion can lock in a larger CP size.
     """
     multiple = int(microbatch_group_size_per_vp_stage)
     remainder = (-len(sample_id_groups)) % multiple
@@ -1174,6 +1228,8 @@ def align_sample_id_groups(
         return new_mb, old_mb
 
     def fill_empty_by_expanding_cp(sample_id_group):
+        if fill_empty_ranks is not None:
+            return fill_empty_ranks(sample_id_group)
         if allow_arbitrary_group_starts:
             # A logical group can absorb any tail length, including one smaller
             # than its current CP size. Repeating its rank assignment changes

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from functools import lru_cache
-from math import ceil, lcm
+from math import ceil, isfinite, lcm
 from typing import Dict, List, Literal, Optional, Sequence, Tuple
 
 import torch
@@ -630,6 +630,140 @@ def get_batch_and_global_seqlens(data_iterator, num_microbatches, dp_group):
 # =============================================================================
 
 
+def _dcp_communication_overhead(
+    compute_work: float,
+    local_tokens: float,
+    cp_size: int,
+    crosses_nvlink: bool,
+    communication_cost: Tuple[float, float],
+) -> float:
+    """Extra exposed ring communication, in the same token-squared units as compute."""
+    if not crosses_nvlink or cp_size == 1:
+        return 0.0
+    per_step = compute_work / cp_size
+    local, remote = (weight * local_tokens for weight in communication_cost)
+    # CP-1 exchanges overlap CP compute steps; subtract the local baseline.
+    return (cp_size - 1) * (max(per_step, remote) - max(per_step, local))
+
+
+def _dcp_communication_tokens(local_tokens, capacity, padding_alignment):
+    """Count physical payload rows, including the existing THD tail-padding policy."""
+    if padding_alignment == 'max':
+        return capacity
+    if padding_alignment is not None:
+        return ceil(local_tokens / padding_alignment) * padding_alignment
+    return local_tokens
+
+
+def _validate_dcp_nvlink_cost(nvlink_domains, communication_cost, total_gpus):
+    if nvlink_domains is not None and len(nvlink_domains) != total_gpus:
+        raise ValueError('nvlink_domains must contain one domain per DPxCP rank')
+    if (
+        len(communication_cost) != 2
+        or not all(isfinite(value) for value in communication_cost)
+        or not 0 <= communication_cost[0] <= communication_cost[1]
+    ):
+        raise ValueError('communication_cost requires finite 0 <= local <= remote weights')
+    return (
+        nvlink_domains is not None
+        and len(set(nvlink_domains)) > 1
+        and communication_cost[1] > communication_cost[0]
+    )
+
+
+def reorder_dcp_groups(
+    sample_id_group: List[List[int]],
+    sample_lengths: Dict[int, int],
+    nvlink_domains: Sequence[int],
+    communication_cost: Tuple[float, float] = (1024.0, 2304.0),
+    sequence_parallel_size: int = 1,
+    max_seq_len_per_rank: int | None = None,
+    padding_alignment: int | str | None = None,
+) -> List[List[int]]:
+    """Compact/fill a rank layout, then greedily place whole packs within NVLink domains.
+
+    CP sizes and sample membership are preserved except when absorbing unused
+    ranks. Compare complete layouts before accepting a reorder; no search solver
+    or measured-model dependency runs in the training path.
+    """
+    if not _validate_dcp_nvlink_cost(nvlink_domains, communication_cost, len(sample_id_group)):
+        return sample_id_group
+    groups = []
+    for samples in sample_id_group:
+        if not samples:
+            continue
+        if groups and groups[-1][1] == tuple(samples):
+            groups[-1] = (groups[-1][0] + 1, groups[-1][1])
+        else:
+            groups.append((1, tuple(samples)))
+    if not groups:
+        return sample_id_group
+
+    @lru_cache(maxsize=None)
+    def pack_work(cp_size, samples):
+        alignment = _cp_sequence_alignment(cp_size, sequence_parallel_size)
+        local = [ceil(sample_lengths[sid] / alignment) * (alignment // cp_size) for sid in samples]
+        return sum(length**2 * cp_size for length in local), sum(local)
+
+    def cost(group, start):
+        cp_size, samples = group
+        compute, tokens = pack_work(cp_size, samples)
+        tokens = _dcp_communication_tokens(tokens, capacity, padding_alignment)
+        domains = nvlink_domains[start : start + cp_size]
+        boundaries = sum(a != b for a, b in zip(domains, domains[1:]))
+        extra = _dcp_communication_overhead(
+            compute, tokens, cp_size, boundaries > 0, communication_cost
+        )
+        # Boundaries are a tie-break only: different cross-domain links can run concurrently.
+        return compute + extra, extra, boundaries * (cp_size - 1) * tokens
+
+    def score(ordered):
+        start, maximum, work, traffic = 0, 0.0, 0.0, 0.0
+        for group in ordered:
+            duration, _, cross_traffic = cost(group, start)
+            maximum = max(maximum, duration)
+            work += group[0] * duration
+            traffic += cross_traffic
+            start += group[0]
+        return maximum, work, traffic
+
+    def place(remaining):
+        remaining, ordered, start = list(remaining), [], 0
+        while remaining:
+            index = min(
+                range(len(remaining)),
+                key=lambda i: (*cost(remaining[i], start)[1:], -remaining[i][0], i),
+            )
+            group = remaining.pop(index)
+            ordered.append(group)
+            start += group[0]
+        return ordered
+
+    capacity = max_seq_len_per_rank
+    if capacity is None:
+        capacity = max(pack_work(*group)[1] for group in groups)
+    missing = len(sample_id_group) - sum(cp for cp, _ in groups)
+    best, best_score = None, None
+    # Check CP1 -> CP>1 explicitly: zigzag alignment can grow very short sequences.
+    for expanded in range(len(groups)) if missing else (None,):
+        filled = [
+            (cp + (missing if i == expanded else 0), samples)
+            for i, (cp, samples) in enumerate(groups)
+        ]
+        if any(pack_work(*group)[1] > capacity for group in filled):
+            continue
+        candidate_score = score(filled)
+        if best is None or candidate_score < best_score:
+            best, best_score = filled, candidate_score
+    if best is None:
+        raise ValueError('Cannot fill DPxCP ranks without exceeding per-rank token capacity')
+    # Only one placement pass, not one per expansion candidate: O(number_of_groups * ranks).
+    placed = place(best)
+    if score(placed) < best_score:
+        best = placed
+    return [list(samples) for cp, samples in best for _ in range(cp)]
+
+
 def next_hdp_group_packing_aware(
     sample_seqlens: List[Tuple[int, int]],
     total_gpus: int,
@@ -637,6 +771,9 @@ def next_hdp_group_packing_aware(
     min_cp_size: int = 1,
     allow_arbitrary_group_starts: bool = False,
     sequence_parallel_size: int = 1,
+    nvlink_domains: Sequence[int] | None = None,
+    communication_cost: Tuple[float, float] = (1024.0, 2304.0),
+    padding_alignment: int | str | None = None,
 ) -> Tuple[List[List[int]], List[Tuple[int, int]], List[float], List[List[int]]]:
     """Form one DCP microbatch with packing-aware CP group selection.
 
@@ -653,7 +790,15 @@ def next_hdp_group_packing_aware(
     ``allow_arbitrary_group_starts`` lets lightweight logical groups occupy any
     free contiguous interval. Legacy ProcessGroups keep their pre-created,
     size-aligned partitions.
+
+    Optional ``nvlink_domains`` identifies domains in parent-rank order. The
+    local/remote communication weights convert per-rank tokens to compute-proxy
+    units; only unhidden extra communication affects the primary score. They
+    are tunable reference coefficients, not hardware-independent timings.
     """
+    topology_aware = _validate_dcp_nvlink_cost(nvlink_domains, communication_cost, total_gpus)
+    if topology_aware and not allow_arbitrary_group_starts:
+        raise ValueError('NVLink-aware placement requires arbitrary logical CP groups')
     if not sample_seqlens:
         return (
             [[] for _ in range(total_gpus)],
@@ -680,6 +825,17 @@ def next_hdp_group_packing_aware(
     def workload(seq_len: int, cp_size: int) -> float:
         return per_rank_length(seq_len, cp_size) ** 2 * cp_size
 
+    def communication(compute, tokens, members):
+        crosses = topology_aware and any(
+            nvlink_domains[rank] != nvlink_domains[members[0]] for rank in members[1:]
+        )
+        if crosses:
+            tokens = _dcp_communication_tokens(tokens, max_seq_len_per_rank, padding_alignment)
+        extra = _dcp_communication_overhead(
+            compute, tokens, len(members), crosses, communication_cost
+        )
+        return extra, (len(members) - 1) * tokens if crosses else 0.0
+
     sample_seqlens = sorted(sample_seqlens, key=lambda x: x[1], reverse=True)
     local_tall = sample_seqlens[0][1]
     cap = float(local_tall) * float(max_seq_len_per_rank) * (1.0 + _DYNAMIC_CP_WORKLOAD_CAP_DELTA)
@@ -692,6 +848,7 @@ def next_hdp_group_packing_aware(
     gpu_group_id: List[Optional[int]] = [None] * total_gpus
     group_members: Dict[int, List[int]] = {}
     group_size: Dict[int, int] = {}
+    group_compute: Dict[int, float] = {}
     next_gid = 0
 
     sample_id, seq_len = sample_seqlens[0]
@@ -707,16 +864,42 @@ def next_hdp_group_packing_aware(
     group_size[group_id] = cp_size
     packing_sequence_len[group_id] = per_rank_length(seq_len, cp_size)
     per_gpu_cost = workload(seq_len, cp_size)
+    group_compute[group_id] = per_gpu_cost
+    extra, _ = communication(per_gpu_cost, packing_sequence_len[group_id], members)
     for rank in members:
         gpu_group_id[rank] = group_id
         micro_batches[rank].append(seq_len)
-        exec_times[rank] += per_gpu_cost
+        exec_times[rank] = per_gpu_cost + extra
         sample_ids_per_gpu[rank].append(sample_id)
 
     leftovers: List[Tuple[int, int]] = []
+
+    def candidate_score(compute, tokens, members, group_id=None):
+        # The packing cap remains a compute/capacity constraint, not a network penalty.
+        if (
+            max(
+                compute,
+                max((value for gid, value in group_compute.items() if gid != group_id), default=0),
+            )
+            > cap
+        ):
+            return None
+        extra, traffic = communication(compute, tokens, members)
+        if group_id is not None:
+            _, previous = communication(
+                group_compute[group_id], packing_sequence_len[group_id], members
+            )
+            traffic -= previous
+        other = max(
+            (exec_times[ranks[0]] for gid, ranks in group_members.items() if gid != group_id),
+            default=0.0,
+        )
+        return max(other, compute + extra), traffic
+
     for sample_id, seq_len in sample_seqlens[1:]:
         min_needed = cp_min_fn(seq_len)
         best = None
+        free_starts = [rank for rank, group in enumerate(gpu_group_id) if group is None]
 
         cp_size = min_needed
         while cp_size <= total_gpus:
@@ -731,34 +914,31 @@ def next_hdp_group_packing_aware(
                 ):
                     continue
                 members = group_members[group_id]
-                member_set = set(members)
-                projected_max = max(
-                    time + per_gpu_cost if rank in member_set else time
-                    for rank, time in enumerate(exec_times)
+                score = candidate_score(
+                    group_compute[group_id] + per_gpu_cost,
+                    packing_sequence_len[group_id] + per_rank_length(seq_len, cp_size),
+                    members,
+                    group_id,
                 )
-                if projected_max <= cap and (best is None or projected_max < best[0]):
-                    best = (projected_max, cp_size, "add", group_id, None)
+                if score is not None and (best is None or score < best[0]):
+                    best = (score, cp_size, "add", group_id, None)
 
             group_start_step = 1 if allow_arbitrary_group_starts else cp_size
-            for group_start in range(0, total_gpus - cp_size + 1, group_start_step):
+            for group_start in free_starts if len(free_starts) >= cp_size else ():
+                if group_start % group_start_step or group_start + cp_size > total_gpus:
+                    continue
                 chosen_members = list(range(group_start, group_start + cp_size))
                 if any(gpu_group_id[rank] is not None for rank in chosen_members):
                     continue
-                chosen_set = set(chosen_members)
-                projected_max = max(
-                    time + per_gpu_cost if rank in chosen_set else time
-                    for rank, time in enumerate(exec_times)
+                score = candidate_score(
+                    per_gpu_cost, per_rank_length(seq_len, cp_size), chosen_members
                 )
-                if projected_max <= cap and (
+                if score is not None and (
                     best is None
-                    or projected_max < best[0]
-                    or (
-                        allow_arbitrary_group_starts
-                        and projected_max == best[0]
-                        and best[2] == "add"
-                    )
+                    or score < best[0]
+                    or (allow_arbitrary_group_starts and score == best[0] and best[2] == "add")
                 ):
-                    best = (projected_max, cp_size, "new", None, chosen_members)
+                    best = (score, cp_size, "new", None, chosen_members)
 
             cp_size = cp_size + 1 if allow_arbitrary_group_starts else cp_size * 2
 
@@ -771,20 +951,26 @@ def next_hdp_group_packing_aware(
         if action == "add":
             members = group_members[group_id]
             packing_sequence_len[group_id] += per_rank_length(seq_len, selected_cp_size)
+            group_compute[group_id] += per_gpu_cost
+            extra, _ = communication(
+                group_compute[group_id], packing_sequence_len[group_id], members
+            )
             for rank in members:
                 micro_batches[rank].append(seq_len)
-                exec_times[rank] += per_gpu_cost
+                exec_times[rank] = group_compute[group_id] + extra
                 sample_ids_per_gpu[rank].append(sample_id)
         else:
             group_id = next_gid
             next_gid += 1
             group_members[group_id] = chosen_members
             group_size[group_id] = selected_cp_size
+            group_compute[group_id] = per_gpu_cost
             packing_sequence_len[group_id] = per_rank_length(seq_len, selected_cp_size)
+            extra, _ = communication(per_gpu_cost, packing_sequence_len[group_id], chosen_members)
             for rank in chosen_members:
                 gpu_group_id[rank] = group_id
                 micro_batches[rank].append(seq_len)
-                exec_times[rank] += per_gpu_cost
+                exec_times[rank] = per_gpu_cost + extra
                 sample_ids_per_gpu[rank].append(sample_id)
 
     def fill_empty_gpus_once() -> bool:
@@ -898,6 +1084,31 @@ def next_hdp_group_packing_aware(
         exec_times = [per_rank_work for _ in range(total_gpus)]
         sample_ids_per_gpu = [list(selected_ids) for _ in range(total_gpus)]
         leftovers = next_leftovers
+
+    if topology_aware:
+        lengths = dict(sample_seqlens)
+        sample_ids_per_gpu = reorder_dcp_groups(
+            sample_ids_per_gpu,
+            lengths,
+            nvlink_domains,
+            communication_cost,
+            sequence_parallel_size,
+            max_seq_len_per_rank,
+            padding_alignment,
+        )
+        micro_batches = [[lengths[sid] for sid in samples] for samples in sample_ids_per_gpu]
+        rank = 0
+        while rank < total_gpus:
+            end = rank + 1
+            while end < total_gpus and sample_ids_per_gpu[end] == sample_ids_per_gpu[rank]:
+                end += 1
+            members = list(range(rank, end))
+            compute = sum(workload(length, len(members)) for length in micro_batches[rank])
+            tokens = sum(per_rank_length(length, len(members)) for length in micro_batches[rank])
+            exec_times[rank:end] = [compute + communication(compute, tokens, members)[0]] * len(
+                members
+            )
+            rank = end
 
     while any(not micro_batch for micro_batch in micro_batches):
         empty_ranks = [rank for rank, micro_batch in enumerate(micro_batches) if not micro_batch]

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from functools import lru_cache
-from math import ceil, log2
+from math import ceil
 from typing import Dict, List, Literal, Optional, Sequence, Tuple
 
 import torch
@@ -234,19 +234,33 @@ def _pack_sequences(
     padded_lengths: torch.Tensor,
     original_lengths: torch.Tensor,
     local_cp_size: Optional[torch.Tensor],
+    local_cp_group_start: Optional[torch.Tensor],
     dev: torch.device,
 ) -> Dict[str, torch.Tensor]:
     """Pack multiple samples into a single packed sample."""
 
+    padded_lengths = padded_lengths.to(device=dev, dtype=torch.int32, non_blocking=True).reshape(-1)
+    if local_cp_size is not None and int(local_cp_size.item()) > 1:
+        alignment = 2 * int(local_cp_size.item())
+        padded_lengths = ((padded_lengths + alignment - 1) // alignment) * alignment
+    padded_lengths_cpu = padded_lengths.cpu().tolist()
+
     def _pack_tensors(tensors):
-        return torch.cat([t.reshape(-1) for t in tensors], dim=0)
+        chunks = []
+        for tensor, length in zip(tensors, padded_lengths_cpu):
+            tensor = tensor.reshape(-1)
+            pad = length - tensor.numel()
+            assert (
+                pad >= 0
+            ), f"Packed length {length} is shorter than tensor length {tensor.numel()}"
+            chunks.append(torch.nn.functional.pad(tensor, (0, pad)))
+        return torch.cat(chunks, dim=0)
 
     new_sample = {}
     for key in ['tokens', 'labels', 'loss_mask', 'position_ids']:
         if key in samples[0]:
             new_sample[key] = _pack_tensors([sample[key] for sample in samples])
 
-    padded_lengths = padded_lengths.to(device=dev, dtype=torch.int32, non_blocking=True).reshape(-1)
     cu_seqlens_padded = torch.empty(padded_lengths.numel() + 1, device=dev, dtype=torch.int32)
     cu_seqlens_padded[0] = 0
     cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
@@ -265,6 +279,8 @@ def _pack_sequences(
 
     if local_cp_size is not None:
         new_sample["local_cp_size"] = local_cp_size
+    if local_cp_group_start is not None:
+        new_sample["local_cp_group_start"] = local_cp_group_start
 
     return new_sample
 
@@ -333,6 +349,8 @@ def create_data_iterator(
             metadata_keys = ["max_seqlen", "cu_seqlens", "cu_seqlens_padded"]
             if is_dynamic_cp:
                 metadata_keys.append("local_cp_size")
+                if getattr(config, "use_native_cp_transport", False):
+                    metadata_keys.append("local_cp_group_start")
             new_data_iterator = []
             for i in range(vpp_size):
                 if vpp_needs_data is not None and vpp_needs_data[i]:
@@ -503,20 +521,26 @@ def build_packed_microbatches(
     ]
 
     local_cp_sizes_gpu = None
+    local_cp_group_starts_gpu = None
     if is_dynamic_cp:
         local_cp_sizes_cpu: List[int] = []
+        local_cp_group_starts_cpu: List[int] = []
         for i in range(num_micro_batches):
             sample_ids_this_group = sample_id_groups[i][dcp_rank]
-            local_cp_sizes_cpu.append(
-                len(
-                    [
-                        1
-                        for sample_ids in sample_id_groups[i]
-                        if sample_ids_this_group[0] in sample_ids
-                    ]
-                )
-            )
+            member_ranks = [
+                rank
+                for rank, sample_ids in enumerate(sample_id_groups[i])
+                if sample_ids_this_group[0] in sample_ids
+            ]
+            assert member_ranks == list(
+                range(member_ranks[0], member_ranks[-1] + 1)
+            ), f"Dynamic CP group must be contiguous, got ranks {member_ranks}"
+            local_cp_sizes_cpu.append(len(member_ranks))
+            local_cp_group_starts_cpu.append(member_ranks[0])
         local_cp_sizes_gpu = torch.tensor(local_cp_sizes_cpu, dtype=torch.int32, device=dev)
+        local_cp_group_starts_gpu = torch.tensor(
+            local_cp_group_starts_cpu, dtype=torch.int32, device=dev
+        )
 
     for i in range(num_micro_batches):
         samples = grouped_samples[i]
@@ -533,7 +557,10 @@ def build_packed_microbatches(
         lens_padded = padded_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
         lens_original = original_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
         local_cp_size = local_cp_sizes_gpu[i] if is_dynamic_cp else None
-        new_sample = _pack_sequences(samples, lens_padded, lens_original, local_cp_size, dev)
+        local_cp_group_start = local_cp_group_starts_gpu[i] if is_dynamic_cp else None
+        new_sample = _pack_sequences(
+            samples, lens_padded, lens_original, local_cp_size, local_cp_group_start, dev
+        )
         new_samples.append(new_sample)
 
     return new_samples
@@ -594,6 +621,7 @@ def next_hdp_group_packing_aware(
     total_gpus: int,
     max_seq_len_per_rank: int,
     min_cp_size: int = 1,
+    allow_arbitrary_group_starts: bool = False,
 ) -> Tuple[List[List[int]], List[Tuple[int, int]], List[float], List[List[int]]]:
     """Form one DCP microbatch with packing-aware CP group selection.
 
@@ -605,9 +633,11 @@ def next_hdp_group_packing_aware(
        the local tallest sequence in the microbatch.
 
     The scheduler keeps the legacy invariant that each returned microbatch has
-    no empty DPxCP rank after the fill step. For non-power-of-two DPxCP layouts,
-    it falls back to the full DPxCP group if power-of-two expansion cannot fill
-    every rank.
+    no empty DPxCP rank after the fill step.
+
+    ``allow_arbitrary_group_starts`` lets lightweight logical groups occupy any
+    free contiguous interval. Legacy ProcessGroups keep their pre-created,
+    size-aligned partitions.
     """
     if not sample_seqlens:
         return (
@@ -618,10 +648,18 @@ def next_hdp_group_packing_aware(
         )
 
     def cp_min_fn(seq_len: int) -> int:
-        return dcp_gpus_needed(seq_len, max_seq_len_per_rank, min_cp_size)
+        return dcp_gpus_needed(
+            seq_len,
+            max_seq_len_per_rank,
+            min_cp_size,
+            round_to_power_of_two=not allow_arbitrary_group_starts,
+        )
+
+    def per_rank_length(seq_len: int, cp_size: int) -> int:
+        return 2 * ceil(seq_len / (2 * cp_size))
 
     def workload(seq_len: int, cp_size: int) -> float:
-        return (seq_len * seq_len) / cp_size
+        return per_rank_length(seq_len, cp_size) ** 2 * cp_size
 
     sample_seqlens = sorted(sample_seqlens, key=lambda x: x[1], reverse=True)
     local_tall = sample_seqlens[0][1]
@@ -648,7 +686,7 @@ def next_hdp_group_packing_aware(
     members = list(range(cp_size))
     group_members[group_id] = members
     group_size[group_id] = cp_size
-    packing_sequence_len[group_id] = seq_len / cp_size
+    packing_sequence_len[group_id] = per_rank_length(seq_len, cp_size)
     per_gpu_cost = workload(seq_len, cp_size)
     for rank in members:
         gpu_group_id[rank] = group_id
@@ -668,7 +706,10 @@ def next_hdp_group_packing_aware(
             for group_id, size in list(group_size.items()):
                 if size != cp_size:
                     continue
-                if packing_sequence_len.get(group_id, 0) + seq_len / cp_size > max_seq_len_per_rank:
+                if (
+                    packing_sequence_len.get(group_id, 0) + per_rank_length(seq_len, cp_size)
+                    > max_seq_len_per_rank
+                ):
                     continue
                 members = group_members[group_id]
                 member_set = set(members)
@@ -679,22 +720,28 @@ def next_hdp_group_packing_aware(
                 if projected_max <= cap and (best is None or projected_max < best[0]):
                     best = (projected_max, cp_size, "add", group_id, None)
 
-            free_ranks = [
-                rank
-                for rank, assigned_group_id in enumerate(gpu_group_id)
-                if assigned_group_id is None
-            ]
-            if len(free_ranks) >= cp_size:
-                chosen_members = sorted(free_ranks, key=lambda rank: exec_times[rank])[:cp_size]
+            group_start_step = 1 if allow_arbitrary_group_starts else cp_size
+            for group_start in range(0, total_gpus - cp_size + 1, group_start_step):
+                chosen_members = list(range(group_start, group_start + cp_size))
+                if any(gpu_group_id[rank] is not None for rank in chosen_members):
+                    continue
                 chosen_set = set(chosen_members)
                 projected_max = max(
                     time + per_gpu_cost if rank in chosen_set else time
                     for rank, time in enumerate(exec_times)
                 )
-                if projected_max <= cap and (best is None or projected_max < best[0]):
+                if projected_max <= cap and (
+                    best is None
+                    or projected_max < best[0]
+                    or (
+                        allow_arbitrary_group_starts
+                        and projected_max == best[0]
+                        and best[2] == "add"
+                    )
+                ):
                     best = (projected_max, cp_size, "new", None, chosen_members)
 
-            cp_size *= 2
+            cp_size = cp_size + 1 if allow_arbitrary_group_starts else cp_size * 2
 
         if best is None:
             leftovers.append((sample_id, seq_len))
@@ -704,7 +751,7 @@ def next_hdp_group_packing_aware(
         per_gpu_cost = workload(seq_len, selected_cp_size)
         if action == "add":
             members = group_members[group_id]
-            packing_sequence_len[group_id] += seq_len / selected_cp_size
+            packing_sequence_len[group_id] += per_rank_length(seq_len, selected_cp_size)
             for rank in members:
                 micro_batches[rank].append(seq_len)
                 exec_times[rank] += per_gpu_cost
@@ -714,7 +761,7 @@ def next_hdp_group_packing_aware(
             next_gid += 1
             group_members[group_id] = chosen_members
             group_size[group_id] = selected_cp_size
-            packing_sequence_len[group_id] = seq_len / selected_cp_size
+            packing_sequence_len[group_id] = per_rank_length(seq_len, selected_cp_size)
             for rank in chosen_members:
                 gpu_group_id[rank] = group_id
                 micro_batches[rank].append(seq_len)
@@ -746,7 +793,17 @@ def next_hdp_group_packing_aware(
             group_start_rank = members[0]
             group_end_rank = members[-1]
             empty_rank = empty_ranks[0]
-            if group_end_rank + 1 > empty_rank or group_end_rank + needed_count >= total_gpus:
+            if (
+                group_start_rank % next_power
+                or group_end_rank + 1 > empty_rank
+                or empty_rank + needed_count > total_gpus
+                or any(
+                    min(other_members) > group_end_rank
+                    and (min(other_members) + needed_count) % group_size[other_group_id]
+                    for other_group_id, other_members in group_members.items()
+                    if other_group_id != group_id
+                )
+            ):
                 continue
 
             work_to_push = micro_batches[group_end_rank + 1 : empty_rank]
@@ -802,7 +859,7 @@ def next_hdp_group_packing_aware(
         packed_sequence_len = 0.0
 
         for sample_id, seq_len in sample_seqlens:
-            per_rank_len = seq_len / total_gpus
+            per_rank_len = per_rank_length(seq_len, total_gpus)
             if packed_sequence_len + per_rank_len <= max_seq_len_per_rank:
                 selected.append((sample_id, seq_len))
                 packed_sequence_len += per_rank_len
@@ -824,6 +881,10 @@ def next_hdp_group_packing_aware(
         leftovers = next_leftovers
 
     while any(not micro_batch for micro_batch in micro_batches):
+        empty_ranks = [rank for rank, micro_batch in enumerate(micro_batches) if not micro_batch]
+        if not all(not micro_batches[rank] for rank in range(empty_ranks[0], total_gpus)):
+            fill_with_full_dpxcp_group()
+            break
         if not fill_empty_gpus_once():
             fill_with_full_dpxcp_group()
             break
@@ -930,7 +991,14 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
 
 
 @lru_cache(maxsize=128)
-def dcp_gpus_needed(seq_len: int, max_seq_len_per_rank: int, min_cp_size: int = 1) -> int:
-    """Number of GPUs needed, rounded up to the next power of 2, lower-bounded by min_cp_size."""
-    raw = max(1, 2 ** ceil(log2(seq_len / max_seq_len_per_rank)))
+def dcp_gpus_needed(
+    seq_len: int,
+    max_seq_len_per_rank: int,
+    min_cp_size: int = 1,
+    round_to_power_of_two: bool = True,
+) -> int:
+    """Minimum GPUs needed, optionally rounded to the next power of two."""
+    raw = max(1, ceil(seq_len / max_seq_len_per_rank))
+    if round_to_power_of_two:
+        raw = 1 << (raw - 1).bit_length()
     return max(min_cp_size, raw)

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from functools import lru_cache
-from math import ceil
+from math import ceil, lcm
 from typing import Dict, List, Literal, Optional, Sequence, Tuple
 
 import torch
@@ -229,6 +229,11 @@ def _get_global_seqlens_and_ids(subsample_seqlens: torch.Tensor, dp_group):
     return global_id_seqlens, global_ids_this_rank, offsets, seqlens_gathered
 
 
+def _cp_sequence_alignment(cp_size: int, sequence_parallel_size: int = 1) -> int:
+    """Align global rows for both CP zigzag chunks and local sequence parallelism."""
+    return cp_size * lcm(2 if cp_size > 1 else 1, sequence_parallel_size)
+
+
 def _pack_sequences(
     samples: List,
     padded_lengths: torch.Tensor,
@@ -236,12 +241,13 @@ def _pack_sequences(
     local_cp_size: Optional[torch.Tensor],
     local_cp_group_start: Optional[torch.Tensor],
     dev: torch.device,
+    sequence_parallel_size: int = 1,
 ) -> Dict[str, torch.Tensor]:
     """Pack multiple samples into a single packed sample."""
 
     padded_lengths = padded_lengths.to(device=dev, dtype=torch.int32, non_blocking=True).reshape(-1)
-    if local_cp_size is not None and int(local_cp_size.item()) > 1:
-        alignment = 2 * int(local_cp_size.item())
+    if local_cp_size is not None:
+        alignment = _cp_sequence_alignment(int(local_cp_size.item()), sequence_parallel_size)
         padded_lengths = ((padded_lengths + alignment - 1) // alignment) * alignment
     padded_lengths_cpu = padded_lengths.cpu().tolist()
 
@@ -496,6 +502,7 @@ def build_packed_microbatches(
     dcp_rank: int,
     dev: torch.device,
     is_dynamic_cp: bool = False,
+    sequence_parallel_size: int = 1,
 ) -> List[Dict[str, torch.Tensor]]:
     """Build packed samples for each microbatch.
 
@@ -506,6 +513,7 @@ def build_packed_microbatches(
         dcp_rank: This rank's index within the DP×CP group.
         dev: Target device.
         is_dynamic_cp: Whether dynamic context parallel is enabled.
+        sequence_parallel_size: Tensor parallel size when sequence parallelism is enabled.
     """
     num_micro_batches = len(sample_id_groups)
     seg_starts: List[int] = [0]
@@ -559,7 +567,13 @@ def build_packed_microbatches(
         local_cp_size = local_cp_sizes_gpu[i] if is_dynamic_cp else None
         local_cp_group_start = local_cp_group_starts_gpu[i] if is_dynamic_cp else None
         new_sample = _pack_sequences(
-            samples, lens_padded, lens_original, local_cp_size, local_cp_group_start, dev
+            samples,
+            lens_padded,
+            lens_original,
+            local_cp_size,
+            local_cp_group_start,
+            dev,
+            sequence_parallel_size=sequence_parallel_size,
         )
         new_samples.append(new_sample)
 
@@ -622,6 +636,7 @@ def next_hdp_group_packing_aware(
     max_seq_len_per_rank: int,
     min_cp_size: int = 1,
     allow_arbitrary_group_starts: bool = False,
+    sequence_parallel_size: int = 1,
 ) -> Tuple[List[List[int]], List[Tuple[int, int]], List[float], List[List[int]]]:
     """Form one DCP microbatch with packing-aware CP group selection.
 
@@ -648,15 +663,19 @@ def next_hdp_group_packing_aware(
         )
 
     def cp_min_fn(seq_len: int) -> int:
-        return dcp_gpus_needed(
+        cp_size = dcp_gpus_needed(
             seq_len,
             max_seq_len_per_rank,
             min_cp_size,
             round_to_power_of_two=not allow_arbitrary_group_starts,
         )
+        while cp_size <= total_gpus and per_rank_length(seq_len, cp_size) > max_seq_len_per_rank:
+            cp_size = cp_size + 1 if allow_arbitrary_group_starts else cp_size * 2
+        return cp_size
 
     def per_rank_length(seq_len: int, cp_size: int) -> int:
-        return 2 * ceil(seq_len / (2 * cp_size))
+        alignment = _cp_sequence_alignment(cp_size, sequence_parallel_size)
+        return ((seq_len + alignment - 1) // alignment) * (alignment // cp_size)
 
     def workload(seq_len: int, cp_size: int) -> float:
         return per_rank_length(seq_len, cp_size) ** 2 * cp_size
@@ -892,7 +911,11 @@ def next_hdp_group_packing_aware(
     return micro_batches, leftovers, exec_times, sample_ids_per_gpu
 
 
-def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_stage: int) -> List:
+def align_sample_id_groups(
+    sample_id_groups: List,
+    microbatch_group_size_per_vp_stage: int,
+    allow_arbitrary_group_starts: bool = False,
+) -> List:
     """Align len(sample_id_groups) to microbatch_group_size_per_vp_stage when VPP is enabled.
 
     Standalone version extracted from DefaultDynamicCPScheduler.
@@ -916,16 +939,22 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
                 else:
                     break
             assert (
-                prev_cp_size == 0 or cp_size <= prev_cp_size
+                allow_arbitrary_group_starts or prev_cp_size == 0 or cp_size <= prev_cp_size
             ), f"split_group: CP size is not decreasing: prev={prev_cp_size}, cur={cp_size}"
             cu_ranks.append(start_rank + cp_size)
             prev_cp_size = cp_size
         if len(cu_ranks) == 2:
             return None, None
 
-        k = 0
-        while cu_ranks[k] < total_hdp_ranks // 2:
-            k += 1
+        if allow_arbitrary_group_starts:
+            k = min(
+                range(1, len(cu_ranks) - 1),
+                key=lambda index: abs(2 * cu_ranks[index] - total_hdp_ranks),
+            )
+        else:
+            k = 0
+            while cu_ranks[k] < total_hdp_ranks // 2:
+                k += 1
 
         old_mb = sample_id_group[: cu_ranks[k]] + [[] for _ in range(total_hdp_ranks - cu_ranks[k])]
         new_mb = sample_id_group[cu_ranks[k] :] + [[] for _ in range(cu_ranks[k])]
@@ -934,6 +963,17 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
         return new_mb, old_mb
 
     def fill_empty_by_expanding_cp(sample_id_group):
+        if allow_arbitrary_group_starts:
+            # A logical group can absorb any tail length, including one smaller
+            # than its current CP size. Repeating its rank assignment changes
+            # CP only; the two split microbatches retain disjoint sample IDs.
+            tail_start = next(i for i, samples in enumerate(sample_id_group) if not samples)
+            sample_id_group[tail_start:] = [
+                list(sample_id_group[tail_start - 1])
+                for _ in range(len(sample_id_group) - tail_start)
+            ]
+            return sample_id_group
+
         def fill_empty(sample_id_group):
             empty_size = sum(1 for x in sample_id_group if len(x) == 0)
             i = len(sample_id_group) - 1 - empty_size
@@ -963,7 +1003,10 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
             return sample_id_group
 
         while len(sample_id_group[-1]) == 0:
+            filled_ranks = sum(bool(samples) for samples in sample_id_group)
             sample_id_group = fill_empty(sample_id_group)
+            if sum(bool(samples) for samples in sample_id_group) <= filled_ranks:
+                raise RuntimeError('Cannot fill VPP ranks by expanding the available CP groups')
         return sample_id_group
 
     attempts_since_split = 0

--- a/megatron/core/dynamic_cp_group.py
+++ b/megatron/core/dynamic_cp_group.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Lightweight groups for native dynamic context-parallel transport."""
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+import torch
+
+
+def build_bounded_peer_ring(
+    parent_ranks: Sequence[int], group_start: int, cp_size: int
+) -> Tuple[int, ...]:
+    """Build a direct ring whose peers are at most two parent positions apart."""
+    parent_ranks = tuple(parent_ranks)
+    if len(set(parent_ranks)) != len(parent_ranks):
+        raise ValueError("parent_ranks must be unique")
+    if cp_size < 1 or group_start < 0 or group_start + cp_size > len(parent_ranks):
+        raise ValueError(
+            f"Invalid interval start={group_start}, size={cp_size}, "
+            f"parent_size={len(parent_ranks)}"
+        )
+
+    offsets = [0, *range(1, cp_size, 2), *reversed(range(2, cp_size, 2))]
+    if group_start % 2:
+        offsets = [offsets[0], *reversed(offsets[1:])]
+    return tuple(parent_ranks[group_start + offset] for offset in offsets)
+
+
+@dataclass(frozen=True)
+class LogicalCPGroup:
+    """Describe a CP ring without creating a subgroup communicator."""
+
+    ranks: Tuple[int, ...]
+    cp_size: int
+    cp_rank: int
+
+    def __post_init__(self) -> None:
+        if self.cp_size != len(self.ranks):
+            raise ValueError("cp_size must match the rank count")
+        if not 0 <= self.cp_rank < self.cp_size:
+            raise ValueError("cp_rank is outside the logical group")
+
+    @classmethod
+    def from_parent_interval(
+        cls, parent_ranks: Sequence[int], group_start: int, cp_size: int, rank: int
+    ) -> "LogicalCPGroup":
+        """Build the descriptor for one contiguous interval of the parent group."""
+        ring = build_bounded_peer_ring(parent_ranks, group_start, cp_size)
+        if rank not in ring:
+            raise ValueError(
+                f"Rank {rank} is outside interval [{group_start}, {group_start + cp_size})"
+            )
+        return cls(ranks=ring, cp_size=cp_size, cp_rank=ring.index(rank))
+
+    def size(self) -> int:
+        """Return the logical group size."""
+        return self.cp_size
+
+    def rank(self) -> int:
+        """Return this process's rank in the logical ring."""
+        return self.cp_rank
+
+
+def get_process_group_ranks(group) -> Tuple[int, ...]:
+    """Return ranks from a ProcessGroup or a logical CP descriptor."""
+    if isinstance(group, LogicalCPGroup):
+        return group.ranks
+    return tuple(torch.distributed.get_process_group_ranks(group))

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -22,6 +22,7 @@ from typing_extensions import override
 from megatron.core.activations import situlu
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
+from megatron.core.dynamic_cp_group import get_process_group_ranks
 from megatron.core.enums import Fp4Recipe, Fp8Recipe
 from megatron.core.extensions.transformer_engine_int4_fake_qat import (
     maybe_fake_quantize_int4_weight_tensors,
@@ -1811,6 +1812,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
                     pg_collection, "hcp"
                 ), "TEDotProductAttention pg_collection must have hierarchical cp pg"
         self._tp_group = pg_collection.tp
+        self._dynamic_cp_parent_group = getattr(pg_collection, "dp_cp", None)
 
         if is_te_min_version("0.10.0"):
             extra_kwargs["attention_type"] = attention_type
@@ -1875,6 +1877,36 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             extra_kwargs["softmax_scale"] = softmax_scale
         else:
             kv_channels = self.config.kv_channels
+
+        if self.config.use_native_cp_transport:
+            if self._dynamic_cp_parent_group is None:
+                raise RuntimeError("Native CP transport requires pg_collection.dp_cp.")
+            if self.config.max_seqlen_per_dp_cp_rank is None:
+                raise RuntimeError("Native CP transport requires max_seqlen_per_dp_cp_rank.")
+            if cp_comm_type not in (None, "p2p"):
+                raise RuntimeError("Native CP transport only supports cp_comm_type='p2p'.")
+            from transformer_engine.pytorch.attention.native_cp_transport import (
+                initialize_native_cp_transport,
+            )
+
+            tp_size = self._tp_group.size() if self._tp_group is not None else 1
+            local_groups = max(1, self.config.num_query_groups // tp_size)
+            kv_width = (
+                sum(kv_channels) if isinstance(kv_channels, (tuple, list)) else 2 * kv_channels
+            )
+            kv_bytes = (
+                self.config.max_seqlen_per_dp_cp_rank
+                * local_groups
+                * kv_width
+                * torch.empty((), dtype=self.config.params_dtype).element_size()
+            )
+            pair_bytes = 2 * kv_bytes
+            payload_bytes = ((pair_bytes + 255) // 256) * 256 + pair_bytes
+            if self.config.num_moe_experts:
+                max_packed_sequences = max(1, self.config.thd_max_packed_sequences or 1)
+                aux_bytes = self.config.num_moe_experts * max_packed_sequences * 8
+                payload_bytes = max(payload_bytes, ((aux_bytes + 255) // 256) * 256 + aux_bytes)
+            initialize_native_cp_transport(self._dynamic_cp_parent_group, payload_bytes)
 
         if self.config.softmax_type != "vanilla":
             assert is_te_min_version("2.8.0"), (
@@ -1955,6 +1987,14 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         if packed_seq_params is not None:
             # If Dynamic CP group is provided, update TE DPA CP group
             if packed_seq_params.local_cp_size is not None:
+                if self.config.use_native_cp_transport:
+                    from transformer_engine.pytorch.attention.native_cp_transport import (
+                        set_native_cp_parent_group,
+                    )
+
+                    set_native_cp_parent_group(
+                        packed_seq_params.cp_group, self._dynamic_cp_parent_group
+                    )
                 if packed_seq_params.local_cp_size == 1:
                     super().set_context_parallel_group(None, None, None, self.cp_comm_type)
                 else:
@@ -1966,7 +2006,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
                         TEDotProductAttention.cp_stream = torch.cuda.Stream()
                     super().set_context_parallel_group(
                         self.cp_group,
-                        torch.distributed.get_process_group_ranks(self.cp_group),
+                        get_process_group_ranks(self.cp_group),
                         TEDotProductAttention.cp_stream,
                         self.cp_comm_type,
                     )

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1903,7 +1903,8 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             pair_bytes = 2 * kv_bytes
             payload_bytes = ((pair_bytes + 255) // 256) * 256 + pair_bytes
             if self.config.num_moe_experts:
-                max_packed_sequences = max(1, self.config.thd_max_packed_sequences or 1)
+                # PackedSeqParams reserves an additional ID for an implicit padding tail.
+                max_packed_sequences = max(1, self.config.thd_max_packed_sequences or 1) + 1
                 aux_bytes = self.config.num_moe_experts * max_packed_sequences * 8
                 payload_bytes = max(payload_bytes, ((aux_bytes + 255) // 256) * 256 + aux_bytes)
             initialize_native_cp_transport(self._dynamic_cp_parent_group, payload_bytes)

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -2,6 +2,7 @@
 
 import warnings
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import Callable, ContextManager, Literal, Optional, Union
 
 import torch
@@ -94,6 +95,18 @@ class ModelParallelConfig:
 
     use_native_cp_transport: bool = False
     """Use TE's NCCL Device API kernel instead of ProcessGroupNCCL for dynamic-CP rings."""
+
+    dynamic_cp_nvlink_domain_size: Optional[int] = None
+    """Enable topology-aware native DCP scheduling with this many consecutive global ranks
+    per NVLink domain. This is a user-declared physical layout, not topology discovery;
+    it requires Megatron's Cartesian TP/PP/DP/CP rank mapping. None keeps compute-only scoring.
+    """
+
+    dynamic_cp_communication_cost: Optional[list[float]] = None
+    """Intra-domain and cross-domain communication cost coefficients, in equivalent tokens.
+    Requires dynamic_cp_nvlink_domain_size. Values must be finite, nonnegative, and ordered.
+    None uses [1024, 2304], a configurable H100/Qwen attention reference, not a native calibration.
+    """
 
     hybrid_context_parallel: bool = False
     """Deprecated. Use ``dynamic_context_parallel`` instead."""
@@ -523,6 +536,28 @@ class ModelParallelConfig:
                 raise ValueError(
                     f"min_dynamic_context_parallel_size must be >= 1, "
                     f"got {self.min_dynamic_context_parallel_size}"
+                )
+
+        if self.dynamic_cp_nvlink_domain_size is not None:
+            if (
+                not isinstance(self.dynamic_cp_nvlink_domain_size, int)
+                or self.dynamic_cp_nvlink_domain_size < 1
+            ):
+                raise ValueError("dynamic_cp_nvlink_domain_size must be a positive integer.")
+            if not (self.dynamic_context_parallel and self.use_native_cp_transport):
+                raise ValueError(
+                    "dynamic_cp_nvlink_domain_size requires native dynamic context parallelism."
+                )
+        if self.dynamic_cp_communication_cost is not None:
+            cost = self.dynamic_cp_communication_cost
+            if self.dynamic_cp_nvlink_domain_size is None:
+                raise ValueError(
+                    "dynamic_cp_communication_cost requires dynamic_cp_nvlink_domain_size."
+                )
+            if len(cost) != 2 or not all(isfinite(c) for c in cost) or not 0 <= cost[0] <= cost[1]:
+                raise ValueError(
+                    "dynamic_cp_communication_cost must contain two finite coefficients "
+                    "with 0 <= intra-domain <= cross-domain."
                 )
 
         if self.thd_tail_padding_policy not in (None, "append_dummy_seq", "extend_last"):

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -92,6 +92,9 @@ class ModelParallelConfig:
     """Minimum CP group size for dynamic context parallel. Default 1 (no CP).
     The maximum is dp_size * context_parallel_size (the full DPxCP group)."""
 
+    use_native_cp_transport: bool = False
+    """Use TE's NCCL Device API kernel instead of ProcessGroupNCCL for dynamic-CP rings."""
+
     hybrid_context_parallel: bool = False
     """Deprecated. Use ``dynamic_context_parallel`` instead."""
 

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -32,6 +32,7 @@ from megatron.core.transformer.linear_cross_entropy import LinearCrossEntropyMod
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
+    bind_native_mtp_cp_group,
     mtp_on_this_rank,
     prepare_mtp_sequence_roll_context,
     process_mtp_loss,
@@ -583,6 +584,8 @@ class GPTModel(LanguageModule):
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
+        # MTP rolls tokens before SP; decoder preprocessing may shard only its mask.
+        token_padding_mask = padding_mask
         preproc_output = self._preprocess(
             input_ids=input_ids,
             position_ids=position_ids,
@@ -642,7 +645,7 @@ class GPTModel(LanguageModule):
             loss_mask=loss_mask,
             decoder_input=decoder_input,
             attention_mask=attention_mask,
-            padding_mask=padding_mask,
+            padding_mask=token_padding_mask,
             inference_params=inference_params,
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
@@ -704,6 +707,7 @@ class GPTModel(LanguageModule):
             and not (in_inference_mode or is_spec_decode)
         ):
             mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
+            bind_native_mtp_cp_group(mtp_cp_group, getattr(self.pg_collection, "dp_cp", None))
             # Build layout-specific metadata once, then fetch every locally owned
             # MTP field's compact successor rows in one grouped operation. The extra
             # row covers RL's initial label derivation before the per-layer rolls.

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -26,6 +26,7 @@ from megatron.core.transformer.module import GraphableMegatronModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
+    bind_native_mtp_cp_group,
     mtp_on_this_rank,
     prepare_mtp_sequence_roll_context,
     process_mtp_loss,
@@ -623,6 +624,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             and not (in_inference_mode or is_spec_decode)
         ):
             mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
+            bind_native_mtp_cp_group(mtp_cp_group, getattr(self.pg_collection, "dp_cp", None))
             # Build layout-specific metadata once, then fetch every locally owned
             # MTP field's compact successor rows in one grouped operation. The extra
             # row covers RL's initial label derivation before the per-layer rolls.

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -7,6 +7,8 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from torch import Tensor
 
+from megatron.core.dynamic_cp_group import LogicalCPGroup
+
 if TYPE_CHECKING:
     from megatron.core.context_parallel_layout import ThdCpRoute
 
@@ -30,7 +32,7 @@ class PackedSeqParams:
     max_seqlen_q: int = None
     max_seqlen_kv: int = None
     local_cp_size: int = None
-    cp_group: dist.ProcessGroup = None
+    cp_group: Union[dist.ProcessGroup, LogicalCPGroup] = None
     total_tokens: int = None
     seq_idx: Tensor = None
     pad_between_seqs: Optional[bool] = None
@@ -54,7 +56,11 @@ class PackedSeqParams:
         cu_seqlens = (
             self.cu_seqlens_q_padded if self.cu_seqlens_q_padded is not None else self.cu_seqlens_q
         )
-        if isinstance(cu_seqlens, Tensor) and self.total_tokens is not None:
+        if (
+            self.seq_idx is None
+            and isinstance(cu_seqlens, Tensor)
+            and self.total_tokens is not None
+        ):
             total_tokens_tensor = torch.tensor(
                 [self.total_tokens], dtype=cu_seqlens.dtype, device=cu_seqlens.device
             )
@@ -414,7 +420,7 @@ def _resolve_thd_cp_geometry(
     Falling back to ``parallel_state`` preserves legacy call sites.
     """
     if cp_group is not None:
-        return int(dist.get_world_size(group=cp_group)), int(dist.get_rank(group=cp_group))
+        return int(cp_group.size()), int(cp_group.rank())
 
     if cp_size is not None:
         cp_size = int(cp_size)
@@ -425,7 +431,7 @@ def _resolve_thd_cp_geometry(
 
     if packed_seq_params.cp_group is not None:
         cp_group = packed_seq_params.cp_group
-        return int(dist.get_world_size(group=cp_group)), int(dist.get_rank(group=cp_group))
+        return int(cp_group.size()), int(cp_group.rank())
 
     if cp_size is None and packed_seq_params.local_cp_size is not None:
         cp_size = int(packed_seq_params.local_cp_size)
@@ -676,6 +682,7 @@ def pad_sequence_for_thd(
         ),
         local_cp_size=packed_seq_params.local_cp_size,
         cp_group=packed_seq_params.cp_group,
+        seq_idx=_pad_seq_tensor(packed_seq_params.seq_idx, local_target_len),
         cp_partition_mode=packed_seq_params.cp_partition_mode,
         total_tokens=local_target_len if target_cu_entries is None else None,
         pad_between_seqs=(

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -4,14 +4,15 @@
 
 import logging
 import os
+import sys
 import warnings
 from datetime import timedelta
-from math import log2
 from typing import Callable, List, Optional
 
 import numpy as np
 import torch
 
+from megatron.core.dynamic_cp_group import LogicalCPGroup
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 
 from .utils import GlobalMemoryBuffer, is_torch_min_version
@@ -418,22 +419,42 @@ def create_hierarchical_groups(
     return hierarchical_groups, hierarchical_groups_gloo
 
 
-def create_dynamic_dp_cp_groups(rank, ranks, pg_options, min_cp_size=1):
+def create_dynamic_dp_cp_groups(rank, ranks, pg_options, min_cp_size=1, use_logical_groups=False):
     """
     Creates groups required for dynamic DPxCP.
-    Creates a new group for every power of 2 from min_cp_size up to len(ranks).
+    Creates a group for every supported size from min_cp_size up to len(ranks).
     Returns a dictionary indexed by group size.
+
+    Native transport uses topology-only logical groups in bounded-peer ring
+    order. The legacy path keeps its original ProcessGroups and rank order.
     """
     dynamic_dp_cp_groups = {}
-    group_sizes = [2**i for i in range(int(log2(len(ranks)))) if 2**i >= min_cp_size]
+    # The existing DPxCP parent is the largest legacy group. Native mode also
+    # needs a logical descriptor for that size so attention can select its ring.
+    if use_logical_groups:
+        group_sizes = range(min_cp_size, len(ranks) + 1)
+    else:
+        group_sizes = [
+            size
+            for size in (1 << i for i in range(len(ranks).bit_length()))
+            if min_cp_size <= size < len(ranks)
+        ]
     for group_size in group_sizes:
         for i in range(0, len(ranks), group_size):
-            group = create_group(
-                ranks[i : i + group_size],
-                pg_options=pg_options,
-                group_desc=f"DYNAMIC_DP_CP_GROUP_{group_size}",
-            )
-            if rank in ranks[i : i + group_size]:
+            group_ranks = ranks[i : i + group_size]
+            if len(group_ranks) != group_size:
+                continue
+            if use_logical_groups:
+                if rank not in group_ranks:
+                    continue
+                group = LogicalCPGroup.from_parent_interval(ranks, i, group_size, rank)
+            else:
+                group = create_group(
+                    group_ranks,
+                    pg_options=pg_options,
+                    group_desc=f"DYNAMIC_DP_CP_GROUP_{group_size}",
+                )
+            if rank in group_ranks:
                 assert (
                     group_size not in dynamic_dp_cp_groups
                 ), f"Rank {rank} appears in multiple Dynamic DP CP groups of size {group_size}"
@@ -447,9 +468,7 @@ class RankGenerator(object):
     def __init__(
         self, tp: int, ep: int, dp: int, pp: int, cp: int, order: str, rank_offset: int = 0
     ) -> None:
-        assert (
-            ep == 1 or cp == 1
-        ), "Both EP and CP > 1 in not allow in one rank generator. \
+        assert ep == 1 or cp == 1, "Both EP and CP > 1 in not allow in one rank generator. \
             CP is only included in default RankGenerator, and EP only in expert RankGenerator."
 
         self.tp = tp
@@ -565,6 +584,7 @@ def initialize_model_parallel(
     sharp_enabled_group: Optional[str] = None,
     rank_offset: int = 0,
     local_world_size: Optional[int] = None,
+    use_native_cp_transport: bool = False,
 ) -> None:
     """Initialize model data parallel groups.
 
@@ -921,31 +941,37 @@ def initialize_model_parallel(
     if dynamic_context_parallel:
         # TODO: Are gloo groups needed for Dynamic CP?
         global _DYNAMIC_DP_CP_GROUPS
+        if use_native_cp_transport:
+            # Materialize the parent before model construction can load optional native MoE DSOs.
+            torch.distributed.barrier(
+                group=_DATA_PARALLEL_GROUP_WITH_CP, device_ids=[torch.cuda.current_device()]
+            )
+            torch.cuda.synchronize()
         for ranks_with_cp in decoder_rank_generator.get_ranks('dp-cp'):
-            assert (
-                len(ranks_with_cp) % 2 == 0
-            ), "Dynamic context parallel requires an even number of ranks"
             _DYNAMIC_DP_CP_GROUPS.update(
                 create_dynamic_dp_cp_groups(
                     rank,
                     ranks_with_cp,
                     get_nccl_options("dp_cp", nccl_comm_cfgs),
                     min_cp_size=min_dynamic_context_parallel_size,
+                    use_logical_groups=use_native_cp_transport,
                 )
             )
 
         data_parallel_size_with_cp = data_parallel_size * context_parallel_size
-        group_sizes = [
-            2**i
-            for i in range(int(log2(data_parallel_size_with_cp)))
-            if 2**i >= min_dynamic_context_parallel_size
-        ]
-        if data_parallel_size_with_cp not in group_sizes:
-            group_sizes.append(data_parallel_size_with_cp)
-        for group_size in group_sizes:
-            group = get_dynamic_data_context_parallel_groups(group_size=group_size)
-            torch.distributed.barrier(group=group, device_ids=[torch.cuda.current_device()])
-            torch.cuda.synchronize()
+        # Native transport borrows the parent communicator and creates no subgroup NCCL state.
+        if not use_native_cp_transport:
+            group_sizes = [
+                size
+                for size in (1 << i for i in range(data_parallel_size_with_cp.bit_length()))
+                if min_dynamic_context_parallel_size <= size < data_parallel_size_with_cp
+            ]
+            if data_parallel_size_with_cp not in group_sizes:
+                group_sizes.append(data_parallel_size_with_cp)
+            for group_size in group_sizes:
+                group = get_dynamic_data_context_parallel_groups(group_size=group_size)
+                torch.distributed.barrier(group=group, device_ids=[torch.cuda.current_device()])
+                torch.cuda.synchronize()
 
     for ranks in decoder_rank_generator.get_ranks('dp'):
         group = create_group(
@@ -1538,8 +1564,22 @@ def get_hierarchical_context_parallel_groups(check_initialized=True):
     return _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
 
 
-def get_dynamic_data_context_parallel_groups(check_initialized=True, group_size=None):
+def get_dynamic_data_context_parallel_groups(
+    check_initialized=True, group_size=None, group_start=None
+):
     """Get the dynamic context parallel groups the caller rank belongs to."""
+    if group_start is not None:
+        key = (int(group_size), int(group_start))
+        if key not in _DYNAMIC_DP_CP_GROUPS:
+            parent_ranks = torch.distributed.get_process_group_ranks(
+                get_data_parallel_group(with_context_parallel=True)
+            )
+            _DYNAMIC_DP_CP_GROUPS[key] = LogicalCPGroup.from_parent_interval(
+                parent_ranks, int(group_start), int(group_size), torch.distributed.get_rank()
+            )
+        return _DYNAMIC_DP_CP_GROUPS[key]
+    if group_size in _DYNAMIC_DP_CP_GROUPS:
+        return _DYNAMIC_DP_CP_GROUPS[group_size]
     if get_data_parallel_world_size(with_context_parallel=True) == group_size:
         if check_initialized:
             assert _DATA_PARALLEL_GROUP_WITH_CP is not None
@@ -2110,12 +2150,12 @@ def destroy_model_parallel():
     # process group's communicator is torn down. TE registers an atexit ep_finalize that would
     # otherwise run after dist.destroy_process_group() and hit a "corrupted comm object" at exit.
     # Idempotent and a no-op when NCCL EP was never bootstrapped.
-    try:
-        from megatron.core.transformer.moe.fused_a2a import nccl_ep_finalize
-
-        nccl_ep_finalize()
-    except Exception:  # finalize must never block teardown
-        pass
+    fused_a2a = sys.modules.get('megatron.core.transformer.moe.fused_a2a')
+    if fused_a2a is not None:
+        try:
+            fused_a2a.nccl_ep_finalize()
+        except Exception:  # finalize must never block teardown
+            pass
 
     global _MODEL_PARALLEL_GROUP
     _MODEL_PARALLEL_GROUP = None
@@ -2130,6 +2170,15 @@ def destroy_model_parallel():
     _DATA_PARALLEL_GROUP = None
 
     global _DATA_PARALLEL_GROUP_WITH_CP
+    if _DATA_PARALLEL_GROUP_WITH_CP is not None:
+        try:
+            from transformer_engine.pytorch.attention.native_cp_transport import (
+                destroy_native_cp_transport,
+            )
+
+            destroy_native_cp_transport(_DATA_PARALLEL_GROUP_WITH_CP)
+        except ImportError:
+            pass
     _DATA_PARALLEL_GROUP_WITH_CP = None
 
     global _CONTEXT_PARALLEL_GROUP

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -434,15 +434,16 @@ def create_dynamic_dp_cp_groups(rank, ranks, pg_options, min_cp_size=1, use_logi
     if use_logical_groups:
         group_sizes = range(min_cp_size, len(ranks) + 1)
     else:
+        # Preserve the legacy floor(log2(parent_size)) layouts, including tails.
         group_sizes = [
             size
-            for size in (1 << i for i in range(len(ranks).bit_length()))
+            for size in (1 << i for i in range(len(ranks).bit_length() - 1))
             if min_cp_size <= size < len(ranks)
         ]
     for group_size in group_sizes:
         for i in range(0, len(ranks), group_size):
             group_ranks = ranks[i : i + group_size]
-            if len(group_ranks) != group_size:
+            if use_logical_groups and len(group_ranks) != group_size:
                 continue
             if use_logical_groups:
                 if rank not in group_ranks:
@@ -963,7 +964,7 @@ def initialize_model_parallel(
         if not use_native_cp_transport:
             group_sizes = [
                 size
-                for size in (1 << i for i in range(data_parallel_size_with_cp.bit_length()))
+                for size in (1 << i for i in range(data_parallel_size_with_cp.bit_length() - 1))
                 if min_dynamic_context_parallel_size <= size < data_parallel_size_with_cp
             ]
             if data_parallel_size_with_cp not in group_sizes:

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -2,6 +2,7 @@
 
 import torch
 
+from megatron.core.dynamic_cp_group import LogicalCPGroup
 from megatron.core.parallel_state import get_global_memory_buffer
 from megatron.core.utils import get_tensor_model_parallel_group_if_none, is_torch_min_version
 
@@ -26,6 +27,14 @@ def _reduce(input_, group):
     # Bypass the function if we are using only 1 GPU.
     if group.size() == 1:
         return input_
+
+    if isinstance(group, LogicalCPGroup):
+        from transformer_engine.pytorch.attention.native_cp_transport import get_native_cp_transport
+
+        transport = get_native_cp_transport(group)
+        if transport is None:
+            raise RuntimeError("Logical CP group has no native parent transport")
+        return transport.all_reduce(input_, group)
 
     # All-reduce.
     # Note: If input_ is contiguous, it is mutated in-place.

--- a/megatron/core/transformer/moe/moe_logging.py
+++ b/megatron/core/transformer/moe/moe_logging.py
@@ -38,6 +38,7 @@ class MetricEntry:
     reduce_group: Optional[torch.distributed.ProcessGroup] = None
     avg_group: Optional[torch.distributed.ProcessGroup] = None
     needs_dp_avg: bool = True
+    normalize_by_global_tokens: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +467,7 @@ class MoEMetricsTracker:
         reduce_group: Optional[torch.distributed.ProcessGroup] = None,
         avg_group: Optional[torch.distributed.ProcessGroup] = None,
         needs_dp_avg: bool = True,
+        normalize_by_global_tokens: bool = False,
     ) -> None:
         """Accumulate a metric value for a specific layer.
 
@@ -492,6 +494,7 @@ class MoEMetricsTracker:
         entry.reduce_group = reduce_group
         entry.avg_group = avg_group
         entry.needs_dp_avg = needs_dp_avg
+        entry.normalize_by_global_tokens = normalize_by_global_tokens
 
     def report(
         self,
@@ -508,6 +511,7 @@ class MoEMetricsTracker:
         total_loss_dict: Optional[dict[str, torch.Tensor]] = None,
         percentiles: Optional[Dict[str, List[float]]] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        total_real_tokens: Optional[float] = None,
     ) -> str:
         """Sync metrics across ranks, aggregate, log, and clear.
 
@@ -554,7 +558,9 @@ class MoEMetricsTracker:
         self._sync_metrics(metric_names, pg_collection)
 
         num_moe_layers = self._count_moe_layers(num_layers, moe_layer_freq, mtp_num_layers)
-        scalars = self._aggregate(loss_scale, num_moe_layers, metric_names, percentiles)
+        scalars = self._aggregate(
+            loss_scale, num_moe_layers, metric_names, percentiles, total_real_tokens
+        )
 
         # Megatron integration: accumulate loss metrics into total_loss_dict
         console_scalars = dict(scalars)
@@ -570,7 +576,13 @@ class MoEMetricsTracker:
         self._log_scalars(scalars, iteration, writer, wandb_writer)
         if per_layer_logging:
             self._log_per_layer(
-                loss_scale, metric_names, iteration, writer, wandb_writer, percentiles
+                loss_scale,
+                metric_names,
+                iteration,
+                writer,
+                wandb_writer,
+                percentiles,
+                total_real_tokens,
             )
 
         log_string = self._format(console_scalars)
@@ -676,6 +688,7 @@ class MoEMetricsTracker:
         num_moe_layers: int,
         metric_names: List[str],
         percentiles: Optional[Dict[str, List[float]]] = None,
+        total_real_tokens: Optional[float] = None,
     ) -> Dict[str, Union[float, torch.Tensor]]:
         """Aggregate per-layer values into scalar summaries.
 
@@ -689,7 +702,13 @@ class MoEMetricsTracker:
             if name not in self._metrics:
                 continue
 
-            values = self._metrics[name].values.float() * loss_scale
+            entry = self._metrics[name]
+            if entry.normalize_by_global_tokens:
+                if total_real_tokens is None or total_real_tokens <= 0:
+                    raise ValueError(f"{name} requires a positive total_real_tokens value")
+                values = entry.values.float() / total_real_tokens
+            else:
+                values = entry.values.float() * loss_scale
 
             if percentiles and name in percentiles:
                 nonzero = values[values > 0]
@@ -723,13 +742,20 @@ class MoEMetricsTracker:
         writer,
         wandb_writer,
         percentiles: Optional[Dict[str, List[float]]] = None,
+        total_real_tokens: Optional[float] = None,
     ) -> None:
         """Write per-layer metric values to TensorBoard and/or W&B."""
         for name in metric_names:
             if name not in self._metrics:
                 continue
 
-            values = self._metrics[name].values.float() * loss_scale
+            entry = self._metrics[name]
+            if entry.normalize_by_global_tokens:
+                if total_real_tokens is None or total_real_tokens <= 0:
+                    raise ValueError(f"{name} requires a positive total_real_tokens value")
+                values = entry.values.float() / total_real_tokens
+            else:
+                values = entry.values.float() * loss_scale
             is_sparse = percentiles is not None and name in percentiles
             for i, val in enumerate(values.tolist()):
                 if is_sparse and val == 0:

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -9,6 +9,7 @@ import torch
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.mappings import reduce_from_tensor_model_parallel_region
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 from megatron.core.transformer.moe.moe_utils import (
@@ -443,6 +444,11 @@ class TopKRouter(Router):
         if seq_aux_loss_coeff == 0:
             return probs
 
+        if packed_seq_params is not None and packed_seq_params.seq_idx is not None:
+            return self._apply_packed_seq_aux_loss(
+                probs, scores_for_aux_loss, routing_map, seq_aux_loss_coeff, packed_seq_params
+            )
+
         scores_for_aux_loss = scores_for_aux_loss.reshape(seq_length, -1)
         routing_map = routing_map.reshape(seq_length, -1)
 
@@ -485,6 +491,81 @@ class TopKRouter(Router):
             aux_loss_scale_reduce_groups=aux_loss_groups.loss_reduce_groups,
         )
         return probs
+
+    def _apply_packed_seq_aux_loss(
+        self,
+        probs: torch.Tensor,
+        scores_for_aux_loss: torch.Tensor,
+        routing_map: torch.Tensor,
+        seq_aux_loss_coeff: float,
+        packed_seq_params: PackedSeqParams,
+    ) -> torch.Tensor:
+        """Apply token-weighted sequence aux loss to a flattened THD pack.
+
+        Sequence IDs survive CP slicing, so statistics are computed for each
+        original sequence rather than treating the whole flattened pack as one
+        sample.  The token-weighted numerator is additive across arbitrary pack
+        and microbatch boundaries.
+        """
+        seq_idx = packed_seq_params.seq_idx.reshape(-1)
+        local_rows = routing_map.shape[0]
+        if seq_idx.numel() != local_rows:
+            tp_size = self.tp_group.size()
+            if not self.config.sequence_parallel or seq_idx.numel() != local_rows * tp_size:
+                raise RuntimeError(
+                    f"Packed sequence IDs have {seq_idx.numel()} rows, but router input has "
+                    f"{local_rows} rows"
+                )
+            seq_idx = seq_idx.narrow(0, self.tp_group.rank() * local_rows, local_rows)
+        seq_idx = seq_idx.to(torch.int64)
+
+        cu_seqlens = packed_seq_params.cu_seqlens_q
+        if cu_seqlens is None:
+            cu_seqlens = packed_seq_params.cu_seqlens_q_padded
+        if cu_seqlens is None:
+            raise RuntimeError("Packed sequence aux loss requires cu_seqlens metadata")
+        num_sequence_slots = cu_seqlens.numel() - 1
+
+        local_tokens_per_expert = scores_for_aux_loss.new_zeros(
+            (num_sequence_slots, self.config.num_moe_experts)
+        )
+        local_tokens_per_expert.index_add_(
+            0, seq_idx, routing_map.to(dtype=scores_for_aux_loss.dtype)
+        )
+        global_tokens_per_expert = local_tokens_per_expert
+        aux_loss_groups = self._get_aux_loss_groups(packed_seq_params)
+        for group in aux_loss_groups.loss_reduce_groups:
+            global_tokens_per_expert = reduce_from_tensor_model_parallel_region(
+                global_tokens_per_expert, group
+            )
+
+        local_probability_sums = scores_for_aux_loss.new_zeros(
+            (num_sequence_slots, self.config.num_moe_experts)
+        )
+        local_probability_sums.index_add_(0, seq_idx, scores_for_aux_loss)
+
+        tokens_per_sequence = global_tokens_per_expert.sum(dim=-1) / self.topk
+        safe_tokens_per_sequence = tokens_per_sequence.clamp(min=1)
+        weighted_aux_numerator = (
+            (local_probability_sums * global_tokens_per_expert).sum(dim=-1)
+            / safe_tokens_per_sequence
+        ).sum() * (self.config.num_moe_experts / self.topk)
+        total_num_tokens = tokens_per_sequence.sum()
+        aux_loss = weighted_aux_numerator * seq_aux_loss_coeff / total_num_tokens.clamp(min=1)
+        local_num_tokens = local_tokens_per_expert.sum() / self.topk
+
+        return self.attach_and_log_load_balancing_loss(
+            probs,
+            seq_aux_loss_coeff,
+            aux_loss,
+            "seq_load_balancing_loss",
+            self.tp_dp_cp_group,
+            needs_dp_avg=False,
+            valid_token_count=local_num_tokens,
+            aux_loss_scale_num_tokens=total_num_tokens,
+            metric_value=weighted_aux_numerator,
+            normalize_metric_by_global_tokens=True,
+        )
 
     def _apply_global_aux_loss(
         self,
@@ -588,6 +669,8 @@ class TopKRouter(Router):
         aux_loss_logging_reduce_groups: Optional[Sequence[torch.distributed.ProcessGroup]] = None,
         aux_loss_scale_reduce_groups: Optional[Sequence[torch.distributed.ProcessGroup]] = None,
         aux_loss_scale_num_tokens: Optional[Union[int, torch.Tensor]] = None,
+        metric_value: Optional[torch.Tensor] = None,
+        normalize_metric_by_global_tokens: bool = False,
     ):
         """Attach aux loss function to activation and add to logging.
 
@@ -621,11 +704,12 @@ class TopKRouter(Router):
         # results and the reduced load_balancing_loss logging value.
         layer_number, num_layers = self._get_metric_layer_number()
 
-        metric_value = aux_loss / aux_loss_coeff
+        if metric_value is None:
+            metric_value = aux_loss / aux_loss_coeff
         if aux_loss_logging_reduce_groups is not None:
             metric_value = metric_value.detach().clone()
             for group in aux_loss_logging_reduce_groups:
-                torch.distributed.all_reduce(metric_value, group=group)
+                metric_value = reduce_from_tensor_model_parallel_region(metric_value, group)
 
         get_moe_metrics_tracker().record(
             aux_loss_name,
@@ -635,6 +719,7 @@ class TopKRouter(Router):
             reduce_group=reduce_group,
             avg_group=avg_group,
             needs_dp_avg=needs_dp_avg,
+            normalize_by_global_tokens=normalize_metric_by_global_tokens,
         )
         if self.calculate_per_token_loss:
             # --calculate-per-token-loss divides all parameter gradients by the global
@@ -659,7 +744,9 @@ class TopKRouter(Router):
                     assert reduce_group is not None, "reduce_group is required for aux-loss scaling"
                     aux_loss_scale_reduce_groups = (reduce_group,)
                 for group in aux_loss_scale_reduce_groups:
-                    torch.distributed.all_reduce(aux_loss_scale_num_tokens, group=group)
+                    aux_loss_scale_num_tokens = reduce_from_tensor_model_parallel_region(
+                        aux_loss_scale_num_tokens, group
+                    )
             activation = MoEAuxLossAutoScaler.apply(
                 activation, aux_loss * aux_loss_scale_num_tokens
             )

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -519,12 +519,14 @@ class TopKRouter(Router):
             seq_idx = seq_idx.narrow(0, self.tp_group.rank() * local_rows, local_rows)
         seq_idx = seq_idx.to(torch.int64)
 
-        cu_seqlens = packed_seq_params.cu_seqlens_q
+        cu_seqlens = packed_seq_params.cu_seqlens_q_padded
         if cu_seqlens is None:
-            cu_seqlens = packed_seq_params.cu_seqlens_q_padded
+            cu_seqlens = packed_seq_params.cu_seqlens_q
         if cu_seqlens is None:
             raise RuntimeError("Packed sequence aux loss requires cu_seqlens metadata")
-        num_sequence_slots = cu_seqlens.numel() - 1
+        # PackedSeqParams assigns an implicit tail the index len(cu_seqlens) - 1.
+        # Reserve that slot on every CP rank, even ranks with no local tail tokens.
+        num_sequence_slots = cu_seqlens.numel()
 
         local_tokens_per_expert = scores_for_aux_loss.new_zeros(
             (num_sequence_slots, self.config.num_moe_experts)
@@ -697,6 +699,8 @@ class TopKRouter(Router):
             and self.config.mtp_num_layers is not None
         ):
             aux_loss = aux_loss / self.config.mtp_num_layers
+            if metric_value is not None:
+                metric_value = metric_value / self.config.mtp_num_layers
 
         # TODO (zijiey): fix the per_layer_logging for MTP, currently it will incorrectly
         # add the aux loss logging value to other layer's since it is difficult to get the

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import importlib
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -18,21 +19,6 @@ from megatron.core.tensor_parallel import (
     reduce_scatter_to_sequence_parallel_region,
 )
 from megatron.core.transformer.enums import CudaGraphModule
-from megatron.core.transformer.moe.fused_a2a import (
-    HYBRIDEP_TOKEN_ALIGNMENT,
-    deepepv2_combine,
-    deepepv2_dispatch,
-    ensure_nccl_ep_bootstrapped,
-    fused_combine,
-    fused_dispatch,
-    get_elastic_buffer,
-    hybrid_ep_combine,
-    hybrid_ep_dispatch,
-    nccl_ep_combine,
-    nccl_ep_dispatch,
-    new_nccl_ep_buffer,
-    set_deepep_num_sms,
-)
 from megatron.core.transformer.moe.moe_utils import (
     ProcessGroupCollection,
     get_align_size_for_quantization,
@@ -47,6 +33,17 @@ from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
+
+_FUSED_A2A_MODULE = None
+
+
+def _get_fused_a2a_module():
+    """Load optional native MoE transports after distributed initialization."""
+    global _FUSED_A2A_MODULE
+    if _FUSED_A2A_MODULE is None:
+        _FUSED_A2A_MODULE = importlib.import_module("megatron.core.transformer.moe.fused_a2a")
+    return _FUSED_A2A_MODULE
+
 
 """ We use the following notation throughout this file:
      H: hidden size
@@ -1093,6 +1090,7 @@ class _HybridEPManager(_DispatchManager):
         self.num_local_experts = num_local_experts
         self.num_experts = num_experts
         self.config = config
+        self._fused_a2a = _get_fused_a2a_module()
         self.permute_fusion = config.moe_permute_fusion
         self.capacity_factor = config.moe_expert_capacity_factor
         # Drop and pad the input to capacity.
@@ -1111,7 +1109,7 @@ class _HybridEPManager(_DispatchManager):
         # Used for padding the output for each expert
         self.pad_multiple = None
 
-        if hybrid_ep_dispatch is None:
+        if self._fused_a2a.hybrid_ep_dispatch is None:
             raise ImportError(
                 "HybridEP is not installed. Please install HybridEP package from "
                 "https://github.com/deepseek-ai/DeepEP/tree/hybrid-ep."
@@ -1139,7 +1137,8 @@ class _HybridEPManager(_DispatchManager):
                 max_num_tokens_across_ep, op=torch.distributed.ReduceOp.MAX, group=self.group
             )
             padded_num_tokens = int(max_num_tokens_across_ep.item())
-            padded_num_tokens += -padded_num_tokens % HYBRIDEP_TOKEN_ALIGNMENT
+            token_alignment = self._fused_a2a.HYBRIDEP_TOKEN_ALIGNMENT
+            padded_num_tokens += -padded_num_tokens % token_alignment
         self._padded_num_tokens = padded_num_tokens
 
         routing_map = routing_map.reshape(num_tokens, self.num_experts)
@@ -1207,7 +1206,7 @@ class _HybridEPManager(_DispatchManager):
                 [hidden_states, hidden_states.new_zeros((pad_rows, hidden_states.shape[-1]))], dim=0
             )
         dispatched_hidden, self.dispatched_probs, _, tokens_per_expert, self.handle = (
-            hybrid_ep_dispatch(
+            self._fused_a2a.hybrid_ep_dispatch(
                 x=hidden_states,
                 routing_map=self.routing_map,
                 probs=self.token_probs,
@@ -1245,7 +1244,7 @@ class _HybridEPManager(_DispatchManager):
         async_finish: bool = True,
         allocate_on_comm_stream: bool = True,
     ) -> torch.Tensor:
-        hidden_states = hybrid_ep_combine(
+        hidden_states = self._fused_a2a.hybrid_ep_combine(
             x=hidden_states,
             handle=self.handle,
             num_permuted_tokens=self.num_permuted_tokens,
@@ -1325,6 +1324,7 @@ class _DeepepManager(_DispatchManager):
         self.group = group
         self.num_local_experts = num_local_experts
         self.config = config
+        self._fused_a2a = _get_fused_a2a_module()
 
         self.router_topk = router_topk
         self.num_experts = num_experts
@@ -1338,13 +1338,13 @@ class _DeepepManager(_DispatchManager):
         # Handle used for combine operation
         self.handle = None
 
-        if fused_dispatch is None:
+        if self._fused_a2a.fused_dispatch is None:
             raise ImportError(
                 "DeepEP is not installed. Please install DeepEP package from "
                 "https://github.com/deepseek-ai/deepep."
             )
         # None -> 20 (DeepEP's historical mcore default when moe_flex_dispatcher_num_sms is unset).
-        set_deepep_num_sms(
+        self._fused_a2a.set_deepep_num_sms(
             config.moe_flex_dispatcher_num_sms
             if config.moe_flex_dispatcher_num_sms is not None
             else 20
@@ -1376,7 +1376,7 @@ class _DeepepManager(_DispatchManager):
                 )
             self.token_probs = self.token_probs.float()  # downcast or upcast
         hidden_states, dispatched_indices, dispatched_probs, num_tokens_per_expert, handle = (
-            fused_dispatch(
+            self._fused_a2a.fused_dispatch(
                 hidden_states,
                 self.token_indices,
                 self.token_probs,
@@ -1435,7 +1435,7 @@ class _DeepepManager(_DispatchManager):
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
     ) -> torch.Tensor:
-        hidden_states, _ = fused_combine(
+        hidden_states, _ = self._fused_a2a.fused_combine(
             hidden_states,
             self.group,
             self.handle,
@@ -1565,14 +1565,14 @@ class _DeepepV2Manager(_DeepepManager):
         self.handle = None
         self.buffer = None
 
-        if deepepv2_dispatch is None:
+        if self._fused_a2a.deepepv2_dispatch is None:
             raise ImportError(
                 "DeepEP v2 is not installed. Please install a DeepEP package that provides "
                 "ElasticBuffer."
             )
 
     def _get_buffer(self, hidden_states: torch.Tensor):
-        self.buffer = get_elastic_buffer(
+        self.buffer = self._fused_a2a.get_elastic_buffer(
             self.group,
             num_max_tokens_per_rank=hidden_states.shape[0],
             hidden=hidden_states.shape[1],
@@ -1595,7 +1595,7 @@ class _DeepepV2Manager(_DeepepManager):
             self.token_probs = self.token_probs.float()
         buffer = self._get_buffer(hidden_states)
         hidden_states, dispatched_indices, dispatched_probs, num_tokens_per_expert, handle = (
-            deepepv2_dispatch(
+            self._fused_a2a.deepepv2_dispatch(
                 buffer,
                 hidden_states,
                 self.token_indices,
@@ -1621,7 +1621,7 @@ class _DeepepV2Manager(_DeepepManager):
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
     ) -> torch.Tensor:
-        hidden_states, _ = deepepv2_combine(
+        hidden_states, _ = self._fused_a2a.deepepv2_combine(
             self.buffer,
             hidden_states,
             self.handle,
@@ -1678,6 +1678,7 @@ class _NCCLEPManager(_DispatchManager):
         self.router_topk = router_topk
         self.num_experts = num_experts
         self.config = config
+        self._fused_a2a = _get_fused_a2a_module()
         # With MoE latent projections, the dispatcher operates on latent-dim tensors
         # (fc1_latent_proj runs before dispatch; see moe_layer.py), so the EP buffers must be
         # sized to the latent dim, not hidden_size.
@@ -1710,7 +1711,7 @@ class _NCCLEPManager(_DispatchManager):
                     "per-expert counts on device)."
                 )
 
-        if nccl_ep_dispatch is None:
+        if self._fused_a2a.nccl_ep_dispatch is None:
             raise ImportError(
                 "TransformerEngine NCCL EP is unavailable. The 'ncclep' backend requires a "
                 "TransformerEngine build with NCCL EP support (NVTE_BUILD_WITH_NCCL_EP=1)."
@@ -1763,7 +1764,7 @@ class _NCCLEPManager(_DispatchManager):
             budget += -budget % self.alignment
         self._recv_capacity = budget
 
-        ensure_nccl_ep_bootstrapped(
+        self._fused_a2a.ensure_nccl_ep_bootstrapped(
             self.group,
             num_experts=self.num_experts,
             max_tokens_per_rank=self._max_tokens_per_rank,
@@ -1788,7 +1789,7 @@ class _NCCLEPManager(_DispatchManager):
         # opaque ProcessGroup._get_backend()._comm_ptr() access that dynamo cannot trace.
         self._ensure_bootstrap()
         # Fresh buffer per dispatch; held until the matching combine consumes it.
-        self._buffer = new_nccl_ep_buffer(
+        self._buffer = self._fused_a2a.new_nccl_ep_buffer(
             top_k=self.router_topk,
             max_tokens_per_rank=self._max_tokens_per_rank,
             recv_capacity_per_rank=self._recv_capacity,
@@ -1803,7 +1804,7 @@ class _NCCLEPManager(_DispatchManager):
         # hidden_states: [num_local_tokens, H] -> recv_tokens: [recv_capacity_per_rank, H]
         #   tokens_per_expert: [num_local_experts]
         #   dispatched_probs: [recv_capacity_per_rank]
-        recv_tokens, tokens_per_expert, dispatched_probs = nccl_ep_dispatch(
+        recv_tokens, tokens_per_expert, dispatched_probs = self._fused_a2a.nccl_ep_dispatch(
             self._buffer, hidden_states, topk_idx, topk_weights
         )
         self.tokens_per_expert = tokens_per_expert.to(torch.int64)
@@ -1845,7 +1846,7 @@ class _NCCLEPManager(_DispatchManager):
         allocate_on_comm_stream: bool = True,
     ) -> torch.Tensor:
         # hidden_states: [recv_capacity_per_rank, H] -> [num_local_tokens, H]
-        hidden_states = nccl_ep_combine(
+        hidden_states = self._fused_a2a.nccl_ep_combine(
             self._buffer, hidden_states, num_local_tokens=self.num_local_tokens
         )
         # Drop the buffer; backward keeps handle_mem alive via save_for_backward.

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1547,6 +1547,7 @@ class _DeepepV2Manager(_DeepepManager):
         self.group = group
         self.num_local_experts = num_local_experts
         self.config = config
+        self._fused_a2a = _get_fused_a2a_module()
 
         self.router_topk = router_topk
         self.num_experts = num_experts

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -13,6 +13,7 @@ from torch import Tensor
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace_prefix_for_sharding
+from megatron.core.dynamic_cp_group import LogicalCPGroup, get_process_group_ranks
 from megatron.core.enums import Fp8Recipe
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
@@ -21,7 +22,9 @@ from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel import (
+    gather_from_sequence_parallel_region,
     gather_from_tensor_model_parallel_region,
+    reduce_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
 from megatron.core.tensor_parallel.inference_layers import (
@@ -65,6 +68,83 @@ _MTP_SEQUENCE_FIELD_FILL_VALUES = {
     "loss_mask": 0,
     "padding_mask": True,
 }
+
+
+def bind_native_mtp_cp_group(
+    cp_group: torch.distributed.ProcessGroup | LogicalCPGroup | None,
+    parent_group: torch.distributed.ProcessGroup | None,
+) -> None:
+    """Bind a logical MTP group before halo exchange, including before attention.
+
+    Args:
+        cp_group: Effective CP group for this microbatch.
+        parent_group: Existing native transport's parent ProcessGroup.
+    """
+    if isinstance(cp_group, LogicalCPGroup) and cp_group.size() > 1:
+        from transformer_engine.pytorch.attention.native_cp_transport import (
+            set_native_cp_parent_group,
+        )
+
+        set_native_cp_parent_group(cp_group, parent_group)
+
+
+def _get_native_mtp_transport(cp_group):
+    if not isinstance(cp_group, LogicalCPGroup):
+        return None
+    from transformer_engine.pytorch.attention.native_cp_transport import get_native_cp_transport
+
+    transport = get_native_cp_transport(cp_group)
+    if transport is None:
+        raise RuntimeError("Logical MTP CP group has no native parent transport")
+    return transport
+
+
+def _exchange_mtp_halos(cp_group, send_buffers, send_rank, recv_buffers, recv_rank):
+    """Exchange matching field halos, retaining grouped NCCL for real ProcessGroups."""
+    transport = _get_native_mtp_transport(cp_group)
+    if transport is not None:
+        for send, recv in zip(send_buffers, recv_buffers):
+            transport.exchange(send, send_rank, recv, recv_rank, channel=3)
+        return []
+
+    p2p_ops = []
+    if recv_rank is not None:
+        p2p_ops.extend(
+            torch.distributed.P2POp(torch.distributed.irecv, recv, recv_rank, group=cp_group)
+            for recv in recv_buffers
+        )
+    if send_rank is not None:
+        p2p_ops.extend(
+            torch.distributed.P2POp(torch.distributed.isend, send, send_rank, group=cp_group)
+            for send in send_buffers
+        )
+    return torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+
+
+def _exchange_zigzag_mtp_boundaries(cp_group, send_buffers, recv_buffers, fill_value):
+    """Exchange the front and mirrored-tail boundaries in two matching directions."""
+    ranks = get_process_group_ranks(cp_group)
+    rank = cp_group.rank()
+    previous = ranks[rank - 1] if rank else None
+    following = ranks[rank + 1] if rank + 1 < len(ranks) else None
+    transport = _get_native_mtp_transport(cp_group)
+    if transport is not None:
+        transport.exchange(send_buffers[0], previous, recv_buffers[0], following, channel=3)
+        transport.exchange(send_buffers[1], following, recv_buffers[1], previous, channel=3)
+    else:
+        works = []
+        if previous is not None:
+            works.append(torch.distributed.isend(tensor=send_buffers[0], dst=previous))
+            works.append(torch.distributed.irecv(tensor=recv_buffers[1], src=previous))
+        if following is not None:
+            works.append(torch.distributed.irecv(tensor=recv_buffers[0], src=following))
+            works.append(torch.distributed.isend(tensor=send_buffers[1], dst=following))
+        for work in works:
+            work.wait()
+    if previous is None:
+        recv_buffers[1].fill_(fill_value)
+    if following is None:
+        recv_buffers[0].copy_(send_buffers[1])
 
 
 class MTPSequenceRollHalos:
@@ -362,8 +442,8 @@ def _build_contiguous_packed_seq_roll_plan(
 
     local_seq_len = tensor.size(dims)
     cp_size = cp_group.size()
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    local_rank = cp_group.rank()
+    global_ranks = get_process_group_ranks(cp_group)
 
     cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
     if cu.numel() > 1:
@@ -643,33 +723,7 @@ def _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=0
         )
         tensor_recv_list.append(empty_tensor)
 
-    # Get the global rank of next and prev process in the cp group
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    next_rank = global_ranks[(local_rank + 1) % len(global_ranks)]
-    prev_rank = global_ranks[(local_rank - 1) % len(global_ranks)]
-
-    # Start send and recv ops
-    ops = []
-    if local_rank != 0:
-        req_send_first_part = torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank)
-        ops.append(req_send_first_part)
-        req_recv_second_part = torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank)
-        ops.append(req_recv_second_part)
-    else:
-        tensor_recv_list[1] = fill_value
-    if local_rank != len(global_ranks) - 1:
-        req_recv_first_part = torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank)
-        ops.append(req_recv_first_part)
-        req_send_second_part = torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank)
-        ops.append(req_send_second_part)
-    else:
-        # For the last CP rank, the removed elements of second part go into the first part
-        tensor_recv_list[0] = tensor_send_list[1]
-
-    # Wait for all communication operations to complete
-    for op in ops:
-        op.wait()
+    _exchange_zigzag_mtp_boundaries(cp_group, tensor_send_list, tensor_recv_list, fill_value)
 
     # Splicing: Replace boundary elements with received elements from adjacent ranks
     # This ensures proper sequence continuity across CP boundaries
@@ -778,12 +832,6 @@ def _roll_tensor_packed_seq_zigzag_cp(tensor, shifts, dims, cu_seqlens, cp_group
     cp_size = cp_group.size()
     rolled_tensor = tensor.clone()
 
-    # CP enabled: each rank owns two chunks per sequence (front and mirrored tail).
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
-    next_rank = global_ranks[(local_rank + 1) % cp_size]
-    prev_rank = global_ranks[(local_rank - 1) % cp_size]
-
     # Iterate over each sequence individually
     for i in range(len(cu_seqlens) - 1):
         start_idx = cu_seqlens[i]
@@ -821,21 +869,7 @@ def _roll_tensor_packed_seq_zigzag_cp(tensor, shifts, dims, cu_seqlens, cp_group
             tensor_send_list.append(boundary)
             tensor_recv_list.append(torch.empty_like(boundary))
 
-        ops = []
-        if local_rank != 0:
-            ops.append(torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank))
-            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank))
-        else:
-            tensor_recv_list[1].fill_(fill_value)
-
-        if local_rank != cp_size - 1:
-            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank))
-            ops.append(torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank))
-        else:
-            tensor_recv_list[0].copy_(tensor_send_list[1])
-
-        for op in ops:
-            op.wait()
+        _exchange_zigzag_mtp_boundaries(cp_group, tensor_send_list, tensor_recv_list, fill_value)
 
         index = [slice(None)] * rolled_chunks[0].dim()
         index[dims] = shifts
@@ -915,26 +949,12 @@ def _prefetch_contiguous_packed_cp_roll_halos(
         halos.append(tensor.new_full(halo_shape, fill_value))
 
     # Retain contiguous send slices until every grouped work handle completes.
-    send_buffers: List[Tensor] = []
-    p2p_ops = []
-    if plan.has_sequences and plan.recv_rank is not None:
-        for halo in halos:
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.irecv, halo, plan.recv_rank, group=plan.cp_group
-                )
-            )
-    if plan.has_sequences and plan.send_rank is not None:
-        for tensor in tensors:
-            send_buffer = tensor.narrow(-1, 0, width).contiguous()
-            send_buffers.append(send_buffer)
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
-                )
-            )
-
-    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    send_buffers = [tensor.narrow(-1, 0, width).contiguous() for tensor in tensors]
+    works = (
+        _exchange_mtp_halos(plan.cp_group, send_buffers, plan.send_rank, halos, plan.recv_rank)
+        if plan.has_sequences
+        else []
+    )
     for work in works:
         work.wait()
 
@@ -1050,46 +1070,22 @@ def _roll_tensors_packed_seq_contiguous_cp(
             rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
         return rolled_tensors
 
-    recv_buffers: List[Optional[Tensor]] = [None] * len(tensors)
+    recv_buffers = [torch.empty_like(tensor.select(dims, 0)) for tensor in tensors]
     # Keep contiguous send buffers alive until every grouped work handle completes.
-    send_buffers: List[Tensor] = []
-    p2p_ops = []
-
-    if contiguous_roll_plan.recv_rank is not None:
-        # After a left roll, each local tail consumes the first element from the
-        # next contiguous CP shard.
-        for index, tensor in enumerate(tensors):
-            recv_buffer = torch.empty_like(tensor.select(dims, 0))
-            recv_buffers[index] = recv_buffer
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_buffer,
-                    contiguous_roll_plan.recv_rank,
-                    group=contiguous_roll_plan.cp_group,
-                )
-            )
-    if contiguous_roll_plan.send_rank is not None:
-        # This rank's first element becomes the previous shard's local tail.
-        for tensor in tensors:
-            send_buffer = tensor.select(dims, 0).contiguous()
-            send_buffers.append(send_buffer)
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_buffer,
-                    contiguous_roll_plan.send_rank,
-                    group=contiguous_roll_plan.cp_group,
-                )
-            )
-
-    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    send_buffers = [tensor.select(dims, 0).contiguous() for tensor in tensors]
+    works = _exchange_mtp_halos(
+        contiguous_roll_plan.cp_group,
+        send_buffers,
+        contiguous_roll_plan.send_rank,
+        recv_buffers,
+        contiguous_roll_plan.recv_rank,
+    )
     rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
     for work in works:
         work.wait()
 
     for rolled_tensor, recv_buffer, fill_value in zip(rolled_tensors, recv_buffers, fill_values):
-        if recv_buffer is not None:
+        if contiguous_roll_plan.recv_rank is not None:
             rolled_tensor.select(dims, -1).copy_(recv_buffer)
         # Apply the shared boundary mask after installing the adjacent value so a
         # physical packed-sequence end always wins over a cross-rank successor.
@@ -1847,10 +1843,16 @@ def process_mtp_loss(
             # and re-scale by the original token count.
             # Avoid division by zero
             assert original_num_tokens is not None
-            num_tokens_safe = torch.clamp(num_tokens, min=1)
-            mtp_loss_normalized = (
-                mtp_loss_scale * mtp_loss * (original_num_tokens / num_tokens_safe)
-            )
+            normalization_counts = torch.stack((original_num_tokens, num_tokens))
+            if cp_group is not None and cp_group.size() > 1:
+                # All shards of one pack share its original/rolled-token ratio.
+                # Logical groups reduce through the same native parent arena.
+                normalization_counts = reduce_from_tensor_model_parallel_region(
+                    normalization_counts, cp_group
+                )
+            original_count, rolled_count = normalization_counts.unbind()
+            num_tokens_safe = torch.clamp(rolled_count, min=1)
+            mtp_loss_normalized = mtp_loss_scale * mtp_loss * (original_count / num_tokens_safe)
             hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_normalized)
         else:
             safe_num_tokens = num_tokens.clamp(min=1)
@@ -1919,6 +1921,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.layer_number = layer_number + get_mtp_layer_offset(self.config, vp_stage)
         self.vp_stage = vp_stage
         self.cp_group = pg_collection.cp
+        self._mtp_cp_parent_group = getattr(pg_collection, "dp_cp", None)
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
 
@@ -2095,13 +2098,32 @@ class MultiTokenPredictionLayer(MegatronModule):
             embedding: Parent model's embedding module.
             hidden_states: Current-depth hidden states in [s, b, h] layout.
             packed_seq_params: Packed sequence layout metadata.
-            padding_mask: Optional padding mask rolled with input IDs.
+            padding_mask: CP-local padding mask rolled with input IDs. Direct callers
+                may pass an SP shard, which is gathered before token-side rolling.
             sequence_roll_context: Layout-specific state shared by MTP rolls
                 in this microbatch.
             roll_depth: Zero-based prediction depth selecting the prefetched
                 successor row for this repeated roll.
         """
         cp_group = resolve_cp_group(self.cp_group, packed_seq_params)
+        bind_native_mtp_cp_group(cp_group, getattr(self, "_mtp_cp_parent_group", None))
+
+        if padding_mask is not None and padding_mask.shape != input_ids.shape:
+            if (
+                not self.config.sequence_parallel
+                or padding_mask.shape[:-1] != input_ids.shape[:-1]
+                or padding_mask.shape[-1] * self.tp_group.size() != input_ids.shape[-1]
+            ):
+                raise ValueError("MTP padding_mask must match CP-local tokens or their SP shard")
+            padding_mask = (
+                gather_from_sequence_parallel_region(
+                    padding_mask.transpose(0, 1).contiguous(),
+                    tensor_parallel_output_grad=False,
+                    group=self.tp_group,
+                )
+                .transpose(0, 1)
+                .contiguous()
+            )
 
         tensors_to_roll = [input_ids]
         fill_values = [0]
@@ -2589,6 +2611,17 @@ class MultiTokenPredictionLayer(MegatronModule):
             sequence_roll_context=sequence_roll_context,
             roll_depth=roll_depth,
         )
+        # Keep the full CP-local mask for the next MTP depth; only the Transformer
+        # consumes an SP shard alongside its sequence-parallel hidden states.
+        transformer_padding_mask = padding_mask
+        if padding_mask is not None and self.config.sequence_parallel:
+            transformer_padding_mask = (
+                scatter_to_sequence_parallel_region(
+                    padding_mask.transpose(0, 1).contiguous(), group=self.tp_group
+                )
+                .transpose(0, 1)
+                .contiguous()
+            )
 
         # Legacy GPT MTP owns one outer checkpoint around its projection and Transformer
         # layer. Hybrid MTP instead delegates full recompute to the nested HybridStack so
@@ -2604,7 +2637,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 decoder_input=decoder_input,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
-                padding_mask=padding_mask,
+                padding_mask=transformer_padding_mask,
                 context=context,
                 context_mask=context_mask,
                 rotary_pos_emb=rotary_pos_emb,
@@ -2621,7 +2654,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 decoder_input=decoder_input,
                 input_ids=input_ids,
                 attention_mask=attention_mask,
-                padding_mask=padding_mask,
+                padding_mask=transformer_padding_mask,
                 context=context,
                 context_mask=context_mask,
                 rotary_pos_emb=rotary_pos_emb,
@@ -2789,7 +2822,10 @@ class MultiTokenPredictionBlock(MegatronModule):
         # to the roll_tensor function for proper boundary communication
         if pg_collection is None:
             # Use default MPU process groups if not provided
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp'])
+            required_pgs = ['cp', 'tp']
+            if config.use_native_cp_transport:
+                required_pgs.append('dp_cp')
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=required_pgs)
         else:
             # Ensure the provided process groups include CP
             assert hasattr(

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2359,8 +2359,8 @@ def _get_batch_on_this_cp_rank_per_document_balancing(
         dict[str, torch.Tensor]: The batch with sequence-dimension tensors
         partitioned to this CP rank.
     """
-    cp_size = torch.distributed.get_world_size(cp_group)
-    cp_rank = torch.distributed.get_rank(cp_group)
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
 
     if cp_size > 1:
         # cu_seqlens / cu_seqlens_padded carry a leading batch dim (1, n).
@@ -2413,8 +2413,8 @@ def _get_batch_on_this_cp_rank_per_sequence_balancing(
         partitioned to this CP rank.
     """
 
-    cp_size = torch.distributed.get_world_size(cp_group)
-    cp_rank = torch.distributed.get_rank(cp_group)
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
 
     # HybridCP metadata is not partitioned along the sequence dim — skip by key.
     # Intermediate PP stages set non-metadata keys to None, so still skip those.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1603,11 +1603,6 @@ def validate_args(args, defaults={}):
             raise ValueError('--use-native-cp-transport requires --max-seqlen-per-dp-cp-rank.')
         if args.fp8 is not None:
             raise ValueError('--use-native-cp-transport does not support FP8 attention yet.')
-        if args.mtp_num_layers:
-            raise ValueError(
-                '--use-native-cp-transport does not support MTP halo communication yet; '
-                'disable native transport when using --mtp-num-layers.'
-            )
 
     if getattr(args, 'pad_packed_seq_alignment', None) is not None:
         args.pad_packed_seq_alignment = _parse_pad_packed_seq_alignment(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1603,6 +1603,11 @@ def validate_args(args, defaults={}):
             raise ValueError('--use-native-cp-transport requires --max-seqlen-per-dp-cp-rank.')
         if args.fp8 is not None:
             raise ValueError('--use-native-cp-transport does not support FP8 attention yet.')
+        if args.mtp_num_layers:
+            raise ValueError(
+                '--use-native-cp-transport does not support MTP halo communication yet; '
+                'disable native transport when using --mtp-num-layers.'
+            )
 
     if getattr(args, 'pad_packed_seq_alignment', None) is not None:
         args.pad_packed_seq_alignment = _parse_pad_packed_seq_alignment(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1590,6 +1590,20 @@ def validate_args(args, defaults={}):
             f"to {args.data_parallel_size * args.context_parallel_size}."
         )
 
+    if args.use_native_cp_transport:
+        if not args.dynamic_context_parallel:
+            raise ValueError('--use-native-cp-transport requires --dynamic-context-parallel.')
+        if args.distributed_backend != 'nccl':
+            raise ValueError('--use-native-cp-transport requires --distributed-backend=nccl.')
+        if args.transformer_impl != 'transformer_engine':
+            raise ValueError('--use-native-cp-transport requires Transformer Engine.')
+        if args.cp_comm_type != ['p2p']:
+            raise ValueError('--use-native-cp-transport requires --cp-comm-type=p2p.')
+        if args.max_seqlen_per_dp_cp_rank is None:
+            raise ValueError('--use-native-cp-transport requires --max-seqlen-per-dp-cp-rank.')
+        if args.fp8 is not None:
+            raise ValueError('--use-native-cp-transport does not support FP8 attention yet.')
+
     if getattr(args, 'pad_packed_seq_alignment', None) is not None:
         args.pad_packed_seq_alignment = _parse_pad_packed_seq_alignment(
             args.pad_packed_seq_alignment

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -370,6 +370,7 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
                 hierarchical_context_parallel_sizes=args.hierarchical_context_parallel_sizes,
                 dynamic_context_parallel=args.dynamic_context_parallel,
                 min_dynamic_context_parallel_size=args.min_dynamic_context_parallel_size,
+                use_native_cp_transport=args.use_native_cp_transport,
                 expert_model_parallel_size=args.expert_model_parallel_size,
                 num_distributed_optimizer_instances=args.num_distributed_optimizer_instances,
                 expert_tensor_parallel_size=args.expert_tensor_parallel_size,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3651,6 +3651,7 @@ def training_log(
             mtp_num_layers=mtp_num_layers,
             pg_collection=pg_collection,
             total_loss_dict=total_loss_dict,
+            total_real_tokens=total_real_tokens_in_batch,
         )
 
     # Log MTP metrics.

--- a/tests/unit_tests/datasets/test_dcp_nvlink_scheduler.py
+++ b/tests/unit_tests/datasets/test_dcp_nvlink_scheduler.py
@@ -1,0 +1,399 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import random
+from itertools import groupby
+from math import ceil, lcm
+
+import pytest
+
+from megatron.core.datasets.data_schedule import (
+    DefaultDynamicCPScheduler,
+    _get_dynamic_cp_nvlink_domains,
+)
+from megatron.core.datasets.data_schedule_utils import (
+    _dcp_communication_overhead,
+    _dcp_communication_tokens,
+    next_hdp_group_packing_aware,
+    reorder_dcp_groups,
+)
+
+_COST = (1024.0, 2304.0)
+
+
+def _groups(layout):
+    return [(list(samples), len(list(ranks))) for samples, ranks in groupby(layout)]
+
+
+def _local_length(length, cp_size, sp_size=1):
+    alignment = cp_size * lcm(2 if cp_size > 1 else 1, sp_size)
+    return ceil(length / alignment) * alignment // cp_size
+
+
+def _layout_cost(layout, lengths, domains, sp_size=1):
+    costs = []
+    start = 0
+    for samples, cp_size in _groups(layout):
+        local_lengths = [_local_length(lengths[sid], cp_size, sp_size) for sid in samples]
+        compute = sum(length**2 * cp_size for length in local_lengths)
+        crosses = len(set(domains[start : start + cp_size])) > 1
+        extra = _dcp_communication_overhead(compute, sum(local_lengths), cp_size, crosses, _COST)
+        costs.extend([compute + extra] * cp_size)
+        start += cp_size
+    return costs
+
+
+@pytest.mark.parametrize('arbitrary', [False, True])
+@pytest.mark.parametrize('sp_size', [1, 4])
+def test_disabled_topology_preserves_every_scheduler_output(arbitrary, sp_size):
+    rng = random.Random(1729)
+    for _ in range(20):
+        parent = rng.choice([2, 4, 8, 16])
+        samples = [(sid, rng.randrange(1, parent * 256)) for sid in range(rng.randrange(1, 12))]
+        kwargs = dict(
+            total_gpus=parent,
+            max_seq_len_per_rank=256,
+            allow_arbitrary_group_starts=arbitrary,
+            sequence_parallel_size=sp_size,
+        )
+        expected = next_hdp_group_packing_aware(samples, **kwargs)
+        for domains, cost in [
+            (None, _COST),
+            ([0] * parent, _COST),
+            (list(range(parent)), (0.0, 0.0)),
+            (list(range(parent)), (1024.0, 1024.0)),
+        ]:
+            actual = next_hdp_group_packing_aware(
+                samples, **kwargs, nvlink_domains=domains, communication_cost=cost
+            )
+            assert actual == expected
+
+
+@pytest.mark.parametrize('cp_size', range(1, 17))
+def test_topology_does_not_restrict_arbitrary_cp_size(cp_size):
+    length = cp_size * 128
+    microbatches, leftovers, times, samples = next_hdp_group_packing_aware(
+        [(0, length)],
+        total_gpus=cp_size,
+        max_seq_len_per_rank=128,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[rank // 8 for rank in range(cp_size)],
+    )
+    assert not leftovers
+    assert samples == [[0]] * cp_size
+    assert microbatches == [[length]] * cp_size
+    assert times == _layout_cost(samples, {0: length}, [rank // 8 for rank in range(cp_size)])
+
+
+def test_reorder_fits_cp5_plus_cp3_inside_each_nvl8():
+    layout = [[0]] * 5 + [[1]] * 5 + [[2]] * 3 + [[3]] * 3
+    lengths = {0: 2304, 1: 2304, 2: 1408, 3: 1408}
+    domains = [0] * 8 + [1] * 8
+    result = reorder_dcp_groups(layout, lengths, domains, _COST)
+
+    assert sorted(_groups(result)) == sorted(_groups(layout))
+    assert [size for _, size in _groups(result)] == [5, 3, 5, 3]
+    assert max(_layout_cost(result, lengths, domains)) < max(_layout_cost(layout, lengths, domains))
+    start = 0
+    for _, size in _groups(result):
+        assert len(set(domains[start : start + size])) == 1
+        start += size
+    assert layout == [[0]] * 5 + [[1]] * 5 + [[2]] * 3 + [[3]] * 3
+
+
+def test_reorder_compacts_holes_without_merging_every_sample():
+    layout = [[0]] * 5 + [[]] * 3 + [[1]] * 3 + [[]] * 5
+    result = reorder_dcp_groups(layout, {0: 2304, 1: 1408}, [0] * 8 + [1] * 8, _COST)
+
+    assert len(result) == 16
+    assert all(result)
+    assert sorted(samples for samples, _ in _groups(result)) == [[0], [1]]
+    assert all(size >= minimum for (_, size), minimum in zip(sorted(_groups(result)), [5, 3]))
+
+
+@pytest.mark.parametrize('cp_size', [2, 3, 5])
+@pytest.mark.parametrize('capacity', [None, 2, 3])
+def test_reorder_rejects_cp1_expansion_that_exceeds_padded_capacity(cp_size, capacity):
+    # Each one-token sequence grows from one local row on CP1 to two zigzag
+    # rows on CP>1. A two-sequence pack therefore needs four, not two, rows.
+    layout = [[0, 1]] + [[] for _ in range(cp_size - 1)]
+    with pytest.raises(ValueError, match='per-rank token capacity'):
+        reorder_dcp_groups(
+            layout, {0: 1, 1: 1}, list(range(cp_size)), max_seq_len_per_rank=capacity
+        )
+    assert layout == [[0, 1]] + [[] for _ in range(cp_size - 1)]
+
+
+@pytest.mark.parametrize('cp_size', [2, 3, 5])
+def test_reorder_allows_cp1_expansion_when_explicit_capacity_fits_padding(cp_size):
+    result = reorder_dcp_groups(
+        [[0, 1]] + [[] for _ in range(cp_size - 1)],
+        {0: 1, 1: 1},
+        list(range(cp_size)),
+        max_seq_len_per_rank=4,
+    )
+    assert result == [[0, 1]] * cp_size
+    assert sum(_local_length(1, cp_size) for _ in result[0]) == 4
+
+
+@pytest.mark.parametrize('capacity', [None, 2])
+def test_reorder_skips_padding_unsafe_expansion_and_uses_legal_group(capacity):
+    lengths = {0: 1, 1: 1, 2: 4}
+    result = reorder_dcp_groups(
+        [[0, 1], [2], [2], []], lengths, [0, 0, 1, 1], max_seq_len_per_rank=capacity
+    )
+    assert sorted(_groups(result)) == [([0, 1], 1), ([2], 3)]
+    for samples, cp_size in _groups(result):
+        assert sum(_local_length(lengths[sid], cp_size) for sid in samples) <= 2
+
+
+def test_reorder_validates_explicit_capacity_even_without_empty_ranks():
+    layout = [[0]] * 3
+    with pytest.raises(ValueError, match='per-rank token capacity'):
+        reorder_dcp_groups(layout, {0: 13}, [0, 0, 1], max_seq_len_per_rank=5)
+    assert reorder_dcp_groups(layout, {0: 13}, [0, 0, 1], max_seq_len_per_rank=6) == layout
+
+
+@pytest.mark.parametrize('sp_size', [1, 4])
+def test_whole_group_reordering_never_increases_complete_layout_proxy(sp_size):
+    rng = random.Random(491)
+    domains = [rank // 8 for rank in range(32)]
+    for _ in range(30):
+        layout, lengths = [], {}
+        while len(layout) < len(domains):
+            cp_size = rng.randint(1, len(domains) - len(layout))
+            samples = list(range(len(lengths), len(lengths) + rng.randint(1, 3)))
+            lengths.update({sid: rng.randint(1, 8192) for sid in samples})
+            layout.extend([list(samples) for _ in range(cp_size)])
+        result = reorder_dcp_groups(layout, lengths, domains, _COST, sp_size)
+        before = _layout_cost(layout, lengths, domains, sp_size)
+        after = _layout_cost(result, lengths, domains, sp_size)
+        assert (max(after), sum(after)) <= (max(before), sum(before))
+        assert sorted(_groups(result)) == sorted(_groups(layout))
+
+
+@pytest.mark.parametrize('sp_size', [1, 2, 4, 8])
+def test_cross_domain_scheduler_respects_padded_token_capacity(sp_size):
+    lengths = {0: 2040, 1: 128}
+    _, leftovers, times, layout = next_hdp_group_packing_aware(
+        list(lengths.items()),
+        total_gpus=6,
+        max_seq_len_per_rank=510,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=sp_size,
+        nvlink_domains=[0] * 3 + [1] * 3,
+    )
+
+    assert not leftovers
+    assert sorted(samples for samples, _ in _groups(layout)) == [[0], [1]]
+    for samples, cp_size in _groups(layout):
+        local_lengths = [_local_length(lengths[sid], cp_size, sp_size) for sid in samples]
+        assert sum(local_lengths) <= 510
+        assert all(length % sp_size == 0 for length in local_lengths)
+    assert times == _layout_cost(layout, lengths, [0] * 3 + [1] * 3, sp_size)
+
+
+def test_packed_sequences_recompute_exposed_communication_once():
+    # The long sequence's computation hides the short one's transfer in the same
+    # packed attention call. Summing independent per-sequence penalties is wrong.
+    long_compute = 4096**2 * 4
+    short_compute = 128**2 * 4
+    assert _dcp_communication_overhead(short_compute, 128, 4, True, _COST) > 0
+    assert _dcp_communication_overhead(long_compute + short_compute, 4224, 4, True, _COST) == 0
+    _, leftovers, times, layout = next_hdp_group_packing_aware(
+        [(0, 16384), (1, 512)],
+        total_gpus=4,
+        max_seq_len_per_rank=8192,
+        min_cp_size=4,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[0, 0, 1, 1],
+    )
+    assert not leftovers
+    assert layout == [[0, 1]] * 4
+    assert times == [long_compute + short_compute] * 4
+
+
+@pytest.mark.parametrize(
+    'local_tokens,alignment,expected',
+    [
+        (1, None, 1),
+        (511, None, 511),
+        (4096, None, 4096),
+        (1, 256, 256),
+        (255, 256, 256),
+        (256, 256, 256),
+        (257, 256, 512),
+        (4096, 256, 4096),
+        (1, 'max', 4096),
+        (511, 'max', 4096),
+        (4096, 'max', 4096),
+    ],
+)
+def test_communication_payload_counts_padding(local_tokens, alignment, expected):
+    assert _dcp_communication_tokens(local_tokens, 4096, alignment) == expected
+
+
+@pytest.mark.parametrize('alignment,payload', [(None, 500), (512, 512), ('max', 4096)])
+def test_cp5_communication_uses_actual_padded_payload_not_valid_tokens(alignment, payload):
+    # Both sequences share one CP5 pack: 400 + 100 valid local rows, but max
+    # padding sends the full 4096-row communication buffer on every ring hop.
+    compute = (400**2 + 100**2) * 5
+    _, leftovers, times, layout = next_hdp_group_packing_aware(
+        [(0, 2000), (1, 500)],
+        total_gpus=5,
+        max_seq_len_per_rank=4096,
+        min_cp_size=5,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[0, 0, 0, 0, 1],
+        padding_alignment=alignment,
+    )
+    expected_extra = _dcp_communication_overhead(compute, payload, 5, True, _COST)
+    assert not leftovers
+    assert layout == [[0, 1]] * 5
+    assert times == [compute + expected_extra] * 5
+    if alignment == 'max':
+        unpadded_extra = _dcp_communication_overhead(compute, 500, 5, True, _COST)
+        assert expected_extra > 8 * unpadded_extra
+
+
+@pytest.mark.parametrize('alignment,payload', [(None, 3100), (1024, 4096), ('max', 4096)])
+def test_padded_payload_overhead_uses_whole_pack_compute_overlap(alignment, payload):
+    # A long sequence hides most of the fixed-buffer transfer; packing a short
+    # sequence must recompute that overlap, not charge a second buffer transfer.
+    per_sequence_compute = [3000**2 * 5, 100**2 * 5]
+    compute = sum(per_sequence_compute)
+    _, leftovers, times, layout = next_hdp_group_packing_aware(
+        [(0, 15000), (1, 500)],
+        total_gpus=5,
+        max_seq_len_per_rank=4096,
+        min_cp_size=5,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[0, 0, 0, 0, 1],
+        padding_alignment=alignment,
+    )
+    expected_extra = _dcp_communication_overhead(compute, payload, 5, True, _COST)
+    incorrectly_summed = sum(
+        _dcp_communication_overhead(
+            work, _dcp_communication_tokens(tokens, 4096, alignment), 5, True, _COST
+        )
+        for work, tokens in zip(per_sequence_compute, [3000, 100])
+    )
+    assert not leftovers
+    assert layout == [[0, 1]] * 5
+    assert times == [compute + expected_extra] * 5
+    assert expected_extra < incorrectly_summed
+    assert (expected_extra > 0) == (alignment is not None)
+
+
+def test_integer_payload_padding_rounds_the_pack_once():
+    compute = 2 * 100**2 * 5
+    _, leftovers, times, layout = next_hdp_group_packing_aware(
+        [(0, 500), (1, 500)],
+        total_gpus=5,
+        max_seq_len_per_rank=4096,
+        min_cp_size=5,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[0, 0, 0, 0, 1],
+        padding_alignment=256,
+    )
+    # ceil((100 + 100) / 256) * 256, not two separately rounded 256-row payloads.
+    assert not leftovers
+    assert layout == [[0, 1]] * 5
+    assert times == [compute + _dcp_communication_overhead(compute, 256, 5, True, _COST)] * 5
+    assert times != [compute + _dcp_communication_overhead(compute, 512, 5, True, _COST)] * 5
+
+
+@pytest.mark.parametrize('crosses', [False, True])
+@pytest.mark.parametrize('cp_size', [1, 3, 8, 16])
+def test_communication_overhead_matches_exposed_ring_steps(crosses, cp_size):
+    compute, tokens = 16384.0, 128
+    expected = (cp_size - 1) * (
+        max(compute / cp_size, _COST[1] * tokens) - max(compute / cp_size, _COST[0] * tokens)
+    )
+    assert _dcp_communication_overhead(compute, tokens, cp_size, crosses, _COST) == (
+        expected if crosses else 0
+    )
+    assert _dcp_communication_overhead(1e12, tokens, cp_size, crosses, _COST) == 0
+    assert _dcp_communication_overhead(compute, tokens, cp_size, crosses, (0.0, 0.0)) == 0
+
+
+@pytest.mark.parametrize(
+    'cost', [(-1.0, 2.0), (2.0, 1.0), (float('nan'), 2.0), (1.0, float('inf')), (1.0,)]
+)
+def test_scheduler_rejects_invalid_communication_cost(cost):
+    with pytest.raises(ValueError):
+        next_hdp_group_packing_aware(
+            [(0, 128)],
+            2,
+            128,
+            allow_arbitrary_group_starts=True,
+            nvlink_domains=[0, 1],
+            communication_cost=cost,
+        )
+
+
+@pytest.mark.parametrize('domains', [[], [0], [0, 1, 2]])
+def test_scheduler_rejects_wrong_domain_vector_size(domains):
+    with pytest.raises(ValueError):
+        next_hdp_group_packing_aware(
+            [(0, 128)], 2, 128, allow_arbitrary_group_starts=True, nvlink_domains=domains
+        )
+
+
+def test_topology_aware_scheduler_rejects_legacy_real_group_placement():
+    with pytest.raises(ValueError, match='arbitrary logical CP groups'):
+        next_hdp_group_packing_aware(
+            [(0, 128)], 2, 128, allow_arbitrary_group_starts=False, nvlink_domains=[0, 1]
+        )
+
+
+@pytest.mark.parametrize('tp_size,pp_size,parent', [(1, 1, 16), (2, 2, 8), (4, 3, 8), (2, 2, 3)])
+def test_nvlink_domains_are_consistent_across_tp_and_pp_planes(tp_size, pp_size, parent):
+    # Include a non-node-aligned PP stride: TP2 x parent3 x PP2 needs a
+    # conservative boundary from the second PP plane even on the first plane.
+    results = []
+    stride = tp_size * parent
+    for pp in range(pp_size):
+        for tp in range(tp_size):
+            offset = pp * stride + tp
+            for dp in range(parent):
+                results.append(
+                    _get_dynamic_cp_nvlink_domains(
+                        list(range(offset, offset + stride, tp_size)),
+                        list(range(pp * stride + dp * tp_size, pp * stride + (dp + 1) * tp_size)),
+                        [stage * stride + dp * tp_size + tp for stage in range(pp_size)],
+                        offset + dp * tp_size,
+                        stride * pp_size,
+                        8,
+                    )
+                )
+    boundaries = [
+        any(
+            (pp * stride + tp + (dp - 1) * tp_size) // 8 != (pp * stride + tp + dp * tp_size) // 8
+            for pp in range(pp_size)
+            for tp in range(tp_size)
+        )
+        for dp in range(1, parent)
+    ]
+    expected = [sum(boundaries[:dp]) for dp in range(parent)]
+    assert results == [expected] * (tp_size * pp_size * parent)
+
+
+def test_vpp_alignment_keeps_all_samples_after_topology_reordering():
+    lengths = {0: 2304, 1: 2304, 2: 1408, 3: 1408}
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=512,
+        cp_size=16,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=2,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=[0] * 8 + [1] * 8,
+    )
+    layouts = scheduler.get_groups_and_subsamples(list(lengths.items()))
+    assert len(layouts) % 2 == 0
+    seen = []
+    for layout in layouts:
+        assert len(layout) == 16 and all(layout)
+        for samples, cp_size in _groups(layout):
+            seen.extend(samples)
+            assert sum(_local_length(lengths[sid], cp_size) for sid in samples) <= 512
+    assert sorted(seen) == sorted(lengths)

--- a/tests/unit_tests/datasets/test_dcp_nvlink_scheduler.py
+++ b/tests/unit_tests/datasets/test_dcp_nvlink_scheduler.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import random
-from itertools import groupby
+from itertools import groupby, product
 from math import ceil, lcm
 
 import pytest
@@ -13,6 +13,7 @@ from megatron.core.datasets.data_schedule import (
 from megatron.core.datasets.data_schedule_utils import (
     _dcp_communication_overhead,
     _dcp_communication_tokens,
+    align_sample_id_groups,
     next_hdp_group_packing_aware,
     reorder_dcp_groups,
 )
@@ -29,14 +30,15 @@ def _local_length(length, cp_size, sp_size=1):
     return ceil(length / alignment) * alignment // cp_size
 
 
-def _layout_cost(layout, lengths, domains, sp_size=1):
+def _layout_cost(layout, lengths, domains, sp_size=1, padding_alignment=None, capacity=None):
     costs = []
     start = 0
     for samples, cp_size in _groups(layout):
         local_lengths = [_local_length(lengths[sid], cp_size, sp_size) for sid in samples]
         compute = sum(length**2 * cp_size for length in local_lengths)
         crosses = len(set(domains[start : start + cp_size])) > 1
-        extra = _dcp_communication_overhead(compute, sum(local_lengths), cp_size, crosses, _COST)
+        tokens = _dcp_communication_tokens(sum(local_lengths), capacity, padding_alignment)
+        extra = _dcp_communication_overhead(compute, tokens, cp_size, crosses, _COST)
         costs.extend([compute + extra] * cp_size)
         start += cp_size
     return costs
@@ -66,6 +68,29 @@ def test_disabled_topology_preserves_every_scheduler_output(arbitrary, sp_size):
                 samples, **kwargs, nvlink_domains=domains, communication_cost=cost
             )
             assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'domains,cost',
+    [([0] * 8, _COST), ([0] * 4 + [1] * 4, (1024.0, 1024.0)), ([0] * 4 + [1] * 4, (0.0, 0.0))],
+)
+@pytest.mark.parametrize('padding', [None, 'max'])
+def test_single_domain_keeps_three_sequences_in_one_cp8_pack(domains, cost, padding):
+    # Rebalancing before the legacy full-parent packing fallback would split
+    # this into two rounds, despite all three sequences fitting one CP8 pack.
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=4096,
+        cp_size=8,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=None,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=domains,
+        communication_cost=cost,
+        padding_alignment=padding,
+    )
+    assert scheduler.get_groups_and_subsamples([(sid, 8193) for sid in range(3)]) == [
+        [[0, 1, 2]] * 8
+    ]
 
 
 @pytest.mark.parametrize('cp_size', range(1, 17))
@@ -151,6 +176,88 @@ def test_reorder_validates_explicit_capacity_even_without_empty_ranks():
     with pytest.raises(ValueError, match='per-rank token capacity'):
         reorder_dcp_groups(layout, {0: 13}, [0, 0, 1], max_seq_len_per_rank=5)
     assert reorder_dcp_groups(layout, {0: 13}, [0, 0, 1], max_seq_len_per_rank=6) == layout
+
+
+@pytest.mark.parametrize('sp_size', [1, 4])
+@pytest.mark.parametrize('padding', [None, 'max'])
+def test_spare_ranks_are_distributed_across_all_packs(sp_size, padding):
+    # Giving all eight spare ranks to one CP3 pack creates CP11 and leaves
+    # seven slow CP3 packs. CP4 for each pack fills all four NVL8 domains.
+    layout = [[sid] for sid in range(8) for _ in range(3)] + [[] for _ in range(8)]
+    result = reorder_dcp_groups(
+        layout,
+        {sid: 4096 for sid in range(8)},
+        [rank // 8 for rank in range(32)],
+        sequence_parallel_size=sp_size,
+        max_seq_len_per_rank=2048,
+        padding_alignment=padding,
+    )
+    assert result == [[sid] for sid in range(8) for _ in range(4)]
+
+
+def test_rank_allocation_optimizes_total_work_under_the_final_bottleneck():
+    # A later pack sets max=147456. Keeping only one lexicographic prefix state
+    # incorrectly chooses CP2+2+4 (sum=688192); the exact tie is CP1+3+4.
+    lengths, domains = {0: 243, 1: 188, 2: 758}, [0] * 4 + [1] * 4
+    result = reorder_dcp_groups(
+        [[0], [1], [2], [2]] + [[] for _ in range(4)],
+        lengths,
+        domains,
+        sequence_parallel_size=4,
+        max_seq_len_per_rank=512,
+    )
+    assert sorted(_groups(result)) == [([0], 1), ([1], 3), ([2], 4)]
+    costs = _layout_cost(result, lengths, domains, 4)
+    assert (max(costs), sum(costs)) == (147456, 686224)
+
+
+def test_rank_allocation_considers_group_order_before_filling_spare_ranks():
+    # NVL8 plus a four-rank tail: keeping pack order forces CP7+5 across the
+    # boundary. Ordering the larger group first permits domain-local CP8+4.
+    lengths = {0: 336, 1: 282, 2: 345, 3: 390, 4: 390}
+    domains = [0] * 8 + [1] * 4
+    result = reorder_dcp_groups(
+        [[0, 1]] * 3 + [[2, 3, 4]] * 5 + [[] for _ in range(4)],
+        lengths,
+        domains,
+        sequence_parallel_size=4,
+        max_seq_len_per_rank=256,
+        padding_alignment=256,
+    )
+    assert result == [[2, 3, 4]] * 8 + [[0, 1]] * 4
+    costs = _layout_cost(result, lengths, domains, 4, 256, 256)
+    assert (max(costs), sum(costs)) == (58752, 665856)
+
+
+@pytest.mark.parametrize('sp_size', [1, 4])
+@pytest.mark.parametrize('padding', [None, 'max'])
+def test_rank_allocation_matches_bounded_fixed_order_oracle(sp_size, padding):
+    # Exhaustion is intentionally confined to this tiny CPU test, never used
+    # by the training scheduler. Whole-pack reordering may improve further.
+    rng, domains = random.Random(58085), [0] * 4 + [1] * 4
+    for _ in range(10):
+        lengths = {0: rng.randint(1, 512), 1: rng.randint(1, 512), 2: rng.randint(512, 1024)}
+        candidates = []
+        for extras in product(range(5), repeat=3):
+            if sum(extras) != 4:
+                continue
+            sizes = [minimum + extra for minimum, extra in zip([1, 1, 2], extras)]
+            if any(_local_length(lengths[sid], cp, sp_size) > 512 for sid, cp in enumerate(sizes)):
+                continue
+            layout = [[sid] for sid, cp in enumerate(sizes) for _ in range(cp)]
+            costs = _layout_cost(layout, lengths, domains, sp_size, padding, 512)
+            candidates.append((max(costs), sum(costs)))
+        result = reorder_dcp_groups(
+            [[0], [1], [2], [2]] + [[] for _ in range(4)],
+            lengths,
+            domains,
+            sequence_parallel_size=sp_size,
+            max_seq_len_per_rank=512,
+            padding_alignment=padding,
+        )
+        costs = _layout_cost(result, lengths, domains, sp_size, padding, 512)
+        assert (max(costs), sum(costs)) <= min(candidates)
+        assert sorted(samples for samples, _ in _groups(result)) == [[0], [1], [2]]
 
 
 @pytest.mark.parametrize('sp_size', [1, 4])
@@ -397,3 +504,82 @@ def test_vpp_alignment_keeps_all_samples_after_topology_reordering():
             seen.extend(samples)
             assert sum(_local_length(lengths[sid], cp_size) for sid in samples) <= 512
     assert sorted(seen) == sorted(lengths)
+
+
+@pytest.mark.parametrize('sp_size', [1, 4])
+@pytest.mark.parametrize('padding', [None, 'max'])
+def test_vpp_split_allocates_spare_ranks_before_expansion_is_locked_in(sp_size, padding):
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=1024,
+        cp_size=16,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=2,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=sp_size,
+        nvlink_domains=[0] * 8 + [1] * 8,
+        padding_alignment=padding,
+    )
+    result = scheduler.get_groups_and_subsamples([(sid, 4096) for sid in range(4)])
+    assert result == [[[2]] * 8 + [[3]] * 8, [[0]] * 8 + [[1]] * 8]
+    assert sorted(
+        sid for layout in result for samples, _ in _groups(layout) for sid in samples
+    ) == list(range(4))
+
+
+def test_missing_topology_vpp_keeps_legacy_fill_instead_of_noop_callback():
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=1024,
+        cp_size=16,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=2,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=None,
+    )
+    result = scheduler.get_groups_and_subsamples([(sid, 4096) for sid in range(4)])
+    # Exact legacy a9b7cb530 output. A disabled reorder callback would return
+    # holes here; the callback must be omitted so the legacy CP4+12 fill runs.
+    assert result == [[[2]] * 4 + [[3]] * 12, [[0]] * 4 + [[1]] * 12]
+    assert all(all(layout) for layout in result)
+
+
+@pytest.mark.parametrize(
+    'domains,cost',
+    [([0] * 16, _COST), ([0] * 8 + [1] * 8, (1024.0, 1024.0)), ([0] * 8 + [1] * 8, (0.0, 0.0))],
+)
+def test_zero_network_penalty_vpp_preserves_legacy_fill(domains, cost):
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=1024,
+        cp_size=16,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=2,
+        allow_arbitrary_group_starts=True,
+        nvlink_domains=domains,
+        communication_cost=cost,
+    )
+    result = scheduler.get_groups_and_subsamples([(sid, 4096) for sid in range(4)])
+    assert result == [[[2]] * 4 + [[3]] * 12, [[0]] * 4 + [[1]] * 12]
+    assert all(all(layout) for layout in result)
+    assert sorted(
+        sid for layout in result for samples, _ in _groups(layout) for sid in samples
+    ) == list(range(4))
+
+
+def test_vpp_fill_callback_observes_unexpanded_split_groups():
+    seen = []
+
+    def fill(layout):
+        seen.append([list(samples) for samples in layout])
+        return reorder_dcp_groups(
+            layout, {sid: 4096 for sid in range(4)}, [0] * 8 + [1] * 8, max_seq_len_per_rank=1024
+        )
+
+    result = align_sample_id_groups(
+        [[[sid] for sid in range(4) for _ in range(4)]],
+        2,
+        allow_arbitrary_group_starts=True,
+        fill_empty_ranks=fill,
+    )
+    assert len(seen) == 2
+    assert all(sum(not samples for samples in layout) == 8 for layout in seen)
+    assert all([cp for samples, cp in _groups(layout) if samples] == [4, 4] for layout in seen)
+    assert all([cp for _, cp in _groups(layout)] == [8, 8] for layout in result)

--- a/tests/unit_tests/test_parallel_state.py
+++ b/tests/unit_tests/test_parallel_state.py
@@ -584,6 +584,30 @@ def test_legacy_dynamic_cp_groups_remain_power_of_two(monkeypatch):
     assert groups == {1: (0,), 2: (0, 1), 4: (0, 1, 2, 3)}
 
 
+@pytest.mark.parametrize("parent_size", [1, 3, 6, 8, 10, 12, 14, 16])
+@pytest.mark.parametrize("min_cp_size", [1, 2])
+def test_legacy_dynamic_cp_groups_preserve_layouts_and_tails(monkeypatch, parent_size, min_cp_size):
+    """Every legacy rank must retain the layouts requested by initialization warmup."""
+    monkeypatch.setattr(ps, "create_group", lambda ranks, **_kwargs: tuple(ranks))
+    sizes = [2**i for i in range(int(math.log2(parent_size))) if 2**i >= min_cp_size]
+    for parent_rank in range(parent_size):
+        groups = ps.create_dynamic_dp_cp_groups(
+            rank=parent_rank,
+            ranks=list(range(parent_size)),
+            pg_options=None,
+            min_cp_size=min_cp_size,
+        )
+        expected = {
+            size: tuple(
+                range(
+                    parent_rank // size * size, min((parent_rank // size + 1) * size, parent_size)
+                )
+            )
+            for size in sizes
+        }
+        assert groups == expected
+
+
 def test_native_dynamic_cp_group_can_start_at_noncanonical_tail(monkeypatch):
     monkeypatch.setattr(ps, "_DYNAMIC_DP_CP_GROUPS", {})
     monkeypatch.setattr(ps, "get_data_parallel_group", lambda **_kwargs: object())

--- a/tests/unit_tests/test_parallel_state.py
+++ b/tests/unit_tests/test_parallel_state.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
-from math import log2
+import math
 
 import pytest
 import torch
 
 import megatron.core.parallel_state as ps
+from megatron.core.dynamic_cp_group import LogicalCPGroup, build_bounded_peer_ring
 from megatron.core.process_groups_config import ProcessGroupCollection
 from tests.unit_tests.test_utilities import Utils
 
@@ -525,12 +526,74 @@ def test_dynamic_dp_cp_groups(world_size, tp_size, cp_size, dp_size):
     )
 
     dp_cp_size = ps.get_data_parallel_world_size(with_context_parallel=True)
-    group_sizes = [2**i for i in range(int(log2(dp_cp_size)))]
+    dp_cp_rank = ps.get_data_parallel_rank(with_context_parallel=True)
+    group_sizes = [2**i for i in range(int(math.log2(dp_cp_size)))]
     for group_size in group_sizes:
+        if dp_cp_rank >= dp_cp_size - dp_cp_size % group_size:
+            continue
         group = ps.get_dynamic_data_context_parallel_groups(group_size=group_size)
         assert group.size() == group_size
 
     Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize(
+    ("group_start", "cp_size", "expected"),
+    [(0, 3, (0, 1, 2)), (0, 6, (0, 1, 3, 5, 4, 2)), (1, 5, (1, 3, 5, 4, 2))],
+)
+def test_bounded_dynamic_cp_ring(group_start, cp_size, expected):
+    assert build_bounded_peer_ring(range(16), group_start, cp_size) == expected
+
+
+def test_bounded_dynamic_cp_ring_peer_degree():
+    peers = [set() for _ in range(16)]
+    for cp_size in range(1, 17):
+        for group_start in range(0, 17 - cp_size):
+            ring = build_bounded_peer_ring(range(16), group_start, cp_size)
+            assert set(ring) == set(range(group_start, group_start + cp_size))
+            if cp_size == 1:
+                continue
+            for src, dst in zip(ring, ring[1:] + ring[:1]):
+                assert abs(src - dst) <= 2
+                peers[src].add(dst)
+                peers[dst].add(src)
+    assert max(map(len, peers)) == 4
+
+
+def test_native_dynamic_cp_groups_are_logical_and_include_parent(monkeypatch):
+    monkeypatch.setattr(
+        ps, "create_group", lambda *_args, **_kwargs: pytest.fail("created a ProcessGroup")
+    )
+
+    groups = ps.create_dynamic_dp_cp_groups(
+        rank=3, ranks=list(range(8)), pg_options=None, use_logical_groups=True
+    )
+
+    assert isinstance(groups[8], LogicalCPGroup)
+    assert groups[8].ranks == (0, 1, 3, 5, 7, 6, 4, 2)
+    assert groups[8].rank() == 2
+
+
+def test_legacy_dynamic_cp_groups_remain_power_of_two(monkeypatch):
+    monkeypatch.setattr(ps, "create_group", lambda ranks, **_kwargs: tuple(ranks))
+
+    groups = ps.create_dynamic_dp_cp_groups(
+        rank=0, ranks=list(range(8)), pg_options=None, use_logical_groups=False
+    )
+
+    assert groups == {1: (0,), 2: (0, 1), 4: (0, 1, 2, 3)}
+
+
+def test_native_dynamic_cp_group_can_start_at_noncanonical_tail(monkeypatch):
+    monkeypatch.setattr(ps, "_DYNAMIC_DP_CP_GROUPS", {})
+    monkeypatch.setattr(ps, "get_data_parallel_group", lambda **_kwargs: object())
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _group: list(range(8)))
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 7)
+
+    group = ps.get_dynamic_data_context_parallel_groups(group_size=3, group_start=5)
+
+    assert group.ranks == (5, 7, 6)
+    assert group.rank() == 1
 
 
 def test_separate_all_gather_group():

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -12,12 +12,15 @@ from megatron.core.datasets import data_schedule
 from megatron.core.datasets.data_schedule import (
     DefaultDynamicCPScheduler,
     _build_thd_padding_mask,
+    _build_thd_sequence_indices,
     _get_scheduler_max_real_num_seqs,
     _sanitize_thd_padding_values,
     get_batch_on_this_rank_for_sequence_packing,
     wrap_data_iterator,
 )
 from megatron.core.datasets.data_schedule_utils import (
+    _pack_sequences,
+    dcp_gpus_needed,
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
 )
@@ -63,6 +66,10 @@ def test_scheduler_thd_padding_mask_from_cu_seqlens():
     assert torch.equal(
         padding_mask, torch.tensor([False, False, False, True, False, False, True, True])
     )
+    assert torch.equal(
+        _build_thd_sequence_indices(cu_seqlens_padded),
+        torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32),
+    )
 
 
 def test_scheduler_sanitizes_thd_padding_values():
@@ -80,6 +87,24 @@ def test_scheduler_sanitizes_thd_padding_values():
     assert torch.equal(batch['labels'], torch.tensor([12, 13, 0, 22, 0]))
     assert torch.equal(batch['loss_mask'], torch.tensor([1.0, 1.0, 0.0, 1.0, 0.0]))
     assert torch.equal(batch['position_ids'], torch.tensor([0, 1, 0, 0, 0]))
+
+
+def test_pack_sequences_aligns_each_sequence_to_local_cp_size():
+    samples = [{'tokens': torch.arange(1, 6)}, {'tokens': torch.arange(6, 10)}]
+
+    packed = _pack_sequences(
+        samples,
+        padded_lengths=torch.tensor([5, 4]),
+        original_lengths=torch.tensor([5, 4]),
+        local_cp_size=torch.tensor(3),
+        local_cp_group_start=torch.tensor(2),
+        dev=torch.device('cpu'),
+    )
+
+    assert torch.equal(packed['tokens'], torch.tensor([1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 0, 0]))
+    assert torch.equal(packed['cu_seqlens'], torch.tensor([0, 5, 9], dtype=torch.int32))
+    assert torch.equal(packed['cu_seqlens_padded'], torch.tensor([0, 6, 12], dtype=torch.int32))
+    assert packed['local_cp_group_start'].item() == 2
 
 
 def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
@@ -699,6 +724,66 @@ def test_next_hdp_group_packing_aware_can_use_larger_cp_group_for_short_sequence
     assert micro_batches == [[6144, 2048], [6144, 2048]]
     assert sample_ids == [[0, 1], [0, 1]]
     assert exec_times[0] == exec_times[1]
+
+
+def test_next_hdp_group_packing_aware_keeps_legacy_tie_break():
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 128), (1, 5504), (2, 3840)], total_gpus=8, max_seq_len_per_rank=2048, min_cp_size=2
+    )
+
+    assert leftovers == []
+    assert sample_ids == [[1]] * 4 + [[2, 0]] * 4
+
+
+def test_next_hdp_group_packing_aware_uses_topology_compatible_nonpower_cp_size():
+    assert dcp_gpus_needed(257, 128) == 4
+    assert dcp_gpus_needed(257, 128, round_to_power_of_two=False) == 3
+
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 1280), (1, 512), (2, 256)],
+        total_gpus=16,
+        max_seq_len_per_rank=128,
+        allow_arbitrary_group_starts=True,
+    )
+
+    assert leftovers == []
+    assert sample_ids == [[0]] * 10 + [[1]] * 4 + [[2]] * 2
+
+
+def test_next_hdp_group_packing_aware_uses_exact_cp3():
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 384), (1, 128)],
+        total_gpus=4,
+        max_seq_len_per_rank=128,
+        allow_arbitrary_group_starts=True,
+    )
+
+    assert leftovers == []
+    assert sample_ids == [[0], [0], [0], [1]]
+
+
+def test_next_hdp_group_packing_aware_allows_cp5_plus_tail_cp3():
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 2304), (1, 1408)],
+        total_gpus=8,
+        max_seq_len_per_rank=512,
+        allow_arbitrary_group_starts=True,
+    )
+
+    assert leftovers == []
+    assert sample_ids == [[0]] * 5 + [[1]] * 3
+
+
+def test_next_hdp_group_packing_aware_supports_every_cp_size_through_16():
+    for cp_size in range(1, 17):
+        _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+            [(0, cp_size * 128)],
+            total_gpus=cp_size,
+            max_seq_len_per_rank=128,
+            allow_arbitrary_group_starts=True,
+        )
+        assert leftovers == []
+        assert sample_ids == [[0]] * cp_size
 
 
 def test_next_hdp_group_packing_aware_fills_non_power_of_two_dpxcp_group():

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -20,6 +20,8 @@ from megatron.core.datasets.data_schedule import (
 )
 from megatron.core.datasets.data_schedule_utils import (
     _pack_sequences,
+    align_sample_id_groups,
+    build_packed_microbatches,
     dcp_gpus_needed,
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
@@ -105,6 +107,74 @@ def test_pack_sequences_aligns_each_sequence_to_local_cp_size():
     assert torch.equal(packed['cu_seqlens'], torch.tensor([0, 5, 9], dtype=torch.int32))
     assert torch.equal(packed['cu_seqlens_padded'], torch.tensor([0, 6, 12], dtype=torch.int32))
     assert packed['local_cp_group_start'].item() == 2
+
+
+@pytest.mark.parametrize('sequence_parallel_size', [1, 2, 4, 8])
+def test_arbitrary_cp_packing_preserves_sequence_parallel_alignment(sequence_parallel_size):
+    samples = {
+        sid: {
+            'tokens': torch.arange(length),
+            'padded_seq_len': torch.tensor(length),
+            'original_seq_len': torch.tensor(length),
+        }
+        for sid, length in enumerate([1408, 128])
+    }
+    microbatches, leftovers, exec_times, sample_ids = next_hdp_group_packing_aware(
+        [(0, 1408), (1, 128)],
+        total_gpus=4,
+        max_seq_len_per_rank=512,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=sequence_parallel_size,
+    )
+    assert not leftovers
+    assert sample_ids == [[0]] * 3 + [[1]]
+    for rank in range(4):
+        packed = build_packed_microbatches(
+            samples,
+            [sample_ids],
+            rank,
+            torch.device('cpu'),
+            is_dynamic_cp=True,
+            sequence_parallel_size=sequence_parallel_size,
+        )[0]
+        cp_size = packed['local_cp_size'].item()
+        local_rows = packed['tokens'].numel() // cp_size
+        assert local_rows % sequence_parallel_size == 0
+        assert local_rows <= 512
+        assert exec_times[rank] == local_rows**2 * cp_size
+        assert packed['cu_seqlens'][-1].item() == sum(microbatches[rank])
+
+
+def test_arbitrary_cp_scheduler_accounts_for_sp_padding_at_capacity_boundary():
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 1536)],
+        total_gpus=3,
+        max_seq_len_per_rank=515,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=8,
+    )
+    # CP3 fits (512 local rows); 1540 would require 520 aligned rows on CP3.
+    assert not leftovers
+    assert sample_ids == [[0]] * 3
+    with pytest.raises(AssertionError, match='requires CP size 4'):
+        next_hdp_group_packing_aware(
+            [(0, 1540)],
+            total_gpus=3,
+            max_seq_len_per_rank=515,
+            allow_arbitrary_group_starts=True,
+            sequence_parallel_size=8,
+        )
+
+    _, leftovers, _, sample_ids = next_hdp_group_packing_aware(
+        [(0, 2040), (1, 128)],
+        total_gpus=6,
+        max_seq_len_per_rank=510,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=8,
+    )
+    # Raw CP4 would exceed capacity after SP padding (512 > 510), so use CP5.
+    assert not leftovers
+    assert sample_ids == [[0]] * 5 + [[1]]
 
 
 def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
@@ -772,6 +842,43 @@ def test_next_hdp_group_packing_aware_allows_cp5_plus_tail_cp3():
 
     assert leftovers == []
     assert sample_ids == [[0]] * 5 + [[1]] * 3
+
+
+def test_native_dcp_vpp_alignment_handles_cp5_plus_cp3():
+    scheduler = DefaultDynamicCPScheduler(
+        max_seqlen_per_dp_cp_rank=512,
+        cp_size=8,
+        dp_size=1,
+        microbatch_group_size_per_vp_stage=2,
+        allow_arbitrary_group_starts=True,
+        sequence_parallel_size=4,
+    )
+
+    groups = scheduler.get_groups_and_subsamples([(0, 2304), (1, 1408)])
+
+    assert groups == [[[1]] * 8, [[0]] * 8]
+
+
+def test_vpp_alignment_rejects_layout_that_cannot_expand():
+    with pytest.raises(RuntimeError, match='Cannot fill VPP ranks'):
+        align_sample_id_groups([[[0]] * 5 + [[1]] * 3], 2)
+
+
+@pytest.mark.parametrize('group_sizes', [[5, 3], [1, 7], [3, 5], [3, 3, 1, 1], [5, 4, 3, 2, 1, 1]])
+def test_native_dcp_vpp_alignment_preserves_each_sample_once(group_sizes):
+    parent_size = sum(group_sizes)
+    initial_group = [[sid] for sid, size in enumerate(group_sizes) for _ in range(size)]
+    groups = align_sample_id_groups(
+        [initial_group], len(group_sizes), allow_arbitrary_group_starts=True
+    )
+
+    assert len(groups) == len(group_sizes)
+    sample_ids = []
+    for group in groups:
+        assert len(group) == parent_size
+        assert all(rank_samples == group[0] for rank_samples in group)
+        sample_ids.extend(group[0])
+    assert sorted(sample_ids) == list(range(len(group_sizes)))
 
 
 def test_next_hdp_group_packing_aware_supports_every_cp_size_through_16():

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -514,6 +514,101 @@ class TestRouterAuxLoss:
         torch.testing.assert_close(packed_metric, separate_metric)
 
     @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("cp_size", [1, 2])
+    @pytest.mark.parametrize("mask_tail", [False, True])
+    @pytest.mark.parametrize("pad_metadata", [False, True])
+    def test_packed_seq_aux_loss_implicit_tail(self, cp_size, mask_tail, pad_metadata):
+        """An implicit tail must match an explicit sequence on every CP shard."""
+        from megatron.core.packed_seq_params import PackedSeqParams
+
+        Utils.initialize_model_parallel(context_parallel_size=cp_size)
+        router = self.new_router(
+            moe_router_load_balancing_type="seq_aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp64",
+            calculate_per_token_loss=True,
+            params_dtype=torch.float32,
+            bf16=False,
+            context_parallel_size=cp_size,
+        ).cuda()
+        local_rows = 8 // cp_size
+        start = router.cp_group.rank() * local_rows
+        hidden_states = torch.randn(
+            (local_rows, 1, router.config.hidden_size), device="cuda", dtype=torch.float32
+        )
+        padding_mask = (torch.arange(start, start + local_rows, device="cuda") >= 4).view(-1, 1)
+        if not mask_tail:
+            padding_mask.zero_()
+
+        def run(boundaries):
+            cu = torch.tensor(boundaries, device="cuda", dtype=torch.int32)
+            params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu,
+                cu_seqlens_q_padded=torch.cat((cu, cu[-1:].repeat(2))) if pad_metadata else None,
+                total_tokens=8,
+            )
+            # At CP2 only rank 1 owns the implicit tail; reduction shapes must still agree.
+            params.seq_idx = params.seq_idx[:, start : start + local_rows].contiguous()
+            clear_aux_losses_tracker()
+            router.weight.grad = None
+            scores, _ = router(hidden_states, padding_mask=padding_mask, packed_seq_params=params)
+            scores.backward(torch.zeros_like(scores))
+            metric = get_moe_layer_wise_logging_tracker()["seq_load_balancing_loss"][
+                "values"
+            ].clone()
+            return router.weight.grad.clone(), metric
+
+        explicit_grad, explicit_metric = run([0, 2, 4, 8])
+        implicit_grad, implicit_metric = run([0, 2, 4])
+        torch.testing.assert_close(implicit_grad, explicit_grad)
+        torch.testing.assert_close(implicit_metric, explicit_metric)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_packed_seq_aux_loss_repeated_mtp_scales_metric_and_gradient(self, monkeypatch):
+        from megatron.core.packed_seq_params import PackedSeqParams
+        from megatron.core.transformer.moe import moe_logging
+
+        # Earlier cases use one metric slot; this model needs main + MTP slots.
+        monkeypatch.setattr(moe_logging, "_MOE_METRICS_TRACKER", moe_logging.MoEMetricsTracker())
+
+        router = self.new_router(
+            moe_router_load_balancing_type="seq_aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp64",
+            calculate_per_token_loss=True,
+            params_dtype=torch.float32,
+            bf16=False,
+            mtp_num_layers=2,
+        ).cuda()
+        router.is_mtp_layer = True
+        router.mtp_layer_number = 1
+        hidden_states = torch.randn((4, 1, router.config.hidden_size), device="cuda")
+        params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=torch.tensor([0, 2, 4], device="cuda", dtype=torch.int32),
+            total_tokens=4,
+        )
+
+        def run(repeated):
+            router.config.mtp_use_repeated_layer = repeated
+            clear_aux_losses_tracker()
+            router.weight.grad = None
+            scores, _ = router(hidden_states, packed_seq_params=params)
+            scores.backward(torch.zeros_like(scores))
+            metric = get_moe_layer_wise_logging_tracker()["seq_load_balancing_loss"][
+                "values"
+            ].clone()
+            return router.weight.grad.clone(), metric
+
+        baseline_grad, baseline_metric = run(False)
+        repeated_grad, repeated_metric = run(True)
+        torch.testing.assert_close(repeated_grad * 2, baseline_grad)
+        torch.testing.assert_close(repeated_metric * 2, baseline_metric)
+
+    @pytest.mark.internal
     @pytest.mark.skipif(
         not torch.cuda.is_available() or not HAVE_ROUTER_FUSION,
         reason="CUDA or TE fused router ops not available",

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -458,6 +458,62 @@ class TestRouterAuxLoss:
         torch.testing.assert_close(grad_mbs1, grad_mbsN)
 
     @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_varlen_packed_seq_aux_loss_is_pack_invariant(self):
+        """Flattening variable-length sequences must not change seq-aux gradients."""
+        from megatron.core.packed_seq_params import PackedSeqParams
+
+        router = self.new_router(
+            moe_router_load_balancing_type="seq_aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp32",
+            calculate_per_token_loss=True,
+            params_dtype=torch.float32,
+            bf16=False,
+        ).cuda()
+        lengths = (7, 11, 5)
+        hidden_states = torch.randn(
+            (sum(lengths), 1, router.config.hidden_size), device="cuda", dtype=torch.float32
+        )
+
+        def params_for(seq_lengths):
+            cu = torch.tensor(
+                [0, *torch.tensor(seq_lengths).cumsum(0).tolist()], device="cuda", dtype=torch.int32
+            )
+            seq_idx = torch.repeat_interleave(
+                torch.arange(len(seq_lengths), device="cuda", dtype=torch.int32),
+                torch.tensor(seq_lengths, device="cuda"),
+            ).unsqueeze(0)
+            return PackedSeqParams(
+                qkv_format="thd", cu_seqlens_q=cu, cu_seqlens_q_padded=cu, seq_idx=seq_idx
+            )
+
+        clear_aux_losses_tracker()
+        router.weight.grad = None
+        scores, _ = router(hidden_states, packed_seq_params=params_for(lengths))
+        scores.backward(torch.zeros_like(scores))
+        packed_grad = router.weight.grad.clone()
+        packed_metric = get_moe_layer_wise_logging_tracker()["seq_load_balancing_loss"][
+            "values"
+        ].clone()
+
+        clear_aux_losses_tracker()
+        router.weight.grad = None
+        offset = 0
+        for length in lengths:
+            sequence = hidden_states[offset : offset + length].contiguous()
+            scores, _ = router(sequence, packed_seq_params=params_for((length,)))
+            scores.backward(torch.zeros_like(scores))
+            offset += length
+        separate_grad = router.weight.grad.clone()
+        separate_metric = get_moe_layer_wise_logging_tracker()["seq_load_balancing_loss"][
+            "values"
+        ].clone()
+
+        torch.testing.assert_close(packed_grad, separate_grad)
+        torch.testing.assert_close(packed_metric, separate_metric)
+
+    @pytest.mark.internal
     @pytest.mark.skipif(
         not torch.cuda.is_available() or not HAVE_ROUTER_FUSION,
         reason="CUDA or TE fused router ops not available",

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -11,7 +11,11 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodu
 from megatron.core.transformer.moe.fused_a2a import HYBRIDEP_TOKEN_ALIGNMENT, reset_hybrid_ep_buffer
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import get_capacity
-from megatron.core.transformer.moe.token_dispatcher import MoETokenDispatcher, _HybridEPManager
+from megatron.core.transformer.moe.token_dispatcher import (
+    MoETokenDispatcher,
+    _DeepepV2Manager,
+    _HybridEPManager,
+)
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
@@ -80,6 +84,7 @@ def test_set_cudagraph_attr_supports_nested_paths():
 
 def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     manager = object.__new__(_HybridEPManager)
+    manager._fused_a2a = SimpleNamespace(HYBRIDEP_TOKEN_ALIGNMENT=HYBRIDEP_TOKEN_ALIGNMENT)
     manager.config = SimpleNamespace(moe_hybridep_pad_variable_tokens=True)
     manager.group = object()
     manager.num_experts = 2
@@ -106,6 +111,27 @@ def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     assert manager.token_probs.shape == (expected_num_tokens, manager.num_experts)
     assert not manager.routing_map[local_num_tokens:].any()
     assert not manager.token_probs[local_num_tokens:].any()
+
+
+@pytest.mark.parametrize("available", [False, True])
+def test_deepepv2_initializes_optional_transport_without_v1(monkeypatch, available):
+    # A v2-only module deliberately provides no v1 Buffer/dispatch symbols.
+    fused_a2a = SimpleNamespace(deepepv2_dispatch=object() if available else None)
+    monkeypatch.setattr(
+        "megatron.core.transformer.moe.token_dispatcher._get_fused_a2a_module", lambda: fused_a2a
+    )
+    config = SimpleNamespace(
+        moe_router_dtype="fp32",
+        moe_expert_capacity_factor=None,
+        moe_permute_fusion=False,
+        moe_flex_dispatcher_num_sms=None,
+    )
+    if not available:
+        with pytest.raises(ImportError, match="DeepEP v2 is not installed"):
+            _DeepepV2Manager(object(), 4, 2, 8, config)
+    else:
+        manager = _DeepepV2Manager(object(), 4, 2, 8, config)
+        assert manager._fused_a2a is fused_a2a
 
 
 class MoEModelTestContainer:
@@ -210,7 +236,7 @@ class MoEModelTestContainer:
         probs, indices = apply_module(moe_layer.router)(hidden_states)
         probs = torch.ones_like(probs) / moe_layer.router.topk
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -253,7 +279,7 @@ class MoEModelTestContainer:
         restored_hidden_states_answer = hidden_states * local_probss.sum(dim=1).unsqueeze(1)
         restored_hidden_states_answer = restored_hidden_states_answer.to(dtype=self.test_dtype)
 
-        (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = token_permutation(
+        permuted_local_hidden_states, tokens_per_expert, permuted_probs = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs, indices
         )
 
@@ -304,7 +330,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -322,7 +348,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         permuted_input_2 = permuted_input_2 * permuted_probs_2.unsqueeze(-1)
@@ -375,7 +401,7 @@ class MoEModelTestContainer:
         hidden_states.requires_grad = True
 
         probs_1, indices_1 = apply_module(moe_layer.router)(hidden_states)
-        (permuted_input_1, tokens_per_expert_1, permuted_probs_1) = token_permutation(
+        permuted_input_1, tokens_per_expert_1, permuted_probs_1 = token_permutation(
             moe_layer.token_dispatcher, hidden_states, probs_1, indices_1
         )
         permuted_input_1 = permuted_input_1 * permuted_probs_1.unsqueeze(-1)
@@ -392,7 +418,7 @@ class MoEModelTestContainer:
         moe_layer_2.load_state_dict(moe_layer.state_dict())
 
         probs_2, indices_2 = apply_module(moe_layer_2.router)(hidden_states)
-        (permuted_input_2, tokens_per_expert_2, permuted_probs_2) = token_permutation(
+        permuted_input_2, tokens_per_expert_2, permuted_probs_2 = token_permutation(
             moe_layer_2.token_dispatcher, hidden_states, probs_2, indices_2
         )
         assert (

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from torch import Tensor
 
+from megatron.core.dynamic_cp_group import LogicalCPGroup
 from megatron.core.enums import ModelType
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.models.gpt.gpt_layer_specs import (
@@ -28,10 +29,12 @@ from megatron.core.transformer.multi_token_prediction import (
     ContiguousPackedCPRollContext,
     ContiguousPackedCPRollHalos,
     ContiguousPackedSeqRollPlan,
+    MTPLossAutoScaler,
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
     MultiTokenPredictionLayer,
     _mtp_logits_are_vocab_sharded,
+    bind_native_mtp_cp_group,
     prepare_mtp_sequence_roll_context,
     process_mtp_loss,
     roll_tensor,
@@ -60,7 +63,183 @@ else:
 _SEED = 42
 
 
-def test_native_dynamic_cp_rejects_mtp_before_initialization(monkeypatch):
+@pytest.fixture
+def native_mtp_parent():
+    if not torch.cuda.is_available() or not HAVE_TE:
+        pytest.skip("Native MTP requires CUDA and Transformer Engine")
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.attention.native_cp_transport import (
+        destroy_native_cp_transport,
+        initialize_native_cp_transport,
+    )
+
+    if not hasattr(tex, "cp_native_transport_create"):
+        pytest.skip("Transformer Engine was built without native CP transport")
+    Utils.initialize_distributed()
+    parent = torch.distributed.group.WORLD
+    initialize_native_cp_transport(parent, 65536)
+    try:
+        yield parent
+    finally:
+        destroy_native_cp_transport(parent)
+
+
+def _native_mtp_test_group(parent, cp_size):
+    ranks = torch.distributed.get_process_group_ranks(parent)
+    if len(ranks) < cp_size:
+        pytest.skip(f"CP{cp_size} requires at least {cp_size} ranks")
+    rank = torch.distributed.get_rank()
+    if rank not in ranks[:cp_size]:
+        return None
+    group = LogicalCPGroup.from_parent_interval(ranks, 0, cp_size, rank)
+    bind_native_mtp_cp_group(group, parent)
+    return group
+
+
+@pytest.mark.parametrize("cp_size", [1, 3, 5, 8])
+@pytest.mark.parametrize("layout", ["unpacked", "zigzag", "contiguous", "prefetch"])
+def test_native_mtp_repeated_roll_matches_full_sequences(
+    native_mtp_parent, monkeypatch, cp_size, layout
+):
+    group = _native_mtp_test_group(native_mtp_parent, cp_size)
+    if group is None:
+        return
+    lengths = [4 * cp_size, 6 * cp_size]
+    total = sum(lengths)
+    padded_cu = torch.tensor([0, lengths[0], total, total], device="cuda", dtype=torch.int32)
+    cu = torch.tensor([0, lengths[0] - 1, total - 3, total - 3], device="cuda", dtype=torch.int32)
+    full_ids = torch.arange(1, total + 1, device="cuda", dtype=torch.int64).view(1, -1)
+    full_padding = torch.zeros_like(full_ids, dtype=torch.bool)
+    full_padding[:, lengths[0] - 1] = True
+    full_padding[:, -2:] = True
+    full_ids.masked_fill_(full_padding, 0)
+    full_values = [full_ids, full_padding, (~full_padding).float()]
+    params = (
+        None
+        if layout == "unpacked"
+        else PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_q_padded=padded_cu,
+            cp_group=group,
+            local_cp_size=cp_size,
+            cp_partition_mode="contiguous" if layout in ("contiguous", "prefetch") else "zigzag",
+        )
+    )
+    if layout in ("contiguous", "prefetch"):
+        indices = torch.arange(total // cp_size, device="cuda") + group.rank() * (total // cp_size)
+    else:
+        chunks = []
+        start = 0
+        for length in ([total] if layout == "unpacked" else lengths):
+            width = length // (2 * cp_size)
+            for chunk in (group.rank(), 2 * cp_size - 1 - group.rank()):
+                chunks.append(torch.arange(width, device="cuda") + start + chunk * width)
+            start += length
+        indices = torch.cat(chunks)
+    local_values = [value.index_select(-1, indices) for value in full_values]
+    context = prepare_mtp_sequence_roll_context(
+        tensor=local_values[0], cp_group=group, packed_seq_params=params
+    )
+
+    def reject_nccl(*args, **kwargs):
+        raise AssertionError("Logical MTP must not call torch.distributed P2P/all_reduce")
+
+    for name in ("isend", "irecv", "batch_isend_irecv", "all_reduce"):
+        monkeypatch.setattr(torch.distributed, name, reject_nccl)
+    if layout == "prefetch" and context is not None:
+        context = context.prefetch_halos(
+            width=3,
+            input_ids=local_values[0],
+            padding_mask=local_values[1],
+            loss_mask=local_values[2],
+        )
+    fill_values = [0, True, 0]
+    ends = [total - 1] if layout == "unpacked" else [lengths[0] - 1, total - 1]
+    for depth in range(3):
+        local_values = roll_tensor(
+            local_values,
+            cp_group=group,
+            packed_seq_params=params,
+            fill_values=fill_values,
+            roll_context=context,
+            sequence_fields=["input_ids", "padding_mask", "loss_mask"],
+            roll_depth=depth,
+        )
+        for index, fill in enumerate(fill_values):
+            full_values[index] = torch.roll(full_values[index], -1, -1)
+            full_values[index][:, ends] = fill
+            torch.testing.assert_close(
+                local_values[index], full_values[index].index_select(-1, indices)
+            )
+
+
+@pytest.mark.parametrize("cp_size", [1, 3, 5, 8])
+def test_native_mtp_loss_cp_normalization_matches_cp1(native_mtp_parent, monkeypatch, cp_size):
+    group = _native_mtp_test_group(native_mtp_parent, cp_size)
+    if group is None:
+        return
+    length = 4 * cp_size
+    local_length = length // cp_size
+    start = group.rank() * local_length
+    config = TransformerConfig(
+        hidden_size=8,
+        num_layers=2,
+        num_attention_heads=2,
+        mtp_num_layers=2,
+        calculate_per_token_loss=True,
+        mtp_loss_scaling_factor=1.0,
+    )
+    params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=torch.tensor([0, length], device="cuda", dtype=torch.int32),
+        cp_partition_mode="contiguous",
+    )
+    full_labels = torch.ones((1, length), device="cuda", dtype=torch.int64)
+    full_mask = torch.zeros((1, length), device="cuda")
+    valid_positions = [0, 1, 2] if cp_size == 1 else [0, local_length, local_length + 1]
+    full_mask[:, valid_positions] = 1
+    # Rolling moves valid tokens across CP ranks with different local T0/Tk ratios;
+    # some ranks have no rolled tokens, so normalization must use CP-global counts.
+    global_hidden = torch.randn((3, length, 1, 1), device="cuda")
+    monkeypatch.setattr(MTPLossAutoScaler, "main_loss_backward_scale", torch.ones(1, device="cuda"))
+
+    def run(hidden, labels, mask, cp_group):
+        hidden = hidden.detach().clone().reshape(-1, 1, 1).requires_grad_()
+        result = process_mtp_loss(
+            hidden_states=hidden,
+            labels=labels,
+            loss_mask=mask,
+            output_layer=lambda hidden, **kwargs: (hidden, None),
+            output_weight=None,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=lambda labels, logits: logits.squeeze(-1).transpose(0, 1),
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=params,
+        )
+        (result.sum() * 0).backward()
+        return hidden.grad.reshape(3, -1, 1, 1)
+
+    baseline_grad = run(global_hidden, full_labels, full_mask, None)
+
+    def reject_nccl(*args, **kwargs):
+        raise AssertionError("Logical MTP must reduce normalization with the native transport")
+
+    for name in ("isend", "irecv", "batch_isend_irecv", "all_reduce"):
+        monkeypatch.setattr(torch.distributed, name, reject_nccl)
+    local_grad = run(
+        global_hidden[:, start : start + local_length],
+        full_labels[:, start : start + local_length],
+        full_mask[:, start : start + local_length],
+        group,
+    )
+    assert torch.isfinite(local_grad).all()
+    torch.testing.assert_close(local_grad, baseline_grad[:, start : start + local_length])
+
+
+def test_native_dynamic_cp_accepts_mtp(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["test_native_dynamic_cp_mtp"])
     args = parse_args()
     args.num_layers = 2
@@ -80,8 +259,139 @@ def test_native_dynamic_cp_rejects_mtp_before_initialization(monkeypatch):
     args.distributed_backend = "nccl"
     args.cp_comm_type = ["p2p"]
     args.bf16 = True
-    with pytest.raises(ValueError, match="does not support MTP halo communication"):
-        validate_args(args)
+    validate_args(args)
+    assert args.use_native_cp_transport and args.mtp_num_layers == 1
+
+
+def test_gpt_forward_keeps_full_token_padding_mask_for_mtp():
+    """Decoder SP preprocessing must not replace the token mask used by MTP."""
+    tokens = torch.ones((1, 16), dtype=torch.long)
+    padding_mask = torch.arange(16).view(1, -1) % 3 == 0
+    sp_mask = padding_mask[:, :4]
+    hidden = torch.zeros((4, 1, 8))
+    seen = {}
+
+    def decoder(**kwargs):
+        seen["decoder_mask"] = kwargs["padding_mask"]
+        return hidden
+
+    def postprocess(**kwargs):
+        seen["mtp_mask"] = kwargs["padding_mask"]
+        return kwargs["hidden_states"]
+
+    model = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            fine_grained_activation_offloading=False, moe_paged_stash=False, moe_n_hash_layers=0
+        ),
+        mtp_process=True,
+        _preprocess=lambda **kwargs: (hidden, None, None, None, None, sp_mask),
+        decoder=decoder,
+        _postprocess=postprocess,
+    )
+    GPTModel.forward(model, tokens, tokens, None, padding_mask=padding_mask)
+    assert seen["decoder_mask"] is sp_mask
+    assert seen["mtp_mask"] is padding_mask
+
+
+@pytest.mark.parametrize("cp_size", [1, 3])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("initial_sp_mask", [False, True])
+@pytest.mark.parametrize("hybrid", [False, True])
+def test_native_mtp_tp_sp_keeps_token_and_transformer_masks_separate(
+    native_mtp_parent, monkeypatch, cp_size, tp_size, initial_sp_mask, hybrid
+):
+    """Repeated rolls retain full CP masks; only Transformer/checkpoint inputs use SP."""
+    if native_mtp_parent.size() < tp_size * cp_size:
+        pytest.skip(f"TP{tp_size} CP{cp_size} requires at least {tp_size * cp_size} ranks")
+    from megatron.core.transformer import multi_token_prediction as mtp_module
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=tp_size, context_parallel_size=1)
+    try:
+        tp_group = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp"]).tp
+        parent_ranks = torch.distributed.get_process_group_ranks(native_mtp_parent)
+        cp_ranks = parent_ranks[tp_group.rank() :: tp_size][:cp_size]
+        rank = torch.distributed.get_rank()
+        if rank not in cp_ranks:
+            return
+        group = LogicalCPGroup.from_parent_interval(cp_ranks, 0, cp_size, rank)
+        bind_native_mtp_cp_group(group, native_mtp_parent)
+        local_length = 16
+        length = local_length * cp_size
+        start = group.rank() * local_length
+        full_tokens = torch.arange(1, length + 1, device="cuda").view(1, -1)
+        full_mask = full_tokens % 7 == 0
+        tokens = full_tokens[:, start : start + local_length].clone()
+        mask = full_mask[:, start : start + local_length].clone()
+        params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=torch.tensor([0, length], device="cuda", dtype=torch.int32),
+            cp_partition_mode="contiguous",
+            cp_group=group,
+            local_cp_size=cp_size,
+        )
+        context = prepare_mtp_sequence_roll_context(tokens, group, params)
+        if context is not None:
+            context = context.prefetch_halos(width=3, input_ids=tokens, padding_mask=mask)
+        seen = {}
+
+        def transformer(**kwargs):
+            seen["mask"] = kwargs["padding_mask"].clone()
+            assert kwargs["hidden_states"].shape[0] == local_length // tp_size
+            return kwargs["hidden_states"]
+
+        hidden = torch.zeros((local_length // tp_size, 1, 8), device="cuda")
+        embedding = lambda **kwargs: torch.zeros_like(hidden)
+        embedding.add_position_embedding = False
+        layer = types.SimpleNamespace(
+            config=types.SimpleNamespace(
+                sequence_parallel=True, mtp_detach_heads=False, recompute_granularity="full"
+            ),
+            cp_group=group,
+            tp_group=tp_group,
+            _mtp_cp_parent_group=native_mtp_parent,
+            training=True,
+            mtp_layer_pattern="*" if hybrid else None,
+            _proj_and_transformer_layer=transformer,
+            _checkpointed_forward=transformer,
+        )
+        layer._get_embeddings = types.MethodType(MultiTokenPredictionLayer._get_embeddings, layer)
+        original_gather = mtp_module.gather_from_sequence_parallel_region
+        gather_calls = 0
+
+        def counted_gather(*args, **kwargs):
+            nonlocal gather_calls
+            gather_calls += 1
+            return original_gather(*args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "gather_from_sequence_parallel_region", counted_gather)
+        if initial_sp_mask:
+            mask = mask.chunk(tp_size, dim=-1)[tp_group.rank()].contiguous()
+        for depth in range(2):
+            hidden, tokens, _, mask = MultiTokenPredictionLayer.forward(
+                layer,
+                tokens,
+                tokens,
+                hidden,
+                None,
+                padding_mask=mask,
+                packed_seq_params=params,
+                sequence_roll_context=context,
+                roll_depth=depth,
+                embedding=embedding,
+            )
+            full_tokens = torch.roll(full_tokens, -1, -1)
+            full_tokens[:, -1] = 0
+            full_mask = torch.roll(full_mask, -1, -1)
+            full_mask[:, -1] = True
+            expected_mask = full_mask[:, start : start + local_length]
+            torch.testing.assert_close(tokens, full_tokens[:, start : start + local_length])
+            torch.testing.assert_close(mask, expected_mask)
+            torch.testing.assert_close(
+                seen["mask"], expected_mask.chunk(tp_size, -1)[tp_group.rank()]
+            )
+        assert gather_calls == int(initial_sp_mask)
+    finally:
+        Utils.destroy_model_parallel()
 
 
 class TestMultiTokenPredictionLayer:

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -60,6 +60,30 @@ else:
 _SEED = 42
 
 
+def test_native_dynamic_cp_rejects_mtp_before_initialization(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test_native_dynamic_cp_mtp"])
+    args = parse_args()
+    args.num_layers = 2
+    args.hidden_size = 128
+    args.num_attention_heads = 8
+    args.max_position_embeddings = 256
+    args.seq_length = 256
+    args.micro_batch_size = 1
+    args.train_iters = 1
+    args.position_embedding_type = "rope"
+    args.mtp_num_layers = 1
+    args.dynamic_context_parallel = True
+    args.calculate_per_token_loss = True
+    args.use_native_cp_transport = True
+    args.max_seqlen_per_dp_cp_rank = 256
+    args.transformer_impl = "transformer_engine"
+    args.distributed_backend = "nccl"
+    args.cp_comm_type = ["p2p"]
+    args.bf16 = True
+    with pytest.raises(ValueError, match="does not support MTP halo communication"):
+        validate_args(args)
+
+
 class TestMultiTokenPredictionLayer:
     def setup_method(self, method):
         os.environ['CUDA_DEVICE_MAX_CONNECTIONS'] = '1'


### PR DESCRIPTION
## What

- Allow the dynamic-CP scheduler to select arbitrary CP sizes instead of rounding every request to a power of two.
- Add lightweight logical CP descriptors backed by one existing DPxCP parent communicator.
- Order each logical ring so a rank sees at most four peers across all CP sizes and contiguous tail intervals are representable.
- Automatically route supported default GPT/TE full-attention DCP, MoE auxiliary reductions and MTP through native transport; no additional transport CLI flag.
- All ranks agree on model and parent-communicator capability before constructing dynamic CP groups. Unknown/unsupported models or old TE builds retain the legacy ProcessGroup path, with the reason logged; there is no per-rank fallback after native initialization.

## Automatic-selection regression (2026-09-17)

- Exact-source H100 TE rebuild; 27 transport tests passed. Eight-rank MCore selection/MTP regression: 80 passed, 4 skipped (TP4/CP3 needs >=12 ranks).
- Fresh PP2 x CP4 tests verified WORLD-wide agreement when only one rank lacks the TE symbol or parent capability, and native selection when all ranks support it. Capability queries allocated no native transport.
- Four 10-step eager, small GPT/MoE + MTP runs passed: CP5+CP3 and CP4+CP4, each automatic-native versus automatic-legacy fallback, with no transport flag. LM loss max absolute difference <=9.537e-7, sequence aux <=1.193e-7, gradient norm identical; MTP and final parameters passed predeclared tolerances. This is not a new Qwen30B 100-step run or a bitwise-equality claim.
- DFW jobs: build 18816253; consensus/unit tests 18816442; E2E 18816724. No communication-kernel or scheduler-scoring changes in this update.

## Prior transport and scheduler validation

- Formatting, import sorting, Ruff, and Pylint passed.
- Eight scheduler tests cover CP1-16 and CP5 followed by a CP3 tail starting at rank 5.
- Six logical-group/bounded-ring tests passed, including the maximum peer-degree invariant.
- Exact-source Qwen3-30B-A3B training on LongAlign-10k completed 100 fixed-CP16 steps and 100 native arbitrary-DCP steps on 32 H100 GPUs. The runs started from identical sampled parameters and consumed identical real batches at every step.
- LM loss aligned with max/mean absolute differences of 0.000648/0.000131 (Pearson 0.999999589). Sequence auxiliary loss aligned with max/mean absolute differences of 0.005567/0.001644 (Pearson 0.999958020). Different CP layouts change BF16 reduction order, so this is not claimed as bitwise equality.
- The LongAlign run selected CP sizes 2-14 (except 15) and 16, and native arbitrary DCP delivered 7181.77 token/s versus 5811.30 token/s for fixed CP16 (+23.58%).
- On eight GB200 GPUs, the targeted CP5+CP3 case reduced median step time by 18.75% versus the same native transport constrained to CP8, and by 17.07% versus legacy ProcessGroupNCCL CP8.

Depends on NVIDIA/TransformerEngine#3420.
