### PR TITLE
fix: preserve repeated GTP parameter uses

### DIFF
--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -42,6 +42,7 @@ from megatron.core.tensor_parallel.gtp_cuda_graphs import (
     cuda_graph_pool_allocation,
     register_capture_comm,
     register_capture_params_to_ensure_ready,
+    register_capture_wgrad_finalize,
     register_capture_wgrad_ring_slot,
 )
 from megatron.core.tensor_parallel.gtp_symmetric_memory import (
@@ -1854,8 +1855,10 @@ class GTPShardedParam(torch.nn.Parameter):
             dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype, zero=True)
         else:
             dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype)
-        if getattr(param, "_grad_accum_hook", None) is not None:
-            param._grad_accum_hook()
+        hook = getattr(param, "_grad_accum_hook", None)
+        if hook is not None:
+            register_capture_wgrad_finalize(param)
+            hook()
 
         param._set_rs_state(GTPWeightState.NONE)
         return dummy_grad

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1857,7 +1857,8 @@ class GTPShardedParam(torch.nn.Parameter):
             dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype)
         hook = getattr(param, "_grad_accum_hook", None)
         if hook is not None:
-            register_capture_wgrad_finalize(param)
+            if _chain_is_graphed(param.chain_id):
+                register_capture_wgrad_finalize(param)
             hook()
 
         param._set_rs_state(GTPWeightState.NONE)

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -87,6 +87,7 @@ class GTPCaptureCommState:
     ag_streams: list = field(default_factory=list)
     rs_streams: list = field(default_factory=list)
     wgrad_ring_slots: list = field(default_factory=list)
+    finalized_params: list = field(default_factory=list)
     _param_ids: set = field(default_factory=set)
     _param_ids_to_ensure_ready: set = field(default_factory=set)
     _ag_stream_ids: set = field(default_factory=set)
@@ -155,6 +156,12 @@ class GTPCaptureCommState:
             self._wgrad_ring_slot_params[slot_id] = param_id
             self.wgrad_ring_slots.append(slot)
 
+    def register_wgrad_finalize(self, param) -> None:
+        """Record one DDP grad-ready occurrence produced by captured GTP finalization."""
+        # Repeated uses of one parameter must remain repeated: DDP learns the expected ready
+        # count during eager execution, and CUDA graph replay must reproduce that count.
+        self.finalized_params.append(param)
+
 
 _ACTIVE_CAPTURE_COMM_STATE: Optional[GTPCaptureCommState] = None
 
