### PR TITLE
Support paged stash with TE whole-MoE CUDA graphs

### DIFF
--- a/docs/user-guide/features/paged_stash.md
+++ b/docs/user-guide/features/paged_stash.md
@@ -19,6 +19,18 @@
 
 Whenever `moe_expert_rank_capacity_factor` is set, a **runner** wraps forward-backward: after each pass it checks **stash overflow** (only with `--moe-paged-stash`) and **token over-budget**. If either hits any rank, the step **reruns once** without capacity padding and without paged stashing.
 
+For Transformer Engine per-layer CUDA graphs, the whole MoE scope
+(`--cuda-graph-impl transformer_engine --cuda-graph-modules moe`) is supported by the sync-free
+HybridEP + paged-stash configuration above. Its captured graph is tied to the static expert-rank
+and stash capacities. If either capacity overflows, training fails immediately instead of
+attempting the dynamic rerun; increase the corresponding capacity factor and restart the job.
+
+Transformer Engine warmup and graph capture both replay the previously recorded paged-stash
+schedule, preserving the training layer, microbatch, and virtual-pipeline coordinates. This mode
+requires a Transformer Engine version whose ordered warmup follows the real pipeline schedule.
+Each per-layer graph joins the stash and reload work it launched on the auxiliary stream before
+its capture ends because CUDA stream dependencies cannot cross independent capture boundaries.
+
 ## Prerequisites
 
 HybridEP + TE fused grouped experts are required whenever `moe_expert_rank_capacity_factor` is set. With `moe_paged_stash` enabled: capacity factor must be set; no `cpu_offloading`; `offload_modules` must not include `expert_fc1`, `moe_act`, or `fused_group_mlp`. The runner is active whenever capacity factor is set (even without `--moe-paged-stash`) for over-budget reruns; stash overflow is checked only when paged stashing is on.

--- a/docs/user-guide/features/paged_stash.md
+++ b/docs/user-guide/features/paged_stash.md
@@ -22,18 +22,26 @@ Whenever `moe_expert_rank_capacity_factor` is set, a **runner** wraps forward-ba
 For Transformer Engine per-layer CUDA graphs, the whole MoE scope
 (`--cuda-graph-impl transformer_engine --cuda-graph-modules moe`) is supported by the sync-free
 HybridEP + paged-stash configuration above. Its captured graph is tied to the static expert-rank
-and stash capacities. If either capacity overflows, training fails immediately instead of
-attempting the dynamic rerun; increase the corresponding capacity factor and restart the job.
+and stash capacities. Before graph capture, and during eager evaluation, capacity overflow can
+still use the dynamic rerun. After graph capture, training fails immediately instead of attempting
+an invalid rerun; increase the corresponding capacity factor and restart the job.
 
 Transformer Engine warmup and graph capture both replay the previously recorded paged-stash
 layer templates, preserving the training layer, microbatch, and virtual-pipeline coordinates. The
-runtime paged-stash schedule remains unchanged. Graph capture temporarily expands Transformer
-Engine's final `_order` (which may use a larger dynamic-CP slot upper bound) into a capture-only
-schedule and restores the recorded runtime schedule afterward. This mode requires a Transformer
-Engine version whose ordered warmup follows `_order`; it does not use per-callable cursor hooks.
-The stash/reload kernels remain inside their corresponding CUDA graphs.
-Each per-layer graph joins the stash and reload work it launched on the auxiliary stream before
-its capture ends because CUDA stream dependencies cannot cross independent capture boundaries.
+runtime paged-stash schedule remains unchanged. This mode requires a fixed runtime microbatch
+schedule: the microbatch count may not change after capture, and at least two CUDA graph warmup
+steps are required to record the pipeline schedule. Graph capture temporarily expands Transformer
+Engine's final `_order` into a capture-only schedule and restores the recorded runtime schedule
+afterward. This mode requires a Transformer Engine version whose ordered warmup follows `_order`;
+it does not use per-callable cursor hooks. The stash/reload kernels remain inside their
+corresponding CUDA graphs.
+
+Because Transformer Engine captures each MoE layer as an independent graph, the auxiliary
+pack/unpack stream must rejoin the graph's capture stream before that graph ends. These joins are
+captured graph nodes and therefore execute on every replay. Stash/reload work launched by one MoE
+graph consequently cannot overlap eager work or another graph beyond that graph boundary, although
+work inside the same graph may still overlap before the join. This correctness constraint can
+reduce paged-stash overlap and throughput; benchmark the target PP/VPP configuration.
 
 ## Prerequisites
 

--- a/docs/user-guide/features/paged_stash.md
+++ b/docs/user-guide/features/paged_stash.md
@@ -26,8 +26,12 @@ and stash capacities. If either capacity overflows, training fails immediately i
 attempting the dynamic rerun; increase the corresponding capacity factor and restart the job.
 
 Transformer Engine warmup and graph capture both replay the previously recorded paged-stash
-schedule, preserving the training layer, microbatch, and virtual-pipeline coordinates. This mode
-requires a Transformer Engine version whose ordered warmup follows the real pipeline schedule.
+layer templates, preserving the training layer, microbatch, and virtual-pipeline coordinates. The
+runtime paged-stash schedule remains unchanged. Graph capture temporarily expands Transformer
+Engine's final `_order` (which may use a larger dynamic-CP slot upper bound) into a capture-only
+schedule and restores the recorded runtime schedule afterward. This mode requires a Transformer
+Engine version whose ordered warmup follows `_order`; it does not use per-callable cursor hooks.
+The stash/reload kernels remain inside their corresponding CUDA graphs.
 Each per-layer graph joins the stash and reload work it launched on the auxiliary stream before
 its capture ends because CUDA stream dependencies cannot cross independent capture boundaries.
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2850,7 +2850,9 @@ class TECudaGraphHelper:
             )
             with (
                 rng_context,
-                paged_stash_te_graph_capture(te_whole_moe_paged_stash, order=kwargs['_order']),
+                paged_stash_te_graph_capture(
+                    te_whole_moe_paged_stash, order=kwargs['_order'], config=self.config
+                ),
             ):
                 graphs = make_graphed_callables(
                     tuple(self.flattened_callables), sample_args, **kwargs

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2842,7 +2842,13 @@ class TECudaGraphHelper:
                 rng_context = get_cuda_rng_tracker().fork()
             else:
                 rng_context = nullcontext()
-            with rng_context:
+            from megatron.core.transformer.moe.paged_stash import paged_stash_te_graph_capture
+
+            te_whole_moe_paged_stash = (
+                self.config.moe_paged_stash
+                and CudaGraphModule.moe in self.config.cuda_graph_modules
+            )
+            with rng_context, paged_stash_te_graph_capture(te_whole_moe_paged_stash):
                 graphs = make_graphed_callables(
                     tuple(self.flattened_callables), sample_args, **kwargs
                 )

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2848,7 +2848,10 @@ class TECudaGraphHelper:
                 self.config.moe_paged_stash
                 and CudaGraphModule.moe in self.config.cuda_graph_modules
             )
-            with rng_context, paged_stash_te_graph_capture(te_whole_moe_paged_stash):
+            with (
+                rng_context,
+                paged_stash_te_graph_capture(te_whole_moe_paged_stash, order=kwargs['_order']),
+            ):
                 graphs = make_graphed_callables(
                     tuple(self.flattened_callables), sample_args, **kwargs
                 )

--- a/megatron/core/transformer/enums.py
+++ b/megatron/core/transformer/enums.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import enum
 
