### PR TITLE
Add RMSNorm latent up-projection

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1375,6 +1375,150 @@ class TELinear(te.pytorch.Linear):
             super().backward_dw()
 
 
+class TERMSNormDuplicatedLinear(te.pytorch.LayerNormLinear):
+    """Transformer Engine RMSNormLinear with weights duplicated across TP ranks."""
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        *,
+        parallel_mode: Optional[str],
+        config: TransformerConfig,
+        init_method: Callable,
+        bias: bool,
+        skip_bias_add: bool,
+        skip_weight_param_allocation: bool,
+        is_expert: bool = False,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        name: str | None = None,
+        gtp_remat_group: Optional[torch.distributed.ProcessGroup] = None,
+        gtp_replica_group: Optional[torch.distributed.ProcessGroup] = None,
+    ):
+        if not HAVE_TE:
+            raise ImportError(
+                "Transformer Engine is not installed. "
+                "Please install it with `pip install transformer-engine`."
+            )
+        if parallel_mode != "duplicated":
+            raise ValueError("TERMSNormDuplicatedLinear requires parallel_mode='duplicated'.")
+        if is_expert:
+            raise ValueError("TERMSNormDuplicatedLinear does not support expert parameters.")
+        if skip_weight_param_allocation:
+            raise ValueError(
+                "Transformer Engine linear layers do not support skip_weight_param_allocation"
+            )
+
+        self.config = config
+        self.te_return_bias = skip_bias_add and bias
+        self.is_first_microbatch = True
+        self.disable_parameter_transpose_cache = self.config.disable_parameter_transpose_cache
+        self.rng_tracker_name = get_data_parallel_rng_tracker_name()
+
+        extra_kwargs = _get_extra_te_kwargs(config)
+        if self.config.delay_wgrad_compute:
+            if is_te_min_version("2.3.0"):
+                extra_kwargs["delay_wgrad_compute"] = True
+            else:
+                raise RuntimeError("Only TE with version >=2.3.0 supports delay_wgrad_compute now.")
+
+        self.te_quant_params: Optional[TEQuantizationParams] = None
+        quant_config = get_quant_config_or_none(name, config.quant_recipe)
+        self.finish_init(quant_config)
+        init_quant_context = _get_fp8_model_init_for_quant_params(
+            self.te_quant_params, torch.is_grad_enabled()
+        )
+        init_gtp_remat_context = _init_gtp_remat_context(
+            self,
+            output_size,
+            gtp_remat_group,
+            extra_kwargs,
+            rng_via_kwarg=False,
+            replica_group=gtp_replica_group,
+        )
+
+        with init_quant_context, init_gtp_remat_context as output_size:
+            super().__init__(
+                in_features=input_size,
+                out_features=output_size,
+                eps=self.config.layernorm_epsilon,
+                sequence_parallel=False,
+                fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
+                tp_group=None,
+                tp_size=1,
+                get_rng_state_tracker=(
+                    get_cuda_rng_tracker if get_cuda_rng_tracker().is_initialized() else None
+                ),
+                init_method=condition_init_method(config, init_method),
+                bias=bias,
+                normalization="RMSNorm",
+                return_bias=self.te_return_bias,
+                parallel_mode=None,
+                return_layernorm_output=False,
+                zero_centered_gamma=self.config.layernorm_zero_centered_gamma,
+                **extra_kwargs,
+            )
+
+        if bias and gtp_remat_group is not None and gtp_remat_group.size() > 1:
+            # GTP shards only the linear weight. TE sizes bias from the pre-sharded
+            # out_features, so restore its replicated logical width after construction.
+            with torch.no_grad():
+                self.bias.data = self.bias.data.new_zeros(self.out_features)
+
+        self._tp_group = (
+            tp_group
+            if tp_group is not None
+            else get_tensor_model_parallel_group_if_none(tp_group, is_expert=False)
+        )
+        for param in self.parameters():
+            setattr(param, "allreduce", True)
+            setattr(param, "sequence_parallel", self.config.sequence_parallel)
+            setattr(param, "tensor_model_parallel", False)
+
+    def finish_init(self, quantization_config: QuantizationConfig):
+        """Post-init of quantization override."""
+        if quantization_config is None:
+            self.te_quant_params = None
+        else:
+            self.te_quant_params = TEQuantizationParams.parse_from_config(quantization_config)
+
+    def will_execute_quantized(self, is_context_quantized: bool) -> bool:
+        """Return whether the module is configured to execute quantized."""
+        return _get_should_context_be_quantized_params(
+            self.te_quant_params, self.training, is_context_quantized
+        )
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Apply RMSNorm followed by the duplicated linear projection."""
+        _is_first_microbatch = (
+            None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+        )
+        quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
+        with quant_context:
+            out = super().forward(x, is_first_microbatch=_is_first_microbatch)
+        self.is_first_microbatch = False
+        if self.te_return_bias:
+            return out
+        return out, None
+
+    def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        """Replicate parameters across TP and DP checkpoint coordinates."""
+        state_dict = self.state_dict(prefix="", keep_vars=True)
+        return make_sharded_tensors_for_checkpoint(
+            state_dict,
+            prefix,
+            None,
+            sharded_offsets,
+            tp_group=self._tp_group,
+            dp_cp_group=metadata["dp_cp_group"],
+        )
+
+    def backward_dw(self):
+        """Compute weight gradients when delayed wgrad computation is enabled."""
+        if self.config.delay_wgrad_compute:
+            super().backward_dw()
+
+
 class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
     """Wrapper for the Transformer-Engine's `LayerNormLinear` layer
     that combines layernorm and linear layers."""

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -60,9 +60,13 @@ except ImportError:
     HAVE_TRITON = False
 
 if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import TELinear, te_checkpoint
+    from megatron.core.extensions.transformer_engine import (
+        TELinear,
+        TERMSNormDuplicatedLinear,
+        te_checkpoint,
+    )
 else:
-    TELinear, te_checkpoint = None, None
+    TELinear, TERMSNormDuplicatedLinear, te_checkpoint = None, None, None
 
 
 class ExpertsInterface(Protocol):
@@ -266,6 +270,11 @@ class MoELayer(BaseMoELayer):
         if self.config.moe_latent_size:
             assert HAVE_TE, "TransformerEngine is required for MoE latent projections."
             if self.config.transformer_impl == "inference_optimized":
+                if self.config.moe_latent_up_projection_rmsnorm:
+                    raise NotImplementedError(
+                        "The inference-optimized latent projection does not support "
+                        "RMSNorm followed by Linear."
+                    )
                 from megatron.core.tensor_parallel.inference_layers import InferenceLinear
 
                 linear_cls = InferenceLinear
@@ -295,7 +304,15 @@ class MoELayer(BaseMoELayer):
                 name=(name + ".fc1_latent_proj") if name is not None else None,
                 **linear_gtp_kwargs,
             )
-            self.fc2_latent_proj = linear_cls(
+            fc2_linear_cls = (
+                TERMSNormDuplicatedLinear
+                if self.config.moe_latent_up_projection_rmsnorm
+                else linear_cls
+            )
+            fc2_extra_kwargs = dict(linear_gtp_kwargs)
+            if fc2_linear_cls is TERMSNormDuplicatedLinear:
+                fc2_extra_kwargs["tp_group"] = pg_collection.tp
+            self.fc2_latent_proj = fc2_linear_cls(
                 self.config.moe_latent_size,
                 self.config.hidden_size,
                 parallel_mode="duplicated",
@@ -306,7 +323,7 @@ class MoELayer(BaseMoELayer):
                 skip_weight_param_allocation=False,
                 is_expert=False,
                 name=(name + ".fc2_latent_proj") if name is not None else None,
-                **linear_gtp_kwargs,
+                **fc2_extra_kwargs,
             )
             if linear_cls is TELinear:
                 # The duplicated operation has no TP execution group. TELinear uses

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -956,6 +956,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 
+    moe_latent_up_projection_rmsnorm: bool = False
+    """Apply RMSNorm immediately before the duplicated MoE latent up-projection."""
+
     gtp_remat_opt_in_modules: list[str] = field(default_factory=list)
     """Extra modules to apply GTP_remat weight sharding to, beyond the default set (attention,
     Mamba, MLP, expert linears, embeddings). Allowed values:
