### PR TITLE
Fix runtime CP group handling in attention for hybrid CP

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2256,6 +2256,12 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         if packed_seq_params is not None:
             # If Dynamic CP group is provided, update TE DPA CP group
             if packed_seq_params.cp_group is not None:
+                # Hybrid/dynamic CP can enable CP at runtime on a model built
+                # with context_parallel_size == 1, where the constructor never
+                # allocated the auxiliary CP stream. Create it lazily; TE's
+                # AttnFuncWithCPAndKVP2P dereferences it unconditionally.
+                if TEDotProductAttention.cp_stream is None:
+                    TEDotProductAttention.cp_stream = torch.cuda.Stream()
                 self.cp_group = packed_seq_params.cp_group
                 super().set_context_parallel_group(
                     self.cp_group,

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -343,6 +343,9 @@ class Attention(MegatronModule, ABC):
                 pg_collection, 'cp'
             ), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
+        # Build-time CP group, kept so runtime (hybrid/dynamic) CP can restore
+        # it on microbatches that carry no per-microbatch CP group.
+        self._build_time_cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
 
         # Per attention head and per partition values
@@ -1501,14 +1504,19 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
                 rope_freqs_max_seqlen = None
 
-            # Hybrid/dynamic CP: RoPE position math must use the sub-sample's
-            # runtime CP group (packed_seq_params.cp_group), not the static
-            # group the model was built with. The fused THD RoPE kernel takes
-            # the full cu_seqlens plus (cp_size, cp_rank) to locate this rank's
-            # zigzag slice, and the static group reports cp_size=1.
-            rope_cp_group = self.pg_collection.cp
+            # Hybrid/dynamic CP: bind the sub-sample's runtime CP group
+            # (packed_seq_params.cp_group) on the process-group collection so
+            # RoPE below — and any other CP consumer in this forward — uses
+            # the group this microbatch was actually sharded with. The fused
+            # THD RoPE kernel takes the full cu_seqlens plus (cp_size,
+            # cp_rank) to locate this rank's zigzag slice, and the build-time
+            # group reports cp_size=1. Restore the build-time group when no
+            # runtime group is bound (e.g. local_cp_size == 1 sub-samples):
+            # the previous microbatch may have left a larger group behind.
             if packed_seq_params is not None and packed_seq_params.cp_group is not None:
-                rope_cp_group = packed_seq_params.cp_group
+                self.pg_collection.cp = packed_seq_params.cp_group
+            elif self.pg_collection.cp is not self._build_time_cp_group:
+                self.pg_collection.cp = self._build_time_cp_group
 
             if split_qkv:
                 if q_pos_emb is not None:
@@ -1520,7 +1528,7 @@ class Attention(MegatronModule, ABC):
                             config=self.config,
                             cu_seqlens=cu_seqlens_q,
                             mscale=self._yarn_concentration_factor,
-                            cp_group=rope_cp_group,
+                            cp_group=self.pg_collection.cp,
                             max_seqlen=rope_freqs_max_seqlen,
                         )
                     else:
@@ -1539,7 +1547,7 @@ class Attention(MegatronModule, ABC):
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
                         mscale=self._yarn_concentration_factor,
-                        cp_group=rope_cp_group,
+                        cp_group=self.pg_collection.cp,
                         max_seqlen=rope_freqs_max_seqlen,
                     )
             else:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1501,6 +1501,15 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
                 rope_freqs_max_seqlen = None
 
+            # Hybrid/dynamic CP: RoPE position math must use the sub-sample's
+            # runtime CP group (packed_seq_params.cp_group), not the static
+            # group the model was built with. The fused THD RoPE kernel takes
+            # the full cu_seqlens plus (cp_size, cp_rank) to locate this rank's
+            # zigzag slice, and the static group reports cp_size=1.
+            rope_cp_group = self.pg_collection.cp
+            if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+                rope_cp_group = packed_seq_params.cp_group
+
             if split_qkv:
                 if q_pos_emb is not None:
                     # TODO VIJAY: simplify
