### PR TITLE
fix: clear stale gradients in HybridDeviceOptimizer

### DIFF
--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -93,6 +93,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     fp32_param.grad = grad.to(fp32_param.dtype)
                     fp32_param.requires_grad = True
                 else:
+                    fp32_param.grad = None
                     fp32_param.requires_grad = False
 
         # Sync the grads from GPU to CPU.
@@ -101,6 +102,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 gpu_param = self.cpu_copys_map_gpu_param[param]
                 grad = getattr(gpu_param, "decoupled_grad", gpu_param.grad)
                 if grad is None:
+                    param.grad = None
                     param.requires_grad = False
                     continue
 
@@ -109,8 +111,8 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     self.cpu_copy_map_grad[param] = torch.empty(
                         param.shape, dtype=param.dtype, pin_memory=self.pin_cpu_grads, device="cpu"
                     )
-                    param.grad = self.cpu_copy_map_grad[param]
 
+                param.grad = self.cpu_copy_map_grad[param]
                 self.cpu_copy_map_grad[param].data.copy_(grad, non_blocking=True)
             self._cpu_optimizer_map_data_event[optimizer] = self._d2h_stream.record_event()
 

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -75,6 +75,19 @@ class BigNet(nn.Module):
         return x
 
 
+class ConditionalParameterModel(nn.Module):
+    def __init__(self, dtype):
+        super().__init__()
+        self.always = nn.Parameter(torch.tensor(1.0, device="cuda", dtype=dtype))
+        self.optional = nn.Parameter(torch.tensor(1.0, device="cuda", dtype=dtype))
+
+    def forward(self, use_optional):
+        output = self.always
+        if use_optional:
+            output = output + self.optional
+        return output
+
+
 def setup_seed(seed):
     random.seed(seed)  # Set Python's built-in random seed
     np.random.seed(seed)  # Set NumPy's random seed
@@ -129,6 +142,43 @@ def test_load_state_dict_with_native_fp32_param():
 
     restored_model(inputs).sum().backward()
     restored_optimizer.step()
+
+
+@pytest.mark.parametrize(
+    "dtype,offload_fraction,param_update_in_fp32",
+    [(torch.float32, 1.0, False), (torch.bfloat16, 0.0, True)],
+    ids=["cpu-offloaded-param", "gpu-fp32-master-param"],
+)
+def test_conditional_parameter_matches_torch_sgd_reference(
+    dtype, offload_fraction, param_update_in_fp32
+):
+    """HybridDeviceOptimizer must not reuse a previous grad when a param is inactive."""
+    model = ConditionalParameterModel(dtype)
+    reference_model = ConditionalParameterModel(dtype)
+    optimizer = HybridDeviceOptimizer(
+        model.parameters(),
+        offload_fraction=offload_fraction,
+        cpu_optimizer_cls=SGD,
+        gpu_optimizer_cls=SGD,
+        param_update_in_fp32=param_update_in_fp32,
+        overlap_cpu_optimizer_d2h_h2d=False,
+        lr=0.25,
+    )
+    reference_optimizer = SGD(reference_model.parameters(), lr=0.25)
+
+    for use_optional in (True, False, True):
+        optimizer.zero_grad(set_to_none=True)
+        reference_optimizer.zero_grad(set_to_none=True)
+        model(use_optional).backward()
+        reference_model(use_optional).backward()
+        assert (model.optional.grad is None) == (reference_model.optional.grad is None)
+
+        optimizer.step()
+        reference_optimizer.step()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(model.always, reference_model.always)
+        torch.testing.assert_close(model.optional, reference_model.optional)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
- [X] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes a silent stale-gradient update in `HybridDeviceOptimizer` when a parameter is active on one step and has no gradient on a later step.

`HybridDeviceOptimizer` copies source gradients into persistent inner optimizer parameters before stepping its CPU/GPU sub-optimizers. When a source parameter has no gradient on a later step, the current code only sets `requires_grad = False` on the inner parameter. PyTorch optimizers decide whether to skip a parameter from `param.grad is None`, so the previous non-`None` inner gradient can be reused and the inactive parameter can be updated again.