@@ -1742,6 +1745,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.num_moe_experts is not None and self.num_moe_experts <= 0:
             raise ValueError("num_moe_experts must be non-negative.")
+
+        if self.moe_latent_up_projection_rmsnorm and self.moe_latent_size is None:
+            raise ValueError("moe_latent_up_projection_rmsnorm requires moe_latent_size to be set.")
 
         if self.num_moe_experts is not None and self.moe_ffn_hidden_size is None:
             self.moe_ffn_hidden_size = self.ffn_hidden_size

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2339,6 +2339,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
 
     # MoE latent projection.
     _set_arg('moe_latent_size', force=True)
+    _set_arg('moe_latent_up_projection_rmsnorm', force=True)
 
     # Tokenizer args.
     if args.use_tokenizer_model_from_checkpoint_args:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -48,6 +48,7 @@ from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
 import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
 import megatron.core.tensor_parallel.gtp_cuda_graphs as gtp_cuda_graphs
 from megatron.core import parallel_state
+from megatron.core.extensions.transformer_engine import TERMSNormDuplicatedLinear
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     GTPChain,
@@ -56,6 +57,8 @@ from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     wrap_module_params_gtp,
 )
 from megatron.core.tensor_parallel.gtp_cuda_graphs import preserve_gtp_prefetch_state
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
     _make_gtp_linear,
     _make_gtp_remat_grouped_linear,
