### PR TITLE
Reduce CUDA graph side-stream allocator fragmentation

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -10,7 +10,11 @@ import torch
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..optimizer.param_layout import FullParamLayout
 from ..process_groups_config import ProcessGroupCollection
-from ..transformer.cuda_graphs import is_graph_capturing
+from ..transformer.cuda_graphs import (
+    get_cuda_graph_capture_stream,
+    get_cuda_graph_param_ids,
+    is_graph_capturing,
+)
 from ..transformer.transformer_config import TransformerConfig
 from ..utils import PARAM_READY_CALLBACK_ATTR, log_single_rank
 
@@ -435,6 +439,10 @@ class DistributedDataParallel(_BaseDataParallel):
         # Accumulation function for the gradients need to be stored so they
         # don't go out of scope.
         self.grad_accs = []
+        capture_stream = get_cuda_graph_capture_stream()
+        cuda_graph_param_ids = (
+            get_cuda_graph_param_ids(self.module) if capture_stream is not None else set()
+        )
         for param in self.module.parameters():
             if param.requires_grad:
                 # When delay_wgrad_compute is True and the param is marked with
@@ -455,7 +463,17 @@ class DistributedDataParallel(_BaseDataParallel):
                                     break
                 else:
                     # Expand so we get access to grad_fn.