@@ -1511,7 +1520,7 @@ class Attention(MegatronModule, ABC):
                             config=self.config,
                             cu_seqlens=cu_seqlens_q,
                             mscale=self._yarn_concentration_factor,
-                            cp_group=self.pg_collection.cp,
+                            cp_group=rope_cp_group,
                             max_seqlen=rope_freqs_max_seqlen,
                         )
                     else:
@@ -1530,7 +1539,7 @@ class Attention(MegatronModule, ABC):
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
                         mscale=self._yarn_concentration_factor,
-                        cp_group=self.pg_collection.cp,
+                        cp_group=rope_cp_group,
                         max_seqlen=rope_freqs_max_seqlen,
                     )
             else:

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -275,6 +275,10 @@ class TestAttentionDynamicContextParallel:
         )
         rotary_pos_emb = RotaryEmbedding(kv_channels=16, rotary_percent=1.0)(sequence_length)
 
+        build_time_group = self.parallel_attention.pg_collection.cp
+
+        # Microbatch with a runtime CP group: RoPE (and the collection) must
+        # use it.
         runtime_group = self._runtime_cp_group()
         packed_seq_params = make_test_packed_seq_params(sequence_length)
         packed_seq_params.cp_group = runtime_group
@@ -286,7 +290,10 @@ class TestAttentionDynamicContextParallel:
             packed_seq_params=packed_seq_params,
         )
         assert captured and all(group is runtime_group for group in captured)
+        assert self.parallel_attention.pg_collection.cp is runtime_group
 
+        # Next microbatch without a runtime group (e.g. local_cp_size == 1):
+        # the build-time group must be restored, not the previous microbatch's.
         captured.clear()
         packed_seq_params = make_test_packed_seq_params(sequence_length)
         self.parallel_attention(
@@ -295,8 +302,8 @@ class TestAttentionDynamicContextParallel:
             rotary_pos_emb=rotary_pos_emb,
             packed_seq_params=packed_seq_params,
         )
-        static_group = self.parallel_attention.pg_collection.cp
-        assert captured and all(group is static_group for group in captured)
+        assert captured and all(group is build_time_group for group in captured)
+        assert self.parallel_attention.pg_collection.cp is build_time_group
 
     def test_te_cp_stream_lazily_created_for_runtime_cp_group(self, monkeypatch):
         import transformer_engine.pytorch as te_pytorch

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -284,10 +284,7 @@ class TestAttentionDynamicContextParallel:
         packed_seq_params.cp_group = runtime_group
         packed_seq_params.local_cp_size = 2
         self.parallel_attention(
-            hidden_states,
-            None,
-            rotary_pos_emb=rotary_pos_emb,
-            packed_seq_params=packed_seq_params,
+            hidden_states, None, rotary_pos_emb=rotary_pos_emb, packed_seq_params=packed_seq_params
         )
         assert captured and all(group is runtime_group for group in captured)
         assert self.parallel_attention.pg_collection.cp is runtime_group