@@ -308,6 +311,73 @@ class TestLayerNormLinearGTP:
     def test_forward_backward(self):
         _requires_multi_gpu(4)
         _run_distributed(_worker_layernorm_linear, 4)
+
+
+def _worker_rmsnorm_duplicated_linear(rank, world_size, port, bias):
+    torch.manual_seed(0)
+    seq, batch, in_f, out_f = 4, 2, 64, 128
+    dtype = torch.bfloat16
+    gtp_remat_group = dist.new_group(list(range(world_size)))
+    replica_groups = [dist.new_group([replica_rank]) for replica_rank in range(world_size)]
+    replica_group = replica_groups[rank]
+    model_parallel_cuda_manual_seed(
+        42,
+        gtp_remat_rank=rank,
+        egtp_remat_rank=0,
+        gtp_remat_world_size=world_size,
+        egtp_remat_world_size=1,
+        force_reset_rng=True,
+    )
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=in_f,
+        num_attention_heads=4,
+        params_dtype=dtype,
+        tensor_parallel_num_weight_shards=world_size,
+    )
+    layer = TERMSNormDuplicatedLinear(
+        in_f,
+        out_f,
+        parallel_mode="duplicated",
+        config=config,
+        init_method=config.output_layer_init_method,
+        bias=bias,
+        skip_bias_add=False,
+        skip_weight_param_allocation=False,
+        tp_group=replica_group,
+        gtp_remat_group=gtp_remat_group,
+        gtp_replica_group=replica_group,
+    )
+
+    assert isinstance(layer.weight, GTPShardedParam)
+    assert not isinstance(layer.layer_norm_weight, GTPShardedParam)
+    assert layer.weight.shape == (out_f // world_size, in_f)
+    assert layer.layer_norm_weight.shape == (in_f,)
+    assert layer._tp_group is replica_group
+    assert layer.weight.gtp_replica_group is replica_group
+    if bias:
+        assert layer.bias.shape == (out_f,)
+
+    inp = torch.randn(seq, batch, in_f, dtype=dtype, device="cuda", requires_grad=True)
+    dist.broadcast(inp, src=0)
+    out, output_bias = layer(inp)
+    assert output_bias is None
+    assert out.shape == (seq, batch, out_f)
+
+    layer.weight.main_grad = torch.zeros(layer.weight.shape, dtype=dtype, device="cuda")
+    out.sum().backward()
+    assert inp.grad is not None and inp.grad.shape == inp.shape
+    assert layer.layer_norm_weight.grad is not None
+    if bias:
+        assert layer.bias.grad is not None
+
+
+@pytest.mark.launch_on_gb200
+class TestRMSNormDuplicatedLinearGTP:
+    @pytest.mark.parametrize("bias", [False, True])
+    def test_forward_backward(self, bias):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_rmsnorm_duplicated_linear, 4, bias)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -206,6 +206,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_hybridep_num_blocks_unpermute": None,
     "moe_input_jitter_eps": None,
     "moe_latent_size": None,