-                    param_tmp = param.expand_as(param)
+                    grad_acc_on_capture_stream = id(param) in cuda_graph_param_ids
+                    if grad_acc_on_capture_stream:
+                        # DDP retains this AccumulateGrad node for the model's lifetime. Create
+                        # graph parameters' nodes on the capture stream so backward capture does
+                        # not inherit their eager stream affinity. Eager-only parameters remain on
+                        # the caller stream.
+                        with torch.cuda.stream(capture_stream):
+                            param_tmp = param.expand_as(param)
+                    else:
+                        param_tmp = param.expand_as(param)
+                    param._ddp_grad_acc_on_cudagraph_stream = grad_acc_on_capture_stream
                     # Get the gradient accumulator function.
                     grad_acc = param_tmp.grad_fn.next_functions[0][0]
                     if getattr(param, 'is_gtp_weight_remat', False) and hasattr(

--- a/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
+++ b/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
@@ -5,6 +5,8 @@ from typing import Any, Optional
 
 import torch
 
+from megatron.core.transformer.cuda_graph_utils import default_stream_allocation
+
 
 class _ReduceScatterWithFP32AccumulationWorkHandle:
     """Work handle to return to user when using reduce_scatter_with_fp32_accumulation with
@@ -29,10 +31,14 @@ class _ReduceScatterWithFP32AccumulationWorkHandle:
         if self.all_to_all_handle is not None:
             self.all_to_all_handle.wait()
 
-        # Accumulate into a fp32 sum.
-        output_tensor_in_fp32 = torch.sum(
-            self.all_to_all_output_tensor.view((self.world_size, -1)), dim=0, dtype=torch.float32
-        )
+        # The wait may run on a communication or CUDA graph replay stream. Allocate the temporary
+        # result from the default-stream pool, then track its actual consumer stream until the
+        # downcast below completes.
+        all_to_all_output = self.all_to_all_output_tensor.view((self.world_size, -1))
+        with default_stream_allocation():
+            output_tensor_in_fp32 = torch.empty_like(self.output_tensor, dtype=torch.float32)
+        output_tensor_in_fp32.record_stream(torch.cuda.current_stream())
+        torch.sum(all_to_all_output, dim=0, dtype=torch.float32, out=output_tensor_in_fp32.view(-1))
         assert output_tensor_in_fp32.dtype == torch.float32
 
         # Copy downcasted sum into output_tensor.
@@ -77,9 +83,12 @@ def reduce_scatter_with_fp32_accumulation(
 
     # Call all_to_all (every rank should have their respective gradient shards collected from
     # all ranks). We also create a tensor for the all-to-all output (the all-to-all collective
-    # cannot be performed in-place).
+    # cannot be performed in-place). This function may run on a communication or graph replay
+    # stream; default ownership avoids retaining a native allocator segment for that side stream.
     if all_to_all_output_tensor is None:
-        all_to_all_output_tensor = torch.empty_like(input_tensor)
+        with default_stream_allocation():
+            all_to_all_output_tensor = torch.empty_like(input_tensor)
+        all_to_all_output_tensor.record_stream(torch.cuda.current_stream())
     else:
         assert all_to_all_output_tensor.shape == input_tensor.shape, (
             f"all_to_all_output_tensor shape {tuple(all_to_all_output_tensor.shape)} does not "

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from megatron.core.telemetry.fallbacks import trace_fn as _otel_trace_fn
 
+from megatron.core.transformer.cuda_graph_utils import default_stream_allocation
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
@@ -940,9 +941,13 @@ class ChunkOffloadHandler:
         dev, cpu_backup, use_cpu_pool, view_meta = state
         if non_blocking is None:
             non_blocking = cpu_backup.is_pinned()
-        gpu_tensor = torch.empty(
-            cpu_backup.size(), dtype=cpu_backup.dtype, layout=cpu_backup.layout, device=dev
-        )
+        with default_stream_allocation():
+            gpu_tensor = torch.empty(
+                cpu_backup.size(), dtype=cpu_backup.dtype, layout=cpu_backup.layout, device=dev
+            )
+        # The reload runs on the current H2D stream, so prevent allocator reuse until its
+        # asynchronous copy has completed.
+        gpu_tensor.record_stream(torch.cuda.current_stream())
         gpu_tensor.copy_(cpu_backup, non_blocking=non_blocking)
         if use_cpu_pool:
             self.cpu_tensor_pool.free(cpu_backup)

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -115,6 +115,10 @@ class MambaLayer(GraphableMegatronModule):
         ) or CudaGraphModule.mamba in self.config.cuda_graph_modules:
             self.cudagraph_manager = CudaGraphManager(config)
 
+    def _uses_local_cudagraph_for_training(self) -> bool:
+        """Return whether this layer owns a training CUDA graph."""
+        return hasattr(self, "cudagraph_manager")
+
     def mamba_state_shapes_per_request(self) -> Tuple[Tuple[int], Tuple[int]]:
         """Returns the Mamba conv and ssm states shapes per request."""
         return self.mixer.mamba_state_shapes_per_request()

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -48,6 +48,7 @@ from megatron.core.tensor_parallel.gtp_symmetric_memory import (
     is_gtp_symm_pool_registered,
     symmetric_wgrad_pool,
 )
+from megatron.core.transformer.cuda_graph_utils import default_stream_allocation
 from megatron.core.utils import ensure_params_ready, log_single_rank
 
 logger = logging.getLogger(__name__)
@@ -322,15 +323,25 @@ def _alloc_symmetric_wgrad_buffer(weight, dtype, device) -> torch.Tensor:
     return buf
 
 
-def _wgrad_pool_get(shape: tuple, dtype: torch.dtype, device) -> torch.Tensor:
+def _wgrad_pool_get(
+    shape: tuple, dtype: torch.dtype, device, *, allocate_on_default_stream: bool = False
+) -> torch.Tensor:
     """Get a pool buffer or allocate fresh, tagged so _wgrad_pool_put accepts only
-    pool-owned buffers (other callers fall through to the caching allocator on release)."""
+    pool-owned buffers (other callers fall through to the caching allocator on release).
+
+    ``allocate_on_default_stream`` applies only to a fresh allocation; pooled reuse does not
+    enqueue another cross-stream event.
+    """
     key = (shape, dtype)
     pool = _wgrad_buf_pool.get(key)
     if pool:
         buf = pool.pop()
     else:
-        buf = torch.empty(shape, dtype=dtype, device=device, requires_grad=False)
+        allocation_context = (
+            default_stream_allocation() if allocate_on_default_stream else nullcontext()
+        )
+        with allocation_context:
+            buf = torch.empty(shape, dtype=dtype, device=device, requires_grad=False)
     buf._from_gtp_wgrad_pool = True
     return buf
 
@@ -1953,7 +1964,9 @@ class GTPShardedParam(torch.nn.Parameter):
         caller waits the handle (immediately when sync) and then releases the scratch.
 
         The all-to-all scratch is unsharded-sized, so it comes from the wgrad pool: GTP keeps
-        several RS in flight and an empty_like each would add that much peak memory.
+        several RS operations in flight, and an allocation per operation would increase peak
+        memory. Ungraphed chains allocate new pool storage through the default stream to avoid
+        retaining an allocator segment for each communication stream.
         """
         # Local import: tensor_parallel has no top-level dependency on core.distributed.
         from megatron.core.distributed.reduce_scatter_with_fp32_accumulation import (
@@ -1961,11 +1974,26 @@ class GTPShardedParam(torch.nn.Parameter):
         )
 
         tensor = tensor.contiguous()
+        graphed = _chain_is_graphed(self.chain_id)
         if out_buffer is None:
             out_shape = [tensor.shape[0] // self.group.size(), *tensor.shape[1:]]
-            out_buffer = torch.empty(out_shape, dtype=tensor.dtype, device=tensor.device)
+            default_owned_output = not graphed
+            allocation_context = (
+                default_stream_allocation() if default_owned_output else nullcontext()
+            )
+            with allocation_context:
+                out_buffer = torch.empty(out_shape, dtype=tensor.dtype, device=tensor.device)
+            if default_owned_output:
+                # Allocation belongs to the default-stream pool, but the RS stream consumes it.
+                # Transfer allocator lifetime tracking without moving the collective itself.
+                out_buffer.record_stream(torch.cuda.current_stream())
 
-        a2a_buf = _wgrad_pool_get(tuple(tensor.shape), tensor.dtype, tensor.device)
+        a2a_buf = _wgrad_pool_get(
+            tuple(tensor.shape), tensor.dtype, tensor.device, allocate_on_default_stream=not graphed
+        )
+        if not graphed:
+            # The RS stream consumes default-owned storage until its deferred handle is waited.
+            a2a_buf.record_stream(torch.cuda.current_stream())
         handle = reduce_scatter_with_fp32_accumulation(
             out_buffer,
             tensor,

--- a/megatron/core/transformer/cuda_graph_utils.py
+++ b/megatron/core/transformer/cuda_graph_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CUDA graph allocation helpers shared by asynchronous Megatron components."""
+
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def default_stream_allocation():
+    """Run allocations in the current device's default-stream allocator pool.
+
+    If the caller uses another stream, order that stream after the allocation. Callers must also
+    use ``Tensor.record_stream`` when a tensor can be released before its consumer finishes.
+    """
+    caller_stream = torch.cuda.current_stream()
+
+    # Captured allocations must remain on a stream in the active capture session. Their lifetime
+    # is owned by the graph pool rather than the ordinary caching allocator.
+    if torch.cuda.is_current_stream_capturing():
+        yield
+        return
+
+    allocation_stream = torch.cuda.default_stream()
+
+    if caller_stream == allocation_stream:
+        yield
+        return
+
+    with torch.cuda.stream(allocation_stream):
+        yield
+        allocation_ready_event = torch.cuda.Event()
+        allocation_ready_event.record(allocation_stream)
+    caller_stream.wait_event(allocation_ready_event)

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -101,6 +101,7 @@ _IS_GRAPH_WARMUP = False
 _CUDA_GRAPH_STREAM_POOL_SIZE = 3
 _CUDA_GRAPH_STREAM_POOLS = None
 _CUDA_GRAPH_STREAM_NEXT_SLOT = 0
+_STALE_CAPTURE_STREAM_OVERRIDE_WARNING_EMITTED = False
 logger = logging.getLogger(__name__)
 
 
@@ -153,13 +154,28 @@ def _get_cuda_graph_stream() -> torch.cuda.Stream:
 
 @contextmanager
 def _override_stale_capture_stream():
-    """Redirect autograd nodes with stale stream affinity during backward capture."""
-    previous = torch._C._override_stale_capture_stream()
-    torch.autograd.graph.set_override_stale_capture_stream(True)
+    """Redirect stale autograd stream affinity when supported by the PyTorch build."""
+    global _STALE_CAPTURE_STREAM_OVERRIDE_WARNING_EMITTED
+
+    getter = getattr(torch._C, "_override_stale_capture_stream", None)
+    setter = getattr(torch.autograd.graph, "set_override_stale_capture_stream", None)
+    if getter is None or setter is None:
+        if not _STALE_CAPTURE_STREAM_OVERRIDE_WARNING_EMITTED:
+            logger.warning(
+                "PyTorch does not provide the stale capture-stream override; local CUDA graph "
+                "backward capture may fail if an autograd node retains another stream. Upgrade "
+                "to a PyTorch build that includes pytorch/pytorch#180090."
+            )
+            _STALE_CAPTURE_STREAM_OVERRIDE_WARNING_EMITTED = True
+        yield
+        return
+
+    previous = getter()
+    setter(True)
     try:
         yield
     finally:
-        torch.autograd.graph.set_override_stale_capture_stream(previous)
+        setter(previous)
 
 
 def _get_tensor_alias_chain(tensor):
@@ -265,16 +281,23 @@ def get_cuda_graph_capture_stream() -> torch.cuda.Stream | None:
 def get_cuda_graph_param_ids(module: torch.nn.Module) -> set[int]:
     """Return parameter IDs belonging to local CUDA graphs in ``module``.
 
-    Graphable modules describe their visible graph scope through
-    ``_get_submodules_under_cudagraphs``. Parameters reached only through a recomputation or
-    checkpoint closure can be declared separately through
-    ``_get_additional_cudagraph_parameters``.
+    Only modules that opt into training graphs are considered; model and block classes may own
+    inference-only managers. Training graph owners describe their visible scope through
+    ``_get_submodules_under_cudagraphs`` and declare parameters reached only through a
+    recomputation or checkpoint closure through ``_get_additional_cudagraph_parameters``.
     """
     param_ids = set()
     for graph_owner in module.modules():
         config = getattr(graph_owner, "config", None)
+        uses_training_graph = getattr(graph_owner, "_uses_local_cudagraph_for_training", None)
         get_graph_submodules = getattr(graph_owner, "_get_submodules_under_cudagraphs", None)
-        if config is None or config.cuda_graph_impl != "local" or get_graph_submodules is None:
+        if (
+            config is None
+            or config.cuda_graph_impl != "local"
+            or uses_training_graph is None
+            or not uses_training_graph()
+            or get_graph_submodules is None
+        ):
             continue
 
         for graph_submodule in get_graph_submodules():

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -8,7 +8,7 @@ import math
 import os
 import time
 from collections import defaultdict
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
@@ -151,6 +151,17 @@ def _get_cuda_graph_stream() -> torch.cuda.Stream:
     return pool[slot]
 
 
+@contextmanager
+def _override_stale_capture_stream():
+    """Redirect autograd nodes with stale stream affinity during backward capture."""
+    previous = torch._C._override_stale_capture_stream()
+    torch.autograd.graph.set_override_stale_capture_stream(True)
+    try:
+        yield
+    finally:
+        torch.autograd.graph.set_override_stale_capture_stream(previous)
+
+
 def _get_tensor_alias_chain(tensor):
     """Return a tensor followed by each underlying base tensor."""
     aliases = []
@@ -246,6 +257,36 @@ def is_graph_capturing():
     return _IS_GRAPH_CAPTURING
 
 
+def get_cuda_graph_capture_stream() -> torch.cuda.Stream | None:
+    """Return the stream shared by local CUDA graph warmup and capture, if initialized."""
+    return CudaGraphManager.capture_stream
+
+
+def get_cuda_graph_param_ids(module: torch.nn.Module) -> set[int]:
+    """Return parameter IDs belonging to local CUDA graphs in ``module``.
+
+    Graphable modules describe their visible graph scope through
+    ``_get_submodules_under_cudagraphs``. Parameters reached only through a recomputation or
+    checkpoint closure can be declared separately through
+    ``_get_additional_cudagraph_parameters``.
+    """
+    param_ids = set()
+    for graph_owner in module.modules():
+        config = getattr(graph_owner, "config", None)
+        get_graph_submodules = getattr(graph_owner, "_get_submodules_under_cudagraphs", None)
+        if config is None or config.cuda_graph_impl != "local" or get_graph_submodules is None:
+            continue
+
+        for graph_submodule in get_graph_submodules():
+            param_ids.update(id(param) for param in graph_submodule.parameters())
+
+        get_additional_params = getattr(graph_owner, "_get_additional_cudagraph_parameters", None)
+        if get_additional_params is not None:
+            param_ids.update(id(param) for param in get_additional_params())
+
+    return param_ids
+
+
 def _set_capture_start():
     """Set graph capture has started."""
     global _IS_GRAPH_CAPTURING
@@ -334,16 +375,29 @@ class ArgMetadata:
 
 
 def alloc_tensor_from_graph_mempool(meta: ArgMetadata):
-    """Allocates a tensor specified by a ArgMetadata into the graph mempool."""
+    """Allocate a tensor from the graph pool on the fixed capture stream.
 
-    torch._C._cuda_beginAllocateCurrentThreadToPool(
-        torch.cuda.current_device(), CudaGraphManager.global_mempool
-    )
-    out = meta.zeros_like()
+    A shared graph pool must use one stream consistently. Allocating it from each runner's stream
+    partitions the pool into stream-local allocator blocks and increases reserved memory.
+    """
+    capture_stream = CudaGraphManager.capture_stream
+    if capture_stream is None:
+        raise RuntimeError("CUDA graph capture stream has not been initialized")
+
+    device = torch.cuda.current_device()
+    caller_stream = torch.cuda.current_stream()
+    with torch.cuda.stream(capture_stream):
+        torch._C._cuda_beginAllocateCurrentThreadToPool(device, CudaGraphManager.global_mempool)
+        try:
+            out = meta.zeros_like()
+        finally:
+            torch._C._cuda_endAllocateToPool(device, CudaGraphManager.global_mempool)
+
     out.is_from_global_mempool = True
     out.requires_grad_(meta.requires_grad)
-
-    torch._C._cuda_endAllocateToPool(torch.cuda.current_device(), CudaGraphManager.global_mempool)
+    if caller_stream != capture_stream:
+        # The caller may consume the tensor immediately after this function returns.
+        caller_stream.wait_stream(capture_stream)
     return out
 
 
@@ -725,6 +779,13 @@ class _CudagraphGlobalRecord:
 
         torch.cuda.set_stream(torch.cuda.default_stream())
 
+        # Auxiliary-stream warmups may leave empty expandable segments in the native allocator.
+        # Capture is complete, so unused segments can be released without moving live graph-pool
+        # allocations.
+        torch.cuda.synchronize()
+        gc.collect()
+        torch.cuda.empty_cache()
+
         # Return capture time and memory usage.
         return capture_stats
 
@@ -774,6 +835,7 @@ def delete_cuda_graphs():
     torch.cuda.empty_cache()
 
     CudaGraphManager.global_mempool = None
+    CudaGraphManager.capture_stream = None
 
 
 class _GraphStatus(Enum):
@@ -1304,9 +1366,15 @@ class _CudaGraphRunner(torch.nn.Module):
             self.fwd_graph_input_args, self.fwd_graph_input_kwargs
         )
 
