### PR TITLE
ci: bump Cerno commit to f0cf5b7

### DIFF
--- a/docker/Dockerfile.linting
+++ b/docker/Dockerfile.linting
@@ -24,7 +24,7 @@ RUN --mount=type=secret,id=JET_INDEX_URLS \
 
 # Keep this in the internal-only stage so public CI has no internal service dependency.
 ARG CI_SERVER_URL
-ARG CERNO_COMMIT=3219afcbfcdbddd1d55e013d94e54a15986e2b1f
+ARG CERNO_COMMIT=f0cf5b75a6c52dfec2d01ce7886a3e7d850be0c0
 RUN --mount=type=secret,id=CERNO_TOKEN \
       GIT_CONFIG_COUNT=1 \
       GIT_CONFIG_KEY_0=http.extraHeader \


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Bumps the internal linting image's immutable Cerno pin from `3219afcbfcdbddd1d55e013d94e54a15986e2b1f` to `f0cf5b75a6c52dfec2d01ce7886a3e7d850be0c0`, picking up explicit Slack link and media unfurl suppression for notification follow-ups.

## Issue tracking

Linked issue: N/A — internal CI dependency bump.

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

The unchecked items are not applicable to this one-line immutable dependency pin update.

## Validation

- Cerno commit `f0cf5b75a6c52dfec2d01ce7886a3e7d850be0c0`: 235 tests passed
- `python -m pytest -q tests/test_utils/test_ci_triage.py -k 'not cerno_hard_cutover_contract'`: 21 passed, 1 deselected
- verified `docker/Dockerfile.linting` contains the exact immutable Cerno pin
- `git diff --check`

The deselected contract test already fails unchanged on `upstream/main`: it expects a `report_artifacts` key that the checked-in `.gitlab/cerno.yml` does not contain.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