+    "moe_latent_up_projection_rmsnorm": False,
     "moe_layer_freq": 1,
     "moe_layer_recompute": False,
     "moe_ncclep_zero_copy": False,

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -200,6 +200,29 @@ def test_load_args_restores_gdp_num_householder_from_checkpoint(
     assert restored_args.gdp_num_householder == expected_num_householder
 
 
+def test_load_args_restores_latent_rmsnorm_from_checkpoint():
+    """The latent dimension and its RMSNorm up-projection are reconstructed together."""
+    checkpoint_args = SimpleNamespace(moe_latent_size=16, moe_latent_up_projection_rmsnorm=True)
+    args = SimpleNamespace(
+        load="checkpoint",
+        iteration=0,
+        moe_latent_size=None,
+        moe_latent_up_projection_rmsnorm=False,
+        use_tokenizer_model_from_checkpoint_args=False,
+        use_mp_args_from_checkpoint_args=False,
+    )
+    state_dict = {"args": checkpoint_args, "iteration": 12}
+
+    with mock.patch(
+        "megatron.training.checkpointing._load_base_checkpoint",
+        return_value=(state_dict, "checkpoint", False, CheckpointType.LEGACY),
+    ):
+        restored_args, _ = load_args_from_checkpoint(args)
+
+    assert restored_args.moe_latent_size == 16
+    assert restored_args.moe_latent_up_projection_rmsnorm is True
+
+
 def create_checkpoint(load_path, ckpt_format):
     """Setup a dummy checkpoint directory."""
     iteration = 123

--- a/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
@@ -3,7 +3,10 @@
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.extensions import transformer_engine as transformer_engine_module
+from megatron.core.extensions.transformer_engine import TELinear, TERMSNormDuplicatedLinear
+from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_submodules,
     get_gpt_layer_with_transformer_engine_submodules,
@@ -32,6 +35,10 @@ class _RecordingLinear(torch.nn.Module):
         return transformer_engine_module.TELinear.sharded_state_dict(
             self, prefix=prefix, sharded_offsets=sharded_offsets, metadata=metadata
         )
+
+
+class _RecordingRMSNormLinear(_RecordingLinear):
+    calls = []
 
 
 class _RecordingInferenceLinear(torch.nn.Module):
@@ -143,9 +150,105 @@ def test_latent_projections_use_owning_tp_group_for_checkpoint_only(monkeypatch)
     )
 
 
