### PR TITLE
Pass the config container to pretrain in the multimodal example

### DIFF
--- a/examples/multimodal/train.py
+++ b/examples/multimodal/train.py
@@ -5,6 +5,7 @@ import os
 import sys
 from functools import partial
 
+from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.training.arguments import parse_and_validate_args
 import torch
 import yaml
@@ -390,6 +391,7 @@ if __name__ == "__main__":
     )
     full_config = pretrain_cfg_container_from_args(args)
     pretrain(
+        full_config,
         train_valid_test_dataloaders_provider,
         ModelType.encoder_or_decoder,
         forward_step,


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Makes `examples/multimodal/train.py` start again. It currently cannot.

Two halves of one incomplete migration, both in the `__main__` block:

1. Line 391 calls `pretrain_cfg_container_from_args(args)`, but the module's only import from that package is `from megatron.training.arguments import parse_and_validate_args`. The symbol lives in `megatron.training.argument_utils`, which this file never imports, and there is no star-import — so the line raises `NameError`.
2. The `full_config` it builds is never passed. `pretrain()` now begins `(cfg_container, train_valid_test_dataset_provider, model_type, forward_step_func, model_provider=None, ...)`, and the call here begins with the dataloader provider, so every positional argument binds one slot early: `cfg_container` gets the dataloader provider, `train_valid_test_dataset_provider` gets `ModelType.encoder_or_decoder`, `model_type` gets `forward_step`. `pretrain` dereferences its first argument immediately as `cfg_container.logger.log_progress`, so there is no legacy order to fall back on.

The ModelBuilder migration in #5516 applied both halves correctly to `pretrain_vlm.py`, `examples/mimo/train.py` and `examples/bert/pretrain_bert.py`; this brings the multimodal entry point in line with those three. `pretrain_vlm.py:500-502` is the exact shape used here.

A reviewer raised this on #5516 — https://github.com/NVIDIA/Megatron-LM/pull/5516#discussion_r3487219346 — and the thread was closed as *"resolved in af7f1b60f96c0653dc442c76ae04313929788622"*. That sha is not in the repository (the PR was squash-merged), and the merged result contains only the `args_defaults` / `extra_args_provider` half of the fix; the import and the first positional argument are still missing on `main` and on `dev`.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended**.

Linked issue: none — 2-line bug fix. Related to #5516 (comment linked above).

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests — nothing in `tests/` imports `examples/multimodal/train.py`, which is why the migration could land without breaking anything visible. Happy to add a smoke test if you want one.
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code — the touched lines carry no annotations.
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR — the changeset is empty under its scope (`megatron/core` and `tests/`), and the new import is placed where `isort` would put it (`argument_utils` sorts before `arguments`).

### How to reproduce, and how we checked it

`examples/multimodal/pretrain_mistral_clip.sh:133` runs `torchrun --nproc_per_node 8 examples/multimodal/train.py ${OPTIONS}`, and `examples/multimodal/README.md:89` documents running that script. The failure is at module `__main__`, before any GPU work, so no GPU or data is needed to see it.

Checked on 8xL4 / torch 2.12.0+cu130: an AST pass collected every name bound at module scope (no star-imports present), confirmed `pretrain_cfg_container_from_args` is not among them, read `inspect.signature(pretrain)` as beginning `['cfg_container', 'train_valid_test_dataset_provider', 'model_type', 'forward_step_func', 'model_provider']`, and executed the file's real `__main__` block with every bound name stubbed — which raises `NameError: name 'pretrain_cfg_container_from_args' is not defined`.

**What we did not do:** we did not run the LLaVA example end to end, so this is verified to remove the `NameError` and the argument shift, not to demonstrate that multimodal pretraining converges after the ModelBuilder migration. Nothing was benchmarked and no performance claim is made.

### The strongest objection to this change

This is an `examples/` script that no CI job executes, and it has been broken identically on `dev` for hundreds of commits — so the two-line patch fixes the entry point without showing that the documented example works after it. If `examples/multimodal/train.py` is superseded by `pretrain_vlm.py`, the right change is deleting the file or the README pointer rather than fixing it, and we would rather be told that than guess.
