### PR TITLE
Add cumulative prefix-cache pairwise coverage and fixes

### DIFF
--- a/megatron/core/inference/contexts/base_context.py
+++ b/megatron/core/inference/contexts/base_context.py
@@ -17,6 +17,8 @@ class BaseInferenceContext(abc.ABC):
         Args:
         """
         self.config = inference_config
+        self.cuda_graphs_available = True
+        self.is_creating_cuda_graphs = False
 
     @abc.abstractmethod
     def is_static_batching(self) -> bool:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3296,15 +3296,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         num_matched_blocks = len(matched_block_ids)
         effective_kv_offset = req.finished_chunk_token_count + prefix_skip_tokens
 
-        # Track prefix cache hits. num_cached_tokens accumulates across prefill
-        # chunks: each chunk matches a disjoint block range (start advances with
-        # finished_chunk_token_count), so a long cached prefix is discovered
-        # incrementally and must be summed, not overwritten.
-        if num_matched_blocks > 0:
-            self.prefix_cache_hits += 1
-            self.prefix_cache_blocks_matched += num_matched_blocks
-            req.num_cached_tokens += num_matched_blocks * self.block_size_tokens
-
         # Slice tokens to skip matched prefix
         this_round_tokens = req.remaining_prompt_tokens[prefix_skip_tokens:prefill_chunk_length]
 
@@ -3332,6 +3323,14 @@ class DynamicInferenceContext(BaseInferenceContext):
                 if matched_tensor is not None:
                     self.kv_block_allocator.block_ref_counts[matched_tensor] -= 1
                 raise BlockOverflowError(req.request_id)
+
+        # Track prefix cache hits only after allocation succeeds. num_cached_tokens
+        # accumulates across successful prefill chunks; a failed admission can be
+        # retried and must not count the same cached prefix twice.
+        if num_matched_blocks > 0:
+            self.prefix_cache_hits += 1
+            self.prefix_cache_blocks_matched += num_matched_blocks
+            req.num_cached_tokens += num_matched_blocks * self.block_size_tokens
 
         # Note that we decremented the total_request_count for the chunked prefill request
         # in update_requests, so setting current_id to the total_request_count will again

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -967,8 +967,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if (
             self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD
             and not self._uses_torch_memory_saver
+            and self.unified_memory_level == 0
         ):
-            assert self.unified_memory_level == 0
             self._offloadable_tensor_names.add("memory_buffer")
             self._offloadable_cpu_backups["memory_buffer"] = torch.empty_like(
                 self.memory_buffer, device="cpu"
@@ -1044,8 +1044,8 @@ class DynamicInferenceContext(BaseInferenceContext):
             if (
                 self.kv_cache_management_mode == KVCacheManagementMode.OFFLOAD
                 and not self._uses_torch_memory_saver
+                and self.unified_memory_level == 0
             ):
-                assert self.unified_memory_level == 0
                 self._offloadable_tensor_names.add("mamba_conv_states")
                 self._offloadable_cpu_backups["mamba_conv_states"] = torch.empty_like(
                     self.mamba_conv_states, device="cpu"
@@ -2434,14 +2434,16 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         self.batch_dimensions = batch_dimensions
 
-        best_graph = CUDAGraphBatchDimensionBuilder.match_graph_config(
-            batch_dimensions,
-            self.cuda_graph_batch_dimensions_list,
-            strict=self.is_hybrid_model,
-            ep_group=self.expert_model_parallel_group,
-            match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
-            ep_zmq_communicator=self._ep_zmq_communicator,
-        )
+        best_graph = None
+        if self.cuda_graphs_available or construct_graph_dimensions is not None:
+            best_graph = CUDAGraphBatchDimensionBuilder.match_graph_config(
+                batch_dimensions,
+                self.cuda_graph_batch_dimensions_list,
+                strict=self.is_hybrid_model,
+                ep_group=self.expert_model_parallel_group,
+                match_ep_token_counts=self._nccl_ep_dispatcher or self._training_ep_dispatcher,
+                ep_zmq_communicator=self._ep_zmq_communicator,
+            )
         self._using_cuda_graph_this_step = best_graph is not None
 
         if construct_graph_dimensions is not None:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3481,11 +3481,15 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # compute_and_store_offsets sets CPU state + GPU staging buffers that
         # commit_intermediate_states() consumes after the forward pass. Run it for
-        # EVERY prefill chunk (not just the first): the last complete block of a
+        # EVERY cacheable prefill chunk (not just the first): the last complete block of a
         # multi-chunk prompt falls in a continuation chunk, and caching its Mamba
         # state is precisely what lets a later turn skip prefill on a hybrid model.
         # Mamba slot allocation / state restore above stays first-chunk-only.
-        if self.is_hybrid_model and self.mamba_slot_allocator is not None:
+        if (
+            self.is_hybrid_model
+            and self.mamba_slot_allocator is not None
+            and req.precomputed_block_hashes
+        ):
             self.mamba_slot_allocator.compute_and_store_offsets(
                 req,
                 current_id,

--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -312,6 +312,47 @@ class KVBlockAllocator:
     # Prefix caching methods
     # =========================================================================
 
+    def invalidate_prefix_cache(self) -> None:
+        """Make all cached prefixes undiscoverable without disrupting live requests.
+
+        Evictable blocks are returned to the free pool immediately. Blocks that
+        are still referenced by live requests keep their storage until those
+        requests release them, but their hashes and replay metadata are cleared
+        so a new request cannot reuse state computed by an older model.
+        """
+        if not self.enable_prefix_caching:
+            return
+
+        registered_mask = self.block_hashes != -1
+        registered_ids = torch.nonzero(registered_mask, as_tuple=True)[0]
+        if registered_ids.numel() == 0:
+            return
+
+        registered_ids_list = registered_ids.tolist()
+        registered_hashes = set(self.block_hashes[registered_ids].tolist())
+        self.kv_hash_to_block_id.clear()
+
+        evictable_ids = registered_ids[self.block_ref_counts[registered_ids] == 0]
+        if evictable_ids.numel() > 0:
+            count = evictable_ids.numel()
+            self.block_bag[self.pool_avail : self.pool_avail + count] = evictable_ids
+            self.pool_avail += count
+            routed_ids = set(evictable_ids.tolist()) & self.block_routing.keys()
+            deque(map(self.block_routing.pop, routed_ids), maxlen=0)
+
+        self.block_hashes[registered_ids] = -1
+        if self.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
+            self.block_timestamps[registered_ids] = 0
+            self.block_parent_id[registered_ids] = -1
+            self.block_child_count[registered_ids] = 0
+
+        # Preserve the normal deregistration ordering: callbacks observe committed
+        # KV bookkeeping, including during a model-generation epoch change.
+        if self.on_blocks_deregistered is not None:
+            self.on_blocks_deregistered(registered_ids_list, registered_hashes)
+        for observer in tuple(self._blocks_deregistered_observers):
+            observer(registered_ids_list, registered_hashes)
+
     def register_kv_block_hashes(
         self,
         block_ids: list[int],

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -717,17 +717,21 @@ class MambaSlotAllocator:
     # Reset
     # =========================================================================
 
-    def reset(self) -> None:
-        """Reset all state (mappings, free pool, cache, intermediate tracking)."""
+    def invalidate_cache(self) -> None:
+        """Discard durable and pending prefix state without touching GPU storage."""
         self.block_to_slot.fill_(-1)
         self.slot_to_block.fill_(-1)
         torch.arange(self.max_slots, out=self.free_slots)
         self.free_count = self.max_slots
         self.hash_to_block_id.clear()
-        self.intermediate_ssm_out.zero_()
-        self.intermediate_conv_out.zero_()
         self._intermediate_offsets_cpu.fill_(0)
         self._intermediate_counts_cpu.fill_(0)
         self._intermediate_block_ids_cpu.fill_(-1)
         self._eos_cache_block_id_cpu.fill_(-1)
         self._has_intermediates = False
+
+    def reset(self) -> None:
+        """Reset all state (mappings, free pool, cache, intermediate tracking)."""
+        self.invalidate_cache()
+        self.intermediate_ssm_out.zero_()
+        self.intermediate_conv_out.zero_()

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -468,7 +468,7 @@ class MambaSlotAllocator:
         # later turns could not skip prefill.
         chunk_start = req.finished_chunk_token_count + skip_tokens
         seq_len = prefill_chunk_length - skip_tokens  # tokens computed this chunk
-        is_last_chunk = req.finished_chunk_token_count + prefill_chunk_length >= prompt_len
+        chunk_end = req.finished_chunk_token_count + prefill_chunk_length
 
         # Candidate absolute block boundaries at which to cache Mamba state.
         kv_div_abs = num_matched_blocks * bs
@@ -505,13 +505,12 @@ class MambaSlotAllocator:
             self._has_intermediates = True
         self._intermediate_counts_cpu[current_id] = count
 
-        # Block-aligned EOS: when the prompt length is exactly block-aligned, the
-        # request's live final state IS the last block boundary's state and can be
-        # cached directly. Only valid on the final chunk (otherwise the live state
-        # is mid-prompt). Non-block-aligned prompts cache their last complete block
-        # via the intermediate-extraction path above instead.
-        if is_last_chunk and last_aligned_abs == prompt_len and prompt_len > 0:
-            last_block_idx = prompt_len // bs - 1
+        # At a block-aligned chunk end, the request's live state is exactly the
+        # state for that block boundary and can be cached directly. This covers
+        # both aligned final prompts and non-final boundaries, which cannot use
+        # intermediate extraction because their offset equals `seq_len`.
+        if chunk_end > 0 and chunk_end % bs == 0:
+            last_block_idx = chunk_end // bs - 1
             if last_block_idx >= 0:
                 self._eos_cache_block_id_cpu[current_id] = ctx.request_to_kv_block_ids[current_id][
                     last_block_idx

--- a/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/coordinator.py
@@ -223,6 +223,7 @@ class DataParallelInferenceCoordinator:
         # timestamps (positive int).  Missing entries are implicitly zero.
         self._hash_table: dict[int, dict[int, int]] = {}
         self._hash_assignment_counter = 0
+        self._generation_epoch = None
 
         # Clients that have completed the CONNECT handshake.
         self.known_clients = set()

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -239,6 +239,12 @@ def handle_control_signal(coordinator, sender_identity, payload):
     if transition.new_state is not None:
         coordinator.state = transition.new_state
 
+    if header == Headers.SET_GENERATION_EPOCH:
+        generation_epoch = payload[1]
+        if generation_epoch != coordinator._generation_epoch:
+            coordinator._hash_table.clear()
+            coordinator._generation_epoch = generation_epoch
+
     # Broadcast the control signal. Forward the full deserialized payload so
     # that data-bearing signals (e.g. SET_GENERATION_EPOCH) retain their args.
     coordinator._broadcast_to_engines(payload)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -473,6 +473,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self._pending_signals = deque()
 
         self.resume_request_ids = None
+        self._cuda_graph_rebuild_pending = not self.context.cuda_graphs_available
 
         # Speculative decoding acceptance tracking (per-position).
         # Each tensor has length num_speculative_tokens; index i tracks position i+1
@@ -525,6 +526,9 @@ class DynamicInferenceEngine(AbstractEngine):
 
         context = self.context
         controller = self.controller
+        assert (
+            context.total_request_count == 0 and context.chunked_prefill_request_id == -1
+        ), "CUDA graph capture requires an empty inference context"
 
         time_start = time.time()
         mem_stats_start = torch.cuda.memory_stats()
@@ -629,7 +633,7 @@ class DynamicInferenceEngine(AbstractEngine):
                                 cache_key=("mtp", n, depth),
                             )
 
-                context.reset()
+                context.reset(preserve_prefix_cache=True, preserve_counters=True)
 
             # Per-iteration memory accounting, scoped to the CUDA-graph mempool.
             # This isolates pool growth from process-wide scratch churn (KV cache,
@@ -673,6 +677,16 @@ class DynamicInferenceEngine(AbstractEngine):
         )
 
         self.capture_stats = capture_stats
+        context.cuda_graphs_available = True
+        self._cuda_graph_rebuild_pending = False
+
+    def _can_rebuild_cuda_graphs(self) -> bool:
+        """Return whether dummy graph capture cannot overwrite live request state."""
+        return (
+            self._cuda_graph_rebuild_pending
+            and self.context.total_request_count == 0
+            and self.context.chunked_prefill_request_id == -1
+        )
 
     @internal_api
     async def start_listening_to_data_parallel_coordinator(
@@ -981,6 +995,12 @@ class DynamicInferenceEngine(AbstractEngine):
             and not self.context.static_kv_memory_pointers
         ):
             delete_cuda_graphs()
+            if (
+                self.inference_cuda_graph_scope != InferenceCudaGraphScope.none
+                and self.cuda_graph_impl == "local"
+            ):
+                self.context.cuda_graphs_available = False
+                self._cuda_graph_rebuild_pending = True
 
         # Build the list of requests to re-add on resume.
         # All waiting requests are always included; active requests are included
@@ -1037,6 +1057,7 @@ class DynamicInferenceEngine(AbstractEngine):
             if (
                 self.context.kv_cache_management_mode != KVCacheManagementMode.PERSIST
                 and not self.context.static_kv_memory_pointers
+                and self._can_rebuild_cuda_graphs()
             ):
                 self.create_cuda_graphs()
             capture_time = time.time() - capture_time
@@ -2484,6 +2505,11 @@ class DynamicInferenceEngine(AbstractEngine):
         # If suspended, no stepping.
         if self.state in (EngineState.SUSPENDED, EngineState.SUSPENDING):
             raise EngineSuspendedError(self.context.step_count)
+
+        # OFFLOAD keeps live KV/Mamba state, so dummy graph capture must wait until
+        # those requests drain. Rebuild before admitting the next waiting request.
+        if self._can_rebuild_cuda_graphs():
+            self.create_cuda_graphs()
 
         # Discard registrations left by an interrupted prior step before this
         # step's scheduling queues new registrations.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1800,11 +1800,7 @@ class DynamicInferenceEngine(AbstractEngine):
 
                 if request_id in finished_request_ids:
                     # Reconstruct routing from per-block storage before popping.
-                    if (
-                        finished_routing_block_ids
-                        and request_id in finished_routing_block_ids
-                        and len(self.requests[request_id].record.requests) == 1
-                    ):
+                    if finished_routing_block_ids and request_id in finished_routing_block_ids:
                         block_ids = finished_routing_block_ids[request_id]
                         total_tokens = len(request.prompt_tokens) + len(request.generated_tokens)
                         request.routing_indices = (

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1261,6 +1261,17 @@ class DynamicInferenceEngine(AbstractEngine):
         """
 
         request_id = request.request_id
+        if (
+            self.context.enable_prefix_caching
+            and request.enable_prefix_caching
+            and request.sampling_params.return_log_probs
+            and not request.sampling_params.skip_prompt_log_probs
+        ):
+            # Cached tokens do not retain logits. Compute this request normally so
+            # prompt log probabilities stay complete while other requests can still
+            # use the shared prefix cache.
+            request.enable_prefix_caching = False
+            request.precomputed_block_hashes = []
 
         # Add request to self.requests. If the engine has previously been
         # suspended, then the request may already exist.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -3054,6 +3054,53 @@ class DynamicInferenceEngine(AbstractEngine):
 
         return finished_request_records_list
 