@@ -67,7 +67,7 @@ class CudaGraphModule(enum.Enum):
 
     attn = 1  # Captures attention layers
     mlp = 2  # Captures MLP layers (dense layers only)
-    moe = 3  # Captures MoE layers (drop-and-pad MoE layers only)
+    moe = 3  # Captures drop-and-pad or sync-free HybridEP MoE layers
     moe_router = 4  # Captures MoE router part
     moe_preprocess = 5  # Captures MoE preprocessing part (requires moe_router)
     mamba = 6  # Captures Mamba layers

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -685,20 +685,139 @@ class PagedStashManager:
         self.current_layer[vp_stage_index] = 1
         self.current_microbatch[vp_stage_index] += 1
 
-    def start_te_graph_capture(self):
-        """Prepare paged-stash state for TE's repeated per-layer capture passes."""
+    def _get_pp_layer_templates(self):
+        """Return per-VP paged-layer templates from the recorded runtime schedule."""
+        if not self._pp_schedule:
+            raise RuntimeError("Paged stash has no recorded pipeline schedule.")
+
+        events = {}
+        for schedule_layer in self._pp_schedule:
+            encoded_layer = abs(schedule_layer)
+            vp_stage = encoded_layer // 1_000_000
+            layer_and_microbatch = encoded_layer % 1_000_000
+            layer_no = layer_and_microbatch // 1_000
+            microbatch_no = layer_and_microbatch % 1_000
+            direction = 1 if schedule_layer > 0 else -1
+            events.setdefault((direction, vp_stage, microbatch_no), []).append(layer_no)
+
+        layer_templates = {}
+        microbatch_starts = {}
+        for vp_stage in range(1, self.vp_size + 1):
+            forward_microbatches = sorted(
+                microbatch_no
+                for direction, event_vp_stage, microbatch_no in events
+                if direction == 1 and event_vp_stage == vp_stage
+            )
+            if not forward_microbatches:
+                continue
+            if forward_microbatches != list(
+                range(forward_microbatches[0], forward_microbatches[-1] + 1)
+            ):
+                raise RuntimeError(
+                    "Paged-stash warmup recorded non-contiguous microbatch IDs for VP stage "
+                    f"{vp_stage}: {forward_microbatches}."
+                )
+
+            template = events[(1, vp_stage, forward_microbatches[0])]
+            for microbatch_no in forward_microbatches:
+                forward_layers = events[(1, vp_stage, microbatch_no)]
+                backward_layers = events.get((-1, vp_stage, microbatch_no))
+                if forward_layers != template:
+                    raise RuntimeError(
+                        "Paged-stash layer order changed across warmup microbatches for VP stage "
+                        f"{vp_stage}: {forward_layers} != {template}."
+                    )
+                if backward_layers != list(reversed(template)):
+                    raise RuntimeError(
+                        "Paged-stash backward layer order does not reverse the forward order for "
+                        f"VP stage {vp_stage}, microbatch {microbatch_no}: "
+                        f"{backward_layers} != {list(reversed(template))}."
+                    )
+
+            layer_templates[vp_stage] = tuple(template)
+            microbatch_starts[vp_stage] = forward_microbatches[0]
+
+        if not layer_templates:
+            raise RuntimeError("Paged-stash warmup did not record any paged layers.")
+        return layer_templates, microbatch_starts
+
+    def _build_te_graph_capture_schedule(self, order):
+        """Expand TE's chunk-level order into capture-only paged-layer entries."""
+        if order is None:
+            raise RuntimeError("Paged stash requires TE's pipeline order for graph capture.")
+
+        layer_templates, microbatch_starts = self._get_pp_layer_templates()
+        next_forward_microbatch = dict(microbatch_starts)
+        next_backward_microbatch = dict(microbatch_starts)
+        schedule = []
+        for chunk_id in order:
+            if not isinstance(chunk_id, int):
+                raise RuntimeError(
+                    "Paged stash requires a chunk-level integer PP order; layer-wise overlap "
+                    f"entry {chunk_id!r} is not supported."
+                )
+            vp_stage = abs(chunk_id)
+            template = layer_templates.get(vp_stage)
+            if template is None:
+                continue
+            if chunk_id > 0:
+                microbatch_no = next_forward_microbatch[vp_stage]
+                next_forward_microbatch[vp_stage] += 1
+                for layer_no in template:
+                    schedule.append(self.get_schedule_layer(vp_stage, layer_no, microbatch_no))
+            else:
+                microbatch_no = next_backward_microbatch[vp_stage]
+                next_backward_microbatch[vp_stage] += 1
+                for layer_no in reversed(template):
+                    schedule.append(-self.get_schedule_layer(vp_stage, layer_no, microbatch_no))
+
+        if not schedule:
+            raise RuntimeError("The pipeline order did not contain any paged-stash VP stage.")
+        for vp_stage in layer_templates:
+            if next_forward_microbatch[vp_stage] != next_backward_microbatch[vp_stage]:
+                raise RuntimeError(
+                    "Paged-stash pipeline order has unbalanced forward/backward passes for VP "
+                    f"stage {vp_stage}: next forward microbatch "
+                    f"{next_forward_microbatch[vp_stage]}, next backward microbatch "
+                    f"{next_backward_microbatch[vp_stage]}."
+                )
+        return schedule
+
+    def start_te_graph_capture(self, order):
+        """Temporarily install TE's final capture order as the paged-stash schedule."""
         if not self.enabled or self.status != 'captured':
             raise RuntimeError(
                 "Paged stash must finish its schedule and buffer warmup before TE graph capture."
             )
-        if not self._pp_schedule:
-            raise RuntimeError("Paged stash has no pipeline schedule for TE graph capture.")
+        if self._te_graph_capture:
+            raise RuntimeError("Paged-stash TE graph capture is already active.")
+        runtime_state = (
+            self._pp_schedule,
+            self.current_schedule_index,
+            self.current_layer,
+            self.current_microbatch,
+            self.current_vp_stage,
+        )
+        self._pp_schedule = self._build_te_graph_capture_schedule(order)
         self._te_graph_capture = True
         self.current_schedule_index = 0
+        self.current_layer = [1 for _ in range(self.vp_size)]
+        self.current_microbatch = [0 for _ in range(self.vp_size)]
+        self.current_vp_stage = 0
+        return runtime_state
 
-    def finish_te_graph_capture(self):
-        """Leave TE's per-layer graph-capture mode."""
+    def finish_te_graph_capture(self, runtime_state):
+        """Leave TE capture mode and restore the current global-batch schedule."""
+        if not self._te_graph_capture:
+            return
         self._te_graph_capture = False
+        (
+            self._pp_schedule,
+            self.current_schedule_index,
+            self.current_layer,
+            self.current_microbatch,
+            self.current_vp_stage,
+        ) = runtime_state
 
     def finish_te_graph_capture_group_io(self):
         """Join auxiliary stash streams before a TE per-layer graph capture ends."""
@@ -960,18 +1079,18 @@ def paged_stash_init_chunk_handler(vp_size, vp_stage):
 
 
 @contextmanager
-def paged_stash_te_graph_capture(enabled):
-    """Scope repeated TE per-layer graph capture over the recorded stash schedule."""
+def paged_stash_te_graph_capture(enabled, order=None):
+    """Scope TE capture over a stash schedule built from TE's final capture order."""
     if not enabled:
         yield
         return
 
     stash_manager = PagedStashManager.get_instance()
