### PR TITLE
Restore the batch schema bridge for hybrid CP sub-samples

### DIFF
--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -543,8 +543,26 @@ def hybrid_context_parallel_forward_backward(
             partner_cp_size = len(
                 [True for sample_ids in sample_id_groups[group_id] if sub_sample_id in sample_ids]
             )
-            sample["local_cp_size"] = torch.tensor(partner_cp_size, dtype=torch.int32)
-            new_data_iterator = RerunDataIterator(iter([sample]))
+            # Bridge the 1-D sub-sample dict from HybridCPDataLoaderWrapper.unpack_batch
+            # (token-level keys only, no cu_seqlens/max_seqlen) to the 2-D batched
+            # schema get_batch_on_this_tp_rank expects under is_hybrid_cp. The
+            # original bridge helper (get_batch_on_this_hybrid_cp_rank) was removed
+            # in the get_batch consolidation refactor, leaving the two ends
+            # incompatible; this restores the minimal contract.
+            dev = torch.cuda.current_device()
+            seq_len = sample["tokens"].shape[-1]
+            bridged = {
+                key: sample[key].unsqueeze(0)
+                for key in ("tokens", "labels", "loss_mask", "position_ids")
+            }
+            cu = torch.tensor([[0, seq_len]], dtype=torch.int32, device=dev)
+            bridged["cu_seqlens"] = cu
+            bridged["cu_seqlens_padded"] = cu.clone()
+            bridged["max_seqlen"] = torch.tensor([seq_len], dtype=torch.int32, device=dev)
+            bridged["local_cp_size"] = torch.tensor(
+                [partner_cp_size], dtype=torch.int32, device=dev
+            )
+            new_data_iterator = RerunDataIterator(iter([bridged]))
         else:
             partner_cp_size = 0
             new_data_iterator = None

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -165,7 +165,17 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
         lambda group=None: barrier_groups.append(group),
     )
 
-    batch = [{"id": 0}, {"id": 1}, {"id": 2}]
+    def _make_sub_sample(length):
+        # Shape of a real HybridCPDataLoaderWrapper.unpack_batch sub-sample:
+        # 1-D token-level tensors, no cu_seqlens/max_seqlen keys.
+        return {
+            "tokens": torch.arange(length, dtype=torch.int64),
+            "labels": torch.arange(1, length + 1, dtype=torch.int64),
+            "loss_mask": torch.ones(length, dtype=torch.float32),
+            "position_ids": torch.arange(length, dtype=torch.int64),
+        }
+
+    batch = [_make_sub_sample(16), _make_sub_sample(24), _make_sub_sample(8)]
     sample_id_groups = [[[0], [0], []], [[1, 2], [1], [1, 2]]]
     forward_calls = []
 
@@ -182,9 +192,21 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
     ):
         assert isinstance(data_iterator, RerunDataIterator)
         sample = next(data_iterator)
+        # The schedule must hand forward_step the bridged 2-D batched schema
+        # that get_batch_on_this_tp_rank requires under is_hybrid_cp; a raw
+        # 1-D unpack_batch sub-sample here is the regression this test guards.
+        length = sample["tokens"].shape[-1]
+        for key in ("tokens", "labels", "loss_mask", "position_ids"):
+            assert sample[key].shape == (1, length)
+        assert sample["cu_seqlens"].dtype == torch.int32
+        assert sample["cu_seqlens"].tolist() == [[0, length]]
+        assert sample["cu_seqlens_padded"].tolist() == [[0, length]]
+        assert sample["max_seqlen"].shape == (1,)
+        assert int(sample["max_seqlen"].item()) == length
+        assert sample["local_cp_size"].shape == (1,)
         forward_calls.append(
             {
-                "sample_id": sample["id"],
+                "length": int(length),
                 "local_cp_size": int(sample["local_cp_size"].item()),
                 "local_cp_size_dtype": sample["local_cp_size"].dtype,
                 "cp_group_size": cp_group_size,
@@ -227,7 +249,7 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
     assert total_num_tokens == 30
     assert forward_calls == [
         {
-            "sample_id": 0,
+            "length": 16,
             "local_cp_size": 2,
             "local_cp_size_dtype": torch.int32,
             "cp_group_size": 2,
@@ -235,7 +257,7 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
             "is_first_microbatch": True,
         },
         {
-            "sample_id": 1,
+            "length": 24,
             "local_cp_size": 3,
             "local_cp_size_dtype": torch.int32,
             "cp_group_size": 3,
@@ -243,7 +265,7 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
             "is_first_microbatch": False,
         },
         {
-            "sample_id": 2,
+            "length": 8,
             "local_cp_size": 2,
             "local_cp_size_dtype": torch.int32,
             "cp_group_size": 2,


### PR DESCRIPTION
## What does this PR do?

Fixes the missing schema bridge that makes `--hybrid-context-parallel` crash on
its first training step. `HybridCPDataLoaderWrapper.unpack_batch` emits 1-D
sub-sample dicts with token-level keys only (it deliberately strips
`cu_seqlens`/`max_seqlen`), while `get_batch_on_this_tp_rank` under
`is_hybrid_cp` requires 2-D batched tensors plus `cu_seqlens`, `max_seqlen`
and `local_cp_size`. The helper that used to bridge the two schemas was
removed in the get_batch consolidation refactor. Symptom: `IndexError` on
`batch['tokens'].shape[1]` at TP=1, asymmetric-broadcast hang at TP>1. Also
fixes `local_cp_size` being a 0-dim CPU tensor while receiving TP ranks
allocate a `(1,)` CUDA buffer for its broadcast.

## Test

The existing schedule unit test previously fed placeholder `{"id": N}` dicts;
it now feeds realistic 1-D `unpack_batch`-shaped sub-samples and asserts the
full bridged 2-D schema, so re-deleting the bridge fails the test. (The only
prior hybrid-CP coverage hand-built the post-bridge schema, which is why this
was invisible to CI.)

## Validation

End to end on 4x GB200: 8B GPT, 100k-token THD workload, mixed CP1/2/4 groups,
finite losses/grad norms. One of three independent fixes required to make
hybrid CP runnable (siblings: runtime-attention and rerun-iterator PRs);
supersedes the combined draft #6816.