+    @torch.inference_mode()
+    def _set_generation_epoch(self, generation_epoch: int) -> None:
+        """Apply a model-generation epoch received from the inference client."""
+        if generation_epoch == self._generation_epoch:
+            return
+
+        self.context.kv_block_allocator.invalidate_prefix_cache()
+        if self.context.mamba_slot_allocator is not None:
+            self.context.mamba_slot_allocator.invalidate_cache()
+        self.context.dynamo_helper.notify_kv_cache_cleared()
+        self._generation_epoch = generation_epoch
+
+        # RECOMPUTE suspension deletes tensor attributes, and no request owns live
+        # KV in that state. OFFLOAD and PERSIST retain their bookkeeping tensors.
+        if hasattr(self.context, "request_ids"):
+            context_request_ids = set(
+                self.context.request_ids[: self.context.total_request_count].tolist()
+            )
+            if self.context.chunked_prefill_request_id != -1:
+                context_request_ids.add(self.context.chunked_prefill_request_id)
+        else:
+            context_request_ids = set()
+
+        # Stamp all requests with the new epoch. Each field stores a
+        # sparse list of (start_token_index, epoch) boundaries.
+        for request_id, entry in self.requests.items():
+            request = entry.record[-1]
+            owns_live_kv = request_id in context_request_ids
+            if owns_live_kv and request.enable_prefix_caching:
+                # This request may still own KV computed by the prior model.
+                # Let it finish, but do not publish any more of its blocks for
+                # reuse by requests that start in the new epoch.
+                request.enable_prefix_caching = False
+                request.precomputed_block_hashes = []
+            total = len(request.prompt_tokens) + len(request.generated_tokens)
+            if total > 0:
+                boundary = (total - 1, generation_epoch)
+                never_started = not owns_live_kv and len(entry.record.requests) == 1
+                if request.policy_epoch is None or never_started:
+                    request.policy_epoch = [(0, generation_epoch)]
+                else:
+                    request.policy_epoch.append(boundary)
+                if request.kv_cache_epoch is None or not owns_live_kv:
+                    request.kv_cache_epoch = [(0, generation_epoch)]
+                else:
+                    request.kv_cache_epoch.append(boundary)
+
     def schedule_requests(self) -> int:
         """Drains the ZMQ socket for a batch of requests and adds them to the engine.
 
@@ -3204,22 +3251,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self._poll_pending_kv_pushes()
 
         if new_generation_epoch is not None:
-            self._generation_epoch = new_generation_epoch
-            # Stamp all active requests with the new epoch.
-            # Each field stores a sparse list of (start_token_index, epoch) boundaries.
-            for entry in self.requests.values():
-                request = entry.record[-1]
-                total = len(request.prompt_tokens) + len(request.generated_tokens)
-                if total > 0:
-                    boundary = (total - 1, new_generation_epoch)
-                    if request.policy_epoch is None:
-                        request.policy_epoch = [(0, new_generation_epoch)]
-                    else:
-                        request.policy_epoch.append(boundary)
-                    if request.kv_cache_epoch is None:
-                        request.kv_cache_epoch = [(0, new_generation_epoch)]
-                    else:
-                        request.kv_cache_epoch.append(boundary)
+            self._set_generation_epoch(new_generation_epoch)
 
         # Second pass: apply at most one control signal (the engine loop
         # processes one state transition per iteration).

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -887,10 +887,10 @@ class DynamicInferenceRequestRecord:
         """
 
         def merge_lists(key):
-            if getattr(self.requests[0], key) is None:
+            values = [getattr(request, key) for request in self.requests]
+            if all(value is None for value in values):
                 return None
-            else:
-                return [v for r in self.requests for v in getattr(r, key)]
+            return [item for value in values if value is not None for item in value]
 
         prompt_tokens = self.requests[0].prompt_tokens
         prompt_text = self.requests[0].prompt

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -950,7 +950,7 @@ try:
 
             logprobs_content = None
             if sampling_params.return_log_probs:
-                token_logprobs = result.get('log_probs', [])
+                token_logprobs = result.get("generated_log_probs") or []
 
                 tokens_to_decode = [[tok] for tok in result["generated_tokens"]]
                 tokens = list(map(tokenizer.detokenize, tokens_to_decode))

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import time
+import weakref
 from collections import defaultdict
 from contextlib import nullcontext
 from copy import deepcopy
@@ -769,6 +770,9 @@ def delete_cuda_graphs():
     _CudagraphGlobalRecord.cudagraph_record = []
     _CudagraphGlobalRecord.cudagraph_inference_record = []
     _GTP_RUNNER_STREAMS.clear()
+    for manager in list(CudaGraphManager._instances):
+        manager.cudagraph_runners.clear()
+        manager.custom_cudagraphs_lookup_table.clear()
 
     # TODO: Optional?: Force garbage collection to clean up memory
     gc.collect()
@@ -1879,6 +1883,17 @@ class CudaGraphManager(torch.nn.Module):
 
     """A global mempool for when 'cuda_graph_use_single_mempool' is used."""
     global_mempool = None