-    stash_manager.start_te_graph_capture()
+    runtime_state = stash_manager.start_te_graph_capture(order)
     try:
         yield
     finally:
-        stash_manager.finish_te_graph_capture()
+        stash_manager.finish_te_graph_capture(runtime_state)
 
 
 def paged_stash_reset(enabled=True, config=None):

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import torch
@@ -9,6 +9,7 @@ import torch
 from megatron.core._rank_utils import log_single_rank
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.ops.paged_stash import (
     GLOBAL_BLOCK_SIZE,
     paged_stash_copy_kernel,
@@ -324,6 +325,7 @@ class PipelinePreScheduleFunction(torch.autograd.Function):
             ]
             if next_schedule_layer < 0:
                 ctx.stash_manager.reload_paged_tensors(-next_schedule_layer)
+                ctx.stash_manager.finish_te_graph_capture_group_io()
 
         return grad_output + (None,)
 
@@ -359,6 +361,7 @@ class PipelinePostScheduleFunction(torch.autograd.Function):
             else:
                 ctx.stash_manager.remove_paged_tensor_from_stash()
 
+        ctx.stash_manager.finish_te_graph_capture_group_io()
         ctx.stash_manager.current_schedule_index += 1
         # return the identical tensor
         return tensor
@@ -422,6 +425,7 @@ class PagedStashManager:
         self.current_layer = None
         self.current_microbatch = None
         self.current_schedule_index = None
+        self._te_graph_capture = False
 
         # Track max tokens needed across all vp_stages grouped by dtype and hidden_size
         self.max_tokens_across_vp_stages = None
@@ -681,6 +685,69 @@ class PagedStashManager:
         self.current_layer[vp_stage_index] = 1
         self.current_microbatch[vp_stage_index] += 1
 
+    def start_te_graph_capture(self):
+        """Prepare paged-stash state for TE's repeated per-layer capture passes."""
+        if not self.enabled or self.status != 'captured':
+            raise RuntimeError(
+                "Paged stash must finish its schedule and buffer warmup before TE graph capture."
+            )
+        if not self._pp_schedule:
+            raise RuntimeError("Paged stash has no pipeline schedule for TE graph capture.")
+        self._te_graph_capture = True
+        self.current_schedule_index = 0
+
+    def finish_te_graph_capture(self):
+        """Leave TE's per-layer graph-capture mode."""
+        self._te_graph_capture = False
+
+    def finish_te_graph_capture_group_io(self):
+        """Join auxiliary stash streams before a TE per-layer graph capture ends."""
+        if not self._te_graph_capture:
+            return
+
+        self.wait_for_stash_to_complete()
+        if self._unpack_stream_status == 'reloading':
+            torch.cuda.current_stream().wait_stream(self.unpack_stream)
+            self._unpack_stream_status = 'idle'
+
+    def prepare_te_graph_capture_forward(self):
+        """Align CPU schedule state before each TE capture-time MoE forward.
+
+        ``make_graphed_callables`` captures layers directly without calling the model-level
+        paged-stash chunk handlers. Reuse the already-recorded pipeline schedule as the
+        source of truth for each capture-time forward.
+        """
+        if not self._te_graph_capture:
+            return
+        if self.current_schedule_index == len(self._pp_schedule):
+            self.current_schedule_index = 0
+        if not 0 <= self.current_schedule_index < len(self._pp_schedule):
+            raise RuntimeError(
+                "Paged-stash TE graph capture schedule index is out of range: "
+                f"{self.current_schedule_index} of {len(self._pp_schedule)}."
+            )
+
+        schedule_layer = self._pp_schedule[self.current_schedule_index]
+        if schedule_layer <= 0:
+            raise RuntimeError(
+                "Paged-stash TE graph capture expected a forward schedule entry, "
+                f"but found {schedule_layer} at index {self.current_schedule_index}."
+            )
+
+        vp_stage = schedule_layer // 1_000_000
+        layer_and_microbatch = schedule_layer % 1_000_000
+        layer_no = layer_and_microbatch // 1_000
+        microbatch_no = layer_and_microbatch % 1_000
+        if not 1 <= vp_stage <= self.vp_size:
+            raise RuntimeError(f"Paged-stash TE graph capture decoded invalid VP stage {vp_stage}.")
+
+        if self.current_layer is None or len(self.current_layer) != self.vp_size:
+            self.current_layer = [1 for _ in range(self.vp_size)]
+            self.current_microbatch = [0 for _ in range(self.vp_size)]
+        self.current_vp_stage = vp_stage - 1
+        self.current_layer[self.current_vp_stage] = layer_no
+        self.current_microbatch[self.current_vp_stage] = microbatch_no
+
     def on_save_for_backward(self, tensor: torch.Tensor) -> Any:
         """
         Hook called when autograd saves a tensor for backward pass.
@@ -854,6 +921,7 @@ def paged_stash_group_start(tensor):
     stash_manager = PagedStashManager.get_instance()
     if not stash_manager.enabled:
         return tensor
+    stash_manager.prepare_te_graph_capture_forward()
     return PipelinePreScheduleFunction.apply(tensor, stash_manager)
 
 
@@ -889,6 +957,21 @@ def paged_stash_init_chunk_handler(vp_size, vp_stage):
     stash_manager.vp_size = vp_size if vp_size is not None else 1
     stash_manager.current_vp_stage = vp_stage if vp_stage is not None else 0
     stash_manager.update_model_chunk(stash_manager.current_vp_stage)
+
+
+@contextmanager
+def paged_stash_te_graph_capture(enabled):
+    """Scope repeated TE per-layer graph capture over the recorded stash schedule."""
+    if not enabled:
+        yield
+        return
+
+    stash_manager = PagedStashManager.get_instance()
+    stash_manager.start_te_graph_capture()
+    try:
+        yield
+    finally:
+        stash_manager.finish_te_graph_capture()
 
 
 def paged_stash_reset(enabled=True, config=None):
@@ -1130,6 +1213,26 @@ class PagedStashRunner:
 
         return stash_overflow_ranks, overbudget_ranks, host_spill_ranks
 
+    def _raise_if_te_whole_moe_graph_overflow(
+        self, stash_overflow_ranks: int, overbudget_ranks: int
+    ) -> None:
+        """Fail fast when a captured TE whole-MoE graph exceeds its static buffers."""
+        te_whole_moe_graph = (
+            self.config.cuda_graph_impl == "transformer_engine"
+            and CudaGraphModule.moe in self.config.cuda_graph_modules
+        )
+        if not te_whole_moe_graph or (stash_overflow_ranks == 0 and overbudget_ranks == 0):
+            return
+
+        raise RuntimeError(
+            "Transformer Engine whole-MoE CUDA graph overflowed its static sync-free buffers: "
+            f"paged stash overflow on {stash_overflow_ranks} rank(s), "
+            f"expert-rank token budget overflow on {overbudget_ranks} rank(s). "
+            "Dynamic fallback is not supported for an already captured TE whole-MoE graph. "
+            "Increase --moe-expert-rank-capacity-factor and/or "
+            "--moe-paged-stash-buffer-size-factor-cuda, then restart the job."
+        )
+
     def prepare_for_rerun(self, is_training=True):
         """Prepare for rerun: go dropless, disable paged stashing, and reset grads/graph.
 
@@ -1261,6 +1364,7 @@ class PagedStashRunner:
             result = self.forward_backward_func(*args, **kwargs)
 
             stash_overflow_ranks, overbudget_ranks, host_spill_ranks = self.check_moe_overflow()
