### PR TITLE
GDP CP Support

### DIFF
--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -32,6 +32,7 @@ from megatron.core.models.hybrid.layers.hybrid_hyper_connection import HyperConn
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.recompute import checkpointed_forward
+from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_cp_metadata
 from megatron.core.tensor_parallel.random import CheckpointWithoutOutputManager
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.cuda_graphs import annotate_first_last_layer
@@ -160,6 +161,11 @@ class HybridStack(MegatronModule):
         self._mhc_block_end_plan: Optional[List[bool]] = None
 
         self.layer_config_list = layer_config_list
+        self._has_linear_layer_with_chunkwise_cp = self.cp_group.size() > 1 and any(
+            type(layer_config) is layer_utils.MambaLayerConfig
+            and layer_config.linear_cp_mode == "chunkwise"
+            for layer_config in self.layer_config_list
+        )
         self._cp_layout_manager = None
         if self.cp_group.size() > 1:
             layer_layouts = tuple(
@@ -440,9 +446,24 @@ class HybridStack(MegatronModule):
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
+        if self._has_linear_layer_with_chunkwise_cp and padding_mask is not None:
+            raise NotImplementedError(
+                "Hybrid chunkwise context parallelism does not support padding masks."
+            )
+
         cp_layout_state = None
         if self._cp_layout_manager is not None:
             cp_layout_state = self._cp_layout_manager.build_forward_state(packed_seq_params)
+
+        packed_sequence_cp_metadata = None
+        if self._has_linear_layer_with_chunkwise_cp and packed_seq_params is not None:
+            if packed_seq_params.seq_idx is None:
+                raise ValueError("Packed chunkwise CP requires packed_seq_params.seq_idx")
+            packed_sequence_cp_metadata = build_packed_sequence_cp_metadata(
+                packed_seq_params.seq_idx,
+                cp_rank=self.cp_group.rank(),
+                cp_size=self.cp_group.size(),
+            )
 
         if not self.pre_process:
             # See set_input_tensor()
@@ -526,6 +547,7 @@ class HybridStack(MegatronModule):
                     padding_mask=padding_mask,
                     use_inner_quantization_context=(use_inner_fp8_context or use_fp4_context),
                     cp_layout_state=cp_layout_state,
+                    packed_sequence_cp_metadata=packed_sequence_cp_metadata,
                 )
             else:
                 for layer_idx, (layer_config, layer) in enumerate(
@@ -543,6 +565,12 @@ class HybridStack(MegatronModule):
                     mhc_manager = mhc_layer_managers[layer_idx]
                     if mhc_manager is not None:
                         mhc_manager.is_last_layer_in_recompute_block = mhc_block_ends[layer_idx]
+                    layer_cp_metadata = (
+                        packed_sequence_cp_metadata
+                        if type(layer_config) is layer_utils.MambaLayerConfig
+                        and layer_config.linear_cp_mode == "chunkwise"
+                        else None
+                    )
 
                     with inner_quant_context:
                         if isinstance(layer, (TransformerLayer, HyperConnectionHybridLayer)):
@@ -555,11 +583,21 @@ class HybridStack(MegatronModule):
                                 packed_seq_params=layer_packed_seq_params,
                                 padding_mask=padding_mask,
                             )
+                            if layer_cp_metadata is not None:
+                                layer_kwargs["packed_sequence_cp_metadata"] = layer_cp_metadata
                             if mhc_manager is not None and isinstance(
                                 layer, HyperConnectionHybridLayer
                             ):
                                 layer_kwargs["mhc_recompute_manager"] = mhc_manager
                             hidden_states, _ = layer(**layer_kwargs)
+                        elif layer_cp_metadata is not None:
+                            hidden_states = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                inference_context=inference_context,
+                                packed_seq_params=layer_packed_seq_params,
+                                packed_sequence_cp_metadata=layer_cp_metadata,
+                            )
                         else:  # MambaLayer, Expert, or MLP
                             hidden_states = layer(
                                 hidden_states=hidden_states,

--- a/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
+++ b/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.ssm.context_parallel.chunkwise import PackedSequenceCPMetadata
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.hyper_connection import HyperConnectionModule
 from megatron.core.transformer.identity_op import IdentityOp
@@ -55,6 +56,7 @@ class HyperConnectionHybridLayer(MegatronModule):
         rotary_pos_emb: Optional[Tensor],
         sequence_len_offset: Optional[Tensor],
         packed_seq_params: Optional[PackedSeqParams],
+        packed_sequence_cp_metadata: Optional[PackedSequenceCPMetadata],
         padding_mask: Optional[Tensor],
     ) -> Tuple[Tensor, Optional[Tensor]]:
         if isinstance(self.inner_layer, TransformerLayer):
@@ -69,11 +71,15 @@ class HyperConnectionHybridLayer(MegatronModule):
             )
         else:
             # Mamba-like layers only consume the common HybridStack arguments.
+            extra_kwargs = {}
+            if packed_sequence_cp_metadata is not None:
+                extra_kwargs["packed_sequence_cp_metadata"] = packed_sequence_cp_metadata
             output = self.inner_layer(
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,
                 inference_context=inference_context,
                 packed_seq_params=packed_seq_params,
+                **extra_kwargs,
             )
 
         if isinstance(output, tuple):
