### PR TITLE
Add end-to-end TV loss for MTP

### DIFF
--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -27,6 +27,16 @@ The following table summarizes MTP configuration fields:
 | --- | --- |
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
+| `mtp_loss_type` | MTP training objective: `cross_entropy` or `e2e_tv`. Default: `cross_entropy`. |
+
+## End-to-End TV Loss
+
+Set `mtp_loss_type: e2e_tv` and `mtp_detach_heads: true` to enable the end-to-end
+TV objective. This mode requires `mtp_num_layers >= 1` and uses
+`mtp_loss_scaling_factor` to scale the auxiliary loss. To train only MTP parameters,
+the optimizer must additionally freeze the base model or select only MTP parameters;
+`mtp_detach_heads` does not change the optimizer parameter set. See
+[Bebop](https://arxiv.org/abs/2606.12370) for the objective definition.
 
 ## Pipeline Parallel Layout for MTP
 

--- a/megatron/core/fusions/fused_mtp_prefix.py
+++ b/megatron/core/fusions/fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Sync-free prefix objective for MTP end-to-end acceptance probabilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _mtp_prefix_forward_kernel(
+        acceptances,
+        output,
+        prefix_losses,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute the prefix losses and their mean."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        prefix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+        prefix_loss_sum = tl.zeros((BLOCK_SIZE,), tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_product *= acceptance
+            prefix_loss = 1.0 - prefix_product
+            prefix_loss_sum += prefix_loss
+            tl.store(prefix_losses + depth * num_rows + rows, prefix_loss, mask=row_mask)
+            depth += 1
+
+        tl.store(output + rows, prefix_loss_sum * inv_num_depths, mask=row_mask)
+
+    @triton.jit
+    def _mtp_prefix_backward_kernel(
+        acceptances,
+        grad_output,
+        grad_acceptances,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Apply a zero-safe analytical gradient without dividing by acceptance."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        output_gradient = tl.load(grad_output + rows, mask=row_mask, other=0.0).to(tl.float32)
+        prefix_before = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            suffix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_sum = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_depth = depth + 1
+            while suffix_depth < num_depths:
+                suffix_acceptance = tl.load(
+                    acceptances + suffix_depth * num_rows + rows, mask=row_mask, other=1.0
+                ).to(tl.float32)
+                suffix_product *= suffix_acceptance
+                suffix_sum += suffix_product
+                suffix_depth += 1
+
+            gradient = -output_gradient * inv_num_depths * prefix_before * suffix_sum
+            tl.store(grad_acceptances + depth * num_rows + rows, gradient, mask=row_mask)
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_before *= acceptance
+            depth += 1
+
+
+def fused_mtp_prefix_unavailable_reason(acceptances: Tensor) -> Optional[str]:
+    """Return why the fused prefix objective cannot consume the input."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if not acceptances.is_cuda:
+        return "acceptances are not a CUDA tensor"
+    # The fused TV primitive produces FP32 acceptance probabilities for both
+    # BF16 and FP32 logits. Keep this internal contract narrow instead of
+    # introducing different BF16 prefix-rounding semantics that production
+    # cannot exercise.
+    if acceptances.dtype != torch.float32:
+        return f"acceptance dtype {acceptances.dtype} is not supported"
+    if acceptances.ndim == 0 or acceptances.size(0) == 0:
+        return "acceptances must have a non-empty depth dimension"
+    if acceptances.numel() == 0:
+        return "acceptances must have at least one row"
+    if not acceptances.is_contiguous():
+        return "acceptances are not contiguous"
+    return None
+
+
+class _FusedMTPPrefixObjective(torch.autograd.Function):
+    """Triton prefix objective with a zero-safe analytical backward."""
+
+    @staticmethod
+    def forward(ctx, acceptances: Tensor) -> tuple[Tensor, Tensor]:
+        """Compute the mean and per-depth rejection probabilities."""
+        num_depths = acceptances.size(0)
+        num_rows = acceptances.numel() // num_depths
+        inv_num_depths = float(num_depths**-1)
+        output = torch.empty(
+            acceptances.shape[1:], dtype=acceptances.dtype, device=acceptances.device
+        )
+        prefix_losses = torch.empty_like(acceptances)
+        _mtp_prefix_forward_kernel[(triton.cdiv(num_rows, 256),)](
+            acceptances,
+            output,
+            prefix_losses,
+            num_rows=num_rows,
+            num_depths=num_depths,
+            inv_num_depths=inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(acceptances)
+        ctx.num_depths = num_depths
+        ctx.num_rows = num_rows
+        ctx.inv_num_depths = inv_num_depths
+        ctx.mark_non_differentiable(prefix_losses)
+        return output, prefix_losses
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor, _grad_prefix_losses: Tensor) -> tuple[Tensor]:
+        """Return the analytical gradient for every acceptance probability."""
+        (acceptances,) = ctx.saved_tensors
+        grad_acceptances = torch.empty_like(acceptances)
+        _mtp_prefix_backward_kernel[(triton.cdiv(ctx.num_rows, 256),)](
+            acceptances,
+            grad_output.contiguous(),
+            grad_acceptances,
+            num_rows=ctx.num_rows,
+            num_depths=ctx.num_depths,
+            inv_num_depths=ctx.inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        return (grad_acceptances,)
+
+
+def _reference_mtp_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Preserve the established PyTorch implementation as an oracle and fallback."""
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses.detach()
+
+
+def mtp_e2e_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Compute mean and detached per-depth E2E-TV losses with automatic dispatch."""
+    if fused_mtp_prefix_unavailable_reason(acceptances) is None:
+        return _FusedMTPPrefixObjective.apply(acceptances)
+    return _reference_mtp_prefix_objective(acceptances)

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -447,7 +447,7 @@ class _VocabParallelTVDistance(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: Tensor):
         """Apply the analytical Bebop gradient to the draft logits only."""
-        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+        draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask = (
             ctx.saved_tensors
         )
 

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -1,0 +1,502 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Full-vocabulary TV distance with fused CUDA dispatch and a PyTorch fallback."""
+
+# Triton kernel signatures and programs naturally exceed the host-code lint limits.
+# pylint: disable=invalid-name,too-many-arguments,too-many-locals
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core import parallel_state
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+_BLOCK_SIZE = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _tv_row_stats_kernel(
+        draft, target, maxima, denominators, vocab_size, BLOCK_SIZE: tl.constexpr
+    ):
+        """Compute stable local softmax maxima and denominators for one row."""
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = -float("inf")
+        target_max = -float("inf")
+        draft_sum = 0.0
+        target_sum = 0.0
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            target_values = tl.load(target + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+
+            draft_tile_max = tl.max(draft_values, axis=0)
+            target_tile_max = tl.max(target_values, axis=0)
+            draft_new_max = tl.maximum(draft_max, draft_tile_max)
+            target_new_max = tl.maximum(target_max, target_tile_max)
+            draft_old_scale = tl.where(
+                draft_max == -float("inf"), 0.0, tl.exp(draft_max - draft_new_max)
+            )
+            target_old_scale = tl.where(
+                target_max == -float("inf"), 0.0, tl.exp(target_max - target_new_max)
+            )
+            draft_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(draft_values - draft_new_max), 0.0), axis=0
+            )
+            target_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(target_values - target_new_max), 0.0), axis=0
+            )
+            draft_sum = draft_sum * draft_old_scale + draft_tile_sum
+            target_sum = target_sum * target_old_scale + target_tile_sum
+            draft_max = draft_new_max
+            target_max = target_new_max
+
+        num_rows = tl.num_programs(0)
+        tl.store(maxima + row, draft_max)
+        tl.store(maxima + num_rows + row, target_max)
+        tl.store(denominators + row, draft_sum)
+        tl.store(denominators + num_rows + row, target_sum)
+
+    @triton.jit
+    def _tv_rescale_denominators_kernel(
+        local_maxima, global_maxima, denominators, num_values, BLOCK_SIZE: tl.constexpr
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < num_values
+        local_max = tl.load(local_maxima + offsets, mask=mask)
+        global_max = tl.load(global_maxima + offsets, mask=mask)
+        denominator = tl.load(denominators + offsets, mask=mask)
+        denominator *= tl.exp(local_max - global_max)
+        tl.store(denominators + offsets, denominator, mask=mask)
+
+    @triton.jit
+    def _tv_overlap_kernel(
+        draft,
+        target,
+        maxima,
+        denominators,
+        overlap_and_s,
+        draft_above_target_bits,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute local overlap and the draft mass at or below the target."""
+        row = tl.program_id(0).to(tl.int64)
+        num_rows = tl.num_programs(0)
+        row_start = row * vocab_size
+        draft_max = tl.load(maxima + row)
+        target_max = tl.load(maxima + num_rows + row)
+        draft_denominator = tl.load(denominators + row)
+        target_denominator = tl.load(denominators + num_rows + row)
+        overlap = 0.0
+        draft_mass_below_target = 0.0
+
+        bit_offsets = tl.arange(0, 8)
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            byte_offsets = tl.arange(0, BLOCK_SIZE // 8)
+            cols = col_start + byte_offsets[:, None] * 8 + bit_offsets[None, :]
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            target_values = tl.load(target + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            target_prob = tl.exp(target_values - target_max) / target_denominator
+            overlap += tl.sum(
+                tl.sum(tl.where(mask, tl.minimum(draft_prob, target_prob), 0.0), axis=1), axis=0
+            )
+            draft_mass_below_target += tl.sum(
+                tl.sum(tl.where(mask & (draft_prob <= target_prob), draft_prob, 0.0), axis=1),
+                axis=0,
+            )
+            packed_above_target = tl.sum(
+                tl.where(mask & (draft_prob > target_prob), 1 << bit_offsets[None, :], 0), axis=1
+            )
+            packed_offsets = col_start // 8 + byte_offsets
+            tl.store(
+                draft_above_target_bits + row * packed_vocab_size + packed_offsets,
+                packed_above_target,
+                mask=packed_offsets < packed_vocab_size,
+            )
+
+        tl.store(overlap_and_s + row, overlap)
+        tl.store(overlap_and_s + num_rows + row, draft_mass_below_target)
+
+    @triton.jit
+    def _tv_finalize_kernel(
+        overlap, output, clamp_gradient_mask, num_rows, BLOCK_SIZE: tl.constexpr
+    ):
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = rows < num_rows
+        raw_distance = 1.0 - tl.load(overlap + rows, mask=mask)
+        distance = tl.maximum(0.0, tl.minimum(1.0, raw_distance))
+        tl.store(output + rows, distance, mask=mask)
+        tl.store(
+            clamp_gradient_mask + rows, (raw_distance >= 0.0) & (raw_distance <= 1.0), mask=mask
+        )
+
+    @triton.jit
+    def _tv_backward_kernel(
+        draft,
+        draft_maxima,
+        draft_denominators,
+        draft_mass_below_target,
+        draft_above_target_bits,
+        clamp_gradient_mask,
+        grad_output,
+        grad_draft,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = tl.load(draft_maxima + row)
+        draft_denominator = tl.load(draft_denominators + row)
+        draft_mass = tl.load(draft_mass_below_target + row)
+        row_gradient = tl.load(grad_output + row).to(tl.float32)
+        row_gradient *= tl.load(clamp_gradient_mask + row).to(tl.float32)
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            packed_above_target = tl.load(
+                draft_above_target_bits + row * packed_vocab_size + cols // 8, mask=mask, other=0
+            ).to(tl.int32)
+            draft_above_target = (packed_above_target >> (cols % 8)) & 1
+            gradient = draft_prob * (draft_mass - 1.0 + draft_above_target.to(tl.float32))
+            gradient *= row_gradient
+            tl.store(grad_draft + row_start + cols, gradient, mask=mask)
+
+
+def fused_mtp_tv_unavailable_reason(  # pylint: disable=too-many-return-statements
+    draft_logits: Tensor, target_logits: Tensor
+) -> Optional[str]:
+    """Return why the fused kernel cannot consume the two logits tensors."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if draft_logits.shape != target_logits.shape:
+        return "draft and target logits have different shapes"
+    if draft_logits.device != target_logits.device:
+        return "draft and target logits are on different devices"
+    if not draft_logits.is_cuda:
+        return "logits are not CUDA tensors"
+    if draft_logits.dtype not in (torch.bfloat16, torch.float32):
+        return f"draft dtype {draft_logits.dtype} is not supported"
+    if target_logits.dtype != draft_logits.dtype:
+        return "draft and target logits have different dtypes"
+    if draft_logits.ndim == 0 or draft_logits.size(-1) == 0:
+        return "logits must have a non-empty vocabulary dimension"
+    if draft_logits.numel() == 0:
+        return "logits must have at least one row"
+    if not draft_logits.is_contiguous() or not target_logits.is_contiguous():
+        return "logits are not contiguous"
+    return None
+
+
+class _FusedVocabParallelTVDistance(torch.autograd.Function):
+    """Triton TV distance with compact analytical-backward state."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Run fused forward passes and preserve compact backward state."""
+        unavailable_reason = fused_mtp_tv_unavailable_reason(draft_logits, target_logits)
+        if unavailable_reason is not None:
+            raise RuntimeError(f"Fused MTP TV distance is unavailable: {unavailable_reason}.")
+
+        vocab_size = draft_logits.size(-1)
+        output_shape = draft_logits.shape[:-1]
+        num_rows = draft_logits.numel() // vocab_size
+        maxima = torch.empty((2, num_rows), dtype=torch.float32, device=draft_logits.device)
+        denominators = torch.empty_like(maxima)
+        _tv_row_stats_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            vocab_size=vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        if logits_are_vocab_sharded and tp_size > 1:
+            local_maxima = maxima
+            maxima = local_maxima.clone()
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+            num_stats = maxima.numel()
+            _tv_rescale_denominators_kernel[(triton.cdiv(num_stats, 256),)](
+                local_maxima,
+                maxima,
+                denominators,
+                num_values=num_stats,
+                BLOCK_SIZE=256,
+                num_warps=4,
+            )
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        overlap_and_s = torch.empty_like(maxima)
+        packed_vocab_size = (vocab_size + 7) // 8
+        draft_above_target_bits = torch.empty(
+            (num_rows, packed_vocab_size), dtype=torch.uint8, device=draft_logits.device
+        )
+        _tv_overlap_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            overlap_and_s,
+            draft_above_target_bits,
+            vocab_size=vocab_size,
+            packed_vocab_size=packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        output = torch.empty(num_rows, dtype=torch.float32, device=draft_logits.device)
+        clamp_gradient_mask = torch.empty(num_rows, dtype=torch.bool, device=draft_logits.device)
+        _tv_finalize_kernel[(triton.cdiv(num_rows, 256),)](
+            overlap_and_s,
+            output,
+            clamp_gradient_mask,
+            num_rows=num_rows,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(
+            draft_logits,
+            maxima[0],
+            denominators[0],
+            overlap_and_s[1],
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        )
+        ctx.vocab_size = vocab_size
+        ctx.packed_vocab_size = packed_vocab_size
+        return output.view(output_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical draft-logit gradient from packed metadata."""
+        (
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        ) = ctx.saved_tensors
+        num_rows = draft_logits.numel() // ctx.vocab_size
+        grad_draft = torch.empty_like(draft_logits)
+        _tv_backward_kernel[(num_rows,)](
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+            grad_output.contiguous(),
+            grad_draft,
+            vocab_size=ctx.vocab_size,
+            packed_vocab_size=ctx.packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        return grad_draft, None, None, None
+
+
+def _fused_vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    logits_are_vocab_sharded: bool,
+) -> Tensor:
+    """Compute TV distance using Triton and TP collectives."""
+    return _FusedVocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )
+
+
+def _validate_vocab_parallel_tv_group(
+    tp_group: Optional[torch.distributed.ProcessGroup], logits_are_vocab_sharded: bool
+) -> None:
+    """Reject vocab-sharded TV before a missing TP group can change its normalization."""
+    # Compatibility guard retained from the original MTP-local dispatcher. New
+    # callers should pass the explicit TP group instead of relying on MPU state.
+    if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
+        initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if initialized_tp_size > 1:
+            raise ValueError(
+                "tp_group must be provided for TV distance over vocab-sharded logits "
+                f"when tensor parallel size is {initialized_tp_size}."
+            )
+
+
+class _VocabParallelTVDistance(torch.autograd.Function):
+    """Full-vocabulary TV distance with a TP-aware analytical backward.
+
+    The implementation follows Algorithms 1 and 2 in the Bebop paper
+    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
+    distribution detached and returns gradients for draft logits only.
+
+    This PyTorch implementation establishes the mathematical contract and is
+    retained as the oracle and fallback for unsupported fused-kernel inputs.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Compute the TV distance and save the draft-side backward state."""
+        if draft_logits.shape != target_logits.shape:
+            raise ValueError(
+                "Draft and target logits must have identical shapes, got "
+                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+            )
+        if draft_logits.device != target_logits.device:
+            raise ValueError("Draft and target logits must be on the same device.")
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+        draft_logits_fp32 = draft_logits.float()
+        target_logits_fp32 = target_logits.float()
+        maxima = torch.stack(
+            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        draft_max, target_max = maxima.unbind(dim=0)
+
+        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
+        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
+        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        draft_denominator, target_denominator = denominators.unbind(dim=0)
+
+        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
+        target_prob = target_exp / target_denominator.unsqueeze(-1)
+        draft_below_target = draft_prob <= target_prob
+        overlap_and_s = torch.stack(
+            (
+                torch.minimum(draft_prob, target_prob).sum(dim=-1),
+                (draft_prob * draft_below_target).sum(dim=-1),
+            )
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        overlap, s = overlap_and_s.unbind(dim=0)
+
+        raw_tv_distance = 1.0 - overlap
+        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
+        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
+        ctx.save_for_backward(
+            draft_logits,
+            draft_max,
+            draft_denominator,
+            s,
+            draft_prob > target_prob,
+            clamp_gradient_mask,
+        )
+        return tv_distance
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical Bebop gradient to the draft logits only."""
+        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+            ctx.saved_tensors
+        )
+
+        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
+        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
+        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
+        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
+        return grad_draft.to(draft_logits.dtype), None, None, None
+
+
+def vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    logits_are_vocab_sharded: bool = True,
+) -> Tensor:
+    """Compute full-vocabulary TV distance with automatic fused/reference dispatch.
+
+    Args:
+        draft_logits: Trainable draft logits with vocabulary in the last dimension.
+        target_logits: Detached target logits with the same local or global vocabulary layout.
+        tp_group: Tensor-parallel group owning vocabulary shards.
+        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+
+    Returns:
+        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
+        ``draft_logits``.
+    """
+    if draft_logits.shape != target_logits.shape:
+        raise ValueError(
+            "Draft and target logits must have identical shapes, got "
+            f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+        )
+    if draft_logits.device != target_logits.device:
+        raise ValueError("Draft and target logits must be on the same device.")
+    _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+    # Materialized sequence rolls produce a noncontiguous target view. Pack only
+    # that detached input when the trainable draft otherwise supports Triton.
+    if (
+        not target_logits.is_contiguous()
+        and fused_mtp_tv_unavailable_reason(draft_logits, draft_logits) is None
+    ):
+        target_logits = target_logits.detach().contiguous()
+
+    if fused_mtp_tv_unavailable_reason(draft_logits, target_logits) is None:
+        return _fused_vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group, logits_are_vocab_sharded
+        )
+    return _VocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -15,6 +15,8 @@ from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace
 from megatron.core.enums import Fp8Recipe
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.fusions.fused_mtp_prefix import mtp_e2e_prefix_objective
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -724,126 +726,6 @@ def _compute_mtp_acceptance_counts(
     return correct, total
 
 
-class _VocabParallelTVDistance(torch.autograd.Function):
-    """Full-vocabulary TV distance with a TP-aware analytical backward.
-
-    The implementation follows Algorithms 1 and 2 in the Bebop paper
-    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
-    distribution detached and returns gradients for draft logits only.
-
-    This PyTorch implementation establishes the mathematical contract. It does
-    not yet fuse the vocabulary passes into a dedicated GPU kernel.
-    """
-
-    @staticmethod
-    def forward(
-        ctx,
-        draft_logits: Tensor,
-        target_logits: Tensor,
-        tp_group: Optional[torch.distributed.ProcessGroup],
-        logits_are_vocab_sharded: bool,
-    ) -> Tensor:
-        """Compute the TV distance and save the draft-side backward state."""
-        if draft_logits.shape != target_logits.shape:
-            raise ValueError(
-                "Draft and target logits must have identical shapes, got "
-                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
-            )
-        if draft_logits.device != target_logits.device:
-            raise ValueError("Draft and target logits must be on the same device.")
-
-        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
-        if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
-            initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
-            if initialized_tp_size > 1:
-                raise ValueError(
-                    "tp_group must be provided for TV distance over vocab-sharded logits "
-                    f"when tensor parallel size is {initialized_tp_size}."
-                )
-
-        draft_logits_fp32 = draft_logits.float()
-        target_logits_fp32 = target_logits.float()
-        maxima = torch.stack(
-            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
-        )
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
-        draft_max, target_max = maxima.unbind(dim=0)
-
-        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
-        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
-        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(
-                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
-        draft_denominator, target_denominator = denominators.unbind(dim=0)
-
-        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
-        target_prob = target_exp / target_denominator.unsqueeze(-1)
-        draft_below_target = draft_prob <= target_prob
-        overlap_and_s = torch.stack(
-            (
-                torch.minimum(draft_prob, target_prob).sum(dim=-1),
-                (draft_prob * draft_below_target).sum(dim=-1),
-            )
-        )
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(
-                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
-        overlap, s = overlap_and_s.unbind(dim=0)
-
-        raw_tv_distance = 1.0 - overlap
-        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
-        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
-        ctx.save_for_backward(
-            draft_logits,
-            draft_max,
-            draft_denominator,
-            s,
-            draft_prob > target_prob,
-            clamp_gradient_mask,
-        )
-        return tv_distance
-
-    @staticmethod
-    def backward(ctx, grad_output: Tensor):
-        """Apply the analytical Bebop gradient to the draft logits only."""
-        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
-            ctx.saved_tensors
-        )
-
-        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
-        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
-        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
-        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
-        return grad_draft.to(draft_logits.dtype), None, None, None
-
-
-def vocab_parallel_tv_distance(
-    draft_logits: Tensor,
-    target_logits: Tensor,
-    tp_group: Optional[torch.distributed.ProcessGroup] = None,
-    logits_are_vocab_sharded: bool = True,
-) -> Tensor:
-    """Compute per-position full-vocabulary TV distance between draft and target logits.
-
-    Args:
-        draft_logits: Trainable draft logits with vocabulary in the last dimension.
-        target_logits: Detached target logits with the same local or global vocabulary layout.
-        tp_group: Tensor-parallel group owning vocabulary shards.
-        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
-
-    Returns:
-        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
-        ``draft_logits``.
-    """
-    return _VocabParallelTVDistance.apply(
-        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
-    )
-
-
 @dataclass
 class MultiTokenPredictionLayerSubmodules:
     """
@@ -1117,10 +999,11 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             draft_logits = scale_logits_fn(draft_logits)
+        aligned_target_logits = target_logits.permute(2, 0, 1)
         tv_distances.append(
             vocab_parallel_tv_distance(
                 draft_logits,
-                target_logits.permute(2, 0, 1),
+                aligned_target_logits,
                 tp_group=tp_group,
                 logits_are_vocab_sharded=logits_are_vocab_sharded,
             )
@@ -1128,9 +1011,7 @@ def _process_mtp_e2e_tv_loss(
 
     tv_distances_tensor = torch.stack(tv_distances, dim=0)
     per_step_acceptance = 1.0 - tv_distances_tensor
-    prefix_acceptance = torch.cumprod(per_step_acceptance, dim=0)
-    prefix_losses = 1.0 - prefix_acceptance
-    e2e_tv_loss = prefix_losses.mean(dim=0)
+    e2e_tv_loss, prefix_losses = mtp_e2e_prefix_objective(per_step_acceptance)
 
     chain_mask = chain_valid.transpose(0, 1).to(e2e_tv_loss.dtype)
     num_tokens = chain_mask.sum()

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -724,6 +724,126 @@ def _compute_mtp_acceptance_counts(
     return correct, total
 
 
+class _VocabParallelTVDistance(torch.autograd.Function):
+    """Full-vocabulary TV distance with a TP-aware analytical backward.
+
+    The implementation follows Algorithms 1 and 2 in the Bebop paper
+    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
+    distribution detached and returns gradients for draft logits only.
+
+    This PyTorch implementation establishes the mathematical contract. It does
+    not yet fuse the vocabulary passes into a dedicated GPU kernel.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Compute the TV distance and save the draft-side backward state."""
+        if draft_logits.shape != target_logits.shape:
+            raise ValueError(
+                "Draft and target logits must have identical shapes, got "
+                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+            )
+        if draft_logits.device != target_logits.device:
+            raise ValueError("Draft and target logits must be on the same device.")
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
+            initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
+            if initialized_tp_size > 1:
+                raise ValueError(
+                    "tp_group must be provided for TV distance over vocab-sharded logits "
+                    f"when tensor parallel size is {initialized_tp_size}."
+                )
+
+        draft_logits_fp32 = draft_logits.float()
+        target_logits_fp32 = target_logits.float()
+        maxima = torch.stack(
+            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        draft_max, target_max = maxima.unbind(dim=0)
+
+        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
+        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
+        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        draft_denominator, target_denominator = denominators.unbind(dim=0)
+
+        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
+        target_prob = target_exp / target_denominator.unsqueeze(-1)
+        draft_below_target = draft_prob <= target_prob
+        overlap_and_s = torch.stack(
+            (
+                torch.minimum(draft_prob, target_prob).sum(dim=-1),
+                (draft_prob * draft_below_target).sum(dim=-1),
+            )
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        overlap, s = overlap_and_s.unbind(dim=0)
+
+        raw_tv_distance = 1.0 - overlap
+        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
+        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
+        ctx.save_for_backward(
+            draft_logits,
+            draft_max,
+            draft_denominator,
+            s,
+            draft_prob > target_prob,
+            clamp_gradient_mask,
+        )
+        return tv_distance
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical Bebop gradient to the draft logits only."""
+        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+            ctx.saved_tensors
+        )
+
+        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
+        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
+        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
+        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
+        return grad_draft.to(draft_logits.dtype), None, None, None
+
+
+def vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    logits_are_vocab_sharded: bool = True,
+) -> Tensor:
+    """Compute per-position full-vocabulary TV distance between draft and target logits.
+
+    Args:
+        draft_logits: Trainable draft logits with vocabulary in the last dimension.
+        target_logits: Detached target logits with the same local or global vocabulary layout.
+        tp_group: Tensor-parallel group owning vocabulary shards.
+        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+
+    Returns:
+        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
+        ``draft_logits``.
+    """
+    return _VocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )
+
+
 @dataclass
 class MultiTokenPredictionLayerSubmodules:
     """
@@ -929,9 +1049,127 @@ class MTPLossAutoScaler(torch.autograd.Function):
         MTPLossAutoScaler.main_loss_backward_scale = scale
 
 
+def _process_mtp_e2e_tv_loss(
+    hidden_states_list: tuple[Tensor, ...],
+    loss_mask: Tensor,
+    output_layer: Callable,
+    output_weight: Tensor,
+    runtime_gather_output: Optional[bool],
+    is_training: bool,
+    config: TransformerConfig,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    packed_seq_params: Optional[PackedSeqParams],
+    scale_logits_fn: Optional[Callable[[Tensor], Tensor]],
+    original_num_tokens: Tensor,
+) -> Tensor:
+    """Apply the end-to-end TV objective to MTP draft hidden states.
+
+    The frozen backbone is projected once. For depth ``i``, its target logits are
+    shifted by ``i + 1`` positions to align with the MTP draft distribution for
+    the same future token. Only start positions with a complete chain across all
+    configured MTP depths contribute to the objective.
+    """
+    hidden_states = hidden_states_list[0]
+    logits_are_vocab_sharded = _mtp_logits_are_vocab_sharded(output_layer, runtime_gather_output)
+
+    # Project the frozen backbone once, then align each target distribution by
+    # rolling logits. Re-projecting one shifted hidden tensor per MTP depth would
+    # add a full vocabulary GEMM for every draft step.
+    with torch.no_grad():
+        target_logits, _ = output_layer(
+            hidden_states.detach(),
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            target_logits = scale_logits_fn(target_logits)
+    # roll_tensor handles packed boundaries and CP communication along its last
+    # dimension. Keep vocabulary before sequence while preparing target alignment.
+    target_logits = target_logits.permute(1, 2, 0)
+    current_loss_mask = loss_mask
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    tv_distances = []
+
+    for mtp_layer_number in range(config.mtp_num_layers):
+        target_logits, _ = roll_tensor(
+            target_logits,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
+        )
+        current_loss_mask, _ = roll_tensor(
+            current_loss_mask,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
+        )
+        chain_valid &= current_loss_mask.bool()
+
+        draft_logits, _ = output_layer(
+            hidden_states_list[mtp_layer_number + 1],
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            draft_logits = scale_logits_fn(draft_logits)
+        tv_distances.append(
+            vocab_parallel_tv_distance(
+                draft_logits,
+                target_logits.permute(2, 0, 1),
+                tp_group=tp_group,
+                logits_are_vocab_sharded=logits_are_vocab_sharded,
+            )
+        )
+
+    tv_distances_tensor = torch.stack(tv_distances, dim=0)
+    per_step_acceptance = 1.0 - tv_distances_tensor
+    prefix_acceptance = torch.cumprod(per_step_acceptance, dim=0)
+    prefix_losses = 1.0 - prefix_acceptance
+    e2e_tv_loss = prefix_losses.mean(dim=0)
+
+    chain_mask = chain_valid.transpose(0, 1).to(e2e_tv_loss.dtype)
+    num_tokens = chain_mask.sum()
+    masked_e2e_tv_loss = e2e_tv_loss * chain_mask
+
+    if is_training:
+        avg_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        for mtp_layer_number in range(config.mtp_num_layers):
+            loss_for_log = (
+                torch.sum(prefix_losses[mtp_layer_number] * chain_mask)
+                / num_tokens.clamp(min=1)
+            )
+            correct = torch.sum(per_step_acceptance[mtp_layer_number] * chain_mask)
+            MTPLossLoggingHelper.save_metrics_to_tracker(
+                loss_for_log,
+                correct,
+                num_tokens,
+                mtp_layer_number,
+                config.mtp_num_layers,
+                avg_group=avg_group,
+            )
+
+    assert config.mtp_loss_scaling_factor is not None
+    if config.calculate_per_token_loss:
+        normalized_loss = (
+            config.mtp_loss_scaling_factor
+            * masked_e2e_tv_loss
+            * (original_num_tokens / num_tokens.clamp(min=1))
+        )
+    else:
+        normalized_loss = (
+            config.mtp_loss_scaling_factor * masked_e2e_tv_loss / num_tokens.clamp(min=1)
+        )
+    return MTPLossAutoScaler.apply(hidden_states, normalized_loss)
+
+
 def process_mtp_loss(
     hidden_states: Tensor,
-    labels: Tensor,
+    labels: Optional[Tensor],
     loss_mask: Optional[Tensor],
     output_layer: Callable,
     output_weight: Optional[Tensor],
@@ -1008,6 +1246,23 @@ def process_mtp_loss(
     # when calculate_per_token_loss is enabled. This ensures MTP gradients are
     # correctly scaled relative to the main loss gradients in finalize_model_grads.
     original_num_tokens = loss_mask.sum()
+
+    if config.mtp_loss_type == "e2e_tv":
+        assert output_weight is not None
+        return _process_mtp_e2e_tv_loss(
+            hidden_states_list=hidden_states_list,
+            loss_mask=loss_mask,
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+            is_training=is_training,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            scale_logits_fn=scale_logits_fn,
+            original_num_tokens=original_num_tokens,
+        )
 
     for mtp_layer_number in range(config.mtp_num_layers):
         mtp_logits, _ = output_layer(

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1020,10 +1020,9 @@ def _process_mtp_e2e_tv_loss(
     if is_training:
         avg_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
         for mtp_layer_number in range(config.mtp_num_layers):
-            loss_for_log = (
-                torch.sum(prefix_losses[mtp_layer_number] * chain_mask)
-                / num_tokens.clamp(min=1)
-            )
+            loss_for_log = torch.sum(
+                prefix_losses[mtp_layer_number] * chain_mask
+            ) / num_tokens.clamp(min=1)
             correct = torch.sum(per_step_acceptance[mtp_layer_number] * chain_mask)
             MTPLossLoggingHelper.save_metrics_to_tracker(
                 loss_for_log,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -80,6 +80,14 @@ class TransformerConfig(ModelParallelConfig):
     which serves as an additional training objective.
     """
 
