### PR TITLE
Share DSA indexer output and latent KV across repeated MTP steps

### DIFF
--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -27,6 +27,16 @@ The following table summarizes MTP configuration fields:
 | --- | --- |
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
+| `mtp_use_repeated_layer` | Reuse one physical MTP layer for every prediction depth. Parameters are shared, while the hidden state, shifted token input, and query are recomputed at each iteration. Default: `False`. |
+| `dsa_mtp_index_kv_share` | For repeated-layer DSA MTP, compute latent KV and indexer top-k at iteration 0 and reuse them at later iterations. Queries and sparse attention are still evaluated at every iteration. Default: `False`. |
+
+## Repeated DSA MTP IndexShare and KVShare
+
+Set `mtp_use_repeated_layer: true`, choose more than one MTP iteration, and enable `dsa_mtp_index_kv_share` to use GLM-5.2-style sharing across MTP iterations. The physical MTP layer must be a DSA indexer-compute layer under the model's `dsa_indexer_topk_freq` and `dsa_indexer_skip_topk_offset` schedule.
+
+Iteration 0 produces the post-RoPE, post-TP/CP-gather latent key and top-k indices. Later iterations reuse those tensors while recomputing the query and running sparse attention. The shared key remains attached to autograd. Under full activation recomputation it is an explicit checkpoint output from iteration 0 and an explicit checkpoint input to later iterations, so gradients from all sparse-attention consumers accumulate into the iteration-0 KV projection. Under selective `mla_up_proj` recompute, only the query up-projection is checkpointed; the source key is constructed outside that checkpoint and stays available to every consumer iteration.
+
+The current implementation uses the split indexer-top-k and sparse-attention path because the combined DSA kernel does not expose top-k for reuse. Fused top-k and fused sparse-attention kernels remain available independently. CUDA graph scopes that capture attention are not supported with MTP iteration sharing; MoE-only CUDA graph scopes remain supported.
 
 ## Pipeline Parallel Layout for MTP
 
@@ -55,4 +65,4 @@ Use `m` for MTP layers in the pipeline layout string. For example:
 
 ## Unsupported Combinations
 
-Context Parallel (CP), arbitrary `AttnMaskType`, and learned absolute position embeddings are not supported with MTP.
+Arbitrary `AttnMaskType` and learned absolute position embeddings are not supported with MTP. MTP supports Context Parallel execution for attention implementations that provide a compatible CP path; repeated DSA sharing requires DSA all-gather CP and reuses the iteration-0 global latent key within the same microbatch CP group.

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -303,6 +303,7 @@ class Attention(MegatronModule, ABC):
         cp_comm_type: str | None = None,
         pg_collection: ProcessGroupCollection | None = None,
         pp_layer_offset: Optional[int] = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ):
         """
@@ -314,6 +315,7 @@ class Attention(MegatronModule, ABC):
         self.config = config
         self.layer_number = layer_number
         self._pp_layer_offset = pp_layer_offset
+        self.is_mtp_layer = is_mtp_layer
 
         self.attn_mask_type = attn_mask_type
         self.attention_type = attention_type
@@ -1668,6 +1670,7 @@ class SelfAttention(Attention):
         cp_comm_type: str | None = None,
         pg_collection: ProcessGroupCollection | None = None,
         pp_layer_offset: Optional[int] = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ):
         """
@@ -1683,6 +1686,7 @@ class SelfAttention(Attention):
             cp_comm_type=cp_comm_type,
             pg_collection=pg_collection,
             pp_layer_offset=pp_layer_offset,
+            is_mtp_layer=is_mtp_layer,
             name=name,
         )
 