+        # Autograd nodes remember the stream on which warmup executes. Use the exact capture
+        # stream for warmup so capture does not inherit waits on a stale, non-capturing stream.
+        capture_stream = CudaGraphManager.capture_stream
+        assert capture_stream is not None
+        capture_stream.wait_stream(torch.cuda.current_stream())
+
         grad_context = torch.no_grad() if not self.grad_enabled else nullcontext()
         warmup_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext()
-        with grad_context, warmup_comm_context as warmup_comms:
+        with torch.cuda.stream(capture_stream), grad_context, warmup_comm_context as warmup_comms:
             # Warm up again because CUDA graph capture mode may execute a different codepath
             _set_warmup_start()
 
@@ -1378,7 +1446,10 @@ class _CudaGraphRunner(torch.nn.Module):
                 with (
                     capture_comm_context as capture_comms,
                     torch.cuda.graph(
-                        self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
+                        self.fwd_graph,
+                        pool=self.mempool,
+                        stream=CudaGraphManager.capture_stream,
+                        capture_error_mode="thread_local",
                     ),
                 ):
 
@@ -1455,6 +1526,26 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.params_to_backprop = self.get_connected_params(warmup_outputs)
             else:
                 self.params_to_backprop = self.get_connected_params(fwd_graph_outputs)