@@ -149,6 +155,7 @@ class HyperConnectionHybridLayer(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[Tensor] = None,
+        packed_sequence_cp_metadata: Optional[PackedSequenceCPMetadata] = None,
         mhc_recompute_manager=None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Run the wrapped hybrid layer through one layer-boundary mHC update."""
@@ -173,6 +180,7 @@ class HyperConnectionHybridLayer(MegatronModule):
                 rotary_pos_emb,
                 sequence_len_offset,
                 packed_seq_params,
+                packed_sequence_cp_metadata,
                 padding_mask,
             )
             if self.config.fp32_residual_connection and aggregated.dtype != layer_output.dtype:

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -10,6 +10,7 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.ssm.mamba_layer_config import MambaLayerConfig
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_layer import TransformerLayer
 
@@ -33,6 +34,7 @@ def checkpointed_forward(
     extract_layer_indices: Optional[Set[int]] = None,
     layer_offset: int = 0,
     cp_layout_state: Optional[ContextParallelLayoutState] = None,
+    packed_sequence_cp_metadata: object | None = None,
 ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
     """Forward method with activation checkpointing.
 
@@ -44,6 +46,7 @@ def checkpointed_forward(
             pipeline stage. Used to convert local layer indices to
             global indices when checking extract_layer_indices.
         cp_layout_state (ContextParallelLayoutState, optional): CP layout state for this forward.
+        packed_sequence_cp_metadata (optional): Packed-sequence CP metadata for Mamba layers.
 
     Returns:
         If extract_layer_indices is empty: hidden_states tensor
@@ -120,6 +123,14 @@ def checkpointed_forward(
                     else:  # MambaLayer (HybridStack `M` slot)
                         for k in ("context", "context_mask", "attention_bias", "padding_mask"):
                             layer_kwargs.pop(k, None)
+                        if (
+                            packed_sequence_cp_metadata is not None
+                            and type(layer.config) is MambaLayerConfig
+                            and layer.config.linear_cp_mode == "chunkwise"
+                        ):
+                            layer_kwargs["packed_sequence_cp_metadata"] = (
+                                packed_sequence_cp_metadata
+                            )
                         hidden_states = layer(**layer_kwargs)
                         context = None
 

--- a/megatron/core/ssm/context_parallel/__init__.py
+++ b/megatron/core/ssm/context_parallel/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Chunkwise context-parallel support for stateful sequence mixers."""

--- a/megatron/core/ssm/context_parallel/chunkwise.py
+++ b/megatron/core/ssm/context_parallel/chunkwise.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Common chunkwise context-parallel interfaces for linear attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
+
+import torch
+
+
+@dataclass(frozen=True)
+class CPForwardUnpackedSummary:
+    """One shard's unpacked ``S_out = M S_in + delta_S`` summary."""
+
+    transition: torch.Tensor
+    state_update: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CPForwardPackedSummary:
+    """One shard's packed ``S_out = M S_in + delta_S`` summary."""
+
+    packed: torch.Tensor
+
+
+CPForwardSummary = CPForwardUnpackedSummary | CPForwardPackedSummary
+
+
+@dataclass(frozen=True)
+class CPBackwardUnpackedSummary:
+    """One shard's unpacked ``dS_in = M^T dS_out + gamma`` summary."""
+
+    transition: torch.Tensor
+    local_state_grad: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CPBackwardPackedSummary:
+    """One shard's packed ``dS_in = M^T dS_out + gamma`` summary."""
+
+    packed: torch.Tensor
+
+
+CPBackwardSummary = CPBackwardUnpackedSummary | CPBackwardPackedSummary
+
+
+@dataclass(frozen=True)
+class CPSavedContext:
+    """Backend state saved from forward for backward.
+
+    ``metadata`` must not contain tensors; tensor state belongs in ``tensors`` so that the
+    variant's autograd adapter can save it with ``ctx.save_for_backward``.
+    """
+
+    tensors: tuple[torch.Tensor, ...]
+    metadata: object | None = None
+
+
+@dataclass(frozen=True)
+class PackedSequenceCPMetadata:
+    """Rank-local metadata for chunkwise CP over packed sequences.
+
+    Args:
+        local_seq_idx: Per-token sequence IDs for the local contiguous shard.
+        local_cu_seqlens: Sequence boundaries within the local contiguous shard.
+        preceding_rank_start: Inclusive start of the forward-summary prefix.
+        following_rank_stop: Exclusive end of the backward-summary suffix.
+    """
+
+    local_seq_idx: torch.Tensor
+    local_cu_seqlens: torch.Tensor
+    preceding_rank_start: int
+    following_rank_stop: int
+
+
+CPInputT = TypeVar("CPInputT")
+LocalContextT = TypeVar("LocalContextT")
+BackwardContextT = TypeVar("BackwardContextT")
+CPGradientsT = TypeVar("CPGradientsT")
+
+
+class LinearAttentionCPBackend(Protocol[CPInputT, LocalContextT, BackwardContextT, CPGradientsT]):
+    """Local kernel interface for one contiguous chunkwise-CP shard.
+
+    Megatron owns all process-group operations and passes only selected summary slices to these
+    methods.
+    """
+
+    def cp_forward_prepare(self, inputs: CPInputT) -> tuple[CPForwardSummary, LocalContextT]:
+        """Compute the local state summary with zero incoming state."""
+        ...
+
+    def cp_forward_apply(
+        self, local_context: LocalContextT, preceding_summaries: CPForwardSummary
+    ) -> tuple[torch.Tensor, CPSavedContext]:
+        """Compose the preceding summaries and compute the local output."""
+        ...
+
+    def cp_backward_prepare(
+        self, output_grad: torch.Tensor, saved_context: CPSavedContext
+    ) -> tuple[CPBackwardSummary, BackwardContextT]:
+        """Compute local ``gamma`` with zero outgoing-state gradient."""
+        ...
+
+    def cp_backward_apply(
+        self, backward_context: BackwardContextT, following_summaries: CPBackwardSummary
+    ) -> CPGradientsT:
+        """Compose the reverse-causal suffix and finish the local input gradients."""
+        ...
+
+
+@dataclass(frozen=True)
+class CPForwardResult:
+    """Results retained by a variant-specific autograd adapter after CP forward."""
+
+    output: torch.Tensor
+    saved_context: CPSavedContext
+
+
+def chunkwise_cp_forward(
+    backend: LinearAttentionCPBackend[CPInputT, LocalContextT, BackwardContextT, CPGradientsT],
+    inputs: CPInputT,
+    cp_group: torch.distributed.ProcessGroup,
+    preceding_slice: slice,
+) -> CPForwardResult:
+    """Gather local summaries and apply the selected causal prefix."""
+    local_summary, local_context = backend.cp_forward_prepare(inputs=inputs)
+    gathered_summary = _all_gather_forward_summary(local_summary, cp_group)
+    preceding_summaries = _slice_forward_summary(gathered_summary, preceding_slice)
+    output, saved_context = backend.cp_forward_apply(
+        local_context=local_context, preceding_summaries=preceding_summaries
+    )
+
+    return CPForwardResult(output=output, saved_context=saved_context)
+
+
+def chunkwise_cp_backward(
+    backend: LinearAttentionCPBackend[CPInputT, LocalContextT, BackwardContextT, CPGradientsT],
+    output_grad: torch.Tensor,
+    saved_context: CPSavedContext,
+    cp_group: torch.distributed.ProcessGroup,
+    following_slice: slice,
+) -> CPGradientsT:
+    """Gather local adjoint summaries and apply the selected reverse-causal suffix."""
+    local_summary, backward_context = backend.cp_backward_prepare(
+        output_grad=output_grad, saved_context=saved_context
+    )
+    gathered_summary = _all_gather_backward_summary(local_summary, cp_group)
+    following_summaries = _slice_backward_summary(gathered_summary, following_slice)
+    return backend.cp_backward_apply(
+        backward_context=backward_context, following_summaries=following_summaries
+    )
+
+
+def _all_gather_forward_summary(
+    local_summary: CPForwardSummary, cp_group: torch.distributed.ProcessGroup
+) -> CPForwardSummary:
+    if isinstance(local_summary, CPForwardPackedSummary):
+        return CPForwardPackedSummary(_all_gather_tensor(local_summary.packed, cp_group))
+
+    transition, state_update = _all_gather_unpacked_summary(
+        local_summary.transition, local_summary.state_update, cp_group
+    )
+    return CPForwardUnpackedSummary(transition=transition, state_update=state_update)
+
+
+def _all_gather_backward_summary(
+    local_summary: CPBackwardSummary, cp_group: torch.distributed.ProcessGroup
+) -> CPBackwardSummary:
+    if isinstance(local_summary, CPBackwardPackedSummary):
+        return CPBackwardPackedSummary(_all_gather_tensor(local_summary.packed, cp_group))
+
+    transition, local_state_grad = _all_gather_unpacked_summary(
+        local_summary.transition, local_summary.local_state_grad, cp_group
+    )
+    return CPBackwardUnpackedSummary(transition=transition, local_state_grad=local_state_grad)
+
+
+def _slice_forward_summary(summary: CPForwardSummary, rank_slice: slice) -> CPForwardSummary:
+    if isinstance(summary, CPForwardPackedSummary):
+        return CPForwardPackedSummary(summary.packed[rank_slice])
+    return CPForwardUnpackedSummary(
+        transition=summary.transition[rank_slice], state_update=summary.state_update[rank_slice]
+    )
+
+
+def _slice_backward_summary(summary: CPBackwardSummary, rank_slice: slice) -> CPBackwardSummary:
+    if isinstance(summary, CPBackwardPackedSummary):
+        return CPBackwardPackedSummary(summary.packed[rank_slice])
+    return CPBackwardUnpackedSummary(
+        transition=summary.transition[rank_slice],
+        local_state_grad=summary.local_state_grad[rank_slice],
+    )
+
+
+def build_packed_sequence_cp_metadata(
+    global_seq_idx: torch.Tensor, cp_rank: int, cp_size: int
+) -> PackedSequenceCPMetadata:
+    """Build rank-local packed-sequence metadata for chunkwise CP.
+
+    Args:
+        global_seq_idx: Nondecreasing global per-token sequence IDs in ``[1, T]`` layout.
+        cp_rank: This rank's position in causal order.
+        cp_size: Number of contiguous CP shards.
+
+    Returns:
+        The local sequence IDs, local sequence boundaries, and summary slice bounds for this rank.
+    """
+    if global_seq_idx.ndim != 2 or global_seq_idx.shape[0] != 1:
+        raise ValueError("Chunkwise CP packed sequences require global_seq_idx with shape [1, T]")
+    if global_seq_idx.dtype != torch.int32:
+        raise ValueError(f"global_seq_idx must have dtype torch.int32, got {global_seq_idx.dtype}")
+    if global_seq_idx.shape[1] % cp_size != 0:
+        raise ValueError(
+            "The packed token count must be divisible by the CP size, got "
+            f"{global_seq_idx.shape[1]} and {cp_size}"
+        )
+    if global_seq_idx.shape[1] == 0:
+        raise ValueError("Packed chunkwise CP input must contain at least one token")
+
+    local_sequence_length = global_seq_idx.shape[1] // cp_size
+    shard_start = cp_rank * local_sequence_length
+    shard_stop = shard_start + local_sequence_length
+    sequence_ids = global_seq_idx[0]
+    local_seq_idx = global_seq_idx[:, shard_start:shard_stop]
+    first_sequence_id = local_seq_idx[0, 0]
+    last_sequence_id = local_seq_idx[0, -1]
+    first_token = torch.searchsorted(sequence_ids, first_sequence_id, right=False)
+    last_token = torch.searchsorted(sequence_ids, last_sequence_id, right=True) - 1
+    first_token_index, last_token_index = torch.stack((first_token, last_token)).tolist()
+
+    sequence_change = local_seq_idx[:, 1:] != local_seq_idx[:, :-1]
+    sequence_starts = torch.nonzero(sequence_change[0], as_tuple=False).flatten() + 1
+    local_cu_seqlens = torch.cat(
+        (
+            sequence_starts.new_zeros(1),
+            sequence_starts,
+            sequence_starts.new_tensor([local_sequence_length]),
+        )
+    ).to(torch.int32)
+    return PackedSequenceCPMetadata(
+        local_seq_idx=local_seq_idx,
+        local_cu_seqlens=local_cu_seqlens,
+        preceding_rank_start=first_token_index // local_sequence_length,
+        following_rank_stop=last_token_index // local_sequence_length + 1,
+    )
+
+
+def _all_gather_unpacked_summary(
+    transition: torch.Tensor, state_update: torch.Tensor, cp_group: torch.distributed.ProcessGroup
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """All-gather an unpacked state summary without packing its tensors."""
+    _validate_summary_tensor(transition)
+    _validate_summary_tensor(state_update)
+    if transition.device != state_update.device:
+        raise ValueError("All tensors in a CP summary must be on the same device")
+
+    with torch.distributed._coalescing_manager(group=cp_group, device=transition.device):
+        gathered_transition = _all_gather_tensor(transition, cp_group)
+        gathered_state_update = _all_gather_tensor(state_update, cp_group)
+    return gathered_transition, gathered_state_update
+
+
+def _all_gather_tensor(
+    local_tensor: torch.Tensor, cp_group: torch.distributed.ProcessGroup
+) -> torch.Tensor:
+    _validate_summary_tensor(local_tensor)
+
+    output = torch.empty(
+        (cp_group.size(), *local_tensor.shape), dtype=local_tensor.dtype, device=local_tensor.device
+    )
+    torch.distributed.all_gather_into_tensor(output, local_tensor, group=cp_group)
+    return output
+
+
+def _validate_summary_tensor(tensor: torch.Tensor) -> None:
+    """Validate a tensor communicated as part of a CP summary."""
+    if tensor.dtype != torch.float32:
+        raise ValueError("CP summary tensors must use torch.float32")
+    if not tensor.is_contiguous():
+        raise ValueError("CP summary tensors must be contiguous")

--- a/megatron/core/ssm/context_parallel/gdp.py
+++ b/megatron/core/ssm/context_parallel/gdp.py
@@ -1,0 +1,789 @@
+# Copyright (c) 2023-2026 Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Adapted from the Gated Delta Product context-parallel implementation in
+# flash-linear-attention (https://github.com/fla-org/flash-linear-attention).
+#
+# Licensed under the MIT license; see the LICENSE file in the repository root.
+
+"""FLA backend for Gated Delta Product chunkwise context parallelism."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+try:
+    import triton
+    from fla.ops.common.chunk_delta_h import (
+        chunk_gated_delta_rule_bwd_dhu,
+        chunk_gated_delta_rule_fwd_h,
+    )
+    from fla.ops.common.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local
+    from fla.ops.common.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+    from fla.ops.cp.chunk_delta_h import (
+        merge_fwd_bwd_kernel,
+        pre_process_bwd_kernel_merged,
+        pre_process_fwd_kernel_merged,
+    )
+    from fla.ops.gated_delta_product.chunk_deltaproduct_h import chunk_gated_delta_product_fwd_h
+    from fla.ops.gated_delta_product.chunk_deltaproduct_o import chunk_gated_delta_product_fwd_o
+    from fla.ops.gated_delta_rule.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+    from fla.ops.utils import chunk_local_cumsum, solve_tril
+    from fla.ops.utils.constant import RCP_LN2
+    from fla.ops.utils.index import prepare_chunk_indices
+    from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, tensor_cache
+except ImportError as exc:
+    # The caller guards this optional backend; this marker handles direct imports in CI.
+    raise ImportError("UnavailableError: FLA GDP chunkwise CP backend is unavailable") from exc
+
+from megatron.core.ssm.context_parallel.chunkwise import (
+    CPBackwardPackedSummary,
+    CPBackwardSummary,
+    CPForwardPackedSummary,
+    CPForwardSummary,
+    CPSavedContext,
+    LinearAttentionCPBackend,
+    chunkwise_cp_backward,
+    chunkwise_cp_forward,
+)
+
+
+@tensor_cache
+def _expand_cu_seqlens(cu_seqlens: torch.Tensor, num_householder: int) -> torch.Tensor:
+    if num_householder == 1:
+        return cu_seqlens
+    return cu_seqlens * num_householder
+
+
+@dataclass(frozen=True)
+class GDPInputs:
+    """Local FLA GDP operands passed to the CP backend."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    g: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    num_householder: int
+    scale: float
+
+
+GDPInputGradients = tuple[
+    torch.Tensor,  # dq
+    torch.Tensor,  # dk
+    torch.Tensor,  # dv
+    torch.Tensor,  # dg
+    torch.Tensor,  # dbeta
+]
+
+
+@dataclass(frozen=True)
+class GDPSavedInputs:
+    """GDP operands retained for the FLA backward kernels."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens_dp: torch.Tensor | None
+    num_householder: int
+    scale: float
+    g_dtype: torch.dtype
+
+
+@dataclass(frozen=True)
+class GDPLocalContext:
+    """FLA GDP workspace passed from forward prepare to forward apply."""
+
+    inputs: GDPInputs
+    g_cumsum: torch.Tensor
+    g_interleaved: torch.Tensor
+    A: torch.Tensor
+    w: torch.Tensor
+    u: torch.Tensor
+    cu_seqlens_dp: torch.Tensor | None
+    chunk_indices: torch.Tensor | None
+    chunk_indices_dp: torch.Tensor | None
+
+
+@dataclass(frozen=True)
+class GDPSavedMetadata:
+    """Non-tensor GDP state saved for backward."""
+
+    num_householder: int
+    scale: float
+    has_cu_seqlens: bool
+    g_dtype: torch.dtype
+
+
+@dataclass(frozen=True)
+class GDPBackwardContext:
+    """GDP state passed from backward prepare to backward apply."""
+
+    inputs: GDPSavedInputs
+    g_interleaved: torch.Tensor
+    A: torch.Tensor
+    initial_state: torch.Tensor
+    chunk_indices_dp: torch.Tensor | None
+    q_interleaved: torch.Tensor
+    output_grad_interleaved: torch.Tensor
+    w: torch.Tensor
+    h: torch.Tensor
+    v_new: torch.Tensor
+    dv: torch.Tensor
+
+
+class FLAGatedDeltaProductCPBackend:
+    """FLA implementation of the linear-attention chunkwise-CP interface."""
+
+    def cp_forward_prepare(self, inputs: GDPInputs) -> tuple[CPForwardSummary, GDPLocalContext]:
+        """Compute the local state summary and reusable FLA forward workspace."""
+        local_context = _prepare_fla_forward(inputs)
+        packed_summary = _compute_fragment_summary(
+            k=inputs.k,
+            w=local_context.w,
+            u=local_context.u,
+            g=local_context.g_interleaved,
+            cu_seqlens=local_context.cu_seqlens_dp,
+        )
+        return CPForwardPackedSummary(packed=packed_summary), local_context
+
+    def cp_forward_apply(
+        self, local_context: GDPLocalContext, preceding_summaries: CPForwardSummary
+    ) -> tuple[torch.Tensor, CPSavedContext]:
+        """Compose the incoming state and compute the local GDP output."""
+        inputs = local_context.inputs
+        initial_state = _build_initial_state(inputs, preceding_summaries)
+        h, v_new, _ = chunk_gated_delta_product_fwd_h(
+            k=inputs.k,
+            w=local_context.w,
+            u=local_context.u,
+            g=local_context.g_interleaved,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=local_context.cu_seqlens_dp,
+            num_householder=inputs.num_householder,
+            chunk_indices=local_context.chunk_indices,
+        )
+        output = chunk_gated_delta_product_fwd_o(
+            q=inputs.q,
+            k=inputs.k,
+            v=v_new,
+            h=h,
+            g=local_context.g_cumsum,
+            scale=inputs.scale,
+            cu_seqlens=inputs.cu_seqlens,
+            num_householder=inputs.num_householder,
+            chunk_indices=local_context.chunk_indices,
+        )
+
+        saved_tensors = [
+            inputs.q,
+            inputs.k,
+            inputs.v,
+            inputs.beta,
+            local_context.g_interleaved,
+            local_context.A,
+            initial_state,
+        ]
+        if inputs.cu_seqlens is not None:
+            assert local_context.cu_seqlens_dp is not None
+            assert local_context.chunk_indices_dp is not None
+            saved_tensors.extend((local_context.cu_seqlens_dp, local_context.chunk_indices_dp))
+        return output, CPSavedContext(
+            tensors=tuple(saved_tensors),
+            metadata=GDPSavedMetadata(
+                num_householder=inputs.num_householder,
+                scale=inputs.scale,
+                has_cu_seqlens=inputs.cu_seqlens is not None,
+                g_dtype=inputs.g.dtype,
+            ),
+        )
+
+    def cp_backward_prepare(
+        self, output_grad: torch.Tensor, saved_context: CPSavedContext
+    ) -> tuple[CPBackwardSummary, GDPBackwardContext]:
+        """Compute the local output contribution to the incoming-state gradient."""
+        inputs, g_interleaved, A, initial_state, chunk_indices_dp = _restore_saved_context(
+            saved_context
+        )
+        q_interleaved = _interleave_last_update(inputs.q, inputs.num_householder)
+        output_grad_interleaved = _interleave_last_update(output_grad, inputs.num_householder)
+
+        w, u = recompute_w_u_fwd(
+            k=inputs.k,
+            v=inputs.v,
+            beta=inputs.beta,
+            A=A,
+            g=g_interleaved,
+            cu_seqlens=inputs.cu_seqlens_dp,
+            chunk_indices=chunk_indices_dp,
+        )
+        h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+            k=inputs.k,
+            w=w,
+            u=u,
+            g=g_interleaved,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=inputs.cu_seqlens_dp,
+            chunk_indices=chunk_indices_dp,
+        )
+        dv = chunk_bwd_dv_local(
+            q=q_interleaved,
+            k=inputs.k,
+            g=g_interleaved,
+            do=output_grad_interleaved,
+            scale=inputs.scale,
+            cu_seqlens=inputs.cu_seqlens_dp,
+            chunk_indices=chunk_indices_dp,
+        )
+        packed_summary = _compute_backward_fragment_summary(
+            q=q_interleaved,
+            k=inputs.k,
+            w=w,
+            g=g_interleaved,
+            do=output_grad_interleaved,
+            dv=dv,
+            scale=inputs.scale,
+            cu_seqlens=inputs.cu_seqlens_dp,
+        )
+        return CPBackwardPackedSummary(packed=packed_summary), GDPBackwardContext(
+            inputs=inputs,
+            g_interleaved=g_interleaved,
+            A=A,
+            initial_state=initial_state,
+            chunk_indices_dp=chunk_indices_dp,
+            q_interleaved=q_interleaved,
+            output_grad_interleaved=output_grad_interleaved,
+            w=w,
+            h=h,
+            v_new=v_new,
+            dv=dv,
+        )
+
+    def cp_backward_apply(
+        self, backward_context: GDPBackwardContext, following_summaries: CPBackwardSummary
+    ) -> GDPInputGradients:
+        """Compose the outgoing-state gradient and compute all local GDP gradients."""
+        final_state_grad = _build_final_state_grad(backward_context.inputs, following_summaries)
+        return _apply_fla_backward(backward_context, final_state_grad)
+
+
+def _prepare_fla_forward(inputs: GDPInputs) -> GDPLocalContext:
+    """Build the GDP WY representation used by both summary and output kernels."""
+    cu_seqlens_dp = (
+        _expand_cu_seqlens(inputs.cu_seqlens, inputs.num_householder)
+        if inputs.cu_seqlens is not None
+        else None
+    )
+    chunk_indices = (
+        prepare_chunk_indices(inputs.cu_seqlens, 64) if inputs.cu_seqlens is not None else None
+    )
+    chunk_indices_dp = (
+        prepare_chunk_indices(cu_seqlens_dp, 64) if cu_seqlens_dp is not None else None
+    )
+
+    g_interleaved = inputs.g.new_zeros(
+        inputs.g.shape[0],
+        inputs.g.shape[1],
+        inputs.num_householder,
+        inputs.g.shape[2],
+        dtype=torch.float32,
+    )
+    g_interleaved[:, :, 0] = inputs.g
+    g_interleaved = g_interleaved.flatten(1, 2).contiguous()
+    g_cumsum = chunk_local_cumsum(
+        inputs.g,
+        chunk_size=64,
+        scale=RCP_LN2,
+        cu_seqlens=inputs.cu_seqlens,
+        output_dtype=torch.float32,
+        chunk_indices=chunk_indices,
+    )
+    g_interleaved = chunk_local_cumsum(
+        g_interleaved,
+        chunk_size=64,
+        scale=RCP_LN2,
+        cu_seqlens=cu_seqlens_dp,
+        output_dtype=torch.float32,
+        chunk_indices=chunk_indices_dp,
+    )
+    A = chunk_scaled_dot_kkt_fwd(
+        k=inputs.k,
+        g=g_interleaved,
+        beta=inputs.beta,
+        cu_seqlens=cu_seqlens_dp,
+        output_dtype=torch.float32,
+        chunk_indices=chunk_indices_dp,
+    )
+    A = solve_tril(
+        A=A, cu_seqlens=cu_seqlens_dp, chunk_indices=chunk_indices_dp, output_dtype=inputs.k.dtype
+    )
+    w, u = recompute_w_u_fwd(
+        k=inputs.k,
+        v=inputs.v,
+        beta=inputs.beta,
+        A=A,
+        g=g_interleaved,
+        cu_seqlens=cu_seqlens_dp,
+        chunk_indices=chunk_indices_dp,
+    )
+    return GDPLocalContext(
+        inputs=inputs,
+        g_cumsum=g_cumsum,
+        g_interleaved=g_interleaved,
+        A=A,
+        w=w,
+        u=u,
+        cu_seqlens_dp=cu_seqlens_dp,
+        chunk_indices=chunk_indices,
+        chunk_indices_dp=chunk_indices_dp,
+    )
+
+
+def _compute_fragment_summary(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+) -> torch.Tensor:
+    """Compute packed ``[delta_S | M]`` for the rank-local trailing boundary fragment."""
+    batch, length, key_heads, key_dim = k.shape
+    value_heads = u.shape[2]
+    value_dim = u.shape[-1]
+    if u.shape[:2] != (batch, length):
+        raise ValueError("FLA GDP chunkwise CP requires key and value sequence shapes to match")
+    if value_heads % key_heads != 0:
+        raise ValueError(
+            "FLA GDP chunkwise CP requires the number of value heads to be divisible by "
+            f"the number of key heads, got {value_heads} and {key_heads}"
+        )
+    if key_dim > 256:
+        raise ValueError(f"FLA GDP chunkwise CP supports key dimensions up to 256, got {key_dim}")
+
+    block_size = 32 if key_dim <= 64 else 64
+    grid_columns = triton.cdiv(value_dim, block_size) + triton.cdiv(key_dim, block_size)
+    if cu_seqlens is None:
+        summary = k.new_zeros(batch, value_heads, key_dim, value_dim + key_dim, dtype=torch.float32)
+        grid = (grid_columns, value_heads, batch)
+        boundary_cu_seqlens = None
+        multiple_sequences = True
+    else:
+        boundary_cu_seqlens = cu_seqlens[-2:]
+        summary = k.new_zeros(value_heads, key_dim, value_dim + key_dim, dtype=torch.float32)
+        grid = (grid_columns, value_heads)
+        multiple_sequences = False
+
+    pre_process_fwd_kernel_merged[grid](
+        k=k,
+        v=u,
+        w=w,
+        g=g,
+        gk=None,
+        bg=None,
+        u=u,
+        hm=summary,
+        cu_seqlens=boundary_cu_seqlens,
+        T=length,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK1=triton.next_power_of_2(key_dim),
+        BLOCK_SIZE=block_size,
+        MULTI_SEQS=multiple_sequences,
+    )
+    return summary
+
+
+def _compute_backward_fragment_summary(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    g: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None,
+) -> torch.Tensor:
+    """Compute packed ``[gamma | M^T]`` for the rank-local leading boundary fragment."""
+    batch, length, query_heads, key_dim = q.shape
+    value_heads = do.shape[2]
+    value_dim = do.shape[-1]
+    if value_heads % query_heads != 0:
+        raise ValueError(
+            "FLA GDP chunkwise CP requires the number of value heads to be divisible by "
+            f"the number of query heads, got {value_heads} and {query_heads}"
+        )
+    if key_dim > 256:
+        raise ValueError(f"FLA GDP chunkwise CP supports key dimensions up to 256, got {key_dim}")
+
+    block_size = 32 if key_dim <= 64 else 64
+    grid = (triton.cdiv(value_dim, block_size) + triton.cdiv(key_dim, block_size), value_heads)
+
+    def launch(
+        q_fragment: torch.Tensor,
+        k_fragment: torch.Tensor,
+        w_fragment: torch.Tensor,
+        g_fragment: torch.Tensor,
+        do_fragment: torch.Tensor,
+        dv_fragment: torch.Tensor,
+        summary: torch.Tensor,
+        boundary_cu_seqlens: torch.Tensor | None,
+    ) -> None:
+        pre_process_bwd_kernel_merged[grid](
+            q=q_fragment,
+            k=k_fragment,
+            w=w_fragment,
+            g=g_fragment,
+            gk=None,
+            do=do_fragment,
+            dhm=summary,
+            dv=dv_fragment,
+            cu_seqlens=boundary_cu_seqlens,
+            scale=scale,
+            T=length,
+            H=query_heads,
+            HV=value_heads,
+            K=key_dim,
+            V=value_dim,
+            BT=64,
+            BK1=triton.next_power_of_2(key_dim),
+            BLOCK_SIZE=block_size,
+            USE_BG=False,
+        )
+
+    if cu_seqlens is None:
+        merged_summary = q.new_zeros(
+            batch, value_heads, key_dim, value_dim + key_dim, dtype=torch.float32
+        )
+        # Unlike the forward prepare kernel, FLA's backward prepare kernel has no MULTI_SEQS
+        # mode and handles one sequence per launch. BLH treats every batch element as an
+        # independent sequence, so launch the same FLA kernel for each element.
+        for batch_index in range(batch):
+            batch_slice = slice(batch_index, batch_index + 1)
+            launch(
+                q[batch_slice],
+                k[batch_slice],
+                w[batch_slice],
+                g[batch_slice],
+                do[batch_slice],
+                dv[batch_slice],
+                merged_summary[batch_index],
+                None,
+            )
+    else:
+        merged_summary = q.new_zeros(value_heads, key_dim, value_dim + key_dim, dtype=torch.float32)
+        launch(q, k, w, g, do, dv, merged_summary, cu_seqlens[:2])
+
+    return merged_summary
+
+
+def _merge_affine_summaries(
+    packed_summaries: torch.Tensor, output: torch.Tensor, forward: bool
+) -> torch.Tensor:
+    """Compose an already-selected summary slice from zero into ``output``."""
+    summary_count = packed_summaries.shape[0]
+    if summary_count == 0:
+        output.zero_()
+        return output
+
+    heads, key_dim, value_dim = output.shape[-3:]
+    merge_heads = heads
+    output_state = output
+    if output.ndim == 4:
+        batch = output.shape[0]
+        merge_heads = batch * heads
+        packed_summaries = packed_summaries.flatten(1, 2)
+        output_state = output.view(merge_heads, key_dim, value_dim)
+
+    def grid(meta):
+        return (triton.cdiv(value_dim, meta["BV"]), merge_heads)
+
+    # The interface passes only the selected summary slice, so rebase FLA's CP merge indices onto
+    # that slice. Forward visits [0, n); backward visits [n - 1, ..., 0].
+    merge_rank = summary_count if forward else -1
+
+    merge_fwd_bwd_kernel[grid](
+        h=output_state,
+        ag_hm=packed_summaries,
+        pre_or_post_num_ranks=summary_count,
+        rank=merge_rank,
+        seq_offsets=None,
+        init_offsets=None,
+        h0_seq_ids=None,
+        h0=None,
+        HV=merge_heads,
+        K=key_dim,
+        V=value_dim,
+        BK=triton.next_power_of_2(key_dim),
+        FORWARD=forward,
+        INTRACARD_MODE=False,
+        NUM_SEQ_ENTRIES=0,
+        STATE_V_FIRST=False,
+    )
+    return output
+
+
+def _merge_forward_summaries(summaries: CPForwardSummary, output: torch.Tensor) -> torch.Tensor:
+    if not isinstance(summaries, CPForwardPackedSummary):
+        raise TypeError("The FLA GDP backend requires packed forward summaries")
+    return _merge_affine_summaries(summaries.packed, output, forward=True)
+
+
+def _merge_backward_summaries(
+    summaries: CPBackwardSummary, output_grad: torch.Tensor
+) -> torch.Tensor:
+    if not isinstance(summaries, CPBackwardPackedSummary):
+        raise TypeError("The FLA GDP backend requires packed backward summaries")
+    return _merge_affine_summaries(summaries.packed, output_grad, forward=False)
+
+
+def _state_shape(
+    q: torch.Tensor, v: torch.Tensor, cu_seqlens: torch.Tensor | None
+) -> tuple[int, int, int, int]:
+    sequence_count = q.shape[0] if cu_seqlens is None else cu_seqlens.numel() - 1
+    return sequence_count, v.shape[2], q.shape[3], v.shape[3]
+
+
+def _build_initial_state(inputs: GDPInputs, summaries: CPForwardSummary) -> torch.Tensor:
+    initial_state = inputs.q.new_zeros(
+        _state_shape(inputs.q, inputs.v, inputs.cu_seqlens), dtype=torch.float32
+    )
+    if inputs.cu_seqlens is None:
+        return _merge_forward_summaries(summaries, initial_state)
+    _merge_forward_summaries(summaries, initial_state[0])
+    return initial_state
+
+
+def _build_final_state_grad(inputs: GDPSavedInputs, summaries: CPBackwardSummary) -> torch.Tensor:
+    final_state_grad = inputs.q.new_zeros(
+        _state_shape(inputs.q, inputs.v, inputs.cu_seqlens_dp), dtype=torch.float32
+    )
+    if inputs.cu_seqlens_dp is None:
+        return _merge_backward_summaries(summaries, final_state_grad)
+    _merge_backward_summaries(summaries, final_state_grad[-1])
+    return final_state_grad
+
+
+def _restore_saved_context(
+    saved_context: CPSavedContext,
+) -> tuple[GDPSavedInputs, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    metadata = saved_context.metadata
+    if not isinstance(metadata, GDPSavedMetadata):
+        raise TypeError("FLAGatedDeltaProductCPBackend received incompatible saved metadata")
+    expected_count = 7 + 2 * metadata.has_cu_seqlens
+    if len(saved_context.tensors) != expected_count:
+        raise ValueError("FLAGatedDeltaProductCPBackend received an incompatible tensor bundle")
+
+    q, k, v, beta, g_interleaved, A, initial_state = saved_context.tensors[:7]
+    cu_seqlens_dp = saved_context.tensors[7] if metadata.has_cu_seqlens else None
+    chunk_indices_dp = saved_context.tensors[8] if metadata.has_cu_seqlens else None
+    return (
+        GDPSavedInputs(
+            q=q,
+            k=k,
+            v=v,
+            beta=beta,
+            cu_seqlens_dp=cu_seqlens_dp,
+            num_householder=metadata.num_householder,
+            scale=metadata.scale,
+            g_dtype=metadata.g_dtype,
+        ),
+        g_interleaved,
+        A,
+        initial_state,
+        chunk_indices_dp,
+    )
+
+
+def _interleave_last_update(tensor: torch.Tensor, num_householder: int) -> torch.Tensor:
+    interleaved = tensor.new_zeros(
+        tensor.shape[0], tensor.shape[1], num_householder, tensor.shape[2], tensor.shape[3]
+    )
+    interleaved[:, :, -1] = tensor
+    return interleaved.flatten(1, 2).contiguous()
+
+
+def _apply_fla_backward(
+    context: GDPBackwardContext, final_state_grad: torch.Tensor
+) -> GDPInputGradients:
+    """Apply FLA's GDP backward kernels using Megatron-composed boundary state gradients."""
+    inputs = context.inputs
+
+    dh, _, dv = chunk_gated_delta_rule_bwd_dhu(
+        q=context.q_interleaved,
+        k=inputs.k,
+        w=context.w,
+        g=context.g_interleaved,
+        h0=None,
+        dht=final_state_grad,
+        do=context.output_grad_interleaved,
+        dv=context.dv,
+        scale=inputs.scale,
+        cu_seqlens=inputs.cu_seqlens_dp,
+        chunk_indices=context.chunk_indices_dp,
+    )
+    dq, dk, dw, dg = chunk_bwd_dqkwg(
+        q=context.q_interleaved,
+        k=inputs.k,
+        v=context.v_new,
+        w=context.w,
+        g=context.g_interleaved,
+        h=context.h,
+        dv=dv,
+        do=context.output_grad_interleaved,
+        dh=dh,
+        scale=inputs.scale,
+        cu_seqlens=inputs.cu_seqlens_dp,
+        chunk_indices=context.chunk_indices_dp,
+    )
+    assert dw is not None
+    assert dg is not None
+    dk2, dv, db, dg2 = prepare_wy_repr_bwd(
+        k=inputs.k,
+        v=inputs.v,
+        beta=inputs.beta,
+        g=context.g_interleaved,
+        A=context.A,
+        dw=dw,
+        du=dv,
+        cu_seqlens=inputs.cu_seqlens_dp,
+        chunk_indices=context.chunk_indices_dp,
+    )
+    assert dg2 is not None
+    dk.add_(dk2)
+    dg.add_(dg2)
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=64,
+        reverse=True,
+        cu_seqlens=inputs.cu_seqlens_dp,
+        chunk_indices=context.chunk_indices_dp,
+    )
+
+    dq = dq.unflatten(1, (inputs.q.shape[1], inputs.num_householder))[:, :, -1].contiguous()
+    dg = dg.unflatten(1, (inputs.q.shape[1], inputs.num_householder))[:, :, 0].contiguous()
+    return (
+        dq.to(inputs.q),
+        dk.to(inputs.k),
+        dv.to(inputs.v),
+        dg.to(dtype=inputs.g_dtype),
+        db.to(inputs.beta),
+    )
+
+
+class _GDPChunkwiseContextParallel(torch.autograd.Function):
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        num_householder,
+        scale,
+        cp_group,
+        backend,
+        preceding_rank_start,
+        following_rank_stop,
+    ):
+        """Run chunkwise-CP forward and save the backend context for backward."""
+        inputs = GDPInputs(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+            num_householder=num_householder,
+            scale=scale,
+        )
+        cp_rank = cp_group.rank()
+        result = chunkwise_cp_forward(
+            backend=backend,
+            inputs=inputs,
+            cp_group=cp_group,
+            preceding_slice=slice(preceding_rank_start, cp_rank),
+        )
+        ctx.save_for_backward(*result.saved_context.tensors)
+        ctx.saved_context_metadata = result.saved_context.metadata
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.following_rank_stop = following_rank_stop
+        ctx.backend = backend
+        return result.output
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, output_grad):
+        """Run chunkwise-CP backward using the saved backend context."""
+        saved_context = CPSavedContext(
+            tensors=ctx.saved_tensors, metadata=ctx.saved_context_metadata
+        )
+        dq, dk, dv, dg, dbeta = chunkwise_cp_backward(
+            backend=ctx.backend,
+            output_grad=output_grad,
+            saved_context=saved_context,
+            cp_group=ctx.cp_group,
+            following_slice=slice(ctx.cp_rank + 1, ctx.following_rank_stop),
+        )
+        return dq, dk, dv, dg, dbeta, None, None, None, None, None, None, None
+
+
+@torch.compiler.disable
+def gdp_chunkwise_context_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    num_householder: int,
+    scale: float,
+    cp_group: torch.distributed.ProcessGroup,
+    backend: LinearAttentionCPBackend[
+        GDPInputs, GDPLocalContext, GDPBackwardContext, GDPInputGradients
+    ],
+    preceding_rank_start: int = 0,
+    following_rank_stop: int | None = None,
+) -> torch.Tensor:
+    """Run FLA GDP with Megatron-owned chunkwise-CP communication."""
+    if following_rank_stop is None:
+        following_rank_stop = cp_group.size()
+    cp_rank = cp_group.rank()
+    if not 0 <= preceding_rank_start <= cp_rank:
+        raise ValueError(
+            "preceding_rank_start must be in [0, cp_rank], got "
+            f"{preceding_rank_start} for rank {cp_rank}"
+        )
+    if not cp_rank < following_rank_stop <= cp_group.size():
+        raise ValueError(
+            "following_rank_stop must be in (cp_rank, cp_size], got "
+            f"{following_rank_stop} for rank {cp_rank} and size {cp_group.size()}"
+        )
+    return _GDPChunkwiseContextParallel.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        num_householder,
+        scale,
+        cp_group,
+        backend,
+        preceding_rank_start,
+        following_rank_stop,
+    )