+def test_latent_rmsnorm_up_projection_receives_gtp_groups(monkeypatch):
+    """The fused up-projection receives GTP groups while keeping duplicated TP execution."""
+    tp_group = _FakeProcessGroup()
+    ep_group = _FakeProcessGroup()
+    gtp_remat_group = _FakeProcessGroup()
+    gtp_replica_group = _FakeProcessGroup()
+    pg_collection = ProcessGroupCollection(
+        tp=tp_group, ep=ep_group, dp_cp=gtp_replica_group, gtp_remat=gtp_remat_group
+    )
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        num_moe_experts=1,
+        moe_router_topk=1,
+        moe_router_pre_softmax=True,
+        moe_token_dispatcher_type="allgather",
+        moe_ffn_hidden_size=16,
+        moe_latent_size=4,
+        moe_latent_up_projection_rmsnorm=True,
+        use_cpu_initialization=True,
+        add_bias_linear=False,
+        gtp_remat_opt_in_modules=["moe_latent_proj"],
+    )
+    submodules = MoESubmodules(experts=_build_dummy_module, router=_build_dummy_module)
+
+    _RecordingLinear.calls.clear()
+    _RecordingRMSNormLinear.calls.clear()
+    monkeypatch.setattr(moe_layer_module, "HAVE_TE", True)
+    monkeypatch.setattr(moe_layer_module, "TELinear", _RecordingLinear)
+    monkeypatch.setattr(moe_layer_module, "TERMSNormDuplicatedLinear", _RecordingRMSNormLinear)
+    monkeypatch.setattr(moe_layer_module, "MoEAllGatherTokenDispatcher", _DummyDispatcher)
+
+    layer = MoELayer(config, submodules, pg_collection=pg_collection)
+
+    assert len(_RecordingLinear.calls) == 1
+    assert len(_RecordingRMSNormLinear.calls) == 1
+    _, kwargs = _RecordingRMSNormLinear.calls[0]
+    assert kwargs["parallel_mode"] == "duplicated"
+    assert kwargs["tp_group"] is tp_group
+    assert kwargs["gtp_remat_group"] is gtp_remat_group
+    assert kwargs["gtp_replica_group"] is gtp_replica_group
+    assert layer.fc2_latent_proj._tp_group is tp_group
+
+
+@pytest.mark.skipif(
+    not is_te_min_version("1.7.0.dev0"),
+    reason="Transformer Engine RMSNormLinear requires TE 1.7.0 or later.",
+)
+def test_rmsnorm_duplicated_linear_checkpoint_metadata(monkeypatch):
+    """Duplicated RMSNormLinear keeps its explicit TP group in checkpoint metadata."""
+    tp_group = _FakeProcessGroup()
+    dp_cp_group = _FakeProcessGroup()
+    checkpoint_call = {}
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=32,
+        num_attention_heads=4,
+        tensor_model_parallel_size=2,
+        sequence_parallel=True,
+        use_cpu_initialization=True,
+        params_dtype=torch.bfloat16,
+    )
+    layer = TERMSNormDuplicatedLinear(
+        16,
+        32,
+        parallel_mode="duplicated",
+        config=config,
+        init_method=config.output_layer_init_method,
+        bias=False,
+        skip_bias_add=False,
+        skip_weight_param_allocation=False,
+        tp_group=tp_group,
+    )
+
+    def record_checkpoint_call(state_dict, prefix, axis_map, sharded_offsets, **kwargs):
+        checkpoint_call.update(
+            state_dict=state_dict, prefix=prefix, axis_map=axis_map, kwargs=kwargs
+        )
+        return {}
+
+    monkeypatch.setattr(
+        transformer_engine_module, "make_sharded_tensors_for_checkpoint", record_checkpoint_call
+    )
+    layer.sharded_state_dict(prefix="latent_up.", metadata={"dp_cp_group": dp_cp_group})
+
+    assert layer._tp_group is tp_group
+    assert checkpoint_call["prefix"] == "latent_up."
+    assert checkpoint_call["axis_map"] is None
+    assert checkpoint_call["kwargs"]["tp_group"] is tp_group
+    assert checkpoint_call["kwargs"]["dp_cp_group"] is dp_cp_group
+
+
 class TestLatentMoELayer:
     def setup_method(self, method):
         pass
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
 
     @pytest.mark.skipif(
         not is_te_min_version("1.7.0.dev0"),
@@ -225,5 +328,170 @@ class TestLatentMoELayer:
         hidden_states = hidden_states.cuda()
         output, _ = moe_layer(hidden_states)
         assert output.shape[2] == config.hidden_size
+
+        Utils.destroy_model_parallel()
+
+    def test_latent_up_projection_rmsnorm_requires_latent_size(self):
+        with pytest.raises(
+            ValueError, match="moe_latent_up_projection_rmsnorm requires moe_latent_size"
+        ):
+            TransformerConfig(
+                num_layers=1,
+                hidden_size=32,
+                num_attention_heads=4,
+                moe_latent_up_projection_rmsnorm=True,
+            )
+
+    @pytest.mark.skipif(
+        not is_te_min_version("1.7.0.dev0"),
+        reason="Expert with TE Linear is only supported in TE 1.7.0 and later.",
+    )
+    @pytest.mark.parametrize(
+        "tp_size",
+        [
+            1,
+            pytest.param(
+                2,
+                marks=pytest.mark.skipif(
+                    Utils.world_size < 2 or Utils.world_size % 2,
+                    reason="TP2/SP runtime test requires an even world size >= 2.",
+                ),
+            ),
+        ],
+    )
+    def test_latent_up_projection_rmsnorm(self, tp_size):
+        Utils.initialize_model_parallel(tp_size, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            moe_token_dispatcher_type="alltoall",
+            moe_router_topk=2,
+            moe_grouped_gemm=True,
+            moe_ffn_hidden_size=128,
+            activation_func=torch.nn.functional.silu,
+            gated_linear_unit=True,
+            add_bias_linear=False,
+            params_dtype=torch.bfloat16,
+            tensor_model_parallel_size=tp_size,
+            sequence_parallel=tp_size > 1,
+            moe_latent_size=16,
+            moe_latent_up_projection_rmsnorm=True,
+        )
+        submodules = get_submodules(
+            get_gpt_layer_with_transformer_engine_submodules(
+                num_experts=4, moe_grouped_gemm=True
+            ).mlp
+        )
+        moe_layer = MoELayer(config, submodules).cuda()
+
+        assert isinstance(moe_layer.fc1_latent_proj, TELinear)
+        assert isinstance(moe_layer.fc2_latent_proj, TERMSNormDuplicatedLinear)
+        assert moe_layer.fc2_latent_proj.normalization == "RMSNorm"
+        assert moe_layer.fc2_latent_proj.parallel_mode is None
+        assert moe_layer.fc2_latent_proj.tp_size == 1
+        assert (
+            moe_layer.fc2_latent_proj._tp_group is parallel_state.get_tensor_model_parallel_group()
+        )
+        assert all(
+            getattr(param, "allreduce", False)
+            and getattr(param, "sequence_parallel", False) == (tp_size > 1)
+            and not getattr(param, "tensor_model_parallel", True)
+            for param in moe_layer.fc2_latent_proj.parameters()
+        )
+        if tp_size > 1:
+            for param in moe_layer.fc2_latent_proj.parameters():
+                gathered = [torch.empty_like(param) for _ in range(tp_size)]
+                torch.distributed.all_gather(
+                    gathered, param, group=moe_layer.fc2_latent_proj._tp_group
+                )
+                for replica in gathered[1:]:
+                    torch.testing.assert_close(gathered[0], replica, rtol=0, atol=0)
+
+        latent = 4 * torch.randn(8, config.moe_latent_size, device="cuda", dtype=torch.bfloat16) + 2
+        latent.requires_grad_(True)
+        output, output_bias = moe_layer.fc2_latent_proj(latent)
+        assert output_bias is None
+
+        latent_ref = latent.detach().float().requires_grad_(True)
+        norm_weight_ref = (
+            moe_layer.fc2_latent_proj.layer_norm_weight.detach().float().requires_grad_(True)
+        )
+        linear_weight_ref = moe_layer.fc2_latent_proj.weight.detach().float().requires_grad_(True)
+        normalized_ref = latent_ref * torch.rsqrt(
+            latent_ref.square().mean(dim=-1, keepdim=True) + config.layernorm_epsilon
+        )
+        normalized_ref = normalized_ref * norm_weight_ref
+        output_ref = torch.nn.functional.linear(normalized_ref, linear_weight_ref)
+        torch.testing.assert_close(output.float(), output_ref, rtol=1e-2, atol=1e-2)
+
+        output_grad = torch.randn_like(output)
+        output.backward(output_grad)
+        output_ref.backward(output_grad.float())
+        torch.testing.assert_close(latent.grad.float(), latent_ref.grad, rtol=3e-2, atol=3e-2)
+        torch.testing.assert_close(
+            moe_layer.fc2_latent_proj.layer_norm_weight.grad.float(),
+            norm_weight_ref.grad,
+            rtol=3e-2,
+            atol=3e-2,
+        )
+        torch.testing.assert_close(
+            moe_layer.fc2_latent_proj.weight.grad.float(),
+            linear_weight_ref.grad,
+            rtol=3e-2,
+            atol=3e-2,
+        )
+
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10,
+        reason="MXFP8 requires compute capability >= 10.0 (Blackwell).",
+    )
+    @pytest.mark.skipif(
+        not is_te_min_version("2.1.0"),
+        reason="Transformer Engine MXFP8 requires TE 2.1.0 or later.",
+    )
+    def test_latent_up_projection_rmsnorm_mxfp8(self):
+        """MXFP8 RMSNorm up-projection produces finite forward and backward tensors."""
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            params_dtype=torch.bfloat16,
+            fp8="e4m3",
+            fp8_recipe="mxfp8",
+        )
+        layer = TERMSNormDuplicatedLinear(
+            32,
+            64,
+            parallel_mode="duplicated",
+            config=config,
+            init_method=config.output_layer_init_method,
+            bias=False,
+            skip_bias_add=False,
+            skip_weight_param_allocation=False,
+            tp_group=parallel_state.get_tensor_model_parallel_group(),
+        ).cuda()
+        latent = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+        with get_fp8_context(config):
+            output, output_bias = layer(latent)
+        assert output_bias is None
+        assert layer.fp8
+        assert output.dtype == torch.bfloat16
+        assert output.shape == (32, 64)
+        assert torch.isfinite(output).all()
+
+        output.square().mean().backward()
+        for tensor in (latent.grad, layer.layer_norm_weight.grad, layer.weight.grad):
+            assert tensor is not None
+            assert torch.isfinite(tensor).all()
+            assert torch.count_nonzero(tensor)
 
         Utils.destroy_model_parallel()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Add an optional RMSNorm immediately before LatentMoE's duplicated latent up-projection. This matches the routed-expert aggregation in the [Kimi K3 technical report](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf), where the combined routed latent result is normalized before projecting back to model width.

