### PR TITLE
feat: save Bridge-compatible train_state.pt checkpoints

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -46,7 +46,10 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 from megatron.core.msc_utils import MultiStorageClientFeature, maybe_msc
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from megatron.core.optimizer import DistributedOptimizer
-from megatron.core.post_training.modelopt.checkpointing import save_modelopt_state, save_sharded_modelopt_state
+from megatron.core.post_training.modelopt.checkpointing import (
+    save_modelopt_state,
+    save_sharded_modelopt_state,
+)
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.utils import get_pg_rank, get_pg_size, unwrap_model
@@ -59,6 +62,7 @@ from . import ft_integration, wandb_utils
 from .async_utils import get_save_and_finalize_callbacks, is_empty_async_queue, schedule_async_save
 from .global_vars import get_args
 from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
+from .train_state import TRAIN_STATE_FILENAME, TrainState, load_train_state, save_train_state
 from .utils import append_to_progress_log, is_last_rank, print_rank_0, print_rank_last, warn_rank_0
 
 try:
@@ -518,6 +522,14 @@ class CheckpointType(Enum):
     FSDP_DTENSOR = auto()
 
 
+def _get_checkpoint_train_state_filename(checkpoint_name, ckpt_type):
+    """Return the per-iteration train-state sidecar path for a loaded checkpoint."""
+    checkpoint_path = maybe_msc.Path(checkpoint_name)
+    if ckpt_type == CheckpointType.LEGACY:
+        checkpoint_path = checkpoint_path.parent.parent
+    return str(checkpoint_path.joinpath(TRAIN_STATE_FILENAME))
+
+
 def _build_sharded_state_dict_metadata(
     args: Namespace, dp_cp_group: Optional[torch.distributed.ProcessGroup] = None
 ) -> dict:
@@ -727,6 +739,11 @@ def save_checkpoint(
         expert_rank=expert_rank,
         return_base_dir=return_base_dir,
     )
