### PR TITLE
Keep RerunDataIterator wrapping on the hybrid CP data iterator

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1497,6 +1497,17 @@ def preprocess_common_state_dict(common_state_dict):
     return preprocessed_common_state_dict
 
 
+def wrap_hybrid_cp_data_iterator(train_data_iterator, config):
+    """Wrap the training data iterator for hybrid context parallelism.
+
+    The rerun state machine asserts that every training data iterator is a
+    RerunDataIterator; a raw iter() around HybridCPDataLoaderWrapper would
+    strip the wrapping applied at dataloader build time and fail that assert
+    on the first train step.
+    """
+    return RerunDataIterator(iter(HybridCPDataLoaderWrapper(train_data_iterator, config)))
+
+
 def pretrain(
     cfg_container: PretrainConfigContainer,
     train_valid_test_dataset_provider,
@@ -4302,7 +4313,7 @@ def train(
     one_logger = get_one_logger()
 
     if args.hybrid_context_parallel:
-        train_data_iterator = iter(HybridCPDataLoaderWrapper(train_data_iterator, config))
+        train_data_iterator = wrap_hybrid_cp_data_iterator(train_data_iterator, config)
 
     if args.run_workload_inspector_server:
         try:

--- a/tests/unit_tests/training/test_hybrid_cp_data_iterator.py
+++ b/tests/unit_tests/training/test_hybrid_cp_data_iterator.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import megatron.core.datasets.data_schedule as data_schedule
+from megatron.core.rerun_state_machine import RerunDataIterator, RerunMode, RerunStateMachine
+from megatron.training.training import wrap_hybrid_cp_data_iterator
+
+
+def test_wrap_hybrid_cp_data_iterator_returns_rerun_iterator(monkeypatch):
+    """The rerun state machine asserts on the RerunDataIterator type at every
+    train step (rerun_state_machine._sanitize_data_iterators); the hybrid-CP
+    wrap must preserve it. Regression: a raw iter() around
+    HybridCPDataLoaderWrapper stripped the wrapping and crashed before the
+    first iteration.
+    """
+    fake_group = SimpleNamespace(size=lambda: 4, rank=lambda: 0)
+    monkeypatch.setattr(
+        data_schedule.parallel_state,
+        "get_data_parallel_group",
+        lambda with_context_parallel=False: fake_group,
+    )
+    monkeypatch.setattr(
+        data_schedule.parallel_state, "get_tensor_model_parallel_group", lambda: fake_group
+    )
+
+    config = SimpleNamespace(max_seqlen_per_dp_cp_rank=128)
+    wrapped = wrap_hybrid_cp_data_iterator(iter([]), config)
+
+    assert isinstance(wrapped, RerunDataIterator)
+    # The exact production check: sanitization must accept the iterator.
+    sanitized = RerunStateMachine._sanitize_data_iterators(
+        SimpleNamespace(mode=RerunMode.VALIDATE_RESULTS), wrapped
+    )
+    assert sanitized == [wrapped]


### PR DESCRIPTION
## What does this PR do?

`--hybrid-context-parallel` rewrapped the training iterator as a raw
`iter(HybridCPDataLoaderWrapper(...))`, discarding the `RerunDataIterator`
applied at dataloader build time. The rerun state machine asserts on the
wrapper type at every train step (default `rerun_mode` is
`validate_results`), so any hybrid-CP run died before iteration 1 with
"data iterator is not wrapped with RerunDataIterator". The wrapping is
factored into `wrap_hybrid_cp_data_iterator` so the invariant is
unit-testable.

## Test

New unit test asserts the returned type and runs the exact production check
(`RerunStateMachine._sanitize_data_iterators`) against the wrapped iterator.

## Validation

End to end on 4x GB200: 8B GPT, 100k-token THD workload, mixed CP1/2/4
groups. One of three independent fixes required to make hybrid CP runnable
(siblings: schema-bridge and runtime-attention PRs); supersedes the combined
draft #6816.