@@ -163,6 +170,12 @@ def register_capture_comm(param, stream: torch.cuda.Stream, *, reduce_scatter: b
     """Register communication with the active capture, if one exists."""
     if _ACTIVE_CAPTURE_COMM_STATE is not None:
         _ACTIVE_CAPTURE_COMM_STATE.register_comm(param, stream, reduce_scatter=reduce_scatter)
+
+
+def register_capture_wgrad_finalize(param) -> None:
+    """Record one GTP wgrad-finalization occurrence with the active capture."""
+    if _ACTIVE_CAPTURE_COMM_STATE is not None:
+        _ACTIVE_CAPTURE_COMM_STATE.register_wgrad_finalize(param)
 
 
 def register_capture_params_to_ensure_ready(params: Iterable) -> None:

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -157,7 +157,7 @@ class GTPCaptureCommState:
             self.wgrad_ring_slots.append(slot)
 
     def register_wgrad_finalize(self, param) -> None:
-        """Record one DDP grad-ready occurrence produced by captured GTP finalization."""
+        """Record one DDP grad-ready occurrence produced by GRAPHED GTP finalization."""
         # Repeated uses of one parameter must remain repeated: DDP learns the expected ready
         # count during eager execution, and CUDA graph replay must reproduce that count.
         self.finalized_params.append(param)
@@ -173,7 +173,7 @@ def register_capture_comm(param, stream: torch.cuda.Stream, *, reduce_scatter: b
 
 
 def register_capture_wgrad_finalize(param) -> None:
-    """Record one GTP wgrad-finalization occurrence with the active capture."""
+    """Record one GRAPHED GTP wgrad-finalization occurrence with the active capture."""
     if _ACTIVE_CAPTURE_COMM_STATE is not None:
         _ACTIVE_CAPTURE_COMM_STATE.register_wgrad_finalize(param)
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1059,6 +1059,27 @@ class _CudaGraphRunner(torch.nn.Module):
         for s in side_streams:
             torch.cuda.current_stream().wait_stream(s)
 
+    def _set_gtp_finalize_hook_plan(self, finalized_params):
+        """Build the replay hook plan from captured GRAPHED finalization occurrences."""
+        self.finalized_during_bwd_capture = list(finalized_params) if self.gtp_remat else []
+        self._gtp_finalize_hook_plan = []
+        if not self.finalized_during_bwd_capture:
+            return
+
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=["gtp_remat", "expt_gtp_remat"]
+        )
+        dense_group = pg_collection.gtp_remat
+        expert_group = pg_collection.expt_gtp_remat
+        params_by_group = defaultdict(list)
+        for param in self.finalized_during_bwd_capture:
+            is_expert = not getattr(param, 'allreduce', True)
+            params_by_group[expert_group if is_expert else dense_group].append(param)
+        self._gtp_finalize_hook_plan = [
+            (get_rs_stream(GTPChain.GRAPHED.value, group), params)
+            for group, params in params_by_group.items()
+        ]
+
     def __str__(self):
         return "%s; hid %s" % (
             self.base_module.__class__.__name__,
@@ -1549,28 +1570,8 @@ class _CudaGraphRunner(torch.nn.Module):
         if FREEZE_GC:
             gc.unfreeze()
 
-        self.finalized_during_bwd_capture = (
-            list(capture_comms.finalized_params) if self.gtp_remat else []
-        )
         self._gtp_wgrad_ring_slots = list(capture_comms.wgrad_ring_slots) if self.gtp_remat else []
-
-        # Precompute the (rs_stream, params) DDP grad-ready hook plan once — it's
-        # replay-invariant — so Graphed.backward avoids per-replay group lookups.
-        self._gtp_finalize_hook_plan = []
-        if self.gtp_remat and self.finalized_during_bwd_capture:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=["gtp_remat", "expt_gtp_remat"]
-            )
-            dense_group = pg_collection.gtp_remat
-            expert_group = pg_collection.expt_gtp_remat
-            params_by_group = defaultdict(list)
-            for param in self.finalized_during_bwd_capture:
-                is_expert = not getattr(param, 'allreduce', True)
-                params_by_group[expert_group if is_expert else dense_group].append(param)
-            self._gtp_finalize_hook_plan = [
-                (get_rs_stream(GTPChain.GRAPHED.value, group), params)
-                for group, params in params_by_group.items()
-            ]
+        self._set_gtp_finalize_hook_plan(capture_comms.finalized_params if self.gtp_remat else ())
 
         for arg in args_to_clear_buffers:
             arg.cg_buffer_metadata.bwd_cudagraph_buffer = None

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -8,7 +8,7 @@ import math
 import os
 import time
 from collections import defaultdict
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
@@ -504,19 +504,18 @@ fwd_buffer_reuse_ref_count = 0
 bwd_buffer_reuse_ref_count = 0
 
 
-def _backup_grads_before_capture(runner):
-    """Snapshot main_grad so create_fwd_graph's eager warmup can't corrupt the finalized grads;
-    restore with '_restore_grads_after_capture'.
-    """
+def _backup_grads_before_capture(runner, parameters=None):
+    """Snapshot main_grad so CUDA-graph capture cannot corrupt finalized gradients."""
     backup = {}
-    for p in runner.base_module.parameters():
+    parameters = tuple(runner.base_module.parameters() if parameters is None else parameters)
+    for p in parameters:
         mg = getattr(p, "main_grad", None)
         if mg is not None:
             backup[id(p)] = (p, mg.clone())
 
     if runner.gtp_remat:
         # GTP only: also protect the cross-graph next_w the cascade accumulates into.
-        for p in runner.base_module.parameters():
+        for p in parameters:
             nw = getattr(p, "next_w", None) if getattr(p, "is_gtp_weight_remat", False) else None
             if nw is None:
                 continue
@@ -532,6 +531,38 @@ def _restore_grads_after_capture(backup):
     """Restore the main_grad snapshots taken by '_backup_grads_before_capture'."""
     for p, saved in backup.values():
         p.main_grad.copy_(saved)
+
+
+@contextmanager
+def _preserve_parameter_grads_during_backward_capture(runner):
+    """Give each backward runner fresh accumulation state without changing the training step."""
+
+    parameters = tuple(runner.params_to_backprop)
+    main_grad_backup = _backup_grads_before_capture(runner, parameters=parameters)
+    missing = object()
+    parameter_state = [
+        (param, param.grad, getattr(param, "grad_added_to_main_grad", missing))
+        for param in parameters
+    ]
+
+    # A module can back multiple runners, as with a repeated MTP layer. Each runner must capture
+    # its own contribution instead of inheriting another runner's accumulation flag or stale grad.
+    for param, _, _ in parameter_state:
+        param.grad = None
+        if hasattr(param, "grad_added_to_main_grad"):
+            param.grad_added_to_main_grad = False
+
+    try:
+        yield
+    finally:
+        _restore_grads_after_capture(main_grad_backup)
+        for param, grad, grad_added_to_main_grad in parameter_state:
+            param.grad = grad
+            if grad_added_to_main_grad is missing:
+                if hasattr(param, "grad_added_to_main_grad"):
+                    delattr(param, "grad_added_to_main_grad")
+            else:
+                param.grad_added_to_main_grad = grad_added_to_main_grad
 
 
 class _CudagraphGlobalRecord:
@@ -1512,6 +1543,7 @@ class _CudaGraphRunner(torch.nn.Module):
         capture_comm_context = track_gtp_capture_comms() if self.gtp_remat else nullcontext(None)
         with (
             capture_comm_context as capture_comms,
+            _preserve_parameter_grads_during_backward_capture(self),
             torch.cuda.graph(self.bwd_graph, pool=self.mempool),
         ):
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -990,9 +990,9 @@ class _CudaGraphRunner(torch.nn.Module):
         self.needs_recompute_param_discovery = False
         self.use_stream = False
         self.gtp_remat = False
-        # Populated by create_bwd_graph: GTP params whose main_grad.add_ was captured in THIS
-        # graph.  Used in Graphed.backward's post-replay hook loop to fire DDP hooks only in the
-        # graph whose replay populates main_grad.
+        # Populated by create_bwd_graph: one entry per captured GTP wgrad-finalization occurrence.
+        # Repeated parameters intentionally appear more than once so replay matches eager DDP
+        # grad-ready accounting.
         self.finalized_during_bwd_capture = []
         # (rs_stream, params) DDP grad-ready hook plan; built in create_bwd_graph.
         self._gtp_finalize_hook_plan = []
@@ -1058,32 +1058,6 @@ class _CudaGraphRunner(torch.nn.Module):
         """
         for s in side_streams:
             torch.cuda.current_stream().wait_stream(s)
-
-    def _compute_finalized_during_bwd_capture(self):
-        """Return GTP params whose DDP grad-ready hook fires post-replay
-        of THIS bwd_graph.
-
-        A param's hook must fire in the graph that physically populates its
-        main_grad. Rules, given the cascade walk in wgrad_reduce_scatter
-        finalizes p.next_w on behalf of p:
-          - p.prev_w is None → p is sync-finalized in p's own graph; add p.
-          - p.next_w is not None → p.next_w's main_grad.add_ is captured here
-            via p's cascade; add p.next_w. (For cross-graph chain tails the
-            wait was captured in the producer's Phase 2, but the add lives
-            here regardless, bridged by external rs_event.)
-        """
-        finalized = {}  # id → param
-        for p in self.params_to_backprop:
-            if not getattr(p, 'is_gtp_weight_remat', False):
-                continue
-            if getattr(p, "prev_w", None) is None:
-                for w in getattr(p, "_weights", [p]):
-                    finalized[id(w)] = w
-            next_w = getattr(p, "next_w", None)
-            if next_w is not None:
-                for w in getattr(next_w, "_weights", [next_w]):
-                    finalized[id(w)] = w
-        return list(finalized.values())
 
     def __str__(self):
         return "%s; hid %s" % (
@@ -1575,9 +1549,8 @@ class _CudaGraphRunner(torch.nn.Module):
         if FREEZE_GC:
             gc.unfreeze()
 
-        # See _compute_finalized_during_bwd_capture for what's in this set and why.
         self.finalized_during_bwd_capture = (
-            self._compute_finalized_during_bwd_capture() if self.gtp_remat else []
+            list(capture_comms.finalized_params) if self.gtp_remat else []
         )
         self._gtp_wgrad_ring_slots = list(capture_comms.wgrad_ring_slots) if self.gtp_remat else []
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1602,6 +1602,17 @@ class TestActivationRecomputePhaseFlag:
 
 
 class TestGTPCaptureParamReadiness:
+    def test_wgrad_finalization_preserves_repeated_occurrences(self):
+        first = object()
+        second = object()
+
+        with gtp_cuda_graphs.track_gtp_capture_comms() as capture:
+            gtp_cuda_graphs.register_capture_wgrad_finalize(first)
+            gtp_cuda_graphs.register_capture_wgrad_finalize(second)
+            gtp_cuda_graphs.register_capture_wgrad_finalize(first)
+
+        assert capture.finalized_params == [first, second, first]
+
     def test_forward_gather_registers_params_before_ensuring_readiness(self, monkeypatch):
         class StopAfterReadiness(Exception):
             pass

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -47,6 +47,7 @@ from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
 
 import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
 import megatron.core.tensor_parallel.gtp_cuda_graphs as gtp_cuda_graphs
+import megatron.core.transformer.cuda_graphs as cuda_graphs_module
 from megatron.core import parallel_state
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
@@ -1602,16 +1603,71 @@ class TestActivationRecomputePhaseFlag:
 
 
 class TestGTPCaptureParamReadiness:
-    def test_wgrad_finalization_preserves_repeated_occurrences(self):
-        first = object()
-        second = object()
+    def test_wgrad_finalization_registration_matches_hook_calls(self, monkeypatch):
+        hook_calls = []
+
+        class Param:
+            main_grad = torch.empty(2, 3)
+            dtype = torch.float32
+            zero_out_wgrad = False
+
+            def __init__(self):
+                self.chain_id = GTPChain.GRAPHED.value
+                self._grad_accum_hook = lambda: hook_calls.append(self)
+                self.rs_states = []
+
+            def _set_rs_state(self, state):
+                self.rs_states.append(state)
+
+        param = Param()
+        dummy_wgrad = object()
+        monkeypatch.setattr(gtp_module, "get_dummy_wgrad", lambda *args, **kwargs: dummy_wgrad)
 
         with gtp_cuda_graphs.track_gtp_capture_comms() as capture:
-            gtp_cuda_graphs.register_capture_wgrad_finalize(first)
-            gtp_cuda_graphs.register_capture_wgrad_finalize(second)
-            gtp_cuda_graphs.register_capture_wgrad_finalize(first)
+            assert GTPShardedParam._handle_megatron_grad_accum(param) is dummy_wgrad
+            assert GTPShardedParam._handle_megatron_grad_accum(param) is dummy_wgrad
+            param.chain_id = GTPChain.UNGRAPHED.value
+            assert GTPShardedParam._handle_megatron_grad_accum(param) is dummy_wgrad
+            param._grad_accum_hook = None
+            assert GTPShardedParam._handle_megatron_grad_accum(param) is dummy_wgrad
 
-        assert capture.finalized_params == [first, second, first]
+        assert capture.finalized_params == [param, param]
+        assert hook_calls == [param, param, param]
+        assert param.rs_states == [gtp_module.GTPWeightState.NONE] * 4
+
+    def test_finalize_hook_plan_groups_streams_and_preserves_occurrences(self, monkeypatch):
+        dense_group = object()
+        expert_group = object()
+        pg_collection = type(
+            "ProcessGroups", (), {"gtp_remat": dense_group, "expt_gtp_remat": expert_group}
+        )()
+        monkeypatch.setattr(
+            cuda_graphs_module.ProcessGroupCollection,
+            "use_mpu_process_groups",
+            staticmethod(lambda required_pgs: pg_collection),
+        )
+        monkeypatch.setattr(
+            cuda_graphs_module, "get_rs_stream", lambda chain_id, group: (chain_id, group)
+        )
+
+        class Param:
+            def __init__(self, chain_id, *, allreduce=True):
+                self.chain_id = chain_id
+                self.allreduce = allreduce
+
+        dense = Param(GTPChain.GRAPHED.value)
+        expert = Param(GTPChain.GRAPHED.value, allreduce=False)
+        runner = type("Runner", (), {"gtp_remat": True})()
+
+        cuda_graphs_module._CudaGraphRunner._set_gtp_finalize_hook_plan(
+            runner, [dense, expert, dense]
+        )
+
+        assert runner.finalized_during_bwd_capture == [dense, expert, dense]
+        assert runner._gtp_finalize_hook_plan == [
+            ((GTPChain.GRAPHED.value, dense_group), [dense, dense]),
+            ((GTPChain.GRAPHED.value, expert_group), [expert]),
+        ]
 
     def test_forward_gather_registers_params_before_ensuring_readiness(self, monkeypatch):
         class StopAfterReadiness(Exception):

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1770,6 +1770,20 @@ class _CheckpointDependencyModule(MegatronModule):
         return output
 
 
+class _RepeatedParameterModule(MegatronModule):
+    """Invoke one graphed operation twice so two runners share its parameter."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.weight = torch.nn.Parameter(torch.randn(config.hidden_size))
+
+    def forward(self, x):
+        return self.project(x) + self.project(0.5 * x)
+
+    def project(self, x):
+        return x + self.weight
+
+
 class _SimpleNonModule:
     """non-nn.Module base_module for testing the function_name= form of `CudaGraphManager`."""
 