@@ -297,10 +294,7 @@ class TestAttentionDynamicContextParallel:
         captured.clear()
         packed_seq_params = make_test_packed_seq_params(sequence_length)
         self.parallel_attention(
-            hidden_states,
-            None,
-            rotary_pos_emb=rotary_pos_emb,
-            packed_seq_params=packed_seq_params,
+            hidden_states, None, rotary_pos_emb=rotary_pos_emb, packed_seq_params=packed_seq_params
         )
         assert captured and all(group is build_time_group for group in captured)
         assert self.parallel_attention.pg_collection.cp is build_time_group

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -199,3 +199,151 @@ class TestParallelAttentionWithPackedPaddedSequence(TestParallelAttentionWithPac
         assert output.shape[0] == sequence_length
         assert output.shape[1] == micro_batch_size
         assert output.shape[2] == config.hidden_size
+
+
+class TestAttentionDynamicContextParallel:
+    """Regression tests for runtime (hybrid/dynamic) CP.
+
+    A model built with static context_parallel_size == 1 can be handed a
+    per-microbatch CP group at runtime via PackedSeqParams.cp_group. Two
+    contracts must hold: RoPE position math must use that runtime group (not
+    the static one), and TEDotProductAttention must lazily create its
+    auxiliary CP stream (the constructor only allocates it for static CP > 1).
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+        self.transformer_config = TransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.bfloat16,
+            autocast_dtype=torch.bfloat16,
+        )
+        self.parallel_attention = SelfAttention(
+            self.transformer_config,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _runtime_cp_group(self):
+        # A 1-rank group standing in for the group the hybrid-CP scheduler
+        # binds per microbatch; identity is what the assertions check.
+        return torch.distributed.new_group(ranks=[torch.distributed.get_rank()])
+
+    def test_rope_uses_runtime_cp_group(self, monkeypatch):
+        import megatron.core.transformer.attention as attention_module
+        from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
+
+        captured = []
+        real_apply = attention_module.apply_rotary_pos_emb
+
+        def spying_apply(t, freqs, **kwargs):
+            captured.append(kwargs.get("cp_group"))
+            return real_apply(t, freqs, **kwargs)
+
+        monkeypatch.setattr(attention_module, "apply_rotary_pos_emb", spying_apply)
+
+        # Bypass core attention: this test only checks RoPE's group selection.
+        # (Patch the class forward: nn.Module.__setattr__ refuses to replace a
+        # registered submodule with a plain callable.)
+        hidden_size = self.transformer_config.hidden_size
+
+        def fake_core_attention_forward(module_self, query, *args, **kwargs):
+            return torch.zeros(
+                (query.shape[0], hidden_size), dtype=torch.bfloat16, device=query.device
+            )
+
+        monkeypatch.setattr(
+            type(self.parallel_attention.core_attention), "forward", fake_core_attention_forward
+        )
+
+        sequence_length = 32
+        self.parallel_attention.cuda()
+        hidden_states = torch.ones(
+            (sequence_length, 1, self.transformer_config.hidden_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        rotary_pos_emb = RotaryEmbedding(kv_channels=16, rotary_percent=1.0)(sequence_length)
+
+        runtime_group = self._runtime_cp_group()
+        packed_seq_params = make_test_packed_seq_params(sequence_length)
+        packed_seq_params.cp_group = runtime_group
+        packed_seq_params.local_cp_size = 1
+        self.parallel_attention(
+            hidden_states,
+            None,
+            rotary_pos_emb=rotary_pos_emb,
+            packed_seq_params=packed_seq_params,
+        )
+        assert captured and all(group is runtime_group for group in captured)
+
+        captured.clear()
+        packed_seq_params = make_test_packed_seq_params(sequence_length)
+        self.parallel_attention(
+            hidden_states,
+            None,
+            rotary_pos_emb=rotary_pos_emb,
+            packed_seq_params=packed_seq_params,
+        )
+        static_group = self.parallel_attention.pg_collection.cp
+        assert captured and all(group is static_group for group in captured)
+
+    def test_te_cp_stream_lazily_created_for_runtime_cp_group(self, monkeypatch):
+        import transformer_engine.pytorch as te_pytorch
+
+        from megatron.core.extensions.transformer_engine import TEDotProductAttention
+
+        core_attention = self.parallel_attention.core_attention
+        assert isinstance(core_attention, TEDotProductAttention)
+
+        # Model built with context_parallel_size == 1: constructor allocated no stream.
+        monkeypatch.setattr(TEDotProductAttention, "cp_stream", None)
+
+        captured = {}
+
+        def fake_set_context_parallel_group(self, cp_group, ranks, stream, comm_type=None):
+            captured["stream"] = stream
+
+        def fake_forward(self, query, *args, **kwargs):
+            return torch.zeros(
+                (query.shape[0], query.shape[-2] * query.shape[-1]),
+                dtype=query.dtype,
+                device=query.device,
+            )
+
+        monkeypatch.setattr(
+            te_pytorch.DotProductAttention,
+            "set_context_parallel_group",
+            fake_set_context_parallel_group,
+        )
+        monkeypatch.setattr(te_pytorch.DotProductAttention, "forward", fake_forward)
+
+        core_attention.cuda()
+        query = torch.zeros(32, 4, 16, dtype=torch.bfloat16, device="cuda")
+        key = torch.zeros_like(query)
+        value = torch.zeros_like(query)
+        packed_seq_params = make_test_packed_seq_params(32)
+        packed_seq_params.cp_group = self._runtime_cp_group()
+        packed_seq_params.local_cp_size = 1
+
+        core_attention(
+            query,
+            key,
+            value,
+            None,
+            AttnMaskType.padding_causal,
+            packed_seq_params=packed_seq_params,
+        )
+
+        assert isinstance(captured.get("stream"), torch.cuda.Stream)
+        assert isinstance(TEDotProductAttention.cp_stream, torch.cuda.Stream)

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -282,7 +282,7 @@ class TestAttentionDynamicContextParallel:
         runtime_group = self._runtime_cp_group()
         packed_seq_params = make_test_packed_seq_params(sequence_length)
         packed_seq_params.cp_group = runtime_group
-        packed_seq_params.local_cp_size = 1
+        packed_seq_params.local_cp_size = 2
         self.parallel_attention(
             hidden_states,
             None,
@@ -341,7 +341,7 @@ class TestAttentionDynamicContextParallel:
         value = torch.zeros_like(query)
         packed_seq_params = make_test_packed_seq_params(32)
         packed_seq_params.cp_group = self._runtime_cp_group()
-        packed_seq_params.local_cp_size = 1
+        packed_seq_params.local_cp_size = 2
 
         core_attention(
             query,


### PR DESCRIPTION
## What does this PR do?

Two fixes for runtime (hybrid/dynamic) CP in the attention stack, where a
model built with static `context_parallel_size == 1` binds a CP group per
microbatch via `PackedSeqParams.cp_group`:

1. **Lazily create TE's auxiliary CP stream.** The constructor only allocates
   `TEDotProductAttention.cp_stream` when static CP > 1, so the runtime branch
   passed `cp_stream=None` into TE and `AttnFuncWithCPAndKVP2P` crashed with
   `AttributeError: 'NoneType' object has no attribute 'wait_event'`.
2. **Route the runtime CP group to RoPE.** `apply_rotary_pos_emb` derives
   `(cp_size, cp_rank)` for the fused THD RoPE kernel from its `cp_group`
   argument, but attention always passed the static `pg_collection.cp`. Under
   runtime CP each rank holds only its group's zigzag slice while `cu_seqlens`
   describe the full sequence, so the kernel indexed positions past the
   tensor: illegal memory accesses on short sub-samples (caught with
   `CUDA_LAUNCH_BLOCKING=1` in `fused_rope_forward`), and wrong positions,
   NaN gradients, then a softmax-lse device assert on long ones. This is the
   dangerous one: with different luck it trains-but-wrong.

## Test

New unit tests assert (a) RoPE receives the runtime group when
`packed_seq_params.cp_group` is bound and the static group otherwise, and
(b) the CP stream is lazily created and handed to TE's
`set_context_parallel_group`.

## Validation

End to end on 4x GB200: 8B GPT, 100k-token THD workload, mixed CP1/2/4
groups, finite losses/grad norms. One of three independent fixes required to
make hybrid CP runnable (siblings: schema-bridge and rerun-iterator PRs);
supersedes the combined draft #6816.