Dev counterpart: https://github.com/NVIDIA/Megatron-LM/pull/6804

## Design

- Add `moe_latent_up_projection_rmsnorm`, valid only when `moe_latent_size` is set.
- Add `TERMSNormDuplicatedLinear`, a thin MCore wrapper around TE `LayerNormLinear` with `normalization="RMSNorm"` hard-coded.
- Keep TE execution local (`tp_size=1`) because the latent up-projection is duplicated across TP ranks, while retaining the owning TP group for checkpoint metadata and MCore gradient-reduction/SP tags.
- Select the fused RMSNorm-linear wrapper only for the latent up-projection. The latent down-projection and shared-expert path are unchanged; shared-expert output is added after the routed up-projection.
- Reject the unsupported inference-optimized combination explicitly instead of silently dropping RMSNorm.
- Thread the existing GTP rematerialization and replica groups into the wrapper. Only the linear weight is GTP-sharded; the RMSNorm scale and optional full-width bias remain replicated.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

Focused unit coverage includes BF16 numerical forward/backward checks, real TP2 with sequence parallelism, explicit checkpoint process-group metadata, Blackwell MXFP8 forward/backward with aligned dimensions, and real four-rank GTP execution with and without bias. No separate functional test was added because this is a module-local selection and wrapper change.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

## Testing

Validated on NVIDIA B200 GPUs with PyTorch 2.12 nightly and Transformer Engine 2.20 development sources.

Checkpoint/rebase validation on the current tip also passed:

- `--use-checkpoint-args` restores both `moe_latent_size` and `moe_latent_up_projection_rmsnorm`.
- The hybrid-model golden-config comparator includes the new selector and passes.
- The repository autoformatter and `git diff --check` pass.

```text
2 ranks: tests/unit_tests/transformer/moe/test_latent_moe_layer.py
Result: 19 passed per rank

4 ranks: tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py -k RMSNormDuplicatedLinearGTP
Result: 2 passed per rank
```

The test suites exercise TP1 BF16, real TP2+SP BF16, MXFP8 forward/backward, and main-only GTP bias/no-bias behavior. `git diff --check`, import sorting, and Python compilation also pass.

