### PR TITLE
Reject blends that mix parseable and unparseable weights

### DIFF
--- a/megatron/core/datasets/utils.py
+++ b/megatron/core/datasets/utils.py
@@ -81,7 +81,11 @@ def get_blend_from_list(
                 weight = None
             weight_per_dataset.append(weight)
 
-        is_none = map(lambda _: _ is None, weight_per_dataset)
+        # Materialize the list: a `map` iterator is consumed by ``any`` below, so
+        # ``all`` would then see an exhausted iterator and pass vacuously, letting
+        # a blend with a mix of parseable and unparseable weights (e.g. a typo'd
+        # weight) fall through and be misread as a prefix-only list.
+        is_none = [_ is None for _ in weight_per_dataset]
         if any(is_none):
             assert all(is_none)
             weight_per_dataset = None

--- a/tests/unit_tests/data/test_builder.py
+++ b/tests/unit_tests/data/test_builder.py
@@ -552,5 +552,22 @@ def test_fast_builder(
             torch.distributed.barrier()
 
 
+def test_get_blend_from_list():
+    # Plain prefix lists (odd or even length, no parseable weights).
+    assert get_blend_from_list(["p1", "p2", "p3"]) == (["p1", "p2", "p3"], None)
+    assert get_blend_from_list(["p1", "p2"]) == (["p1", "p2"], None)
+
+    # Zipped [weight, prefix, ...] list.
+    assert get_blend_from_list(["30", "p1", "70", "p2"]) == (["p1", "p2"], [30.0, 70.0])
+
+    assert get_blend_from_list(None) is None
+
+    # A malformed even-length blend that mixes a parseable weight with an
+    # unparseable one must be rejected, not silently read as a prefix-only list.
+    with pytest.raises(AssertionError):
+        get_blend_from_list(["30", "p1", "not_a_weight", "p2"])
+
+
 if __name__ == "__main__":
     test_builder()
+    test_get_blend_from_list()


### PR DESCRIPTION
### Description

`get_blend_from_list` guards against a blend list that mixes parseable and unparseable "weights" (e.g. a typo'd weight), but builds the check as a lazy `map` iterator:

```python
is_none = map(lambda _: _ is None, weight_per_dataset)
if any(is_none):
    assert all(is_none)
    weight_per_dataset = None
    raw_prefix_per_dataset = blend
```

`any()` consumes the `map` iterator, so `all()` then iterates an already-exhausted iterator and passes vacuously. As a result the assertion never fires, and an even-length blend where only *some* entries parse as weights is silently reinterpreted as a **prefix-only list** — loading the wrong datasets with no error.

```python
from megatron.core.datasets.utils import get_blend_from_list

# a typo'd weight ("not_a_weight") in an otherwise weighted blend:
get_blend_from_list(["30", "path/a", "not_a_weight", "path/b"])
# returns (["30", "path/a", "not_a_weight", "path/b"], None)  -> 4 "datasets"
# expected: AssertionError (mixing weights and prefixes is ambiguous)
```

### Fix

Materialize the boolean list so both `any()` and `all()` observe every element. Genuine cases are unchanged: an all-parseable blend still returns weights, and a pure prefix list (odd or even length, no parseable weights) is still accepted; only the mixed/malformed case now raises as intended.

Adds `test_get_blend_from_list` to `tests/unit_tests/data/test_builder.py`.

### Contribution process

- [x] Signed-off-by (DCO) and signed commit.
- [x] Unit test added.