@@ -1874,6 +1888,96 @@ class TestCheckpointParameterDiscovery:
             for name, param in module.named_parameters():
                 assert param.grad is None
                 torch.testing.assert_close(param.main_grad, reference_wgrads[name])
+
+
+class TestRepeatedParameterCapture:
+    """Local-CG capture preserves every use of a parameter shared by multiple runners."""
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel()
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        if _CudagraphGlobalRecord.cudagraph_created:
+            delete_cuda_graphs()
+        else:
+            _CudagraphGlobalRecord.cudagraph_record = []
+            _CudagraphGlobalRecord.cudagraph_inference_record = []
+            CudaGraphManager.global_mempool = None
+        torch.cuda.set_stream(torch.cuda.default_stream())
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    def test_two_runners_accumulate_shared_parameter_and_preserve_record_grad(self):
+        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() < 2:
+            pytest.skip("test requires at least two data-parallel ranks")
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_warmup_steps=0,
+        )
+        torch.manual_seed(123)
+        reference = _RepeatedParameterModule(config).cuda()
+        module = _RepeatedParameterModule(config).cuda()
+        module.load_state_dict(reference.state_dict())
+
+        manager = CudaGraphManager(
+            config, base_module=module, function_name="project", need_backward=True
+        )
+        ddp_model = DistributedDataParallel(
+            config,
+            DistributedDataParallelConfig(overlap_grad_reduce=True, bucket_size=1_000_000),
+            module,
+        )
+
+        torch.manual_seed(1000 + ddp_model.dp_group.rank())
+        test_input = torch.randn(4, config.hidden_size, device="cuda", requires_grad=True)
+        reference_output = reference(test_input.detach().clone().requires_grad_(True))
+        reference_output_value = reference_output.detach().clone()
+        reference_output.sum().backward()
+        reference_local_wgrad = reference.weight.grad.detach().clone()
+        reference_wgrad = reference_local_wgrad.clone()
+        torch.distributed.all_reduce(reference_wgrad, group=ddp_model.dp_group)
+        reference_wgrad.div_(ddp_model.dp_group.size())
+
+        ddp_model.zero_grad_buffer()
+        record_output = ddp_model(test_input.detach().clone().requires_grad_(True))
+        record_output.sum().backward()
+        ddp_model.finish_grad_sync()
+        record_wgrad = module.weight.main_grad.detach().clone()
+        torch.testing.assert_close(record_wgrad, reference_wgrad)
+
+        create_cudagraphs()
+
+        assert len(manager.cudagraph_runners) == 2
+        torch.testing.assert_close(module.weight.main_grad, record_wgrad)
+
+        ddp_model.zero_grad_buffer()
+        with ddp_model.no_sync():
+            replay_output = ddp_model(test_input.detach().clone().requires_grad_(True))
+            replay_output.sum().backward()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(replay_output, reference_output_value)
+        torch.testing.assert_close(module.weight.main_grad, reference_local_wgrad)
+
+        for _ in range(2):
+            ddp_model.zero_grad_buffer()
+            replay_output = ddp_model(test_input.detach().clone().requires_grad_(True))
+            replay_output.sum().backward()
+            ddp_model.finish_grad_sync()
+            torch.cuda.synchronize()
+
+            torch.testing.assert_close(replay_output, reference_output_value)
+            torch.testing.assert_close(module.weight.main_grad, reference_wgrad)
 
 
 class TestInlineCaptureManager:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