+    mtp_loss_type: str = "cross_entropy"
+    """Training objective for Multi-Token Prediction (MTP) heads.
+
+    Supported values are ``cross_entropy`` and ``e2e_tv``. The end-to-end total
+    variation objective directly optimizes the normalized expected acceptance
+    length under rejection-sampling verification.
+    """
+
     mtp_use_repeated_layer: bool = False
     """Use a single MTP layer repeatedly instead of multiple separate layers."""
 
@@ -1476,6 +1484,20 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.mtp_hsm and (self.mtp_num_layers is None or self.mtp_num_layers < 2):
             raise ValueError("mtp_hsm=True requires mtp_num_layers >= 2.")
+
+        if self.mtp_loss_type not in ("cross_entropy", "e2e_tv"):
+            raise ValueError(
+                "mtp_loss_type must be one of 'cross_entropy' or 'e2e_tv', "
+                f"got {self.mtp_loss_type!r}."
+            )
+        if self.mtp_loss_type == "e2e_tv":
+            if self.mtp_num_layers is None or self.mtp_num_layers < 1:
+                raise ValueError("mtp_loss_type='e2e_tv' requires mtp_num_layers >= 1.")
+            if not self.mtp_detach_heads:
+                raise ValueError(
+                    "mtp_loss_type='e2e_tv' requires mtp_detach_heads=True so the target "
+                    "distribution and shared backbone remain frozen."
+                )
 
         # When fp32 residual connections are enabled, pipeline parallel communication must
         # use fp32 to match the dtype of the residual stream between pipeline stages.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -976,7 +976,8 @@ def num_floating_point_operations(
                      gdn_qk_head_dim=128, gdn_v_head_dim=128,
                      gdn_num_qk_heads=16, gdn_num_v_heads=32,
                      gdn_conv_kernel_dim=4, gdn_use_gdn2=False,