+            self._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks, overbudget_ranks)
             if stash_overflow_ranks == 0 and overbudget_ranks == 0:
                 if host_spill_ranks > 0:
                     log_single_rank(

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -654,6 +654,44 @@ class PagedStashManager:
             ),
         )
 
+    def prepare_stash_buffers(self, config=None):
+        """Allocate and reset buffers for an already-recorded paged-stash schedule.
+
+        This intentionally leaves the iteration and pipeline schedule coordinates unchanged so
+        TE graph capture can recover buffers released by a warmup fallback without pretending to
+        start another training iteration.
+        """
+        assert (
+            self.status == 'captured'
+        ), "Paged stash buffers can only be prepared after the schedule has been captured."
+        if self.stash_buffers is None:
+            cuda_factor = (
+                config.moe_paged_stash_buffer_size_factor_cuda if config is not None else 1.10
+            )
+            cpu_factor = (
+                config.moe_paged_stash_buffer_size_factor_cpu if config is not None else 0.0
+            )
+            self.allocate_stash_buffers(
+                moe_paged_stash_buffer_size_factor_cuda=cuda_factor,
+                moe_paged_stash_buffer_size_factor_cpu=cpu_factor,
+            )
+
+        assert (
+            self.stash_buffers is not None
+        ), "Paged stash: captured state but stash_buffers is None after allocation."
+        for dtype_buffers in self.stash_buffers.values():
+            for stash_buffer in dtype_buffers.values():
+                stash_buffer.reset()
+        self.overflow.zero_()
+        self.host_spill.zero_()
+        assert (
+            len(self.paged_tensors_to_stash) == 0
+        ), f"paged_tensors_to_stash is not empty {self.paged_tensors_to_stash}"
+        assert len(self.paged_tensors_stash_in_progress) == 0, (
+            f"paged_tensors_stash_in_progress is not empty "
+            f"{self.paged_tensors_stash_in_progress}"
+        )
+
     def update_pp_schedule(self, vp_stage, layer_no=None, microbatch_no=None):
         """Update the pp schedule."""
         if self._pp_schedule is None:
@@ -757,6 +795,11 @@ class PagedStashManager:
                     f"entry {chunk_id!r} is not supported."
                 )
             vp_stage = abs(chunk_id)
+            if not 1 <= vp_stage <= self.vp_size:
+                raise RuntimeError(
+                    "Paged stash received an invalid VP stage in TE's graph capture order: "
+                    f"chunk ID {chunk_id}, expected magnitude in [1, {self.vp_size}]."
+                )
             template = layer_templates.get(vp_stage)
             if template is None:
                 continue
@@ -783,27 +826,36 @@ class PagedStashManager:
                 )
         return schedule
 
-    def start_te_graph_capture(self, order):
+    def start_te_graph_capture(self, order, config=None):
         """Temporarily install TE's final capture order as the paged-stash schedule."""
-        if not self.enabled or self.status != 'captured':
+        if self.status != 'captured':
             raise RuntimeError(
                 "Paged stash must finish its schedule and buffer warmup before TE graph capture."
             )
         if self._te_graph_capture:
             raise RuntimeError("Paged-stash TE graph capture is already active.")
+        capture_schedule = self._build_te_graph_capture_schedule(order)
+        self.prepare_stash_buffers(config)
         runtime_state = (
+            self.enabled,
             self._pp_schedule,
             self.current_schedule_index,
             self.current_layer,
             self.current_microbatch,
             self.current_vp_stage,
         )
-        self._pp_schedule = self._build_te_graph_capture_schedule(order)
+        self._pp_schedule = capture_schedule
+        # Forward-only evaluation disables the singleton manager and can run immediately before
+        # capture. Capture readiness is tracked by ``status``; temporarily re-enable the manager
+        # so the directly-invoked TE callables still execute their stash hooks.
+        self.enabled = True
         self._te_graph_capture = True
         self.current_schedule_index = 0
-        self.current_layer = [1 for _ in range(self.vp_size)]
-        self.current_microbatch = [0 for _ in range(self.vp_size)]
-        self.current_vp_stage = 0
+        # Install capture-private schedule coordinates. The list cursors must not alias the
+        # saved runtime lists; the VP stage stays unset until decoded from the capture schedule.
+        self.current_layer = None
+        self.current_microbatch = None
+        self.current_vp_stage = None
         return runtime_state
 
     def finish_te_graph_capture(self, runtime_state):