--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -22,17 +22,15 @@ from megatron.core.inference.contexts import BaseInferenceContext, DynamicInfere
 from megatron.core.inference.contexts.attention_context.triton.tensor_ops import (
     tensor_masked_update,
 )
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic
+from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic, causal_conv1d_cp
+from megatron.core.ssm.context_parallel.chunkwise import PackedSequenceCPMetadata
 from megatron.core.ssm.gdp_context_parallel import GDPContextParallel
-from megatron.core.ssm.packed_seq_helpers import (
-    build_packed_seq_idx,
-    check_fla_sequence_packing_support,
-    get_cu_seqlens,
-)
+from megatron.core.ssm.packed_seq_helpers import check_fla_sequence_packing_support, get_cu_seqlens
 from megatron.core.ssm.ssm_inference import SSMDynamicInferenceMixin
 from megatron.core.tensor_parallel import get_cuda_rng_tracker
 from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
@@ -80,6 +78,18 @@ try:
     HAVE_FLA = True
 except ImportError:
     HAVE_FLA = False
+
+try:
+    from megatron.core.ssm.context_parallel.gdp import (
+        FLAGatedDeltaProductCPBackend,
+        gdp_chunkwise_context_parallel,
+    )
+
+    HAVE_FLA_GDP_CP = True
+except ImportError:
+    FLAGatedDeltaProductCPBackend = None
+    gdp_chunkwise_context_parallel = None
+    HAVE_FLA_GDP_CP = False
 
 try:
     from gdp_attn import chunk_gated_delta_product as cutedsl_chunk_gated_delta_product