+            params_with_stale_ddp_nodes = [
+                param
+                for param in self.params_to_backprop
+                if getattr(param, "_ddp_grad_acc_on_cudagraph_stream", None) is False
+            ]
+            if params_with_stale_ddp_nodes:
+                param_names = {
+                    id(param): name for name, param in self.base_module.named_parameters()
+                }
+                names = [
+                    param_names.get(id(param), "<unnamed>") for param in params_with_stale_ddp_nodes
+                ]
+                raise RuntimeError(
+                    "Local CUDA graph backward discovered DDP parameters whose AccumulateGrad "
+                    "nodes were created outside the capture stream: "
+                    + ", ".join(names)
+                    + ". Add visible modules to _get_submodules_under_cudagraphs() or hidden "
+                    "checkpoint/recomputation dependencies to "
+                    "_get_additional_cudagraph_parameters()."
+                )
             self.num_dgrads = len(self.fwd_graph_input_surface)
             self.fwd_graph_input_surface = self.fwd_graph_input_surface + self.params_to_backprop
 
@@ -1515,8 +1606,11 @@ class _CudaGraphRunner(torch.nn.Module):
 
         capture_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext(None)
         with (
+            _override_stale_capture_stream(),
             capture_comm_context as capture_comms,
-            torch.cuda.graph(self.bwd_graph, pool=self.mempool),
+            torch.cuda.graph(
+                self.bwd_graph, pool=self.mempool, stream=CudaGraphManager.capture_stream
+            ),
         ):
 
             grad_inputs = torch.autograd.grad(
@@ -1856,6 +1950,8 @@ class CudaGraphManager(torch.nn.Module):
 
     """A global mempool for when 'cuda_graph_use_single_mempool' is used."""
     global_mempool = None
+    # One stream serves every local forward/backward capture.
+    capture_stream = None
 
     def __init__(
         self,
@@ -1931,9 +2027,9 @@ class CudaGraphManager(torch.nn.Module):
             # storage directly into it (created before the first graphed forward).
             if HAVE_GTP:
                 set_cuda_graph_mempool(torch.cuda.current_device(), CudaGraphManager.global_mempool)
-            # Cudagraph stream capture requires no operations on the default stream prior to the
-            # capture, so change to a side stream.
-            torch.cuda.set_stream(torch.cuda.Stream())
+            # CUDA graphs cannot capture on the default stream. Retain one side stream so every
+            # local graph warms up and captures with the same stream affinity.
+            CudaGraphManager.capture_stream = _get_cuda_graph_stream()
 
         # Enable one hook for the eager recording phase. Repeated manager construction is
         # idempotent, and graph creation removes the hook before capture begins.

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -297,6 +297,15 @@ class GraphableMegatronModule(MegatronModule):
         """
         return [self]
 
+    def _uses_local_cudagraph_for_training(self) -> bool:
+        """Return whether this module owns a training-time local CUDA graph.
+
+        Model and block classes also inherit ``GraphableMegatronModule`` for inference graphs.
+        Training graph owners must opt in so their default ``[self]`` scope does not classify an
+        eager model or block subtree as graph-owned.
+        """
+        return False
+
     def _get_additional_cudagraph_parameters(self):
         """Return graph parameters outside the selected graph submodule trees.
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -297,6 +297,14 @@ class GraphableMegatronModule(MegatronModule):
         """
         return [self]
 
+    def _get_additional_cudagraph_parameters(self):
+        """Return graph parameters outside the selected graph submodule trees.
+
+        Override when a recomputation or checkpoint closure reaches a parameter that
+        ``_get_submodules_under_cudagraphs`` does not expose.
+        """
+        return ()
+
     def _te_cuda_graph_capture(self, *args, **kwargs):
         """
         CUDA Graph capture for this layer using TE interface.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -2083,6 +2083,19 @@ class MoETransformerLayer(TransformerLayer):
         ):
             self.transition_cudagraph_scope('partial')
 
+    def _get_additional_cudagraph_parameters(self):
+        """Return latent-projection parameters used by partial MoE graphs."""
+        params = list(super()._get_additional_cudagraph_parameters())
+        if CudaGraphModule.moe_router in (self.config.cuda_graph_modules or []):
+            # Router and postprocess graph closures call these projections even though they are
+            # outside the selected ``mlp.router`` tree. DDP must create their AccumulateGrad nodes
+            # on the capture stream as well.
+            for name in ("fc1_latent_proj", "fc2_latent_proj"):
+                projection = getattr(self.mlp, name, None)
+                if projection is not None:
+                    params.extend(projection.parameters())
+        return params
+
     def _resolve_token_dispatcher_attr(self, attr_name: str) -> tuple[Any, str]:
         parent_attr_name, _, leaf_attr_name = attr_name.rpartition('.')
         obj = self.mlp.token_dispatcher

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1264,6 +1264,17 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 submodules += [self.mlp.shared_experts]
         return submodules
 
+    def _uses_local_cudagraph_for_training(self) -> bool:
+        """Return whether this layer owns a full or partial training CUDA graph."""
+        return any(
+            hasattr(self, attr)
+            for attr in (
+                "cudagraph_manager",
+                "cudagraph_manager_router",
+                "cudagraph_manager_postprocess",
+            )
+        )
+
     def _te_cuda_graph_capture(self, *args, **kwargs):
         """
         CUDA Graph capture for this layer using TE interface.

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -5,6 +5,7 @@ import logging
 import os
 from contextlib import nullcontext
 from typing import Dict, List, Optional, Tuple
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -122,6 +123,32 @@ def _make_chunk_handler_for_offload_reload():
     handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
     handler.cpu_tensor_pool = OffloadTensorPool(device="cpu", pin_memory=True)
     return handler
+
+
+def test_chunk_offload_handler_reload_uses_default_stream_allocation(monkeypatch):
+    from megatron.core.pipeline_parallel import fine_grained_activation_offload as offload
+
+    handler = _make_chunk_handler_for_offload_reload()
+    cpu_backup = Mock()
+    cpu_backup.is_pinned.return_value = True
+    cpu_backup.size.return_value = (16,)
+    cpu_backup.dtype = torch.float32
+    cpu_backup.layout = torch.strided
+    gpu_tensor = Mock()
+    consumer_stream = Mock()
+    allocation_context = Mock(return_value=nullcontext())
+    empty = Mock(return_value=gpu_tensor)
+
+    monkeypatch.setattr(offload, "default_stream_allocation", allocation_context)
+    monkeypatch.setattr(torch.cuda, "current_stream", Mock(return_value=consumer_stream))
+    monkeypatch.setattr(torch, "empty", empty)
+
+    state = (torch.device("cuda"), cpu_backup, False, None)
+    assert handler.reload(state) is gpu_tensor
+
+    allocation_context.assert_called_once_with()
+    gpu_tensor.record_stream.assert_called_once_with(consumer_stream)
+    gpu_tensor.copy_.assert_called_once_with(cpu_backup, non_blocking=True)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")

--- a/tests/unit_tests/transformer/test_cuda_graph_utils.py
+++ b/tests/unit_tests/transformer/test_cuda_graph_utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import torch
+
+import megatron.core.transformer.cuda_graph_utils as cuda_graph_utils
+
+
+def test_default_stream_allocation_is_noop_on_default_stream(monkeypatch):
+    default_stream = Mock()
+    stream_context = Mock(side_effect=AssertionError("unexpected stream context"))
+    event = Mock(side_effect=AssertionError("unexpected allocation event"))
+
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: default_stream)
+    monkeypatch.setattr(torch.cuda, "default_stream", lambda: default_stream)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(torch.cuda, "stream", stream_context)
+    monkeypatch.setattr(torch.cuda, "Event", event)
+
+    with cuda_graph_utils.default_stream_allocation():
+        pass
+
+    stream_context.assert_not_called()
+    event.assert_not_called()
+
+
+def test_default_stream_allocation_preserves_capture_stream(monkeypatch):
+    capture_stream = Mock()
+    default_stream = Mock(side_effect=AssertionError("unexpected default-stream query"))
+
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: capture_stream)
+    monkeypatch.setattr(torch.cuda, "default_stream", default_stream)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    with cuda_graph_utils.default_stream_allocation():
+        pass
+
+    default_stream.assert_not_called()
+
+
+def test_default_stream_allocation_orders_caller(monkeypatch):
+    caller_stream = Mock()
+    allocation_stream = Mock()
+    allocation_ready_event = Mock()
+    stream_context = Mock(return_value=nullcontext())
+
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: caller_stream)
+    monkeypatch.setattr(torch.cuda, "default_stream", lambda: allocation_stream)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(torch.cuda, "stream", stream_context)
+    monkeypatch.setattr(torch.cuda, "Event", Mock(return_value=allocation_ready_event))
+
+    with cuda_graph_utils.default_stream_allocation():
+        pass
+
+    stream_context.assert_called_once_with(allocation_stream)
+    allocation_ready_event.record.assert_called_once_with(allocation_stream)
+    caller_stream.wait_event.assert_called_once_with(allocation_ready_event)

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -42,6 +42,7 @@ from megatron.core.transformer.cuda_graphs import (
     _CudaGraphRunner,
     create_cudagraphs,
     delete_cuda_graphs,
+    get_cuda_graph_param_ids,
 )
 from megatron.core.transformer.enums import (
     AttnBackend,
@@ -90,6 +91,40 @@ def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
     assert len(created_streams) == pool_size
     assert len({stream.cuda_stream for stream in created_streams}) == pool_size
     assert assigned[:pool_size] == assigned[pool_size:]
+
+
+@pytest.mark.parametrize("missing_api", ["getter", "setter"])
+def test_stale_capture_stream_override_is_optional_and_warns_once(monkeypatch, missing_api):
+    warnings = []
+    if missing_api == "getter":
+        monkeypatch.setattr(torch._C, "_override_stale_capture_stream", None)
+    else:
+        monkeypatch.setattr(torch.autograd.graph, "set_override_stale_capture_stream", None)
+    monkeypatch.setattr(cuda_graphs_module, "_STALE_CAPTURE_STREAM_OVERRIDE_WARNING_EMITTED", False)
+    monkeypatch.setattr(cuda_graphs_module.logger, "warning", warnings.append)
+
+    with cuda_graphs_module._override_stale_capture_stream():
+        pass
+    with cuda_graphs_module._override_stale_capture_stream():
+        pass
+
+    assert len(warnings) == 1
+    assert "pytorch/pytorch#180090" in warnings[0]
+
+
+def test_stale_capture_stream_override_restores_state_after_error(monkeypatch):
+    setter_calls = []
+    monkeypatch.setattr(torch._C, "_override_stale_capture_stream", lambda: False)
+    monkeypatch.setattr(
+        torch.autograd.graph, "set_override_stale_capture_stream", setter_calls.append
+    )
+
+    with pytest.raises(RuntimeError, match="capture failed"):
+        with cuda_graphs_module._override_stale_capture_stream():
+            assert setter_calls == [True]
+            raise RuntimeError("capture failed")
+
+    assert setter_calls == [True, False]
 
 
 def _base_cuda_graph_config(**kwargs) -> TransformerConfig:
@@ -522,6 +557,24 @@ class TestParallelTransformerBlockCudagraphs:
         assert block.layers
         assert all(not layer.is_moe_layer for layer in block.layers)
         assert all(isinstance(layer.cudagraph_manager, CudaGraphManager) for layer in block.layers)
+
+    def test_training_graph_param_discovery_skips_inference_only_block_manager(self):
+        config = TransformerConfig(
+            num_layers=8,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_modules=[CudaGraphModule.mlp],
+        )
+        block = TransformerBlock(config, get_gpt_layer_with_transformer_engine_spec())
+
+        graph_param_ids = get_cuda_graph_param_ids(block)
+        for layer in block.layers:
+            assert {id(param) for param in layer.mlp.parameters()} <= graph_param_ids
+            assert {id(param) for param in layer.self_attention.parameters()}.isdisjoint(
+                graph_param_ids
+            )
 
 
 @pytest.mark.skipif(
@@ -1769,6 +1822,9 @@ class _CheckpointDependencyModule(MegatronModule):
         # Model a visible graph scope that does not own the checkpointed child.
         return (self.projection,)
 
+    def _uses_local_cudagraph_for_training(self):
+        return True
+
     def _get_additional_cudagraph_parameters(self):
         # The recompute closure reaches this child outside the visible projection scope.
         return self.checkpointed.parameters()
@@ -1817,6 +1873,9 @@ class _ScopedCudaGraphModule(MegatronModule):
 
     def _get_submodules_under_cudagraphs(self):
         return tuple(getattr(self, scope.name) for scope in self.config.cuda_graph_modules)
+
+    def _uses_local_cudagraph_for_training(self):
+        return True
 
 
 class _SimpleNonModule:

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1753,9 +1753,10 @@ class _CheckpointDependencyModule(MegatronModule):
         super().__init__(config)
         self.checkpointed = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
         self.projection = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.eager_only = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
 
     def forward(self, x):
-        return self.my_op(x)
+        return self.my_op(x) + self.eager_only(x)
 
     def my_op(self, x):
         checkpoint = CheckpointWithoutOutput()
@@ -1763,6 +1764,59 @@ class _CheckpointDependencyModule(MegatronModule):
         output = self.projection(hidden)
         checkpoint.discard_output_and_register_recompute(output)
         return output
+
+    def _get_submodules_under_cudagraphs(self):
+        # Model a visible graph scope that does not own the checkpointed child.
+        return (self.projection,)
+
+    def _get_additional_cudagraph_parameters(self):
+        # The recompute closure reaches this child outside the visible projection scope.
+        return self.checkpointed.parameters()
+
+
+class _ScopedCudaGraphModule(MegatronModule):
+    """Small mixed eager/graph model that mirrors the production partial-CG scope names."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.mamba = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.attn = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.moe_router = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.eager_tail = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+
+        self.cudagraph_managers = torch.nn.ModuleDict()
+        for scope, function_name in (
+            (CudaGraphModule.mamba, "run_mamba"),
+            (CudaGraphModule.attn, "run_attn"),
+            (CudaGraphModule.moe_router, "run_moe_router"),
+        ):
+            if scope in config.cuda_graph_modules:
+                self.cudagraph_managers[scope.name] = CudaGraphManager(
+                    config, base_module=self, function_name=function_name
+                )
+
+    def run_mamba(self, x):
+        return self.mamba(x)
+
+    def run_attn(self, x):
+        return self.attn(x)
+
+    def run_moe_router(self, x):
+        return self.moe_router(x)
+
+    @property
+    def moe_preprocess(self):
+        # Local-CG configuration expands moe_router into the paired preprocess/router scopes.
+        return self.moe_router
+
+    def forward(self, x):
+        x = self.run_mamba(x)
+        x = self.run_attn(x)
+        x = self.run_moe_router(x)
+        return self.eager_tail(x)
+
+    def _get_submodules_under_cudagraphs(self):
+        return tuple(getattr(self, scope.name) for scope in self.config.cuda_graph_modules)
 
 
 class _SimpleNonModule:
@@ -1832,11 +1886,14 @@ class TestCheckpointParameterDiscovery:
             DistributedDataParallelConfig(overlap_grad_reduce=True, bucket_size=1_000_000),
             module,
         )
