### PR TITLE
[Inference] Support video modality in Megatron-Inference.

### DIFF
--- a/examples/inference/llava_multimodal_infer.py
+++ b/examples/inference/llava_multimodal_infer.py
@@ -1,0 +1,413 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""End-to-end LLaVAModel image/video inference through Megatron Inference.
+
+Unlike the toy unit tests, this script loads real Nemotron Omni weights into the
+legacy MCore ``LLaVAModel`` contract, runs the real vision encoder, injects the
+projected media embeddings through ``VLMInferenceWrapper``, and executes the real
+language-model decoder.
+
+Launch on an even number of GPUs (TP2/EP2, with remaining replicas used for DP):
+
+    torchrun --standalone --nproc-per-node=4 \
+      examples/inference/llava_multimodal_infer.py \
+      --hf-model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16 \
+      --media image
+
+Use ``--media video`` to exercise frame decoding and video placeholder expansion.
+This is a correctness/debugging example, not a benchmark. The legacy LLaVA
+checkpoint contract is intentionally selected even though the canonical Omni
+model now uses an expanded-sequence implementation.
+"""
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from functools import partial
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from PIL import Image, ImageDraw
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.nemotron_omni.nemotron_omni_bridge import (
+    NemotronOmniLlavaBridge,
+)
+from megatron.core.inference.apis import MegatronAsyncLLM, MegatronLLM
+from megatron.core.inference.apis.serve_config import ServeConfig
+from megatron.core.inference.config import (
+    ImageProcessingConfig,
+    InferenceConfig,
+    MambaInferenceStateConfig,
+    VideoProcessingConfig,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (
+    VLMInferenceWrapper,
+)
+from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.models.multimodal.llava_model import LLaVAModel
+from megatron.core.tokenizers.text.text_tokenizer import MegatronTokenizerText
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hf-model",
+        default="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        help="HF model ID or local HF checkpoint directory.",
+    )
+    parser.add_argument("--api", choices=("async", "sync", "completions"), default="async")
+    parser.add_argument("--media", choices=("image", "video"), default="image")
+    parser.add_argument("--graph-mode", choices=("off", "decode", "all"), default="off")
+    parser.add_argument(
+        "--cuda-graph-scope", choices=("layer", "block", "none"), default="none"
+    )
+    parser.add_argument("--num-cuda-graphs", type=int, default=-1)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--max-sequence-length", type=int, default=2048)
+    parser.add_argument("--max-tokens", type=int, default=1024)
+    parser.add_argument("--kv-cache-gb", type=int, default=4)
+    parser.add_argument("--image-max-patches", type=int, default=128)
+    parser.add_argument("--video-num-frames", type=int, default=8)
+    parser.add_argument("--coordinator-port", type=int, default=50055)
+    parser.add_argument("--http-host", default="127.0.0.1")
+    parser.add_argument("--http-port", type=int, default=5000)
+    parser.add_argument(
+        "--prompt",
+        default="Describe the visual content, including colors, shapes, text, and any motion.",
+    )
+    return parser.parse_args()
+
+
+def make_mock_png() -> bytes:
+    """Create a deterministic image without external data."""
+    image = Image.new("RGB", (384, 256), color=(235, 240, 248))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((30, 35, 170, 185), fill=(32, 112, 220), outline="black", width=4)
+    draw.ellipse((215, 45, 350, 180), fill=(242, 92, 84), outline="black", width=4)
+    draw.text((115, 215), "LLAVA", fill=(10, 10, 10))
+    stream = io.BytesIO()
+    image.save(stream, format="PNG")
+    return stream.getvalue()
+
+
+def make_mock_mp4(num_frames: int) -> bytes:
+    """Create a deterministic moving-shape video without external data."""
+    if num_frames <= 0:
+        raise ValueError("--video-num-frames must be positive.")
+    try:
+        import av  # type: ignore[import-not-found]
+    except ImportError as error:
+        raise RuntimeError("Mock video generation requires PyAV (`pip install av`).") from error
+
+    output = io.BytesIO()
+    container = av.open(output, mode="w", format="mp4")
+    video_stream = container.add_stream("mpeg4", rate=4)
+    video_stream.width = 384
+    video_stream.height = 256
+    video_stream.pix_fmt = "yuv420p"
+    for frame_index in range(num_frames):
+        image = Image.new("RGB", (384, 256), color=(235, 240, 248))
+        draw = ImageDraw.Draw(image)
+        progress = frame_index / max(num_frames - 1, 1)
+        x = 25 + round(progress * 230)
+        draw.rectangle((x, 55, x + 100, 155), fill=(32, 112, 220), outline="black", width=4)
+        draw.text((20, 15), f"LLAVA FRAME {frame_index + 1}", fill=(10, 10, 10))
+        frame = av.VideoFrame.from_image(image)
+        for packet in video_stream.encode(frame):
+            container.mux(packet)
+    for packet in video_stream.encode():
+        container.mux(packet)
+    container.close()
+    return output.getvalue()
+
+
+def configure_provider(provider: Any, args: argparse.Namespace) -> None:
+    """Configure the known-good TP2/EP2 LLaVA checkpoint layout."""
+    provider.tensor_model_parallel_size = 2
+    provider.pipeline_model_parallel_size = 1
+    provider.expert_model_parallel_size = 2
+    provider.expert_tensor_parallel_size = 1
+    provider.sequence_parallel = True
+    provider.pipeline_dtype = torch.bfloat16
+    provider.dynamic_resolution = True
+    provider.temporal_patch_dim = 1
+    provider.separate_video_embedder = False
+    provider.temporal_ckpt_compat = False
+    provider.vision_class_token_len = 10
+    provider.cuda_graph_impl = "none" if args.graph_mode == "off" else "local"
+    provider.inference_cuda_graph_scope = (
+        "none" if args.graph_mode == "off" else args.cuda_graph_scope
+    )
+    provider.moe_pad_experts_for_cuda_graph_inference = args.graph_mode != "off"
+
+
+def load_llava_model(args: argparse.Namespace) -> LLaVAModel:
+    """Load HF weights explicitly through the historical LLaVA bridge."""
+    auto_bridge = AutoBridge.from_hf_pretrained(args.hf_model, trust_remote_code=True)
+    llava_bridge = NemotronOmniLlavaBridge()
+    provider = llava_bridge.provider_bridge(auto_bridge.hf_pretrained)
+    configure_provider(provider, args)
+    provider.perform_initialization = False
+    provider.register_pre_wrap_hook(
+        partial(llava_bridge.load_weights_hf_to_megatron, auto_bridge.hf_pretrained)
+    )
+    provider.initialize_model_parallel(
+        seed=1234,
+        seed_kwargs={"inference_rng_tracker": True},
+    )
+    provider.finalize()
+    distributed_models = provider.provide_distributed_model(wrap_with_ddp=False)
+    if len(distributed_models) != 1:
+        raise RuntimeError(
+            "This example requires pipeline_model_parallel_size=1 and one local model chunk."
+        )
+
+    model = distributed_models[0].cuda().bfloat16().eval()
+    model = model.module if hasattr(model, "module") else model
+    if not hasattr(model, "llava_model"):
+        raise TypeError(f"Expected a legacy LLaVA wrapper, got {type(model).__name__}.")
+    llava_model = model.llava_model
+    if not isinstance(llava_model, LLaVAModel):
+        raise TypeError(f"Expected LLaVAModel, got {type(llava_model).__name__}.")
+
+    llava_model.config.grad_scale_func = None
+    llava_model.language_model.config.grad_scale_func = None
+    return llava_model
+
+
+def build_tokenizer(model_path: str) -> MegatronTokenizerText:
+    return MegatronTokenizerText(
+        model_path,
+        {"library": "huggingface"},
+        trust_remote_code=True,
+        use_fast=True,
+        include_special_tokens=True,
+    )
+
+
+def build_prompt_tokens(tokenizer, user_prompt: str) -> list[int]:
+    """Build one compact media-marker prompt for the VLM wrapper."""
+    marker_tokens = tokenizer.tokenize("<image>")
+    if len(marker_tokens) != 1:
+        raise RuntimeError(
+            f"Expected <image> to tokenize to one ID, got {marker_tokens}. "
+            "Check that the tokenizer matches the checkpoint."
+        )
+    marker_id = int(marker_tokens[0])
+    content = f"<img><image></img>\n{user_prompt}"
+    prompt = tokenizer.apply_chat_template(
+        [
+            {"role": "system", "content": "/no_think"},
+            {"role": "user", "content": content},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    tokens = tokenizer.tokenize(prompt)
+    if tokens.count(marker_id) != 1:
+        raise RuntimeError(f"Expected one compact <image> marker, got {tokens.count(marker_id)}.")
+    return tokens
+
+
+def build_inference_config(model: LLaVAModel, args: argparse.Namespace) -> InferenceConfig:
+    image_config = ImageProcessingConfig(
+        patch_dim=int(model.patch_dim),
+        dynamic_resolution=True,
+        use_tiling=False,
+        pixel_shuffle=bool(model._pixel_shuffle),
+        spatial_merge_size=1,
+        dynamic_resolution_min_patches=16,
+        dynamic_resolution_max_patches=args.image_max_patches,
+        vision_model_type="radio",
+    )
+    return InferenceConfig(
+        block_size_tokens=256,
+        buffer_size_gb=args.kv_cache_gb,
+        max_requests=2,
+        max_tokens=args.max_tokens,
+        max_sequence_length=args.max_sequence_length,
+        mamba_inference_state_config=MambaInferenceStateConfig.from_model(model.language_model),
+        pg_collection=model.pg_collection,
+        num_cuda_graphs=None if args.graph_mode == "off" else args.num_cuda_graphs,
+        use_cuda_graphs_for_non_decode_steps=args.graph_mode == "all",
+        cuda_graph_max_tokens=min(args.max_tokens, 512),
+        image_preprocessing_config=image_config,
+        video_preprocessing_config=VideoProcessingConfig(
+            image_config=image_config,
+            num_frames=args.video_num_frames,
+            temporal_patch_size=int(model.temporal_patch_dim),
+        ),
+    )
+
+
+def sampling_params(tokenizer, args: argparse.Namespace) -> SamplingParams:
+    return SamplingParams(
+        temperature=1.0,
+        top_k=1,
+        num_tokens_to_generate=args.max_new_tokens,
+        termination_id=tokenizer.eod,
+        skip_prompt_log_probs=True,
+    )
+
+
+def print_generated_text(text: str) -> None:
+    if dist.get_rank() == 0:
+        print("\n======== LLAVA OUTPUT ========")
+        print(text)
+        print("==============================")
+
+
+def validate_generation_result(result) -> None:
+    """Surface engine-side admission or generation failures."""
+    status = getattr(result, "status", None)
+    if getattr(status, "name", status) == "COMPLETED":
+        return
+    errors = [
+        str(event.payload)
+        for event in getattr(result, "events", [])
+        if getattr(getattr(event, "type", None), "name", "").startswith("ERROR_")
+    ]
+    details = "; ".join(errors) if errors else f"request status is {status}"
+    raise RuntimeError(f"Generation failed: {details}")
+
+
+async def run_async(args, model, tokenizer, config, prompt_tokens, media_bytes) -> None:
+    async with MegatronAsyncLLM(
+        model=model,
+        tokenizer=tokenizer,
+        inference_config=config,
+        use_coordinator=True,
+        coordinator_port=args.coordinator_port,
+        inference_wrapper_cls=VLMInferenceWrapper,
+    ) as llm:
+        if llm.is_primary_rank:
+            result = await llm.generate(
+                prompt_tokens,
+                sampling_params(tokenizer, args),
+                multi_modal_data={args.media: media_bytes},
+            )
+            validate_generation_result(result)
+            torch.cuda.synchronize()
+            print_generated_text(result.generated_text)
+
+
+def run_sync(args, model, tokenizer, config, prompt_tokens, media_bytes) -> None:
+    with MegatronLLM(
+        model=model,
+        tokenizer=tokenizer,
+        inference_config=config,
+        use_coordinator=True,
+        coordinator_port=args.coordinator_port,
+        inference_wrapper_cls=VLMInferenceWrapper,
+    ) as llm:
+        if llm.is_primary_rank:
+            result = llm.generate(
+                prompt_tokens,
+                sampling_params(tokenizer, args),
+                multi_modal_data={args.media: media_bytes},
+            )[0]
+            validate_generation_result(result)
+            torch.cuda.synchronize()
+            print_generated_text(result.generated_text)
+
+
+def post_completion(args, prompt_tokens, media_bytes) -> dict:
+    payload = json.dumps(
+        {
+            "prompt": prompt_tokens,
+            "temperature": 1.0,
+            "top_k": 1,
+            "top_p": 0.0,
+            "max_tokens": args.max_new_tokens,
+            "multi_modal_data": {
+                args.media: base64.b64encode(media_bytes).decode("ascii")
+            },
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"http://{args.http_host}:{args.http_port}/v1/completions",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    for attempt in range(50):
+        try:
+            with urllib.request.urlopen(request, timeout=300) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Completions endpoint returned HTTP {error.code}: {details}"
+            ) from error
+        except urllib.error.URLError:
+            if attempt == 49:
+                raise
+            time.sleep(0.1)
+    raise RuntimeError("Completions endpoint did not become ready.")
+
+
+async def run_completions(args, model, tokenizer, config, prompt_tokens, media_bytes) -> None:
+    lifecycle_group = dist.new_group(backend="gloo")
+    try:
+        async with MegatronAsyncLLM(
+            model=model,
+            tokenizer=tokenizer,
+            inference_config=config,
+            use_coordinator=True,
+            coordinator_port=args.coordinator_port,
+            inference_wrapper_cls=VLMInferenceWrapper,
+        ) as llm:
+            await llm.serve(
+                ServeConfig(host=args.http_host, port=args.http_port, frontend_replicas=1),
+                blocking=False,
+            )
+            dist.barrier(group=lifecycle_group)
+            if llm.is_primary_rank:
+                response = await asyncio.to_thread(
+                    post_completion, args, prompt_tokens, media_bytes
+                )
+                print_generated_text(response["choices"][0]["text"])
+            dist.barrier(group=lifecycle_group)
+    finally:
+        dist.destroy_process_group(lifecycle_group)
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO)
+    model = load_llava_model(args)
+    tokenizer = build_tokenizer(args.hf_model)
+    prompt_tokens = build_prompt_tokens(tokenizer, args.prompt)
+    media_bytes = (
+        make_mock_mp4(args.video_num_frames)
+        if args.media == "video"
+        else make_mock_png()
+    )
+    config = build_inference_config(model, args)
+
+    if dist.get_rank() == 0:
+        print(
+            f"model={type(model).__name__}, api={args.api}, media={args.media}, "
+            f"graph_mode={args.graph_mode}, prompt_tokens={len(prompt_tokens)}"
+        )
+
+    if args.api == "async":
+        asyncio.run(run_async(args, model, tokenizer, config, prompt_tokens, media_bytes))
+    elif args.api == "completions":
+        asyncio.run(
+            run_completions(args, model, tokenizer, config, prompt_tokens, media_bytes)
+        )
+    else:
+        run_sync(args, model, tokenizer, config, prompt_tokens, media_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inference/omni_multimodal_infer.py
+++ b/examples/inference/omni_multimodal_infer.py
@@ -1,0 +1,468 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Minimal Nemotron Omni text+image/video inference through MegatronAsyncLLM.
+
+This is intentionally a debugging example rather than a benchmark. It loads the
+Megatron-Bridge Nemotron Omni model, creates mock media in memory, and submits
+one multimodal request through the high-level dynamic-inference API.
+
+Launch with any number of GPUs. Each GPU hosts one complete data-parallel model replica:
+
+    torchrun --standalone --nproc-per-node=<num-gpus> \
+      examples/inference/omni_multimodal_infer.py \
+      --hf-model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16 \
+      --graph-mode decode
+
+Use ``--graph-mode off`` as the eager baseline and ``--graph-mode all`` to
+include multimodal prefill steps in CUDA-graph selection.
+
+Requires pip installation of Megatron-Bridge for the model provider, and
+at least 2 GPUs with around 40GB of memory or higher!
+"""
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from PIL import Image, ImageDraw
+
+from megatron.bridge import AutoBridge
+from megatron.core.inference.apis import MegatronAsyncLLM, MegatronLLM
+from megatron.core.inference.apis.serve_config import ServeConfig
+from megatron.core.inference.config import (
+    ImageProcessingConfig,
+    InferenceConfig,
+    MambaInferenceStateConfig,
+    VideoProcessingConfig,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.nemotron_omni_inference_wrapper import (
+    NemotronOmniInferenceWrapper,
+)
+from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.tokenizers.text.text_tokenizer import MegatronTokenizerText
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hf-model",
+        default="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        help="HF model ID or local HF checkpoint directory.",
+    )
+    parser.add_argument(
+        "--megatron-checkpoint",
+        default=None,
+        help="Optional converted Megatron checkpoint. Without it, Bridge converts HF weights.",
+    )
+    parser.add_argument(
+        "--api",
+        choices=("async", "sync", "completions"),
+        default="async",
+        help="Submit directly or through the OpenAI-compatible completions endpoint.",
+    )
+    parser.add_argument(
+        "--graph-mode",
+        choices=("off", "decode", "all"),
+        default="off",
+        help="CUDA graphs off, decode-only, or decode+prefill.",
+    )
+    parser.add_argument(
+        "--cuda-graph-scope",
+        choices=("layer", "block", "none"),
+        default="none",
+        help="Megatron local CUDA-graph capture granularity.",
+    )
+    parser.add_argument("--num-cuda-graphs", type=int, default=-1)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--max-sequence-length", type=int, default=2048)
+    parser.add_argument("--max-tokens", type=int, default=1024)
+    parser.add_argument("--kv-cache-gb", type=int, default=4)
+    parser.add_argument(
+        "--media",
+        choices=("image", "video"),
+        default="image",
+        help="Send either the generated mock PNG or mock MP4.",
+    )
+    parser.add_argument("--image-max-patches", type=int, default=128)
+    parser.add_argument(
+        "--video-num-frames",
+        type=int,
+        default=8,
+        help="Number of frames generated and sampled for mock video input.",
+    )
+    parser.add_argument("--coordinator-port", type=int, default=50055)
+    parser.add_argument("--http-host", default="127.0.0.1")
+    parser.add_argument("--http-port", type=int, default=5000)
+    parser.add_argument(
+        "--prompt",
+        default="Describe the visual content, including colors, shapes, text, and any motion.",
+    )
+    return parser.parse_args()
+
+
+def make_mock_png() -> bytes:
+    """Create a deterministic image without downloading a dataset."""
+    image = Image.new("RGB", (384, 256), color=(235, 240, 248))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((30, 35, 170, 185), fill=(32, 112, 220), outline="black", width=4)
+    draw.ellipse((215, 45, 350, 180), fill=(242, 92, 84), outline="black", width=4)
+    draw.text((95, 215), "NEMOTRON OMNI", fill=(10, 10, 10))
+    stream = io.BytesIO()
+    image.save(stream, format="PNG")
+    return stream.getvalue()
+
+
+def make_mock_mp4(num_frames: int) -> bytes:
+    """Create a deterministic moving-shape video without downloading a dataset."""
+    if num_frames <= 0:
+        raise ValueError("--video-num-frames must be positive.")
+
+    try:
+        import av  # type: ignore[import-not-found]
+    except ImportError as error:
+        raise RuntimeError("Mock video generation requires PyAV (`pip install av`).") from error
+
+    output = io.BytesIO()
+    container = av.open(output, mode="w", format="mp4")
+    video_stream = container.add_stream("mpeg4", rate=4)
+    video_stream.width = 384
+    video_stream.height = 256
+    video_stream.pix_fmt = "yuv420p"
+
+    for frame_index in range(num_frames):
+        image = Image.new("RGB", (384, 256), color=(235, 240, 248))
+        draw = ImageDraw.Draw(image)
+        progress = frame_index / max(num_frames - 1, 1)
+        x = 25 + round(progress * 230)
+        draw.rectangle((x, 55, x + 100, 155), fill=(32, 112, 220), outline="black", width=4)
+        draw.ellipse((260 - x // 3, 165, 330 - x // 3, 235), fill=(242, 92, 84))
+        draw.text((20, 15), f"NEMOTRON OMNI - FRAME {frame_index + 1}", fill=(10, 10, 10))
+        frame = av.VideoFrame.from_image(image)
+        for packet in video_stream.encode(frame):
+            container.mux(packet)
+
+    for packet in video_stream.encode():
+        container.mux(packet)
+    container.close()
+    return output.getvalue()
+
+
+def configure_provider(provider: Any, args: argparse.Namespace) -> None:
+    """Use TP2/EP2 across both ranks and apply the requested graph mode."""
+    provider.tensor_model_parallel_size = 2
+    provider.pipeline_model_parallel_size = 1
+    provider.expert_model_parallel_size = 2
+    provider.expert_tensor_parallel_size = 1
+    provider.sequence_parallel = True
+    provider.pipeline_dtype = torch.bfloat16
+    provider.dynamic_resolution = True
+    provider.temporal_patch_dim = 1
+    provider.separate_video_embedder = False
+    provider.temporal_ckpt_compat = False
+    provider.vision_class_token_len = 10
+    provider.cuda_graph_impl = "none" if args.graph_mode == "off" else "local"
+    provider.inference_cuda_graph_scope = (
+        "none" if args.graph_mode == "off" else args.cuda_graph_scope
+    )
+    provider.moe_pad_experts_for_cuda_graph_inference = args.graph_mode != "off"
+
+
+def model_overrides(args: argparse.Namespace) -> dict:
+    """Return overrides needed when loading an already converted checkpoint."""
+    return {
+        "tensor_model_parallel_size": 2,
+        "pipeline_model_parallel_size": 1,
+        "expert_model_parallel_size": 2,
+        "expert_tensor_parallel_size": 1,
+        "sequence_parallel": True,
+        "pipeline_dtype": torch.bfloat16,
+        "dynamic_resolution": True,
+        "temporal_patch_dim": 1,
+        "separate_video_embedder": False,
+        "temporal_ckpt_compat": False,
+        "vision_class_token_len": 10,
+        "cuda_graph_impl": "none" if args.graph_mode == "off" else "local",
+        "inference_cuda_graph_scope": (
+            "none" if args.graph_mode == "off" else args.cuda_graph_scope
+        ),
+    }
+
+
+def load_model(args: argparse.Namespace):
+    """Load/convert and return the canonical Bridge NemotronOmniModel."""
+    bridge = AutoBridge.from_hf_pretrained(args.hf_model, trust_remote_code=True)
+    provider = bridge.to_megatron_provider(load_weights=args.megatron_checkpoint is None)
+    configure_provider(provider, args)
+    provider.initialize_model_parallel(
+        seed=1234,
+        seed_kwargs={"inference_rng_tracker": True},
+    )
+
+    if args.megatron_checkpoint:
+        distributed_models = bridge.load_megatron_model(
+            args.megatron_checkpoint,
+            mp_overrides=model_overrides(args),
+            wrap_with_ddp=False,
+        )
+    else:
+        provider.finalize()
+        distributed_models = provider.provide_distributed_model(wrap_with_ddp=False)
+
+    if len(distributed_models) != 1:
+        raise RuntimeError(
+            "This example requires pipeline_model_parallel_size=1 and one local model chunk."
+        )
+
+    model = distributed_models[0].cuda().bfloat16().eval()
+    model = model.module if hasattr(model, "module") else model
+
+    # Training checkpoints may retain a bound optimizer loss scaler.
+    model.config.grad_scale_func = None
+    model.language_model.config.grad_scale_func = None
+    return model
+
+
+def build_tokenizer(model_path: str) -> MegatronTokenizerText:
+    return MegatronTokenizerText(
+        model_path,
+        {"library": "huggingface"},
+        trust_remote_code=True,
+        use_fast=True,
+        include_special_tokens=True,
+    )
+
+
+def build_prompt_tokens(tokenizer, model, user_prompt: str) -> list[int]:
+    content = f"<img><image></img>\n{user_prompt}"
+    prompt = tokenizer.apply_chat_template(
+        [
+            {"role": "system", "content": "/no_think"},
+            {"role": "user", "content": content},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    tokens = tokenizer.tokenize(prompt)
+    marker_count = tokens.count(int(model.image_token_index))
+    if marker_count != 1:
+        raise RuntimeError(
+            f"Expected one image marker token ({model.image_token_index}), got {marker_count}. "
+            "Check that the HF tokenizer matches the checkpoint."
+        )
+    return tokens
+
+
+def build_inference_config(model, args: argparse.Namespace) -> InferenceConfig:
+    image_config = ImageProcessingConfig(
+        patch_dim=int(model.patch_dim),
+        dynamic_resolution=True,
+        use_tiling=False,
+        pixel_shuffle=True,
+        spatial_merge_size=1,
+        dynamic_resolution_min_patches=16,
+        dynamic_resolution_max_patches=args.image_max_patches,
+        vision_model_type="radio",
+    )
+    return InferenceConfig(
+        block_size_tokens=256,
+        buffer_size_gb=args.kv_cache_gb,
+        max_requests=2,
+        max_tokens=args.max_tokens,
+        max_sequence_length=args.max_sequence_length,
+        mamba_inference_state_config=MambaInferenceStateConfig.from_model(
+            model.language_model
+        ),
+        pg_collection=model.pg_collection,
+        num_cuda_graphs=(
+            None if args.graph_mode == "off" else args.num_cuda_graphs
+        ),
+        use_cuda_graphs_for_non_decode_steps=args.graph_mode == "all",
+        cuda_graph_max_tokens=min(args.max_tokens, 512),
+        image_preprocessing_config=image_config,
+        video_preprocessing_config=VideoProcessingConfig(
+            image_config=image_config,
+            num_frames=args.video_num_frames,
+            temporal_patch_size=int(
+                getattr(model.vision_model, "temporal_patch_dim", 1)
+            ),
+        ),
+    )
+
+
+def print_result(result) -> None:
+    print_generated_text(result.generated_text)
+
+
+def print_generated_text(text: str) -> None:
+    if dist.get_rank() != 0:
+        return
+    print("\n======== NEMOTRON OMNI OUTPUT ========")
+    print(text)
+    print("======================================")
+
+
+async def run_async(args, model, tokenizer, config, prompt_tokens, media_bytes) -> None:
+    async with MegatronAsyncLLM(
+        model=model,
+        tokenizer=tokenizer,
+        inference_config=config,
+        use_coordinator=True,
+        coordinator_port=args.coordinator_port,
+        inference_wrapper_cls=NemotronOmniInferenceWrapper,
+    ) as llm:
+        if llm.is_primary_rank:
+            result = await llm.generate(
+                prompt_tokens,
+                SamplingParams(
+                    temperature=1.0,
+                    top_k=1,
+                    num_tokens_to_generate=args.max_new_tokens,
+                    termination_id=tokenizer.eod,
+                    skip_prompt_log_probs=True,
+                ),
+                multi_modal_data={args.media: media_bytes},
+            )
+            torch.cuda.synchronize()
+            print_result(result)
+
+
+def post_completion(args, prompt_tokens, media_bytes) -> dict:
+    """POST one request to the local OpenAI-compatible completions endpoint."""
+    payload = json.dumps(
+        {
+            "prompt": prompt_tokens,
+            "temperature": 1.0,
+            "top_k": 1,
+            "top_p": 0.0,
+            "max_tokens": args.max_new_tokens,
+            "multi_modal_data": {
+                args.media: base64.b64encode(media_bytes).decode("ascii")
+            },
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"http://{args.http_host}:{args.http_port}/v1/completions",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    # The listening socket is bound before serve() returns, but the frontend
+    # worker may still be importing dependencies when the first POST arrives.
+    for attempt in range(50):
+        try:
+            with urllib.request.urlopen(request, timeout=300) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Completions endpoint returned HTTP {error.code}: {details}"
+            ) from error
+        except urllib.error.URLError:
+            if attempt == 49:
+                raise
+            time.sleep(0.1)
+    raise RuntimeError("Completions endpoint did not become ready.")
+
+
+async def run_completions(
+    args, model, tokenizer, config, prompt_tokens, media_bytes
+) -> None:
+    # Lifecycle synchronization must not use the default NCCL group while the
+    # background engine is running. A worker blocked in an NCCL barrier cannot
+    # participate in the TP/EP collectives required by rank 0's HTTP request.
+    lifecycle_group = dist.new_group(backend="gloo")
+    try:
+        async with MegatronAsyncLLM(
+            model=model,
+            tokenizer=tokenizer,
+            inference_config=config,
+            use_coordinator=True,
+            coordinator_port=args.coordinator_port,
+            inference_wrapper_cls=NemotronOmniInferenceWrapper,
+        ) as llm:
+            await llm.serve(
+                ServeConfig(
+                    host=args.http_host,
+                    port=args.http_port,
+                    frontend_replicas=1,
+                ),
+                blocking=False,
+            )
+            dist.barrier(group=lifecycle_group)
+            if llm.is_primary_rank:
+                response = await asyncio.to_thread(
+                    post_completion, args, prompt_tokens, media_bytes
+                )
+                print_generated_text(response["choices"][0]["text"])
+            dist.barrier(group=lifecycle_group)
+    finally:
+        dist.destroy_process_group(lifecycle_group)
+
+
+def run_sync(args, model, tokenizer, config, prompt_tokens, media_bytes) -> None:
+    with MegatronLLM(
+        model=model,
+        tokenizer=tokenizer,
+        inference_config=config,
+        use_coordinator=True,
+        coordinator_port=args.coordinator_port,
+        inference_wrapper_cls=NemotronOmniInferenceWrapper,
+    ) as llm:
+        if llm.is_primary_rank:
+            result = llm.generate(
+                prompt_tokens,
+                SamplingParams(
+                    temperature=1.0,
+                    top_k=1,
+                    num_tokens_to_generate=args.max_new_tokens,
+                    termination_id=tokenizer.eod,
+                    skip_prompt_log_probs=True,
+                ),
+                multi_modal_data={args.media: media_bytes},
+            )[0]
+            torch.cuda.synchronize()
+            print_result(result)
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO)
+    model = load_model(args)
+    tokenizer = build_tokenizer(args.hf_model)
+    prompt_tokens = build_prompt_tokens(tokenizer, model, args.prompt)
+    media_bytes = (
+        make_mock_mp4(args.video_num_frames)
+        if args.media == "video"
+        else make_mock_png()
+    )
+    config = build_inference_config(model, args)
+
+    if dist.get_rank() == 0:
+        print(
+            f"dp_replicas={dist.get_world_size()}, api={args.api}, media={args.media}, "
+            f"graph_mode={args.graph_mode}, "
+            f"graph_scope={args.cuda_graph_scope}, prompt_tokens={len(prompt_tokens)}"
+        )
+
+    if args.api == "async":
+        asyncio.run(run_async(args, model, tokenizer, config, prompt_tokens, media_bytes))
+    elif args.api == "completions":
+        asyncio.run(
+            run_completions(args, model, tokenizer, config, prompt_tokens, media_bytes)
+        )
+    else:
+        run_sync(args, model, tokenizer, config, prompt_tokens, media_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/megatron/core/inference/apis/__init__.py
+++ b/megatron/core/inference/apis/__init__.py
@@ -3,10 +3,7 @@
 from megatron.core.inference.apis.async_llm import MegatronAsyncLLM
 from megatron.core.inference.apis.llm import MegatronLLM
 from megatron.core.inference.apis.serve_config import ServeConfig
-from megatron.core.inference.config import (
-    MediaPromptSpec,
-    MultimodalPromptConfig,
-)
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
     DynamicInferenceRequestRecord,

--- a/megatron/core/inference/apis/__init__.py
+++ b/megatron/core/inference/apis/__init__.py
@@ -3,6 +3,10 @@
 from megatron.core.inference.apis.async_llm import MegatronAsyncLLM
 from megatron.core.inference.apis.llm import MegatronLLM
 from megatron.core.inference.apis.serve_config import ServeConfig
+from megatron.core.inference.config import (
+    MediaPromptSpec,
+    MultimodalPromptConfig,
+)
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
     DynamicInferenceRequestRecord,
@@ -14,6 +18,8 @@ __all__ = [
     "DynamicInferenceRequestRecord",
     "MegatronAsyncLLM",
     "MegatronLLM",
+    "MediaPromptSpec",
+    "MultimodalPromptConfig",
     "SamplingParams",
     "ServeConfig",
 ]

--- a/megatron/core/inference/apis/async_llm.py
+++ b/megatron/core/inference/apis/async_llm.py
@@ -213,10 +213,6 @@ class MegatronAsyncLLM(_MegatronLLMBase):
             )
 
             assert self._coord_runtime is not None
-            multimodal_prompt_config = (
-                serve_config.multimodal_prompt_config
-                or self._controller.inference_wrapped_model.get_multimodal_prompt_config()
-            )
             start_text_gen_server(
                 coordinator_addr=self._coord_runtime.coord_addr,
                 tokenizer=self._controller.tokenizer,
@@ -227,7 +223,9 @@ class MegatronAsyncLLM(_MegatronLLMBase):
                 num_replicas=serve_config.frontend_replicas,
                 hostname=serve_config.host,
                 sock=serve_config.sock,
-                multimodal_prompt_config=multimodal_prompt_config,
+                multimodal_prompt_config=(
+                    self._controller.inference_wrapped_model.multimodal_prompt_config
+                ),
             )
             self._serve_started = True
 

--- a/megatron/core/inference/apis/async_llm.py
+++ b/megatron/core/inference/apis/async_llm.py
@@ -93,8 +93,8 @@ class MegatronAsyncLLM(_MegatronLLMBase):
             ``"image"`` accepts raw image bytes, a list of raw image bytes, or
             a preprocessed image tensor dictionary.
         Video:
-            Video does not yet have any supported data preprocessing or
-            modeling formats.
+            ``"video"`` accepts raw video bytes, a list of raw video bytes, or
+            a preprocessed video tensor dictionary.
         Audio:
             Audio does not yet have any supported data preprocessing or
             modeling formats.
@@ -213,6 +213,10 @@ class MegatronAsyncLLM(_MegatronLLMBase):
             )
 
             assert self._coord_runtime is not None
+            multimodal_prompt_config = (
+                serve_config.multimodal_prompt_config
+                or self._controller.inference_wrapped_model.get_multimodal_prompt_config()
+            )
             start_text_gen_server(
                 coordinator_addr=self._coord_runtime.coord_addr,
                 tokenizer=self._controller.tokenizer,
@@ -223,6 +227,7 @@ class MegatronAsyncLLM(_MegatronLLMBase):
                 num_replicas=serve_config.frontend_replicas,
                 hostname=serve_config.host,
                 sock=serve_config.sock,
+                multimodal_prompt_config=multimodal_prompt_config,
             )
             self._serve_started = True
 

--- a/megatron/core/inference/apis/llm.py
+++ b/megatron/core/inference/apis/llm.py
@@ -206,10 +206,6 @@ class MegatronLLM(_MegatronLLMBase):
             )
 
             assert self._coord_runtime is not None
-            multimodal_prompt_config = (
-                serve_config.multimodal_prompt_config
-                or self._controller.inference_wrapped_model.get_multimodal_prompt_config()
-            )
             start_text_gen_server(
                 coordinator_addr=self._coord_runtime.coord_addr,
                 tokenizer=self._controller.tokenizer,
@@ -220,7 +216,9 @@ class MegatronLLM(_MegatronLLMBase):
                 num_replicas=serve_config.frontend_replicas,
                 hostname=serve_config.host,
                 sock=serve_config.sock,
-                multimodal_prompt_config=multimodal_prompt_config,
+                multimodal_prompt_config=(
+                    self._controller.inference_wrapped_model.multimodal_prompt_config
+                ),
             )
             self._serve_started = True
 

--- a/megatron/core/inference/apis/llm.py
+++ b/megatron/core/inference/apis/llm.py
@@ -83,8 +83,8 @@ class MegatronLLM(_MegatronLLMBase):
             ``"image"`` accepts raw image bytes, a list of raw image bytes, or
             a preprocessed image tensor dictionary.
         Video:
-            Video does not yet have any supported data preprocessing or
-            modeling formats.
+            ``"video"`` accepts raw video bytes, a list of raw video bytes, or
+            a preprocessed video tensor dictionary.
         Audio:
             Audio does not yet have any supported data preprocessing or
             modeling formats.
@@ -206,6 +206,10 @@ class MegatronLLM(_MegatronLLMBase):
             )
 
             assert self._coord_runtime is not None
+            multimodal_prompt_config = (
+                serve_config.multimodal_prompt_config
+                or self._controller.inference_wrapped_model.get_multimodal_prompt_config()
+            )
             start_text_gen_server(
                 coordinator_addr=self._coord_runtime.coord_addr,
                 tokenizer=self._controller.tokenizer,
@@ -216,6 +220,7 @@ class MegatronLLM(_MegatronLLMBase):
                 num_replicas=serve_config.frontend_replicas,
                 hostname=serve_config.host,
                 sock=serve_config.sock,
+                multimodal_prompt_config=multimodal_prompt_config,
             )
             self._serve_started = True
 

--- a/megatron/core/inference/apis/serve_config.py
+++ b/megatron/core/inference/apis/serve_config.py
@@ -2,6 +2,9 @@
 
 import socket
 from dataclasses import dataclass, field
+from typing import Optional
+
+from megatron.core.inference.config import MultimodalPromptConfig
 
 
 @dataclass
@@ -49,3 +52,6 @@ class ServeConfig:
 
     Must already be bound to a real port; when set, `host` / `port` are not used for binding.
     """
+
+    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None
+    """Optional override for model-specific image and video prompt lowering."""

--- a/megatron/core/inference/apis/serve_config.py
+++ b/megatron/core/inference/apis/serve_config.py
@@ -2,9 +2,6 @@
 
 import socket
 from dataclasses import dataclass, field
-from typing import Optional
-
-from megatron.core.inference.config import MultimodalPromptConfig
 
 
 @dataclass
@@ -52,6 +49,3 @@ class ServeConfig:
 
     Must already be bound to a real port; when set, `host` / `port` are not used for binding.
     """
-
-    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None
-    """Optional override for model-specific image and video prompt lowering."""

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -248,6 +248,7 @@ class VideoProcessingConfig:
     temporal_patch_size: int = 1
     frame_manifest_magic: Optional[bytes] = None
     """Prefix for payloads encoded as ``magic + UTF-8 {"frame_paths": [...]}``."""
+    video_maintain_aspect_ratio: bool = True
 
 
 @dataclass(frozen=True)
@@ -255,7 +256,6 @@ class MediaPromptSpec:
     """Map one API media type to the model's prompt-token contract."""
 
     model_token: str = "<image>"
-    model_token_id: Optional[int] = None
     prefix: str = ""
     suffix: str = ""
     input_marker: Optional[str] = None

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -455,7 +455,7 @@ class InferenceConfig:
     """Maximum GPU bytes retained for reusable vision embeddings.
 
     A value of zero disables the cache. Cache entries use an automatically
-    generated media-content key and, unless ``allow_stale_vision_embeddings``
+    generated media-content key and, unless ``allow_stale_multimodal_embeddings``
     is enabled, are discarded whenever the inference engine is suspended or its
     generation epoch changes.
     """
@@ -597,7 +597,7 @@ class InferenceConfig:
     """Whether to log detailed context configuration at initialization.
     This is an InitVar and is not stored as a field on the config."""
 
-    allow_stale_vision_embeddings: bool = False
+    allow_stale_multimodal_embeddings: bool = False
     """Allow projected-media embeddings to survive weight-change boundaries.
 
     By default, suspend/resume and generation-epoch changes invalidate both the

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import warnings
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, dataclass, field
 from enum import Enum
 from typing import List, Literal, Optional, Tuple
 
@@ -230,6 +230,53 @@ class ImageProcessingConfig:
 
 
 @dataclass
+class VideoProcessingConfig:
+    """Configuration for decoding raw video bytes into model input tensors."""
+
+    image_config: ImageProcessingConfig
+    num_frames: int = 8
+    temporal_patch_size: int = 1
+    frame_manifest_magic: Optional[bytes] = None
+    """Prefix for payloads encoded as ``magic + UTF-8 {"frame_paths": [...]}``."""
+
+
+@dataclass(frozen=True)
+class MediaPromptSpec:
+    """Map one API media type to the model's prompt-token contract."""
+
+    model_token: str = "<image>"
+    model_token_id: Optional[int] = None
+    prefix: str = ""
+    suffix: str = ""
+    input_marker: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MultimodalPromptConfig:
+    """Prompt contracts used to lower structured image/video blocks."""
+
+    image_spec: MediaPromptSpec = field(default_factory=MediaPromptSpec)
+    video_spec: MediaPromptSpec = field(default_factory=MediaPromptSpec)
+
+    def get_spec(self, modality: str) -> MediaPromptSpec:
+        """Return the prompt specification for ``image`` or ``video``."""
+        if modality == "image":
+            return self.image_spec
+        if modality == "video":
+            return self.video_spec
+        raise ValueError(f"Unsupported media modality: {modality!r}")
+
+    @classmethod
+    def from_dict(cls, value):
+        if not value:
+            return cls()
+        return cls(
+            image_spec=MediaPromptSpec(**value.get("image_spec", {})),
+            video_spec=MediaPromptSpec(**value.get("video_spec", {})),
+        )
+
+
+@dataclass
 class InferenceConfig:
     """
     Config for inference.
@@ -366,6 +413,9 @@ class InferenceConfig:
     image_preprocessing_config: Optional[ImageProcessingConfig] = None
     """Configuration for preprocessing raw image payloads."""
 
+    video_preprocessing_config: Optional[VideoProcessingConfig] = None
+    """Configuration for decoding and preprocessing raw video payloads."""
+
     use_flashinfer_fused_rope: Optional[bool] = False
     """
     If True, use flashinfer's fused rope implementation.
@@ -389,6 +439,13 @@ class InferenceConfig:
 
     enable_prefix_caching: bool = False
     """Whether to enable prefix caching for KV cache block sharing."""
+
+    vision_embedding_cache_max_bytes: int = 0
+    """Maximum GPU bytes retained for reusable vision embeddings.
+
+    A value of zero disables the cache. Cache entries are keyed explicitly by
+    callers and are discarded whenever the inference engine is suspended.
+    """
 
     prefix_caching_eviction_policy: PrefixCachingEvictionPolicy = (
         PrefixCachingEvictionPolicy.REF_ZERO

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -455,8 +455,9 @@ class InferenceConfig:
     """Maximum GPU bytes retained for reusable vision embeddings.
 
     A value of zero disables the cache. Cache entries use an automatically
-    generated media-content key and are discarded whenever the inference engine
-    is suspended.
+    generated media-content key and, unless ``allow_stale_vision_embeddings``
+    is enabled, are discarded whenever the inference engine is suspended or its
+    generation epoch changes.
     """
 
     prefix_caching_eviction_policy: PrefixCachingEvictionPolicy = (
@@ -595,6 +596,14 @@ class InferenceConfig:
     verbose: InitVar[bool] = False
     """Whether to log detailed context configuration at initialization.
     This is an InitVar and is not stored as a field on the config."""
+
+    allow_stale_vision_embeddings: bool = False
+    """Allow projected-media embeddings to survive weight-change boundaries.
+
+    By default, suspend/resume and generation-epoch changes invalidate both the
+    shared vision-embedding cache and request-local vision state. Enable this
+    only when model weights are guaranteed not to change across those boundaries.
+    """
 
     def __post_init__(self, verbose: bool):
         self._verbose = verbose

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -169,6 +169,16 @@ class PrefixCachingCoordinatorPolicy(str, Enum):
     """Route to the rank with the fewest in-flight requests. Ignores prefix affinity."""
 
 
+class MediaCacheCoordinatorPolicy(str, Enum):
+    """Routing policy for the DP inference coordinator with media caching."""
+
+    AFFINITY = "affinity"
+    """Prefer ranks assigned the same media key when vision embeddings are cached."""
+
+    LOAD_BALANCED = "load_balanced"
+    """Ignore media affinity and route using prefix affinity and load."""
+
+
 class KVCacheManagementMode(str, Enum):
     """Mode for handling large tensors (KV cache, Mamba states) during suspend/resume."""
 
@@ -268,6 +278,7 @@ class MultimodalPromptConfig:
 
     @classmethod
     def from_dict(cls, value):
+        """Build from image and video specs."""
         if not value:
             return cls()
         return cls(
@@ -443,8 +454,9 @@ class InferenceConfig:
     vision_embedding_cache_max_bytes: int = 0
     """Maximum GPU bytes retained for reusable vision embeddings.
 
-    A value of zero disables the cache. Cache entries are keyed explicitly by
-    callers and are discarded whenever the inference engine is suspended.
+    A value of zero disables the cache. Cache entries use an automatically
+    generated media-content key and are discarded whenever the inference engine
+    is suspended.
     """
 
     prefix_caching_eviction_policy: PrefixCachingEvictionPolicy = (
@@ -468,6 +480,25 @@ class InferenceConfig:
     """Weight for prefix-aware scoring: score = alpha * match + (1 - alpha) * normalized_load.
     Higher alpha favors prefix cache hits; lower alpha favors load balance.
     Must be in [0, 1]. Only applies when enable_prefix_caching is True and using a coordinator.
+    """
+
+    media_cache_coordinator_policy: MediaCacheCoordinatorPolicy = (
+        MediaCacheCoordinatorPolicy.AFFINITY
+    )
+    """Media-cache routing policy for the DP inference coordinator.
+
+    Media affinity is active only when ``vision_embedding_cache_max_bytes`` is
+    greater than zero. Media-salted prefix affinity is controlled separately by
+    ``prefix_caching_coordinator_policy``.
+    """
+
+    media_cache_routing_weight: float = 1.0
+    """Estimated vision-encoder reuse cost in compact-prompt block units.
+
+    Multimodal coordinator routing combines this media-hit value with the number
+    of matching routing-prefix blocks before blending cache affinity with load
+    using ``prefix_caching_routing_alpha``. The engine independently uses
+    post-expansion hashes for authoritative KV lookup. Must be non-negative.
     """
 
     prefix_caching_mamba_gb: Optional[float] = None
@@ -572,6 +603,11 @@ class InferenceConfig:
             raise ValueError(
                 f"prefix_caching_routing_alpha must be in [0, 1], "
                 f"got {self.prefix_caching_routing_alpha}"
+            )
+        if self.media_cache_routing_weight < 0:
+            raise ValueError(
+                "media_cache_routing_weight must be non-negative, "
+                f"got {self.media_cache_routing_weight}"
             )
 
         if self.logprobs_mode not in ("raw_logprobs", "processed_logprobs"):

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -337,6 +337,8 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Hyperparameter for choosing to prioritize prefix hit matches vs minimizing idle load
         self.prefix_caching_routing_alpha = inference_config.prefix_caching_routing_alpha
+        self.media_cache_coordinator_policy = inference_config.media_cache_coordinator_policy
+        self.media_cache_routing_weight = inference_config.media_cache_routing_weight
 
         # Monotonic clock for prefix caching LRU eviction ordering.
         # Incremented each engine step but kept independent so the engine step

--- a/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
@@ -6,7 +6,7 @@ import json
 import logging
 import signal
 import socket
-from collections import deque
+from collections import OrderedDict, deque
 from multiprocessing import Event
 from multiprocessing.connection import Connection
 
@@ -223,6 +223,8 @@ class DataParallelInferenceCoordinator:
         # timestamps (positive int).  Missing entries are implicitly zero.
         self._hash_table: dict[int, dict[int, int]] = {}
         self._hash_assignment_counter = 0
+        self._media_cache_affinity: OrderedDict[str, bytes] = OrderedDict()
+        self._media_cache_affinity_max_entries = 65536
 
         # Clients that have completed the CONNECT handshake.
         self.known_clients = set()
@@ -243,6 +245,21 @@ class DataParallelInferenceCoordinator:
             raise RuntimeError("No engines connected")
         best_idx = int(np.argmin(self._pending_counts))
         return self._identities_list[best_idx]
+
+    def get_media_affine_data_parallel_rank(self, media_cache_key: str):
+        """Keep equal media keys on one DP rank while balancing new media."""
+        identity = self._media_cache_affinity.pop(media_cache_key, None)
+        if identity in self.identities_of_data_parallel_ranks:
+            rank_idx = self.identity_to_rank_index[identity]
+            if self._pending_counts[rank_idx] < self.max_requests:
+                self._media_cache_affinity[media_cache_key] = identity
+                return identity
+
+        identity = self.get_least_loaded_data_parallel_rank()
+        self._media_cache_affinity[media_cache_key] = identity
+        if len(self._media_cache_affinity) > self._media_cache_affinity_max_entries:
+            self._media_cache_affinity.popitem(last=False)
+        return identity
 
     def _register_rank_identity(self, identity):
         """Register a new rank identity in the scoring data structures.

--- a/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
@@ -40,6 +40,10 @@ try:
 except:
     HAVE_MSGPACK = False
 
+# Bound coordinator routing metadata; engine-side embedding caches are
+# byte-bounded separately, so older affinity entries are only opportunistic.
+_DEFAULT_MEDIA_CACHE_AFFINITY_MAX_ENTRIES = 65_536
+
 # Register faulthandler to emit stack traces upon process kill.
 faulthandler.enable()
 faulthandler.register(signal.SIGTERM, all_threads=False, chain=True)
@@ -243,7 +247,7 @@ class DataParallelInferenceCoordinator:
         self._hash_table: dict[int, dict[int, int]] = {}
         self._hash_assignment_counter = 0
         self._media_cache_affinity: OrderedDict[str, bytes] = OrderedDict()
-        self._media_cache_affinity_max_entries = 65536
+        self._media_cache_affinity_max_entries = _DEFAULT_MEDIA_CACHE_AFFINITY_MAX_ENTRIES
 
         # Clients that have completed the CONNECT handshake.
         self.known_clients = set()
@@ -301,6 +305,11 @@ class DataParallelInferenceCoordinator:
         """
         self.identities_of_data_parallel_ranks.remove(identity)
         self.removed_engine_identities.add(identity)
+        self._media_cache_affinity = OrderedDict(
+            (media_key, assigned_identity)
+            for media_key, assigned_identity in self._media_cache_affinity.items()
+            if assigned_identity != identity
+        )
         idx = self.identity_to_rank_index.pop(identity, None)
         if idx is None:
             return

--- a/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
@@ -13,7 +13,10 @@ from multiprocessing.connection import Connection
 import numpy as np
 import torch
 
-from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
+from megatron.core.inference.config import (
+    MediaCacheCoordinatorPolicy,
+    PrefixCachingCoordinatorPolicy,
+)
 from megatron.core.inference.headers import Headers, UnknownHeaderError
 from megatron.core.inference.inference_request import compute_block_hashes_batched
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
@@ -99,6 +102,11 @@ class DataParallelInferenceCoordinator:
             PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK
         ),
         prefix_caching_routing_alpha: float = 0.5,
+        media_cache_coordinator_policy: MediaCacheCoordinatorPolicy = (
+            MediaCacheCoordinatorPolicy.AFFINITY
+        ),
+        media_cache_routing_weight: float = 1.0,
+        vision_embedding_cache_enabled: bool = False,
         schedule_output_path: str | None = None,
         hostname: str | None = None,
     ):
@@ -117,6 +125,12 @@ class DataParallelInferenceCoordinator:
             inference_coordinator_port (Optional[int]): The TCP port number to bind the server to.
             prefix_caching_routing_alpha (float): Weight for prefix-aware routing score:
                 score = alpha * match + (1 - alpha) * normalized_load.
+            media_cache_coordinator_policy (MediaCacheCoordinatorPolicy):
+                Routing policy for media-cache affinity.
+            media_cache_routing_weight (float): Estimated vision-encoder cost in
+                units of one cached prompt block, used for multimodal routing.
+            vision_embedding_cache_enabled (bool): Whether engines retain
+                reusable projected media embeddings.
             max_requests (int): Max concurrent requests per rank, used to
                 compute normalized_load for prefix-aware scoring.
         """
@@ -200,6 +214,11 @@ class DataParallelInferenceCoordinator:
         self.enable_prefix_caching = enable_prefix_caching
         self.prefix_caching_coordinator_policy = prefix_caching_coordinator_policy
         self.prefix_caching_routing_alpha = prefix_caching_routing_alpha
+        self.media_cache_coordinator_policy = media_cache_coordinator_policy
+        self.media_cache_routing_weight = media_cache_routing_weight
+        self.vision_embedding_cache_enabled = vision_embedding_cache_enabled
+        if self.media_cache_routing_weight < 0:
+            raise ValueError("media_cache_routing_weight must be non-negative.")
         self.max_requests = max_requests
         assert self.max_requests is not None and self.max_requests > 0
 
@@ -246,20 +265,12 @@ class DataParallelInferenceCoordinator:
         best_idx = int(np.argmin(self._pending_counts))
         return self._identities_list[best_idx]
 
-    def get_media_affine_data_parallel_rank(self, media_cache_key: str):
-        """Keep equal media keys on one DP rank while balancing new media."""
-        identity = self._media_cache_affinity.pop(media_cache_key, None)
-        if identity in self.identities_of_data_parallel_ranks:
-            rank_idx = self.identity_to_rank_index[identity]
-            if self._pending_counts[rank_idx] < self.max_requests:
-                self._media_cache_affinity[media_cache_key] = identity
-                return identity
-
-        identity = self.get_least_loaded_data_parallel_rank()
+    def _update_media_affinity(self, media_cache_key: str, identity: bytes) -> None:
+        """Record the rank most recently assigned a generated media key."""
+        self._media_cache_affinity.pop(media_cache_key, None)
         self._media_cache_affinity[media_cache_key] = identity
         if len(self._media_cache_affinity) > self._media_cache_affinity_max_entries:
             self._media_cache_affinity.popitem(last=False)
-        return identity
 
     def _register_rank_identity(self, identity):
         """Register a new rank identity in the scoring data structures.
@@ -341,14 +352,23 @@ class DataParallelInferenceCoordinator:
         for data_parallel_rank_id in list(self.identities_of_data_parallel_ranks):
             self._send_to_engine(data_parallel_rank_id, serialized)
 
-    def compute_request_hashes(self, prompt):
-        """Compute block hashes for a prompt on CPU.
+    def compute_request_hashes(self, prompt, cache_salt: str | None = None):
+        """Compute compact-prompt affinity hashes on CPU.
+
+        For text requests these equal the engine's KV block hashes. For
+        multimodal requests they are routing proxies: the coordinator does not
+        preprocess media or expand placeholders, so the engine independently
+        computes authoritative KV hashes from its post-expansion tokens. With a
+        common media salt, compact-prefix matches remain a useful affinity
+        signal because equal media have equal expansion behavior.
 
         Args:
             prompt: Either a string (to be tokenized) or a list of token IDs.
+            cache_salt: Optional media identity mixed into the prompt hash
+                chain for multimodal affinity.
 
         Returns:
-            List of integer block hashes, or empty list if prefix caching is disabled.
+            List of integer routing hashes, or empty list if prefix caching is disabled.
         """
         if not self.enable_prefix_caching or self.block_size_tokens is None:
             return []
@@ -357,41 +377,81 @@ class DataParallelInferenceCoordinator:
         else:
             tokens = list(prompt)
         token_tensor = torch.tensor(tokens, dtype=torch.int64)
-        return compute_block_hashes_batched(token_tensor, self.block_size_tokens)
+        return compute_block_hashes_batched(
+            token_tensor, self.block_size_tokens, cache_salt=cache_salt
+        )
 
-    def get_best_data_parallel_rank(self, request_hashes):
-        """Select the best DP rank based on prefix cache affinity and load.
+    def get_best_data_parallel_rank(self, request_hashes, media_cache_key: str | None = None):
+        """Select the best DP rank based on media affinity, prefix affinity, and load.
 
-        Uses a scoring function: score = alpha * match + (1 - alpha) * normalized_load
-        where *match* is a policy-dependent affinity score in [0, 1] (binary for
-        ``first_prefix_block``, normalized prefix depth for ``longest_prefix``)
-        and normalized_load = free_slots / max_requests (higher means more free
-        capacity).
+        Uses ``score = alpha * cache_score + (1 - alpha) * normalized_load``,
+        where ``cache_score`` combines matching prefix blocks with a weighted
+        media-cache hit, and ``normalized_load`` is the rank's free capacity.
 
         Args:
             request_hashes: List of block hashes for the request.
+            media_cache_key: Internally generated content key for request media.
 
         Returns:
             bytes: The ZMQ identity of the selected data parallel rank.
         """
-        if self.prefix_caching_coordinator_policy == PrefixCachingCoordinatorPolicy.LOAD_BALANCED:
+        # Use load-balancing if text or multimodal coordination affinity is deactivated.
+        has_media = isinstance(media_cache_key, str) and bool(media_cache_key)
+        use_prefix_affinity = (
+            self.enable_prefix_caching
+            and bool(request_hashes)
+            and self.prefix_caching_coordinator_policy
+            != PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+        )
+        use_media_affinity = (
+            has_media
+            and self.vision_embedding_cache_enabled
+            and self.media_cache_coordinator_policy == MediaCacheCoordinatorPolicy.AFFINITY
+        )
+        if not use_prefix_affinity and not use_media_affinity:
             return self.get_least_loaded_data_parallel_rank()
 
-        # Without prefix caching (or when the request has no hashes to match on)
-        # fall back to load-balanced routing.
-        if not self.enable_prefix_caching or not request_hashes:
+        # Compute text affinity.
+        n_ranks = len(self._identities_list)
+        prefix_match = np.zeros(n_ranks, dtype=np.float64)
+        recency = np.zeros(n_ranks, dtype=np.float64)
+        if use_prefix_affinity:
+            prefix_match, recency = self._match_vector(request_hashes)
+
+        # Compute multimodal affinity.
+        media_hit = np.zeros(n_ranks, dtype=np.float64)
+        if use_media_affinity:
+            media_identity = self._media_cache_affinity.get(media_cache_key)
+            media_rank_idx = self.identity_to_rank_index.get(media_identity)
+            if (
+                media_rank_idx is not None
+                and self._pending_counts[media_rank_idx] < self.max_requests
+            ):
+                media_hit[media_rank_idx] = 1.0
+
+        # If there are no hits anywhere, just fall-back to load balancing.
+        if not prefix_match.any() and not media_hit.any():
             return self.get_least_loaded_data_parallel_rank()
 
-        match, recency = self._match_vector(request_hashes)
+        # Compute the affinity / cache score based on matched prefix blocks
+        # and a hit on the multimodal media cache per DP rank.
+        prefix_block_count = len(request_hashes) if use_prefix_affinity else 0
+        matched_prefix_blocks = prefix_match * prefix_block_count
+        reusable_work = matched_prefix_blocks + media_hit * self.media_cache_routing_weight
+        maximum_reusable_work = prefix_block_count + (
+            self.media_cache_routing_weight if use_media_affinity else 0.0
+        )
+        cache_score = (
+            reusable_work / maximum_reusable_work if maximum_reusable_work > 0 else reusable_work
+        )
 
+        # Compute a coordinator score for every DP rank, weighting the cache score
+        # against the number of free request slots for each DP rank.
         alpha = self.prefix_caching_routing_alpha
-
-        # Vectorized score: alpha * match + (1-alpha) * free_capacity_fraction.
         free_slots = np.maximum(0, self.max_requests - self._pending_counts).astype(np.float64)
-        scores = alpha * match + (1.0 - alpha) * (free_slots / self.max_requests)
+        scores = alpha * cache_score + (1.0 - alpha) * (free_slots / self.max_requests)
 
         # Tiebreak: highest score, then highest recency, then lowest rank index.
-        n_ranks = len(self._identities_list)
         order = np.lexsort((np.arange(n_ranks), -recency, -scores))
         best_idx = int(order[0])
         return self._identities_list[best_idx]
@@ -506,6 +566,11 @@ class DataParallelInferenceCoordinator:
             PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK
         ),
         prefix_caching_routing_alpha: float = 0.5,
+        media_cache_coordinator_policy: MediaCacheCoordinatorPolicy = (
+            MediaCacheCoordinatorPolicy.AFFINITY
+        ),
+        media_cache_routing_weight: float = 1.0,
+        vision_embedding_cache_enabled: bool = False,
         schedule_output_path: str | None = None,
         hostname: str | None = None,
     ):
@@ -527,6 +592,12 @@ class DataParallelInferenceCoordinator:
             prefix_caching_coordinator_policy (PrefixCachingCoordinatorPolicy): Routing policy.
             schedule_output_path (Optional[str]): Path to write scheduling decisions JSON.
             prefix_caching_routing_alpha (float): Weight for prefix-aware routing score.
+            media_cache_coordinator_policy (MediaCacheCoordinatorPolicy):
+                Routing policy for media-cache affinity.
+            media_cache_routing_weight (float): Vision reuse cost in equivalent
+                cached prompt blocks.
+            vision_embedding_cache_enabled (bool): Whether engines retain
+                reusable projected media embeddings.
             max_requests (int): Max concurrent requests per rank.
         """
         coordinator = cls(
@@ -540,6 +611,9 @@ class DataParallelInferenceCoordinator:
             enable_prefix_caching=enable_prefix_caching,
             prefix_caching_coordinator_policy=prefix_caching_coordinator_policy,
             prefix_caching_routing_alpha=prefix_caching_routing_alpha,
+            media_cache_coordinator_policy=media_cache_coordinator_policy,
+            media_cache_routing_weight=media_cache_routing_weight,
+            vision_embedding_cache_enabled=vision_embedding_cache_enabled,
             schedule_output_path=schedule_output_path,
             hostname=hostname,
         )

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -115,6 +115,11 @@ def handle_submit_request(coordinator, sender_identity, payload):
     # cache reuse can't happen; clearing hashes here just prevents affinity
     # routing that would concentrate multimodal requests onto whichever rank
     # happened to serve a text-identical prompt first.
+    media_cache_key = (
+        multi_modal_data.get("media_cache_key")
+        if isinstance(multi_modal_data, dict)
+        else None
+    )
     if multi_modal_data:
         request_hashes = []
     else:
@@ -127,7 +132,12 @@ def handle_submit_request(coordinator, sender_identity, payload):
 
     # Account for the fact that some engines may have died.
     for _ in range(len(coordinator.identities_of_data_parallel_ranks)):
-        next_identity = coordinator.get_best_data_parallel_rank(request_hashes)
+        if isinstance(media_cache_key, str):
+            next_identity = coordinator.get_media_affine_data_parallel_rank(
+                media_cache_key
+            )
+        else:
+            next_identity = coordinator.get_best_data_parallel_rank(request_hashes)
         if coordinator._send_to_engine(next_identity, engine_payload):
             break
     else:

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -17,7 +17,10 @@ import logging
 
 import torch
 
-from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
+from megatron.core.inference.config import (
+    MediaCacheCoordinatorPolicy,
+    PrefixCachingCoordinatorPolicy,
+)
 from megatron.core.inference.headers import Headers
 
 from .state import CONTROL_TRANSITIONS, CoordinatorState
@@ -110,34 +113,23 @@ def handle_submit_request(coordinator, sender_identity, payload):
         use_bin_type=True,
     )
 
-    # Skip prefix-aware routing for image-bearing requests. Prefix *caching*
-    # itself is disabled for these requests in _build_vlm_request, so cross-image
-    # cache reuse can't happen; clearing hashes here just prevents affinity
-    # routing that would concentrate multimodal requests onto whichever rank
-    # happened to serve a text-identical prompt first.
+    # Multimodal routing hashes cover the compact prompt and are salted with
+    # the internally generated media identity to compute coordinator affinity.
     media_cache_key = (
-        multi_modal_data.get("media_cache_key")
-        if isinstance(multi_modal_data, dict)
-        else None
+        multi_modal_data.get("media_cache_key") if isinstance(multi_modal_data, dict) else None
     )
-    if multi_modal_data:
-        request_hashes = []
-    else:
-        request_hashes = coordinator.compute_request_hashes(prompt)
-        if (
-            coordinator.prefix_caching_coordinator_policy
-            == PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK
-        ):
-            request_hashes = request_hashes[:1]
+    request_hashes = coordinator.compute_request_hashes(prompt, cache_salt=media_cache_key)
+    if (
+        coordinator.prefix_caching_coordinator_policy
+        == PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK
+    ):
+        request_hashes = request_hashes[:1]
 
     # Account for the fact that some engines may have died.
     for _ in range(len(coordinator.identities_of_data_parallel_ranks)):
-        if isinstance(media_cache_key, str):
-            next_identity = coordinator.get_media_affine_data_parallel_rank(
-                media_cache_key
-            )
-        else:
-            next_identity = coordinator.get_best_data_parallel_rank(request_hashes)
+        next_identity = coordinator.get_best_data_parallel_rank(
+            request_hashes, media_cache_key=media_cache_key
+        )
         if coordinator._send_to_engine(next_identity, engine_payload):
             break
     else:
@@ -150,6 +142,12 @@ def handle_submit_request(coordinator, sender_identity, payload):
 
     coordinator.request_id_to_rank[request_id] = next_identity
     coordinator._pending_counts[coordinator.identity_to_rank_index[next_identity]] += 1
+    if (
+        isinstance(media_cache_key, str)
+        and coordinator.vision_embedding_cache_enabled
+        and coordinator.media_cache_coordinator_policy == MediaCacheCoordinatorPolicy.AFFINITY
+    ):
+        coordinator._update_media_affinity(media_cache_key, next_identity)
     if request_hashes:
         coordinator._update_rank_hashes(next_identity, request_hashes)
     if coordinator.schedule_records is not None:

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -83,13 +83,6 @@ class AsyncZMQCommunicator:
     on the CPU.
     """
 
-    _READINESS_TOPIC_PREFIX = b"\x00megatron-ready:"
-
-    @classmethod
-    def _readiness_topic(cls, rank: int) -> bytes:
-        """Return the exact XPUB subscription topic identifying one group rank."""
-        return cls._READINESS_TOPIC_PREFIX + struct.pack("!I", rank)
-
     def __init__(
         self,
         zmq_context: zmq.Context,
@@ -147,35 +140,6 @@ class AsyncZMQCommunicator:
         # Rank-specific topics make duplicate reconnect notifications idempotent.
         if self.is_leader:
             broadcast_pub_sub.wait_for_subscribers(self.bcast_sock, range(1, self.world_size))
-
-        # Wait until every ProcessGroup peer has subscribed to the leader.
-        # Rank-specific topics make duplicate reconnect notifications idempotent.
-        if self.is_leader:
-            expected_topics = {self._readiness_topic(rank) for rank in range(1, self.world_size)}
-            subscribed_topics = set()
-            self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
-            try:
-                while subscribed_topics != expected_topics:
-                    notification = self.bcast_sock.recv()
-                    event, topic = notification[:1], notification[1:]
-                    if topic not in expected_topics:
-                        continue
-                    if event == b"\x01":
-                        subscribed_topics.add(topic)
-                    elif event == b"\x00":
-                        subscribed_topics.discard(topic)
-            except zmq.Again as exc:
-                missing_ranks = [
-                    rank
-                    for rank in range(1, self.world_size)
-                    if self._readiness_topic(rank) not in subscribed_topics
-                ]
-                raise RuntimeError(
-                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers; "
-                    f"missing process-group ranks: {missing_ranks}"
-                ) from exc
-            finally:
-                self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)
 
     async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -83,6 +83,13 @@ class AsyncZMQCommunicator:
     on the CPU.
     """
 
+    _READINESS_TOPIC_PREFIX = b"\x00megatron-ready:"
+
+    @classmethod
+    def _readiness_topic(cls, rank: int) -> bytes:
+        """Return the exact XPUB subscription topic identifying one group rank."""
+        return cls._READINESS_TOPIC_PREFIX + struct.pack("!I", rank)
+
     def __init__(
         self,
         zmq_context: zmq.Context,
@@ -141,23 +148,31 @@ class AsyncZMQCommunicator:
         if self.is_leader:
             broadcast_pub_sub.wait_for_subscribers(self.bcast_sock, range(1, self.world_size))
 
-        # Wait until all ProcessGroup peers have subscribed to the ZMQ leader.
-        # Otherwise, ranks that fail to subscribe in time will deadlock.
+        # Wait until every ProcessGroup peer has subscribed to the leader.
+        # Rank-specific topics make duplicate reconnect notifications idempotent.
         if self.is_leader:
-            # XPUB subscription messages are one byte for an empty-topic
-            # subscription: b"\x01". XPUB_VERBOSE is required so identical
-            # subs from every peer are reported rather than coalesced.
-            subscribed_peers = 0
+            expected_topics = {self._readiness_topic(rank) for rank in range(1, self.world_size)}
+            subscribed_topics = set()
             self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
             try:
-                while subscribed_peers < self.world_size - 1:
-                    subscription = self.bcast_sock.recv()
-                    if subscription == b"\x01":
-                        subscribed_peers += 1
+                while subscribed_topics != expected_topics:
+                    notification = self.bcast_sock.recv()
+                    event, topic = notification[:1], notification[1:]
+                    if topic not in expected_topics:
+                        continue
+                    if event == b"\x01":
+                        subscribed_topics.add(topic)
+                    elif event == b"\x00":
+                        subscribed_topics.discard(topic)
             except zmq.Again as exc:
+                missing_ranks = [
+                    rank
+                    for rank in range(1, self.world_size)
+                    if self._readiness_topic(rank) not in subscribed_topics
+                ]
                 raise RuntimeError(
-                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers: "
-                    f"{subscribed_peers}/{self.world_size - 1} connected"
+                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers; "
+                    f"missing process-group ranks: {missing_ranks}"
                 ) from exc
             finally:
                 self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)

--- a/megatron/core/inference/engines/async_zmq_communicator.py
+++ b/megatron/core/inference/engines/async_zmq_communicator.py
@@ -141,6 +141,27 @@ class AsyncZMQCommunicator:
         if self.is_leader:
             broadcast_pub_sub.wait_for_subscribers(self.bcast_sock, range(1, self.world_size))
 
+        # Wait until all ProcessGroup peers have subscribed to the ZMQ leader.
+        # Otherwise, ranks that fail to subscribe in time will deadlock.
+        if self.is_leader:
+            # XPUB subscription messages are one byte for an empty-topic
+            # subscription: b"\x01". XPUB_VERBOSE is required so identical
+            # subs from every peer are reported rather than coalesced.
+            subscribed_peers = 0
+            self.bcast_sock.setsockopt(zmq.RCVTIMEO, 60_000)
+            try:
+                while subscribed_peers < self.world_size - 1:
+                    subscription = self.bcast_sock.recv()
+                    if subscription == b"\x01":
+                        subscribed_peers += 1
+            except zmq.Again as exc:
+                raise RuntimeError(
+                    "[AsyncZMQCommunicator] Timed out waiting for ZMQ subscribers: "
+                    f"{subscribed_peers}/{self.world_size - 1} connected"
+                ) from exc
+            finally:
+                self.bcast_sock.setsockopt(zmq.RCVTIMEO, -1)
+
     async def all_reduce_max(self, *local_vals: int, async_op=True) -> int | tuple[int, ...]:
         """Element-wise all-reduce max of one or more integers.
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -8,7 +8,7 @@ import multiprocessing
 import socket
 import time
 import warnings
-from collections import deque
+from collections import OrderedDict, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -300,6 +300,13 @@ class DynamicInferenceEngine(AbstractEngine):
         self.use_synchronous_zmq_collectives = inference_config.use_synchronous_zmq_collectives
         self.disable_ep_consensus = inference_config.disable_ep_consensus
         self.ep_consensus_interval = inference_config.ep_consensus_interval
+        self.vision_embedding_cache_max_bytes = int(
+            getattr(inference_config, "vision_embedding_cache_max_bytes", 0)
+        )
+        if self.vision_embedding_cache_max_bytes < 0:
+            raise ValueError("vision_embedding_cache_max_bytes must be non-negative.")
+        self._vision_embedding_cache: OrderedDict[str, Tensor] = OrderedDict()
+        self._vision_embedding_cache_bytes = 0
         self.cuda_graph_impl = model_config.cuda_graph_impl
         self.inference_cuda_graph_scope = model_config.inference_cuda_graph_scope
         self.cuda_graph_modules = model_config.cuda_graph_modules
@@ -434,6 +441,7 @@ class DynamicInferenceEngine(AbstractEngine):
         """Reset by removing all requests and reset all state."""
 
         self._reset_pending_kv_imports()
+        self.clear_vision_embedding_cache()
         self.context.reset()
 
         # Request state.
@@ -494,6 +502,42 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Coordinator state.
         self.use_coordinator = False
+
+    @staticmethod
+    def _tensor_nbytes(tensor: Tensor) -> int:
+        return tensor.numel() * tensor.element_size()
+
+    def clear_vision_embedding_cache(self) -> None:
+        """Release all projected-media embeddings retained by this engine."""
+        self._vision_embedding_cache.clear()
+        self._vision_embedding_cache_bytes = 0
+
+    def _get_cached_vision_embedding(self, cache_key: Optional[str]) -> Optional[Tensor]:
+        if not cache_key or self.vision_embedding_cache_max_bytes == 0:
+            return None
+        embedding = self._vision_embedding_cache.pop(cache_key, None)
+        if embedding is not None:
+            self._vision_embedding_cache[cache_key] = embedding
+        return embedding
+
+    def _cache_vision_embedding(self, cache_key: Optional[str], embedding: Tensor) -> None:
+        if not cache_key or self.vision_embedding_cache_max_bytes == 0:
+            return
+        embedding_bytes = self._tensor_nbytes(embedding)
+        if embedding_bytes > self.vision_embedding_cache_max_bytes:
+            return
+        previous = self._vision_embedding_cache.pop(cache_key, None)
+        if previous is not None:
+            self._vision_embedding_cache_bytes -= self._tensor_nbytes(previous)
+        while (
+            self._vision_embedding_cache
+            and self._vision_embedding_cache_bytes + embedding_bytes
+            > self.vision_embedding_cache_max_bytes
+        ):
+            _, evicted = self._vision_embedding_cache.popitem(last=False)
+            self._vision_embedding_cache_bytes -= self._tensor_nbytes(evicted)
+        self._vision_embedding_cache[cache_key] = embedding
+        self._vision_embedding_cache_bytes += embedding_bytes
 
     async def wait_until(self, state: EngineState):
         """Wait until the engine reaches the given state.
@@ -957,6 +1001,9 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
+        # A suspend may be followed by an in-place weight refit. Projected
+        # media embeddings are weight-dependent and must never cross it.
+        self.clear_vision_embedding_cache()
         InferenceMode.unset_active()
         dynamo_helper = getattr(self.context, "dynamo_helper", None)
         if dynamo_helper is not None:
@@ -1360,6 +1407,8 @@ class DynamicInferenceEngine(AbstractEngine):
         num_tiles: Optional[Tensor] = None,
         num_img_embeddings_per_tile: int = 0,
         imgs_sizes: Optional[Tensor] = None,
+        num_frames: Optional[Tensor] = None,
+        media_cache_key: Optional[str] = None,
     ) -> asyncio.Future[DynamicInferenceRequest]:
         """Add request to inference context.
 
@@ -1389,6 +1438,9 @@ class DynamicInferenceEngine(AbstractEngine):
                 Static resolution.
             imgs_sizes (Optional[Tensor]): Per-image sizes [N, 2] with [H, W].
                 Dynamic resolution.
+            num_frames (Optional[Tensor]): Number of frames per image/video item.
+            media_cache_key (Optional[str]): Stable identity for the exact
+                preprocessed media. Equal keys reuse projected vision embeddings.
 
         Return:
             Returns an asyncio `Future[DynamicInferenceRequest]` for the user to wait on.
@@ -1423,7 +1475,12 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             raise Exception("specialize for <%s>." % type(prompt).__name__)
 
-        if imgs is not None or num_tiles is not None or imgs_sizes is not None:
+        if (
+            imgs is not None
+            or num_tiles is not None
+            or imgs_sizes is not None
+            or num_frames is not None
+        ):
             request = self._build_vlm_request(
                 request_id=request_id,
                 prompt_str=prompt_str,
@@ -1434,6 +1491,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 num_img_embeddings_per_tile=num_img_embeddings_per_tile,
                 imgs_sizes=imgs_sizes,
                 precomputed_block_hashes=precomputed_block_hashes,
+                num_frames=num_frames,
+                media_cache_key=media_cache_key,
             )
             # _build_vlm_request has already registered the image embeddings
             # and token mask into the context (add_vlm_request_data). If
@@ -1486,6 +1545,8 @@ class DynamicInferenceEngine(AbstractEngine):
         num_img_embeddings_per_tile: int,
         imgs_sizes: Optional[Tensor],
         precomputed_block_hashes: Optional[List[int]] = None,
+        num_frames: Optional[Tensor] = None,
+        media_cache_key: Optional[str] = None,
     ) -> DynamicVLMInferenceRequest:
         """Expand image tokens, run the vision encoder, register per-request
         image data on the context, and return a DynamicVLMInferenceRequest.
@@ -1505,12 +1566,12 @@ class DynamicInferenceEngine(AbstractEngine):
                 )
 
         device = torch.cuda.current_device()
-        if imgs is not None:
-            imgs = imgs.to(device=device)
         if num_tiles is not None:
             num_tiles = num_tiles.to(device=device)
         if imgs_sizes is not None:
             imgs_sizes = imgs_sizes.to(device=device)
+        if num_frames is not None:
+            num_frames = num_frames.to(device=device)
 
         is_dynamic_resolution = imgs_sizes is not None and imgs is not None
         # Dynamic-resolution requests derive their embedding count from
@@ -1528,12 +1589,20 @@ class DynamicInferenceEngine(AbstractEngine):
 
         mask_tensor: Optional[Tensor] = None
         image_embeddings: Optional[Tensor] = None
+        compact_prompt_tokens: Optional[Tensor] = None
 
         if has_images:
+            compact_prompt_tokens = tokens.clone()
             token_list: List[List[int]] = [tokens.tolist()]
+            expansion_kwargs = {
+                "num_tiles": num_tiles,
+                "imgs_sizes": imgs_sizes,
+            }
+            if num_frames is not None:
+                expansion_kwargs["num_frames"] = num_frames
             expanded_tokens_list, mask_list = (
                 self.controller.inference_wrapped_model.expand_image_tokens(
-                    token_list, num_tiles=num_tiles, imgs_sizes=imgs_sizes
+                    token_list, **expansion_kwargs
                 )
             )
             # expand_image_tokens pads the embedding slots with -1, but the mask
@@ -1551,14 +1620,39 @@ class DynamicInferenceEngine(AbstractEngine):
             mask_tensor = torch.tensor(
                 [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
             )
+            image_embeddings = self._get_cached_vision_embedding(media_cache_key)
+            if image_embeddings is not None:
+                referenced_indices = [int(v) for v in mask_list[0] if v is not None]
+                expected_embedding_count = (
+                    max(referenced_indices) + 1 if referenced_indices else 0
+                )
+                cached_embedding_count = (
+                    image_embeddings.numel() // image_embeddings.shape[-1]
+                    if image_embeddings.ndim > 0
+                    else 0
+                )
+                if cached_embedding_count != expected_embedding_count:
+                    image_embeddings = None
+            if image_embeddings is None and imgs is not None:
+                imgs = imgs.to(device=device)
 
         # PP>1 is rejected above, so we're on the (only) stage that owns the
         # vision encoder — no is_pipeline_first_stage check needed here.
         if has_images and imgs is not None:
-            with torch.inference_mode():
-                image_embeddings = self.controller.inference_wrapped_model._forward_vision_encoder(
-                    imgs, num_image_tiles=num_tiles, imgs_sizes=imgs_sizes
-                )
+            if image_embeddings is None:
+                with torch.inference_mode():
+                    encoder_kwargs = {
+                        "num_image_tiles": num_tiles,
+                        "imgs_sizes": imgs_sizes,
+                    }
+                    if num_frames is not None:
+                        encoder_kwargs["num_frames"] = num_frames
+                    image_embeddings = (
+                        self.controller.inference_wrapped_model._forward_vision_encoder(
+                            imgs, **encoder_kwargs
+                        )
+                    )
+                self._cache_vision_embedding(media_cache_key, image_embeddings)
 
         self.context.add_vlm_request_data(
             request_id, image_embeddings=image_embeddings, image_token_mask=mask_tensor
@@ -1578,6 +1672,7 @@ class DynamicInferenceEngine(AbstractEngine):
             request_id=request_id,
             prompt=prompt_str,
             prompt_tokens=tokens,
+            compact_prompt_tokens=compact_prompt_tokens,
             sampling_params=sampling_params,
             block_size_tokens=self.context.block_size_tokens,
             enable_prefix_caching=enable_prefix_caching,
@@ -3094,8 +3189,8 @@ class DynamicInferenceEngine(AbstractEngine):
                     request_id, prompt, sampling_params, multi_modal_data = fields[:4]
                 sampling_params = SamplingParams.deserialize(sampling_params)
                 nvtx_range_push("add_request")
-                # TODO(perf): image preprocessing (PIL decode / resize /
-                # normalize / patchify) runs synchronously on the engine step
+                # TODO(perf): media preprocessing (decode / resize / normalize /
+                # patchify) runs synchronously on the engine step
                 # loop, adding directly to inter-token latency for every
                 # in-flight request. Move off the engine thread — either via a
                 # bounded ThreadPoolExecutor here or, better, on the
@@ -3113,6 +3208,9 @@ class DynamicInferenceEngine(AbstractEngine):
                             multi_modal_data,
                             image_preprocessing_config=(
                                 self.context.config.image_preprocessing_config
+                            ),
+                            video_preprocessing_config=(
+                                self.context.config.video_preprocessing_config
                             ),
                         )
                     if vlm_kwargs:
@@ -3172,6 +3270,8 @@ class DynamicInferenceEngine(AbstractEngine):
         self._poll_pending_kv_pushes()
 
         if new_generation_epoch is not None:
+            if new_generation_epoch != self._generation_epoch:
+                self.clear_vision_embedding_cache()
             self._generation_epoch = new_generation_epoch
             # Stamp all active requests with the new epoch.
             # Each field stores a sparse list of (start_token_index, epoch) boundaries.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1459,6 +1459,13 @@ class DynamicInferenceEngine(AbstractEngine):
         Return:
             Returns an asyncio `Future[DynamicInferenceRequest]` for the user to wait on.
         """
+        input_modalities = ["text"]
+        if num_frames is not None:
+            input_modalities.append("video")
+        elif imgs is not None:
+            input_modalities.append("image")
+        self.controller.inference_wrapped_model.validate_input_modalities(*input_modalities)
+
         prompt_str = None
         # Tokenize prompt if text.
         if isinstance(prompt, str):
@@ -1492,6 +1499,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if (
             imgs is not None
             or num_tiles is not None
+            or num_img_embeddings_per_tile != 0
             or imgs_sizes is not None
             or num_frames is not None
         ):
@@ -1531,22 +1539,6 @@ class DynamicInferenceEngine(AbstractEngine):
 
         return self._add_request(request)
 
-    def _resolve_image_token_id(self) -> Optional[int]:
-        """Return the model's image token id, whichever wrapper level holds it.
-
-        None when the model marks images with a negative sentinel instead of a
-        real vocabulary entry (LLaVA's DEFAULT_IMAGE_TOKEN_INDEX), since such an
-        id is no more decodable than the padding it would replace.
-        """
-        module = getattr(self.controller.inference_wrapped_model, "model", None)
-        while module is not None:
-            image_token_index = getattr(module, "image_token_index", None)
-            if image_token_index is not None:
-                image_token_index = int(image_token_index)
-                return image_token_index if image_token_index >= 0 else None
-            module = getattr(module, "module", None)
-        return None
-
     def _build_vlm_request(
         self,
         *,
@@ -1565,82 +1557,103 @@ class DynamicInferenceEngine(AbstractEngine):
         """Prepare media tokens, run the vision encoder, register per-request
         media data on the context, and return a DynamicVLMInferenceRequest.
         """
+        if num_frames is not None:
+            missing = [
+                name
+                for name, value in (("imgs", imgs), ("imgs_sizes", imgs_sizes))
+                if value is None
+            ]
+            if missing:
+                raise ValueError(
+                    "Video input requires imgs, imgs_sizes, and num_frames; "
+                    f"missing {missing}."
+                )
+        elif imgs_sizes is not None:
+            if imgs is None:
+                raise ValueError("Dynamic-resolution image input requires imgs and imgs_sizes.")
+        elif imgs is None or num_tiles is None or num_img_embeddings_per_tile <= 0:
+            raise ValueError(
+                "Static-tiling image input requires imgs, num_tiles, and "
+                "num_img_embeddings_per_tile > 0."
+            )
+
         # PP>1 needs a non-first-stage embedding recv path (the wrapper's
         # _recv_only_vision_embeds TODO). Until that lands, only PP=1 is
         # correct: non-first stages would see None embeddings but a non-None
         # mask and silently skip image splicing.
         pp_group = self.controller.pp_group
-        if pp_group is not None and torch.distributed.is_initialized():
-            pp_world_size = torch.distributed.get_world_size(pp_group)
-            if pp_world_size > 1:
-                raise NotImplementedError(
-                    "Dynamic VLM inference does not support pipeline parallel. "
-                    "PP>1 requires the non-first-stage embedding recv path "
-                    "which is not yet available upstream."
-                )
+        if (
+            pp_group is not None
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size(pp_group) > 1
+        ):
+            raise NotImplementedError(
+                "Dynamic VLM inference does not support pipeline parallel. "
+                "PP>1 requires the non-first-stage embedding recv path "
+                "which is not yet available upstream."
+            )
 
         # Compute multimodal media cache key, which is used by generators to
         # skip re-computing multimodal embeddings if the cache is hit.
+        modality = "video" if num_frames is not None else "image"
         media_cache_key = None
         needs_media_identity = self.context.enable_prefix_caching or (
             getattr(self, "vision_embedding_cache_max_bytes", 0) > 0
         )
         if imgs is not None and needs_media_identity:
-            modality = "video" if num_frames is not None else "image"
             media_inputs = {"imgs": imgs}
-            if num_tiles is not None:
-                media_inputs["num_tiles"] = num_tiles
-            if imgs_sizes is not None:
-                media_inputs["imgs_sizes"] = imgs_sizes
-            if num_frames is not None:
-                media_inputs["num_frames"] = num_frames
+            for name, value in (
+                ("num_tiles", num_tiles),
+                ("imgs_sizes", imgs_sizes),
+                ("num_frames", num_frames),
+            ):
+                if value is not None:
+                    media_inputs[name] = value
             if num_img_embeddings_per_tile:
                 media_inputs["num_img_embeddings_per_tile"] = num_img_embeddings_per_tile
             media_cache_key = compute_media_cache_key(modality, media_inputs)
 
         device = torch.cuda.current_device()
-        if num_tiles is not None:
-            num_tiles = num_tiles.to(device=device)
-        if imgs_sizes is not None:
-            imgs_sizes = imgs_sizes.to(device=device)
-        if num_frames is not None:
-            num_frames = num_frames.to(device=device)
+        num_tiles = num_tiles.to(device=device) if num_tiles is not None else None
+        imgs_sizes = imgs_sizes.to(device=device) if imgs_sizes is not None else None
+        num_frames = num_frames.to(device=device) if num_frames is not None else None
 
-        is_dynamic_resolution = imgs_sizes is not None and imgs is not None
         # Dynamic-resolution requests derive their embedding count from
         # imgs_sizes downstream and don't need num_tiles.sum() at admission.
         # Static-tiling requests do; only pay the D2H sync on that path so
         # dynamic-res admissions stay sync-free here.
-        if is_dynamic_resolution:
-            total_num_tiles = 0
-            num_img_embeddings = 0
-            has_images = True
-        else:
+        has_images = imgs_sizes is not None and imgs is not None
+        if not has_images:
             total_num_tiles = int(num_tiles.sum().item()) if num_tiles is not None else 0
             num_img_embeddings = num_img_embeddings_per_tile * total_num_tiles
             has_images = num_img_embeddings > 0
+        if not has_images:
+            raise ValueError("Multimodal input did not contain any processable media.")
 
         mask_tensor: Optional[Tensor] = None
         image_embeddings: Optional[Tensor] = None
         compact_prompt_tokens: Optional[Tensor] = None
+        expected_embedding_count = 0
 
         if has_images:
+            inference_wrapper = self.controller.inference_wrapped_model
             if media_tokens_preexpanded:
-                modality = "video" if num_frames is not None else "image"
-                mask_tensor = (
-                    self.controller.inference_wrapped_model.build_preexpanded_media_token_mask(
-                        tokens, modality
-                    )
+                mask_tensor = inference_wrapper.build_preexpanded_media_token_mask(
+                    tokens, modality
                 )
+                expected_embedding_count = int((mask_tensor >= 0).sum().item())
             else:
+                media_token_id = inference_wrapper.resolve_media_token_id(
+                    self.controller.tokenizer, modality
+                )
                 compact_prompt_tokens = tokens.clone()
                 token_list: List[List[int]] = [tokens.tolist()]
                 expansion_kwargs = {"num_tiles": num_tiles, "imgs_sizes": imgs_sizes}
                 if num_frames is not None:
                     expansion_kwargs["num_frames"] = num_frames
                 expanded_tokens_list, mask_list = (
-                    self.controller.inference_wrapped_model.expand_image_tokens(
-                        token_list, **expansion_kwargs
+                    inference_wrapper.expand_image_tokens(
+                        token_list, image_token_id=media_token_id, **expansion_kwargs
                     )
                 )
                 # expand_image_tokens pads the embedding slots with -1, but the mask
@@ -1648,33 +1661,21 @@ class DynamicInferenceEngine(AbstractEngine):
                 # prompt_tokens where the model has one: they are echoed to HTTP
                 # clients, detokenized for raw_text and hashed for prefix caching, and
                 # none of those accept a negative id.
-                expanded_tokens = expanded_tokens_list[0]
-                image_token_id = self._resolve_image_token_id()
-                if image_token_id is not None:
-                    expanded_tokens = [
-                        image_token_id if token < 0 else token for token in expanded_tokens
-                    ]
+                expanded_tokens = [
+                    media_token_id if token < 0 else token
+                    for token in expanded_tokens_list[0]
+                ]
                 tokens = torch.tensor(expanded_tokens, dtype=torch.int64, device=device)
                 mask_tensor = torch.tensor(
                     [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
                 )
+                expected_embedding_count = sum(value is not None for value in mask_list[0])
+
             image_embeddings = self._get_cached_vision_embedding(media_cache_key)
-            if image_embeddings is not None:
-                expected_embedding_count = int((mask_tensor >= 0).sum().item())
-                cached_embedding_count = (
-                    image_embeddings.numel() // image_embeddings.shape[-1]
-                    if image_embeddings.ndim > 0
-                    else 0
-                )
-                if cached_embedding_count != expected_embedding_count:
-                    image_embeddings = None
             if image_embeddings is None and imgs is not None:
                 imgs = imgs.to(device=device)
-
-        # PP>1 is rejected above, so we're on the (only) stage that owns the
-        # vision encoder — no is_pipeline_first_stage check needed here.
-        if has_images and imgs is not None:
-            if image_embeddings is None:
+                # PP>1 is rejected above, so this is the only stage that owns
+                # the vision encoder.
                 with torch.inference_mode():
                     encoder_kwargs = {"num_image_tiles": num_tiles, "imgs_sizes": imgs_sizes}
                     if num_frames is not None:
@@ -1685,21 +1686,20 @@ class DynamicInferenceEngine(AbstractEngine):
                         )
                     )
 
-        if has_images and image_embeddings is not None and mask_tensor is not None:
-            expected_embedding_count = int((mask_tensor >= 0).sum().item())
-            actual_embedding_count = (
-                image_embeddings.numel() // image_embeddings.shape[-1]
-                if image_embeddings.ndim > 0
-                else 0
-            )
-            if actual_embedding_count != expected_embedding_count:
-                prompt_kind = "Pre-expanded" if media_tokens_preexpanded else "Expanded"
-                raise ValueError(
-                    f"{prompt_kind} prompt has {expected_embedding_count} media-token "
-                    f"position(s), but the vision encoder produced "
-                    f"{actual_embedding_count} embedding(s)."
+            if image_embeddings is not None:
+                actual_embedding_count = (
+                    image_embeddings.numel() // image_embeddings.shape[-1]
+                    if image_embeddings.ndim > 0
+                    else 0
                 )
-            self._cache_vision_embedding(media_cache_key, image_embeddings)
+                if actual_embedding_count != expected_embedding_count:
+                    prompt_kind = "Pre-expanded" if media_tokens_preexpanded else "Expanded"
+                    raise ValueError(
+                        f"{prompt_kind} prompt has {expected_embedding_count} media-token "
+                        f"position(s), but the vision encoder produced "
+                        f"{actual_embedding_count} embedding(s)."
+                    )
+                self._cache_vision_embedding(media_cache_key, image_embeddings)
 
         self.context.add_vlm_request_data(
             request_id, image_embeddings=image_embeddings, image_token_mask=mask_tensor

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1565,8 +1565,7 @@ class DynamicInferenceEngine(AbstractEngine):
             ]
             if missing:
                 raise ValueError(
-                    "Video input requires imgs, imgs_sizes, and num_frames; "
-                    f"missing {missing}."
+                    "Video input requires imgs, imgs_sizes, and num_frames; " f"missing {missing}."
                 )
         elif imgs_sizes is not None:
             if imgs is None:
@@ -1638,9 +1637,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if has_images:
             inference_wrapper = self.controller.inference_wrapped_model
             if media_tokens_preexpanded:
-                mask_tensor = inference_wrapper.build_preexpanded_media_token_mask(
-                    tokens, modality
-                )
+                mask_tensor = inference_wrapper.build_preexpanded_media_token_mask(tokens, modality)
                 expected_embedding_count = int((mask_tensor >= 0).sum().item())
             else:
                 media_token_id = inference_wrapper.resolve_media_token_id(
@@ -1651,10 +1648,8 @@ class DynamicInferenceEngine(AbstractEngine):
                 expansion_kwargs = {"num_tiles": num_tiles, "imgs_sizes": imgs_sizes}
                 if num_frames is not None:
                     expansion_kwargs["num_frames"] = num_frames
-                expanded_tokens_list, mask_list = (
-                    inference_wrapper.expand_image_tokens(
-                        token_list, image_token_id=media_token_id, **expansion_kwargs
-                    )
+                expanded_tokens_list, mask_list = inference_wrapper.expand_image_tokens(
+                    token_list, image_token_id=media_token_id, **expansion_kwargs
                 )
                 # expand_image_tokens pads the embedding slots with -1, but the mask
                 # below is what splices the embeddings in, so keep a real token id in
@@ -1662,8 +1657,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 # clients, detokenized for raw_text and hashed for prefix caching, and
                 # none of those accept a negative id.
                 expanded_tokens = [
-                    media_token_id if token < 0 else token
-                    for token in expanded_tokens_list[0]
+                    media_token_id if token < 0 else token for token in expanded_tokens_list[0]
                 ]
                 tokens = torch.tensor(expanded_tokens, dtype=torch.int64, device=device)
                 mask_tensor = torch.tensor(

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -308,6 +308,9 @@ class DynamicInferenceEngine(AbstractEngine):
         self.vision_embedding_cache_max_bytes = int(
             getattr(inference_config, "vision_embedding_cache_max_bytes", 0)
         )
+        self.allow_stale_vision_embeddings = bool(
+            getattr(inference_config, "allow_stale_vision_embeddings", False)
+        )
         if self.vision_embedding_cache_max_bytes < 0:
             raise ValueError("vision_embedding_cache_max_bytes must be non-negative.")
         self._vision_embedding_cache: OrderedDict[str, Tensor] = OrderedDict()
@@ -516,6 +519,82 @@ class DynamicInferenceEngine(AbstractEngine):
         """Release all projected-media embeddings retained by this engine."""
         self._vision_embedding_cache.clear()
         self._vision_embedding_cache_bytes = 0
+
+    def _invalidate_vision_state(self) -> None:
+        """Mark cached and request-local projected media as weight-stale."""
+        if getattr(self, "allow_stale_vision_embeddings", False):
+            return
+        self.clear_vision_embedding_cache()
+        for entry in self.requests.values():
+            request = entry.record[-1]
+            if isinstance(request, DynamicVLMInferenceRequest):
+                request.image_embeddings = None
+                request.image_token_mask = None
+
+    def _refresh_vlm_request_data(self, request: DynamicVLMInferenceRequest) -> None:
+        """Rebuild missing media state for a known-multimodal request."""
+        if request.image_embeddings is not None and request.image_token_mask is not None:
+            return
+        if request.imgs is None:
+            raise RuntimeError(
+                f"Cannot refresh vision state for request {request.request_id}: raw media "
+                "tensors were not retained."
+            )
+
+        # Re-construct the input mask that provides multimodal embedding injection guidelines
+        # for the inference wrapper decoder inputs.
+        wrapper = self.controller.inference_wrapped_model
+        modality = "video" if request.num_frames is not None else "image"
+        if request.media_tokens_preexpanded:
+            mask = wrapper.build_preexpanded_media_token_mask(request.prompt_tokens, modality)
+        else:
+            if request.compact_prompt_tokens is None:
+                raise RuntimeError(
+                    f"Cannot refresh vision state for request {request.request_id}: the compact "
+                    "multimodal prompt was not retained."
+                )
+            media_token_id = wrapper.resolve_media_token_id(self.controller.tokenizer, modality)
+            expansion_kwargs = {"num_tiles": request.num_tiles, "imgs_sizes": request.imgs_sizes}
+            if request.num_frames is not None:
+                expansion_kwargs["num_frames"] = request.num_frames
+            _, mask_list = wrapper.expand_image_tokens(
+                [request.compact_prompt_tokens.tolist()],
+                image_token_id=media_token_id,
+                **expansion_kwargs,
+            )
+            mask_values = [(-1 if value is None else int(value)) for value in mask_list[0]]
+            generated_suffix_length = len(request.prompt_tokens) - len(mask_values)
+            if generated_suffix_length < 0:
+                raise RuntimeError(
+                    f"Refreshed media mask for request {request.request_id} is longer than "
+                    "its checkpointed prompt."
+                )
+            mask = torch.tensor(
+                mask_values + ([-1] * generated_suffix_length),
+                dtype=torch.int64,
+                device=request.prompt_tokens.device,
+            )
+
+        encoder_kwargs = {"num_image_tiles": request.num_tiles, "imgs_sizes": request.imgs_sizes}
+        if request.num_frames is not None:
+            encoder_kwargs["num_frames"] = request.num_frames
+        with torch.inference_mode():
+            embeddings = wrapper._forward_vision_encoder(request.imgs, **encoder_kwargs)
+
+        expected_count = int((mask >= 0).sum().item())
+        actual_count = embeddings.numel() // embeddings.shape[-1] if embeddings.ndim > 0 else 0
+        if actual_count != expected_count:
+            raise ValueError(
+                f"Refreshed request {request.request_id} has {expected_count} media-token "
+                f"position(s), but the vision encoder produced {actual_count} embedding(s)."
+            )
+
+        request.image_embeddings = embeddings
+        request.image_token_mask = mask
+        self._cache_vision_embedding(request.block_hash_salt, embeddings)
+        self.context.add_vlm_request_data(
+            request.request_id, image_embeddings=embeddings, image_token_mask=mask
+        )
 
     def _get_cached_vision_embedding(self, cache_key: Optional[str]) -> Optional[Tensor]:
         if not cache_key or self.vision_embedding_cache_max_bytes == 0:
@@ -1015,9 +1094,9 @@ class DynamicInferenceEngine(AbstractEngine):
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             return
 
-        # A suspend may be followed by an in-place weight refit. Projected
-        # media embeddings are weight-dependent and must never cross it.
-        self.clear_vision_embedding_cache()
+        # A suspend may be followed by an in-place weight refit. Invalidate
+        # shared and request-local projected media unless explicitly permitted.
+        self._invalidate_vision_state()
         InferenceMode.unset_active()
         dynamo_helper = getattr(self.context, "dynamo_helper", None)
         if dynamo_helper is not None:
@@ -1103,19 +1182,24 @@ class DynamicInferenceEngine(AbstractEngine):
                 self.create_cuda_graphs()
             capture_time = time.time() - capture_time
 
+            # Request records outlive the context buffers. Refresh every stale
+            # VLM record, including PERSIST/OFFLOAD requests that need not be
+            # re-added below, so no later checkpoint can carry old projections.
+            for entry in self.requests.values():
+                request = entry.record[-1]
+                if isinstance(request, DynamicVLMInferenceRequest):
+                    self._refresh_vlm_request_data(request)
+
             # Re-add requests saved during suspend.
             add_time = time.time()
             torch.cuda.synchronize()
             for request_id in self.resume_request_ids:
                 request = self.get_request(request_id)
                 self._add_request(request)
-                # Buffer reinit above wipes the context's per-request image
-                # maps. Re-register them from the preserved VLM request fields
-                # so the resumed request sees its own image_embeddings /
-                # image_token_mask when the controller calls
-                # current_image_token_mask on the next step, rather than
-                # falling through to the text-only path.
                 if isinstance(request, DynamicVLMInferenceRequest):
+                    # Buffer reinitialization wipes the context maps. Restore
+                    # either the freshly recomputed state or the explicitly
+                    # permitted retained state.
                     self.context.add_vlm_request_data(
                         request_id,
                         image_embeddings=request.image_embeddings,
@@ -1636,6 +1720,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if has_images:
             inference_wrapper = self.controller.inference_wrapped_model
+
+            # Compute input mask that provides multimodal embedding injection
+            # guidelines for the inference wrapper decoder inputs.
             if media_tokens_preexpanded:
                 mask_tensor = inference_wrapper.build_preexpanded_media_token_mask(tokens, modality)
                 expected_embedding_count = int((mask_tensor >= 0).sum().item())
@@ -1665,6 +1752,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 )
                 expected_embedding_count = sum(value is not None for value in mask_list[0])
 
+            # Retrieve or compute the vision embedding.
             image_embeddings = self._get_cached_vision_embedding(media_cache_key)
             if image_embeddings is None and imgs is not None:
                 imgs = imgs.to(device=device)
@@ -1680,6 +1768,7 @@ class DynamicInferenceEngine(AbstractEngine):
                         )
                     )
 
+            # Cache the image embedding.
             if image_embeddings is not None:
                 actual_embedding_count = (
                     image_embeddings.numel() // image_embeddings.shape[-1]
@@ -1723,6 +1812,9 @@ class DynamicInferenceEngine(AbstractEngine):
             num_img_embeddings_per_tile=num_img_embeddings_per_tile,
             imgs=imgs,
             num_tiles=num_tiles,
+            imgs_sizes=imgs_sizes,
+            num_frames=num_frames,
+            media_tokens_preexpanded=media_tokens_preexpanded,
             decoder_seq_length=0,
             image_embeddings=image_embeddings,
             image_token_mask=mask_tensor,
@@ -3314,7 +3406,14 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if new_generation_epoch is not None:
             if new_generation_epoch != self._generation_epoch:
-                self.clear_vision_embedding_cache()
+                self._invalidate_vision_state()
+                # Unlike suspend/resume, an epoch transition does not naturally
+                # re-admit requests. Refresh active request-local state here so
+                # a later checkpoint cannot retain projections from old weights.
+                for entry in self.requests.values():
+                    request = entry.record[-1]
+                    if isinstance(request, DynamicVLMInferenceRequest):
+                        self._refresh_vlm_request_data(request)
             self._generation_epoch = new_generation_epoch
             # Stamp all active requests with the new epoch.
             # Each field stores a sparse list of (start_token_index, epoch) boundaries.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -23,7 +23,11 @@ from megatron.core.inference.batch_dimensions_utils import (
     CUDAGraphBatchDimensionBuilder,
     InferenceBatchDimensions,
 )
-from megatron.core.inference.config import AsyncScheduleMode, KVCacheManagementMode
+from megatron.core.inference.config import (
+    AsyncScheduleMode,
+    KVCacheManagementMode,
+    MediaCacheCoordinatorPolicy,
+)
 from megatron.core.inference.contexts.dynamic_context import (
     BlockOverflowError,
     DynamicInferenceContext,
@@ -43,6 +47,7 @@ from megatron.core.inference.inference_request import (
     DynamicVLMInferenceRequest,
     FinishedRequestRecord,
     Status,
+    compute_media_cache_key,
     resolve_multimodal_data_for_engine,
 )
 from megatron.core.inference.sampling_params import SamplingParams
@@ -824,6 +829,15 @@ class DynamicInferenceEngine(AbstractEngine):
                     "enable_prefix_caching": self.context.enable_prefix_caching,
                     "prefix_caching_coordinator_policy": self.context.prefix_caching_coordinator_policy,
                     "prefix_caching_routing_alpha": self.context.prefix_caching_routing_alpha,
+                    "media_cache_coordinator_policy": getattr(
+                        self.context,
+                        "media_cache_coordinator_policy",
+                        MediaCacheCoordinatorPolicy.AFFINITY,
+                    ),
+                    "media_cache_routing_weight": getattr(
+                        self.context, "media_cache_routing_weight", 1.0
+                    ),
+                    "vision_embedding_cache_enabled": (self.vision_embedding_cache_max_bytes > 0),
                     "schedule_output_path": coordinator_schedule_output_path,
                     "hostname": hostname,
                 },
@@ -1408,7 +1422,6 @@ class DynamicInferenceEngine(AbstractEngine):
         num_img_embeddings_per_tile: int = 0,
         imgs_sizes: Optional[Tensor] = None,
         num_frames: Optional[Tensor] = None,
-        media_cache_key: Optional[str] = None,
         media_tokens_preexpanded: bool = False,
     ) -> asyncio.Future[DynamicInferenceRequest]:
         """Add request to inference context.
@@ -1440,8 +1453,6 @@ class DynamicInferenceEngine(AbstractEngine):
             imgs_sizes (Optional[Tensor]): Per-image sizes [N, 2] with [H, W].
                 Dynamic resolution.
             num_frames (Optional[Tensor]): Number of frames per image/video item.
-            media_cache_key (Optional[str]): Stable identity for the exact
-                preprocessed media. Equal keys reuse projected vision embeddings.
             media_tokens_preexpanded (bool): Whether prompt token IDs already contain
                 one model token per projected media embedding.
 
@@ -1495,7 +1506,6 @@ class DynamicInferenceEngine(AbstractEngine):
                 imgs_sizes=imgs_sizes,
                 precomputed_block_hashes=precomputed_block_hashes,
                 num_frames=num_frames,
-                media_cache_key=media_cache_key,
                 media_tokens_preexpanded=media_tokens_preexpanded,
             )
             # _build_vlm_request has already registered the image embeddings
@@ -1550,7 +1560,6 @@ class DynamicInferenceEngine(AbstractEngine):
         imgs_sizes: Optional[Tensor],
         precomputed_block_hashes: Optional[List[int]] = None,
         num_frames: Optional[Tensor] = None,
-        media_cache_key: Optional[str] = None,
         media_tokens_preexpanded: bool = False,
     ) -> DynamicVLMInferenceRequest:
         """Prepare media tokens, run the vision encoder, register per-request
@@ -1569,6 +1578,25 @@ class DynamicInferenceEngine(AbstractEngine):
                     "PP>1 requires the non-first-stage embedding recv path "
                     "which is not yet available upstream."
                 )
+
+        # Compute multimodal media cache key, which is used by generators to
+        # skip re-computing multimodal embeddings if the cache is hit.
+        media_cache_key = None
+        needs_media_identity = self.context.enable_prefix_caching or (
+            getattr(self, "vision_embedding_cache_max_bytes", 0) > 0
+        )
+        if imgs is not None and needs_media_identity:
+            modality = "video" if num_frames is not None else "image"
+            media_inputs = {"imgs": imgs}
+            if num_tiles is not None:
+                media_inputs["num_tiles"] = num_tiles
+            if imgs_sizes is not None:
+                media_inputs["imgs_sizes"] = imgs_sizes
+            if num_frames is not None:
+                media_inputs["num_frames"] = num_frames
+            if num_img_embeddings_per_tile:
+                media_inputs["num_img_embeddings_per_tile"] = num_img_embeddings_per_tile
+            media_cache_key = compute_media_cache_key(modality, media_inputs)
 
         device = torch.cuda.current_device()
         if num_tiles is not None:
@@ -1607,10 +1635,7 @@ class DynamicInferenceEngine(AbstractEngine):
             else:
                 compact_prompt_tokens = tokens.clone()
                 token_list: List[List[int]] = [tokens.tolist()]
-                expansion_kwargs = {
-                    "num_tiles": num_tiles,
-                    "imgs_sizes": imgs_sizes,
-                }
+                expansion_kwargs = {"num_tiles": num_tiles, "imgs_sizes": imgs_sizes}
                 if num_frames is not None:
                     expansion_kwargs["num_frames"] = num_frames
                 expanded_tokens_list, mask_list = (
@@ -1651,10 +1676,7 @@ class DynamicInferenceEngine(AbstractEngine):
         if has_images and imgs is not None:
             if image_embeddings is None:
                 with torch.inference_mode():
-                    encoder_kwargs = {
-                        "num_image_tiles": num_tiles,
-                        "imgs_sizes": imgs_sizes,
-                    }
+                    encoder_kwargs = {"num_image_tiles": num_tiles, "imgs_sizes": imgs_sizes}
                     if num_frames is not None:
                         encoder_kwargs["num_frames"] = num_frames
                     image_embeddings = (
@@ -1683,16 +1705,15 @@ class DynamicInferenceEngine(AbstractEngine):
             request_id, image_embeddings=image_embeddings, image_token_mask=mask_tensor
         )
 
-        # Image-bearing requests: skip prefix caching. After image expansion,
-        # two requests with the same text but different images produce
-        # identical token sequences (runs of -1 pads), so KV block hashes
-        # collide and the second request would serve completions conditioned
-        # on the first request's image. Disabling caching at the request
-        # level is a correctness fix; a follow-up could mix an image digest
-        # into the block hash for cross-request reuse of identical (text,
-        # image) pairs.
+        # Image-bearing requests can share KV only when their block-hash chain
+        # is salted by the media identity computed from resolved media tensors.
+        # Requests without enough media data to derive an identity remain
+        # uncached rather than risk cross-media KV reuse for identical
+        # placeholder token sequences.
         request_has_images = has_images
-        enable_prefix_caching = self.context.enable_prefix_caching and not request_has_images
+        enable_prefix_caching = self.context.enable_prefix_caching and (
+            not request_has_images or bool(media_cache_key)
+        )
         return DynamicVLMInferenceRequest(
             request_id=request_id,
             prompt=prompt_str,
@@ -1701,7 +1722,10 @@ class DynamicInferenceEngine(AbstractEngine):
             sampling_params=sampling_params,
             block_size_tokens=self.context.block_size_tokens,
             enable_prefix_caching=enable_prefix_caching,
-            precomputed_block_hashes=precomputed_block_hashes or [],
+            # Recompute the block hashes for multimodal embeddings,
+            # which are injected dynamically into the sequence.
+            precomputed_block_hashes=[] if request_has_images else (precomputed_block_hashes or []),
+            block_hash_salt=media_cache_key if request_has_images else None,
             num_img_embeddings_per_tile=num_img_embeddings_per_tile,
             imgs=imgs,
             num_tiles=num_tiles,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1409,6 +1409,7 @@ class DynamicInferenceEngine(AbstractEngine):
         imgs_sizes: Optional[Tensor] = None,
         num_frames: Optional[Tensor] = None,
         media_cache_key: Optional[str] = None,
+        media_tokens_preexpanded: bool = False,
     ) -> asyncio.Future[DynamicInferenceRequest]:
         """Add request to inference context.
 
@@ -1418,7 +1419,7 @@ class DynamicInferenceEngine(AbstractEngine):
         resolution or imgs_sizes for dynamic resolution.
 
         When multimodal kwargs are provided the method will:
-        1. Expand image tokens in the prompt (replace <image> with padding).
+        1. Expand compact media tokens, or derive a mask from pre-expanded tokens.
         2. Run the vision encoder to produce image embeddings.
         3. Store the embeddings and mask in the context for later use by the
            controller's forward step.
@@ -1441,6 +1442,8 @@ class DynamicInferenceEngine(AbstractEngine):
             num_frames (Optional[Tensor]): Number of frames per image/video item.
             media_cache_key (Optional[str]): Stable identity for the exact
                 preprocessed media. Equal keys reuse projected vision embeddings.
+            media_tokens_preexpanded (bool): Whether prompt token IDs already contain
+                one model token per projected media embedding.
 
         Return:
             Returns an asyncio `Future[DynamicInferenceRequest]` for the user to wait on.
@@ -1493,6 +1496,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 precomputed_block_hashes=precomputed_block_hashes,
                 num_frames=num_frames,
                 media_cache_key=media_cache_key,
+                media_tokens_preexpanded=media_tokens_preexpanded,
             )
             # _build_vlm_request has already registered the image embeddings
             # and token mask into the context (add_vlm_request_data). If
@@ -1547,9 +1551,10 @@ class DynamicInferenceEngine(AbstractEngine):
         precomputed_block_hashes: Optional[List[int]] = None,
         num_frames: Optional[Tensor] = None,
         media_cache_key: Optional[str] = None,
+        media_tokens_preexpanded: bool = False,
     ) -> DynamicVLMInferenceRequest:
-        """Expand image tokens, run the vision encoder, register per-request
-        image data on the context, and return a DynamicVLMInferenceRequest.
+        """Prepare media tokens, run the vision encoder, register per-request
+        media data on the context, and return a DynamicVLMInferenceRequest.
         """
         # PP>1 needs a non-first-stage embedding recv path (the wrapper's
         # _recv_only_vision_embeds TODO). Until that lands, only PP=1 is
@@ -1592,40 +1597,45 @@ class DynamicInferenceEngine(AbstractEngine):
         compact_prompt_tokens: Optional[Tensor] = None
 
         if has_images:
-            compact_prompt_tokens = tokens.clone()
-            token_list: List[List[int]] = [tokens.tolist()]
-            expansion_kwargs = {
-                "num_tiles": num_tiles,
-                "imgs_sizes": imgs_sizes,
-            }
-            if num_frames is not None:
-                expansion_kwargs["num_frames"] = num_frames
-            expanded_tokens_list, mask_list = (
-                self.controller.inference_wrapped_model.expand_image_tokens(
-                    token_list, **expansion_kwargs
+            if media_tokens_preexpanded:
+                modality = "video" if num_frames is not None else "image"
+                mask_tensor = (
+                    self.controller.inference_wrapped_model.build_preexpanded_media_token_mask(
+                        tokens, modality
+                    )
                 )
-            )
-            # expand_image_tokens pads the embedding slots with -1, but the mask
-            # below is what splices the embeddings in, so keep a real token id in
-            # prompt_tokens where the model has one: they are echoed to HTTP
-            # clients, detokenized for raw_text and hashed for prefix caching, and
-            # none of those accept a negative id.
-            expanded_tokens = expanded_tokens_list[0]
-            image_token_id = self._resolve_image_token_id()
-            if image_token_id is not None:
-                expanded_tokens = [
-                    image_token_id if token < 0 else token for token in expanded_tokens
-                ]
-            tokens = torch.tensor(expanded_tokens, dtype=torch.int64, device=device)
-            mask_tensor = torch.tensor(
-                [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
-            )
+            else:
+                compact_prompt_tokens = tokens.clone()
+                token_list: List[List[int]] = [tokens.tolist()]
+                expansion_kwargs = {
+                    "num_tiles": num_tiles,
+                    "imgs_sizes": imgs_sizes,
+                }
+                if num_frames is not None:
+                    expansion_kwargs["num_frames"] = num_frames
+                expanded_tokens_list, mask_list = (
+                    self.controller.inference_wrapped_model.expand_image_tokens(
+                        token_list, **expansion_kwargs
+                    )
+                )
+                # expand_image_tokens pads the embedding slots with -1, but the mask
+                # below is what splices the embeddings in, so keep a real token id in
+                # prompt_tokens where the model has one: they are echoed to HTTP
+                # clients, detokenized for raw_text and hashed for prefix caching, and
+                # none of those accept a negative id.
+                expanded_tokens = expanded_tokens_list[0]
+                image_token_id = self._resolve_image_token_id()
+                if image_token_id is not None:
+                    expanded_tokens = [
+                        image_token_id if token < 0 else token for token in expanded_tokens
+                    ]
+                tokens = torch.tensor(expanded_tokens, dtype=torch.int64, device=device)
+                mask_tensor = torch.tensor(
+                    [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
+                )
             image_embeddings = self._get_cached_vision_embedding(media_cache_key)
             if image_embeddings is not None:
-                referenced_indices = [int(v) for v in mask_list[0] if v is not None]
-                expected_embedding_count = (
-                    max(referenced_indices) + 1 if referenced_indices else 0
-                )
+                expected_embedding_count = int((mask_tensor >= 0).sum().item())
                 cached_embedding_count = (
                     image_embeddings.numel() // image_embeddings.shape[-1]
                     if image_embeddings.ndim > 0
@@ -1652,7 +1662,22 @@ class DynamicInferenceEngine(AbstractEngine):
                             imgs, **encoder_kwargs
                         )
                     )
-                self._cache_vision_embedding(media_cache_key, image_embeddings)
+
+        if has_images and image_embeddings is not None and mask_tensor is not None:
+            expected_embedding_count = int((mask_tensor >= 0).sum().item())
+            actual_embedding_count = (
+                image_embeddings.numel() // image_embeddings.shape[-1]
+                if image_embeddings.ndim > 0
+                else 0
+            )
+            if actual_embedding_count != expected_embedding_count:
+                prompt_kind = "Pre-expanded" if media_tokens_preexpanded else "Expanded"
+                raise ValueError(
+                    f"{prompt_kind} prompt has {expected_embedding_count} media-token "
+                    f"position(s), but the vision encoder produced "
+                    f"{actual_embedding_count} embedding(s)."
+                )
+            self._cache_vision_embedding(media_cache_key, image_embeddings)
 
         self.context.add_vlm_request_data(
             request_id, image_embeddings=image_embeddings, image_token_mask=mask_tensor

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -308,8 +308,8 @@ class DynamicInferenceEngine(AbstractEngine):
         self.vision_embedding_cache_max_bytes = int(
             getattr(inference_config, "vision_embedding_cache_max_bytes", 0)
         )
-        self.allow_stale_vision_embeddings = bool(
-            getattr(inference_config, "allow_stale_vision_embeddings", False)
+        self.allow_stale_multimodal_embeddings = bool(
+            getattr(inference_config, "allow_stale_multimodal_embeddings", False)
         )
         if self.vision_embedding_cache_max_bytes < 0:
             raise ValueError("vision_embedding_cache_max_bytes must be non-negative.")
@@ -522,7 +522,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
     def _invalidate_vision_state(self) -> None:
         """Mark cached and request-local projected media as weight-stale."""
-        if getattr(self, "allow_stale_vision_embeddings", False):
+        if getattr(self, "allow_stale_multimodal_embeddings", False):
             return
         self.clear_vision_embedding_cache()
         for entry in self.requests.values():

--- a/megatron/core/inference/inference_client.py
+++ b/megatron/core/inference/inference_client.py
@@ -116,8 +116,8 @@ class InferenceClient:
                     ``"image"`` accepts raw image bytes, a list of raw image
                     bytes, or a preprocessed image tensor dictionary.
                 Video:
-                    Video does not yet have any supported data preprocessing
-                    or modeling formats.
+                    ``"video"`` accepts raw video bytes, a list of raw video
+                    bytes, or a preprocessed video tensor dictionary.
                 Audio:
                     Audio does not yet have any supported data preprocessing
                     or modeling formats.
@@ -265,8 +265,8 @@ class InferenceClient:
                     ``"image"`` accepts raw image bytes, a list of raw image
                     bytes, or a preprocessed image tensor dictionary.
                 Video:
-                    Video does not yet have any supported data preprocessing
-                    or modeling formats.
+                    ``"video"`` accepts raw video bytes, a list of raw video
+                    bytes, or a preprocessed video tensor dictionary.
                 Audio:
                     Audio does not yet have any supported data preprocessing
                     or modeling formats.

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -49,6 +49,20 @@ def deserialize_tensor(tensor_as_list: List) -> torch.Tensor:
     return tensor
 
 
+def _with_multimodal_metadata(
+    payload: Dict[str, Any],
+    *,
+    media_cache_key: Optional[str],
+    media_tokens_preexpanded: bool,
+) -> Dict[str, Any]:
+    """Attach optional request-level metadata to a multimodal payload."""
+    if media_cache_key is not None:
+        payload["media_cache_key"] = media_cache_key
+    if media_tokens_preexpanded:
+        payload["media_tokens_preexpanded"] = True
+    return payload
+
+
 def serialize_multimodal_data(
     multi_modal_data: Any,
 ) -> Optional[Dict[str, Any]]:
@@ -73,7 +87,12 @@ def serialize_multimodal_data(
     if not isinstance(multi_modal_data, dict):
         raise TypeError(f"multi_modal_data must be a dict or None, got {type(multi_modal_data)}.")
 
-    unsupported = set(multi_modal_data) - {"image", "video", "media_cache_key"}
+    unsupported = set(multi_modal_data) - {
+        "image",
+        "video",
+        "media_cache_key",
+        "media_tokens_preexpanded",
+    }
     if unsupported:
         raise NotImplementedError(
             f"Unsupported multimodal modalities: {sorted(unsupported)}; "
@@ -87,6 +106,12 @@ def serialize_multimodal_data(
     modality_data = multi_modal_data.get(modality)
     if modality_data is None:
         return None
+    media_tokens_preexpanded = multi_modal_data.get("media_tokens_preexpanded", False)
+    if not isinstance(media_tokens_preexpanded, bool):
+        raise TypeError(
+            "multi_modal_data['media_tokens_preexpanded'] must be a bool, "
+            f"got {type(media_tokens_preexpanded)}."
+        )
     media_cache_key = multi_modal_data.get("media_cache_key")
     if media_cache_key is not None and not isinstance(media_cache_key, str):
         raise TypeError(
@@ -103,16 +128,15 @@ def serialize_multimodal_data(
             digest.update(item)
         return digest.hexdigest()
 
-    def with_cache_key(payload: Dict[str, Any]) -> Dict[str, Any]:
-        if media_cache_key is not None:
-            payload["media_cache_key"] = media_cache_key
-        return payload
-
     if isinstance(modality_data, (bytes, bytearray)):
         items = [bytes(modality_data)]
         if media_cache_key is None:
             media_cache_key = key_for_bytes(items)
-        return with_cache_key({modality: items})
+        return _with_multimodal_metadata(
+            {modality: items},
+            media_cache_key=media_cache_key,
+            media_tokens_preexpanded=media_tokens_preexpanded,
+        )
     if isinstance(modality_data, list):
         if any(not isinstance(item, (bytes, bytearray)) for item in modality_data):
             raise TypeError(
@@ -121,7 +145,11 @@ def serialize_multimodal_data(
         items = [bytes(item) for item in modality_data]
         if media_cache_key is None:
             media_cache_key = key_for_bytes(items)
-        return with_cache_key({modality: items})
+        return _with_multimodal_metadata(
+            {modality: items},
+            media_cache_key=media_cache_key,
+            media_tokens_preexpanded=media_tokens_preexpanded,
+        )
     if not isinstance(modality_data, dict):
         raise TypeError(
             f"multi_modal_data[{modality!r}] must be bytes, list[bytes], or a "
@@ -148,7 +176,15 @@ def serialize_multimodal_data(
         wire["num_img_embeddings_per_tile"] = int(
             modality_data["num_img_embeddings_per_tile"]
         )
-    return with_cache_key({modality: wire}) if wire else None
+    return (
+        _with_multimodal_metadata(
+            {modality: wire},
+            media_cache_key=media_cache_key,
+            media_tokens_preexpanded=media_tokens_preexpanded,
+        )
+        if wire
+        else None
+    )
 
 
 def resolve_multimodal_data_for_engine(
@@ -177,7 +213,12 @@ def resolve_multimodal_data_for_engine(
     if not isinstance(multi_modal_data, dict):
         raise TypeError(f"multi_modal_data must be a dict or None, got {type(multi_modal_data)}.")
 
-    unsupported = set(multi_modal_data) - {"image", "video", "media_cache_key"}
+    unsupported = set(multi_modal_data) - {
+        "image",
+        "video",
+        "media_cache_key",
+        "media_tokens_preexpanded",
+    }
     if unsupported:
         raise NotImplementedError(
             f"Unsupported multimodal modalities: {sorted(unsupported)}; "
@@ -191,17 +232,18 @@ def resolve_multimodal_data_for_engine(
     modality_data = multi_modal_data.get(modality)
     if modality_data is None:
         return {}
+    media_tokens_preexpanded = multi_modal_data.get("media_tokens_preexpanded", False)
+    if not isinstance(media_tokens_preexpanded, bool):
+        raise TypeError(
+            "multi_modal_data['media_tokens_preexpanded'] must be a bool, "
+            f"got {type(media_tokens_preexpanded)}."
+        )
     media_cache_key = multi_modal_data.get("media_cache_key")
     if media_cache_key is not None and not isinstance(media_cache_key, str):
         raise TypeError(
             "multi_modal_data['media_cache_key'] must be a string or None, "
             f"got {type(media_cache_key)}."
         )
-
-    def with_cache_key(kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        if media_cache_key is not None:
-            kwargs["media_cache_key"] = media_cache_key
-        return kwargs
 
     if isinstance(modality_data, list):
         if modality == "video":
@@ -218,10 +260,12 @@ def resolve_multimodal_data_for_engine(
                 if torch.cuda.is_available()
                 else None
             )
-            return with_cache_key(
+            return _with_multimodal_metadata(
                 preprocess_video_bytes_list(
                     modality_data, video_preprocessing_config, device=device
-                )
+                ),
+                media_cache_key=media_cache_key,
+                media_tokens_preexpanded=media_tokens_preexpanded,
             )
 
         from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501
@@ -233,10 +277,12 @@ def resolve_multimodal_data_for_engine(
         device = (
             torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else None
         )
-        return with_cache_key(
+        return _with_multimodal_metadata(
             preprocess_image_bytes_list(
                 modality_data, image_preprocessing_config, device=device
-            )
+            ),
+            media_cache_key=media_cache_key,
+            media_tokens_preexpanded=media_tokens_preexpanded,
         )
     if not isinstance(modality_data, dict):
         raise TypeError(
@@ -281,7 +327,11 @@ def resolve_multimodal_data_for_engine(
                 "Preprocessed video payload requires imgs, imgs_sizes, and num_frames; "
                 f"missing {sorted(missing)}."
             )
-    return with_cache_key(kwargs)
+    return _with_multimodal_metadata(
+        kwargs,
+        media_cache_key=media_cache_key,
+        media_tokens_preexpanded=media_tokens_preexpanded,
+    )
 
 
 def serialize_ndarray(arr: np.ndarray) -> dict:

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import torch
 
-from megatron.core.inference.config import ImageProcessingConfig
+from megatron.core.inference.config import ImageProcessingConfig, VideoProcessingConfig
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.utils import experimental_api, nvtx_range_pop, nvtx_range_push
@@ -51,7 +51,7 @@ def deserialize_tensor(tensor_as_list: List) -> torch.Tensor:
 
 def serialize_multimodal_data(
     multi_modal_data: Any,
-) -> Optional[Dict[str, Union[List[bytes], Dict[str, Any]]]]:
+) -> Optional[Dict[str, Any]]:
     """Serialize one request's vLLM-style multimodal dictionary.
 
     Supported modalities:
@@ -61,8 +61,9 @@ def serialize_multimodal_data(
         preprocessed tensor dictionary containing ``imgs`` / ``imgs_sizes``
         or ``imgs`` / ``num_tiles``.
     Video:
-        Video does not yet have any supported data preprocessing or modeling
-        formats.
+        ``"video"`` accepts raw video bytes, a list of raw video bytes, or a
+        preprocessed tensor dictionary containing ``imgs``, ``imgs_sizes``,
+        and ``num_frames``.
     Audio:
         Audio does not yet have any supported data preprocessing or modeling
         formats.
@@ -72,45 +73,89 @@ def serialize_multimodal_data(
     if not isinstance(multi_modal_data, dict):
         raise TypeError(f"multi_modal_data must be a dict or None, got {type(multi_modal_data)}.")
 
-    unsupported = set(multi_modal_data) - {"image"}
+    unsupported = set(multi_modal_data) - {"image", "video", "media_cache_key"}
     if unsupported:
         raise NotImplementedError(
             f"Unsupported multimodal modalities: {sorted(unsupported)}; "
-            "only 'image' is currently supported."
+            "supported modalities are 'image' and 'video'."
         )
-    image_data = multi_modal_data.get("image")
-    if image_data is None:
+    if multi_modal_data.get("image") is not None and multi_modal_data.get("video") is not None:
+        raise NotImplementedError(
+            "Mixing image and video inputs in one inference request is not supported."
+        )
+    modality = "video" if multi_modal_data.get("video") is not None else "image"
+    modality_data = multi_modal_data.get(modality)
+    if modality_data is None:
         return None
-
-    if isinstance(image_data, (bytes, bytearray)):
-        return {"image": [bytes(image_data)]}
-    if isinstance(image_data, list):
-        if any(not isinstance(item, (bytes, bytearray)) for item in image_data):
-            raise TypeError("multi_modal_data['image'] list must contain only bytes.")
-        return {"image": [bytes(item) for item in image_data]}
-    if not isinstance(image_data, dict):
+    media_cache_key = multi_modal_data.get("media_cache_key")
+    if media_cache_key is not None and not isinstance(media_cache_key, str):
         raise TypeError(
-            "multi_modal_data['image'] must be bytes, list[bytes], or a "
-            f"preprocessed tensor dict; got {type(image_data)}."
+            "multi_modal_data['media_cache_key'] must be a string or None, "
+            f"got {type(media_cache_key)}."
+        )
+
+    def key_for_bytes(items: List[bytes]) -> str:
+        digest = hashlib.sha256()
+        digest.update(b"megatron-media-v1\0")
+        digest.update(modality.encode())
+        for item in items:
+            digest.update(len(item).to_bytes(8, "big"))
+            digest.update(item)
+        return digest.hexdigest()
+
+    def with_cache_key(payload: Dict[str, Any]) -> Dict[str, Any]:
+        if media_cache_key is not None:
+            payload["media_cache_key"] = media_cache_key
+        return payload
+
+    if isinstance(modality_data, (bytes, bytearray)):
+        items = [bytes(modality_data)]
+        if media_cache_key is None:
+            media_cache_key = key_for_bytes(items)
+        return with_cache_key({modality: items})
+    if isinstance(modality_data, list):
+        if any(not isinstance(item, (bytes, bytearray)) for item in modality_data):
+            raise TypeError(
+                f"multi_modal_data[{modality!r}] list must contain only bytes."
+            )
+        items = [bytes(item) for item in modality_data]
+        if media_cache_key is None:
+            media_cache_key = key_for_bytes(items)
+        return with_cache_key({modality: items})
+    if not isinstance(modality_data, dict):
+        raise TypeError(
+            f"multi_modal_data[{modality!r}] must be bytes, list[bytes], or a "
+            f"preprocessed tensor dict; got {type(modality_data)}."
         )
 
     wire: Dict[str, Any] = {}
-    for key in ("imgs", "imgs_sizes", "num_tiles"):
-        value = image_data.get(key)
+    tensor_keys = ("imgs", "imgs_sizes", "num_frames") if modality == "video" else (
+        "imgs",
+        "imgs_sizes",
+        "num_tiles",
+    )
+    for key in tensor_keys:
+        value = modality_data.get(key)
         if value is None:
             continue
         if not isinstance(value, torch.Tensor):
             raise TypeError(
-                f"multi_modal_data['image'][{key!r}] must be a Tensor, " f"got {type(value)}."
+                f"multi_modal_data[{modality!r}][{key!r}] must be a Tensor, "
+                f"got {type(value)}."
             )
         wire[key] = serialize_tensor(value)
-    if "num_img_embeddings_per_tile" in image_data:
-        wire["num_img_embeddings_per_tile"] = int(image_data["num_img_embeddings_per_tile"])
-    return {"image": wire} if wire else None
+    if "num_img_embeddings_per_tile" in modality_data:
+        wire["num_img_embeddings_per_tile"] = int(
+            modality_data["num_img_embeddings_per_tile"]
+        )
+    return with_cache_key({modality: wire}) if wire else None
 
 
 def resolve_multimodal_data_for_engine(
-    multi_modal_data: Any, *, image_preprocessing_config: Optional[ImageProcessingConfig] = None
+    multi_modal_data: Any,
+    *,
+    image_preprocessing_config: Optional[ImageProcessingConfig] = None,
+    video_preprocessing_config: Optional[VideoProcessingConfig] = None,
 ) -> Dict[str, Any]:
     """Resolve wire-format multimodal data into dynamic-engine arguments.
 
@@ -121,8 +166,8 @@ def resolve_multimodal_data_for_engine(
         in-process preprocessed image tensor dictionaries are passed through
         as dynamic-engine image arguments.
     Video:
-        Video does not yet have any supported data preprocessing or modeling
-        formats.
+        Raw video bytes are decoded and sampled into model inputs. Serialized
+        or in-process preprocessed tensor dictionaries are passed through.
     Audio:
         Audio does not yet have any supported data preprocessing or modeling
         formats.
@@ -132,18 +177,54 @@ def resolve_multimodal_data_for_engine(
     if not isinstance(multi_modal_data, dict):
         raise TypeError(f"multi_modal_data must be a dict or None, got {type(multi_modal_data)}.")
 
-    unsupported = set(multi_modal_data) - {"image"}
+    unsupported = set(multi_modal_data) - {"image", "video", "media_cache_key"}
     if unsupported:
         raise NotImplementedError(
             f"Unsupported multimodal modalities: {sorted(unsupported)}; "
-            "only 'image' is currently supported."
+            "supported modalities are 'image' and 'video'."
         )
-    image_data = multi_modal_data.get("image")
-    if image_data is None:
+    if multi_modal_data.get("image") is not None and multi_modal_data.get("video") is not None:
+        raise NotImplementedError(
+            "Mixing image and video inputs in one inference request is not supported."
+        )
+    modality = "video" if multi_modal_data.get("video") is not None else "image"
+    modality_data = multi_modal_data.get(modality)
+    if modality_data is None:
         return {}
+    media_cache_key = multi_modal_data.get("media_cache_key")
+    if media_cache_key is not None and not isinstance(media_cache_key, str):
+        raise TypeError(
+            "multi_modal_data['media_cache_key'] must be a string or None, "
+            f"got {type(media_cache_key)}."
+        )
 
-    if isinstance(image_data, list):
-        from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501  # pylint: disable=line-too-long
+    def with_cache_key(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        if media_cache_key is not None:
+            kwargs["media_cache_key"] = media_cache_key
+        return kwargs
+
+    if isinstance(modality_data, list):
+        if modality == "video":
+            from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501
+                preprocess_video_bytes_list,
+            )
+
+            if video_preprocessing_config is None:
+                raise RuntimeError(
+                    "Raw video data require InferenceConfig.video_preprocessing_config."
+                )
+            device = (
+                torch.device("cuda", torch.cuda.current_device())
+                if torch.cuda.is_available()
+                else None
+            )
+            return with_cache_key(
+                preprocess_video_bytes_list(
+                    modality_data, video_preprocessing_config, device=device
+                )
+            )
+
+        from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501
             preprocess_image_bytes_list,
         )
 
@@ -152,37 +233,55 @@ def resolve_multimodal_data_for_engine(
         device = (
             torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else None
         )
-        return preprocess_image_bytes_list(image_data, image_preprocessing_config, device=device)
-    if not isinstance(image_data, dict):
+        return with_cache_key(
+            preprocess_image_bytes_list(
+                modality_data, image_preprocessing_config, device=device
+            )
+        )
+    if not isinstance(modality_data, dict):
         raise TypeError(
-            "Wire multi_modal_data['image'] must be list[bytes] or a serialized "
-            f"tensor dict; got {type(image_data)}."
+            f"Wire multi_modal_data[{modality!r}] must be list[bytes] or a "
+            f"serialized tensor dict; got {type(modality_data)}."
         )
 
     kwargs: Dict[str, Any] = {}
-    for key in ("imgs", "imgs_sizes", "num_tiles"):
-        if key in image_data:
-            value = image_data[key]
-            kwargs[key] = value if isinstance(value, torch.Tensor) else deserialize_tensor(value)
-    if "num_img_embeddings_per_tile" in image_data:
-        kwargs["num_img_embeddings_per_tile"] = int(image_data["num_img_embeddings_per_tile"])
-
-    # Reject incomplete static-tiling payloads. Static tiling (imgs +
-    # num_tiles, no imgs_sizes) needs num_img_embeddings_per_tile to size the
-    # image-token expansion; without it the engine defaults the count to
-    # zero, has_images silently becomes False, and neither the image-token
-    # expansion nor the vision encoder runs. Fail fast at the wire boundary
-    # instead of returning a text-only completion for what the client thinks
-    # is a multimodal request.
-    has_num_tiles = "num_tiles" in kwargs
-    has_imgs_sizes = "imgs_sizes" in kwargs
-    has_per_tile = kwargs.get("num_img_embeddings_per_tile", 0) > 0
-    if has_num_tiles and not has_imgs_sizes and not has_per_tile:
-        raise ValueError(
-            "Static-tiling image payload requires num_img_embeddings_per_tile > 0 "
-            "when num_tiles is provided without imgs_sizes."
+    tensor_keys = ("imgs", "imgs_sizes", "num_frames") if modality == "video" else (
+        "imgs",
+        "imgs_sizes",
+        "num_tiles",
+    )
+    for key in tensor_keys:
+        if key in modality_data:
+            value = modality_data[key]
+            kwargs[key] = (
+                value if isinstance(value, torch.Tensor) else deserialize_tensor(value)
+            )
+    if "num_img_embeddings_per_tile" in modality_data:
+        kwargs["num_img_embeddings_per_tile"] = int(
+            modality_data["num_img_embeddings_per_tile"]
         )
-    return kwargs
+
+    if modality == "image":
+        # Reject incomplete static-tiling payloads. Static tiling (imgs +
+        # num_tiles, no imgs_sizes) needs num_img_embeddings_per_tile to size
+        # image-token expansion. Without it, the request would silently run as
+        # text-only.
+        has_num_tiles = "num_tiles" in kwargs
+        has_imgs_sizes = "imgs_sizes" in kwargs
+        has_per_tile = kwargs.get("num_img_embeddings_per_tile", 0) > 0
+        if has_num_tiles and not has_imgs_sizes and not has_per_tile:
+            raise ValueError(
+                "Static-tiling image payload requires num_img_embeddings_per_tile > 0 "
+                "when num_tiles is provided without imgs_sizes."
+            )
+    else:
+        missing = {"imgs", "imgs_sizes", "num_frames"} - set(kwargs)
+        if missing:
+            raise ValueError(
+                "Preprocessed video payload requires imgs, imgs_sizes, and num_frames; "
+                f"missing {sorted(missing)}."
+            )
+    return with_cache_key(kwargs)
 
 
 def serialize_ndarray(arr: np.ndarray) -> dict:
@@ -509,6 +608,7 @@ class DynamicInferenceRequest(InferenceRequest):
     uid: str = field(default_factory=lambda: f"chatcmpl-{uuid.uuid4().hex}")
     prompt: Optional[str] = None
     prompt_tokens: Optional[torch.Tensor] = None
+    compact_prompt_tokens: Optional[torch.Tensor] = None
     # remaining prompt tokens are used for chunked prefill
     remaining_prompt_tokens: Optional[torch.Tensor] = None
     policy_epoch: Optional[list[tuple[int, int]]] = None
@@ -896,7 +996,8 @@ class DynamicInferenceRequestRecord:
             else:
                 return [v for r in self.requests for v in getattr(r, key)]
 
-        prompt_tokens = self.requests[0].prompt_tokens
+        first_request = self.requests[0]
+        prompt_tokens = first_request.prompt_tokens
         prompt_text = self.requests[0].prompt
         routing_indices = None
         routing_parts = [r.routing_indices for r in self.requests if r.routing_indices is not None]
@@ -919,6 +1020,7 @@ class DynamicInferenceRequestRecord:
             uid=self.requests[0].uid,
             prompt=prompt_text,
             prompt_tokens=prompt_tokens,
+            compact_prompt_tokens=first_request.compact_prompt_tokens,
             prompt_log_probs=self.requests[0].prompt_log_probs,
             prompt_top_n_logprobs=self.requests[0].prompt_top_n_logprobs,
             generated_text=generated_text,

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -7,7 +7,7 @@ import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
 from enum import Enum, auto
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -49,23 +49,67 @@ def deserialize_tensor(tensor_as_list: List) -> torch.Tensor:
     return tensor
 
 
-def _with_multimodal_metadata(
-    payload: Dict[str, Any],
-    *,
-    media_cache_key: Optional[str],
-    media_tokens_preexpanded: bool,
-) -> Dict[str, Any]:
-    """Attach optional request-level metadata to a multimodal payload."""
-    if media_cache_key is not None:
-        payload["media_cache_key"] = media_cache_key
-    if media_tokens_preexpanded:
-        payload["media_tokens_preexpanded"] = True
-    return payload
+def compute_media_cache_key(modality: str, modality_data: Any) -> str:
+    """Return a stable content key for raw or preprocessed media.
+
+    The key is generated inside the inference stack so callers do not need to
+    understand vision-embedding cache identity. Tensor metadata is included to
+    prevent equal byte streams with different shapes or dtypes from colliding.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"megatron-media-v2\0")
+    digest.update(modality.encode())
+    digest.update(b"\0")
+
+    if isinstance(modality_data, (bytes, bytearray)):
+        items = [bytes(modality_data)]
+    elif isinstance(modality_data, list):
+        items = [bytes(item) for item in modality_data]
+    else:
+        items = None
+
+    if items is not None:
+        digest.update(b"raw\0")
+        for item in items:
+            digest.update(len(item).to_bytes(8, "big"))
+            digest.update(item)
+        return digest.hexdigest()
+
+    if not isinstance(modality_data, dict):
+        raise TypeError(f"Cannot compute a media cache key for {type(modality_data).__name__}.")
+
+    digest.update(b"preprocessed\0")
+    tensor_fields = (
+        {"imgs", "imgs_sizes", "num_frames"}
+        if modality == "video"
+        else {"imgs", "imgs_sizes", "num_tiles"}
+    )
+    cache_fields = tensor_fields | {"num_img_embeddings_per_tile"}
+    for name in sorted(set(modality_data) & cache_fields):
+        value = modality_data[name]
+        digest.update(name.encode())
+        digest.update(b"\0")
+        if isinstance(value, torch.Tensor):
+            tensor = value.detach().contiguous().cpu()
+            digest.update(str(tensor.dtype).encode())
+            digest.update(b"\0")
+            digest.update(repr(tuple(tensor.shape)).encode())
+            digest.update(b"\0")
+            # Viewing a flattened tensor as uint8 works for dtypes such as
+            # bfloat16 that NumPy cannot represent directly.
+            digest.update(tensor.reshape(-1).view(torch.uint8).numpy().tobytes())
+        elif name == "num_img_embeddings_per_tile":
+            digest.update(str(int(value)).encode())
+        else:
+            raise TypeError(
+                f"Cannot compute a media cache key from field {name!r} "
+                f"of type {type(value).__name__}."
+            )
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
-def serialize_multimodal_data(
-    multi_modal_data: Any,
-) -> Optional[Dict[str, Any]]:
+def serialize_multimodal_data(multi_modal_data: Any) -> Optional[Dict[str, Any]]:
     """Serialize one request's vLLM-style multimodal dictionary.
 
     Supported modalities:
@@ -87,12 +131,12 @@ def serialize_multimodal_data(
     if not isinstance(multi_modal_data, dict):
         raise TypeError(f"multi_modal_data must be a dict or None, got {type(multi_modal_data)}.")
 
-    unsupported = set(multi_modal_data) - {
-        "image",
-        "video",
-        "media_cache_key",
-        "media_tokens_preexpanded",
-    }
+    unsupported = set(multi_modal_data) - {"image", "video", "media_tokens_preexpanded"}
+    if "media_cache_key" in unsupported:
+        raise ValueError(
+            "multi_modal_data['media_cache_key'] is internal and must not be "
+            "provided; media identity is computed automatically."
+        )
     if unsupported:
         raise NotImplementedError(
             f"Unsupported multimodal modalities: {sorted(unsupported)}; "
@@ -112,55 +156,29 @@ def serialize_multimodal_data(
             "multi_modal_data['media_tokens_preexpanded'] must be a bool, "
             f"got {type(media_tokens_preexpanded)}."
         )
-    media_cache_key = multi_modal_data.get("media_cache_key")
-    if media_cache_key is not None and not isinstance(media_cache_key, str):
-        raise TypeError(
-            "multi_modal_data['media_cache_key'] must be a string or None, "
-            f"got {type(media_cache_key)}."
-        )
-
-    def key_for_bytes(items: List[bytes]) -> str:
-        digest = hashlib.sha256()
-        digest.update(b"megatron-media-v1\0")
-        digest.update(modality.encode())
-        for item in items:
-            digest.update(len(item).to_bytes(8, "big"))
-            digest.update(item)
-        return digest.hexdigest()
-
+    metadata = {"media_tokens_preexpanded": True} if media_tokens_preexpanded else {}
     if isinstance(modality_data, (bytes, bytearray)):
         items = [bytes(modality_data)]
-        if media_cache_key is None:
-            media_cache_key = key_for_bytes(items)
-        return _with_multimodal_metadata(
-            {modality: items},
-            media_cache_key=media_cache_key,
-            media_tokens_preexpanded=media_tokens_preexpanded,
-        )
+        media_cache_key = compute_media_cache_key(modality, items)
+        return {modality: items, "media_cache_key": media_cache_key, **metadata}
     if isinstance(modality_data, list):
         if any(not isinstance(item, (bytes, bytearray)) for item in modality_data):
-            raise TypeError(
-                f"multi_modal_data[{modality!r}] list must contain only bytes."
-            )
+            raise TypeError(f"multi_modal_data[{modality!r}] list must contain only bytes.")
         items = [bytes(item) for item in modality_data]
-        if media_cache_key is None:
-            media_cache_key = key_for_bytes(items)
-        return _with_multimodal_metadata(
-            {modality: items},
-            media_cache_key=media_cache_key,
-            media_tokens_preexpanded=media_tokens_preexpanded,
-        )
+        media_cache_key = compute_media_cache_key(modality, items)
+        return {modality: items, "media_cache_key": media_cache_key, **metadata}
     if not isinstance(modality_data, dict):
         raise TypeError(
             f"multi_modal_data[{modality!r}] must be bytes, list[bytes], or a "
             f"preprocessed tensor dict; got {type(modality_data)}."
         )
+    media_cache_key = compute_media_cache_key(modality, modality_data)
 
     wire: Dict[str, Any] = {}
-    tensor_keys = ("imgs", "imgs_sizes", "num_frames") if modality == "video" else (
-        "imgs",
-        "imgs_sizes",
-        "num_tiles",
+    tensor_keys = (
+        ("imgs", "imgs_sizes", "num_frames")
+        if modality == "video"
+        else ("imgs", "imgs_sizes", "num_tiles")
     )
     for key in tensor_keys:
         value = modality_data.get(key)
@@ -168,23 +186,12 @@ def serialize_multimodal_data(
             continue
         if not isinstance(value, torch.Tensor):
             raise TypeError(
-                f"multi_modal_data[{modality!r}][{key!r}] must be a Tensor, "
-                f"got {type(value)}."
+                f"multi_modal_data[{modality!r}][{key!r}] must be a Tensor, " f"got {type(value)}."
             )
         wire[key] = serialize_tensor(value)
     if "num_img_embeddings_per_tile" in modality_data:
-        wire["num_img_embeddings_per_tile"] = int(
-            modality_data["num_img_embeddings_per_tile"]
-        )
-    return (
-        _with_multimodal_metadata(
-            {modality: wire},
-            media_cache_key=media_cache_key,
-            media_tokens_preexpanded=media_tokens_preexpanded,
-        )
-        if wire
-        else None
-    )
+        wire["num_img_embeddings_per_tile"] = int(modality_data["num_img_embeddings_per_tile"])
+    return {modality: wire, "media_cache_key": media_cache_key, **metadata} if wire else None
 
 
 def resolve_multimodal_data_for_engine(
@@ -238,19 +245,13 @@ def resolve_multimodal_data_for_engine(
             "multi_modal_data['media_tokens_preexpanded'] must be a bool, "
             f"got {type(media_tokens_preexpanded)}."
         )
-    media_cache_key = multi_modal_data.get("media_cache_key")
-    if media_cache_key is not None and not isinstance(media_cache_key, str):
-        raise TypeError(
-            "multi_modal_data['media_cache_key'] must be a string or None, "
-            f"got {type(media_cache_key)}."
+    metadata = {"media_tokens_preexpanded": True} if media_tokens_preexpanded else {}
+    if isinstance(modality_data, list):
+        from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
+            image_preprocessing,
         )
 
-    if isinstance(modality_data, list):
         if modality == "video":
-            from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501
-                preprocess_video_bytes_list,
-            )
-
             if video_preprocessing_config is None:
                 raise RuntimeError(
                     "Raw video data require InferenceConfig.video_preprocessing_config."
@@ -260,30 +261,24 @@ def resolve_multimodal_data_for_engine(
                 if torch.cuda.is_available()
                 else None
             )
-            return _with_multimodal_metadata(
-                preprocess_video_bytes_list(
+            return {
+                **image_preprocessing.preprocess_video_bytes_list(
                     modality_data, video_preprocessing_config, device=device
                 ),
-                media_cache_key=media_cache_key,
-                media_tokens_preexpanded=media_tokens_preexpanded,
-            )
-
-        from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (  # noqa: E501
-            preprocess_image_bytes_list,
-        )
+                **metadata,
+            }
 
         if image_preprocessing_config is None:
             raise RuntimeError("Raw image data require InferenceConfig.image_preprocessing_config.")
         device = (
             torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else None
         )
-        return _with_multimodal_metadata(
-            preprocess_image_bytes_list(
+        return {
+            **image_preprocessing.preprocess_image_bytes_list(
                 modality_data, image_preprocessing_config, device=device
             ),
-            media_cache_key=media_cache_key,
-            media_tokens_preexpanded=media_tokens_preexpanded,
-        )
+            **metadata,
+        }
     if not isinstance(modality_data, dict):
         raise TypeError(
             f"Wire multi_modal_data[{modality!r}] must be list[bytes] or a "
@@ -291,21 +286,17 @@ def resolve_multimodal_data_for_engine(
         )
 
     kwargs: Dict[str, Any] = {}
-    tensor_keys = ("imgs", "imgs_sizes", "num_frames") if modality == "video" else (
-        "imgs",
-        "imgs_sizes",
-        "num_tiles",
+    tensor_keys = (
+        ("imgs", "imgs_sizes", "num_frames")
+        if modality == "video"
+        else ("imgs", "imgs_sizes", "num_tiles")
     )
     for key in tensor_keys:
         if key in modality_data:
             value = modality_data[key]
-            kwargs[key] = (
-                value if isinstance(value, torch.Tensor) else deserialize_tensor(value)
-            )
+            kwargs[key] = value if isinstance(value, torch.Tensor) else deserialize_tensor(value)
     if "num_img_embeddings_per_tile" in modality_data:
-        kwargs["num_img_embeddings_per_tile"] = int(
-            modality_data["num_img_embeddings_per_tile"]
-        )
+        kwargs["num_img_embeddings_per_tile"] = int(modality_data["num_img_embeddings_per_tile"])
 
     if modality == "image":
         # Reject incomplete static-tiling payloads. Static tiling (imgs +
@@ -327,11 +318,7 @@ def resolve_multimodal_data_for_engine(
                 "Preprocessed video payload requires imgs, imgs_sizes, and num_frames; "
                 f"missing {sorted(missing)}."
             )
-    return _with_multimodal_metadata(
-        kwargs,
-        media_cache_key=media_cache_key,
-        media_tokens_preexpanded=media_tokens_preexpanded,
-    )
+    return {**kwargs, **metadata}
 
 
 def serialize_ndarray(arr: np.ndarray) -> dict:
@@ -375,7 +362,9 @@ class Status(Enum):
 # =========================================================================
 
 
-def compute_block_hashes_batched(prompt_tokens: torch.Tensor, block_size: int) -> List[int]:
+def compute_block_hashes_batched(
+    prompt_tokens: torch.Tensor, block_size: int, cache_salt: Optional[str] = None
+) -> List[int]:
     """Compute SHA-256 based hashes for all complete blocks in a prompt.
 
     Each block hash is computed as SHA-256(parent_digest || block_bytes), where
@@ -386,6 +375,9 @@ def compute_block_hashes_batched(prompt_tokens: torch.Tensor, block_size: int) -
     Args:
         prompt_tokens: All prompt token IDs, shape [seq_len].
         block_size: Number of tokens per block.
+        cache_salt: Optional request-input identity mixed into every chained
+            block hash. Multimodal requests use their generated media key so
+            equal token placeholders backed by different media cannot share KV.
 
     Returns:
         List of positive integer hash values in [1, 2^63-1], one per complete block.
@@ -400,7 +392,12 @@ def compute_block_hashes_batched(prompt_tokens: torch.Tensor, block_size: int) -
     block_byte_size = block_size * tokens_cpu.element_size()  # 8 bytes per int64
 
     hashes = []
-    parent_digest = b'\x00' * 32  # SHA-256 digest size
+    if cache_salt is None:
+        parent_digest = b'\x00' * 32  # Preserve text-only hash compatibility.
+    else:
+        parent_digest = hashlib.sha256(
+            b"megatron-prefix-cache-salt-v1\0" + cache_salt.encode()
+        ).digest()
 
     for i in range(num_complete_blocks):
         block_bytes = tokens_bytes[i * block_byte_size : (i + 1) * block_byte_size]
@@ -680,6 +677,7 @@ class DynamicInferenceRequest(InferenceRequest):
     # match rather than computed. Accumulated across prefill chunks by the context,
     # which uses it to avoid rewriting KV into blocks that already hold it.
     num_matched_prefix_blocks: int = 0
+    block_hash_salt: Optional[str] = None  # Media identity for multimodal KV safety.
 
     # Computed field - not passed by caller
     precomputed_block_hashes: List[int] = field(default_factory=list)
@@ -712,7 +710,7 @@ class DynamicInferenceRequest(InferenceRequest):
         - precomputed_block_hashes is [hash1, ...] for N complete blocks
         """
         self.precomputed_block_hashes = compute_block_hashes_batched(
-            self.prompt_tokens, self.block_size_tokens
+            self.prompt_tokens, self.block_size_tokens, cache_salt=self.block_hash_salt
         )
 
     @property
@@ -1006,6 +1004,7 @@ class DynamicInferenceRequestRecord:
             kv_cache_epoch=kv_cache_epoch,
             block_size_tokens=old_request.block_size_tokens,
             enable_prefix_caching=old_request.enable_prefix_caching,
+            block_hash_salt=old_request.block_hash_salt,
         )
         # Preserve the VLM subtype and multimodal fields so a suspend/resume
         # cycle doesn't downcast the request to text-only and lose its imgs /
@@ -1089,6 +1088,7 @@ class DynamicInferenceRequestRecord:
             routing_indices=routing_indices,
             block_size_tokens=self.requests[0].block_size_tokens,
             enable_prefix_caching=self.requests[0].enable_prefix_caching,
+            block_hash_salt=self.requests[0].block_hash_salt,
             precomputed_block_hashes=self.requests[0].precomputed_block_hashes,
             num_cached_tokens=self.requests[0].num_cached_tokens,
             disaggregated_params=disaggregated_params,

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -49,6 +49,26 @@ def deserialize_tensor(tensor_as_list: List) -> torch.Tensor:
     return tensor
 
 
+def _normalize_raw_media_items(modality_data: Any) -> Optional[List[bytes]]:
+    """Normalize supported raw-media inputs, or return None for preprocessed data."""
+    if isinstance(modality_data, (bytes, bytearray)):
+        return [bytes(modality_data)]
+    if isinstance(modality_data, list):
+        if any(not isinstance(item, (bytes, bytearray)) for item in modality_data):
+            raise TypeError("Raw media lists must contain only bytes or bytearray values.")
+        return [bytes(item) for item in modality_data]
+    return None
+
+
+def _media_tensor_keys(modality: str) -> Tuple[str, ...]:
+    """Return the tensor fields that define a preprocessed media input."""
+    if modality == "video":
+        return ("imgs", "imgs_sizes", "num_frames")
+    if modality == "image":
+        return ("imgs", "imgs_sizes", "num_tiles")
+    raise ValueError(f"Unsupported media modality: {modality!r}.")
+
+
 def compute_media_cache_key(modality: str, modality_data: Any) -> str:
     """Return a stable content key for raw or preprocessed media.
 
@@ -61,52 +81,41 @@ def compute_media_cache_key(modality: str, modality_data: Any) -> str:
     digest.update(modality.encode())
     digest.update(b"\0")
 
-    if isinstance(modality_data, (bytes, bytearray)):
-        items = [bytes(modality_data)]
-    elif isinstance(modality_data, list):
-        items = [bytes(item) for item in modality_data]
-    else:
-        items = None
-
-    if items is not None:
+    raw_items = _normalize_raw_media_items(modality_data)
+    if raw_items is not None:
         digest.update(b"raw\0")
-        for item in items:
+        for item in raw_items:
             digest.update(len(item).to_bytes(8, "big"))
             digest.update(item)
         return digest.hexdigest()
 
-    if not isinstance(modality_data, dict):
-        raise TypeError(f"Cannot compute a media cache key for {type(modality_data).__name__}.")
+    if isinstance(modality_data, dict):
+        digest.update(b"preprocessed\0")
+        cache_fields = set(_media_tensor_keys(modality)) | {"num_img_embeddings_per_tile"}
+        for name in sorted(set(modality_data) & cache_fields):
+            value = modality_data[name]
+            digest.update(name.encode())
+            digest.update(b"\0")
+            if isinstance(value, torch.Tensor):
+                tensor = value.detach().contiguous().cpu()
+                digest.update(str(tensor.dtype).encode())
+                digest.update(b"\0")
+                digest.update(repr(tuple(tensor.shape)).encode())
+                digest.update(b"\0")
+                # Viewing a flattened tensor as uint8 works for dtypes such as
+                # bfloat16 that NumPy cannot represent directly.
+                digest.update(tensor.reshape(-1).view(torch.uint8).numpy().tobytes())
+            elif name == "num_img_embeddings_per_tile":
+                digest.update(str(int(value)).encode())
+            else:
+                raise TypeError(
+                    f"Cannot compute a media cache key from field {name!r} "
+                    f"of type {type(value).__name__}."
+                )
+            digest.update(b"\0")
+        return digest.hexdigest()
 
-    digest.update(b"preprocessed\0")
-    tensor_fields = (
-        {"imgs", "imgs_sizes", "num_frames"}
-        if modality == "video"
-        else {"imgs", "imgs_sizes", "num_tiles"}
-    )
-    cache_fields = tensor_fields | {"num_img_embeddings_per_tile"}
-    for name in sorted(set(modality_data) & cache_fields):
-        value = modality_data[name]
-        digest.update(name.encode())
-        digest.update(b"\0")
-        if isinstance(value, torch.Tensor):
-            tensor = value.detach().contiguous().cpu()
-            digest.update(str(tensor.dtype).encode())
-            digest.update(b"\0")
-            digest.update(repr(tuple(tensor.shape)).encode())
-            digest.update(b"\0")
-            # Viewing a flattened tensor as uint8 works for dtypes such as
-            # bfloat16 that NumPy cannot represent directly.
-            digest.update(tensor.reshape(-1).view(torch.uint8).numpy().tobytes())
-        elif name == "num_img_embeddings_per_tile":
-            digest.update(str(int(value)).encode())
-        else:
-            raise TypeError(
-                f"Cannot compute a media cache key from field {name!r} "
-                f"of type {type(value).__name__}."
-            )
-        digest.update(b"\0")
-    return digest.hexdigest()
+    raise TypeError(f"Cannot compute a media cache key for {type(modality_data).__name__}.")
 
 
 def serialize_multimodal_data(multi_modal_data: Any) -> Optional[Dict[str, Any]]:
@@ -157,41 +166,31 @@ def serialize_multimodal_data(multi_modal_data: Any) -> Optional[Dict[str, Any]]
             f"got {type(media_tokens_preexpanded)}."
         )
     metadata = {"media_tokens_preexpanded": True} if media_tokens_preexpanded else {}
-    if isinstance(modality_data, (bytes, bytearray)):
-        items = [bytes(modality_data)]
-        media_cache_key = compute_media_cache_key(modality, items)
-        return {modality: items, "media_cache_key": media_cache_key, **metadata}
-    if isinstance(modality_data, list):
-        if any(not isinstance(item, (bytes, bytearray)) for item in modality_data):
-            raise TypeError(f"multi_modal_data[{modality!r}] list must contain only bytes.")
-        items = [bytes(item) for item in modality_data]
-        media_cache_key = compute_media_cache_key(modality, items)
-        return {modality: items, "media_cache_key": media_cache_key, **metadata}
-    if not isinstance(modality_data, dict):
+    raw_items = _normalize_raw_media_items(modality_data)
+    if raw_items is not None:
+        media_cache_key = compute_media_cache_key(modality, raw_items)
+        return {modality: raw_items, "media_cache_key": media_cache_key, **metadata}
+    elif isinstance(modality_data, dict):
+        media_cache_key = compute_media_cache_key(modality, modality_data)
+        wire: Dict[str, Any] = {}
+        for key in _media_tensor_keys(modality):
+            value = modality_data.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(
+                    f"multi_modal_data[{modality!r}][{key!r}] must be a Tensor, "
+                    f"got {type(value)}."
+                )
+            wire[key] = serialize_tensor(value)
+        if "num_img_embeddings_per_tile" in modality_data:
+            wire["num_img_embeddings_per_tile"] = int(modality_data["num_img_embeddings_per_tile"])
+        return {modality: wire, "media_cache_key": media_cache_key, **metadata} if wire else None
+    else:
         raise TypeError(
             f"multi_modal_data[{modality!r}] must be bytes, list[bytes], or a "
             f"preprocessed tensor dict; got {type(modality_data)}."
         )
-    media_cache_key = compute_media_cache_key(modality, modality_data)
-
-    wire: Dict[str, Any] = {}
-    tensor_keys = (
-        ("imgs", "imgs_sizes", "num_frames")
-        if modality == "video"
-        else ("imgs", "imgs_sizes", "num_tiles")
-    )
-    for key in tensor_keys:
-        value = modality_data.get(key)
-        if value is None:
-            continue
-        if not isinstance(value, torch.Tensor):
-            raise TypeError(
-                f"multi_modal_data[{modality!r}][{key!r}] must be a Tensor, " f"got {type(value)}."
-            )
-        wire[key] = serialize_tensor(value)
-    if "num_img_embeddings_per_tile" in modality_data:
-        wire["num_img_embeddings_per_tile"] = int(modality_data["num_img_embeddings_per_tile"])
-    return {modality: wire, "media_cache_key": media_cache_key, **metadata} if wire else None
 
 
 def resolve_multimodal_data_for_engine(
@@ -999,6 +998,7 @@ class DynamicInferenceRequestRecord:
         common_kwargs = dict(
             request_id=old_request.request_id,
             prompt_tokens=new_prompt_tokens,
+            compact_prompt_tokens=old_request.compact_prompt_tokens,
             sampling_params=new_sampling_params,
             policy_epoch=policy_epoch,
             kv_cache_epoch=kv_cache_epoch,
@@ -1015,6 +1015,9 @@ class DynamicInferenceRequestRecord:
                 num_img_embeddings_per_tile=old_request.num_img_embeddings_per_tile,
                 imgs=old_request.imgs,
                 num_tiles=old_request.num_tiles,
+                imgs_sizes=old_request.imgs_sizes,
+                num_frames=old_request.num_frames,
+                media_tokens_preexpanded=old_request.media_tokens_preexpanded,
                 decoder_seq_length=old_request.decoder_seq_length,
                 image_embeddings=old_request.image_embeddings,
                 image_token_mask=old_request.image_token_mask,
@@ -1173,3 +1176,6 @@ class DynamicVLMInferenceRequest(DynamicInferenceRequest, VLMInferenceRequest):
 
     image_embeddings: Optional[torch.Tensor] = None  # [seq_img, 1, hidden]
     image_token_mask: Optional[torch.Tensor] = None  # 1D, -1=text, >=0=image index
+    imgs_sizes: Optional[torch.Tensor] = None
+    num_frames: Optional[torch.Tensor] = None
+    media_tokens_preexpanded: bool = False

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -106,9 +106,7 @@ class AbstractModelInferenceWrapper(abc.ABC):
             if modality not in capabilities:
                 raise ValueError(f"Unknown input modality: {modality!r}.")
             if not capabilities[modality]:
-                raise ValueError(
-                    f"{type(self).__name__} does not support {modality} inputs."
-                )
+                raise ValueError(f"{type(self).__name__} does not support {modality} inputs.")
 
     def resolve_media_token_id(self, tokenizer, modality: str) -> int:
         """Resolve a compact media marker to one nonnegative tokenizer ID."""

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -12,6 +12,7 @@ from megatron.core.inference.communication_utils import (
     recv_from_prev_pipeline_rank_,
     send_to_next_pipeline_rank,
 )
+from megatron.core.inference.config import MultimodalPromptConfig
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -82,6 +83,10 @@ class AbstractModelInferenceWrapper(abc.ABC):
         )
 
         self.inference_context.reset()
+
+    def get_multimodal_prompt_config(self) -> Optional[MultimodalPromptConfig]:
+        """Return this model's structured-media prompt contract, if any."""
+        return None
 
     @abc.abstractmethod
     def prep_inference_input(self, prompt_tokens) -> Dict[str, Any]:

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -100,23 +100,18 @@ class AbstractModelInferenceWrapper(abc.ABC):
         """Map pre-expanded media-token positions to sequential embedding indices."""
         prompt_config = self.get_multimodal_prompt_config()
         if prompt_config is None:
-            raise ValueError(
-                f"{type(self).__name__} does not define a multimodal prompt contract."
-            )
+            raise ValueError(f"{type(self).__name__} does not define a multimodal prompt contract.")
         media_token_id = prompt_config.get_spec(modality).model_token_id
         if media_token_id is None:
             raise ValueError(
-                f"{type(self).__name__} does not define a model token id for "
-                f"{modality} inputs."
+                f"{type(self).__name__} does not define a model token id for " f"{modality} inputs."
             )
 
         media_positions = prompt_tokens == int(media_token_id)
         media_indices = torch.nonzero(media_positions, as_tuple=False).flatten()
         mask = torch.full_like(prompt_tokens, -1, dtype=torch.int64)
         mask[media_indices] = torch.arange(
-            media_indices.numel(),
-            dtype=torch.int64,
-            device=prompt_tokens.device,
+            media_indices.numel(), dtype=torch.int64, device=prompt_tokens.device
         )
         return mask
 

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -94,19 +94,89 @@ class AbstractModelInferenceWrapper(abc.ABC):
         """Return this model's structured-media prompt contract, if any."""
         return None
 
+    def validate_input_modalities(self, *modalities: str) -> None:
+        """Reject input modalities that this wrapper does not support."""
+        capabilities = {
+            "text": self.supports_text,
+            "image": self.supports_image,
+            "video": self.supports_video,
+            "audio": self.supports_audio,
+        }
+        for modality in modalities:
+            if modality not in capabilities:
+                raise ValueError(f"Unknown input modality: {modality!r}.")
+            if not capabilities[modality]:
+                raise ValueError(
+                    f"{type(self).__name__} does not support {modality} inputs."
+                )
+
+    def resolve_media_token_id(self, tokenizer, modality: str) -> int:
+        """Resolve a compact media marker to one nonnegative tokenizer ID."""
+        prompt_config = self.get_multimodal_prompt_config()
+        if prompt_config is None:
+            raise ValueError(f"{type(self).__name__} does not define a multimodal prompt contract.")
+        spec = prompt_config.get_spec(modality)
+        if not spec.model_token:
+            raise ValueError(
+                f"{type(self).__name__} does not define a model token for {modality} inputs."
+            )
+
+        candidates = [
+            getattr(getattr(tokenizer, "_tokenizer", None), "tokenizer", None),
+            getattr(tokenizer, "_tokenizer", None),
+            getattr(tokenizer, "tokenizer", None),
+            tokenizer,
+        ]
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            resolved_id = None
+            if hasattr(candidate, "convert_tokens_to_ids"):
+                try:
+                    resolved_id = candidate.convert_tokens_to_ids(spec.model_token)
+                except (TypeError, ValueError):
+                    resolved_id = candidate.convert_tokens_to_ids([spec.model_token])
+                if isinstance(resolved_id, (list, tuple)):
+                    resolved_id = resolved_id[0] if len(resolved_id) == 1 else None
+                if resolved_id == getattr(candidate, "unk_token_id", None):
+                    resolved_id = None
+            if resolved_id is None and hasattr(candidate, "encode"):
+                try:
+                    encoded = candidate.encode(spec.model_token, add_special_tokens=False)
+                except TypeError:
+                    encoded = candidate.encode(spec.model_token)
+                if torch.is_tensor(encoded):
+                    encoded = encoded.reshape(-1).tolist()
+                if isinstance(encoded, (list, tuple)) and len(encoded) == 1:
+                    resolved_id = encoded[0]
+            if resolved_id is None and hasattr(candidate, "tokenize"):
+                encoded = candidate.tokenize(spec.model_token)
+                if torch.is_tensor(encoded):
+                    encoded = encoded.reshape(-1).tolist()
+                if isinstance(encoded, (list, tuple)) and len(encoded) == 1:
+                    resolved_id = encoded[0]
+            try:
+                resolved_id = int(resolved_id) if resolved_id is not None else None
+            except (TypeError, ValueError):
+                resolved_id = None
+            if resolved_id is not None and resolved_id >= 0:
+                return resolved_id
+
+        raise ValueError(
+            f"Tokenizer does not define {spec.model_token!r} as one nonnegative token."
+        )
+
+    def get_preexpanded_media_token_id(self, modality: str) -> int:
+        """Return the model-internal marker used by already-expanded prompts."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must define its pre-expanded {modality} token id."
+        )
+
     def build_preexpanded_media_token_mask(
         self, prompt_tokens: torch.Tensor, modality: str
     ) -> torch.Tensor:
         """Map pre-expanded media-token positions to sequential embedding indices."""
-        prompt_config = self.get_multimodal_prompt_config()
-        if prompt_config is None:
-            raise ValueError(f"{type(self).__name__} does not define a multimodal prompt contract.")
-        media_token_id = prompt_config.get_spec(modality).model_token_id
-        if media_token_id is None:
-            raise ValueError(
-                f"{type(self).__name__} does not define a model token id for " f"{modality} inputs."
-            )
-
+        media_token_id = self.get_preexpanded_media_token_id(modality)
         media_positions = prompt_tokens == int(media_token_id)
         media_indices = torch.nonzero(media_positions, as_tuple=False).flatten()
         mask = torch.full_like(prompt_tokens, -1, dtype=torch.int64)

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -94,6 +94,32 @@ class AbstractModelInferenceWrapper(abc.ABC):
         """Return this model's structured-media prompt contract, if any."""
         return None
 
+    def build_preexpanded_media_token_mask(
+        self, prompt_tokens: torch.Tensor, modality: str
+    ) -> torch.Tensor:
+        """Map pre-expanded media-token positions to sequential embedding indices."""
+        prompt_config = self.get_multimodal_prompt_config()
+        if prompt_config is None:
+            raise ValueError(
+                f"{type(self).__name__} does not define a multimodal prompt contract."
+            )
+        media_token_id = prompt_config.get_spec(modality).model_token_id
+        if media_token_id is None:
+            raise ValueError(
+                f"{type(self).__name__} does not define a model token id for "
+                f"{modality} inputs."
+            )
+
+        media_positions = prompt_tokens == int(media_token_id)
+        media_indices = torch.nonzero(media_positions, as_tuple=False).flatten()
+        mask = torch.full_like(prompt_tokens, -1, dtype=torch.int64)
+        mask[media_indices] = torch.arange(
+            media_indices.numel(),
+            dtype=torch.int64,
+            device=prompt_tokens.device,
+        )
+        return mask
+
     @abc.abstractmethod
     def prep_inference_input(self, prompt_tokens) -> Dict[str, Any]:
         """Prepares the inference input data.

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -41,6 +41,7 @@ class AbstractModelInferenceWrapper(abc.ABC):
     supports_image: ClassVar[bool] = False
     supports_video: ClassVar[bool] = False
     supports_audio: ClassVar[bool] = False
+    multimodal_prompt_config: ClassVar[Optional[MultimodalPromptConfig]] = None
 
     @deprecate_args(*DEPRECATED_ARGS)
     def __init__(
@@ -90,10 +91,6 @@ class AbstractModelInferenceWrapper(abc.ABC):
 
         self.inference_context.reset()
 
-    def get_multimodal_prompt_config(self) -> Optional[MultimodalPromptConfig]:
-        """Return this model's structured-media prompt contract, if any."""
-        return None
-
     def validate_input_modalities(self, *modalities: str) -> None:
         """Reject input modalities that this wrapper does not support."""
         capabilities = {
@@ -110,7 +107,7 @@ class AbstractModelInferenceWrapper(abc.ABC):
 
     def resolve_media_token_id(self, tokenizer, modality: str) -> int:
         """Resolve a compact media marker to one nonnegative tokenizer ID."""
-        prompt_config = self.get_multimodal_prompt_config()
+        prompt_config = self.multimodal_prompt_config
         if prompt_config is None:
             raise ValueError(f"{type(self).__name__} does not define a multimodal prompt contract.")
         spec = prompt_config.get_spec(modality)

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import abc
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Any, ClassVar, Dict, Iterable, Optional, Union
 
 import torch
 
@@ -35,6 +35,12 @@ class AbstractModelInferenceWrapper(abc.ABC):
         inference_context (BaseInferenceContext): Context for managing KV
             cache and other inference params.
     """
+
+    # Input modalities accepted by this wrapper.
+    supports_text: ClassVar[bool] = True
+    supports_image: ClassVar[bool] = False
+    supports_video: ClassVar[bool] = False
+    supports_audio: ClassVar[bool] = False
 
     @deprecate_args(*DEPRECATED_ARGS)
     def __init__(

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -64,9 +64,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             )
         return super().run_one_forward_step(inference_input, recv_buffer_seq_len)
 
-    def expand_image_tokens(
-        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None
-    ):
+    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None):
         """Expand compact image/video placeholders and build embedding masks."""
         if imgs_sizes is None:
             raise NotImplementedError(
@@ -79,22 +77,16 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             raise ValueError("NemotronOmniModel must have dynamic_resolution enabled.")
 
         frame_embedding_counts = dynamic_media_embedding_counts(
-            imgs_sizes,
-            patch_dim=model.patch_dim,
-            pixel_shuffle=True,
+            imgs_sizes, patch_dim=model.patch_dim, pixel_shuffle=True
         )
         placeholder_count = sum(
-            token == model.image_token_index
-            for sample_tokens in tokens
-            for token in sample_tokens
+            token == model.image_token_index for sample_tokens in tokens for token in sample_tokens
         )
 
         replacement_counts = dynamic_media_replacement_counts(
             frame_embedding_counts,
             num_frames=num_frames,
-            temporal_patch_size=int(
-                getattr(model.vision_model, "temporal_patch_dim", 1)
-            ),
+            temporal_patch_size=int(getattr(model.vision_model, "temporal_patch_dim", 1)),
             placeholder_count=placeholder_count,
         )
 
@@ -138,18 +130,13 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         media_kind = "video" if num_frames is not None else "image"
         if num_frames is None:
             num_frames = torch.ones(
-                imgs_sizes.shape[0],
-                dtype=torch.int32,
-                device=imgs_sizes.device,
+                imgs_sizes.shape[0], dtype=torch.int32, device=imgs_sizes.device
             )
 
         model = resolve_wrapped_model(self.model)
         with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
             embeddings = model._encode_images(
-                images,
-                imgs_sizes,
-                vision_packed_seq_params=None,
-                num_frames=num_frames,
+                images, imgs_sizes, vision_packed_seq_params=None, num_frames=num_frames
             )
         return embeddings.unsqueeze(1)
 

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -31,6 +31,11 @@ from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
 class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
     """Dynamic-inference adapter for canonical, expanded-sequence Nemotron Omni."""
 
+    supports_text = True
+    supports_image = True
+    supports_video = True
+    supports_audio = False
+
     def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
         """Return Nemotron Omni's compact visual-span contract."""
         model = resolve_wrapped_model(self.model)

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -36,12 +36,10 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
     supports_video = True
     supports_audio = False
 
-    def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
-        """Return Nemotron Omni's compact visual-span contract."""
-        return MultimodalPromptConfig(
-            image_spec=MediaPromptSpec(model_token="<image>", prefix="<img>", suffix="</img>"),
-            video_spec=MediaPromptSpec(model_token="<image>", prefix="<img>", suffix="</img>"),
-        )
+    _media_prompt_spec = MediaPromptSpec(model_token="<image>", prefix="<img>", suffix="</img>")
+    multimodal_prompt_config = MultimodalPromptConfig(
+        image_spec=_media_prompt_spec, video_spec=_media_prompt_spec
+    )
 
     def get_preexpanded_media_token_id(self, modality: str) -> int:
         """Return the model's internal sentinel for already-expanded visual prompts."""

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -24,8 +24,8 @@ from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper 
 from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
     dynamic_media_embedding_counts,
     dynamic_media_replacement_counts,
-    resolve_wrapped_model,
 )
+from megatron.core.utils import get_attr_wrapped_model
 
 
 class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
@@ -38,21 +38,26 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
 
     def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
         """Return Nemotron Omni's compact visual-span contract."""
-        model = resolve_wrapped_model(self.model)
         return MultimodalPromptConfig(
             image_spec=MediaPromptSpec(
                 model_token="<image>",
-                model_token_id=int(model.image_token_index),
                 prefix="<img>",
                 suffix="</img>",
             ),
             video_spec=MediaPromptSpec(
                 model_token="<image>",
-                model_token_id=int(model.image_token_index),
                 prefix="<img>",
                 suffix="</img>",
             ),
         )
+
+    def get_preexpanded_media_token_id(self, modality: str) -> int:
+        """Return the model's internal sentinel for already-expanded visual prompts."""
+        del modality
+        model = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
+        return int(model.image_token_index)
 
     def run_one_forward_step(
         self, inference_input: Dict[str, Any], recv_buffer_seq_len: Optional[int] = None
@@ -64,7 +69,15 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             )
         return super().run_one_forward_step(inference_input, recv_buffer_seq_len)
 
-    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None):
+    def expand_image_tokens(
+        self,
+        tokens,
+        num_tiles=None,
+        imgs_sizes=None,
+        num_frames=None,
+        *,
+        image_token_id=None,
+    ):
         """Expand compact image/video placeholders and build embedding masks."""
         if imgs_sizes is None:
             raise NotImplementedError(
@@ -72,7 +85,12 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             )
         if num_tiles is not None:
             raise ValueError("num_tiles must be omitted for dynamic-resolution Omni inference.")
-        model = resolve_wrapped_model(self.model)
+        model = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
+        image_token_index = (
+            model.image_token_index if image_token_id is None else int(image_token_id)
+        )
         if not getattr(model, "dynamic_resolution", False):
             raise ValueError("NemotronOmniModel must have dynamic_resolution enabled.")
 
@@ -80,15 +98,20 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             imgs_sizes, patch_dim=model.patch_dim, pixel_shuffle=True
         )
         placeholder_count = sum(
-            token == model.image_token_index for sample_tokens in tokens for token in sample_tokens
+            token == image_token_index for sample_tokens in tokens for token in sample_tokens
         )
 
         replacement_counts = dynamic_media_replacement_counts(
             frame_embedding_counts,
             num_frames=num_frames,
             temporal_patch_size=int(getattr(model.vision_model, "temporal_patch_dim", 1)),
-            placeholder_count=placeholder_count,
         )
+        media_kind = "video" if num_frames is not None else "image"
+        if placeholder_count != len(replacement_counts):
+            raise ValueError(
+                f"Expected one compact placeholder per {media_kind}: "
+                f"expected {len(replacement_counts)}, got {placeholder_count}."
+            )
 
         expanded_tokens = []
         image_masks = []
@@ -98,7 +121,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             expanded_sample = []
             mask_sample = []
             for token in sample_tokens:
-                if token != model.image_token_index:
+                if token != image_token_index:
                     expanded_sample.append(token)
                     mask_sample.append(None)
                     continue
@@ -133,7 +156,9 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
                 imgs_sizes.shape[0], dtype=torch.int32, device=imgs_sizes.device
             )
 
-        model = resolve_wrapped_model(self.model)
+        model = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
         with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
             embeddings = model._encode_images(
                 images, imgs_sizes, vision_packed_seq_params=None, num_frames=num_frames
@@ -161,9 +186,12 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input["attention_mask"]
         image_token_mask = inference_input["image_token_mask"]
         image_embeddings = inference_input.get("image_embeddings")
-        model = resolve_wrapped_model(self.model)
+        model = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
 
-        input_ids_text = tokens.masked_fill(tokens == -1, 0)
+        # The mask covers compact-path padding and pre-expanded model sentinels.
+        input_ids_text = tokens.masked_fill(image_token_mask >= 0, 0)
         decoder_input = model.language_model.embedding(
             input_ids=input_ids_text, position_ids=position_ids
         )

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -175,6 +175,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         )
         combined_embeddings = decoder_input.transpose(0, 1).contiguous()
 
+        # Inject vision embeddings into the decoder input.
         image_positions = image_token_mask >= 0
         if image_positions.any():
             if image_embeddings is None:

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -39,24 +39,14 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
     def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
         """Return Nemotron Omni's compact visual-span contract."""
         return MultimodalPromptConfig(
-            image_spec=MediaPromptSpec(
-                model_token="<image>",
-                prefix="<img>",
-                suffix="</img>",
-            ),
-            video_spec=MediaPromptSpec(
-                model_token="<image>",
-                prefix="<img>",
-                suffix="</img>",
-            ),
+            image_spec=MediaPromptSpec(model_token="<image>", prefix="<img>", suffix="</img>"),
+            video_spec=MediaPromptSpec(model_token="<image>", prefix="<img>", suffix="</img>"),
         )
 
     def get_preexpanded_media_token_id(self, modality: str) -> int:
         """Return the model's internal sentinel for already-expanded visual prompts."""
         del modality
-        model = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        model = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         return int(model.image_token_index)
 
     def run_one_forward_step(
@@ -70,13 +60,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         return super().run_one_forward_step(inference_input, recv_buffer_seq_len)
 
     def expand_image_tokens(
-        self,
-        tokens,
-        num_tiles=None,
-        imgs_sizes=None,
-        num_frames=None,
-        *,
-        image_token_id=None,
+        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None, *, image_token_id=None
     ):
         """Expand compact image/video placeholders and build embedding masks."""
         if imgs_sizes is None:
@@ -85,9 +69,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             )
         if num_tiles is not None:
             raise ValueError("num_tiles must be omitted for dynamic-resolution Omni inference.")
-        model = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        model = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         image_token_index = (
             model.image_token_index if image_token_id is None else int(image_token_id)
         )
@@ -156,9 +138,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
                 imgs_sizes.shape[0], dtype=torch.int32, device=imgs_sizes.device
             )
 
-        model = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        model = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
             embeddings = model._encode_images(
                 images, imgs_sizes, vision_packed_seq_params=None, num_frames=num_frames
@@ -186,9 +166,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input["attention_mask"]
         image_token_mask = inference_input["image_token_mask"]
         image_embeddings = inference_input.get("image_embeddings")
-        model = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        model = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
 
         # The mask covers compact-path padding and pre-expanded model sentinels.
         input_ids_text = tokens.masked_fill(image_token_mask >= 0, 0)

--- a/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/nemotron_omni_inference_wrapper.py
@@ -17,28 +17,37 @@ from typing import Any, Dict, Optional
 import torch
 
 from megatron.core import tensor_parallel
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
 )
-
-
-def _image_embedding_counts(imgs_sizes: torch.Tensor, patch_dim: int) -> torch.Tensor:
-    """Return projected RADIO token counts for dynamic-resolution images."""
-    if patch_dim <= 0:
-        raise ValueError("patch_dim must be greater than 0.")
-    if imgs_sizes.ndim != 2 or imgs_sizes.shape[1] != 2:
-        raise ValueError(f"imgs_sizes must have shape [N, 2], got {tuple(imgs_sizes.shape)}.")
-
-    grid_sizes = torch.div(imgs_sizes, patch_dim, rounding_mode="floor")
-    if torch.any(grid_sizes * patch_dim != imgs_sizes):
-        raise ValueError("Image dimensions must be divisible by patch_dim.")
-    if torch.any(grid_sizes % 2 != 0):
-        raise ValueError("Image patch grids must be even for pixel shuffle.")
-    return (grid_sizes.prod(dim=1) // 4).to(dtype=torch.int)
+from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
+    dynamic_media_embedding_counts,
+    dynamic_media_replacement_counts,
+    resolve_wrapped_model,
+)
 
 
 class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
     """Dynamic-inference adapter for canonical, expanded-sequence Nemotron Omni."""
+
+    def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
+        """Return Nemotron Omni's compact visual-span contract."""
+        model = resolve_wrapped_model(self.model)
+        return MultimodalPromptConfig(
+            image_spec=MediaPromptSpec(
+                model_token="<image>",
+                model_token_id=int(model.image_token_index),
+                prefix="<img>",
+                suffix="</img>",
+            ),
+            video_spec=MediaPromptSpec(
+                model_token="<image>",
+                model_token_id=int(model.image_token_index),
+                prefix="<img>",
+                suffix="</img>",
+            ),
+        )
 
     def run_one_forward_step(
         self, inference_input: Dict[str, Any], recv_buffer_seq_len: Optional[int] = None
@@ -50,30 +59,39 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             )
         return super().run_one_forward_step(inference_input, recv_buffer_seq_len)
 
-    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None):
-        """Expand compact image placeholders and build embedding-index masks."""
+    def expand_image_tokens(
+        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None
+    ):
+        """Expand compact image/video placeholders and build embedding masks."""
         if imgs_sizes is None:
             raise NotImplementedError(
                 "Canonical Nemotron Omni inference supports dynamic-resolution images only."
             )
         if num_tiles is not None:
             raise ValueError("num_tiles must be omitted for dynamic-resolution Omni inference.")
-        if not getattr(self.model, "dynamic_resolution", False):
+        model = resolve_wrapped_model(self.model)
+        if not getattr(model, "dynamic_resolution", False):
             raise ValueError("NemotronOmniModel must have dynamic_resolution enabled.")
 
-        replacement_counts = _image_embedding_counts(
-            imgs_sizes, patch_dim=self.model.patch_dim
-        ).tolist()
+        frame_embedding_counts = dynamic_media_embedding_counts(
+            imgs_sizes,
+            patch_dim=model.patch_dim,
+            pixel_shuffle=True,
+        )
         placeholder_count = sum(
-            token == self.model.image_token_index
+            token == model.image_token_index
             for sample_tokens in tokens
             for token in sample_tokens
         )
-        if placeholder_count != len(replacement_counts):
-            raise ValueError(
-                f"Expected {placeholder_count} image-size entries, "
-                f"got {len(replacement_counts)}."
-            )
+
+        replacement_counts = dynamic_media_replacement_counts(
+            frame_embedding_counts,
+            num_frames=num_frames,
+            temporal_patch_size=int(
+                getattr(model.vision_model, "temporal_patch_dim", 1)
+            ),
+            placeholder_count=placeholder_count,
+        )
 
         expanded_tokens = []
         image_masks = []
@@ -83,7 +101,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             expanded_sample = []
             mask_sample = []
             for token in sample_tokens:
-                if token != self.model.image_token_index:
+                if token != model.image_token_index:
                     expanded_sample.append(token)
                     mask_sample.append(None)
                     continue
@@ -104,6 +122,7 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         images: torch.Tensor,
         num_image_tiles: Optional[torch.Tensor] = None,
         imgs_sizes: Optional[torch.Tensor] = None,
+        num_frames: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Encode and project dynamic-resolution images once per request."""
         if imgs_sizes is None:
@@ -111,12 +130,22 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         if num_image_tiles is not None:
             raise ValueError("num_image_tiles is not used by canonical Nemotron Omni.")
 
-        embeddings = self.model._encode_images(
-            images,
-            imgs_sizes,
-            vision_packed_seq_params=None,
-            num_frames=torch.ones(imgs_sizes.shape[0], dtype=torch.int32, device=imgs_sizes.device),
-        )
+        media_kind = "video" if num_frames is not None else "image"
+        if num_frames is None:
+            num_frames = torch.ones(
+                imgs_sizes.shape[0],
+                dtype=torch.int32,
+                device=imgs_sizes.device,
+            )
+
+        model = resolve_wrapped_model(self.model)
+        with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
+            embeddings = model._encode_images(
+                images,
+                imgs_sizes,
+                vision_packed_seq_params=None,
+                num_frames=num_frames,
+            )
         return embeddings.unsqueeze(1)
 
     def _forward(self, inference_input: Dict[str, Any]) -> torch.Tensor:
@@ -140,9 +169,10 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input["attention_mask"]
         image_token_mask = inference_input["image_token_mask"]
         image_embeddings = inference_input.get("image_embeddings")
+        model = resolve_wrapped_model(self.model)
 
         input_ids_text = tokens.masked_fill(tokens == -1, 0)
-        decoder_input = self.model.language_model.embedding(
+        decoder_input = model.language_model.embedding(
             input_ids=input_ids_text, position_ids=position_ids
         )
         combined_embeddings = decoder_input.transpose(0, 1).contiguous()
@@ -164,12 +194,12 @@ class NemotronOmniInferenceWrapper(GPTInferenceWrapper):
             combined_embeddings[image_positions] = flat_image_embeddings[image_indices]
 
         decoder_input = combined_embeddings.transpose(0, 1).contiguous()
-        if self.model.sequence_parallel_lm:
+        if model.sequence_parallel_lm:
             decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
-                decoder_input, group=self.model.pg_collection.tp
+                decoder_input, group=model.pg_collection.tp
             ).contiguous()
 
-        return self.model.language_model(
+        return model.language_model(
             input_ids=None,
             position_ids=position_ids,
             attention_mask=attention_mask,

--- a/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
@@ -2,20 +2,6 @@
 
 import torch
 
-from megatron.core.utils import unwrap_model
-
-
-def resolve_wrapped_model(model):
-    """Return the innermost model across supported and lightweight wrappers."""
-    module = unwrap_model(model)
-    for _ in range(4):
-        inner = getattr(module, "module", None)
-        if inner is None or inner is module:
-            break
-        module = inner
-    return module
-
-
 def dynamic_media_embedding_counts(
     imgs_sizes: torch.Tensor,
     patch_dim: int,
@@ -59,15 +45,9 @@ def dynamic_media_replacement_counts(
     *,
     num_frames,
     temporal_patch_size: int,
-    placeholder_count: int,
 ) -> list[int]:
-    """Map per-frame counts to image, tubelet, or whole-video placeholders."""
+    """Map per-frame counts to one compact placeholder per image or video."""
     if num_frames is None:
-        if placeholder_count != len(frame_embedding_counts):
-            raise ValueError(
-                f"Expected {len(frame_embedding_counts)} image placeholders, "
-                f"got {placeholder_count}."
-            )
         return frame_embedding_counts
 
     if isinstance(num_frames, int):
@@ -90,22 +70,12 @@ def dynamic_media_replacement_counts(
     if temporal_patch_size <= 0:
         raise ValueError("temporal_patch_size must be positive.")
 
-    per_tubelet_counts = []
     per_video_counts = []
     frame_offset = 0
     for frame_count in frame_groups:
         video_frame_counts = frame_embedding_counts[frame_offset : frame_offset + frame_count]
         tubelet_counts = video_frame_counts[::temporal_patch_size]
-        per_tubelet_counts.extend(tubelet_counts)
         per_video_counts.append(sum(tubelet_counts))
         frame_offset += frame_count
 
-    if placeholder_count == len(per_tubelet_counts):
-        return per_tubelet_counts
-    if placeholder_count == len(per_video_counts):
-        return per_video_counts
-    raise ValueError(
-        "Video prompt placeholders must match either the number of "
-        f"videos ({len(per_video_counts)}) or tubelets "
-        f"({len(per_tubelet_counts)}); got {placeholder_count}."
-    )
+    return per_video_counts

--- a/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+
+from megatron.core.utils import unwrap_model
+
+
+def resolve_wrapped_model(model):
+    """Return the innermost model across supported and lightweight wrappers."""
+    module = unwrap_model(model)
+    for _ in range(4):
+        inner = getattr(module, "module", None)
+        if inner is None or inner is module:
+            break
+        module = inner
+    return module
+
+
+def dynamic_media_embedding_counts(
+    imgs_sizes: torch.Tensor,
+    patch_dim: int,
+    *,
+    pixel_shuffle: bool,
+    pixel_shuffle_size: int = 2,
+    spatial_merge_size: int = 1,
+) -> list[int]:
+    """Return projected token counts for dynamic-resolution media frames."""
+    if patch_dim <= 0:
+        raise ValueError("patch_dim must be greater than 0.")
+    if imgs_sizes.ndim != 2 or imgs_sizes.shape[1] != 2:
+        raise ValueError(f"imgs_sizes must have shape [N, 2], got {tuple(imgs_sizes.shape)}.")
+    if pixel_shuffle and pixel_shuffle_size <= 0:
+        raise ValueError("pixel_shuffle_size must be greater than 0.")
+    if spatial_merge_size <= 0:
+        raise ValueError("spatial_merge_size must be greater than 0.")
+
+    counts = []
+    for height, width in imgs_sizes.tolist():
+        if height % patch_dim or width % patch_dim:
+            raise ValueError("Media dimensions must be divisible by patch_dim.")
+        patch_height = height // patch_dim
+        patch_width = width // patch_dim
+        if pixel_shuffle and (
+            patch_height % pixel_shuffle_size or patch_width % pixel_shuffle_size
+        ):
+            raise ValueError(
+                "Media patch grids must be divisible by pixel_shuffle_size."
+            )
+        count = patch_height * patch_width
+        if pixel_shuffle:
+            count //= pixel_shuffle_size**2
+        merge_factor = spatial_merge_size**2
+        if count % merge_factor:
+            raise ValueError(
+                "Media token count must be divisible by the spatial merge factor."
+            )
+        counts.append(count // merge_factor)
+    return counts
+
+
+def dynamic_media_replacement_counts(
+    frame_embedding_counts: list[int],
+    *,
+    num_frames,
+    temporal_patch_size: int,
+    placeholder_count: int,
+) -> list[int]:
+    """Map per-frame counts to image, tubelet, or whole-video placeholders."""
+    if num_frames is None:
+        if placeholder_count != len(frame_embedding_counts):
+            raise ValueError(
+                f"Expected {len(frame_embedding_counts)} image placeholders, "
+                f"got {placeholder_count}."
+            )
+        return frame_embedding_counts
+
+    if isinstance(num_frames, int):
+        frame_groups = [num_frames]
+    elif hasattr(num_frames, "tolist"):
+        values = num_frames.tolist()
+        frame_groups = (
+            [int(values)]
+            if not isinstance(values, list)
+            else [int(value) for value in values]
+        )
+    else:
+        frame_groups = [int(value) for value in num_frames]
+    if any(value <= 0 for value in frame_groups):
+        raise ValueError("num_frames entries must be positive.")
+    if sum(frame_groups) != len(frame_embedding_counts):
+        raise ValueError(
+            "num_frames must partition imgs_sizes exactly: "
+            f"sum(num_frames)={sum(frame_groups)}, "
+            f"imgs_sizes={len(frame_embedding_counts)}."
+        )
+    if temporal_patch_size <= 0:
+        raise ValueError("temporal_patch_size must be positive.")
+
+    per_tubelet_counts = []
+    per_video_counts = []
+    frame_offset = 0
+    for frame_count in frame_groups:
+        video_frame_counts = frame_embedding_counts[
+            frame_offset : frame_offset + frame_count
+        ]
+        tubelet_counts = video_frame_counts[::temporal_patch_size]
+        per_tubelet_counts.extend(tubelet_counts)
+        per_video_counts.append(sum(tubelet_counts))
+        frame_offset += frame_count
+
+    if placeholder_count == len(per_tubelet_counts):
+        return per_tubelet_counts
+    if placeholder_count == len(per_video_counts):
+        return per_video_counts
+    raise ValueError(
+        "Video prompt placeholders must match either the number of "
+        f"videos ({len(per_video_counts)}) or tubelets "
+        f"({len(per_tubelet_counts)}); got {placeholder_count}."
+    )

--- a/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
@@ -2,6 +2,7 @@
 
 import torch
 
+
 def dynamic_media_embedding_counts(
     imgs_sizes: torch.Tensor,
     patch_dim: int,
@@ -41,10 +42,7 @@ def dynamic_media_embedding_counts(
 
 
 def dynamic_media_replacement_counts(
-    frame_embedding_counts: list[int],
-    *,
-    num_frames,
-    temporal_patch_size: int,
+    frame_embedding_counts: list[int], *, num_frames, temporal_patch_size: int
 ) -> list[int]:
     """Map per-frame counts to one compact placeholder per image or video."""
     if num_frames is None:

--- a/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/utils.py
@@ -43,17 +43,13 @@ def dynamic_media_embedding_counts(
         if pixel_shuffle and (
             patch_height % pixel_shuffle_size or patch_width % pixel_shuffle_size
         ):
-            raise ValueError(
-                "Media patch grids must be divisible by pixel_shuffle_size."
-            )
+            raise ValueError("Media patch grids must be divisible by pixel_shuffle_size.")
         count = patch_height * patch_width
         if pixel_shuffle:
             count //= pixel_shuffle_size**2
         merge_factor = spatial_merge_size**2
         if count % merge_factor:
-            raise ValueError(
-                "Media token count must be divisible by the spatial merge factor."
-            )
+            raise ValueError("Media token count must be divisible by the spatial merge factor.")
         counts.append(count // merge_factor)
     return counts
 
@@ -79,9 +75,7 @@ def dynamic_media_replacement_counts(
     elif hasattr(num_frames, "tolist"):
         values = num_frames.tolist()
         frame_groups = (
-            [int(values)]
-            if not isinstance(values, list)
-            else [int(value) for value in values]
+            [int(values)] if not isinstance(values, list) else [int(value) for value in values]
         )
     else:
         frame_groups = [int(value) for value in num_frames]
@@ -100,9 +94,7 @@ def dynamic_media_replacement_counts(
     per_video_counts = []
     frame_offset = 0
     for frame_count in frame_groups:
-        video_frame_counts = frame_embedding_counts[
-            frame_offset : frame_offset + frame_count
-        ]
+        video_frame_counts = frame_embedding_counts[frame_offset : frame_offset + frame_count]
         tubelet_counts = video_frame_counts[::temporal_patch_size]
         per_tubelet_counts.extend(tubelet_counts)
         per_video_counts.append(sum(tubelet_counts))

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -31,10 +31,10 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
     _recv_only_vision_embeds: bool = False
     _encoder_only: bool = False
 
-    def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
-        """Use the conventional compact ``<image>`` placeholder."""
-        spec = MediaPromptSpec(model_token="<image>")
-        return MultimodalPromptConfig(image_spec=spec, video_spec=spec)
+    _media_prompt_spec = MediaPromptSpec(model_token="<image>")
+    multimodal_prompt_config = MultimodalPromptConfig(
+        image_spec=_media_prompt_spec, video_spec=_media_prompt_spec
+    )
 
     def get_preexpanded_media_token_id(self, modality: str) -> int:
         """Return LLaVA's internal sentinel without exposing it as a vocabulary ID."""

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -16,8 +16,8 @@ from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper 
 from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
     dynamic_media_embedding_counts,
     dynamic_media_replacement_counts,
-    resolve_wrapped_model,
 )
+from megatron.core.utils import get_attr_wrapped_model
 
 
 # pylint: disable=line-too-long
@@ -33,12 +33,16 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
     def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
         """Use the conventional compact ``<image>`` placeholder."""
-        module = resolve_wrapped_model(self.model)
-        token_id = getattr(module, "image_token_index", None)
-        spec = MediaPromptSpec(
-            model_token="<image>", model_token_id=int(token_id) if token_id is not None else None
-        )
+        spec = MediaPromptSpec(model_token="<image>")
         return MultimodalPromptConfig(image_spec=spec, video_spec=spec)
+
+    def get_preexpanded_media_token_id(self, modality: str) -> int:
+        """Return LLaVA's internal sentinel without exposing it as a vocabulary ID."""
+        del modality
+        module = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
+        return int(module.image_token_index)
 
     def prep_model_for_inference(self, prompts_tokens: Optional[torch.Tensor] = None):
         """A utility function for preparing model for inference
@@ -147,7 +151,15 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
     # ---- Dynamic inference methods ----
 
-    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None):
+    def expand_image_tokens(
+        self,
+        tokens,
+        num_tiles=None,
+        imgs_sizes=None,
+        num_frames=None,
+        *,
+        image_token_id=None,
+    ):
         """Expand image tokens to multiple pad tokens.
 
         Supports two modes:
@@ -166,8 +178,12 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             mask (List[List[int or None]]): Mask indicating image embedding indices for each
                 position, None for non-image positions.
         """
-        module = resolve_wrapped_model(self.model)
-        image_token_index = module.image_token_index
+        module = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
+        image_token_index = (
+            module.image_token_index if image_token_id is None else int(image_token_id)
+        )
 
         pad_value = -1
         batch_size = len(tokens)
@@ -209,8 +225,13 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
                 frame_embedding_counts,
                 num_frames=num_frames,
                 temporal_patch_size=int(getattr(module, "temporal_patch_dim", 1)),
-                placeholder_count=placeholder_count,
             )
+            media_kind = "video" if num_frames is not None else "image"
+            if placeholder_count != len(per_image_embeddings):
+                raise ValueError(
+                    f"Expected one compact placeholder per {media_kind}: "
+                    f"expected {len(per_image_embeddings)}, got {placeholder_count}."
+                )
         else:
             # Static resolution: fixed embeddings per tile
             img_embeddings_per_tile = module.img_seq_len
@@ -300,7 +321,11 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         return expanded_tokens_list, mask_list
 
     def _forward_vision_encoder(
-        self, images, num_image_tiles=None, imgs_sizes=None, num_frames=None
+        self,
+        images,
+        num_image_tiles=None,
+        imgs_sizes=None,
+        num_frames=None,
     ) -> torch.Tensor:
         """Run the vision encoder only, returning image embeddings.
 
@@ -317,7 +342,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         """
         from megatron.core.packed_seq_params import PackedSeqParams
 
-        module = resolve_wrapped_model(self.model)
+        module = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
 
         # Reject dynamic-resolution requests when the model does not expose
         # the required attributes (see expand_image_tokens for context).
@@ -396,12 +423,19 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input.get("attention_mask", None)
         image_embeddings = inference_input.get("image_embeddings", None)
 
-        module = resolve_wrapped_model(self.model)
+        module = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
+        )
 
         if is_pipeline_first_stage(self.pp_group) or self._recv_only_vision_embeds:
-            # Replace -1 padding with 0 for embedding lookup
+            # Media positions may contain either compact-path padding or the
+            # model's pre-expanded sentinel (for example, -200). The mask is
+            # authoritative for both representations.
             input_ids_text = tokens.clone()
-            input_ids_text[input_ids_text == -1] = 0
+            if image_token_mask is not None:
+                input_ids_text[image_token_mask >= 0] = 0
+            else:
+                input_ids_text[input_ids_text == -1] = 0
 
             # Get language embeddings: [seq_len, b, h_language]
             language_embeddings = module.language_model.embedding(
@@ -573,9 +607,10 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             return super().run_one_forward_step(inference_input)
 
         # Static VLM path
-        num_image_tokens = (
-            (tokens == resolve_wrapped_model(self.model).image_token_index).sum().item()
+        module = get_attr_wrapped_model(
+            self.model, "image_token_index", return_model_obj=True
         )
+        num_image_tokens = (tokens == module.image_token_index).sum().item()
         num_img_embeddings = inference_input["num_img_embeddings"]
         decoder_seq_length = inference_input["decoder_seq_length"]
         num_tokens = tokens.size(1)

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -8,9 +8,15 @@ from megatron.core.inference.communication_utils import (
     is_pipeline_first_stage,
     is_pipeline_last_stage,
 )
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
 from megatron.core.inference.contexts import StaticInferenceContext
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
+    dynamic_media_embedding_counts,
+    dynamic_media_replacement_counts,
+    resolve_wrapped_model,
 )
 
 
@@ -20,6 +26,16 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
     _recv_only_vision_embeds: bool = False
     _encoder_only: bool = False
+
+    def get_multimodal_prompt_config(self) -> MultimodalPromptConfig:
+        """Use the conventional compact ``<image>`` placeholder."""
+        module = resolve_wrapped_model(self.model)
+        token_id = getattr(module, "image_token_index", None)
+        spec = MediaPromptSpec(
+            model_token="<image>",
+            model_token_id=int(token_id) if token_id is not None else None,
+        )
+        return MultimodalPromptConfig(image_spec=spec, video_spec=spec)
 
     def prep_model_for_inference(self, prompts_tokens: Optional[torch.Tensor] = None):
         """A utility function for preparing model for inference
@@ -128,7 +144,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
     # ---- Dynamic inference methods ----
 
-    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None):
+    def expand_image_tokens(
+        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None
+    ):
         """Expand image tokens to multiple pad tokens.
 
         Supports two modes:
@@ -147,9 +165,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             mask (List[List[int or None]]): Mask indicating image embedding indices for each
                 position, None for non-image positions.
         """
-        module = (
-            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
-        )
+        module = resolve_wrapped_model(self.model)
         image_token_index = module.image_token_index
 
         pad_value = -1
@@ -170,21 +186,33 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
         # Compute per-image embedding counts
         if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
-            # Dynamic resolution: compute per-image embedding count from imgs_sizes.
-            patch_dim = module.patch_dim
-            do_pixel_shuffle = module._pixel_shuffle
-
-            # One D2H sync total instead of two per image. Previous code did
-            # imgs_sizes[i][0].item() + imgs_sizes[i][1].item() inside a Python
-            # loop, incurring 2 * num_images blocking syncs per admission.
-            imgs_sizes_cpu = imgs_sizes.tolist()
-            per_image_embeddings = []
-            for row in imgs_sizes_cpu:
-                h, w = row[0], row[1]
-                num_embeddings = (h // patch_dim) * (w // patch_dim)
-                if do_pixel_shuffle:
-                    num_embeddings //= 4
-                per_image_embeddings.append(num_embeddings)
+            frame_embedding_counts = dynamic_media_embedding_counts(
+                imgs_sizes,
+                module.patch_dim,
+                pixel_shuffle=module._pixel_shuffle,
+                spatial_merge_size=2 if module._conv_merging else 1,
+            )
+            if not module._drop_vision_class_token:
+                class_token_len = int(getattr(module, "_class_token_len", 0))
+                if module._pixel_shuffle and class_token_len > 0:
+                    raise ValueError(
+                        "Dynamic-resolution pixel shuffle requires dropping "
+                        "vision class tokens."
+                    )
+                frame_embedding_counts = [
+                    count + class_token_len for count in frame_embedding_counts
+                ]
+            placeholder_count = sum(
+                token == image_token_index
+                for sample_tokens in tokens
+                for token in sample_tokens
+            )
+            per_image_embeddings = dynamic_media_replacement_counts(
+                frame_embedding_counts,
+                num_frames=num_frames,
+                temporal_patch_size=int(getattr(module, "temporal_patch_dim", 1)),
+                placeholder_count=placeholder_count,
+            )
         else:
             # Static resolution: fixed embeddings per tile
             img_embeddings_per_tile = module.img_seq_len
@@ -274,7 +302,11 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         return expanded_tokens_list, mask_list
 
     def _forward_vision_encoder(
-        self, images, num_image_tiles=None, imgs_sizes=None
+        self,
+        images,
+        num_image_tiles=None,
+        imgs_sizes=None,
+        num_frames=None,
     ) -> torch.Tensor:
         """Run the vision encoder only, returning image embeddings.
 
@@ -291,9 +323,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         """
         from megatron.core.packed_seq_params import PackedSeqParams
 
-        module = (
-            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
-        )
+        module = resolve_wrapped_model(self.model)
 
         # Reject dynamic-resolution requests when the model does not expose
         # the required attributes (see expand_image_tokens for context).
@@ -327,18 +357,21 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
         old_add_decoder = module.add_decoder
         module.add_decoder = False
+        media_kind = "video" if num_frames is not None else "image"
         try:
-            output = self.model(
-                images,
-                [],
-                position_ids=None,
-                attention_mask=None,
-                inference_context=self.inference_context,
-                num_image_tiles=num_image_tiles,
-                runtime_gather_output=True,
-                imgs_sizes=imgs_sizes,
-                vision_packed_seq_params=vision_packed_seq_params,
-            )
+            with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
+                output = self.model(
+                    images,
+                    [],
+                    position_ids=None,
+                    attention_mask=None,
+                    inference_context=self.inference_context,
+                    num_image_tiles=num_image_tiles,
+                    runtime_gather_output=True,
+                    imgs_sizes=imgs_sizes,
+                    vision_packed_seq_params=vision_packed_seq_params,
+                    num_frames=num_frames,
+                )
         finally:
             module.add_decoder = old_add_decoder
 
@@ -369,9 +402,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input.get("attention_mask", None)
         image_embeddings = inference_input.get("image_embeddings", None)
 
-        module = (
-            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
-        )
+        module = resolve_wrapped_model(self.model)
 
         if is_pipeline_first_stage(self.pp_group) or self._recv_only_vision_embeds:
             # Replace -1 padding with 0 for embedding lookup
@@ -548,7 +579,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             return super().run_one_forward_step(inference_input)
 
         # Static VLM path
-        num_image_tokens = (tokens == self.model.module.image_token_index).sum().item()
+        num_image_tokens = (
+            tokens == resolve_wrapped_model(self.model).image_token_index
+        ).sum().item()
         num_img_embeddings = inference_input["num_img_embeddings"]
         decoder_seq_length = inference_input["decoder_seq_length"]
         num_tokens = tokens.size(1)

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -39,9 +39,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
     def get_preexpanded_media_token_id(self, modality: str) -> int:
         """Return LLaVA's internal sentinel without exposing it as a vocabulary ID."""
         del modality
-        module = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         return int(module.image_token_index)
 
     def prep_model_for_inference(self, prompts_tokens: Optional[torch.Tensor] = None):
@@ -152,13 +150,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
     # ---- Dynamic inference methods ----
 
     def expand_image_tokens(
-        self,
-        tokens,
-        num_tiles=None,
-        imgs_sizes=None,
-        num_frames=None,
-        *,
-        image_token_id=None,
+        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None, *, image_token_id=None
     ):
         """Expand image tokens to multiple pad tokens.
 
@@ -178,9 +170,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             mask (List[List[int or None]]): Mask indicating image embedding indices for each
                 position, None for non-image positions.
         """
-        module = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         image_token_index = (
             module.image_token_index if image_token_id is None else int(image_token_id)
         )
@@ -321,11 +311,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         return expanded_tokens_list, mask_list
 
     def _forward_vision_encoder(
-        self,
-        images,
-        num_image_tiles=None,
-        imgs_sizes=None,
-        num_frames=None,
+        self, images, num_image_tiles=None, imgs_sizes=None, num_frames=None
     ) -> torch.Tensor:
         """Run the vision encoder only, returning image embeddings.
 
@@ -342,9 +328,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         """
         from megatron.core.packed_seq_params import PackedSeqParams
 
-        module = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
 
         # Reject dynamic-resolution requests when the model does not expose
         # the required attributes (see expand_image_tokens for context).
@@ -423,9 +407,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input.get("attention_mask", None)
         image_embeddings = inference_input.get("image_embeddings", None)
 
-        module = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
 
         if is_pipeline_first_stage(self.pp_group) or self._recv_only_vision_embeds:
             # Media positions may contain either compact-path padding or the
@@ -607,9 +589,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             return super().run_one_forward_step(inference_input)
 
         # Static VLM path
-        module = get_attr_wrapped_model(
-            self.model, "image_token_index", return_model_obj=True
-        )
+        module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
         num_image_tokens = (tokens == module.image_token_index).sum().item()
         num_img_embeddings = inference_input["num_img_embeddings"]
         decoder_seq_length = inference_input["decoder_seq_length"]

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -24,6 +24,10 @@ from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
 class VLMInferenceWrapper(GPTInferenceWrapper):
     """Inference wrapper for VLMs"""
 
+    supports_text = True
+    supports_image = True
+    supports_video = True
+    supports_audio = False
     _recv_only_vision_embeds: bool = False
     _encoder_only: bool = False
 

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -180,19 +180,17 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         img_embeddings_per_tile = 0  # set below in the static-resolution branch
 
         # Reject dynamic-resolution requests when the model does not expose
-        # the required attributes. Upstream LLaVAModel sets neither
-        # _dynamic_resolution nor patch_dim / _class_token_len; without those,
-        # falling through to the static path would silently miscount tokens.
-        if imgs_sizes is not None and not getattr(module, '_dynamic_resolution', False):
+        # the required attributes; falling through to the static path would
+        # silently miscount tokens.
+        if imgs_sizes is not None and not getattr(module, 'dynamic_resolution', False):
             raise NotImplementedError(
                 "Dynamic-resolution image expansion requires LLaVAModel "
-                "attributes (_dynamic_resolution, patch_dim, _class_token_len) "
-                "not yet available upstream. Use num_tiles (static resolution) "
-                "or wait for the companion LLaVAModel changes."
+                "with dynamic_resolution enabled and patch_dim/_class_token_len "
+                "available. Use num_tiles for static-resolution inputs."
             )
 
         # Compute per-image embedding counts
-        if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
+        if imgs_sizes is not None and getattr(module, 'dynamic_resolution', False):
             frame_embedding_counts = dynamic_media_embedding_counts(
                 imgs_sizes,
                 module.patch_dim,
@@ -329,20 +327,22 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         from megatron.core.packed_seq_params import PackedSeqParams
 
         module = get_attr_wrapped_model(self.model, "image_token_index", return_model_obj=True)
+        target_dtype = module.vision_model.config.params_dtype
+        if images.dtype != target_dtype:
+            images = images.to(dtype=target_dtype)
 
         # Reject dynamic-resolution requests when the model does not expose
         # the required attributes (see expand_image_tokens for context).
-        if imgs_sizes is not None and not getattr(module, '_dynamic_resolution', False):
+        if imgs_sizes is not None and not getattr(module, 'dynamic_resolution', False):
             raise NotImplementedError(
-                "Dynamic-resolution vision-encoder forward requires "
-                "LLaVAModel._dynamic_resolution/patch_dim, not yet available "
-                "upstream. Use num_tiles (static resolution) or wait for the "
-                "companion LLaVAModel changes."
+                "Dynamic-resolution vision-encoder forward requires LLaVAModel "
+                "with dynamic_resolution enabled and patch_dim available. "
+                "Use num_tiles for static-resolution inputs."
             )
 
         # Build vision_packed_seq_params for dynamic resolution
         vision_packed_seq_params = None
-        if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
+        if imgs_sizes is not None and getattr(module, 'dynamic_resolution', False):
             patch_dim = module.patch_dim
             seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
             cu_seqlens = torch.cat(
@@ -363,11 +363,12 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         old_add_decoder = module.add_decoder
         module.add_decoder = False
         media_kind = "video" if num_frames is not None else "image"
+        empty_input_ids = torch.empty((1, 0), dtype=torch.long, device=images.device)
         try:
             with torch.cuda.nvtx.range(f"megatron.multimodal.{media_kind}_encoder"):
                 output = self.model(
                     images,
-                    [],
+                    empty_input_ids,
                     position_ids=None,
                     attention_mask=None,
                     inference_context=self.inference_context,

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -36,8 +36,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         module = resolve_wrapped_model(self.model)
         token_id = getattr(module, "image_token_index", None)
         spec = MediaPromptSpec(
-            model_token="<image>",
-            model_token_id=int(token_id) if token_id is not None else None,
+            model_token="<image>", model_token_id=int(token_id) if token_id is not None else None
         )
         return MultimodalPromptConfig(image_spec=spec, video_spec=spec)
 
@@ -148,9 +147,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
     # ---- Dynamic inference methods ----
 
-    def expand_image_tokens(
-        self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None
-    ):
+    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None, num_frames=None):
         """Expand image tokens to multiple pad tokens.
 
         Supports two modes:
@@ -200,16 +197,13 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
                 class_token_len = int(getattr(module, "_class_token_len", 0))
                 if module._pixel_shuffle and class_token_len > 0:
                     raise ValueError(
-                        "Dynamic-resolution pixel shuffle requires dropping "
-                        "vision class tokens."
+                        "Dynamic-resolution pixel shuffle requires dropping " "vision class tokens."
                     )
                 frame_embedding_counts = [
                     count + class_token_len for count in frame_embedding_counts
                 ]
             placeholder_count = sum(
-                token == image_token_index
-                for sample_tokens in tokens
-                for token in sample_tokens
+                token == image_token_index for sample_tokens in tokens for token in sample_tokens
             )
             per_image_embeddings = dynamic_media_replacement_counts(
                 frame_embedding_counts,
@@ -306,11 +300,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         return expanded_tokens_list, mask_list
 
     def _forward_vision_encoder(
-        self,
-        images,
-        num_image_tiles=None,
-        imgs_sizes=None,
-        num_frames=None,
+        self, images, num_image_tiles=None, imgs_sizes=None, num_frames=None
     ) -> torch.Tensor:
         """Run the vision encoder only, returning image embeddings.
 
@@ -584,8 +574,8 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
         # Static VLM path
         num_image_tokens = (
-            tokens == resolve_wrapped_model(self.model).image_token_index
-        ).sum().item()
+            (tokens == resolve_wrapped_model(self.model).image_token_index).sum().item()
+        )
         num_img_embeddings = inference_input["num_img_embeddings"]
         decoder_seq_length = inference_input["decoder_seq_length"]
         num_tokens = tokens.size(1)

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -430,6 +430,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             embed_dim = language_embeddings.shape[-1]
             final_embedding = language_embeddings.clone()
 
+            # Inject vision embeddings into the decoder input.
             if image_token_mask is not None and image_embeddings is not None:
                 image_positions = image_token_mask >= 0
 

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -19,6 +19,7 @@ _IMAGE_FETCH_TIMEOUT_S = 5.0
 _MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MiB
 _IMAGE_FETCH_USER_AGENT = "megatron-inference"
 
+from megatron.core.inference.config import MultimodalPromptConfig
 from megatron.core.inference.inference_request import unwrap_serialized_tensors
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.tokenizers.text.parsers import PARSER_MAPPING
@@ -301,27 +302,32 @@ def _extract_image_url_bytes(url: str) -> bytes:
     raise ValueError(f"Unsupported image_url scheme: {url[:40]!r}")
 
 
-def _extract_images_from_messages(messages):
-    """Pull image_url blocks out of OpenAI-style multimodal messages.
+def _extract_multimodal_from_messages(
+    messages, prompt_config: MultimodalPromptConfig
+):
+    """Extract media bytes and replace structured blocks with internal slots.
 
-    Walks the message list, extracting bytes from each ``image_url`` block,
-    replacing it with an inline ``<image>`` text marker, and returning both
-    the rewritten messages and the ordered list of image bytes. Messages
-    with plain string ``content`` are passed through unchanged.
-
-    Fetching a remote ``image_url`` blocks, so call this off the event loop.
-
-    Returns:
-        (messages_with_markers, image_bytes_list)
-
-    Raises:
-        ValueError: an ``image_url`` could not be loaded.
+    Remote image fetching is blocking, so callers must run this function off
+    the event loop.
     """
     if not isinstance(messages, list):
-        return messages, []
+        return messages, [], [], []
 
     rewritten = []
     image_bytes_list: list[bytes] = []
+    video_bytes_list: list[bytes] = []
+    media_slots = []
+
+    def add_slot(modality):
+        """Preserve a media block's position while the chat template renders text.
+
+        The actual bytes travel separately. After rendering,
+        _tokenize_with_media_slots replaces this sentinel with the
+        model-specific MediaPromptSpec tokens.
+        """
+        sentinel = f"__MCORE_MEDIA_SLOT_{len(media_slots)}__"
+        media_slots.append((sentinel, modality))
+        return {"type": "text", "text": sentinel}
 
     for message in messages:
         if not isinstance(message, dict):
@@ -334,7 +340,7 @@ def _extract_images_from_messages(messages):
             continue
 
         new_chunks = []
-        found_image = False
+        found_modalities = set()
         for chunk in content:
             if isinstance(chunk, dict) and chunk.get("type") == "image_url":
                 url = chunk.get("image_url", {}).get("url", "")
@@ -347,19 +353,55 @@ def _extract_images_from_messages(messages):
                     # text-only, handing the client a confident answer about an
                     # image the model never saw. Surface it as a 400 instead.
                     raise ValueError(f"Failed to load image_url: {e}") from e
-                new_chunks.append({"type": "text", "text": "<image>"})
-                found_image = True
+                new_chunks.append(add_slot("image"))
+                found_modalities.add("image")
+            elif isinstance(chunk, dict) and chunk.get("type") in {
+                "video_url",
+                "input_video",
+            }:
+                video_value = chunk.get("video_url") or chunk.get("video")
+                url = (
+                    video_value.get("url", "")
+                    if isinstance(video_value, dict)
+                    else video_value
+                )
+                if not isinstance(url, str) or not url.startswith("data:"):
+                    raise ValueError(
+                        "Megatron chat video inputs must be base64 data URLs."
+                    )
+                try:
+                    video_bytes_list.append(_extract_image_url_bytes(url))
+                except Exception as e:
+                    raise ValueError(f"Failed to load video_url: {e}") from e
+                new_chunks.append(add_slot("video"))
+                found_modalities.add("video")
             else:
                 new_chunks.append(chunk)
 
-        if found_image:
+        if found_modalities:
+            input_markers = {
+                prompt_config.get_spec(modality).input_marker
+                for modality in found_modalities
+            } - {None}
+            for index, chunk in enumerate(new_chunks):
+                if isinstance(chunk, dict) and chunk.get("type") == "text":
+                    chunk = dict(chunk)
+                    for marker in input_markers:
+                        chunk["text"] = str(chunk.get("text", "")).replace(
+                            marker, ""
+                        )
+                    new_chunks[index] = chunk
             msg_copy = dict(message)
             msg_copy["content"] = new_chunks
             rewritten.append(msg_copy)
         else:
             rewritten.append(message)
 
-    return rewritten, image_bytes_list
+    if image_bytes_list and video_bytes_list:
+        raise ValueError(
+            "Mixing image and video blocks in one request is not supported."
+        )
+    return rewritten, image_bytes_list, video_bytes_list, media_slots
 
 
 def _sanitize_messages_for_template(messages):
@@ -546,6 +588,122 @@ def _coerce_to_token_id_list(result):
     return list(result)
 
 
+def _media_model_token_ids(chat_tok, prompt_config):
+    """Resolve the model token ids that stand in for media in a chat template."""
+    token_ids = set()
+    for modality in ("image", "video"):
+        spec = prompt_config.get_spec(modality)
+        token_id = spec.model_token_id
+        if token_id is None and hasattr(chat_tok, "convert_tokens_to_ids"):
+            resolved_id = chat_tok.convert_tokens_to_ids(spec.model_token)
+            if resolved_id is not None and resolved_id != getattr(
+                chat_tok, "unk_token_id", None
+            ):
+                token_id = resolved_id
+        if token_id is not None:
+            token_ids.add(int(token_id))
+    return token_ids
+
+
+def _collapse_expanded_media_tokens(token_ids, media_token_ids):
+    """Collapse each consecutive run of a media token ID to one token.
+
+    ``token_ids`` contains the expanded model-input prompt, while
+    ``media_token_ids`` contains the image/video marker IDs from
+    ``MediaPromptSpec``. The result matches the compact chat-template token form.
+    """
+    if not media_token_ids:
+        return list(token_ids)
+
+    collapsed = []
+    previous_token_id = None
+    for token_id in token_ids:
+        if token_id in media_token_ids and token_id == previous_token_id:
+            continue
+        collapsed.append(token_id)
+        previous_token_id = token_id
+    return collapsed
+
+
+async def _tokenize_with_media_slots(
+    chat_tok,
+    messages,
+    media_slots,
+    prompt_config,
+    *,
+    tools,
+    chat_template_kwargs,
+    add_generation_prompt=True,
+):
+    """Render a chat template and lower internal media slots to model tokens."""
+    rendered = await asyncio.to_thread(
+        functools.partial(
+            chat_tok.apply_chat_template,
+            messages,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            **chat_template_kwargs,
+        )
+    )
+    if not isinstance(rendered, str):
+        raise TypeError("Multimodal chat template rendering must return a string.")
+
+    positioned_slots = []
+    for sentinel, modality in media_slots:
+        if rendered.count(sentinel) != 1:
+            raise ValueError(f"Chat template did not preserve media slot {sentinel}.")
+        positioned_slots.append((rendered.index(sentinel), sentinel, modality))
+
+    prompt_tokens = []
+    cursor = 0
+    for position, sentinel, modality in sorted(positioned_slots):
+        prompt_tokens.extend(
+            _coerce_to_token_id_list(
+                chat_tok(rendered[cursor:position], add_special_tokens=False)
+            )
+        )
+        spec = prompt_config.get_spec(modality)
+        token_id = spec.model_token_id
+        resolved_id = (
+            chat_tok.convert_tokens_to_ids(spec.model_token)
+            if hasattr(chat_tok, "convert_tokens_to_ids")
+            else None
+        )
+        if resolved_id == getattr(chat_tok, "unk_token_id", None):
+            resolved_id = None
+        if token_id is None:
+            if resolved_id is None:
+                raise ValueError(
+                    f"Tokenizer does not define media token {spec.model_token!r}."
+                )
+            token_id = resolved_id
+        elif resolved_id is not None and token_id != resolved_id:
+            raise ValueError(
+                f"Configured token id {token_id} does not match "
+                f"{spec.model_token!r} id {resolved_id}."
+            )
+        prompt_tokens.extend(
+            _coerce_to_token_id_list(
+                chat_tok(spec.prefix, add_special_tokens=False)
+            )
+        )
+        prompt_tokens.append(int(token_id))
+        prompt_tokens.extend(
+            _coerce_to_token_id_list(
+                chat_tok(spec.suffix, add_special_tokens=False)
+            )
+        )
+        cursor = position + len(sentinel)
+
+    prompt_tokens.extend(
+        _coerce_to_token_id_list(
+            chat_tok(rendered[cursor:], add_special_tokens=False)
+        )
+    )
+    return prompt_tokens
+
+
 try:
     import orjson
 
@@ -625,17 +783,20 @@ try:
             return Response("Missing 'messages' field", status=400)
         if not isinstance(messages, list):
             return Response("'messages' must be a list", status=400)
-        # Extract any image_url blocks before template sanitization, which would
-        # otherwise drop them. Replaces each image block with an inline <image>
-        # text marker that the chat template can substitute. Runs in a worker
-        # thread because a remote image_url fetch blocks, which would otherwise
-        # stall every other in-flight generation on this rank.
+        prompt_config = current_app.config['multimodal_prompt_config']
+        # Extract structured media before template sanitization. Remote image
+        # fetches block, so keep this work off the event loop.
         try:
-            messages, image_bytes_list = await asyncio.to_thread(
-                _extract_images_from_messages, messages
+            messages, image_bytes_list, video_bytes_list, media_slots = await asyncio.to_thread(
+                _extract_multimodal_from_messages, messages, prompt_config
             )
-        except ValueError as e:
-            return Response(str(e), status=400)
+        except ValueError as error:
+            return Response(str(error), status=400)
+        multi_modal_data = None
+        if image_bytes_list:
+            multi_modal_data = {"image": image_bytes_list}
+        elif video_bytes_list:
+            multi_modal_data = {"video": video_bytes_list}
         template_messages = _sanitize_messages_for_template(messages)
         template_tools = _sanitize_tools_for_template(tools)
 
@@ -668,18 +829,29 @@ try:
                 # rejected in _sanitize_chat_template_kwargs -- that is the actual
                 # fix. The real win here is the tokenizer half, which drops into
                 # Rust and releases the GIL for long conversations.
-                prompt_tokens = _coerce_to_token_id_list(
-                    await asyncio.to_thread(
-                        functools.partial(
-                            chat_tok.apply_chat_template,
-                            template_messages,
-                            tokenize=True,
-                            add_generation_prompt=True,
-                            tools=template_tools,
-                            **chat_template_kwargs,
+                if media_slots:
+                    prompt_tokens = await _tokenize_with_media_slots(
+                        chat_tok,
+                        template_messages,
+                        media_slots,
+                        prompt_config,
+                        tools=template_tools,
+                        chat_template_kwargs=chat_template_kwargs,
+                        add_generation_prompt=True,
+                    )
+                else:
+                    prompt_tokens = _coerce_to_token_id_list(
+                        await asyncio.to_thread(
+                            functools.partial(
+                                chat_tok.apply_chat_template,
+                                template_messages,
+                                tokenize=True,
+                                add_generation_prompt=True,
+                                tools=template_tools,
+                                **chat_template_kwargs,
+                            )
                         )
                     )
-                )
 
                 if req.get("prevent_retokenization", True):
                     # If we are avoiding retokenization, we need to replace some prompt tokens with the prompt/generation tokens from the previous generation
@@ -702,8 +874,8 @@ try:
                     # Dataset-provided conversation history won't have these fields.
                     if (
                         last_assistant_message is not None
-                        and "prompt_token_ids" in last_assistant_message
-                        and "generation_token_ids" in last_assistant_message
+                        and isinstance(last_assistant_message.get("prompt_token_ids"), list)
+                        and isinstance(last_assistant_message.get("generation_token_ids"), list)
                     ):
                         eos_token_id = tokenizer.eos_id
                         assert eos_token_id is not None, "Your tokenizer must have an EOS token ID!"
@@ -719,42 +891,60 @@ try:
                         ]
 
                         # Get the templated tokenization of just the previous generation
-                        retokenized_previous_turn_token_ids = _coerce_to_token_id_list(
-                            await asyncio.to_thread(
-                                functools.partial(
-                                    chat_tok.apply_chat_template,
+                        previous_media_slots = [
+                            slot
+                            for slot in media_slots
+                            if slot[0] in str(messages_to_last_assistant_message)
+                        ]
+                        if previous_media_slots:
+                            retokenized_previous_turn_token_ids = (
+                                await _tokenize_with_media_slots(
+                                    chat_tok,
                                     messages_to_last_assistant_message,
-                                    tokenize=True,
-                                    add_generation_prompt=False,
+                                    previous_media_slots,
+                                    prompt_config,
                                     tools=template_tools,
-                                    **chat_template_kwargs,
+                                    chat_template_kwargs=chat_template_kwargs,
+                                    add_generation_prompt=False,
                                 )
                             )
+                        else:
+                            retokenized_previous_turn_token_ids = (
+                                _coerce_to_token_id_list(
+                                    await asyncio.to_thread(
+                                        functools.partial(
+                                            chat_tok.apply_chat_template,
+                                            messages_to_last_assistant_message,
+                                            tokenize=True,
+                                            add_generation_prompt=False,
+                                            tools=template_tools,
+                                            **chat_template_kwargs,
+                                        )
+                                    )
+                                )
+                            )
+
+                        # Responses carry model-input tokens, but prefix stitching happens
+                        # before media expansion, so undo the expansion first.
+                        previous_turn_token_ids = (
+                            _collapse_expanded_media_tokens(
+                                last_assistant_message["prompt_token_ids"],
+                                _media_model_token_ids(chat_tok, prompt_config),
+                            )
+                            + last_assistant_message["generation_token_ids"]
+                        )
+                        prompt_tokens = _replace_prefix_tokens(
+                            eos_token_id,
+                            previous_turn_token_ids,
+                            retokenized_previous_turn_token_ids,
+                            prompt_tokens,
                         )
 
-                        # Replace the prefix tokens with the tokens from the previous generation.
-                        # If prior token IDs are unavailable, fall back to normal retokenized prompt
-                        # instead of failing the request.
-                        prompt_token_ids = last_assistant_message.get("prompt_token_ids")
-                        generation_token_ids = last_assistant_message.get("generation_token_ids")
-
-                        if isinstance(prompt_token_ids, list) and isinstance(
-                            generation_token_ids, list
-                        ):
-                            previous_turn_token_ids = prompt_token_ids + generation_token_ids
-                            prompt_tokens = _replace_prefix_tokens(
-                                eos_token_id,
-                                previous_turn_token_ids,
-                                retokenized_previous_turn_token_ids,
-                                prompt_tokens,
-                            )
-                        else:
-                            logger.warning(
-                                "Last assistant message missing prompt_token_ids/"
-                                "generation_token_ids; skipping prefix replacement."
-                            )
-
             else:
+                if media_slots:
+                    raise ValueError(
+                        "Multimodal chat requests require a chat template."
+                    )
                 warnings.warn(
                     "Tokenizer does not support 'apply_chat_template'. Using tokenize instead."
                 )
@@ -856,7 +1046,7 @@ try:
                 client.add_request_streaming(
                     prompt_tokens,
                     sampling_params,
-                    multi_modal_data=({"image": image_bytes_list} if image_bytes_list else None),
+                    multi_modal_data=multi_modal_data,
                 )
                 for _ in range(n)
             ]
@@ -914,7 +1104,7 @@ try:
             client.add_request(
                 prompt_tokens,
                 sampling_params,
-                multi_modal_data=({"image": image_bytes_list} if image_bytes_list else None),
+                multi_modal_data=multi_modal_data,
             )
             for _ in range(n)
         ]
@@ -1063,6 +1253,9 @@ try:
                 message["reasoning_content"] = metadata["reasoning"]
 
             if return_tokenized_data:
+                # Wire contract matches vLLM: prompt_token_ids are model-input tokens
+                # (post vision/video expansion). Compact chat-template tokens stay
+                # engine-internal (compact_prompt_tokens) and are never returned.
                 message["prompt_token_ids"] = result["prompt_tokens"]
                 message["generation_token_ids"] = result["generated_tokens"]
             if return_raw_text:

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -307,9 +307,7 @@ def _extract_media_url_bytes(url: str, *, max_bytes: int) -> bytes:
             or ip.is_reserved
             or ip.is_unspecified
         ):
-            raise ValueError(
-                f"Refusing to fetch media from non-public address: {parsed.hostname}"
-            )
+            raise ValueError(f"Refusing to fetch media from non-public address: {parsed.hostname}")
         req = urllib.request.Request(url, headers={"User-Agent": _MEDIA_FETCH_USER_AGENT})
         with _no_redirect_opener.open(req, timeout=_MEDIA_FETCH_TIMEOUT_S) as response:
             data = response.read(max_bytes + 1)
@@ -831,9 +829,7 @@ try:
                             : last_assistant_message_idx + 1
                         ]
                         previous_media_slots = [
-                            slot
-                            for slot in media_slots
-                            if slot[2] <= last_assistant_message_idx
+                            slot for slot in media_slots if slot[2] <= last_assistant_message_idx
                         ]
                         previous_prompt_token_ids = last_assistant_message.get(
                             "compact_prompt_token_ids"
@@ -844,9 +840,7 @@ try:
                                 "from the previous Megatron-Inference response."
                             )
                         eos_token_id = tokenizer.eos_id
-                        assert (
-                            eos_token_id is not None
-                        ), "Your tokenizer must have an EOS token ID!"
+                        assert eos_token_id is not None, "Your tokenizer must have an EOS token ID!"
 
                         warnings.warn(
                             "Avoiding prefix retokenization."

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -302,9 +302,7 @@ def _extract_image_url_bytes(url: str) -> bytes:
     raise ValueError(f"Unsupported image_url scheme: {url[:40]!r}")
 
 
-def _extract_multimodal_from_messages(
-    messages, prompt_config: MultimodalPromptConfig
-):
+def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptConfig):
     """Extract media bytes and replace structured blocks with internal slots.
 
     Remote image fetching is blocking, so callers must run this function off
@@ -355,20 +353,11 @@ def _extract_multimodal_from_messages(
                     raise ValueError(f"Failed to load image_url: {e}") from e
                 new_chunks.append(add_slot("image"))
                 found_modalities.add("image")
-            elif isinstance(chunk, dict) and chunk.get("type") in {
-                "video_url",
-                "input_video",
-            }:
+            elif isinstance(chunk, dict) and chunk.get("type") in {"video_url", "input_video"}:
                 video_value = chunk.get("video_url") or chunk.get("video")
-                url = (
-                    video_value.get("url", "")
-                    if isinstance(video_value, dict)
-                    else video_value
-                )
+                url = video_value.get("url", "") if isinstance(video_value, dict) else video_value
                 if not isinstance(url, str) or not url.startswith("data:"):
-                    raise ValueError(
-                        "Megatron chat video inputs must be base64 data URLs."
-                    )
+                    raise ValueError("Megatron chat video inputs must be base64 data URLs.")
                 try:
                     video_bytes_list.append(_extract_image_url_bytes(url))
                 except Exception as e:
@@ -380,16 +369,13 @@ def _extract_multimodal_from_messages(
 
         if found_modalities:
             input_markers = {
-                prompt_config.get_spec(modality).input_marker
-                for modality in found_modalities
+                prompt_config.get_spec(modality).input_marker for modality in found_modalities
             } - {None}
             for index, chunk in enumerate(new_chunks):
                 if isinstance(chunk, dict) and chunk.get("type") == "text":
                     chunk = dict(chunk)
                     for marker in input_markers:
-                        chunk["text"] = str(chunk.get("text", "")).replace(
-                            marker, ""
-                        )
+                        chunk["text"] = str(chunk.get("text", "")).replace(marker, "")
                     new_chunks[index] = chunk
             msg_copy = dict(message)
             msg_copy["content"] = new_chunks
@@ -398,9 +384,7 @@ def _extract_multimodal_from_messages(
             rewritten.append(message)
 
     if image_bytes_list and video_bytes_list:
-        raise ValueError(
-            "Mixing image and video blocks in one request is not supported."
-        )
+        raise ValueError("Mixing image and video blocks in one request is not supported.")
     return rewritten, image_bytes_list, video_bytes_list, media_slots
 
 
@@ -596,9 +580,7 @@ def _media_model_token_ids(chat_tok, prompt_config):
         token_id = spec.model_token_id
         if token_id is None and hasattr(chat_tok, "convert_tokens_to_ids"):
             resolved_id = chat_tok.convert_tokens_to_ids(spec.model_token)
-            if resolved_id is not None and resolved_id != getattr(
-                chat_tok, "unk_token_id", None
-            ):
+            if resolved_id is not None and resolved_id != getattr(chat_tok, "unk_token_id", None):
                 token_id = resolved_id
         if token_id is not None:
             token_ids.add(int(token_id))
@@ -659,9 +641,7 @@ async def _tokenize_with_media_slots(
     cursor = 0
     for position, sentinel, modality in sorted(positioned_slots):
         prompt_tokens.extend(
-            _coerce_to_token_id_list(
-                chat_tok(rendered[cursor:position], add_special_tokens=False)
-            )
+            _coerce_to_token_id_list(chat_tok(rendered[cursor:position], add_special_tokens=False))
         )
         spec = prompt_config.get_spec(modality)
         token_id = spec.model_token_id
@@ -674,9 +654,7 @@ async def _tokenize_with_media_slots(
             resolved_id = None
         if token_id is None:
             if resolved_id is None:
-                raise ValueError(
-                    f"Tokenizer does not define media token {spec.model_token!r}."
-                )
+                raise ValueError(f"Tokenizer does not define media token {spec.model_token!r}.")
             token_id = resolved_id
         elif resolved_id is not None and token_id != resolved_id:
             raise ValueError(
@@ -684,22 +662,16 @@ async def _tokenize_with_media_slots(
                 f"{spec.model_token!r} id {resolved_id}."
             )
         prompt_tokens.extend(
-            _coerce_to_token_id_list(
-                chat_tok(spec.prefix, add_special_tokens=False)
-            )
+            _coerce_to_token_id_list(chat_tok(spec.prefix, add_special_tokens=False))
         )
         prompt_tokens.append(int(token_id))
         prompt_tokens.extend(
-            _coerce_to_token_id_list(
-                chat_tok(spec.suffix, add_special_tokens=False)
-            )
+            _coerce_to_token_id_list(chat_tok(spec.suffix, add_special_tokens=False))
         )
         cursor = position + len(sentinel)
 
     prompt_tokens.extend(
-        _coerce_to_token_id_list(
-            chat_tok(rendered[cursor:], add_special_tokens=False)
-        )
+        _coerce_to_token_id_list(chat_tok(rendered[cursor:], add_special_tokens=False))
     )
     return prompt_tokens
 
@@ -942,9 +914,7 @@ try:
 
             else:
                 if media_slots:
-                    raise ValueError(
-                        "Multimodal chat requests require a chat template."
-                    )
+                    raise ValueError("Multimodal chat requests require a chat template.")
                 warnings.warn(
                     "Tokenizer does not support 'apply_chat_template'. Using tokenize instead."
                 )
@@ -1044,9 +1014,7 @@ try:
 
             streams = [
                 client.add_request_streaming(
-                    prompt_tokens,
-                    sampling_params,
-                    multi_modal_data=multi_modal_data,
+                    prompt_tokens, sampling_params, multi_modal_data=multi_modal_data
                 )
                 for _ in range(n)
             ]
@@ -1101,11 +1069,7 @@ try:
             return response
 
         tasks = [
-            client.add_request(
-                prompt_tokens,
-                sampling_params,
-                multi_modal_data=multi_modal_data,
-            )
+            client.add_request(prompt_tokens, sampling_params, multi_modal_data=multi_modal_data)
             for _ in range(n)
         ]
 

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -15,9 +15,10 @@ import urllib.request
 import uuid
 import warnings
 
-_IMAGE_FETCH_TIMEOUT_S = 5.0
+_MEDIA_FETCH_TIMEOUT_S = 5.0
 _MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MiB
-_IMAGE_FETCH_USER_AGENT = "megatron-inference"
+_MAX_VIDEO_BYTES = 256 * 1024 * 1024  # 256 MiB
+_MEDIA_FETCH_USER_AGENT = "megatron-inference"
 
 from megatron.core.inference.config import MultimodalPromptConfig
 from megatron.core.inference.inference_request import unwrap_serialized_tensors
@@ -265,23 +266,37 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
 _no_redirect_opener = urllib.request.build_opener(_NoRedirectHandler())
 
 
-def _extract_image_url_bytes(url: str) -> bytes:
-    """Extract raw bytes from an OpenAI-style image_url value.
+def _extract_media_url_bytes(url: str, *, max_bytes: int) -> bytes:
+    """Extract size-bounded bytes from an OpenAI-style media URL.
 
     Supports base64-encoded data URLs (``data:image/...;base64,<b64>``) and
     plain ``http(s)://`` URLs.
     """
     if url.startswith("data:"):
-        _, b64_data = url.split(",", 1)
-        return base64.b64decode(b64_data)
+        # Base64 encodes each three input bytes as four characters. Bound the
+        # complete request before splitting or decoding it; 256 characters is
+        # ample for the data-URL metadata preceding the comma.
+        max_encoded_chars = 4 * ((max_bytes + 2) // 3)
+        if len(url) > max_encoded_chars + 256:
+            raise ValueError(f"Media data URL exceeds {max_bytes} byte limit")
+        try:
+            metadata, b64_data = url.split(",", 1)
+        except ValueError as exc:
+            raise ValueError(f"Malformed media data URL: {url[:40]!r}") from exc
+        if len(b64_data) > max_encoded_chars:
+            raise ValueError(f"{metadata} payload exceeds {max_bytes} byte limit")
+        data = base64.b64decode(b64_data)
+        if len(data) > max_bytes:
+            raise ValueError(f"{metadata} payload exceeds {max_bytes} byte limit")
+        return data
     if url.startswith(("http://", "https://")):
         parsed = urllib.parse.urlparse(url)
         if not parsed.hostname:
-            raise ValueError(f"Invalid image_url: {url[:40]!r}")
+            raise ValueError(f"Invalid media URL: {url[:40]!r}")
         try:
             ip = ipaddress.ip_address(socket.gethostbyname(parsed.hostname))
         except (socket.gaierror, ValueError) as exc:
-            raise ValueError(f"Cannot resolve image_url host: {parsed.hostname}") from exc
+            raise ValueError(f"Cannot resolve media URL host: {parsed.hostname}") from exc
         # Refuse SSRF-prone destinations (loopback, RFC1918, link-local,
         # multicast, reserved, unspecified). Public addresses only.
         if (
@@ -292,14 +307,16 @@ def _extract_image_url_bytes(url: str) -> bytes:
             or ip.is_reserved
             or ip.is_unspecified
         ):
-            raise ValueError(f"Refusing to fetch image from non-public address: {parsed.hostname}")
-        req = urllib.request.Request(url, headers={"User-Agent": _IMAGE_FETCH_USER_AGENT})
-        with _no_redirect_opener.open(req, timeout=_IMAGE_FETCH_TIMEOUT_S) as response:
-            data = response.read(_MAX_IMAGE_BYTES + 1)
-        if len(data) > _MAX_IMAGE_BYTES:
-            raise ValueError(f"Image at {parsed.hostname} exceeds {_MAX_IMAGE_BYTES} byte limit")
+            raise ValueError(
+                f"Refusing to fetch media from non-public address: {parsed.hostname}"
+            )
+        req = urllib.request.Request(url, headers={"User-Agent": _MEDIA_FETCH_USER_AGENT})
+        with _no_redirect_opener.open(req, timeout=_MEDIA_FETCH_TIMEOUT_S) as response:
+            data = response.read(max_bytes + 1)
+        if len(data) > max_bytes:
+            raise ValueError(f"Media at {parsed.hostname} exceeds {max_bytes} byte limit")
         return data
-    raise ValueError(f"Unsupported image_url scheme: {url[:40]!r}")
+    raise ValueError(f"Unsupported media URL scheme: {url[:40]!r}")
 
 
 def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptConfig):
@@ -316,7 +333,7 @@ def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptC
     video_bytes_list: list[bytes] = []
     media_slots = []
 
-    def add_slot(modality):
+    def add_slot(modality, message_index):
         """Preserve a media block's position while the chat template renders text.
 
         The actual bytes travel separately. After rendering,
@@ -324,10 +341,10 @@ def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptC
         model-specific MediaPromptSpec tokens.
         """
         sentinel = f"__MCORE_MEDIA_SLOT_{len(media_slots)}__"
-        media_slots.append((sentinel, modality))
+        media_slots.append((sentinel, modality, message_index))
         return {"type": "text", "text": sentinel}
 
-    for message in messages:
+    for message_index, message in enumerate(messages):
         if not isinstance(message, dict):
             rewritten.append(message)
             continue
@@ -345,13 +362,15 @@ def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptC
                 if not url:
                     continue
                 try:
-                    image_bytes_list.append(_extract_image_url_bytes(url))
+                    image_bytes_list.append(
+                        _extract_media_url_bytes(url, max_bytes=_MAX_IMAGE_BYTES)
+                    )
                 except Exception as e:
                     # Dropping the image would answer the request as if it were
                     # text-only, handing the client a confident answer about an
                     # image the model never saw. Surface it as a 400 instead.
                     raise ValueError(f"Failed to load image_url: {e}") from e
-                new_chunks.append(add_slot("image"))
+                new_chunks.append(add_slot("image", message_index))
                 found_modalities.add("image")
             elif isinstance(chunk, dict) and chunk.get("type") in {"video_url", "input_video"}:
                 video_value = chunk.get("video_url") or chunk.get("video")
@@ -359,10 +378,12 @@ def _extract_multimodal_from_messages(messages, prompt_config: MultimodalPromptC
                 if not isinstance(url, str) or not url.startswith("data:"):
                     raise ValueError("Megatron chat video inputs must be base64 data URLs.")
                 try:
-                    video_bytes_list.append(_extract_image_url_bytes(url))
+                    video_bytes_list.append(
+                        _extract_media_url_bytes(url, max_bytes=_MAX_VIDEO_BYTES)
+                    )
                 except Exception as e:
                     raise ValueError(f"Failed to load video_url: {e}") from e
-                new_chunks.append(add_slot("video"))
+                new_chunks.append(add_slot("video", message_index))
                 found_modalities.add("video")
             else:
                 new_chunks.append(chunk)
@@ -572,41 +593,6 @@ def _coerce_to_token_id_list(result):
     return list(result)
 
 
-def _media_model_token_ids(chat_tok, prompt_config):
-    """Resolve the model token ids that stand in for media in a chat template."""
-    token_ids = set()
-    for modality in ("image", "video"):
-        spec = prompt_config.get_spec(modality)
-        token_id = spec.model_token_id
-        if token_id is None and hasattr(chat_tok, "convert_tokens_to_ids"):
-            resolved_id = chat_tok.convert_tokens_to_ids(spec.model_token)
-            if resolved_id is not None and resolved_id != getattr(chat_tok, "unk_token_id", None):
-                token_id = resolved_id
-        if token_id is not None:
-            token_ids.add(int(token_id))
-    return token_ids
-
-
-def _collapse_expanded_media_tokens(token_ids, media_token_ids):
-    """Collapse each consecutive run of a media token ID to one token.
-
-    ``token_ids`` contains the expanded model-input prompt, while
-    ``media_token_ids`` contains the image/video marker IDs from
-    ``MediaPromptSpec``. The result matches the compact chat-template token form.
-    """
-    if not media_token_ids:
-        return list(token_ids)
-
-    collapsed = []
-    previous_token_id = None
-    for token_id in token_ids:
-        if token_id in media_token_ids and token_id == previous_token_id:
-            continue
-        collapsed.append(token_id)
-        previous_token_id = token_id
-    return collapsed
-
-
 async def _tokenize_with_media_slots(
     chat_tok,
     messages,
@@ -632,7 +618,7 @@ async def _tokenize_with_media_slots(
         raise TypeError("Multimodal chat template rendering must return a string.")
 
     positioned_slots = []
-    for sentinel, modality in media_slots:
+    for sentinel, modality, _message_index in media_slots:
         if rendered.count(sentinel) != 1:
             raise ValueError(f"Chat template did not preserve media slot {sentinel}.")
         positioned_slots.append((rendered.index(sentinel), sentinel, modality))
@@ -644,7 +630,6 @@ async def _tokenize_with_media_slots(
             _coerce_to_token_id_list(chat_tok(rendered[cursor:position], add_special_tokens=False))
         )
         spec = prompt_config.get_spec(modality)
-        token_id = spec.model_token_id
         resolved_id = (
             chat_tok.convert_tokens_to_ids(spec.model_token)
             if hasattr(chat_tok, "convert_tokens_to_ids")
@@ -652,19 +637,12 @@ async def _tokenize_with_media_slots(
         )
         if resolved_id == getattr(chat_tok, "unk_token_id", None):
             resolved_id = None
-        if token_id is None:
-            if resolved_id is None:
-                raise ValueError(f"Tokenizer does not define media token {spec.model_token!r}.")
-            token_id = resolved_id
-        elif resolved_id is not None and token_id != resolved_id:
-            raise ValueError(
-                f"Configured token id {token_id} does not match "
-                f"{spec.model_token!r} id {resolved_id}."
-            )
+        if resolved_id is None:
+            raise ValueError(f"Tokenizer does not define media token {spec.model_token!r}.")
         prompt_tokens.extend(
             _coerce_to_token_id_list(chat_tok(spec.prefix, add_special_tokens=False))
         )
-        prompt_tokens.append(int(token_id))
+        prompt_tokens.append(int(resolved_id))
         prompt_tokens.extend(
             _coerce_to_token_id_list(chat_tok(spec.suffix, add_special_tokens=False))
         )
@@ -849,8 +827,26 @@ try:
                         and isinstance(last_assistant_message.get("prompt_token_ids"), list)
                         and isinstance(last_assistant_message.get("generation_token_ids"), list)
                     ):
+                        messages_to_last_assistant_message = template_messages[
+                            : last_assistant_message_idx + 1
+                        ]
+                        previous_media_slots = [
+                            slot
+                            for slot in media_slots
+                            if slot[2] <= last_assistant_message_idx
+                        ]
+                        previous_prompt_token_ids = last_assistant_message.get(
+                            "compact_prompt_token_ids"
+                        )
+                        if not isinstance(previous_prompt_token_ids, list):
+                            raise ValueError(
+                                "Prefix stitching requires compact_prompt_token_ids "
+                                "from the previous Megatron-Inference response."
+                            )
                         eos_token_id = tokenizer.eos_id
-                        assert eos_token_id is not None, "Your tokenizer must have an EOS token ID!"
+                        assert (
+                            eos_token_id is not None
+                        ), "Your tokenizer must have an EOS token ID!"
 
                         warnings.warn(
                             "Avoiding prefix retokenization."
@@ -858,16 +854,7 @@ try:
                             " This may cause unexpected behavior if messages (including system messages) are altered between generations."
                         )
 
-                        messages_to_last_assistant_message = template_messages[
-                            : last_assistant_message_idx + 1
-                        ]
-
-                        # Get the templated tokenization of just the previous generation
-                        previous_media_slots = [
-                            slot
-                            for slot in media_slots
-                            if slot[0] in str(messages_to_last_assistant_message)
-                        ]
+                        # Get the templated tokenization of just the previous generation.
                         if previous_media_slots:
                             retokenized_previous_turn_token_ids = (
                                 await _tokenize_with_media_slots(
@@ -896,13 +883,8 @@ try:
                                 )
                             )
 
-                        # Responses carry model-input tokens, but prefix stitching happens
-                        # before media expansion, so undo the expansion first.
                         previous_turn_token_ids = (
-                            _collapse_expanded_media_tokens(
-                                last_assistant_message["prompt_token_ids"],
-                                _media_model_token_ids(chat_tok, prompt_config),
-                            )
+                            previous_prompt_token_ids
                             + last_assistant_message["generation_token_ids"]
                         )
                         prompt_tokens = _replace_prefix_tokens(
@@ -921,6 +903,9 @@ try:
                 prompt_tokens = tokenizer.tokenize(
                     "\n".join([message["content"] for message in messages])
                 )
+        except ValueError as e:
+            logger.error(f"{traceback.format_exc()}")
+            return Response(f"Invalid 'messages': {e}", status=400)
         except Exception as e:
             logger.error(f"{traceback.format_exc()}")
             return Response(f"Error processing 'messages': {e}", status=500)
@@ -1218,9 +1203,12 @@ try:
 
             if return_tokenized_data:
                 # Wire contract matches vLLM: prompt_token_ids are model-input tokens
-                # (post vision/video expansion). Compact chat-template tokens stay
-                # engine-internal (compact_prompt_tokens) and are never returned.
+                # (post vision/video expansion). Preserve the exact compact form
+                # separately for lossless multi-turn prefix stitching.
                 message["prompt_token_ids"] = result["prompt_tokens"]
+                message["compact_prompt_token_ids"] = (
+                    result.get("compact_prompt_tokens") or result["prompt_tokens"]
+                )
                 message["generation_token_ids"] = result["generated_tokens"]
             if return_raw_text:
                 prompt_str = tokenizer.detokenize(result["prompt_tokens"])

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -850,29 +850,25 @@ try:
 
                         # Get the templated tokenization of just the previous generation.
                         if previous_media_slots:
-                            retokenized_previous_turn_token_ids = (
-                                await _tokenize_with_media_slots(
-                                    chat_tok,
-                                    messages_to_last_assistant_message,
-                                    previous_media_slots,
-                                    prompt_config,
-                                    tools=template_tools,
-                                    chat_template_kwargs=chat_template_kwargs,
-                                    add_generation_prompt=False,
-                                )
+                            retokenized_previous_turn_token_ids = await _tokenize_with_media_slots(
+                                chat_tok,
+                                messages_to_last_assistant_message,
+                                previous_media_slots,
+                                prompt_config,
+                                tools=template_tools,
+                                chat_template_kwargs=chat_template_kwargs,
+                                add_generation_prompt=False,
                             )
                         else:
-                            retokenized_previous_turn_token_ids = (
-                                _coerce_to_token_id_list(
-                                    await asyncio.to_thread(
-                                        functools.partial(
-                                            chat_tok.apply_chat_template,
-                                            messages_to_last_assistant_message,
-                                            tokenize=True,
-                                            add_generation_prompt=False,
-                                            tools=template_tools,
-                                            **chat_template_kwargs,
-                                        )
+                            retokenized_previous_turn_token_ids = _coerce_to_token_id_list(
+                                await asyncio.to_thread(
+                                    functools.partial(
+                                        chat_tok.apply_chat_template,
+                                        messages_to_last_assistant_message,
+                                        tokenize=True,
+                                        add_generation_prompt=False,
+                                        tools=template_tools,
+                                        **chat_template_kwargs,
                                     )
                                 )
                             )

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
@@ -98,24 +98,50 @@ try:
 
             ignore_eos = bool(req.get("ignore_eos", False))
 
-            # Optional vLLM-style multimodal input. Image entries are
-            # base64-encoded bytes ordered to match prompt placeholders.
+            # Optional vLLM-style multimodal input. HTTP callers provide
+            # base64/data-URL bytes; preprocessed tensors are direct-API only.
             request_multi_modal_data = req.get("multi_modal_data") or {}
             if not isinstance(request_multi_modal_data, dict):
                 raise ValueError("multi_modal_data must be a dictionary.")
-            unsupported_modalities = set(request_multi_modal_data) - {"image"}
+            unsupported_modalities = set(request_multi_modal_data) - {
+                "image",
+                "video",
+            }
             if unsupported_modalities:
                 raise ValueError(
                     "Unsupported multimodal modalities: "
-                    f"{sorted(unsupported_modalities)}; only 'image' is supported."
+                    f"{sorted(unsupported_modalities)}."
                 )
-            encoded_images = request_multi_modal_data.get("image") or []
-            if isinstance(encoded_images, str):
-                encoded_images = [encoded_images]
-            if not isinstance(encoded_images, list):
-                raise ValueError("multi_modal_data.image must be a string or list.")
-            image_bytes_list = [base64.b64decode(encoded_image) for encoded_image in encoded_images]
-            multi_modal_data = {"image": image_bytes_list} if image_bytes_list else None
+            populated_modalities = [
+                modality
+                for modality in ("image", "video")
+                if request_multi_modal_data.get(modality)
+            ]
+            if len(populated_modalities) > 1:
+                raise ValueError(
+                    "A completions request cannot mix image and video inputs."
+                )
+            multi_modal_data = None
+            if populated_modalities:
+                modality = populated_modalities[0]
+                encoded_media = request_multi_modal_data[modality]
+                if isinstance(encoded_media, str):
+                    encoded_media = [encoded_media]
+                if not isinstance(encoded_media, list) or any(
+                    not isinstance(item, str) for item in encoded_media
+                ):
+                    raise ValueError(
+                        f"multi_modal_data.{modality} must be a string or list[str]."
+                    )
+                media_bytes = [
+                    base64.b64decode(
+                        item.split(",", 1)[1]
+                        if item.startswith("data:") and "," in item
+                        else item
+                    )
+                    for item in encoded_media
+                ]
+                multi_modal_data = {modality: media_bytes}
 
             sampling_params = SamplingParams(
                 temperature=temperature,

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/completions.py
@@ -103,14 +103,10 @@ try:
             request_multi_modal_data = req.get("multi_modal_data") or {}
             if not isinstance(request_multi_modal_data, dict):
                 raise ValueError("multi_modal_data must be a dictionary.")
-            unsupported_modalities = set(request_multi_modal_data) - {
-                "image",
-                "video",
-            }
+            unsupported_modalities = set(request_multi_modal_data) - {"image", "video"}
             if unsupported_modalities:
                 raise ValueError(
-                    "Unsupported multimodal modalities: "
-                    f"{sorted(unsupported_modalities)}."
+                    "Unsupported multimodal modalities: " f"{sorted(unsupported_modalities)}."
                 )
             populated_modalities = [
                 modality
@@ -118,9 +114,7 @@ try:
                 if request_multi_modal_data.get(modality)
             ]
             if len(populated_modalities) > 1:
-                raise ValueError(
-                    "A completions request cannot mix image and video inputs."
-                )
+                raise ValueError("A completions request cannot mix image and video inputs.")
             multi_modal_data = None
             if populated_modalities:
                 modality = populated_modalities[0]
@@ -130,14 +124,10 @@ try:
                 if not isinstance(encoded_media, list) or any(
                     not isinstance(item, str) for item in encoded_media
                 ):
-                    raise ValueError(
-                        f"multi_modal_data.{modality} must be a string or list[str]."
-                    )
+                    raise ValueError(f"multi_modal_data.{modality} must be a string or list[str].")
                 media_bytes = [
                     base64.b64decode(
-                        item.split(",", 1)[1]
-                        if item.startswith("data:") and "," in item
-                        else item
+                        item.split(",", 1)[1] if item.startswith("data:") and "," in item else item
                     )
                     for item in encoded_media
                 ]

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
@@ -29,12 +29,8 @@ def _video_target_resolution(image, config: ImageProcessingConfig) -> tuple[int,
     if required_divisor > 1:
         height_remainder = patch_height % required_divisor
         width_remainder = patch_width % required_divisor
-        height_up = patch_height + (
-            required_divisor - height_remainder if height_remainder else 0
-        )
-        width_up = patch_width + (
-            required_divisor - width_remainder if width_remainder else 0
-        )
+        height_up = patch_height + (required_divisor - height_remainder if height_remainder else 0)
+        width_up = patch_width + (required_divisor - width_remainder if width_remainder else 0)
         if height_up * width_up <= target_patches:
             patch_height, patch_width = height_up, width_up
         else:
@@ -62,10 +58,7 @@ def _resolve_pixel_stats(vision_model_type: str):
     return list(fields["pixel_mean"].default), list(fields["pixel_std"].default)
 
 
-def _load_frame_sequence_manifest(
-    payload: bytes,
-    frame_manifest_magic: Optional[bytes],
-):
+def _load_frame_sequence_manifest(payload: bytes, frame_manifest_magic: Optional[bytes]):
     """Load PIL images from a configured frame-sequence manifest."""
     if not frame_manifest_magic or not payload.startswith(frame_manifest_magic):
         return None
@@ -85,9 +78,7 @@ def _load_frame_sequence_manifest(
         or not frame_paths
         or not all(isinstance(path, str) and path for path in frame_paths)
     ):
-        raise ValueError(
-            "Frame-sequence manifest requires non-empty string frame_paths."
-        )
+        raise ValueError("Frame-sequence manifest requires non-empty string frame_paths.")
 
     frames = []
     for frame_path in frame_paths:
@@ -161,10 +152,7 @@ def dynamic_res_preprocess(
 
 
 def preprocess_image(
-    image,
-    config: ImageProcessingConfig,
-    target_hw=None,
-    device: Optional[torch.device] = None,
+    image, config: ImageProcessingConfig, target_hw=None, device: Optional[torch.device] = None
 ) -> tuple:
     """Convert one PIL image into packed vision patches and its resized shape."""
     try:
@@ -227,12 +215,7 @@ def preprocess_image_bytes(
     from PIL import Image
 
     with Image.open(io.BytesIO(image_bytes)) as image:
-        return preprocess_image(
-            image,
-            config,
-            target_hw=target_hw,
-            device=device,
-        )
+        return preprocess_image(image, config, target_hw=target_hw, device=device)
 
 
 def preprocess_image_bytes_list(
@@ -294,9 +277,7 @@ def preprocess_image_bytes_list(
 
 
 def preprocess_video_bytes_list(
-    video_bytes_list,
-    config: VideoProcessingConfig,
-    device: Optional[torch.device] = None,
+    video_bytes_list, config: VideoProcessingConfig, device: Optional[torch.device] = None
 ) -> dict:
     """Decode videos and return packed dynamic-resolution engine inputs.
 
@@ -308,13 +289,8 @@ def preprocess_video_bytes_list(
     if config.num_frames <= 0:
         raise ValueError("VideoProcessingConfig.num_frames must be positive.")
     if config.temporal_patch_size <= 0:
-        raise ValueError(
-            "VideoProcessingConfig.temporal_patch_size must be positive."
-        )
-    if (
-        not config.image_config.dynamic_resolution
-        or config.image_config.use_tiling
-    ):
+        raise ValueError("VideoProcessingConfig.temporal_patch_size must be positive.")
+    if not config.image_config.dynamic_resolution or config.image_config.use_tiling:
         raise NotImplementedError(
             "Raw video preprocessing currently requires dynamic-resolution, "
             "non-tiled vision inputs."
@@ -323,23 +299,14 @@ def preprocess_video_bytes_list(
     import numpy as np
 
     def decode_frames(encoded_video):
-        frames = _load_frame_sequence_manifest(
-            encoded_video,
-            config.frame_manifest_magic,
-        )
+        frames = _load_frame_sequence_manifest(encoded_video, config.frame_manifest_magic)
         if frames is not None:
             return frames, True
 
         import av
 
         with av.open(io.BytesIO(encoded_video)) as container:
-            return (
-                [
-                    frame.to_image().convert("RGB")
-                    for frame in container.decode(video=0)
-                ],
-                False,
-            )
+            return ([frame.to_image().convert("RGB") for frame in container.decode(video=0)], False)
 
     packed_videos = []
     packed_sizes = []
@@ -362,10 +329,7 @@ def preprocess_video_bytes_list(
             sampled_frames = frames
         else:
             sample_count = min(config.num_frames, len(frames))
-            if (
-                config.temporal_patch_size > 1
-                and sample_count % config.temporal_patch_size
-            ):
+            if config.temporal_patch_size > 1 and sample_count % config.temporal_patch_size:
                 rounded_down = (
                     sample_count // config.temporal_patch_size
                 ) * config.temporal_patch_size
@@ -375,9 +339,7 @@ def preprocess_video_bytes_list(
                     else min(config.temporal_patch_size, len(frames))
                 )
             sample_indices = (
-                np.rint(np.linspace(0, len(frames) - 1, num=sample_count))
-                .astype(np.int64)
-                .tolist()
+                np.rint(np.linspace(0, len(frames) - 1, num=sample_count)).astype(np.int64).tolist()
             )
             sampled_frames = [frames[index] for index in sample_indices]
         sample_count = len(sampled_frames)
@@ -385,15 +347,10 @@ def preprocess_video_bytes_list(
         frame_tensors = []
         frame_sizes = []
         if reference_hw is None:
-            reference_hw = _video_target_resolution(
-                sampled_frames[0], config.image_config
-            )
+            reference_hw = _video_target_resolution(sampled_frames[0], config.image_config)
         for frame in sampled_frames:
             imgs, imgs_sizes = preprocess_image(
-                frame,
-                config.image_config,
-                target_hw=reference_hw,
-                device=device,
+                frame, config.image_config, target_hw=reference_hw, device=device
             )
             frame_tensors.append(imgs)
             frame_sizes.append(imgs_sizes)
@@ -405,7 +362,5 @@ def preprocess_video_bytes_list(
     return {
         "imgs": torch.cat(packed_videos, dim=1),
         "imgs_sizes": torch.cat(packed_sizes, dim=0),
-        "num_frames": torch.tensor(
-            frame_counts, dtype=torch.int32, device=packed_videos[0].device
-        ),
+        "num_frames": torch.tensor(frame_counts, dtype=torch.int32, device=packed_videos[0].device),
     }

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
@@ -19,26 +19,6 @@ from megatron.core.inference.config import ImageProcessingConfig, VideoProcessin
 from megatron.core.models.vision.encoder_registry import REGISTRY as _ENCODER_REGISTRY
 
 
-def _video_target_resolution(image, config: ImageProcessingConfig) -> tuple[int, int]:
-    """Return a video frame target as ``(height, width)``."""
-    target_patches = config.dynamic_resolution_max_patches
-    aspect_ratio = image.width / max(image.height, 1)
-    patch_height = max(1, round(math.sqrt(target_patches / aspect_ratio)))
-    patch_width = max(1, round(math.sqrt(target_patches * aspect_ratio)))
-    required_divisor = 2 if config.pixel_shuffle else 1
-    if required_divisor > 1:
-        height_remainder = patch_height % required_divisor
-        width_remainder = patch_width % required_divisor
-        height_up = patch_height + (required_divisor - height_remainder if height_remainder else 0)
-        width_up = patch_width + (required_divisor - width_remainder if width_remainder else 0)
-        if height_up * width_up <= target_patches:
-            patch_height, patch_width = height_up, width_up
-        else:
-            patch_height = max(required_divisor, patch_height - height_remainder)
-            patch_width = max(required_divisor, patch_width - width_remainder)
-    return patch_height * config.patch_dim, patch_width * config.patch_dim
-
-
 def _resolve_pixel_stats(vision_model_type: str):
     """Return (pixel_mean, pixel_std) for a vision encoder.
 
@@ -96,9 +76,13 @@ def dynamic_res_preprocess(
     factor_max=1.0,
     pixel_shuffle=False,
     spatial_merge_size=1,
+    video_maintain_aspect_ratio=None,
 ):
     """Resize image to fit within [min_patches, max_patches] preserving aspect ratio.
 
+    When ``video_maintain_aspect_ratio`` is not None, use a fixed per-frame
+    ``max_patches`` budget. True preserves the source aspect ratio; False uses
+    a square grid. Images leave this as None and use adaptive resizing.
     For pixel_shuffle, patch grid dimensions are rounded to even numbers for
     compatibility.
 
@@ -112,38 +96,69 @@ def dynamic_res_preprocess(
     """
     orig_width, orig_height = image.size
 
-    # Use math.ceil, not round(x + 0.5) — the latter is banker's rounding and
-    # produces off-by-one, non-monotonic patch counts on exactly-aligned sides.
-    closest_patch_height = math.ceil(orig_height / res_step)
-    closest_patch_width = math.ceil(orig_width / res_step)
-    patches = closest_patch_height * closest_patch_width
-
-    factor = min(math.sqrt(max_patches / patches), factor_max)
-    target_patch_height = math.floor(factor * closest_patch_height)
-    target_patch_width = math.floor(factor * closest_patch_width)
-
-    if target_patch_height * target_patch_width < min_patches:
-        up_factor = math.sqrt(min_patches / max(target_patch_height * target_patch_width, 1))
-        target_patch_height = math.ceil(up_factor * target_patch_height)
-        target_patch_width = math.ceil(up_factor * target_patch_width)
-
-    grid_multiple = max(2 if pixel_shuffle else 1, spatial_merge_size)
-    if grid_multiple > 1:
-        if target_patch_height % grid_multiple:
-            increase = grid_multiple - target_patch_height % grid_multiple
-            if (target_patch_height + increase) * target_patch_width <= max_patches:
-                target_patch_height += increase
+    if video_maintain_aspect_ratio is not None:
+        if video_maintain_aspect_ratio:
+            aspect_ratio = orig_width / max(orig_height, 1)
+            target_patch_height = max(1, round(math.sqrt(max_patches / aspect_ratio)))
+            target_patch_width = max(1, round(math.sqrt(max_patches * aspect_ratio)))
+            # Preserve the former _video_target_resolution behavior exactly.
+            grid_multiple = 2 if pixel_shuffle else 1
+        else:
+            target_patch_height = target_patch_width = max(1, math.isqrt(max_patches))
+            grid_multiple = max(2 if pixel_shuffle else 1, spatial_merge_size)
+        if grid_multiple > 1:
+            height_remainder = target_patch_height % grid_multiple
+            width_remainder = target_patch_width % grid_multiple
+            height_up = target_patch_height + (
+                grid_multiple - height_remainder if height_remainder else 0
+            )
+            width_up = target_patch_width + (
+                grid_multiple - width_remainder if width_remainder else 0
+            )
+            if height_up * width_up <= max_patches:
+                target_patch_height, target_patch_width = height_up, width_up
             else:
-                target_patch_height -= target_patch_height % grid_multiple
-        if target_patch_width % grid_multiple:
-            increase = grid_multiple - target_patch_width % grid_multiple
-            if target_patch_height * (target_patch_width + increase) <= max_patches:
-                target_patch_width += increase
-            else:
-                target_patch_width -= target_patch_width % grid_multiple
+                target_patch_height = max(
+                    grid_multiple, target_patch_height - height_remainder
+                )
+                target_patch_width = max(
+                    grid_multiple, target_patch_width - width_remainder
+                )
+    else:
+        grid_multiple = max(2 if pixel_shuffle else 1, spatial_merge_size)
+        # Use math.ceil, not round(x + 0.5) — the latter is banker's rounding and
+        # produces off-by-one, non-monotonic patch counts on exactly-aligned sides.
+        closest_patch_height = math.ceil(orig_height / res_step)
+        closest_patch_width = math.ceil(orig_width / res_step)
+        patches = closest_patch_height * closest_patch_width
 
-        target_patch_height = max(grid_multiple, target_patch_height)
-        target_patch_width = max(grid_multiple, target_patch_width)
+        factor = min(math.sqrt(max_patches / patches), factor_max)
+        target_patch_height = math.floor(factor * closest_patch_height)
+        target_patch_width = math.floor(factor * closest_patch_width)
+
+        if target_patch_height * target_patch_width < min_patches:
+            up_factor = math.sqrt(
+                min_patches / max(target_patch_height * target_patch_width, 1)
+            )
+            target_patch_height = math.ceil(up_factor * target_patch_height)
+            target_patch_width = math.ceil(up_factor * target_patch_width)
+
+        if grid_multiple > 1:
+            if target_patch_height % grid_multiple:
+                increase = grid_multiple - target_patch_height % grid_multiple
+                if (target_patch_height + increase) * target_patch_width <= max_patches:
+                    target_patch_height += increase
+                else:
+                    target_patch_height -= target_patch_height % grid_multiple
+            if target_patch_width % grid_multiple:
+                increase = grid_multiple - target_patch_width % grid_multiple
+                if target_patch_height * (target_patch_width + increase) <= max_patches:
+                    target_patch_width += increase
+                else:
+                    target_patch_width -= target_patch_width % grid_multiple
+
+            target_patch_height = max(grid_multiple, target_patch_height)
+            target_patch_width = max(grid_multiple, target_patch_width)
 
     assert target_patch_height * target_patch_width <= max_patches
 
@@ -276,6 +291,71 @@ def preprocess_image_bytes_list(
     return {"imgs": imgs, "imgs_sizes": imgs_sizes}
 
 
+def _video_sample_indices(total_frames: int, config: VideoProcessingConfig) -> list[int]:
+    """Return the existing uniformly spaced sample indices for a video."""
+    import numpy as np
+
+    sample_count = min(config.num_frames, total_frames)
+    if config.temporal_patch_size > 1 and sample_count % config.temporal_patch_size:
+        rounded_down = (
+            sample_count // config.temporal_patch_size
+        ) * config.temporal_patch_size
+        sample_count = (
+            rounded_down
+            if rounded_down > 0
+            else min(config.temporal_patch_size, total_frames)
+        )
+    return (
+        np.rint(np.linspace(0, total_frames - 1, num=sample_count))
+        .astype(np.int64)
+        .tolist()
+    )
+
+
+def _decode_sampled_video_frames(encoded_video: bytes, config: VideoProcessingConfig):
+    """Decode the stream while converting only uniformly sampled frames to RGB."""
+    import av
+
+    def decode_selected(total_frames: int):
+        sample_indices = _video_sample_indices(total_frames, config)
+        wanted = set(sample_indices)
+        sampled_frames = []
+        decoded_count = 0
+        with av.open(io.BytesIO(encoded_video)) as container:
+            stream = container.streams.video[0]
+            for index, frame in enumerate(container.decode(stream)):
+                decoded_count = index + 1
+                if index in wanted:
+                    sampled_frames.append(frame.to_image().convert("RGB"))
+        return sampled_frames, decoded_count
+
+    # Prefer container metadata so indexed streams need only one decode pass.
+    with av.open(io.BytesIO(encoded_video)) as container:
+        declared_frames = int(container.streams.video[0].frames or 0)
+
+    if declared_frames > 0:
+        sampled_frames, decoded_count = decode_selected(declared_frames)
+        if decoded_count == declared_frames:
+            return sampled_frames
+        # Some containers report an inaccurate frame count. Redecode using the
+        # observed count to preserve the original exact uniform indices.
+        if decoded_count > 0:
+            sampled_frames, _ = decode_selected(decoded_count)
+        return sampled_frames
+
+    # Unindexed streams need a count-only pass before exact uniform indices can
+    # be selected. No AVFrame or RGB image is retained during this pass.
+    total_frames = 0
+    with av.open(io.BytesIO(encoded_video)) as container:
+        stream = container.streams.video[0]
+        for total_frames, _ in enumerate(container.decode(stream), start=1):
+            pass
+    if total_frames == 0:
+        return []
+    sampled_frames, _ = decode_selected(total_frames)
+    return sampled_frames
+
+
 def preprocess_video_bytes_list(
     video_bytes_list, config: VideoProcessingConfig, device: Optional[torch.device] = None
 ) -> dict:
@@ -296,22 +376,16 @@ def preprocess_video_bytes_list(
             "non-tiled vision inputs."
         )
 
-    import numpy as np
-
     def decode_frames(encoded_video):
         frames = _load_frame_sequence_manifest(encoded_video, config.frame_manifest_magic)
         if frames is not None:
             return frames, True
 
-        import av
-
-        with av.open(io.BytesIO(encoded_video)) as container:
-            return ([frame.to_image().convert("RGB") for frame in container.decode(video=0)], False)
+        return _decode_sampled_video_frames(encoded_video, config), False
 
     packed_videos = []
     packed_sizes = []
     frame_counts = []
-    reference_hw = None
 
     for encoded_video in video_bytes_list:
         if not isinstance(encoded_video, (bytes, bytearray)):
@@ -320,34 +394,26 @@ def preprocess_video_bytes_list(
         if not frames:
             raise ValueError("Decoded video contains no frames.")
 
-        if is_frame_sequence:
-            if len(frames) != config.num_frames:
-                raise ValueError(
-                    "Frame-sequence count must match the configured count: "
-                    f"{len(frames)} != {config.num_frames}."
-                )
-            sampled_frames = frames
-        else:
-            sample_count = min(config.num_frames, len(frames))
-            if config.temporal_patch_size > 1 and sample_count % config.temporal_patch_size:
-                rounded_down = (
-                    sample_count // config.temporal_patch_size
-                ) * config.temporal_patch_size
-                sample_count = (
-                    rounded_down
-                    if rounded_down > 0
-                    else min(config.temporal_patch_size, len(frames))
-                )
-            sample_indices = (
-                np.rint(np.linspace(0, len(frames) - 1, num=sample_count)).astype(np.int64).tolist()
+        if is_frame_sequence and len(frames) != config.num_frames:
+            raise ValueError(
+                "Frame-sequence count must match the configured count: "
+                f"{len(frames)} != {config.num_frames}."
             )
-            sampled_frames = [frames[index] for index in sample_indices]
+        sampled_frames = frames
         sample_count = len(sampled_frames)
 
         frame_tensors = []
         frame_sizes = []
-        if reference_hw is None:
-            reference_hw = _video_target_resolution(sampled_frames[0], config.image_config)
+        reference_image = dynamic_res_preprocess(
+            sampled_frames[0],
+            min_patches=config.image_config.dynamic_resolution_min_patches,
+            max_patches=config.image_config.dynamic_resolution_max_patches,
+            res_step=config.image_config.patch_dim,
+            pixel_shuffle=config.image_config.pixel_shuffle,
+            spatial_merge_size=config.image_config.spatial_merge_size,
+            video_maintain_aspect_ratio=config.video_maintain_aspect_ratio,
+        )
+        reference_hw = (reference_image.height, reference_image.width)
         for frame in sampled_frames:
             imgs, imgs_sizes = preprocess_image(
                 frame, config.image_config, target_hw=reference_hw, device=device

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
@@ -8,13 +8,39 @@ can import it without circular dependencies.
 """
 
 import io
+import json
 import math
+from pathlib import Path
 from typing import Optional
 
 import torch
 
-from megatron.core.inference.config import ImageProcessingConfig
+from megatron.core.inference.config import ImageProcessingConfig, VideoProcessingConfig
 from megatron.core.models.vision.encoder_registry import REGISTRY as _ENCODER_REGISTRY
+
+
+def _video_target_resolution(image, config: ImageProcessingConfig) -> tuple[int, int]:
+    """Return a video frame target as ``(height, width)``."""
+    target_patches = config.dynamic_resolution_max_patches
+    aspect_ratio = image.width / max(image.height, 1)
+    patch_height = max(1, round(math.sqrt(target_patches / aspect_ratio)))
+    patch_width = max(1, round(math.sqrt(target_patches * aspect_ratio)))
+    required_divisor = 2 if config.pixel_shuffle else 1
+    if required_divisor > 1:
+        height_remainder = patch_height % required_divisor
+        width_remainder = patch_width % required_divisor
+        height_up = patch_height + (
+            required_divisor - height_remainder if height_remainder else 0
+        )
+        width_up = patch_width + (
+            required_divisor - width_remainder if width_remainder else 0
+        )
+        if height_up * width_up <= target_patches:
+            patch_height, patch_width = height_up, width_up
+        else:
+            patch_height = max(required_divisor, patch_height - height_remainder)
+            patch_width = max(required_divisor, patch_width - width_remainder)
+    return patch_height * config.patch_dim, patch_width * config.patch_dim
 
 
 def _resolve_pixel_stats(vision_model_type: str):
@@ -34,6 +60,41 @@ def _resolve_pixel_stats(vision_model_type: str):
 
     fields = EncoderSpec.__dataclass_fields__
     return list(fields["pixel_mean"].default), list(fields["pixel_std"].default)
+
+
+def _load_frame_sequence_manifest(
+    payload: bytes,
+    frame_manifest_magic: Optional[bytes],
+):
+    """Load PIL images from a configured frame-sequence manifest."""
+    if not frame_manifest_magic or not payload.startswith(frame_manifest_magic):
+        return None
+
+    from PIL import Image
+
+    try:
+        manifest = json.loads(payload[len(frame_manifest_magic) :])
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Invalid frame-sequence manifest JSON.") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("Frame-sequence manifest must be a JSON object.")
+
+    frame_paths = manifest.get("frame_paths")
+    if (
+        not isinstance(frame_paths, list)
+        or not frame_paths
+        or not all(isinstance(path, str) and path for path in frame_paths)
+    ):
+        raise ValueError(
+            "Frame-sequence manifest requires non-empty string frame_paths."
+        )
+
+    frames = []
+    for frame_path in frame_paths:
+        resolved = Path(frame_path).expanduser().resolve()
+        with Image.open(resolved) as image:
+            frames.append(image.convert("RGB").copy())
+    return frames
 
 
 def dynamic_res_preprocess(
@@ -99,28 +160,13 @@ def dynamic_res_preprocess(
     return resized_img
 
 
-def preprocess_image_bytes(
-    image_bytes: bytes,
+def preprocess_image(
+    image,
     config: ImageProcessingConfig,
     target_hw=None,
     device: Optional[torch.device] = None,
 ) -> tuple:
-    """Preprocess raw image bytes into tensors for dynamic-resolution inference.
-
-    Args:
-        image_bytes: Raw image file bytes (e.g. JPEG/PNG).
-        config: Image preprocessing configuration.
-        target_hw: Optional (H, W) tuple in pixels. If given, resize to exactly
-            this size instead of running dynamic_res_preprocess. Used to keep
-            all images in a multi-image request at the same patch dimensions.
-
-    Returns:
-        (imgs, imgs_sizes) tensors on CUDA.
-        imgs shape: [1, num_patches, C*patch_dim*patch_dim]
-        imgs_sizes shape: [1, 2] with [H, W] in pixels.
-    """
-    from PIL import Image
-
+    """Convert one PIL image into packed vision patches and its resized shape."""
     try:
         from torchvision import transforms as T
     except ImportError as exc:
@@ -130,7 +176,7 @@ def preprocess_image_bytes(
             "PyTorch container that ships one."
         ) from exc
 
-    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    img = image.convert("RGB")
 
     patch_dim = config.patch_dim
 
@@ -169,6 +215,24 @@ def preprocess_image_bytes(
     if device is not None:
         return images.to(device), imgs_sizes.to(device)
     return images, imgs_sizes
+
+
+def preprocess_image_bytes(
+    image_bytes: bytes,
+    config: ImageProcessingConfig,
+    target_hw=None,
+    device: Optional[torch.device] = None,
+) -> tuple:
+    """Decode image bytes and return packed vision patches and its resized shape."""
+    from PIL import Image
+
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        return preprocess_image(
+            image,
+            config,
+            target_hw=target_hw,
+            device=device,
+        )
 
 
 def preprocess_image_bytes_list(
@@ -227,3 +291,121 @@ def preprocess_image_bytes_list(
     imgs = torch.cat(all_imgs, dim=1) if len(all_imgs) > 1 else all_imgs[0]
     imgs_sizes = torch.cat(all_sizes, dim=0) if len(all_sizes) > 1 else all_sizes[0]
     return {"imgs": imgs, "imgs_sizes": imgs_sizes}
+
+
+def preprocess_video_bytes_list(
+    video_bytes_list,
+    config: VideoProcessingConfig,
+    device: Optional[torch.device] = None,
+) -> dict:
+    """Decode videos and return packed dynamic-resolution engine inputs.
+
+    Frames are sampled uniformly, resized using the same image preprocessing
+    configuration as still images, and kept grouped through ``num_frames``.
+    """
+    if not video_bytes_list:
+        return {}
+    if config.num_frames <= 0:
+        raise ValueError("VideoProcessingConfig.num_frames must be positive.")
+    if config.temporal_patch_size <= 0:
+        raise ValueError(
+            "VideoProcessingConfig.temporal_patch_size must be positive."
+        )
+    if (
+        not config.image_config.dynamic_resolution
+        or config.image_config.use_tiling
+    ):
+        raise NotImplementedError(
+            "Raw video preprocessing currently requires dynamic-resolution, "
+            "non-tiled vision inputs."
+        )
+
+    import numpy as np
+
+    def decode_frames(encoded_video):
+        frames = _load_frame_sequence_manifest(
+            encoded_video,
+            config.frame_manifest_magic,
+        )
+        if frames is not None:
+            return frames, True
+
+        import av
+
+        with av.open(io.BytesIO(encoded_video)) as container:
+            return (
+                [
+                    frame.to_image().convert("RGB")
+                    for frame in container.decode(video=0)
+                ],
+                False,
+            )
+
+    packed_videos = []
+    packed_sizes = []
+    frame_counts = []
+    reference_hw = None
+
+    for encoded_video in video_bytes_list:
+        if not isinstance(encoded_video, (bytes, bytearray)):
+            raise TypeError("video payloads must contain only bytes.")
+        frames, is_frame_sequence = decode_frames(bytes(encoded_video))
+        if not frames:
+            raise ValueError("Decoded video contains no frames.")
+
+        if is_frame_sequence:
+            if len(frames) != config.num_frames:
+                raise ValueError(
+                    "Frame-sequence count must match the configured count: "
+                    f"{len(frames)} != {config.num_frames}."
+                )
+            sampled_frames = frames
+        else:
+            sample_count = min(config.num_frames, len(frames))
+            if (
+                config.temporal_patch_size > 1
+                and sample_count % config.temporal_patch_size
+            ):
+                rounded_down = (
+                    sample_count // config.temporal_patch_size
+                ) * config.temporal_patch_size
+                sample_count = (
+                    rounded_down
+                    if rounded_down > 0
+                    else min(config.temporal_patch_size, len(frames))
+                )
+            sample_indices = (
+                np.rint(np.linspace(0, len(frames) - 1, num=sample_count))
+                .astype(np.int64)
+                .tolist()
+            )
+            sampled_frames = [frames[index] for index in sample_indices]
+        sample_count = len(sampled_frames)
+
+        frame_tensors = []
+        frame_sizes = []
+        if reference_hw is None:
+            reference_hw = _video_target_resolution(
+                sampled_frames[0], config.image_config
+            )
+        for frame in sampled_frames:
+            imgs, imgs_sizes = preprocess_image(
+                frame,
+                config.image_config,
+                target_hw=reference_hw,
+                device=device,
+            )
+            frame_tensors.append(imgs)
+            frame_sizes.append(imgs_sizes)
+
+        packed_videos.append(torch.cat(frame_tensors, dim=1))
+        packed_sizes.append(torch.cat(frame_sizes, dim=0))
+        frame_counts.append(sample_count)
+
+    return {
+        "imgs": torch.cat(packed_videos, dim=1),
+        "imgs_sizes": torch.cat(packed_sizes, dim=0),
+        "num_frames": torch.tensor(
+            frame_counts, dtype=torch.int32, device=packed_videos[0].device
+        ),
+    }

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/image_preprocessing.py
@@ -118,12 +118,8 @@ def dynamic_res_preprocess(
             if height_up * width_up <= max_patches:
                 target_patch_height, target_patch_width = height_up, width_up
             else:
-                target_patch_height = max(
-                    grid_multiple, target_patch_height - height_remainder
-                )
-                target_patch_width = max(
-                    grid_multiple, target_patch_width - width_remainder
-                )
+                target_patch_height = max(grid_multiple, target_patch_height - height_remainder)
+                target_patch_width = max(grid_multiple, target_patch_width - width_remainder)
     else:
         grid_multiple = max(2 if pixel_shuffle else 1, spatial_merge_size)
         # Use math.ceil, not round(x + 0.5) — the latter is banker's rounding and
@@ -137,9 +133,7 @@ def dynamic_res_preprocess(
         target_patch_width = math.floor(factor * closest_patch_width)
 
         if target_patch_height * target_patch_width < min_patches:
-            up_factor = math.sqrt(
-                min_patches / max(target_patch_height * target_patch_width, 1)
-            )
+            up_factor = math.sqrt(min_patches / max(target_patch_height * target_patch_width, 1))
             target_patch_height = math.ceil(up_factor * target_patch_height)
             target_patch_width = math.ceil(up_factor * target_patch_width)
 
@@ -297,19 +291,11 @@ def _video_sample_indices(total_frames: int, config: VideoProcessingConfig) -> l
 
     sample_count = min(config.num_frames, total_frames)
     if config.temporal_patch_size > 1 and sample_count % config.temporal_patch_size:
-        rounded_down = (
-            sample_count // config.temporal_patch_size
-        ) * config.temporal_patch_size
+        rounded_down = (sample_count // config.temporal_patch_size) * config.temporal_patch_size
         sample_count = (
-            rounded_down
-            if rounded_down > 0
-            else min(config.temporal_patch_size, total_frames)
+            rounded_down if rounded_down > 0 else min(config.temporal_patch_size, total_frames)
         )
-    return (
-        np.rint(np.linspace(0, total_frames - 1, num=sample_count))
-        .astype(np.int64)
-        .tolist()
-    )
+    return np.rint(np.linspace(0, total_frames - 1, num=sample_count)).astype(np.int64).tolist()
 
 
 def _decode_sampled_video_frames(encoded_video: bytes, config: VideoProcessingConfig):

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
@@ -17,6 +17,7 @@ except ImportError as e:
     HAS_BACKEND = False
 
 import megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints as endpoints
+from megatron.core.inference.config import MultimodalPromptConfig
 from megatron.core.inference.inference_client import InferenceClient
 from megatron.core.utils import trace_async_exceptions
 
@@ -50,6 +51,7 @@ async def _run_text_gen_server(
     fd: Optional[int] = None,
     hostname: Optional[str] = None,
     chat_template: Optional[str] = None,
+    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None,
 ):
     """
     Initializes and runs the async web server. Automatically starts and
@@ -82,6 +84,9 @@ async def _run_text_gen_server(
         app.config['parsers'] = parsers
         app.config['verbose'] = verbose
         app.config['chat_template'] = chat_template
+        app.config['multimodal_prompt_config'] = (
+            multimodal_prompt_config or MultimodalPromptConfig()
+        )
 
         # Register all blueprints from the 'endpoints' package
         for endpoint in endpoints.__all__:
@@ -123,6 +128,7 @@ def _server_process_worker(
     fd: Optional[int] = None,
     hostname: Optional[str] = None,
     chat_template: Optional[str] = None,
+    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None,
 ):
     """Synchronous worker function that sets up a new event loop for the separate process."""
     loop = asyncio.new_event_loop()
@@ -139,6 +145,7 @@ def _server_process_worker(
                 fd,
                 hostname,
                 chat_template,
+                multimodal_prompt_config,
             )
         )
     except KeyboardInterrupt:
@@ -163,6 +170,7 @@ def start_text_gen_server(
     hostname: Optional[str] = None,
     sock: Optional[socket.socket] = None,
     chat_template: Optional[str] = None,
+    multimodal_prompt_config: Optional[MultimodalPromptConfig] = None,
 ):
     """Start the text generation server."""
     global _SERVER_PROCESSES
@@ -212,6 +220,7 @@ def start_text_gen_server(
                 fd,
                 hostname,
                 chat_template,
+                multimodal_prompt_config,
             ),
             daemon=True,
         )

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -155,29 +155,41 @@ class LLaVAModel(MegatronModule):
             "LLaVA is work in progress. Features are missing and methods can change.",
         )
 
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        language_model_type = getattr(language_transformer_config, "language_model_type", "")
+
+        # Constructor configuration and initial module state.
         self.pre_process = pre_process
         self.post_process = post_process
         self.add_encoder = add_encoder
         self.add_decoder = add_decoder
         self.vp_stage = vp_stage
-        self._dynamic_resolution = dynamic_resolution
-        self.patch_dim = patch_dim
-        self._conv_merging = conv_merging
-
-        self.encoder_hidden_state = None
-        self.vision_model = None
-        self.vision_projection = None
-        self.language_model = None
-        self._vision_projection_input_size = None
-
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         self.pg_collection = pg_collection
-
-        language_model_type = getattr(language_transformer_config, "language_model_type", "")
         self.sequence_parallel_lm = language_transformer_config.sequence_parallel
         self.tp_comm_overlap_lm = language_transformer_config.tp_comm_overlap
         self.context_parallel_lm = language_transformer_config.context_parallel_size
+        self.tensor_model_parallel_size_lm = language_transformer_config.tensor_model_parallel_size
+        # Used by finalize_model_grads._allreduce_word_embedding_grads.
+        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
+
+        # Audio/video/image attributes.
+        self.image_token_index = image_token_index
+        self.patch_dim = patch_dim
+        self._pixel_shuffle = pixel_shuffle
+        self._conv_merging = conv_merging
+        self._tile_tags = tile_tags
+        self._max_num_tiles = max_num_tiles
+        self.sound_token_index = sound_token_index
+        self.dynamic_resolution = dynamic_resolution
+        self.radio_force_eval_mode = radio_force_eval_mode
+        self.radio_force_cpe_eval_mode = radio_force_cpe_eval_mode
+        self.radio_interpolate_only_cpe = radio_interpolate_only_cpe
+        self.radio_cpe_aspect_ratio_select = radio_cpe_aspect_ratio_select
+        self.radio_disable_cpe = radio_disable_cpe
+        self.temporal_patch_dim = temporal_patch_dim
+        self.separate_video_embedder = separate_video_embedder
+        self.temporal_ckpt_compat = temporal_ckpt_compat
         if self.sequence_parallel_lm or self.context_parallel_lm > 1:
             if not (
                 language_model_type.startswith('nemotron5-hybrid')
@@ -206,12 +218,10 @@ class LLaVAModel(MegatronModule):
                 ), "Context Parallelism in LLaVA requires TE v1.10 or higher"
             else:
                 self.cp_group = None
-        self.tensor_model_parallel_size_lm = language_transformer_config.tensor_model_parallel_size
 
-        # This attribute is needed to check if an all-reduce is required
-        # on the word embeddings inside `finalize_model_grads._allreduce_word_embedding_grads`.
-        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
-
+        self.language_model = None
+        self.sound_model = sound_model
+        self.sound_projection = sound_projection
         if self.add_decoder:
             if getattr(language_transformer_config, "language_model_type", "").startswith("hf://"):
                 from megatron.core.models.huggingface.module import build_hf_model
@@ -273,6 +283,9 @@ class LLaVAModel(MegatronModule):
         # Save the constructor arg before local reassignment shadows it.
         _class_token_len_override = class_token_len
         class_token_len = 1
+        self.vision_model = None
+        self.vision_projection = None
+        self._vision_projection_input_size = None
         if self.add_encoder:
             self._drop_vision_class_token = drop_vision_class_token
             add_class_token = True
@@ -493,6 +506,7 @@ class LLaVAModel(MegatronModule):
                 _load_state_dict_hook_ignore_extra_state
             )
 
+        # Finalize derived image attributes after resolving the vision backbone.
         self.img_seq_len = get_num_image_embeddings(
             img_h,
             img_w,
@@ -506,20 +520,8 @@ class LLaVAModel(MegatronModule):
             tokenizer_type,
         )
 
-        self.image_token_index = image_token_index
-        self._pixel_shuffle = pixel_shuffle
-        self._tile_tags = tile_tags
-        self._max_num_tiles = max_num_tiles
-        self.patch_dim = patch_dim
         self._class_token_len = class_token_len
-
-        # Audio/video attributes.
-        self.sound_model = sound_model
-        self.sound_projection = sound_projection
-        self.sound_token_index = sound_token_index
-        self.temporal_patch_dim = temporal_patch_dim
-        self.separate_video_embedder = separate_video_embedder
-        self.temporal_ckpt_compat = temporal_ckpt_compat
+        self.encoder_hidden_state = None
 
     @property
     def decoder(self):
@@ -681,10 +683,14 @@ class LLaVAModel(MegatronModule):
             return language_embeddings, labels, loss_mask, input_ids, position_ids
 
         # Temporal media count index for the number of frame/tubelet embeddings only per "video".
+        if num_image_tiles is None:
+            num_image_tiles = torch.empty((0,), dtype=torch.int32, device=input_ids.device)
         if media_token_counts is not None:
             media_token_counts = media_token_counts.to(device=input_ids.device)
         media_counts = media_token_counts if media_token_counts is not None else num_image_tiles
-        if media_counts.numel() == 0:
+        has_sound_embeddings = sound_embeddings is not None and sound_embeddings.numel() > 0
+        if media_counts.numel() == 0 and not has_sound_embeddings:
+            # No multimodal embeddings. Just return the text embeddings early.
             final_embedding = None
             if self.pre_process:
                 final_embedding = language_embeddings
@@ -697,7 +703,7 @@ class LLaVAModel(MegatronModule):
             return final_embedding, labels, loss_mask, input_ids, position_ids
 
         img_seq_len = self.img_seq_len
-        if self._dynamic_resolution and imgs_sizes is not None and media_token_counts is None:
+        if self.dynamic_resolution and imgs_sizes is not None and media_token_counts is None:
             # Per-tile token counts for dynamic resolution.
             img_seq_len = torch.prod(imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32) + (
                 0 if self._drop_vision_class_token else self.vision_model.class_token_len
@@ -747,7 +753,7 @@ class LLaVAModel(MegatronModule):
                     [counts.sum() for counts in media_token_counts_batch]
                 )
                 seq_lens = media_tokens_per_batch - num_images_per_sample + text_seq_len
-            elif self._dynamic_resolution and imgs_sizes is not None:
+            elif self.dynamic_resolution and imgs_sizes is not None:
                 packed_length_per_batch = torch.sum(img_seq_len, dim=-1)
                 seq_lens = packed_length_per_batch - num_images_per_sample + text_seq_len
             else:
@@ -777,7 +783,7 @@ class LLaVAModel(MegatronModule):
             # -1 is for the removed image token index.
             if media_token_counts is not None:
                 image_token_mask_lens[image_token_mask] = media_token_counts - 1
-            elif self._dynamic_resolution and imgs_sizes is not None:
+            elif self.dynamic_resolution and imgs_sizes is not None:
                 image_token_mask_lens[image_token_mask] = img_seq_len - 1
             else:
                 image_token_mask_lens[image_token_mask] = num_image_tiles * img_seq_len - 1
@@ -860,12 +866,45 @@ class LLaVAModel(MegatronModule):
             # NOTE: DDP/FSDP can hang with text-only samples because vision projection
             # params have no gradient path. Workaround: add a zero-contribution from
             # image_embeddings so they participate in the backward graph.
-            if media_counts.shape[0] == 0 and image_embeddings.shape[0] > 0:
-                final_embedding[:1, :1, :1] += 0 * image_embeddings[:1, :1, :1]
+            if media_counts.shape[0] == 0:
+                if image_embeddings is not None and image_embeddings.numel() > 0:
+                    final_embedding[:1, :1, :1] += 0 * image_embeddings[:1, :1, :1]
             else:
                 final_embedding[images_mask] = (
                     image_embeddings.permute(1, 0, 2).reshape(-1, embed_dim).contiguous()
                 )
+
+            # Replace sound-token positions after image expansion has established
+            # their positions in the combined sequence.
+            if sound_embeddings is not None:
+                sound_mask = input_ids == self.sound_token_index
+                if sound_mask.any():
+                    sound_batch_indices, sound_token_indices = torch.where(sound_mask)
+                    sound_new_position_ids = new_position_ids[
+                        sound_batch_indices, sound_token_indices
+                    ]
+                    if self.sound_model is not None and getattr(
+                        getattr(self.sound_model, "config", None),
+                        "sound_pad_to_clip_duration",
+                        False,
+                    ):
+                        flat_sound = sound_embeddings.permute(1, 0, 2).reshape(-1, embed_dim)
+                    else:
+                        flat_sound = torch.cat(
+                            [
+                                embeddings[:length]
+                                for embeddings, length in zip(
+                                    sound_embeddings.permute(1, 0, 2), sound_embeddings_len
+                                )
+                            ],
+                            dim=0,
+                        )
+                    final_embedding[sound_batch_indices, sound_new_position_ids] = (
+                        flat_sound.reshape(-1, embed_dim)
+                    )
+                    # Keep model-internal sound sentinels out of downstream token consumers
+                    # (for example MTP); decoder_input carries the actual sound embeddings.
+                    final_input_ids[sound_batch_indices, sound_new_position_ids] = 0
 
         # Create the final labels and loss mask (if this is the last language model stage).
         final_labels, final_loss_mask = None, None
@@ -1118,8 +1157,7 @@ class LLaVAModel(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         imgs_sizes: Optional[torch.Tensor] = None,
         vision_packed_seq_params: Optional[PackedSeqParams] = None,
-        # Audio remains unsupported by this implementation. Video uses RADIO's
-        # temporal tubelet path when temporal_patch_dim > 1.
+        # Audio and video inputs.
         sound_clips: Optional[torch.Tensor] = None,
         sound_length: Optional[torch.Tensor] = None,
         sound_timestamps: Optional[torch.Tensor] = None,
@@ -1158,20 +1196,13 @@ class LLaVAModel(MegatronModule):
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
-        if (
-            sound_clips is not None
-            or sound_length is not None
-            or sound_timestamps is not None
-            or num_sound_clips is not None
-        ):
-            raise NotImplementedError(
-                "LLaVAModel.forward: audio (sound_*) inputs are not supported."
-            )
-
         use_inference_kv_cache = (
             inference_context is not None
             and hasattr(inference_context, 'key_value_memory_dict')
-            and "image_tokens_count" in inference_context.key_value_memory_dict
+            and (
+                "image_tokens_count" in inference_context.key_value_memory_dict
+                or "sound_tokens_count" in inference_context.key_value_memory_dict
+            )
         )
         has_images = images is not None and images.shape[0] > 0
         media_token_counts = None
@@ -1418,6 +1449,36 @@ class LLaVAModel(MegatronModule):
         else:
             image_embeddings = self.encoder_hidden_state
 
+        # The data path uses a [1, 1] zero tensor as a no-sound sentinel.
+        has_sounds = sound_clips is not None and sound_clips.numel() > 0
+        if has_sounds and sound_clips.shape == torch.Size([1, 1]):
+            has_sounds = sound_clips[0, 0].item() != 0
+
+        if use_inference_kv_cache:
+            sound_embeddings = None
+            sound_embeddings_len = None
+        elif self.add_encoder and not has_sounds:
+            device = sound_clips.device if sound_clips is not None else input_ids.device
+            dtype = sound_clips.dtype if sound_clips is not None else torch.float32
+            sound_embeddings = torch.empty((0, 0, 0), dtype=dtype, device=device)
+            sound_embeddings_len = torch.empty((0,), dtype=torch.long, device=device)
+        elif self.add_encoder and has_sounds:
+            if self.sound_model is None or self.sound_projection is None:
+                raise ValueError("Sound inputs require both sound_model and sound_projection.")
+            sound_embeddings, sound_embeddings_len = self.sound_model(sound_clips, sound_length)
+            sound_embeddings = sound_embeddings.permute(1, 0, 2).contiguous()
+            sound_embeddings = self.sound_projection(sound_embeddings).contiguous()
+
+            if inference_context is not None and hasattr(
+                inference_context, 'key_value_memory_dict'
+            ):
+                inference_context.key_value_memory_dict["sound_tokens_count"] = (
+                    sound_embeddings.shape[1]
+                )
+        else:
+            sound_embeddings = self.encoder_hidden_state
+            sound_embeddings_len = None
+
         if not self.add_decoder:
             return image_embeddings, loss_mask
 
@@ -1425,6 +1486,7 @@ class LLaVAModel(MegatronModule):
         if self.pre_process:
             input_ids_text = input_ids.clone()
             input_ids_text[input_ids_text == self.image_token_index] = 0
+            input_ids_text[input_ids_text == self.sound_token_index] = 0
             # Note: This adds absolute position embedding but not RoPE.
             # Each image is counted as one position.
             # RoPE is added in language_model forward. Each image embedding is one position.
@@ -1462,6 +1524,9 @@ class LLaVAModel(MegatronModule):
             num_image_tiles,
             imgs_sizes=imgs_sizes,
             position_ids=position_ids,
+            sound_embeddings=sound_embeddings,
+            sound_embeddings_len=sound_embeddings_len,
+            sound_timestamps=sound_timestamps,
             media_token_counts=media_token_counts,
         )  # [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
 

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -751,9 +751,7 @@ class LLaVAModel(MegatronModule):
                 seq_lens = packed_length_per_batch - num_images_per_sample + text_seq_len
             else:
                 # Number of tiles per sample.
-                num_image_tiles_batch = num_image_tiles.split(
-                    num_images_per_sample.tolist(), dim=0
-                )
+                num_image_tiles_batch = num_image_tiles.split(num_images_per_sample.tolist(), dim=0)
                 num_image_tiles_batch = torch.tensor(
                     [x.sum() for x in num_image_tiles_batch], device=input_ids.device
                 )
@@ -1436,9 +1434,7 @@ class LLaVAModel(MegatronModule):
 
         # Assume 1 tile per image if the number of tiles is not provided.
         if num_image_tiles is None and images is not None:
-            num_image_tiles = torch.ones(
-                images.shape[0], dtype=torch.int, device=input_ids.device
-            )
+            num_image_tiles = torch.ones(images.shape[0], dtype=torch.int, device=input_ids.device)
 
         # if context_parallel_lm == 1:
         #   [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
@@ -1685,8 +1681,7 @@ def _group_temporal_token_counts(
 
 
 def _group_temporal_token_counts_tensor(
-    tubelet_token_counts: torch.Tensor,
-    media_tubelet_counts: list[int],
+    tubelet_token_counts: torch.Tensor, media_tubelet_counts: list[int]
 ) -> torch.Tensor:
     """Return one device-side token count per temporal media item."""
     if sum(media_tubelet_counts) != tubelet_token_counts.numel():

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -12,10 +12,6 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt import GPTModel
 from megatron.core.models.hybrid.hybrid_model import HybridModel
-from megatron.core.models.multimodal.context_parallel import (
-    gather_from_context_parallel_ranks_dynamic_res,
-    split_to_context_parallel_ranks_dynamic_res,
-)
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel, get_num_image_embeddings
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.radio import RADIOViTModel
@@ -630,7 +626,7 @@ class LLaVAModel(MegatronModule):
         sound_embeddings=None,
         sound_embeddings_len=None,
         sound_timestamps=None,
-        is_packed_dynamic_res: bool = False,
+        media_token_counts: Optional[torch.Tensor] = None,
     ):
         """Preprocess input data before input to language model.
 
@@ -684,7 +680,10 @@ class LLaVAModel(MegatronModule):
         if use_inference_kv_cache:
             return language_embeddings, labels, loss_mask, input_ids, position_ids
 
-        if num_image_tiles.numel() == 0:
+        if media_token_counts is not None:
+            media_token_counts = media_token_counts.to(device=input_ids.device)
+        media_counts = media_token_counts if media_token_counts is not None else num_image_tiles
+        if media_counts.numel() == 0:
             final_embedding = None
             if self.pre_process:
                 final_embedding = language_embeddings
@@ -696,10 +695,8 @@ class LLaVAModel(MegatronModule):
                     final_embedding = final_embedding.transpose(1, 0).contiguous()
             return final_embedding, labels, loss_mask, input_ids, position_ids
 
-        # Packed temporal outputs store the exact token count for each media
-        # placeholder in num_image_tiles, with one embedding row per count.
-        img_seq_len = 1 if is_packed_dynamic_res else self.img_seq_len
-        if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
+        img_seq_len = self.img_seq_len
+        if self._dynamic_resolution and imgs_sizes is not None and media_token_counts is None:
             # Per-tile token counts for dynamic resolution.
             img_seq_len = torch.prod(imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32) + (
                 0 if self._drop_vision_class_token else self.vision_model.class_token_len
@@ -732,27 +729,34 @@ class LLaVAModel(MegatronModule):
             image_token_mask = input_ids == image_token_index
             num_images_per_sample = torch.sum(image_token_mask, dim=-1)
 
-            # If num_image_tiles is empty but <image> tokens exist, the images were
-            # all filtered (e.g. too small for dynamic resolution -> 0 patches).
+            # If the applicable media counts are empty but <image> tokens exist,
+            # the images were all filtered (e.g. too small for dynamic resolution -> 0 patches).
             # Fall back to text-only: strip <image> tokens from the mask so the
             # split below doesn't crash.
-            if num_image_tiles.numel() == 0 and num_images_per_sample.sum() > 0:
+            if media_counts.numel() == 0 and num_images_per_sample.sum() > 0:
                 image_token_mask = torch.zeros_like(image_token_mask)
                 num_images_per_sample = torch.zeros_like(num_images_per_sample)
 
-            # Number of tiles per sample.
-            num_image_tiles_batch = num_image_tiles.split(num_images_per_sample.tolist(), dim=0)
-            num_image_tiles_batch = torch.tensor(
-                [x.sum() for x in num_image_tiles_batch], device=input_ids.device
-            )
-
-            # Sequence length for each sample is the image sequence length multiplied by
-            # the number of tiles for that image, minus image token indices,
-            # plus text sequence length.
-            if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
+            # Determine each sample's expanded length from the applicable media units.
+            if media_token_counts is not None:
+                media_token_counts_batch = media_token_counts.split(
+                    num_images_per_sample.tolist(), dim=0
+                )
+                media_tokens_per_batch = torch.stack(
+                    [counts.sum() for counts in media_token_counts_batch]
+                )
+                seq_lens = media_tokens_per_batch - num_images_per_sample + text_seq_len
+            elif self._dynamic_resolution and imgs_sizes is not None:
                 packed_length_per_batch = torch.sum(img_seq_len, dim=-1)
                 seq_lens = packed_length_per_batch - num_images_per_sample + text_seq_len
             else:
+                # Number of tiles per sample.
+                num_image_tiles_batch = num_image_tiles.split(
+                    num_images_per_sample.tolist(), dim=0
+                )
+                num_image_tiles_batch = torch.tensor(
+                    [x.sum() for x in num_image_tiles_batch], device=input_ids.device
+                )
                 seq_lens = (
                     num_image_tiles_batch * img_seq_len - num_images_per_sample + text_seq_len
                 )
@@ -772,7 +776,9 @@ class LLaVAModel(MegatronModule):
             # new_position_ids = [576, 577, 578, 579]. text_position_ids are then [577, 578, 579].
             image_token_mask_lens = image_token_mask.int().clone()
             # -1 is for the removed image token index.
-            if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
+            if media_token_counts is not None:
+                image_token_mask_lens[image_token_mask] = media_token_counts - 1
+            elif self._dynamic_resolution and imgs_sizes is not None:
                 image_token_mask_lens[image_token_mask] = img_seq_len - 1
             else:
                 image_token_mask_lens[image_token_mask] = num_image_tiles * img_seq_len - 1
@@ -855,7 +861,7 @@ class LLaVAModel(MegatronModule):
             # NOTE: DDP/FSDP can hang with text-only samples because vision projection
             # params have no gradient path. Workaround: add a zero-contribution from
             # image_embeddings so they participate in the backward graph.
-            if num_image_tiles.shape[0] == 0 and image_embeddings.shape[0] > 0:
+            if media_counts.shape[0] == 0 and image_embeddings.shape[0] > 0:
                 final_embedding[:1, :1, :1] += 0 * image_embeddings[:1, :1, :1]
             else:
                 final_embedding[images_mask] = (
@@ -1145,7 +1151,6 @@ class LLaVAModel(MegatronModule):
             packed_seq_params (PackedSeqParams): 1) If using sequence packing, must contain
                 subsample length information. 2) If using SP/CP with padding mask type,
                 must contain padded token information.
-
         Returns:
             output (torch.Tensor): Loss of shape [b, s] if labels are provided,
                 otherwise logits of shape [b, s, vocab_size].
@@ -1170,7 +1175,7 @@ class LLaVAModel(MegatronModule):
             and "image_tokens_count" in inference_context.key_value_memory_dict
         )
         has_images = images is not None and images.shape[0] > 0
-        is_packed_dynamic_res = False
+        media_token_counts = None
 
         # If running inference, we can skip image token computation
         # if they were computed already earlier for this sample.
@@ -1211,12 +1216,9 @@ class LLaVAModel(MegatronModule):
 
             if self.temporal_patch_dim > 1 and imgs_sizes is not None and num_frames is None:
                 num_frames = [1] * len(imgs_sizes)
-            use_temporal = self.temporal_patch_dim > 1 and imgs_sizes is not None
-            if use_temporal:
-                if not isinstance(self.vision_model, RADIOViTModel):
-                    raise NotImplementedError(
-                        "Temporal video encoding is currently supported only by RADIOViTModel."
-                    )
+            if num_frames is not None:
+                if imgs_sizes is None:
+                    raise ValueError("Video inputs require imgs_sizes.")
                 if isinstance(num_frames, int):
                     num_frames = [num_frames]
                 elif torch.is_tensor(num_frames):
@@ -1233,6 +1235,12 @@ class LLaVAModel(MegatronModule):
                         "num_frames must partition imgs_sizes exactly: "
                         f"sum(num_frames)={sum(num_frames)}, imgs_sizes={len(imgs_sizes)}."
                     )
+            use_temporal = self.temporal_patch_dim > 1 and imgs_sizes is not None
+            if use_temporal:
+                if not isinstance(self.vision_model, RADIOViTModel):
+                    raise NotImplementedError(
+                        "Temporal video encoding is currently supported only by RADIOViTModel."
+                    )
                 media_tubelet_counts = [
                     (
                         1
@@ -1245,32 +1253,10 @@ class LLaVAModel(MegatronModule):
                     raise NotImplementedError(
                         "Tile tagging is not supported with temporal video inputs."
                     )
-                num_padded_imgs = 0
-                split_vision_across_cp = (
-                    self.context_parallel_lm > 1
-                    and vision_packed_seq_params is not None
-                    and not self.separate_video_embedder
-                )
-                if split_vision_across_cp:
-                    (
-                        images,
-                        imgs_sizes,
-                        vision_packed_seq_params,
-                        _has_pad_img,
-                        num_padded_imgs,
-                        local_num_frames,
-                    ) = split_to_context_parallel_ranks_dynamic_res(
-                        images,
-                        imgs_sizes,
-                        vision_packed_seq_params,
-                        fp8_enabled=False,
-                        fp8_recipe=getattr(self.config, "fp8_recipe", None),
-                        patch_dim=self.vision_model.patch_dim,
-                        num_frames=num_frames,
-                        temporal_patch_size=self.temporal_patch_dim,
+                if self.context_parallel_lm > 1:
+                    raise NotImplementedError(
+                        "Temporal video encoding does not support context parallelism."
                     )
-                    if local_num_frames is not None:
-                        num_frames = local_num_frames
 
                 image_embeddings, post_imgs_sizes, _ = self.vision_model(
                     images,
@@ -1302,48 +1288,19 @@ class LLaVAModel(MegatronModule):
                             "Temporal pixel shuffle requires dropping vision class tokens."
                         )
                     chunks = _pixel_shuffle_dynamic_resolution_chunks(chunks, sizes, patch_dim)
-                tubelet_token_counts_tensor = torch.tensor(
-                    [chunk.shape[0] for chunk in chunks],
-                    dtype=torch.int,
-                    device=image_embeddings.device,
+                tubelet_token_counts = (
+                    [chunk.shape[0] for chunk in chunks] if self.add_decoder else None
                 )
                 image_embeddings = torch.cat(chunks, dim=0)
 
-                if split_vision_across_cp:
-                    image_embeddings = gather_from_context_parallel_ranks_dynamic_res(
-                        image_embeddings, num_padded_imgs
-                    )
-                    tubelet_token_counts_tensor = gather_from_context_parallel_ranks_dynamic_res(
-                        tubelet_token_counts_tensor, num_padded_imgs
-                    )
-
-                is_packed_dynamic_res = True
-                tubelet_token_counts = [
-                    int(value) for value in tubelet_token_counts_tensor.tolist()
-                ]
                 image_embeddings = image_embeddings.unsqueeze(0)
-                placeholder_count = (
-                    int(
-                        (
-                            input_ids
-                            == (
-                                image_token_index
-                                if image_token_index is not None
-                                else self.image_token_index
-                            )
-                        )
-                        .sum()
-                        .item()
+                if tubelet_token_counts is not None:
+                    placeholder_token_counts = _group_temporal_token_counts(
+                        tubelet_token_counts, media_tubelet_counts
                     )
-                    if torch.is_tensor(input_ids)
-                    else len(tubelet_token_counts)
-                )
-                placeholder_token_counts = _group_temporal_token_counts(
-                    tubelet_token_counts, media_tubelet_counts, placeholder_count
-                )
-                num_image_tiles = torch.tensor(
-                    placeholder_token_counts, dtype=torch.int, device=image_embeddings.device
-                )
+                    media_token_counts = torch.tensor(
+                        placeholder_token_counts, dtype=torch.int, device=image_embeddings.device
+                    )
             else:
                 # Stock CLIPViTModel does not accept VLM-specific kwargs.
                 vision_kwargs = {}
@@ -1405,6 +1362,34 @@ class LLaVAModel(MegatronModule):
                             image_embeddings
                         )  # [num_tiles, img_seq_len_shuffled, h_vision_shuffled]
 
+                # With temporal_patch_dim=1, encode frames independently but
+                # retain num_frames so one video placeholder can consume the
+                # concatenated embeddings from all of its frames.
+                if num_frames is not None and imgs_sizes is not None and self.add_decoder:
+                    if torch.is_tensor(imgs_sizes):
+                        frame_token_counts = torch.prod(
+                            imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32
+                        )
+                    else:
+                        frame_token_counts = torch.tensor(
+                            [
+                                (int(height) // self.patch_dim) * (int(width) // self.patch_dim)
+                                for height, width in imgs_sizes
+                            ],
+                            dtype=torch.int32,
+                            device=image_embeddings.device,
+                        )
+                    if not self._drop_vision_class_token:
+                        class_token_len = int(getattr(self.vision_model, "class_token_len", 0))
+                        frame_token_counts = frame_token_counts + class_token_len
+                    if self._pixel_shuffle:
+                        frame_token_counts = frame_token_counts // 4
+                    if self._conv_merging:
+                        frame_token_counts = frame_token_counts // 4
+                    media_token_counts = _group_temporal_token_counts_tensor(
+                        frame_token_counts, num_frames
+                    )
+
             # contiguous() required as `permute` can sparsify the tensor and this breaks pipelining
             image_embeddings = image_embeddings.permute(
                 1, 0, 2
@@ -1451,12 +1436,9 @@ class LLaVAModel(MegatronModule):
 
         # Assume 1 tile per image if the number of tiles is not provided.
         if num_image_tiles is None and images is not None:
-            num_images = (
-                imgs_sizes.shape[0]
-                if imgs_sizes is not None and self._dynamic_resolution
-                else images.shape[0]
+            num_image_tiles = torch.ones(
+                images.shape[0], dtype=torch.int, device=input_ids.device
             )
-            num_image_tiles = torch.ones(num_images, dtype=torch.int, device=input_ids.device)
 
         # if context_parallel_lm == 1:
         #   [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
@@ -1480,7 +1462,7 @@ class LLaVAModel(MegatronModule):
             num_image_tiles,
             imgs_sizes=imgs_sizes,
             position_ids=position_ids,
-            is_packed_dynamic_res=is_packed_dynamic_res,
+            media_token_counts=media_token_counts,
         )  # [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
 
         # Rebuild packed_seq_params to match post-truncation tensor dims.
@@ -1687,31 +1669,46 @@ def _pixel_shuffle_dynamic_resolution_chunks(
 
 
 def _group_temporal_token_counts(
-    tubelet_token_counts: list[int], media_tubelet_counts: list[int], placeholder_count: int
+    tubelet_token_counts: list[int], media_tubelet_counts: list[int]
 ) -> list[int]:
-    """Return token counts for either per-tubelet or per-media placeholders."""
+    """Return one token count per temporal media item."""
     if sum(media_tubelet_counts) != len(tubelet_token_counts):
         raise ValueError("media_tubelet_counts must partition tubelet_token_counts exactly.")
-    if placeholder_count == len(tubelet_token_counts):
-        return tubelet_token_counts
-    if placeholder_count == len(media_tubelet_counts):
-        media_token_counts = []
-        tubelet_offset = 0
-        for tubelet_count in media_tubelet_counts:
-            media_token_counts.append(
-                sum(tubelet_token_counts[tubelet_offset : tubelet_offset + tubelet_count])
-            )
-            tubelet_offset += tubelet_count
-        return media_token_counts
-    raise ValueError(
-        "Temporal media placeholders must match either the number "
-        f"of media items ({len(media_tubelet_counts)}) or tubelets "
-        f"({len(tubelet_token_counts)}); got {placeholder_count}."
-    )
+    media_token_counts = []
+    tubelet_offset = 0
+    for tubelet_count in media_tubelet_counts:
+        media_token_counts.append(
+            sum(tubelet_token_counts[tubelet_offset : tubelet_offset + tubelet_count])
+        )
+        tubelet_offset += tubelet_count
+    return media_token_counts
+
+
+def _group_temporal_token_counts_tensor(
+    tubelet_token_counts: torch.Tensor,
+    media_tubelet_counts: list[int],
+) -> torch.Tensor:
+    """Return one device-side token count per temporal media item."""
+    if sum(media_tubelet_counts) != tubelet_token_counts.numel():
+        raise ValueError("media_tubelet_counts must partition tubelet_token_counts exactly.")
+    media_token_counts = []
+    tubelet_offset = 0
+    for tubelet_count in media_tubelet_counts:
+        media_token_counts.append(
+            tubelet_token_counts[tubelet_offset : tubelet_offset + tubelet_count].sum()
+        )
+        tubelet_offset += tubelet_count
+    return torch.stack(media_token_counts)
 
 
 def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
-    """Pixel shuffle based on InternVL but adapted for our use case.
+    """Spatially group neighboring vision patches following the InternVL convention.
+
+    This is the canonical MCore LLaVA ordering: for a 0.5 scale, each output
+    token concatenates one spatial 2x2 neighborhood, including on non-square
+    grids. Explicit ``h`` and ``w`` must therefore both be divisible by the
+    reduction factor. The MIMO RADIO provider retains an equivalent local
+    implementation of this ordering.
 
     Args:
         x (torch.Tensor): Vision model outputs [num_tiles, img_seq_len, h_vision]
@@ -1755,7 +1752,8 @@ def pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim, scale_factor=0.5, versio
     """Pixel shuffle for dynamic resolution (variable tile sizes).
 
     Splits the packed sequence by per-tile lengths, applies pixel shuffle to each tile,
-    then re-concatenates.
+    then re-concatenates using :func:`pixel_shuffle`'s canonical spatial-neighborhood
+    ordering.
 
     Args:
         x (torch.Tensor): Vision model outputs [batch, total_seq_len, h_vision]

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -1234,10 +1234,11 @@ class LLaVAModel(MegatronModule):
                         f"sum(num_frames)={sum(num_frames)}, imgs_sizes={len(imgs_sizes)}."
                     )
                 media_tubelet_counts = [
-                    1
-                    if frame_count == 1
-                    else (frame_count + self.temporal_patch_dim - 1)
-                    // self.temporal_patch_dim
+                    (
+                        1
+                        if frame_count == 1
+                        else (frame_count + self.temporal_patch_dim - 1) // self.temporal_patch_dim
+                    )
                     for frame_count in num_frames
                 ]
                 if self._tile_tags is not None:
@@ -1289,13 +1290,10 @@ class LLaVAModel(MegatronModule):
                     else 0
                 )
                 sequence_lengths = [
-                    (int(height) // patch_dim) * (int(width) // patch_dim)
-                    + class_token_len
+                    (int(height) // patch_dim) * (int(width) // patch_dim) + class_token_len
                     for height, width in sizes
                 ]
-                chunks = list(
-                    torch.split(image_embeddings.squeeze(0), sequence_lengths, dim=0)
-                )
+                chunks = list(torch.split(image_embeddings.squeeze(0), sequence_lengths, dim=0))
                 if self._drop_vision_class_token and class_token_len > 0:
                     chunks = [chunk[class_token_len:] for chunk in chunks]
                 if self._pixel_shuffle:
@@ -1303,9 +1301,7 @@ class LLaVAModel(MegatronModule):
                         raise ValueError(
                             "Temporal pixel shuffle requires dropping vision class tokens."
                         )
-                    chunks = _pixel_shuffle_dynamic_resolution_chunks(
-                        chunks, sizes, patch_dim
-                    )
+                    chunks = _pixel_shuffle_dynamic_resolution_chunks(chunks, sizes, patch_dim)
                 tubelet_token_counts_tensor = torch.tensor(
                     [chunk.shape[0] for chunk in chunks],
                     dtype=torch.int,
@@ -1317,10 +1313,8 @@ class LLaVAModel(MegatronModule):
                     image_embeddings = gather_from_context_parallel_ranks_dynamic_res(
                         image_embeddings, num_padded_imgs
                     )
-                    tubelet_token_counts_tensor = (
-                        gather_from_context_parallel_ranks_dynamic_res(
-                            tubelet_token_counts_tensor, num_padded_imgs
-                        )
+                    tubelet_token_counts_tensor = gather_from_context_parallel_ranks_dynamic_res(
+                        tubelet_token_counts_tensor, num_padded_imgs
                     )
 
                 is_packed_dynamic_res = True
@@ -1345,14 +1339,10 @@ class LLaVAModel(MegatronModule):
                     else len(tubelet_token_counts)
                 )
                 placeholder_token_counts = _group_temporal_token_counts(
-                    tubelet_token_counts,
-                    media_tubelet_counts,
-                    placeholder_count,
+                    tubelet_token_counts, media_tubelet_counts, placeholder_count
                 )
                 num_image_tiles = torch.tensor(
-                    placeholder_token_counts,
-                    dtype=torch.int,
-                    device=image_embeddings.device,
+                    placeholder_token_counts, dtype=torch.int, device=image_embeddings.device
                 )
             else:
                 # Stock CLIPViTModel does not accept VLM-specific kwargs.
@@ -1394,9 +1384,7 @@ class LLaVAModel(MegatronModule):
                             torch.cat([seq_lens.new_zeros(1), seq_lens + class_token_len]), dim=0
                         )[:-1]
                         class_offsets = segment_starts.unsqueeze(1) + torch.arange(
-                            class_token_len,
-                            device=image_embeddings.device,
-                            dtype=seq_lens.dtype,
+                            class_token_len, device=image_embeddings.device, dtype=seq_lens.dtype
                         ).unsqueeze(0)
                         remove_mask[class_offsets.reshape(-1)] = False
                         image_embeddings = image_embeddings[:, remove_mask, :]
@@ -1468,9 +1456,7 @@ class LLaVAModel(MegatronModule):
                 if imgs_sizes is not None and self._dynamic_resolution
                 else images.shape[0]
             )
-            num_image_tiles = torch.ones(
-                num_images, dtype=torch.int, device=input_ids.device
-            )
+            num_image_tiles = torch.ones(num_images, dtype=torch.int, device=input_ids.device)
 
         # if context_parallel_lm == 1:
         #   [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
@@ -1683,9 +1669,7 @@ def _pixel_shuffle_dynamic_resolution_chunks(
     chunks, image_sizes, patch_dim, scale_factor=0.5, version=2
 ):
     """Pixel-shuffle dynamic-resolution chunks using their real patch grids."""
-    assert len(chunks) == len(image_sizes), (
-        "each image chunk requires a matching image size"
-    )
+    assert len(chunks) == len(image_sizes), "each image chunk requires a matching image size"
     shuffled_chunks = []
     for chunk, (height, width) in zip(chunks, image_sizes):
         restore_2d = chunk.ndim == 2
@@ -1703,15 +1687,11 @@ def _pixel_shuffle_dynamic_resolution_chunks(
 
 
 def _group_temporal_token_counts(
-    tubelet_token_counts: list[int],
-    media_tubelet_counts: list[int],
-    placeholder_count: int,
+    tubelet_token_counts: list[int], media_tubelet_counts: list[int], placeholder_count: int
 ) -> list[int]:
     """Return token counts for either per-tubelet or per-media placeholders."""
     if sum(media_tubelet_counts) != len(tubelet_token_counts):
-        raise ValueError(
-            "media_tubelet_counts must partition tubelet_token_counts exactly."
-        )
+        raise ValueError("media_tubelet_counts must partition tubelet_token_counts exactly.")
     if placeholder_count == len(tubelet_token_counts):
         return tubelet_token_counts
     if placeholder_count == len(media_tubelet_counts):
@@ -1719,11 +1699,7 @@ def _group_temporal_token_counts(
         tubelet_offset = 0
         for tubelet_count in media_tubelet_counts:
             media_token_counts.append(
-                sum(
-                    tubelet_token_counts[
-                        tubelet_offset : tubelet_offset + tubelet_count
-                    ]
-                )
+                sum(tubelet_token_counts[tubelet_offset : tubelet_offset + tubelet_count])
             )
             tubelet_offset += tubelet_count
         return media_token_counts
@@ -1748,13 +1724,11 @@ def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
     """
     if h is not None or w is not None:
         assert h is not None and w is not None, "h and w must both be provided"
-        assert h * w == x.shape[1], (
-            f"h*w ({h}*{w}={h * w}) must equal patches ({x.shape[1]})"
-        )
+        assert h * w == x.shape[1], f"h*w ({h}*{w}={h * w}) must equal patches ({x.shape[1]})"
         reduction = int(1 / scale_factor)
-        assert h % reduction == 0 and w % reduction == 0, (
-            f"h and w ({h}, {w}) must both be divisible by {reduction}"
-        )
+        assert (
+            h % reduction == 0 and w % reduction == 0
+        ), f"h and w ({h}, {w}) must both be divisible by {reduction}"
     else:
         h = w = int(x.shape[1] ** 0.5)
     x = x.reshape(x.shape[0], h, w, -1)  # [num_tiles, sq, sq, h_vision]
@@ -1796,15 +1770,9 @@ def pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim, scale_factor=0.5, versio
     seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
     splits = torch.split(x, seq_lens.tolist(), dim=-2)
 
-    sizes = (
-        imgs_sizes.tolist() if torch.is_tensor(imgs_sizes) else list(imgs_sizes)
-    )
+    sizes = imgs_sizes.tolist() if torch.is_tensor(imgs_sizes) else list(imgs_sizes)
     out = _pixel_shuffle_dynamic_resolution_chunks(
-        splits,
-        sizes,
-        patch_dim,
-        scale_factor=scale_factor,
-        version=version,
+        splits, sizes, patch_dim, scale_factor=scale_factor, version=version
     )
     x = torch.cat(out, dim=-2)
     return x

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -680,6 +680,7 @@ class LLaVAModel(MegatronModule):
         if use_inference_kv_cache:
             return language_embeddings, labels, loss_mask, input_ids, position_ids
 
+        # Temporal media count index for the number of frame/tubelet embeddings only per "video".
         if media_token_counts is not None:
             media_token_counts = media_token_counts.to(device=input_ids.device)
         media_counts = media_token_counts if media_token_counts is not None else num_image_tiles
@@ -1287,17 +1288,20 @@ class LLaVAModel(MegatronModule):
                         )
                     chunks = _pixel_shuffle_dynamic_resolution_chunks(chunks, sizes, patch_dim)
                 tubelet_token_counts = (
-                    [chunk.shape[0] for chunk in chunks] if self.add_decoder else None
+                    torch.tensor(
+                        [chunk.shape[0] for chunk in chunks],
+                        dtype=torch.int32,
+                        device=image_embeddings.device,
+                    )
+                    if self.add_decoder
+                    else None
                 )
                 image_embeddings = torch.cat(chunks, dim=0)
 
                 image_embeddings = image_embeddings.unsqueeze(0)
                 if tubelet_token_counts is not None:
-                    placeholder_token_counts = _group_temporal_token_counts(
+                    media_token_counts = _group_temporal_token_counts_tensor(
                         tubelet_token_counts, media_tubelet_counts
-                    )
-                    media_token_counts = torch.tensor(
-                        placeholder_token_counts, dtype=torch.int, device=image_embeddings.device
                     )
             else:
                 # Stock CLIPViTModel does not accept VLM-specific kwargs.
@@ -1662,22 +1666,6 @@ def _pixel_shuffle_dynamic_resolution_chunks(
         )
         shuffled_chunks.append(shuffled.squeeze(0) if restore_2d else shuffled)
     return shuffled_chunks
-
-
-def _group_temporal_token_counts(
-    tubelet_token_counts: list[int], media_tubelet_counts: list[int]
-) -> list[int]:
-    """Return one token count per temporal media item."""
-    if sum(media_tubelet_counts) != len(tubelet_token_counts):
-        raise ValueError("media_tubelet_counts must partition tubelet_token_counts exactly.")
-    media_token_counts = []
-    tubelet_offset = 0
-    for tubelet_count in media_tubelet_counts:
-        media_token_counts.append(
-            sum(tubelet_token_counts[tubelet_offset : tubelet_offset + tubelet_count])
-        )
-        tubelet_offset += tubelet_count
-    return media_token_counts
 
 
 def _group_temporal_token_counts_tensor(

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -12,6 +12,10 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt import GPTModel
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.multimodal.context_parallel import (
+    gather_from_context_parallel_ranks_dynamic_res,
+    split_to_context_parallel_ranks_dynamic_res,
+)
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel, get_num_image_embeddings
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.radio import RADIOViTModel
@@ -136,9 +140,7 @@ class LLaVAModel(MegatronModule):
         radio_interpolate_only_cpe: bool = False,
         radio_cpe_aspect_ratio_select: bool = False,
         radio_disable_cpe: bool = False,
-        # Audio/video params kept for API compatibility with upstream LLaVAModel.
-        # Not exercised by the VLM inference path this PR adds; they are accepted
-        # and stored on ``self`` but do not otherwise affect behavior here.
+        # Audio/video configuration.
         sound_model: Optional[torch.nn.Module] = None,
         sound_projection: Optional[torch.nn.Module] = None,
         sound_token_index: int = DEFAULT_SOUND_TOKEN_INDEX,
@@ -379,6 +381,9 @@ class LLaVAModel(MegatronModule):
                     interpolate_only_cpe=radio_interpolate_only_cpe,
                     cpe_aspect_ratio_select=radio_cpe_aspect_ratio_select,
                     has_cpe=not radio_disable_cpe,
+                    temporal_patch_dim=temporal_patch_dim,
+                    separate_video_embedder=separate_video_embedder,
+                    temporal_ckpt_compat=temporal_ckpt_compat,
                     pg_collection=self.pg_collection,
                     vp_stage=self.vp_stage,
                 )
@@ -512,8 +517,7 @@ class LLaVAModel(MegatronModule):
         self.patch_dim = patch_dim
         self._class_token_len = class_token_len
 
-        # Audio/video attributes kept for API compatibility with upstream. The
-        # VLM inference path in this PR does not exercise them.
+        # Audio/video attributes.
         self.sound_model = sound_model
         self.sound_projection = sound_projection
         self.sound_token_index = sound_token_index
@@ -626,6 +630,7 @@ class LLaVAModel(MegatronModule):
         sound_embeddings=None,
         sound_embeddings_len=None,
         sound_timestamps=None,
+        is_packed_dynamic_res: bool = False,
     ):
         """Preprocess input data before input to language model.
 
@@ -691,8 +696,10 @@ class LLaVAModel(MegatronModule):
                     final_embedding = final_embedding.transpose(1, 0).contiguous()
             return final_embedding, labels, loss_mask, input_ids, position_ids
 
-        img_seq_len = self.img_seq_len
-        if self._dynamic_resolution and imgs_sizes is not None:
+        # Packed temporal outputs store the exact token count for each media
+        # placeholder in num_image_tiles, with one embedding row per count.
+        img_seq_len = 1 if is_packed_dynamic_res else self.img_seq_len
+        if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
             # Per-tile token counts for dynamic resolution.
             img_seq_len = torch.prod(imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32) + (
                 0 if self._drop_vision_class_token else self.vision_model.class_token_len
@@ -742,7 +749,7 @@ class LLaVAModel(MegatronModule):
             # Sequence length for each sample is the image sequence length multiplied by
             # the number of tiles for that image, minus image token indices,
             # plus text sequence length.
-            if self._dynamic_resolution and imgs_sizes is not None:
+            if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
                 packed_length_per_batch = torch.sum(img_seq_len, dim=-1)
                 seq_lens = packed_length_per_batch - num_images_per_sample + text_seq_len
             else:
@@ -765,7 +772,7 @@ class LLaVAModel(MegatronModule):
             # new_position_ids = [576, 577, 578, 579]. text_position_ids are then [577, 578, 579].
             image_token_mask_lens = image_token_mask.int().clone()
             # -1 is for the removed image token index.
-            if self._dynamic_resolution and imgs_sizes is not None:
+            if self._dynamic_resolution and imgs_sizes is not None and not is_packed_dynamic_res:
                 image_token_mask_lens[image_token_mask] = img_seq_len - 1
             else:
                 image_token_mask_lens[image_token_mask] = num_image_tiles * img_seq_len - 1
@@ -1106,16 +1113,13 @@ class LLaVAModel(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         imgs_sizes: Optional[torch.Tensor] = None,
         vision_packed_seq_params: Optional[PackedSeqParams] = None,
-        # Audio/video params kept for API compatibility with the upstream
-        # LLaVAModel.forward signature. The VLM inference path this PR adds does
-        # not consume them; matching stubs exist on the constructor (sound_model,
-        # sound_projection, sound_token_index, temporal_patch_dim,
-        # separate_video_embedder, temporal_ckpt_compat).
+        # Audio remains unsupported by this implementation. Video uses RADIO's
+        # temporal tubelet path when temporal_patch_dim > 1.
         sound_clips: Optional[torch.Tensor] = None,
         sound_length: Optional[torch.Tensor] = None,
         sound_timestamps: Optional[torch.Tensor] = None,
         num_sound_clips: Optional[List[int]] = None,
-        num_frames: Optional[int] = None,
+        num_frames: Optional[int | List[int] | torch.Tensor] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
     ) -> torch.Tensor:
@@ -1150,28 +1154,14 @@ class LLaVAModel(MegatronModule):
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
-        # The audio and video (temporal) paths were dropped when this
-        # PR reduced the multimodal example tree to the LLaVA + vision
-        # inference path this engine needs. The kwargs stay on the
-        # signature so callers passing the upstream shape don't hit a
-        # TypeError, but any non-None value is now silently ignored --
-        # fail loudly so a user with an audio- or video-capable
-        # checkpoint sees a clear message rather than a wrong-modality
-        # completion. The audio path can be restored in a follow-up
-        # once the accompanying sound_model / sound_projection wiring
-        # is back.
         if (
             sound_clips is not None
             or sound_length is not None
             or sound_timestamps is not None
             or num_sound_clips is not None
-            or (num_frames is not None and num_frames != 1)
         ):
             raise NotImplementedError(
-                "LLaVAModel.forward: audio (sound_*) and video (num_frames > 1) "
-                "inputs are not supported on the VLM inference path added in "
-                "this PR. These kwargs are accepted for signature compatibility "
-                "with upstream LLaVAModel and must be left at their defaults."
+                "LLaVAModel.forward: audio (sound_*) inputs are not supported."
             )
 
         use_inference_kv_cache = (
@@ -1180,6 +1170,7 @@ class LLaVAModel(MegatronModule):
             and "image_tokens_count" in inference_context.key_value_memory_dict
         )
         has_images = images is not None and images.shape[0] > 0
+        is_packed_dynamic_res = False
 
         # If running inference, we can skip image token computation
         # if they were computed already earlier for this sample.
@@ -1218,65 +1209,213 @@ class LLaVAModel(MegatronModule):
                     max_seqlen_kv=max_seqlen,
                 )
 
-            # Only pass VLM-specific kwargs when they're non-None. The stock
-            # CLIPViTModel.forward() signature does not accept these kwargs,
-            # so passing them unconditionally breaks CLIP-based test fixtures.
-            vision_kwargs = {}
-            if vision_packed_seq_params is not None:
-                vision_kwargs["packed_seq_params"] = vision_packed_seq_params
-            if imgs_sizes is not None:
-                vision_kwargs["imgs_sizes"] = imgs_sizes
-            image_embeddings = self.vision_model(
-                images, **vision_kwargs
-            )  # [num_tiles, img_seq_len, h_vision]
-
-            if self._drop_vision_class_token:
-                if (
-                    imgs_sizes is not None
-                    and getattr(self.vision_model, 'dynamic_resolution', False)
-                    and self.vision_model.class_token_len > 0
-                ):
-                    # Class tokens are interleaved between tiles; build mask to remove them.
-                    remove_mask = torch.full(
-                        (image_embeddings.shape[-2],),
-                        True,
-                        dtype=torch.bool,
-                        device=image_embeddings.device,
+            if self.temporal_patch_dim > 1 and imgs_sizes is not None and num_frames is None:
+                num_frames = [1] * len(imgs_sizes)
+            use_temporal = self.temporal_patch_dim > 1 and imgs_sizes is not None
+            if use_temporal:
+                if not isinstance(self.vision_model, RADIOViTModel):
+                    raise NotImplementedError(
+                        "Temporal video encoding is currently supported only by RADIOViTModel."
                     )
-                    patch_dim = self.vision_model.patch_dim
-                    if torch.is_tensor(imgs_sizes):
-                        seq_lens = torch.prod(
-                            imgs_sizes.to(device=image_embeddings.device) // patch_dim, dim=-1
+                if isinstance(num_frames, int):
+                    num_frames = [num_frames]
+                elif torch.is_tensor(num_frames):
+                    values = num_frames.tolist()
+                    num_frames = (
+                        [int(values)] if num_frames.ndim == 0 else [int(value) for value in values]
+                    )
+                else:
+                    num_frames = [int(value) for value in num_frames]
+                if any(value <= 0 for value in num_frames):
+                    raise ValueError("num_frames entries must be positive.")
+                if sum(num_frames) != len(imgs_sizes):
+                    raise ValueError(
+                        "num_frames must partition imgs_sizes exactly: "
+                        f"sum(num_frames)={sum(num_frames)}, imgs_sizes={len(imgs_sizes)}."
+                    )
+                media_tubelet_counts = [
+                    1
+                    if frame_count == 1
+                    else (frame_count + self.temporal_patch_dim - 1)
+                    // self.temporal_patch_dim
+                    for frame_count in num_frames
+                ]
+                if self._tile_tags is not None:
+                    raise NotImplementedError(
+                        "Tile tagging is not supported with temporal video inputs."
+                    )
+                num_padded_imgs = 0
+                split_vision_across_cp = (
+                    self.context_parallel_lm > 1
+                    and vision_packed_seq_params is not None
+                    and not self.separate_video_embedder
+                )
+                if split_vision_across_cp:
+                    (
+                        images,
+                        imgs_sizes,
+                        vision_packed_seq_params,
+                        _has_pad_img,
+                        num_padded_imgs,
+                        local_num_frames,
+                    ) = split_to_context_parallel_ranks_dynamic_res(
+                        images,
+                        imgs_sizes,
+                        vision_packed_seq_params,
+                        fp8_enabled=False,
+                        fp8_recipe=getattr(self.config, "fp8_recipe", None),
+                        patch_dim=self.vision_model.patch_dim,
+                        num_frames=num_frames,
+                        temporal_patch_size=self.temporal_patch_dim,
+                    )
+                    if local_num_frames is not None:
+                        num_frames = local_num_frames
+
+                image_embeddings, post_imgs_sizes, _ = self.vision_model(
+                    images,
+                    imgs_sizes=imgs_sizes,
+                    packed_seq_params=vision_packed_seq_params,
+                    num_frames=num_frames,
+                )
+                sizes = (
+                    post_imgs_sizes.tolist()
+                    if torch.is_tensor(post_imgs_sizes)
+                    else list(post_imgs_sizes)
+                )
+                patch_dim = int(self.vision_model.patch_dim)
+                class_token_len = (
+                    self.vision_model.class_token_len
+                    if getattr(self.vision_model, "add_class_token", False)
+                    else 0
+                )
+                sequence_lengths = [
+                    (int(height) // patch_dim) * (int(width) // patch_dim)
+                    + class_token_len
+                    for height, width in sizes
+                ]
+                chunks = list(
+                    torch.split(image_embeddings.squeeze(0), sequence_lengths, dim=0)
+                )
+                if self._drop_vision_class_token and class_token_len > 0:
+                    chunks = [chunk[class_token_len:] for chunk in chunks]
+                if self._pixel_shuffle:
+                    if class_token_len > 0 and not self._drop_vision_class_token:
+                        raise ValueError(
+                            "Temporal pixel shuffle requires dropping vision class tokens."
                         )
-                    else:
-                        seq_lens = torch.tensor(
-                            [(h // patch_dim) * (w // patch_dim) for h, w in imgs_sizes],
+                    chunks = _pixel_shuffle_dynamic_resolution_chunks(
+                        chunks, sizes, patch_dim
+                    )
+                tubelet_token_counts_tensor = torch.tensor(
+                    [chunk.shape[0] for chunk in chunks],
+                    dtype=torch.int,
+                    device=image_embeddings.device,
+                )
+                image_embeddings = torch.cat(chunks, dim=0)
+
+                if split_vision_across_cp:
+                    image_embeddings = gather_from_context_parallel_ranks_dynamic_res(
+                        image_embeddings, num_padded_imgs
+                    )
+                    tubelet_token_counts_tensor = (
+                        gather_from_context_parallel_ranks_dynamic_res(
+                            tubelet_token_counts_tensor, num_padded_imgs
+                        )
+                    )
+
+                is_packed_dynamic_res = True
+                tubelet_token_counts = [
+                    int(value) for value in tubelet_token_counts_tensor.tolist()
+                ]
+                image_embeddings = image_embeddings.unsqueeze(0)
+                placeholder_count = (
+                    int(
+                        (
+                            input_ids
+                            == (
+                                image_token_index
+                                if image_token_index is not None
+                                else self.image_token_index
+                            )
+                        )
+                        .sum()
+                        .item()
+                    )
+                    if torch.is_tensor(input_ids)
+                    else len(tubelet_token_counts)
+                )
+                placeholder_token_counts = _group_temporal_token_counts(
+                    tubelet_token_counts,
+                    media_tubelet_counts,
+                    placeholder_count,
+                )
+                num_image_tiles = torch.tensor(
+                    placeholder_token_counts,
+                    dtype=torch.int,
+                    device=image_embeddings.device,
+                )
+            else:
+                # Stock CLIPViTModel does not accept VLM-specific kwargs.
+                vision_kwargs = {}
+                if vision_packed_seq_params is not None:
+                    vision_kwargs["packed_seq_params"] = vision_packed_seq_params
+                if imgs_sizes is not None:
+                    vision_kwargs["imgs_sizes"] = imgs_sizes
+                image_embeddings = self.vision_model(
+                    images, **vision_kwargs
+                )  # [num_tiles, img_seq_len, h_vision]
+
+                if self._drop_vision_class_token:
+                    if (
+                        imgs_sizes is not None
+                        and getattr(self.vision_model, 'dynamic_resolution', False)
+                        and self.vision_model.class_token_len > 0
+                    ):
+                        # Class tokens are interleaved between tiles; build mask to remove them.
+                        remove_mask = torch.full(
+                            (image_embeddings.shape[-2],),
+                            True,
+                            dtype=torch.bool,
                             device=image_embeddings.device,
                         )
-                    seq_lens = seq_lens.to(torch.long)
-                    class_token_len = self.vision_model.class_token_len
-                    segment_starts = torch.cumsum(
-                        torch.cat([seq_lens.new_zeros(1), seq_lens + class_token_len]), dim=0
-                    )[:-1]
-                    class_offsets = segment_starts.unsqueeze(1) + torch.arange(
-                        class_token_len, device=image_embeddings.device, dtype=seq_lens.dtype
-                    ).unsqueeze(0)
-                    remove_mask[class_offsets.reshape(-1)] = False
-                    image_embeddings = image_embeddings[:, remove_mask, :]
-                else:
-                    image_embeddings = image_embeddings[:, self.vision_model.class_token_len :, :]
+                        patch_dim = self.vision_model.patch_dim
+                        if torch.is_tensor(imgs_sizes):
+                            seq_lens = torch.prod(
+                                imgs_sizes.to(device=image_embeddings.device) // patch_dim, dim=-1
+                            )
+                        else:
+                            seq_lens = torch.tensor(
+                                [(h // patch_dim) * (w // patch_dim) for h, w in imgs_sizes],
+                                device=image_embeddings.device,
+                            )
+                        seq_lens = seq_lens.to(torch.long)
+                        class_token_len = self.vision_model.class_token_len
+                        segment_starts = torch.cumsum(
+                            torch.cat([seq_lens.new_zeros(1), seq_lens + class_token_len]), dim=0
+                        )[:-1]
+                        class_offsets = segment_starts.unsqueeze(1) + torch.arange(
+                            class_token_len,
+                            device=image_embeddings.device,
+                            dtype=seq_lens.dtype,
+                        ).unsqueeze(0)
+                        remove_mask[class_offsets.reshape(-1)] = False
+                        image_embeddings = image_embeddings[:, remove_mask, :]
+                    else:
+                        image_embeddings = image_embeddings[
+                            :, self.vision_model.class_token_len :, :
+                        ]
 
-            if self._pixel_shuffle:
-                if imgs_sizes is not None and getattr(
-                    self.vision_model, 'dynamic_resolution', False
-                ):
-                    image_embeddings = pixel_shuffle_dynamic_res(
-                        image_embeddings, imgs_sizes, self.vision_model.patch_dim
-                    )
-                else:
-                    image_embeddings = pixel_shuffle(
-                        image_embeddings
-                    )  # [num_tiles, img_seq_len_shuffled, h_vision_shuffled]
+                if self._pixel_shuffle:
+                    if imgs_sizes is not None and getattr(
+                        self.vision_model, 'dynamic_resolution', False
+                    ):
+                        image_embeddings = pixel_shuffle_dynamic_res(
+                            image_embeddings, imgs_sizes, self.vision_model.patch_dim
+                        )
+                    else:
+                        image_embeddings = pixel_shuffle(
+                            image_embeddings
+                        )  # [num_tiles, img_seq_len_shuffled, h_vision_shuffled]
 
             # contiguous() required as `permute` can sparsify the tensor and this breaks pipelining
             image_embeddings = image_embeddings.permute(
@@ -1324,7 +1463,14 @@ class LLaVAModel(MegatronModule):
 
         # Assume 1 tile per image if the number of tiles is not provided.
         if num_image_tiles is None and images is not None:
-            num_image_tiles = torch.ones(images.shape[0], dtype=torch.int, device=input_ids.device)
+            num_images = (
+                imgs_sizes.shape[0]
+                if imgs_sizes is not None and self._dynamic_resolution
+                else images.shape[0]
+            )
+            num_image_tiles = torch.ones(
+                num_images, dtype=torch.int, device=input_ids.device
+            )
 
         # if context_parallel_lm == 1:
         #   [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
@@ -1348,6 +1494,7 @@ class LLaVAModel(MegatronModule):
             num_image_tiles,
             imgs_sizes=imgs_sizes,
             position_ids=position_ids,
+            is_packed_dynamic_res=is_packed_dynamic_res,
         )  # [combined_seq_len, b, h_language], [b, combined_seq_len], [b, combined_seq_len]
 
         # Rebuild packed_seq_params to match post-truncation tensor dims.
@@ -1532,6 +1679,61 @@ def _load_state_dict_hook_ignore_extra_state(
 # pylint: disable-next=line-too-long
 # Based on https://github.com/OpenGVLab/InternVL/blob/c7c5af1a8930b4862afe8ed14672307082ef61fa/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py#L218
 # Copyright (c) 2023 OpenGVLab.
+def _pixel_shuffle_dynamic_resolution_chunks(
+    chunks, image_sizes, patch_dim, scale_factor=0.5, version=2
+):
+    """Pixel-shuffle dynamic-resolution chunks using their real patch grids."""
+    assert len(chunks) == len(image_sizes), (
+        "each image chunk requires a matching image size"
+    )
+    shuffled_chunks = []
+    for chunk, (height, width) in zip(chunks, image_sizes):
+        restore_2d = chunk.ndim == 2
+        if restore_2d:
+            chunk = chunk.unsqueeze(0)
+        shuffled = pixel_shuffle(
+            chunk,
+            scale_factor=scale_factor,
+            version=version,
+            h=int(height) // int(patch_dim),
+            w=int(width) // int(patch_dim),
+        )
+        shuffled_chunks.append(shuffled.squeeze(0) if restore_2d else shuffled)
+    return shuffled_chunks
+
+
+def _group_temporal_token_counts(
+    tubelet_token_counts: list[int],
+    media_tubelet_counts: list[int],
+    placeholder_count: int,
+) -> list[int]:
+    """Return token counts for either per-tubelet or per-media placeholders."""
+    if sum(media_tubelet_counts) != len(tubelet_token_counts):
+        raise ValueError(
+            "media_tubelet_counts must partition tubelet_token_counts exactly."
+        )
+    if placeholder_count == len(tubelet_token_counts):
+        return tubelet_token_counts
+    if placeholder_count == len(media_tubelet_counts):
+        media_token_counts = []
+        tubelet_offset = 0
+        for tubelet_count in media_tubelet_counts:
+            media_token_counts.append(
+                sum(
+                    tubelet_token_counts[
+                        tubelet_offset : tubelet_offset + tubelet_count
+                    ]
+                )
+            )
+            tubelet_offset += tubelet_count
+        return media_token_counts
+    raise ValueError(
+        "Temporal media placeholders must match either the number "
+        f"of media items ({len(media_tubelet_counts)}) or tubelets "
+        f"({len(tubelet_token_counts)}); got {placeholder_count}."
+    )
+
+
 def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
     """Pixel shuffle based on InternVL but adapted for our use case.
 
@@ -1546,11 +1748,15 @@ def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
     """
     if h is not None or w is not None:
         assert h is not None and w is not None, "h and w must both be provided"
-        assert h * w == x.shape[1], f"h*w ({h}*{w}={h*w}) must equal patches ({x.shape[1]})"
-        r = int(1 / scale_factor)
-        n, patches, c = x.shape
-        return x.reshape(n, patches // (r * r), c * r * r)
-    h = w = int(x.shape[1] ** 0.5)  # sq
+        assert h * w == x.shape[1], (
+            f"h*w ({h}*{w}={h * w}) must equal patches ({x.shape[1]})"
+        )
+        reduction = int(1 / scale_factor)
+        assert h % reduction == 0 and w % reduction == 0, (
+            f"h and w ({h}, {w}) must both be divisible by {reduction}"
+        )
+    else:
+        h = w = int(x.shape[1] ** 0.5)
     x = x.reshape(x.shape[0], h, w, -1)  # [num_tiles, sq, sq, h_vision]
 
     n, w, h, c = x.size()
@@ -1590,24 +1796,15 @@ def pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim, scale_factor=0.5, versio
     seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
     splits = torch.split(x, seq_lens.tolist(), dim=-2)
 
-    out = []
-    for i, sv in enumerate(splits):
-        h = imgs_sizes[i][0] // patch_dim
-        w = imgs_sizes[i][1] // patch_dim
-        sv = sv.reshape(sv.shape[0], h, w, -1)
-
-        n, h, w, c = sv.size()
-        sv = sv.view(n, h, int(w * scale_factor), int(c / scale_factor))
-        sv = sv.permute(0, 2, 1, 3).contiguous()
-        sv = sv.view(
-            n, int(w * scale_factor), int(h * scale_factor), int(c / (scale_factor * scale_factor))
-        )
-
-        if version == 2:
-            sv = sv.permute(0, 2, 1, 3).contiguous()
-
-        sv = sv.reshape(sv.shape[0], -1, sv.shape[-1])
-        out.append(sv)
-
+    sizes = (
+        imgs_sizes.tolist() if torch.is_tensor(imgs_sizes) else list(imgs_sizes)
+    )
+    out = _pixel_shuffle_dynamic_resolution_chunks(
+        splits,
+        sizes,
+        patch_dim,
+        scale_factor=scale_factor,
+        version=version,
+    )
     x = torch.cat(out, dim=-2)
     return x

--- a/megatron/rl/inference/megatron.py
+++ b/megatron/rl/inference/megatron.py
@@ -158,6 +158,9 @@ class MegatronLocal(InferenceServer, ReturnsTokens, ReturnsRaw):
                 server_port=kwargs.get('port', 8294),
                 parsers=args.rl_inference_parsers,
                 verbose=kwargs.get('verbose', False),
+                multimodal_prompt_config=(
+                    inference_engine.controller.inference_wrapped_model.get_multimodal_prompt_config()
+                ),
             )
         else:
             client = None

--- a/megatron/rl/inference/megatron.py
+++ b/megatron/rl/inference/megatron.py
@@ -159,7 +159,7 @@ class MegatronLocal(InferenceServer, ReturnsTokens, ReturnsRaw):
                 parsers=args.rl_inference_parsers,
                 verbose=kwargs.get('verbose', False),
                 multimodal_prompt_config=(
-                    inference_engine.controller.inference_wrapped_model.get_multimodal_prompt_config()
+                    inference_engine.controller.inference_wrapped_model.multimodal_prompt_config
                 ),
             )
         else:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2219,6 +2219,23 @@ def _add_inference_args(parser):
                        'score = alpha * match + (1 - alpha) * normalized_load. '
                        'Higher alpha favors prefix cache hits; lower alpha '
                        'favors load balance. Default: 0.5.')
+    group.add_argument('--inference-dynamic-batching-media-cache-coordinator-policy',
+                       type=str, default='affinity',
+                       choices=['affinity', 'load_balanced'],
+                       dest='inference_dynamic_batching_media_cache_coordinator_policy',
+                       help='Coordinator routing policy for media caching. '
+                       '"affinity" prefers a rank assigned the same media; '
+                       '"load_balanced" ignores standalone media affinity.')
+    group.add_argument('--inference-dynamic-batching-media-cache-routing-weight',
+                       type=float, default=1.0,
+                       dest='inference_dynamic_batching_media_cache_routing_weight',
+                       help='Media-cache hit weight in equivalent compact-prompt blocks. '
+                       'Default: 1.0.')
+    group.add_argument('--inference-dynamic-batching-vision-embedding-cache-max-bytes',
+                       type=int, default=0,
+                       dest='inference_dynamic_batching_vision_embedding_cache_max_bytes',
+                       help='Maximum GPU bytes retained per engine for reusable vision '
+                       'embeddings. Zero disables the cache. Default: 0.')
     group.add_argument('--inference-dynamic-batching-prefix-caching-mamba-gb',
                        type=float, default=None,
                        dest='inference_dynamic_batching_prefix_caching_mamba_gb',

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2236,10 +2236,10 @@ def _add_inference_args(parser):
                        dest='inference_dynamic_batching_vision_embedding_cache_max_bytes',
                        help='Maximum GPU bytes retained per engine for reusable vision '
                        'embeddings. Zero disables the cache. Default: 0.')
-    group.add_argument('--inference-dynamic-batching-allow-stale-vision-embeddings',
+    group.add_argument('--inference-dynamic-batching-allow-stale-multimodal-embeddings',
                        action='store_true',
-                       dest='inference_dynamic_batching_allow_stale_vision_embeddings',
-                       help='Allow request-local and cached vision embeddings to survive '
+                       dest='inference_dynamic_batching_allow_stale_multimodal_embeddings',
+                       help='Allow request-local and cached multimodal embeddings to survive '
                        'suspend/resume and generation-epoch changes. Use only when model '
                        'weights do not change across these boundaries.')
     group.add_argument('--inference-dynamic-batching-prefix-caching-mamba-gb',

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2236,6 +2236,12 @@ def _add_inference_args(parser):
                        dest='inference_dynamic_batching_vision_embedding_cache_max_bytes',
                        help='Maximum GPU bytes retained per engine for reusable vision '
                        'embeddings. Zero disables the cache. Default: 0.')
+    group.add_argument('--inference-dynamic-batching-allow-stale-vision-embeddings',
+                       action='store_true',
+                       dest='inference_dynamic_batching_allow_stale_vision_embeddings',
+                       help='Allow request-local and cached vision embeddings to survive '
+                       'suspend/resume and generation-epoch changes. Use only when model '
+                       'weights do not change across these boundaries.')
     group.add_argument('--inference-dynamic-batching-prefix-caching-mamba-gb',
                        type=float, default=None,
                        dest='inference_dynamic_batching_prefix_caching_mamba_gb',

--- a/megatron/training/config/inference_config.py
+++ b/megatron/training/config/inference_config.py
@@ -262,6 +262,9 @@ class InferenceSetupConfig:
     use_flashinfer_fused_rope: bool = False
     """Use flashinfer's fused rope implementation. Mirrors ``--use-flashinfer-fused-rope``."""
 
+    inference_dynamic_batching_allow_stale_vision_embeddings: bool = False
+    """Allow request-local and cached vision embeddings across weight-change boundaries."""
+
     def to_inference_config(
         self,
         model: "MegatronModule",
@@ -389,6 +392,9 @@ class InferenceSetupConfig:
             media_cache_routing_weight=self.inference_dynamic_batching_media_cache_routing_weight,
             vision_embedding_cache_max_bytes=(
                 self.inference_dynamic_batching_vision_embedding_cache_max_bytes
+            ),
+            allow_stale_vision_embeddings=(
+                self.inference_dynamic_batching_allow_stale_vision_embeddings
             ),
             prefix_caching_mamba_gb=self.inference_dynamic_batching_prefix_caching_mamba_gb,
             metrics_writer=metrics_writer,

--- a/megatron/training/config/inference_config.py
+++ b/megatron/training/config/inference_config.py
@@ -262,8 +262,8 @@ class InferenceSetupConfig:
     use_flashinfer_fused_rope: bool = False
     """Use flashinfer's fused rope implementation. Mirrors ``--use-flashinfer-fused-rope``."""
 
-    inference_dynamic_batching_allow_stale_vision_embeddings: bool = False
-    """Allow request-local and cached vision embeddings across weight-change boundaries."""
+    inference_dynamic_batching_allow_stale_multimodal_embeddings: bool = False
+    """Allow request-local and cached multimodal embeddings across weight-change boundaries."""
 
     def to_inference_config(
         self,
@@ -393,8 +393,8 @@ class InferenceSetupConfig:
             vision_embedding_cache_max_bytes=(
                 self.inference_dynamic_batching_vision_embedding_cache_max_bytes
             ),
-            allow_stale_vision_embeddings=(
-                self.inference_dynamic_batching_allow_stale_vision_embeddings
+            allow_stale_multimodal_embeddings=(
+                self.inference_dynamic_batching_allow_stale_multimodal_embeddings
             ),
             prefix_caching_mamba_gb=self.inference_dynamic_batching_prefix_caching_mamba_gb,
             metrics_writer=metrics_writer,

--- a/megatron/training/config/inference_config.py
+++ b/megatron/training/config/inference_config.py
@@ -198,6 +198,17 @@ class InferenceSetupConfig:
     """Weight for prefix-aware routing score: score = alpha * match + (1 - alpha) * normalized_load.
     Higher alpha favors prefix cache hits; lower alpha favors load balance."""
 
+    inference_dynamic_batching_media_cache_coordinator_policy: Literal[
+        "affinity", "load_balanced"
+    ] = "affinity"
+    """Coordinator routing policy for media caching."""
+
+    inference_dynamic_batching_media_cache_routing_weight: float = 1.0
+    """Media-cache hit weight in equivalent compact-prompt blocks."""
+
+    inference_dynamic_batching_vision_embedding_cache_max_bytes: int = 0
+    """Maximum GPU bytes retained per engine for reusable vision embeddings."""
+
     inference_dynamic_batching_prefix_caching_mamba_gb: float | None = None
     """GPU memory budget (in GB) for the Mamba state cache used by prefix caching on hybrid models.
     When set, Mamba states at block boundaries are cached for reuse."""
@@ -296,6 +307,7 @@ class InferenceSetupConfig:
             InferenceConfig,
             KVCacheManagementMode,
             MambaInferenceStateConfig,
+            MediaCacheCoordinatorPolicy,
             PrefixCachingCoordinatorPolicy,
             PrefixCachingEvictionPolicy,
         )
@@ -371,6 +383,13 @@ class InferenceSetupConfig:
                 self.inference_dynamic_batching_prefix_caching_coordinator_policy
             ),
             prefix_caching_routing_alpha=self.inference_dynamic_batching_prefix_caching_routing_alpha,
+            media_cache_coordinator_policy=MediaCacheCoordinatorPolicy(
+                self.inference_dynamic_batching_media_cache_coordinator_policy
+            ),
+            media_cache_routing_weight=self.inference_dynamic_batching_media_cache_routing_weight,
+            vision_embedding_cache_max_bytes=(
+                self.inference_dynamic_batching_vision_embedding_cache_max_bytes
+            ),
             prefix_caching_mamba_gb=self.inference_dynamic_batching_prefix_caching_mamba_gb,
             metrics_writer=metrics_writer,
             logging_step_interval=self.inference_logging_step_interval,

--- a/tests/unit_tests/inference/contexts/test_kv_event_publication.py
+++ b/tests/unit_tests/inference/contexts/test_kv_event_publication.py
@@ -111,6 +111,8 @@ def test_suspend_clears_only_recomputed_cache(cache_mode, expect_clear):
     engine.requests = {}
     engine.waiting_request_ids = deque()
     engine.use_coordinator = False
+    engine._vision_embedding_cache = {}
+    engine._vision_embedding_cache_bytes = 0
 
     with (
         mock.patch.object(DynamicInferenceEngine, "suspend_resume_ctx", return_value=nullcontext()),

--- a/tests/unit_tests/inference/coordinator_test_utils.py
+++ b/tests/unit_tests/inference/coordinator_test_utils.py
@@ -3,11 +3,14 @@
 """Shared test fixtures and helpers for inference tests."""
 
 import itertools
-from collections import deque
+from collections import OrderedDict, deque
 
 import numpy as np
 
-from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
+from megatron.core.inference.config import (
+    MediaCacheCoordinatorPolicy,
+    PrefixCachingCoordinatorPolicy,
+)
 from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
@@ -21,6 +24,8 @@ def make_coordinator_direct(
     prefix_caching_routing_alpha=0.5,
     max_requests=10,
     policy=PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+    media_policy=MediaCacheCoordinatorPolicy.AFFINITY,
+    vision_embedding_cache_enabled=True,
     tokenizer=None,
     rank_name_template="rank_{}",
 ):
@@ -36,6 +41,8 @@ def make_coordinator_direct(
         prefix_caching_routing_alpha: Alpha for prefix-aware scoring.
         max_requests: Max requests per rank (None disables vectorized scoring).
         policy: Prefix caching coordinator routing policy.
+        media_policy: Media-cache coordinator routing policy.
+        vision_embedding_cache_enabled: Whether projected media embeddings are cached.
         tokenizer: Optional tokenizer instance (set on the coordinator).
         rank_name_template: Format string for rank names, e.g. ``"rank_{}"``
             or ``"rank-{}"``.  The integer rank index is substituted.
@@ -47,6 +54,9 @@ def make_coordinator_direct(
     coordinator.enable_prefix_caching = enable_prefix_caching
     coordinator.prefix_caching_coordinator_policy = policy
     coordinator.prefix_caching_routing_alpha = prefix_caching_routing_alpha
+    coordinator.media_cache_coordinator_policy = media_policy
+    coordinator.media_cache_routing_weight = 1.0
+    coordinator.vision_embedding_cache_enabled = vision_embedding_cache_enabled
     coordinator.max_requests = max_requests
 
     # Create fake rank identities.
@@ -65,6 +75,8 @@ def make_coordinator_direct(
     n_ranks = data_parallel_size
     coordinator._hash_table = {}
     coordinator._hash_assignment_counter = 0
+    coordinator._media_cache_affinity = OrderedDict()
+    coordinator._media_cache_affinity_max_entries = 65536
 
     sorted_identities = sorted(coordinator.identities_of_data_parallel_ranks)
     coordinator.identity_to_rank_index = {

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -89,6 +89,93 @@ except ImportError:
     HAVE_GDP_DEPS = False
 
 
+def _build_mock_vlm_engine(image_embeddings):
+    engine = object.__new__(DynamicInferenceEngine)
+    wrapper = mock.Mock()
+    wrapper._forward_vision_encoder.return_value = image_embeddings
+    controller = mock.Mock()
+    controller.pp_group = None
+    controller.inference_wrapped_model = wrapper
+    engine.controller = controller
+    engine.context = mock.Mock(
+        block_size_tokens=256,
+        enable_prefix_caching=False,
+    )
+    engine._get_cached_vision_embedding = mock.Mock(return_value=None)
+    engine._cache_vision_embedding = mock.Mock()
+    engine._resolve_image_token_id = mock.Mock(return_value=99)
+    return engine, wrapper
+
+
+def _call_build_vlm_request(engine, tokens, *, media_tokens_preexpanded):
+    with mock.patch.object(
+        torch.cuda, "current_device", return_value=torch.device("cpu")
+    ):
+        return engine._build_vlm_request(
+            request_id=1,
+            prompt_str=None,
+            tokens=tokens,
+            sampling_params=SamplingParams(
+                num_tokens_to_generate=1, termination_id=0
+            ),
+            imgs=torch.ones(1, 2, 4),
+            num_tiles=None,
+            num_img_embeddings_per_tile=0,
+            imgs_sizes=torch.tensor([[2, 2]]),
+            media_tokens_preexpanded=media_tokens_preexpanded,
+        )
+
+
+def test_build_vlm_request_preserves_preexpanded_tokens_and_derives_mask():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
+    tokens = torch.tensor([10, 99, 99, 20], dtype=torch.int64)
+    wrapper.build_preexpanded_media_token_mask.return_value = torch.tensor(
+        [-1, 0, 1, -1], dtype=torch.int64
+    )
+
+    request = _call_build_vlm_request(
+        engine, tokens, media_tokens_preexpanded=True
+    )
+
+    assert torch.equal(request.prompt_tokens, tokens)
+    assert request.compact_prompt_tokens is None
+    assert request.image_token_mask.tolist() == [-1, 0, 1, -1]
+    wrapper.expand_image_tokens.assert_not_called()
+    wrapper.build_preexpanded_media_token_mask.assert_called_once_with(tokens, "image")
+
+
+def test_build_vlm_request_rejects_preexpanded_embedding_count_mismatch():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(1, 4))
+    wrapper.build_preexpanded_media_token_mask.return_value = torch.tensor(
+        [-1, 0, 1, -1], dtype=torch.int64
+    )
+
+    with pytest.raises(ValueError, match="2 media-token position.*1 embedding"):
+        _call_build_vlm_request(
+            engine,
+            torch.tensor([10, 99, 99, 20], dtype=torch.int64),
+            media_tokens_preexpanded=True,
+        )
+
+
+def test_build_vlm_request_keeps_compact_expansion_path():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
+    compact_tokens = torch.tensor([10, 42, 20], dtype=torch.int64)
+    wrapper.expand_image_tokens.return_value = (
+        [[10, -1, -1, 20]],
+        [[None, 0, 1, None]],
+    )
+
+    request = _call_build_vlm_request(
+        engine, compact_tokens, media_tokens_preexpanded=False
+    )
+
+    wrapper.expand_image_tokens.assert_called_once()
+    assert request.prompt_tokens.tolist() == [10, 99, 99, 20]
+    assert torch.equal(request.compact_prompt_tokens, compact_tokens)
+    assert request.image_token_mask.tolist() == [-1, 0, 1, -1]
+
+
 def skip_if_mamba_sequence_packing_not_available(model_provider: str, ssm_mixer: str = "mamba"):
     if model_provider != "hybrid":
         return

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -90,10 +90,48 @@ except ImportError:
     HAVE_GDP_DEPS = False
 
 
+class _ImageOnlyCapabilityWrapper:
+    supports_text = True
+    supports_image = True
+    supports_video = False
+    supports_audio = False
+    validate_input_modalities = GPTInferenceWrapper.validate_input_modalities
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "modality"),
+    [
+        ({"imgs": torch.ones(1)}, "image"),
+        ({"imgs": torch.ones(1), "num_frames": torch.ones(1, dtype=torch.int64)}, "video"),
+    ],
+)
+def test_add_request_rejects_unsupported_media_before_tokenization(kwargs, modality):
+    engine = object.__new__(DynamicInferenceEngine)
+    wrapper = _ImageOnlyCapabilityWrapper()
+    if modality == "image":
+        wrapper.supports_image = False
+    engine.controller = mock.Mock(inference_wrapped_model=wrapper)
+
+    with pytest.raises(
+        ValueError, match=rf"_ImageOnlyCapabilityWrapper does not support {modality} inputs"
+    ):
+        engine.add_request(request_id=1, prompt=[1], **kwargs)
+
+    engine.controller.tokenize_prompt.assert_not_called()
+
+
+def test_validate_input_modalities_rejects_unsupported_audio():
+    wrapper = _ImageOnlyCapabilityWrapper()
+
+    with pytest.raises(ValueError, match="does not support audio inputs"):
+        wrapper.validate_input_modalities("audio")
+
+
 def _build_mock_vlm_engine(image_embeddings):
     engine = object.__new__(DynamicInferenceEngine)
     wrapper = mock.Mock()
     wrapper._forward_vision_encoder.return_value = image_embeddings
+    wrapper.resolve_media_token_id.return_value = 99
     controller = mock.Mock()
     controller.pp_group = None
     controller.inference_wrapped_model = wrapper
@@ -101,7 +139,6 @@ def _build_mock_vlm_engine(image_embeddings):
     engine.context = mock.Mock(block_size_tokens=256, enable_prefix_caching=False)
     engine._get_cached_vision_embedding = mock.Mock(return_value=None)
     engine._cache_vision_embedding = mock.Mock()
-    engine._resolve_image_token_id = mock.Mock(return_value=99)
     return engine, wrapper
 
 
@@ -120,6 +157,44 @@ def _call_build_vlm_request(engine, tokens, *, media_tokens_preexpanded):
         )
 
 
+@pytest.mark.parametrize(
+    ("media_kwargs", "error"),
+    [
+        (
+            {"num_frames": torch.tensor([2])},
+            "Video input requires imgs, imgs_sizes, and num_frames",
+        ),
+        (
+            {"imgs_sizes": torch.tensor([[2, 2]])},
+            "Dynamic-resolution image input requires imgs and imgs_sizes",
+        ),
+        (
+            {"imgs": torch.ones(1, 2, 4), "num_tiles": torch.tensor([1])},
+            "Static-tiling image input requires imgs, num_tiles",
+        ),
+    ],
+)
+def test_build_vlm_request_rejects_incomplete_media(media_kwargs, error):
+    engine, _ = _build_mock_vlm_engine(torch.ones(2, 4))
+    kwargs = {
+        "imgs": None,
+        "num_tiles": None,
+        "num_img_embeddings_per_tile": 0,
+        "imgs_sizes": None,
+        "num_frames": None,
+    }
+    kwargs.update(media_kwargs)
+
+    with pytest.raises(ValueError, match=error):
+        engine._build_vlm_request(
+            request_id=1,
+            prompt_str=None,
+            tokens=torch.tensor([10, 20], dtype=torch.int64),
+            sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=0),
+            **kwargs,
+        )
+
+
 def test_build_vlm_request_preserves_preexpanded_tokens_and_derives_mask():
     engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
     tokens = torch.tensor([10, 99, 99, 20], dtype=torch.int64)
@@ -133,6 +208,7 @@ def test_build_vlm_request_preserves_preexpanded_tokens_and_derives_mask():
     assert request.compact_prompt_tokens is None
     assert request.image_token_mask.tolist() == [-1, 0, 1, -1]
     wrapper.expand_image_tokens.assert_not_called()
+    wrapper.resolve_media_token_id.assert_not_called()
     wrapper.build_preexpanded_media_token_mask.assert_called_once_with(tokens, "image")
 
 
@@ -148,6 +224,21 @@ def test_build_vlm_request_rejects_preexpanded_embedding_count_mismatch():
         )
 
 
+def test_build_vlm_request_validates_cached_embedding_count_once():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
+    engine._get_cached_vision_embedding.return_value = torch.ones(1, 4)
+    wrapper.build_preexpanded_media_token_mask.return_value = torch.tensor(
+        [-1, 0, 1, -1], dtype=torch.int64
+    )
+
+    with pytest.raises(ValueError, match="2 media-token position.*1 embedding"):
+        _call_build_vlm_request(
+            engine, torch.tensor([10, 99, 99, 20], dtype=torch.int64), media_tokens_preexpanded=True
+        )
+
+    wrapper._forward_vision_encoder.assert_not_called()
+
+
 def test_build_vlm_request_keeps_compact_expansion_path():
     engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
     compact_tokens = torch.tensor([10, 42, 20], dtype=torch.int64)
@@ -156,9 +247,27 @@ def test_build_vlm_request_keeps_compact_expansion_path():
     request = _call_build_vlm_request(engine, compact_tokens, media_tokens_preexpanded=False)
 
     wrapper.expand_image_tokens.assert_called_once()
+    encoder_args, encoder_kwargs = wrapper._forward_vision_encoder.call_args
+    assert torch.equal(encoder_args[0], torch.ones(1, 2, 4))
+    assert encoder_kwargs["num_image_tiles"] is None
+    assert torch.equal(encoder_kwargs["imgs_sizes"], torch.tensor([[2, 2]]))
     assert request.prompt_tokens.tolist() == [10, 99, 99, 20]
     assert torch.equal(request.compact_prompt_tokens, compact_tokens)
     assert request.image_token_mask.tolist() == [-1, 0, 1, -1]
+
+
+def test_build_vlm_request_preserves_adjacent_compact_media_placeholders():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
+    compact_tokens = torch.tensor([10, 42, 42, 20], dtype=torch.int64)
+    # The expanded sequence is structurally ambiguous: it could also represent
+    # one placeholder expanded to two positions. The saved compact prompt is
+    # therefore required for lossless multi-turn reconstruction.
+    wrapper.expand_image_tokens.return_value = ([[10, -1, -1, 20]], [[None, 0, 1, None]])
+
+    request = _call_build_vlm_request(engine, compact_tokens, media_tokens_preexpanded=False)
+
+    assert request.prompt_tokens.tolist() == [10, 99, 99, 20]
+    assert torch.equal(request.compact_prompt_tokens, compact_tokens)
 
 
 def test_build_vlm_request_enables_media_salted_prefix_caching():

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -41,6 +41,7 @@ from megatron.core.inference.inference_request import (
     DynamicInferenceRequestRecord,
     Status,
     compute_block_hashes_batched,
+    compute_media_cache_key,
 )
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
@@ -97,10 +98,7 @@ def _build_mock_vlm_engine(image_embeddings):
     controller.pp_group = None
     controller.inference_wrapped_model = wrapper
     engine.controller = controller
-    engine.context = mock.Mock(
-        block_size_tokens=256,
-        enable_prefix_caching=False,
-    )
+    engine.context = mock.Mock(block_size_tokens=256, enable_prefix_caching=False)
     engine._get_cached_vision_embedding = mock.Mock(return_value=None)
     engine._cache_vision_embedding = mock.Mock()
     engine._resolve_image_token_id = mock.Mock(return_value=99)
@@ -108,16 +106,12 @@ def _build_mock_vlm_engine(image_embeddings):
 
 
 def _call_build_vlm_request(engine, tokens, *, media_tokens_preexpanded):
-    with mock.patch.object(
-        torch.cuda, "current_device", return_value=torch.device("cpu")
-    ):
+    with mock.patch.object(torch.cuda, "current_device", return_value=torch.device("cpu")):
         return engine._build_vlm_request(
             request_id=1,
             prompt_str=None,
             tokens=tokens,
-            sampling_params=SamplingParams(
-                num_tokens_to_generate=1, termination_id=0
-            ),
+            sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=0),
             imgs=torch.ones(1, 2, 4),
             num_tiles=None,
             num_img_embeddings_per_tile=0,
@@ -133,9 +127,7 @@ def test_build_vlm_request_preserves_preexpanded_tokens_and_derives_mask():
         [-1, 0, 1, -1], dtype=torch.int64
     )
 
-    request = _call_build_vlm_request(
-        engine, tokens, media_tokens_preexpanded=True
-    )
+    request = _call_build_vlm_request(engine, tokens, media_tokens_preexpanded=True)
 
     assert torch.equal(request.prompt_tokens, tokens)
     assert request.compact_prompt_tokens is None
@@ -152,28 +144,41 @@ def test_build_vlm_request_rejects_preexpanded_embedding_count_mismatch():
 
     with pytest.raises(ValueError, match="2 media-token position.*1 embedding"):
         _call_build_vlm_request(
-            engine,
-            torch.tensor([10, 99, 99, 20], dtype=torch.int64),
-            media_tokens_preexpanded=True,
+            engine, torch.tensor([10, 99, 99, 20], dtype=torch.int64), media_tokens_preexpanded=True
         )
 
 
 def test_build_vlm_request_keeps_compact_expansion_path():
     engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
     compact_tokens = torch.tensor([10, 42, 20], dtype=torch.int64)
-    wrapper.expand_image_tokens.return_value = (
-        [[10, -1, -1, 20]],
-        [[None, 0, 1, None]],
-    )
+    wrapper.expand_image_tokens.return_value = ([[10, -1, -1, 20]], [[None, 0, 1, None]])
 
-    request = _call_build_vlm_request(
-        engine, compact_tokens, media_tokens_preexpanded=False
-    )
+    request = _call_build_vlm_request(engine, compact_tokens, media_tokens_preexpanded=False)
 
     wrapper.expand_image_tokens.assert_called_once()
     assert request.prompt_tokens.tolist() == [10, 99, 99, 20]
     assert torch.equal(request.compact_prompt_tokens, compact_tokens)
     assert request.image_token_mask.tolist() == [-1, 0, 1, -1]
+
+
+def test_build_vlm_request_enables_media_salted_prefix_caching():
+    engine, wrapper = _build_mock_vlm_engine(torch.ones(2, 4))
+    engine.context.enable_prefix_caching = True
+    engine.context.block_size_tokens = 2
+    wrapper.expand_image_tokens.return_value = ([[10, -1, -1, 20]], [[None, 0, 1, None]])
+
+    request = _call_build_vlm_request(
+        engine, torch.tensor([10, 42, 20], dtype=torch.int64), media_tokens_preexpanded=False
+    )
+
+    media_cache_key = compute_media_cache_key(
+        "image", {"imgs": torch.ones(1, 2, 4), "imgs_sizes": torch.tensor([[2, 2]])}
+    )
+    assert request.enable_prefix_caching
+    assert request.block_hash_salt == media_cache_key
+    assert request.precomputed_block_hashes == compute_block_hashes_batched(
+        request.prompt_tokens, block_size=2, cache_salt=media_cache_key
+    )
 
 
 def skip_if_mamba_sequence_packing_not_available(model_provider: str, ssm_mixer: str = "mamba"):

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -39,6 +39,7 @@ from megatron.core.inference.engines.dynamic_engine import EngineState
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
     DynamicInferenceRequestRecord,
+    DynamicVLMInferenceRequest,
     Status,
     compute_block_hashes_batched,
     compute_media_cache_key,
@@ -982,6 +983,8 @@ def test_recompute_suspend_resume_readds_prefix_cached_request_with_fresh_hashes
     engine.state = EngineState.RUNNING
     engine.unified_memory_level = 0
     engine.use_coordinator = False
+    engine._vision_embedding_cache = {}
+    engine._vision_embedding_cache_bytes = 0
     engine._add_request = mock.Mock()
     engine._notify_cond_for_new_request = mock.Mock(return_value=None)
     engine._loop = types.SimpleNamespace(call_soon_threadsafe=mock.Mock())
@@ -1007,6 +1010,87 @@ def test_recompute_suspend_resume_readds_prefix_cached_request_with_fresh_hashes
     assert engine.state == EngineState.RUNNING
     assert engine._add_request.call_count == 1
     assert engine._add_request.call_args.args[0] is checkpointed
+
+
+def test_vision_state_invalidation_marks_request_local_embeddings_stale():
+    request = DynamicVLMInferenceRequest(
+        request_id=31,
+        prompt_tokens=torch.tensor([99, 99, 5]),
+        compact_prompt_tokens=torch.tensor([99, 5]),
+        sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=-1),
+        num_img_embeddings_per_tile=0,
+        imgs=torch.ones(1),
+        num_tiles=torch.tensor([1]),
+        imgs_sizes=torch.tensor([[1, 1]]),
+        decoder_seq_length=0,
+        image_embeddings=torch.ones(2, 1, 4),
+        image_token_mask=torch.tensor([0, 1, -1]),
+    )
+    engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
+    engine.allow_stale_vision_embeddings = False
+    engine._vision_embedding_cache = {"media": request.image_embeddings}
+    engine._vision_embedding_cache_bytes = request.image_embeddings.numel() * 4
+    engine.requests = {
+        request.request_id: types.SimpleNamespace(
+            record=DynamicInferenceRequestRecord.from_request(request)
+        )
+    }
+
+    engine._invalidate_vision_state()
+
+    assert not engine._vision_embedding_cache
+    assert engine._vision_embedding_cache_bytes == 0
+    assert request.image_embeddings is None
+    assert request.image_token_mask is None
+
+
+def test_vision_state_invalidation_can_explicitly_retain_stale_embeddings():
+    engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
+    engine.allow_stale_vision_embeddings = True
+    engine._vision_embedding_cache = {"media": torch.ones(1)}
+    engine._vision_embedding_cache_bytes = 4
+    engine.requests = {}
+
+    engine._invalidate_vision_state()
+
+    assert "media" in engine._vision_embedding_cache
+    assert engine._vision_embedding_cache_bytes == 4
+
+
+def test_refresh_vlm_request_recomputes_embeddings_and_mask():
+    request = DynamicVLMInferenceRequest(
+        request_id=32,
+        prompt_tokens=torch.tensor([99, 99, 5, 7]),
+        compact_prompt_tokens=torch.tensor([99, 5]),
+        sampling_params=SamplingParams(num_tokens_to_generate=1, termination_id=-1),
+        block_hash_salt="media",
+        num_img_embeddings_per_tile=0,
+        imgs=torch.ones(1),
+        num_tiles=torch.tensor([1]),
+        imgs_sizes=torch.tensor([[1, 1]]),
+        decoder_seq_length=0,
+        image_embeddings=None,
+        image_token_mask=None,
+    )
+    wrapper = types.SimpleNamespace(
+        resolve_media_token_id=mock.Mock(return_value=99),
+        expand_image_tokens=mock.Mock(return_value=([[99, 99, 5]], [[0, 1, None]])),
+        _forward_vision_encoder=mock.Mock(return_value=torch.ones(2, 1, 4)),
+    )
+    engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
+    engine.controller = types.SimpleNamespace(inference_wrapped_model=wrapper, tokenizer=object())
+    engine.context = types.SimpleNamespace(add_vlm_request_data=mock.Mock())
+    engine._cache_vision_embedding = mock.Mock()
+
+    engine._refresh_vlm_request_data(request)
+
+    assert request.image_embeddings is wrapper._forward_vision_encoder.return_value
+    assert request.image_token_mask.tolist() == [0, 1, -1, -1]
+    engine.context.add_vlm_request_data.assert_called_once_with(
+        request.request_id,
+        image_embeddings=request.image_embeddings,
+        image_token_mask=request.image_token_mask,
+    )
 
 
 def test_streaming_partials_are_sent():

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -1027,7 +1027,7 @@ def test_vision_state_invalidation_marks_request_local_embeddings_stale():
         image_token_mask=torch.tensor([0, 1, -1]),
     )
     engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
-    engine.allow_stale_vision_embeddings = False
+    engine.allow_stale_multimodal_embeddings = False
     engine._vision_embedding_cache = {"media": request.image_embeddings}
     engine._vision_embedding_cache_bytes = request.image_embeddings.numel() * 4
     engine.requests = {
@@ -1046,7 +1046,7 @@ def test_vision_state_invalidation_marks_request_local_embeddings_stale():
 
 def test_vision_state_invalidation_can_explicitly_retain_stale_embeddings():
     engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
-    engine.allow_stale_vision_embeddings = True
+    engine.allow_stale_multimodal_embeddings = True
     engine._vision_embedding_cache = {"media": torch.ones(1)}
     engine._vision_embedding_cache_bytes = 4
     engine.requests = {}

--- a/tests/unit_tests/inference/model_inference_wrappers/test_abstract_model_inference_wrapper.py
+++ b/tests/unit_tests/inference/model_inference_wrappers/test_abstract_model_inference_wrapper.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
+from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
+    GPTInferenceWrapper,
+)
+
+
+def _wrapper(prompt_config=None):
+    wrapper = object.__new__(GPTInferenceWrapper)
+    wrapper.multimodal_prompt_config = prompt_config
+    return wrapper
+
+
+def test_validate_input_modalities_accepts_declared_capabilities_and_rejects_others():
+    wrapper = _wrapper()
+    wrapper.supports_image = True
+
+    wrapper.validate_input_modalities("text", "image")
+
+    with pytest.raises(ValueError, match="does not support video inputs"):
+        wrapper.validate_input_modalities("video")
+    with pytest.raises(ValueError, match="Unknown input modality"):
+        wrapper.validate_input_modalities("depth")
+
+
+def test_resolve_media_token_id_uses_nested_tokenizer_and_list_conversion_fallback():
+    class _Tokenizer:
+        unk_token_id = 0
+
+        def convert_tokens_to_ids(self, tokens):
+            if isinstance(tokens, str):
+                raise TypeError("this tokenizer requires a list")
+            return [42]
+
+    wrapper = _wrapper(MultimodalPromptConfig(image_spec=MediaPromptSpec(model_token="<image>")))
+    tokenizer = SimpleNamespace(_tokenizer=SimpleNamespace(tokenizer=_Tokenizer()))
+
+    assert wrapper.resolve_media_token_id(tokenizer, "image") == 42
+
+
+def test_resolve_media_token_id_ignores_unknown_id_and_uses_tensor_encode_fallback():
+    tokenizer = SimpleNamespace(
+        unk_token_id=0,
+        convert_tokens_to_ids=lambda _token: 0,
+        encode=lambda _token, add_special_tokens=False: torch.tensor([57]),
+    )
+    wrapper = _wrapper(MultimodalPromptConfig(video_spec=MediaPromptSpec(model_token="<video>")))
+
+    assert wrapper.resolve_media_token_id(tokenizer, "video") == 57
+
+
+@pytest.mark.parametrize(
+    ("prompt_config", "tokenizer", "error"),
+    [
+        (None, SimpleNamespace(), "does not define a multimodal prompt contract"),
+        (
+            MultimodalPromptConfig(image_spec=MediaPromptSpec(model_token="")),
+            SimpleNamespace(),
+            "does not define a model token",
+        ),
+        (
+            MultimodalPromptConfig(image_spec=MediaPromptSpec(model_token="<image>")),
+            SimpleNamespace(
+                encode=lambda _token, add_special_tokens=False: [1, 2],
+                tokenize=lambda _token: [1, 2],
+            ),
+            "does not define '<image>' as one nonnegative token",
+        ),
+    ],
+)
+def test_resolve_media_token_id_rejects_missing_or_ambiguous_contracts(
+    prompt_config, tokenizer, error
+):
+    with pytest.raises(ValueError, match=error):
+        _wrapper(prompt_config).resolve_media_token_id(tokenizer, "image")
+
+
+def test_build_preexpanded_media_token_mask_numbers_only_media_positions():
+    wrapper = _wrapper()
+    wrapper.get_preexpanded_media_token_id = lambda modality: -200
+    prompt_tokens = torch.tensor([10, -200, 20, -200, -200], dtype=torch.int32)
+
+    mask = wrapper.build_preexpanded_media_token_mask(prompt_tokens, "image")
+
+    assert mask.dtype == torch.int64
+    assert mask.tolist() == [-1, 0, -1, 1, 2]
+
+
+def test_build_preexpanded_media_token_mask_handles_text_only_prompt():
+    wrapper = _wrapper()
+    wrapper.get_preexpanded_media_token_id = lambda modality: -200
+
+    mask = wrapper.build_preexpanded_media_token_mask(torch.tensor([10, 20, 30]), "video")
+
+    assert mask.tolist() == [-1, -1, -1]
+
+
+def test_base_preexpanded_media_token_id_requires_model_specific_implementation():
+    wrapper = _wrapper()
+
+    with pytest.raises(NotImplementedError, match="pre-expanded video token id"):
+        wrapper.get_preexpanded_media_token_id("video")

--- a/tests/unit_tests/inference/test_chat_completions.py
+++ b/tests/unit_tests/inference/test_chat_completions.py
@@ -28,7 +28,8 @@ def test_extract_media_data_url_rejects_decoded_payload_over_limit():
         _extract_media_url_bytes(url, max_bytes=4)
 
 
-def test_media_slot_uses_tokenizer_id_when_model_id_is_unspecified():
+@pytest.mark.asyncio
+async def test_media_slot_uses_tokenizer_id_when_model_id_is_unspecified():
     class _Tokenizer:
         unk_token_id = 0
 
@@ -45,7 +46,7 @@ def test_media_slot_uses_tokenizer_id_when_model_id_is_unspecified():
     spec = MediaPromptSpec(model_token="<image>")
     prompt_config = MultimodalPromptConfig(image_spec=spec, video_spec=spec)
 
-    tokens = _tokenize_with_media_slots(
+    tokens = await _tokenize_with_media_slots(
         _Tokenizer(),
         messages=[],
         media_slots=[("__MEDIA__", "image", 0)],

--- a/tests/unit_tests/inference/test_chat_completions.py
+++ b/tests/unit_tests/inference/test_chat_completions.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import base64
+
+import pytest
+
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints.chat_completions import (
+    _extract_media_url_bytes,
+    _tokenize_with_media_slots,
+)
+
+
+def test_extract_media_data_url_accepts_payload_at_limit():
+    payload = b"four"
+    url = f"data:video/mp4;base64,{base64.b64encode(payload).decode()}"
+
+    assert _extract_media_url_bytes(url, max_bytes=len(payload)) == payload
+
+
+def test_extract_media_data_url_rejects_decoded_payload_over_limit():
+    # Four- and five-byte payloads both occupy eight base64 characters, so
+    # this exercises the decoded-size check in addition to the encoded bound.
+    payload = b"five!"
+    url = f"data:video/mp4;base64,{base64.b64encode(payload).decode()}"
+
+    with pytest.raises(ValueError, match="data:video/mp4;base64 payload exceeds 4 byte limit"):
+        _extract_media_url_bytes(url, max_bytes=4)
+
+
+def test_media_slot_uses_tokenizer_id_when_model_id_is_unspecified():
+    class _Tokenizer:
+        unk_token_id = 0
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            return "__MEDIA__"
+
+        def convert_tokens_to_ids(self, token):
+            return 99 if token == "<image>" else self.unk_token_id
+
+        def __call__(self, _text, add_special_tokens=False):
+            assert add_special_tokens is False
+            return []
+
+    spec = MediaPromptSpec(model_token="<image>")
+    prompt_config = MultimodalPromptConfig(image_spec=spec, video_spec=spec)
+
+    tokens = _tokenize_with_media_slots(
+        _Tokenizer(),
+        messages=[],
+        media_slots=[("__MEDIA__", "image", 0)],
+        prompt_config=prompt_config,
+        tools=None,
+        chat_template_kwargs={},
+    )
+
+    assert tokens == [99]

--- a/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
+++ b/tests/unit_tests/inference/test_disagg_handoff_lifecycle.py
@@ -629,13 +629,25 @@ def test_peer_failure_quarantines_an_unfinished_local_transfer(handoff_loop):
     engine._pending_kv_imports.append(pending)
     engine._record_handoff_completion_notification(4, failed=True)
 
-    engine._poll_pending_kv_imports()
-    engine._admit_pending_kv_imports()
+    with (
+        mock.patch(
+            "megatron.core.inference.disaggregation.inference_state_handoff.logging.error"
+        ) as log_error,
+        mock.patch(
+            "megatron.core.inference.disaggregation.inference_state_handoff.logging.exception"
+        ) as log_exception,
+    ):
+        engine._poll_pending_kv_imports()
+        engine._admit_pending_kv_imports()
 
     assert isinstance(pending.future.exception(), RuntimeError)
     assert engine.context.kv_block_allocator.releases == []
     assert not engine._pending_kv_imports
     assert engine._quarantined_kv_imports == [pending]
+    log_error.assert_called_once_with(
+        "Quarantining request %d cache storage after an incomplete handoff", 4
+    )
+    log_exception.assert_called_once_with("DISAGG_DECODE_PULL_FAILED request_id=%d", 4)
 
 
 def test_completed_handoff_keeps_notification_while_decode_is_full(handoff_loop):
@@ -995,11 +1007,15 @@ def test_handoff_submission_failure_is_reported_to_model_parallel_coordinator(ha
     engine._handoff_completion_tracker.report.assert_called_once_with(8, True)
 
     engine._record_handoff_completion_notification(8, failed=True)
-    engine._admit_pending_kv_imports()
+    with mock.patch(
+        "megatron.core.inference.disaggregation.inference_state_handoff.logging.exception"
+    ) as log_exception:
+        engine._admit_pending_kv_imports()
 
     assert isinstance(future.exception(), RuntimeError)
     assert engine.context.kv_block_allocator.releases == [[10, 11, 12]]
     assert not engine._pending_kv_imports
+    log_exception.assert_called_once_with("DISAGG_DECODE_PULL_FAILED request_id=%d", 8)
 
 
 def test_nixl_handoff_trims_pipeline_stage_block_lists(handoff_loop):

--- a/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
+++ b/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
@@ -397,6 +397,17 @@ class TestMultimodalAffinityRouting:
         coordinator._update_media_affinity("image-a", media_rank)
         assert coordinator.get_best_data_parallel_rank([], media_cache_key="image-a") == media_rank
 
+    def test_removing_engine_prunes_its_media_affinity(self):
+        coordinator = make_coordinator_direct()
+        removed_rank, retained_rank = coordinator._identities_list
+        coordinator._update_media_affinity("removed-image", removed_rank)
+        coordinator._update_media_affinity("retained-image", retained_rank)
+
+        coordinator._remove_engine(removed_rank)
+
+        assert "removed-image" not in coordinator._media_cache_affinity
+        assert coordinator._media_cache_affinity["retained-image"] == retained_rank
+
     def test_cold_media_falls_back_to_least_loaded_rank(self):
         coordinator = make_coordinator_direct(
             enable_prefix_caching=False, prefix_caching_routing_alpha=1.0

--- a/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
+++ b/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
@@ -18,7 +18,10 @@ import numpy as np
 import pytest
 import torch
 
-from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
+from megatron.core.inference.config import (
+    MediaCacheCoordinatorPolicy,
+    PrefixCachingCoordinatorPolicy,
+)
 from megatron.core.inference.data_parallel_inference_coordinator import (
     DataParallelInferenceCoordinator,
 )
@@ -199,6 +202,8 @@ def make_coordinator_direct(
     enable_prefix_caching=True,
     deterministic_mode=True,
     prefix_caching_routing_alpha=0.5,
+    media_policy=MediaCacheCoordinatorPolicy.AFFINITY,
+    vision_embedding_cache_enabled=True,
     max_requests=10,
 ):
     """Create a coordinator with mock ZMQ, for unit testing routing logic.
@@ -216,6 +221,8 @@ def make_coordinator_direct(
         enable_prefix_caching=enable_prefix_caching,
         deterministic_mode=deterministic_mode,
         prefix_caching_routing_alpha=prefix_caching_routing_alpha,
+        media_policy=media_policy,
+        vision_embedding_cache_enabled=vision_embedding_cache_enabled,
         max_requests=max_requests,
         tokenizer=DummyTokenizer(),
     )
@@ -369,6 +376,93 @@ class TestCoordinatorPrefixRouting:
             coordinator._pending_counts[coordinator.identity_to_rank_index[identity]] = 2
         coordinator._pending_counts[coordinator.identity_to_rank_index[identities[1]]] = 0
         assert coordinator.get_best_data_parallel_rank([1, 2, 3]) == identities[1]
+
+
+class TestMultimodalAffinityRouting:
+    """Media and prompt-prefix reuse participate in one routing score."""
+
+    def test_media_salt_partitions_prompt_affinity(self):
+        coordinator = make_coordinator_direct()
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+        image_a = coordinator.compute_request_hashes(tokens, cache_salt="image-a")
+        image_b = coordinator.compute_request_hashes(tokens, cache_salt="image-b")
+        assert image_a != image_b
+        assert image_a == coordinator.compute_request_hashes(tokens, cache_salt="image-a")
+
+    def test_media_affinity_works_without_prefix_caching(self):
+        coordinator = make_coordinator_direct(
+            enable_prefix_caching=False, prefix_caching_routing_alpha=1.0
+        )
+        media_rank = coordinator._identities_list[1]
+        coordinator._update_media_affinity("image-a", media_rank)
+        assert coordinator.get_best_data_parallel_rank([], media_cache_key="image-a") == media_rank
+
+    def test_cold_media_falls_back_to_least_loaded_rank(self):
+        coordinator = make_coordinator_direct(
+            enable_prefix_caching=False, prefix_caching_routing_alpha=1.0
+        )
+        busy_rank, free_rank = coordinator._identities_list
+        coordinator._pending_counts[coordinator.identity_to_rank_index[busy_rank]] = 5
+        coordinator._pending_counts[coordinator.identity_to_rank_index[free_rank]] = 1
+        assert (
+            coordinator.get_best_data_parallel_rank([], media_cache_key="unseen-image") == free_rank
+        )
+
+    def test_media_affinity_is_ignored_when_vision_cache_is_disabled(self):
+        coordinator = make_coordinator_direct(
+            enable_prefix_caching=False,
+            prefix_caching_routing_alpha=1.0,
+            vision_embedding_cache_enabled=False,
+        )
+        load_rank, media_rank = coordinator._identities_list
+        coordinator._pending_counts[coordinator.identity_to_rank_index[media_rank]] = 1
+        coordinator._update_media_affinity("image-a", media_rank)
+        assert coordinator.get_best_data_parallel_rank([], media_cache_key="image-a") == load_rank
+
+    def test_prefix_load_balanced_policy_still_uses_media_affinity(self):
+        coordinator = make_coordinator_direct(enable_prefix_caching=False)
+        coordinator.prefix_caching_coordinator_policy = PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+        _, media_rank = coordinator._identities_list
+        coordinator._pending_counts[coordinator.identity_to_rank_index[media_rank]] = 1
+        coordinator._update_media_affinity("image-a", media_rank)
+        assert coordinator.get_best_data_parallel_rank([], media_cache_key="image-a") == media_rank
+
+    def test_both_load_balanced_policies_ignore_media_affinity(self):
+        coordinator = make_coordinator_direct(
+            enable_prefix_caching=False, media_policy=MediaCacheCoordinatorPolicy.LOAD_BALANCED
+        )
+        coordinator.prefix_caching_coordinator_policy = PrefixCachingCoordinatorPolicy.LOAD_BALANCED
+        load_rank, media_rank = coordinator._identities_list
+        coordinator._pending_counts[coordinator.identity_to_rank_index[media_rank]] = 1
+        coordinator._update_media_affinity("image-a", media_rank)
+        assert coordinator.get_best_data_parallel_rank([], media_cache_key="image-a") == load_rank
+
+    def test_long_prefix_can_outweigh_media_hit(self):
+        coordinator = make_coordinator_direct(prefix_caching_routing_alpha=1.0)
+        coordinator.media_cache_routing_weight = 1.0
+        hashes = coordinator.compute_request_hashes([1, 2, 3, 4, 5, 6, 7, 8], cache_salt="image-a")
+        media_rank, prefix_rank = coordinator._identities_list
+        coordinator._update_media_affinity("image-a", media_rank)
+        for block_hash in hashes:
+            _set_hash_rank(coordinator, block_hash, prefix_rank, 1)
+
+        assert (
+            coordinator.get_best_data_parallel_rank(hashes, media_cache_key="image-a")
+            == prefix_rank
+        )
+
+    def test_expensive_media_can_outweigh_long_prefix(self):
+        coordinator = make_coordinator_direct(prefix_caching_routing_alpha=1.0)
+        coordinator.media_cache_routing_weight = 3.0
+        hashes = coordinator.compute_request_hashes([1, 2, 3, 4, 5, 6, 7, 8], cache_salt="image-a")
+        media_rank, prefix_rank = coordinator._identities_list
+        coordinator._update_media_affinity("image-a", media_rank)
+        for block_hash in hashes:
+            _set_hash_rank(coordinator, block_hash, prefix_rank, 1)
+
+        assert (
+            coordinator.get_best_data_parallel_rank(hashes, media_cache_key="image-a") == media_rank
+        )
 
 
 class TestCoordinatorShadowState:

--- a/tests/unit_tests/inference/test_image_preprocessing.py
+++ b/tests/unit_tests/inference/test_image_preprocessing.py
@@ -1,11 +1,20 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import io
+import json
 import sys
 from types import SimpleNamespace
 
+import pytest
+import torch
+
+from megatron.core.inference.config import ImageProcessingConfig, VideoProcessingConfig
 from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (
     _decode_sampled_video_frames,
+    _load_frame_sequence_manifest,
     _video_sample_indices,
+    preprocess_image_bytes_list,
+    preprocess_video_bytes_list,
 )
 
 
@@ -69,3 +78,116 @@ def test_unindexed_stream_counts_then_converts_only_sampled_frames(monkeypatch):
 
     assert sampled == [0, 4, 9]
     assert sum(frame.conversions for frame in frames) == 3
+
+
+def test_frame_sequence_manifest_loads_rgb_copies(tmp_path):
+    image_module = pytest.importorskip("PIL.Image")
+    frame_paths = []
+    for index, mode in enumerate(("RGBA", "L")):
+        frame_path = tmp_path / f"frame-{index}.png"
+        image_module.new(mode, (2, 2)).save(frame_path)
+        frame_paths.append(str(frame_path))
+
+    magic = b"frames:"
+    payload = magic + json.dumps({"frame_paths": frame_paths}).encode()
+    frames = _load_frame_sequence_manifest(payload, magic)
+
+    assert [frame.mode for frame in frames] == ["RGB", "RGB"]
+    assert [frame.size for frame in frames] == [(2, 2), (2, 2)]
+
+
+@pytest.mark.parametrize(
+    ("manifest", "error"),
+    [
+        (b"{", "Invalid frame-sequence manifest JSON"),
+        (json.dumps([]).encode(), "must be a JSON object"),
+        (json.dumps({"frame_paths": []}).encode(), "requires non-empty string frame_paths"),
+    ],
+)
+def test_frame_sequence_manifest_rejects_invalid_payloads(manifest, error):
+    with pytest.raises(ValueError, match=error):
+        _load_frame_sequence_manifest(b"frames:" + manifest, b"frames:")
+
+
+def test_image_bytes_list_preserves_per_image_aspect_ratios():
+    image_module = pytest.importorskip("PIL.Image")
+    pytest.importorskip("torchvision")
+    encoded_images = []
+    for size in ((4, 2), (2, 4)):
+        buffer = io.BytesIO()
+        image_module.new("RGB", size, color="red").save(buffer, format="PNG")
+        encoded_images.append(buffer.getvalue())
+    config = ImageProcessingConfig(
+        patch_dim=2,
+        dynamic_resolution=True,
+        dynamic_resolution_max_patches=16,
+        pixel_mean=[0.0, 0.0, 0.0],
+        pixel_std=[1.0, 1.0, 1.0],
+    )
+
+    result = preprocess_image_bytes_list(encoded_images, config)
+
+    assert result["imgs"].shape == (1, 4, 12)
+    assert result["imgs_sizes"].tolist() == [[2, 4], [4, 2]]
+
+
+def test_video_manifest_packs_frames_with_one_shared_resolution(monkeypatch):
+    image_module = pytest.importorskip("PIL.Image")
+    frames = [
+        image_module.new("RGB", (8, 4), color="red"),
+        image_module.new("RGB", (4, 8), color="blue"),
+    ]
+    target_shapes = []
+
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
+        image_preprocessing,
+    )
+
+    monkeypatch.setattr(
+        image_preprocessing, "_load_frame_sequence_manifest", lambda _payload, _magic: frames
+    )
+    monkeypatch.setattr(
+        image_preprocessing,
+        "dynamic_res_preprocess",
+        lambda *_args, **_kwargs: SimpleNamespace(height=4, width=6),
+    )
+
+    def fake_preprocess_image(_frame, _config, target_hw=None, device=None):
+        assert device is None
+        target_shapes.append(target_hw)
+        return torch.ones(1, 1, 2), torch.tensor([target_hw], dtype=torch.int32)
+
+    monkeypatch.setattr(image_preprocessing, "preprocess_image", fake_preprocess_image)
+    config = VideoProcessingConfig(
+        image_config=ImageProcessingConfig(patch_dim=2, dynamic_resolution=True),
+        num_frames=2,
+        frame_manifest_magic=b"frames:",
+    )
+
+    result = preprocess_video_bytes_list([b"frames:{}"], config)
+
+    assert target_shapes == [(4, 6), (4, 6)]
+    assert result["imgs"].shape == (1, 2, 2)
+    assert result["imgs_sizes"].tolist() == [[4, 6], [4, 6]]
+    assert result["num_frames"].tolist() == [2]
+
+
+def test_video_manifest_rejects_wrong_frame_count(monkeypatch):
+    image_module = pytest.importorskip("PIL.Image")
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
+        image_preprocessing,
+    )
+
+    monkeypatch.setattr(
+        image_preprocessing,
+        "_load_frame_sequence_manifest",
+        lambda _payload, _magic: [image_module.new("RGB", (2, 2))],
+    )
+    config = VideoProcessingConfig(
+        image_config=ImageProcessingConfig(patch_dim=2, dynamic_resolution=True),
+        num_frames=2,
+        frame_manifest_magic=b"frames:",
+    )
+
+    with pytest.raises(ValueError, match="Frame-sequence count must match"):
+        preprocess_video_bytes_list([b"frames:{}"], config)

--- a/tests/unit_tests/inference/test_image_preprocessing.py
+++ b/tests/unit_tests/inference/test_image_preprocessing.py
@@ -26,9 +26,7 @@ class _FakeFrame:
 class _FakeContainer:
     def __init__(self, frames, declared_frames):
         self._frames = frames
-        self.streams = SimpleNamespace(
-            video=[SimpleNamespace(frames=declared_frames)]
-        )
+        self.streams = SimpleNamespace(video=[SimpleNamespace(frames=declared_frames)])
 
     def __enter__(self):
         return self
@@ -42,9 +40,7 @@ class _FakeContainer:
 
 def _install_fake_av(monkeypatch, *, total_frames, declared_frames):
     frames = [_FakeFrame(index) for index in range(total_frames)]
-    fake_av = SimpleNamespace(
-        open=lambda _: _FakeContainer(frames, declared_frames)
-    )
+    fake_av = SimpleNamespace(open=lambda _: _FakeContainer(frames, declared_frames))
     monkeypatch.setitem(sys.modules, "av", fake_av)
     return frames
 

--- a/tests/unit_tests/inference/test_image_preprocessing.py
+++ b/tests/unit_tests/inference/test_image_preprocessing.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import sys
+from types import SimpleNamespace
+
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.image_preprocessing import (
+    _decode_sampled_video_frames,
+    _video_sample_indices,
+)
+
+
+class _FakeFrame:
+    def __init__(self, index):
+        self.index = index
+        self.conversions = 0
+
+    def to_image(self):
+        self.conversions += 1
+        return self
+
+    def convert(self, mode):
+        assert mode == "RGB"
+        return self.index
+
+
+class _FakeContainer:
+    def __init__(self, frames, declared_frames):
+        self._frames = frames
+        self.streams = SimpleNamespace(
+            video=[SimpleNamespace(frames=declared_frames)]
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return None
+
+    def decode(self, _stream):
+        return iter(self._frames)
+
+
+def _install_fake_av(monkeypatch, *, total_frames, declared_frames):
+    frames = [_FakeFrame(index) for index in range(total_frames)]
+    fake_av = SimpleNamespace(
+        open=lambda _: _FakeContainer(frames, declared_frames)
+    )
+    monkeypatch.setitem(sys.modules, "av", fake_av)
+    return frames
+
+
+def test_video_sample_indices_preserve_temporal_rounding():
+    config = SimpleNamespace(num_frames=3, temporal_patch_size=2)
+
+    assert _video_sample_indices(3, config) == [0, 2]
+
+
+def test_declared_frame_count_converts_only_sampled_frames(monkeypatch):
+    frames = _install_fake_av(monkeypatch, total_frames=10, declared_frames=10)
+    config = SimpleNamespace(num_frames=3, temporal_patch_size=1)
+
+    sampled = _decode_sampled_video_frames(b"video", config)
+
+    assert sampled == [0, 4, 9]
+    assert sum(frame.conversions for frame in frames) == 3
+
+
+def test_unindexed_stream_counts_then_converts_only_sampled_frames(monkeypatch):
+    frames = _install_fake_av(monkeypatch, total_frames=10, declared_frames=0)
+    config = SimpleNamespace(num_frames=3, temporal_patch_size=1)
+
+    sampled = _decode_sampled_video_frames(b"video", config)
+
+    assert sampled == [0, 4, 9]
+    assert sum(frame.conversions for frame in frames) == 3

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -119,14 +119,14 @@ class TestInferenceConfig:
                 "2.5",
                 "--inference-dynamic-batching-vision-embedding-cache-max-bytes",
                 "1048576",
-                "--inference-dynamic-batching-allow-stale-vision-embeddings",
+                "--inference-dynamic-batching-allow-stale-multimodal-embeddings",
             ]
         )
         assert args.inference_dynamic_batching_async_sched_mode == "async"
         assert args.inference_dynamic_batching_media_cache_coordinator_policy == "load_balanced"
         assert args.inference_dynamic_batching_media_cache_routing_weight == 2.5
         assert args.inference_dynamic_batching_vision_embedding_cache_max_bytes == 1048576
-        assert args.inference_dynamic_batching_allow_stale_vision_embeddings is True
+        assert args.inference_dynamic_batching_allow_stale_multimodal_embeddings is True
 
     @pytest.mark.parametrize("invalid_mode", ["serial", "overlap"])
     def test_async_sched_argparse_rejects_removed_modes(self, invalid_mode):
@@ -148,7 +148,7 @@ class TestInferenceConfig:
             inference_dynamic_batching_media_cache_coordinator_policy="load_balanced",
             inference_dynamic_batching_media_cache_routing_weight=2.5,
             inference_dynamic_batching_vision_embedding_cache_max_bytes=1048576,
-            inference_dynamic_batching_allow_stale_vision_embeddings=True,
+            inference_dynamic_batching_allow_stale_multimodal_embeddings=True,
         )
 
         inference_config = setup_config.to_inference_config(
@@ -166,7 +166,7 @@ class TestInferenceConfig:
         )
         assert inference_config.media_cache_routing_weight == 2.5
         assert inference_config.vision_embedding_cache_max_bytes == 1048576
-        assert inference_config.allow_stale_vision_embeddings is True
+        assert inference_config.allow_stale_multimodal_embeddings is True
 
     def test_offset_sampling_seed_argparse_plumbing(self):
         """Ensure the CLI can select a shared sampling seed across DP ranks."""

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -11,6 +11,7 @@ from megatron.core.inference.config import (
     AsyncScheduleMode,
     InferenceConfig,
     MambaInferenceStateConfig,
+    MediaCacheCoordinatorPolicy,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend
 from megatron.core.inference.quantization.utils import resolve_mxfp8_backend
@@ -96,11 +97,34 @@ class TestInferenceConfig:
         with pytest.raises(ValueError):
             InferenceConfig(async_sched_mode=invalid_mode)
 
+    def test_media_cache_routing_weight_must_be_non_negative(self):
+        with pytest.raises(ValueError, match="media_cache_routing_weight"):
+            InferenceConfig(media_cache_routing_weight=-1.0)
+
+    def test_media_cache_coordinator_policy_defaults_to_affinity(self):
+        assert (
+            InferenceConfig().media_cache_coordinator_policy == MediaCacheCoordinatorPolicy.AFFINITY
+        )
+
     def test_async_sched_argparse_plumbing(self):
         """Ensure the CLI exposes async scheduling mode."""
         parser = _add_inference_args(ArgumentParser())
-        args = parser.parse_args(["--inference-dynamic-batching-async-sched-mode", "async"])
+        args = parser.parse_args(
+            [
+                "--inference-dynamic-batching-async-sched-mode",
+                "async",
+                "--inference-dynamic-batching-media-cache-coordinator-policy",
+                "load_balanced",
+                "--inference-dynamic-batching-media-cache-routing-weight",
+                "2.5",
+                "--inference-dynamic-batching-vision-embedding-cache-max-bytes",
+                "1048576",
+            ]
+        )
         assert args.inference_dynamic_batching_async_sched_mode == "async"
+        assert args.inference_dynamic_batching_media_cache_coordinator_policy == "load_balanced"
+        assert args.inference_dynamic_batching_media_cache_routing_weight == 2.5
+        assert args.inference_dynamic_batching_vision_embedding_cache_max_bytes == 1048576
 
     @pytest.mark.parametrize("invalid_mode", ["serial", "overlap"])
     def test_async_sched_argparse_rejects_removed_modes(self, invalid_mode):
@@ -117,7 +141,12 @@ class TestInferenceConfig:
             pg_collection="pg",
             decoder=SimpleNamespace(layer_type_list=None),
         )
-        setup_config = InferenceSetupConfig(inference_dynamic_batching_async_sched_mode="async")
+        setup_config = InferenceSetupConfig(
+            inference_dynamic_batching_async_sched_mode="async",
+            inference_dynamic_batching_media_cache_coordinator_policy="load_balanced",
+            inference_dynamic_batching_media_cache_routing_weight=2.5,
+            inference_dynamic_batching_vision_embedding_cache_max_bytes=1048576,
+        )
 
         inference_config = setup_config.to_inference_config(
             model=model,
@@ -128,6 +157,12 @@ class TestInferenceConfig:
         )
 
         assert inference_config.async_sched_mode == AsyncScheduleMode.ASYNC
+        assert (
+            inference_config.media_cache_coordinator_policy
+            == MediaCacheCoordinatorPolicy.LOAD_BALANCED
+        )
+        assert inference_config.media_cache_routing_weight == 2.5
+        assert inference_config.vision_embedding_cache_max_bytes == 1048576
 
     def test_offset_sampling_seed_argparse_plumbing(self):
         """Ensure the CLI can select a shared sampling seed across DP ranks."""

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -119,12 +119,14 @@ class TestInferenceConfig:
                 "2.5",
                 "--inference-dynamic-batching-vision-embedding-cache-max-bytes",
                 "1048576",
+                "--inference-dynamic-batching-allow-stale-vision-embeddings",
             ]
         )
         assert args.inference_dynamic_batching_async_sched_mode == "async"
         assert args.inference_dynamic_batching_media_cache_coordinator_policy == "load_balanced"
         assert args.inference_dynamic_batching_media_cache_routing_weight == 2.5
         assert args.inference_dynamic_batching_vision_embedding_cache_max_bytes == 1048576
+        assert args.inference_dynamic_batching_allow_stale_vision_embeddings is True
 
     @pytest.mark.parametrize("invalid_mode", ["serial", "overlap"])
     def test_async_sched_argparse_rejects_removed_modes(self, invalid_mode):
@@ -146,6 +148,7 @@ class TestInferenceConfig:
             inference_dynamic_batching_media_cache_coordinator_policy="load_balanced",
             inference_dynamic_batching_media_cache_routing_weight=2.5,
             inference_dynamic_batching_vision_embedding_cache_max_bytes=1048576,
+            inference_dynamic_batching_allow_stale_vision_embeddings=True,
         )
 
         inference_config = setup_config.to_inference_config(
@@ -163,6 +166,7 @@ class TestInferenceConfig:
         )
         assert inference_config.media_cache_routing_weight == 2.5
         assert inference_config.vision_embedding_cache_max_bytes == 1048576
+        assert inference_config.allow_stale_vision_embeddings is True
 
     def test_offset_sampling_seed_argparse_plumbing(self):
         """Ensure the CLI can select a shared sampling seed across DP ranks."""

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -9,9 +9,13 @@ import torch
 
 from megatron.core.inference.config import (
     AsyncScheduleMode,
+    ImageProcessingConfig,
     InferenceConfig,
     MambaInferenceStateConfig,
     MediaCacheCoordinatorPolicy,
+    MediaPromptSpec,
+    MultimodalPromptConfig,
+    VideoProcessingConfig,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend
 from megatron.core.inference.quantization.utils import resolve_mxfp8_backend
@@ -105,6 +109,32 @@ class TestInferenceConfig:
         assert (
             InferenceConfig().media_cache_coordinator_policy == MediaCacheCoordinatorPolicy.AFFINITY
         )
+
+    def test_multimodal_prompt_config_builds_independent_specs_from_dict(self):
+        config = MultimodalPromptConfig.from_dict(
+            {
+                "image_spec": {"model_token": "<image>", "prefix": "<img>"},
+                "video_spec": {"model_token": "<video>", "suffix": "</video>"},
+            }
+        )
+
+        assert config.get_spec("image") == MediaPromptSpec(model_token="<image>", prefix="<img>")
+        assert config.get_spec("video") == MediaPromptSpec(model_token="<video>", suffix="</video>")
+        with pytest.raises(ValueError, match="Unsupported media modality"):
+            config.get_spec("audio")
+
+    def test_video_processing_config_preserves_image_contract_and_defaults(self):
+        image_config = ImageProcessingConfig(
+            patch_dim=14, dynamic_resolution=True, pixel_shuffle=True
+        )
+
+        video_config = VideoProcessingConfig(image_config=image_config)
+
+        assert video_config.image_config is image_config
+        assert video_config.num_frames == 8
+        assert video_config.temporal_patch_size == 1
+        assert video_config.video_maintain_aspect_ratio is True
+        assert video_config.frame_manifest_magic is None
 
     def test_async_sched_argparse_plumbing(self):
         """Ensure the CLI exposes async scheduling mode."""

--- a/tests/unit_tests/inference/test_inference_request.py
+++ b/tests/unit_tests/inference/test_inference_request.py
@@ -16,7 +16,9 @@ from megatron.core.inference.inference_request import (
     compute_block_hashes_batched,
     deserialize_ndarray,
     deserialize_tensor,
+    resolve_multimodal_data_for_engine,
     serialize_ndarray,
+    serialize_multimodal_data,
     serialize_tensor,
     unwrap_serialized_tensors,
 )
@@ -55,6 +57,37 @@ def test_serialization_helpers_round_trip():
     assert out["a"] == [1, 2, 3]
     assert out["b"] == "plain"
     assert out["c"] == ("ndarray", {"data": [], "dtype": "int32"})
+
+
+def test_preexpanded_multimodal_request_round_trip():
+    media = {
+        "image": {
+            "imgs": torch.ones(1, 2, 4),
+            "imgs_sizes": torch.tensor([[2, 2]]),
+        },
+        "media_tokens_preexpanded": True,
+    }
+
+    wire = serialize_multimodal_data(media)
+    assert wire["media_tokens_preexpanded"] is True
+
+    resolved = resolve_multimodal_data_for_engine(wire)
+    assert resolved["media_tokens_preexpanded"] is True
+    assert torch.equal(resolved["imgs"], media["image"]["imgs"])
+    assert torch.equal(resolved["imgs_sizes"], media["image"]["imgs_sizes"])
+
+
+def test_gym_style_compact_multimodal_request_omits_preexpanded_flag():
+    wire = serialize_multimodal_data(
+        {
+            "image": {
+                "imgs": torch.ones(1, 2, 4),
+                "imgs_sizes": torch.tensor([[2, 2]]),
+            }
+        }
+    )
+    assert "media_tokens_preexpanded" not in wire
+    assert "media_tokens_preexpanded" not in resolve_multimodal_data_for_engine(wire)
 
 
 def test_compute_block_hashes_batched():

--- a/tests/unit_tests/inference/test_inference_request.py
+++ b/tests/unit_tests/inference/test_inference_request.py
@@ -17,8 +17,8 @@ from megatron.core.inference.inference_request import (
     deserialize_ndarray,
     deserialize_tensor,
     resolve_multimodal_data_for_engine,
-    serialize_ndarray,
     serialize_multimodal_data,
+    serialize_ndarray,
     serialize_tensor,
     unwrap_serialized_tensors,
 )
@@ -61,10 +61,7 @@ def test_serialization_helpers_round_trip():
 
 def test_preexpanded_multimodal_request_round_trip():
     media = {
-        "image": {
-            "imgs": torch.ones(1, 2, 4),
-            "imgs_sizes": torch.tensor([[2, 2]]),
-        },
+        "image": {"imgs": torch.ones(1, 2, 4), "imgs_sizes": torch.tensor([[2, 2]])},
         "media_tokens_preexpanded": True,
     }
 
@@ -79,15 +76,51 @@ def test_preexpanded_multimodal_request_round_trip():
 
 def test_gym_style_compact_multimodal_request_omits_preexpanded_flag():
     wire = serialize_multimodal_data(
+        {"image": {"imgs": torch.ones(1, 2, 4), "imgs_sizes": torch.tensor([[2, 2]])}}
+    )
+    assert "media_tokens_preexpanded" not in wire
+    assert "media_tokens_preexpanded" not in resolve_multimodal_data_for_engine(wire)
+
+
+def test_multimodal_serialization_generates_stable_content_keys():
+    raw_a = serialize_multimodal_data({"image": [b"same-image"]})
+    raw_b = serialize_multimodal_data({"image": [b"same-image"]})
+    raw_c = serialize_multimodal_data({"image": [b"different-image"]})
+    assert raw_a["media_cache_key"] == raw_b["media_cache_key"]
+    assert raw_a["media_cache_key"] != raw_c["media_cache_key"]
+
+    tensor_a = serialize_multimodal_data(
         {
             "image": {
-                "imgs": torch.ones(1, 2, 4),
+                "imgs": torch.arange(8, dtype=torch.float32).reshape(1, 2, 4),
                 "imgs_sizes": torch.tensor([[2, 2]]),
             }
         }
     )
-    assert "media_tokens_preexpanded" not in wire
-    assert "media_tokens_preexpanded" not in resolve_multimodal_data_for_engine(wire)
+    tensor_b = serialize_multimodal_data(
+        {
+            "image": {
+                "imgs": torch.arange(8, dtype=torch.float32).reshape(1, 2, 4),
+                "imgs_sizes": torch.tensor([[2, 2]]),
+            }
+        }
+    )
+    tensor_c = serialize_multimodal_data(
+        {
+            "image": {
+                "imgs": torch.arange(8, dtype=torch.float32).reshape(2, 1, 4),
+                "imgs_sizes": torch.tensor([[2, 2]]),
+            }
+        }
+    )
+    assert tensor_a["media_cache_key"] == tensor_b["media_cache_key"]
+    # Shape participates in identity even when the flattened bytes are equal.
+    assert tensor_a["media_cache_key"] != tensor_c["media_cache_key"]
+
+
+def test_multimodal_serialization_rejects_user_media_cache_key():
+    with pytest.raises(ValueError, match="computed automatically"):
+        serialize_multimodal_data({"image": [b"image"], "media_cache_key": "user-provided"})
 
 
 def test_compute_block_hashes_batched():
@@ -107,6 +140,11 @@ def test_compute_block_hashes_batched():
     assert (
         compute_block_hashes_batched(torch.arange(8, dtype=torch.int64), block_size=4)[1] != h_b[1]
     )
+    tokens = torch.arange(8, dtype=torch.int64)
+    media_a = compute_block_hashes_batched(tokens, block_size=4, cache_salt="media-a")
+    media_b = compute_block_hashes_batched(tokens, block_size=4, cache_salt="media-b")
+    assert media_a != media_b
+    assert media_a == compute_block_hashes_batched(tokens, block_size=4, cache_salt="media-a")
 
 
 def test_inference_parameters_alias_warns_and_copies():

--- a/tests/unit_tests/inference/test_kv_allocator_observers.py
+++ b/tests/unit_tests/inference/test_kv_allocator_observers.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -56,7 +56,10 @@ def test_listener_failure_does_not_interrupt_block_deregistration():
 
     healthy_listener.side_effect = assert_allocator_committed
     allocator.register_kv_block_hashes(blocks.tolist(), [101, 202])
-    allocator.release_memory_blocks(blocks)
+    with patch(
+        "megatron.core.inference.contexts.dynamic_context.logging.exception"
+    ) as log_exception:
+        allocator.release_memory_blocks(blocks)
 
     assert not allocator.kv_hash_to_block_id
     assert torch.all(allocator.block_hashes[blocks.to(torch.int64)] == -1)
@@ -67,3 +70,4 @@ def test_listener_failure_does_not_interrupt_block_deregistration():
     assert healthy_listener.call_args.args[0] == "removed"
     assert set(failing_listener.call_args.args[1]["block_hashes"]) == {101, 202}
     assert set(healthy_listener.call_args.args[1]["block_hashes"]) == {101, 202}
+    log_exception.assert_called_once_with("KV-event listener failed while handling %r", "removed")

--- a/tests/unit_tests/inference/test_multimodal_entrypoints.py
+++ b/tests/unit_tests/inference/test_multimodal_entrypoints.py
@@ -256,6 +256,10 @@ def toy_media_preprocessing(monkeypatch):
             _toy_preprocessed_media("video") if media == [_MEDIA_BYTES] else None
         ),
     )
+    # Keep this toy E2E path on CPU even when the test worker can see a GPU.
+    # Otherwise resolve_multimodal_data_for_engine constructs a CUDA device
+    # before the mocked preprocessors have a chance to ignore it.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
 
 

--- a/tests/unit_tests/inference/test_multimodal_entrypoints.py
+++ b/tests/unit_tests/inference/test_multimodal_entrypoints.py
@@ -332,13 +332,16 @@ async def test_completions_multimodal_entrypoint_with_toy_model(
     app = quart.Quart(__name__)
     app.config.update(client=service, tokenizer=service.tokenizer, verbose=False)
     app.register_blueprint(bp)
+    encoded_media = base64.b64encode(_MEDIA_BYTES).decode("ascii")
+    if modality == "video":
+        encoded_media = f"data:video/mp4;base64,{encoded_media}"
 
     response = await app.test_client().post(
         "/v1/completions",
         json={
             "prompt": _PROMPT_TOKENS,
             "max_tokens": 1,
-            "multi_modal_data": {modality: base64.b64encode(_MEDIA_BYTES).decode("ascii")},
+            "multi_modal_data": {modality: encoded_media},
         },
     )
 
@@ -351,3 +354,33 @@ async def test_completions_multimodal_entrypoint_with_toy_model(
     assert int((service.last_request.image_token_mask >= 0).sum()) == (
         service.last_request.image_embeddings.shape[0]
     )
+
+
+@pytest.mark.internal
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("multi_modal_data", "error"),
+    [
+        ({"audio": "payload"}, "Unsupported multimodal modalities"),
+        ({"image": "aW1hZ2U=", "video": "dmlkZW8="}, "cannot mix image and video"),
+        ({"video": ["dmlkZW8=", 1]}, "must be a string or list"),
+    ],
+)
+async def test_completions_rejects_invalid_multimodal_payloads(multi_modal_data, error):
+    quart = pytest.importorskip("quart")
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints.completions import (
+        bp,
+    )
+
+    service = _ToyInferenceService(VLMInferenceWrapper, deserialize=False)
+    app = quart.Quart(__name__)
+    app.config.update(client=service, tokenizer=service.tokenizer, verbose=False)
+    app.register_blueprint(bp)
+
+    response = await app.test_client().post(
+        "/v1/completions", json={"prompt": _PROMPT_TOKENS, "multi_modal_data": multi_modal_data}
+    )
+
+    assert response.status_code == 400
+    assert error in (await response.get_data(as_text=True))
+    assert service.last_request is None

--- a/tests/unit_tests/inference/test_multimodal_entrypoints.py
+++ b/tests/unit_tests/inference/test_multimodal_entrypoints.py
@@ -86,7 +86,6 @@ def _build_toy_wrapper(wrapper_cls):
     model = SimpleNamespace(
         image_token_index=-200,
         dynamic_resolution=True,
-        _dynamic_resolution=True,
         patch_dim=2,
         _pixel_shuffle=False,
         _conv_merging=False,

--- a/tests/unit_tests/inference/test_multimodal_entrypoints.py
+++ b/tests/unit_tests/inference/test_multimodal_entrypoints.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Mini end-to-end coverage for multimodal inference entrypoints.
+
+These tests keep the HTTP/API plumbing and real LLaVA/Omni prompt expansion,
+while replacing media decoding and the vision backbone with deterministic toy
+tensors. They intentionally do not require checkpoints or distributed setup.
+"""
+
+import asyncio
+import base64
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.core.inference.apis.async_llm import MegatronAsyncLLM
+from megatron.core.inference.config import ImageProcessingConfig, VideoProcessingConfig
+from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+from megatron.core.inference.inference_request import (
+    resolve_multimodal_data_for_engine,
+    serialize_multimodal_data,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.nemotron_omni_inference_wrapper import (
+    NemotronOmniInferenceWrapper,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
+    dynamic_media_embedding_counts,
+    dynamic_media_replacement_counts,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (
+    VLMInferenceWrapper,
+)
+from megatron.core.inference.sampling_params import SamplingParams
+from tests.unit_tests.inference.coordinator_test_utils import make_coordinator_direct
+
+_MEDIA_TOKEN_ID = 99
+_PROMPT_TOKENS = [10, _MEDIA_TOKEN_ID, 20]
+_MEDIA_BYTES = b"toy-media"
+
+
+class _ToyTokenizer:
+    unk_token_id = 0
+    eod = 0
+
+    def convert_tokens_to_ids(self, token):
+        return _MEDIA_TOKEN_ID if token == "<image>" else self.unk_token_id
+
+    def detokenize(self, token_ids):
+        return " ".join(str(token_id) for token_id in token_ids)
+
+
+class _InlineLoopManager:
+    async def run_async(self, awaitable):
+        return await awaitable
+
+
+class _ToyLanguageModel:
+    def __init__(self):
+        self.last_decoder_input = None
+
+    def embedding(self, input_ids, position_ids):
+        del position_ids
+        batch_size, sequence_length = input_ids.shape
+        return torch.zeros(sequence_length, batch_size, 4)
+
+    def __call__(self, *, decoder_input, **_kwargs):
+        self.last_decoder_input = decoder_input
+        return decoder_input
+
+
+def _toy_preprocessed_media(modality):
+    if modality == "video":
+        return {
+            "imgs": torch.ones(2, 3, 4, 4),
+            "imgs_sizes": torch.tensor([[4, 4], [4, 4]], dtype=torch.int32),
+            "num_frames": torch.tensor([2], dtype=torch.int32),
+        }
+    return {"imgs": torch.ones(1, 3, 4, 4), "imgs_sizes": torch.tensor([[4, 4]], dtype=torch.int32)}
+
+
+def _build_toy_wrapper(wrapper_cls):
+    language_model = _ToyLanguageModel()
+    model = SimpleNamespace(
+        image_token_index=-200,
+        dynamic_resolution=True,
+        _dynamic_resolution=True,
+        patch_dim=2,
+        _pixel_shuffle=False,
+        _conv_merging=False,
+        _drop_vision_class_token=True,
+        _class_token_len=0,
+        temporal_patch_dim=1,
+        vision_model=SimpleNamespace(temporal_patch_dim=1),
+        language_model=language_model,
+        sequence_parallel_lm=False,
+    )
+    model.forward_lm_only = mock.Mock(
+        side_effect=lambda *, combined_embeddings, **_kwargs: combined_embeddings
+    )
+    wrapper = object.__new__(wrapper_cls)
+    wrapper.model = SimpleNamespace(module=model) if wrapper_cls is VLMInferenceWrapper else model
+    wrapper.inference_context = None
+    wrapper.pp_group = None
+
+    def toy_vision_forward(_images, num_image_tiles=None, imgs_sizes=None, num_frames=None):
+        assert num_image_tiles is None
+        frame_counts = dynamic_media_embedding_counts(
+            imgs_sizes,
+            patch_dim=model.patch_dim,
+            pixel_shuffle=wrapper_cls is NemotronOmniInferenceWrapper,
+        )
+        replacement_counts = dynamic_media_replacement_counts(
+            frame_counts,
+            num_frames=num_frames,
+            temporal_patch_size=model.vision_model.temporal_patch_dim,
+        )
+        return torch.ones(sum(replacement_counts), 1, 4)
+
+    wrapper._forward_vision_encoder = mock.Mock(side_effect=toy_vision_forward)
+    return wrapper
+
+
+class _ToyInferenceService:
+    """Mimic the client/coordinator boundary and admit into a real VLM request builder."""
+
+    def __init__(self, wrapper_cls, *, deserialize):
+        self.deserialize = deserialize
+        self.tokenizer = _ToyTokenizer()
+        wrapper = _build_toy_wrapper(wrapper_cls)
+        self.wrapper = wrapper
+        self.model = wrapper.model.module if wrapper_cls is VLMInferenceWrapper else wrapper.model
+
+        self.engine = object.__new__(DynamicInferenceEngine)
+        self.engine.controller = SimpleNamespace(
+            inference_wrapped_model=wrapper, tokenizer=self.tokenizer, pp_group=None
+        )
+        self.engine.context = SimpleNamespace(
+            block_size_tokens=16, enable_prefix_caching=False, add_vlm_request_data=mock.Mock()
+        )
+        self.engine.vision_embedding_cache_max_bytes = 1 << 20
+        self.engine._vision_embedding_cache = OrderedDict()
+        self.engine._vision_embedding_cache_bytes = 0
+        self.coordinator = make_coordinator_direct(
+            enable_prefix_caching=False, prefix_caching_routing_alpha=1.0
+        )
+        self.selected_ranks = []
+        self._request_id = 0
+        self.last_request = None
+        self.last_wire_data = None
+
+        image_config = ImageProcessingConfig(patch_dim=2, dynamic_resolution=True)
+        self.image_config = image_config
+        self.video_config = VideoProcessingConfig(
+            image_config=image_config, num_frames=2, temporal_patch_size=1
+        )
+
+    def _run_toy_decoder(self, request):
+        sequence_length = len(request.prompt_tokens)
+        inference_input = {
+            "tokens": request.prompt_tokens.unsqueeze(0),
+            "position_ids": torch.arange(sequence_length).unsqueeze(0),
+            "attention_mask": None,
+            "image_token_mask": request.image_token_mask.unsqueeze(0),
+            "image_embeddings": request.image_embeddings,
+        }
+        if isinstance(self.wrapper, VLMInferenceWrapper):
+            with mock.patch(
+                "megatron.core.inference.model_inference_wrappers.multimodal."
+                "vlm_inference_wrapper.is_pipeline_first_stage",
+                return_value=True,
+            ):
+                decoder_output = self.wrapper._forward_dynamic(inference_input)
+        else:
+            decoder_output = self.wrapper._forward_dynamic(inference_input).transpose(0, 1)
+
+        image_positions = inference_input["image_token_mask"] >= 0
+        assert torch.all(decoder_output[image_positions] == 1)
+        assert torch.all(decoder_output[~image_positions] == 0)
+
+    def add_request(self, prompt, sampling_params, *, multi_modal_data=None):
+        future = asyncio.get_running_loop().create_future()
+        try:
+            self.last_wire_data = serialize_multimodal_data(multi_modal_data)
+            media_cache_key = self.last_wire_data["media_cache_key"]
+            request_hashes = self.coordinator.compute_request_hashes(
+                prompt, cache_salt=media_cache_key
+            )
+            selected_rank = self.coordinator.get_best_data_parallel_rank(
+                request_hashes, media_cache_key=media_cache_key
+            )
+            self.coordinator._update_media_affinity(media_cache_key, selected_rank)
+            rank_index = self.coordinator.identity_to_rank_index[selected_rank]
+            self.coordinator._pending_counts[rank_index] += 1
+            self.selected_ranks.append(selected_rank)
+
+            engine_kwargs = resolve_multimodal_data_for_engine(
+                self.last_wire_data,
+                image_preprocessing_config=self.image_config,
+                video_preprocessing_config=self.video_config,
+            )
+            media_tokens_preexpanded = engine_kwargs.pop("media_tokens_preexpanded", False)
+            engine_kwargs.setdefault("num_tiles", None)
+            self._request_id += 1
+            request = self.engine._build_vlm_request(
+                request_id=self._request_id,
+                prompt_str=None,
+                tokens=torch.tensor(prompt, dtype=torch.int64),
+                sampling_params=sampling_params,
+                num_img_embeddings_per_tile=0,
+                precomputed_block_hashes=None,
+                media_tokens_preexpanded=media_tokens_preexpanded,
+                **engine_kwargs,
+            )
+            request.generated_text = "toy output"
+            request.generated_tokens = [7]
+            self._run_toy_decoder(request)
+            self.last_request = request
+            if self.deserialize:
+                result = request
+            else:
+                result = {
+                    "uid": "toy-request",
+                    "status": "COMPLETED",
+                    "generated_text": request.generated_text,
+                    "generated_tokens": request.generated_tokens,
+                    "prompt_tokens": request.prompt_tokens.tolist(),
+                    "sampling_params": {"num_tokens_to_generate": 1},
+                    "routing_indices": None,
+                }
+            future.set_result(result)
+        except Exception as error:
+            future.set_exception(error)
+        return future
+
+
+@pytest.fixture
+def toy_media_preprocessing(monkeypatch):
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
+        image_preprocessing,
+    )
+
+    monkeypatch.setattr(
+        image_preprocessing,
+        "preprocess_image_bytes_list",
+        lambda media, _config, device=None: (
+            _toy_preprocessed_media("image") if media == [_MEDIA_BYTES] else None
+        ),
+    )
+    monkeypatch.setattr(
+        image_preprocessing,
+        "preprocess_video_bytes_list",
+        lambda media, _config, device=None: (
+            _toy_preprocessed_media("video") if media == [_MEDIA_BYTES] else None
+        ),
+    )
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+
+
+def _build_toy_async_llm(service):
+    llm = object.__new__(MegatronAsyncLLM)
+    llm._is_primary_rank = True
+    llm._use_coordinator = True
+    llm._loop_manager = _InlineLoopManager()
+    llm._coord_runtime = SimpleNamespace(client=service)
+    return llm
+
+
+@pytest.mark.internal
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapper_cls", [VLMInferenceWrapper, NemotronOmniInferenceWrapper])
+@pytest.mark.parametrize("modality", ["image", "video"])
+async def test_generate_multimodal_entrypoint_with_toy_model(
+    wrapper_cls, modality, toy_media_preprocessing
+):
+    service = _ToyInferenceService(wrapper_cls, deserialize=True)
+    llm = _build_toy_async_llm(service)
+
+    result = await llm.generate(
+        _PROMPT_TOKENS,
+        SamplingParams(num_tokens_to_generate=1, termination_id=0),
+        multi_modal_data={modality: _MEDIA_BYTES},
+    )
+
+    assert result is service.last_request
+    assert result.compact_prompt_tokens.tolist() == _PROMPT_TOKENS
+    assert result.generated_text == "toy output"
+    assert service.last_wire_data[modality] == [_MEDIA_BYTES]
+    assert service.wrapper._forward_vision_encoder.call_count == 1
+    assert int((result.image_token_mask >= 0).sum()) == result.image_embeddings.shape[0]
+
+
+@pytest.mark.internal
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapper_cls", [VLMInferenceWrapper, NemotronOmniInferenceWrapper])
+@pytest.mark.parametrize("modality", ["image", "video"])
+async def test_repeated_media_hits_vision_cache_and_coordinator_affinity(
+    wrapper_cls, modality, toy_media_preprocessing
+):
+    service = _ToyInferenceService(wrapper_cls, deserialize=True)
+    llm = _build_toy_async_llm(service)
+    sampling_params = SamplingParams(num_tokens_to_generate=1, termination_id=0)
+    multi_modal_data = {modality: _MEDIA_BYTES}
+
+    first = await llm.generate(_PROMPT_TOKENS, sampling_params, multi_modal_data=multi_modal_data)
+    second = await llm.generate(_PROMPT_TOKENS, sampling_params, multi_modal_data=multi_modal_data)
+
+    assert service.selected_ranks[0] == service.selected_ranks[1]
+    assert service.wrapper._forward_vision_encoder.call_count == 1
+    assert len(service.engine._vision_embedding_cache) == 1
+    assert second.image_embeddings is first.image_embeddings
+
+
+@pytest.mark.internal
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapper_cls", [VLMInferenceWrapper, NemotronOmniInferenceWrapper])
+@pytest.mark.parametrize("modality", ["image", "video"])
+async def test_completions_multimodal_entrypoint_with_toy_model(
+    wrapper_cls, modality, toy_media_preprocessing
+):
+    quart = pytest.importorskip("quart")
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints.completions import (
+        bp,
+    )
+
+    service = _ToyInferenceService(wrapper_cls, deserialize=False)
+    app = quart.Quart(__name__)
+    app.config.update(client=service, tokenizer=service.tokenizer, verbose=False)
+    app.register_blueprint(bp)
+
+    response = await app.test_client().post(
+        "/v1/completions",
+        json={
+            "prompt": _PROMPT_TOKENS,
+            "max_tokens": 1,
+            "multi_modal_data": {modality: base64.b64encode(_MEDIA_BYTES).decode("ascii")},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = await response.get_json()
+    assert payload["choices"][0]["text"] == "toy output"
+    assert service.last_request.compact_prompt_tokens.tolist() == _PROMPT_TOKENS
+    assert service.last_wire_data[modality] == [_MEDIA_BYTES]
+    assert service.wrapper._forward_vision_encoder.call_count == 1
+    assert int((service.last_request.image_token_mask >= 0).sum()) == (
+        service.last_request.image_embeddings.shape[0]
+    )

--- a/tests/unit_tests/inference/test_text_generation_server.py
+++ b/tests/unit_tests/inference/test_text_generation_server.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server import (
+    text_generation_server,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provide_config", [False, True])
+async def test_server_exposes_multimodal_prompt_config(monkeypatch, provide_config):
+    apps = []
+    clients = []
+
+    class FakeApp:
+        def __init__(self, _name):
+            self.config = {}
+            self.blueprints = []
+            apps.append(self)
+
+        def register_blueprint(self, blueprint):
+            self.blueprints.append(blueprint)
+
+    class FakeClient:
+        def __init__(self, address, deserialize):
+            self.address = address
+            self.deserialize = deserialize
+            self.started = False
+            self.stopped = False
+            clients.append(self)
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.stopped = True
+
+    served = []
+
+    async def fake_serve(app, config):
+        served.append((app, config))
+
+    custom_config = MultimodalPromptConfig(video_spec=MediaPromptSpec(model_token="<video>"))
+    supplied_config = custom_config if provide_config else None
+    monkeypatch.setattr(text_generation_server, "HAS_BACKEND", True)
+    monkeypatch.setattr(text_generation_server, "InferenceClient", FakeClient)
+    monkeypatch.setattr(text_generation_server, "Quart", FakeApp, raising=False)
+    monkeypatch.setattr(
+        text_generation_server, "Config", lambda: SimpleNamespace(bind=None), raising=False
+    )
+    monkeypatch.setattr(text_generation_server, "serve", fake_serve, raising=False)
+    monkeypatch.setattr(
+        text_generation_server.endpoints, "__all__", ["completion-blueprint", "chat-blueprint"]
+    )
+
+    await text_generation_server._run_text_gen_server(
+        "coordinator:1234",
+        tokenizer=object(),
+        rank=0,
+        server_port=8080,
+        hostname="127.0.0.1",
+        multimodal_prompt_config=supplied_config,
+    )
+
+    assert len(apps) == len(clients) == len(served) == 1
+    app = apps[0]
+    assert app.config["multimodal_prompt_config"] == (
+        custom_config if provide_config else MultimodalPromptConfig()
+    )
+    assert app.blueprints == ["completion-blueprint", "chat-blueprint"]
+    assert served[0][0] is app
+    assert served[0][1].bind == ["127.0.0.1:8080"]
+    assert clients[0].address == "coordinator:1234"
+    assert clients[0].deserialize is False
+    assert clients[0].started is True
+    assert clients[0].stopped is True
+
+
+def test_start_server_forwards_multimodal_prompt_config_to_worker(monkeypatch):
+    processes = []
+
+    class FakeSocket:
+        def getsockname(self):
+            return "127.0.0.1", 8080
+
+        def setblocking(self, _blocking):
+            pass
+
+        def set_inheritable(self, _inheritable):
+            pass
+
+        def fileno(self):
+            return 12
+
+    class FakeProcess:
+        def __init__(self, *, target, args, daemon):
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.pid = 123
+            processes.append(self)
+
+        def start(self):
+            pass
+
+    prompt_config = MultimodalPromptConfig(video_spec=MediaPromptSpec(model_token="<video>"))
+    monkeypatch.setattr(text_generation_server, "_SERVER_PROCESSES", [])
+    monkeypatch.setattr(text_generation_server, "_SHARED_SOCKET", None)
+    monkeypatch.setattr(text_generation_server.mp, "Process", FakeProcess)
+
+    text_generation_server.start_text_gen_server(
+        "coordinator:1234",
+        tokenizer=object(),
+        rank=0,
+        server_port=0,
+        num_replicas=1,
+        sock=FakeSocket(),
+        multimodal_prompt_config=prompt_config,
+    )
+
+    assert len(processes) == 1
+    assert processes[0].target is text_generation_server._server_process_worker
+    assert processes[0].args[-1] is prompt_config
+    assert processes[0].daemon is True
+
+
+def test_start_server_rejects_socket_without_real_port(monkeypatch):
+    socket_without_port = SimpleNamespace(getsockname=lambda: ("127.0.0.1", 0))
+    monkeypatch.setattr(text_generation_server, "_SERVER_PROCESSES", [])
+    monkeypatch.setattr(text_generation_server, "_SHARED_SOCKET", None)
+
+    with pytest.raises(ValueError, match="socket must be bound to a real port"):
+        text_generation_server.start_text_gen_server(
+            "coordinator:1234", tokenizer=object(), rank=0, server_port=0, sock=socket_without_port
+        )
+
+    assert text_generation_server._SHARED_SOCKET is None
+
+
+def test_start_server_is_noop_when_replicas_are_running(monkeypatch):
+    existing_process = object()
+    monkeypatch.setattr(text_generation_server, "_SERVER_PROCESSES", [existing_process])
+    monkeypatch.setattr(
+        text_generation_server.mp,
+        "Process",
+        lambda **_kwargs: pytest.fail("must not create another process"),
+    )
+
+    text_generation_server.start_text_gen_server(
+        "coordinator:1234", tokenizer=object(), rank=0, server_port=8080
+    )
+
+    assert text_generation_server._SERVER_PROCESSES == [existing_process]
+
+
+def test_stop_server_cleans_up_processes_and_shared_socket(monkeypatch):
+    class FakeProcess:
+        def __init__(self, *, exits_on_terminate):
+            self.alive = True
+            self.exits_on_terminate = exits_on_terminate
+            self.terminated = False
+            self.killed = False
+            self.join_timeouts = []
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminated = True
+            if self.exits_on_terminate:
+                self.alive = False
+
+        def join(self, timeout=None):
+            self.join_timeouts.append(timeout)
+
+        def kill(self):
+            self.killed = True
+            self.alive = False
+
+    graceful = FakeProcess(exits_on_terminate=True)
+    stubborn = FakeProcess(exits_on_terminate=False)
+    shared_socket = SimpleNamespace(closed=False)
+
+    def close_socket():
+        shared_socket.closed = True
+
+    shared_socket.close = close_socket
+    monkeypatch.setattr(text_generation_server, "_SERVER_PROCESSES", [graceful, stubborn])
+    monkeypatch.setattr(text_generation_server, "_SHARED_SOCKET", shared_socket)
+
+    text_generation_server.stop_text_gen_server()
+
+    assert graceful.terminated is stubborn.terminated is True
+    assert graceful.killed is False
+    assert stubborn.killed is True
+    assert graceful.join_timeouts == [3]
+    assert stubborn.join_timeouts == [3, None]
+    assert shared_socket.closed is True
+    assert text_generation_server._SERVER_PROCESSES == []
+    assert text_generation_server._SHARED_SOCKET is None

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -17,12 +17,12 @@ from megatron.core.inference.inference_request import InferenceRequest, Status, 
 from megatron.core.inference.model_inference_wrappers.multimodal.nemotron_omni_inference_wrapper import (
     NemotronOmniInferenceWrapper,
 )
-from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (
-    VLMInferenceWrapper,
-)
 from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
     dynamic_media_embedding_counts,
     dynamic_media_replacement_counts,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (
+    VLMInferenceWrapper,
 )
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.vlm_text_generation_controller import (
@@ -45,9 +45,7 @@ def test_vlm_wrapper_builds_preexpanded_media_token_mask():
     wrapper = object.__new__(VLMInferenceWrapper)
     wrapper.model = SimpleNamespace(image_token_index=99)
 
-    mask = wrapper.build_preexpanded_media_token_mask(
-        torch.tensor([10, 99, 99, 20]), "image"
-    )
+    mask = wrapper.build_preexpanded_media_token_mask(torch.tensor([10, 99, 99, 20]), "image")
 
     assert mask.tolist() == [-1, 0, 1, -1]
 
@@ -64,23 +62,15 @@ def test_vlm_wrapper_preexpanded_mask_requires_model_token_id():
 @pytest.mark.internal
 def test_dynamic_video_embedding_counts_support_video_and_tubelet_markers():
     frame_counts = dynamic_media_embedding_counts(
-        torch.tensor([[448, 576]] * 4),
-        patch_dim=16,
-        pixel_shuffle=True,
+        torch.tensor([[448, 576]] * 4), patch_dim=16, pixel_shuffle=True
     )
     assert frame_counts == [252] * 4
 
     assert dynamic_media_replacement_counts(
-        frame_counts,
-        num_frames=torch.tensor([4]),
-        temporal_patch_size=2,
-        placeholder_count=2,
+        frame_counts, num_frames=torch.tensor([4]), temporal_patch_size=2, placeholder_count=2
     ) == [252, 252]
     assert dynamic_media_replacement_counts(
-        frame_counts,
-        num_frames=torch.tensor(4),
-        temporal_patch_size=2,
-        placeholder_count=1,
+        frame_counts, num_frames=torch.tensor(4), temporal_patch_size=2, placeholder_count=1
     ) == [504]
 
 
@@ -88,10 +78,7 @@ def test_dynamic_video_embedding_counts_support_video_and_tubelet_markers():
 def test_dynamic_video_embedding_counts_reject_misaligned_placeholders():
     with pytest.raises(ValueError, match="must match either"):
         dynamic_media_replacement_counts(
-            [252] * 4,
-            num_frames=torch.tensor([4]),
-            temporal_patch_size=2,
-            placeholder_count=3,
+            [252] * 4, num_frames=torch.tensor([4]), temporal_patch_size=2, placeholder_count=3
         )
 
 
@@ -110,9 +97,7 @@ def test_vlm_wrapper_expands_one_video_marker_to_all_tubelet_embeddings():
     )
 
     expanded, masks = wrapper.expand_image_tokens(
-        [[11, -200, 12]],
-        imgs_sizes=torch.tensor([[448, 576]] * 4),
-        num_frames=torch.tensor([4]),
+        [[11, -200, 12]], imgs_sizes=torch.tensor([[448, 576]] * 4), num_frames=torch.tensor([4])
     )
 
     assert expanded == [[11] + [-1] * 504 + [12]]
@@ -140,16 +125,9 @@ def test_vlm_and_omni_wrappers_expand_tubelet_markers_consistently():
     omni_wrapper = object.__new__(NemotronOmniInferenceWrapper)
     omni_wrapper.model = model
 
-    kwargs = {
-        "imgs_sizes": torch.tensor([[448, 576]] * 4),
-        "num_frames": torch.tensor([4]),
-    }
-    vlm_expanded, vlm_masks = vlm_wrapper.expand_image_tokens(
-        [[11, -200, -200, 12]], **kwargs
-    )
-    omni_expanded, omni_masks = omni_wrapper.expand_image_tokens(
-        [[11, -200, -200, 12]], **kwargs
-    )
+    kwargs = {"imgs_sizes": torch.tensor([[448, 576]] * 4), "num_frames": torch.tensor([4])}
+    vlm_expanded, vlm_masks = vlm_wrapper.expand_image_tokens([[11, -200, -200, 12]], **kwargs)
+    omni_expanded, omni_masks = omni_wrapper.expand_image_tokens([[11, -200, -200, 12]], **kwargs)
 
     assert vlm_expanded == [[11] + [-1] * 504 + [12]]
     assert omni_expanded == [[11] + [-1] * 504 + [12]]

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -41,6 +41,27 @@ from tests.unit_tests.test_utilities import Utils
 
 
 @pytest.mark.internal
+def test_vlm_wrapper_builds_preexpanded_media_token_mask():
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = SimpleNamespace(image_token_index=99)
+
+    mask = wrapper.build_preexpanded_media_token_mask(
+        torch.tensor([10, 99, 99, 20]), "image"
+    )
+
+    assert mask.tolist() == [-1, 0, 1, -1]
+
+
+@pytest.mark.internal
+def test_vlm_wrapper_preexpanded_mask_requires_model_token_id():
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="does not define a model token id"):
+        wrapper.build_preexpanded_media_token_mask(torch.tensor([10, 20]), "image")
+
+
+@pytest.mark.internal
 def test_dynamic_video_embedding_counts_support_video_and_tubelet_markers():
     frame_counts = dynamic_media_embedding_counts(
         torch.tensor([[448, 576]] * 4),

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -58,7 +58,7 @@ def test_vlm_wrapper_resolves_media_id_from_tokenizer_not_model_sentinel():
         convert_tokens_to_ids=lambda token: 99 if token == "<image>" else 0, unk_token_id=0
     )
 
-    assert wrapper.get_multimodal_prompt_config().image_spec.model_token == "<image>"
+    assert wrapper.multimodal_prompt_config.image_spec.model_token == "<image>"
     assert wrapper.resolve_media_token_id(tokenizer, "image") == 99
 
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -5,6 +5,7 @@ import random
 import string
 import time
 from collections import OrderedDict
+from types import SimpleNamespace
 from typing import Dict, List
 from unittest import mock
 
@@ -13,8 +14,15 @@ import torch
 
 from megatron.core.inference.contexts import StaticInferenceContext
 from megatron.core.inference.inference_request import InferenceRequest, Status, VLMInferenceRequest
+from megatron.core.inference.model_inference_wrappers.multimodal.nemotron_omni_inference_wrapper import (
+    NemotronOmniInferenceWrapper,
+)
 from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (
     VLMInferenceWrapper,
+)
+from megatron.core.inference.model_inference_wrappers.multimodal.utils import (
+    dynamic_media_embedding_counts,
+    dynamic_media_replacement_counts,
 )
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.vlm_text_generation_controller import (
@@ -30,6 +38,102 @@ from megatron.core.transformer.spec_utils import ModuleSpec, get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.internal
+def test_dynamic_video_embedding_counts_support_video_and_tubelet_markers():
+    frame_counts = dynamic_media_embedding_counts(
+        torch.tensor([[448, 576]] * 4),
+        patch_dim=16,
+        pixel_shuffle=True,
+    )
+    assert frame_counts == [252] * 4
+
+    assert dynamic_media_replacement_counts(
+        frame_counts,
+        num_frames=torch.tensor([4]),
+        temporal_patch_size=2,
+        placeholder_count=2,
+    ) == [252, 252]
+    assert dynamic_media_replacement_counts(
+        frame_counts,
+        num_frames=torch.tensor(4),
+        temporal_patch_size=2,
+        placeholder_count=1,
+    ) == [504]
+
+
+@pytest.mark.internal
+def test_dynamic_video_embedding_counts_reject_misaligned_placeholders():
+    with pytest.raises(ValueError, match="must match either"):
+        dynamic_media_replacement_counts(
+            [252] * 4,
+            num_frames=torch.tensor([4]),
+            temporal_patch_size=2,
+            placeholder_count=3,
+        )
+
+
+@pytest.mark.internal
+def test_vlm_wrapper_expands_one_video_marker_to_all_tubelet_embeddings():
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = SimpleNamespace()
+    wrapper.model.module = SimpleNamespace(
+        image_token_index=-200,
+        _dynamic_resolution=True,
+        patch_dim=16,
+        _pixel_shuffle=True,
+        _conv_merging=False,
+        _drop_vision_class_token=True,
+        temporal_patch_dim=2,
+    )
+
+    expanded, masks = wrapper.expand_image_tokens(
+        [[11, -200, 12]],
+        imgs_sizes=torch.tensor([[448, 576]] * 4),
+        num_frames=torch.tensor([4]),
+    )
+
+    assert expanded == [[11] + [-1] * 504 + [12]]
+    assert masks[0][0] is None
+    assert masks[0][1:-1] == list(range(504))
+    assert masks[0][-1] is None
+
+
+@pytest.mark.internal
+def test_vlm_and_omni_wrappers_expand_tubelet_markers_consistently():
+    model = SimpleNamespace(
+        image_token_index=-200,
+        _dynamic_resolution=True,
+        dynamic_resolution=True,
+        patch_dim=16,
+        _pixel_shuffle=True,
+        _conv_merging=False,
+        _drop_vision_class_token=True,
+        temporal_patch_dim=2,
+    )
+    model.vision_model = SimpleNamespace(temporal_patch_dim=2)
+
+    vlm_wrapper = object.__new__(VLMInferenceWrapper)
+    vlm_wrapper.model = SimpleNamespace(module=model)
+    omni_wrapper = object.__new__(NemotronOmniInferenceWrapper)
+    omni_wrapper.model = model
+
+    kwargs = {
+        "imgs_sizes": torch.tensor([[448, 576]] * 4),
+        "num_frames": torch.tensor([4]),
+    }
+    vlm_expanded, vlm_masks = vlm_wrapper.expand_image_tokens(
+        [[11, -200, -200, 12]], **kwargs
+    )
+    omni_expanded, omni_masks = omni_wrapper.expand_image_tokens(
+        [[11, -200, -200, 12]], **kwargs
+    )
+
+    assert vlm_expanded == [[11] + [-1] * 504 + [12]]
+    assert omni_expanded == [[11] + [-1] * 504 + [12]]
+    assert vlm_masks == omni_masks
+    assert vlm_masks[0][1:-1] == list(range(504))
 
 
 class TestVLMTextGenerationController:

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -104,6 +104,45 @@ def test_vlm_dynamic_forward_sanitizes_preexpanded_media_sentinel():
 
 
 @pytest.mark.internal
+@pytest.mark.parametrize("is_video", [False, True])
+def test_vlm_vision_forward_casts_images_and_passes_tensor_input_ids(is_video):
+    module = SimpleNamespace(
+        image_token_index=-200,
+        vision_model=SimpleNamespace(config=SimpleNamespace(params_dtype=torch.bfloat16)),
+        dynamic_resolution=False,
+        add_decoder=True,
+    )
+
+    class WrappedVisionModel:
+        def __init__(self):
+            self.module = module
+            self.call_args = None
+
+        def __call__(self, *args, **kwargs):
+            self.call_args = (args, kwargs)
+            return torch.zeros(2, 1, 4, dtype=torch.bfloat16), None
+
+    model = WrappedVisionModel()
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = model
+    wrapper.inference_context = None
+
+    output = wrapper._forward_vision_encoder(
+        torch.ones(1, 3, 2, 2, dtype=torch.float32),
+        num_image_tiles=torch.tensor([1]),
+        num_frames=torch.tensor([1]) if is_video else None,
+    )
+
+    args, _ = model.call_args
+    assert args[0].dtype == torch.bfloat16
+    assert isinstance(args[1], torch.Tensor)
+    assert args[1].shape == (1, 0)
+    assert args[1].device == args[0].device
+    assert module.add_decoder is True
+    assert output.dtype == torch.bfloat16
+
+
+@pytest.mark.internal
 def test_dynamic_video_embedding_counts_group_one_placeholder_per_video():
     frame_counts = dynamic_media_embedding_counts(
         torch.tensor([[448, 576]] * 4), patch_dim=16, pixel_shuffle=True
@@ -129,7 +168,7 @@ def test_vlm_wrapper_expands_one_video_marker_to_all_tubelet_embeddings():
     wrapper.model = SimpleNamespace()
     wrapper.model.module = SimpleNamespace(
         image_token_index=-200,
-        _dynamic_resolution=True,
+        dynamic_resolution=True,
         patch_dim=16,
         _pixel_shuffle=True,
         _conv_merging=False,
@@ -156,7 +195,7 @@ def test_vlm_wrapper_rejects_multiple_compact_markers_for_one_video():
     wrapper.model = SimpleNamespace()
     wrapper.model.module = SimpleNamespace(
         image_token_index=-200,
-        _dynamic_resolution=True,
+        dynamic_resolution=True,
         patch_dim=16,
         _pixel_shuffle=True,
         _conv_merging=False,
@@ -177,7 +216,6 @@ def test_vlm_wrapper_rejects_multiple_compact_markers_for_one_video():
 def test_vlm_and_omni_wrappers_expand_video_markers_consistently():
     model = SimpleNamespace(
         image_token_index=-200,
-        _dynamic_resolution=True,
         dynamic_resolution=True,
         patch_dim=16,
         _pixel_shuffle=True,

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -43,42 +43,88 @@ from tests.unit_tests.test_utilities import Utils
 @pytest.mark.internal
 def test_vlm_wrapper_builds_preexpanded_media_token_mask():
     wrapper = object.__new__(VLMInferenceWrapper)
-    wrapper.model = SimpleNamespace(image_token_index=99)
+    wrapper.model = SimpleNamespace(image_token_index=-200)
 
-    mask = wrapper.build_preexpanded_media_token_mask(torch.tensor([10, 99, 99, 20]), "image")
+    mask = wrapper.build_preexpanded_media_token_mask(
+        torch.tensor([10, -200, -200, 20]), "image"
+    )
 
     assert mask.tolist() == [-1, 0, 1, -1]
 
 
 @pytest.mark.internal
-def test_vlm_wrapper_preexpanded_mask_requires_model_token_id():
+def test_vlm_wrapper_resolves_media_id_from_tokenizer_not_model_sentinel():
     wrapper = object.__new__(VLMInferenceWrapper)
-    wrapper.model = SimpleNamespace()
+    wrapper.model = SimpleNamespace(image_token_index=-200)
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda token: 99 if token == "<image>" else 0,
+        unk_token_id=0,
+    )
 
-    with pytest.raises(ValueError, match="does not define a model token id"):
-        wrapper.build_preexpanded_media_token_mask(torch.tensor([10, 20]), "image")
+    assert wrapper.get_multimodal_prompt_config().image_spec.model_token == "<image>"
+    assert wrapper.resolve_media_token_id(tokenizer, "image") == 99
 
 
 @pytest.mark.internal
-def test_dynamic_video_embedding_counts_support_video_and_tubelet_markers():
+def test_vlm_wrapper_resolves_media_id_with_encode_fallback():
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = SimpleNamespace(image_token_index=-200)
+    tokenizer = SimpleNamespace(encode=lambda token, add_special_tokens: [99])
+
+    assert wrapper.resolve_media_token_id(tokenizer, "image") == 99
+
+
+@pytest.mark.internal
+def test_vlm_dynamic_forward_sanitizes_preexpanded_media_sentinel():
+    embedding = mock.Mock(return_value=torch.zeros(3, 1, 4))
+    model = SimpleNamespace(
+        image_token_index=-200,
+        language_model=SimpleNamespace(embedding=embedding),
+        forward_lm_only=mock.Mock(return_value=torch.zeros(1, 3, 8)),
+    )
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = model
+    wrapper.pp_group = mock.Mock()
+    wrapper._recv_only_vision_embeds = False
+    wrapper.inference_context = None
+
+    with mock.patch(
+        "megatron.core.inference.model_inference_wrappers.multimodal."
+        "vlm_inference_wrapper.is_pipeline_first_stage",
+        return_value=True,
+    ):
+        wrapper._forward_dynamic(
+            {
+                "tokens": torch.tensor([[10, -200, -200]]),
+                "position_ids": torch.tensor([[0, 1, 2]]),
+                "image_token_mask": torch.tensor([[-1, 0, 1]]),
+                "image_embeddings": torch.zeros(2, 1, 4),
+                "attention_mask": None,
+            }
+        )
+
+    assert torch.equal(
+        embedding.call_args.kwargs["input_ids"], torch.tensor([[10, 0, 0]])
+    )
+
+
+@pytest.mark.internal
+def test_dynamic_video_embedding_counts_group_one_placeholder_per_video():
     frame_counts = dynamic_media_embedding_counts(
         torch.tensor([[448, 576]] * 4), patch_dim=16, pixel_shuffle=True
     )
     assert frame_counts == [252] * 4
 
     assert dynamic_media_replacement_counts(
-        frame_counts, num_frames=torch.tensor([4]), temporal_patch_size=2, placeholder_count=2
-    ) == [252, 252]
-    assert dynamic_media_replacement_counts(
-        frame_counts, num_frames=torch.tensor(4), temporal_patch_size=2, placeholder_count=1
+        frame_counts, num_frames=torch.tensor(4), temporal_patch_size=2
     ) == [504]
 
 
 @pytest.mark.internal
-def test_dynamic_video_embedding_counts_reject_misaligned_placeholders():
-    with pytest.raises(ValueError, match="must match either"):
+def test_dynamic_video_embedding_counts_reject_misaligned_frames():
+    with pytest.raises(ValueError, match="must partition"):
         dynamic_media_replacement_counts(
-            [252] * 4, num_frames=torch.tensor([4]), temporal_patch_size=2, placeholder_count=3
+            [252] * 4, num_frames=torch.tensor([3]), temporal_patch_size=2
         )
 
 
@@ -97,7 +143,10 @@ def test_vlm_wrapper_expands_one_video_marker_to_all_tubelet_embeddings():
     )
 
     expanded, masks = wrapper.expand_image_tokens(
-        [[11, -200, 12]], imgs_sizes=torch.tensor([[448, 576]] * 4), num_frames=torch.tensor([4])
+        [[11, 99, 12]],
+        imgs_sizes=torch.tensor([[448, 576]] * 4),
+        num_frames=torch.tensor([4]),
+        image_token_id=99,
     )
 
     assert expanded == [[11] + [-1] * 504 + [12]]
@@ -107,7 +156,30 @@ def test_vlm_wrapper_expands_one_video_marker_to_all_tubelet_embeddings():
 
 
 @pytest.mark.internal
-def test_vlm_and_omni_wrappers_expand_tubelet_markers_consistently():
+def test_vlm_wrapper_rejects_multiple_compact_markers_for_one_video():
+    wrapper = object.__new__(VLMInferenceWrapper)
+    wrapper.model = SimpleNamespace()
+    wrapper.model.module = SimpleNamespace(
+        image_token_index=-200,
+        _dynamic_resolution=True,
+        patch_dim=16,
+        _pixel_shuffle=True,
+        _conv_merging=False,
+        _drop_vision_class_token=True,
+        temporal_patch_dim=2,
+    )
+
+    with pytest.raises(ValueError, match="one compact placeholder per video"):
+        wrapper.expand_image_tokens(
+            [[11, 99, 99, 12]],
+            imgs_sizes=torch.tensor([[448, 576]] * 4),
+            num_frames=torch.tensor([4]),
+            image_token_id=99,
+        )
+
+
+@pytest.mark.internal
+def test_vlm_and_omni_wrappers_expand_video_markers_consistently():
     model = SimpleNamespace(
         image_token_index=-200,
         _dynamic_resolution=True,
@@ -125,9 +197,13 @@ def test_vlm_and_omni_wrappers_expand_tubelet_markers_consistently():
     omni_wrapper = object.__new__(NemotronOmniInferenceWrapper)
     omni_wrapper.model = model
 
-    kwargs = {"imgs_sizes": torch.tensor([[448, 576]] * 4), "num_frames": torch.tensor([4])}
-    vlm_expanded, vlm_masks = vlm_wrapper.expand_image_tokens([[11, -200, -200, 12]], **kwargs)
-    omni_expanded, omni_masks = omni_wrapper.expand_image_tokens([[11, -200, -200, 12]], **kwargs)
+    kwargs = {
+        "imgs_sizes": torch.tensor([[448, 576]] * 4),
+        "num_frames": torch.tensor([4]),
+        "image_token_id": 99,
+    }
+    vlm_expanded, vlm_masks = vlm_wrapper.expand_image_tokens([[11, 99, 12]], **kwargs)
+    omni_expanded, omni_masks = omni_wrapper.expand_image_tokens([[11, 99, 12]], **kwargs)
 
     assert vlm_expanded == [[11] + [-1] * 504 + [12]]
     assert omni_expanded == [[11] + [-1] * 504 + [12]]

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -45,9 +45,7 @@ def test_vlm_wrapper_builds_preexpanded_media_token_mask():
     wrapper = object.__new__(VLMInferenceWrapper)
     wrapper.model = SimpleNamespace(image_token_index=-200)
 
-    mask = wrapper.build_preexpanded_media_token_mask(
-        torch.tensor([10, -200, -200, 20]), "image"
-    )
+    mask = wrapper.build_preexpanded_media_token_mask(torch.tensor([10, -200, -200, 20]), "image")
 
     assert mask.tolist() == [-1, 0, 1, -1]
 
@@ -57,8 +55,7 @@ def test_vlm_wrapper_resolves_media_id_from_tokenizer_not_model_sentinel():
     wrapper = object.__new__(VLMInferenceWrapper)
     wrapper.model = SimpleNamespace(image_token_index=-200)
     tokenizer = SimpleNamespace(
-        convert_tokens_to_ids=lambda token: 99 if token == "<image>" else 0,
-        unk_token_id=0,
+        convert_tokens_to_ids=lambda token: 99 if token == "<image>" else 0, unk_token_id=0
     )
 
     assert wrapper.get_multimodal_prompt_config().image_spec.model_token == "<image>"
@@ -103,9 +100,7 @@ def test_vlm_dynamic_forward_sanitizes_preexpanded_media_sentinel():
             }
         )
 
-    assert torch.equal(
-        embedding.call_args.kwargs["input_ids"], torch.tensor([[10, 0, 0]])
-    )
+    assert torch.equal(embedding.call_args.kwargs["input_ids"], torch.tensor([[10, 0, 0]]))
 
 
 @pytest.mark.internal

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -286,6 +286,51 @@ class TestLLaVAModel:
         assert torch.allclose(loss_mask[4], expected_loss_mask)
 
     @pytest.mark.internal
+    def test_preprocess_data_with_media_token_counts(self):
+        self.model.cuda()
+
+        hidden_size = 8
+        image_token_index = self.model.image_token_index
+        image_embeddings = (
+            torch.arange(5 * hidden_size, dtype=torch.float)
+            .reshape(5, 1, hidden_size)
+            .cuda()
+        )
+        language_embeddings = (
+            -torch.arange(2 * 3 * hidden_size, dtype=torch.float)
+            .reshape(2, 3, hidden_size)
+            .cuda()
+        )
+        input_ids = torch.tensor(
+            [[image_token_index, 1, 2], [3, image_token_index, 4]],
+            dtype=torch.long,
+            device="cuda",
+        )
+        num_image_tiles = torch.ones(2, dtype=torch.int, device="cuda")
+        media_token_counts = torch.tensor([2, 3], dtype=torch.int, device="cuda")
+
+        embeddings, _, _, _, _ = self.model._preprocess_data(
+            image_embeddings,
+            language_embeddings,
+            input_ids,
+            loss_mask=None,
+            labels=None,
+            use_inference_kv_cache=False,
+            inference_context=None,
+            image_token_index=image_token_index,
+            num_image_tiles=num_image_tiles,
+            media_token_counts=media_token_counts,
+        )
+
+        assert embeddings.shape == (5, 2, hidden_size)
+        assert torch.equal(embeddings[:2, 0], image_embeddings[:2, 0])
+        assert torch.equal(embeddings[2:4, 0], language_embeddings[0, 1:])
+        assert torch.count_nonzero(embeddings[4, 0]) == 0
+        assert torch.equal(embeddings[0, 1], language_embeddings[1, 0])
+        assert torch.equal(embeddings[1:4, 1], image_embeddings[2:, 0])
+        assert torch.equal(embeddings[4, 1], language_embeddings[1, 2])
+
+    @pytest.mark.internal
     def test_forward(self):
         self.model.cuda()
 

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -292,19 +292,13 @@ class TestLLaVAModel:
         hidden_size = 8
         image_token_index = self.model.image_token_index
         image_embeddings = (
-            torch.arange(5 * hidden_size, dtype=torch.float)
-            .reshape(5, 1, hidden_size)
-            .cuda()
+            torch.arange(5 * hidden_size, dtype=torch.float).reshape(5, 1, hidden_size).cuda()
         )
         language_embeddings = (
-            -torch.arange(2 * 3 * hidden_size, dtype=torch.float)
-            .reshape(2, 3, hidden_size)
-            .cuda()
+            -torch.arange(2 * 3 * hidden_size, dtype=torch.float).reshape(2, 3, hidden_size).cuda()
         )
         input_ids = torch.tensor(
-            [[image_token_index, 1, 2], [3, image_token_index, 4]],
-            dtype=torch.long,
-            device="cuda",
+            [[image_token_index, 1, 2], [3, image_token_index, 4]], dtype=torch.long, device="cuda"
         )
         num_image_tiles = torch.ones(2, dtype=torch.int, device="cuda")
         media_token_counts = torch.tensor([2, 3], dtype=torch.int, device="cuda")

--- a/tests/unit_tests/models/test_llava_sound.py
+++ b/tests/unit_tests/models/test_llava_sound.py
@@ -168,6 +168,81 @@ class TestHasSoundsSentinel:
         assert self._has_sounds(torch.empty(0)) is False
 
 
+def test_forward_encodes_projects_and_forwards_sound_embeddings():
+    class _SoundModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(sound_pad_to_clip_duration=False)
+            self.calls = []
+
+        def forward(self, clips, lengths):
+            self.calls.append((clips, lengths))
+            return torch.ones(1, 1, 3), torch.tensor([1])
+
+    class _LanguageModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding_input_ids = None
+            self.forward_kwargs = None
+
+        def embedding(self, input_ids, position_ids):
+            del position_ids
+            self.embedding_input_ids = input_ids
+            return torch.zeros(input_ids.shape[1], input_ids.shape[0], 3)
+
+        def forward(self, **kwargs):
+            self.forward_kwargs = kwargs
+            return kwargs["decoder_input"]
+
+    model = object.__new__(LLaVAModel)
+    torch.nn.Module.__init__(model)
+    model.add_encoder = True
+    model.add_decoder = True
+    model.pre_process = True
+    model.post_process = True
+    model.vision_model = None
+    model.vision_projection = None
+    model._vision_projection_input_size = None
+    model.sound_model = _SoundModel()
+    model.sound_projection = torch.nn.Identity()
+    model.language_model = _LanguageModel()
+    model.encoder_hidden_state = None
+    model.image_token_index = -200
+    model.sound_token_index = DEFAULT_SOUND_TOKEN_INDEX
+    model.img_seq_len = 4
+    model.patch_dim = 2
+    model.dynamic_resolution = False
+    model._drop_vision_class_token = False
+    model._pixel_shuffle = False
+    model._conv_merging = False
+    model._max_num_tiles = 1
+    model._language_max_sequence_length = 64
+    model._language_is_pipeline_parallel = False
+    model.context_parallel_lm = 1
+    model.sequence_parallel_lm = False
+    clips = torch.ones(1, 16)
+    lengths = torch.tensor([16])
+
+    output, loss_mask = LLaVAModel.forward(
+        model,
+        images=None,
+        input_ids=torch.tensor([[1, DEFAULT_SOUND_TOKEN_INDEX, 2]]),
+        position_ids=torch.tensor([[0, 1, 2]]),
+        attention_mask=None,
+        sound_clips=clips,
+        sound_length=lengths,
+    )
+
+    assert len(model.sound_model.calls) == 1
+    assert torch.equal(model.sound_model.calls[0][0], clips)
+    assert torch.equal(model.sound_model.calls[0][1], lengths)
+    assert model.language_model.embedding_input_ids.tolist() == [[1, 0, 2]]
+    assert model.language_model.forward_kwargs["input_ids"].tolist() == [[1, 0, 2]]
+    assert output.shape == (3, 1, 3)
+    assert torch.equal(output[1, 0], torch.ones(3))
+    assert loss_mask is None
+
+
 # ---------------------------------------------------------------------------
 # Sound replacement in _preprocess_data (light integration)
 # ---------------------------------------------------------------------------
@@ -195,6 +270,11 @@ def _build_preprocess_stub(
         sound_token_index=sound_token_index,
         sound_model=sound_model,
         vision_model=None,
+        dynamic_resolution=False,
+        _drop_vision_class_token=False,
+        _pixel_shuffle=False,
+        _conv_merging=False,
+        _max_num_tiles=1,
         _language_max_sequence_length=language_max_sequence_length,
         _language_is_pipeline_parallel=False,
         context_parallel_lm=1,
@@ -226,12 +306,6 @@ def _make_inputs(*, batch=1, text_seq=8, embed_dim=4, sound_position=4, image_to
     )
 
 
-@pytest.mark.skip(
-    reason="Sound-embedding replacement inside _preprocess_data was removed during "
-    "the VLM refactor; sound_* kwargs are still accepted for API compatibility but "
-    "are not spliced into the combined embedding. Restore this test class if the "
-    "sound feature is re-added."
-)
 class TestPreprocessDataSoundReplacement:
     """Light integration tests for the sound replacement block of
     ``_preprocess_data`` (lines ~654–679 of ``llava_model.py``)."""
@@ -249,20 +323,22 @@ class TestPreprocessDataSoundReplacement:
         sound_embeddings = torch.full((5, 1, 4), 7.0)  # [s, b, h], capacity 5
         sound_embeddings_len = torch.tensor([1])  # only the first 1 is real
 
-        final_embedding, _final_labels, _final_loss_mask = LLaVAModel._preprocess_data(
-            stub,
-            image_embeddings=inputs.image_embeddings,
-            language_embeddings=inputs.language_embeddings,
-            input_ids=inputs.input_ids,
-            loss_mask=inputs.loss_mask,
-            labels=inputs.labels,
-            use_inference_kv_cache=False,
-            inference_context=None,
-            image_token_index=inputs.image_token_index,
-            num_image_tiles=inputs.num_image_tiles,
-            sound_embeddings=sound_embeddings,
-            sound_embeddings_len=sound_embeddings_len,
-            sound_timestamps=None,
+        final_embedding, _final_labels, _final_loss_mask, final_input_ids, _ = (
+            LLaVAModel._preprocess_data(
+                stub,
+                image_embeddings=inputs.image_embeddings,
+                language_embeddings=inputs.language_embeddings,
+                input_ids=inputs.input_ids,
+                loss_mask=inputs.loss_mask,
+                labels=inputs.labels,
+                use_inference_kv_cache=False,
+                inference_context=None,
+                image_token_index=inputs.image_token_index,
+                num_image_tiles=inputs.num_image_tiles,
+                sound_embeddings=sound_embeddings,
+                sound_embeddings_len=sound_embeddings_len,
+                sound_timestamps=None,
+            )
         )
 
         # final_embedding is returned as [s, b, h] (transposed) when CP=1.
@@ -273,6 +349,7 @@ class TestPreprocessDataSoundReplacement:
         assert torch.allclose(
             sound_slot, torch.full((4,), 7.0)
         ), f"sound slot was {sound_slot.tolist()}, expected all 7.0"
+        assert final_input_ids[0, 4].item() == 0
 
     @pytest.mark.internal
     def test_sound_pad_to_clip_duration_true_uses_full_buffer(self):
@@ -289,7 +366,7 @@ class TestPreprocessDataSoundReplacement:
         sound_embeddings = torch.arange(3 * 1 * 4, dtype=torch.float32).reshape(3, 1, 4)
         sound_embeddings_len = torch.tensor([3])
 
-        final_embedding, _, _ = LLaVAModel._preprocess_data(
+        final_embedding, _, _, _, _ = LLaVAModel._preprocess_data(
             stub,
             image_embeddings=inputs.image_embeddings,
             language_embeddings=inputs.language_embeddings,
@@ -327,7 +404,7 @@ class TestPreprocessDataSoundReplacement:
         sound_embeddings_len = torch.tensor([1])
 
         # Should run without error and not modify the embedding at the would-be slot.
-        final_embedding, _, _ = LLaVAModel._preprocess_data(
+        final_embedding, _, _, _, _ = LLaVAModel._preprocess_data(
             stub,
             image_embeddings=inputs.image_embeddings,
             language_embeddings=inputs.language_embeddings,
@@ -358,6 +435,11 @@ class TestPreprocessDataSoundReplacement:
             sound_token_index=DEFAULT_SOUND_TOKEN_INDEX,
             sound_model=SimpleNamespace(config=SimpleNamespace()),  # no attr
             vision_model=None,
+            dynamic_resolution=False,
+            _drop_vision_class_token=False,
+            _pixel_shuffle=False,
+            _conv_merging=False,
+            _max_num_tiles=1,
             _language_max_sequence_length=64,
             _language_is_pipeline_parallel=False,
             context_parallel_lm=1,

--- a/tests/unit_tests/models/test_llava_vision.py
+++ b/tests/unit_tests/models/test_llava_vision.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Focused image and video tests for ``LLaVAModel``."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.models.multimodal.llava_model import LLaVAModel
+from megatron.core.models.vision.radio import RADIOViTModel
+
+
+def _minimal_llava_forward(model, **kwargs):
+    return LLaVAModel.forward(
+        model,
+        images=kwargs.pop("images", torch.ones(2, 3, 2, 2)),
+        input_ids=torch.tensor([[1, 2]], dtype=torch.long),
+        position_ids=torch.tensor([[0, 1]], dtype=torch.long),
+        attention_mask=None,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("imgs_sizes", "num_frames", "error"),
+    [
+        (None, [2], "Video inputs require imgs_sizes"),
+        (torch.tensor([[2, 2], [2, 2]]), [0, 2], "num_frames entries must be positive"),
+        (torch.tensor([[2, 2], [2, 2]]), [1], "num_frames must partition imgs_sizes exactly"),
+    ],
+)
+def test_forward_rejects_invalid_video_frame_partitions(imgs_sizes, num_frames, error):
+    model = object.__new__(LLaVAModel)
+    model.add_encoder = True
+    model.temporal_patch_dim = 1
+    model.vision_model = SimpleNamespace(dynamic_resolution=False)
+
+    with pytest.raises(ValueError, match=error):
+        _minimal_llava_forward(model, imgs_sizes=imgs_sizes, num_frames=num_frames)
+
+
+def test_forward_temporal_video_groups_tubelet_counts_per_placeholder():
+    vision_model = object.__new__(RADIOViTModel)
+    torch.nn.Module.__init__(vision_model)
+    vision_model.dynamic_resolution = False
+    vision_model.patch_dim = 2
+    vision_model.class_token_len = 0
+    vision_model.add_class_token = False
+    vision_calls = []
+
+    def vision_forward(images, *, imgs_sizes, packed_seq_params, num_frames):
+        vision_calls.append((images, imgs_sizes, packed_seq_params, num_frames))
+        post_sizes = torch.tensor([[4, 4], [4, 4]], dtype=torch.int32)
+        return torch.arange(16, dtype=torch.float32).reshape(1, 8, 2), post_sizes, None
+
+    vision_model.forward = vision_forward
+
+    class _LanguageModel(torch.nn.Module):
+        def embedding(self, input_ids, position_ids):
+            del position_ids
+            return torch.zeros(input_ids.shape[1], input_ids.shape[0], 2)
+
+        def forward(self, **kwargs):
+            return kwargs["decoder_input"]
+
+    model = object.__new__(LLaVAModel)
+    torch.nn.Module.__init__(model)
+    model.add_encoder = True
+    model.add_decoder = True
+    model.pre_process = True
+    model.temporal_patch_dim = 2
+    model.vision_model = vision_model
+    model.vision_projection = torch.nn.Identity()
+    model.language_model = _LanguageModel()
+    model.image_token_index = -200
+    model.sound_token_index = -300
+    model.context_parallel_lm = 1
+    model.sequence_parallel_lm = False
+    model._drop_vision_class_token = True
+    model._pixel_shuffle = False
+    model._conv_merging = False
+    model._tile_tags = None
+    captured = {}
+
+    def preprocess(*args, **kwargs):
+        captured["media_token_counts"] = kwargs["media_token_counts"]
+        return torch.zeros(2, 1, 2), None, None, None, None
+
+    model._preprocess_data = preprocess
+
+    output, loss_mask = _minimal_llava_forward(
+        model,
+        images=torch.ones(4, 3, 4, 4),
+        imgs_sizes=torch.tensor([[4, 4]] * 4, dtype=torch.int32),
+        num_frames=[4],
+    )
+
+    assert vision_calls[0][3] == [4]
+    assert captured["media_token_counts"].tolist() == [8]
+    assert output.shape == (2, 1, 2)
+    assert loss_mask is None
+
+
+@pytest.mark.parametrize(("modality", "num_media_embeddings"), [("image", 4), ("video", 8)])
+def test_forward_image_and_video_inference_prefill_reuses_kv_cache(modality, num_media_embeddings):
+    class _VisionModel(torch.nn.Module):
+        dynamic_resolution = False
+        class_token_len = 0
+
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def forward(self, images, **kwargs):
+            self.calls.append((images, kwargs))
+            return torch.ones(images.shape[0], 4, 2)
+
+    class _LanguageModel(torch.nn.Module):
+        def embedding(self, input_ids, position_ids):
+            del position_ids
+            return torch.zeros(input_ids.shape[1], input_ids.shape[0], 2)
+
+        def forward(self, **kwargs):
+            return kwargs["decoder_input"]
+
+    model = object.__new__(LLaVAModel)
+    torch.nn.Module.__init__(model)
+    model.add_encoder = True
+    model.add_decoder = True
+    model.pre_process = True
+    model.post_process = True
+    model.vision_model = _VisionModel()
+    model.vision_projection = torch.nn.Identity()
+    model.sound_model = None
+    model.sound_projection = None
+    model.language_model = _LanguageModel()
+    model.encoder_hidden_state = None
+    model.image_token_index = -200
+    model.sound_token_index = -300
+    model.temporal_patch_dim = 1
+    model.img_seq_len = 4
+    model.patch_dim = 2
+    model.dynamic_resolution = False
+    model._drop_vision_class_token = False
+    model._pixel_shuffle = False
+    model._conv_merging = False
+    model._tile_tags = None
+    model._max_num_tiles = 1
+    model._language_max_sequence_length = 64
+    model._language_is_pipeline_parallel = False
+    model.context_parallel_lm = 1
+    model.sequence_parallel_lm = False
+
+    if modality == "video":
+        images = torch.ones(2, 3, 4, 4)
+        imgs_sizes = torch.tensor([[4, 4], [4, 4]], dtype=torch.int32)
+        num_frames = [2]
+    else:
+        images = torch.ones(1, 3, 4, 4)
+        imgs_sizes = None
+        num_frames = None
+
+    inference_context = SimpleNamespace(key_value_memory_dict={})
+    prefill_output, _ = LLaVAModel.forward(
+        model,
+        images=images,
+        input_ids=torch.tensor([[10, model.image_token_index, 11]]),
+        position_ids=torch.tensor([[0, 1, 2]]),
+        attention_mask=None,
+        imgs_sizes=imgs_sizes,
+        num_frames=num_frames,
+        inference_context=inference_context,
+    )
+
+    assert len(model.vision_model.calls) == 1
+    assert inference_context.key_value_memory_dict["image_tokens_count"] == num_media_embeddings
+    assert prefill_output.shape == (num_media_embeddings + 2, 1, 2)
+    assert int(torch.all(prefill_output == 1, dim=-1).sum()) == num_media_embeddings
+
+    decode_output, _ = LLaVAModel.forward(
+        model,
+        images=None,
+        input_ids=torch.tensor([[12]]),
+        position_ids=torch.tensor([[3]]),
+        attention_mask=None,
+        inference_context=inference_context,
+    )
+
+    assert len(model.vision_model.calls) == 1
+    assert decode_output.shape == (1, 1, 2)

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -373,18 +373,17 @@ class TestPixelShuffleNonSquare:
 
     @pytest.mark.internal
     def test_temporal_token_counts_group_one_placeholder_per_media(self):
-        from megatron.core.models.multimodal.llava_model import (
-            _group_temporal_token_counts,
-            _group_temporal_token_counts_tensor,
-        )
+        from megatron.core.models.multimodal.llava_model import _group_temporal_token_counts_tensor
 
-        tubelet_counts = [252, 252, 128]
+        tubelet_counts = torch.tensor([252, 252, 128], dtype=torch.int32, device="cuda")
         media_tubelet_counts = [2, 1]
-        assert _group_temporal_token_counts(tubelet_counts, media_tubelet_counts) == [504, 128]
+        grouped_counts = _group_temporal_token_counts_tensor(tubelet_counts, media_tubelet_counts)
+        assert torch.equal(
+            grouped_counts, torch.tensor([504, 128], dtype=torch.int32, device="cuda")
+        )
 
         # temporal_patch_dim=1 makes every frame one tubelet. A per-video
         # placeholder therefore receives the sum of all frame embeddings.
-        assert _group_temporal_token_counts([64, 64, 32], [2, 1]) == [128, 32]
         device_counts = torch.tensor([64, 64, 32], dtype=torch.int32, device="cuda")
         grouped_counts = _group_temporal_token_counts_tensor(device_counts, [2, 1])
         assert torch.equal(
@@ -392,7 +391,7 @@ class TestPixelShuffleNonSquare:
         )
 
         with pytest.raises(ValueError, match="must partition"):
-            _group_temporal_token_counts(tubelet_counts, [1, 1])
+            _group_temporal_token_counts_tensor(tubelet_counts, [1, 1])
 
 
 class TestRADIODynamicResAndTemporal:

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -311,6 +311,30 @@ class TestPixelShuffleNonSquare:
         torch.testing.assert_close(out, expected)
 
     @pytest.mark.internal
+    def test_dynamic_resolution_non_square_image_golden_values(self):
+        from megatron.core.models.multimodal.llava_model import pixel_shuffle_dynamic_res
+
+        x = torch.arange(24, dtype=torch.float32).reshape(1, 24, 1)
+        imgs_sizes = torch.tensor([[4, 6]], dtype=torch.int32)
+
+        out = pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim=1)
+
+        expected = torch.tensor(
+            [
+                [
+                    [0, 1, 6, 7],
+                    [2, 3, 8, 9],
+                    [4, 5, 10, 11],
+                    [12, 13, 18, 19],
+                    [14, 15, 20, 21],
+                    [16, 17, 22, 23],
+                ]
+            ],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(out, expected)
+
+    @pytest.mark.internal
     def test_non_square_h_w_must_be_even(self):
         from megatron.core.models.multimodal.llava_model import pixel_shuffle
 
@@ -348,20 +372,27 @@ class TestPixelShuffleNonSquare:
         assert shuffled_images[0].shape == (1, 252, 32)
 
     @pytest.mark.internal
-    def test_temporal_token_counts_support_media_or_tubelet_placeholders(self):
-        from megatron.core.models.multimodal.llava_model import _group_temporal_token_counts
+    def test_temporal_token_counts_group_one_placeholder_per_media(self):
+        from megatron.core.models.multimodal.llava_model import (
+            _group_temporal_token_counts,
+            _group_temporal_token_counts_tensor,
+        )
 
         tubelet_counts = [252, 252, 128]
         media_tubelet_counts = [2, 1]
-        assert _group_temporal_token_counts(
-            tubelet_counts, media_tubelet_counts, placeholder_count=3
-        ) == [252, 252, 128]
-        assert _group_temporal_token_counts(
-            tubelet_counts, media_tubelet_counts, placeholder_count=2
-        ) == [504, 128]
+        assert _group_temporal_token_counts(tubelet_counts, media_tubelet_counts) == [504, 128]
 
-        with pytest.raises(ValueError, match="must match either"):
-            _group_temporal_token_counts(tubelet_counts, media_tubelet_counts, placeholder_count=1)
+        # temporal_patch_dim=1 makes every frame one tubelet. A per-video
+        # placeholder therefore receives the sum of all frame embeddings.
+        assert _group_temporal_token_counts([64, 64, 32], [2, 1]) == [128, 32]
+        device_counts = torch.tensor([64, 64, 32], dtype=torch.int32, device="cuda")
+        grouped_counts = _group_temporal_token_counts_tensor(device_counts, [2, 1])
+        assert torch.equal(
+            grouped_counts, torch.tensor([128, 32], dtype=torch.int32, device="cuda")
+        )
+
+        with pytest.raises(ValueError, match="must partition"):
+            _group_temporal_token_counts(tubelet_counts, [1, 1])
 
 
 class TestRADIODynamicResAndTemporal:

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -337,25 +337,19 @@ class TestPixelShuffleNonSquare:
         # helper must also continue accepting packed 3D image chunks.
         video_chunks = [torch.randn(1008, 8) for _ in range(8)]
         shuffled_video = _pixel_shuffle_dynamic_resolution_chunks(
-            video_chunks,
-            [(448, 576)] * 8,
-            patch_dim=16,
+            video_chunks, [(448, 576)] * 8, patch_dim=16
         )
         assert all(chunk.shape == (252, 32) for chunk in shuffled_video)
 
         packed_image_chunks = [torch.randn(1, 1008, 8)]
         shuffled_images = _pixel_shuffle_dynamic_resolution_chunks(
-            packed_image_chunks,
-            [(448, 576)],
-            patch_dim=16,
+            packed_image_chunks, [(448, 576)], patch_dim=16
         )
         assert shuffled_images[0].shape == (1, 252, 32)
 
     @pytest.mark.internal
     def test_temporal_token_counts_support_media_or_tubelet_placeholders(self):
-        from megatron.core.models.multimodal.llava_model import (
-            _group_temporal_token_counts,
-        )
+        from megatron.core.models.multimodal.llava_model import _group_temporal_token_counts
 
         tubelet_counts = [252, 252, 128]
         media_tubelet_counts = [2, 1]
@@ -367,9 +361,7 @@ class TestPixelShuffleNonSquare:
         ) == [504, 128]
 
         with pytest.raises(ValueError, match="must match either"):
-            _group_temporal_token_counts(
-                tubelet_counts, media_tubelet_counts, placeholder_count=1
-            )
+            _group_temporal_token_counts(tubelet_counts, media_tubelet_counts, placeholder_count=1)
 
 
 class TestRADIODynamicResAndTemporal:

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -290,12 +290,33 @@ class TestPixelShuffleNonSquare:
     def test_non_square_h_w_required_for_dynamic_res(self):
         from megatron.core.models.multimodal.llava_model import pixel_shuffle
 
-        # 12 patches arranged as 3×4 (non-square). With h, w supplied the
-        # function must accept this and produce the shuffled output.
+        # Pixel shuffle must group spatial 2x2 neighborhoods rather than four
+        # consecutive entries in the flattened non-square grid.
+        x = torch.arange(24, dtype=torch.float32).reshape(1, 24, 1)
+        out = pixel_shuffle(x, h=4, w=6)
+
+        expected = torch.tensor(
+            [
+                [
+                    [0, 1, 6, 7],
+                    [2, 3, 8, 9],
+                    [4, 5, 10, 11],
+                    [12, 13, 18, 19],
+                    [14, 15, 20, 21],
+                    [16, 17, 22, 23],
+                ]
+            ],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(out, expected)
+
+    @pytest.mark.internal
+    def test_non_square_h_w_must_be_even(self):
+        from megatron.core.models.multimodal.llava_model import pixel_shuffle
+
         x = torch.randn(1, 12, 4)
-        out = pixel_shuffle(x, h=3, w=4)
-        # scale=0.5 ⇒ each spatial dim halves ⇒ output area = (3*4)/(2*2) = 3.
-        assert out.shape == (1, 3, 16)
+        with pytest.raises(AssertionError, match="must both be divisible"):
+            pixel_shuffle(x, h=3, w=4)
 
     @pytest.mark.internal
     def test_h_w_mismatch_raises(self):
@@ -305,6 +326,50 @@ class TestPixelShuffleNonSquare:
         # Mismatch: h*w != patches.
         with pytest.raises(AssertionError):
             pixel_shuffle(x, h=2, w=2)
+
+    @pytest.mark.internal
+    def test_dynamic_resolution_video_chunks_use_real_non_square_grids(self):
+        from megatron.core.models.multimodal.llava_model import (
+            _pixel_shuffle_dynamic_resolution_chunks,
+        )
+
+        # The temporal encoder returns one 2D chunk per tubelet. The shared
+        # helper must also continue accepting packed 3D image chunks.
+        video_chunks = [torch.randn(1008, 8) for _ in range(8)]
+        shuffled_video = _pixel_shuffle_dynamic_resolution_chunks(
+            video_chunks,
+            [(448, 576)] * 8,
+            patch_dim=16,
+        )
+        assert all(chunk.shape == (252, 32) for chunk in shuffled_video)
+
+        packed_image_chunks = [torch.randn(1, 1008, 8)]
+        shuffled_images = _pixel_shuffle_dynamic_resolution_chunks(
+            packed_image_chunks,
+            [(448, 576)],
+            patch_dim=16,
+        )
+        assert shuffled_images[0].shape == (1, 252, 32)
+
+    @pytest.mark.internal
+    def test_temporal_token_counts_support_media_or_tubelet_placeholders(self):
+        from megatron.core.models.multimodal.llava_model import (
+            _group_temporal_token_counts,
+        )
+
+        tubelet_counts = [252, 252, 128]
+        media_tubelet_counts = [2, 1]
+        assert _group_temporal_token_counts(
+            tubelet_counts, media_tubelet_counts, placeholder_count=3
+        ) == [252, 252, 128]
+        assert _group_temporal_token_counts(
+            tubelet_counts, media_tubelet_counts, placeholder_count=2
+        ) == [504, 128]
+
+        with pytest.raises(ValueError, match="must match either"):
+            _group_temporal_token_counts(
+                tubelet_counts, media_tubelet_counts, placeholder_count=1
+            )
 
 
 class TestRADIODynamicResAndTemporal:

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -19,7 +19,10 @@ if _EXAMPLES_MULTIMODAL not in sys.path:
 import torch  # noqa: E402
 
 from examples.multimodal.multimodal_args import add_multimodal_extra_args  # noqa: E402
-from megatron.core.inference.config import ImageProcessingConfig  # noqa: E402
+from megatron.core.inference.config import (  # noqa: E402
+    ImageProcessingConfig,
+    VideoProcessingConfig,
+)
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext  # noqa: E402
 from megatron.core.inference.engines import DynamicInferenceEngine  # noqa: E402
 from megatron.core.inference.model_inference_wrappers.multimodal.vlm_inference_wrapper import (  # noqa: E402,E501
@@ -147,6 +150,17 @@ def _build_engine_for_vlm_or_gpt(is_vlm: bool) -> DynamicInferenceEngine:
         use_thumbnail=getattr(args, 'use_thumbnail', False),
         num_img_embeddings_per_tile=args.num_img_embeddings_per_tile,
     )
+    inference_config.video_preprocessing_config = VideoProcessingConfig(
+        image_config=inference_config.image_preprocessing_config,
+        num_frames=int(getattr(args, "num_frames", 8)),
+        temporal_patch_size=int(
+            getattr(
+                model,
+                "temporal_patch_dim",
+                getattr(getattr(model, "vision_model", None), "temporal_patch_dim", 1),
+            )
+        ),
+    )
 
     context = DynamicInferenceContext(model.config, inference_config)
     wrapped_model = VLMInferenceWrapper(model, context)
@@ -190,6 +204,9 @@ async def run_text_generation_server(
                 verbose=args.inference_text_gen_server_logging,
                 hostname=hostname,
                 chat_template=chat_template,
+                multimodal_prompt_config=(
+                    engine.controller.inference_wrapped_model.get_multimodal_prompt_config()
+                ),
             )
 
         # Await the engine loop directly since the server is running in a separate process

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -205,7 +205,7 @@ async def run_text_generation_server(
                 hostname=hostname,
                 chat_template=chat_template,
                 multimodal_prompt_config=(
-                    engine.controller.inference_wrapped_model.get_multimodal_prompt_config()
+                    engine.controller.inference_wrapped_model.multimodal_prompt_config
                 ),
             )
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Associated with: https://github.com/NVIDIA-NeMo/RL/pull/3834

- Extend image modality to support video modalities in Megatron-Inference. 
  - Modalities
    - Images can be either shipped into the completions endpoint as raw bytes (`{"image": [image1_bytes, image2_bytes]}`), or passed `Megatron(Async)LLM.generate` as preprocessed Tensors (`{"image": {"imgs": ..., "imgs_sizes": ..., "num_tiles": ..., "num_img_embeddings_per_tile": ...}}`).
    - Video can be either shipped into the completions endpoint as raw bytes (`{"video": [video1_bytes, video2_bytes]}`) or a byte-string containing paths to video frame images (`VideoProcessingConfig.frame_manifest_magic + json.dumps({"frame_paths": [...]}).encode("utf-8")`), or passed to `Megatron(Async)LLM.generate` as preprocessed Tensors (`{"video": {"imgs": ..., "imgs_sizes": ..., "num_frames": ... }}`).
    - Pre-processed Tensors can be optionally pre-expanded with multimodal placeholders by RL or the user using the config `media_tokens_preexpanded: bool` in the `multi_modal_data` dictionary input to `Megatron(Async)LLM.generate`.
      - In a nutshell, pre-processed + pre-expanded Tensors = NeMo-RL non-Gym handles the multimodal preprocessing, while bytes = NeMo-RL Gym sends over the raw data for Megatron-Inference to handle the multimodal preprocessing. Having direct engine access in the first (Tensor) case is generally something we want to keep maintaining, not only to support non-Gym in RL but also for users to have direct control over what Tensors go into the encoder/decoder.
    - If you ever see the term "compact" describing prompt tokens it means "prior to expansion" where we have a single token placeholder representing an image or frame or video that will be expanded into many placeholder multimodal tokens for embedding injection before generation. This form is stored and used in some situations where we want to return a non-negative prompt of tokens back to RL and also in multi-turn chat where we re-tokenize and re-expand these compact prompts for chat continuation.
    - These match existing NeMo-RL vLLM API's for multimodal. (But it's honestly a mess of possible inputs depending on what each multimodal dataset prefers...)
  - Just like images, the video embeddings are computed in `_build_vlm_request` before the controller takes over decoding, and the embedding installed in the request can be used for checkpointing, etc. I hope I didn't unintentionally change too much for the trunk of the decoder engine here.
  - Caching / Routing - A cache key is computed here depending on the bytes: `inference_request.py/compute_media_cache_key`
    - Support media affinity via cache key in coordinator routing, which mixes into the affinity score produced by prefix hits for text.
    - Support vision embedding caching to skip the encoder pass on subsequent generations. The cache is LRU-cleared and cleared on suspend.
    - Salt in a media cache key in `compute_block_hashes_batched` to make prefix caching aware of the multimodal data in the prompt as well.
      - Note to self: `DynamicVLMInferenceRequest` saves the media key into the context and this is used later (`_compute_block_hashes`) to salt and recompute the engine-internal KV cache hash, which uses the expanded prompt with ``
  - Inference wrappers have a few more methods that are common to multimodal: `supports_<modality>` for quick-checking what a wrapper can support for a model, `MultimodalPromptConfig` and `resolve_media_token_id` for looking up what image/video placeholders and token IDs should be for a model so that the inference engine can use them as embedding placeholders in `expand_image_tokens` called by `_build_vlm_request`. This is a very _**experimental**_ API for inference wrappers.
    - Added a new inference wrapper for Nemotron Omni: `NemotronOmniInferenceWrapper`.
    - Also updated `VLMInferenceWrapper` for video and LLaVA.
  - `dynamic_res_preprocess` has been updated to support multiple ways of patching frames, and `video_maintain_aspect_ratio=True` is required for parity with RL + vLLM.
  - For video frames, we only sample up to `num_frames` so we can sample first, then convert the sampled frames to PIL / Tensor.

For both images and video, we have vLLM parity: https://wandb.ai/adlr/mllm-rl-dev?nw=nwusercye_nv
<img width="2139" height="1105" alt="Screenshot 2026-08-25 at 1 26 50 PM" src="https://github.com/user-attachments/assets/3c52844a-6a9d-4f3c-9134-05e16744aeab" />
Log prob error, gradient norms, and gen KL error all look reasonable as well, with some noise.

In the RL NSight profile, multimodal embeddings are computed once per prompt group and cached for future use, and then subsequent forward passes are decoder-only, all overlapped with RL training for async non-colocated (trajectory age = 2):
<img width="1646" height="550" alt="Screenshot 2026-08-26 at 1 40 41 AM" src="https://github.com/user-attachments/assets/8fe22f7f-2923-417d-8d11-4c8743d1c7d4" />

There's a known issue with this gap appearing in the generation loop, will debug in a future PR.

# Bugs

- Added back LLaVA audio support which seems to have been reverted for not much reason, referring to this PR: https://github.com/NVIDIA/Megatron-LM/pull/4402 -> https://github.com/NVIDIA/Megatron-LM/pull/6260

# Testing

- RL
  - https://github.com/cspades/RL/blob/cye/rl_mllm_omni_multimodal_scripts/scripts has 1N and 8N scripts with easy swapping between vLLM and MLLM.
- E2E Multimodal Inference
  - Run `examples/inference/*_multimodal_infer.py` on 2 GPUs with at least 40 GB. (For me, my two A6000's.)

```
uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -vvs tests/unit_tests/inference

========= 2601 passed, 108 skipped, 2872 warnings in 971.37s (0:16:11) ==========
```

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