@@ -146,11 +156,12 @@ class ExtendedRMSNorm(RMSNormGated):
 @dataclass
 class GatedDeltaProductMixerSubmodules:
     """
-    Contains the module specs for the input and output linear layers.
+    Contains the module specs for the projections and chunkwise-CP backend.
     """
 
     in_proj: Union[ModuleSpec, type] = None
     out_proj: Union[ModuleSpec, type] = None
+    chunkwise_cp_backend: Union[ModuleSpec, type] = FLAGatedDeltaProductCPBackend
 
 
 class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
@@ -268,6 +279,21 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.norm_before_gate = norm_before_gate
         assert pg_collection is not None, "pg_collection must be provided for MambaMixer"
         self.pg_collection = pg_collection
+        self.chunkwise_context_parallel = (
+            self.config.linear_cp_mode == "chunkwise" and self.pg_collection.cp.size() > 1
+        )
+        if self.chunkwise_context_parallel and self.config.gdp_cutedsl_kernel:
+            raise NotImplementedError(
+                "GDP chunkwise context parallelism supports only the FLA kernel."
+            )
+        self.chunkwise_cp_backend = None
+        if self.chunkwise_context_parallel:
+            if not HAVE_FLA_GDP_CP:
+                raise ImportError(
+                    "GDP chunkwise CP requires Triton and an FLA build with "
+                    "fla.ops.cp.chunk_delta_h"
+                )
+            self.chunkwise_cp_backend = build_module(submodules.chunkwise_cp_backend)
 
         self.d_state = self.config.mamba_state_dim
         self.headdim = self.config.mamba_head_dim