+        assert module.projection.weight._ddp_grad_acc_on_cudagraph_stream
+        assert module.checkpointed.weight._ddp_grad_acc_on_cudagraph_stream
+        assert not module.eager_only.weight._ddp_grad_acc_on_cudagraph_stream
 
         # Distinct inputs make the expected DDP result the average of different local gradients.
         torch.manual_seed(1000 + ddp_model.dp_group.rank())
         test_input = torch.randn(4, config.hidden_size, device="cuda", requires_grad=True)
-        reference_output = reference.my_op(test_input.detach().clone().requires_grad_(True))
+        reference_output = reference(test_input.detach().clone().requires_grad_(True))
         reference_output_value = reference_output.detach().clone()
         reference_output.sum().backward()
         reference_wgrads = {
@@ -1869,6 +1926,110 @@ class TestCheckpointParameterDiscovery:
             for name, param in module.named_parameters():
                 assert param.grad is None
                 torch.testing.assert_close(param.main_grad, reference_wgrads[name])
+
+
+class TestScopedDDPCudaGraphCapture:
+    """DDP backward capture works for the partial-CG scopes used by hybrid training."""
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    @pytest.mark.parametrize("tp_size", [1, 2])
+    @pytest.mark.parametrize(
+        "cuda_graph_modules",
+        [
+            pytest.param([CudaGraphModule.mamba, CudaGraphModule.attn], id="mamba-attn"),
+            pytest.param([CudaGraphModule.moe_router], id="moe-router"),
+            pytest.param(
+                [CudaGraphModule.mamba, CudaGraphModule.attn, CudaGraphModule.moe_router],
+                id="mamba-attn-moe-router",
+            ),
+        ],
+    )
+    def test_scoped_capture_and_backward_replay(self, tp_size, cuda_graph_modules):
+        if int(os.environ.get("WORLD_SIZE", 1)) % tp_size != 0:
+            pytest.skip(f"world size must be divisible by TP{tp_size}")
+
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp_size)
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        model_parallel_cuda_manual_seed(123)
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            tensor_model_parallel_size=tp_size,
+            num_moe_experts=(4 if CudaGraphModule.moe_router in cuda_graph_modules else None),
+            add_bias_linear=False,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_modules=cuda_graph_modules,
+            cuda_graph_warmup_steps=0,
+        )
+        torch.manual_seed(123)
+        module = _ScopedCudaGraphModule(config).cuda()
+        ddp_model = DistributedDataParallel(
+            config,
+            DistributedDataParallelConfig(overlap_grad_reduce=True, bucket_size=1_000_000),
+            module,
+        )
+
+        selected_names = {scope.name for scope in cuda_graph_modules}
+        for name in ("mamba", "attn", "moe_router"):
+            param = getattr(module, name).weight
+            assert param._ddp_grad_acc_on_cudagraph_stream == (name in selected_names)
+        assert not module.eager_tail.weight._ddp_grad_acc_on_cudagraph_stream
+
+        # Use the same input on every DP rank so this test isolates scoped graph capture and
+        # replay. The checkpoint/DDP test above uses rank-distinct inputs to validate reduction.
+        input_generator = torch.Generator(device="cuda").manual_seed(456)
+        test_input = torch.randn(
+            4, config.hidden_size, device="cuda", generator=input_generator, requires_grad=True
+        )
+
+        def run_backward():
+            ddp_model.zero_grad_buffer()
+            output = ddp_model(test_input.detach().clone().requires_grad_(True))
+            output.square().mean().backward()
+            ddp_model.finish_grad_sync()
+            torch.cuda.synchronize()
+            return output.detach().clone(), {
+                name: param.main_grad.detach().clone() for name, param in module.named_parameters()
+            }
+
+        try:
+            expected_output, _ = run_backward()
+            ddp_model.zero_grad_buffer()
+            create_cudagraphs()
+
+            assert _CudagraphGlobalRecord.cudagraph_created
+            assert len(module.cudagraph_managers) == len(cuda_graph_modules)
+            assert all(
+                len(manager.cudagraph_runners) == 1
+                for manager in module.cudagraph_managers.values()
+            )
+
+            first_replay_grads = None
+            for _ in range(2):
+                replay_output, replay_grads = run_backward()
+                torch.testing.assert_close(replay_output, expected_output)
+                for grad in replay_grads.values():
+                    assert torch.isfinite(grad).all()
+                    assert torch.count_nonzero(grad) > 0
+                if first_replay_grads is None:
+                    first_replay_grads = replay_grads
+                else:
+                    for name, expected_grad in first_replay_grads.items():
+                        torch.testing.assert_close(
+                            replay_grads[name],
+                            expected_grad,
+                            msg=lambda message: f"{name}: {message}",
+                        )
+        finally:
+            torch.cuda.synchronize()
+            delete_cuda_graphs()
+            Utils.destroy_model_parallel()
 
 
 class TestInlineCaptureManager:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Reduces CUDA allocator fragmentation from asynchronous side-stream allocations and gives local CUDA graphs a consistent stream affinity for graph-pool allocation, warmup, capture, and DDP backward nodes.