@@ -2085,6 +2089,7 @@ class CrossAttention(Attention):
         attn_mask_type: AttnMaskType = AttnMaskType.padding,
         cp_comm_type: str | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ):
         """
@@ -2099,6 +2104,7 @@ class CrossAttention(Attention):
             attention_type="cross",
             cp_comm_type=cp_comm_type,
             pg_collection=pg_collection,
+            is_mtp_layer=is_mtp_layer,
             name=name,
         )
 

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -146,6 +146,7 @@ class AbsorbedMLASelfAttention(Attention):
         cp_comm_type: Optional[str] = None,
         pg_collection: ProcessGroupCollection = None,
         pp_layer_offset: Optional[int] = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ):
         if pg_collection is None:
@@ -160,6 +161,7 @@ class AbsorbedMLASelfAttention(Attention):
             cp_comm_type=cp_comm_type,
             pg_collection=pg_collection,
             pp_layer_offset=pp_layer_offset,
+            is_mtp_layer=is_mtp_layer,
             name=name,
         )
 
@@ -226,6 +228,7 @@ class AbsorbedMLASelfAttention(Attention):
             v_channels=self.config.kv_lora_rank,
             cp_comm_type=cp_comm_type,
             pg_collection=self.pg_collection,
+            is_mtp_layer=is_mtp_layer,
         )
 
         # Output.
@@ -393,6 +396,7 @@ class AbsorbedMLASelfAttention(Attention):
         key_value_states=None,
         packed_seq_params=None,
         inference_context=None,
+        mtp_dsa_context=None,
         *,
         inference_params=None,
     ):
@@ -410,6 +414,14 @@ class AbsorbedMLASelfAttention(Attention):
             Please disable dynamic context parallel."
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
+        shared_key = None
+        if mtp_dsa_context is not None and mtp_dsa_context.reuses_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            shared_key = mtp_dsa_context.shared_tensors.key
 
         # =========================================
         # Prepare RoPE and seqlen related params
@@ -487,36 +499,41 @@ class AbsorbedMLASelfAttention(Attention):
         #     kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim) / TP]
         # elif linear_kv_down_proj is Linear:
         #     kv_combined: [s / TP, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-        kv_combined, _ = self.linear_kv_down_proj(hidden_states)
-        if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
-            # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-            kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
-            # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if self.config.sequence_parallel:
+        if shared_key is None:
+            kv_combined, _ = self.linear_kv_down_proj(hidden_states)
+            if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
+                # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
+                kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
+                # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if self.config.sequence_parallel:
+                    # kv_compressed:[s / TP, b, kv_lora_rank]
+                    kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+            else:
                 # kv_compressed:[s / TP, b, kv_lora_rank]
-                kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+                # k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                    # k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                    k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
         else:
-            # kv_compressed:[s / TP, b, kv_lora_rank], k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-                # k_pos_emb: [s, b, qk_pos_emb_head_dim]
-                k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
+            kv_compressed = k_pos_emb = None
 
         if packed_seq_params is not None:
             assert q_compressed.ndim == 3 and q_compressed.size(1) == 1
-            assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
-            assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
             # If sequence packing, TE expect [t, h, d] shaped qkv input.
             # In Megatron-Core, the qkv shape is [t, 1, h, d].
             # So we need to reshape qkv from [t, 1, h, d] to [t, h, d].
             q_compressed = q_compressed.squeeze(1)
-            kv_compressed = kv_compressed.squeeze(1)
-            k_pos_emb = k_pos_emb.squeeze(1)
+            if shared_key is None:
+                assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
+                assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
+                kv_compressed = kv_compressed.squeeze(1)
+                k_pos_emb = k_pos_emb.squeeze(1)
 
         # =========================================
         # Apply norm
@@ -525,23 +542,33 @@ class AbsorbedMLASelfAttention(Attention):
             # q_compressed: [num_tokens, q_lora_rank]
             q_compressed = self.q_layernorm(q_compressed)
 
-        kv_compressed = self.kv_layernorm(kv_compressed)
-        # Because we won't apply V up projection to the compressed KV, so we need to gather it
-        # manually.
-        if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-            kv_compressed = gather_from_sequence_parallel_region(kv_compressed, group=self.tp_group)
+        if shared_key is None:
+            kv_compressed = self.kv_layernorm(kv_compressed)
+            # Because we won't apply V up projection to the compressed KV, so we need to gather it
+            # manually.
+            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                kv_compressed = gather_from_sequence_parallel_region(
+                    kv_compressed, group=self.tp_group
+                )
 
         # =========================================
         # QKV up projection and RoPE apply
         # =========================================
+        # Capture the active group by value for checkpoint recomputation in backward.
+        active_cp_group = self.pg_collection.cp
 
-        def qkv_up_proj_and_rope_apply(q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb):
-            """
-            Apply the up projection and RoPE to the query and key.
-            When sequence packing enabled, the input tensors adopt a packed shape of [t, ...];
-            otherwise, they maintain the unpacked shape [s, b, ...]. In subsequent code comments,
-            we uniformly use [num_tokens, ...] to denote [s, b, ...] or [t, ...] for two cases.
-            """
+        def select_rotary_pos_emb(rotary_pos_emb, num_tokens):
+            """Select the RoPE rows used by both the query and key branches."""
+            if inference_context is not None:
+                sequence_start = inference_context.sequence_len_offset
+                sequence_end = sequence_start + num_tokens
+                return rotary_pos_emb[sequence_start:sequence_end]
+            if packed_seq_params is None or self.config.context_parallel_size == 1:
+                return rotary_pos_emb[:num_tokens]
+            return rotary_pos_emb
+
+        def q_up_proj_and_rope_apply(q_compressed, rotary_pos_emb):
+            """Apply Q up projection, K-weight absorption, and query RoPE."""
             if self.config.q_lora_rank is not None:
                 # q_compressed: [num_tokens, q_lora_rank]
                 # q: [num_tokens, n * (qk_head_dim + qk_pos_emb_head_dim)]
@@ -553,11 +580,6 @@ class AbsorbedMLASelfAttention(Attention):
 
             # q: [num_tokens, n, q_head_dim]
             q = q.view(*q.size()[:-1], self.num_attention_heads_per_partition, self.q_head_dim)
-
-            # [num_tokens, kv_lora_rank] -> [num_tokens, 1, kv_lora_rank]
-            kv_compressed = torch.unsqueeze(kv_compressed, -2)
-            # [num_tokens, qk_pos_emb_head_dim] -> [num_tokens, 1, qk_pos_emb_head_dim]
-            k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
 
             k_up_weight, _ = self._get_kv_up_weights()
 
@@ -578,11 +600,9 @@ class AbsorbedMLASelfAttention(Attention):
 
                 # q_absorbed: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]
                 q_absorbed = torch.cat([q_absorbed, q_pos_emb], dim=-1)
-                # kv_compressed: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
-                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
 
-                cp_rank = self.pg_collection.cp.rank()
-                cp_size = self.pg_collection.cp.size()
+                cp_rank = active_cp_group.rank()
+                cp_size = active_cp_group.size()
                 q_absorbed = fused_apply_mla_rope_for_q(
                     q_absorbed,
                     rotary_pos_cos,
@@ -593,34 +613,7 @@ class AbsorbedMLASelfAttention(Attention):
                     cp_rank,
                     cp_size,
                 )
-                kv_compressed = fused_apply_mla_rope_for_q(
-                    kv_compressed,
-                    rotary_pos_cos,
-                    rotary_pos_sin,
-                    self.config.kv_lora_rank,
-                    self.config.qk_pos_emb_head_dim,
-                    cu_seqlens_kv,
-                    cp_rank,
-                    cp_size,
-                )
             else:
-                q_len = q.size()[0]
-                if inference_context is not None:
-                    # add offset to the sequence start for inference
-                    sequence_start = inference_context.sequence_len_offset
-                    sequence_end = sequence_start + q_len
-                    rotary_pos_emb = rotary_pos_emb[sequence_start:sequence_end]
-                elif packed_seq_params is None or self.config.context_parallel_size == 1:
-                    # Shorten rotary_pos_emb to the sequence length when inference_params
-                    # is not provided. This makes sure we can run forward directly with
-                    # any sequence length. During training, the sequence length is always
-                    # the full rotary_pos_emb length, except for sequence packing + CP.
-                    # When sequence packing and context parallel are both enabled, the
-                    # position embedding will not split rotary_pos_emb, so it may exceed
-                    # the sequence length on this CP rank, but we need the full rotary_pos_emb
-                    # to cover the full sequence, so we do not shorten it here.
-                    rotary_pos_emb = rotary_pos_emb[0:q_len]
-
                 # q_no_pe: [num_tokens, n, qk_head_dim]
                 # q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                 q_no_pe, q_pos_emb = torch.split(
@@ -638,33 +631,63 @@ class AbsorbedMLASelfAttention(Attention):
                 # Apply RoPE to q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                 q_pos_emb = apply_rotary_pos_emb(
                     q_pos_emb,
-                    rotary_pos_emb,
+                    select_rotary_pos_emb(rotary_pos_emb, q.size(0)),
                     config=self.config,
                     cu_seqlens=cu_seqlens_q,
                     mscale=mscale,
-                    cp_group=self.pg_collection.cp,
-                    mla_rotary_interleaved=True,
-                    max_seqlen=rope_freqs_max_seqlen,
-                )
-                # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
-                k_pos_emb = apply_rotary_pos_emb(
-                    k_pos_emb,
-                    rotary_pos_emb,
-                    config=self.config,
-                    cu_seqlens=cu_seqlens_kv,
-                    mscale=mscale,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=active_cp_group,
                     mla_rotary_interleaved=True,
                     max_seqlen=rope_freqs_max_seqlen,
                 )
 
                 # query: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]
                 q_absorbed = torch.cat([q_absorbed, q_pos_emb], dim=-1)
-                # key: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
-                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
 
             assert q_absorbed.is_contiguous()
+            return q_absorbed
+
+        def key_rope_apply(kv_compressed, k_pos_emb, rotary_pos_emb, num_query_tokens):
+            """Assemble the latent attention key and apply key RoPE."""
+            kv_compressed = torch.unsqueeze(kv_compressed, -2)
+            k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
+
+            if self.config.apply_rope_fusion:
+                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
+                kv_compressed = fused_apply_mla_rope_for_q(
+                    kv_compressed,
+                    rotary_pos_cos,
+                    rotary_pos_sin,
+                    self.config.kv_lora_rank,
+                    self.config.qk_pos_emb_head_dim,
+                    cu_seqlens_kv,
+                    active_cp_group.rank(),
+                    active_cp_group.size(),
+                )
+            else:
+                k_pos_emb = apply_rotary_pos_emb(
+                    k_pos_emb,
+                    select_rotary_pos_emb(rotary_pos_emb, num_query_tokens),
+                    config=self.config,
+                    cu_seqlens=cu_seqlens_kv,
+                    mscale=mscale,
+                    cp_group=active_cp_group,
+                    mla_rotary_interleaved=True,
+                    max_seqlen=rope_freqs_max_seqlen,
+                )
+                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
+
             assert kv_compressed.is_contiguous()
+            return kv_compressed
+
+        def qkv_up_proj_and_rope_apply(q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb):
+            """Compose the ordinary joint Q/K checkpoint path from shared primitives."""
+            q_absorbed = q_up_proj_and_rope_apply(q_compressed, rotary_pos_emb)
+            if shared_key is None:
+                kv_compressed = key_rope_apply(
+                    kv_compressed, k_pos_emb, rotary_pos_emb, q_absorbed.size(0)
+                )
+            else:
+                kv_compressed = shared_key
 
             return q_absorbed, kv_compressed
 
@@ -672,14 +695,32 @@ class AbsorbedMLASelfAttention(Attention):
             quantization = self.config.fp8 or self.config.fp4
             assert not quantization, "FP8/FP4 is not supported for AbsorbedMLA"
             self.qkv_up_checkpoint = tensor_parallel.CheckpointWithoutOutput(fp8=quantization)
-            q_absorbed, kv_compressed = self.qkv_up_checkpoint.checkpoint(
-                qkv_up_proj_and_rope_apply, q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb
-            )
+            if mtp_dsa_context is not None:
+                q_absorbed = self.qkv_up_checkpoint.checkpoint(
+                    q_up_proj_and_rope_apply, q_compressed, rotary_pos_emb
+                )
+                if shared_key is None:
+                    kv_compressed = key_rope_apply(
+                        kv_compressed, k_pos_emb, rotary_pos_emb, q_absorbed.size(0)
+                    )
+                else:
+                    kv_compressed = shared_key
+            else:
+                q_absorbed, kv_compressed = self.qkv_up_checkpoint.checkpoint(
+                    qkv_up_proj_and_rope_apply,
+                    q_compressed,
+                    kv_compressed,
+                    k_pos_emb,
+                    rotary_pos_emb,
+                )
         else:
             assert not self.cache_mla_latents, "cache_mla_latents is not supported for AbsorbedMLA"
             q_absorbed, kv_compressed = qkv_up_proj_and_rope_apply(
                 q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb
             )
+
+        assert q_absorbed.is_contiguous()
+        assert kv_compressed.is_contiguous()
 
         return q_absorbed, kv_compressed, q_compressed
 
@@ -755,6 +796,7 @@ class AbsorbedMLASelfAttention(Attention):
         position_ids=None,
         attn_mask_type=None,
         packed_seq_params=None,
+        mtp_dsa_context=None,
     ):
         """Forward method with selective activation checkpointing."""
 
@@ -767,6 +809,9 @@ class AbsorbedMLASelfAttention(Attention):
             up_v_weight = inputs[5]
             attn_mask_type = inputs[6]
             attn_mask_type = AttnMaskType(attn_mask_type.item())
+            core_attention_kwargs = {}
+            if mtp_dsa_context is not None:
+                core_attention_kwargs["mtp_dsa_context"] = mtp_dsa_context
             output_ = self.core_attention(
                 q_absorbed,
                 k_compressed,
@@ -778,6 +823,7 @@ class AbsorbedMLASelfAttention(Attention):
                 position_ids=position_ids,
                 attn_mask_type=attn_mask_type,
                 packed_seq_params=packed_seq_params,
+                **core_attention_kwargs,
             )
             return output_
 
@@ -812,6 +858,7 @@ class AbsorbedMLASelfAttention(Attention):
         packed_seq_params=None,
         position_ids=None,
         sequence_len_offset=None,
+        mtp_dsa_context=None,
         *,
         inference_params=None,
     ):
@@ -833,7 +880,11 @@ class AbsorbedMLASelfAttention(Attention):
         # Query, Key, and Value
         # =====================
         q_absorbed, kv_compressed, q_compressed = self.get_query_key_value_tensors(
-            hidden_states, key_value_states, packed_seq_params, inference_context=inference_context
+            hidden_states,
+            key_value_states,
+            packed_seq_params,
+            inference_context=inference_context,
+            mtp_dsa_context=mtp_dsa_context,
         )
 
         assert q_absorbed.is_contiguous()
@@ -854,8 +905,12 @@ class AbsorbedMLASelfAttention(Attention):
                 v_up_weight,
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
+                mtp_dsa_context=mtp_dsa_context,
             )
         else:
+            core_attention_kwargs = {}
+            if mtp_dsa_context is not None:
+                core_attention_kwargs["mtp_dsa_context"] = mtp_dsa_context
             core_attn_out = self.core_attention(
                 q_absorbed,
                 kv_compressed,
@@ -867,6 +922,7 @@ class AbsorbedMLASelfAttention(Attention):
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
                 attn_mask_type=self.attn_mask_type,
+                **core_attention_kwargs,
             )
 
         # ==================================

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1554,23 +1554,31 @@ class DSAttention(MegatronModule):
         v_channels: Optional[int] = None,
         cp_comm_type: str = "p2p",
         pg_collection: ProcessGroupCollection = None,
+        is_mtp_layer: bool = False,
     ):
         super().__init__(config=config)
 
-        self.layer_number = layer_number
+        self.layer_number = layer_number + self.config.num_layers if is_mtp_layer else layer_number
         self.index_topk = self.config.dsa_indexer_topk
         self.index_topk_freq = self.config.dsa_indexer_topk_freq or 1
         self.index_skip_topk_offset = self.config.dsa_indexer_skip_topk_offset or 0
         self.index_share = self.index_topk_freq > 1
         self.skip_topk = self.index_share and is_dsa_skip_topk_layer(
-            layer_number, self.index_skip_topk_offset, self.index_topk_freq
+            self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
         )
+        self.mtp_index_share = self.config.dsa_mtp_index_kv_share and is_mtp_layer
+        if self.mtp_index_share and self.skip_topk:
+            raise ValueError(
+                "dsa_mtp_index_kv_share requires the repeated MTP layer to compute "
+                "its own top-k. Adjust dsa_indexer_skip_topk_offset/topk_freq so MTP layer "
+                f"{self.layer_number} is a computing layer."
+            )
         self.source_layer = (
             source_dsa_compute_layer(
-                layer_number, self.index_skip_topk_offset, self.index_topk_freq
+                self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
             )
             if self.index_share
-            else layer_number
+            else self.layer_number
         )
 
         if pg_collection is None:
@@ -1637,6 +1645,7 @@ class DSAttention(MegatronModule):
         attention_bias: torch.Tensor = None,
         packed_seq_params: PackedSeqParams = None,
         up_v_weight: Optional[torch.Tensor] = None,
+        mtp_dsa_context=None,
     ):
         """
         Forward pass for Sparse Attention.