+    train_state_filename = os.path.join(
+        get_checkpoint_name(save_dir, iteration, release=release, return_base_dir=True),
+        TRAIN_STATE_FILENAME,
+    )
+    train_state = TrainState.from_args(args, iteration, num_floating_point_operations_so_far)
 
     # Save dataloader state if the external dataloader supports it.
     maybe_save_dataloader_state(
@@ -1073,6 +1090,8 @@ def save_checkpoint(
 
             def iter_finalize_fn():
                 prev_iteration = 0
+                ensure_directory_exists(train_state_filename)
+                save_train_state(train_state, train_state_filename)
                 save_retain_interval = getattr(
                     args, 'save_retain_interval', None
                 )  # For backwards compatibility of tests.
@@ -2846,6 +2865,12 @@ def load_checkpoint(
         # Iteration and num_floating_point_operations_so_far default to 0.
         return 0, 0
 
+    train_state = None
+    if not args.finetune and not release and ckpt_type != CheckpointType.LOCAL:
+        train_state_filename = _get_checkpoint_train_state_filename(checkpoint_name, ckpt_type)
+        if maybe_msc.os.path.isfile(train_state_filename):
+            train_state = load_train_state(train_state_filename)
+
     # Set checkpoint version.
     set_checkpoint_version(state_dict.get('checkpoint_version', 0))
 
@@ -2857,6 +2882,8 @@ def load_checkpoint(
     # Set iteration.
     if args.finetune or release:
         iteration = 0
+    elif train_state is not None:
+        iteration = train_state.step
     else:
         try:
             iteration = state_dict['iteration']
@@ -2870,7 +2897,11 @@ def load_checkpoint(
                     )
                 )
                 sys.exit()
-    num_floating_point_operations_so_far = state_dict.get('num_floating_point_operations_so_far', 0)
+    num_floating_point_operations_so_far = (
+        train_state.floating_point_operations_so_far
+        if train_state is not None
+        else state_dict.get('num_floating_point_operations_so_far', 0)
+    )
 
     # Check arguments.
     if 'args' in state_dict and not args.finetune:
@@ -2881,12 +2912,18 @@ def load_checkpoint(
         # compatibility check.
         skip_args = {'num_layers'} if gpt_compat_layer_maps is not None else None
         check_checkpoint_args(checkpoint_args, skip_args=skip_args)
-        args.consumed_train_samples = getattr(checkpoint_args, 'consumed_train_samples', 0)
-        args.skipped_train_samples = getattr(checkpoint_args, 'skipped_train_samples', 0)
-        update_num_microbatches(consumed_samples=args.consumed_train_samples, verbose=True)
-        args.consumed_valid_samples = getattr(checkpoint_args, 'consumed_valid_samples', 0)
+        if train_state is None:
+            args.consumed_train_samples = getattr(checkpoint_args, 'consumed_train_samples', 0)
+            args.skipped_train_samples = getattr(checkpoint_args, 'skipped_train_samples', 0)
+            args.consumed_valid_samples = getattr(checkpoint_args, 'consumed_valid_samples', 0)
     else:
         print_rank_0('could not find arguments in the checkpoint ...')
+
+    if train_state is not None:
+        train_state.apply_to_args(args)
+
+    if not args.finetune and (train_state is not None or 'args' in state_dict):
+        update_num_microbatches(consumed_samples=args.consumed_train_samples, verbose=True)
 
     # --override-ckpt-iteration: rewind the data loader to this iteration, operating on `args`
     # (not state_dict) so it also works on checkpoints with no saved `args` (release / HF). The

--- a/megatron/training/train_state.py
+++ b/megatron/training/train_state.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Bridge-compatible mutable training state for Megatron-LM checkpoints."""
+
+from dataclasses import dataclass
+from os import PathLike
+from typing import Any
+
+import torch
+from torch.distributed.checkpoint.stateful import Stateful
+
+from megatron.core.msc_utils import maybe_msc
+
+TRAIN_STATE_FILENAME = "train_state.pt"
+
+
+@dataclass
+class TrainState(Stateful):
+    """Mutable training progress stored alongside a model checkpoint.
+
+    The serialized tensor dictionary intentionally matches Megatron Bridge's
+    ``TrainState`` schema so either project can resume the other's checkpoint.
+    """
+
+    step: int = 0
+    consumed_train_samples: int = 0
+    skipped_train_samples: int = 0
+    consumed_valid_samples: int = 0
+    floating_point_operations_so_far: int = 0
+    do_train: bool = False
+    do_valid: bool = False
+    do_test: bool = False
+
+    @classmethod
+    def from_args(cls, args: Any, step: int, floating_point_operations_so_far: int) -> "TrainState":
+        """Create a train state from Megatron-LM's mutable arguments.
+
+        Args:
+            args: Megatron-LM argument namespace.
+            step: Completed training iteration.
+            floating_point_operations_so_far: FLOPs accumulated by the run.
+
+        Returns:
+            A populated train state.
+        """
+        return cls(
+            step=step,
+            consumed_train_samples=getattr(args, "consumed_train_samples", 0),
+            skipped_train_samples=getattr(args, "skipped_train_samples", 0),
+            consumed_valid_samples=getattr(args, "consumed_valid_samples", 0),
+            floating_point_operations_so_far=floating_point_operations_so_far,
+            do_train=getattr(args, "do_train", False),
+            do_valid=getattr(args, "do_valid", False),
+            do_test=getattr(args, "do_test", False),
+        )
+
+    def apply_to_args(self, args: Any) -> None:
+        """Copy mutable training fields into a Megatron-LM argument namespace.
+
+        Args:
+            args: Megatron-LM argument namespace to update.
+        """
+        args.consumed_train_samples = self.consumed_train_samples
+        args.skipped_train_samples = self.skipped_train_samples
+        args.consumed_valid_samples = self.consumed_valid_samples
+        args.do_train = self.do_train
+        args.do_valid = self.do_valid
+        args.do_test = self.do_test
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        """Serialize the training state using the Megatron Bridge schema."""
+        return {
+            "step": torch.tensor(self.step, dtype=torch.int64),
+            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int64),
+            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int64),
+            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int64),
+            "floating_point_operations_so_far": torch.tensor(
+                self.floating_point_operations_so_far, dtype=torch.float64
+            ),
+            "do_train": torch.tensor(self.do_train, dtype=torch.bool),
+            "do_valid": torch.tensor(self.do_valid, dtype=torch.bool),
+            "do_test": torch.tensor(self.do_test, dtype=torch.bool),
+        }
+
+    def load_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
+        """Restore the training state from a Bridge-compatible tensor dictionary.
+
+        Args:
+            state_dict: Serialized mutable training fields.
+        """
+        self.step = state_dict["step"].item()
+        self.consumed_train_samples = state_dict["consumed_train_samples"].item()
+        self.skipped_train_samples = state_dict["skipped_train_samples"].item()
+        self.consumed_valid_samples = state_dict["consumed_valid_samples"].item()
+        self.floating_point_operations_so_far = state_dict[
+            "floating_point_operations_so_far"
+        ].item()
+        self.do_train = state_dict["do_train"].item()
+        self.do_valid = state_dict["do_valid"].item()
+        self.do_test = state_dict["do_test"].item()
+
+
+def save_train_state(train_state: TrainState, filename: str | PathLike[str]) -> None:
+    """Write a Bridge-compatible train-state sidecar.
+
+    Args:
+        train_state: Mutable state to serialize.
+        filename: Destination ``train_state.pt`` path.
+    """
+    maybe_msc.torch.save(train_state.state_dict(), filename)
+
+
+def load_train_state(filename: str | PathLike[str]) -> TrainState:
+    """Load a Bridge-compatible sidecar on rank zero and broadcast it.
+
+    Args:
+        filename: Source ``train_state.pt`` path.
+
+    Returns:
+        The restored mutable training state.
+
+    Raises:
+        RuntimeError: If the sidecar cannot be loaded.
+    """
+    distributed = torch.distributed.is_initialized()
+    state_obj: list[dict[str, Any] | None] = [None]
+
+    if not distributed or torch.distributed.get_rank() == 0:
+        try:
+            state_obj[0] = {
+                "state_dict": maybe_msc.torch.load(filename, map_location="cpu", weights_only=True)
+            }
+        except Exception as error:
+            state_obj[0] = {"error": f"Unable to load train state file {filename}: {error}"}
+
+    if distributed:
+        torch.distributed.broadcast_object_list(state_obj, src=0)
+
+    payload = state_obj[0]
+    if payload is None or "error" in payload:
+        message = (
+            "Train-state broadcast returned no payload" if payload is None else payload["error"]
+        )
+        raise RuntimeError(message)
+
+    train_state = TrainState()
+    train_state.load_state_dict(payload["state_dict"])
+    return train_state

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -31,6 +31,7 @@ from megatron.training.checkpointing import (
     save_checkpoint,
 )
 from megatron.training.global_vars import set_args
+from megatron.training.train_state import TrainState
 from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
@@ -371,6 +372,7 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
             assert iteration == int(f.read())
 
         ckpt_dir = args.save / "iter_0000123"
+        train_state_path = ckpt_dir / "train_state.pt"
 
         expected_ckpt_path = None
         if ckpt_format == "torch":
@@ -379,6 +381,13 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
             expected_ckpt_path = ckpt_dir / ".metadata"
 
         assert os.path.exists(expected_ckpt_path)
+        assert os.path.exists(train_state_path)
+        train_state_dict = torch.load(train_state_path, map_location="cpu", weights_only=True)
+        assert train_state_dict["step"].item() == iteration
+        assert (
+            train_state_dict["floating_point_operations_so_far"].item()
+            == num_floating_point_operations_so_far
+        )
 
 
 @pytest.mark.parametrize("ckpt_format", ["torch"])
@@ -398,6 +407,12 @@ def test_load_checkpoint(
         args.load = ckpt_dir
         args.save = ckpt_dir
         args.save_tokenizer_assets = False
+        args.consumed_train_samples = 11
+        args.skipped_train_samples = 12
+        args.consumed_valid_samples = 13
+        args.do_train = True
+        args.do_valid = False
+        args.do_test = True
         set_args(args)
 
         # Create and save a checkpoint first.
@@ -413,6 +428,29 @@ def test_load_checkpoint(
             iteration, [model], optimizer, opt_param_scheduler, num_floating_point_operations_so_far
         )
 
+        # Make the sidecar differ from legacy checkpoint args to verify it is preferred.
+        sidecar_state = TrainState(
+            step=321,
+            consumed_train_samples=31,
+            skipped_train_samples=32,
+            consumed_valid_samples=33,
+            floating_point_operations_so_far=654,
+            do_train=False,
+            do_valid=True,
+            do_test=False,
+        )
+        sidecar_path = ckpt_dir / "iter_0000123" / "train_state.pt"
+        if torch.distributed.get_rank() == 0:
+            torch.save(sidecar_state.state_dict(), sidecar_path)
+        torch.distributed.barrier()
+
+        args.consumed_train_samples = 0
+        args.skipped_train_samples = 0
+        args.consumed_valid_samples = 0
+        args.do_train = True
+        args.do_valid = False
+        args.do_test = True
+
         # Create new model, optimizer, and scheduler instances to load into.
         new_model = MockModel(config)
         new_optimizer = MockState({"optimizer": "dummy1"})
@@ -423,14 +461,38 @@ def test_load_checkpoint(
             [new_model], new_optimizer, new_opt_param_scheduler, strict=True
         )
 
-        assert loaded_iter == iteration
-        assert loaded_flops == num_floating_point_operations_so_far
+        assert loaded_iter == sidecar_state.step
+        assert loaded_flops == sidecar_state.floating_point_operations_so_far
+        assert args.consumed_train_samples == sidecar_state.consumed_train_samples
+        assert args.skipped_train_samples == sidecar_state.skipped_train_samples
+        assert args.consumed_valid_samples == sidecar_state.consumed_valid_samples
+        assert args.do_train == sidecar_state.do_train
+        assert args.do_valid == sidecar_state.do_valid
+        assert args.do_test == sidecar_state.do_test
 
         for k in model.state_dict():
             assert torch.equal(model.state_dict()[k], new_model.state_dict()[k])
 
         assert new_optimizer.state_dict() == optimizer.state_dict()
         assert new_opt_param_scheduler.state_dict() == opt_param_scheduler.state_dict()
+
+        # Removing the sidecar preserves the legacy mutable-state fallback.
+        if torch.distributed.get_rank() == 0:
+            sidecar_path.unlink()
+        torch.distributed.barrier()
+        args.consumed_train_samples = 0
+        args.skipped_train_samples = 0
+        args.consumed_valid_samples = 0
+
+        loaded_iter, loaded_flops = load_checkpoint(
+            [new_model], new_optimizer, new_opt_param_scheduler, strict=True
+        )
+
+        assert loaded_iter == iteration
+        assert loaded_flops == num_floating_point_operations_so_far
+        assert args.consumed_train_samples == 11
+        assert args.skipped_train_samples == 12
+        assert args.consumed_valid_samples == 13
 
 
 @pytest.mark.parametrize("ckpt_format", ["torch"])

--- a/tests/unit_tests/training/test_train_state.py
+++ b/tests/unit_tests/training/test_train_state.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the Bridge-compatible Megatron-LM training state."""
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.training.train_state import TrainState, load_train_state, save_train_state
+
+
+def test_train_state_matches_bridge_schema():
+    args = SimpleNamespace(
+        consumed_train_samples=11,
+        skipped_train_samples=12,
+        consumed_valid_samples=13,
+        do_train=True,
+        do_valid=False,
+        do_test=True,
+    )
+
+    train_state = TrainState.from_args(args, step=14, floating_point_operations_so_far=15)
+    state_dict = train_state.state_dict()
+
+    assert set(state_dict) == {
+        "step",
+        "consumed_train_samples",
+        "skipped_train_samples",
+        "consumed_valid_samples",
+        "floating_point_operations_so_far",
+        "do_train",
+        "do_valid",
+        "do_test",
+    }
+    assert state_dict["step"].dtype == torch.int64
+    assert state_dict["consumed_train_samples"].dtype == torch.int64
+    assert state_dict["skipped_train_samples"].dtype == torch.int64
+    assert state_dict["consumed_valid_samples"].dtype == torch.int64
+    assert state_dict["floating_point_operations_so_far"].dtype == torch.float64
+    assert state_dict["do_train"].dtype == torch.bool
+    assert state_dict["do_valid"].dtype == torch.bool
+    assert state_dict["do_test"].dtype == torch.bool
+
+
+def test_train_state_save_load_and_apply(tmp_path):
+    expected = TrainState(
+        step=21,
+        consumed_train_samples=22,
+        skipped_train_samples=23,
+        consumed_valid_samples=24,
+        floating_point_operations_so_far=25,
+        do_train=True,
+        do_valid=True,
+        do_test=False,
+    )
+    filename = tmp_path / "train_state.pt"
+
+    save_train_state(expected, filename)
+    actual = load_train_state(filename)
+    args = SimpleNamespace()
+    actual.apply_to_args(args)
+
+    assert actual == expected
+    assert args.consumed_train_samples == 22
+    assert args.skipped_train_samples == 23
+    assert args.consumed_valid_samples == 24
+    assert args.do_train is True
+    assert args.do_valid is True
+    assert args.do_test is False


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds Bridge-compatible `train_state.pt` save and load support to Megatron-LM checkpoints.

The new `TrainState` uses the same tensor schema as Megatron Bridge for iteration, consumed and skipped samples, validation samples, accumulated FLOPs, and train/valid/test flags. Rank zero writes the sidecar into each iteration directory before the checkpoint tracker advances, including async-save finalization. On resume, the sidecar is loaded on rank zero, broadcast to other ranks, and preferred over mutable values stored in checkpoint `args`; checkpoints without the sidecar retain the existing legacy loading path.

Unit coverage verifies the Bridge schema and dtypes, sidecar round trips, preference over legacy mutable values, and fallback when `train_state.pt` is absent.

## Issue tracking

Fixes #6004

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

- `python -m pytest -q --confcutdir=tests/unit_tests/training tests/unit_tests/training/test_train_state.py` (2 passed in an isolated CPU container)
- `python -m py_compile megatron/training/checkpointing.py megatron/training/train_state.py tests/unit_tests/test_checkpointing.py tests/unit_tests/training/test_train_state.py`
- repository commit and push hooks (`black`, `pylint`, and `isort` passed)
- `isort==5.13.2` and `black==26.3.0` applied to the touched files

The multi-GPU checkpoint integration test requires the repository's GPU test environment and is left to CI.