-                     vocab_size=256000, mtp_num_layers=0):
+                     vocab_size=256000, mtp_num_layers=0,
+                     mtp_loss_type="cross_entropy"):
         """Calculate total FLOPs for the hybrid model."""
         mamba_flops = (
             gated_delta_product_layer_flops(total_tokens, hidden_size,
@@ -1004,7 +1005,14 @@ def num_floating_point_operations(
                                                   gdn_conv_kernel_dim, gdn_use_gdn2) +
                 (2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
         )
-        return flops_fwd * 3
+        # E2E TV projects the frozen backbone once to produce target logits.
+        # This projection has no backward pass because the target distribution
+        # is detached. Softmax/overlap elementwise work is omitted consistently
+        # with the existing cross-entropy FLOPs convention.
+        e2e_tv_target_projection_flops = (
+            2 * total_tokens * hidden_size * vocab_size if mtp_loss_type == "e2e_tv" else 0
+        )
+        return flops_fwd * 3 + e2e_tv_target_projection_flops
 
     def transformer_flops():
         """Calculate FLOPs for a standard Transformer model."""
@@ -1301,6 +1309,11 @@ def num_floating_point_operations(
                 * args.hidden_size
                 * args.padded_vocab_size
                 * (mtp_num_layers + 1)  # MTP + final logit
+                # E2E TV target distribution: one frozen forward-only output projection.
+                + fma_expansion_factor
+                * args.hidden_size
+                * args.padded_vocab_size
+                * int(getattr(args, "mtp_loss_type", "cross_entropy") == "e2e_tv")
             )
             # Self Attention (core L^2 part). For BSHD the default
             # ``seqlen_squared_sum_in_batch = batch_size * seq_length^2`` recovers the
@@ -1382,6 +1395,7 @@ def num_floating_point_operations(
             gdn_use_gdn2=(args.experimental_attention_variant == "gdn2"),
             vocab_size=args.padded_vocab_size,
             mtp_num_layers=mtp_num_layers,
+            mtp_loss_type=getattr(args, "mtp_loss_type", "cross_entropy"),
         )
     else:
         # Compute standard Transformer model FLOPs.

--- a/tests/unit_tests/fusions/test_fused_mtp_prefix.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and graph-safety tests for the fused MTP prefix objective."""
+
+import pytest
+import torch
+
+from megatron.core.fusions.fused_mtp_prefix import (
+    fused_mtp_prefix_unavailable_reason,
+    mtp_e2e_prefix_objective,
+)
+
+
+def _native_prefix_objective(acceptances):
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses
+
+
+def _run_objective_and_gradient(function, acceptance_data, grad_output):
+    acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    output, prefix_losses = function(acceptances)
+    (output * grad_output).sum().backward()
+    return output.detach(), prefix_losses.detach(), acceptances.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("num_depths", [1, 2, 7])
+def test_fused_mtp_prefix_matches_native_forward_and_backward(num_depths):
+    """Dynamic draft depths match an independent cumprod oracle."""
+    torch.manual_seed(51 + num_depths)
+    acceptance_data = torch.rand(num_depths, 37, 2, device="cuda")
+    grad_output = torch.randn(37, 2, device="cuda")
+
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is None
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("zero_depth", [0, 3, 6])
+def test_fused_mtp_prefix_backward_is_zero_safe(zero_depth):
+    """Exact zero acceptance never produces division artifacts or nonfinite gradients."""
+    torch.manual_seed(71)
+    acceptance_data = torch.rand(7, 19, device="cuda")
+    acceptance_data[zero_depth] = 0
+    grad_output = torch.randn(19, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert torch.isfinite(actual_grad).all()
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_preserves_near_zero_loss():
+    """The fused mean must not cancel a one-ULP rejection near convergence."""
+    one = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    almost_one = torch.nextafter(one, torch.zeros_like(one))
+    acceptance_data = torch.stack((one, almost_one)).reshape(2, 1)
+    grad_output = torch.ones(1, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert actual.item() > 0.0
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=0, atol=0)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=0, atol=0)
+
+
+def test_mtp_prefix_unsupported_input_uses_reference_fallback(monkeypatch):
+    """CPU and noncontiguous inputs preserve the PyTorch reference path."""
+    acceptance_data = torch.rand(2, 5, 3).transpose(1, 2)
+    assert not acceptance_data.is_contiguous()
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    calls = 0
+    original_cumprod = torch.cumprod
+
+    def record_cumprod(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_cumprod(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "cumprod", record_cumprod)
+    actual = mtp_e2e_prefix_objective(acceptance_data)
+    reference = _native_prefix_objective(acceptance_data)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+    assert calls == 2
+
+
+def test_mtp_prefix_empty_rows_use_reference_fallback():
+    """An empty row dimension never dispatches a zero-program Triton grid."""
+    acceptance_data = torch.empty(7, 0)
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    if torch.cuda.is_available():
+        acceptance_data = acceptance_data.cuda()
+        assert fused_mtp_prefix_unavailable_reason(acceptance_data) == (
+            "acceptances must have at least one row"
+        )
+        actual, prefix_losses = mtp_e2e_prefix_objective(acceptance_data)
+        assert actual.shape == (0,)
+        assert prefix_losses.shape == (7, 0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mtp_prefix_bf16_acceptance_uses_reference_fallback():
+    """BF16 model logits still reach this primitive as FP32 fused-TV outputs."""
+    bf16_acceptances = torch.rand(2, 5, device="cuda", dtype=torch.bfloat16)
+    assert fused_mtp_prefix_unavailable_reason(bf16_acceptances) == (
+        "acceptance dtype torch.bfloat16 is not supported"
+    )
+    actual = mtp_e2e_prefix_objective(bf16_acceptances)
+    reference = _native_prefix_objective(bf16_acceptances)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_is_deterministic_and_cuda_graph_safe():
+    """Forward and analytical backward replay deterministically inside a CUDA Graph."""
+    torch.manual_seed(83)
+    acceptance_data = torch.rand(7, 67, device="cuda")
+    grad_output = torch.randn(67, device="cuda")
+    first = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    second = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    for first_tensor, second_tensor in zip(first, second):
+        assert torch.equal(first_tensor, second_tensor)
+
+    static_acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    static_acceptances.grad = torch.zeros_like(static_acceptances)
+    graph = torch.cuda.CUDAGraph()
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_acceptances.grad.zero_()
+            warmup_output, _ = mtp_e2e_prefix_objective(static_acceptances)
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    with torch.cuda.graph(graph):
+        static_acceptances.grad.zero_()
+        graph_output, graph_prefix_losses = mtp_e2e_prefix_objective(static_acceptances)
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, first[0], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(graph_prefix_losses, first[1], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_acceptances.grad, first[2], rtol=1e-5, atol=1e-6)

--- a/tests/unit_tests/fusions/test_fused_mtp_tv.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_tv.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and dispatch tests for the fused MTP TV primitive."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.fusions import fused_mtp_tv as fused_mtp_tv_module
+from megatron.core.fusions.fused_mtp_tv import (
+    fused_mtp_tv_unavailable_reason,
+    vocab_parallel_tv_distance,
+)
+
+
+def _native_tv_distance(draft_logits, target_logits):
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return (1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)).clamp(0.0, 1.0)
+
+
+def _run_tv_and_gradient(function, draft_data, target_logits, grad_output):
+    draft_logits = draft_data.detach().clone().requires_grad_(True)
+    output = function(draft_logits, target_logits)
+    (output * grad_output).sum().backward()
+    return output.detach(), draft_logits.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("vocab_size", [257, 154880])
+def test_fused_mtp_tv_matches_native_forward_and_backward(dtype, vocab_size):
+    """Cover an odd block tail and GLM-5.2's production vocabulary."""
+    torch.manual_seed(1234)
+    shape = (3, 2, vocab_size)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype, requires_grad=True)
+    grad_output = torch.randn(shape[:-1], device="cuda", dtype=torch.float32)
+
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) is None
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    assert actual.dtype == torch.float32
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    rtol = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    atol = 3e-3 if dtype == torch.bfloat16 else 1e-6
+    torch.testing.assert_close(actual, reference, rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=rtol, atol=atol)
+    assert target_logits.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_clamp_boundaries_and_zero_acceptance():
+    """The fused path preserves both clamp endpoints and finite gradients."""
+    vocab_size = 257
+    identical = torch.randn(2, vocab_size, device="cuda", dtype=torch.float32)
+    identical_output, identical_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        identical,
+        identical,
+        torch.ones(2, device="cuda"),
+    )
+    torch.testing.assert_close(
+        identical_output, torch.zeros_like(identical_output), atol=1e-6, rtol=0
+    )
+    torch.testing.assert_close(identical_grad, torch.zeros_like(identical_grad), atol=1e-6, rtol=0)
+
+    draft = torch.full((1, vocab_size), -100.0, device="cuda")
+    target = torch.full_like(draft, -100.0)
+    draft[:, 0] = 100.0
+    target[:, 1] = 100.0
+    output, gradient = _run_tv_and_gradient(
+        lambda draft_logits, target_logits: vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        ),
+        draft,
+        target,
+        torch.ones(1, device="cuda"),
+    )
+    torch.testing.assert_close(output, torch.ones_like(output), atol=1e-6, rtol=0)
+    assert torch.isfinite(gradient).all()
+    torch.testing.assert_close(gradient, torch.zeros_like(gradient), atol=1e-6, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_logits_use_reference_fallback(monkeypatch):
+    """Unsupported strides retain the PyTorch reference behavior."""
+    torch.manual_seed(17)
+    draft_data = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(draft_data.shape[:-1], device="cuda")
+    assert not draft_data.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) == "logits are not contiguous"
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("The fused kernel must not receive unsupported noncontiguous logits")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_target_is_packed_before_fused_dispatch(monkeypatch):
+    """A materialized-roll view is packed centrally when the draft supports Triton."""
+    torch.manual_seed(19)
+    draft_data = torch.randn(2, 3, 257, device="cuda")
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(2, 3, device="cuda")
+    assert draft_data.is_contiguous()
+    assert not target_logits.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, draft_data) is None
+
+    original_fused = fused_mtp_tv_module._fused_vocab_parallel_tv_distance
+    fused_calls = 0
+
+    def record_fused(draft, target, *args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        assert target.is_contiguous()
+        return original_fused(draft, target, *args, **kwargs)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", record_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    assert fused_calls == 1
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_saves_only_compact_full_vocab_metadata():
+    """Backward state must pack its only vocabulary-sized comparison mask."""
+    torch.manual_seed(29)
+    draft_logits = torch.randn(3, 2, 4097, device="cuda", requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+    saved_tensors = []
+
+    def pack_hook(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        output = vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        )
+        output.sum().backward()
+
+    full_vocab_tensors = [
+        tensor for tensor in saved_tensors if tensor.numel() == draft_logits.numel()
+    ]
+    assert len(full_vocab_tensors) == 1
+    assert full_vocab_tensors[0].data_ptr() == draft_logits.data_ptr()
+    packed_masks = [tensor for tensor in saved_tensors if tensor.dtype == torch.uint8]
+    assert [tuple(tensor.shape) for tensor in packed_masks] == [(6, (4097 + 7) // 8)]
+    assert not any(
+        tensor.dtype in (torch.bool, torch.uint8) and tensor.numel() == draft_logits.numel()
+        for tensor in saved_tensors
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_mtp_tv_is_deterministic(dtype):
+    """Repeated launches of the same implementation are bitwise stable."""
+    torch.manual_seed(2026)
+    draft_data = torch.randn(4, 1031, device="cuda", dtype=dtype)
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+
+    def function(draft, target):
+        return vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+
+    first_output, first_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    second_output, second_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    assert torch.equal(first_output, second_output)
+    assert torch.equal(first_grad, second_grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_is_cuda_graph_safe():
+    """The fused forward and analytical backward replay inside a CUDA Graph."""
+    torch.manual_seed(2031)
+    draft_data = torch.randn(4, 1031, device="cuda")
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+    expected_output, expected_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+
+    static_draft = draft_data.detach().clone().requires_grad_(True)
+    static_draft.grad = torch.zeros_like(static_draft)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_draft.grad.zero_()
+            warmup_output = vocab_parallel_tv_distance(
+                static_draft, target_logits, logits_are_vocab_sharded=False
+            )
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_draft.grad.zero_()
+        graph_output = vocab_parallel_tv_distance(
+            static_draft, target_logits, logits_are_vocab_sharded=False
+        )
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, expected_output, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_draft.grad, expected_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("shape", [(0, 257), (3, 0, 257)])
+def test_empty_row_logits_use_reference_fallback(shape):
+    """Empty leading dimensions never dispatch a zero-program Triton grid."""
+    draft = torch.empty(shape)
+    target = torch.empty_like(draft)
+    assert fused_mtp_tv_unavailable_reason(draft, target) is not None
+
+    if torch.cuda.is_available():
+        draft = draft.cuda()
+        target = target.cuda()
+        assert fused_mtp_tv_unavailable_reason(draft, target) == "logits must have at least one row"
+        actual = vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+        assert actual.shape == draft.shape[:-1]
+        assert actual.numel() == 0

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -255,6 +255,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mtp_detach_heads": False,
     "mtp_hsm": False,
     "mtp_hybrid_override_pattern": None,
+    "mtp_loss_type": "cross_entropy",
     "mtp_loss_scaling_factor": 0.1,
     "mtp_num_layers": None,
     "mtp_standalone": False,

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -151,6 +151,26 @@ class TestBSHDBackwardCompat:
         assert default_flops == explicit_flops
 
 
+class TestMTPE2ETVFlops:
+    """E2E TV adds one frozen target-output projection to the FLOPs count."""
+
+    @pytest.mark.parametrize("hybrid", [False, True])
+    def test_counts_one_forward_only_target_projection(self, hybrid):
+        args = _make_hybrid_args() if hybrid else _make_gpt_args()
+        args.mtp_num_layers = 3
+        args.mtp_loss_type = "cross_entropy"
+        batch_size = 2
+        cross_entropy_flops = num_floating_point_operations(args, batch_size)
+
+        args.mtp_loss_type = "e2e_tv"
+        e2e_tv_flops = num_floating_point_operations(args, batch_size)
+
+        expected_extra = (
+            2 * batch_size * args.seq_length * args.hidden_size * args.padded_vocab_size
+        )
+        assert e2e_tv_flops - cross_entropy_flops == expected_extra
+
+
 class TestTHDScaling:
     """Only the L^2 attention term should depend on ``seqlen_squared_sum_in_batch``."""
 

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import parallel_state
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer import multi_token_prediction as mtp_module
+from megatron.core.transformer.multi_token_prediction import (
+    MTPLossAutoScaler,
+    process_mtp_loss,
+    vocab_parallel_tv_distance,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+_BEBOP_PAPER = "https://arxiv.org/abs/2606.12370"
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _native_tv_distance(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (10)."""
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return 1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)
+
+
+def _native_e2e_tv_loss(
+    draft_logits: list[torch.Tensor], target_logits: list[torch.Tensor]
+) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (13)."""
+    per_step_acceptance = torch.stack(
+        [
+            1.0 - _native_tv_distance(draft_step, target_step)
+            for draft_step, target_step in zip(draft_logits, target_logits)
+        ],
+        dim=0,
+    )
+    return 1.0 - torch.cumprod(per_step_acceptance, dim=0).mean(dim=0)
+
+
+def _native_roll_packed_sequence_first(
+    tensor: torch.Tensor, cu_seqlens: tuple[int, ...]
+) -> torch.Tensor:
+    """Independent packed left roll for tensors whose first dimension is sequence."""
+    rolled = torch.zeros_like(tensor)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        rolled[start : end - 1] = tensor[start + 1 : end]
+    return rolled
+
+
+def _cosine_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    return F.cosine_similarity(
+        a.flatten().double().unsqueeze(0), b.flatten().double().unsqueeze(0)
+    ).item()
+
+
+def _tensor_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    a, b = a.double(), b.double()
+    denom = (a * a + b * b).sum()
+    return (2.0 * (a * b).sum() / denom).item() if denom else 1.0
+
+
+def _assert_similarity(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-5):
+    assert torch.isfinite(a).all()
+    assert torch.isfinite(b).all()
+    assert _cosine_sim(a, b) > 1 - eps
+    assert _tensor_sim(a, b) > 1 - eps
+
+
+class _OutputLayer(torch.nn.Module):
+    """Small output projection with the same call contract as MCore's output layer."""
+
+    gather_output = True
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = torch.nn.Parameter(weight)
+
+    def forward(self, hidden, weight=None, runtime_gather_output=None):
+        del runtime_gather_output
+        weight = self.weight if weight is None else weight
+        return torch.matmul(hidden, weight.t()), None
+
+
+def _make_tv_config(mtp_num_layers: int, hidden_size: int) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=1,
+        mtp_num_layers=mtp_num_layers,
+        mtp_loss_type="e2e_tv",
+        mtp_loss_scaling_factor=1.0,
+        mtp_detach_heads=True,
+        use_cpu_initialization=True,
+    )
+
+
+def test_mtp_loss_type_validation():
+    default_config = TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=1)
+    assert default_config.mtp_loss_type == "cross_entropy"
+
+    with pytest.raises(ValueError, match="mtp_loss_type must be one of"):
+        TransformerConfig(
+            num_layers=1, hidden_size=8, num_attention_heads=1, mtp_loss_type="unknown"
+        )
+    with pytest.raises(ValueError, match="requires mtp_num_layers"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_loss_type="e2e_tv",
+            mtp_detach_heads=True,
+        )
+    with pytest.raises(ValueError, match="requires mtp_detach_heads=True"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_num_layers=2,
+            mtp_loss_type="e2e_tv",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_full_vocab_tv_forward_and_gradient_match_native_reference(dtype):
+    """Use GLM-5/5.2's production vocabulary size with paper-native math.
+
+    The reference is derived independently from Eq. (10) in ``_BEBOP_PAPER``;
+    it does not invoke MCore's analytical backward.
+    """
+    torch.manual_seed(1234)
+    shape = (2, 1, 128256)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype)
+    grad_weight = torch.tensor([[[0.25]], [[1.5]]], device="cuda")
+
+    draft_actual = draft_data.detach().clone().requires_grad_(True)
+    actual = vocab_parallel_tv_distance(draft_actual, target_logits, logits_are_vocab_sharded=False)
+    (actual * grad_weight.squeeze(-1)).sum().backward()
+
+    draft_reference = draft_data.detach().clone().requires_grad_(True)
+    reference = _native_tv_distance(draft_reference, target_logits)
+    (reference * grad_weight.squeeze(-1)).sum().backward()
+
+    tolerance = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(actual, reference, rtol=tolerance, atol=tolerance)
+    assert draft_actual.grad is not None
+    assert draft_reference.grad is not None
+    _assert_similarity(draft_actual.grad, draft_reference.grad, eps=tolerance)
+    assert target_logits.grad is None
+
+
+def test_process_mtp_e2e_tv_matches_native_alignment_and_gradient():
+    """Check shifted target alignment, Eq. (13), and draft-only gradients on CPU."""
+    torch.manual_seed(7)
+    mtp_num_layers = 2
+    seq_len = 6
+    batch_size = 1
+    hidden_size = 7
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+
+    hidden_data = torch.randn(
+        (1 + mtp_num_layers) * seq_len, batch_size, hidden_size, dtype=torch.float32
+    )
+    hidden_actual = hidden_data.detach().clone().requires_grad_(True)
+    labels = torch.zeros(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_actual,
+        labels=labels,
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    base_hidden, *draft_hidden = torch.chunk(hidden_data, 1 + mtp_num_layers, dim=0)
+    target_hidden = base_hidden.detach().permute(1, 2, 0)
+    target_logits = []
+    draft_logits = []
+    draft_references = []
+    reference_mask = loss_mask.clone()
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    for draft_hidden_step in draft_hidden:
+        target_hidden = torch.roll(target_hidden, shifts=-1, dims=-1)
+        target_hidden[..., -1] = 0
+        target_logits.append(target_hidden.permute(2, 0, 1))
+
+        draft_reference = draft_hidden_step.detach().clone().requires_grad_(True)
+        draft_references.append(draft_reference)
+        draft_logits.append(draft_reference)
+
+        reference_mask = torch.roll(reference_mask, shifts=-1, dims=-1)
+        reference_mask[..., -1] = 0
+        chain_valid &= reference_mask.bool()
+
+    chain_mask = chain_valid.transpose(0, 1).float()
+    reference_loss = _native_e2e_tv_loss(draft_logits, target_logits)
+    (reference_loss * chain_mask).sum().div(chain_mask.sum()).backward()
+
+    assert hidden_actual.grad is not None
+    actual_chunks = torch.chunk(hidden_actual.grad, 1 + mtp_num_layers, dim=0)
+    torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+    for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+        assert draft_reference.grad is not None
+        _assert_similarity(actual_grad, draft_reference.grad)
+        torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    assert output_layer.weight.grad is None
+
+
+def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
+    """A fixed-gamma objective must neither wrap nor train across THD segments."""
+    torch.manual_seed(17)
+    mtp_num_layers = 2
+    seq_len = 7
+    hidden_size = 5
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+    hidden_states = torch.randn((1 + mtp_num_layers) * seq_len, 1, hidden_size, requires_grad=True)
+    packed_seq_params = PackedSeqParams(
+        cu_seqlens_q=torch.tensor([0, 3, 7], dtype=torch.int32),
+        cu_seqlens_kv=torch.tensor([0, 3, 7], dtype=torch.int32),
+        max_seqlen_q=4,
+        max_seqlen_kv=4,
+        qkv_format="thd",
+    )
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, seq_len, dtype=torch.long),
+        loss_mask=torch.ones(1, seq_len),
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+        packed_seq_params=packed_seq_params,
+    )
+    result.sum().backward()
+
+    assert hidden_states.grad is not None
+    _, draft_0_grad, draft_1_grad = torch.chunk(hidden_states.grad, 3, dim=0)
+    expected_valid = torch.tensor([True, False, False, True, True, False, False])
+    assert torch.count_nonzero(draft_0_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_1_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_0_grad[expected_valid]) > 0
+    assert torch.count_nonzero(draft_1_grad[expected_valid]) > 0
+
+
+def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monkeypatch):
+    """Contiguous packed CP rolls target distributions without crossing segments."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        mtp_num_layers = 2
+        global_seq_len = 8
+        local_seq_len = global_seq_len // 2
+        hidden_size = 5
+        cu_seqlens = (0, 6, 8)
+
+        torch.manual_seed(23)
+        full_hidden = torch.randn(
+            (1 + mtp_num_layers) * global_seq_len, 1, hidden_size, device="cuda"
+        )
+        full_chunks = torch.chunk(full_hidden, 1 + mtp_num_layers, dim=0)
+        local_start = cp_rank * local_seq_len
+        local_chunks = [
+            chunk.narrow(0, local_start, local_seq_len).clone() for chunk in full_chunks
+        ]
+        local_hidden = torch.cat(local_chunks, dim=0).requires_grad_(True)
+        output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+        config = _make_tv_config(mtp_num_layers, hidden_size)
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens_tensor,
+            cu_seqlens_kv=cu_seqlens_tensor,
+            cu_seqlens_q_padded=cu_seqlens_tensor,
+            cu_seqlens_kv_padded=cu_seqlens_tensor,
+            max_seqlen_q=6,
+            max_seqlen_kv=6,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
+        captured_target_steps = []
+        tv_distance = mtp_module.vocab_parallel_tv_distance
+
+        def capture_target(draft_logits, target_logits, **kwargs):
+            captured_target_steps.append(target_logits.detach().clone())
+            return tv_distance(draft_logits, target_logits, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", capture_target)
+
+        MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+        result = process_mtp_loss(
+            hidden_states=local_hidden,
+            labels=torch.zeros(1, local_seq_len, dtype=torch.long, device="cuda"),
+            loss_mask=local_loss_mask,
+            output_layer=output_layer,
+            output_weight=None,
+            runtime_gather_output=True,
+            is_training=False,
+            compute_language_model_loss=lambda *_: pytest.fail(
+                "cross entropy must not run for e2e TV"
+            ),
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+        )
+        result.sum().backward()
+
+        reference_weight = output_layer.weight.detach()
+        target_logits = torch.matmul(full_chunks[0].detach(), reference_weight.t())
+        full_mask = torch.ones(global_seq_len, 1, device="cuda")
+        full_chain_valid = torch.ones_like(full_mask, dtype=torch.bool)
+        target_steps = []
+        draft_references = []
+        draft_steps = []
+        for full_draft in full_chunks[1:]:
+            target_logits = _native_roll_packed_sequence_first(target_logits, cu_seqlens)
+            target_steps.append(target_logits.narrow(0, local_start, local_seq_len))
+            full_mask = _native_roll_packed_sequence_first(full_mask, cu_seqlens)
+            full_chain_valid &= full_mask.bool()
+
+            draft_reference = (
+                full_draft.narrow(0, local_start, local_seq_len)
+                .detach()
+                .clone()
+                .requires_grad_(True)
+            )
+            draft_references.append(draft_reference)
+            draft_steps.append(torch.matmul(draft_reference, reference_weight.t()))
+
+        local_chain_mask = full_chain_valid.narrow(0, local_start, local_seq_len).float()
+        assert len(captured_target_steps) == mtp_num_layers
+        for captured_target, target_step in zip(captured_target_steps, target_steps):
+            torch.testing.assert_close(captured_target, target_step, rtol=0, atol=0)
+        reference_loss = _native_e2e_tv_loss(draft_steps, target_steps)
+        (reference_loss * local_chain_mask).sum().div(
+            local_chain_mask.sum().clamp(min=1)
+        ).backward()
+
+        assert local_hidden.grad is not None
+        actual_chunks = torch.chunk(local_hidden.grad, 1 + mtp_num_layers, dim=0)
+        torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+        for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+            assert draft_reference.grad is not None
+            torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
+    """TP-sharded forward and local gradients match a full-vocabulary reference."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        torch.manual_seed(2026)
+        full_shape = (2, 1, 128256)
+        full_draft_data = torch.randn(full_shape, dtype=torch.float32).cuda()
+        full_target = torch.randn(full_shape, dtype=torch.float32).cuda()
+        local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
+        local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+
+        local_draft = local_draft_data.detach().clone().requires_grad_(True)
+        actual = vocab_parallel_tv_distance(
+            local_draft, local_target, tp_group=tp_group, logits_are_vocab_sharded=True
+        )
+        actual.sum().backward()
+
+        full_draft = full_draft_data.detach().clone().requires_grad_(True)
+        reference = _native_tv_distance(full_draft, full_target)
+        reference.sum().backward()
+
+        torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+        assert local_draft.grad is not None
+        assert full_draft.grad is not None
+        expected_local_grad = full_draft.grad.chunk(2, dim=-1)[tp_rank]
+        _assert_similarity(local_draft.grad, expected_local_grad)
+        torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -9,10 +9,7 @@ from megatron.core.fusions import fused_mtp_tv as fused_tv_module
 from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
-from megatron.core.transformer.multi_token_prediction import (
-    MTPLossAutoScaler,
-    process_mtp_loss,
-)
+from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler, process_mtp_loss
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -265,15 +262,17 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
         fused_prefix_losses.append(prefix_losses.detach().clone())
         return objective, prefix_losses
 
-    def record_loss(loss_sum, num_tokens, layer_number, num_layers, **kwargs):
+    def record_metrics(loss, correct, total, layer_number, num_layers, **kwargs):
         assert num_layers == mtp_num_layers
         assert kwargs["avg_group"] is None
-        logged.append((loss_sum.detach().clone(), num_tokens.detach().clone(), layer_number))
+        logged.append(
+            (loss.detach().clone(), correct.detach().clone(), total.detach().clone(), layer_number)
+        )
 
     monkeypatch.setattr(fused_tv_module, "_fused_vocab_parallel_tv_distance", record_fused_tv)
     monkeypatch.setattr(mtp_module, "mtp_e2e_prefix_objective", record_prefix_objective)
     monkeypatch.setattr(parallel_state, "get_data_parallel_group", lambda **_: None)
-    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_loss_to_tracker", record_loss)
+    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_metrics_to_tracker", record_metrics)
 
     MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
     result = process_mtp_loss(
@@ -298,11 +297,19 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
     chain_mask = torch.zeros(sequence_length, 1, device="cuda")
     chain_mask[: sequence_length - mtp_num_layers] = 1
     assert len(logged) == mtp_num_layers
-    for layer_number, (loss_sum, num_tokens, logged_layer_number) in enumerate(logged):
+    expected_total = chain_mask.sum()
+    expected_acceptances = 1.0 - actual_tv_distances
+    for layer_number, (loss, correct, total, logged_layer_number) in enumerate(logged):
         assert logged_layer_number == layer_number
-        torch.testing.assert_close(num_tokens, chain_mask.sum(), rtol=0, atol=0)
+        torch.testing.assert_close(total, expected_total, rtol=0, atol=0)
         torch.testing.assert_close(
-            loss_sum, torch.sum(fused_prefix_losses[0][layer_number] * chain_mask), rtol=0, atol=0
+            loss,
+            torch.sum(fused_prefix_losses[0][layer_number] * chain_mask) / expected_total,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            correct, torch.sum(expected_acceptances[layer_number] * chain_mask), rtol=0, atol=0
         )
 
 
@@ -347,8 +354,8 @@ def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
     assert torch.count_nonzero(draft_1_grad[expected_valid]) > 0
 
 
-def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monkeypatch):
-    """Contiguous packed CP rolls target distributions without crossing segments."""
+def test_process_mtp_e2e_tv_packed_zigzag_cp2_matches_global_reference(monkeypatch):
+    """Two-chunk packed CP rolls target distributions without crossing segments."""
     if Utils.world_size < 2:
         pytest.skip("A distributed run with at least two ranks is required")
 
@@ -356,21 +363,32 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
     try:
         cp_group = parallel_state.get_context_parallel_group()
         cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = torch.distributed.get_world_size(group=cp_group)
         mtp_num_layers = 2
-        global_seq_len = 8
-        local_seq_len = global_seq_len // 2
+        global_seq_len = 12
         hidden_size = 5
-        cu_seqlens = (0, 6, 8)
+        cu_seqlens = (0, 8, 12)
+
+        # Main's CP layout gives each rank two chunks from every packed sequence:
+        # chunk ``rank`` and its mirrored tail chunk ``2 * cp_size - rank - 1``.
+        local_indices = []
+        for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+            sequence_length = end - start
+            assert sequence_length % (2 * cp_size) == 0
+            chunk_length = sequence_length // (2 * cp_size)
+            front_start = start + cp_rank * chunk_length
+            tail_start = start + (2 * cp_size - cp_rank - 1) * chunk_length
+            local_indices.extend(range(front_start, front_start + chunk_length))
+            local_indices.extend(range(tail_start, tail_start + chunk_length))
+        local_indices = torch.tensor(local_indices, dtype=torch.long, device="cuda")
+        local_seq_len = local_indices.numel()
 
         torch.manual_seed(23)
         full_hidden = torch.randn(
             (1 + mtp_num_layers) * global_seq_len, 1, hidden_size, device="cuda"
         )
         full_chunks = torch.chunk(full_hidden, 1 + mtp_num_layers, dim=0)
-        local_start = cp_rank * local_seq_len
-        local_chunks = [
-            chunk.narrow(0, local_start, local_seq_len).clone() for chunk in full_chunks
-        ]
+        local_chunks = [chunk.index_select(0, local_indices).clone() for chunk in full_chunks]
         local_hidden = torch.cat(local_chunks, dim=0).requires_grad_(True)
         output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
         config = _make_tv_config(mtp_num_layers, hidden_size)
@@ -379,12 +397,9 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         packed_seq_params = PackedSeqParams(
             cu_seqlens_q=cu_seqlens_tensor,
             cu_seqlens_kv=cu_seqlens_tensor,
-            cu_seqlens_q_padded=cu_seqlens_tensor,
-            cu_seqlens_kv_padded=cu_seqlens_tensor,
-            max_seqlen_q=6,
-            max_seqlen_kv=6,
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
             qkv_format="thd",
-            cp_partition_mode="contiguous",
         )
         local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
         captured_target_steps = []
@@ -423,20 +438,17 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         draft_steps = []
         for full_draft in full_chunks[1:]:
             target_logits = _native_roll_packed_sequence_first(target_logits, cu_seqlens)
-            target_steps.append(target_logits.narrow(0, local_start, local_seq_len))
+            target_steps.append(target_logits.index_select(0, local_indices))
             full_mask = _native_roll_packed_sequence_first(full_mask, cu_seqlens)
             full_chain_valid &= full_mask.bool()
 
             draft_reference = (
-                full_draft.narrow(0, local_start, local_seq_len)
-                .detach()
-                .clone()
-                .requires_grad_(True)
+                full_draft.index_select(0, local_indices).detach().clone().requires_grad_(True)
             )
             draft_references.append(draft_reference)
             draft_steps.append(torch.matmul(draft_reference, reference_weight.t()))
 
-        local_chain_mask = full_chain_valid.narrow(0, local_start, local_seq_len).float()
+        local_chain_mask = full_chain_valid.index_select(0, local_indices).float()
         assert len(captured_target_steps) == mtp_num_layers
         for captured_target, target_step in zip(captured_target_steps, target_steps):
             torch.testing.assert_close(captured_target, target_step, rtol=0, atol=0)

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -5,12 +5,13 @@ import torch
 import torch.nn.functional as F
 
 from megatron.core import parallel_state
+from megatron.core.fusions import fused_mtp_tv as fused_tv_module
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossAutoScaler,
     process_mtp_loss,
-    vocab_parallel_tv_distance,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -123,6 +124,19 @@ def test_mtp_loss_type_validation():
         )
 
 
+def test_process_mtp_e2e_tv_requires_tp_group_for_sharded_logits(monkeypatch):
+    """A missing explicit TP group cannot silently normalize each vocab shard."""
+    monkeypatch.setattr(parallel_state, "is_initialized", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 2)
+    draft_logits = torch.randn(2, 1, 7, requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+
+    with pytest.raises(ValueError, match="tp_group must be provided"):
+        vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group=None, logits_are_vocab_sharded=True
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_full_vocab_tv_forward_and_gradient_match_native_reference(dtype):
@@ -216,6 +230,80 @@ def test_process_mtp_e2e_tv_matches_native_alignment_and_gradient():
         _assert_similarity(actual_grad, draft_reference.grad)
         torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
     assert output_layer.weight.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch):
+    """The integrated materialized-roll path dispatches both fused objectives."""
+    torch.manual_seed(26)
+    mtp_num_layers = 2
+    sequence_length = 7
+    hidden_size = 257
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+    hidden_states = torch.randn(
+        (1 + mtp_num_layers) * sequence_length, 1, hidden_size, device="cuda", requires_grad=True
+    )
+    loss_mask = torch.ones(1, sequence_length, device="cuda")
+    fused_tv_distances = []
+    fused_prefix_losses = []
+    logged = []
+
+    original_fused_tv = fused_tv_module._fused_vocab_parallel_tv_distance
+
+    def record_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded):
+        assert draft_logits.is_contiguous()
+        assert target_logits.is_contiguous()
+        result = original_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded)
+        fused_tv_distances.append(result.detach().clone())
+        return result
+
+    original_prefix_objective = mtp_module.mtp_e2e_prefix_objective
+
+    def record_prefix_objective(acceptances):
+        objective, prefix_losses = original_prefix_objective(acceptances)
+        fused_prefix_losses.append(prefix_losses.detach().clone())
+        return objective, prefix_losses
+
+    def record_loss(loss_sum, num_tokens, layer_number, num_layers, **kwargs):
+        assert num_layers == mtp_num_layers
+        assert kwargs["avg_group"] is None
+        logged.append((loss_sum.detach().clone(), num_tokens.detach().clone(), layer_number))
+
+    monkeypatch.setattr(fused_tv_module, "_fused_vocab_parallel_tv_distance", record_fused_tv)
+    monkeypatch.setattr(mtp_module, "mtp_e2e_prefix_objective", record_prefix_objective)
+    monkeypatch.setattr(parallel_state, "get_data_parallel_group", lambda **_: None)
+    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_loss_to_tracker", record_loss)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, sequence_length, dtype=torch.long, device="cuda"),
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=True,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    assert len(fused_tv_distances) == mtp_num_layers
+    assert len(fused_prefix_losses) == 1
+    actual_tv_distances = torch.stack(fused_tv_distances)
+    expected_prefix_losses = 1.0 - torch.cumprod(1.0 - actual_tv_distances, dim=0)
+    torch.testing.assert_close(fused_prefix_losses[0], expected_prefix_losses, rtol=1e-5, atol=1e-6)
+
+    chain_mask = torch.zeros(sequence_length, 1, device="cuda")
+    chain_mask[: sequence_length - mtp_num_layers] = 1
+    assert len(logged) == mtp_num_layers
+    for layer_number, (loss_sum, num_tokens, logged_layer_number) in enumerate(logged):
+        assert logged_layer_number == layer_number
+        torch.testing.assert_close(num_tokens, chain_mask.sum(), rtol=0, atol=0)
+        torch.testing.assert_close(
+            loss_sum, torch.sum(fused_prefix_losses[0][layer_number] * chain_mask), rtol=0, atol=0
+        )
 
 
 def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
@@ -367,8 +455,9 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         Utils.destroy_model_parallel()
 
 
-def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
-    """TP-sharded forward and local gradients match a full-vocabulary reference."""
+@pytest.mark.parametrize("logits_are_vocab_sharded", [False, True], ids=["gathered", "sharded"])
+def test_vocab_parallel_tv_tp2_matches_full_vocab_reference(logits_are_vocab_sharded):
+    """TP gathered/sharded forward and local gradients match a full-vocabulary reference."""
     if Utils.world_size < 2:
         pytest.skip("A distributed run with at least two ranks is required")
     Utils.initialize_model_parallel(tensor_model_parallel_size=2)
@@ -379,12 +468,19 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
         full_shape = (2, 1, 128256)
         full_draft_data = torch.randn(full_shape, dtype=torch.float32).cuda()
         full_target = torch.randn(full_shape, dtype=torch.float32).cuda()
-        local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
-        local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+        if logits_are_vocab_sharded:
+            local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
+            local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+        else:
+            local_draft_data = full_draft_data
+            local_target = full_target
 
         local_draft = local_draft_data.detach().clone().requires_grad_(True)
         actual = vocab_parallel_tv_distance(
-            local_draft, local_target, tp_group=tp_group, logits_are_vocab_sharded=True
+            local_draft,
+            local_target,
+            tp_group=tp_group,
+            logits_are_vocab_sharded=logits_are_vocab_sharded,
         )
         actual.sum().backward()
 
@@ -395,7 +491,11 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
         torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
         assert local_draft.grad is not None
         assert full_draft.grad is not None
-        expected_local_grad = full_draft.grad.chunk(2, dim=-1)[tp_rank]
+        expected_local_grad = (
+            full_draft.grad.chunk(2, dim=-1)[tp_rank]
+            if logits_are_vocab_sharded
+            else full_draft.grad
+        )
         _assert_similarity(local_draft.grad, expected_local_grad)
         torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
     finally:


### PR DESCRIPTION
## Summary

Main-branch counterpart of #6473.

Add Bebop's end-to-end total-variation objective as an alternative MTP training loss.

Set `mtp_loss_type=e2e_tv` with `mtp_detach_heads=True` to enable it.

- Project the detached target distribution once.
- Compute TP-aware full-vocabulary TV distance for every draft step.
- Apply the analytical draft-only backward.
- Mask incomplete packed-sequence prediction chains.
- Account for the additional target projection in model FLOPs.
- Provide fused Triton implementations with PyTorch fallbacks.

The existing cross-entropy objective remains the default. This port follows main's current MTP logging API and packed zigzag context-parallel layout. It is distinct from the offline cached-logits KD workflow proposed in #6023.

## Test plan

- [x] Megatron autoformat check against the latest `main` (Black 26.3.0, isort, pylint, and Ruff).
- [x] `git diff --check`.
- [ ] Run `tests/unit_tests/transformer/test_mtp_tv_loss.py`.
- [ ] Run `tests/unit_tests/fusions/test_fused_mtp_prefix.py`.
- [ ] Run `tests/unit_tests/fusions/test_fused_mtp_tv.py`.
- [ ] Run distributed TP2 and packed zigzag CP2 parity coverage.
- [ ] Run GitHub unit and integration CI.

## Related PR

- Dev counterpart: #6473
