### PR TITLE
Assert the runtime-CP group contract both ways

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2296,6 +2296,13 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         if packed_seq_params is not None:
             # If Dynamic CP group is provided, update TE DPA CP group
             if packed_seq_params.cp_group is not None:
+                # Converse of the assert below: a CP-off (local_cp_size == 1)
+                # sub-sample must not carry a CP group, otherwise it would be
+                # routed through the CP attention path. Producers must only
+                # bind cp_group when local_cp_size > 1.
+                assert (
+                    packed_seq_params.local_cp_size is None or packed_seq_params.local_cp_size > 1
+                ), "cp_group must not be set when local_cp_size == 1 (CP-off convention)"
                 # Hybrid/dynamic CP can enable CP at runtime on a model built
                 # with context_parallel_size == 1, where the constructor never
                 # allocated the auxiliary CP stream. Create it lazily; TE's

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -20,6 +20,11 @@ class PackedSeqParams:
     cu_seqlens_kv_padded: Tensor = None
     max_seqlen_q: int = None
     max_seqlen_kv: int = None
+    # Runtime (hybrid/dynamic) context parallelism, set per microbatch by
+    # get_batch_on_this_cp_rank. Invariant: local_cp_size == 1 means CP is off
+    # for this sub-sample and cp_group MUST be None (consumers fall back to
+    # their build-time group); cp_group is only bound when local_cp_size > 1.
+    # TEDotProductAttention asserts both directions of this contract.
     local_cp_size: int = None
     cp_group: dist.ProcessGroup = None
     total_tokens: int = None

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -20,8 +20,8 @@ class PackedSeqParams:
     cu_seqlens_kv_padded: Tensor = None
     max_seqlen_q: int = None
     max_seqlen_kv: int = None
-    # Runtime (hybrid/dynamic) context parallelism, set per microbatch by
-    # get_batch_on_this_cp_rank. Invariant: local_cp_size == 1 means CP is off
+    # When doing runtime (hybrid/dynamic) context parallelism, these are set
+    # per microbatch by get_batch_on_this_cp_rank. local_cp_size == 1 means CP is off
     # for this sub-sample and cp_group MUST be None (consumers fall back to
     # their build-time group); cp_group is only bound when local_cp_size > 1.
     # TEDotProductAttention asserts both directions of this contract.

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -348,3 +348,53 @@ class TestAttentionDynamicContextParallel:
 
         assert isinstance(captured.get("stream"), torch.cuda.Stream)
         assert isinstance(TEDotProductAttention.cp_stream, torch.cuda.Stream)
+
+
+class TestRuntimeCPGroupContract:
+    """Guard the runtime-CP contract: local_cp_size == 1 means CP is off for
+    the sub-sample and cp_group must be None. A producer that starts binding
+    size-1 groups would silently route CP-off microbatches through the CP
+    attention path; this test makes that loud.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+        transformer_config = TransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.bfloat16,
+            autocast_dtype=torch.bfloat16,
+        )
+        self.parallel_attention = SelfAttention(
+            transformer_config,
+            get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_cp_group_with_local_cp_size_one_is_rejected(self):
+        core_attention = self.parallel_attention.core_attention.cuda()
+        query = torch.zeros(32, 4, 16, dtype=torch.bfloat16, device="cuda")
+        packed_seq_params = make_test_packed_seq_params(32)
+        packed_seq_params.cp_group = torch.distributed.new_group(
+            ranks=[torch.distributed.get_rank()]
+        )
+        packed_seq_params.local_cp_size = 1
+
+        with pytest.raises(AssertionError, match="local_cp_size == 1"):
+            core_attention(
+                query,
+                torch.zeros_like(query),
+                torch.zeros_like(query),
+                None,
+                AttnMaskType.padding_causal,
+                packed_seq_params=packed_seq_params,
+            )


### PR DESCRIPTION
## What does this PR do?

Follow-up to the review discussion on #6821. Runtime (hybrid/dynamic) CP uses
the convention `local_cp_size == 1 <=> cp_group is None` (the producer,
`get_batch_on_this_cp_rank`, only binds a group when `local_cp_size > 1`).
TEDotProductAttention asserted one direction ("no group => size must be 1");
this adds the converse assert ("size 1 => no group"), documents the invariant
on `PackedSeqParams`, and adds a unit test — so a future producer that starts
binding size-1 groups fails loudly instead of silently routing CP-off
microbatches through the CP attention path.

Audit of all `packed_seq_params.cp_group` / `local_cp_size` consumers in core
(for the discussion in #6821): the TE wrapper handles/asserts the None case,
`gpt_model`'s rotary call sites are safe (the `packed_seq=True` path never
CP-slices — that happens in the fused THD kernel), and MLA hard-asserts
hybrid CP off. No other latent group-assumption bugs found.

Note: trivially overlaps #6821 in `transformer_engine.py` (adjacent lines);
whichever lands second rebases.