This PR clears the persistent inner `.grad` when the current source gradient is absent:

- FP32 GPU master parameters set `fp32_param.grad = None`;
- CPU-offloaded parameter copies set `param.grad = None`;
- CPU-offloaded parameters reattach their cached CPU grad buffer whenever a new gradient is present, so a previous no-grad step cannot leave the optimizer disconnected from the refreshed grad buffer.

The regression test compares `HybridDeviceOptimizer` against native `torch.optim.SGD` for an active/inactive/active parameter sequence. It covers both a CPU-offloaded parameter and a GPU FP32 master parameter. On the inactive step, the optional parameter has `grad is None` and must remain unchanged.

## Issue tracking

Linked issue: None.

Related CPU-offload PRs were checked. The closest work addresses checkpoint reload (#5071), mixed-precision parameter mapping (#4046), pinned-memory performance (#4547), or DTensor/checkpoint state (#4623); none clears missing gradients in `_set_sub_optimizer_grads()`.

## Contribution process

### Pre-checks

- [X] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [X] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

The patch does not change a public API, typing contract, or documented configuration. The repository `LLaVAModel` check below is supplemental validation rather than a new CI functional test.

## Tests

```bash
python -m py_compile \
  megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py \
  tests/unit_tests/test_optimizer_cpu_offloading.py
```

Passed.

```bash
ruff check --no-fix \
  megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py \
  tests/unit_tests/test_optimizer_cpu_offloading.py
```

Passed.

```bash
git diff --check
```

Passed.

```bash
OMP_NUM_THREADS=1 python -m torch.distributed.run --standalone --nproc_per_node=1 \
  -m pytest -q -s \
  tests/unit_tests/test_optimizer_cpu_offloading.py::test_conditional_parameter_matches_torch_sgd_reference
```

Current `main` with only the regression test fails both cases:

- `cpu-offloaded-param`: expected optional parameter `0.75`, got `0.5`;
- `gpu-fp32-master-param`: same stale-gradient failure.

With this PR applied, both cases pass: `2 passed in 1.12s`.

### Supplemental real-model validation

A repository `LLaVAModel` was trained for an `image -> text-only -> image` sequence while tracking `vision_model.class_token`. The text-only step produced no gradient for that parameter.

| Tree             | Gradient present on the text-only step | Parameter delta on the text-only step |
| ---------------- | -------------------------------------- | ------------------------------------: |
| Current `main` | No                                     |                      `0.0009999275` |
| Fixed            | No                                     |                               `0.0` |
| Exact fix revert | No                                     |        Non-zero stale update restored |

This confirms that the stale gradient reaches a real model parameter without raising an error, the fix prevents the update, and reverting only the fix restores it.

### Optimizer-step overhead

The fix adds only `.grad` reference assignments and no synchronization, copy, or kernel. A supplemental optimizer-step benchmark used public `Qwen2.5-VL-7B-Instruct` parameter shapes: 8,292,166,656 parameters across 729 tensors, one H200, 21 CPU threads, 100% optimizer CPU offload, FP32 masters, and full gradients. After two warmups, each variant was measured for five steps in a baseline-before/fixed/baseline-after sequence.

| Variant        | Step times (seconds)                            | Median (seconds) |
| -------------- | ----------------------------------------------- | ---------------: |
| Current before | `2.77995, 2.77133, 2.77273, 2.76785, 2.80149` |      `2.77273` |
| Fixed          | `2.76050, 2.74055, 2.77214, 2.74754, 2.77483` |      `2.76050` |
| Current after  | `2.89842, 2.90422, 2.91965, 2.92183, 2.72082` |      `2.90422` |

The interpolated current median is `2.83847 s`; the fixed median is `2.75%` lower. This shows no observed latency regression, not a speedup claim.
