### PR TITLE
Add gated histogram quantile balancing

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -21,7 +21,10 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 
 from .. import parallel_state
-from ..transformer.moe.moe_utils import get_updated_expert_bias
+from ..transformer.moe.moe_utils import (
+    get_updated_expert_bias,
+    get_updated_expert_bias_quantile_balancing,
+)
 from ..transformer.transformer_config import TransformerConfig
 from ..utils import (
     get_attr_wrapped_model,
@@ -326,6 +329,8 @@ def reset_model_temporary_tensors(config: TransformerConfig, model: List[torch.n
                 or "global_aux_loss" in config.moe_router_load_balancing_type
             ) and hasattr(module, 'reset_global_aux_loss_tracker'):
                 module.reset_global_aux_loss_tracker()
+            if getattr(module, 'local_quantile_balancing_histogram', None) is not None:
+                module.local_quantile_balancing_histogram.zero_()
             if getattr(module, 'qb_beta_accum', None) is not None:
                 module.qb_beta_accum.zero_()
                 module.qb_beta_count.zero_()
@@ -374,40 +379,70 @@ def _update_router_expert_bias(
 def _update_router_qb_beta(
     model: List[torch.nn.Module],
     config: TransformerConfig,
-    dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    tp_dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
-    """Update the quantile-balancing per-expert bias once per global batch.
+    """Update QB bias using either the gated histogram or original PR implementation."""
+    if not config.moe_router_quantile_balancing_histogram:
+        qb_beta_list = []
+        qb_beta_accum_list = []
+        qb_beta_count_list = []
+        for model_chunk in model:
+            for module in get_attr_wrapped_model(model_chunk, 'modules')():
+                if getattr(module, 'qb_beta_accum', None) is not None and module.training:
+                    qb_beta_list.append(module.qb_beta)
+                    qb_beta_accum_list.append(module.qb_beta_accum)
+                    qb_beta_count_list.append(module.qb_beta_count)
+        if not qb_beta_list:
+            return
+        stacked_beta = torch.stack(qb_beta_list, dim=0)
+        stacked_local_average = torch.stack(
+            [
+                accum / count.clamp(min=1).to(accum.dtype)
+                for accum, count in zip(qb_beta_accum_list, qb_beta_count_list)
+            ],
+            dim=0,
+        )
+        torch.distributed.all_reduce(
+            stacked_local_average, op=torch.distributed.ReduceOp.AVG, group=tp_dp_cp_group
+        )
+        updated = config.moe_router_quantile_balancing_ema * stacked_beta + (
+            1.0 - config.moe_router_quantile_balancing_ema
+        ) * stacked_local_average
+        updated -= updated.mean(dim=-1, keepdim=True)
+        for qb_beta, new_beta in zip(qb_beta_list, updated):
+            qb_beta.copy_(new_beta)
+        return
 
-    Averages each router's accumulated quantile (qb_beta_accum/qb_beta_count) across
-    DP, EMA-blends it with the current qb_beta, re-centers, and writes it back.
-    """
+    """Pool whole-step QB histograms and update the per-expert bias once per global batch."""
     qb_beta_list = []
-    qb_beta_accum_list = []
-    qb_beta_count_list = []
+    histogram_list = []
+    ema_step_list = []
     for model_chunk in model:
         for module in get_attr_wrapped_model(model_chunk, 'modules')():
-            if getattr(module, 'qb_beta_accum', None) is not None and module.training:
+            if (
+                getattr(module, 'local_quantile_balancing_histogram', None) is not None
+                and module.training
+            ):
                 qb_beta_list.append(module.qb_beta)
-                qb_beta_accum_list.append(module.qb_beta_accum)
-                qb_beta_count_list.append(module.qb_beta_count)
+                histogram_list.append(module.local_quantile_balancing_histogram)
+                if getattr(module, 'qb_beta_ema_step', None) is not None:
+                    module.qb_beta_ema_step.add_(1)
+                    ema_step_list.append(module.qb_beta_ema_step)
 
     if len(qb_beta_list) == 0:
         return
 
     stacked_beta = torch.stack(qb_beta_list, dim=0)
-    local_avg_list = [
-        accum / count.clamp(min=1).to(accum.dtype)
-        for accum, count in zip(qb_beta_accum_list, qb_beta_count_list)
-    ]
-    stacked_local_avg = torch.stack(local_avg_list, dim=0)
-
-    torch.distributed.all_reduce(
-        stacked_local_avg, op=torch.distributed.ReduceOp.AVG, group=dp_cp_group
+    stacked_histogram = torch.stack(histogram_list, dim=0)
+    stacked_ema_step = torch.stack(ema_step_list, dim=0) if ema_step_list else None
+    stacked_new_beta = get_updated_expert_bias_quantile_balancing(
+        stacked_histogram,
+        stacked_beta,
+        topk=config.moe_router_topk,
+        ema_beta=config.moe_router_quantile_balancing_ema,
+        ema_step=stacked_ema_step,
+        tp_dp_cp_group=tp_dp_cp_group,
     )
-
-    ema = config.moe_router_quantile_balancing_ema
-    stacked_new_beta = ema * stacked_beta + (1.0 - ema) * stacked_local_avg
-    stacked_new_beta = stacked_new_beta - stacked_new_beta.mean(dim=-1, keepdim=True)
 
     for qb_beta, new_beta in zip(qb_beta_list, stacked_new_beta):
         qb_beta.copy_(new_beta)
@@ -589,7 +624,10 @@ def finalize_model_grads(
             "If you don't need pos_embd_group, you need to explicitly set it to None."
         )
         assert hasattr(pg_collection, 'dp_cp')
-        if config.moe_router_enable_expert_bias:
+        if (
+            config.moe_router_enable_expert_bias
+            or config.moe_router_load_balancing_type == "quantile_balancing"
+        ):
             assert hasattr(pg_collection, 'tp_dp_cp') and pg_collection.tp_dp_cp is not None, (
                 "pg_collection must have tp_dp_cp when " "moe_router_enable_expert_bias is enabled."
             )
@@ -687,7 +725,11 @@ def finalize_model_grads(
         _update_router_expert_bias(model, config, tp_dp_cp_group=tp_dp_cp_group)
 
     if config.moe_router_load_balancing_type == "quantile_balancing":
-        _update_router_qb_beta(model, config, dp_cp_group=dp_cp_group)
+        if pg_collection is None:
+            tp_dp_cp_group = parallel_state.get_tensor_and_data_parallel_group(
+                with_context_parallel=True
+            )
+        _update_router_qb_beta(model, config, tp_dp_cp_group=tp_dp_cp_group)
 
     reset_model_temporary_tensors(config, model)
 

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -245,6 +245,93 @@ def qb_dual_update(
     return indices, beta_local
 
 
+def compute_quantile_balancing_histogram(
+    scores: torch.Tensor,
+    expert_bias: torch.Tensor,
+    topk: int,
+    num_bins: int,
+    score_span: float = 1.0,
+) -> torch.Tensor:
+    """Histogram the per-expert bias required to reach each token's top-k cutoff."""
+    with torch.no_grad():
+        scores = scores.float()
+        expert_bias = expert_bias.float()
+        num_tokens, num_experts = scores.shape
+        if topk >= num_experts:
+            raise ValueError("Quantile Balancing requires topk < num_experts.")
+        if num_bins <= 0 or score_span <= 0.0:
+            raise ValueError("Quantile Balancing requires positive histogram bins and score span.")
+
+        histogram = torch.zeros((num_experts, num_bins), dtype=torch.int32, device=scores.device)
+        if num_tokens == 0:
+            return histogram
+
+        cutoff = (scores + expert_bias).kthvalue(num_experts - topk, dim=1).values.unsqueeze(1)
+        required_bias = cutoff - scores
+        lower_bound = expert_bias.min() - score_span
+        bin_width = (expert_bias.max() - expert_bias.min() + 2.0 * score_span) / num_bins
+        bin_indices = torch.floor((required_bias - lower_bound) / bin_width).to(torch.int64)
+        bin_indices.clamp_(min=0, max=num_bins - 1)
+        expert_offsets = torch.arange(num_experts, dtype=torch.int64, device=scores.device).unsqueeze(0)
+        histogram.view(-1).scatter_add_(
+            0,
+            (bin_indices + expert_offsets * num_bins).flatten(),
+            torch.ones_like(bin_indices, dtype=histogram.dtype).flatten(),
+        )
+        return histogram
+
+
+def get_updated_expert_bias_quantile_balancing(
+    histogram: torch.Tensor,
+    expert_bias: torch.Tensor,
+    topk: int,
+    score_span: float = 1.0,
+    ema_beta: float = 0.0,
+    ema_step: Optional[torch.Tensor] = None,
+    tp_dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """All-reduce whole-step QB histograms and recover mean-centered expert biases."""
+    with torch.no_grad():
+        if not 0.0 <= ema_beta < 1.0:
+            raise ValueError("Quantile Balancing EMA must be in [0, 1).")
+        if tp_dp_cp_group is None:
+            tp_dp_cp_group = parallel_state.get_tensor_and_data_parallel_group(
+                with_context_parallel=True
+            )
+        torch.distributed.all_reduce(histogram, group=tp_dp_cp_group)
+
+        histogram = histogram.to(torch.int64)
+        expert_bias = expert_bias.float()
+        num_experts, num_bins = histogram.shape[-2:]
+        flat_histogram = histogram.reshape(-1, num_experts, num_bins)
+        flat_bias = expert_bias.reshape(-1, num_experts)
+        tokens = flat_histogram[:, 0, :].sum(dim=-1)
+        cumulative = flat_histogram.cumsum(dim=-1)
+        target = tokens.float() * topk / num_experts
+        target_count = target.ceil().to(torch.int64)
+        selected_bins = torch.searchsorted(
+            cumulative,
+            target_count[:, None, None].expand(-1, num_experts, 1).contiguous(),
+        ).squeeze(-1).clamp(max=num_bins - 1)
+        counts_in_bin = flat_histogram.gather(-1, selected_bins.unsqueeze(-1)).squeeze(-1)
+        counts_before = cumulative.gather(-1, selected_bins.unsqueeze(-1)).squeeze(-1) - counts_in_bin
+        fraction = ((target[:, None] - counts_before.float()) / counts_in_bin.clamp_min(1).float()).clamp_(0, 1)
+        lower_bound = flat_bias.min(dim=-1).values - score_span
+        bin_width = (flat_bias.max(dim=-1).values - flat_bias.min(dim=-1).values + 2.0 * score_span) / num_bins
+        updated = lower_bound[:, None] + (selected_bins.float() + fraction) * bin_width[:, None]
+        if ema_beta > 0.0:
+            if ema_step is None:
+                beta = ema_beta
+            else:
+                step = ema_step.reshape(-1, 1).to(flat_bias.dtype).clamp_min(1.0)
+                beta_pow_step = torch.pow(torch.full_like(step, ema_beta), step)
+                beta = (ema_beta - beta_pow_step) / (1.0 - beta_pow_step)
+            updated = beta * flat_bias + (1.0 - beta) * updated
+        updated -= updated.mean(dim=-1, keepdim=True)
+        updated = torch.where((tokens > 0)[:, None], updated, flat_bias)
+        return updated.reshape_as(expert_bias)
+
+
 def get_capacity(
     num_tokens: int, num_experts: int, capacity_factor: float, min_capacity: Optional[int] = None
 ) -> int:

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -18,6 +18,7 @@ from megatron.core.transformer.moe.moe_utils import (
     apply_biased_logits,
     apply_random_logits,
     apply_router_token_dropping,
+    compute_quantile_balancing_histogram,
     compute_routing_scores_for_aux_loss,
     get_tokens_per_expert_and_token_count,
     qb_dual_update,
@@ -225,8 +226,8 @@ class TopKRouter(Router):
             self.ga_steps = None
 
         # Quantile balancing replaces the aux loss with a per-expert bias `qb_beta`.
-        # `qb_beta_accum`/`qb_beta_count` collect the per-microbatch quantile, reduced
-        # and reset each global batch.
+        # Histogram QB is explicitly opt-in; the PR's original local-quantile update
+        # remains available for direct comparisons.
         if self.routing_type == "quantile_balancing":
             assert not self.is_aux_loss_enabled(), (
                 "Quantile balancing handles load balance via the bias update; "
@@ -240,22 +241,49 @@ class TopKRouter(Router):
                     device=torch.cuda.current_device(),
                 ),
             )
-            self.register_buffer(
-                'qb_beta_accum',
-                torch.zeros(
-                    self.config.num_moe_experts,
-                    dtype=torch.float32,
-                    device=torch.cuda.current_device(),
-                ),
-                persistent=False,
-            )
-            self.register_buffer(
-                'qb_beta_count',
-                torch.zeros((), dtype=torch.long, device=torch.cuda.current_device()),
-                persistent=False,
-            )
+            if self.config.moe_router_quantile_balancing_histogram:
+                self.register_buffer(
+                    'local_quantile_balancing_histogram',
+                    torch.zeros(
+                        (
+                            self.config.num_moe_experts,
+                            self.config.moe_router_quantile_balancing_num_bins,
+                        ),
+                        dtype=torch.int32,
+                        device=torch.cuda.current_device(),
+                    ),
+                    persistent=False,
+                )
+                if self.config.moe_router_quantile_balancing_ema > 0.0:
+                    self.register_buffer(
+                        'qb_beta_ema_step',
+                        torch.zeros(1, dtype=torch.int64, device=torch.cuda.current_device()),
+                    )
+                else:
+                    self.qb_beta_ema_step = None
+                self.qb_beta_accum = None
+                self.qb_beta_count = None
+            else:
+                self.register_buffer(
+                    'qb_beta_accum',
+                    torch.zeros(
+                        self.config.num_moe_experts,
+                        dtype=torch.float32,
+                        device=torch.cuda.current_device(),
+                    ),
+                    persistent=False,
+                )
+                self.register_buffer(
+                    'qb_beta_count',
+                    torch.zeros((), dtype=torch.long, device=torch.cuda.current_device()),
+                    persistent=False,
+                )
+                self.local_quantile_balancing_histogram = None
+                self.qb_beta_ema_step = None
         else:
             self.qb_beta = None
+            self.local_quantile_balancing_histogram = None
+            self.qb_beta_ema_step = None
             self.qb_beta_accum = None
             self.qb_beta_count = None
 
@@ -314,7 +342,9 @@ class TopKRouter(Router):
         scores = logits * map
         return scores, map
 
-    def quantile_balancing(self, logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def quantile_balancing(
+        self, logits: torch.Tensor, padding_mask: Optional[torch.Tensor] = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Apply quantile-balancing (QB) routing to the logits tensor.
 
         Selects top-k experts per token using a dual coordinate-descent update on
@@ -335,48 +365,26 @@ class TopKRouter(Router):
             self.config.moe_router_num_groups is None and self.config.moe_router_group_topk is None
         ), "Quantile balancing routing does not support group-limited routing."
 
-        local_num_tokens = logits.shape[0]
-        # Gather logits across TP/CP so the quantile sees a whole sequence's tokens.
-        # The DP reduction and qb_beta update run at the global-batch boundary in
-        # finalize_model_grads._update_router_qb_beta.
-        gather_group = self.tp_cp_group
-        gather_size = gather_group.size() if gather_group is not None else 1
-
-        should_update_beta = self.training and torch.is_grad_enabled()
-
+        should_update_bias = self.training and torch.is_grad_enabled()
         with torch.no_grad():
-            logits_fp32 = logits.detach().to(dtype=torch.float32)
-
-            if gather_size > 1:
-                full_logits = torch.empty(
-                    (local_num_tokens * gather_size, self.config.num_moe_experts),
-                    dtype=logits_fp32.dtype,
-                    device=logits_fp32.device,
-                )
-                torch.distributed.all_gather_into_tensor(
-                    full_logits, logits_fp32.contiguous(), group=gather_group
-                )
-                gather_rank = torch.distributed.get_rank(group=gather_group)
+            if self.config.moe_router_quantile_balancing_histogram:
+                scores = torch.sigmoid(logits.detach().float())
+                if should_update_bias:
+                    histogram_scores = scores if padding_mask is None else scores[~padding_mask]
+                    self.local_quantile_balancing_histogram += compute_quantile_balancing_histogram(
+                        histogram_scores,
+                        self.qb_beta,
+                        self.topk,
+                        num_bins=self.config.moe_router_quantile_balancing_num_bins,
+                    )
+                indices = (scores + self.qb_beta).topk(self.topk, dim=1).indices
             else:
-                full_logits = logits_fp32
-                gather_rank = 0
-
-            # Route with the previous batch's qb_beta; in training, accumulate this
-            # microbatch's quantile for the next update.
-            full_indices, beta_local = qb_dual_update(
-                full_logits, self.topk, self.qb_beta, update_beta=should_update_beta
-            )
-            if should_update_beta:
-                self.qb_beta_accum.add_(beta_local)
-                self.qb_beta_count.add_(1)
-
-            # Take this rank's rows (all_gather orders rows by rank).
-            if gather_size > 1:
-                indices = full_indices[
-                    gather_rank * local_num_tokens : (gather_rank + 1) * local_num_tokens
-                ].contiguous()
-            else:
-                indices = full_indices
+                indices, beta_local = qb_dual_update(
+                    logits.detach().float(), self.topk, self.qb_beta, update_beta=should_update_bias
+                )
+                if should_update_bias:
+                    self.qb_beta_accum.add_(beta_local)
+                    self.qb_beta_count.add_(1)
 
         # QB only picks the experts; reuse the shared score function for the probs.
         return topk_routing_with_score_function(
@@ -775,10 +783,7 @@ class TopKRouter(Router):
         if self.routing_type == "sinkhorn":
             probs, routing_map = self.sinkhorn_load_balancing(logits)
         elif self.routing_type == "quantile_balancing":
-            assert (
-                padding_mask is None
-            ), "Quantile balancing routing does not support padding masks yet."
-            probs, routing_map = self.quantile_balancing(logits)
+            probs, routing_map = self.quantile_balancing(logits, padding_mask=padding_mask)
         else:
             probs, routing_map = topk_routing_with_score_function(
                 logits,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -749,9 +749,9 @@ class TransformerConfig(ModelParallelConfig):
     for each individual sample.
     - "global_aux_loss": Load balancing loss calculated at global batch level.
     - "sinkhorn": Balancing algorithm used in S-BASE.
-    - "quantile_balancing": Dual coordinate-descent quantile balancing (QB). Load balance is
-    handled entirely by an internal per-expert bias update; auxiliary losses must be disabled
-    (`moe_aux_loss_coeff` = 0) when QB is selected.
+    - "quantile_balancing": Loss-free Quantile Balancing (QB). The original PR implementation
+    is used by default; set `moe_router_quantile_balancing_histogram` for the Kimi K3-style
+    histogram-based whole-step update. Auxiliary losses must be disabled (`moe_aux_loss_coeff` = 0).
     - "none": No load balancing.
     A list of strings can be provided to combine multiple aux-loss load balancing types.
     The default is "aux_loss".
@@ -828,10 +828,15 @@ class TransformerConfig(ModelParallelConfig):
     The default value 1e-3 is same as that used in DeepSeekV3."""
 
     moe_router_quantile_balancing_ema: float = 0.0
-    """EMA coefficient for the quantile-balancing per-expert bias (`qb_beta`), used only when
-    `moe_router_load_balancing_type` is "quantile_balancing". At each global batch the bias is
-    updated as `qb_beta = ema * qb_beta + (1 - ema) * local_quantile`. The default 0.0 means
-    no memory: the bias is replaced by the latest global-batch quantile estimate each step."""
+    """EMA coefficient for the quantile-balancing per-expert bias (`qb_beta`). The recovered
+    whole-step global quantile is blended with the previous bias; the persistent update counter
+    applies bias correction so a newly resumed EMA is not artificially pulled toward zero."""
+
+    moe_router_quantile_balancing_num_bins: int = 1000
+    """Number of uniform per-expert bins used to pool whole-step QB histograms."""
+
+    moe_router_quantile_balancing_histogram: bool = False
+    """Opt in to Kimi K3-style whole-step histogram QB. False retains the original QB update."""
 
     moe_router_force_load_balancing: bool = False
     """[Experimental] Force load balancing with random logits for MoE router, supports naive topk 
@@ -2626,6 +2631,20 @@ class TransformerConfig(ModelParallelConfig):
                 "score functions. Please set --moe-router-score-function to 'sigmoid' or "
                 "'sqrtsoftplus', or unset --moe-router-enable-expert-bias."
             )
+
+        if self.moe_router_load_balancing_type == "quantile_balancing":
+            if not 0.0 <= self.moe_router_quantile_balancing_ema < 1.0:
+                raise ValueError("Quantile Balancing EMA must be in [0, 1).")
+        if (
+            self.moe_router_load_balancing_type == "quantile_balancing"
+            and self.moe_router_quantile_balancing_histogram
+        ):
+            if self.moe_router_score_function != "sigmoid":
+                raise ValueError("Histogram Quantile Balancing requires sigmoid router scores.")
+            if self.moe_router_quantile_balancing_num_bins <= 0:
+                raise ValueError("Quantile Balancing histogram bins must be positive.")
+            if self.moe_router_topk >= self.num_moe_experts:
+                raise ValueError("Quantile Balancing requires moe_router_topk < num_moe_experts.")
 
         if self.num_moe_experts and self.fp8:
             # TE version below 1.7.0 will raise Error when handle zeros tokens for expert

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3534,7 +3534,13 @@ def _add_moe_args(parser):
     group.add_argument('--moe-router-load-balancing-type', nargs='+', type=str,
                        choices=['aux_loss', 'seq_aux_loss', 'global_aux_loss', 'sinkhorn', 'quantile_balancing', 'none'],
                        default='aux_loss',
-                       help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE; "quantile_balancing" (QB) uses dual coordinate descent on a per-expert bias to handle load balance internally; "none" implies no load balancing. The default is "aux_loss".')
+                       help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the loss used in DeepSeekV2; "sinkhorn" corresponds to S-BASE; "quantile_balancing" (QB) updates a routing bias without an auxiliary loss, with the Kimi K3 histogram variant separately gated; "none" implies no load balancing. The default is "aux_loss".')
+    group.add_argument('--moe-router-quantile-balancing-ema', type=float, default=0.0,
+                       help='EMA coefficient for the whole-step quantile-balancing expert bias.')
+    group.add_argument('--moe-router-quantile-balancing-num-bins', type=int, default=1000,
+                       help='Number of per-expert histogram bins used by whole-step quantile balancing.')
+    group.add_argument('--moe-router-quantile-balancing-histogram', action='store_true',
+                       help='Opt in to Kimi K3-style whole-step histogram quantile balancing.')
     group.add_argument('--moe-aux-loss-coeff', type=float, nargs='+', default=0.0,
                        help='Scaling coefficient for the aux loss: a starting value of 1e-2 is recommended.')
     # Token dispatcher arguments

--- a/tests/unit_tests/distributed/test_finalize_model_grads.py
+++ b/tests/unit_tests/distributed/test_finalize_model_grads.py
@@ -23,6 +23,7 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.moe.moe_utils import get_updated_expert_bias_quantile_balancing
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.training.initialize import _set_random_seed
@@ -148,10 +149,11 @@ class TestUpdateRouterQBBeta:
             num_moe_experts=num_experts,
             use_cpu_initialization=True,
             moe_router_load_balancing_type="quantile_balancing",
-            moe_router_score_function="softmax",
+            moe_router_score_function="sigmoid",
             moe_router_topk=2,
             moe_aux_loss_coeff=0,
             moe_router_quantile_balancing_ema=ema,
+            moe_router_quantile_balancing_histogram=True,
             bf16=True,
             params_dtype=torch.bfloat16,
             add_bias_linear=False,
@@ -170,48 +172,46 @@ class TestUpdateRouterQBBeta:
         # Non-zero prior bias so the EMA term is actually exercised.
         router.qb_beta.copy_(torch.randn_like(router.qb_beta))
 
-        # The real router forward populates qb_beta_accum / qb_beta_count.
+        # The real router forward accumulates a whole-step histogram.
         hidden = torch.randn((32, 2, config.hidden_size)).cuda().bfloat16()
         router(hidden)
         router(hidden)
-        assert router.qb_beta_count.item() == 2
-        assert router.qb_beta_accum.abs().sum().item() > 0
-
-        # Expected from the real accumulators: DP-avg(accum/count), EMA-blend, re-center.
-        local_avg = router.qb_beta_accum / router.qb_beta_count.clamp(min=1).to(torch.float32)
-        torch.distributed.all_reduce(
-            local_avg, op=torch.distributed.ReduceOp.AVG, group=dist.group.WORLD
+        histogram = router.local_quantile_balancing_histogram.clone()
+        assert histogram.sum().item() > 0
+        expected = get_updated_expert_bias_quantile_balancing(
+            histogram,
+            router.qb_beta,
+            topk=config.moe_router_topk,
+            ema_beta=ema,
+            ema_step=torch.ones(1, dtype=torch.int64, device=router.qb_beta.device),
+            tp_dp_cp_group=dist.group.WORLD,
         )
-        blended = ema * router.qb_beta + (1.0 - ema) * local_avg
-        expected = blended - blended.mean(dim=-1, keepdim=True)
 
-        _update_router_qb_beta([moe_layer], config, dp_cp_group=dist.group.WORLD)
+        _update_router_qb_beta([moe_layer], config, tp_dp_cp_group=dist.group.WORLD)
 
         torch.testing.assert_close(router.qb_beta, expected)
         torch.testing.assert_close(
             router.qb_beta.mean(), torch.zeros((), device=router.qb_beta.device)
         )
 
-        # reset_model_temporary_tensors clears the accumulators for the next global batch.
+        # reset_model_temporary_tensors clears the histogram for the next global batch.
         reset_model_temporary_tensors(config, [moe_layer])
-        torch.testing.assert_close(router.qb_beta_accum, torch.zeros_like(router.qb_beta_accum))
-        assert router.qb_beta_count.item() == 0
+        torch.testing.assert_close(
+            router.local_quantile_balancing_histogram,
+            torch.zeros_like(router.local_quantile_balancing_histogram),
+        )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_update_router_qb_beta_skips_eval(self):
         config, moe_layer = self._build_moe_layer(ema=0.0)
         router = moe_layer.router
-        # Non-zero prior + non-uniform accumulator, so a broken eval guard would visibly
-        # change qb_beta (a uniform accumulator re-centers to zero and hides the bug).
+        # Non-zero prior + non-empty histogram, so a broken eval guard would visibly change qb_beta.
         router.qb_beta.copy_(torch.ones_like(router.qb_beta))
-        router.qb_beta_accum.copy_(
-            torch.arange(router.qb_beta.numel(), dtype=torch.float32, device=router.qb_beta.device)
-        )
-        router.qb_beta_count.fill_(1)
+        router.local_quantile_balancing_histogram.fill_(1)
         before = router.qb_beta.clone()
         router.eval()
 
-        _update_router_qb_beta([moe_layer], config, dp_cp_group=dist.group.WORLD)
+        _update_router_qb_beta([moe_layer], config, tp_dp_cp_group=dist.group.WORLD)
 
         # Eval-mode modules are skipped, so qb_beta is unchanged.
         torch.testing.assert_close(router.qb_beta, before)

--- a/tests/unit_tests/transformer/moe/test_qb_routing.py
+++ b/tests/unit_tests/transformer/moe/test_qb_routing.py
@@ -7,7 +7,10 @@ import torch
 
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
-from megatron.core.transformer.moe.moe_utils import qb_dual_update
+from megatron.core.transformer.moe.moe_utils import (
+    compute_quantile_balancing_histogram,
+    get_updated_expert_bias_quantile_balancing,
+)
 from megatron.core.transformer.moe.router import Router
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -15,24 +18,19 @@ from megatron.training.initialize import _set_random_seed
 from tests.unit_tests.test_utilities import Utils
 
 
-class TestQBDualUpdate:
-    """Pure-tensor tests for the quantile-balancing dual update (CPU, no distributed)."""
+class TestQBHistogram:
+    """Pure-tensor tests for whole-step histogram Quantile Balancing."""
 
     @pytest.mark.internal
     @pytest.mark.parametrize("m,n,k", [(64, 8, 2), (40, 8, 1), (12, 4, 1)])
-    def test_column_quantile_contract(self, m, n, k):
-        """qb_beta_local is the (col_target+1)-th largest score minus alpha per expert."""
+    def test_histograms_are_additive_across_microbatches(self, m, n, k):
         torch.manual_seed(123)
-        scores = torch.randn(m, n)
+        scores = torch.sigmoid(torch.randn(m, n))
         beta = torch.zeros(n)
-
-        _, beta_local = qb_dual_update(scores, k, beta, update_beta=True)
-
-        alpha = (scores - beta).topk(k + 1, dim=1).values[:, -1:]
-        adjusted = scores - alpha
-        col_target = m * k // n
-        expected = adjusted.sort(dim=0, descending=True).values[col_target]
-        torch.testing.assert_close(beta_local, expected)
+        whole = compute_quantile_balancing_histogram(scores, beta, k, num_bins=1000)
+        split = compute_quantile_balancing_histogram(scores[: m // 2], beta, k, num_bins=1000)
+        split += compute_quantile_balancing_histogram(scores[m // 2 :], beta, k, num_bins=1000)
+        torch.testing.assert_close(split, whole)
 
 
 class TestQuantileBalancingRouter:
@@ -47,9 +45,10 @@ class TestQuantileBalancingRouter:
             num_moe_experts=self.num_moe_experts,
             use_cpu_initialization=True,
             moe_router_load_balancing_type="quantile_balancing",
-            moe_router_score_function="softmax",
+            moe_router_score_function="sigmoid",
             moe_router_topk=2,
             moe_aux_loss_coeff=0,
+            moe_router_quantile_balancing_histogram=True,
             bf16=True,
             params_dtype=torch.bfloat16,
             add_bias_linear=False,
@@ -83,18 +82,29 @@ class TestQuantileBalancingRouter:
         )
         router = MoELayer(config, self.submodules).router
         assert router.qb_beta is None
-        assert router.qb_beta_accum is None
-        assert router.qb_beta_count is None
+        assert router.local_quantile_balancing_histogram is None
+
+    @pytest.mark.internal
+    def test_original_qb_remains_the_default_variant(self):
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            num_moe_experts=self.num_moe_experts,
+            use_cpu_initialization=True,
+            moe_router_load_balancing_type="quantile_balancing",
+            moe_router_score_function="softmax",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0,
+        )
+        router = MoELayer(config, self.submodules).router
+        assert router.local_quantile_balancing_histogram is None
+        assert router.qb_beta_accum is not None
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    @pytest.mark.parametrize("moe_router_pre_softmax", [True, False])
-    @pytest.mark.parametrize("score_function", ["softmax", "sigmoid"])
-    def test_qb_router_forward(self, score_function, moe_router_pre_softmax):
+    def test_qb_router_forward(self):
         self.router = self.router.cuda()
-        self.router.config.moe_router_score_function = score_function
-        self.router.score_function = score_function
-        self.router.config.moe_router_pre_softmax = moe_router_pre_softmax
 
         num_tokens = 32 * 2
         hidden_states = torch.randn((32, 2, self.router.config.hidden_size)).cuda().bfloat16()
@@ -108,32 +118,33 @@ class TestQuantileBalancingRouter:
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_qb_beta_accumulates_in_training(self):
+    def test_qb_histogram_accumulates_in_training(self):
         self.router = self.router.cuda()
         self.router.train()
         hidden_states = torch.randn((32, 2, self.router.config.hidden_size)).cuda().bfloat16()
 
-        assert self.router.qb_beta_count.item() == 0
+        assert self.router.local_quantile_balancing_histogram.sum().item() == 0
         self.router(hidden_states)
-        assert self.router.qb_beta_count.item() == 1
-        assert self.router.qb_beta_accum.abs().sum().item() > 0
+        first_histogram = self.router.local_quantile_balancing_histogram.clone()
+        assert first_histogram.sum().item() > 0
         self.router(hidden_states)
-        assert self.router.qb_beta_count.item() == 2
+        assert self.router.local_quantile_balancing_histogram.sum().item() == 2 * first_histogram.sum().item()
 
         # No accumulation outside the training path (eval / recompute).
-        accum_before = self.router.qb_beta_accum.clone()
+        histogram_before = self.router.local_quantile_balancing_histogram.clone()
         with torch.no_grad():
             self.router(hidden_states)
-        assert self.router.qb_beta_count.item() == 2
-        torch.testing.assert_close(self.router.qb_beta_accum, accum_before)
+        torch.testing.assert_close(self.router.local_quantile_balancing_histogram, histogram_before)
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_qb_router_rejects_padding_mask(self):
+    def test_qb_router_excludes_padding_from_histogram(self):
         self.router = self.router.cuda()
         hidden_states = torch.randn((32, 2, self.router.config.hidden_size)).cuda().bfloat16()
         padding_mask = torch.zeros((32, 2), dtype=torch.bool, device=hidden_states.device)
         padding_mask[-2:] = True
 
-        with pytest.raises(AssertionError, match="does not support padding masks"):
-            self.router(hidden_states, padding_mask=padding_mask)
+        self.router.train()
+        self.router(hidden_states, padding_mask=padding_mask)
+        valid_tokens = padding_mask.numel() - padding_mask.sum().item()
+        assert self.router.local_quantile_balancing_histogram.sum().item() == valid_tokens * self.num_moe_experts


### PR DESCRIPTION
Enable the Kimi K3-style whole-step histogram implementation with:

--moe-router-load-balancing-type quantile_balancing

--moe-router-quantile-balancing-histogram

--moe-router-score-function sigmoid

--moe-aux-loss-coeff 0

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