@@ -443,26 +469,32 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             name=(name + f".out_proj") if name is not None else None,
         )
 
-        # Regarding `conv1d`.{`weight`, `bias`}, `dt_bias`, `A_log`, and `D`: these are the
-        # trainable variables for the current tensor parallel rank, with each tensor parallel rank
-        # having indepdendent trainable variables. All context parallel ranks in a tensor parallel
-        # rank store the same trainable variables, but only use and update their unique/independent
-        # slice of them.
-        self.cp = GDPContextParallel(
-            cp_group=self.pg_collection.cp,
-            d_inner_local_tp=self.d_inner_local_tp,
-            nheads_local_tp=self.nheads_local_tp,
-            ngroups_local_tp=self.ngroups_local_tp,
-            d_state=self.d_state,
-            num_householder=self.num_householder,
-            headdim=self.headdim,
-            conv1d_cp1=self.conv1d,
-            dt_bias_cp1=self.dt_bias,
-            A_log_cp1=self.A_log,
-            D_cp1=self.D,
-            D_has_hdim=self.D_has_hdim,
-            sequence_is_contiguous=self.config.linear_cp_layout == "contiguous",
-        )
+        # Headwise CP slices TP-local parameters across CP ranks. Chunkwise CP keeps the full
+        # TP-local head set on every CP rank and partitions only the sequence.
+        self.cp = None
+        if not self.chunkwise_context_parallel:
+            self.cp = GDPContextParallel(
+                cp_group=self.pg_collection.cp,
+                d_inner_local_tp=self.d_inner_local_tp,
+                nheads_local_tp=self.nheads_local_tp,
+                ngroups_local_tp=self.ngroups_local_tp,
+                d_state=self.d_state,
+                num_householder=self.num_householder,
+                headdim=self.headdim,
+                conv1d_cp1=self.conv1d,
+                dt_bias_cp1=self.dt_bias,
+                A_log_cp1=self.A_log,
+                D_cp1=self.D,
+                D_has_hdim=self.D_has_hdim,
+                sequence_is_contiguous=self.config.linear_cp_layout == "contiguous",
+            )
+            self.d_inner_local_cp = self.cp.d_inner_local_tpcp
+            self.nheads_local_cp = self.cp.nheads_local_tpcp
+            self.ngroups_local_cp = self.cp.ngroups_local_tpcp
+        else:
+            self.d_inner_local_cp = self.d_inner_local_tp
+            self.nheads_local_cp = self.nheads_local_tp
+            self.ngroups_local_cp = self.ngroups_local_tp
 
     def forward(
         self,
@@ -471,9 +503,15 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         packed_seq_params=None,
+        packed_sequence_cp_metadata: PackedSequenceCPMetadata | None = None,
     ):
         """Run the gated delta product mixer on hidden states."""
         inference_context = deprecate_inference_params(inference_context, inference_params)
+
+        if self.chunkwise_context_parallel and inference_context is not None:
+            raise NotImplementedError(
+                "GDP chunkwise context parallelism does not support inference."
+            )
 
         _, batch_size, _ = hidden_states.shape
 
@@ -524,29 +562,26 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             conv_state=conv_state,
             ssm_state=ssm_state,
             packed_seq_params=packed_seq_params,
+            packed_sequence_cp_metadata=packed_sequence_cp_metadata,
         )
 
         out, out_bias = self.out_proj(y)
 
         return out, out_bias
 
-    def _packed_metadata(self, packed_seq_params, pack_length):
-        """Return the ``(seq_idx, cu_seqlens)`` pair describing packed (THD) sequences.
-
-        ``seq_idx`` is built from ``pack_length`` rather than the pre-projection sequence
-        length so that it matches the conv1d's input after in_proj's SP all-gather and
-        ``pre_conv_ssm``'s CP all-to-all, regardless of SP/CP/TP upstream-slicing.
-        Mirrors mamba_mixer.py, which calls _create_packed_seq_idx after the same gather
-        points. Both are ``None`` when sequences are not packed.
-        """
+    def _packed_metadata(self, packed_seq_params):
+        """Return sequence indices and cumulative lengths for packed input."""
         if packed_seq_params is None:
             return None, None
-        return build_packed_seq_idx(packed_seq_params, pack_length), get_cu_seqlens(
-            packed_seq_params
-        )
+        return packed_seq_params.seq_idx, get_cu_seqlens(packed_seq_params)
 
     def _gdp_chunk_forward(
-        self, hidden_states, conv_state=None, ssm_state=None, packed_seq_params=None
+        self,
+        hidden_states,
+        conv_state=None,
+        ssm_state=None,
+        packed_seq_params=None,
+        packed_sequence_cp_metadata: PackedSequenceCPMetadata | None = None,
     ):
         """Chunked-kernel forward, shared by training and static-batching prefill: input
         projection, causal conv, QKV preparation, and the chunked gated delta product
@@ -579,7 +614,16 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 hidden_states, packed_seq_params=packed_seq_params
             )
 
-        seq_idx_packed, cu_seqlens_packed = self._packed_metadata(packed_seq_params, VKQ.shape[1])
+        preceding_rank_start = 0
+        following_rank_stop = self.pg_collection.cp.size()
+        if self.chunkwise_context_parallel:
+            seq_idx_packed, cu_seqlens_packed, preceding_rank_start, following_rank_stop = (
+                self._chunkwise_packed_metadata(
+                    packed_seq_params, VKQ.shape[1], packed_sequence_cp_metadata
+                )
+            )
+        else:
+            seq_idx_packed, cu_seqlens_packed = self._packed_metadata(packed_seq_params)
 
         # The offload group captures the tensors saved for backward inside the causal
         # conv and QKV preparation: the checkpoint's saved input VKQ when QKV recompute
@@ -620,6 +664,8 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             VKQ,
             output_final_state=(ssm_state is not None),
             cu_seqlens=cu_seqlens_packed,
+            preceding_rank_start=preceding_rank_start,
+            following_rank_stop=following_rank_stop,
         )
 
         if ssm_state is not None:
@@ -644,7 +690,19 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
 
         return y
 
-    def _run_gdp_kernel(self, query, key, value, g, beta, VKQ, output_final_state, cu_seqlens=None):
+    def _run_gdp_kernel(
+        self,
+        query,
+        key,
+        value,
+        g,
+        beta,
+        VKQ,
+        output_final_state,
+        cu_seqlens=None,
+        preceding_rank_start=0,
+        following_rank_stop=None,
+    ):
         """Run the selected chunked gated delta product kernel and return
         (core_attn_out, final_state).
 