## Problem

  MTP can use the same GTP parameter multiple times in one forward/backward pass. Each completed GTP wgrad reduction contributes to main_grad and produces one DDP grad-ready
  occurrence. DDP learns this per-parameter occurrence count during eager execution and waits for the same count in later iterations before dispatching the bucket reduction.

  Local CUDA graph replay does not execute the Python GTP finalization path directly. Previously, it inferred finalized parameters from the captured graph structure and
  deduplicated them by parameter identity. If a parameter was finalized twice, replay reported it ready only once, leaving DDP waiting for the second occurrence and
  preventing the bucket reduction from being dispatched.

  ## Solution

  Record every actual GTP wgrad-finalization occurrence during backward graph capture, at the point where GTP invokes the DDP grad-ready hook.

  The captured occurrence list intentionally preserves duplicate parameters. After graph replay, the hook plan reproduces the same number of grad-ready notifications as
  eager execution, allowing DDP’s per-parameter ready counts to reach their expected values.

  This also removes the previous graph-structure-based inference, so replay bookkeeping reflects the finalizations that actually occurred during capture.

  ## Validation

  - Added a unit test verifying that capture preserves repeated finalization occurrences such as [param_a, param_b, param_a].
  - Full 4-GPU GTP unit-test suite: 159 passed, 8 skipped.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

