### PR TITLE
Fix hybrid context parallel end-to-end integration

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2256,6 +2256,12 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         if packed_seq_params is not None:
             # If Dynamic CP group is provided, update TE DPA CP group
             if packed_seq_params.cp_group is not None:
+                # Hybrid/dynamic CP can enable CP at runtime on a model built
+                # with context_parallel_size == 1, where the constructor never
+                # allocated the auxiliary CP stream. Create it lazily; TE's
+                # AttnFuncWithCPAndKVP2P dereferences it unconditionally.
+                if TEDotProductAttention.cp_stream is None:
+                    TEDotProductAttention.cp_stream = torch.cuda.Stream()
                 self.cp_group = packed_seq_params.cp_group
                 super().set_context_parallel_group(
                     self.cp_group,

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -543,8 +543,26 @@ def hybrid_context_parallel_forward_backward(
             partner_cp_size = len(
                 [True for sample_ids in sample_id_groups[group_id] if sub_sample_id in sample_ids]
             )
-            sample["local_cp_size"] = torch.tensor(partner_cp_size, dtype=torch.int32)
-            new_data_iterator = RerunDataIterator(iter([sample]))
+            # Bridge the 1-D sub-sample dict from HybridCPDataLoaderWrapper.unpack_batch
+            # (token-level keys only, no cu_seqlens/max_seqlen) to the 2-D batched
+            # schema get_batch_on_this_tp_rank expects under is_hybrid_cp. The
+            # original bridge helper (get_batch_on_this_hybrid_cp_rank) was removed
+            # in the get_batch consolidation refactor, leaving the two ends
+            # incompatible; this restores the minimal contract.
+            dev = torch.cuda.current_device()
+            seq_len = sample["tokens"].shape[-1]
+            bridged = {
+                key: sample[key].unsqueeze(0)
+                for key in ("tokens", "labels", "loss_mask", "position_ids")
+            }
+            cu = torch.tensor([[0, seq_len]], dtype=torch.int32, device=dev)
+            bridged["cu_seqlens"] = cu
+            bridged["cu_seqlens_padded"] = cu.clone()
+            bridged["max_seqlen"] = torch.tensor([seq_len], dtype=torch.int32, device=dev)
+            bridged["local_cp_size"] = torch.tensor(
+                [partner_cp_size], dtype=torch.int32, device=dev
+            )
+            new_data_iterator = RerunDataIterator(iter([bridged]))
         else:
             partner_cp_size = 0
             new_data_iterator = None

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1501,6 +1501,15 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
                 rope_freqs_max_seqlen = None
 
+            # Hybrid/dynamic CP: RoPE position math must use the sub-sample's
+            # runtime CP group (packed_seq_params.cp_group), not the static
+            # group the model was built with. The fused THD RoPE kernel takes
+            # the full cu_seqlens plus (cp_size, cp_rank) to locate this rank's
+            # zigzag slice, and the static group reports cp_size=1.
+            rope_cp_group = self.pg_collection.cp
+            if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+                rope_cp_group = packed_seq_params.cp_group
+
             if split_qkv:
                 if q_pos_emb is not None:
                     # TODO VIJAY: simplify
@@ -1511,7 +1520,7 @@ class Attention(MegatronModule, ABC):
                             config=self.config,
                             cu_seqlens=cu_seqlens_q,
                             mscale=self._yarn_concentration_factor,
-                            cp_group=self.pg_collection.cp,
+                            cp_group=rope_cp_group,
                             max_seqlen=rope_freqs_max_seqlen,
                         )
                     else:
@@ -1530,7 +1539,7 @@ class Attention(MegatronModule, ABC):
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
                         mscale=self._yarn_concentration_factor,
-                        cp_group=self.pg_collection.cp,
+                        cp_group=rope_cp_group,
                         max_seqlen=rope_freqs_max_seqlen,
                     )
             else:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4302,7 +4302,12 @@ def train(
     one_logger = get_one_logger()
 
     if args.hybrid_context_parallel:
-        train_data_iterator = iter(HybridCPDataLoaderWrapper(train_data_iterator, config))
+        # Re-wrap in RerunDataIterator: the rerun state machine asserts every
+        # training iterator is one, and the raw iter() here strips the wrapping
+        # applied at dataloader build time.
+        train_data_iterator = RerunDataIterator(
+            iter(HybridCPDataLoaderWrapper(train_data_iterator, config))
+        )
 
     if args.run_workload_inspector_server:
         try:


### PR DESCRIPTION
## What does this PR do?

Fixes four integration bugs that make `--hybrid-context-parallel` (dynamic
context parallelism) unusable end to end on main. Each fix is one atomic
commit; each bug was hit live, in this order, while bringing the feature up
on a GB200 node — the feature currently has no end-to-end test, and the sole
hybrid-CP unit test (`tests/unit_tests/data/test_get_batch.py`) hand-builds
the batch schema the real dataloader never produces, so none of these are
visible to CI.

1. **Missing dataloader→get_batch schema bridge** (`hybrid_cp_schedule.py`).
   `HybridCPDataLoaderWrapper.unpack_batch` emits 1-D sub-sample dicts without
   `cu_seqlens`/`max_seqlen`, while `get_batch_on_this_tp_rank` under
   `is_hybrid_cp` requires 2-D batched tensors plus `cu_seqlens`,
   `max_seqlen`, `local_cp_size`. The bridging helper was dropped in the
   get_batch consolidation refactor. Symptom: `IndexError` on
   `batch['tokens'].shape[1]` (TP=1) or asymmetric-broadcast hang (TP>1).
2. **RerunDataIterator wrapping stripped** (`training.py`). The hybrid branch
   rewraps the train iterator as raw `iter(...)`; the rerun state machine
   asserts on the wrapper type at every step. Symptom: "data iterator is not
   wrapped with RerunDataIterator" before iteration 1.
3. **TE CP stream never allocated** (`extensions/transformer_engine.py`). The
   ctor only creates `cp_stream` when `context_parallel_size > 1`, but dynamic
   CP builds the model with static CP=1 and binds groups at runtime. Symptom:
   `AttributeError: 'NoneType' object has no attribute 'wait_event'` in
   `AttnFuncWithCPAndKVP2P`.
4. **RoPE bound to the static CP group** (`transformer/attention.py`). The
   fused THD RoPE kernel derives `(cp_size, cp_rank)` from the passed
   `cp_group`; with the static group (size 1) each rank indexes full-sequence
   positions into its zigzag slice. Symptom: illegal memory access in
   `fused_rope_forward` on short sub-samples; NaN grads then a softmax-lse
   device assert on long ones.

## Validation

No e2e test exists for this path, so validation was a real workload: 8B
Llama-arch GPT on 4x GB200 (NeMo 26.06.01 container, TE 2.16), THD sequences
36k–97k tokens at 99,840 cap, `--hybrid-context-parallel
--max-seqlen-per-dp-cp-rank {49920, 24960}` producing mixed CP1/CP2/CP4
groups per iteration. Before the series: crashes above, in order. After:
clean training, finite losses and grad norms, `CUDA_LAUNCH_BLOCKING=1` clean.
Happy to contribute the deterministic varlen benchmark driver used here as a
functional test in a follow-up.

## Known adjacent issues (out of scope, worth tracking)

- The sequence-packing scheduler half of the DCP stack is currently
  unreachable from main: no `--sequence-packing-scheduler` flag or config
  field survived the merge, and `wrap_data_iterator` /
  `get_batch_on_this_rank_for_sequence_packing` have no non-test callers
  (`data_schedule.py:710` would `AttributeError` if ever reached).
- `SFTDataset._calculate_padding_divisor` pads to `cp*2`, but hybrid CP
  requires divisibility by `2*local_cp_size` where `local_cp_size` can reach
  the full DP×CP pool (`gpt_dataset.py` documents `dp*cp*2`).
- `MockSFTLowLevelDataset` referenced by `gpt_dataset.py` docs does not exist
  on main.
