### PR TITLE
Fuse standard RoPE packing for MLA and DSA

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -95,6 +95,7 @@ def _mla_rope_fwd_inplace_kernel(
     cp_size,
     INVERSE: tl.constexpr,
     REMOVE_INTERLEAVING: tl.constexpr,
+    ROPE_FIRST: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
@@ -138,7 +139,8 @@ def _mla_rope_fwd_inplace_kernel(
 
     Q = Q + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
-    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
+    rope_offset = 0 if ROPE_FIRST else nope_dim
+    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + rope_offset
     mask = x_off < head_num * stride_x_nheads
     # x1 = t[..., 0::2], x2 = t[..., 1::2]
     x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
@@ -193,6 +195,7 @@ def _mla_rope_bwd_inplace_kernel(
     cp_size,
     INVERSE: tl.constexpr,
     REMOVE_INTERLEAVING: tl.constexpr,
+    ROPE_FIRST: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
@@ -234,7 +237,8 @@ def _mla_rope_bwd_inplace_kernel(
 
     DO = DO + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
-    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
+    rope_offset = 0 if ROPE_FIRST else nope_dim
+    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + rope_offset
     mask = x_off < head_num * stride_x_nheads
     if REMOVE_INTERLEAVING:
         x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
@@ -258,8 +262,7 @@ def _mla_rope_bwd_inplace_kernel(
 
 class _FusedMLARoPEInplace(torch.autograd.Function):
     """
-    Autograd function for applying RoPE inplace to the trailing emb_dim
-    elements of a multi-head tensor (leaving the first nope_dim elements unchanged).
+    Autograd function for applying RoPE inplace to either end of a multi-head tensor.
     """
 
     @staticmethod
@@ -277,6 +280,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
         inverse=False,
         remove_interleaving=False,
         position_ids=None,
+        rope_first=False,
     ):
         """
         Forward function for _FusedMLARoPEInplace.
@@ -288,6 +292,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             cu_seqlens_q: [seq_num + 1] accumulated sequence lengths for thd format
             rotary_interleaved: whether to apply RoPE interleaved, only supports False for now
             inverse: if True, negate sin inside the kernel to apply the inverse rotation
+            rope_first: if True, rotate the leading emb_dim elements instead of the trailing ones
         """
         assert not rotary_interleaved
         max_seqlen = None
@@ -331,6 +336,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             cp_size,
             INVERSE=inverse,
             REMOVE_INTERLEAVING=remove_interleaving,
+            ROPE_FIRST=rope_first,
         )
         ctx.save_for_backward(cos, sin, *(() if position_ids is None else (position_ids,)))
         ctx.has_position_ids = position_ids is not None
@@ -340,6 +346,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
         ctx.rotary_interleaved = rotary_interleaved
         ctx.inverse = inverse
         ctx.remove_interleaving = remove_interleaving
+        ctx.rope_first = rope_first
         ctx.cp_rank = cp_rank
         ctx.cp_size = cp_size
         if cu_seqlens_q is None:
@@ -394,10 +401,11 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             ctx.cp_size,
             INVERSE=ctx.inverse,
             REMOVE_INTERLEAVING=ctx.remove_interleaving,
+            ROPE_FIRST=ctx.rope_first,
         )
         if ctx.cu_seqlens_q is None:
             grad = grad.view(max_seqlen, batch_size, nheads, headdim)
-        return grad, None, None, None, None, None, None, None, None, None, None, None
+        return grad, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def fused_mla_rope_inplace(
@@ -413,10 +421,11 @@ def fused_mla_rope_inplace(
     inverse: bool = False,
     remove_interleaving: bool = False,
     position_ids: Optional[torch.Tensor] = None,
+    rope_first: bool = False,
 ) -> torch.Tensor:
     """
-    Fused RoPE applied inplace to the trailing emb_dim elements of a tensor,
-    leaving the first nope_dim elements unchanged.
+    Fused RoPE applied inplace to emb_dim elements at either end of a tensor,
+    leaving the nope_dim elements unchanged.
     It supports both sbhd and thd input formats.
 
     When ``inverse=True`` the rotation is reversed, which is useful for
@@ -436,6 +445,7 @@ def fused_mla_rope_inplace(
         remove_interleaving: if True, output RoPE dims in non-interleaved layout
         position_ids: optional THD row positions. When supplied, these positions
             replace the built-in CP row-to-position mapping.
+        rope_first: if True, rotate the leading emb_dim elements instead of the trailing ones.
 
     Returns:
         t: inplace modified input tensor
@@ -453,6 +463,7 @@ def fused_mla_rope_inplace(
         inverse,
         remove_interleaving,
         position_ids,
+        rope_first,
     )
 
 

--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -99,7 +99,8 @@ def _mla_rope_fwd_inplace_kernel(
     BLOCK_H: tl.constexpr,
 ):
     """
-    Forward pass: apply RoPE inplace to the trailing emb_dim elements.
+    Forward pass: apply RoPE inplace to the leading emb_dim elements when ROPE_FIRST is true,
+    otherwise to the trailing emb_dim elements.
     Reads from interleaved layout, writes back to interleaved layout.
 
     Input:
@@ -199,7 +200,8 @@ def _mla_rope_bwd_inplace_kernel(
     BLOCK_H: tl.constexpr,
 ):
     """
-    Backward pass: inverse RoPE inplace on the trailing emb_dim elements.
+    Backward pass: inverse RoPE inplace on the leading emb_dim elements when ROPE_FIRST is true,
+    otherwise on the trailing emb_dim elements.
     Reads from interleaved layout, writes to interleaved layout.
 
     Input:

--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -503,6 +503,329 @@ def fused_mla_rope_out_of_place(
         triton.Config({"BLOCK_H": 64}),
         triton.Config({"BLOCK_H": 128}),
     ],
+    key=["nope_dim", "emb_dim", "head_num"],
+)
+@triton.jit
+def _mla_rope_concat_fwd_kernel(
+    NOPE,
+    ROPE,
+    OUTPUT,
+    COS,
+    SIN,
+    nope_dim: tl.constexpr,
+    emb_dim: tl.constexpr,
+    head_num: tl.constexpr,
+    batch_size,
+    seq_num,
+    cu_seqlens,
+    stride_nope_seq,
+    stride_nope_batch,
+    stride_nope_head,
+    stride_nope_dim,
+    stride_rope_seq,
+    stride_rope_batch,
+    stride_rope_head,
+    stride_rope_dim,
+    stride_output_seq,
+    stride_output_head,
+    stride_cos_seq,
+    stride_sin_seq,
+    cp_rank,
+    cp_size,
+    IS_THD: tl.constexpr,
+    NOPE_BLOCK: tl.constexpr,
+    ROT_BLOCK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Concatenate the non-RoPE part with a rotated positional part."""
+    pid_m = tl.program_id(axis=0)
+    pid_head = tl.program_id(axis=1)
+
+    if IS_THD:
+        token_idx = _get_thd_token_idx(cu_seqlens, pid_m, seq_num, cp_rank, cp_size)
+        nope_row = NOPE + pid_m * stride_nope_seq
+        rope_row = ROPE + pid_m * stride_rope_seq
+    else:
+        seq_idx = pid_m // batch_size
+        batch_idx = pid_m % batch_size
+        token_idx = seq_idx
+        nope_row = NOPE + seq_idx * stride_nope_seq + batch_idx * stride_nope_batch
+        rope_row = ROPE + seq_idx * stride_rope_seq + batch_idx * stride_rope_batch
+
+    head_idx = pid_head * BLOCK_H + tl.arange(0, BLOCK_H)
+    head_mask = head_idx < head_num
+
+    nope_idx = tl.arange(0, NOPE_BLOCK)
+    nope_mask = head_mask[:, None] & (nope_idx[None, :] < nope_dim)
+    nope_offsets = head_idx[:, None] * stride_nope_head + nope_idx[None, :] * stride_nope_dim
+    nope = tl.load(nope_row + nope_offsets, mask=nope_mask)
+
+    rope_idx = tl.arange(0, ROT_BLOCK)
+    rope_mask = head_mask[:, None] & (rope_idx[None, :] < emb_dim // 2)
+    rope_base = head_idx[:, None] * stride_rope_head
+    rope_pair = rope_idx[None, :] * 2 * stride_rope_dim
+    x_1 = tl.load(rope_row + rope_base + rope_pair, mask=rope_mask)
+    x_2 = tl.load(rope_row + rope_base + rope_pair + stride_rope_dim, mask=rope_mask)
+
+    cos_left = tl.load(COS + token_idx * stride_cos_seq + rope_idx, mask=rope_idx < emb_dim // 2)
+    sin_left = tl.load(SIN + token_idx * stride_sin_seq + rope_idx, mask=rope_idx < emb_dim // 2)
+    cos_right = tl.load(
+        COS + token_idx * stride_cos_seq + emb_dim // 2 + rope_idx, mask=rope_idx < emb_dim // 2
+    )
+    sin_right = tl.load(
+        SIN + token_idx * stride_sin_seq + emb_dim // 2 + rope_idx, mask=rope_idx < emb_dim // 2
+    )
+    x_left = x_1 * cos_left[None, :] - x_2 * sin_left[None, :]
+    x_right = x_2 * cos_right[None, :] + x_1 * sin_right[None, :]
+
+    output_row = OUTPUT + pid_m * stride_output_seq
+    output_base = head_idx[:, None] * stride_output_head
+    output_nope_offsets = output_base + nope_idx[None, :]
+    tl.store(output_row + output_nope_offsets, nope, mask=nope_mask)
+    output_rope_offsets = output_base + nope_dim + rope_idx[None, :]
+    tl.store(output_row + output_rope_offsets, x_left, mask=rope_mask)
+    tl.store(output_row + output_rope_offsets + emb_dim // 2, x_right, mask=rope_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 1}),
+        triton.Config({"BLOCK_H": 2}),
+        triton.Config({"BLOCK_H": 4}),
+        triton.Config({"BLOCK_H": 8}),
+        triton.Config({"BLOCK_H": 16}),
+        triton.Config({"BLOCK_H": 32}),
+        triton.Config({"BLOCK_H": 64}),
+        triton.Config({"BLOCK_H": 128}),
+    ],
+    key=["nope_dim", "emb_dim", "head_num"],
+)
+@triton.jit
+def _mla_rope_concat_bwd_kernel(
+    DOUTPUT,
+    DNOPE,
+    DROPE,
+    COS,
+    SIN,
+    nope_dim: tl.constexpr,
+    emb_dim: tl.constexpr,
+    head_num: tl.constexpr,
+    batch_size,
+    seq_num,
+    cu_seqlens,
+    stride_doutput_seq,
+    stride_doutput_head,
+    stride_dnope_seq,
+    stride_dnope_head,
+    stride_drope_seq,
+    stride_drope_head,
+    stride_cos_seq,
+    stride_sin_seq,
+    cp_rank,
+    cp_size,
+    IS_THD: tl.constexpr,
+    NOPE_BLOCK: tl.constexpr,
+    ROT_BLOCK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Split the output gradient and apply the inverse rotation."""
+    pid_m = tl.program_id(axis=0)
+    pid_head = tl.program_id(axis=1)
+
+    if IS_THD:
+        token_idx = _get_thd_token_idx(cu_seqlens, pid_m, seq_num, cp_rank, cp_size)
+    else:
+        token_idx = pid_m // batch_size
+
+    head_idx = pid_head * BLOCK_H + tl.arange(0, BLOCK_H)
+    head_mask = head_idx < head_num
+    doutput_row = DOUTPUT + pid_m * stride_doutput_seq
+    doutput_base = head_idx[:, None] * stride_doutput_head
+
+    nope_idx = tl.arange(0, NOPE_BLOCK)
+    nope_mask = head_mask[:, None] & (nope_idx[None, :] < nope_dim)
+    nope_offsets = doutput_base + nope_idx[None, :]
+    dnope = tl.load(doutput_row + nope_offsets, mask=nope_mask)
+    dnope_row = DNOPE + pid_m * stride_dnope_seq
+    dnope_offsets = head_idx[:, None] * stride_dnope_head + nope_idx[None, :]
+    tl.store(dnope_row + dnope_offsets, dnope, mask=nope_mask)
+
+    rope_idx = tl.arange(0, ROT_BLOCK)
+    rope_mask = head_mask[:, None] & (rope_idx[None, :] < emb_dim // 2)
+    rope_offsets = doutput_base + nope_dim + rope_idx[None, :]
+    dx_left = tl.load(doutput_row + rope_offsets, mask=rope_mask)
+    dx_right = tl.load(doutput_row + rope_offsets + emb_dim // 2, mask=rope_mask)
+
+    cos_left = tl.load(COS + token_idx * stride_cos_seq + rope_idx, mask=rope_idx < emb_dim // 2)
+    sin_left = tl.load(SIN + token_idx * stride_sin_seq + rope_idx, mask=rope_idx < emb_dim // 2)
+    cos_right = tl.load(
+        COS + token_idx * stride_cos_seq + emb_dim // 2 + rope_idx, mask=rope_idx < emb_dim // 2
+    )
+    sin_right = tl.load(
+        SIN + token_idx * stride_sin_seq + emb_dim // 2 + rope_idx, mask=rope_idx < emb_dim // 2
+    )
+    dx_1 = dx_left * cos_left[None, :] + dx_right * sin_right[None, :]
+    dx_2 = -dx_left * sin_left[None, :] + dx_right * cos_right[None, :]
+
+    drope_row = DROPE + pid_m * stride_drope_seq
+    drope_base = head_idx[:, None] * stride_drope_head
+    drope_pair = rope_idx[None, :] * 2
+    tl.store(drope_row + drope_base + drope_pair, dx_1, mask=rope_mask)
+    tl.store(drope_row + drope_base + drope_pair + 1, dx_2, mask=rope_mask)
+
+
+class _FusedMLARoPEConcat(torch.autograd.Function):
+    """Autograd wrapper for fused MLA packing and RoPE."""
+
+    @staticmethod
+    def forward(ctx, nope, rope, cos, sin, cu_seqlens, cp_rank, cp_size):
+        """Pack non-positional and RoPE channels while applying rotary embeddings."""
+        assert nope.ndim in (3, 4)
+        assert rope.ndim == nope.ndim
+        assert nope.shape[:-1] == rope.shape[:-1]
+        assert nope.dtype == rope.dtype
+        assert nope.device == rope.device == cos.device == sin.device
+        assert cos.stride(-1) == 1 and sin.stride(-1) == 1
+
+        is_thd = nope.ndim == 3
+        if is_thd:
+            total_seqlen, nheads, nope_dim = nope.shape
+            seq_num = len(cu_seqlens) - 1
+            batch_size = 1
+            nope_strides = (nope.stride(0), 0, nope.stride(1), nope.stride(2))
+            rope_strides = (rope.stride(0), 0, rope.stride(1), rope.stride(2))
+        else:
+            max_seqlen, batch_size, nheads, nope_dim = nope.shape
+            total_seqlen = max_seqlen * batch_size
+            seq_num = 0
+            assert cu_seqlens is None
+            nope_strides = nope.stride()
+            rope_strides = rope.stride()
+
+        emb_dim = rope.size(-1)
+        assert emb_dim % 4 == 0
+        nope_block = triton.next_power_of_2(nope_dim)
+        rot_block = triton.next_power_of_2(emb_dim // 2)
+
+        output = nope.new_empty(total_seqlen, nheads, nope_dim + emb_dim)
+        grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+        _mla_rope_concat_fwd_kernel[grid](
+            nope,
+            rope,
+            output,
+            cos,
+            sin,
+            nope_dim,
+            emb_dim,
+            nheads,
+            batch_size,
+            seq_num,
+            cu_seqlens,
+            *nope_strides,
+            *rope_strides,
+            output.stride(0),
+            output.stride(1),
+            cos.stride(0),
+            sin.stride(0),
+            cp_rank,
+            cp_size,
+            IS_THD=is_thd,
+            NOPE_BLOCK=nope_block,
+            ROT_BLOCK=rot_block,
+        )
+
+        ctx.save_for_backward(cos, sin)
+        ctx.input_shape = nope.shape
+        ctx.cu_seqlens = cu_seqlens
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.nope_dim = nope_dim
+        ctx.emb_dim = emb_dim
+        ctx.is_thd = is_thd
+        if not is_thd:
+            output = output.view(max_seqlen, batch_size, nheads, nope_dim + emb_dim)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Compute gradients for the packed non-positional and RoPE inputs."""
+        cos, sin = ctx.saved_tensors
+        grad_output = grad_output.contiguous()
+        if ctx.is_thd:
+            total_seqlen, nheads, _ = grad_output.shape
+            batch_size = 1
+            seq_num = len(ctx.cu_seqlens) - 1
+        else:
+            max_seqlen, batch_size, nheads, _ = grad_output.shape
+            total_seqlen = max_seqlen * batch_size
+            grad_output = grad_output.view(total_seqlen, nheads, -1)
+            seq_num = 0
+
+        dnope = grad_output.new_empty(total_seqlen, nheads, ctx.nope_dim)
+        drope = grad_output.new_empty(total_seqlen, nheads, ctx.emb_dim)
+        nope_block = triton.next_power_of_2(ctx.nope_dim)
+        rot_block = triton.next_power_of_2(ctx.emb_dim // 2)
+        grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+        _mla_rope_concat_bwd_kernel[grid](
+            grad_output,
+            dnope,
+            drope,
+            cos,
+            sin,
+            ctx.nope_dim,
+            ctx.emb_dim,
+            nheads,
+            batch_size,
+            seq_num,
+            ctx.cu_seqlens,
+            grad_output.stride(0),
+            grad_output.stride(1),
+            dnope.stride(0),
+            dnope.stride(1),
+            drope.stride(0),
+            drope.stride(1),
+            cos.stride(0),
+            sin.stride(0),
+            ctx.cp_rank,
+            ctx.cp_size,
+            IS_THD=ctx.is_thd,
+            NOPE_BLOCK=nope_block,
+            ROT_BLOCK=rot_block,
+        )
+        dnope = dnope.view(ctx.input_shape)
+        drope = drope.view(*ctx.input_shape[:-1], ctx.emb_dim)
+        return dnope, drope, None, None, None, None, None
+
+
+def fused_mla_rope_concat(
+    nope: torch.Tensor,
+    rope: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+) -> torch.Tensor:
+    """Pack MLA's non-positional and positional parts while applying RoPE.
+
+    ``nope`` and ``rope`` may use arbitrary input strides. The returned SBHD
+    or THD tensor is contiguous and stores the rotated positional channels
+    after the non-positional channels.
+    """
+    return _FusedMLARoPEConcat.apply(nope, rope, cos, sin, cu_seqlens, cp_rank, cp_size)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 1}),
+        triton.Config({"BLOCK_H": 2}),
+        triton.Config({"BLOCK_H": 4}),
+        triton.Config({"BLOCK_H": 8}),
+        triton.Config({"BLOCK_H": 16}),
+        triton.Config({"BLOCK_H": 32}),
+        triton.Config({"BLOCK_H": 64}),
+        triton.Config({"BLOCK_H": 128}),
+    ],
     key=["emb_dim", "k_dim", "v_dim", "head_num"],
 )
 @triton.jit

--- a/megatron/core/models/common/embeddings/__init__.py
+++ b/megatron/core/models/common/embeddings/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
-from .rope_utils import apply_rotary_pos_emb
+from .rope_utils import apply_rotary_pos_emb, should_use_fused_mla_rope
 from .rotary_pos_embedding import MultimodalRotaryEmbedding, RotaryEmbedding
 from .yarn_rotary_pos_embedding import YarnRotaryEmbedding, _yarn_get_mscale

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -16,6 +16,7 @@ from torch import Tensor
 from megatron.core import parallel_state
 
 logger = logging.getLogger(__name__)
+_ROPE_FUSION_FALLBACK_WARNINGS: set[str] = set()
 
 try:
     from megatron.core.extensions.transformer_engine import fused_apply_rotary_pos_emb
@@ -42,7 +43,35 @@ __all__ = [
     'fused_apply_rotary_pos_emb',
     'fused_apply_rotary_pos_emb_thd',
     'get_pos_emb_on_this_cp_rank',
+    'should_use_fused_mla_rope',
 ]
+
+
+def _warn_rope_fusion_fallback_once(key: str, message: str) -> None:
+    if key in _ROPE_FUSION_FALLBACK_WARNINGS:
+        return
+    _ROPE_FUSION_FALLBACK_WARNINGS.add(key)
+    warnings.warn(message, stacklevel=2)
+
+
+def should_use_fused_mla_rope(config: TransformerConfig) -> bool:
+    """Return whether MLA's custom fused RoPE kernels support this configuration.
+
+    Standard RoPE can rotate only a prefix of the positional channels when
+    ``rotary_percent < 1``. The custom MLA kernels currently rotate the full
+    positional slice, so partial rotary embeddings must retain the unfused path
+    that preserves the trailing pass-through channels.
+    """
+    if not config.apply_rope_fusion:
+        return False
+    if config.rope_type == "rope" and config.rotary_percent < 1.0:
+        _warn_rope_fusion_fallback_once(
+            "mla-partial-standard-rope",
+            "MLA/DSA RoPE fusion requires rotary_percent=1.0 for standard RoPE; "
+            f"got rotary_percent={config.rotary_percent}. Falling back to the unfused path.",
+        )
+        return False
+    return True
 
 
 def get_pos_emb_on_this_cp_rank(
@@ -355,9 +384,10 @@ def apply_rotary_pos_emb(
                 )
                 use_unfused = True
             if mla_rotary_interleaved:
-                warnings.warn(
-                    "apply_rope_fusion does not support MLA-style interleaving in RoPE."
-                    "Using unfused implementation."
+                _warn_rope_fusion_fallback_once(
+                    "te-rope-mla-rotary-interleaved",
+                    "apply_rope_fusion does not support MLA-style interleaving in RoPE. "
+                    "Using unfused implementation.",
                 )
                 use_unfused = True
             if inverse:
@@ -378,9 +408,10 @@ def apply_rotary_pos_emb(
                 )
                 use_unfused = True
             if mla_rotary_interleaved:
-                warnings.warn(
-                    "apply_rope_fusion does not support MLA-style interleaving in RoPE."
-                    "Using unfused implementation."
+                _warn_rope_fusion_fallback_once(
+                    "te-rope-mla-rotary-interleaved",
+                    "apply_rope_fusion does not support MLA-style interleaving in RoPE. "
+                    "Using unfused implementation.",
                 )
                 use_unfused = True
             if inverse:

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -25,6 +25,7 @@ from megatron.core.models.common.embeddings import (
     YarnRotaryEmbedding,
     _yarn_get_mscale,
     apply_rotary_pos_emb,
+    should_use_fused_mla_rope,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear
@@ -418,7 +419,8 @@ class AbsorbedMLASelfAttention(Attention):
         rotary_pos_cos = None
         rotary_pos_sin = None
         packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
-        if self.config.apply_rope_fusion:
+        use_fused_rope = should_use_fused_mla_rope(self.config)
+        if use_fused_rope:
             rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
                 rotary_seq_len, dtype=hidden_states.dtype, packed_seq=packed_seq
             )
@@ -555,7 +557,7 @@ class AbsorbedMLASelfAttention(Attention):
 
             k_up_weight, _ = self._get_kv_up_weights()
 
-            if self.config.apply_rope_fusion:
+            if use_fused_rope:
                 # q_no_pe: [num_tokens, n, qk_head_dim]
                 # q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                 q_no_pe, q_pos_emb = torch.split(

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -41,13 +41,9 @@ from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.utils import deprecate_inference_params, get_pg_size, is_te_min_version
 
 try:
-    from megatron.core.fusions.fused_mla_yarn_rope_apply import (
-        fused_apply_mla_rope_for_kv,
-        fused_apply_mla_rope_for_q,
-    )
+    from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_concat
 except ImportError:
-    fused_apply_mla_rope_for_kv = None
-    fused_apply_mla_rope_for_q = None
+    fused_mla_rope_concat = None
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import (
@@ -429,7 +425,7 @@ class AbsorbedMLASelfAttention(Attention):
             rotary_pos_emb = None
             assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
             assert (
-                fused_apply_mla_rope_for_q is not None and fused_apply_mla_rope_for_kv is not None
+                fused_mla_rope_concat is not None
             ), "Fused MLA RoPE apply is not imported successfully"
         elif self.config.rope_type == "rope":
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
@@ -569,34 +565,26 @@ class AbsorbedMLASelfAttention(Attention):
                 # Absorb k_up_weight into q_no_pe
                 # q_absorbed: [num_tokens, n, kv_lora_rank]
                 q_absorbed = torch.einsum("...nd,ndk->...nk", q_no_pe, k_up_weight)
-                q_absorbed = q_absorbed.contiguous()
                 assert q_absorbed.ndim == q.ndim
                 assert q_absorbed.shape[:-1] == q.shape[:-1]
                 assert q_absorbed.size(-1) == self.config.kv_lora_rank
 
-                # q_absorbed: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]
-                q_absorbed = torch.cat([q_absorbed, q_pos_emb], dim=-1)
-                # kv_compressed: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
-                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
-
                 cp_rank = self.pg_collection.cp.rank()
                 cp_size = self.pg_collection.cp.size()
-                q_absorbed = fused_apply_mla_rope_for_q(
+                q_absorbed = fused_mla_rope_concat(
                     q_absorbed,
+                    q_pos_emb,
                     rotary_pos_cos,
                     rotary_pos_sin,
-                    self.config.kv_lora_rank,
-                    self.config.qk_pos_emb_head_dim,
                     cu_seqlens_q,
                     cp_rank,
                     cp_size,
                 )
-                kv_compressed = fused_apply_mla_rope_for_q(
+                kv_compressed = fused_mla_rope_concat(
                     kv_compressed,
+                    k_pos_emb,
                     rotary_pos_cos,
                     rotary_pos_sin,
-                    self.config.kv_lora_rank,
-                    self.config.qk_pos_emb_head_dim,
                     cu_seqlens_kv,
                     cp_rank,
                     cp_size,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -422,21 +422,19 @@ class AbsorbedMLASelfAttention(Attention):
         rotary_pos_cos = None
         rotary_pos_sin = None
         packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
-        if self.config.rope_type == "rope":
+        if self.config.apply_rope_fusion:
+            rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
+                rotary_seq_len, dtype=hidden_states.dtype, packed_seq=packed_seq
+            )
+            rotary_pos_emb = None
+            assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
+            assert (
+                fused_apply_mla_rope_for_q is not None and fused_apply_mla_rope_for_kv is not None
+            ), "Fused MLA RoPE apply is not imported successfully"
+        elif self.config.rope_type == "rope":
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
         else:
-            if self.config.apply_rope_fusion:
-                rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
-                    rotary_seq_len, dtype=hidden_states.dtype, packed_seq=packed_seq
-                )
-                rotary_pos_emb = None
-                assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
-                assert (
-                    fused_apply_mla_rope_for_q is not None
-                    and fused_apply_mla_rope_for_kv is not None
-                ), "Fused MLA RoPE apply is not imported successfully"
-            else:
-                rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+            rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
 
         if packed_seq_params is not None and packed_seq_params.qkv_format == 'thd':
             if packed_seq_params.cu_seqlens_q_padded is not None:

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -29,6 +29,11 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_pg_size
 
 try:
+    from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_inplace
+except ImportError:
+    fused_mla_rope_inplace = None
+
+try:
     from fast_hadamard_transform import hadamard_transform
 except ImportError:
     hadamard_transform = None
@@ -1210,11 +1215,39 @@ class DSAIndexer(MegatronModule):
     def _apply_rope(
         self,
         x: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        rotary_pos_emb: Optional[torch.Tensor],
         mscale: float,
         cu_seqlens: Optional[torch.Tensor] = None,
+        rotary_pos_cos: Optional[torch.Tensor] = None,
+        rotary_pos_sin: Optional[torch.Tensor] = None,
     ):
         """Apply RoPE to the input tensor."""
+        if rotary_pos_cos is not None or rotary_pos_sin is not None:
+            assert rotary_pos_cos is not None and rotary_pos_sin is not None
+            assert fused_mla_rope_inplace is not None, "Fused MLA RoPE is not available"
+            if cu_seqlens is not None and cu_seqlens.device != x.device:
+                cu_seqlens = cu_seqlens.to(device=x.device)
+            squeezed_batch_dim = False
+            # THD RoPE expects [t, h, d], while indexer tensors are [t, 1, h, d].
+            if cu_seqlens is not None and x.ndim == 4 and x.size(1) == 1:
+                x = x.squeeze(1)
+                squeezed_batch_dim = True
+            x = fused_mla_rope_inplace(
+                x,
+                rotary_pos_cos,
+                rotary_pos_sin,
+                nope_dim=self.index_head_dim - self.qk_pos_emb_head_dim,
+                emb_dim=self.qk_pos_emb_head_dim,
+                cu_seqlens_q=cu_seqlens,
+                cp_rank=self.pg_collection.cp.rank(),
+                cp_size=self.pg_collection.cp.size(),
+                rope_first=True,
+            )
+            if squeezed_batch_dim:
+                x = x.unsqueeze(1)
+            return x
+
+        assert rotary_pos_emb is not None
         # x_pe   [seqlen, batch, *, qk_pos_emb_head_dim]
         # x_nope [seqlen, batch, *, index_head_dim - qk_pos_emb_head_dim]
         # To align with DeepSeek's implementation,
@@ -1257,7 +1290,17 @@ class DSAIndexer(MegatronModule):
         rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
             None, None, x, self.config, packed_seq_params
         )
-        if self.config.rope_type == "rope":
+        fused_indexer_rope = (
+            self.config.apply_rope_fusion and self.config.dsa_indexer_rope_interleaved
+        )
+        rotary_pos_cos = rotary_pos_sin = None
+        if fused_indexer_rope:
+            rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
+                rotary_seq_len, dtype=x.dtype, packed_seq=packed_seq
+            )
+            rotary_pos_emb = None
+            mscale = 1.0
+        elif self.config.rope_type == "rope":
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
             mscale = 1.0
         else:
@@ -1287,7 +1330,14 @@ class DSAIndexer(MegatronModule):
         # [seqlen, batch, index_n_heads * index_head_dim]
         #   -> [seqlen, batch, index_n_heads, index_head_dim]
         q = q.reshape(seqlen, bsz, self.index_n_heads, self.index_head_dim)
-        q = self._apply_rope(q, rotary_pos_emb, mscale, cu_seqlens=cu_seqlens_q)
+        q = self._apply_rope(
+            q,
+            rotary_pos_emb,
+            mscale,
+            cu_seqlens=cu_seqlens_q,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+        )
 
         # =========================================
         # k linear and apply rope to k
@@ -1301,7 +1351,14 @@ class DSAIndexer(MegatronModule):
             k = self.k_norm(k)
         # [seqlen, batch, index_head_dim] -> [seqlen, batch, 1, index_head_dim]
         k = k.reshape(seqlen, bsz, 1, self.index_head_dim)
-        k = self._apply_rope(k, rotary_pos_emb, mscale, cu_seqlens=cu_seqlens_kv)
+        k = self._apply_rope(
+            k,
+            rotary_pos_emb,
+            mscale,
+            cu_seqlens=cu_seqlens_kv,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+        )
         # [seqlen, batch, 1, index_head_dim] -> [seqlen, batch, index_head_dim]
         k = k.reshape(seqlen, bsz, self.index_head_dim)
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -12,6 +12,7 @@ from megatron.core.models.common.embeddings import (
     RotaryEmbedding,
     YarnRotaryEmbedding,
     apply_rotary_pos_emb,
+    should_use_fused_mla_rope,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -1290,8 +1291,8 @@ class DSAIndexer(MegatronModule):
         rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
             None, None, x, self.config, packed_seq_params
         )
-        fused_indexer_rope = (
-            self.config.apply_rope_fusion and self.config.dsa_indexer_rope_interleaved
+        fused_indexer_rope = self.config.dsa_indexer_rope_interleaved and should_use_fused_mla_rope(
+            self.config
         )
         rotary_pos_cos = rotary_pos_sin = None
         if fused_indexer_rope:

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -23,6 +23,7 @@ from megatron.core.models.common.embeddings import (
     YarnRotaryEmbedding,
     _yarn_get_mscale,
     apply_rotary_pos_emb,
+    should_use_fused_mla_rope,
 )
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -701,7 +702,8 @@ class MLASelfAttention(MultiLatentAttention):
         rotary_pos_cos = None
         rotary_pos_sin = None
         thd_packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
-        if self.config.apply_rope_fusion:
+        use_fused_rope = should_use_fused_mla_rope(self.config)
+        if use_fused_rope:
             rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
                 rotary_seq_len, dtype=hidden_states.dtype, packed_seq=thd_packed_seq
             )
@@ -881,7 +883,7 @@ class MLASelfAttention(MultiLatentAttention):
             k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
 
             # todo add assert about fusions and caching
-            if self.config.apply_rope_fusion:
+            if use_fused_rope:
                 cp_rank = self.pg_collection.cp.rank()
                 cp_size = self.pg_collection.cp.size()
                 query = fused_apply_mla_rope_for_q(

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -701,23 +701,19 @@ class MLASelfAttention(MultiLatentAttention):
         rotary_pos_cos = None
         rotary_pos_sin = None
         thd_packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
-        if self.config.rope_type == "rope":
+        if self.config.apply_rope_fusion:
+            rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
+                rotary_seq_len, dtype=hidden_states.dtype, packed_seq=thd_packed_seq
+            )
+            rotary_pos_emb = None
+            assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
+            assert (
+                fused_apply_mla_rope_for_q is not None and fused_apply_mla_rope_for_kv is not None
+            ), "Fused MLA RoPE apply is not imported successfully"
+        elif self.config.rope_type == "rope":
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=thd_packed_seq)
         else:
-            if self.config.apply_rope_fusion:
-                rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
-                    rotary_seq_len, dtype=hidden_states.dtype, packed_seq=thd_packed_seq
-                )
-                rotary_pos_emb = None
-                assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
-                assert (
-                    fused_apply_mla_rope_for_q is not None
-                    and fused_apply_mla_rope_for_kv is not None
-                ), "Fused MLA RoPE apply is not imported successfully"
-            else:
-                rotary_pos_emb, mscale = self.rotary_pos_emb(
-                    rotary_seq_len, packed_seq=thd_packed_seq
-                )
+            rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=thd_packed_seq)
 
         if packed_seq_params is not None and packed_seq_params.qkv_format == 'thd':
             if packed_seq_params.cu_seqlens_q_padded is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3393,9 +3393,6 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        if self.multi_latent_attention and self.apply_rope_fusion and self.rope_type != "yarn":
-            raise ValueError("apply_rope_fusion for MLA only works with YARN RoPE.")
-
         if self.attention_output_gate:
             raise NotImplementedError("Output gate is not supported for MLA yet.")
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3211,7 +3211,6 @@ class TransformerConfig(ModelParallelConfig):
             assert not self.use_kitchen
 
         if self.experimental_attention_variant == "dsa":
-            assert not self.apply_rope_fusion, "RoPE fusion is not supported for DSAttention"
             if self.context_parallel_size > 1:
                 cp_comm_types = (
                     self.cp_comm_type

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -8,6 +8,7 @@ import torch
 
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings import rope_utils as rope_utils_module
+from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -17,12 +18,14 @@ from tests.unit_tests.test_utilities import Utils
 try:
     from megatron.core.fusions.fused_mla_yarn_rope_apply import (
         fused_apply_mla_rope_for_q,
+        fused_mla_rope_concat,
         fused_mla_rope_inplace,
         fused_mla_rope_kv_split,
         fused_mla_rope_out_of_place,
     )
 except Exception:
     fused_apply_mla_rope_for_q = None
+    fused_mla_rope_concat = None
     fused_mla_rope_inplace = None
     fused_mla_rope_kv_split = None
     fused_mla_rope_out_of_place = None
@@ -49,8 +52,6 @@ class FakeCPGroup:
 
     def rank(self):
         return self._rank
-
-
 class TestApplyRotaryPosEmbTHD:
     @pytest.mark.parametrize(
         ("unsupported_kwargs", "warning_text"),
@@ -171,8 +172,6 @@ class TestApplyRotaryPosEmbTHD:
 
         torch.testing.assert_close(out, expected)
         torch.testing.assert_close(out, compatibility_out)
-
-
 class _SaveOutputForBackward(torch.autograd.Function):
     """Minimal stand-in for a kernel whose backward consumes its output."""
 
@@ -413,6 +412,101 @@ def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
         msg=lambda msg: f"Mismatch in emb bwd: {msg}",
         **tols,
     )
+
+
+def _make_noncontiguous_leaf(values):
+    storage = torch.empty(
+        *values.shape[:-1], values.size(-1) * 2, dtype=values.dtype, device=values.device
+    )
+    result = storage[..., ::2]
+    result.copy_(values)
+    return result.detach().requires_grad_(True)
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("num_heads", [1, 64])
+@pytest.mark.parametrize("layout", ["sbhd", "thd", "thd_cp_padding"])
+def test_mla_rope_concat_matches_native(layout, num_heads, dtype):
+    """Fused packing must match an independent PyTorch RoPE + concat reference."""
+    assert fused_mla_rope_concat is not None
+    nope_dim = 512
+    emb_dim = 64
+    config = TransformerConfig(
+        num_attention_heads=num_heads,
+        num_layers=1,
+        rotary_interleaved=False,
+        multi_latent_attention=True,
+    )
+
+    if layout == "sbhd":
+        max_seqlen = 16
+        input_shape = (max_seqlen, 2, num_heads)
+        cu_seqlens = None
+        cp_size, cp_rank = 1, 0
+        valid_tokens = input_shape[0] * input_shape[1]
+    elif layout == "thd":
+        seqlens = [12, 20, 24]
+        max_seqlen = max(seqlens)
+        cu_seqlens = torch.tensor([0, 12, 32, 56], dtype=torch.int32, device="cuda")
+        input_shape = (56, num_heads)
+        cp_size, cp_rank = 1, 0
+        valid_tokens = input_shape[0]
+    else:
+        global_seqlens = [16, 24, 32]
+        max_seqlen = max(global_seqlens)
+        cu_seqlens = torch.tensor([0, 16, 40, 72], dtype=torch.int32, device="cuda")
+        cp_size, cp_rank = 2, 1
+        valid_tokens = sum(global_seqlens) // cp_size
+        input_shape = (valid_tokens + 4, num_heads)
+
+    rotary = RotaryEmbedding(emb_dim, rotary_percent=1.0, rotary_base=10000)
+    freqs = rotary(max_seqlen, packed_seq=cu_seqlens is not None)
+    cos = freqs.cos().to(device="cuda", dtype=dtype).contiguous()
+    sin = freqs.sin().to(device="cuda", dtype=dtype).contiguous()
+    nope_values = torch.randn(*input_shape, nope_dim, dtype=dtype, device="cuda")
+    rope_values = torch.randn(*input_shape, emb_dim, dtype=dtype, device="cuda")
+
+    native_nope = _make_noncontiguous_leaf(nope_values)
+    native_rope = _make_noncontiguous_leaf(rope_values)
+    fused_nope = _make_noncontiguous_leaf(nope_values)
+    fused_rope = _make_noncontiguous_leaf(rope_values)
+    assert not fused_nope.is_contiguous() and not fused_rope.is_contiguous()
+
+    rotated = apply_rotary_pos_emb(
+        native_rope,
+        freqs,
+        config,
+        cu_seqlens=cu_seqlens,
+        cp_group=FakeCPGroup(cp_size, cp_rank),
+        mla_rotary_interleaved=True,
+        max_seqlen=max_seqlen if cu_seqlens is not None else None,
+    )
+    native_output = torch.cat((native_nope, rotated), dim=-1)
+    fused_output = fused_mla_rope_concat(
+        fused_nope, fused_rope, cos, sin, cu_seqlens=cu_seqlens, cp_rank=cp_rank, cp_size=cp_size
+    )
+    assert fused_output.is_contiguous()
+
+    if layout == "sbhd":
+        valid_output = (slice(None),)
+    else:
+        valid_output = (slice(0, valid_tokens),)
+    tols = dtype_tols(dtype)
+    torch.testing.assert_close(
+        native_output[valid_output].float(), fused_output[valid_output].float(), **tols
+    )
+
+    grad = torch.randn_like(fused_output)
+    if layout != "sbhd" and valid_tokens < grad.size(0):
+        grad[valid_tokens:] = 0
+    native_output.backward(grad)
+    fused_output.backward(grad)
+    torch.testing.assert_close(native_nope.grad.float(), fused_nope.grad.float(), **tols)
+    torch.testing.assert_close(native_rope.grad.float(), fused_rope.grad.float(), **tols)
 
 
 @pytest.mark.experimental

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -52,6 +52,8 @@ class FakeCPGroup:
 
     def rank(self):
         return self._rank
+
+
 class TestApplyRotaryPosEmbTHD:
     @pytest.mark.parametrize(
         ("unsupported_kwargs", "warning_text"),
@@ -172,6 +174,8 @@ class TestApplyRotaryPosEmbTHD:
 
         torch.testing.assert_close(out, expected)
         torch.testing.assert_close(out, compatibility_out)
+
+
 class _SaveOutputForBackward(torch.autograd.Function):
     """Minimal stand-in for a kernel whose backward consumes its output."""
 
@@ -187,7 +191,9 @@ class _SaveOutputForBackward(torch.autograd.Function):
         return saved_output
 
 
-def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleaving=False):
+def _test_fused_mla_rope_inplace(
+    input_format, inverse=False, remove_interleaving=False, rope_first=False
+):
     assert fused_mla_rope_inplace is not None
     num_heads = 32
     q_dim = 128
@@ -236,11 +242,14 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         )
 
     pytorch_fwd_input.requires_grad_(True)
-    fused_fwd_input = pytorch_fwd_input.detach()
+    fused_fwd_input = pytorch_fwd_input.detach().clone()
     fused_fwd_input.requires_grad_(True)
-    fused_bwd_input = pytorch_bwd_input.detach()
+    fused_bwd_input = pytorch_bwd_input.detach().clone()
 
-    no_pe, pe = torch.split(pytorch_fwd_input, [q_dim, emb_dim], dim=-1)
+    if rope_first:
+        pe, no_pe = torch.split(pytorch_fwd_input, [emb_dim, q_dim], dim=-1)
+    else:
+        no_pe, pe = torch.split(pytorch_fwd_input, [q_dim, emb_dim], dim=-1)
     pe_output = apply_rotary_pos_emb(
         pe,
         freqs,
@@ -253,7 +262,11 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         inverse=inverse,
         mla_output_remove_interleaving=remove_interleaving,
     )
-    pytorch_output = torch.concat([no_pe, pe_output], dim=-1)
+    pytorch_output = (
+        torch.concat([pe_output, no_pe], dim=-1)
+        if rope_first
+        else torch.concat([no_pe, pe_output], dim=-1)
+    )
     pytorch_output.backward(pytorch_bwd_input, retain_graph=True)
 
     fused_output = fused_mla_rope_inplace(
@@ -265,6 +278,7 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         cu_seqlens_q=cu_seqlens,
         inverse=inverse,
         remove_interleaving=remove_interleaving,
+        rope_first=rope_first,
     )
     fused_output.backward(fused_bwd_input, retain_graph=True)
 
@@ -280,6 +294,13 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         fused_fwd_input.grad.float(),
         msg=lambda msg: f"Mismatch in bwd: {msg}",
         **tols,
+    )
+    nope_slice = slice(emb_dim, None) if rope_first else slice(0, q_dim)
+    torch.testing.assert_close(
+        fused_output[..., nope_slice], pytorch_fwd_input.detach()[..., nope_slice], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        fused_fwd_input.grad[..., nope_slice], pytorch_bwd_input[..., nope_slice], rtol=0, atol=0
     )
 
 
@@ -522,6 +543,10 @@ class TestFusedMLARope:
         _test_fused_mla_rope_inplace(
             input_format, inverse=inverse, remove_interleaving=remove_interleaving
         )
+
+    @pytest.mark.parametrize("rope_first", [False, True], ids=["nope-first", "rope-first"])
+    def test_inplace_leading_rope_forward_backward(self, input_format, rope_first):
+        _test_fused_mla_rope_inplace(input_format, rope_first=rope_first)
 
     @pytest.mark.parametrize("remove_interleaving", [False, True])
     def test_kv_split_forward_backward(self, input_format, remove_interleaving):

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import warnings
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ import torch
 
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings import rope_utils as rope_utils_module
+from megatron.core.models.common.embeddings import should_use_fused_mla_rope
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -29,6 +31,53 @@ except Exception:
     fused_mla_rope_inplace = None
     fused_mla_rope_kv_split = None
     fused_mla_rope_out_of_place = None
+
+
+@pytest.mark.parametrize(
+    ("apply_rope_fusion", "rope_type", "rotary_percent", "expected"),
+    [
+        (False, "rope", 1.0, False),
+        (True, "rope", 1.0, True),
+        (True, "rope", 0.5, False),
+        (True, "yarn", 0.5, True),
+    ],
+)
+def test_mla_rope_fusion_selection(apply_rope_fusion, rope_type, rotary_percent, expected):
+    """Partial standard RoPE falls back while full RoPE and YaRN retain fusion."""
+    config = SimpleNamespace(
+        apply_rope_fusion=apply_rope_fusion, rope_type=rope_type, rotary_percent=rotary_percent
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert should_use_fused_mla_rope(config) is expected
+
+
+def test_partial_standard_rope_fallback_warns_once(monkeypatch):
+    """Partial standard RoPE preserves its tail and reports each fallback only once."""
+    config = SimpleNamespace(
+        apply_rope_fusion=True,
+        mrope_section=None,
+        multi_latent_attention=True,
+        rope_type="rope",
+        rotary_interleaved=False,
+        rotary_percent=0.5,
+    )
+    monkeypatch.setattr(rope_utils_module, "_ROPE_FUSION_FALLBACK_WARNINGS", set())
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        for _ in range(2):
+            assert not should_use_fused_mla_rope(config)
+            values = torch.randn(8, 1, 2, 64)
+            freqs = torch.randn(8, 1, 1, 32)
+            output = apply_rotary_pos_emb(
+                values, freqs, config=config, cp_group=FakeCPGroup(), mla_rotary_interleaved=True
+            )
+            torch.testing.assert_close(output[..., 32:], values[..., 32:], rtol=0, atol=0)
+
+    messages = [str(warning.message) for warning in recorded]
+    assert sum("Falling back to the unfused path" in message for message in messages) == 1
+    assert sum("MLA-style interleaving" in message for message in messages) == 1
 
 
 def dtype_tols(dtype):
@@ -701,6 +750,7 @@ class TestApplyRotaryPosEmbMlaFusionConflict:
 
         fused_mock = MagicMock(return_value=t.clone())
         with (
+            patch.object(rope_utils_module, "_ROPE_FUSION_FALLBACK_WARNINGS", set()),
             patch.object(rope_utils_module, "fused_apply_rotary_pos_emb", fused_mock),
             patch.object(
                 rope_utils_module,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -130,6 +130,7 @@ def get_mock_mla_config(
     qk_layernorm: bool,
     apply_rope_fusion: bool = False,
     rope_type: str = "yarn",
+    rotary_percent: float = 1.0,
 ) -> MLATransformerConfig:
     """Create test config with all attributes used in MLA."""
     return MLATransformerConfig(
@@ -154,6 +155,7 @@ def get_mock_mla_config(
         context_parallel_size=context_parallel_size,
         apply_rope_fusion=apply_rope_fusion,
         rope_type=rope_type,
+        rotary_percent=rotary_percent,
         rotary_scaling_factor=40,
         mscale=1.0,
         mscale_all_dim=1.0,
@@ -568,3 +570,110 @@ def test_standard_rope_fusion_functionality(qkv_format: str):
         rope_type="rope",
         check_hidden_grad=True,
     )
+
+
+@pytest.mark.parametrize("attention_type", ["standard", "absorbed"])
+@pytest.mark.parametrize(("qkv_format", "cp_size"), [("sbhd", 1), ("thd", 1), ("thd", 2)])
+@pytest.mark.parametrize("rotary_percent", [1.0, 0.5], ids=["full", "partial-fallback"])
+def test_standard_rope_fused_unfused_parity(attention_type, qkv_format, cp_size, rotary_percent):
+    """Standard RoPE fusion or fallback must preserve outputs and all gradients."""
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+    model_parallel_cuda_manual_seed(123)
+
+    configs = [
+        get_mock_mla_config(
+            tensor_model_parallel_size=1,
+            context_parallel_size=cp_size,
+            qk_layernorm=True,
+            apply_rope_fusion=apply_rope_fusion,
+            rope_type="rope",
+            rotary_percent=rotary_percent,
+        )
+        for apply_rope_fusion in (False, True)
+    ]
+
+    if attention_type == "absorbed":
+        attention_cls = AbsorbedMLASelfAttention
+        submodules = [
+            get_absorbed_mla_submodules(
+                down_proj_use_column_parallel=False, qk_layernorm=True, rms_norm=True
+            )
+            for _ in configs
+        ]
+    else:
+        attention_cls = MLASelfAttention
+        submodules = [
+            get_mla_submodules(
+                down_proj_use_column_parallel=False, qk_layernorm=True, rms_norm=True
+            )
+            for _ in configs
+        ]
+
+    attentions = [
+        attention_cls(
+            config=config,
+            submodules=module_spec,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            cp_comm_type="all_gather" if cp_size > 1 else None,
+            pg_collection=None,
+        ).cuda()
+        for config, module_spec in zip(configs, submodules)
+    ]
+    attentions[1].load_state_dict(attentions[0].state_dict())
+
+    if qkv_format == "thd":
+        seqlens = [96, 160, 64]
+        cu_seqlens = torch.tensor([0, 96, 256, 320], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=max(seqlens),
+            max_seqlen_kv=max(seqlens),
+            qkv_format="thd",
+        )
+        hidden_states = torch.randn(
+            (sum(seqlens) // cp_size, 1, configs[0].hidden_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+    else:
+        packed_seq_params = None
+        hidden_states = torch.randn(
+            (320 // cp_size, 2, configs[0].hidden_size), dtype=torch.bfloat16, device="cuda"
+        )
+
+    inputs = [hidden_states.detach().clone().requires_grad_(True) for _ in attentions]
+    output_grad = torch.randn_like(hidden_states)
+    outputs = []
+    for attention, input_tensor in zip(attentions, inputs):
+        output, _ = attention(
+            input_tensor, attention_mask=None, packed_seq_params=packed_seq_params
+        )
+        output.backward(output_grad)
+        outputs.append(output)
+
+    torch.testing.assert_close(outputs[1], outputs[0], atol=5e-3, rtol=5e-3)
+    torch.testing.assert_close(inputs[1].grad, inputs[0].grad, atol=5e-3, rtol=5e-3)
+
+    unfused_parameters = dict(attentions[0].named_parameters())
+    fused_parameters = dict(attentions[1].named_parameters())
+    assert fused_parameters.keys() == unfused_parameters.keys()
+    for name in unfused_parameters:
+        unfused_grad = unfused_parameters[name].grad
+        fused_grad = fused_parameters[name].grad
+        assert unfused_grad is not None, f"unfused parameter {name} has no gradient"
+        assert fused_grad is not None, f"fused parameter {name} has no gradient"
+        fused_grad_fp64 = fused_grad.double()
+        unfused_grad_fp64 = unfused_grad.double()
+        denominator = (fused_grad_fp64.square() + unfused_grad_fp64.square()).sum()
+        similarity = (
+            1.0
+            if denominator == 0
+            else (2 * fused_grad_fp64 * unfused_grad_fp64).sum() / denominator
+        )
+        assert similarity > 0.9999, f"parameter {name} gradient similarity = {similarity}"
+
+    Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -125,7 +125,11 @@ class MockCoreAttention(torch.nn.Module):
 
 
 def get_mock_mla_config(
-    tensor_model_parallel_size: int, context_parallel_size: int, qk_layernorm: bool
+    tensor_model_parallel_size: int,
+    context_parallel_size: int,
+    qk_layernorm: bool,
+    apply_rope_fusion: bool = False,
+    rope_type: str = "yarn",
 ) -> MLATransformerConfig:
     """Create test config with all attributes used in MLA."""
     return MLATransformerConfig(
@@ -148,8 +152,8 @@ def get_mock_mla_config(
         tensor_model_parallel_size=tensor_model_parallel_size,
         sequence_parallel=tensor_model_parallel_size > 1,
         context_parallel_size=context_parallel_size,
-        apply_rope_fusion=False,
-        rope_type="yarn",
+        apply_rope_fusion=apply_rope_fusion,
+        rope_type=rope_type,
         rotary_scaling_factor=40,
         mscale=1.0,
         mscale_all_dim=1.0,
@@ -388,10 +392,14 @@ def test_load_from_state_dict_backwards_compatible_with_split_kv_up_projection(m
     assert f"{prefix}linear_v_up_proj._extra_state" not in captured_state_dict
 
 
-@pytest.mark.parametrize("tp_cp", [[1, 1], [2, 1], [1, 2], [2, 2]])
-@pytest.mark.parametrize("qkv_format", ['sbhd', 'thd'])
-@pytest.mark.parametrize("down_proj_use_column_parallel", [False, True])
-def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_parallel: bool):
+def _run_functionality(
+    tp_cp: List[int],
+    qkv_format: str,
+    down_proj_use_column_parallel: bool,
+    apply_rope_fusion: bool = False,
+    rope_type: str = "yarn",
+    check_hidden_grad: bool = False,
+):
     """Test that AbsorbedMLASelfAttention is equivalent to standard MLA."""
     tp_size, cp_size = tp_cp
     Utils.initialize_model_parallel(
@@ -402,7 +410,11 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
     # Create model
     qk_layernorm = True
     config = get_mock_mla_config(
-        tensor_model_parallel_size=tp_size, context_parallel_size=cp_size, qk_layernorm=qk_layernorm
+        tensor_model_parallel_size=tp_size,
+        context_parallel_size=cp_size,
+        qk_layernorm=qk_layernorm,
+        apply_rope_fusion=apply_rope_fusion,
+        rope_type=rope_type,
     )
     absorbed_submodules = get_absorbed_mla_submodules(
         down_proj_use_column_parallel=down_proj_use_column_parallel,
@@ -470,12 +482,15 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
         grads = torch.randn_like(hidden_states)
         packed_seq_params = None
 
+    absorbed_hidden_states = hidden_states.detach().requires_grad_(check_hidden_grad)
+    standard_hidden_states = hidden_states.detach().clone().requires_grad_(check_hidden_grad)
+
     # Forward & Backward
     for name, param in absorbed_mla.named_parameters():
         if param.grad is not None:
             param.grad.zero_()
     absorbed_outputs, _ = absorbed_mla(
-        hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
+        absorbed_hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
     )
     absorbed_outputs.backward(grads)
 
@@ -483,7 +498,7 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
         if param.grad is not None:
             param.grad.zero_()
     standard_outputs, _ = standard_mla(
-        hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
+        standard_hidden_states, attention_mask=None, packed_seq_params=packed_seq_params
     )
     standard_outputs.backward(grads)
 
@@ -504,6 +519,10 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
     assert cosine_sim > 0.9999, f"output cosine similarity = {cosine_sim} < 0.9999"
     assert _calculate_tensor_similarity(absorbed_outputs, standard_outputs) > 0.9999
     torch.testing.assert_close(absorbed_outputs, standard_outputs, atol=5e-3, rtol=5e-3)
+    if check_hidden_grad:
+        torch.testing.assert_close(
+            absorbed_hidden_states.grad, standard_hidden_states.grad, atol=5e-3, rtol=5e-3
+        )
 
     for name, param in absorbed_mla.named_parameters():
         assert param.grad is not None
@@ -528,3 +547,24 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
         assert _calculate_tensor_similarity(absorbed_grad, standard_grad) > 0.9999
 
     Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("tp_cp", [[1, 1], [2, 1], [1, 2], [2, 2]])
+@pytest.mark.parametrize("qkv_format", ['sbhd', 'thd'])
+@pytest.mark.parametrize("down_proj_use_column_parallel", [False, True])
+def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_parallel: bool):
+    """Test that absorbed MLA is equivalent to standard MLA."""
+    _run_functionality(tp_cp, qkv_format, down_proj_use_column_parallel)
+
+
+@pytest.mark.parametrize("qkv_format", ['sbhd', 'thd'])
+def test_standard_rope_fusion_functionality(qkv_format: str):
+    """Absorbed MLA's fused packing must match standard MLA end to end."""
+    _run_functionality(
+        [1, 1],
+        qkv_format,
+        down_proj_use_column_parallel=False,
+        apply_rope_fusion=True,
+        rope_type="rope",
+        check_hidden_grad=True,
+    )

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -2367,14 +2367,16 @@ class TestDSAIndexer:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.parametrize("packed", [False, True], ids=["sbhd", "thd"])
-    def test_dsa_indexer_fused_rope_matches_unfused(self, seqlen, packed):
-        """Fused leading-channel RoPE must preserve indexer values and all gradients."""
+    @pytest.mark.parametrize("rotary_percent", [1.0, 0.5], ids=["full", "partial-fallback"])
+    def test_dsa_indexer_fused_rope_matches_unfused(self, seqlen, packed, rotary_percent):
+        """Fused leading-channel RoPE or fallback must preserve values and all gradients."""
         from megatron.core.extensions.transformer_engine import TELinear, TENorm
         from megatron.core.transformer.spec_utils import ModuleSpec
 
         def build_indexer(apply_rope_fusion):
             config = copy.deepcopy(self.config)
             config.apply_rope_fusion = apply_rope_fusion
+            config.rotary_percent = rotary_percent
             config.dsa_indexer_rope_interleaved = True
             config.dsa_indexer_k_norm_fp32 = True
             config.dsa_indexer_rotate_activation = False

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import copy
 import logging
+import math
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -2364,6 +2366,108 @@ class TestDSAIndexer:
         _assert_valid_topk_indices_unique(topk_indices)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("packed", [False, True], ids=["sbhd", "thd"])
+    def test_dsa_indexer_fused_rope_matches_unfused(self, seqlen, packed):
+        """Fused leading-channel RoPE must preserve indexer values and all gradients."""
+        from megatron.core.extensions.transformer_engine import TELinear, TENorm
+        from megatron.core.transformer.spec_utils import ModuleSpec
+
+        def build_indexer(apply_rope_fusion):
+            config = copy.deepcopy(self.config)
+            config.apply_rope_fusion = apply_rope_fusion
+            config.dsa_indexer_rope_interleaved = True
+            config.dsa_indexer_k_norm_fp32 = True
+            config.dsa_indexer_rotate_activation = False
+            submodules = DSAIndexerSubmodules(
+                linear_wq_b=ModuleSpec(module=TELinear),
+                linear_wk=ModuleSpec(module=TELinear),
+                k_norm=ModuleSpec(module=TENorm),
+                linear_weights_proj=ModuleSpec(module=TELinear),
+            )
+            return DSAIndexer(config, submodules, self.pg_collection).cuda()
+
+        unfused_indexer = build_indexer(False)
+        fused_indexer = build_indexer(True)
+        fused_indexer.load_state_dict(unfused_indexer.state_dict())
+        batch_size = 1
+        x_values = torch.randn(
+            seqlen, batch_size, self.config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        )
+        qr_values = torch.randn(
+            seqlen, batch_size, self.config.q_lora_rank, dtype=torch.bfloat16, device="cuda"
+        )
+        q_grad = torch.randn(
+            seqlen,
+            batch_size,
+            unfused_indexer.index_n_heads,
+            unfused_indexer.index_head_dim,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        k_grad = torch.randn(
+            seqlen, batch_size, unfused_indexer.index_head_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        weights_grad = torch.randn(
+            seqlen, batch_size, unfused_indexer.index_n_heads, dtype=torch.bfloat16, device="cuda"
+        )
+        packed_seq_params = None
+        if packed:
+            first_seqlen = seqlen // 4
+            cu_seqlens = torch.tensor([0, first_seqlen, seqlen], dtype=torch.int32, device="cuda")
+            packed_seq_params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=seqlen - first_seqlen,
+                max_seqlen_kv=seqlen - first_seqlen,
+            )
+
+        def run(indexer):
+            x = x_values.detach().clone().requires_grad_(True)
+            qr = qr_values.detach().clone().requires_grad_(True)
+            q, k, weights = indexer.forward_before_topk(x, qr, packed_seq_params)
+            torch.autograd.backward((q, k, weights), (q_grad, k_grad, weights_grad))
+            parameter_grads = {
+                name: parameter.grad.detach().clone()
+                for name, parameter in indexer.named_parameters()
+                if parameter.grad is not None
+            }
+            return (
+                (q.detach().clone(), k.detach().clone(), weights.detach().clone()),
+                (x.grad.detach().clone(), qr.grad.detach().clone()),
+                parameter_grads,
+            )
+
+        unfused = run(unfused_indexer)
+        fused = run(fused_indexer)
+
+        for actual, expected in zip(fused[0], unfused[0]):
+            torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=5e-2)
+        for actual, expected in zip(fused[1], unfused[1]):
+            torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=5e-2)
+        assert fused[2].keys() == unfused[2].keys()
+        for name in fused[2]:
+            actual = fused[2][name].float()
+            expected = unfused[2][name].float()
+            relative_l2_error = torch.linalg.vector_norm(
+                actual - expected
+            ) / torch.linalg.vector_norm(expected).clamp_min(torch.finfo(torch.float32).tiny)
+            assert relative_l2_error < 1e-2, (
+                f"gradient relative L2 mismatch for {name}: "
+                f"{relative_l2_error.item():.6e} >= 1e-2"
+            )
+            torch.testing.assert_close(
+                actual,
+                expected,
+                rtol=2e-2,
+                # Parameter gradients reduce over the sequence dimension. Scale the
+                # near-zero absolute tolerance with the square root of the reduction
+                # length, while the relative-L2 check above bounds aggregate error.
+                atol=5e-2 * math.sqrt(seqlen),
+                msg=lambda msg: f"gradient mismatch for {name}: {msg}",
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_indexer_forward_with_scores(self, seqlen):
         """Test indexer forward pass with scores."""
         batch_size = 2
@@ -3865,6 +3969,11 @@ class TestDSAModuleSpecDispatch:
         """DSA config validation rejects bias because absorbed MLA does not support it."""
         with pytest.raises(ValueError, match="requires add_bias_linear=False"):
             self._make_dsa_config(experimental_attention_variant="dsa", add_bias_linear=True)
+
+    def test_dsa_accepts_fused_standard_rope(self):
+        """DSA can use the absorbed-MLA fused path with standard RoPE."""
+        config = self._make_dsa_config(experimental_attention_variant="dsa", apply_rope_fusion=True)
+        assert config.apply_rope_fusion
 
     def test_dsa_cp_requires_allgather_cp_comm_type(self):
         """DSA context parallelism should fail early for unsupported CP communication."""

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -642,11 +642,7 @@ class TestTensorParallelMLAAttention:
 )
 @pytest.mark.parametrize(
     ("rope_type", "apply_rope_fusion"),
-    (
-        ('rope', False),
-        ('yarn', False),
-        ('yarn', True),  # apply_rope_fusion for MLA only works with YARN RoPE.
-    ),
+    (('rope', False), ('rope', True), ('yarn', False), ('yarn', True)),
 )
 class TestContextParallelMLAAttention:
 
@@ -895,11 +891,7 @@ class TestParallelMLAAttentionPrecision:
 )
 @pytest.mark.parametrize(
     ("rope_type", "apply_rope_fusion"),
-    (
-        ('rope', False),
-        ('yarn', False),
-        ('yarn', True),  # apply_rope_fusion for MLA only works with YARN RoPE.
-    ),
+    (('rope', False), ('rope', True), ('yarn', False), ('yarn', True)),
 )
 class TestContextParallelMLAAttentionPrecision:
 
@@ -1431,11 +1423,7 @@ class TestMLAClipQK:
 @pytest.mark.experimental
 @pytest.mark.parametrize(
     ("rope_type", "apply_rope_fusion"),
-    [
-        ("rope", False),
-        ("yarn", False),
-        ("yarn", True),  # apply_rope_fusion for MLA only works with YARN RoPE.
-    ],
+    [("rope", False), ("rope", True), ("yarn", False), ("yarn", True)],
 )
 @pytest.mark.parametrize(
     ("tp", "sp", "cp"),


### PR DESCRIPTION
## Summary

Main-branch counterpart of #6343.

- enable the fused MLA RoPE path for standard RoPE while preserving YaRN, unfused, and inference behavior
- fuse absorbed-MLA non-positional packing, RoPE, and contiguous output into one Triton kernel with a fused backward
- extend the shared in-place MLA RoPE primitive to rotate leading channels, allowing the DSA indexer to operate directly on its packed `[PE, NOPE]` projection output
- keep partial standard RoPE (`rotary_percent < 1`) on the unfused path because the custom MLA kernels currently rotate the full positional slice, with a one-time fallback warning

## Performance

Carries forward the formal 8x B200 GLM-5.2 proxy A/B results from #6343, using 8 warmup and 20 measured iterations:

| Workload | Step time | Peak device memory |
|---|---:|---:|
| THD 4K, dynamic effective CP1 | -2.11% | <0.2% change |
| THD 32K, CP8 | -2.80% | <0.2% change |

In the targeted absorbed-MLA packing region, the long-sequence path is reduced from 85 kernels to 2 kernels, and GPU kernel time falls from 0.848 ms to 0.099 ms per attention call. Whole self-attention GPU span falls by 10.6% for THD 4K and 11.5% for THD 32K.

The DSA indexer in-place integration is included for a cleaner packed-tensor path and shared primitive ownership. No additional end-to-end speedup is claimed for that follow-up beyond the MLA A/B results above.

## Testing

- clean merge and test against `main` at `35e42f006`
- main-target autoformat checks: Black 26.3.0, isort, pylint, and ruff
- `test_mla_yarn_rope_apply.py` on 8x H100: 13 fast-path tests and 24 CUDA-path tests passed on every rank
- `test_absorbed_mla.py` on 8x H100: 36 tests passed on every rank, including MLASelfAttention and AbsorbedMLA output, hidden-gradient, and parameter-gradient parity for full and partial standard RoPE across SBHD, THD, and CP2
- `test_attention_variant_dsa.py` on 8x H100: 110 tests passed on every rank, including DSA indexer fused/unfused parity for full and partial standard RoPE across SBHD and THD
- partial standard RoPE fusion-selection, one-time warning, and pass-through-tail regression coverage