## Problem

Short-lived buffers for GTP reduce-scatter, FP32 reduce-scatter accumulation, and activation reload can be allocated while a communication, replay, or offload stream is current. With the native expandable allocator, spreading these allocations across many side streams can retain separate allocator segments and increase reserved memory.

Local CUDA graphs had the same problem at a larger scope: tensors in the shared graph memory pool could be allocated or warmed up on different runner streams. This partitions allocator storage by stream and leaves autograd nodes with stream affinity that does not match backward capture.

DDP makes the latter a correctness concern. Its retained `AccumulateGrad` nodes remember the stream on which they were created. Graph-owned parameters therefore need their nodes created on the local capture stream. Parameters reached only through checkpoint or recomputation closures are not necessarily visible in the selected graph submodule tree and must also be classified correctly.

## Solution

- Add a `default_stream_allocation()` helper that allocates outside capture through the default-stream allocator and orders the actual consumer stream after allocation. Callers record that consumer stream for safe asynchronous lifetime tracking.
- Use default-stream-owned storage for activation reloads, FP32 reduce-scatter temporaries and outputs, and fresh ungraphed GTP reduce-scatter buffers. Captured allocations remain owned by the active graph pool.
- Retain one local CUDA graph capture stream and use it consistently for graph-pool allocation, eager warmup, forward capture, and backward capture.
- Create DDP `AccumulateGrad` nodes for graph-owned parameters on that capture stream while leaving eager-only parameters on the caller stream.
- Let graphable modules declare parameters reached through hidden checkpoint or recomputation dependencies, include the MoE latent projections used by router/postprocess graph closures, and fail before backward capture when a required DDP parameter was misclassified.
- Release empty native allocator segments left by auxiliary-stream warmups after capture without moving live graph-pool allocations.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Testing

- `tools/autoformat.sh`: Black, isort, pylint, and Ruff passed; pylint score 10.00/10.
- `python -m py_compile` passed for all changed Python files.
- Four-GPU `torchrun --nproc-per-node 4 -m pytest -v` covering the new allocation tests, FP32 reduce-scatter, fine-grained activation offload, checkpoint/DDP parameter discovery, scoped DDP local-CG capture, and the full generalized tensor-parallel suite: each rank completed with 213 passed and 8 skipped (Slurm job 559332, exit code 0).
