### PR TITLE
Make hybrid MoE grouped GEMM configurable

### DIFF
--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
+from dataclasses import replace
 from functools import partial
 
 from megatron.core.extensions.transformer_engine import (
@@ -238,6 +239,30 @@ hybrid_stack_spec = ModuleSpec(
 )
 
 
+def get_te_hybrid_stack_spec(moe_grouped_gemm: bool = False) -> ModuleSpec:
+    """Build the Transformer Engine hybrid-stack spec.
+
+    Args:
+        moe_grouped_gemm: Whether MoE experts use Transformer Engine grouped GEMM.
+
+    Returns:
+        A hybrid-stack module spec configured for the requested MoE implementation.
+    """
+    moe_spec = get_moe_module_spec(
+        use_te=True,
+        num_experts=8,  # Can be any positive integer (must not be None).
+        moe_grouped_gemm=moe_grouped_gemm,
+    )
+    moe_layer = replace(
+        hybrid_stack_spec.submodules.moe_layer,
+        submodules=replace(hybrid_stack_spec.submodules.moe_layer.submodules, mlp=moe_spec),
+    )
+    return ModuleSpec(
+        module=hybrid_stack_spec.module,
+        submodules=replace(hybrid_stack_spec.submodules, moe_layer=moe_layer),
+    )
+
+
 gated_delta_product_stack_spec = ModuleSpec(
     module=HybridStack,
     submodules=HybridStackSubmodules(
@@ -423,6 +448,7 @@ gated_delta_product_inference_stack_spec = ModuleSpec(
 
 
 # Backward-compatible aliases
+get_te_mamba_stack_spec = get_te_hybrid_stack_spec
 mamba_stack_spec = hybrid_stack_spec
 mamba_inference_stack_spec = hybrid_inference_stack_spec
 gdp_stack_spec = gated_delta_product_stack_spec

--- a/tests/unit_tests/models/test_hybrid_layer_specs.py
+++ b/tests/unit_tests/models/test_hybrid_layer_specs.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for configurable hybrid-stack module specs."""
+
+from unittest import mock
+
+import pytest
+
+from megatron.core.models.hybrid import hybrid_layer_specs
+
+
+@pytest.mark.parametrize("moe_grouped_gemm", [False, True])
+def test_te_hybrid_stack_spec_configures_moe_grouped_gemm(moe_grouped_gemm):
+    moe_spec = object()
+
+    with mock.patch.object(
+        hybrid_layer_specs, "get_moe_module_spec", return_value=moe_spec
+    ) as get_moe_module_spec:
+        stack_spec = hybrid_layer_specs.get_te_hybrid_stack_spec(moe_grouped_gemm)
+
+    get_moe_module_spec.assert_called_once_with(
+        use_te=True, num_experts=8, moe_grouped_gemm=moe_grouped_gemm
+    )
+    assert stack_spec.submodules.moe_layer.submodules.mlp is moe_spec
+    assert (
+        stack_spec.submodules.moe_layer.module
+        is hybrid_layer_specs.hybrid_stack_spec.submodules.moe_layer.module
+    )
+    assert (
+        stack_spec.submodules.mamba_layer
+        is hybrid_layer_specs.hybrid_stack_spec.submodules.mamba_layer
+    )
+
+
+def test_te_mamba_stack_spec_is_backward_compatible_alias():
+    assert hybrid_layer_specs.get_te_mamba_stack_spec is hybrid_layer_specs.get_te_hybrid_stack_spec


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds a hybrid-stack spec factory that makes Transformer Engine grouped GEMM configurable for MoE layers while preserving the existing prebuilt spec and Mamba naming alias.

## Issue tracking

Linked issue: Fixes #4106

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

- `python -m pytest -q --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_hybrid_layer_specs.py` (3 passed)
- `isort` and `black` on the changed Python files
- pre-commit `black`, `pylint`, and `isort` hooks

GPU-dependent CI is left to the project CI environment.

### Code review

This PR intentionally starts as a draft and will be marked ready only after applicable CI passes and merge conflicts are resolved.
