### PR TITLE
[dev] Fix per-microbatch CuTe and per-sequence-length cuDNN DSA recompiles in CSA

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/cp_layout_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/cp_layout_kernels.py
@@ -605,11 +605,19 @@ def _run_compiled_launch(
 ) -> None:
     """Compile/cache a CuTe launch function and invoke it on the current stream."""
     static_arg_set = set(static_arg_indices)
+    # Tensor layouts are marked dynamic below, so one compiled kernel serves every
+    # shape/stride whose last dimension is contiguous; all sizes reach the kernel as
+    # runtime scalars. Keying on shapes would recompile once per microbatch because
+    # l_local, sequence count, and compact length change with each batch.
+    for tensor in tensor_args:
+        if tensor.ndim != 0 and tensor.stride(-1) != 1:
+            raise RuntimeError(
+                f"CSA CP CuTe kernel {launch_fn.__name__} requires last-dim-contiguous "
+                f"tensors, got shape {tuple(tensor.shape)} stride {tuple(tensor.stride())}."
+            )
     key = (
         launch_fn.__name__,
-        tuple(
-            (tensor.dtype, tuple(tensor.shape), tuple(tensor.stride())) for tensor in tensor_args
-        ),
+        tuple((tensor.dtype, tensor.ndim) for tensor in tensor_args),
         tuple((i, scalar_args[i]) for i in static_arg_indices),
     )
     compiled = _COMPILED_LAUNCH_CACHE.get(key)

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -122,6 +122,24 @@ def _get_topk_alignment() -> int:
     return 128
 
 
+def _align_topk_width(topk_idxs: Tensor) -> Tensor:
+    """Right-pad ``topk_idxs`` with ``-1`` so its width hits the GPU alignment.
+
+    The forward kernel pads internally, but the backward wrapper keys its
+    compile cache on ``topk_idxs.shape[1]`` (``max_topk``). Aligning once at
+    the autograd boundary makes forward and backward agree on the width and
+    quantizes the number of distinct backward compile keys, which otherwise
+    grows with every new sequence length on the paths whose top-k width is
+    ``window + sq // compress_ratio``.
+    """
+    topk = topk_idxs.shape[-1]
+    align = _get_topk_alignment()
+    padded = (topk + align - 1) // align * align
+    if padded == topk:
+        return topk_idxs
+    return torch.nn.functional.pad(topk_idxs, (0, padded - topk), value=-1)
+
+
 def _csa_fwd_flash_mla(
     q: Tensor,
     kv: Tensor,
@@ -718,6 +736,12 @@ class CSASparseAttnFunc(torch.autograd.Function):
         indexer_topk: int,
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
         """Run FlashMLA sparse-attention forward and save tensors for backward."""
+        # Align before the forward call so the tensor handed to the backward
+        # wrapper has the same width the forward kernel ran on; otherwise the
+        # backward compile cache is keyed on the raw (unaligned) width and
+        # recompiles on every distinct sequence length.
+        topk_idxs = _align_topk_width(topk_idxs)
+
         out, lse, lse_indexer = _csa_fwd_flash_mla(
             q,
             kv,


### PR DESCRIPTION

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## What

Two independent compile-cache keys in the CSA (DeepSeek-V4-style compressed sparse attention) path change on almost every step, so kernels that should be compiled once are recompiled throughout training. This PR makes both keys stable.

## Why

**1. `cp_layout_kernels.py` — CuTe launch cache keyed on shapes/strides**

`_run_compiled_launch()` keyed `_COMPILED_LAUNCH_CACHE` on `(dtype, shape, stride)` of every tensor argument. But the tensors are compiled with `mark_layout_dynamic(leading_dim=ndim - 1)` and every size is passed to the kernel as a runtime `cutlass.Int32` scalar, so a single compiled kernel already serves any shape whose last dimension is contiguous. Because `l_local`, the sequence count and the compact top-k length differ per microbatch, the shape key produced a fresh `cute.compile()` per microbatch instead of one compile per kernel.

**2. `fused_sparse_attention.py` — DSA backward cache keyed on unaligned top-k width**

`_csa_fwd_flash_mla()` pads `topk_idxs` to the arch alignment internally (128 on SM90, 64 on SM100+), but `CSASparseAttnFunc.forward` saved the *unpadded* tensor for backward. `cudnn.DSA.sparse_attention_backward_wrapper` keys its own compile cache on `topk_idxs.shape[1]` (`max_topk`), and on the paths whose width is `window + sq // compress_ratio` that value changes with every distinct sequence length — so backward recompiled for each new sequence length seen.

## Changes

- `_run_compiled_launch()` now keys the cache on `(launch_fn name, per-tensor  (dtype, ndim), static scalar args)` and validates the assumption the dynamic layout relies on: any non-0-d tensor argument must be last-dim contiguous,  otherwise a `RuntimeError` names the kernel, shape and stride.
- New `_align_topk_width()` right-pads `topk_idxs` with `-1` to the arch alignment, applied once in `CSASparseAttnFunc.forward` before calling the forward kernel. Forward and backward now agree on the width, and the number of distinct backward compile keys is quantized to alignment multiples. The pad inside `_csa_fwd_flash_mla()` becomes a no-op for this path (kept for direct callers).

## Validation
Setup: 64ranks GB200, DSV4 model, TP1 / EP8 / CP8, GBS 1536, bf16, cudnn-frontend (e002833). Timings are end-to-end training step times from the same job configuration.

- Step 1: 2503 s → 1727 s (-31%)
- Step 2: 1612 s → 614 s (-61%)

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