@@ -1656,6 +1665,16 @@ class DSAttention(MegatronModule):
         Returns:
             output: Output tensor [sq, b, hidden_size]
         """
+        if self.mtp_index_share and mtp_dsa_context is None:
+            raise RuntimeError(
+                "The repeated MTP DSA layer requires an explicit per-iteration sharing context."
+            )
+        if not self.mtp_index_share and mtp_dsa_context is not None:
+            raise RuntimeError(
+                "Received an MTP DSA sharing context for an attention layer that is not "
+                "configured for MTP iteration sharing."
+            )
+        reuse_mtp_source = bool(mtp_dsa_context is not None and mtp_dsa_context.reuses_source)
         query, _ = dsa_layout.ensure_sbhd(query, "query")
         key, _ = dsa_layout.ensure_sbhd(key, "key")
         if value is not None:
@@ -1864,6 +1883,11 @@ class DSAttention(MegatronModule):
 
         skv = key.size(0)
 
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            source_key = key
+        else:
+            source_key = None
+
         if not packed_thd and sequence_parallel_query_is_local:
             nonpacked_query_positions = dsa_layout.extract_query_positions_from_position_ids(
                 position_ids, sq, query.device
@@ -1888,7 +1912,7 @@ class DSAttention(MegatronModule):
         qr = qr.detach()
 
         indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
-        computes_topk = not self.skip_topk
+        computes_topk = not self.skip_topk and not reuse_mtp_source
         use_indexer_loss = (
             self.training and torch.is_grad_enabled() and indexer_loss_coeff > 0 and computes_topk
         )
@@ -1958,7 +1982,15 @@ class DSAttention(MegatronModule):
             local_packed_cp_query_start = sequence_parallel_tp_row_start
             local_packed_cp_query_len = sequence_parallel_tp_full_rows
 
-        if self.skip_topk:
+        if reuse_mtp_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            topk_indices = mtp_dsa_context.shared_tensors.topk_indices
+            topk_length = mtp_dsa_context.shared_tensors.optional_topk_length()
+        elif self.skip_topk:
             assert topk_holder is not None
             if self.source_layer not in topk_holder:
                 raise RuntimeError(
@@ -2034,7 +2066,7 @@ class DSAttention(MegatronModule):
             )
 
         fused_output = None
-        if use_fused_kernels and not self.index_share:
+        if use_fused_kernels and not self.index_share and not self.mtp_index_share:
             assert q is not None and k is not None and weights is not None
             fused_output = dsa_kernels.run_fused_dsa_attention(
                 config=self.config,
@@ -2216,6 +2248,10 @@ class DSAttention(MegatronModule):
             topk_holder[self.layer_number] = topk_indices
             if topk_length_holder is not None and topk_length is not None:
                 topk_length_holder[self.layer_number] = topk_length
+
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            assert source_key is not None and topk_indices is not None
+            mtp_dsa_context.capture(source_key, topk_indices, topk_length)
 
         # ===================================
         # Run sparse attention kernel

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -296,8 +296,17 @@ class DSAIndexerLossLoggingHelper:
             return
 
         tracker = DSAIndexerLossLoggingHelper.tracker
+        # MTP layers use global layer numbers beyond the decoder-layer count. Grow the
+        # tracker to the largest observed layer number so those losses remain addressable.
+        needed = max(num_layers, layer_number)
         if "values" not in tracker:
-            tracker["values"] = torch.zeros(num_layers, device=torch.cuda.current_device())
+            tracker["values"] = torch.zeros(needed, device=torch.cuda.current_device())
+        elif tracker["values"].shape[0] < needed:
+            grown = torch.zeros(
+                needed, device=tracker["values"].device, dtype=tracker["values"].dtype
+            )
+            grown[: tracker["values"].shape[0]] = tracker["values"]
+            tracker["values"] = grown
         tracker["values"][layer_number - 1] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group
@@ -312,16 +321,41 @@ class DSAIndexerLossLoggingHelper:
         tracker["avg_group"] = None
 
     @staticmethod
-    def reduce_loss_in_tracker():
-        """Collect and reduce the indexer losses across ranks."""
+    def reduce_loss_in_tracker(num_layers: Optional[int] = None):
+        """Collect and reduce the indexer losses across ranks.
+
+        Pipeline ranks can observe different highest layer numbers when MTP is placed on
+        only one stage. Negotiate one tracker size before reducing the loss values so every
+        rank enters the collective with the same tensor shape.
+        """
         tracker = DSAIndexerLossLoggingHelper.tracker
-        if "values" not in tracker:
+        pp_group = parallel_state.get_pipeline_model_parallel_group()
+
+        if tracker.get("agreed_size") is not None:
+            size = tracker["agreed_size"]
+        else:
+            local_size = tracker["values"].shape[0] if "values" in tracker else (num_layers or 0)
+            size_tensor = torch.tensor(
+                [local_size], device=torch.cuda.current_device(), dtype=torch.long
+            )
+            torch.distributed.all_reduce(
+                size_tensor, op=torch.distributed.ReduceOp.MAX, group=pp_group
+            )
+            size = int(size_tensor.item())
+            tracker["agreed_size"] = size
+        if size == 0:
             return
+        if "values" not in tracker:
+            tracker["values"] = torch.zeros(size, device=torch.cuda.current_device())
+        elif tracker["values"].shape[0] < size:
+            grown = torch.zeros(
+                size, device=tracker["values"].device, dtype=tracker["values"].dtype
+            )
+            grown[: tracker["values"].shape[0]] = tracker["values"]
+            tracker["values"] = grown
         values = tracker["values"]
 
-        torch.distributed.all_reduce(
-            values, group=parallel_state.get_pipeline_model_parallel_group()
-        )
+        torch.distributed.all_reduce(values, group=pp_group)
         # Reduce indexer losses across ranks.
         if tracker.get('reduce_group') is not None:
             torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
@@ -1798,8 +1832,16 @@ class DSAttention(MegatronModule):
                 sq=sq, skv=key.size(0), cp_size=cp_size, cp_group=cp_group, device=query.device
             )
 
+        shared_key_is_tp_cp_global = (
+            reuse_mtp_source
+            and sequence_parallel_tp
+            and cp_size > 1
+            and key.size(0) == sequence_parallel_tp_full_rows * cp_size
+        )
         if sequence_parallel_tp:
-            if key.size(0) == local_sequence_rows:
+            if shared_key_is_tp_cp_global:
+                pass
+            elif key.size(0) == local_sequence_rows:
                 key = gather_from_sequence_parallel_region(key, group=tp_group)
             elif key.size(0) != sequence_parallel_tp_full_rows:
                 raise RuntimeError(

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -144,6 +144,7 @@ class MultiLatentAttention(Attention):
         cp_comm_type: Optional[str] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
         pp_layer_offset: Optional[int] = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ) -> None:
         # TODO(nschank): Restructure so that the Attention initializer knows which specific
@@ -156,6 +157,7 @@ class MultiLatentAttention(Attention):
             attn_mask_type=attn_mask_type,
             pg_collection=pg_collection,
             pp_layer_offset=pp_layer_offset,
+            is_mtp_layer=is_mtp_layer,
             name=name,
         )
         self.config: MLATransformerConfig
@@ -484,6 +486,7 @@ class MLASelfAttention(MultiLatentAttention):
         cp_comm_type: Optional[str] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
         pp_layer_offset: Optional[int] = None,
+        is_mtp_layer: bool = False,
         name: str | None = None,
     ):
         if pg_collection is None:
@@ -498,6 +501,7 @@ class MLASelfAttention(MultiLatentAttention):
             cp_comm_type=cp_comm_type,
             pg_collection=pg_collection,
             pp_layer_offset=pp_layer_offset,
+            is_mtp_layer=is_mtp_layer,
             name=name,
         )
 

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -65,6 +65,53 @@ else:
 
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
+
+@dataclass(frozen=True)
+class MTPDSASharedTensors:
+    """DSA tensors produced by the first repeated MTP iteration and reused thereafter."""
+
+    key: Tensor
+    topk_indices: Tensor
+    topk_length: Tensor
+
+    def optional_topk_length(self) -> Optional[Tensor]:
+        """Return ``None`` when the producer did not emit per-row top-k lengths."""
+        return None if self.topk_length.numel() == 0 else self.topk_length
+
+
+@dataclass
+class MTPDSAIterationContext:
+    """Per-iteration carrier for explicit MTP DSA IndexShare and KVShare tensors."""
+
+    iteration: int
+    shared_tensors: Optional[MTPDSASharedTensors] = None
+    produced_tensors: Optional[MTPDSASharedTensors] = None
+
+    @property
+    def is_source(self) -> bool:
+        """Whether this iteration computes the shared tensors."""
+        return self.iteration == 0
+
+    @property
+    def reuses_source(self) -> bool:
+        """Whether this iteration consumes tensors from the source iteration."""
+        return self.iteration > 0
+
+    def capture(self, key: Tensor, topk_indices: Tensor, topk_length: Optional[Tensor]) -> None:
+        """Capture source tensors without detaching their autograd graph."""
+        if not self.is_source:
+            raise RuntimeError("Only MTP iteration 0 may produce shared DSA tensors.")
+        if topk_length is None:
+            topk_length = topk_indices.new_empty((0,), dtype=torch.int32)
+        self.produced_tensors = MTPDSASharedTensors(key, topk_indices, topk_length)
+
+    def require_source_tensors(self) -> MTPDSASharedTensors:
+        """Return the tensors captured by iteration 0 or fail at the producer boundary."""
+        if self.produced_tensors is None:
+            raise RuntimeError("MTP iteration 0 did not produce DSA KV/top-k tensors.")
+        return self.produced_tensors
+
+
 _HIDDEN_STATE_MIXING_RNG_TRACKER_NAME = 'mtp-hsm-rng'
 _HIDDEN_STATE_MIXING_RNG_SEED_OFFSET = 1 << 40
 
@@ -1125,6 +1172,11 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if self.config.dsa_mtp_index_kv_share and mtp_layer_pattern is not None:
+            raise ValueError(
+                "dsa_mtp_index_kv_share currently supports the GPT MTP path only, "
+                "not a hybrid MTP layer pattern."
+            )
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -1373,6 +1425,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[torch.Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ) -> torch.Tensor:
         """
         Concatenates embeddings with hidden states and then applies transformer layer forward.
@@ -1411,6 +1464,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                     )
                 else:
                     # GPT path: single TransformerLayer
+                    attention_variant_kwargs = {}
+                    if mtp_dsa_context is not None:
+                        attention_variant_kwargs["mtp_dsa_context"] = mtp_dsa_context
                     hidden_states, _ = self.mtp_model_layer(
                         hidden_states=hidden_states,
                         attention_mask=attention_mask,
@@ -1424,6 +1480,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                         packed_seq_params=packed_seq_params,
                         sequence_len_offset=sequence_len_offset,
                         padding_mask=padding_mask,
+                        **attention_variant_kwargs,
                     )
 
         hidden_states = self._postprocess(hidden_states)