@@ -654,6 +712,24 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         already applied the L2 norm in _prepare_qkv. ``cu_seqlens`` is the packed-sequence
         layout when THD packing is active; otherwise the CuTeDSL path synthesizes the
         uniform-length equivalent and the FLA path leaves it unset."""
+        if self.chunkwise_context_parallel:
+            assert self.chunkwise_cp_backend is not None
+            core_attn_out = gdp_chunkwise_context_parallel(
+                q=query,
+                k=key,
+                v=value,
+                g=g,
+                beta=beta,
+                cu_seqlens=cu_seqlens,
+                num_householder=self.num_householder,
+                scale=query.shape[-1] ** -0.5,
+                cp_group=self.pg_collection.cp,
+                backend=self.chunkwise_cp_backend,
+                preceding_rank_start=preceding_rank_start,
+                following_rank_stop=following_rank_stop,
+            )
+            return core_attn_out, None
+
         if self.config.gdp_cutedsl_kernel and cu_seqlens is None:
             # query/key/value are already collapsed to (b l) ..., so read the batch and
             # sequence dimensions from VKQ, which is still in (b, l, d) layout.
@@ -679,6 +755,40 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             )
         return core_attn_out, final_state
 
+    def _chunkwise_packed_metadata(
+        self,
+        packed_seq_params: PackedSeqParams | None,
+        local_sequence_length: int,
+        metadata: PackedSequenceCPMetadata | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, int, int]:
+        """Return cached local FLA metadata and cross-rank summary bounds for packed GDP."""
+        cp_rank = self.pg_collection.cp.rank()
+        cp_size = self.pg_collection.cp.size()
+        if packed_seq_params is None:
+            return None, None, 0, cp_size
+
+        global_seq_idx = packed_seq_params.seq_idx
+        if global_seq_idx is None:
+            raise ValueError("Packed GDP chunkwise CP requires packed_seq_params.seq_idx")
+        if metadata is None:
+            raise ValueError(
+                "Packed GDP chunkwise CP requires cached PackedSequenceCPMetadata from "
+                "HybridStack"
+            )
+        expected_shape = (1, local_sequence_length)
+        if metadata.local_seq_idx.shape != expected_shape:
+            raise ValueError(
+                "Packed sequence CP metadata has local_seq_idx shape "
+                f"{tuple(metadata.local_seq_idx.shape)}, expected {expected_shape}"
+            )
+
+        return (
+            global_seq_idx,
+            metadata.local_cu_seqlens,
+            metadata.preceding_rank_start,
+            metadata.following_rank_stop,
+        )
+
     def _in_proj_preprocess(self, hidden_states, packed_seq_params=None):
         """Run the input projection, gather its output across CP ranks, switch to
         (b, l, d) layout, and split it into the z, VKQ, and ba groups.
@@ -689,7 +799,9 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         """
         zVKQba, _ = self.in_proj(hidden_states)
 
-        zVKQba = self.cp.pre_conv_ssm(zVKQba, packed_seq_params=packed_seq_params)
+        if not self.chunkwise_context_parallel:
+            assert self.cp is not None
+            zVKQba = self.cp.pre_conv_ssm(zVKQba, packed_seq_params=packed_seq_params)
 
         return self._preprocess(zVKQba)
 
@@ -702,10 +814,10 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         return torch.split(
             zVKQba,
             [
-                self.cp.d_inner_local_tpcp,
-                self.cp.d_inner_local_tpcp * self.num_householder
-                + (self.num_householder + 1) * self.cp.ngroups_local_tpcp * self.d_state,
-                self.cp.nheads_local_tpcp * (self.num_householder + 1),
+                self.d_inner_local_cp,
+                self.d_inner_local_cp * self.num_householder
+                + (self.num_householder + 1) * self.ngroups_local_cp * self.d_state,
+                self.nheads_local_cp * (self.num_householder + 1),
             ],
             dim=-1,
         )
@@ -756,6 +868,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         )
 
         if is_decode:
+            assert self.cp is not None
             # Indexed conv update: reads/writes the per-request conv state rows selected
             # by ``conv_state_indices``, in place. Unlike ``causal_conv1d_fn`` below, the
             # Triton ``causal_conv1d_update`` takes ``x`` as (batch, seq_len, dim) -- a
@@ -770,6 +883,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 conv_state_indices=conv_state_indices,
             )
         elif precomputed_seq_idx is not None:
+            assert self.cp is not None
             # Forked varlen conv. Stays in the (b, l, d) layout like the decode branch
             # above: the kernel takes a packed ``(T, d)`` sequence, so squeeze the
             # batch dim rather than transposing to [B, D, L]. `conv_initial_states`
@@ -786,36 +900,50 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 precomputed_seq_start=precomputed_seq_start,
             ).unsqueeze(0)
         else:
-            # ``causal_conv1d_fn`` expects a ``[B, D, L]`` tensor in channels-last memory,
-            # which is also what it requires when ``seq_idx`` is set. ``x`` is a view into
-            # the channels-last ``zVKQba``, so the transpose alone already gives
-            # stride(1) == 1 and no copy is needed on either path.
-            x = rearrange(x, "b l d -> b d l")
-            if conv_state is not None:
-                # Static-batching prefill: seed the conv state from the prompt's tail.
-                # If we just take x[:, :, -self.d_conv :], it errors if seqlen < d_conv.
-                # Instead F.pad pads with zeros if seqlen < d_conv, and truncates otherwise.
-                conv_state.copy_(F.pad(x, (self.d_conv - x.shape[-1], 0)))  # state (B D W)
-            if causal_conv1d_fn is None:
-                seqlen = x.size(2)
-                x = self.act(self.cp.conv1d(x)[..., :seqlen])
-            else:
-                # causal_conv1d uses seq_idx to reset the convolution boundaries
-                x = causal_conv1d_fn(
+            if self.chunkwise_context_parallel:
+                assert (
+                    conv_state is None
+                ), "GDP chunkwise context parallelism does not support inference."
+                x = causal_conv1d_cp(
                     x=x,
-                    weight=rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
-                    bias=self.cp.get_conv1d_bias(),
+                    weight=rearrange(self.conv1d.weight, "d 1 w -> d w"),
+                    bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=seq_idx,
+                    cp_group=self.pg_collection.cp,
+                    global_seq_idx=seq_idx,
                 )
-            x = rearrange(x, "b d l ->  b l d")
+            else:
+                assert self.cp is not None
+                # ``causal_conv1d_fn`` expects a ``[B, D, L]`` tensor in channels-last memory,
+                # which is also what it requires when ``seq_idx`` is set. ``x`` is a view into
+                # the channels-last ``zVKQba``, so the transpose alone already gives
+                # stride(1) == 1 and no copy is needed on either path.
+                x = rearrange(x, "b l d -> b d l")
+                if conv_state is not None:
+                    # Static-batching prefill: seed the conv state from the prompt's tail.
+                    # If we just take x[:, :, -self.d_conv :], it errors if seqlen < d_conv.
+                    # Instead F.pad pads with zeros if seqlen < d_conv, and truncates otherwise.
+                    conv_state.copy_(F.pad(x, (self.d_conv - x.shape[-1], 0)))  # state (B D W)
+                if causal_conv1d_fn is None:
+                    seqlen = x.size(2)
+                    x = self.act(self.cp.conv1d(x)[..., :seqlen])
+                else:
+                    # causal_conv1d uses seq_idx to reset the convolution boundaries
+                    x = causal_conv1d_fn(
+                        x=x,
+                        weight=rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
+                        bias=self.cp.get_conv1d_bias(),
+                        activation=self.activation,
+                        seq_idx=seq_idx,
+                    )
+                x = rearrange(x, "b d l ->  b l d")
 
         value, key, query = torch.split(
             x,
             [
-                self.cp.d_inner_local_tpcp * self.num_householder,
-                self.cp.ngroups_local_tpcp * self.d_state * self.num_householder,
-                self.cp.ngroups_local_tpcp * self.d_state,
+                self.d_inner_local_cp * self.num_householder,
+                self.ngroups_local_cp * self.d_state * self.num_householder,
+                self.ngroups_local_cp * self.d_state,
             ],
             dim=-1,
         )
@@ -843,13 +971,9 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             query = l2_norm(query)
             key = l2_norm(key)
 
-        if self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp > 1:
-            query = query.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
-            )
-            key = key.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
-            )
+        if self.nheads_local_cp // self.ngroups_local_cp > 1:
+            query = query.repeat_interleave(self.nheads_local_cp // self.ngroups_local_cp, dim=-2)
+            key = key.repeat_interleave(self.nheads_local_cp // self.ngroups_local_cp, dim=-2)
 
         if self.config.gdp_cutedsl_kernel:
             # Collapse batch/seq and the feature axes into the flat layout the kernel wants.
@@ -861,16 +985,21 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
     def _compute_gating(self, ba):
         """Compute the beta and g gating tensors from the ba slice."""
         b, a = torch.split(
-            ba,
-            [self.cp.nheads_local_tpcp * self.num_householder, self.cp.nheads_local_tpcp],
-            dim=-1,
+            ba, [self.nheads_local_cp * self.num_householder, self.nheads_local_cp], dim=-1
         )
 
         b, a = b.contiguous(), a.contiguous()
         beta = b.sigmoid()
 
         # If the model is loaded in fp16, without the .float() here, A might be -inf
-        g = -self.cp.get_A_log().float().exp() * F.softplus(a.float() + self.cp.get_dt_bias())
+        if self.chunkwise_context_parallel:
+            A_log = self.A_log
+            dt_bias = self.dt_bias
+        else:
+            assert self.cp is not None
+            A_log = self.cp.get_A_log()
+            dt_bias = self.cp.get_dt_bias()
+        g = -A_log.float().exp() * F.softplus(a.float() + dt_bias)
 
         if self.config.gdp_cutedsl_kernel:
             beta = rearrange(beta, "b l d -> (b l) d")
@@ -884,10 +1013,13 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         """Switch back to (l, b, d) layout, scatter across CP ranks, and apply the
         gated output norm."""
         y = rearrange(core_attn_out, "b l h p -> l b (h p)").contiguous()
-        y = self.cp.post_conv_ssm(y, packed_seq_params=packed_seq_params)
+        if not self.chunkwise_context_parallel:
+            assert self.cp is not None
+            y = self.cp.post_conv_ssm(y, packed_seq_params=packed_seq_params)
         if self.rmsnorm:
             z = rearrange(z, "b l d -> l b d").contiguous()
-            z = self.cp.post_conv_ssm(z, packed_seq_params=packed_seq_params)
+            if not self.chunkwise_context_parallel:
+                z = self.cp.post_conv_ssm(z, packed_seq_params=packed_seq_params)
             y = self.norm(y, z)
         return y
 

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -22,6 +22,7 @@ from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm.context_parallel.chunkwise import PackedSequenceCPMetadata
 from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import GraphableMegatronModule
@@ -128,6 +129,7 @@ class MambaLayer(GraphableMegatronModule):
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
+        packed_sequence_cp_metadata: PackedSequenceCPMetadata | None = None,
     ):
         """
         Perform a forward pass through the Mamba layer.
@@ -142,6 +144,8 @@ class MambaLayer(GraphableMegatronModule):
             inference_context (BaseInferenceContext, optional): Parameters for inference-time
                 optimizations.
             rotary_pos_emb (Tensor, optional): Rotary positional embeddings.