@@ -812,6 +864,7 @@ class PagedStashManager:
             return
         self._te_graph_capture = False
         (
+            self.enabled,
             self._pp_schedule,
             self.current_schedule_index,
             self.current_layer,
@@ -1079,14 +1132,14 @@ def paged_stash_init_chunk_handler(vp_size, vp_stage):
 
 
 @contextmanager
-def paged_stash_te_graph_capture(enabled, order=None):
+def paged_stash_te_graph_capture(enabled, order=None, config=None):
     """Scope TE capture over a stash schedule built from TE's final capture order."""
     if not enabled:
         yield
         return
 
     stash_manager = PagedStashManager.get_instance()
-    runtime_state = stash_manager.start_te_graph_capture(order)
+    runtime_state = stash_manager.start_te_graph_capture(order, config=config)
     try:
         yield
     finally:
@@ -1114,45 +1167,11 @@ def paged_stash_reset(enabled=True, config=None):
         stash_manager.status = 'capture'
     elif stash_manager.status == 'capture':
         stash_manager.status = 'captured'
-        cuda_factor = config.moe_paged_stash_buffer_size_factor_cuda if config is not None else 1.10
-        cpu_factor = config.moe_paged_stash_buffer_size_factor_cpu if config is not None else 0.0
-        stash_manager.allocate_stash_buffers(
-            moe_paged_stash_buffer_size_factor_cuda=cuda_factor,
-            moe_paged_stash_buffer_size_factor_cpu=cpu_factor,
-        )
-    elif stash_manager.status == 'captured':
-        # Buffers may have been released after a PagedStashRunner fallback; reallocate using
-        # the same capture-derived maxima and current config factors.
-        if stash_manager.stash_buffers is None:
-            cuda_factor = (
-                config.moe_paged_stash_buffer_size_factor_cuda if config is not None else 1.10
-            )
-            cpu_factor = (
-                config.moe_paged_stash_buffer_size_factor_cpu if config is not None else 0.0
-            )
-            stash_manager.allocate_stash_buffers(
-                moe_paged_stash_buffer_size_factor_cuda=cuda_factor,
-                moe_paged_stash_buffer_size_factor_cpu=cpu_factor,
-            )
 
     if stash_manager.status == 'captured':
-        assert (
-            stash_manager.stash_buffers is not None
-        ), "Paged stash: captured state but stash_buffers is None after reset/allocation."
-        for dtype in stash_manager.stash_buffers.keys():
-            for hidden_size in stash_manager.stash_buffers[dtype].keys():
-                stash_manager.stash_buffers[dtype][hidden_size].reset()
-        stash_manager.overflow.zero_()
-        stash_manager.host_spill.zero_()
+        stash_manager.prepare_stash_buffers(config)
         stash_manager.current_layer = [1 for _ in range(stash_manager.vp_size)]
         stash_manager.current_microbatch = [0 for _ in range(stash_manager.vp_size)]
-        assert (
-            len(stash_manager.paged_tensors_to_stash) == 0
-        ), f"paged_tensors_to_stash is not empty {stash_manager.paged_tensors_to_stash}"
-        assert len(stash_manager.paged_tensors_stash_in_progress) == 0, (
-            f"paged_tensors_stash_in_progress is not empty "
-            f"{stash_manager.paged_tensors_stash_in_progress}"
-        )
 
 
 def check_paged_stash_overflow():
@@ -1182,6 +1201,8 @@ class PagedStashRunner:
         self.model = model
         self.optimizer = optimizer
         self.forward_backward_func = forward_backward_func
+        self._te_graph_capture_finished = False
+        self._te_graph_runtime_num_microbatches: int | None = None
         self.moe_layers = []
         # Peak per-rank receive capacity the last over-budget step needed, and the
         # moe_expert_rank_capacity_factor that would have covered it, if the backend reports
@@ -1254,6 +1275,11 @@ class PagedStashRunner:
         """Set moe_paged_stash on every tracked training, model, and MoE config."""
         for c in self._configs_to_sync_moe_paged_stash:
             c.moe_paged_stash = value
+
+    def mark_te_graph_captured(self, num_microbatches: int) -> None:
+        """Record rank-consistent TE capture completion and its runtime schedule size."""
+        self._te_graph_capture_finished = True
+        self._te_graph_runtime_num_microbatches = num_microbatches
 
     def data_read(self, data_iterator, model, training, num_microbatches):
         """Read all microbatch inputs from Dataloader and copy to static buffers."""
@@ -1333,14 +1359,16 @@ class PagedStashRunner:
         return stash_overflow_ranks, overbudget_ranks, host_spill_ranks
 
     def _raise_if_te_whole_moe_graph_overflow(
-        self, stash_overflow_ranks: int, overbudget_ranks: int
+        self, stash_overflow_ranks: int, overbudget_ranks: int, training: bool
     ) -> None:
         """Fail fast when a captured TE whole-MoE graph exceeds its static buffers."""
-        te_whole_moe_graph = (
-            self.config.cuda_graph_impl == "transformer_engine"
+        te_whole_moe_graph_replay = (
+            training
+            and self.config.cuda_graph_impl == "transformer_engine"
             and CudaGraphModule.moe in self.config.cuda_graph_modules
+            and self._te_graph_capture_finished
         )
-        if not te_whole_moe_graph or (stash_overflow_ranks == 0 and overbudget_ranks == 0):
+        if not te_whole_moe_graph_replay or (stash_overflow_ranks == 0 and overbudget_ranks == 0):
             return
 
         raise RuntimeError(
@@ -1351,6 +1379,25 @@ class PagedStashRunner:
             "Increase --moe-expert-rank-capacity-factor and/or "
             "--moe-paged-stash-buffer-size-factor-cuda, then restart the job."
         )
+
+    def _validate_te_whole_moe_graph_runtime(self, training: bool, num_microbatches: int) -> None:
+        """Require the runtime microbatch count to remain fixed after TE graph capture."""
+        te_whole_moe_paged_stash_replay = (
+            training
+            and self.config.cuda_graph_impl == "transformer_engine"
+            and CudaGraphModule.moe in self.config.cuda_graph_modules
+            and self.config.moe_paged_stash
+            and self._te_graph_capture_finished
+        )
+        if not te_whole_moe_paged_stash_replay:
+            return
+
+        if num_microbatches != self._te_graph_runtime_num_microbatches:
+            raise RuntimeError(
+                "Transformer Engine whole-MoE CUDA graphs with paged stash require a fixed "
+                "runtime microbatch count after capture: expected "
+                f"{self._te_graph_runtime_num_microbatches}, got {num_microbatches}."
+            )
 
     def prepare_for_rerun(self, is_training=True):
         """Prepare for rerun: go dropless, disable paged stashing, and reset grads/graph.
@@ -1469,6 +1516,7 @@ class PagedStashRunner:
 
         training = not kwargs['forward_only']
         data_iterator = kwargs['data_iterator']
+        self._validate_te_whole_moe_graph_runtime(training, num_microbatches)
         saved_moe_paged_stash_values = [
             (config, config.moe_paged_stash) for config in self._configs_to_sync_moe_paged_stash
         ]
@@ -1483,7 +1531,9 @@ class PagedStashRunner:
             result = self.forward_backward_func(*args, **kwargs)
 
             stash_overflow_ranks, overbudget_ranks, host_spill_ranks = self.check_moe_overflow()
-            self._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks, overbudget_ranks)
+            self._raise_if_te_whole_moe_graph_overflow(
+                stash_overflow_ranks, overbudget_ranks, training
+            )
             if stash_overflow_ranks == 0 and overbudget_ranks == 0:
                 if host_spill_ranks > 0:
                     log_single_rank(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2890,9 +2890,22 @@ class TransformerConfig(ModelParallelConfig):
                         self.moe_expert_capacity_factor is None
                         or not self.moe_pad_expert_input_to_capacity
                     ):
+                        sync_free_hybridep_moe_graph = (
+                            self.cuda_graph_impl == "transformer_engine"
+                            and self.moe_token_dispatcher_type == "flex"
+                            and self.moe_flex_dispatcher_backend == "hybridep"
+                            and self.moe_expert_rank_capacity_factor is not None
+                            and self.moe_paged_stash
+                            and self.use_transformer_engine_op_fuser
+                        )
                         assert (
                             CudaGraphModule.moe not in self.cuda_graph_modules
-                        ), 'moe cuda graph is only supported with drop-padding MoE.'
+                            or sync_free_hybridep_moe_graph
+                        ), (
+                            "moe cuda graph is only supported with drop-padding MoE or "
+                            "transformer_engine sync-free HybridEP with rank capacity and "
+                            "paged stash."
+                        )
                         if self.moe_token_dispatcher_type == 'alltoall' and (
                             self.moe_expert_capacity_factor is not None
                             or self.moe_router_padding_for_fp8

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2915,6 +2915,17 @@ class TransformerConfig(ModelParallelConfig):
                                 'DtoH copies and synchronizations in the preprocess step.'
                             )
 
+            te_whole_moe_paged_stash = (
+                self.cuda_graph_impl == "transformer_engine"
+                and CudaGraphModule.moe in self.cuda_graph_modules
+                and self.moe_paged_stash
+            )
+            if te_whole_moe_paged_stash:
+                assert self.cuda_graph_warmup_steps >= 2, (
+                    "Transformer Engine whole-MoE CUDA graphs with paged stash require at least "
+                    "2 cuda_graph_warmup_steps to record the pipeline schedule before capture."
+                )
+
             if self.recompute_granularity:
                 if self.recompute_granularity != "selective":
                     assert (

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4655,6 +4655,8 @@ def train(
                 if args.cuda_graph_warmup_steps > 0 and should_disable_forward_pre_hook(args):
                     enable_forward_pre_hook(model)
                     cuda_graph_helper.cuda_graph_set_manual_hooks()
+                if isinstance(forward_backward_func, PagedStashRunner):
+                    forward_backward_func.mark_te_graph_captured(num_microbatches)
 
         # Completely skip iteration if needed.
         if (iteration + 1) in args.iterations_to_skip:

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -33,34 +33,90 @@ from tests.unit_tests.transformer.moe.test_token_dispatcher import is_nccl_ep_fp
 pytestmark = pytest.mark.launch_on_gb200
 
 
-def test_te_graph_capture_replays_paged_stash_schedule():
+def _make_schedule_manager(recorded_schedule, vp_size=1):
     manager = PagedStashManager.__new__(PagedStashManager)
     manager.enabled = True
     manager.status = 'captured'
-    manager.vp_size = 1
-    manager._pp_schedule = [1_001_000, 1_002_000, -1_002_000, -1_001_000]
-    manager.current_layer = [99]
-    manager.current_microbatch = [99]
+    manager.vp_size = vp_size
+    manager._pp_schedule = recorded_schedule
+    manager.current_layer = [99] * vp_size
+    manager.current_microbatch = [99] * vp_size
     manager.current_vp_stage = 0
     manager.current_schedule_index = len(manager._pp_schedule)
     manager._te_graph_capture = False
+    return manager
 
-    manager.start_te_graph_capture()
-    manager.prepare_te_graph_capture_forward()
+
+def test_te_graph_capture_uses_capture_order_then_restores_runtime_schedule():
+    runtime_schedule = [
+        1_001_000,
+        1_002_000,
+        1_001_001,
+        1_002_001,
+        -1_002_000,
+        -1_001_000,
+        -1_002_001,
+        -1_001_001,
+    ]
+    manager = _make_schedule_manager(runtime_schedule)
+
+    runtime_state = manager.start_te_graph_capture([1, 1, 1, -1, -1, -1])
+
+    assert manager._pp_schedule != runtime_schedule
+    assert len(manager._pp_schedule) == 12
     assert manager.current_schedule_index == 0
+    manager.prepare_te_graph_capture_forward()
     assert manager.current_layer == [1]
     assert manager.current_microbatch == [0]
 
-    manager.current_schedule_index = 1
+    # TE repeats the complete order for warmup and capture. The first forward naturally
+    # wraps a fully consumed schedule without any per-callable cursor hook.
+    manager.current_schedule_index = len(manager._pp_schedule)
     manager.prepare_te_graph_capture_forward()
-    assert manager.current_layer == [2]
+    assert manager.current_schedule_index == 0
 
-    manager.current_schedule_index = 2
-    with pytest.raises(RuntimeError, match="expected a forward schedule entry"):
-        manager.prepare_te_graph_capture_forward()
-
-    manager.finish_te_graph_capture()
+    manager.finish_te_graph_capture(runtime_state)
     assert not manager._te_graph_capture
+    assert manager._pp_schedule is runtime_schedule
+    assert manager.current_schedule_index == len(runtime_schedule)
+    assert manager.current_layer == [99]
+    assert manager.current_microbatch == [99]
+
+
+def test_paged_stash_schedule_supports_distinct_vp_layer_templates():
+    manager = _make_schedule_manager(
+        [
+            1_001_000,
+            1_002_000,
+            2_001_000,
+            -2_001_000,
+            1_001_001,
+            1_002_001,
+            -1_002_000,
+            -1_001_000,
+            2_001_001,
+            -1_002_001,
+            -1_001_001,
+            -2_001_001,
+        ],
+        vp_size=2,
+    )
+
+    rebuilt = manager._build_te_graph_capture_schedule([1, 2, -2, 1, -1, 2, -1, -2])
+
+    assert rebuilt == manager._pp_schedule
+
+
+def test_paged_stash_schedule_rejects_invalid_recording_or_order():
+    manager = _make_schedule_manager([1_001_000, -1_002_000])
+    with pytest.raises(RuntimeError, match="backward layer order"):
+        manager._build_te_graph_capture_schedule([1, -1])
+
+    manager = _make_schedule_manager([1_001_000, -1_001_000])
+    with pytest.raises(RuntimeError, match="unbalanced forward/backward"):
+        manager._build_te_graph_capture_schedule([1, 1, -1])
+    with pytest.raises(RuntimeError, match="chunk-level integer PP order"):
+        manager._build_te_graph_capture_schedule([1.0, -1.0])
 
 
 def test_te_graph_capture_joins_auxiliary_streams_per_layer(monkeypatch):

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -19,6 +19,7 @@ from megatron.core.transformer.moe.paged_stash import (
     check_paged_stash_overflow,
     paged_stash_init_chunk_handler,
     paged_stash_reset,
+    paged_stash_te_graph_capture,
 )
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -44,6 +45,11 @@ def _make_schedule_manager(recorded_schedule, vp_size=1):
     manager.current_vp_stage = 0
     manager.current_schedule_index = len(manager._pp_schedule)
     manager._te_graph_capture = False
+    manager.stash_buffers = {}
+    manager.overflow = torch.zeros(1, dtype=torch.int64)
+    manager.host_spill = torch.zeros(1, dtype=torch.int64)
+    manager.paged_tensors_to_stash = []
+    manager.paged_tensors_stash_in_progress = []
     return manager
 
 
@@ -59,15 +65,24 @@ def test_te_graph_capture_uses_capture_order_then_restores_runtime_schedule():
         -1_001_001,
     ]
     manager = _make_schedule_manager(runtime_schedule)
+    runtime_current_layer = manager.current_layer
+    runtime_current_microbatch = manager.current_microbatch
+    runtime_current_vp_stage = manager.current_vp_stage
 
     runtime_state = manager.start_te_graph_capture([1, 1, 1, -1, -1, -1])
 
     assert manager._pp_schedule != runtime_schedule
     assert len(manager._pp_schedule) == 12
     assert manager.current_schedule_index == 0
+    assert manager.current_layer is None
+    assert manager.current_microbatch is None
+    assert manager.current_vp_stage is None
     manager.prepare_te_graph_capture_forward()
     assert manager.current_layer == [1]
     assert manager.current_microbatch == [0]
+    assert manager.current_vp_stage == 0
+    assert manager.current_layer is not runtime_current_layer
+    assert manager.current_microbatch is not runtime_current_microbatch
 
     # TE repeats the complete order for warmup and capture. The first forward naturally
     # wraps a fully consumed schedule without any per-callable cursor hook.
@@ -79,8 +94,65 @@ def test_te_graph_capture_uses_capture_order_then_restores_runtime_schedule():
     assert not manager._te_graph_capture
     assert manager._pp_schedule is runtime_schedule
     assert manager.current_schedule_index == len(runtime_schedule)
-    assert manager.current_layer == [99]
-    assert manager.current_microbatch == [99]
+    assert manager.current_layer is runtime_current_layer
+    assert manager.current_microbatch is runtime_current_microbatch
+    assert manager.current_vp_stage == runtime_current_vp_stage
+
+
+def test_te_graph_capture_after_eval_restores_disabled_state_on_failure(monkeypatch):
+    runtime_schedule = [1_001_000, -1_001_000]
+    manager = _make_schedule_manager(runtime_schedule)
+    manager.enabled = False
+    runtime_current_layer = manager.current_layer
+    runtime_current_microbatch = manager.current_microbatch
+    monkeypatch.setattr(PagedStashManager, "STASH_MGR", manager)
+
+    with pytest.raises(RuntimeError, match="capture failed"):
+        with paged_stash_te_graph_capture(True, order=[1, -1]):
+            assert manager.enabled
+            assert manager._te_graph_capture
+            raise RuntimeError("capture failed")
+
+    assert not manager.enabled
+    assert not manager._te_graph_capture
+    assert manager._pp_schedule is runtime_schedule
+    assert manager.current_layer is runtime_current_layer
+    assert manager.current_microbatch is runtime_current_microbatch
+
+
+def test_te_graph_capture_reallocates_buffers_released_by_warmup_fallback(monkeypatch):
+    manager = _make_schedule_manager([1_001_000, -1_001_000])
+    manager.stash_buffers = None
+    reset_calls = []
+
+    class FakeStashBuffer:
+        def reset(self):
+            reset_calls.append("reset")
+
+    allocation_args = []
+
+    def fake_allocate_stash_buffers(
+        moe_paged_stash_buffer_size_factor_cuda, moe_paged_stash_buffer_size_factor_cpu
+    ):
+        allocation_args.append(
+            (moe_paged_stash_buffer_size_factor_cuda, moe_paged_stash_buffer_size_factor_cpu)
+        )
+        manager.stash_buffers = {"dtype": {128: FakeStashBuffer()}}
+        manager.overflow.fill_(1)
+        manager.host_spill.fill_(1)
+
+    monkeypatch.setattr(manager, "allocate_stash_buffers", fake_allocate_stash_buffers)
+    config = SimpleNamespace(
+        moe_paged_stash_buffer_size_factor_cuda=1.25, moe_paged_stash_buffer_size_factor_cpu=0.5
+    )
+
+    runtime_state = manager.start_te_graph_capture([1, -1], config=config)
+
+    assert allocation_args == [(1.25, 0.5)]
+    assert reset_calls == ["reset"]
+    assert manager.overflow.item() == 0
+    assert manager.host_spill.item() == 0
+    manager.finish_te_graph_capture(runtime_state)
 
 
 def test_paged_stash_schedule_supports_distinct_vp_layer_templates():
@@ -117,6 +189,14 @@ def test_paged_stash_schedule_rejects_invalid_recording_or_order():
         manager._build_te_graph_capture_schedule([1, 1, -1])
     with pytest.raises(RuntimeError, match="chunk-level integer PP order"):
         manager._build_te_graph_capture_schedule([1.0, -1.0])
+    with pytest.raises(RuntimeError, match="invalid VP stage"):
+        manager._build_te_graph_capture_schedule([2, -2])
+
+
+def test_paged_stash_schedule_skips_valid_vp_stage_without_paged_layers():
+    manager = _make_schedule_manager([1_001_000, -1_001_000], vp_size=2)
+
+    assert manager._build_te_graph_capture_schedule([1, 2, -2, -1]) == manager._pp_schedule
 
 
 def test_te_graph_capture_joins_auxiliary_streams_per_layer(monkeypatch):
@@ -152,13 +232,54 @@ def test_te_whole_moe_graph_overflow_fails_instead_of_dynamic_fallback():
     runner.config = SimpleNamespace(
         cuda_graph_impl="transformer_engine", cuda_graph_modules=[CudaGraphModule.moe]
     )
+    runner._te_graph_capture_finished = False
+
+    # Warmup runs eagerly, so overflow can still use the dynamic fallback.
+    runner._raise_if_te_whole_moe_graph_overflow(
+        stash_overflow_ranks=1, overbudget_ranks=0, training=True
+    )
+
+    runner.mark_te_graph_captured(num_microbatches=2)
+
+    # Evaluation also runs eagerly even after training graphs have been captured.
+    runner._raise_if_te_whole_moe_graph_overflow(
+        stash_overflow_ranks=1, overbudget_ranks=0, training=False
+    )
 
     with pytest.raises(RuntimeError, match="Dynamic fallback is not supported"):
-        runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=1, overbudget_ranks=0)
+        runner._raise_if_te_whole_moe_graph_overflow(
+            stash_overflow_ranks=1, overbudget_ranks=0, training=True
+        )
     with pytest.raises(RuntimeError, match="expert-rank token budget overflow on 2 rank"):
-        runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=0, overbudget_ranks=2)
+        runner._raise_if_te_whole_moe_graph_overflow(
+            stash_overflow_ranks=0, overbudget_ranks=2, training=True
+        )
 
-    runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=0, overbudget_ranks=0)
+    runner._raise_if_te_whole_moe_graph_overflow(
+        stash_overflow_ranks=0, overbudget_ranks=0, training=True
+    )
+
+
+def test_te_whole_moe_paged_stash_requires_fixed_runtime_microbatch_count():
+    runner = PagedStashRunner.__new__(PagedStashRunner)
+    runner.config = SimpleNamespace(
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_modules=[CudaGraphModule.moe],
+        moe_paged_stash=True,
+    )
+    runner._te_graph_runtime_num_microbatches = None
+    runner._te_graph_capture_finished = False
+
+    runner._validate_te_whole_moe_graph_runtime(training=True, num_microbatches=2)
+    assert runner._te_graph_runtime_num_microbatches is None
+
+    runner.mark_te_graph_captured(num_microbatches=2)
+    runner._validate_te_whole_moe_graph_runtime(training=False, num_microbatches=4)
+    assert runner._te_graph_runtime_num_microbatches == 2
+
+    with pytest.raises(RuntimeError, match="expected 2, got 3"):
+        runner._validate_te_whole_moe_graph_runtime(training=True, num_microbatches=3)
+    runner._validate_te_whole_moe_graph_runtime(training=True, num_microbatches=2)
 
 
 def _global_tokens_per_expert_from_local_routing_map(routing_map: torch.Tensor) -> torch.Tensor:

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -1,4 +1,6 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -8,9 +10,12 @@ from megatron.core import config
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.moe_utils import get_align_size_for_quantization
 from megatron.core.transformer.moe.paged_stash import (
+    PagedStashManager,
+    PagedStashRunner,
     check_paged_stash_overflow,
     paged_stash_init_chunk_handler,
     paged_stash_reset,
@@ -26,6 +31,78 @@ from tests.unit_tests.transformer.moe.test_token_dispatcher import is_nccl_ep_fp
 # whole module for the GB200 CI bucket (selection there is marker-driven; see
 # tests/unit_tests/find_test_cases.py and recipes/gb200/unit-tests.yaml).
 pytestmark = pytest.mark.launch_on_gb200
+
+
+def test_te_graph_capture_replays_paged_stash_schedule():
+    manager = PagedStashManager.__new__(PagedStashManager)
+    manager.enabled = True
+    manager.status = 'captured'
+    manager.vp_size = 1
+    manager._pp_schedule = [1_001_000, 1_002_000, -1_002_000, -1_001_000]
+    manager.current_layer = [99]
+    manager.current_microbatch = [99]
+    manager.current_vp_stage = 0
+    manager.current_schedule_index = len(manager._pp_schedule)
+    manager._te_graph_capture = False
+
+    manager.start_te_graph_capture()
+    manager.prepare_te_graph_capture_forward()
+    assert manager.current_schedule_index == 0
+    assert manager.current_layer == [1]
+    assert manager.current_microbatch == [0]
+
+    manager.current_schedule_index = 1
+    manager.prepare_te_graph_capture_forward()
+    assert manager.current_layer == [2]
+
+    manager.current_schedule_index = 2
+    with pytest.raises(RuntimeError, match="expected a forward schedule entry"):
+        manager.prepare_te_graph_capture_forward()
+
+    manager.finish_te_graph_capture()
+    assert not manager._te_graph_capture
+
+
+def test_te_graph_capture_joins_auxiliary_streams_per_layer(monkeypatch):
+    manager = PagedStashManager.__new__(PagedStashManager)
+    manager._te_graph_capture = True
+    manager._unpack_stream_status = 'reloading'
+    manager._unpack_stream = object()
+
+    calls = []
+    manager.wait_for_stash_to_complete = lambda: calls.append("stash")
+
+    class FakeCurrentStream:
+        def wait_stream(self, stream):
+            calls.append(("reload", stream))
+
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: FakeCurrentStream())
+
+    manager.finish_te_graph_capture_group_io()
+
+    assert calls == ["stash", ("reload", manager.unpack_stream)]
+    assert manager._unpack_stream_status == 'idle'
+
+    manager._te_graph_capture = False
+    manager._unpack_stream_status = 'reloading'
+    calls.clear()
+    manager.finish_te_graph_capture_group_io()
+    assert calls == []
+    assert manager._unpack_stream_status == 'reloading'
+
+
+def test_te_whole_moe_graph_overflow_fails_instead_of_dynamic_fallback():
+    runner = PagedStashRunner.__new__(PagedStashRunner)
+    runner.config = SimpleNamespace(
+        cuda_graph_impl="transformer_engine", cuda_graph_modules=[CudaGraphModule.moe]
+    )
+
+    with pytest.raises(RuntimeError, match="Dynamic fallback is not supported"):
+        runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=1, overbudget_ranks=0)
+    with pytest.raises(RuntimeError, match="expert-rank token budget overflow on 2 rank"):
+        runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=0, overbudget_ranks=2)
+
+    runner._raise_if_te_whole_moe_graph_overflow(stash_overflow_ranks=0, overbudget_ranks=0)
 
 
 def _global_tokens_per_expert_from_local_routing_map(routing_map: torch.Tensor) -> torch.Tensor:

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -96,6 +96,21 @@ def _base_cuda_graph_config(**kwargs) -> TransformerConfig:
     return TransformerConfig(num_layers=2, hidden_size=64, num_attention_heads=4, **kwargs)
 
 
+def _te_whole_moe_paged_stash_config(**overrides) -> TransformerConfig:
+    kwargs = {
+        "cuda_graph_impl": "transformer_engine",
+        "cuda_graph_modules": [CudaGraphModule.moe],
+        "num_moe_experts": 4,
+        "moe_token_dispatcher_type": "flex",
+        "moe_flex_dispatcher_backend": "hybridep",
+        "moe_expert_rank_capacity_factor": 1.2,
+        "moe_paged_stash": True,
+        "use_transformer_engine_op_fuser": True,
+    }
+    kwargs.update(overrides)
+    return _base_cuda_graph_config(**kwargs)
+
+
 def _validated_cuda_graph_cli_args(monkeypatch, cli_args=None, **overrides):
     destroy_global_vars()
     destroy_num_microbatches_calculator()
@@ -189,18 +204,14 @@ class TestCudaGraphConfigAndArguments:
             )
 
     def test_te_whole_moe_graph_allows_sync_free_hybridep_paged_stash(self):
-        cfg = _base_cuda_graph_config(
-            cuda_graph_impl="transformer_engine",
-            cuda_graph_modules=[CudaGraphModule.moe],
-            num_moe_experts=4,
-            moe_token_dispatcher_type="flex",
-            moe_flex_dispatcher_backend="hybridep",
-            moe_expert_rank_capacity_factor=1.2,
-            moe_paged_stash=True,
-            use_transformer_engine_op_fuser=True,
-        )
+        cfg = _te_whole_moe_paged_stash_config(cuda_graph_warmup_steps=2)
 
         assert cfg.cuda_graph_modules == [CudaGraphModule.moe]
+
+    @pytest.mark.parametrize("warmup_steps", [0, 1])
+    def test_te_whole_moe_paged_stash_requires_two_warmup_steps(self, warmup_steps):
+        with pytest.raises(AssertionError, match="require at least 2 cuda_graph_warmup_steps"):
+            _te_whole_moe_paged_stash_config(cuda_graph_warmup_steps=warmup_steps)
 
     def test_te_whole_moe_graph_rejects_sync_free_hybridep_without_paged_stash(self):
         with pytest.raises(

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -188,6 +188,34 @@ class TestCudaGraphConfigAndArguments:
                 num_moe_experts=4,
             )
 
+    def test_te_whole_moe_graph_allows_sync_free_hybridep_paged_stash(self):
+        cfg = _base_cuda_graph_config(
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.moe],
+            num_moe_experts=4,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_expert_rank_capacity_factor=1.2,
+            moe_paged_stash=True,
+            use_transformer_engine_op_fuser=True,
+        )
+
+        assert cfg.cuda_graph_modules == [CudaGraphModule.moe]
+
+    def test_te_whole_moe_graph_rejects_sync_free_hybridep_without_paged_stash(self):
+        with pytest.raises(
+            AssertionError, match="sync-free HybridEP with rank capacity and paged stash"
+        ):
+            _base_cuda_graph_config(
+                cuda_graph_impl="transformer_engine",
+                cuda_graph_modules=[CudaGraphModule.moe],
+                num_moe_experts=4,
+                moe_token_dispatcher_type="flex",
+                moe_flex_dispatcher_backend="hybridep",
+                moe_expert_rank_capacity_factor=1.2,
+                use_transformer_engine_op_fuser=True,
+            )
+
     def test_full_iteration_impl_requires_empty_scope(self):
         with pytest.raises(
             AssertionError,


### PR DESCRIPTION
## Summary

This PR enables Transformer Engine per-layer whole-MoE CUDA graphs for the sync-free HybridEP + paged-stash path on `main`:

```text
--cuda-graph-impl transformer_engine
--cuda-graph-modules moe
--moe-token-dispatcher-type flex
--moe-flex-dispatcher-backend hybridep
--moe-expert-rank-capacity-factor <factor>
--moe-paged-stash
--use-transformer-engine-op-fuser
```

- Build a capture-only paged-stash schedule by expanding Transformer Engine's final `_order` with the per-VP layer templates recorded during eager warmup, then restore the original runtime schedule and cursor state after capture.
- Join auxiliary stash and reload streams at each independent TE per-layer graph boundary so their work is captured and replayed correctly.
- Require at least two CUDA graph warmup steps and a fixed training microbatch count after capture. Eager warmup and evaluation retain the dynamic overflow fallback, while captured training replay fails fast on stash or expert-rank capacity overflow.
- Handle evaluation immediately before capture by temporarily re-enabling the paged-stash manager and restoring its previous state afterward, including on capture failure.
- Re-prepare stash buffers if the final eager warmup falls back and releases them, without advancing the iteration or changing the recorded runtime schedule coordinates.
- Preserve `main`'s per-config paged-stash restoration, NCCL-EP capacity recovery, and OTel CUDA graph capture span.
- Add focused configuration, schedule reconstruction, lifecycle, stream synchronization, and error-path coverage, together with user documentation.

Unlike `dev`, `main` does not contain the dev-only `cuda_graph_dynamic_microbatches` API, and this PR does not introduce it. The main implementation records the training microbatch count when graph capture completes and rejects a changed count during captured training replay.

## Dependency

Requires a Transformer Engine build containing [NVIDIA/TransformerEngine#2831](https://github.com/NVIDIA/TransformerEngine/pull/2831), so ordered warmup follows the final `_order`.

## Tests

- CW H100 CI container, 8 ranks: `tests/unit_tests/transformer/test_cuda_graphs.py` — 71 passed, 3 skipped, 20 deselected per rank.
- OCI-HSG GB200 CI container, 4 ranks: `tests/unit_tests/transformer/moe/test_paged_stashing.py` — 11 passed, 8 deselected per rank.
- Megatron autoformat check against `main` (Black, isort, pylint, and Ruff).
- Python 3.11 compilation and `git diff --check`.

Validated at `6b6912e268f96bb1c8349a9e229751297e217d7d`.

## Dev PR

Target-main counterpart of [NVIDIA/Megatron-LM#6022](https://github.com/NVIDIA/Megatron-LM/pull/6022).