@@ -1504,6 +1561,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ):
         """Forward through ``_proj_and_transformer_layer`` with activation
         recomputation.
@@ -1537,8 +1595,22 @@ class MultiTokenPredictionLayer(MegatronModule):
             rotary_pos_cos,
             rotary_pos_sin,
             sequence_len_offset,
+            shared_key,
+            shared_topk_indices,
+            shared_topk_length,
         ):
-            return self._proj_and_transformer_layer(
+            recompute_context = None
+            if mtp_dsa_context is not None:
+                shared_tensors = None
+                if mtp_dsa_context.reuses_source:
+                    shared_tensors = MTPDSASharedTensors(
+                        shared_key, shared_topk_indices, shared_topk_length
+                    )
+                recompute_context = MTPDSAIterationContext(
+                    iteration=mtp_dsa_context.iteration, shared_tensors=shared_tensors
+                )
+
+            outputs = self._proj_and_transformer_layer(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
                 attention_mask=attention_mask,
@@ -1552,7 +1624,24 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                mtp_dsa_context=recompute_context,
             )
+            if recompute_context is not None and recompute_context.is_source:
+                produced = recompute_context.require_source_tensors()
+                return outputs, produced.key, produced.topk_indices, produced.topk_length
+            return outputs
+
+        if mtp_dsa_context is not None and mtp_dsa_context.reuses_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            shared_key = mtp_dsa_context.shared_tensors.key
+            shared_topk_indices = mtp_dsa_context.shared_tensors.topk_indices
+            shared_topk_length = mtp_dsa_context.shared_tensors.topk_length
+        else:
+            shared_key = shared_topk_indices = shared_topk_length = None
 
         # Decide the outer quantization context, matching
         # ``transformer_block._checkpointed_forward``. Only ``fp8 + delayed
@@ -1596,6 +1685,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
+                    shared_key,
+                    shared_topk_indices,
+                    shared_topk_length,
                 )
             else:
                 # tensor_parallel.checkpoint stashes args via autograd's
@@ -1616,6 +1708,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
+                    shared_key,
+                    shared_topk_indices,
+                    shared_topk_length,
                 )
 
         if self.config.recompute_method == 'uniform':
@@ -1646,10 +1741,20 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                mtp_dsa_context=mtp_dsa_context,
             )
         else:
             raise ValueError("Invalid activation recompute method.")
 
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            if isinstance(outputs, torch.Tensor):
+                return outputs, mtp_dsa_context.require_source_tensors()
+            hidden_states, shared_key, shared_topk_indices, shared_topk_length = outputs
+            return hidden_states, MTPDSASharedTensors(
+                shared_key, shared_topk_indices, shared_topk_length
+            )
+        if mtp_dsa_context is not None:
+            return outputs, mtp_dsa_context.shared_tensors
         return outputs
 
     def forward(
@@ -1669,6 +1774,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -1702,8 +1808,12 @@ class MultiTokenPredictionLayer(MegatronModule):
             packed_seq_params=packed_seq_params,
         )
 
+        mtp_dsa_kwargs = {}
+        if mtp_dsa_context is not None:
+            mtp_dsa_kwargs["mtp_dsa_context"] = mtp_dsa_context
+
         if self.config.recompute_granularity == 'full' and self.training:
-            hidden_states = self._checkpointed_forward(
+            checkpoint_outputs = self._checkpointed_forward(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
                 attention_mask=attention_mask,
@@ -1717,7 +1827,13 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                **mtp_dsa_kwargs,
             )
+            if mtp_dsa_context is not None:
+                hidden_states, shared_tensors = checkpoint_outputs
+            else:
+                hidden_states = checkpoint_outputs
+                shared_tensors = None
         else:
             hidden_states = self._proj_and_transformer_layer(
                 hidden_states=hidden_states,
@@ -1733,8 +1849,18 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                **mtp_dsa_kwargs,
             )
 
+            if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+                shared_tensors = mtp_dsa_context.require_source_tensors()
+            elif mtp_dsa_context is not None:
+                shared_tensors = mtp_dsa_context.shared_tensors
+            else:
+                shared_tensors = None
+
+        if mtp_dsa_context is not None:
+            return hidden_states, input_ids, position_ids, padding_mask, shared_tensors
         return hidden_states, input_ids, position_ids, padding_mask
 
     def sharded_state_dict(
@@ -2045,6 +2171,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         if hidden_state_mixing_enabled:
             hidden_state_history = [hidden_states]
 
+        shared_dsa_tensors = None
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
 
@@ -2112,7 +2239,15 @@ class MultiTokenPredictionBlock(MegatronModule):
             else:
                 hidden_states_input = hidden_states
 
-            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
+            mtp_dsa_context = None
+            if self.config.dsa_mtp_index_kv_share:
+                mtp_dsa_context = MTPDSAIterationContext(
+                    iteration=iteration, shared_tensors=shared_dsa_tensors
+                )
+            mtp_dsa_kwargs = {}
+            if mtp_dsa_context is not None:
+                mtp_dsa_kwargs["mtp_dsa_context"] = mtp_dsa_context
+            layer_outputs = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states_input,
@@ -2125,8 +2260,16 @@ class MultiTokenPredictionBlock(MegatronModule):
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
+                **mtp_dsa_kwargs,
                 **(extra_block_kwargs or {}),
             )
+
+            if mtp_dsa_context is not None:
+                hidden_states, input_ids, position_ids, padding_mask, shared_dsa_tensors = (
+                    layer_outputs
+                )
+            else:
+                hidden_states, input_ids, position_ids, padding_mask = layer_outputs
 
             if hidden_state_mixing_enabled:
                 hidden_state_history.append(hidden_states)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -331,6 +331,9 @@ class TransformerConfig(ModelParallelConfig):
     dsa_indexer_skip_topk_offset: int = 0
     """Layer offset for DSA cross-layer top-k sharing."""
 
+    dsa_mtp_index_kv_share: bool = False
+    """Reuse iteration-0 DSA top-k indices and latent KV across repeated MTP iterations."""
+
     dsa_indexer_loss_coeff: Optional[float] = None
     """Coefficient for the DSA indexer KL divergence loss. Set to 0 to disable indexer loss."""
 
@@ -1468,6 +1471,11 @@ class TransformerConfig(ModelParallelConfig):
                 self.experimental_attention_variant
             )
 
+        if self.dsa_mtp_index_kv_share and self.experimental_attention_variant != "dsa":
+            raise ValueError(
+                "dsa_mtp_index_kv_share requires experimental_attention_variant='dsa'."
+            )
+
         if self.use_transformer_engine_op_fuser and self.moe_grouped_gemm:
             self.moe_use_grouped_tensor = True
 
@@ -1584,6 +1592,11 @@ class TransformerConfig(ModelParallelConfig):
                     "dsa_indexer_skip_topk_offset must be non-negative, got "
                     f"{self.dsa_indexer_skip_topk_offset}."
                 )
+            if self.dsa_mtp_index_kv_share:
+                if not self.mtp_use_repeated_layer:
+                    raise ValueError("dsa_mtp_index_kv_share requires mtp_use_repeated_layer=True.")
+                if self.mtp_num_layers is None or self.mtp_num_layers <= 1:
+                    raise ValueError("dsa_mtp_index_kv_share requires mtp_num_layers > 1.")
 
         if self.fp8:
             # cannot support first last layer bf16 with delayed scaling
@@ -2855,6 +2868,18 @@ class TransformerConfig(ModelParallelConfig):
         assert not (
             self.cuda_graph_impl == "full_iteration" and self.cuda_graph_modules
         ), 'cuda_graph_modules must be empty when cuda_graph_impl="full_iteration".'
+
+        if self.dsa_mtp_index_kv_share and self.cuda_graph_impl != "none":
+            captures_attention = (
+                self.cuda_graph_impl == "full_iteration"
+                or not self.cuda_graph_modules
+                or CudaGraphModule.attn in self.cuda_graph_modules
+            )
+            if captures_attention:
+                raise ValueError(
+                    "dsa_mtp_index_kv_share does not yet support CUDA graph scopes "
+                    "that capture attention. MoE-only CUDA graph scopes remain supported."
+                )
 
         if self.cuda_graph_impl != "none":
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -392,15 +392,16 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         attention_optional_kwargs["pg_collection"] = pg_collection
         if pp_layer_offset is not None:
             attention_optional_kwargs["pp_layer_offset"] = pp_layer_offset
-        if is_mtp_layer:
-            attention_optional_kwargs["is_mtp_layer"] = True
+        self_attention_optional_kwargs = dict(attention_optional_kwargs)
+        if is_mtp_layer and config.dsa_mtp_index_kv_share:
+            self_attention_optional_kwargs["is_mtp_layer"] = True
 
         # [Module 2: SelfAttention]
         self.self_attention = build_module(
             submodules.self_attention,
             config=self.config,
             layer_number=self.layer_number,
-            **attention_optional_kwargs,
+            **self_attention_optional_kwargs,
             name=(name + ".self_attention") if name is not None else None,
         )
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, Union
 
 if TYPE_CHECKING:
     from megatron.core.tensor_parallel.random import CheckpointWithoutOutputManager
+    from megatron.core.transformer.multi_token_prediction import MTPDSAIterationContext
 
 import torch
 import torch.distributed
@@ -391,6 +392,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         attention_optional_kwargs["pg_collection"] = pg_collection
         if pp_layer_offset is not None:
             attention_optional_kwargs["pp_layer_offset"] = pp_layer_offset
+        if is_mtp_layer:
+            attention_optional_kwargs["is_mtp_layer"] = True
 
         # [Module 2: SelfAttention]
         self.self_attention = build_module(
@@ -627,6 +630,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -669,6 +673,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             self._set_proj_residual(residual)
 
         nvtx_range_push(suffix="self_attention")
+        attention_variant_kwargs = {}
+        if mtp_dsa_context is not None:
+            attention_variant_kwargs["mtp_dsa_context"] = mtp_dsa_context
         with _otel_managed_span('layer', 'megatron.layer.self_attention'):
             attention_output_with_bias = self.self_attention(
                 input_layernorm_output,
@@ -681,6 +688,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                **attention_variant_kwargs,
             )
         nvtx_range_pop(suffix="self_attention")
 

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -99,6 +99,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "dsa_indexer_topk_freq": 1,
     "dsa_indexer_use_sparse_loss": False,
     "dsa_kernel_backend": "none",
+    "dsa_mtp_index_kv_share": False,
     "embedding_init_method": {},
     "embedding_init_method_std": 0.014,
     "enable_autocast": False,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -122,6 +122,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
 
@@ -144,6 +145,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
         attention = DSAttention(
@@ -170,6 +172,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
         attention = DSAttention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
@@ -30,12 +30,24 @@ from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     MultiTokenPredictionLayer,
 )
-from megatron.core.transformer.spec_utils import build_module
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
 from megatron.core.utils import init_method_normal, scaled_init_method_normal
 from tests.unit_tests.test_utilities import Utils
 
 pytestmark = pytest.mark.launch_on_gb200
+
+
+class _CustomAttentionWithoutMTPKeyword(nn.Module):
+    """Minimal custom attention builder retaining the pre-existing constructor contract."""
+
+    def __init__(self, *, config, layer_number, pg_collection, name=None):
+        super().__init__()
+        self.config = config
+        self.layer_number = layer_number
+        self.pg_collection = pg_collection
+        self.name = name
 
 
 def _make_config(**overrides) -> MLATransformerConfig:
@@ -120,6 +132,29 @@ def test_iteration_sharing_accepts_selective_mla_up_projection_recompute():
     config = _make_config(recompute_granularity="selective", recompute_modules=["mla_up_proj"])
 
     assert config.recompute_modules == ["mla_up_proj"]
+
+
+def test_feature_off_mtp_keeps_custom_attention_builder_contract():
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        config = _make_config(
+            dsa_mtp_index_kv_share=False,
+            experimental_attention_variant=None,
+            multi_latent_attention=False,
+        )
+        custom_attention = ModuleSpec(module=_CustomAttentionWithoutMTPKeyword)
+        layer = TransformerLayer(
+            config,
+            TransformerLayerSubmodules(
+                self_attention=custom_attention, cross_attention=custom_attention
+            ),
+            is_mtp_layer=True,
+        )
+
+        assert isinstance(layer.self_attention, _CustomAttentionWithoutMTPKeyword)
+        assert isinstance(layer.cross_attention, _CustomAttentionWithoutMTPKeyword)
+    finally:
+        Utils.destroy_model_parallel()
 
 
 def test_nonsharing_selective_mla_up_projection_keeps_joint_qk_checkpoint(monkeypatch):
@@ -527,8 +562,9 @@ def test_repeated_mtp_dsa_index_and_kv_share_native_parity(
         Utils.destroy_model_parallel()
 
 
-def test_indexer_loss_is_computed_only_by_the_source_iteration(monkeypatch):
+def test_indexer_loss_is_computed_only_by_the_source_iteration():
     Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    dsa_module.DSAIndexerLossLoggingHelper.tracker.clear()
     try:
         model_parallel_cuda_manual_seed(2345)
         torch.manual_seed(2345)
@@ -541,13 +577,6 @@ def test_indexer_loss_is_computed_only_by_the_source_iteration(monkeypatch):
             .bfloat16()
             .cuda()
         )
-        tracked_losses = []
-        monkeypatch.setattr(
-            dsa_module.DSAIndexerLossLoggingHelper,
-            "save_loss_to_tracker",
-            staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
-        )
-
         total_tokens = 9
         valid = _causal_segment_mask(total_tokens, None, device="cuda")
         attention_mask = torch.zeros(
@@ -574,14 +603,50 @@ def test_indexer_loss_is_computed_only_by_the_source_iteration(monkeypatch):
 
         sum(output.float().sum() for output in outputs).backward()
 
-        assert len(tracked_losses) == 1
-        assert tracked_losses[0].requires_grad
+        tracker_values = dsa_module.DSAIndexerLossLoggingHelper.tracker["values"]
+        assert tracker_values.shape == (config.num_layers + 1,)
+        assert tracker_values[config.num_layers] > 0
         for name in ("linear_wq_b.weight", "linear_wk.weight", "linear_weights_proj.weight"):
             parameter = dict(attention.core_attention.indexer.named_parameters())[name]
             assert parameter.grad is not None
             assert torch.isfinite(parameter.grad).all()
     finally:
+        dsa_module.DSAIndexerLossLoggingHelper.tracker.clear()
         Utils.destroy_model_parallel()
+
+
+def test_indexer_loss_tracker_negotiates_mtp_size_on_empty_pp_rank(monkeypatch):
+    tracker = dsa_module.DSAIndexerLossLoggingHelper.tracker
+    tracker.clear()
+    pp_group = object()
+    dp_group = object()
+    collectives = []
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+    monkeypatch.setattr(parallel_state, "get_pipeline_model_parallel_group", lambda: pp_group)
+    monkeypatch.setattr(
+        parallel_state, "get_data_parallel_group", lambda with_context_parallel=False: dp_group
+    )
+
+    def fake_all_reduce(tensor, op=None, group=None):
+        collectives.append((tensor.shape, op, group))
+        if tensor.dtype == torch.long:
+            tensor.fill_(3)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    try:
+        dsa_module.DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=2)
+
+        assert tracker["agreed_size"] == 3
+        assert tracker["values"].shape == (3,)
+        assert torch.count_nonzero(tracker["values"]) == 0
+        assert collectives[0] == ((1,), torch.distributed.ReduceOp.MAX, pp_group)
+        assert collectives[1][0] == (3,)
+        assert collectives[1][2] is pp_group
+        assert collectives[-1][2] is dp_group
+    finally:
+        tracker.clear()
 
 
 def test_source_indexer_loss_and_gradients_match_unshared_oracle(monkeypatch):
@@ -863,6 +928,133 @@ def test_tp2_sequence_parallel_reuses_global_source_kv_and_topk(monkeypatch):
         assert torch.isfinite(source_hidden.grad).all()
         assert torch.isfinite(consumer_hidden.grad).all()
         assert call_counts == {"kv": 1, "indexer": 1, "sparse": 2}
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_tp2_cp2_reuses_already_global_source_kv_without_regather(monkeypatch):
+    if Utils.world_size < 4:
+        pytest.skip("TP2 x CP2 MTP DSA sharing requires at least four distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=2)
+    try:
+        model_parallel_cuda_manual_seed(4123)
+        rank_seed = (
+            4123
+            + parallel_state.get_tensor_model_parallel_rank()
+            + 2 * parallel_state.get_context_parallel_rank()
+        )
+        torch.manual_seed(rank_seed)
+        torch.cuda.manual_seed(rank_seed)
+
+        config = _make_config(
+            tensor_model_parallel_size=2,
+            context_parallel_size=2,
+            sequence_parallel=True,
+            cp_comm_type="all_gather",
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(
+                attention_spec,
+                config=config,
+                layer_number=1,
+                cp_comm_type=config.cp_comm_type,
+                is_mtp_layer=True,
+            )
+            .bfloat16()
+            .cuda()
+        )
+        call_counts = {
+            "kv": 0,
+            "indexer": 0,
+            "sparse": 0,
+            "kv_cp_gather": 0,
+            "indexer_cp_gather": 0,
+        }
+        hooks = [
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+        original_gather = dsa_module.gather_from_sequence_parallel_region
+
+        def counted_gather(tensor, group=None, **kwargs):
+            if group is parallel_state.get_context_parallel_group():
+                if tensor.size(-1) == config.kv_lora_rank + config.qk_pos_emb_head_dim:
+                    call_counts["kv_cp_gather"] += 1
+                elif tensor.size(-1) == config.dsa_indexer_head_dim:
+                    call_counts["indexer_cp_gather"] += 1
+            return original_gather(tensor, group=group, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "gather_from_sequence_parallel_region", counted_gather)
+
+        local_tokens = 8
+        tp_cp_tokens = local_tokens * config.tensor_model_parallel_size
+        global_tokens = tp_cp_tokens * config.context_parallel_size
+        cu_seqlens = torch.tensor([0, global_tokens], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens.clone(),
+            cu_seqlens_kv_padded=cu_seqlens.clone(),
+            max_seqlen_q=global_tokens,
+            max_seqlen_kv=global_tokens,
+        )
+        source_hidden = torch.randn(
+            local_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        consumer_hidden = torch.randn_like(source_hidden, requires_grad=True)
+
+        source_context = MTPDSAIterationContext(iteration=0)
+        attention(
+            source_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=source_context,
+        )
+        shared = source_context.require_source_tensors()
+        consumer_context = MTPDSAIterationContext(iteration=1, shared_tensors=shared)
+        consumer_output, _ = attention(
+            consumer_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=consumer_context,
+        )
+        consumer_output.float().square().mean().backward()
+
+        assert shared.key.size(0) == global_tokens
+        assert shared.topk_indices.size(1) == tp_cp_tokens
+        assert torch.all(shared.topk_indices >= -1)
+        assert torch.all(shared.topk_indices < global_tokens)
+        assert source_hidden.grad is not None and source_hidden.grad.float().norm() > 0
+        assert consumer_hidden.grad is not None and consumer_hidden.grad.float().norm() > 0
+        assert torch.isfinite(source_hidden.grad).all()
+        assert torch.isfinite(consumer_hidden.grad).all()
+        assert call_counts == {
+            "kv": 1,
+            "indexer": 1,
+            "sparse": 2,
+            "kv_cp_gather": 1,
+            "indexer_cp_gather": 1,
+        }
         for hook in hooks:
             hook.remove()
     finally:

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
@@ -1,0 +1,1081 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Native parity coverage for repeated-MTP DSA IndexShare and KVShare."""
+
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import megatron.core.parallel_state as parallel_state
+from megatron.core.enums import Fp8Recipe
+from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+    get_dsa_module_spec_for_backend,
+    get_transformer_layer_with_experimental_attention_variant_spec,
+)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.random import (
+    CheckpointWithoutOutput,
+    model_parallel_cuda_manual_seed,
+)
+from megatron.core.transformer.enums import AttnBackend, CudaGraphModule
+from megatron.core.transformer.experimental_attention_variant import dsa as dsa_module
+from megatron.core.transformer.multi_token_prediction import (
+    MTPDSAIterationContext,
+    MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
+)
+from megatron.core.transformer.spec_utils import build_module
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.utils import init_method_normal, scaled_init_method_normal
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _make_config(**overrides) -> MLATransformerConfig:
+    kwargs = dict(
+        num_layers=2,
+        mtp_num_layers=7,
+        mtp_use_repeated_layer=True,
+        dsa_mtp_index_kv_share=True,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_query_groups=4,
+        kv_channels=8,
+        multi_latent_attention=True,
+        experimental_attention_variant="dsa",
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_head_dim=8,
+        qk_pos_emb_head_dim=4,
+        v_head_dim=8,
+        dsa_indexer_n_heads=4,
+        dsa_indexer_head_dim=8,
+        dsa_indexer_topk=4,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=3,
+        dsa_indexer_loss_coeff=0.0,
+        dsa_indexer_rotate_activation=False,
+        dsa_indexer_scoring_relu=False,
+        dsa_kernel_backend="none",
+        attention_backend=AttnBackend.unfused,
+        add_bias_linear=False,
+        qk_layernorm=True,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        sequence_parallel=False,
+        apply_rope_fusion=False,
+        rope_type="rope",
+        rotary_base=10000,
+        gradient_accumulation_fusion=False,
+        init_method=init_method_normal(0.02),
+        output_layer_init_method=scaled_init_method_normal(0.02, 2, multiplier=2.0),
+        use_cpu_initialization=False,
+        perform_initialization=True,
+    )
+    kwargs.update(overrides)
+    return MLATransformerConfig(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"experimental_attention_variant": None}, "requires experimental_attention_variant"),
+        ({"mtp_use_repeated_layer": False}, "requires mtp_use_repeated_layer"),
+        ({"mtp_num_layers": 1}, "requires mtp_num_layers > 1"),
+        (
+            {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": ["attn"]},
+            "does not yet support CUDA graph scopes that capture attention",
+        ),
+    ],
+)
+def test_iteration_sharing_rejects_incompatible_config(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _make_config(**overrides)
+
+
+def test_iteration_sharing_accepts_moe_only_cuda_graph_scope():
+    config = _make_config(
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_modules=["moe_router", "moe_preprocess"],
+        num_moe_experts=4,
+    )
+
+    assert config.cuda_graph_modules == [CudaGraphModule.moe_router, CudaGraphModule.moe_preprocess]
+
+
+def test_iteration_sharing_accepts_selective_mla_up_projection_recompute():
+    config = _make_config(recompute_granularity="selective", recompute_modules=["mla_up_proj"])
+
+    assert config.recompute_modules == ["mla_up_proj"]
+
+
+def test_nonsharing_selective_mla_up_projection_keeps_joint_qk_checkpoint(monkeypatch):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(1122)
+        config = _make_config(
+            dsa_mtp_index_kv_share=False,
+            recompute_granularity="selective",
+            recompute_modules=["mla_up_proj"],
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = build_module(attention_spec, config=config, layer_number=1).bfloat16().cuda()
+
+        checkpoint_output_arities = []
+        original_checkpoint = CheckpointWithoutOutput.checkpoint
+
+        def observed_checkpoint(checkpoint, run_function, *args):
+            outputs = original_checkpoint(checkpoint, run_function, *args)
+            checkpoint_output_arities.append(
+                1 if isinstance(outputs, torch.Tensor) else len(outputs)
+            )
+            return outputs
+
+        monkeypatch.setattr(CheckpointWithoutOutput, "checkpoint", observed_checkpoint)
+
+        total_tokens = 9
+        hidden_states = torch.randn(
+            total_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+
+        output, _ = attention(hidden_states, attention_mask=attention_mask)
+        output.float().square().mean().backward()
+
+        assert checkpoint_output_arities == [2]
+        assert hidden_states.grad is not None and torch.isfinite(hidden_states.grad).all()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def _rope_positions(total_tokens: int, segment_lengths: list[int] | None, device) -> torch.Tensor:
+    if segment_lengths is None:
+        return torch.arange(total_tokens, device=device)
+    return torch.cat([torch.arange(length, device=device) for length in segment_lengths])
+
+
+def _apply_rope(
+    x: torch.Tensor, positions: torch.Tensor, base: float, interleaved: bool
+) -> torch.Tensor:
+    dtype = x.dtype
+    dim = x.size(-1)
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=x.device) / dim))
+    freqs = torch.outer(positions.float(), freqs)
+    freqs = torch.polar(torch.ones_like(freqs), freqs).view(x.size(0), 1, 1, -1)
+    if interleaved:
+        x_pairs = x.float().reshape(*x.shape[:-1], -1, 2)
+    else:
+        x_pairs = x.float().reshape(*x.shape[:-1], 2, -1).transpose(-1, -2).contiguous()
+    x_complex = torch.view_as_complex(x_pairs)
+    output = torch.view_as_real(x_complex * freqs).flatten(-2)
+    if not interleaved:
+        output = torch.cat([output[..., 0::2], output[..., 1::2]], dim=-1)
+    return output.to(dtype=dtype)
+
+
+def _causal_segment_mask(
+    total_tokens: int, segment_lengths: list[int] | None, device
+) -> torch.Tensor:
+    valid = torch.zeros((total_tokens, total_tokens), dtype=torch.bool, device=device)
+    start = 0
+    for length in segment_lengths or [total_tokens]:
+        valid[start : start + length, start : start + length] = torch.tril(
+            torch.ones((length, length), dtype=torch.bool, device=device)
+        )
+        start += length
+    return valid
+
+
+class _NativeSharedAbsorbedDSA(nn.Module):
+    """Pure-PyTorch repeated-iteration DSA oracle with explicit source tensor reuse."""
+
+    _PARAMETER_MAP = {
+        "q_down_weight": "linear_q_down_proj.weight",
+        "q_norm_weight": "q_layernorm.weight",
+        "q_up_weight": "linear_q_up_proj.weight",
+        "kv_down_weight": "linear_kv_down_proj.weight",
+        "kv_norm_weight": "kv_layernorm.weight",
+        "kv_up_weight": "linear_kv_up_proj.weight",
+        "output_weight": "linear_proj.weight",
+        "index_q_weight": "core_attention.indexer.linear_wq_b.weight",
+        "index_k_weight": "core_attention.indexer.linear_wk.weight",
+        "index_k_norm_weight": "core_attention.indexer.k_norm.weight",
+        "index_k_norm_bias": "core_attention.indexer.k_norm.bias",
+        "index_weight_proj": "core_attention.indexer.linear_weights_proj.weight",
+    }
+
+    def __init__(self, real_attention, config: MLATransformerConfig):
+        super().__init__()
+        self.config = config
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in self._PARAMETER_MAP.items():
+            setattr(self, native_name, nn.Parameter(real_parameters[real_name].detach().clone()))
+
+    def _project_query(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        qr = F.linear(hidden_states, self.q_down_weight)
+        qr = F.rms_norm(
+            qr, (self.config.q_lora_rank,), self.q_norm_weight, self.config.layernorm_epsilon
+        )
+        query = F.linear(qr, self.q_up_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.qk_pos_emb_head_dim,
+        )
+        query_nope, query_rope = torch.split(
+            query, [self.config.qk_head_dim, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=True)
+
+        kv_up = self.kv_up_weight.view(
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.v_head_dim,
+            self.config.kv_lora_rank,
+        )
+        k_up = kv_up[:, : self.config.qk_head_dim]
+        query_absorbed = torch.einsum("sbhd,hdc->sbhc", query_nope, k_up)
+        return torch.cat([query_absorbed, query_rope], dim=-1), qr, kv_up
+
+    def _project_key(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        kv_combined = F.linear(hidden_states, self.kv_down_weight)
+        kv_latent, key_rope = torch.split(
+            kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        kv_latent = F.rms_norm(
+            kv_latent,
+            (self.config.kv_lora_rank,),
+            self.kv_norm_weight,
+            self.config.layernorm_epsilon,
+        )
+        key_rope = _apply_rope(
+            key_rope.unsqueeze(2), positions, self.config.rotary_base, interleaved=True
+        )
+        return torch.cat([kv_latent.unsqueeze(2), key_rope], dim=-1)
+
+    def _compute_topk(
+        self,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+    ) -> torch.Tensor:
+        source = hidden_states.detach()
+        qr = qr.detach()
+        query = F.linear(qr, self.index_q_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.dsa_indexer_n_heads,
+            self.config.dsa_indexer_head_dim,
+        )
+        query_rope, query_nope = torch.split(
+            query,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=False)
+        query = torch.cat([query_rope, query_nope], dim=-1)
+
+        key = F.linear(source, self.index_k_weight)
+        key = F.layer_norm(
+            key,
+            (self.config.dsa_indexer_head_dim,),
+            self.index_k_norm_weight,
+            self.index_k_norm_bias,
+            self.config.dsa_indexer_k_norm_epsilon or self.config.layernorm_epsilon,
+        )
+        key = key.unsqueeze(2)
+        key_rope, key_nope = torch.split(
+            key,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        key_rope = _apply_rope(key_rope, positions, self.config.rotary_base, interleaved=False)
+        key = torch.cat([key_rope, key_nope], dim=-1).squeeze(2)
+
+        weights = F.linear(source, self.index_weight_proj)
+        weights = weights * (self.config.dsa_indexer_n_heads**-0.5)
+        weights = weights * (self.config.dsa_indexer_head_dim**-0.5)
+        scores = torch.einsum("sbhd,tbd->bsht", query.float(), key.float())
+        scores = (scores * weights.transpose(0, 1).unsqueeze(-1)).sum(dim=2)
+        scores = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
+        topk_scores, topk = scores.topk(min(self.config.dsa_indexer_topk, key.size(0)), dim=-1)
+        return topk.masked_fill(topk_scores == float("-inf"), -1)
+
+    def forward_iteration(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+        shared_key: torch.Tensor | None,
+        shared_topk: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        query, qr, kv_up = self._project_query(hidden_states, positions)
+        key = self._project_key(hidden_states, positions) if shared_key is None else shared_key
+        topk = (
+            self._compute_topk(hidden_states, qr, positions, valid)
+            if shared_topk is None
+            else shared_topk
+        )
+
+        scores = torch.einsum("sbhd,tbnd->bhst", query.float(), key.float())
+        scores = scores * (self.config.qk_head_dim + self.config.qk_pos_emb_head_dim) ** -0.5
+        selected = torch.zeros_like(valid, dtype=torch.int32).unsqueeze(0)
+        selected.scatter_add_(-1, topk.clamp_min(0), (topk >= 0).to(dtype=selected.dtype))
+        sparse_valid = valid.unsqueeze(0) & (selected > 0)
+        scores = scores.masked_fill(~sparse_valid.unsqueeze(1), float("-inf"))
+        probabilities = torch.softmax(scores, dim=-1).to(dtype=key.dtype)
+        latent_value = key[..., : self.config.kv_lora_rank]
+        latent_output = torch.einsum("bhst,tbnd->sbhd", probabilities, latent_value)
+        v_up = kv_up[:, self.config.qk_head_dim :]
+        output = torch.einsum("sbhc,hdc->sbhd", latent_output, v_up)
+        output = F.linear(output.reshape(*hidden_states.shape[:-1], -1), self.output_weight)
+        return output, key, topk
+
+
+def _cosine_similarity(left: torch.Tensor, right: torch.Tensor) -> float:
+    return F.cosine_similarity(
+        left.flatten().double().unsqueeze(0), right.flatten().double().unsqueeze(0)
+    ).item()
+
+
+def _tensor_similarity(left: torch.Tensor, right: torch.Tensor) -> float:
+    left = left.double()
+    right = right.double()
+    denominator = (left.square() + right.square()).sum()
+    if denominator == 0:
+        return 1.0
+    return (2.0 * (left * right).sum() / denominator).item()
+
+
+def _assert_similarity(left: torch.Tensor, right: torch.Tensor, tolerance: float = 2e-2):
+    assert torch.isfinite(left).all()
+    assert torch.isfinite(right).all()
+    assert _cosine_similarity(left, right) > 1 - tolerance
+    assert _tensor_similarity(left, right) > 1 - tolerance
+
+
+@pytest.mark.parametrize("segment_lengths", [None, [5, 4]])
+@pytest.mark.parametrize("recompute_up_proj", [False, True])
+def test_repeated_mtp_dsa_index_and_kv_share_native_parity(
+    monkeypatch, segment_lengths, recompute_up_proj
+):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(1234)
+        torch.manual_seed(1234)
+        torch.cuda.manual_seed(1234)
+
+        recompute_overrides = {}
+        if recompute_up_proj:
+            recompute_overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["mla_up_proj"],
+            }
+        config = _make_config(**recompute_overrides)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        real_attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        native_attention = _NativeSharedAbsorbedDSA(real_attention, config).bfloat16().cuda()
+
+        total_tokens = sum(segment_lengths) if segment_lengths is not None else 9
+        positions = _rope_positions(total_tokens, segment_lengths, device="cuda")
+        valid = _causal_segment_mask(total_tokens, segment_lengths, device="cuda")
+        if segment_lengths is None:
+            attention_mask = torch.zeros(
+                (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+            ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+            packed_seq_params = None
+        else:
+            cu_seqlens = torch.tensor(
+                [0, segment_lengths[0], total_tokens], dtype=torch.int32, device="cuda"
+            )
+            attention_mask = None
+            packed_seq_params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(segment_lengths),
+                max_seqlen_kv=max(segment_lengths),
+            )
+
+        call_counts = {"q": 0, "kv": 0, "indexer": 0, "sparse": 0}
+        checkpoint_output_arities = []
+        original_checkpoint = CheckpointWithoutOutput.checkpoint
+
+        def observed_checkpoint(checkpoint, run_function, *args):
+            outputs = original_checkpoint(checkpoint, run_function, *args)
+            checkpoint_output_arities.append(
+                1 if isinstance(outputs, torch.Tensor) else len(outputs)
+            )
+            return outputs
+
+        monkeypatch.setattr(CheckpointWithoutOutput, "checkpoint", observed_checkpoint)
+        hooks = [
+            real_attention.linear_q_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("q", call_counts["q"] + 1)
+            ),
+            real_attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            real_attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        real_inputs = [
+            torch.randn(
+                total_tokens,
+                1,
+                config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+                requires_grad=True,
+            )
+            for _ in range(config.mtp_num_layers)
+        ]
+        native_inputs = [value.detach().clone().requires_grad_(True) for value in real_inputs]
+        output_grads = [torch.randn_like(value) for value in real_inputs]
+
+        real_outputs = []
+        native_outputs = []
+        real_shared = None
+        native_key = native_topk = None
+        for iteration in range(config.mtp_num_layers):
+            context = MTPDSAIterationContext(iteration, shared_tensors=real_shared)
+            real_output, _ = real_attention(
+                real_inputs[iteration],
+                attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
+                mtp_dsa_context=context,
+            )
+            if context.is_source:
+                real_shared = context.require_source_tensors()
+            real_outputs.append(real_output)
+
+            native_output, current_key, current_topk = native_attention.forward_iteration(
+                native_inputs[iteration], positions, valid, native_key, native_topk
+            )
+            if iteration == 0:
+                native_key, native_topk = current_key, current_topk
+            native_outputs.append(native_output)
+
+        assert real_shared is not None
+        assert real_shared.key.untyped_storage().nbytes() > 0
+        assert torch.equal(real_shared.topk_indices, native_topk)
+        for row, indices in enumerate(real_shared.topk_indices[0]):
+            indices = indices[indices >= 0]
+            assert valid[row, indices].all()
+        for output, reference in zip(real_outputs, native_outputs):
+            _assert_similarity(output, reference)
+
+        torch.autograd.backward(real_outputs, output_grads)
+        torch.autograd.backward(native_outputs, output_grads)
+        for real_input, native_input in zip(real_inputs, native_inputs):
+            _assert_similarity(real_input.grad, native_input.grad)
+
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in native_attention._PARAMETER_MAP.items():
+            native_parameter = getattr(native_attention, native_name)
+            real_parameter = real_parameters[real_name]
+            if native_parameter.grad is None or real_parameter.grad is None:
+                assert native_parameter.grad is None and real_parameter.grad is None
+                continue
+            _assert_similarity(real_parameter.grad, native_parameter.grad)
+
+        assert call_counts == {"q": 7, "kv": 1, "indexer": 1, "sparse": 7}
+        assert checkpoint_output_arities == ([1] * 7 if recompute_up_proj else [])
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_indexer_loss_is_computed_only_by_the_source_iteration(monkeypatch):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(2345)
+        torch.manual_seed(2345)
+        torch.cuda.manual_seed(2345)
+
+        config = _make_config(dsa_indexer_loss_coeff=0.1)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        tracked_losses = []
+        monkeypatch.setattr(
+            dsa_module.DSAIndexerLossLoggingHelper,
+            "save_loss_to_tracker",
+            staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
+        )
+
+        total_tokens = 9
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+        shared = None
+        outputs = []
+        for iteration in range(config.mtp_num_layers):
+            context = MTPDSAIterationContext(iteration, shared_tensors=shared)
+            hidden_states = torch.randn(
+                total_tokens,
+                1,
+                config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+                requires_grad=True,
+            )
+            output, _ = attention(
+                hidden_states, attention_mask=attention_mask, mtp_dsa_context=context
+            )
+            if context.is_source:
+                shared = context.require_source_tensors()
+            outputs.append(output)
+
+        sum(output.float().sum() for output in outputs).backward()
+
+        assert len(tracked_losses) == 1
+        assert tracked_losses[0].requires_grad
+        for name in ("linear_wq_b.weight", "linear_wk.weight", "linear_weights_proj.weight"):
+            parameter = dict(attention.core_attention.indexer.named_parameters())[name]
+            assert parameter.grad is not None
+            assert torch.isfinite(parameter.grad).all()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_source_indexer_loss_and_gradients_match_unshared_oracle(monkeypatch):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(3456)
+        torch.manual_seed(3456)
+        torch.cuda.manual_seed(3456)
+
+        shared_config = _make_config(dsa_indexer_loss_coeff=0.1)
+        oracle_config = _make_config(dsa_indexer_loss_coeff=0.1, dsa_mtp_index_kv_share=False)
+        shared_spec = get_dsa_module_spec_for_backend(shared_config, backend=TESpecProvider())
+        oracle_spec = get_dsa_module_spec_for_backend(oracle_config, backend=TESpecProvider())
+        shared_attention = (
+            build_module(shared_spec, config=shared_config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        oracle_attention = (
+            build_module(oracle_spec, config=oracle_config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        oracle_attention.load_state_dict(shared_attention.state_dict())
+
+        tracked_losses = []
+        monkeypatch.setattr(
+            dsa_module.DSAIndexerLossLoggingHelper,
+            "save_loss_to_tracker",
+            staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
+        )
+
+        total_tokens = 9
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+        source_input = torch.randn(
+            total_tokens, 1, shared_config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        )
+
+        shared_tensors = None
+        shared_outputs = []
+        for iteration in range(shared_config.mtp_num_layers):
+            context = MTPDSAIterationContext(iteration, shared_tensors=shared_tensors)
+            hidden_states = (
+                source_input.detach().clone() if iteration == 0 else torch.randn_like(source_input)
+            ).requires_grad_(True)
+            output, _ = shared_attention(
+                hidden_states, attention_mask=attention_mask, mtp_dsa_context=context
+            )
+            if context.is_source:
+                shared_tensors = context.require_source_tensors()
+            shared_outputs.append(output)
+
+        oracle_input = source_input.detach().clone().requires_grad_(True)
+        oracle_output, _ = oracle_attention(oracle_input, attention_mask=attention_mask)
+
+        assert len(tracked_losses) == 2
+        torch.testing.assert_close(tracked_losses[0], tracked_losses[1], rtol=0, atol=0)
+
+        sum(output.float().sum() for output in shared_outputs).backward()
+        oracle_output.float().sum().backward()
+
+        shared_indexer_parameters = dict(shared_attention.core_attention.indexer.named_parameters())
+        oracle_indexer_parameters = dict(oracle_attention.core_attention.indexer.named_parameters())
+        for name in ("linear_wq_b.weight", "linear_wk.weight", "linear_weights_proj.weight"):
+            shared_grad = shared_indexer_parameters[name].grad
+            oracle_grad = oracle_indexer_parameters[name].grad
+            assert shared_grad is not None and oracle_grad is not None
+            torch.testing.assert_close(shared_grad, oracle_grad, rtol=0, atol=0)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("recompute_up_proj", [False, True])
+def test_cp2_reuses_global_source_kv_and_topk_with_gradient_flow(monkeypatch, recompute_up_proj):
+    if Utils.world_size < 2:
+        pytest.skip("CP2 MTP DSA sharing requires at least two distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        model_parallel_cuda_manual_seed(3456)
+        torch.manual_seed(3456 + parallel_state.get_context_parallel_rank())
+        torch.cuda.manual_seed(3456 + parallel_state.get_context_parallel_rank())
+
+        recompute_overrides = {}
+        if recompute_up_proj:
+            recompute_overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["mla_up_proj"],
+            }
+        config = _make_config(
+            context_parallel_size=2, cp_comm_type="all_gather", **recompute_overrides
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(
+                attention_spec,
+                config=config,
+                layer_number=1,
+                cp_comm_type=config.cp_comm_type,
+                is_mtp_layer=True,
+            )
+            .bfloat16()
+            .cuda()
+        )
+        call_counts = {
+            "kv": 0,
+            "indexer": 0,
+            "sparse": 0,
+            "kv_cp_gather": 0,
+            "indexer_cp_gather": 0,
+        }
+        hooks = [
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+        original_gather = dsa_module.gather_from_sequence_parallel_region
+
+        def counted_cp_gather(tensor, group=None, **kwargs):
+            if group is parallel_state.get_context_parallel_group():
+                if tensor.size(-1) == config.kv_lora_rank + config.qk_pos_emb_head_dim:
+                    call_counts["kv_cp_gather"] += 1
+                elif tensor.size(-1) == config.dsa_indexer_head_dim:
+                    call_counts["indexer_cp_gather"] += 1
+            return original_gather(tensor, group=group, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "gather_from_sequence_parallel_region", counted_cp_gather)
+
+        local_tokens = 8
+        global_tokens = local_tokens * 2
+        cu_seqlens = torch.tensor([0, global_tokens], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens.clone(),
+            cu_seqlens_kv_padded=cu_seqlens.clone(),
+            max_seqlen_q=global_tokens,
+            max_seqlen_kv=global_tokens,
+        )
+        source_hidden = torch.randn(
+            local_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        consumer_hidden = torch.randn_like(source_hidden, requires_grad=True)
+
+        source_context = MTPDSAIterationContext(iteration=0)
+        attention(
+            source_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=source_context,
+        )
+        shared = source_context.require_source_tensors()
+        source_key_data_ptr = shared.key.data_ptr()
+        assert shared.key.untyped_storage().nbytes() > 0
+        consumer_context = MTPDSAIterationContext(iteration=1, shared_tensors=shared)
+        consumer_output, _ = attention(
+            consumer_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=consumer_context,
+        )
+        consumer_output.float().square().mean().backward()
+
+        assert shared.key.size(0) == global_tokens
+        assert shared.key.data_ptr() == source_key_data_ptr
+        assert shared.key.untyped_storage().nbytes() > 0
+        assert torch.all(shared.topk_indices >= -1)
+        assert torch.all(shared.topk_indices < global_tokens)
+        assert source_hidden.grad is not None and source_hidden.grad.float().norm() > 0
+        assert consumer_hidden.grad is not None and consumer_hidden.grad.float().norm() > 0
+        assert torch.isfinite(source_hidden.grad).all()
+        assert torch.isfinite(consumer_hidden.grad).all()
+        assert call_counts == {
+            "kv": 1,
+            "indexer": 1,
+            "sparse": 2,
+            "kv_cp_gather": 1,
+            "indexer_cp_gather": 1,
+        }
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_tp2_sequence_parallel_reuses_global_source_kv_and_topk(monkeypatch):
+    if Utils.world_size < 2:
+        pytest.skip("TP2 MTP DSA sharing requires at least two distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(3789)
+        torch.manual_seed(3789 + parallel_state.get_tensor_model_parallel_rank())
+        torch.cuda.manual_seed(3789 + parallel_state.get_tensor_model_parallel_rank())
+
+        config = _make_config(tensor_model_parallel_size=2, sequence_parallel=True)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        call_counts = {"kv": 0, "indexer": 0, "sparse": 0}
+        hooks = [
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        local_tokens = 8
+        global_tokens = local_tokens * 2
+        source_hidden = torch.randn(
+            local_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        consumer_hidden = torch.randn_like(source_hidden, requires_grad=True)
+        valid = _causal_segment_mask(global_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, global_tokens, global_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, global_tokens, global_tokens), float("-inf"))
+        position_ids = torch.arange(global_tokens, device="cuda").view(1, global_tokens)
+
+        source_context = MTPDSAIterationContext(iteration=0)
+        attention(
+            source_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            mtp_dsa_context=source_context,
+        )
+        shared = source_context.require_source_tensors()
+        consumer_context = MTPDSAIterationContext(iteration=1, shared_tensors=shared)
+        consumer_output, _ = attention(
+            consumer_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            mtp_dsa_context=consumer_context,
+        )
+        consumer_output.float().square().mean().backward()
+
+        assert shared.key.size(0) == global_tokens
+        # Absorbed MLA gathers the sequence before its Q up-projection, so DSA sees
+        # global query rows even though the TransformerLayer input/output remain SP-local.
+        assert shared.topk_indices.size(1) == global_tokens
+        assert torch.all(shared.topk_indices >= -1)
+        assert torch.all(shared.topk_indices < global_tokens)
+        assert source_hidden.grad is not None and source_hidden.grad.float().norm() > 0
+        assert consumer_hidden.grad is not None and consumer_hidden.grad.float().norm() > 0
+        assert torch.isfinite(source_hidden.grad).all()
+        assert torch.isfinite(consumer_hidden.grad).all()
+        assert call_counts == {"kv": 1, "indexer": 1, "sparse": 2}
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("use_mxfp8", [False, True])
+def test_full_recompute_threads_shared_kv_as_checkpoint_tensor_inputs(use_mxfp8):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(4321)
+        scale = nn.Parameter(torch.tensor(1.25, device="cuda"))
+        dummy_layer = SimpleNamespace(
+            config=SimpleNamespace(
+                fp8="e4m3" if use_mxfp8 else None,
+                fp8_recipe=Fp8Recipe.mxfp8 if use_mxfp8 else None,
+                fp4=False,
+                distribute_saved_activations=False,
+                recompute_method="uniform",
+                recompute_num_layers=1,
+            ),
+            scale=scale,
+        )
+
+        def projected_forward(self, hidden_states, decoder_input, mtp_dsa_context=None, **_kwargs):
+            combined = hidden_states + decoder_input
+            if mtp_dsa_context.is_source:
+                key = combined * self.scale
+                topk = torch.zeros(
+                    (1, combined.size(0), 1), dtype=torch.int64, device=combined.device
+                )
+                mtp_dsa_context.capture(key, topk, None)
+                return combined.square()
+            return combined + 3 * mtp_dsa_context.shared_tensors.key
+
+        dummy_layer._proj_and_transformer_layer = types.MethodType(projected_forward, dummy_layer)
+
+        hidden = [torch.randn(4, 1, 3, device="cuda", requires_grad=True) for _ in range(3)]
+        decoder = [torch.randn_like(value) for value in hidden]
+        shared = None
+        outputs = []
+        for iteration in range(3):
+            context = MTPDSAIterationContext(iteration, shared_tensors=shared)
+            output, shared = MultiTokenPredictionLayer._checkpointed_forward(
+                dummy_layer,
+                hidden_states=hidden[iteration],
+                decoder_input=decoder[iteration],
+                mtp_dsa_context=context,
+            )
+            outputs.append(output)
+
+        sum(output.sum() for output in outputs).backward()
+
+        reference_scale = nn.Parameter(scale.detach().clone())
+        reference_hidden = [value.detach().clone().requires_grad_(True) for value in hidden]
+        source = (reference_hidden[0] + decoder[0]) * reference_scale
+        reference_outputs = [
+            (reference_hidden[0] + decoder[0]).square(),
+            reference_hidden[1] + decoder[1] + 3 * source,
+            reference_hidden[2] + decoder[2] + 3 * source,
+        ]
+        sum(output.sum() for output in reference_outputs).backward()
+
+        assert shared is not None and shared.key.grad_fn is not None
+        torch.testing.assert_close(scale.grad, reference_scale.grad)
+        for actual, expected in zip(hidden, reference_hidden):
+            torch.testing.assert_close(actual.grad, expected.grad)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_mtp_block_passes_one_source_state_through_all_repeated_iterations():
+    observed = []
+
+    class FakeRepeatedLayer:
+        def __call__(
+            self,
+            input_ids,
+            position_ids,
+            hidden_states,
+            padding_mask=None,
+            mtp_dsa_context=None,
+            **_kwargs,
+        ):
+            assert mtp_dsa_context is not None
+            observed.append((mtp_dsa_context.iteration, mtp_dsa_context.shared_tensors))
+            if mtp_dsa_context.is_source:
+                topk = torch.zeros((1, hidden_states.size(0), 1), dtype=torch.int64)
+                mtp_dsa_context.capture(hidden_states * 2, topk, None)
+                shared = mtp_dsa_context.require_source_tensors()
+            else:
+                shared = mtp_dsa_context.shared_tensors
+            return hidden_states + 1, input_ids, position_ids, padding_mask, shared
+
+    block = SimpleNamespace(
+        config=SimpleNamespace(
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=7,
+            mtp_detach_heads=False,
+            mtp_hsm=False,
+            dsa_mtp_index_kv_share=True,
+        ),
+        vp_stage=None,
+        mtp_use_repeated_layer=True,
+        layers=[FakeRepeatedLayer()],
+        training=False,
+    )
+    hidden_states = torch.randn(4, 1, 3)
+    output = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=torch.arange(4).view(1, 4),
+        position_ids=torch.arange(4).view(1, 4),
+        hidden_states=hidden_states,
+        attention_mask=None,
+    )
+
+    assert output.shape == (32, 1, 3)
+    assert [iteration for iteration, *_ in observed] == list(range(7))
+    source_state = observed[1][1]
+    assert source_state is not None
+    assert observed[0][1] is None
+    assert all(shared is source_state for _, shared in observed[1:])
+
+
+@pytest.mark.parametrize("full_recompute", [False, True])
+def test_real_mtp_block_threads_sharing_through_transformer_and_absorbed_dsa(
+    monkeypatch, full_recompute
+):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(5678)
+        torch.manual_seed(5678)
+        torch.cuda.manual_seed(5678)
+
+        recompute_overrides = {}
+        if full_recompute:
+            recompute_overrides = {
+                "recompute_granularity": "full",
+                "recompute_method": "uniform",
+                "recompute_num_layers": 1,
+            }
+        config = _make_config(**recompute_overrides)
+        decoder_layer_specs = get_transformer_layer_with_experimental_attention_variant_spec(
+            config=config, backend=TESpecProvider()
+        )
+        mtp_spec = get_gpt_mtp_block_spec(
+            config=config, spec=decoder_layer_specs[-1], use_transformer_engine=True
+        )
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_spec).bfloat16().cuda()
+        attention = mtp.layers[0].mtp_model_layer.self_attention
+
+        call_counts = {"q": 0, "kv": 0, "indexer": 0, "sparse": 0}
+        hooks = [
+            attention.linear_q_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("q", call_counts["q"] + 1)
+            ),
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        total_tokens = 9
+        embedding = nn.Embedding(32, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+
+        def embed(input_ids, position_ids):
+            del position_ids
+            return embedding(input_ids).transpose(0, 1).contiguous()
+
+        input_ids = torch.arange(total_tokens, device="cuda").view(1, total_tokens)
+        position_ids = input_ids.clone()
+        hidden_states = torch.randn(
+            total_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+
+        output = mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            embedding=embed,
+        )
+        output[total_tokens:].float().square().mean().backward()
+
+        assert output.shape == (total_tokens * (config.mtp_num_layers + 1), 1, config.hidden_size)
+        assert hidden_states.grad is not None and torch.isfinite(hidden_states.grad).all()
+        assert embedding.weight.grad is not None and torch.isfinite(embedding.weight.grad).all()
+        recompute_multiplier = 2 if full_recompute else 1
+        assert call_counts == {
+            "q": 7 * recompute_multiplier,
+            "kv": 1 * recompute_multiplier,
+            "indexer": 1 * recompute_multiplier,
+            "sparse": 7 * recompute_multiplier,
+        }
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary

Main-branch counterpart of #6472.

Share the DSA indexer result and CP-gathered latent KV across repeated MTP steps while preserving query-dependent sparse attention in every step.

- Let the first MTP step produce a typed sharing context containing latent KV, top-k indices, and top-k length.
- Reuse that context in later MTP steps instead of rerunning the indexer or gathering the same latent KV.
- Preserve query-dependent up-projection and sparse attention in every step.
- Support CP1, CP>1, TP/SP, full and selective recompute, and indexer-loss gradients.
- Keep the existing non-sharing path unchanged.
- Add main-specific plumbing plus hardening for tracker sizing, TP2×CP2 shared-KV handling, and custom attention builders.

## Test plan

- [x] Megatron autoformat check against the latest `main` (Black 26.3.0, isort, pylint, and Ruff).
- [x] `git diff --check`.
- [ ] Run `tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py`.
- [ ] Run focused distributed TP/CP parity coverage on GPU.
- [ ] Run GitHub unit and integration CI.

## Related PR

- Dev counterpart: #6472
