### PR TITLE
Add norm before up projection for LatentMoE

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -60,9 +60,9 @@ except ImportError:
     HAVE_TRITON = False
 
 if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import TELinear, te_checkpoint
+    from megatron.core.extensions.transformer_engine import TELinear, TENorm, te_checkpoint
 else:
-    TELinear, te_checkpoint = None, None
+    TELinear, TENorm, te_checkpoint = None, None, None
 
 
 class ExpertsInterface(Protocol):
@@ -295,6 +295,12 @@ class MoELayer(BaseMoELayer):
                 name=(name + ".fc1_latent_proj") if name is not None else None,
                 **linear_gtp_kwargs,
             )
+            if self.config.moe_use_norm_before_up_proj:
+                self.fc2_norm = TENorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.layernorm_epsilon,
+                )
             self.fc2_latent_proj = linear_cls(
                 self.config.moe_latent_size,
                 self.config.hidden_size,
@@ -600,6 +606,8 @@ class MoELayer(BaseMoELayer):
 
         output = self.token_dispatcher.combine_postprocess(output)
         if self.config.moe_latent_size:
+            if self.config.moe_use_norm_before_up_proj:
+                output = self.fc2_norm(output)
             output, _ = self.fc2_latent_proj(output)
 
         if shared_expert_output is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -955,6 +955,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 
+    moe_use_norm_before_up_proj: bool = False
+    """Apply normalization before the latent MoE up-projection. Requires moe_latent_size."""
+
     gtp_remat_opt_in_modules: list[str] = field(default_factory=list)
     """Extra modules to apply GTP_remat weight sharding to, beyond the default set (attention,
     Mamba, MLP, expert linears, embeddings). Allowed values:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1976,6 +1976,10 @@ def validate_args(args, defaults={}):
     if args.mla_down_proj_fusion:
         assert args.multi_latent_attention, "--mla-down-proj-fusion requires --multi-latent-attention"
 
+    assert (
+        not args.moe_use_norm_before_up_proj or args.moe_latent_size is not None
+    ), "--moe-use-norm-before-up-proj requires --moe-latent-size to be set."
+
     # MoE latent projections
     if args.moe_latent_size is not None:
         assert args.moe_latent_size > 0, "MoE latent projection dimension has to be greater than zero."

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2339,6 +2339,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
 
     # MoE latent projection.
     _set_arg('moe_latent_size', force=True)
+    _set_arg('moe_use_norm_before_up_proj', force=True)
 
     # Tokenizer args.
     if args.use_tokenizer_model_from_checkpoint_args:

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -200,6 +200,36 @@ def test_load_args_restores_gdp_num_householder_from_checkpoint(
     assert restored_args.gdp_num_householder == expected_num_householder
 
 
+@pytest.mark.parametrize(
+    ("checkpoint_args", "configured_norm", "expected_norm"),
+    [
+        (SimpleNamespace(moe_latent_size=256, moe_use_norm_before_up_proj=True), False, True),
+        (SimpleNamespace(moe_latent_size=256), True, True),
+    ],
+)
+def test_load_args_restores_latent_moe_norm_from_checkpoint(
+    checkpoint_args, configured_norm, expected_norm
+):
+    args = SimpleNamespace(
+        load="checkpoint",
+        iteration=0,
+        moe_latent_size=None,
+        moe_use_norm_before_up_proj=configured_norm,
+        use_tokenizer_model_from_checkpoint_args=False,
+        use_mp_args_from_checkpoint_args=False,
+    )
+    state_dict = {"args": checkpoint_args, "iteration": 12}
+
+    with mock.patch(
+        "megatron.training.checkpointing._load_base_checkpoint",
+        return_value=(state_dict, "checkpoint", False, CheckpointType.LEGACY),
+    ):
+        restored_args, _ = load_args_from_checkpoint(args)
+
+    assert restored_args.moe_latent_size == 256
+    assert restored_args.moe_use_norm_before_up_proj is expected_norm
+
+
 def create_checkpoint(load_path, ckpt_format):
     """Setup a dummy checkpoint directory."""
     iteration = 123

--- a/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
@@ -176,6 +176,7 @@ class TestLatentMoELayer:
             gated_linear_unit=True,
             add_bias_linear=False,
             moe_latent_size=moe_latent_size,
+            moe_use_norm_before_up_proj=True,
         )
         if use_te:
             transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
@@ -190,6 +191,8 @@ class TestLatentMoELayer:
         moe_layer = MoELayer(self.transformer_config, submodules)
         moe_layer.cuda()
         config = moe_layer.config
+
+        assert hasattr(moe_layer, "fc2_norm")
 
         assert (
             moe_layer.shared_experts.linear_fc1.weight.shape[1] == config.hidden_size


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Add an optional normalization layer after LatentMoE expert-output combination and before the latent up-projection:

```
experts → combine → fc2_norm → fc2_latent_proj → transformer hidden size
```

The option is exposed as `moe_use_norm_before_up_proj` and remains disabled by default, so existing LatentMoE models are unchanged.

When enabled, `TENorm` selects LayerNorm or RMSNorm from the existing transformer configuration and uses `moe_latent_size` as the normalized dimension. The LatentMoE projection path already requires Transformer Engine.

This PR also restores `moe_use_norm_before_up_proj` from checkpoint arguments alongside `moe_latent_size`. This ensures checkpoint loading reconstructs the norm module and consumes saved `mlp.fc2_norm.weight` tensors. Without restoring the option, strict checkpoint auditing reports those tensors as unconsumed because the runtime model does not construct `fc2_norm`.

Regression coverage exercises normalized LatentMoE execution across dispatcher, expert implementation, grouped-GEMM, and latent-size combinations, plus checkpoint-argument restoration.

Related PR: #6449 proposes similar normalized-LatentMoE behavior under the configuration name `moe_latent_output_norm` and targets `dev`. This PR retains `moe_use_norm_before_up_proj` because that key is persisted in existing GDP checkpoint metadata. The naming or compatibility approach can be aligned during review.

## Issue tracking

Linked issue: N/A — compatibility fix for existing LatentMoE checkpoints.

## Testing

- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
  - Black, isort, pylint, and ruff passed.
- Focused distributed unit tests on four GPUs, Slurm job `557079`:
  - `TestLatentMoELayer::test_latent_moe_layer` across all 12 parameter combinations
  - `test_load_args_restores_latent_moe_norm_from_checkpoint` across both parameter combinations
  - Relevant result: 14 norm/checkpoint cases passed per rank.
- The checkpoint restoration path was also exercised while loading the phase1_v2 GDP/MIMO checkpoints on the staging branch.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate review.

All PRs start as **draft**. Mark this PR ready only after CI is passing.