+            packed_sequence_cp_metadata (PackedSequenceCPMetadata, optional): Rank-local
+                packed-sequence metadata for chunkwise CP.
 
         Returns:
             output (Tensor): Transformed hidden states of shape [s, b, h].
@@ -167,11 +171,19 @@ class MambaLayer(GraphableMegatronModule):
             # transformer layer's self_attention/mlp (this is where the SSD kernel autotune
             # lands on the first pass).
             with _otel_managed_span('layer', 'megatron.layer.mamba'):
-                mixer_out_with_bias = self.mixer(
-                    hidden_states,
-                    inference_context=inference_context,
-                    packed_seq_params=packed_seq_params,
-                )
+                if packed_sequence_cp_metadata is None:
+                    mixer_out_with_bias = self.mixer(
+                        hidden_states,
+                        inference_context=inference_context,
+                        packed_seq_params=packed_seq_params,
+                    )
+                else:
+                    mixer_out_with_bias = self.mixer(
+                        hidden_states,
+                        inference_context=inference_context,
+                        packed_seq_params=packed_seq_params,
+                        packed_sequence_cp_metadata=packed_sequence_cp_metadata,
+                    )
 
             with self.bias_dropout_add_exec_handler():
                 hidden_states = self.mamba_bda(

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -225,6 +225,10 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.cached_batch_size = None
         assert pg_collection is not None, "pg_collection must be provided for MambaMixer"
         self.pg_collection = pg_collection
+        if self.config.linear_cp_mode == "chunkwise" and self.pg_collection.cp.size() > 1:
+            raise NotImplementedError(
+                "This branch supports linear_cp_mode='chunkwise' only for FLA GDP mixers."
+            )
         self.use_mem_eff_path = self.config.use_mamba_mem_eff_path
         self.mamba_training_ssm_states_dtype = (
             config.mamba_training_ssm_states_dtype or config.params_dtype

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1072,6 +1072,9 @@ class TransformerConfig(ModelParallelConfig):
     and P2P communications in high-level CP groups (e.g., via IBLink).
     """
 
+    linear_cp_mode: Literal["headwise", "chunkwise"] = "headwise"
+    """Context-parallel algorithm for recurrent and linear-attention layers."""
+
     linear_cp_layout: CPLayout = "zigzag"
     """CP layout for linear-attention layers."""
 
@@ -1481,16 +1484,8 @@ class TransformerConfig(ModelParallelConfig):
 
     def _validate_cp_layouts(self) -> None:
         """Validate context-parallel layout settings."""
-        if self.linear_cp_layout not in ("contiguous", "zigzag"):
-            raise ValueError(
-                "linear_cp_layout must be either 'contiguous' or 'zigzag', "
-                f"got {self.linear_cp_layout!r}"
-            )
-        if self.attention_cp_layout not in ("contiguous", "zigzag"):
-            raise ValueError(
-                "attention_cp_layout must be either 'contiguous' or 'zigzag', "
-                f"got {self.attention_cp_layout!r}"
-            )
+        if self.linear_cp_mode == "chunkwise" and self.linear_cp_layout != "contiguous":
+            raise ValueError("linear_cp_mode='chunkwise' requires linear_cp_layout='contiguous'.")
         if self.context_parallel_size > 1 and self.attention_cp_layout == "contiguous":
             raise ValueError(
                 "attention_cp_layout='contiguous' is not yet supported with context parallelism."

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -171,6 +171,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "layernorm_zero_centered_gamma": False,
     "linear_attention_freq": None,
     "linear_cp_layout": "zigzag",
+    "linear_cp_mode": "headwise",
     "linear_conv_kernel_dim": 4,
     "linear_key_head_dim": 128,
     "linear_num_key_heads": 16,

--- a/tests/unit_tests/ssm/test_chunkwise_context_parallel.py
+++ b/tests/unit_tests/ssm/test_chunkwise_context_parallel.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+from megatron.core.ssm.context_parallel.chunkwise import (
+    CPBackwardPackedSummary,
+    CPBackwardUnpackedSummary,
+    CPForwardPackedSummary,
+    _all_gather_backward_summary,
+    _all_gather_forward_summary,
+    _slice_backward_summary,
+    _slice_forward_summary,
+    build_packed_sequence_cp_metadata,
+)
+
+
+class _FakeGroup:
+    def size(self) -> int:
+        return 2
+
+
+def test_unpacked_backward_summary_gather_and_slice(monkeypatch):
+    transition = torch.randn(2, 3)
+    state_grad = torch.randn(2, 3, 4)
+
+    def fake_all_gather_into_tensor(output, input_, group):
+        output.copy_(input_.expand_as(output))
+
+    monkeypatch.setattr(torch.distributed, "_coalescing_manager", lambda **_kwargs: nullcontext())
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    gathered = _all_gather_backward_summary(
+        CPBackwardUnpackedSummary(transition=transition, local_state_grad=state_grad), _FakeGroup()
+    )
+    following = _slice_backward_summary(gathered, slice(1, 2))
+
+    assert following.transition.shape == (1, *transition.shape)
+    assert following.local_state_grad.shape == (1, *state_grad.shape)
+    torch.testing.assert_close(following.transition[0], transition)
+    torch.testing.assert_close(following.local_state_grad[0], state_grad)
+
+
+def test_packed_summary_gather_and_slice(monkeypatch):
+    forward_packed = torch.randn(2, 3, 4)
+    backward_packed = torch.randn(2, 3, 4)
+    gathered_inputs = []
+
+    def fake_all_gather_into_tensor(output, input_, group):
+        gathered_inputs.append(input_)
+        output.copy_(input_.expand_as(output))
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+    group = _FakeGroup()
+
+    gathered_forward = _all_gather_forward_summary(
+        CPForwardPackedSummary(packed=forward_packed), group
+    )
+    preceding = _slice_forward_summary(gathered_forward, slice(0, 1))
+    gathered_backward = _all_gather_backward_summary(
+        CPBackwardPackedSummary(packed=backward_packed), group
+    )
+    following = _slice_backward_summary(gathered_backward, slice(1, 2))
+
+    assert len(gathered_inputs) == 2
+    assert gathered_inputs[0].data_ptr() == forward_packed.data_ptr()
+    assert gathered_inputs[1].data_ptr() == backward_packed.data_ptr()
+    torch.testing.assert_close(preceding.packed[0], forward_packed)
+    torch.testing.assert_close(following.packed[0], backward_packed)
+
+
+@pytest.mark.parametrize(
+    "cp_rank,expected_bounds,expected_cu_seqlens",
+    [(0, (0, 1), [0, 4]), (1, (0, 2), [0, 1, 4]), (2, (1, 3), [0, 1, 4]), (3, (2, 3), [0, 4])],
+)
+def test_build_packed_sequence_cp_metadata(cp_rank, expected_bounds, expected_cu_seqlens):
+    global_seq_idx = torch.repeat_interleave(
+        torch.arange(3, dtype=torch.int32), torch.tensor([5, 4, 7])
+    ).unsqueeze(0)
+
+    metadata = build_packed_sequence_cp_metadata(global_seq_idx, cp_rank=cp_rank, cp_size=4)
+
+    assert (metadata.preceding_rank_start, metadata.following_rank_stop - 1) == expected_bounds
+    assert (
+        metadata.local_seq_idx.untyped_storage().data_ptr()
+        == global_seq_idx.untyped_storage().data_ptr()
+    )
+    torch.testing.assert_close(
+        metadata.local_seq_idx, global_seq_idx[:, cp_rank * 4 : (cp_rank + 1) * 4]
+    )
+    torch.testing.assert_close(
+        metadata.local_cu_seqlens, torch.tensor(expected_cu_seqlens, dtype=torch.int32)
+    )

--- a/tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py
+++ b/tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_cp_metadata
+from megatron.core.ssm.gated_delta_product import HAVE_FLA_GDP_CP, GatedDeltaProductMixer
+
+if HAVE_FLA_GDP_CP:
+    import megatron.core.ssm.context_parallel.gdp as gdp_cp_module
+else:
+    gdp_cp_module = None
+
+
+class _FakeGroup:
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+@pytest.mark.skipif(not HAVE_FLA_GDP_CP, reason="FLA GDP CP kernels are not installed")
+def test_interleave_last_update():
+    """Verify backward values align with each token's final Householder update."""
+    assert gdp_cp_module is not None
+    tensor = torch.arange(12).reshape(1, 3, 2, 2)
+
+    interleaved = gdp_cp_module._interleave_last_update(tensor, num_householder=3)
+
+    assert interleaved.shape == (1, 9, 2, 2)
+    torch.testing.assert_close(interleaved[:, 2::3], tensor)
+    torch.testing.assert_close(interleaved[:, 0::3], torch.zeros_like(tensor))
+    torch.testing.assert_close(interleaved[:, 1::3], torch.zeros_like(tensor))
+
+
+def test_reuse_rank_local_metadata():
+    """Verify GDP reuses cached local sequence boundaries and CP summary bounds."""
+    global_seq_idx = torch.tensor([[0, 0, 0, 0, 0, 1, 1, 1]], dtype=torch.int32)
+    metadata = build_packed_sequence_cp_metadata(global_seq_idx, cp_rank=1, cp_size=2)
+    mixer = GatedDeltaProductMixer.__new__(GatedDeltaProductMixer)
+    mixer.pg_collection = SimpleNamespace(cp=_FakeGroup(rank=1, size=2))
+    packed_seq_params = PackedSeqParams(qkv_format="thd", seq_idx=global_seq_idx)
+
+    returned_seq_idx, local_cu_seqlens, preceding_start, following_stop = (
+        mixer._chunkwise_packed_metadata(
+            packed_seq_params, local_sequence_length=4, metadata=metadata
+        )
+    )
+
+    assert returned_seq_idx is global_seq_idx
+    assert local_cu_seqlens is metadata.local_cu_seqlens
+    torch.testing.assert_close(local_cu_seqlens, torch.tensor([0, 1, 4], dtype=torch.int32))
+    assert preceding_start == 0
+    assert following_stop == 2

--- a/tests/unit_tests/ssm/test_gdp_packed_seq.py
+++ b/tests/unit_tests/ssm/test_gdp_packed_seq.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""GDP v4 packed-sequence + context-parallel equivalence tests.
+"""GDP v4 context-parallel equivalence tests.
 
 Verifies that ``GatedDeltaProductMixer`` (v4) produces forward outputs and
-parameter gradients under ``cp_size=2`` that match a ``cp_size=1`` reference
+parameter gradients under context parallelism that match a ``cp_size=1`` reference
 run on the same packed (THD/SFT-format) input.
 
 Style mirrors ``test_mamba_context_parallel.py``: ``Utils.initialize_model_parallel``,
@@ -31,12 +31,14 @@ from megatron.core.extensions.transformer_engine import (
 )
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_cp_metadata
 from megatron.core.ssm.gated_delta_product import (
     GatedDeltaProductMixer,
     GatedDeltaProductMixerSubmodules,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
+from megatron.core.utils import is_causal_conv1d_min_version
 from tests.unit_tests.test_utilities import Utils
 
 try:
@@ -104,10 +106,11 @@ def _make_packed_seq_params(seq_lens: List[int]) -> PackedSeqParams:
         cu_seqlens_kv_padded=None,
         max_seqlen_q=total,
         max_seqlen_kv=total,
+        total_tokens=total,
     )
 
 
-def _make_config(cp_size: int) -> TransformerConfig:
+def _make_config(cp_size: int, linear_cp_mode: str = "headwise") -> TransformerConfig:
     """Small-but-shape-valid TransformerConfig for the v4 GDP mixer."""
     return TransformerConfig(
         num_layers=1,
@@ -124,12 +127,14 @@ def _make_config(cp_size: int) -> TransformerConfig:
         tensor_model_parallel_size=1,
         sequence_parallel=False,
         context_parallel_size=cp_size,
+        linear_cp_mode=linear_cp_mode,
+        linear_cp_layout="contiguous" if linear_cp_mode == "chunkwise" else "zigzag",
     )
 
 
-def _build_mixer(cp_group):
+def _build_mixer(cp_group, linear_cp_mode: str = "headwise"):
     """Construct a v4 GDP mixer wired to the given CP group."""
-    config = _make_config(cp_group.size())
+    config = _make_config(cp_group.size(), linear_cp_mode=linear_cp_mode)
     pg = ProcessGroupCollection(tp=parallel_state.get_tensor_model_parallel_group(), cp=cp_group)
     submodules = GatedDeltaProductMixerSubmodules(
         in_proj=TELayerNormColumnParallelLinear, out_proj=TERowParallelLinear
@@ -151,10 +156,10 @@ def _sync_weights_from_rank0(mixer):
         torch.distributed.broadcast(p.data, src=0)
 
 
-def _build_cp_pair():
-    """Build CP=2 + per-rank CP=1 reference mixers with identical weights.
+def _build_cp_pair(linear_cp_mode: str = "headwise"):
+    """Build a CP mixer and per-rank CP=1 reference mixers with identical weights.
 
-    Returns ``(mixer_cp2, mixer_cp1, config, cp_group, cp_rank)``. The cp=1
+    Returns ``(mixer_cp, mixer_cp1, config, cp_group, cp_rank)``. The cp=1
     instance lives in a 1-rank subgroup (containing only this rank), so the
     same mixer code path runs in cp=1 mode and provides a numerical reference.
     """
@@ -166,17 +171,17 @@ def _build_cp_pair():
     cp1_groups = [torch.distributed.new_group(ranks=[r]) for r in range(world_size)]
     cp1_group = cp1_groups[global_rank]
 
-    mixer_cp2, _ = _build_mixer(cp_group)
-    mixer_cp1, config = _build_mixer(cp1_group)
-    _sync_weights_from_rank0(mixer_cp2)
-    mixer_cp1.load_state_dict(mixer_cp2.state_dict())
-    return mixer_cp2, mixer_cp1, config, cp_group, cp_rank
+    mixer_cp, _ = _build_mixer(cp_group, linear_cp_mode=linear_cp_mode)
+    mixer_cp1, config = _build_mixer(cp1_group, linear_cp_mode=linear_cp_mode)
+    _sync_weights_from_rank0(mixer_cp)
+    mixer_cp1.load_state_dict(mixer_cp.state_dict())
+    return mixer_cp, mixer_cp1, config, cp_group, cp_rank
 
 
 def _make_hidden_packed(seq_lens, hidden_size):
     """Build a packed [total_tokens, 1, hidden] input + matching PackedSeqParams.
 
-    The tensor is broadcast from rank 0 so cp=1 reference and cp=2 sliced
+    The tensor is broadcast from rank 0 so the CP=1 reference and CP-sliced
     paths see bit-identical input.
     """
     psp = _make_packed_seq_params(seq_lens)
@@ -185,6 +190,67 @@ def _make_hidden_packed(seq_lens, hidden_size):
     hidden_full = torch.randn(total_tokens, 1, hidden_size, device="cuda", dtype=torch.bfloat16)
     torch.distributed.broadcast(hidden_full, src=0)
     return hidden_full, psp
+
+
+def _assert_chunkwise_equivalence(
+    mixer_cp, mixer_reference, cp_group, cp_rank, hidden_full, packed_seq_params=None
+):
+    """Compare one contiguous-CP GDP forward/backward against a full-sequence reference."""
+    mixer_cp.eval()
+    mixer_reference.eval()
+    for parameter in mixer_reference.parameters():
+        parameter.grad = None
+    for parameter in mixer_cp.parameters():
+        parameter.grad = None
+
+    local_sequence_length = hidden_full.shape[0] // cp_group.size()
+    local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+
+    reference_input = hidden_full.detach().clone().requires_grad_(True)
+    reference_output = mixer_reference(reference_input, packed_seq_params=packed_seq_params)[0]
+    reference_loss = reference_output.float().square().sum()
+    reference_loss.backward()
+
+    local_input = hidden_full[local_slice].detach().clone().requires_grad_(True)
+    packed_sequence_cp_metadata = None
+    if packed_seq_params is not None:
+        packed_sequence_cp_metadata = build_packed_sequence_cp_metadata(
+            packed_seq_params.seq_idx, cp_rank=cp_rank, cp_size=cp_group.size()
+        )
+    local_output = mixer_cp(
+        local_input,
+        packed_seq_params=packed_seq_params,
+        packed_sequence_cp_metadata=packed_sequence_cp_metadata,
+    )[0]
+    local_loss = local_output.float().square().sum()
+    local_loss.backward()
+
+    reference_parameters = dict(mixer_reference.named_parameters())
+    local_parameters = dict(mixer_cp.named_parameters())
+    reduced_gradients = []
+    for name, local_parameter in local_parameters.items():
+        local_grad = local_parameter.grad
+        reference_parameter = reference_parameters.get(name)
+        reference_grad = None if reference_parameter is None else reference_parameter.grad
+        reduced_grad = (
+            torch.zeros_like(local_parameter)
+            if local_grad is None
+            else local_grad.clone().contiguous()
+        )
+        torch.distributed.all_reduce(reduced_grad, group=cp_group)
+        reduced_gradients.append((name, local_grad, reference_grad, reduced_grad))
+
+    torch.testing.assert_close(local_output, reference_output[local_slice], atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(
+        local_input.grad, reference_input.grad[local_slice], atol=8e-2, rtol=8e-2
+    )
+    assert set(reference_parameters) == set(local_parameters)
+    for name, local_grad, reference_grad, reduced_grad in reduced_gradients:
+        if local_grad is None and reference_grad is None:
+            continue
+        assert local_grad is not None, f"chunkwise CP has no gradient for {name}"
+        assert reference_grad is not None, f"reference has no gradient for {name}"
+        torch.testing.assert_close(reduced_grad, reference_grad, atol=8e-2, rtol=8e-2)
 
 
 @pytest.mark.internal
@@ -196,7 +262,7 @@ def _make_hidden_packed(seq_lens, hidden_size):
 @pytest.mark.skipif(not HAVE_MAMBA_DEPS, reason="GDP mixer requires mamba_ssm + einops")
 @pytest.mark.skipif(not HAVE_FLA, reason="GDP mixer requires fla")
 class TestGDPPackedSequence:
-    """v4 GDP forward + backward equivalence under CP=2 with packed (THD) input."""
+    """v4 GDP forward + backward equivalence under CP=2."""
 
     @pytest.fixture(autouse=True)
     def setup_method(self):
@@ -318,3 +384,63 @@ class TestGDPPackedSequence:
             + "\n".join(f"  {n} {s}: {m}" for n, s, m in mismatches)
         )
         assert n_compared > 0, "no parameters received a gradient — test setup is wrong"
+
+    @pytest.mark.parametrize("packed", [False, True], ids=["blh", "thd"])
+    def test_chunkwise_forward_and_backward_equivalence(self, packed):
+        """Contiguous GDP CP matches a full-sequence FLA run for BLH and THD."""
+        if packed and not is_causal_conv1d_min_version("1.7.0"):
+            pytest.skip("THD CP causal convolution requires causal-conv1d >= 1.7.0")
+        mixer_cp, mixer_reference, config, cp_group, cp_rank = _build_cp_pair(
+            linear_cp_mode="chunkwise"
+        )
+        if packed:
+            hidden_full, packed_seq_params = _make_hidden_packed([20, 28], config.hidden_size)
+        else:
+            packed_seq_params = None
+            torch.manual_seed(0)
+            hidden_full = torch.randn(
+                48, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+            torch.distributed.broadcast(hidden_full, src=0)
+
+        _assert_chunkwise_equivalence(
+            mixer_cp, mixer_reference, cp_group, cp_rank, hidden_full, packed_seq_params
+        )
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA + NCCL")
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 4 if torch.cuda.is_available() else True,
+    reason="CP=4 test requires at least 4 GPUs",
+)
+@pytest.mark.skipif(_WORLD_SIZE < 4, reason="CP=4 test requires at least 4 distributed ranks")
+@pytest.mark.skipif(not HAVE_MAMBA_DEPS, reason="GDP mixer requires mamba_ssm + einops")
+@pytest.mark.skipif(not HAVE_FLA, reason="GDP mixer requires fla")
+@pytest.mark.skipif(
+    not is_causal_conv1d_min_version("1.7.0"),
+    reason="THD CP causal convolution requires causal-conv1d >= 1.7.0",
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        pytest.param([10, 44, 10], id="spans-all-ranks"),
+        pytest.param([16, 16, 32], id="truncated-summary-slices"),
+    ],
+)
+def test_chunkwise_thd_forward_and_backward_equivalence(seq_lens):
+    """Verify CP=4 THD matches CP=1 for full-span and truncated summary slices."""
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, context_parallel_size=4
+    )
+    try:
+        model_parallel_cuda_manual_seed(123)
+        mixer_cp, mixer_reference, config, cp_group, cp_rank = _build_cp_pair(
+            linear_cp_mode="chunkwise"
+        )
+        hidden_full, packed_seq_params = _make_hidden_packed(seq_lens, config.hidden_size)
+        _assert_chunkwise_equivalence(
+            mixer_cp, mixer_reference, cp_group, cp_rank, hidden_full, packed_seq_params
+        )
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary
This PR adds chunkwise context parallelism for the FLA implementation of Gated Delta Product (GDP).
The main change is a unified chunkwise CP interface that separates Megatron’s distributed orchestration from backend-specific linear attention kernels.

## Interface
LinearAttentionCPBackend divides the operation into four stages:
- cp_forward_prepare: compute the local recurrent-state summary with a zero incoming state.
- cp_forward_apply: combine preceding-rank summaries and compute the local output.
- cp_backward_prepare: compute the local backward summary with a zero outgoing-state gradient.
- cp_backward_apply: combine following-rank summaries and finish the local input gradients.

Megatron owns:

- CP process groups and collectives.
- All-gathering local summaries.
- Selecting the causally relevant prefix or suffix of gathered summaries.

The backend doesn't see process groups

## FLA GDP backend

The GDP kernel implementation is mostly adapted from FLA’s chunkwise context-parallel implementation.
The Megatron-specific code adapts those kernels to the new CP interface.

## Integration
- Adds --linear-cp-mode chunkwise and --linear-cp-layout contiguous.

## Tests
```
uv run python -m torch.distributed.run --nproc-per-node 4 -m pytest -q \
    tests/unit_tests/ssm/test_chunkwise_context_parallel.py \
    tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py \
    tests/unit_tests/ssm/test_gdp_packed_seq.py
```

Validated on Nemotron models