### PR TITLE
fix: restore each rank's own RNG state on checkpoint load

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -459,7 +459,7 @@ def get_rng_state(
     """Collect rng state across data parallel ranks.
 
     dp_group threads the data-parallel group used for RNG gather/indexing.
-    dp_cp_group threads the data-parallel (with context-parallel) group used for checkpoint replica id.
+    dp_cp_group threads the data-parallel (with context-parallel) group used for the rng shard key.
     key_prefix namespaces the rng ShardedObject key so disjoint grids avoid a key collision (default '').
     """
     args = get_args()
@@ -485,24 +485,30 @@ def get_rng_state(
     else:
         rng_state_list = [rng_state]
 
-    dp_cp_rank = (
-        get_pg_rank(dp_cp_group)
+    dp_cp_group = (
+        dp_cp_group
         if dp_cp_group is not None
-        else mpu.get_data_parallel_rank(with_context_parallel=True)
+        else mpu.get_data_parallel_group(with_context_parallel=True)
     )
+    dp_cp_rank = get_pg_rank(dp_cp_group)
     if ckpt_format == 'torch_dist':
         pp_rank = get_pg_rank(pp_group)
         pp_size = get_pg_size(pp_group)
         tp_rank = get_pg_rank(tp_group)
         tp_size = get_pg_size(tp_group)
+        # Tracker streams are seeded per rank (tensor_parallel/random.py), so an axis left out
+        # of the key becomes a replica and those ranks restore a peer's stream. ep/etp/gtp_remat
+        # do not tile the grid; pp x tp x dp_cp does.
+        dp_cp_size = get_pg_size(dp_cp_group)
         rng_state_list = ShardedObject(
             f'{key_prefix}rng_state',
             rng_state_list,
-            (pp_size, tp_size),
-            (pp_rank, tp_rank),
-            replica_id=dp_cp_rank,
+            (pp_size, tp_size, dp_cp_size),
+            (pp_rank, tp_rank, dp_cp_rank),
         )
     elif ckpt_format == 'fsdp_dtensor':
+        # TODO: this key omits dp_cp, so dp_cp peers become replicas and restore each other's
+        # tracker streams. Fixing it also needs the matching lookup in load_checkpoint.
         pp_rank = get_pg_rank(pp_group)
         tp_rank = get_pg_rank(tp_group)
         rng_state_list = {f'({pp_rank}, {tp_rank})': rng_state_list}
@@ -2577,8 +2583,11 @@ def load_checkpoint(
         )
 
         # Determine if RNG state will be loaded
+        # world_size must match too: the rng shard key includes dp_cp, so a DP rescale leaves this
+        # rank with no shard to load.
         if (
             ckpt_tp_pp == run_tp_pp
+            and ckpt_world_size == run_world_size
             and not release
             and not args.finetune
             and not args.no_load_rng
@@ -2600,6 +2609,8 @@ def load_checkpoint(
             gen_sd_rng_state = None
             if ckpt_tp_pp != run_tp_pp:
                 print_rank_0('{}: RNG state will be ignored'.format(mismatch_msg))
+            elif ckpt_world_size != run_world_size:
+                print_rank_0('Job sharding has changed: RNG state will be ignored')
 
         if ckpt_type == CheckpointType.LOCAL:
             sharded_sd_metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=dp_cp_group)

--- a/megatron/training/datasets/data_samplers.py
+++ b/megatron/training/datasets/data_samplers.py
@@ -117,6 +117,11 @@ def build_pretraining_data_loader(dataset, consumed_samples):
         extra_kwargs = {"collate_fn": lambda x: x}
     else:
         extra_kwargs = {}
+    # Own generator: otherwise _BaseDataLoaderIter draws _base_seed from the default CPU generator
+    # on ITERATOR creation, after load_checkpoint has restored it. initial_seed() reads the seed
+    # without consuming a draw.
+    loader_generator = torch.Generator()
+    loader_generator.manual_seed(torch.initial_seed())
     return torch.utils.data.DataLoader(
         dataset,
         batch_sampler=batch_sampler,
@@ -124,6 +129,7 @@ def build_pretraining_data_loader(dataset, consumed_samples):
         pin_memory=True,
         persistent_workers=True if args.num_workers > 0 else False,
         worker_init_fn=maybe_worker_init_fn,
+        generator=loader_generator,
         **extra_kwargs,
     )
 

--- a/tests/unit_tests/data/test_data_samplers.py
+++ b/tests/unit_tests/data/test_data_samplers.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Restoring a checkpoint then building the data iterators must leave the CPU RNG where it was.
+
+Mirrors pretrain(): _set_random_seed, then load_checkpoint restores the saved state, then
+build_train_valid_test_data_iterators. Nothing between the restore and the first step draws from
+the default CPU generator -- except, on the pre-fix code, iterator creation itself.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+import megatron.training.datasets.data_samplers as data_samplers
+from tests.unit_tests.test_utilities import Utils
+
+SEED = 1234
+
+
+def _set_random_seed():
+    """What _set_random_seed does at process start (tp=pp=1, so it collapses to SEED)."""
+    torch.manual_seed(SEED)
+
+
+def _load_checkpoint_rng(saved_rng):
+    """What load_checkpoint does with the saved rng_state, before the data iterators exist."""
+    torch.set_rng_state(saved_rng)
+
+
+class _Dataset(torch.utils.data.Dataset):
+    def __len__(self):
+        return 64
+
+    def __getitem__(self, idx):
+        return torch.tensor([idx])
+
+
+class TestDataLoaderResume:
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_building_data_iterators_does_not_move_cpu_rng(self, monkeypatch):
+        Utils.initialize_model_parallel(1, 1)
+        monkeypatch.setattr(
+            data_samplers,
+            'get_args',
+            lambda: SimpleNamespace(
+                dataloader_type='single',
+                micro_batch_size=1,
+                global_batch_size=Utils.world_size,
+                num_workers=0,
+                hybrid_context_parallel=False,
+                sequence_packing_scheduler=None,
+                use_varlen_dataset=False,
+                varlen_sbhd_validation=False,
+            ),
+        )
+        steps_before_save = 3
+
+        _set_random_seed()
+        loader = data_samplers.build_pretraining_data_loader(_Dataset(), consumed_samples=0)
+        it = iter(loader)
+        for _ in range(steps_before_save):
+            next(it)
+        saved_rng = torch.get_rng_state()  # what save_checkpoint stores
+        continuous_rest = [b.tolist() for b in it]
+
+        # The resumed process, in pretrain()'s order.
+        _set_random_seed()
+        _load_checkpoint_rng(saved_rng)
+        resumed = data_samplers.build_pretraining_data_loader(
+            _Dataset(), consumed_samples=steps_before_save * Utils.world_size
+        )
+        resumed_rest = [b.tolist() for b in resumed]
+
+        # Data position rides on consumed_samples, not RNG, so this holds either way -- it pins
+        # that independence rather than guarding the fix.
+        assert resumed_rest == continuous_rest, (
+            f"resumed loader did not continue where the saving run stopped: "
+            f"got {resumed_rest[:2]}, expected {continuous_rest[:2]}"
+        )
+        assert torch.equal(torch.get_rng_state(), saved_rng), (
+            "building the data iterators moved the CPU RNG off the state load_checkpoint "
+            "restored, so the resumed run diverges from the run that saved"
+        )

--- a/tests/unit_tests/dist_checkpointing/test_rng_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_rng_state.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Does every rank get its OWN cuda_rng_tracker state back from a checkpoint?
+
+The tracker streams are seeded per rank (tensor_parallel/random.py), e.g.
+``expert_parallel_seed = seed + 1024 + 100 * ep_rank + etp_rank``. When ``get_rng_state`` keyed on
+``(pp, tp)`` with ``replica_id=dp_cp_rank``, expert parallelism became a replica axis: one rank's
+state was written and its peers restored it, so only expert-parallel rank 0 resumed on the stream
+it had saved.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.training.checkpointing as checkpointing
+from megatron.core import mpu, tensor_parallel
+from megatron.core.dist_checkpointing import load, save
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+# tp * pp * cp * dp == 8, with ep dividing dp. cp earns its rows because a (pp, tp, dp) key
+# passes at cp=1 and only collides differing ranks at cp=2.
+LAYOUTS = [
+    (1, 1, 1, 2),
+    (2, 1, 1, 2),
+    (1, 2, 1, 2),
+    (1, 1, 2, 2),
+    (2, 2, 1, 2),
+    (2, 1, 2, 2),
+    (1, 2, 2, 2),
+]
+
+
+@pytest.mark.parametrize(('tp', 'pp', 'cp', 'ep'), LAYOUTS)
+class TestRNGStateCheckpoint:
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_each_rank_restores_the_state_it_saved(
+        self, tmp_path_dist_ckpt, monkeypatch, tp, pp, cp, ep
+    ):
+        Utils.initialize_model_parallel(
+            tp, pp, context_parallel_size=cp, expert_model_parallel_size=ep
+        )
+        # get_rng_state reads only args.data_parallel_random_init.
+        monkeypatch.setattr(
+            checkpointing, 'get_args', lambda: SimpleNamespace(data_parallel_random_init=False)
+        )
+        # Seeds every tracker stream as a function of this rank's position on each parallel axis.
+        tensor_parallel.model_parallel_cuda_manual_seed(123)
+
+        def rng_sharded_object():
+            return checkpointing.get_rng_state(
+                'torch_dist',
+                mpu.get_tensor_model_parallel_group(),
+                mpu.get_pipeline_model_parallel_group(),
+                dp_cp_group=mpu.get_data_parallel_group(with_context_parallel=True),
+                dp_group=mpu.get_data_parallel_group(),
+            )
+
+        # get_states() copies the dict but not the tensors, so clone to survive re-seeding.
+        expected = {
+            k: v.clone() for k, v in tensor_parallel.get_cuda_rng_tracker().get_states().items()
+        }
+
+        with TempNamedDir(tmp_path_dist_ckpt / f'rng_{tp}_{pp}_{cp}_{ep}') as ckpt_dir:
+            save({'rng_state': rng_sharded_object()}, ckpt_dir)
+
+            # Perturb every stream, so a load that silently restores nothing cannot pass.
+            tensor_parallel.model_parallel_cuda_manual_seed(456)
+
+            loaded = load({'rng_state': rng_sharded_object()}, ckpt_dir)['rng_state']
+
+        restored = loaded[0]['rng_tracker_states']
+        for name, want in expected.items():
+            assert name in restored, f"'{name}' missing after load on rank {Utils.rank}"
+            assert torch.equal(want, restored[name]), (
+                f"rank {Utils.rank} restored a different '{name}' stream than it saved "
+                f"(tp={tp} pp={pp} cp={cp} ep={ep}) -- the shard key does not separate this rank "
+                f"from its peers on some parallel axis"
+            )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes `load_checkpoint` restoring the wrong RNG state on most ranks.

## Issue tracking

Linked issue: <!-- e.g. Fixes #1234 -->

## The bug

`cuda_rng_tracker` streams are seeded **per rank** so ranks draw independently
(`tensor_parallel/random.py`: `expert_parallel_seed = seed + 1024 + 100*ep_rank + etp_rank`).

Those streams are consumed on every forward. The MoE router draws from this one
(`moe_utils.py:1277`):

```python
with get_cuda_rng_tracker().fork(get_expert_parallel_rng_tracker_name()):
    random_logits = logits.clone().normal_()      # advances the expert-parallel stream
```

Expert dropout forks the same tracker (`extensions/transformer_engine.py:1242`).

But `get_rng_state` passed `replica_id=dp_cp_rank`, which tells dist-checkpointing *"my copy
duplicates someone else's"*. That is false. Only one rank's state was written, and its peers
restored it — so any rank with `ep_rank > 0` resumed on someone else's stream, and the independence
the seeding exists to create was gone for the rest of the run.

Measured on a 120B MoE run at 64 nodes: **`expert-parallel-rng` differed from the saved value on
252 of 256 ranks**; every correct rank was an expert-parallel rank 0. Not gated on any flag — any
resume with EP > 1 hits it, and the load reports success.

## The fix

Move `dp_cp_rank` out of `replica_id` and into the offset. These ranks hold different data, so they
need different addresses:

```python
-  (pp_size, tp_size),              (pp_rank, tp_rank),  replica_id=dp_cp_rank
+  (pp_size, tp_size, dp_cp_size),  (pp_rank, tp_rank, dp_cp_rank)
```

## What reviewers should know

- **Old checkpoints won't load their RNG state** — 2-D key vs 3-D request. This is the
  compatibility break, and the operator sees a raw dist-checkpointing key error rather than a
  graceful skip; `--no-load-rng` is the workaround. Recording the key layout in the checkpoint's
  content metadata would let the load path degrade the way the world-size case does — worth doing,
  but a larger change than this fix.
- **DP rescale** now keeps its freshly-seeded RNG and logs why, rather than failing
  (`load_checkpoint` gained a `world_size` check beside the existing `(TP, PP)` one).
- **Size**: +47 MB at 4096 ranks. The old count was smaller only because it discarded most ranks'
  state. No extra files, no added collectives.
- **Scope**: `torch_dist` only. `fsdp_dtensor` has the same defect, marked `TODO` in source.

`dp_cp` separates more ranks than strictly necessary — `dp`/`cp` enter no seed, so ranks sharing an
`ep_rank` hold identical state. The tighter key `(pp, tp, ep, etp, …)` is rejected by the format:
`ShardedObject` needs a product-shaped `global_shape` and those axes are interdependent. `dp_cp` is
the least-separating legal key.

The third commit is separate and smaller: `DataLoader` iterator creation draws from the default CPU
generator *after* `load_checkpoint` restores it, so `torch_rng_state` doesn't round-trip. It does
not change training output — resume position comes from `consumed_samples`, and samplers shuffle
with their own epoch-seeded generators.

## Testing

Every test was also run against `main` — one that passes either way proves nothing.

| test | this PR | `main` |
|---|---|---|
| RNG round trip, `(tp,pp,cp,ep)` = (1,1,1,2), (2,1,1,2), (1,1,2,2) | pass | **fail** — `restored a different 'expert-parallel-rng' stream` |
| resumed loader continues a saved run (same samples + same CPU RNG state) | pass | **fail** — `the resumed process holds a different CPU RNG state than the run it continued` |

The `cp=2` case matters: a `(pp, tp, dp)` key passes at `cp=1` and collides differing ranks at
`cp=2`.

End-to-end, 2 nodes EP=4, checkpoint at step 5 of 10, comparing the resumed run's checkpoint
against a continuous run's byte-for-byte — clean with the router flag on, with it off, and with
`--data-parallel-random-init`.

At 64 nodes, EP=64, resume at step 25 of 50: continuous and resumed match on lm loss, grad norm and
params norm at full float32, while the same comparison still reports the pre-fix run diverging at
step 26 (`grad-norm rel 2.8e-05`).

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