+    _instances = weakref.WeakSet()
+
+    @classmethod
+    def _ensure_global_mempool(cls):
+        if cls.global_mempool is None:
+            cls.global_mempool = torch.cuda.graph_pool_handle()
+            if HAVE_GTP:
+                set_cuda_graph_mempool(torch.cuda.current_device(), cls.global_mempool)
+            # Capture requires no prior work on the default stream.
+            torch.cuda.set_stream(torch.cuda.Stream())
+        return cls.global_mempool
 
     def __init__(
         self,
@@ -1943,20 +1958,13 @@ class CudaGraphManager(torch.nn.Module):
         self.cudagraph_runners: list[_CudaGraphRunner] = []
         self.custom_cudagraphs_lookup_table: dict = defaultdict(lambda: None)
         self.is_first_microbatch = False
+        self._instances.add(self)
 
         # Without pipeline parallelism, microbatches execute one at a time.
         # Therefore modules will always execute in the same order, so cudagraphs
         # can both be reused and share a single mempool.
         self.reuse_cudagraphs = self.pg_collection.pp.size() == 1
-        if CudaGraphManager.global_mempool is None:
-            CudaGraphManager.global_mempool = torch.cuda.graph_pool_handle()
-            # Register the pool so GTP allocates GRAPHED-chain buffers + quantized
-            # storage directly into it (created before the first graphed forward).
-            if HAVE_GTP:
-                set_cuda_graph_mempool(torch.cuda.current_device(), CudaGraphManager.global_mempool)
-            # Cudagraph stream capture requires no operations on the default stream prior to the
-            # capture, so change to a side stream.
-            torch.cuda.set_stream(torch.cuda.Stream())
+        self._ensure_global_mempool()
 
         # Enable one hook for the eager recording phase. Repeated manager construction is
         # idempotent, and graph creation removes the hook before capture begins.
@@ -1985,6 +1993,7 @@ class CudaGraphManager(torch.nn.Module):
         length of 'self.cudagraph_runners'.
         Otherwise, we assign a mempool per microbatch, which allows cudagraphs to be reused
         over different microbatches by tracking their respective fwd and bwd passes.'''
+        mempool = self._ensure_global_mempool()
         if reuse_cudagraphs:
             if cache_key is not None:
                 runner = self.custom_cudagraphs_lookup_table[cache_key]
@@ -2014,12 +2023,7 @@ class CudaGraphManager(torch.nn.Module):
                     )
                 else:
                     runner = _CudaGraphRunner(
-                        megatron_module,
-                        CudaGraphManager.global_mempool,
-                        args,
-                        kwargs,
-                        self.func,
-                        self.need_backward,
+                        megatron_module, mempool, args, kwargs, self.func, self.need_backward
                     )
                     if self._num_warmup_steps is not None:
                         runner.num_warmup_steps = self._num_warmup_steps
@@ -2034,12 +2038,7 @@ class CudaGraphManager(torch.nn.Module):
                 self.cudagraph_runners = self.cudagraph_runners[1:] + self.cudagraph_runners[:1]
             else:
                 runner = _CudaGraphRunner(
-                    megatron_module,
-                    CudaGraphManager.global_mempool,
-                    args,
-                    kwargs,
-                    self.func,
-                    self.need_backward,
+                    megatron_module, mempool, args, kwargs, self.func, self.need_backward
                 )
                 self.cudagraph_runners.append(runner)
 
@@ -2059,6 +2058,15 @@ class CudaGraphManager(torch.nn.Module):
                 If `inference_context` is provided, this gets set to the correct value.
         """
         is_inference_mode = 'inference_context' in kwargs.keys() and kwargs['inference_context']
+        if is_inference_mode:
+            inference_context = kwargs['inference_context']
+            if (
+                not inference_context.cuda_graphs_available
+                and not inference_context.is_creating_cuda_graphs
+            ):
+                if self.func is not None:
+                    return self.func(*args, **kwargs)
+                return super(MegatronModule, megatron_module).__call__(*args, **kwargs)
         if cache_key is None and is_inference_mode:
             inference_context = kwargs['inference_context']
             if inference_context.is_static_batching():

--- a/megatron/rl/inference/megatron.py
+++ b/megatron/rl/inference/megatron.py
@@ -57,10 +57,11 @@ class MegatronLocal(InferenceServer, ReturnsTokens, ReturnsRaw):
         # Things that may be problematic when doing this switch
         # - Add BOS token
         # - Skip prompt logprobs
+        temperature = request.generation_args.temperature
         response = await client.chat.completions.create(
             model="",
             messages=[message.model_dump() for message in request.prompt],
-            temperature=request.generation_args.temperature or 1.0,
+            temperature=1.0 if temperature is None else temperature,
             top_p=request.generation_args.top_p or 0.0,
             n=1,
             logprobs=True,

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -2027,6 +2027,121 @@ class TestPerBlockRouting(PrefixCachingTestBase):
         assert np.allclose(alloc.get_block_routing(b1), routing_b1)
 
 
+class TestPrefixCachePromptLogprobs(PrefixCachingTestBase):
+    """Focused real-engine prompt-logprob coverage."""
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_prompt_logprobs_bypass_prefix_cache(self):
+        block_size = 256
+        prompt_length = 2 * block_size + 5
+        generated_length = 4
+
+        def run_request(enable_prefix_caching):
+            config = DynamicEngineTestConfig(
+                num_requests=0,
+                min_prompt_length=prompt_length,
+                max_prompt_length=prompt_length,
+                num_tokens_to_generate=generated_length,
+                max_sequence_length=prompt_length + generated_length + 4,
+                context_buffer_size_gb=0.02,
+                context_block_size_tokens=block_size,
+                context_max_requests=32,
+                context_max_tokens=4096,
+                model_provider="gpt",
+                enable_prefix_caching=enable_prefix_caching,
+                materialize_only_last_token_logits=False,
+            )
+            engine = DynamicInferenceEngineTestBase._build_test_env(config).engine
+            engine.controller.tokenizer = SimpleNamespace(
+                vocab_size=config.vocab_size,
+                eod=-1,
+                detokenize=lambda tokens: "".join(f"{token} " for token in tokens),
+            )
+            prompt = torch.arange(prompt_length, device=torch.cuda.current_device()) % (
+                config.vocab_size - 1
+            )
+
+            donor = DynamicInferenceRequest(
+                request_id=100,
+                prompt_tokens=prompt.clone(),
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=8, termination_id=-1, top_k=1
+                ),
+                block_size_tokens=block_size,
+                enable_prefix_caching=enable_prefix_caching,
+            )
+            engine._add_request(donor)
+            engine.step_modern()
+            if enable_prefix_caching:
+                assert donor.precomputed_block_hashes
+                assert set(donor.precomputed_block_hashes) <= (
+                    engine.context.kv_block_allocator.kv_hash_to_block_id.keys()
+                )
+
+            request = DynamicInferenceRequest(
+                request_id=101,
+                prompt_tokens=prompt,
+                sampling_params=SamplingParams(
+                    num_tokens_to_generate=generated_length,
+                    termination_id=-1,
+                    top_k=1,
+                    return_log_probs=True,
+                    skip_prompt_log_probs=False,
+                    top_n_logprobs=5,
+                ),
+                block_size_tokens=block_size,
+                enable_prefix_caching=enable_prefix_caching,
+            )
+            if enable_prefix_caching:
+                assert request.precomputed_block_hashes
+            hits_before = engine._prefix_cache_hits
+            engine._add_request(request)
+            assert not request.enable_prefix_caching
+            assert request.precomputed_block_hashes == []
+
+            output = None
+            for _ in range(32):
+                result = engine.step_modern()
+                for record in result["finished_request_records"]:
+                    merged = record.merge()
+                    if merged.request_id == request.request_id:
+                        output = merged
+                if output is not None:
+                    break
+
+            assert output is not None, "prompt-logprob request did not finish"
+            assert engine._prefix_cache_hits == hits_before
+            assert output.num_cached_tokens == 0
+            assert len(output.prompt_log_probs) == prompt_length - 1
+            return output
+
+        cached = run_request(enable_prefix_caching=True)
+        baseline = run_request(enable_prefix_caching=False)
+        assert cached.generated_tokens == baseline.generated_tokens
+        assert (
+            len(cached.generated_log_probs) == len(baseline.generated_log_probs) == generated_length
+        )
+        np.testing.assert_allclose(
+            cached.prompt_log_probs, baseline.prompt_log_probs, atol=1e-5, rtol=0
+        )
+        np.testing.assert_allclose(
+            cached.generated_log_probs, baseline.generated_log_probs, atol=1e-5, rtol=0
+        )
+
+        for cached_values, baseline_values, expected_length in (
+            (cached.prompt_top_n_logprobs, baseline.prompt_top_n_logprobs, prompt_length - 1),
+            (cached.generated_top_n_logprobs, baseline.generated_top_n_logprobs, generated_length),
+        ):
+            assert cached_values is not None and baseline_values is not None
+            assert len(cached_values) == len(baseline_values) == expected_length
+            for cached_top_n, baseline_top_n in zip(cached_values, baseline_values):
+                assert tuple(cached_top_n) == tuple(baseline_top_n)
+                np.testing.assert_allclose(
+                    list(cached_top_n.values()), list(baseline_top_n.values()), atol=1e-5, rtol=0
+                )
+
+
 class TestPrefixCacheReuse(PrefixCachingTestBase):
     """Cross-request prefix reuse on hybrid (Mamba) models:
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -5,6 +5,7 @@ import gc
 from collections import deque
 from types import SimpleNamespace
 
+import msgpack
 import numpy as np
 import pytest
 import torch
@@ -12,6 +13,7 @@ import torch
 from megatron.core.inference.config import (
     InferenceConfig,
     KVCacheManagementMode,
+    PrefixCachingCoordinatorPolicy,
     PrefixCachingEvictionPolicy,
 )
 from megatron.core.inference.contexts.dynamic_context import (
@@ -22,10 +24,18 @@ from megatron.core.inference.contexts.mamba_slot_allocator import (
     MambaSlotAllocator,
     MambaSlotCapacityError,
 )
+from megatron.core.inference.data_parallel_inference_coordinator.coordinator import (
+    DataParallelInferenceCoordinator,
+)
+from megatron.core.inference.data_parallel_inference_coordinator.handlers import (
+    handle_control_signal,
+)
+from megatron.core.inference.data_parallel_inference_coordinator.state import CoordinatorState
 from megatron.core.inference.disaggregation.inference_state_handoff import (
     InferenceStateHandoffMixin,
 )
 from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+from megatron.core.inference.headers import Headers
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
     DynamicInferenceRequestRecord,
@@ -182,12 +192,22 @@ class PrefixCachingTestBase:
 
 class _StubEngine(DynamicInferenceEngine):
 
+    @staticmethod
+    def _close_notification(_callback, coroutine):
+        coroutine.close()
+
     def __init__(self, context: DynamicInferenceContext, *, enable_chunked_prefill=False):
         self.context = context
+        self.controller = SimpleNamespace(tokenizer=SimpleNamespace(eod=0))
+        self.rank = 0
+        self.materialize_only_last_token_logits = False
         self.enable_chunked_prefill = enable_chunked_prefill
         self.cuda_graph_all_prefills = False
         self._prefix_coordination_waits = 0
         self._loop = asyncio.new_event_loop()
+        # This synchronous stub never runs its event loop, so consume scheduler
+        # notification coroutines instead of leaving them queued at teardown.
+        self._loop.call_soon_threadsafe = self._close_notification
         self.waiting_request_ids: deque = deque()
         self.requests = {}
         self._generation_epoch = None
@@ -761,6 +781,281 @@ class TestDisabledAndEngineScheduling(PrefixCachingTestBase):
         req.status = Status.ACTIVE_AND_GENERATING_TOKENS
         req.sampling_params.num_tokens_to_generate = 10
         engine.waiting_request_ids.append(request_id)
+
+    @pytest.mark.internal
+    def test_generation_epoch_invalidates_coordinator_prefix_assignments(self):
+        def serialized_epoch_payload(epoch):
+            wire_payload = msgpack.packb(
+                [Headers.SET_GENERATION_EPOCH.value, epoch], use_bin_type=True
+            )
+            return msgpack.unpackb(wire_payload, raw=False)
+
+        client = b"client"
+        ranks = [f"rank-{index}".encode() for index in range(4)]
+        broadcasts = []
+        coordinator = DataParallelInferenceCoordinator.__new__(DataParallelInferenceCoordinator)
+        coordinator.known_clients = {client}
+        coordinator.state = CoordinatorState.RUNNING
+        coordinator._generation_epoch = None
+        coordinator._identities_list = ranks
+        coordinator.identity_to_rank_index = {rank: index for index, rank in enumerate(ranks)}
+        coordinator._pending_counts = np.zeros(len(ranks), dtype=np.int32)
+        coordinator.max_requests = 16
+        coordinator.enable_prefix_caching = True
+        coordinator.prefix_caching_coordinator_policy = (
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX
+        )
+        coordinator.prefix_caching_routing_alpha = 0.5
+        coordinator._hash_table = {}
+        coordinator._hash_assignment_counter = 0
+        coordinator._broadcast_to_engines = broadcasts.append
+
+        owners = []
+        for group in range(8):
+            hashes = [100 + 2 * group, 101 + 2 * group]
+            owner = coordinator.get_best_data_parallel_rank(hashes)
+            coordinator._update_rank_hashes(owner, hashes)
+            coordinator._pending_counts[coordinator.identity_to_rank_index[owner]] += 1
+            assert coordinator.get_best_data_parallel_rank(hashes) == owner
+            owners.append(owner)
+        assert set(owners) == set(ranks)
+        assert len(coordinator._hash_table) == 16
+
+        epoch_one = serialized_epoch_payload(1)
+        handle_control_signal(coordinator, client, epoch_one)
+        assert coordinator._hash_table == {}
+        coordinator._update_rank_hashes(ranks[-1], [999])
+        handle_control_signal(coordinator, client, serialized_epoch_payload(1))
+        assert coordinator._hash_table == {999: {3: coordinator._hash_assignment_counter}}
+        epoch_two = serialized_epoch_payload(2)
+        handle_control_signal(coordinator, client, epoch_two)
+        assert coordinator._hash_table == {}
+        assert broadcasts == [epoch_one, epoch_one, epoch_two]
+
+    @pytest.mark.internal
+    def test_epoch_change_keeps_unstarted_requests_cacheable(self):
+        ctx = self._ctx()
+        alloc = ctx.kv_block_allocator
+        seed = self._req(ctx, self._prompt(ctx.block_size_tokens), request_id=99)
+        ctx.add_request(seed)
+        seed_hash = seed.precomputed_block_hashes[0]
+        ctx.release_memory_blocks_from_request_indexes(torch.tensor([0]))
+        ctx.reset_metadata(preserve_prefix_cache=True)
+        assert seed_hash in alloc.kv_hash_to_block_id
+
+        engine = self._engine(ctx)
+        before = self._req(ctx, self._prompt(ctx.block_size_tokens), request_id=1)
+        before_hashes = list(before.precomputed_block_hashes)
+        engine._add_request(before)
+
+        engine._set_generation_epoch(1)
+
+        assert seed_hash not in alloc.kv_hash_to_block_id
+        assert before.enable_prefix_caching
+        assert before.precomputed_block_hashes == before_hashes
+        assert before.policy_epoch == [(0, 1)]
+        assert before.kv_cache_epoch == [(0, 1)]
+
+        after = self._req(ctx, before.prompt_tokens.clone(), request_id=2)
+        engine._add_request(after)
+        assert after.enable_prefix_caching
+        assert after.policy_epoch == [(0, 1)]
+        assert after.kv_cache_epoch == [(0, 1)]
+
+        engine._set_generation_epoch(1)
+        assert before.policy_epoch == after.policy_epoch == [(0, 1)]
+        assert before.kv_cache_epoch == after.kv_cache_epoch == [(0, 1)]
+        engine.schedule_non_chunked_prefill()
+        assert ctx.total_request_count == 1 and list(engine.waiting_request_ids) == [2]
+        engine.schedule_non_chunked_prefill()
+        assert ctx.total_request_count == 2
+        assert after.num_cached_tokens == ctx.block_size_tokens
+
+    @pytest.mark.internal
+    def test_epoch_change_disables_hidden_chunked_prefill_cache_publication(self):
+        ctx = self._ctx(
+            block_size_tokens=256,
+            max_sequence_length=1024,
+            max_tokens=256,
+            max_requests=4,
+            mamba_config=self._mamba_config(),
+            prefix_caching_mamba_gb=0.01,
+        )
+        engine = self._engine(ctx, enable_chunked_prefill=True)
+        request = self._req(ctx, self._prompt(512))
+        self._add_to_waiting(engine, ctx, request)
+
+        engine.schedule_chunked_prefill()
+        assert request.finished_chunk_token_count == 256
+        assert ctx.chunked_prefill_request_id == request.request_id
+        block_id = self._block_ids(ctx, 0, 1)[0]
+        self._mamba_allocate_and_register(ctx, [block_id])
+
+        # update_requests() hides an in-progress chunk at this boundary while
+        # retaining its KV and Mamba state for the next prefill chunk.
+        ctx.total_request_count = 0
+        ctx.active_token_count = 0
+        engine._set_generation_epoch(1)
+
+        assert not request.enable_prefix_caching
+        assert request.precomputed_block_hashes == []
+        assert not ctx.kv_block_allocator.kv_hash_to_block_id
+        assert not ctx.mamba_slot_allocator.hash_to_block_id
+
+        engine.schedule_chunked_prefill()
+        assert ctx.chunked_prefill_request_id == -1
+        assert len(request.remaining_prompt_tokens) == 0
+        assert not ctx.kv_block_allocator.kv_hash_to_block_id
+        assert not ctx.mamba_slot_allocator.hash_to_block_id
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("hybrid", [False, True], ids=["gpt", "hybrid"])
+    def test_epoch_change_invalidates_inference_tensors_outside_inference_mode(self, hybrid):
+        with torch.inference_mode():
+            ctx = self._ctx(
+                max_tokens=128,
+                max_requests=4,
+                mamba_config=self._mamba_config() if hybrid else None,
+                prefix_caching_mamba_gb=0.01 if hybrid else None,
+            )
+            alloc = ctx.kv_block_allocator
+            engine = self._engine(ctx)
+            request = self._req(ctx, self._prompt(ctx.block_size_tokens))
+            ctx.add_request(request)
+            (block_id,) = self._block_ids(ctx, 0, 1)
+            block_hash = request.precomputed_block_hashes[0]
+            if hybrid:
+                mamba = ctx.mamba_slot_allocator
+                (slot,) = self._mamba_allocate_and_register(ctx, [block_id])
+                mamba._intermediate_offsets_cpu[0, 0] = 1
+                mamba._intermediate_counts_cpu[0] = 1
+                mamba._intermediate_block_ids_cpu[0, 0] = block_id
+                mamba._eos_cache_block_id_cpu[0] = block_id
+                mamba._has_intermediates = True
+            ctx.release_memory_blocks_from_request_indexes(torch.tensor([0]))
+            pool_avail_before = alloc.pool_avail
+            assert alloc.block_bag.is_inference()
+            if hybrid:
+                assert mamba.block_to_slot.is_inference()
+                assert mamba.free_count == mamba.max_slots - 1
+
+        assert not torch.is_inference_mode_enabled()
+        engine._set_generation_epoch(1)
+
+        assert block_hash not in alloc.kv_hash_to_block_id
+        assert alloc.block_hashes[block_id].item() == -1
+        assert alloc.pool_avail == pool_avail_before + 1
+        if hybrid:
+            assert mamba.free_count == mamba.max_slots
+            assert not mamba.hash_to_block_id
+            assert mamba.block_to_slot[block_id].item() == -1
+            assert mamba.slot_to_block[slot].item() == -1
+            assert mamba._intermediate_offsets_cpu.count_nonzero().item() == 0
+            assert mamba._intermediate_counts_cpu.count_nonzero().item() == 0
+            assert torch.all(mamba._intermediate_block_ids_cpu == -1)
+            assert torch.all(mamba._eos_cache_block_id_cpu == -1)
+            assert not mamba._has_intermediates
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("hybrid", [False, True], ids=["gpt", "hybrid"])
+    @pytest.mark.parametrize(
+        "policy",
+        [PrefixCachingEvictionPolicy.LRU, PrefixCachingEvictionPolicy.REF_ZERO],
+        ids=["lru", "ref-zero"],
+    )
+    def test_epoch_change_invalidates_cache_without_disrupting_live_request(self, hybrid, policy):
+        ctx = self._ctx(
+            max_tokens=256,
+            max_requests=8,
+            mamba_config=self._mamba_config() if hybrid else None,
+            prefix_caching_mamba_gb=0.01 if hybrid else None,
+            prefix_caching_eviction_policy=policy,
+        )
+        alloc = ctx.kv_block_allocator
+        engine = self._engine(ctx)
+        bs = ctx.block_size_tokens
+
+        live = self._req(ctx, self._prompt(2 * bs), request_id=1)
+        ctx.add_request(live)
+        self._add_to_waiting(engine, ctx, live)
+        live_blocks = self._block_ids(ctx, 0, 2)
+        live_hashes = set(live.precomputed_block_hashes)
+
+        cached = self._req(ctx, self._prompt(bs, offset=10_000), request_id=2)
+        ctx.add_request(cached)
+        (cached_block,) = self._block_ids(ctx, 1, 1)
+        cached_hash = cached.precomputed_block_hashes[0]
+        ctx.release_memory_blocks_from_request_indexes(torch.tensor([1]))
+        assert alloc.block_ref_counts[cached_block].item() == 0
+        if policy == PrefixCachingEvictionPolicy.LRU:
+            assert alloc.kv_hash_to_block_id[cached_hash] == cached_block
+        else:
+            assert cached_hash not in alloc.kv_hash_to_block_id
+            assert alloc.block_hashes[cached_block].item() == -1
+
+        routing = np.ones((bs, 1, 1), dtype=np.int64)
+        alloc.block_routing[live_blocks[0]] = routing.copy()
+        if policy == PrefixCachingEvictionPolicy.LRU:
+            alloc.block_routing[cached_block] = routing.copy()
+        pool_avail_before = alloc.pool_avail
+        if hybrid:
+            mamba_alloc = ctx.mamba_slot_allocator
+            assert mamba_alloc._has_intermediates
+            free_slots = mamba_alloc.free_slots
+            assert not free_slots.is_inference()
+
+        dynamo_events = []
+
+        def _record_dynamo_event(kind, payload):
+            dynamo_events.append((kind, payload, dict(alloc.kv_hash_to_block_id)))
+
+        ctx.dynamo_helper.add_kv_event_listener(_record_dynamo_event)
+        ctx.dynamo_helper.queue_kv_stored_event({"block_hashes": list(live_hashes)})
+
+        engine._set_generation_epoch(1)
+
+        assert [kind for kind, _, _ in dynamo_events] == ["removed", "cleared"]
+        expected_removed_hashes = live_hashes | (
+            {cached_hash} if policy == PrefixCachingEvictionPolicy.LRU else set()
+        )
+        assert set(dynamo_events[0][1]["block_hashes"]) == expected_removed_hashes
+        assert dynamo_events[1][:2] == ("cleared", {})
+        assert all(discoverable == {} for _, _, discoverable in dynamo_events)
+        events_after_change = list(dynamo_events)
+        engine._set_generation_epoch(1)
+        ctx.dynamo_helper.publish_pending_kv_stored_events()
+        assert dynamo_events == events_after_change
+
+        assert live.enable_prefix_caching is False
+        assert live.precomputed_block_hashes == []
+        assert live.kv_cache_epoch == [(0, 1)]
+        assert live_hashes.isdisjoint(alloc.kv_hash_to_block_id)
+        assert cached_hash not in alloc.kv_hash_to_block_id
+        assert all(alloc.block_hashes[block_id].item() == -1 for block_id in live_blocks)
+        assert all(alloc.block_ref_counts[block_id].item() == 1 for block_id in live_blocks)
+        expected_reclaimed = int(policy == PrefixCachingEvictionPolicy.LRU)
+        assert alloc.pool_avail == pool_avail_before + expected_reclaimed
+        assert live_blocks[0] in alloc.block_routing
+        assert cached_block not in alloc.block_routing
+        replacement = alloc.allocate_memory_blocks(1)
+        assert replacement is not None and replacement.item() == cached_block
+
+        if hybrid:
+            assert mamba_alloc.free_slots is free_slots
+            assert not mamba_alloc.free_slots.is_inference()
+            assert not mamba_alloc._has_intermediates
+            assert mamba_alloc.free_count == mamba_alloc.max_slots
+            (slot,) = mamba_alloc.allocate_slots_batch(replacement.tolist())
+            mamba_alloc.invalidate_block(replacement.item())
+            assert mamba_alloc.free_slots[-1].item() == slot
+            durable_free_before = mamba_alloc.free_count
+            uncacheable = self._req(
+                ctx, self._prompt(2 * bs, offset=20_000), request_id=3, enable_prefix_caching=False
+            )
+            ctx.add_request(uncacheable)
+            assert not mamba_alloc._has_intermediates
+            mamba_alloc.commit_intermediate_states()
+            assert mamba_alloc.free_count == durable_free_before
 
     @pytest.mark.internal
     def test_disabled_mode(self):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -123,11 +123,15 @@ class PrefixCachingTestBase:
         )
 
     @staticmethod
-    def _req(ctx, prompt_tokens, request_id=1, *, enable_prefix_caching=True):
+    def _req(ctx, prompt_tokens, request_id=1, *, enable_prefix_caching=True, sampling_params=None):
         return DynamicInferenceRequest(
             request_id=request_id,
             prompt_tokens=prompt_tokens,
-            sampling_params=SamplingParams(num_tokens_to_generate=10),
+            sampling_params=(
+                sampling_params
+                if sampling_params is not None
+                else SamplingParams(num_tokens_to_generate=10)
+            ),
             block_size_tokens=ctx.block_size_tokens,
             enable_prefix_caching=enable_prefix_caching,
         )
@@ -1738,6 +1742,78 @@ class TestMambaSlotAllocator(PrefixCachingTestBase):
 
 class TestPerBlockRouting(PrefixCachingTestBase):
     """Tests for per-block routing storage and reconstruction."""
+
+    @pytest.mark.internal
+    def test_finished_checkpointed_request_reconstructs_full_routing(self):
+        ctx = self._ctx()
+        bs = ctx.block_size_tokens
+        generated = [bs + 1, bs + 2, bs + 3, bs + 4]
+        prompt = self._prompt(2 * bs)
+        producer = self._req(ctx, prompt.clone(), request_id=99)
+        ctx.add_request(producer)
+        ctx.release_memory_blocks_from_request_indexes(torch.tensor([0]))
+        request = self._req(
+            ctx,
+            prompt,
+            request_id=0,
+            sampling_params=SamplingParams(
+                num_tokens_to_generate=4,
+                termination_id=-1,
+                return_log_probs=True,
+                skip_prompt_log_probs=True,
+            ),
+        )
+        ctx.add_request(request)
+        assert request.num_cached_tokens == 2 * bs
+        engine = _StubEngine(ctx)
+        future = engine._add_request(request)
+        engine.waiting_request_ids.clear()
+        record = engine.requests[request.request_id].record
+        record.checkpoint()
+        current = record[-1]
+        current.generated_tokens = generated[:3]
+        current.generated_log_probs = [-0.1, -0.2, -0.3]
+        assert len(record.requests) == 2
+        assert all(part.routing_indices is None for part in record.requests)
+
+        block_ids = self._block_ids(ctx, 1, 2)
+        block_ids += ctx.kv_block_allocator.allocate_memory_blocks(1).tolist()
+        routing = np.arange(3 * bs * 4, dtype=np.int16).reshape(3 * bs, 2, 2)
+        for block_idx, block_id in enumerate(block_ids):
+            start = block_idx * bs
+            ctx.kv_block_allocator.store_block_routing(
+                block_id, np.arange(bs), routing[start : start + bs]
+            )
+
+        engine.finished_request_count = 0
+        engine.evicted_request_count = 0
+        engine.track_generated_token_events = False
+        engine.num_speculative_tokens = 0
+        engine.stop_word_being_finished_ids = set()
+        active_ids, finished_records = engine.post_process_requests(
+            request_ids=torch.tensor([request.request_id]),
+            finished_request_ids=torch.tensor([request.request_id]),
+            evict_request_ids=torch.empty(0, dtype=torch.int64),
+            step_time=0.0,
+            sample=torch.tensor(generated[3:]),
+            accepted_tokens=None,
+            log_probs=[[-0.4]],
+            consumed_chunked_prefill_request_id=-1,
+            finished_routing_block_ids={request.request_id: block_ids},
+        )
+
+        expected = routing[: 2 * bs + 3]
+        merged = record.merge()
+        assert active_ids == []
+        assert finished_records == [record]
+        assert future.result() is record
+        assert merged.generated_tokens == generated
+        assert merged.generated_log_probs == [-0.1, -0.2, -0.3, -0.4]
+        np.testing.assert_array_equal(current.routing_indices, expected)
+        np.testing.assert_array_equal(merged.routing_indices, expected)
+        assert merged.routing_indices.shape[0] == (
+            len(merged.prompt_tokens) + len(merged.generated_tokens) - 1
+        )
 
     @pytest.mark.internal
     def test_store_and_get_block_routing(self):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -9,7 +9,10 @@ import pytest
 import torch
 
 from megatron.core.inference.config import InferenceConfig, PrefixCachingEvictionPolicy
-from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.contexts.dynamic_context import (
+    BlockOverflowError,
+    DynamicInferenceContext,
+)
 from megatron.core.inference.contexts.mamba_slot_allocator import (
     MambaSlotAllocator,
     MambaSlotCapacityError,
@@ -538,6 +541,53 @@ class TestPrefixCachingCore(PrefixCachingTestBase):
         assert alloc.block_parent_id[s1].item() == s0
         assert alloc.block_parent_id[sx].item() == s1
         assert alloc.kv_hash_to_block_id[h1] == s1
+
+    @pytest.mark.internal
+    def test_failed_partial_hit_admission_rolls_back_and_retries(self):
+        """A failed allocation must not pin or double-count a matched prefix."""
+        ctx = self._ctx()
+        alloc = ctx.kv_block_allocator
+        bs = ctx.block_size_tokens
+
+        producer = self._req(ctx, self._prompt(2 * bs))
+        ctx.add_request(producer)
+        matched_blocks = self._block_ids(ctx, 0, 2)
+        matched_hashes = list(producer.precomputed_block_hashes)
+        ctx.release_memory_blocks_from_request_indexes(torch.tensor([0]))
+        ctx.total_request_count = 0
+
+        # Keep every raw pool block in use. The only allocatable blocks are the
+        # two cached matches, which the follower pins before requesting its tail.
+        drained = alloc.allocate_memory_blocks(alloc.pool_avail)
+        assert drained is not None
+        assert alloc.pool_avail == 0
+        assert int(alloc.get_evictable_block_count()) == 2
+
+        follower = self._req(ctx, self._prompt(3 * bs), request_id=2)
+        hits_before = ctx.prefix_cache_hits
+        blocks_before = ctx.prefix_cache_blocks_matched
+        with pytest.raises(BlockOverflowError):
+            ctx.add_request(follower)
+
+        assert ctx.total_request_count == 0
+        assert follower.num_cached_tokens == 0
+        assert ctx.prefix_cache_hits == hits_before
+        assert ctx.prefix_cache_blocks_matched == blocks_before
+        assert [alloc.block_ref_counts[block].item() for block in matched_blocks] == [0, 0]
+        assert all(
+            alloc.kv_hash_to_block_id[hash_] == block
+            for hash_, block in zip(matched_hashes, matched_blocks)
+        )
+
+        # Releasing one unregistered block makes the retry succeed. The prefix
+        # is counted once, and the cached blocks stay shared rather than evicted.
+        alloc.release_memory_blocks(drained[:1])
+        ctx.add_request(follower)
+        assert follower.num_cached_tokens == 2 * bs
+        assert ctx.prefix_cache_hits == hits_before + 1
+        assert ctx.prefix_cache_blocks_matched == blocks_before + 2
+        assert self._block_ids(ctx, 0, 2) == matched_blocks
+        assert len(set(self._block_ids(ctx, 0, 3))) == 3
 
     @pytest.mark.internal
     def test_check_availability_excludes_already_pinned_matches(self):

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -9,7 +9,11 @@ import numpy as np
 import pytest
 import torch
 
-from megatron.core.inference.config import InferenceConfig, PrefixCachingEvictionPolicy
+from megatron.core.inference.config import (
+    InferenceConfig,
+    KVCacheManagementMode,
+    PrefixCachingEvictionPolicy,
+)
 from megatron.core.inference.contexts.dynamic_context import (
     BlockOverflowError,
     DynamicInferenceContext,
@@ -31,7 +35,8 @@ from megatron.core.inference.inference_request import (
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.ssm.mamba_mixer import _check_mamba_sequence_packing_support
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.cuda_graphs import CudaGraphManager, delete_cuda_graphs
+from megatron.core.transformer.enums import AttnBackend, InferenceCudaGraphScope
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.inference.engines.test_dynamic_engine import (
     DynamicEngineTestConfig,
@@ -2421,6 +2426,11 @@ class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
             model_config=transformer_config,
             inference_config=InferenceConfig(
                 max_sequence_length=test_config.max_sequence_length,
+                num_cuda_graphs=test_config.num_cuda_graphs,
+                use_cuda_graphs_for_non_decode_steps=(
+                    test_config.use_cuda_graphs_for_non_decode_steps
+                ),
+                cuda_graph_all_prefills=test_config.cuda_graph_all_prefills,
                 buffer_size_gb=test_config.context_buffer_size_gb,
                 paused_buffer_size_gb=test_config.context_paused_buffer_size_gb,
                 block_size_tokens=test_config.context_block_size_tokens,
@@ -2428,6 +2438,11 @@ class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
                 max_tokens=test_config.context_max_tokens,
                 mamba_inference_state_config=mamba_inference_state_config,
                 materialize_only_last_token_logits=(test_config.materialize_only_last_token_logits),
+                kv_cache_management_mode=KVCacheManagementMode(
+                    test_config.kv_cache_management_mode
+                ),
+                static_kv_memory_pointers=test_config.static_kv_memory_pointers,
+                unified_memory_level=test_config.unified_memory_level,
                 enable_chunked_prefill=test_config.enable_chunked_prefill,
                 enable_prefix_caching=test_config.enable_prefix_caching,
                 prefix_caching_eviction_policy=test_config.prefix_caching_eviction_policy,
@@ -2439,6 +2454,7 @@ class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
                 ),
                 use_flashinfer_fused_rope=test_config.use_flashinfer_fused_rope,
                 num_speculative_tokens=test_config.num_speculative_tokens,
+                async_sched_mode=test_config.async_sched_mode,
                 sampling_backend="torch",
             ),
         )
@@ -2859,6 +2875,7 @@ class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
     def _clear_engine_runtime():
         """Release per-row model and inference allocations before rebuilding."""
         torch.cuda.synchronize()
+        delete_cuda_graphs()
         gc.collect()
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
@@ -2924,6 +2941,374 @@ class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
         try:
             self._run_engine_case(case)
         finally:
+            DynamicInferenceContext.ROUNDER = 64
+            DynamicInferenceContext.TOKEN_ROUNDER = 64
+            DynamicInferenceContext.REQUEST_ROUNDER = 64
+            Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("kv_cache_management_mode", ["offload", "recompute"])
+    @torch.inference_mode()
+    def test_real_cuda_graph_suspend_resume_lifecycle(self, kv_cache_management_mode):
+        """Rebuild deleted graphs without capturing over live requests or cache state."""
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        self._clear_engine_runtime()
+        try:
+            case = {"feature": "cuda-graph", "policy": PrefixCachingEvictionPolicy.LRU}
+            config = self._case_config(case, enable_prefix_caching=True)
+            config.num_cuda_graphs = 2
+            config.force_build_cuda_graphs = True
+            config.use_cuda_graphs_for_non_decode_steps = False
+            config.inference_cuda_graph_scope = InferenceCudaGraphScope.block
+            config.kv_cache_management_mode = kv_cache_management_mode
+            config.static_kv_memory_pointers = False
+            config.context_max_requests = 1
+
+            env = self._build_test_env(config)
+            engine = env.engine
+            context = engine.context
+            assert context.kv_cache_management_mode == KVCacheManagementMode(
+                kv_cache_management_mode
+            )
+            assert context.cuda_graphs_available
+            assert not engine._cuda_graph_rebuild_pending
+            assert CudaGraphManager.global_mempool is not None
+
+            graph_managers = [
+                manager
+                for manager in list(CudaGraphManager._instances)
+                if manager.cudagraph_runners
+            ]
+            assert graph_managers
+            assert any(manager.custom_cudagraphs_lookup_table for manager in graph_managers)
+
+            block_size = context.block_size_tokens
+            prompt = torch.arange(
+                2 * block_size + 5, dtype=torch.int64, device=torch.cuda.current_device()
+            ) % (config.vocab_size - 1)
+            requests = [
+                self._make_request(context, request_id, prompt.clone(), True)
+                for request_id in range(2)
+            ]
+            engine._add_request(requests[0])
+            first_result = engine.step_modern()
+            assert not first_result["finished_request_records"]
+            assert context.total_request_count == 1
+            engine._add_request(requests[1])
+            assert list(engine.waiting_request_ids) == [1]
+
+            capture_snapshots = []
+            original_create_cuda_graphs = engine.create_cuda_graphs
+
+            def tracked_create_cuda_graphs(*args, **kwargs):
+                assert context.total_request_count == 0
+                assert context.chunked_prefill_request_id == -1
+                counters_before = (
+                    context.step_count,
+                    context.prefix_cache_lru_clock,
+                    context.lifetime_prefill_token_count,
+                    context.async_sched_step_count,
+                    context.async_sched_compaction_step_count,
+                )
+                cache_before = dict(context.kv_block_allocator.kv_hash_to_block_id)
+                result = original_create_cuda_graphs(*args, **kwargs)
+                counters_after = (
+                    context.step_count,
+                    context.prefix_cache_lru_clock,
+                    context.lifetime_prefill_token_count,
+                    context.async_sched_step_count,
+                    context.async_sched_compaction_step_count,
+                )
+                cache_after = dict(context.kv_block_allocator.kv_hash_to_block_id)
+                assert counters_after == counters_before
+                assert cache_after == cache_before
+                capture_snapshots.append((counters_after, cache_after))
+                return result
+
+            engine.create_cuda_graphs = tracked_create_cuda_graphs
+            engine.suspend()
+            assert not context.cuda_graphs_available
+            assert engine._cuda_graph_rebuild_pending
+            assert CudaGraphManager.global_mempool is None
+            assert all(not manager.cudagraph_runners for manager in graph_managers)
+            assert all(not manager.custom_cudagraphs_lookup_table for manager in graph_managers)
+
+            engine.resume()
+            if kv_cache_management_mode == "offload":
+                assert context.total_request_count == 1
+                assert not context.cuda_graphs_available
+                assert engine._cuda_graph_rebuild_pending
+                assert not capture_snapshots
+                with pytest.raises(AssertionError, match="empty inference context"):
+                    original_create_cuda_graphs()
+            else:
+                assert context.cuda_graphs_available
+                assert not engine._cuda_graph_rebuild_pending
+                assert len(capture_snapshots) == 1
+
+            finished = {}
+            saw_unavailable_step = False
+            saw_graph_after_rebuild = False
+            for _ in range(64):
+                result = engine.step_modern()
+                using_cuda_graph = context.using_cuda_graph_this_step()
+                if not context.cuda_graphs_available:
+                    assert not using_cuda_graph
+                    assert all(not manager.cudagraph_runners for manager in graph_managers)
+                    saw_unavailable_step = True
+                elif capture_snapshots and using_cuda_graph:
+                    saw_graph_after_rebuild = True
+                for record in result["finished_request_records"]:
+                    merged = record.merge()
+                    finished[merged.request_id] = merged
+                if not engine.has_unfinished_requests():
+                    break
+            else:
+                pytest.fail(f"{kv_cache_management_mode} graph lifecycle did not converge")
+
+            assert len(capture_snapshots) == 1
+            captured_counters, captured_cache = capture_snapshots[0]
+            assert captured_counters[0] > 0
+            assert captured_counters[1] > 0
+            assert CudaGraphManager.global_mempool is not None
+            assert any(manager.cudagraph_runners for manager in graph_managers)
+            assert any(manager.custom_cudagraphs_lookup_table for manager in graph_managers)
+            assert saw_graph_after_rebuild
+            assert len(finished) == 2
+            assert all(len(request.generated_tokens) == 4 for request in finished.values())
+            assert requests[1].num_cached_tokens >= 2 * block_size
+            if kv_cache_management_mode == "offload":
+                assert saw_unavailable_step
+                assert captured_cache
+            else:
+                assert not saw_unavailable_step
+        finally:
+            self._clear_engine_runtime()
+            DynamicInferenceContext.ROUNDER = 64
+            DynamicInferenceContext.TOKEN_ROUNDER = 64
+            DynamicInferenceContext.REQUEST_ROUNDER = 64
+            Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _live_cuda_graph_manager_state():
+        """Return stable identities for every currently populated graph manager."""
+        state = {}
+        for manager in list(CudaGraphManager._instances):
+            if not manager.cudagraph_runners:
+                continue
+            state[id(manager)] = (
+                tuple(id(runner) for runner in manager.cudagraph_runners),
+                tuple(
+                    sorted(
+                        (repr(key), id(runner))
+                        for key, runner in manager.custom_cudagraphs_lookup_table.items()
+                    )
+                ),
+            )
+        assert state
+        return state
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_static_uvm_preserves_hybrid_state_cache_and_graphs(self):
+        """Static UVM pointers keep live KV/Mamba state and captured graphs valid."""
+        available, reason = _check_mamba_sequence_packing_support()
+        if not available:
+            pytest.skip(reason)
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        self._clear_engine_runtime()
+        try:
+            case = {
+                "feature": "cuda-graph",
+                "model_provider": "hybrid",
+                "policy": PrefixCachingEvictionPolicy.LRU,
+            }
+            config = self._case_config(case, enable_prefix_caching=True)
+            config.num_cuda_graphs = 2
+            config.force_build_cuda_graphs = True
+            config.use_cuda_graphs_for_non_decode_steps = False
+            config.inference_cuda_graph_scope = InferenceCudaGraphScope.block
+            config.kv_cache_management_mode = "offload"
+            config.static_kv_memory_pointers = True
+            config.unified_memory_level = 1
+            config.context_max_requests = 1
+
+            env = self._build_test_env(config)
+            engine = env.engine
+            context = engine.context
+            assert context.is_hybrid_model
+            assert context.unified_memory_level == 1
+            assert context.static_kv_memory_pointers
+            assert context.mamba_slot_allocator is not None
+            graph_state = self._live_cuda_graph_manager_state()
+
+            block_size = context.block_size_tokens
+            prompt = torch.arange(
+                2 * block_size + 5, dtype=torch.int64, device=torch.cuda.current_device()
+            ) % (config.vocab_size - 1)
+            requests = [
+                self._make_request(context, request_id, prompt.clone(), True)
+                for request_id in range(2)
+            ]
+            engine._add_request(requests[0])
+            first_result = engine.step_modern()
+            assert not first_result["finished_request_records"]
+            assert context.total_request_count == 1
+            engine._add_request(requests[1])
+            assert list(engine.waiting_request_ids) == [1]
+
+            block_ids = context.request_to_kv_block_ids[: context.total_request_count]
+            block_ids = torch.unique(block_ids[block_ids >= 0]).to(
+                device=context.memory_buffer.device, dtype=torch.long
+            )
+            assert block_ids.numel() > 0
+            kv_pointer = context.memory_buffer.data_ptr()
+            kv_data = context.memory_buffer.index_select(2, block_ids).clone()
+
+            mamba_index = int(context.mamba_metadata.request_to_mamba_state_idx[0])
+            assert mamba_index >= 0
+            mamba_pointers = (
+                context.mamba_conv_states.data_ptr(),
+                context.mamba_ssm_states.data_ptr(),
+            )
+            mamba_data = (
+                context.mamba_conv_states[:, mamba_index].clone(),
+                context.mamba_ssm_states[:, mamba_index].clone(),
+            )
+            kv_hashes = dict(context.kv_block_allocator.kv_hash_to_block_id)
+            mamba_hashes = dict(context.mamba_slot_allocator.hash_to_block_id)
+            assert kv_hashes
+            assert mamba_hashes
+
+            engine.suspend()
+            assert context.cuda_graphs_available
+            assert not engine._cuda_graph_rebuild_pending
+            engine.resume()
+
+            assert context.memory_buffer.data_ptr() == kv_pointer
+            assert torch.equal(context.memory_buffer.index_select(2, block_ids), kv_data)
+            assert (
+                context.mamba_conv_states.data_ptr(),
+                context.mamba_ssm_states.data_ptr(),
+            ) == mamba_pointers
+            assert torch.equal(context.mamba_conv_states[:, mamba_index], mamba_data[0])
+            assert torch.equal(context.mamba_ssm_states[:, mamba_index], mamba_data[1])
+            assert context.kv_block_allocator.kv_hash_to_block_id == kv_hashes
+            assert context.mamba_slot_allocator.hash_to_block_id == mamba_hashes
+            assert self._live_cuda_graph_manager_state() == graph_state
+
+            finished = {}
+            saw_graph_replay = False
+            for _ in range(64):
+                result = engine.step_modern()
+                saw_graph_replay |= context.using_cuda_graph_this_step()
+                for record in result["finished_request_records"]:
+                    merged = record.merge()
+                    finished[merged.request_id] = merged
+                if not engine.has_unfinished_requests():
+                    break
+            else:
+                pytest.fail("static UVM hybrid graph lifecycle did not converge")
+
+            assert saw_graph_replay
+            assert len(finished) == 2
+            assert requests[1].num_cached_tokens >= 2 * block_size
+            assert self._live_cuda_graph_manager_state() == graph_state
+        finally:
+            self._clear_engine_runtime()
+            DynamicInferenceContext.ROUNDER = 64
+            DynamicInferenceContext.TOKEN_ROUNDER = 64
+            DynamicInferenceContext.REQUEST_ROUNDER = 64
+            Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    @torch.inference_mode()
+    def test_persist_tp2_pp2_replays_same_graphs_after_resume(self):
+        """PERSIST leaves TP2/PP2 graph runners and KV storage live across resume."""
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=2
+        )
+        self._clear_engine_runtime()
+        try:
+            case = {"feature": "cuda-graph", "policy": PrefixCachingEvictionPolicy.LRU}
+            config = self._case_config(case, enable_prefix_caching=True)
+            config.num_cuda_graphs = 2
+            config.force_build_cuda_graphs = True
+            config.use_cuda_graphs_for_non_decode_steps = False
+            config.inference_cuda_graph_scope = InferenceCudaGraphScope.block
+            config.kv_cache_management_mode = "persist"
+            config.static_kv_memory_pointers = True
+            config.context_max_requests = 2
+            config.tensor_model_parallel_size = 2
+            config.pipeline_model_parallel_size = 2
+            config.sequence_parallel = True
+
+            env = self._build_test_env(config)
+            engine = env.engine
+            context = engine.context
+            assert context.kv_cache_management_mode == KVCacheManagementMode.PERSIST
+            assert torch.distributed.get_world_size() >= 4
+            graph_state = self._live_cuda_graph_manager_state()
+
+            block_size = context.block_size_tokens
+            prompt = torch.arange(
+                2 * block_size + 5, dtype=torch.int64, device=torch.cuda.current_device()
+            ) % (config.vocab_size - 1)
+            requests = [
+                self._make_request(context, request_id, prompt.clone(), True)
+                for request_id in range(2)
+            ]
+            engine._add_request(requests[0])
+
+            saw_graph_before = False
+            donor_finished = False
+            for _ in range(16):
+                result = engine.step_modern()
+                saw_graph_before |= context.using_cuda_graph_this_step()
+                donor_finished |= bool(result["finished_request_records"])
+                if donor_finished:
+                    break
+            assert saw_graph_before
+            assert donor_finished
+            assert context.total_request_count == 0
+
+            engine._add_request(requests[1])
+            assert list(engine.waiting_request_ids) == [1]
+
+            kv_pointer = context.memory_buffer.data_ptr()
+            kv_hashes = dict(context.kv_block_allocator.kv_hash_to_block_id)
+            assert kv_hashes
+            engine.suspend()
+            engine.resume()
+
+            assert context.memory_buffer.data_ptr() == kv_pointer
+            assert context.kv_block_allocator.kv_hash_to_block_id == kv_hashes
+            assert context.cuda_graphs_available
+            assert not engine._cuda_graph_rebuild_pending
+            assert self._live_cuda_graph_manager_state() == graph_state
+
+            finished = {}
+            saw_graph_after = False
+            for _ in range(32):
+                result = engine.step_modern()
+                saw_graph_after |= context.using_cuda_graph_this_step()
+                for record in result["finished_request_records"]:
+                    merged = record.merge()
+                    finished[merged.request_id] = merged
+                if not engine.has_unfinished_requests():
+                    break
+            else:
+                pytest.fail("PERSIST TP2/PP2 graph replay did not converge")
+
+            assert saw_graph_after
+            assert requests[1].num_cached_tokens >= 2 * block_size
+            assert self._live_cuda_graph_manager_state() == graph_state
+        finally:
+            self._clear_engine_runtime()
             DynamicInferenceContext.ROUNDER = 64
             DynamicInferenceContext.TOKEN_ROUNDER = 64
             DynamicInferenceContext.REQUEST_ROUNDER = 64

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -2072,6 +2072,91 @@ class TestPrefixCacheReuse(PrefixCachingTestBase):
             == ctx.request_to_kv_block_ids[0][last_aligned_abs // bs - 1].item()
         )
 
+    @pytest.mark.internal
+    def test_mamba_aligned_chunk_endpoint_commits_and_restores(self):
+        # A block boundary exactly at a non-final chunk end is not an extractable
+        # interior offset. Commit it from the live state, then prove that a
+        # matching request skips to and restores that exact boundary.
+        ctx = self._ctx(
+            mamba_config=self._mamba_config(),
+            prefix_caching_mamba_gb=0.01,
+            block_size_tokens=256,
+            max_sequence_length=4096,
+        )
+        bs = ctx.block_size_tokens
+        prompt = self._prompt(2 * bs + 7)
+        seed = self._req(ctx, prompt.clone())
+        ctx.add_request(seed)
+        msa = ctx.mamba_slot_allocator
+
+        seed.finished_chunk_token_count = bs
+        msa.compute_and_store_offsets(
+            seed,
+            current_id=0,
+            skip_tokens=0,
+            prefill_chunk_length=bs,
+            num_matched_blocks=0,
+            matched_block_ids=[],
+            overall_required_blocks=ctx.request_kv_block_counts[0].item(),
+        )
+        seed.finished_chunk_token_count = 0
+
+        endpoint_block = ctx.request_to_kv_block_ids[0][1].item()
+        assert msa._intermediate_counts_cpu[0].item() == 0
+        assert msa._eos_cache_block_id_cpu[0].item() == endpoint_block
+
+        ctx.initialize_attention_state()
+        seed_mamba_idx = ctx.mamba_metadata.request_to_mamba_state_idx[0].item()
+        ctx.mamba_conv_states[:, seed_mamba_idx].fill_(17)
+        ctx.mamba_ssm_states[:, seed_mamba_idx].fill_(23)
+        msa.commit_intermediate_states()
+
+        endpoint_hash = seed.precomputed_block_hashes[1]
+        endpoint_slot = msa.block_to_slot[endpoint_block].item()
+        assert msa.hash_to_block_id[endpoint_hash] == endpoint_block
+        assert torch.all(msa.conv_states[:, endpoint_slot] == 17)
+        assert torch.all(msa.ssm_states[:, endpoint_slot] == 23)
+
+        follower = self._req(ctx, prompt.clone(), request_id=2)
+        matched, _, _, _, prefix_skip, _ = ctx._compute_prefix_match(follower, len(prompt))
+        assert len(matched) == 2 and prefix_skip == 2 * bs
+        ctx.add_request(follower)
+        assert follower._mamba_num_matched_blocks == 2
+        ctx.initialize_attention_state()
+
+        follower_mamba_idx = ctx.mamba_metadata.request_to_mamba_state_idx[1].item()
+        assert torch.all(ctx.mamba_conv_states[:, follower_mamba_idx] == 17)
+        assert torch.all(ctx.mamba_ssm_states[:, follower_mamba_idx] == 23)
+
+    @pytest.mark.internal
+    def test_mamba_cache_disabled_no_hash_request_skips_state_publication(self):
+        ctx = self._ctx(
+            mamba_config=self._mamba_config(),
+            prefix_caching_mamba_gb=0.01,
+            block_size_tokens=256,
+            max_sequence_length=4096,
+        )
+        bs = ctx.block_size_tokens
+        msa = ctx.mamba_slot_allocator
+        free_before = msa.free_count
+        # This aligned prompt would stage both an interior offset and its live
+        # endpoint if add_request sent this uncacheable request to the allocator.
+        request = self._req(ctx, self._prompt(2 * bs), enable_prefix_caching=False)
+        assert request.precomputed_block_hashes == []
+
+        ctx.add_request(request)
+
+        assert msa._intermediate_counts_cpu[0].item() == 0
+        assert msa._eos_cache_block_id_cpu[0].item() == -1
+        assert not msa._has_intermediates
+
+        ctx.initialize_attention_state()
+        msa.commit_intermediate_states()
+
+        assert msa.free_count == free_before
+        assert torch.all(msa.block_to_slot == -1)
+        assert not msa.hash_to_block_id
+
 
 PREFIX_CACHE_CONTEXT_CASES = [
     pytest.param(feature, policy, id=f"{feature}-{policy.name.lower()}")

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import asyncio
+import gc
 from collections import deque
 from types import SimpleNamespace
 
@@ -28,9 +29,14 @@ from megatron.core.inference.inference_request import (
     compute_block_hashes_batched,
 )
 from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.ssm.mamba_mixer import _check_mamba_sequence_packing_support
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.inference.engines.test_dynamic_engine import (
+    DynamicEngineTestConfig,
+    DynamicInferenceEngineTestBase,
+)
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -2065,3 +2071,699 @@ class TestPrefixCacheReuse(PrefixCachingTestBase):
             msa._intermediate_block_ids_cpu[0, idx].item()
             == ctx.request_to_kv_block_ids[0][last_aligned_abs // bs - 1].item()
         )
+
+
+PREFIX_CACHE_CONTEXT_CASES = [
+    pytest.param(feature, policy, id=f"{feature}-{policy.name.lower()}")
+    for feature in (
+        "exact-prefix",
+        "partial-prefix",
+        "missing-prefix",
+        "concurrent-sharing",
+        "mixed-cached-fresh",
+    )
+    for policy in (PrefixCachingEvictionPolicy.LRU, PrefixCachingEvictionPolicy.REF_ZERO)
+]
+
+
+class TestPrefixCachePolicyStressMatrix(PrefixCachingTestBase):
+    """Exercise five context behaviors under both eviction policies and forced pressure."""
+
+    def _apply_local_churn(self, ctx, producer, producer_blocks):
+        """Exhaust the pool and make a new request recycle or evict producer blocks."""
+        alloc = ctx.kv_block_allocator
+        policy = alloc.prefix_caching_eviction_policy
+        ctx.release_memory_blocks_from_request_indexes(torch.arange(ctx.total_request_count))
+
+        if policy == PrefixCachingEvictionPolicy.LRU:
+            cached_before = dict(alloc.kv_hash_to_block_id)
+            assert cached_before
+            filler = alloc.allocate_memory_blocks(alloc.pool_avail)
+            assert filler is not None and alloc.pool_avail == 0
+        else:
+            assert not alloc.kv_hash_to_block_id
+            assert all(alloc.block_hashes[block_id].item() == -1 for block_id in producer_blocks)
+            filler = alloc.allocate_memory_blocks(alloc.pool_avail)
+            assert filler is not None and alloc.pool_avail == 0
+            producer_tensor = torch.tensor(producer_blocks, dtype=torch.int32)
+            assert set(producer_blocks) <= set(filler.tolist())
+            alloc.release_memory_blocks(producer_tensor)
+            assert alloc.pool_avail == len(producer_blocks)
+
+        pressure = self._req(
+            ctx, self._prompt(3 * ctx.block_size_tokens, offset=200_000), request_id=100
+        )
+        pressure_idx = ctx.total_request_count
+        ctx.add_request(pressure)
+        pressure_blocks = set(self._block_ids(ctx, pressure_idx, 3))
+
+        if policy == PrefixCachingEvictionPolicy.LRU:
+            evicted_ids = {
+                block_id
+                for block_hash, block_id in cached_before.items()
+                if block_hash not in alloc.kv_hash_to_block_id
+            }
+            assert pressure_blocks == evicted_ids
+        else:
+            assert pressure_blocks == set(producer_blocks)
+            assert not any(
+                block_hash in alloc.kv_hash_to_block_id
+                for block_hash in producer.precomputed_block_hashes
+            )
+
+    def _run_feature_probe(self, feature, policy):
+        """Execute one sharing behavior, then force policy-specific allocator churn."""
+        ctx = self._ctx(
+            buffer_size_gb=0.001,
+            rounder=1,
+            max_requests=12,
+            max_tokens=512,
+            prefix_caching_eviction_policy=policy,
+        )
+        alloc = ctx.kv_block_allocator
+        block_size = ctx.block_size_tokens
+        prompt = self._prompt(3 * block_size)
+        producer = self._req(ctx, prompt.clone())
+        ctx.add_request(producer)
+        producer_blocks = self._block_ids(ctx, 0, 3)
+        if policy == PrefixCachingEvictionPolicy.LRU:
+            ctx.release_memory_blocks_from_request_indexes(torch.tensor([0]))
+
+        if feature == "exact-prefix":
+            probe = self._req(ctx, prompt.clone(), request_id=2)
+            matched, _, _, _, skipped, effective = ctx._compute_prefix_match(probe, len(prompt))
+            assert matched == producer_blocks
+            assert skipped == 2 * block_size and effective == block_size
+            ctx.add_request(probe)
+            assert probe.num_cached_tokens == 3 * block_size
+
+        elif feature == "partial-prefix":
+            partial = torch.cat((prompt[: 2 * block_size], self._prompt(block_size, offset=50_000)))
+            probe = self._req(ctx, partial, request_id=2)
+            matched, *_ = ctx._compute_prefix_match(probe, len(partial))
+            assert matched == producer_blocks[:2]
+            ctx.add_request(probe)
+            assert probe.num_cached_tokens == 2 * block_size
+
+        elif feature == "missing-prefix":
+            probe = self._req(ctx, self._prompt(3 * block_size, offset=50_000), request_id=2)
+            matched, *_ = ctx._compute_prefix_match(probe, 3 * block_size)
+            assert not matched
+            ctx.add_request(probe)
+            assert probe.num_cached_tokens == 0
+
+        elif feature == "concurrent-sharing":
+            for request_id in range(2, 5):
+                ctx.add_request(self._req(ctx, prompt.clone(), request_id=request_id))
+            expected_refs = 3 + int(policy == PrefixCachingEvictionPolicy.REF_ZERO)
+            assert all(
+                alloc.block_ref_counts[block_id].item() == expected_refs
+                for block_id in producer_blocks
+            )
+            ctx.release_memory_blocks_from_request_indexes(torch.tensor([1, 2, 3]))
+            remaining_refs = int(policy == PrefixCachingEvictionPolicy.REF_ZERO)
+            assert all(
+                alloc.block_ref_counts[block_id].item() == remaining_refs
+                for block_id in producer_blocks
+            )
+
+        else:
+            assert feature == "mixed-cached-fresh"
+            cached = self._req(ctx, prompt.clone(), request_id=2)
+            fresh = self._req(ctx, self._prompt(3 * block_size, offset=50_000), request_id=3)
+            ctx.add_request(cached)
+            ctx.add_request(fresh)
+            assert ctx.request_query_lengths[1].item() == block_size
+            assert ctx.request_query_lengths[2].item() == 3 * block_size
+            assert cached.num_cached_tokens == 3 * block_size
+            assert fresh.num_cached_tokens == 0
+
+        self._apply_local_churn(ctx, producer, producer_blocks)
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("feature,policy", PREFIX_CACHE_CONTEXT_CASES)
+    def test_context_policy_matrix(self, feature, policy):
+        self._run_feature_probe(feature, policy)
+
+
+PREFIX_CACHE_ENGINE_CASES = [
+    pytest.param(
+        dict(name="tp4-ref-zero", feature="tp", tp=4, policy=PrefixCachingEvictionPolicy.REF_ZERO),
+        id="tp4-ref-zero",
+    ),
+    pytest.param(
+        dict(name="pp4-lru", feature="pp", pp=4, policy=PrefixCachingEvictionPolicy.LRU),
+        id="pp4-lru",
+    ),
+    pytest.param(
+        dict(name="ep4-moe-lru", feature="moe", ep=4, policy=PrefixCachingEvictionPolicy.LRU),
+        id="ep4-moe-lru",
+    ),
+    pytest.param(
+        dict(name="gpt-chunked-lru", feature="chunked", policy=PrefixCachingEvictionPolicy.LRU),
+        id="gpt-chunked-lru",
+    ),
+    pytest.param(
+        dict(
+            name="gpt-fused-rope-ref-zero",
+            feature="fused-rope",
+            policy=PrefixCachingEvictionPolicy.REF_ZERO,
+        ),
+        id="gpt-fused-rope-ref-zero",
+    ),
+    pytest.param(
+        dict(name="mtp2-ref-zero", feature="mtp", policy=PrefixCachingEvictionPolicy.REF_ZERO),
+        id="mtp2-ref-zero",
+    ),
+    pytest.param(
+        dict(
+            name="hybrid-mamba-ref-zero",
+            feature="mamba",
+            model_provider="hybrid",
+            policy=PrefixCachingEvictionPolicy.REF_ZERO,
+        ),
+        id="hybrid-mamba-ref-zero",
+    ),
+]
+
+
+class TestPrefixCacheRealEngineMatrix(DynamicInferenceEngineTestBase):
+    """Run real model rows through cache hits, runtime feature paths, and KV pressure."""
+
+    @classmethod
+    def _build_inference_context(
+        cls, test_config, transformer_config, requests, mamba_inference_state_config=None
+    ):
+        """Build the shared harness context with the row's cache eviction policy."""
+        assert not requests
+        return DynamicInferenceContext(
+            model_config=transformer_config,
+            inference_config=InferenceConfig(
+                max_sequence_length=test_config.max_sequence_length,
+                buffer_size_gb=test_config.context_buffer_size_gb,
+                paused_buffer_size_gb=test_config.context_paused_buffer_size_gb,
+                block_size_tokens=test_config.context_block_size_tokens,
+                max_requests=test_config.context_max_requests,
+                max_tokens=test_config.context_max_tokens,
+                mamba_inference_state_config=mamba_inference_state_config,
+                materialize_only_last_token_logits=(test_config.materialize_only_last_token_logits),
+                enable_chunked_prefill=test_config.enable_chunked_prefill,
+                enable_prefix_caching=test_config.enable_prefix_caching,
+                prefix_caching_eviction_policy=test_config.prefix_caching_eviction_policy,
+                prefix_caching_mamba_gb=(
+                    0.2
+                    if test_config.enable_prefix_caching
+                    and mamba_inference_state_config is not None
+                    else None
+                ),
+                use_flashinfer_fused_rope=test_config.use_flashinfer_fused_rope,
+                num_speculative_tokens=test_config.num_speculative_tokens,
+                sampling_backend="torch",
+            ),
+        )
+
+    @staticmethod
+    def _case_config(case, *, enable_prefix_caching):
+        """Build a small real-engine configuration for one capability row."""
+        block_size = 256  # FlashAttention paged KV blocks must be divisible by 256.
+        prompt_length = 2 * block_size + 5
+        feature = case["feature"]
+        config = DynamicEngineTestConfig(
+            num_requests=0,
+            min_prompt_length=prompt_length,
+            max_prompt_length=prompt_length,
+            num_tokens_to_generate=4,
+            max_sequence_length=(
+                prompt_length + block_size + 16 if feature == "chunked" else prompt_length + 8
+            ),
+            context_buffer_size_gb=0.02,
+            context_block_size_tokens=block_size,
+            context_max_requests=32,
+            context_max_tokens=block_size + 8 if feature == "chunked" else 4096,
+            tensor_model_parallel_size=case.get("tp", 1),
+            pipeline_model_parallel_size=case.get("pp", 1),
+            expert_model_parallel_size=case.get("ep", 1),
+            model_provider=case.get("model_provider", "gpt"),
+            enable_prefix_caching=enable_prefix_caching,
+            enable_chunked_prefill=feature == "chunked",
+            num_speculative_tokens=2 if feature == "mtp" else 0,
+            materialize_only_last_token_logits=feature != "mtp",
+            position_embedding_type="rope" if feature == "fused-rope" else "learned_absolute",
+            hidden_size=64 if feature == "fused-rope" else None,
+            top_k=1,
+        )
+        config.prefix_caching_eviction_policy = case["policy"]
+        config.use_flashinfer_fused_rope = feature == "fused-rope"
+        return config
+
+    @staticmethod
+    def _make_request(context, request_id, prompt, enable_prefix_caching):
+        """Build a deterministic request whose hashes are ready before scheduling."""
+        return DynamicInferenceRequest(
+            request_id=request_id,
+            prompt_tokens=prompt,
+            sampling_params=SamplingParams(
+                num_tokens_to_generate=4,
+                termination_id=-1,
+                return_log_probs=True,
+                # Chunked prefill currently emits one extra generated-top-N
+                # entry for an intermediate chunk. This foundation owns
+                # generated-logprob parity there; top-N remains covered by all
+                # non-chunked rows.
+                top_n_logprobs=0 if context.enable_chunked_prefill else 5,
+                skip_prompt_log_probs=True,
+                top_k=1,
+            ),
+            block_size_tokens=context.block_size_tokens,
+            enable_prefix_caching=enable_prefix_caching,
+        )
+
+    @staticmethod
+    def _install_runtime_witnesses(engine, feature):
+        """Count calls on the feature path during the stressed engine run."""
+        evidence = {
+            "tp_reducing_forwards": 0,
+            "pipeline_forwards": 0,
+            "moe_dispatches": 0,
+            "moe_request_ids": set(),
+            "fused_rope_calls": 0,
+            "mamba_restores": 0,
+        }
+        model = engine.controller.inference_wrapped_model.model
+
+        if feature == "tp":
+
+            def trace_tp_reduce(module, *_):
+                assert torch.distributed.get_world_size(module.tp_group) > 1
+                evidence["tp_reducing_forwards"] += 1
+
+            for module in model.modules():
+                if module.__class__.__name__ == "RowParallelLinear":
+                    module.register_forward_pre_hook(trace_tp_reduce)
+
+        if feature == "pp":
+            wrapper = engine.controller.inference_wrapped_model
+            original = wrapper.forward_pass_with_pipeline_parallel
+
+            def traced_pipeline_forward(*args, **kwargs):
+                assert wrapper.model_is_pipeline_parallel
+                evidence["pipeline_forwards"] += 1
+                return original(*args, **kwargs)
+
+            wrapper.forward_pass_with_pipeline_parallel = traced_pipeline_forward
+
+        if feature == "moe":
+            instrumented_layers = 0
+            for module in model.modules():
+                if module.__class__.__name__ != "MoELayer":
+                    continue
+                original = module.dispatch
+
+                def traced_moe_dispatch(*args, _module=module, _original=original, **kwargs):
+                    dispatcher = _module.token_dispatcher
+                    assert torch.distributed.get_world_size(dispatcher.ep_group) > 1
+                    evidence["moe_dispatches"] += 1
+                    active_request_ids = engine.context.request_ids[
+                        engine.context.paused_request_count : engine.context.total_request_count
+                    ]
+                    evidence["moe_request_ids"].update(
+                        request_id for request_id in active_request_ids.tolist() if request_id >= 0
+                    )
+                    return _original(*args, **kwargs)
+
+                module.dispatch = traced_moe_dispatch
+                instrumented_layers += 1
+            assert instrumented_layers > 0
+
+        if feature == "fused-rope":
+            context = engine.context
+            original = context.apply_fused_qk_rotary_emb
+
+            def traced_fused_rope(*args, **kwargs):
+                assert context.use_flashinfer_fused_rope
+                cos_sin_cache = args[2] if len(args) > 2 else kwargs["cos_sin_emb"]
+                assert cos_sin_cache.is_cuda
+                evidence["fused_rope_calls"] += 1
+                return original(*args, **kwargs)
+
+            context.apply_fused_qk_rotary_emb = traced_fused_rope
+
+        if feature == "mamba" and engine.context.mamba_slot_allocator is not None:
+            allocator = engine.context.mamba_slot_allocator
+            original = allocator.restore_to_live
+
+            def traced_mamba_restore(*args, **kwargs):
+                restored = original(*args, **kwargs)
+                evidence["mamba_restores"] += int(restored)
+                return restored
+
+            allocator.restore_to_live = traced_mamba_restore
+
+        return evidence
+
+    @torch.inference_mode()
+    def _run_engine_session(self, case, *, enable_prefix_caching):
+        """Run three donor/follower/pressure waves through one real engine."""
+        config = self._case_config(case, enable_prefix_caching=enable_prefix_caching)
+        env = self._build_test_env(config)
+        engine = env.engine
+        context = engine.context
+        allocator = context.kv_block_allocator
+        engine.controller.tokenizer.detokenize = lambda tokens, **_: f"tok_{tokens[0]}"
+        if case["feature"] == "fused-rope":
+            # The shared test model is CPU-initialized, while FlashInfer requires
+            # its cos/sin cache on CUDA. Establish that kernel precondition here;
+            # lazy cache migration is owned by the separate fused-RoPE fix.
+            model = engine.controller.inference_wrapped_model.model
+            model.rotary_pos_emb.inv_freq = model.rotary_pos_emb.inv_freq.cuda()
+            model.rotary_pos_emb_cache.clear()
+            assert model.config.hidden_size // model.config.num_attention_heads == 16
+        evidence = self._install_runtime_witnesses(engine, case["feature"])
+        pool_size = allocator.pool_size
+        storage_size = context.memory_buffer.untyped_storage().nbytes()
+        finished = {}
+        wave_block_ids = []
+        all_hashes = set()
+        min_pool_avail = allocator.pool_avail
+        saw_chunk = False
+        max_mamba_matched_blocks = 0
+        step_count = 0
+        cached_request_ids = set()
+        feature_seen_for_cached_request = False
+        mtp_seen_for_cached_decode = False
+
+        for cycle in range(3):
+            block_size = context.block_size_tokens
+            base = (
+                torch.arange(
+                    2 * block_size + 5, dtype=torch.int64, device=torch.cuda.current_device()
+                )
+                + cycle * 17
+            ) % (config.vocab_size - 1)
+            pressure = (base + 37) % (config.vocab_size - 1)
+
+            # Cached execution normally needs three producer blocks, one
+            # follower tail, and three divergent blocks. The chunked row gives
+            # the follower a second tail block so the hit-bearing request must
+            # itself continue prefill. Cache-off needs nine blocks normally and
+            # ten for the extended chunked follower, though those requests run
+            # serially under the chunk budget.
+            target_allocatable = (
+                8
+                if enable_prefix_caching and config.enable_chunked_prefill
+                else 7 if enable_prefix_caching or config.enable_chunked_prefill else 9
+            )
+            allocatable = allocator.get_allocatable_count()
+            if allocatable > target_allocatable:
+                filler = allocator.allocate_memory_blocks(allocatable - target_allocatable)
+                assert filler is not None
+            assert allocator.get_allocatable_count() == target_allocatable
+
+            follower_prompt = base.clone()
+            if case["feature"] == "chunked":
+                follower_prompt = torch.cat((base, base[: block_size + 8]))
+            requests = [
+                self._make_request(
+                    context, 3 * cycle, base, enable_prefix_caching=enable_prefix_caching
+                ),
+                self._make_request(context, 3 * cycle + 1, follower_prompt, enable_prefix_caching),
+                self._make_request(context, 3 * cycle + 2, pressure, enable_prefix_caching),
+            ]
+            wave_ids = {request.request_id for request in requests}
+            if enable_prefix_caching:
+                for request in requests:
+                    engine._add_request(request)
+                    all_hashes.update(request.precomputed_block_hashes)
+            else:
+                engine._add_request(requests[0])
+                if not config.enable_chunked_prefill:
+                    engine._add_request(requests[2])
+
+            baseline_follower_pending = not enable_prefix_caching
+            hits_before = engine._prefix_cache_hits
+            blocks_this_wave = set()
+            while wave_ids - finished.keys():
+                step_hits_before = engine._prefix_cache_hits
+                cached_tokens_before = {
+                    request.request_id: request.num_cached_tokens for request in requests
+                }
+                generated_before = {
+                    request.request_id: len(request.generated_tokens) for request in requests
+                }
+                feature_key = {
+                    "tp": "tp_reducing_forwards",
+                    "pp": "pipeline_forwards",
+                    "fused-rope": "fused_rope_calls",
+                    "mamba": "mamba_restores",
+                }.get(case["feature"])
+                feature_before = evidence[feature_key] if feature_key is not None else None
+                mtp_before = int(engine._spec_tokens_proposed_per_pos.sum())
+                result = engine.step_modern()
+                step_count += 1
+                newly_cached_ids = {
+                    request.request_id
+                    for request in requests
+                    if request.num_cached_tokens > cached_tokens_before[request.request_id]
+                }
+                if engine._prefix_cache_hits > step_hits_before:
+                    assert newly_cached_ids
+                    cached_request_ids.update(newly_cached_ids)
+                    if feature_key is not None:
+                        assert evidence[feature_key] > feature_before
+                        feature_seen_for_cached_request = True
+                    elif case["feature"] == "chunked":
+                        assert any(
+                            request.request_id in newly_cached_ids
+                            and (
+                                request.finished_chunk_token_count > 0
+                                or context.chunked_prefill_request_id == request.request_id
+                            )
+                            for request in requests
+                        )
+                        feature_seen_for_cached_request = True
+
+                # MTP intentionally starts after prefill, so its request-specific
+                # witness belongs to a later decode step rather than the hit step.
+                # A cached request whose generated length grows in a step that
+                # records proposals necessarily contributed to the MTP counter.
+                mtp_after = int(engine._spec_tokens_proposed_per_pos.sum())
+                if case["feature"] == "mtp" and mtp_after > mtp_before:
+                    mtp_seen_for_cached_decode |= any(
+                        request.request_id in cached_request_ids
+                        and len(request.generated_tokens) > generated_before[request.request_id]
+                        for request in requests
+                    )
+                if baseline_follower_pending and (
+                    not config.enable_chunked_prefill or context.chunked_prefill_request_id == -1
+                ):
+                    engine._add_request(requests[1])
+                    if config.enable_chunked_prefill:
+                        engine._add_request(requests[2])
+                    baseline_follower_pending = False
+
+                min_pool_avail = min(min_pool_avail, allocator.pool_avail)
+                active_blocks = context.request_to_kv_block_ids[: context.total_request_count]
+                blocks_this_wave.update(active_blocks[active_blocks >= 0].tolist())
+                saw_chunk |= context.chunked_prefill_request_id != -1
+                max_mamba_matched_blocks = max(
+                    max_mamba_matched_blocks,
+                    *(getattr(request, "_mamba_num_matched_blocks", 0) for request in requests),
+                )
+                for record in result["finished_request_records"]:
+                    merged = record.merge()
+                    finished[merged.request_id] = merged
+                assert step_count < 256, f"{case['name']} did not converge"
+
+            torch.cuda.synchronize()
+            assert allocator.pool_size == pool_size
+            assert context.memory_buffer.untyped_storage().nbytes() == storage_size
+            assert context.total_request_count == 0
+            assert allocator.get_active_used() == 0
+            assert allocator.get_allocatable_count() == target_allocatable
+            wave_block_ids.append(blocks_this_wave)
+            if enable_prefix_caching:
+                assert engine._prefix_cache_hits > hits_before
+                if case["policy"] == PrefixCachingEvictionPolicy.REF_ZERO:
+                    assert not allocator.kv_hash_to_block_id
+                    assert all(
+                        allocator.block_ref_counts[block_id].item() == 0
+                        for block_id in blocks_this_wave
+                    )
+
+        assert len(finished) == 9
+        if enable_prefix_caching:
+            assert min_pool_avail == 0
+            assert engine._prefix_cache_hits >= 3
+            assert engine._prefix_cache_blocks_matched >= 6
+            assert engine._prefix_coordination_waits >= 3
+            if case["policy"] == PrefixCachingEvictionPolicy.LRU:
+                assert all_hashes - allocator.kv_hash_to_block_id.keys()
+            else:
+                assert all(
+                    len(previous & current) >= 2
+                    for previous, current in zip(wave_block_ids, wave_block_ids[1:])
+                )
+        else:
+            assert engine._prefix_cache_hits == 0
+
+        if enable_prefix_caching and case["feature"] == "moe":
+            # EP routing evidence is recorded with the live request IDs inside
+            # token_dispatch. The engine drains hit accounting after the forward,
+            # so correlating the dispatcher batch to the cached follower is more
+            # precise than comparing counters on adjacent host steps.
+            assert cached_request_ids & evidence["moe_request_ids"]
+            feature_seen_for_cached_request = True
+
+        return finished, {
+            "saw_chunk": saw_chunk,
+            "mtp_tokens_proposed": int(engine._spec_tokens_proposed_per_pos.sum()),
+            "min_pool_avail": min_pool_avail,
+            "max_mamba_matched_blocks": max_mamba_matched_blocks,
+            "feature_seen_for_cached_request": feature_seen_for_cached_request,
+            "mtp_seen_for_cached_decode": mtp_seen_for_cached_decode,
+            **evidence,
+        }
+
+    @staticmethod
+    def _assert_scalar_logprob_close(value, expected, *, rel=2e-2, abs=5e-2):
+        """Compare one logprob while preserving matching non-finite results."""
+        if np.isnan(value) or np.isnan(expected):
+            assert np.isnan(value) and np.isnan(expected)
+        else:
+            assert value == pytest.approx(expected, rel=rel, abs=abs)
+
+    @staticmethod
+    def _assert_logprob_parity(cached_request, baseline_request):
+        """Check generated and top-N logprobs against the cache-off run."""
+        cached_logprobs = cached_request.generated_log_probs
+        baseline_logprobs = baseline_request.generated_log_probs
+        assert cached_logprobs is not None and baseline_logprobs is not None
+        assert len(cached_logprobs) == len(cached_request.generated_tokens)
+        np.testing.assert_allclose(cached_logprobs, baseline_logprobs, rtol=2e-2, atol=5e-2)
+
+        cached_top_n = cached_request.generated_top_n_logprobs
+        baseline_top_n = baseline_request.generated_top_n_logprobs
+        if cached_request.sampling_params.top_n_logprobs == 0:
+            assert not cached_top_n
+            assert not baseline_top_n
+            assert not cached_request.prompt_log_probs
+            assert not cached_request.prompt_top_n_logprobs
+            return
+        assert cached_top_n is not None and baseline_top_n is not None
+        assert len(cached_top_n) == len(cached_request.generated_tokens)
+        for token, logprob, baseline_logprob, cached_values, baseline_values in zip(
+            cached_request.generated_tokens,
+            cached_logprobs,
+            baseline_logprobs,
+            cached_top_n,
+            baseline_top_n,
+        ):
+            assert 0 < len(cached_values) <= 5
+            assert len(cached_values) == len(baseline_values)
+            cached_keys = set(cached_values)
+            baseline_keys = set(baseline_values)
+            for key in cached_keys & baseline_keys:
+                TestPrefixCacheRealEngineMatrix._assert_scalar_logprob_close(
+                    cached_values[key], baseline_values[key]
+                )
+            token_key = f"tok_{token}"
+            assert token_key in cached_values
+            assert token_key in baseline_values
+            TestPrefixCacheRealEngineMatrix._assert_scalar_logprob_close(
+                cached_values[token_key], logprob, abs=0.1
+            )
+            TestPrefixCacheRealEngineMatrix._assert_scalar_logprob_close(
+                baseline_values[token_key], baseline_logprob, abs=0.1
+            )
+
+            cached_ranked = sorted(cached_values.values(), reverse=True)
+            baseline_ranked = sorted(baseline_values.values(), reverse=True)
+            np.testing.assert_allclose(cached_ranked, baseline_ranked, rtol=2e-2, atol=5e-2)
+            if cached_keys != baseline_keys:
+                cached_cutoff = cached_ranked[-1]
+                baseline_cutoff = baseline_ranked[-1]
+                for key in cached_keys - baseline_keys:
+                    TestPrefixCacheRealEngineMatrix._assert_scalar_logprob_close(
+                        cached_values[key], baseline_cutoff
+                    )
+                for key in baseline_keys - cached_keys:
+                    TestPrefixCacheRealEngineMatrix._assert_scalar_logprob_close(
+                        baseline_values[key], cached_cutoff
+                    )
+
+        assert not cached_request.prompt_log_probs
+        assert not cached_request.prompt_top_n_logprobs
+
+    @staticmethod
+    def _clear_engine_runtime():
+        """Release per-row model and inference allocations before rebuilding."""
+        torch.cuda.synchronize()
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    @torch.inference_mode()
+    def _run_engine_case(self, case):
+        """Compare cache-on and cache-off output while asserting row activation."""
+        self._clear_engine_runtime()
+        try:
+            cached, stats = self._run_engine_session(case, enable_prefix_caching=True)
+            self._clear_engine_runtime()
+            baseline, baseline_stats = self._run_engine_session(case, enable_prefix_caching=False)
+
+            for request_id in range(9):
+                cached_request = cached[request_id]
+                baseline_request = baseline[request_id]
+                assert cached_request.generated_tokens == baseline_request.generated_tokens
+                assert cached_request.generated_text == baseline_request.generated_text
+                assert len(cached_request.generated_tokens) == 4
+                self._assert_logprob_parity(cached_request, baseline_request)
+
+            assert stats["min_pool_avail"] == 0
+            assert baseline_stats["min_pool_avail"] <= 1
+            feature = case["feature"]
+            if feature == "mtp":
+                assert stats["mtp_seen_for_cached_decode"]
+            else:
+                assert stats["feature_seen_for_cached_request"]
+            if feature == "tp":
+                assert stats["tp_reducing_forwards"] > 0
+            elif feature == "pp":
+                assert stats["pipeline_forwards"] > 0
+            elif feature == "moe":
+                assert stats["moe_dispatches"] > 0
+            elif feature == "chunked":
+                assert stats["saw_chunk"]
+            elif feature == "fused-rope":
+                assert stats["fused_rope_calls"] > 0
+            elif feature == "mamba":
+                assert stats["max_mamba_matched_blocks"] > 0
+                assert stats["mamba_restores"] > 0
+            else:
+                assert feature == "mtp"
+                assert stats["mtp_tokens_proposed"] > 0
+        finally:
+            self._clear_engine_runtime()
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("case", PREFIX_CACHE_ENGINE_CASES)
+    def test_real_engine_stress_row(self, case):
+        if case["feature"] == "mamba":
+            available, reason = _check_mamba_sequence_packing_support()
+            if not available:
+                pytest.skip(reason)
+        if case["feature"] == "fused-rope":
+            pytest.importorskip("flashinfer")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=case.get("tp", 1),
+            pipeline_model_parallel_size=case.get("pp", 1),
+            expert_model_parallel_size=case.get("ep", 1),
+            expert_tensor_parallel_size=1,
+        )
+        try:
+            self._run_engine_case(case)
+        finally:
+            DynamicInferenceContext.ROUNDER = 64
+            DynamicInferenceContext.TOKEN_ROUNDER = 64
+            DynamicInferenceContext.REQUEST_ROUNDER = 64
+            Utils.destroy_model_parallel()

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -188,6 +188,7 @@ class DynamicEngineTestConfig:
     suspend_resume_interval: Optional[int] = None
     kv_cache_management_mode: str = "persist"
     static_kv_memory_pointers: bool = True
+    unified_memory_level: int = 0
     track_generated_token_events: bool = False
     num_speculative_tokens: int = 0
     position_embedding_type: str = "learned_absolute"

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -160,6 +160,7 @@ class DynamicEngineTestConfig:
     use_cuda_graphs_for_non_decode_steps: bool = True
     cuda_graph_all_prefills: bool = False
     fp8: bool = False
+    hidden_size: Optional[int] = None
     model_provider: str = "gpt"
     # Which linear-attention mixer a hybrid stack uses ("mamba", "gdp", or
     # "gdn"). Ignored unless model_provider == "hybrid": all three build a
@@ -397,7 +398,11 @@ class DynamicInferenceEngineTestBase:
                 params_dtype=torch.bfloat16,
                 num_layers=4,
                 mtp_num_layers=test_config.num_speculative_tokens,
-                hidden_size=128 if test_config.fp8 else 32,
+                hidden_size=(
+                    test_config.hidden_size
+                    if test_config.hidden_size is not None
+                    else (128 if test_config.fp8 else 32)
+                ),
                 num_attention_heads=4,
                 use_cpu_initialization=True,
                 cuda_graph_impl=effective_cuda_graph_impl,
@@ -439,11 +444,17 @@ class DynamicInferenceEngineTestBase:
                 window_attn_skip_freq=test_config.window_attn_skip_freq,
             )
             if test_config.fp8 or test_config.transformer_impl == "transformer_engine":
-                layer_spec = get_gpt_layer_with_transformer_engine_spec()
+                layer_spec = get_gpt_layer_with_transformer_engine_spec(
+                    num_experts=transformer_config.num_moe_experts
+                )
             elif test_config.transformer_impl == "local":
-                layer_spec = get_gpt_layer_local_spec()
+                layer_spec = get_gpt_layer_local_spec(
+                    num_experts=transformer_config.num_moe_experts
+                )
             elif test_config.transformer_impl == "inference_optimized":
-                layer_spec = get_gpt_layer_with_inference_spec()
+                layer_spec = get_gpt_layer_with_inference_spec(
+                    num_experts=transformer_config.num_moe_experts
+                )
 
             # MTP block spec (needed for speculative decoding).
             mtp_block_spec = None

--- a/tests/unit_tests/inference/test_openai_streaming.py
+++ b/tests/unit_tests/inference/test_openai_streaming.py
@@ -57,6 +57,78 @@ def _make_byte_level_fast_tokenizer():
 
 
 @pytest.mark.asyncio
+async def test_chat_completions_uses_generated_logprobs_only_when_requested():
+    quart = pytest.importorskip("quart")
+    from megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints.chat_completions import (
+        bp as chat_completions_blueprint,
+    )
+
+    class FakeTokenizer:
+        bos = None
+        chat_template = None
+
+        @staticmethod
+        def tokenize(_text):
+            return [11, 12]
+
+        @staticmethod
+        def detokenize(tokens):
+            return "".join(chr(ord("a") + token - 1) for token in tokens)
+
+    class FakeInferenceClient:
+        def __init__(self):
+            self.return_log_probs = []
+
+        async def add_request(self, _prompt_tokens, sampling_params):
+            self.return_log_probs.append(sampling_params.return_log_probs)
+            generated_log_probs = [-0.25, -0.5] if sampling_params.return_log_probs else None
+            return {
+                "status": "COMPLETED",
+                "generated_text": "ab",
+                "prompt_length": 2,
+                "num_cached_tokens": 1,
+                "generated_tokens": [1, 2],
+                "generated_log_probs": generated_log_probs,
+                # This legacy-shaped field catches a regression back to the old lookup.
+                "log_probs": [-9.0, -9.0],
+                "generated_top_n_logprobs": [{"a": -0.25}, {"b": -0.5}],
+                "policy_epoch": [],
+                "kv_cache_epoch": [],
+                "events": [],
+                "sampling_params": {"num_tokens_to_generate": 2},
+                "routing_indices": None,
+            }
+
+    fake_client = FakeInferenceClient()
+    app = quart.Quart(__name__)
+    app.config.update(client=fake_client, tokenizer=FakeTokenizer(), parsers=[], verbose=False)
+    app.register_blueprint(chat_completions_blueprint)
+    client = app.test_client()
+    request_body = {
+        "messages": [{"role": "user", "content": "prompt"}],
+        "max_tokens": 2,
+        "prevent_retokenization": False,
+    }
+
+    with_logprobs = await client.post(
+        "/v1/chat/completions", json={**request_body, "logprobs": True, "top_logprobs": 1}
+    )
+    without_logprobs = await client.post(
+        "/v1/chat/completions", json={**request_body, "logprobs": False}
+    )
+
+    assert with_logprobs.status_code == without_logprobs.status_code == 200
+    with_payload = await with_logprobs.get_json()
+    without_payload = await without_logprobs.get_json()
+    assert fake_client.return_log_probs == [True, False]
+    assert [entry["logprob"] for entry in with_payload["choices"][0]["logprobs"]["content"]] == [
+        -0.25,
+        -0.5,
+    ]
+    assert without_payload["choices"][0]["logprobs"] is None
+
+
+@pytest.mark.asyncio
 async def test_openai_stream_emits_delta_chunks_and_terminal_metadata():
     stream = AsyncStream(request_id=1, cancel=lambda: None)
     stream.put(

--- a/tests/unit_tests/inference/test_openai_streaming.py
+++ b/tests/unit_tests/inference/test_openai_streaming.py
@@ -79,10 +79,11 @@ async def test_chat_completions_uses_generated_logprobs_only_when_requested():
         def __init__(self):
             self.return_log_probs = []
 
-        async def add_request(self, _prompt_tokens, sampling_params):
+        async def add_request(self, _prompt_tokens, sampling_params, multi_modal_data=None):
             self.return_log_probs.append(sampling_params.return_log_probs)
             generated_log_probs = [-0.25, -0.5] if sampling_params.return_log_probs else None
             return {
+                "uid": "request-1",
                 "status": "COMPLETED",
                 "generated_text": "ab",
                 "prompt_length": 2,

--- a/tests/unit_tests/rl/test_rollout_generation.py
+++ b/tests/unit_tests/rl/test_rollout_generation.py
@@ -3,7 +3,7 @@
 import asyncio
 import itertools
 from contextlib import aclosing
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
@@ -22,7 +22,49 @@ from megatron.rl.agent.api import (
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.rollout_pipeline import RolloutPipeline, _SubmissionGate
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
-from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw, ReturnsTokens
+from megatron.rl.inference import (
+    InferenceRequest,
+    InferenceResponse,
+    LLMChatMessage,
+    ReturnsRaw,
+    ReturnsTokens,
+)
+from megatron.rl.inference.megatron import MegatronLocal
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "temperature, expected_temperature", [(None, 1.0), (0.0, 0.0)], ids=["default", "greedy"]
+)
+async def test_megatron_local_preserves_explicit_greedy_temperature(
+    monkeypatch, temperature, expected_temperature
+):
+    monkeypatch.setattr("megatron.rl.inference.megatron.get_args", lambda: MagicMock())
+    monkeypatch.setattr("megatron.rl.inference.megatron.get_tokenizer", lambda: MagicMock(bos=None))
+
+    choice = MagicMock(finish_reason="stop")
+    choice.message.model_dump.return_value = {"role": "assistant", "content": "response"}
+    choice.message.raw_text = "response"
+    choice.message.prompt_token_ids = [1]
+    choice.message.generation_token_ids = [2]
+    choice.message.generation_log_probs = [0.0]
+    choice.message.policy_epoch = [(0, 0)]
+    choice.message.kv_cache_epoch = [(0, 0)]
+    choice.message.num_evictions = 0
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[choice]))
+    server = MegatronLocal(host="localhost", port=0)
+    server._openai_client = client
+    request = InferenceRequest(
+        prompt=[LLMChatMessage(role="user", content="prompt")],
+        generation_args={"temperature": temperature},
+    )
+
+    await server.base_generate(request)
+
+    client.chat.completions.create.assert_awaited_once()
+    assert client.chat.completions.create.await_args.kwargs["temperature"] == expected_temperature
 
 
 class MockInferenceInterface(ReturnsRaw):

--- a/tests/unit_tests/rl/test_rollout_generation.py
+++ b/tests/unit_tests/rl/test_rollout_generation.py
@@ -53,7 +53,9 @@ async def test_megatron_local_preserves_explicit_greedy_temperature(
     choice.message.num_evictions = 0
 
     client = MagicMock()
-    client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[choice]))
+    client.chat.completions.create = AsyncMock(
+        return_value=MagicMock(id="completion-id", choices=[choice])
+    )
     server = MegatronLocal(host="localhost", port=0)
     server._openai_client = client
     request = InferenceRequest(


### PR DESCRIPTION
## What does this PR do?

This draft is the cumulative integration snapshot of the eight current prefix-cache PRs. It applies each source PR's exact net delta to NVIDIA `main` at `cc99d8e89eb1cc64b27891bf3e276b1ff1eab391`, without using either earlier monolithic branch.

It combines:

- the shared unit-only prefix-cache interaction matrix;
- correct hit accounting when admission fails and retries;
- preservation of an explicit greedy RL temperature;
- aligned Mamba-state publication and suppression of unreachable state;
- complete checkpointed score and routing reconstruction;
- safe CUDA-graph deletion, suspend, resume, UVM, and recapture behavior;
- complete prompt and HTTP generated log probabilities; and
- KV, Mamba, and coordinator invalidation across model-generation changes.

### Production fixes and discovery signals

| Source | Production correction | Discovery signal |
| --- | --- | --- |
| [#6416](https://github.com/NVIDIA/Megatron-LM/pull/6416) | Count prefix reuse only after admission succeeds. | Exact counters increased on a rejected allocation and again on retry. |
| [#6417](https://github.com/NVIDIA/Megatron-LM/pull/6417) | Preserve explicit `temperature=0.0` in RL inference. | The mocked client received `1.0` for a request that supplied `0.0`. |
| [fork #38](https://github.com/lmcafee-nvidia/Megatron-LM/pull/38) | Publish aligned Mamba state and skip state with no lookup hashes. | A follower found KV blocks but no Mamba state; an opted-out request consumed unreachable slots. |
| [fork #39](https://github.com/lmcafee-nvidia/Megatron-LM/pull/39) | Merge checkpointed scores and routing across every result record. | Scores and routing produced after resume were absent from the final result. |
| [fork #40](https://github.com/lmcafee-nvidia/Megatron-LM/pull/40) | Make CUDA graphs safe across deletion, suspend, resume, and UVM. | Lifecycle invariants exposed live-state capture, stale runners, and a duplicate-backup assertion. |
| [fork #41](https://github.com/lmcafee-nvidia/Megatron-LM/pull/41) | Recompute complete prompt scores and return the engine's generated-score field. | Cache-on prompt scores were short, and HTTP returned legacy sentinel values. |
| [fork #42](https://github.com/lmcafee-nvidia/Megatron-LM/pull/42) | Invalidate reusable state when the model generation changes. | Old hashes, Mamba mappings, and coordinator owners remained discoverable after an epoch update. |

### Frozen source manifest

| Source | Base SHA | Head SHA |
| --- | --- | --- |
| NVIDIA #6416 | `24bad8e677d22625d86ef2a54c9506b6e4992c93` | `48b67ea0929e0cca43b8f40d412c53f0394a335d` |
| NVIDIA #6417 | `24bad8e677d22625d86ef2a54c9506b6e4992c93` | `a91a0ea48e2dc1b5ccc51e78bd945e9e657d98ca` |
| NVIDIA #6418 | `fb24e8707c94aebe28fb919e4a6253b600ad0528` | `f8aed2caaaf2a424d7866ffdeab1faad05751344` |
| fork #38 | `f8aed2caaaf2a424d7866ffdeab1faad05751344` | `3acfb17acc3a8544dd7cda8918b8bf6e38d3e397` |
| fork #39 | `f8aed2caaaf2a424d7866ffdeab1faad05751344` | `0c05dba3fb0595a548d65cde896462b5a290522d` |
| fork #40 | `f8aed2caaaf2a424d7866ffdeab1faad05751344` | `5a72930867caf41fe770fefbd5e7065bbc731c19` |
| fork #41 | `f8aed2caaaf2a424d7866ffdeab1faad05751344` | `eb1ec33e129036d98fb77a6d946849aac8248d65` |
| fork #42 | `3acfb17acc3a8544dd7cda8918b8bf6e38d3e397` | `a7a731abfb856c4f338a027f73fcb0b2d64375aa` |

## How was the test matrix determined?

An audit found that earlier tests could enable prefix caching without forcing reuse, allocator pressure, eviction, physical block reuse, or execution of the claimed companion feature on cached work.

The matrix therefore has three layers:

1. Ten context cases cross five prefix-sharing behaviors with both `LRU` and `REF_ZERO` policies.
2. Seven real-engine differential rows compare cache off with cache on while one major execution or state path remains active in both sessions.
3. Twenty-one focused regression cases assert the exact invariant that exposed each production defect.

This is differential interaction coverage, not a universal four-cell Boolean 2x2 or a covering array over every inference flag. Companion-disabled cells are not repeated, and expensive engine rows use one representative cache policy because the context matrix already exercises both policy semantics.

## What combinations are tested?

### Context behavior and policy matrix (10 cases)

Prefix caching is enabled in every case. Each behavior runs once under `LRU` and once under `REF_ZERO`, with deliberate allocator exhaustion.

| Behavior | LRU | REF_ZERO | Expected result |
| --- | --- | --- | --- |
| Exact three-block follower | yes | yes | Reuse all three blocks. |
| Two matching blocks and one divergent block | yes | yes | Reuse only the first two blocks. |
| Fully disjoint follower | yes | yes | Reuse zero blocks. |
| Three concurrent followers | yes | yes | Track and release exact shared references. |
| Cached and fresh requests in one batch | yes | yes | Keep query lengths and cache accounting independent. |

### Real-engine differential matrix (7 rows)

Every row executes equivalent cache-off and cache-on sessions while the companion configuration stays active.

| Row | Companion configuration | Cache-on policy |
| --- | --- | --- |
| `tp4-ref-zero` | Tensor parallel size 4 | `REF_ZERO` |
| `pp4-lru` | Pipeline parallel size 4 | `LRU` |
| `ep4-moe-lru` | Expert parallel size 4 with four real experts | `LRU` |
| `gpt-chunked-lru` | Chunked prefill with a hit-bearing continuation chunk | `LRU` |
| `gpt-fused-rope-ref-zero` | FlashInfer fused RoPE with CUDA cache state | `REF_ZERO` |
| `mtp2-ref-zero` | Two speculative MTP tokens and two MTP layers | `REF_ZERO` |
| `hybrid-mamba-ref-zero` | Hybrid Mamba model with durable Mamba prefix storage | `REF_ZERO` |

### Focused production regressions (21 cases)

| Source | Cases | Contract exercised |
| --- | ---: | --- |
| #6416 | 1 | Failed admission, rollback, and successful retry accounting |
| #6417 | 2 | Omitted and explicit-zero RL temperatures |
| fork #38 | 2 | Aligned Mamba publication and no-hash suppression |
| fork #39 | 1 | Multi-record score and routing reconstruction |
| fork #40 | 4 | `OFFLOAD`, `RECOMPUTE`, static UVM, and `PERSIST` TP2/PP2 lifecycle |
| fork #41 | 2 | Complete prompt scores and HTTP generated scores |
| fork #42 | 9 | Generation invalidation across coordinator, queued, live, GPT, hybrid, LRU, and REF_ZERO states |

The exact focused union is 38 unique pytest cases per rank: 17 matrix cases plus 21 production regressions. The Mamba engine row used while validating fork #38 is already one of the 17 foundation cases and is counted once.

## How are results checked?

The context layer checks exact matched blocks, cached-token and query-length accounting, reference counts, hash visibility, LRU victims, and REF_ZERO physical block reuse.

The real-engine rows require allocator pressure and real cache hits before comparing cache-off and cache-on generated token IDs, text, completion state, generated log probabilities, and top-N values where applicable. Runtime witnesses prove that TP, PP, MoE, chunking, fused RoPE, MTP, or Mamba executed on cached work rather than merely being configured.

Focused regressions use the original discovery oracle: exact admission counters, forwarded temperature, Mamba publication/restoration state, checkpointed result fields, graph-lifecycle invariants, prompt and HTTP score alignment, and generation-scoped allocator/coordinator state.

## Scope

This branch contains exactly ten signed commits: one exact source delta per PR in manifest order, followed by the exact append-only compatibility deltas from the updated #6417 and fork #41 tips. A literal merge oracle made every frozen source head an ancestor; an independent sequential application of the same source deltas produced the identical tree `e8ee4c34b67dce8e6d3aca89f2e55bc52f8f2cca`. The final diff is limited to 15 Python files and contains no functional tests, recipes, runners, prompts, goldens, or aggregate-only production behavior.

**Landing warning:** this cumulative draft and the eight source PRs are alternative representations of the same work. Do not merge both. If this draft is chosen for landing, it replaces NVIDIA #6416-#6418 and fork #38-#42; if any source PR lands or changes first, regenerate this branch from current `main` and repeat the tree proof.

## Validation

Exact aggregate tip: `d97582793229d2e71101c936411e7e4119396f2f`

- literal-merge oracle tree and sequential net-delta tree are identical: `e8ee4c34b67dce8e6d3aca89f2e55bc52f8f2cca`
- exact 15-path audit and `git diff --check` passed
- isort check passed on all import-edited files
- Black passed on 14 complete files and on the changed range in `megatron/rl/inference/megatron.py`; its two full-file wrapping deltas are pre-existing on the frozen `main` and outside this PR's hunk
- Ruff and Python bytecode compilation passed on all 15 changed files
- DFW H100 job `16596740` ran the exact 38-case focused union on all 8 ranks at `d97582793229d2e71101c936411e7e4119396f2f`
- every rank reported `38 passed, 0 failed, 0 skipped`; all eight ranks completed successfully
- the source-branch compatibility regressions for completion IDs, multimodal request payloads, and request UIDs passed on every rank
- the DFW checkout remained clean and unchanged at the exact aggregate tip
