### PR TITLE
Add absolute row alignment for MTP sequence rolls

### DIFF
--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -27,6 +27,16 @@ The following table summarizes MTP configuration fields:
 | --- | --- |
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
+| `mtp_loss_type` | MTP training objective: `cross_entropy` or `e2e_tv`. Default: `cross_entropy`. |
+
+## End-to-End TV Loss
+
+Set `mtp_loss_type: e2e_tv` and `mtp_detach_heads: true` to enable the end-to-end
+TV objective. This mode requires `mtp_num_layers >= 1` and uses
+`mtp_loss_scaling_factor` to scale the auxiliary loss. To train only MTP parameters,
+the optimizer must additionally freeze the base model or select only MTP parameters;
+`mtp_detach_heads` does not change the optimizer parameter set. See
+[Bebop](https://arxiv.org/abs/2606.12370) for the objective definition.
 
 ## Pipeline Parallel Layout for MTP
 

--- a/megatron/core/context_parallel/layout.py
+++ b/megatron/core/context_parallel/layout.py
@@ -771,6 +771,7 @@ class ContextParallelLayoutManager:
             total_tokens=None,
             seq_idx=None,
             pad_between_seqs=plan.pad_between_seqs,
+            cp_partition_mode="zigzag",
         )
         return plan, zigzag_packed_seq_params
 

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -751,6 +751,7 @@ def get_batch_on_this_rank_for_sequence_packing(
     mtp_on_this_rank: bool = False,
     vp_stage: Optional[int] = None,
     pg_collection: Optional[ProcessGroupCollection] = None,
+    config=None,
 ):
     """
     Get a batch of data for sequence packing.
@@ -758,6 +759,7 @@ def get_batch_on_this_rank_for_sequence_packing(
         data_iterator (Iterator): The data iterator to get the batch from.
         mtp_on_this_rank (bool): Whether to use multi-token prediction.
         vp_stage (Optional[int]): The stage of the pipeline.
+        config: Transformer configuration used to select graph-safe runtime metadata.
     Returns:
         tuple of (tokens, labels, loss_mask, attention_mask, position_ids,
         packed_seq_params, padding_mask)
@@ -785,10 +787,10 @@ def get_batch_on_this_rank_for_sequence_packing(
 
     # data_iterator should return a batch including the following keys.
     batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen', 'zigzag_cp_min_chunk_size']
-    if is_first_stage:
+    if is_first_stage or mtp_on_this_rank:
         batch_keys.append('tokens')
         batch_keys.append('position_ids')
-    if is_last_stage:
+    if is_last_stage or mtp_on_this_rank:
         batch_keys.append('labels')
         batch_keys.append('loss_mask')
 
@@ -831,7 +833,7 @@ def get_batch_on_this_rank_for_sequence_packing(
             ), "Transformer Engine is required to use Context Parallel with THD format data."
             index = tex.thd_get_partitioned_indices(cu_seqlens, total_tokens, cp_size, cp_rank)
             cp_slice_keys = ['padding_mask']
-            if is_first_or_last_stage:
+            if is_first_or_last_stage or mtp_on_this_rank:
                 cp_slice_keys.extend(['tokens', 'position_ids', 'labels', 'loss_mask'])
             for key in cp_slice_keys:
                 batch[key] = batch[key].index_select(0, index)
@@ -861,7 +863,7 @@ def get_batch_on_this_rank_for_sequence_packing(
         batch['position_ids'] = None
 
     # Step2: Prepare "labels", "loss_mask" on all ranks.
-    if is_last_stage:
+    if is_last_stage or mtp_on_this_rank:
         if is_tp_rank_0:
             assert batch['labels'].dtype == torch.int64
             assert batch['loss_mask'].dtype == torch.float32
@@ -933,7 +935,9 @@ def get_batch_on_this_rank_for_sequence_packing(
         .cpu()
         .tolist()
     )
-    if zigzag_cp_min_chunk_size < 0:
+    if zigzag_cp_min_chunk_size < 0 or (
+        config is not None and getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration'
+    ):
         zigzag_cp_min_chunk_size = None
 
     # Transformer Engine has a bug of cu_seqlens, we must treat cu_seqlens_padded as cu_seqlens to

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -604,7 +604,13 @@ class DpBalancedScheduler(BasePackingScheduler):
             ]
 
             # Step 5: Build packed microbatches
-            new_samples = build_packed_microbatches(grouped_samples, dev)
+            new_samples = build_packed_microbatches(
+                grouped_samples,
+                dev,
+                sample_id_groups=sample_id_groups,
+                dcp_rank=dcp_rank,
+                global_id_seqlens=global_id_seqlens,
+            )
 
             # Step 6: Calculate FLOPs info
             seqlen_sum_this_global_batch = float(sum(seqlens_gathered))
@@ -778,7 +784,7 @@ def get_batch_on_this_rank_for_sequence_packing(
     dev = torch.cuda.current_device()
 
     # data_iterator should return a batch including the following keys.
-    batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen']
+    batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen', 'zigzag_cp_min_chunk_size']
     if is_first_stage:
         batch_keys.append('tokens')
         batch_keys.append('position_ids')
@@ -790,6 +796,10 @@ def get_batch_on_this_rank_for_sequence_packing(
     if is_tp_rank_0:
         assert data_iterator is not None
         batch = next(data_iterator)
+        # External iterators do not carry the optional scheduler certificate.
+        # Unknown geometry keeps MTP on its established zigzag packed-CP roll path.
+        if 'zigzag_cp_min_chunk_size' not in batch:
+            batch['zigzag_cp_min_chunk_size'] = torch.tensor(-1, dtype=torch.int32, device=dev)
         for key in batch_keys:
             assert key in batch, f"{key} is missing in current batch."
     else:
@@ -888,6 +898,17 @@ def get_batch_on_this_rank_for_sequence_packing(
         batch['cu_seqlens_padded'] = torch.empty([cu_seqlen_size], dtype=torch.int32, device=dev)
         batch['max_seqlen'] = torch.empty(1, dtype=torch.int32, device=dev)
 
+    if is_tp_rank_0:
+        if type(batch['zigzag_cp_min_chunk_size']) == int:
+            batch['zigzag_cp_min_chunk_size'] = torch.tensor(
+                batch['zigzag_cp_min_chunk_size'], dtype=torch.int32, device=dev
+            )
+        else:
+            assert batch['zigzag_cp_min_chunk_size'].dtype == torch.int32
+            assert batch['zigzag_cp_min_chunk_size'].numel() == 1
+    else:
+        batch['zigzag_cp_min_chunk_size'] = torch.empty(1, dtype=torch.int32, device=dev)
+
     # Broadcast batch inside TP group.
     broadcast_tensor(batch['tokens'], tp_src_rank, tp_group)
     broadcast_tensor(batch['position_ids'], tp_src_rank, tp_group)
@@ -897,6 +918,7 @@ def get_batch_on_this_rank_for_sequence_packing(
     broadcast_tensor(batch['cu_seqlens'], tp_src_rank, tp_group)
     broadcast_tensor(batch['cu_seqlens_padded'], tp_src_rank, tp_group)
     broadcast_tensor(batch['max_seqlen'], tp_src_rank, tp_group)
+    broadcast_tensor(batch['zigzag_cp_min_chunk_size'], tp_src_rank, tp_group)
 
     # Extract the data from batch after broadcasting.
     tokens = batch['tokens']
@@ -906,7 +928,13 @@ def get_batch_on_this_rank_for_sequence_packing(
     padding_mask = batch['padding_mask']
     cu_seqlens = batch['cu_seqlens']
     cu_seqlens_padded = batch['cu_seqlens_padded']
-    max_seqlen = batch['max_seqlen'].item()
+    max_seqlen, zigzag_cp_min_chunk_size = (
+        torch.cat([batch['max_seqlen'].reshape(1), batch['zigzag_cp_min_chunk_size'].reshape(1)])
+        .cpu()
+        .tolist()
+    )
+    if zigzag_cp_min_chunk_size < 0:
+        zigzag_cp_min_chunk_size = None
 
     # Transformer Engine has a bug of cu_seqlens, we must treat cu_seqlens_padded as cu_seqlens to
     # get the correct result.
@@ -919,6 +947,7 @@ def get_batch_on_this_rank_for_sequence_packing(
         cu_seqlens_kv_padded=cu_seqlens_padded,
         max_seqlen_q=max_seqlen,
         max_seqlen_kv=max_seqlen,
+        zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
     )
 
     # "attention_mask" is not valid for sequence packing, so set it to None.

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
@@ -161,7 +161,11 @@ def _get_global_seqlens_and_ids(subsample_seqlens: torch.Tensor, dp_group):
 
 
 def _pack_sequences(
-    samples: List, padded_lengths: torch.Tensor, original_lengths: torch.Tensor, dev: torch.device
+    samples: List,
+    padded_lengths: torch.Tensor,
+    original_lengths: torch.Tensor,
+    dev: torch.device,
+    zigzag_cp_min_chunk_size: Optional[int] = None,
 ) -> Dict[str, torch.Tensor]:
     """Pack multiple samples into a single packed sample."""
 
@@ -195,6 +199,11 @@ def _pack_sequences(
     cu_seqlens[0] = 0
     cu_seqlens[1:] = torch.cumsum(original_lengths, dim=0).reshape(-1)
     new_sample["cu_seqlens"] = cu_seqlens
+
+    if zigzag_cp_min_chunk_size is not None:
+        new_sample["zigzag_cp_min_chunk_size"] = torch.tensor(
+            zigzag_cp_min_chunk_size, dtype=torch.int32, device=dev
+        )
 
     return new_sample
 
@@ -272,6 +281,8 @@ def broadcast_to_pp_group(
             ]
             for sample in new_samples:
                 tensor_list.append(sample["max_seqlen"].reshape(1))
+            for sample in new_samples:
+                tensor_list.append(sample["zigzag_cp_min_chunk_size"].reshape(1))
             tensor_list.append(cu_seqlens_lengths)
             tensor_list.append(cu_seqlens_padded_lengths)
             for sample in new_samples:
@@ -307,6 +318,8 @@ def broadcast_to_pp_group(
                 cursor = 3
                 max_seqlens = info_to_broadcast[cursor : cursor + num_micro_batches]
                 cursor += num_micro_batches
+                zigzag_cp_min_chunk_sizes = info_to_broadcast[cursor : cursor + num_micro_batches]
+                cursor += num_micro_batches
                 cu_seqlens_lengths = info_to_broadcast[cursor : cursor + num_micro_batches].to(
                     torch.int64
                 )
@@ -322,6 +335,9 @@ def broadcast_to_pp_group(
                     cu_seqlens_padded_len = int(cu_seqlens_padded_lengths[i].item())
                     new_sample = {}
                     new_sample["max_seqlen"] = max_seqlens[i].to(torch.int32)
+                    new_sample["zigzag_cp_min_chunk_size"] = zigzag_cp_min_chunk_sizes[i].to(
+                        torch.int32
+                    )
                     new_sample["cu_seqlens"] = info_to_broadcast[
                         cursor : cursor + cu_seqlens_len
                     ].to(torch.int32)
@@ -382,7 +398,15 @@ def create_data_iterator(new_samples, pp_group, tp_group, config):
         if tp_group.rank() == 0:
             if pp_group.rank() == 0 or pp_group.rank() == pp_group.size() - 1:
                 metadata = [
-                    {k: sample[k] for k in ["max_seqlen", "cu_seqlens", "cu_seqlens_padded"]}
+                    {
+                        k: sample[k]
+                        for k in [
+                            "max_seqlen",
+                            "cu_seqlens",
+                            "cu_seqlens_padded",
+                            "zigzag_cp_min_chunk_size",
+                        ]
+                    }
                     for sample in new_samples
                 ]
                 if pp_group.rank() == 0:
@@ -525,13 +549,35 @@ def reroute_samples_to_dcp_ranks(
 
 
 def build_packed_microbatches(
-    grouped_samples: List[List[Dict[str, torch.Tensor]]], dev: torch.device
+    grouped_samples: List[List[Dict[str, torch.Tensor]]],
+    dev: torch.device,
+    sample_id_groups: Optional[List[List[List[int]]]] = None,
+    dcp_rank: Optional[int] = None,
+    global_id_seqlens: Optional[List[Tuple[int, int]]] = None,
 ) -> List[Dict[str, torch.Tensor]]:
-    """Build packed samples for each microbatch."""
+    """Build packed samples and optional zigzag one-hop scheduler certificates."""
     num_micro_batches = len(grouped_samples)
     seg_starts: List[int] = [0]
     original_lens_tensors = []
     padded_lens_tensors = []
+
+    can_certify_zigzag = (
+        sample_id_groups is not None and dcp_rank is not None and global_id_seqlens is not None
+    )
+    effective_cp_sizes: List[int] = []
+    if can_certify_zigzag:
+        assert sample_id_groups is not None
+        assert dcp_rank is not None
+        for microbatch_groups in sample_id_groups:
+            sample_ids_this_rank = microbatch_groups[dcp_rank]
+            assert sample_ids_this_rank, "Each scheduled DCP rank must own at least one sample."
+            effective_cp_sizes.append(
+                sum(
+                    sample_ids_this_rank[0] in rank_sample_ids
+                    for rank_sample_ids in microbatch_groups
+                )
+            )
+    padded_length_by_id = dict(global_id_seqlens) if global_id_seqlens is not None else None
 
     for i in range(num_micro_batches):
         samples = grouped_samples[i]
@@ -547,7 +593,26 @@ def build_packed_microbatches(
         samples = grouped_samples[i]
         lens_padded = padded_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
         lens_original = original_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
-        new_sample = _pack_sequences(samples, lens_padded, lens_original, dev)
+        zigzag_cp_min_chunk_size = None
+        if can_certify_zigzag:
+            assert sample_id_groups is not None
+            assert dcp_rank is not None
+            assert padded_length_by_id is not None
+            divisor = 2 * effective_cp_sizes[i]
+            padded_lengths_host = [
+                padded_length_by_id[sample_id] for sample_id in sample_id_groups[i][dcp_rank]
+            ]
+            if any(length % divisor != 0 for length in padded_lengths_host):
+                zigzag_cp_min_chunk_size = 0
+            else:
+                zigzag_cp_min_chunk_size = min(length // divisor for length in padded_lengths_host)
+        new_sample = _pack_sequences(
+            samples,
+            lens_padded,
+            lens_original,
+            dev,
+            zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
+        )
         new_samples.append(new_sample)
 
     return new_samples

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2212,6 +2212,8 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
         self.kept_packed_seq_params.discard("seq_idx")
         self.kept_packed_seq_params.discard("tokens_per_sample")
         self.kept_packed_seq_params.discard("cp_scatter_cache")
+        self.kept_packed_seq_params.discard("cp_partition_mode")
+        self.kept_packed_seq_params.discard("zigzag_cp_min_chunk_size")
 
         if get_te_version() < PkgVersion("2.2.0"):
             self.kept_packed_seq_params.discard("pad_between_seqs")

--- a/megatron/core/fusions/fused_mtp_prefix.py
+++ b/megatron/core/fusions/fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Sync-free prefix objective for MTP end-to-end acceptance probabilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _mtp_prefix_forward_kernel(
+        acceptances,
+        output,
+        prefix_losses,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute the prefix losses and their mean."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        prefix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+        prefix_loss_sum = tl.zeros((BLOCK_SIZE,), tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_product *= acceptance
+            prefix_loss = 1.0 - prefix_product
+            prefix_loss_sum += prefix_loss
+            tl.store(prefix_losses + depth * num_rows + rows, prefix_loss, mask=row_mask)
+            depth += 1
+
+        tl.store(output + rows, prefix_loss_sum * inv_num_depths, mask=row_mask)
+
+    @triton.jit
+    def _mtp_prefix_backward_kernel(
+        acceptances,
+        grad_output,
+        grad_acceptances,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Apply a zero-safe analytical gradient without dividing by acceptance."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        output_gradient = tl.load(grad_output + rows, mask=row_mask, other=0.0).to(tl.float32)
+        prefix_before = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            suffix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_sum = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_depth = depth + 1
+            while suffix_depth < num_depths:
+                suffix_acceptance = tl.load(
+                    acceptances + suffix_depth * num_rows + rows, mask=row_mask, other=1.0
+                ).to(tl.float32)
+                suffix_product *= suffix_acceptance
+                suffix_sum += suffix_product
+                suffix_depth += 1
+
+            gradient = -output_gradient * inv_num_depths * prefix_before * suffix_sum
+            tl.store(grad_acceptances + depth * num_rows + rows, gradient, mask=row_mask)
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_before *= acceptance
+            depth += 1
+
+
+def fused_mtp_prefix_unavailable_reason(acceptances: Tensor) -> Optional[str]:
+    """Return why the fused prefix objective cannot consume the input."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if not acceptances.is_cuda:
+        return "acceptances are not a CUDA tensor"
+    # The fused TV primitive produces FP32 acceptance probabilities for both
+    # BF16 and FP32 logits. Keep this internal contract narrow instead of
+    # introducing different BF16 prefix-rounding semantics that production
+    # cannot exercise.
+    if acceptances.dtype != torch.float32:
+        return f"acceptance dtype {acceptances.dtype} is not supported"
+    if acceptances.ndim == 0 or acceptances.size(0) == 0:
+        return "acceptances must have a non-empty depth dimension"
+    if acceptances.numel() == 0:
+        return "acceptances must have at least one row"
+    if not acceptances.is_contiguous():
+        return "acceptances are not contiguous"
+    return None
+
+
+class _FusedMTPPrefixObjective(torch.autograd.Function):
+    """Triton prefix objective with a zero-safe analytical backward."""
+
+    @staticmethod
+    def forward(ctx, acceptances: Tensor) -> tuple[Tensor, Tensor]:
+        """Compute the mean and per-depth rejection probabilities."""
+        num_depths = acceptances.size(0)
+        num_rows = acceptances.numel() // num_depths
+        inv_num_depths = float(num_depths**-1)
+        output = torch.empty(
+            acceptances.shape[1:], dtype=acceptances.dtype, device=acceptances.device
+        )
+        prefix_losses = torch.empty_like(acceptances)
+        _mtp_prefix_forward_kernel[(triton.cdiv(num_rows, 256),)](
+            acceptances,
+            output,
+            prefix_losses,
+            num_rows=num_rows,
+            num_depths=num_depths,
+            inv_num_depths=inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(acceptances)
+        ctx.num_depths = num_depths
+        ctx.num_rows = num_rows
+        ctx.inv_num_depths = inv_num_depths
+        ctx.mark_non_differentiable(prefix_losses)
+        return output, prefix_losses
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor, _grad_prefix_losses: Tensor) -> tuple[Tensor]:
+        """Return the analytical gradient for every acceptance probability."""
+        (acceptances,) = ctx.saved_tensors
+        grad_acceptances = torch.empty_like(acceptances)
+        _mtp_prefix_backward_kernel[(triton.cdiv(ctx.num_rows, 256),)](
+            acceptances,
+            grad_output.contiguous(),
+            grad_acceptances,
+            num_rows=ctx.num_rows,
+            num_depths=ctx.num_depths,
+            inv_num_depths=ctx.inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        return (grad_acceptances,)
+
+
+def _reference_mtp_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Preserve the established PyTorch implementation as an oracle and fallback."""
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses.detach()
+
+
+def mtp_e2e_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Compute mean and detached per-depth E2E-TV losses with automatic dispatch."""
+    if fused_mtp_prefix_unavailable_reason(acceptances) is None:
+        return _FusedMTPPrefixObjective.apply(acceptances)
+    return _reference_mtp_prefix_objective(acceptances)

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -31,8 +31,57 @@ _BLOCK_SIZE = 1024
 if HAVE_TRITON:
 
     @triton.jit
+    def _load_tv_target_values(
+        target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
+        row,
+        cols,
+        vocab_mask,
+        vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
+    ):
+        """Load one target row from local storage, a compact halo, or logical zeros."""
+        if HAS_TARGET_ROW_MAP:
+            target_row = tl.load(target_row_indices + row).to(tl.int64)
+            target_is_valid = tl.load(target_valid_rows + row)
+            target_is_valid = (
+                target_is_valid
+                & (target_row >= 0)
+                & (target_row < local_target_rows + target_halo_rows)
+            )
+            safe_target_row = tl.where(target_is_valid, target_row, 0)
+            target_row_ptr = tl.where(
+                safe_target_row < local_target_rows,
+                target + safe_target_row * vocab_size,
+                target_halo + (safe_target_row - local_target_rows) * vocab_size,
+            )
+            target_values = tl.load(
+                target_row_ptr + cols, mask=vocab_mask & target_is_valid, other=-float("inf")
+            )
+            return tl.where(target_is_valid, target_values.to(tl.float32), 0.0)
+
+        return tl.load(target + row * vocab_size + cols, mask=vocab_mask, other=-float("inf")).to(
+            tl.float32
+        )
+
+    @triton.jit
     def _tv_row_stats_kernel(
-        draft, target, maxima, denominators, vocab_size, BLOCK_SIZE: tl.constexpr
+        draft,
+        target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
+        maxima,
+        denominators,
+        vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
     ):
         """Compute stable local softmax maxima and denominators for one row."""
         row = tl.program_id(0).to(tl.int64)
@@ -48,8 +97,18 @@ if HAVE_TRITON:
             draft_values = tl.load(draft + row_start + cols, mask=mask, other=-float("inf")).to(
                 tl.float32
             )
-            target_values = tl.load(target + row_start + cols, mask=mask, other=-float("inf")).to(
-                tl.float32
+            target_values = _load_tv_target_values(
+                target,
+                target_halo,
+                target_row_indices,
+                target_valid_rows,
+                row,
+                cols,
+                mask,
+                vocab_size,
+                local_target_rows,
+                target_halo_rows,
+                HAS_TARGET_ROW_MAP,
             )
 
             draft_tile_max = tl.max(draft_values, axis=0)
@@ -95,12 +154,18 @@ if HAVE_TRITON:
     def _tv_overlap_kernel(
         draft,
         target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
         maxima,
         denominators,
         overlap_and_s,
         draft_above_target_bits,
         vocab_size,
         packed_vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
         BLOCK_SIZE: tl.constexpr,
     ):
         """Compute local overlap and the draft mass at or below the target."""
@@ -120,7 +185,19 @@ if HAVE_TRITON:
             cols = col_start + byte_offsets[:, None] * 8 + bit_offsets[None, :]
             mask = cols < vocab_size
             draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
-            target_values = tl.load(target + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            target_values = _load_tv_target_values(
+                target,
+                target_halo,
+                target_row_indices,
+                target_valid_rows,
+                row,
+                cols,
+                mask,
+                vocab_size,
+                local_target_rows,
+                target_halo_rows,
+                HAS_TARGET_ROW_MAP,
+            )
             draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
             target_prob = tl.exp(target_values - target_max) / target_denominator
             overlap += tl.sum(
@@ -217,6 +294,59 @@ def fused_mtp_tv_unavailable_reason(  # pylint: disable=too-many-return-statemen
     return None
 
 
+def _validate_target_row_addressing(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    target_row_indices: Optional[Tensor],
+    target_valid_rows: Optional[Tensor],
+    target_halo_logits: Optional[Tensor],
+) -> bool:
+    """Validate optional direct target-row addressing and return whether it is active."""
+    has_target_row_map = target_row_indices is not None
+    if has_target_row_map != (target_valid_rows is not None):
+        raise ValueError("Target row indices and validity must be provided together.")
+    if target_halo_logits is not None and not has_target_row_map:
+        raise ValueError("Target halo logits require target row indices and validity.")
+    if not has_target_row_map:
+        return False
+
+    assert target_row_indices is not None
+    assert target_valid_rows is not None
+    if target_row_indices.shape != draft_logits.shape[:-1]:
+        raise ValueError(
+            "Target row indices must match the draft leading dimensions, got "
+            f"{tuple(target_row_indices.shape)} and {tuple(draft_logits.shape[:-1])}."
+        )
+    if target_valid_rows.shape != target_row_indices.shape:
+        raise ValueError(
+            "Target row validity must match target row indices, got "
+            f"{tuple(target_valid_rows.shape)} and {tuple(target_row_indices.shape)}."
+        )
+    if target_row_indices.device != draft_logits.device:
+        raise ValueError("Target row indices must be on the logits device.")
+    if target_valid_rows.device != draft_logits.device:
+        raise ValueError("Target row validity must be on the logits device.")
+    if target_row_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Target row indices must use torch.int32 or torch.int64.")
+    if target_valid_rows.dtype != torch.bool:
+        raise ValueError("Target row validity must use torch.bool.")
+    if not target_row_indices.is_contiguous() or not target_valid_rows.is_contiguous():
+        raise ValueError("Target row metadata must be contiguous.")
+
+    if target_halo_logits is not None:
+        if target_halo_logits.device != target_logits.device:
+            raise ValueError("Target halo logits must be on the target-logits device.")
+        if target_halo_logits.dtype != target_logits.dtype:
+            raise ValueError("Target halo logits must use the target-logits dtype.")
+        if target_halo_logits.ndim != target_logits.ndim:
+            raise ValueError("Target halo logits must have the target-logits rank.")
+        if target_halo_logits.shape[1:] != target_logits.shape[1:]:
+            raise ValueError("Target halo logits must match non-sequence target dimensions.")
+        if not target_halo_logits.is_contiguous():
+            raise ValueError("Target halo logits must be contiguous.")
+    return True
+
+
 class _FusedVocabParallelTVDistance(torch.autograd.Function):
     """Triton TV distance with compact analytical-backward state."""
 
@@ -227,23 +357,44 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
         target_logits: Tensor,
         tp_group: Optional[torch.distributed.ProcessGroup],
         logits_are_vocab_sharded: bool,
+        target_row_indices: Optional[Tensor],
+        target_valid_rows: Optional[Tensor],
+        target_halo_logits: Optional[Tensor],
     ) -> Tensor:
         """Run fused forward passes and preserve compact backward state."""
         unavailable_reason = fused_mtp_tv_unavailable_reason(draft_logits, target_logits)
         if unavailable_reason is not None:
             raise RuntimeError(f"Fused MTP TV distance is unavailable: {unavailable_reason}.")
 
+        has_target_row_map = _validate_target_row_addressing(
+            draft_logits, target_logits, target_row_indices, target_valid_rows, target_halo_logits
+        )
         vocab_size = draft_logits.size(-1)
         output_shape = draft_logits.shape[:-1]
         num_rows = draft_logits.numel() // vocab_size
         maxima = torch.empty((2, num_rows), dtype=torch.float32, device=draft_logits.device)
         denominators = torch.empty_like(maxima)
+        target_row_indices_arg = target_row_indices if has_target_row_map else draft_logits
+        target_valid_rows_arg = target_valid_rows if has_target_row_map else draft_logits
+        target_halo_logits_arg = (
+            target_halo_logits if target_halo_logits is not None else target_logits
+        )
+        local_target_rows = target_logits.numel() // vocab_size
+        target_halo_rows = (
+            target_halo_logits.numel() // vocab_size if target_halo_logits is not None else 0
+        )
         _tv_row_stats_kernel[(num_rows,)](
             draft_logits,
             target_logits,
+            target_halo_logits_arg,
+            target_row_indices_arg,
+            target_valid_rows_arg,
             maxima,
             denominators,
             vocab_size=vocab_size,
+            local_target_rows=local_target_rows,
+            target_halo_rows=target_halo_rows,
+            HAS_TARGET_ROW_MAP=has_target_row_map,
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
@@ -274,12 +425,18 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
         _tv_overlap_kernel[(num_rows,)](
             draft_logits,
             target_logits,
+            target_halo_logits_arg,
+            target_row_indices_arg,
+            target_valid_rows_arg,
             maxima,
             denominators,
             overlap_and_s,
             draft_above_target_bits,
             vocab_size=vocab_size,
             packed_vocab_size=packed_vocab_size,
+            local_target_rows=local_target_rows,
+            target_halo_rows=target_halo_rows,
+            HAS_TARGET_ROW_MAP=has_target_row_map,
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
@@ -337,7 +494,7 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
-        return grad_draft, None, None, None
+        return grad_draft, None, None, None, None, None, None
 
 
 def _fused_vocab_parallel_tv_distance(
@@ -345,10 +502,20 @@ def _fused_vocab_parallel_tv_distance(
     target_logits: Tensor,
     tp_group: Optional[torch.distributed.ProcessGroup],
     logits_are_vocab_sharded: bool,
+    *,
+    target_row_indices: Optional[Tensor] = None,
+    target_valid_rows: Optional[Tensor] = None,
+    target_halo_logits: Optional[Tensor] = None,
 ) -> Tensor:
-    """Compute TV distance using Triton and TP collectives."""
+    """Compute TV distance using Triton, optional target-row addressing, and TP collectives."""
     return _FusedVocabParallelTVDistance.apply(
-        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+        draft_logits,
+        target_logits.detach(),
+        tp_group,
+        logits_are_vocab_sharded,
+        target_row_indices,
+        target_valid_rows,
+        target_halo_logits.detach() if target_halo_logits is not None else None,
     )
 
 
@@ -463,14 +630,23 @@ def vocab_parallel_tv_distance(
     target_logits: Tensor,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     logits_are_vocab_sharded: bool = True,
+    *,
+    target_row_indices: Optional[Tensor] = None,
+    target_valid_rows: Optional[Tensor] = None,
+    target_halo_logits: Optional[Tensor] = None,
 ) -> Tensor:
     """Compute full-vocabulary TV distance with automatic fused/reference dispatch.
 
     Args:
         draft_logits: Trainable draft logits with vocabulary in the last dimension.
-        target_logits: Detached target logits with the same local or global vocabulary layout.
+        target_logits: Detached local target-logit storage with the same vocabulary layout.
         tp_group: Tensor-parallel group owning vocabulary shards.
         logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+        target_row_indices: Optional flattened row in ``target_logits`` or its halo for each
+            draft row.
+        target_valid_rows: Validity mask paired with ``target_row_indices``. Invalid and
+            out-of-bounds rows select a safe all-zero target-logit vector.
+        target_halo_logits: Optional compact rows logically appended to ``target_logits``.
 
     Returns:
         A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
@@ -484,19 +660,60 @@ def vocab_parallel_tv_distance(
     if draft_logits.device != target_logits.device:
         raise ValueError("Draft and target logits must be on the same device.")
     _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+    has_target_row_map = _validate_target_row_addressing(
+        draft_logits, target_logits, target_row_indices, target_valid_rows, target_halo_logits
+    )
 
     # Materialized sequence rolls produce a noncontiguous target view. Pack only
     # that detached input when the trainable draft otherwise supports Triton.
     if (
-        not target_logits.is_contiguous()
+        not has_target_row_map
+        and not target_logits.is_contiguous()
         and fused_mtp_tv_unavailable_reason(draft_logits, draft_logits) is None
     ):
         target_logits = target_logits.detach().contiguous()
 
     if fused_mtp_tv_unavailable_reason(draft_logits, target_logits) is None:
         return _fused_vocab_parallel_tv_distance(
-            draft_logits, target_logits, tp_group, logits_are_vocab_sharded
+            draft_logits,
+            target_logits,
+            tp_group,
+            logits_are_vocab_sharded,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo_logits,
         )
+
+    if has_target_row_map:
+        assert target_row_indices is not None
+        assert target_valid_rows is not None
+        vocab_size = draft_logits.size(-1)
+        local_targets = target_logits.detach().reshape(-1, vocab_size)
+        flat_indices = target_row_indices.reshape(-1).long()
+        flat_valid = target_valid_rows.reshape(-1)
+        num_local_rows = local_targets.size(0)
+        halo_targets = None
+        num_halo_rows = 0
+        if target_halo_logits is not None:
+            halo_targets = target_halo_logits.detach().reshape(-1, vocab_size)
+            num_halo_rows = halo_targets.size(0)
+
+        num_addressable_rows = num_local_rows + num_halo_rows
+        flat_valid = flat_valid & (flat_indices >= 0) & (flat_indices < num_addressable_rows)
+        safe_local_indices = torch.where(
+            flat_valid & (flat_indices < num_local_rows), flat_indices, 0
+        )
+        materialized_target = local_targets.index_select(0, safe_local_indices)
+        if halo_targets is not None and num_halo_rows > 0:
+            selects_halo = flat_valid & (flat_indices >= num_local_rows)
+            safe_halo_indices = torch.where(selects_halo, flat_indices - num_local_rows, 0)
+            selected_halo = halo_targets.index_select(0, safe_halo_indices)
+            materialized_target = torch.where(
+                selects_halo.unsqueeze(1), selected_halo, materialized_target
+            )
+        materialized_target.masked_fill_(~flat_valid.unsqueeze(1), 0)
+        target_logits = materialized_target.view_as(draft_logits)
+
     return _VocabParallelTVDistance.apply(
         draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
     )

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -447,7 +447,7 @@ class _VocabParallelTVDistance(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: Tensor):
         """Apply the analytical Bebop gradient to the draft logits only."""
-        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+        draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask = (
             ctx.saved_tensors
         )
 

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -1,0 +1,502 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Full-vocabulary TV distance with fused CUDA dispatch and a PyTorch fallback."""
+
+# Triton kernel signatures and programs naturally exceed the host-code lint limits.
+# pylint: disable=invalid-name,too-many-arguments,too-many-locals
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core import parallel_state
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+_BLOCK_SIZE = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _tv_row_stats_kernel(
+        draft, target, maxima, denominators, vocab_size, BLOCK_SIZE: tl.constexpr
+    ):
+        """Compute stable local softmax maxima and denominators for one row."""
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = -float("inf")
+        target_max = -float("inf")
+        draft_sum = 0.0
+        target_sum = 0.0
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            target_values = tl.load(target + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+
+            draft_tile_max = tl.max(draft_values, axis=0)
+            target_tile_max = tl.max(target_values, axis=0)
+            draft_new_max = tl.maximum(draft_max, draft_tile_max)
+            target_new_max = tl.maximum(target_max, target_tile_max)
+            draft_old_scale = tl.where(
+                draft_max == -float("inf"), 0.0, tl.exp(draft_max - draft_new_max)
+            )
+            target_old_scale = tl.where(
+                target_max == -float("inf"), 0.0, tl.exp(target_max - target_new_max)
+            )
+            draft_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(draft_values - draft_new_max), 0.0), axis=0
+            )
+            target_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(target_values - target_new_max), 0.0), axis=0
+            )
+            draft_sum = draft_sum * draft_old_scale + draft_tile_sum
+            target_sum = target_sum * target_old_scale + target_tile_sum
+            draft_max = draft_new_max
+            target_max = target_new_max
+
+        num_rows = tl.num_programs(0)
+        tl.store(maxima + row, draft_max)
+        tl.store(maxima + num_rows + row, target_max)
+        tl.store(denominators + row, draft_sum)
+        tl.store(denominators + num_rows + row, target_sum)
+
+    @triton.jit
+    def _tv_rescale_denominators_kernel(
+        local_maxima, global_maxima, denominators, num_values, BLOCK_SIZE: tl.constexpr
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < num_values
+        local_max = tl.load(local_maxima + offsets, mask=mask)
+        global_max = tl.load(global_maxima + offsets, mask=mask)
+        denominator = tl.load(denominators + offsets, mask=mask)
+        denominator *= tl.exp(local_max - global_max)
+        tl.store(denominators + offsets, denominator, mask=mask)
+
+    @triton.jit
+    def _tv_overlap_kernel(
+        draft,
+        target,
+        maxima,
+        denominators,
+        overlap_and_s,
+        draft_above_target_bits,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute local overlap and the draft mass at or below the target."""
+        row = tl.program_id(0).to(tl.int64)
+        num_rows = tl.num_programs(0)
+        row_start = row * vocab_size
+        draft_max = tl.load(maxima + row)
+        target_max = tl.load(maxima + num_rows + row)
+        draft_denominator = tl.load(denominators + row)
+        target_denominator = tl.load(denominators + num_rows + row)
+        overlap = 0.0
+        draft_mass_below_target = 0.0
+
+        bit_offsets = tl.arange(0, 8)
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            byte_offsets = tl.arange(0, BLOCK_SIZE // 8)
+            cols = col_start + byte_offsets[:, None] * 8 + bit_offsets[None, :]
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            target_values = tl.load(target + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            target_prob = tl.exp(target_values - target_max) / target_denominator
+            overlap += tl.sum(
+                tl.sum(tl.where(mask, tl.minimum(draft_prob, target_prob), 0.0), axis=1), axis=0
+            )
+            draft_mass_below_target += tl.sum(
+                tl.sum(tl.where(mask & (draft_prob <= target_prob), draft_prob, 0.0), axis=1),
+                axis=0,
+            )
+            packed_above_target = tl.sum(
+                tl.where(mask & (draft_prob > target_prob), 1 << bit_offsets[None, :], 0), axis=1
+            )
+            packed_offsets = col_start // 8 + byte_offsets
+            tl.store(
+                draft_above_target_bits + row * packed_vocab_size + packed_offsets,
+                packed_above_target,
+                mask=packed_offsets < packed_vocab_size,
+            )
+
+        tl.store(overlap_and_s + row, overlap)
+        tl.store(overlap_and_s + num_rows + row, draft_mass_below_target)
+
+    @triton.jit
+    def _tv_finalize_kernel(
+        overlap, output, clamp_gradient_mask, num_rows, BLOCK_SIZE: tl.constexpr
+    ):
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = rows < num_rows
+        raw_distance = 1.0 - tl.load(overlap + rows, mask=mask)
+        distance = tl.maximum(0.0, tl.minimum(1.0, raw_distance))
+        tl.store(output + rows, distance, mask=mask)
+        tl.store(
+            clamp_gradient_mask + rows, (raw_distance >= 0.0) & (raw_distance <= 1.0), mask=mask
+        )
+
+    @triton.jit
+    def _tv_backward_kernel(
+        draft,
+        draft_maxima,
+        draft_denominators,
+        draft_mass_below_target,
+        draft_above_target_bits,
+        clamp_gradient_mask,
+        grad_output,
+        grad_draft,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = tl.load(draft_maxima + row)
+        draft_denominator = tl.load(draft_denominators + row)
+        draft_mass = tl.load(draft_mass_below_target + row)
+        row_gradient = tl.load(grad_output + row).to(tl.float32)
+        row_gradient *= tl.load(clamp_gradient_mask + row).to(tl.float32)
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            packed_above_target = tl.load(
+                draft_above_target_bits + row * packed_vocab_size + cols // 8, mask=mask, other=0
+            ).to(tl.int32)
+            draft_above_target = (packed_above_target >> (cols % 8)) & 1
+            gradient = draft_prob * (draft_mass - 1.0 + draft_above_target.to(tl.float32))
+            gradient *= row_gradient
+            tl.store(grad_draft + row_start + cols, gradient, mask=mask)
+
+
+def fused_mtp_tv_unavailable_reason(  # pylint: disable=too-many-return-statements
+    draft_logits: Tensor, target_logits: Tensor
+) -> Optional[str]:
+    """Return why the fused kernel cannot consume the two logits tensors."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if draft_logits.shape != target_logits.shape:
+        return "draft and target logits have different shapes"
+    if draft_logits.device != target_logits.device:
+        return "draft and target logits are on different devices"
+    if not draft_logits.is_cuda:
+        return "logits are not CUDA tensors"
+    if draft_logits.dtype not in (torch.bfloat16, torch.float32):
+        return f"draft dtype {draft_logits.dtype} is not supported"
+    if target_logits.dtype != draft_logits.dtype:
+        return "draft and target logits have different dtypes"
+    if draft_logits.ndim == 0 or draft_logits.size(-1) == 0:
+        return "logits must have a non-empty vocabulary dimension"
+    if draft_logits.numel() == 0:
+        return "logits must have at least one row"
+    if not draft_logits.is_contiguous() or not target_logits.is_contiguous():
+        return "logits are not contiguous"
+    return None
+
+
+class _FusedVocabParallelTVDistance(torch.autograd.Function):
+    """Triton TV distance with compact analytical-backward state."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Run fused forward passes and preserve compact backward state."""
+        unavailable_reason = fused_mtp_tv_unavailable_reason(draft_logits, target_logits)
+        if unavailable_reason is not None:
+            raise RuntimeError(f"Fused MTP TV distance is unavailable: {unavailable_reason}.")
+
+        vocab_size = draft_logits.size(-1)
+        output_shape = draft_logits.shape[:-1]
+        num_rows = draft_logits.numel() // vocab_size
+        maxima = torch.empty((2, num_rows), dtype=torch.float32, device=draft_logits.device)
+        denominators = torch.empty_like(maxima)
+        _tv_row_stats_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            vocab_size=vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        if logits_are_vocab_sharded and tp_size > 1:
+            local_maxima = maxima
+            maxima = local_maxima.clone()
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+            num_stats = maxima.numel()
+            _tv_rescale_denominators_kernel[(triton.cdiv(num_stats, 256),)](
+                local_maxima,
+                maxima,
+                denominators,
+                num_values=num_stats,
+                BLOCK_SIZE=256,
+                num_warps=4,
+            )
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        overlap_and_s = torch.empty_like(maxima)
+        packed_vocab_size = (vocab_size + 7) // 8
+        draft_above_target_bits = torch.empty(
+            (num_rows, packed_vocab_size), dtype=torch.uint8, device=draft_logits.device
+        )
+        _tv_overlap_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            overlap_and_s,
+            draft_above_target_bits,
+            vocab_size=vocab_size,
+            packed_vocab_size=packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        output = torch.empty(num_rows, dtype=torch.float32, device=draft_logits.device)
+        clamp_gradient_mask = torch.empty(num_rows, dtype=torch.bool, device=draft_logits.device)
+        _tv_finalize_kernel[(triton.cdiv(num_rows, 256),)](
+            overlap_and_s,
+            output,
+            clamp_gradient_mask,
+            num_rows=num_rows,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(
+            draft_logits,
+            maxima[0],
+            denominators[0],
+            overlap_and_s[1],
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        )
+        ctx.vocab_size = vocab_size
+        ctx.packed_vocab_size = packed_vocab_size
+        return output.view(output_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical draft-logit gradient from packed metadata."""
+        (
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        ) = ctx.saved_tensors
+        num_rows = draft_logits.numel() // ctx.vocab_size
+        grad_draft = torch.empty_like(draft_logits)
+        _tv_backward_kernel[(num_rows,)](
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+            grad_output.contiguous(),
+            grad_draft,
+            vocab_size=ctx.vocab_size,
+            packed_vocab_size=ctx.packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        return grad_draft, None, None, None
+
+
+def _fused_vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    logits_are_vocab_sharded: bool,
+) -> Tensor:
+    """Compute TV distance using Triton and TP collectives."""
+    return _FusedVocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )
+
+
+def _validate_vocab_parallel_tv_group(
+    tp_group: Optional[torch.distributed.ProcessGroup], logits_are_vocab_sharded: bool
+) -> None:
+    """Reject vocab-sharded TV before a missing TP group can change its normalization."""
+    # Compatibility guard retained from the original MTP-local dispatcher. New
+    # callers should pass the explicit TP group instead of relying on MPU state.
+    if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
+        initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if initialized_tp_size > 1:
+            raise ValueError(
+                "tp_group must be provided for TV distance over vocab-sharded logits "
+                f"when tensor parallel size is {initialized_tp_size}."
+            )
+
+
+class _VocabParallelTVDistance(torch.autograd.Function):
+    """Full-vocabulary TV distance with a TP-aware analytical backward.
+
+    The implementation follows Algorithms 1 and 2 in the Bebop paper
+    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
+    distribution detached and returns gradients for draft logits only.
+
+    This PyTorch implementation establishes the mathematical contract and is
+    retained as the oracle and fallback for unsupported fused-kernel inputs.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Compute the TV distance and save the draft-side backward state."""
+        if draft_logits.shape != target_logits.shape:
+            raise ValueError(
+                "Draft and target logits must have identical shapes, got "
+                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+            )
+        if draft_logits.device != target_logits.device:
+            raise ValueError("Draft and target logits must be on the same device.")
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+        draft_logits_fp32 = draft_logits.float()
+        target_logits_fp32 = target_logits.float()
+        maxima = torch.stack(
+            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        draft_max, target_max = maxima.unbind(dim=0)
+
+        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
+        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
+        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        draft_denominator, target_denominator = denominators.unbind(dim=0)
+
+        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
+        target_prob = target_exp / target_denominator.unsqueeze(-1)
+        draft_below_target = draft_prob <= target_prob
+        overlap_and_s = torch.stack(
+            (
+                torch.minimum(draft_prob, target_prob).sum(dim=-1),
+                (draft_prob * draft_below_target).sum(dim=-1),
+            )
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        overlap, s = overlap_and_s.unbind(dim=0)
+
+        raw_tv_distance = 1.0 - overlap
+        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
+        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
+        ctx.save_for_backward(
+            draft_logits,
+            draft_max,
+            draft_denominator,
+            s,
+            draft_prob > target_prob,
+            clamp_gradient_mask,
+        )
+        return tv_distance
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical Bebop gradient to the draft logits only."""
+        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+            ctx.saved_tensors
+        )
+
+        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
+        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
+        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
+        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
+        return grad_draft.to(draft_logits.dtype), None, None, None
+
+
+def vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    logits_are_vocab_sharded: bool = True,
+) -> Tensor:
+    """Compute full-vocabulary TV distance with automatic fused/reference dispatch.
+
+    Args:
+        draft_logits: Trainable draft logits with vocabulary in the last dimension.
+        target_logits: Detached target logits with the same local or global vocabulary layout.
+        tp_group: Tensor-parallel group owning vocabulary shards.
+        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+
+    Returns:
+        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
+        ``draft_logits``.
+    """
+    if draft_logits.shape != target_logits.shape:
+        raise ValueError(
+            "Draft and target logits must have identical shapes, got "
+            f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+        )
+    if draft_logits.device != target_logits.device:
+        raise ValueError("Draft and target logits must be on the same device.")
+    _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+    # Materialized sequence rolls produce a noncontiguous target view. Pack only
+    # that detached input when the trainable draft otherwise supports Triton.
+    if (
+        not target_logits.is_contiguous()
+        and fused_mtp_tv_unavailable_reason(draft_logits, draft_logits) is None
+    ):
+        target_logits = target_logits.detach().contiguous()
+
+    if fused_mtp_tv_unavailable_reason(draft_logits, target_logits) is None:
+        return _fused_vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group, logits_are_vocab_sharded
+        )
+    return _VocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )

--- a/megatron/core/models/common/fine_grained_callables.py
+++ b/megatron/core/models/common/fine_grained_callables.py
@@ -18,9 +18,15 @@ import torch
 
 from megatron.core import tensor_parallel
 from megatron.core.models.gpt.fine_grained_callables import build_transformer_layer_callables
+from megatron.core.packed_seq_params import resolve_cp_group
 from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionLayer,
+    _scatter_mtp_padding_mask,
     get_mtp_layer_offset,
 )
 from megatron.core.transformer.transformer_layer import TransformerLayer, make_viewless_tensor
@@ -36,8 +42,65 @@ def build_mtp_layer_callables(layer):
 
     forward_funcs, backward_dw = build_layer_callables(layer.mtp_model_layer)
     is_moe, _ = get_layer_moe_metadata(layer.mtp_model_layer)
-    (pre_dispatch_forward, dispatch_forward, mlp_forward, combine_forward, _) = forward_funcs
+    pre_dispatch_forward, dispatch_forward, mlp_forward, combine_forward, _ = forward_funcs
     assert is_moe, "MTP layer in a2a overlap only supports MoE layer for now."
+
+    def prepare_roll_rows(node):
+        """Prepare one absolute-row group shared by scheduled MTP depths and loss."""
+        chunk_state = node.chunk_state
+        materialized = getattr(chunk_state, "mtp_materialized_roll_rows", None)
+        if materialized is not None:
+            return materialized
+
+        input_ids = chunk_state.input_ids
+        labels = chunk_state.labels
+        packed_seq_params = chunk_state.packed_seq_params
+        cp_group = resolve_cp_group(layer.cp_group, packed_seq_params)
+        sequence_roll_context = prepare_mtp_sequence_roll_context(
+            input_ids if input_ids is not None else labels, cp_group, packed_seq_params
+        )
+        fields = []
+        if input_ids is not None:
+            fields.append(MTPSequenceRollField("input_ids", input_ids, -1, 0, 0))
+        if chunk_state.position_ids is not None and getattr(
+            chunk_state.model.embedding, "add_position_embedding", True
+        ):
+            fields.append(MTPSequenceRollField("position_ids", chunk_state.position_ids, -1, 0, 0))
+        if chunk_state.model.post_process and labels is not None:
+            fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+        if chunk_state.model.post_process and chunk_state.loss_mask is not None:
+            fields.append(MTPSequenceRollField("loss_mask", chunk_state.loss_mask, -1, 0, 0))
+        raw_padding_mask = getattr(chunk_state, "mtp_padding_mask", chunk_state.padding_mask)
+        if raw_padding_mask is not None:
+            fields.append(MTPSequenceRollField("padding_mask", raw_padding_mask, -1, 0, True))
+
+        max_offset = layer.config.mtp_num_layers + int(
+            chunk_state.model.post_process and labels is None
+        )
+        if sequence_roll_context is not None and fields and max_offset > 0:
+            if not (
+                sequence_roll_context.max_offset >= max_offset
+                and sequence_roll_context.is_prepared_for_fields(fields)
+            ):
+                sequence_roll_context = sequence_roll_context.prepare_fields(
+                    fields, max_offset=max_offset
+                )
+            if (
+                sequence_roll_context.max_offset >= max_offset
+                and sequence_roll_context.is_prepared_for_fields(fields)
+            ):
+                materialized = {
+                    key: sequence_roll_context.materialize_all(key)
+                    for key in ("input_ids", "position_ids", "padding_mask")
+                    if key in sequence_roll_context.keys
+                }
+            else:
+                materialized = {}
+        else:
+            materialized = {}
+        chunk_state.mtp_sequence_roll_context = sequence_roll_context
+        chunk_state.mtp_materialized_roll_rows = materialized
+        return materialized
 
     def submodule_mtp_pre_dispatch_forward(node, hidden_states):
         # MTP Block Preprocess
@@ -67,27 +130,52 @@ def build_mtp_layer_callables(layer):
             node.chunk_state.mtp_hidden_states = list(torch.chunk(hidden_states, 1 + offset, dim=0))
             hidden_states = node.chunk_state.mtp_hidden_states[offset]
 
+        materialized_rows = prepare_roll_rows(node)
+        absolute_depth = getattr(node, "mtp_absolute_depth", None) or layer.layer_number
+        use_prepared_rows = "input_ids" in materialized_rows
+        input_ids = (
+            materialized_rows["input_ids"][absolute_depth - 1]
+            if use_prepared_rows
+            else node.chunk_state.input_ids
+        )
+        position_ids = (
+            materialized_rows["position_ids"][absolute_depth - 1]
+            if use_prepared_rows and "position_ids" in materialized_rows
+            else node.chunk_state.position_ids
+        )
+        padding_mask = (
+            materialized_rows["padding_mask"][absolute_depth - 1]
+            if use_prepared_rows and "padding_mask" in materialized_rows
+            else (None if use_prepared_rows else node.chunk_state.padding_mask)
+        )
+
         input_ids, position_ids, padding_mask, decoder_input, hidden_states = layer._get_embeddings(
-            input_ids=node.chunk_state.input_ids,
-            position_ids=node.chunk_state.position_ids,
+            input_ids=input_ids,
+            position_ids=position_ids,
             embedding=node.chunk_state.model.embedding,
             hidden_states=hidden_states,
             packed_seq_params=node.chunk_state.packed_seq_params,
-            padding_mask=node.chunk_state.padding_mask,
+            padding_mask=padding_mask,
+            sequence_roll_context=getattr(node.chunk_state, "mtp_sequence_roll_context", None),
+            roll_depth=absolute_depth - 1,
+            _inputs_pre_aligned=use_prepared_rows,
         )
-        node.chunk_state.input_ids = input_ids
-        node.chunk_state.position_ids = position_ids
-        node.chunk_state.padding_mask = padding_mask
+        if use_prepared_rows:
+            padding_mask = _scatter_mtp_padding_mask(
+                padding_mask,
+                sequence_parallel=layer.config.sequence_parallel,
+                tp_group=layer.tp_group,
+            )
+        else:
+            node.chunk_state.input_ids = input_ids
+            node.chunk_state.position_ids = position_ids
+            node.chunk_state.padding_mask = padding_mask
 
         # MTP Layer Preprocess
         # norm, linear projection and transformer
         assert (
             node.chunk_state.context is None
         ), f"multi token prediction + cross attention is not yet supported."
-        assert (
-            node.chunk_state.packed_seq_params is None
-        ), f"multi token prediction + sequence packing is not yet supported."
-
         if layer.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()
         else:
@@ -96,7 +184,7 @@ def build_mtp_layer_callables(layer):
         # fp8 context is added in 1f1b schedule, so we don't need to add it here
         with rng_context:
             hidden_states = layer._concat_embeddings(hidden_states, decoder_input)
-            return pre_dispatch_forward(node, hidden_states)
+            return pre_dispatch_forward(node, hidden_states, padding_mask=padding_mask)
 
     def submodule_mtp_postprocess_forward(node, hidden_states):
         hidden_states = layer._postprocess(hidden_states)

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -400,6 +400,9 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self._model_chunk_state.loss_mask = loss_mask
         self._model_chunk_state.packed_seq_params = packed_seq_params
         self._model_chunk_state.padding_mask = padding_mask
+        self._model_chunk_state.mtp_padding_mask = padding_mask
+        self._model_chunk_state.mtp_sequence_roll_context = None
+        self._model_chunk_state.mtp_materialized_roll_rows = None
         self._model_chunk_state.extra_block_kwargs = extra_block_kwargs
         self._model_chunk_state.runtime_gather_output = runtime_gather_output
         self._model_chunk_state.output_processor = output_processor
@@ -432,16 +435,26 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         if module is None:
             return
         plan_cls = self.LAYER_SCHEDULE_PLAN_CLASS or TransformerLayerSchedulePlan
-        num_layers = len(module.layers)
-        for layer_idx in range(num_layers):
+        is_mtp_module = module is getattr(self._model_chunk_state.model, "mtp", None)
+        is_repeated_mtp = bool(is_mtp_module and getattr(module, "mtp_use_repeated_layer", False))
+        if is_repeated_mtp:
+            assert len(module.layers) == 1
+            num_layers = int(getattr(module, "mtp_num_depths", 0) or module.config.mtp_num_layers)
+            physical_layer = module.layers[0]
+            scheduled_layers = tuple(
+                (physical_layer, physical_layer.layer_number + logical_index)
+                for logical_index in range(num_layers)
+            )
+        else:
+            num_layers = len(module.layers)
+            scheduled_layers = tuple(
+                (layer, layer.layer_number if is_mtp_module else None) for layer in module.layers
+            )
+        for layer_idx, (layer, mtp_absolute_depth) in enumerate(scheduled_layers):
             extra_args = self._extra_args_for_layer(module, layer_idx, num_layers)
+            extra_args["mtp_absolute_depth"] = mtp_absolute_depth
             layer_plan = plan_cls(
-                module.layers[layer_idx],
-                self.event,
-                self.state,
-                comp_stream,
-                comm_stream,
-                extra_args,
+                layer, self.event, self.state, comp_stream, comm_stream, extra_args
             )
             self._transformer_layers.append(layer_plan)
 
@@ -488,6 +501,8 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
     def release_state(self):
         """Release reference, this helps avoid memory leak."""
+        self._model_chunk_state.mtp_sequence_roll_context = None
+        self._model_chunk_state.mtp_materialized_roll_rows = None
         self._model_chunk_state.model = None
         self.pre_process.model_chunk_state = None
         self.pre_process = None

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -204,12 +204,15 @@ class PostProcessNode(ScheduleNode):
             mtp_in_postprocess=False,
             loss_mask=self.chunk_state.loss_mask,
             attention_mask=self.chunk_state.attention_mask,
+            padding_mask=self.chunk_state.padding_mask,
+            mtp_padding_mask=getattr(self.chunk_state, "mtp_padding_mask", None),
             packed_seq_params=self.chunk_state.packed_seq_params,
             sequence_len_offset=self.chunk_state.sequence_len_offset,
             runtime_gather_output=self.chunk_state.runtime_gather_output,
             extra_block_kwargs=self.chunk_state.extra_block_kwargs,
             output_processor=self.chunk_state.output_processor,
             output_processor_context=self.chunk_state.output_processor_context,
+            sequence_roll_context=getattr(self.chunk_state, "mtp_sequence_roll_context", None),
         )
 
         # combined-1F1B currently expects fp32 loss output.
@@ -260,6 +263,7 @@ class TransformerLayerNode(ScheduleNode):
         self.detached = tuple()
         self.before_detached = tuple()
         self.is_mtp = extra_args.get("is_mtp", False)
+        self.mtp_absolute_depth = extra_args.get("mtp_absolute_depth")
         self.post_wgrad_grad_acc_hooks = None
 
         self.is_first_layer = extra_args.get("is_first_layer", False)

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+from functools import partial
 from typing import Optional
 
 import torch
@@ -50,6 +51,13 @@ def build_transformer_layer_callables(layer: TransformerLayer):
           (keys: "pre_dispatch_computation", "mlp").
     """
 
+    # Repeated MTP builds one callable set per logical depth while sharing the
+    # same physical TransformerLayer. Keep the delayed-wgrad wrapper owned by
+    # this callable invocation instead of reading the layer's mutable attribute
+    # after a later logical depth has replaced it.
+    layer.init_backward_dw_wrapper()
+    backward_dw_wrapper = layer.backward_dw_wrapper
+
     is_moe = isinstance(layer.mlp, MoELayer)
     enable_deepep = (
         layer.config.moe_token_dispatcher_type == "flex"
@@ -78,7 +86,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             and hasattr(layer, 'cuda_graphs')
             and layer.cuda_graphs
         ):
-            layer.set_te_cuda_graph_backward_dw_wrapper()
+            backward_dw_wrapper.set_graphed_backward_dw_callable(
+                partial(layer._te_cuda_graph_backward_dw_graph, layer.current_microbatch)
+            )
             forward_func = layer._te_cuda_graph_replay
         else:
             # wrapper function that keeps consistent api with cuda graph replay
@@ -277,8 +287,6 @@ def build_transformer_layer_callables(layer: TransformerLayer):
     mlp_func = submodule_moe_forward if is_moe else mlp_wrapper
     combine_func = submodule_combine_forward if is_moe else raise_not_implemented
 
-    layer.init_backward_dw_wrapper()
-
     forward_funcs = [pre_dispatch_func, dispatch_func, mlp_func, combine_func, None]
-    backward_dw = {"pre_dispatch_computation": layer.backward_dw_wrapper, "mlp": layer.mlp}
+    backward_dw = {"pre_dispatch_computation": backward_dw_wrapper, "mlp": layer.mlp}
     return forward_funcs, backward_dw

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -64,7 +64,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         and layer.config.moe_flex_dispatcher_backend == "ncclep"
     )
 
-    def submodule_pre_dispatch_forward(node: ScheduleNode, hidden_states: torch.Tensor):
+    def submodule_pre_dispatch_forward(
+        node: ScheduleNode, hidden_states: torch.Tensor, padding_mask: Optional[Tensor] = None
+    ):
         """
         Performs the same attention forward logic as GPTModel and the forward pass for
         computations between attention and dispatch:
@@ -88,6 +90,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 rotary_pos_sin: Optional[Tensor] = None,
                 packed_seq_params: Optional[PackedSeqParams] = None,
                 sequence_len_offset: Optional[Tensor] = None,
+                padding_mask: Optional[Tensor] = None,
             ):
                 hidden_states, _ = layer._forward_attention(
                     hidden_states=hidden_states,
@@ -123,13 +126,15 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                     pre_mlp_layernorm_output, hidden_states = pre_mlp_layernorm_output
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)
-                probs, routing_map = layer.mlp.route(pre_mlp_layernorm_output)
+                probs, routing_map = layer.mlp.route(
+                    pre_mlp_layernorm_output, padding_mask=padding_mask
+                )
                 local_tokens, probs = layer.mlp.preprocess(
                     pre_mlp_layernorm_output, probs, routing_map
                 )
                 return hidden_states, local_tokens, probs, shared_expert_output
 
-        hidden_states, local_tokens, probs, shared_expert_output = forward_func(
+        forward_kwargs = dict(
             hidden_states=hidden_states,
             attention_mask=node.chunk_state.attention_mask,
             rotary_pos_emb=node.chunk_state.rotary_pos_emb,
@@ -138,6 +143,12 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             packed_seq_params=node.chunk_state.packed_seq_params,
             sequence_len_offset=node.chunk_state.sequence_len_offset,
         )
+        effective_padding_mask = (
+            padding_mask if padding_mask is not None else node.chunk_state.padding_mask
+        )
+        if is_moe and effective_padding_mask is not None:
+            forward_kwargs["padding_mask"] = effective_padding_mask
+        hidden_states, local_tokens, probs, shared_expert_output = forward_func(**forward_kwargs)
         if not isinstance(layer.mlp, MoELayer):
             return hidden_states
 

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -21,7 +21,7 @@ from megatron.core.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
 from megatron.core.models.common.language_module.language_module import LanguageModule
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -31,6 +31,10 @@ from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 from megatron.core.transformer.enums import InferenceCudaGraphScope, ModelType
 from megatron.core.transformer.module import GraphableMegatronModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     mtp_on_this_rank,
@@ -603,6 +607,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             self.preprocess_for_paged_stash()
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
+        mtp_padding_mask = padding_mask
 
         preproc_output = self._preprocess(
             input_ids=input_ids,
@@ -652,6 +657,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             decoder_input=decoder_input,
             attention_mask=attention_mask,
             padding_mask=padding_mask,
+            mtp_padding_mask=mtp_padding_mask,
             inference_params=inference_params,
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
@@ -676,6 +682,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         decoder_input=None,
         attention_mask=None,
         padding_mask=None,
+        mtp_padding_mask=None,
         inference_params=None,
         packed_seq_params=None,
         sequence_len_offset=None,
@@ -684,6 +691,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         inference_context=None,
         output_processor=None,
         output_processor_context=None,
+        sequence_roll_context=None,
     ):
         """Postprocesses decoder hidden states to generate logits or compute loss.
 
@@ -704,6 +712,48 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
             and inference_context.num_speculative_tokens > 0
         )
 
+        mtp_cp_group = None
+        if (
+            self.config.mtp_num_layers
+            and (mtp_in_postprocess or self.post_process)
+            and not (in_inference_mode or is_spec_decode)
+        ):
+            mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
+            if sequence_roll_context is None:
+                reference = input_ids if input_ids is not None else labels
+                sequence_roll_context = prepare_mtp_sequence_roll_context(
+                    reference, mtp_cp_group, packed_seq_params
+                )
+                if sequence_roll_context is not None:
+                    fields = []
+                    input_source = (
+                        input_ids
+                        if mtp_in_postprocess or (self.post_process and labels is None)
+                        else None
+                    )
+                    if input_source is not None:
+                        fields.append(MTPSequenceRollField("input_ids", input_source, -1, 0, 0))
+                    if (
+                        mtp_in_postprocess
+                        and position_ids is not None
+                        and getattr(self.embedding, "add_position_embedding", True)
+                    ):
+                        fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+                    if self.post_process and labels is not None:
+                        fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+                    if self.post_process and loss_mask is not None:
+                        fields.append(MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0))
+                    if mtp_in_postprocess and mtp_padding_mask is not None:
+                        fields.append(
+                            MTPSequenceRollField("padding_mask", mtp_padding_mask, -1, 0, True)
+                        )
+                    max_offset = self.config.mtp_num_layers + int(
+                        self.post_process and labels is None
+                    )
+                    sequence_roll_context = sequence_roll_context.prepare_fields(
+                        fields, max_offset=max_offset
+                    )
+
         # logits and loss
         output_weight = None
         if self.share_embeddings_and_output_weights:
@@ -719,6 +769,8 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
                 packed_seq_params=packed_seq_params,
+                sequence_roll_context=sequence_roll_context,
+                sequence_roll_padding_mask=mtp_padding_mask,
                 sequence_len_offset=sequence_len_offset,
                 padding_mask=padding_mask,
                 embedding=self.embedding,
@@ -753,11 +805,12 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     is_training=self.training,
                     compute_language_model_loss=self.compute_language_model_loss,
                     config=self.config,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=mtp_cp_group,
                     tp_group=self.tp_group,
                     packed_seq_params=packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
+                    sequence_roll_context=sequence_roll_context,
                 )
         sequence_parallel_override = False
 

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -14,7 +14,7 @@ from megatron.core.models.common.embeddings.language_model_embedding import Lang
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
 from megatron.core.models.common.language_module.language_module import LanguageModule
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -25,6 +25,10 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.enums import InferenceCudaGraphScope, ModelType
 from megatron.core.transformer.module import GraphableMegatronModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     mtp_on_this_rank,
@@ -551,6 +555,41 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             and inference_context.num_speculative_tokens > 0
         )
 
+        mtp_cp_group = None
+        sequence_roll_context = None
+        if (
+            self.config.mtp_num_layers
+            and self.mtp_process
+            and compute_mtp_loss
+            and not (in_inference_mode or is_spec_decode)
+        ):
+            mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
+            reference = input_ids if input_ids is not None else labels
+            sequence_roll_context = prepare_mtp_sequence_roll_context(
+                reference, mtp_cp_group, packed_seq_params
+            )
+            if sequence_roll_context is not None:
+                fields = []
+                if input_ids is not None:
+                    fields.append(MTPSequenceRollField("input_ids", input_ids, -1, 0, 0))
+                if position_ids is not None and getattr(
+                    self.embedding, "add_position_embedding", True
+                ):
+                    fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+                if self.post_process and labels is not None:
+                    fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+                if self.post_process and loss_mask is not None:
+                    fields.append(MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0))
+                if padding_mask is not None:
+                    fields.append(MTPSequenceRollField("padding_mask", padding_mask, -1, 0, True))
+                if fields:
+                    max_offset = self.config.mtp_num_layers + int(
+                        self.post_process and labels is None
+                    )
+                    sequence_roll_context = sequence_roll_context.prepare_fields(
+                        fields, max_offset=max_offset
+                    )
+
         mtp_forward_ran = (
             self.mtp_process and not (in_inference_mode or is_spec_decode) and compute_mtp_loss
         )
@@ -563,6 +602,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 inference_params=inference_params,
                 rotary_pos_emb=rotary_pos_emb,
                 packed_seq_params=packed_seq_params,
+                sequence_roll_context=sequence_roll_context,
+                sequence_roll_padding_mask=padding_mask,
+                padding_mask=padding_mask,
                 embedding=self.embedding,
             )
 
@@ -598,11 +640,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     is_training=self.training,
                     compute_language_model_loss=self.compute_language_model_loss,
                     config=self.config,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=mtp_cp_group,
                     tp_group=self.tp_group,
                     packed_seq_params=packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
                     input_ids=input_ids,
+                    sequence_roll_context=sequence_roll_context,
                 )
         sequence_parallel_override = False
         if (

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal, Optional
 
 import torch
 import torch.distributed as dist
@@ -25,8 +26,17 @@ class PackedSeqParams:
     total_tokens: int = None
     seq_idx: Tensor = None
     tokens_per_sample: int = None
-    pad_between_seqs: bool = None
+    pad_between_seqs: Optional[bool] = None
+    cp_partition_mode: Literal["zigzag", "contiguous"] = "zigzag"
     cp_scatter_cache: object = None
+    # Host-side certificate produced by the packing scheduler. None leaves
+    # zigzag packed-CP MTP on its established roll path. Zero records that the
+    # scheduler inspected the layout but could not certify one-hop addressing;
+    # a positive value proves the minimum non-empty half-chunk size. The
+    # certificate is runtime transport metadata, not part of a graph signature.
+    zigzag_cp_min_chunk_size: Optional[int] = field(
+        default=None, compare=False, metadata={"cuda_graph_ignore": True}
+    )
 
     def __post_init__(self):
         """Pre-compute seq_idx for Mamba mixer CUDA graph compatibility.
@@ -41,6 +51,12 @@ class PackedSeqParams:
         cu_seqlens_q_padded[-1] == max_seqlen then this additional sequence index will not be
         included.
         """
+        if self.zigzag_cp_min_chunk_size is not None and (
+            isinstance(self.zigzag_cp_min_chunk_size, bool)
+            or not isinstance(self.zigzag_cp_min_chunk_size, int)
+        ):
+            raise TypeError("zigzag_cp_min_chunk_size must be a host int or None.")
+
         cu_seqlens = (
             self.cu_seqlens_q_padded if self.cu_seqlens_q_padded is not None else self.cu_seqlens_q
         )
@@ -67,3 +83,12 @@ class PackedSeqParams:
                 .to(torch.int32)
                 .unsqueeze(0)  # Add a batch dimension
             )
+
+
+def resolve_cp_group(
+    static_cp_group: dist.ProcessGroup, packed_seq_params: PackedSeqParams = None
+) -> dist.ProcessGroup:
+    """Return the dynamic CP group from packed_seq_params when available, else the static one."""
+    if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+        return packed_seq_params.cp_group
+    return static_cp_group

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1792,6 +1792,8 @@ class _CudaGraphRunner(torch.nn.Module):
 
             elif is_dataclass(ref.value):
                 for field in dataclasses.fields(ref.value):
+                    if field.metadata.get("cuda_graph_ignore", False):
+                        continue
                     check(
                         ArgMetadata(getattr(val.value, field.name)),
                         ArgMetadata(getattr(ref.value, field.name)),

--- a/megatron/core/transformer/mtp_sequence_roll.py
+++ b/megatron/core/transformer/mtp_sequence_roll.py
@@ -1,0 +1,1935 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
+
+_MTP_SEQUENCE_FIELD_FILL_VALUES = {
+    "input_ids": 0,
+    "position_ids": 0,
+    "labels": 0,
+    "loss_mask": 0,
+    "padding_mask": True,
+}
+
+
+# Shared field state and addressing.
+
+
+@dataclass(frozen=True)
+class MTPSequenceRollField:
+    """One immutable field descriptor for absolute sequence-roll access.
+
+    ``sequence_dim`` and ``batch_dim`` describe the logical row layout. All
+    remaining dimensions are payload dimensions and are preserved when a shifted
+    row is materialized. The context never modifies the source tensor; external
+    mutation is detected through the tensor version when available.
+    """
+
+    key: str
+    tensor: Tensor
+    sequence_dim: int
+    batch_dim: int
+    fill_value: Union[bool, int, float] = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.key, str) or not self.key:
+            raise ValueError("An MTP sequence-roll field key must be a non-empty string.")
+        if not isinstance(self.tensor, Tensor):
+            raise TypeError("An MTP sequence-roll field payload must be a tensor.")
+        if self.tensor.dim() < 2:
+            raise ValueError("An MTP sequence-roll field needs sequence and batch dimensions.")
+        sequence_dim = _normalize_mtp_sequence_roll_dim(
+            self.sequence_dim, self.tensor.dim(), name=f"{self.key}.sequence_dim"
+        )
+        batch_dim = _normalize_mtp_sequence_roll_dim(
+            self.batch_dim, self.tensor.dim(), name=f"{self.key}.batch_dim"
+        )
+        if sequence_dim == batch_dim:
+            raise ValueError(
+                f"MTP sequence-roll field {self.key!r} uses one dimension for sequence and batch."
+            )
+
+
+@dataclass(frozen=True)
+class MTPSequenceRollAddress:
+    """Canonical source-plus-halo address for one absolute roll offset.
+
+    Roll offset zero denotes the source row, and roll offset ``k`` denotes its
+    ``k``-th successor. A legacy cumulative ``roll_depth=d`` therefore consumes
+    absolute roll offset ``d + 1``.
+    """
+
+    source: Tensor
+    halo: Optional[Tensor]
+    row_indices: Tensor
+    valid_rows: Tensor
+
+
+@dataclass(frozen=True)
+class _PreparedMTPSequenceRollField:
+    """Canonical ``[sequence, batch, ...]`` field and layout restoration state."""
+
+    key: str
+    source: Tensor
+    source_id: int
+    source_version: Optional[int]
+    inverse_permutation: Tuple[int, ...]
+    halo: Optional[Tensor]
+    fill_value: Union[bool, int, float]
+    fill_tensor: Tensor
+
+    def restore(self, canonical: Tensor) -> Tensor:
+        """Restore a canonical sequence-roll tensor to its declared layout."""
+        return canonical.permute(self.inverse_permutation)
+
+
+def _normalize_mtp_sequence_roll_dim(dim: int, ndim: int, *, name: str) -> int:
+    """Normalize a field dimension while rejecting out-of-range indexing."""
+    if not isinstance(dim, int) or not -ndim <= dim < ndim:
+        raise ValueError(f"{name}={dim!r} is invalid for a {ndim}-dimensional tensor.")
+    return dim % ndim
+
+
+def _get_mtp_sequence_roll_source_version(tensor: Tensor) -> Optional[int]:
+    """Return the mutation version, or ``None`` for inference tensors."""
+    try:
+        return tensor._version
+    except RuntimeError:
+        # Inference tensors intentionally do not carry version counters. They
+        # may still be prepared, but a context cannot safely prove reuse.
+        return None
+
+
+def _canonicalize_mtp_sequence_roll_field(
+    field: MTPSequenceRollField, *, sequence_length: int, batch_size: int, device: torch.device
+) -> _PreparedMTPSequenceRollField:
+    """Validate one field and expose it as ``[sequence, batch, ...]``."""
+    sequence_dim = _normalize_mtp_sequence_roll_dim(
+        field.sequence_dim, field.tensor.dim(), name=f"{field.key}.sequence_dim"
+    )
+    batch_dim = _normalize_mtp_sequence_roll_dim(
+        field.batch_dim, field.tensor.dim(), name=f"{field.key}.batch_dim"
+    )
+    if sequence_dim == batch_dim:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} uses one dimension for sequence and batch."
+        )
+    permutation = (sequence_dim, batch_dim) + tuple(
+        dim for dim in range(field.tensor.dim()) if dim not in (sequence_dim, batch_dim)
+    )
+    inverse_permutation = tuple(permutation.index(dim) for dim in range(field.tensor.dim()))
+    source = field.tensor.permute(permutation)
+    if source.size(0) != sequence_length:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} has sequence length {source.size(0)}, "
+            f"expected {sequence_length}."
+        )
+    if source.size(1) != batch_size:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} has batch size {source.size(1)}, "
+            f"expected {batch_size}."
+        )
+    if source.device != device:
+        raise ValueError("All fields sharing an MTP sequence-roll context must use its device.")
+    return _PreparedMTPSequenceRollField(
+        key=field.key,
+        source=source,
+        source_id=id(field.tensor),
+        source_version=_get_mtp_sequence_roll_source_version(field.tensor),
+        inverse_permutation=inverse_permutation,
+        halo=None,
+        fill_value=field.fill_value,
+        fill_tensor=field.tensor.new_full((), field.fill_value),
+    )
+
+
+def _validate_mtp_sequence_roll_fields(
+    fields: Sequence[MTPSequenceRollField],
+    *,
+    sequence_length: int,
+    batch_size: int,
+    device: torch.device,
+) -> Tuple[_PreparedMTPSequenceRollField, ...]:
+    """Validate a complete replacement field group before any communication."""
+    fields = tuple(fields)
+    keys = [field.key for field in fields]
+    if len(set(keys)) != len(keys):
+        raise ValueError("Each MTP sequence-roll field key may be prepared only once.")
+    return tuple(
+        _canonicalize_mtp_sequence_roll_field(
+            field, sequence_length=sequence_length, batch_size=batch_size, device=device
+        )
+        for field in fields
+    )
+
+
+def _get_mtp_sequence_roll_field(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...], key: str
+) -> _PreparedMTPSequenceRollField:
+    """Return one prepared field or raise a precise lookup error."""
+    for prepared in prepared_fields:
+        if prepared.key == key:
+            return prepared
+    raise KeyError(f"MTP sequence-roll field {key!r} has not been prepared.")
+
+
+def _mtp_sequence_roll_field_matches_source(
+    prepared: _PreparedMTPSequenceRollField, field: MTPSequenceRollField
+) -> bool:
+    """Return whether a prepared field still describes this exact tensor source."""
+    source_version = _get_mtp_sequence_roll_source_version(field.tensor)
+    if (
+        prepared.key != field.key
+        or prepared.source_id != id(field.tensor)
+        or prepared.source_version is None
+        or source_version is None
+        or prepared.source_version != source_version
+        or prepared.fill_value != field.fill_value
+    ):
+        return False
+    try:
+        candidate = _canonicalize_mtp_sequence_roll_field(
+            field,
+            sequence_length=prepared.source.size(0),
+            batch_size=prepared.source.size(1),
+            device=prepared.source.device,
+        )
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    try:
+        return (
+            candidate.inverse_permutation == prepared.inverse_permutation
+            and candidate.source.shape == prepared.source.shape
+            and candidate.source.stride() == prepared.source.stride()
+            and candidate.source.storage_offset() == prepared.source.storage_offset()
+            and candidate.source.data_ptr() == prepared.source.data_ptr()
+            and candidate.source.dtype == prepared.source.dtype
+            and candidate.source.layout == prepared.source.layout
+        )
+    except RuntimeError:
+        return False
+
+
+def _materialize_mtp_sequence_roll_rows(
+    prepared: _PreparedMTPSequenceRollField, row_indices: Tensor, valid_rows: Tensor
+) -> Tensor:
+    """Materialize canonical rows through safe indices, then apply boundary fills."""
+    source = prepared.source
+    sequence_length, batch_size = source.shape[:2]
+    payload_shape = source.shape[2:]
+    output_shape = tuple(row_indices.shape) + tuple(payload_shape)
+    if row_indices.numel() == 0:
+        return source.new_empty(output_shape)
+
+    flat_source = source.reshape(sequence_length * batch_size, *payload_shape)
+    if prepared.halo is not None:
+        halo = prepared.halo
+        flat_halo = halo.reshape(-1, *payload_shape)
+        flat_source = torch.cat((flat_source, flat_halo), dim=0)
+    gathered = flat_source.index_select(0, row_indices.reshape(-1)).reshape(output_shape)
+    expanded_valid = valid_rows.reshape(tuple(valid_rows.shape) + (1,) * len(payload_shape))
+    return torch.where(expanded_valid, gathered, prepared.fill_tensor)
+
+
+# Layout-neutral context API.
+
+
+class MTPSequenceRollContext:
+    """Base type for layout-specific state shared by MTP sequence rolls.
+
+    The public MTP call chain passes one context without knowing the physical
+    sequence layout. Concrete subtypes own their row geometry, halo transport,
+    and prepared field state while exposing the same roll and addressing API.
+    """
+
+    @property
+    def keys(self) -> Tuple[str, ...]:
+        """Return prepared field keys in their declaration order."""
+        prepared_fields = getattr(self, "_prepared_fields", ())
+        return tuple(prepared.key for prepared in prepared_fields)
+
+    @property
+    def max_offset(self) -> int:
+        """Return the largest prepared roll offset; offset zero denotes the source row."""
+        return getattr(self, "_prepared_max_offset", 0)
+
+    def is_prepared_for_fields(self, fields: Sequence[MTPSequenceRollField]) -> bool:
+        """Return whether prepared payloads still correspond to the current sources."""
+        fields = tuple(fields)
+        if not fields or len({field.key for field in fields}) != len(fields):
+            return False
+        prepared_fields = getattr(self, "_prepared_fields", ())
+        for field in fields:
+            try:
+                prepared = _get_mtp_sequence_roll_field(prepared_fields, field.key)
+            except KeyError:
+                return False
+            if not _mtp_sequence_roll_field_matches_source(prepared, field):
+                return False
+        return True
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare absolute shifted rows when this layout supports them.
+
+        The base implementation is the atomic fallback: unsupported layout
+        contexts remain unchanged and retain their established roll behavior.
+        """
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        return self
+
+    def _validate_prepared_offset(self, offset: int) -> None:
+        if not isinstance(offset, int):
+            raise TypeError("MTP sequence-roll offset must be an integer.")
+        if not 0 <= offset <= self.max_offset:
+            raise ValueError(
+                f"MTP sequence-roll offset {offset} is outside [0, {self.max_offset}]."
+            )
+
+    def address(self, key: str, offset: int) -> MTPSequenceRollAddress:
+        """Return canonical direct-address metadata for one absolute offset."""
+        self._validate_prepared_offset(offset)
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        row_indices = getattr(self, "_roll_row_indices", None)
+        valid_rows = getattr(self, "_roll_valid_rows", None)
+        if row_indices is None or valid_rows is None:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        return MTPSequenceRollAddress(
+            source=prepared.source,
+            halo=prepared.halo,
+            row_indices=row_indices[offset],
+            valid_rows=valid_rows[offset],
+        )
+
+    def materialize(self, key: str, offset: int) -> Tensor:
+        """Materialize one absolute roll offset in the field's declared layout."""
+        self._validate_prepared_offset(offset)
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        if offset == 0:
+            return prepared.restore(prepared.source)
+        address = self.address(key, offset)
+        canonical = _materialize_mtp_sequence_roll_rows(
+            prepared, address.row_indices, address.valid_rows
+        )
+        return prepared.restore(canonical)
+
+    def materialize_all(self, key: str) -> Tuple[Tensor, ...]:
+        """Materialize absolute offsets ``1..max_offset`` with one indexed gather."""
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        if self.max_offset <= 0:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        row_indices = getattr(self, "_roll_row_indices", None)
+        valid_rows = getattr(self, "_roll_valid_rows", None)
+        if row_indices is None or valid_rows is None:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        canonical = _materialize_mtp_sequence_roll_rows(prepared, row_indices[1:], valid_rows[1:])
+        return tuple(prepared.restore(canonical[offset]) for offset in range(self.max_offset))
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Return a context with successor rows prepared for repeated MTP rolls.
+
+        Layout-specific contexts implement the communication and boundary rules.
+        Keeping this operation on the context lets model entry points remain layout
+        neutral while each concrete subtype uses its own transport strategy.
+        Optional fields that are not consumed on this pipeline stage can be omitted.
+
+        Args:
+            width: Number of successor rows required by repeated MTP rolls.
+            input_ids: Local token IDs used by MTP embedding or RL label derivation.
+            position_ids: Local learned-absolute position IDs, when rolled by MTP.
+            labels: Local SFT labels consumed by MTP loss.
+            loss_mask: Local MTP loss mask.
+            padding_mask: Local padding flags rolled by MTP embedding.
+
+        Returns:
+            A context containing the prepared layout-specific halo payload.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support halo prefetch.")
+
+
+# Local CP1 layout.
+
+
+@dataclass(frozen=True, eq=False)
+class LocalRollContext(MTPSequenceRollContext):
+    """Absolute sequence-roll geometry for two-dimensional CP1 sequence fields.
+
+    This subtype adds no communication. A bare context preserves the existing CP1
+    fallback; consumers that prepare fields use absolute roll offsets. Packed
+    boundaries are shared by every batch row; an omitted physical tail is treated
+    as one final sequence, matching the established roll helper.
+    """
+
+    sequence_length: int
+    batch_size: int
+    device: torch.device
+    packed_cu_seqlens: Optional[Tensor] = None
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Return this local context; CP1 has no remote successor halos."""
+        if width <= 0:
+            raise ValueError("Local MTP sequence-roll width must be positive.")
+        return self
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Return an immutable sibling containing local absolute shifted rows."""
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+        if not prepared_fields:
+            return LocalRollContext(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                device=self.device,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+        )
+        if reuse_geometry:
+            prepared_max_offset = self._prepared_max_offset
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+        else:
+            prepared_max_offset = max_offset
+            row_indices, valid_rows = _build_local_roll_geometry(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                max_offset=prepared_max_offset,
+                device=self.device,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        return LocalRollContext(
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+            packed_cu_seqlens=self.packed_cu_seqlens,
+            _prepared_fields=prepared_fields,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+        )
+
+
+def _build_local_roll_geometry(
+    *,
+    sequence_length: int,
+    batch_size: int,
+    max_offset: int,
+    device: torch.device,
+    packed_cu_seqlens: Optional[Tensor],
+) -> Tuple[Tensor, Tensor]:
+    """Build compact int32 row maps for a local CP1 microbatch."""
+    rows = torch.arange(sequence_length, device=device, dtype=torch.long)
+    offsets = torch.arange(max_offset + 1, device=device, dtype=torch.long).unsqueeze(1)
+    targets = rows.unsqueeze(0) + offsets
+    valid = targets < sequence_length
+    if packed_cu_seqlens is not None and sequence_length > 0:
+        cu = packed_cu_seqlens.to(device=device, dtype=torch.long)
+        # Appending the physical capacity also models the legal implicit tail;
+        # a duplicate final endpoint is harmless with right-biased bucketization.
+        boundaries = torch.cat((cu[1:], cu.new_full((1,), sequence_length)))
+        sequence_slots = torch.bucketize(rows, boundaries, right=True).clamp(
+            max=max(boundaries.numel() - 1, 0)
+        )
+        sequence_ends = boundaries.index_select(0, sequence_slots)
+        valid &= targets < sequence_ends.unsqueeze(0)
+
+    safe_targets = targets.clamp(min=0, max=max(sequence_length - 1, 0))
+    batches = torch.arange(batch_size, device=device, dtype=torch.long)
+    row_indices = safe_targets.unsqueeze(-1) * batch_size + batches
+    row_indices = row_indices.to(torch.int32).contiguous()
+    valid_rows = valid.unsqueeze(-1).expand(-1, -1, batch_size).contiguous()
+    return row_indices, valid_rows
+
+
+# Contiguous packed-CP layout.
+
+
+@dataclass(frozen=True)
+class ContiguousPackedSeqRollPlan:
+    """Per-microbatch metadata for one-token contiguous-CP packed-sequence rolls.
+
+    A one-token left roll is local except at the end of a CP shard, where the
+    replacement value may be the first element owned by the next CP rank. Packed
+    sequences add another constraint: positions at a physical packed-sequence
+    boundary must receive a field-specific fill value instead of a value from the
+    following sequence.
+
+    The CP neighbors and boundary mask depend only on the physical packed layout,
+    not on tensor dtype or payload. One context can therefore reuse this plan for
+    input IDs, learned-absolute position IDs, padding masks, labels, and loss masks
+    throughout a microbatch. When prefetched halos are present, the neighbor ranks
+    remain recorded for validation and fallback but no rolling P2P is issued.
+
+    Reuse is valid only for tensors on the recorded device, with the recorded local
+    sequence length, using the recorded CP group. Do not cache a plan across
+    microbatches unless those layout invariants are guaranteed to remain unchanged.
+
+    Attributes:
+        invalid_next: One-dimensional boolean mask over the local sequence axis.
+            True means that the corresponding global position has no immediate
+            physical successor in the same packed sequence. Repeated local rolls
+            propagate fills at internal boundaries; prefetched tail halos are
+            separately sanitized for every prediction depth.
+        sequence_length: Length of the local contiguous CP shard.
+        device: Device on which the boundary mask and compatible payload tensors
+            reside.
+        cp_group: Effective CP process group for this microbatch. This may be the
+            dynamic group injected into PackedSeqParams rather than the model's
+            statically configured CP group.
+        recv_rank: Global rank of the next contiguous CP shard, used by the P2P
+            fallback when no prefetched halo is supplied. None on the last CP rank.
+        send_rank: Global rank of the previous contiguous CP shard, used by the P2P
+            fallback. None on the first CP rank.
+        has_sequences: Whether de-duplicated cumulative sequence lengths describe at
+            least one physical packed sequence.
+        right_halo_valid_count: Number of successor rows after the local final row
+            that remain in the same physical packed sequence. This device scalar
+            sanitizes an arbitrary small halo width without rebuilding packed
+            metadata.
+    """
+
+    invalid_next: Tensor
+    sequence_length: int
+    device: torch.device
+    cp_group: torch.distributed.ProcessGroup
+    recv_rank: Optional[int]
+    send_rank: Optional[int]
+    has_sequences: bool
+    right_halo_valid_count: Tensor
+
+
+def _get_packed_roll_cu_seqlens(packed_seq_params: PackedSeqParams) -> Tensor:
+    """Return the physical packed-sequence boundaries used by MTP rolling."""
+    cu_seqlens = (
+        packed_seq_params.cu_seqlens_q_padded
+        if getattr(packed_seq_params, 'cu_seqlens_q_padded', None) is not None
+        else packed_seq_params.cu_seqlens_q
+    )
+    assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
+    return cu_seqlens
+
+
+def _get_packed_seq_end_indices(
+    cu_seqlens: Tensor, device: torch.device, sequence_length: int
+) -> Tensor:
+    """Return the ends of explicit packed sequences and any implicit tail.
+
+    PackedSeqParams permits the physical tensor to be longer than the final
+    cumulative sequence length. In that case, the remaining buffer is an
+    implicit tail sequence whose final element must also be filled after the
+    full-buffer roll. Duplicate end indices are safe because index_fill_ is
+    idempotent.
+    """
+    sequence_end_indices = cu_seqlens[1:].to(device=device, dtype=torch.long) - 1
+    if sequence_length == 0:
+        return sequence_end_indices.new_empty((0,))
+    implicit_tail_end = sequence_end_indices.new_full((1,), sequence_length - 1)
+    return torch.cat((sequence_end_indices, implicit_tail_end))
+
+
+def _build_contiguous_packed_seq_roll_plan(
+    tensor: Tensor, dims: int, cu_seqlens: Tensor, cp_group: torch.distributed.ProcessGroup
+) -> ContiguousPackedSeqRollPlan:
+    """Build reusable boundary and neighbor metadata for a contiguous-CP shard."""
+    assert (
+        dims == -1 or dims == tensor.dim() - 1
+    ), "Packed sequence roll only supports the last dimension."
+
+    local_seq_len = tensor.size(dims)
+    cp_size = cp_group.size()
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+
+    cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
+    if cu.numel() > 1:
+        # Static packed metadata can repeat its final boundary to pad the number
+        # of cu_seqlens entries. Remove duplicates before assigning positions to
+        # packed intervals so every retained interval has a nonzero length.
+        nonduplicate_boundaries = torch.ones(cu.numel(), device=cu.device, dtype=torch.bool)
+        nonduplicate_boundaries[1:] = cu[1:] != cu[:-1]
+        cu = cu[nonduplicate_boundaries]
+
+    has_sequences = cu.numel() > 1
+    if local_seq_len == 0 or not has_sequences:
+        invalid_next = torch.ones(local_seq_len, device=tensor.device, dtype=torch.bool)
+        right_halo_valid_count = torch.zeros((), device=tensor.device, dtype=cu.dtype)
+    else:
+        global_start = local_rank * local_seq_len
+        global_positions = global_start + torch.arange(
+            local_seq_len, device=tensor.device, dtype=cu.dtype
+        )
+        seq_idx = torch.bucketize(global_positions, cu[1:], right=True).clamp(max=cu.numel() - 2)
+        seq_ends = cu[1:][seq_idx]
+        # This deliberately stays true at the local shard's final position when
+        # the same packed sequence continues on the next CP rank. A prefetched
+        # halo or grouped P2P supplies that successor; only physical ends are masked.
+        valid_next = (global_positions < cu[-1]) & (global_positions + 1 < seq_ends)
+        invalid_next = ~valid_next
+
+        # Successor rows are valid only until the physical sequence containing
+        # this shard's final row ends. Keeping the count as a device scalar avoids
+        # a host synchronization and lets halo preparation build any small width.
+        local_tail = global_positions[-1]
+        right_halo_valid_count = torch.where(
+            local_tail < cu[-1],
+            (seq_ends[-1] - local_tail - 1).clamp_min(0),
+            torch.zeros((), device=tensor.device, dtype=cu.dtype),
+        )
+
+    # A left roll receives from the next contiguous shard and sends the first
+    # local element to the previous shard. Store global ranks because PyTorch's
+    # P2P API interprets peer ranks globally even when a process group is passed.
+    return ContiguousPackedSeqRollPlan(
+        invalid_next=invalid_next,
+        sequence_length=local_seq_len,
+        device=tensor.device,
+        cp_group=cp_group,
+        recv_rank=global_ranks[local_rank + 1] if local_rank < cp_size - 1 else None,
+        send_rank=global_ranks[local_rank - 1] if local_rank > 0 else None,
+        has_sequences=has_sequences,
+        right_halo_valid_count=right_halo_valid_count,
+    )
+
+
+class MTPSequenceRollHalos:
+    """Base type for layout-specific successor rows prepared before MTP.
+
+    Halo storage is owned by the corresponding roll context and never travels through
+    the model's public forward signature. Concrete layouts can choose how to acquire
+    and represent their successor rows without changing GPT, Hybrid, or MTP layers.
+    """
+
+
+@dataclass(frozen=True)
+class ContiguousPackedCPRollHalos(MTPSequenceRollHalos):
+    """Compact successor rows prefetched across contiguous CP ranks.
+
+    Each tensor stores only a small right halo, never a view of the full packed
+    microbatch. Halo index zero is the immediate successor of this CP rank's local
+    final row; halo index d is used by the d-th repeated left roll. Values that cross
+    a physical packed-sequence boundary are replaced with the field's normal
+    boundary fill value once, before MTP starts.
+
+    The explicit optional fields keep this dataclass friendly to CUDA-graph input
+    traversal and make the supported payload contract visible. A pipeline stage
+    may omit fields it does not own.
+
+    Attributes:
+        input_ids: Successor token IDs (the data batch calls this field 'tokens').
+        position_ids: Successor learned-absolute position IDs.
+        labels: Successor SFT labels.
+        loss_mask: Successor loss-mask values.
+        padding_mask: Successor padding flags, with True marking padding.
+    """
+
+    input_ids: Optional[Tensor] = None
+    position_ids: Optional[Tensor] = None
+    labels: Optional[Tensor] = None
+    loss_mask: Optional[Tensor] = None
+    padding_mask: Optional[Tensor] = None
+
+    def __post_init__(self):
+        present_halos = [
+            halo
+            for halo in (
+                self.input_ids,
+                self.position_ids,
+                self.labels,
+                self.loss_mask,
+                self.padding_mask,
+            )
+            if halo is not None
+        ]
+        if not present_halos:
+            raise ValueError("A contiguous packed-CP halo payload must contain at least one field.")
+        widths = {halo.size(-1) for halo in present_halos}
+        if len(widths) != 1:
+            raise ValueError("All contiguous packed-CP halo fields must have the same width.")
+
+    @property
+    def width(self) -> int:
+        """Return the number of prefetched successor rows."""
+        for halo in (
+            self.input_ids,
+            self.position_ids,
+            self.labels,
+            self.loss_mask,
+            self.padding_mask,
+        ):
+            if halo is not None:
+                return halo.size(-1)
+        raise AssertionError("ContiguousPackedCPRollHalos requires at least one field.")
+
+    def get(self, sequence_field: str) -> Optional[Tensor]:
+        """Return the halo for a canonical MTP sequence field."""
+        if sequence_field not in {
+            "input_ids",
+            "position_ids",
+            "labels",
+            "loss_mask",
+            "padding_mask",
+        }:
+            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
+        return getattr(self, sequence_field)
+
+
+@dataclass(frozen=True, eq=False)
+class ContiguousPackedCPRollContext(MTPSequenceRollContext):
+    """State reused by all contiguous packed-CP rolls in one microbatch.
+
+    Attributes:
+        plan: Boundary and CP-neighbor metadata shared by every field and depth.
+        halos: Optional compact successor rows prefetched immediately before MTP.
+            None retains grouped P2P as a correctness fallback for direct callers.
+    """
+
+    plan: ContiguousPackedSeqRollPlan
+    halos: Optional[ContiguousPackedCPRollHalos] = None
+    batch_size: int = 1
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare one field group with a single one-hop grouped P2P exchange.
+
+        A width larger than the local shard would need more than one neighbor hop;
+        that legal but unsupported case returns this context unchanged so callers
+        can atomically retain the established roll fallback.
+        """
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.plan.sequence_length,
+            batch_size=self.batch_size,
+            device=self.plan.device,
+        )
+        if not prepared_fields:
+            return ContiguousPackedCPRollContext(
+                plan=self.plan, halos=self.halos, batch_size=self.batch_size
+            )
+        if any(prepared.source.requires_grad for prepared in prepared_fields):
+            raise ValueError(
+                "Contiguous-CP sequence-roll preparation does not support fields that "
+                "require gradients."
+            )
+        if max_offset > self.plan.sequence_length:
+            return self
+
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+        )
+        if reuse_geometry:
+            prepared_max_offset = self._prepared_max_offset
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+        else:
+            prepared_max_offset = max_offset
+            row_indices, valid_rows = _build_contiguous_packed_cp_roll_geometry(
+                self.plan, batch_size=self.batch_size, max_offset=prepared_max_offset
+            )
+        halos = _exchange_contiguous_packed_cp_roll_field_halos(
+            prepared_fields, max_offset=prepared_max_offset, plan=self.plan
+        )
+        prepared_with_halos = tuple(
+            _PreparedMTPSequenceRollField(
+                key=prepared.key,
+                source=prepared.source,
+                source_id=prepared.source_id,
+                source_version=prepared.source_version,
+                inverse_permutation=prepared.inverse_permutation,
+                halo=halos[prepared.key],
+                fill_value=prepared.fill_value,
+                fill_tensor=prepared.fill_tensor,
+            )
+            for prepared in prepared_fields
+        )
+        return ContiguousPackedCPRollContext(
+            plan=self.plan,
+            halos=self.halos,
+            batch_size=self.batch_size,
+            _prepared_fields=prepared_with_halos,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+        )
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Prefetch contiguous-CP successor rows in one grouped P2P operation.
+
+        The returned context is immutable and shares this context's roll plan. The
+        payload contains only width rows per present field, so it does not retain or
+        copy a full packed microbatch. Missing optional fields keep their later
+        grouped roll calls on the communication fallback.
+
+        Args:
+            width: Number of successor rows required by repeated MTP rolls.
+            input_ids: Local token IDs used by MTP embedding or RL label derivation.
+            position_ids: Local learned-absolute position IDs, when rolled by MTP.
+            labels: Local SFT labels consumed by MTP loss.
+            loss_mask: Local MTP loss mask.
+            padding_mask: Local padding flags rolled by MTP embedding.
+
+        Returns:
+            A new context with compact halos, or this context when prefetch is not
+            applicable to the local shard or no fields are present.
+        """
+        if self.halos is not None:
+            raise ValueError("Contiguous packed-CP halos have already been prefetched.")
+        if width <= 0:
+            raise ValueError("Contiguous packed-CP halo width must be positive.")
+        if width > self.plan.sequence_length:
+            # One neighbor exchange cannot supply rows spanning multiple CP shards.
+            # Keep the established per-roll grouped P2P path for these tiny shards.
+            return self
+
+        tensors_by_field = {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "padding_mask": padding_mask,
+        }
+        sequence_fields = []
+        present_tensors: List[Tensor] = []
+        for field, tensor in tensors_by_field.items():
+            if tensor is not None:
+                sequence_fields.append(field)
+                present_tensors.append(tensor)
+        if not sequence_fields:
+            return self
+
+        return ContiguousPackedCPRollContext(
+            plan=self.plan,
+            halos=_prefetch_contiguous_packed_cp_roll_halos(
+                tensors=present_tensors,
+                sequence_fields=sequence_fields,
+                fill_values=[_MTP_SEQUENCE_FIELD_FILL_VALUES[field] for field in sequence_fields],
+                width=width,
+                plan=self.plan,
+            ),
+            batch_size=self.batch_size,
+            _prepared_fields=self._prepared_fields,
+            _prepared_max_offset=self._prepared_max_offset,
+            _roll_row_indices=self._roll_row_indices,
+            _roll_valid_rows=self._roll_valid_rows,
+        )
+
+
+def _build_contiguous_packed_cp_roll_geometry(
+    plan: ContiguousPackedSeqRollPlan, *, batch_size: int, max_offset: int
+) -> Tuple[Tensor, Tensor]:
+    """Build one-hop absolute row maps from the existing contiguous roll plan."""
+    sequence_length = plan.sequence_length
+    rows = torch.arange(sequence_length, device=plan.device, dtype=torch.long)
+    offsets = torch.arange(max_offset + 1, device=plan.device, dtype=torch.long).unsqueeze(1)
+    targets = rows.unsqueeze(0) + offsets
+
+    # A target is valid only if every traversed local edge is valid. The compact
+    # right-halo count covers the remaining edges after the local final row.
+    invalid_prefix = torch.cat(
+        (
+            torch.zeros(1, device=plan.device, dtype=torch.int32),
+            plan.invalid_next.to(torch.int32).cumsum(0),
+        )
+    )
+    local_edge_end = targets.clamp(max=sequence_length)
+    crossed_invalid = invalid_prefix.index_select(0, local_edge_end.reshape(-1)).reshape(
+        targets.shape
+    ) - invalid_prefix[:-1].unsqueeze(0)
+    halo_rows = (targets - sequence_length).clamp_min(0)
+    halo_valid = (targets < sequence_length) | (halo_rows < plan.right_halo_valid_count)
+    valid = (crossed_invalid == 0) & halo_valid
+
+    addressed_rows = torch.where(targets < sequence_length, targets, sequence_length + halo_rows)
+    addressed_rows = addressed_rows.clamp(min=0, max=max(sequence_length + max_offset - 1, 0))
+    batches = torch.arange(batch_size, device=plan.device, dtype=torch.long)
+    row_indices = addressed_rows.unsqueeze(-1) * batch_size + batches
+    return (
+        row_indices.to(torch.int32).contiguous(),
+        valid.unsqueeze(-1).expand(-1, -1, batch_size).contiguous(),
+    )
+
+
+def _exchange_contiguous_packed_cp_roll_field_halos(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...],
+    *,
+    max_offset: int,
+    plan: ContiguousPackedSeqRollPlan,
+) -> dict[str, Tensor]:
+    """Acquire all generic field halos in one deterministic grouped P2P."""
+    # Sort only the transport order. The returned context preserves declaration
+    # order, while peers that supplied the same keys in a different order still
+    # match send and receive operations deterministically.
+    transport_fields = sorted(prepared_fields, key=lambda prepared: prepared.key)
+    halos = {
+        prepared.key: prepared.source.new_full(
+            (max_offset,) + tuple(prepared.source.shape[1:]), prepared.fill_value
+        )
+        for prepared in transport_fields
+    }
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+    if plan.has_sequences and plan.recv_rank is not None:
+        for prepared in transport_fields:
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    halos[prepared.key],
+                    plan.recv_rank,
+                    group=plan.cp_group,
+                )
+            )
+    if plan.has_sequences and plan.send_rank is not None:
+        for prepared in transport_fields:
+            send_buffer = prepared.source.narrow(0, 0, max_offset).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+    return halos
+
+
+def _prefetch_contiguous_packed_cp_roll_halos(
+    tensors: List[Tensor],
+    sequence_fields: List[str],
+    fill_values: List[Union[bool, int, float]],
+    width: int,
+    plan: ContiguousPackedSeqRollPlan,
+) -> ContiguousPackedCPRollHalos:
+    """Fetch compact right halos for contiguous packed CP in one grouped P2P.
+
+    Each rank sends the first width rows of every requested field to its
+    predecessor and receives the corresponding rows from its successor. Received
+    rows are sanitized once using the physical packed boundary that contains this
+    rank's local final row. Repeated MTP rolls can then consume halo offsets without
+    further communication.
+
+    Args:
+        tensors: Local MTP fields sharing the plan's sequence axis.
+        sequence_fields: Canonical names corresponding to tensors.
+        fill_values: Per-field physical-boundary fill values.
+        width: Number of successor rows required by all MTP prediction depths.
+        plan: Reusable contiguous packed-CP layout and neighbor metadata.
+
+    Returns:
+        Compact, independently allocated successor rows keyed by MTP field.
+
+    Raises:
+        ValueError: If the field metadata is inconsistent with the roll plan.
+    """
+    if width <= 0:
+        raise ValueError("Contiguous packed-CP halo width must be positive.")
+    if len(tensors) != len(sequence_fields) or len(tensors) != len(fill_values):
+        raise ValueError("Each halo tensor must have a canonical field and fill value.")
+    if len(set(sequence_fields)) != len(sequence_fields):
+        raise ValueError("Each contiguous packed-CP halo field may be prefetched only once.")
+    if width > plan.sequence_length:
+        raise ValueError(
+            f"Contiguous packed-CP halo width {width} exceeds local sequence length "
+            f"{plan.sequence_length}."
+        )
+
+    halos: List[Tensor] = []
+    for tensor, sequence_field, fill_value in zip(tensors, sequence_fields, fill_values):
+        if sequence_field not in _MTP_SEQUENCE_FIELD_FILL_VALUES:
+            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
+        expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
+        if fill_value != expected_fill_value:
+            raise ValueError(
+                f"Halo field {sequence_field} requires boundary fill value "
+                f"{expected_fill_value!r}, got {fill_value!r}."
+            )
+        if tensor.device != plan.device:
+            raise ValueError("All halo tensors sharing a roll plan must be on the same device.")
+        if tensor.size(-1) != plan.sequence_length:
+            raise ValueError(
+                "All halo tensors sharing a roll plan must have the same sequence length."
+            )
+
+        halo_shape = list(tensor.shape)
+        halo_shape[-1] = width
+        halos.append(tensor.new_full(halo_shape, fill_value))
+
+    # Retain contiguous send slices until every grouped work handle completes.
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+    if plan.has_sequences and plan.recv_rank is not None:
+        for halo in halos:
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv, halo, plan.recv_rank, group=plan.cp_group
+                )
+            )
+    if plan.has_sequences and plan.send_rank is not None:
+        for tensor in tensors:
+            send_buffer = tensor.narrow(-1, 0, width).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+
+    # Offset d is valid only when the local tail and its (d + 1)-th successor
+    # belong to the same physical packed sequence. Broadcasting this small mask
+    # sanitizes every field without retaining the full packed metadata.
+    invalid_halo = (
+        torch.arange(width, device=plan.device, dtype=plan.right_halo_valid_count.dtype)
+        >= plan.right_halo_valid_count
+    )
+    for halo, fill_value in zip(halos, fill_values):
+        halo.masked_fill_(invalid_halo, fill_value)
+
+    halo_by_field = dict(zip(sequence_fields, halos))
+    return ContiguousPackedCPRollHalos(
+        input_ids=halo_by_field.get("input_ids"),
+        position_ids=halo_by_field.get("position_ids"),
+        labels=halo_by_field.get("labels"),
+        loss_mask=halo_by_field.get("loss_mask"),
+        padding_mask=halo_by_field.get("padding_mask"),
+    )
+
+
+# Zigzag packed-CP layout.
+
+
+@dataclass(frozen=True)
+class _ZigzagPackedCPRollTransport:
+    """Compact prefix rows exchanged with the two physical zigzag neighbors."""
+
+    front_prefix_rows: Tensor
+    back_prefix_rows: Tensor
+    prefix_valid: Tensor
+
+
+@dataclass(frozen=True, eq=False)
+class ZigzagPackedCPRollContext(MTPSequenceRollContext):
+    """One-hop absolute rows for scheduler-certified zigzag packed CP.
+
+    This subtype extends the base sequence-roll interface while preserving the
+    established zigzag dispatcher as the fallback. A positive scheduler certificate
+    proves that every requested roll offset crosses at most one physical half-chunk.
+    If a consumer asks for a wider offset, field preparation leaves this context
+    bare and that consumer atomically uses the original cumulative-roll path.
+    """
+
+    sequence_length: int
+    batch_size: int
+    device: torch.device
+    cp_group: torch.distributed.ProcessGroup
+    packed_cu_seqlens: Tensor
+    min_chunk_size: int
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+    _roll_transport: Optional[_ZigzagPackedCPRollTransport] = None
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare one field group after validating its one-hop certificate."""
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+        if not prepared_fields:
+            return ZigzagPackedCPRollContext(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                device=self.device,
+                cp_group=self.cp_group,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+                min_chunk_size=self.min_chunk_size,
+            )
+        if any(prepared.source.requires_grad for prepared in prepared_fields):
+            raise ValueError(
+                "One-hop zigzag packed-CP sequence-roll preparation does not support "
+                "fields that require gradients."
+            )
+        if max_offset > self.min_chunk_size:
+            return self
+
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+            and self._roll_transport is not None
+        )
+        prepared_max_offset = self._prepared_max_offset if reuse_geometry else max_offset
+        if reuse_geometry:
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+            transport = self._roll_transport
+            assert transport is not None
+        else:
+            row_indices, valid_rows, transport = _build_zigzag_packed_cp_roll_geometry(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                max_offset=prepared_max_offset,
+                device=self.device,
+                cp_group=self.cp_group,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        halos = _exchange_zigzag_packed_cp_roll_field_halos(
+            prepared_fields, cp_group=self.cp_group, transport=transport
+        )
+        prepared_with_halos = tuple(
+            _PreparedMTPSequenceRollField(
+                key=prepared.key,
+                source=prepared.source,
+                source_id=prepared.source_id,
+                source_version=prepared.source_version,
+                inverse_permutation=prepared.inverse_permutation,
+                halo=halos[prepared.key],
+                fill_value=prepared.fill_value,
+                fill_tensor=prepared.fill_tensor,
+            )
+            for prepared in prepared_fields
+        )
+        return ZigzagPackedCPRollContext(
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+            cp_group=self.cp_group,
+            packed_cu_seqlens=self.packed_cu_seqlens,
+            min_chunk_size=self.min_chunk_size,
+            _prepared_fields=prepared_with_halos,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+            _roll_transport=transport,
+        )
+
+
+def _build_zigzag_packed_cp_roll_geometry(
+    *,
+    sequence_length: int,
+    batch_size: int,
+    max_offset: int,
+    device: torch.device,
+    cp_group: torch.distributed.ProcessGroup,
+    packed_cu_seqlens: Tensor,
+) -> Tuple[Tensor, Tensor, _ZigzagPackedCPRollTransport]:
+    """Build exact one-hop row maps and transport for a certified zigzag packed-CP microbatch."""
+    cp_size = cp_group.size()
+    cu = packed_cu_seqlens.to(device=device, dtype=torch.long)
+    if cu.ndim != 1 or cu.numel() < 2:
+        raise ValueError(
+            "Zigzag packed-CP MTP metadata requires one-dimensional cu_seqlens with at least "
+            "two entries."
+        )
+    torch._assert_async(cu[0] == 0, "Zigzag packed-CP MTP cumulative lengths must start at zero.")
+    torch._assert_async(
+        torch.all(cu[1:] >= cu[:-1]),
+        "Zigzag packed-CP MTP cumulative lengths must be nondecreasing.",
+    )
+    torch._assert_async(
+        cu[-1] == sequence_length * cp_size,
+        "Zigzag packed-CP MTP metadata must cover the physical buffer exactly.",
+    )
+
+    physical_lengths = cu[1:] - cu[:-1]
+    divisor = 2 * cp_size
+    torch._assert_async(
+        torch.all((physical_lengths == 0) | (physical_lengths.remainder(divisor) == 0)),
+        "Zigzag packed-CP MTP certificate contradicts physical chunk divisibility.",
+    )
+    local_cu = torch.div(cu, cp_size, rounding_mode="floor")
+    chunk_lengths = torch.div(physical_lengths, divisor, rounding_mode="floor")
+    torch._assert_async(
+        torch.all((physical_lengths == 0) | (chunk_lengths >= max_offset)),
+        "Zigzag packed-CP MTP certificate overstates the minimum physical chunk size.",
+    )
+
+    num_sequence_slots = chunk_lengths.numel()
+    prefix_offsets = torch.arange(max_offset, device=device, dtype=torch.long).unsqueeze(0)
+    prefix_valid = prefix_offsets < chunk_lengths.unsqueeze(1)
+    front_prefix_rows = (local_cu[:-1].unsqueeze(1) + prefix_offsets).clamp(
+        min=0, max=max(sequence_length - 1, 0)
+    )
+    back_prefix_rows = (
+        local_cu[:-1].unsqueeze(1) + chunk_lengths.unsqueeze(1) + prefix_offsets
+    ).clamp(min=0, max=max(sequence_length - 1, 0))
+
+    local_rows = torch.arange(sequence_length, device=device, dtype=torch.long)
+    sequence_slots = torch.bucketize(local_rows, local_cu[1:], right=True).clamp(
+        max=max(num_sequence_slots - 1, 0)
+    )
+    sequence_starts = local_cu[:-1].index_select(0, sequence_slots)
+    row_chunk_lengths = chunk_lengths.index_select(0, sequence_slots)
+    offsets_in_local_sequence = local_rows - sequence_starts
+    is_front_chunk = offsets_in_local_sequence < row_chunk_lengths
+    offsets_in_chunk = torch.where(
+        is_front_chunk, offsets_in_local_sequence, offsets_in_local_sequence - row_chunk_lengths
+    )
+
+    offsets = torch.arange(1, max_offset + 1, device=device, dtype=torch.long).unsqueeze(1)
+    advanced_offsets = offsets_in_chunk.unsqueeze(0) + offsets
+    crosses_chunk = advanced_offsets >= row_chunk_lengths.unsqueeze(0)
+    halo_offsets = advanced_offsets - row_chunk_lengths.unsqueeze(0)
+    local_targets = local_rows.unsqueeze(0) + offsets
+
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    if local_rank == cp_size - 1:
+        front_cross_targets = (
+            sequence_starts.unsqueeze(0) + row_chunk_lengths.unsqueeze(0) + halo_offsets
+        )
+    else:
+        front_cross_targets = (
+            sequence_length + sequence_slots.unsqueeze(0) * max_offset + halo_offsets
+        )
+    if local_rank == 0:
+        back_cross_targets = torch.zeros_like(halo_offsets)
+    else:
+        back_cross_targets = (
+            sequence_length
+            + num_sequence_slots * max_offset
+            + sequence_slots.unsqueeze(0) * max_offset
+            + halo_offsets
+        )
+    cross_targets = torch.where(
+        is_front_chunk.unsqueeze(0), front_cross_targets, back_cross_targets
+    )
+    addressed_rows = torch.where(crosses_chunk, cross_targets, local_targets)
+    valid = ~(crosses_chunk & ~is_front_chunk.unsqueeze(0) & (local_rank == 0))
+
+    batches = torch.arange(batch_size, device=device, dtype=torch.long)
+    shifted_indices = addressed_rows.unsqueeze(-1) * batch_size + batches
+    identity = local_rows.unsqueeze(-1) * batch_size + batches
+    row_indices = torch.cat((identity.unsqueeze(0), shifted_indices), dim=0)
+    valid_rows = torch.cat(
+        (
+            torch.ones((1, sequence_length, batch_size), device=device, dtype=torch.bool),
+            valid.unsqueeze(-1).expand(-1, -1, batch_size),
+        ),
+        dim=0,
+    )
+    return (
+        row_indices.to(torch.int32).contiguous(),
+        valid_rows.contiguous(),
+        _ZigzagPackedCPRollTransport(
+            front_prefix_rows=front_prefix_rows.flatten().contiguous(),
+            back_prefix_rows=back_prefix_rows.flatten().contiguous(),
+            prefix_valid=prefix_valid.flatten().contiguous(),
+        ),
+    )
+
+
+def _exchange_zigzag_packed_cp_roll_field_halos(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...],
+    *,
+    cp_group: torch.distributed.ProcessGroup,
+    transport: _ZigzagPackedCPRollTransport,
+) -> dict[str, Tensor]:
+    """Exchange both zigzag prefix tapes for every field in one P2P batch."""
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    cp_size = cp_group.size()
+    transport_fields = sorted(prepared_fields, key=lambda prepared: prepared.key)
+    next_rank = global_ranks[local_rank + 1] if local_rank < cp_size - 1 else None
+    previous_rank = global_ranks[local_rank - 1] if local_rank > 0 else None
+    # Halo segment zero is the next rank's front prefix; segment one is
+    # the previous rank's back prefix. Keep send and receive peers explicit so
+    # each route has one unambiguous semantic even when every P2P uses tag zero.
+    route_specs = (
+        (transport.front_prefix_rows, previous_rank, next_rank),
+        (transport.back_prefix_rows, next_rank, previous_rank),
+    )
+    segments = {prepared.key: [] for prepared in transport_fields}
+    send_buffers = []
+    p2p_ops = []
+    for send_rows, send_rank, recv_rank in route_specs:
+        for prepared in transport_fields:
+            valid_shape = (-1,) + (1,) * (prepared.source.dim() - 1)
+            send = prepared.source.index_select(0, send_rows)
+            send = send.masked_fill(
+                ~transport.prefix_valid.view(valid_shape), prepared.fill_value
+            ).contiguous()
+            send_buffers.append(send)
+            recv = prepared.source.new_full(send.shape, prepared.fill_value)
+            segments[prepared.key].append(recv)
+            if recv_rank is not None:
+                p2p_ops.append(
+                    torch.distributed.P2POp(
+                        torch.distributed.irecv, recv, recv_rank, group=cp_group
+                    )
+                )
+            if send_rank is not None:
+                p2p_ops.append(
+                    torch.distributed.P2POp(
+                        torch.distributed.isend, send, send_rank, group=cp_group
+                    )
+                )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+    return {
+        key: torch.cat(field_segments, dim=0).contiguous()
+        for key, field_segments in segments.items()
+    }
+
+
+# Public preparation entry points.
+
+
+def prepare_mtp_sequence_roll_context(
+    tensor: Tensor | None,
+    cp_group: torch.distributed.ProcessGroup | None,
+    packed_seq_params: PackedSeqParams | None,
+    dims: int = -1,
+) -> MTPSequenceRollContext | None:
+    """Prepare layout-specific state shared by MTP rolls in one microbatch.
+
+    The public boundary is layout neutral. Two-dimensional CP1 inputs receive a
+    local context capable of optional absolute addressing while retaining the legacy
+    roll helper as fallback. Contiguous packed CP retains its existing plan and halo
+    behavior while also supporting explicit one-hop sequence-roll preparation. A
+    scheduler-certified zigzag packed-CP microbatch receives the same absolute-row
+    interface with two compact neighbor tapes. Uncertified and unsupported layouts
+    return None and keep their established paths.
+
+    Args:
+        tensor: Reference payload that establishes local sequence length and device.
+        cp_group: Effective context-parallel process group for the microbatch.
+        packed_seq_params: Physical packed-sequence layout metadata.
+        dims: Sequence dimension; packed rolling supports only the final dimension.
+
+    Returns:
+        A layout-specific roll context, or None when no prepared state is needed.
+    """
+    if tensor is None:
+        return None
+
+    cp_group = resolve_cp_group(cp_group, packed_seq_params)
+    cp_size = cp_group.size() if cp_group is not None else 1
+    if cp_size <= 1:
+        if tensor.dim() != 2:
+            return None
+        sequence_dim = _normalize_mtp_sequence_roll_dim(dims, tensor.dim(), name="dims")
+        # Packed rolling supports only the final dimension. Do not create a
+        # context that the established dispatcher would reject.
+        if packed_seq_params is not None and sequence_dim != tensor.dim() - 1:
+            return None
+        batch_dim = 1 - sequence_dim
+        return LocalRollContext(
+            sequence_length=tensor.size(sequence_dim),
+            batch_size=tensor.size(batch_dim),
+            device=tensor.device,
+            packed_cu_seqlens=(
+                _get_packed_roll_cu_seqlens(packed_seq_params)
+                if packed_seq_params is not None
+                else None
+            ),
+        )
+
+    if packed_seq_params is None or cp_group is None:
+        return None
+
+    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
+    if cp_partition_mode == "zigzag":
+        min_chunk_size = packed_seq_params.zigzag_cp_min_chunk_size
+        if min_chunk_size is None or min_chunk_size == 0:
+            # Zero is a scheduler-produced "not certifiable" result, not
+            # malformed packed metadata. Preserve the established zigzag roll
+            # path exactly as for an absent certificate.
+            return None
+        if min_chunk_size < 0:
+            raise ValueError("Zigzag packed-CP MTP scheduler certificate cannot be negative.")
+        if (
+            packed_seq_params.local_cp_size is not None
+            and int(packed_seq_params.local_cp_size) != cp_size
+        ):
+            raise ValueError(
+                "Zigzag packed-CP MTP metadata local_cp_size must match "
+                "the effective CP group size."
+            )
+        if (
+            packed_seq_params.qkv_format != "thd"
+            or tensor.dim() != 2
+            or tensor.size(0) != 1
+            or (
+                _normalize_mtp_sequence_roll_dim(dims, tensor.dim(), name="dims")
+                != tensor.dim() - 1
+            )
+        ):
+            return None
+        return ZigzagPackedCPRollContext(
+            sequence_length=tensor.size(-1),
+            batch_size=tensor.size(0),
+            device=tensor.device,
+            cp_group=cp_group,
+            packed_cu_seqlens=_get_packed_roll_cu_seqlens(packed_seq_params),
+            min_chunk_size=min_chunk_size,
+        )
+    if cp_partition_mode != 'contiguous':
+        return None
+
+    return ContiguousPackedCPRollContext(
+        plan=_build_contiguous_packed_seq_roll_plan(
+            tensor, dims, _get_packed_roll_cu_seqlens(packed_seq_params), cp_group
+        ),
+        batch_size=tensor.size(0) if tensor.dim() == 2 else 1,
+    )
+
+
+def prepare_mtp_sequence_roll_fields(
+    sequence_roll_context: Optional[MTPSequenceRollContext],
+    fields: Sequence[MTPSequenceRollField],
+    *,
+    max_offset: int,
+) -> Optional[MTPSequenceRollContext]:
+    """Return one atomically prepared consumer field group when supported.
+
+    A context already containing the complete group for these exact source
+    tensors is reused. Otherwise the fields are late-bound as one replacement
+    group. Unsupported layouts return ``None`` so the caller takes its complete
+    legacy cumulative-roll path; a consumer never mixes addressed and rolled fields.
+    """
+    if sequence_roll_context is None:
+        return None
+    if (
+        sequence_roll_context.max_offset >= max_offset
+        and sequence_roll_context.is_prepared_for_fields(fields)
+    ):
+        return sequence_roll_context
+    prepared_context = sequence_roll_context.prepare_fields(fields, max_offset=max_offset)
+    if prepared_context.max_offset >= max_offset and prepared_context.is_prepared_for_fields(
+        fields
+    ):
+        return prepared_context
+    return None
+
+
+# Cumulative-roll compatibility path.
+
+
+def roll_tensor(
+    tensors: List[Tensor],
+    shifts: int = -1,
+    dims: int = -1,
+    cp_group: torch.distributed.ProcessGroup | None = None,
+    packed_seq_params: PackedSeqParams | None = None,
+    fill_values: List[Union[bool, int, float]] | None = None,
+    roll_context: MTPSequenceRollContext | None = None,
+    sequence_fields: List[str] | None = None,
+    roll_depth: int = 0,
+) -> List[Tensor]:
+    """Roll one or more MTP tensor fields along the sequence dimension.
+
+    All tensors in one call share the same physical sequence layout. Grouping them
+    allows contiguous packed CP to share metadata and use one P2P batch. When a
+    contiguous context owns prefetched halos, the same dispatcher replaces each
+    local tail from the requested field/depth and issues no rolling P2P.
+
+    Args:
+        tensors: Tensor fields to roll together.
+        shifts: Shift along the sequence dimension.
+        dims: Sequence dimension.
+        cp_group: Effective context-parallel process group.
+        packed_seq_params: Packed-sequence layout metadata, when applicable.
+        fill_values: Per-field values written at physical sequence boundaries.
+        roll_context: Layout-specific state prepared for this microbatch. None
+            retains the regular dispatcher and communication fallback.
+        sequence_fields: Canonical source fields corresponding to tensors. These
+            identify prefetched halo payloads and are required only when the
+            context contains halos.
+        roll_depth: Zero-based repeated-roll depth. Depth zero consumes the
+            immediate successor; depth d consumes halo offset d.
+
+    Returns:
+        Rolled tensors in the same order as tensors.
+
+    Raises:
+        ValueError: If field counts, depth, or roll-context arguments are inconsistent.
+    """
+    if not tensors:
+        return []
+    if roll_depth < 0:
+        raise ValueError("roll_depth must be non-negative.")
+    if fill_values is None:
+        fill_values = [0] * len(tensors)
+    if len(tensors) != len(fill_values):
+        raise ValueError("Each tensor must have a corresponding roll fill value.")
+    if sequence_fields is not None and len(tensors) != len(sequence_fields):
+        raise ValueError("Each tensor must have a corresponding canonical sequence field.")
+
+    if packed_seq_params is None:
+        if roll_context is not None and not isinstance(roll_context, LocalRollContext):
+            raise ValueError("A prepared sequence-roll context requires packed parameters.")
+        return _roll_tensors_unpacked(tensors, shifts, dims, cp_group, fill_values)
+
+    return _roll_tensors_packed_seq(
+        tensors,
+        shifts,
+        dims,
+        packed_seq_params,
+        cp_group,
+        fill_values,
+        roll_context,
+        sequence_fields,
+        roll_depth,
+    )
+
+
+def _roll_tensors_unpacked(
+    tensors: List[Tensor],
+    shifts: int,
+    dims: int,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    fill_values: List[Union[bool, int, float]],
+) -> List[Tensor]:
+    """Roll unpacked tensors for CP1 or the standard zigzag CP layout."""
+    if cp_group is None or cp_group.size() == 1:
+        rolled_tensors = [torch.roll(tensor, shifts=shifts, dims=dims) for tensor in tensors]
+        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
+            rolled_tensor.select(dims, shifts).fill_(fill_value)
+        return rolled_tensors
+
+    return [
+        _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=fill_value)
+        for tensor, fill_value in zip(tensors, fill_values)
+    ]
+
+
+def _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=0):
+    """Roll one unpacked tensor in the standard two-chunk zigzag CP layout."""
+    # This matches the batch splitting logic in get_batch_on_this_cp_rank().
+    tensor_list = tensor.chunk(2, dim=dims)
+    rolled_tensor_list = []
+    for i in range(len(tensor_list)):
+        rolled_tensor_list.append(torch.roll(tensor_list[i], shifts=shifts, dims=dims))
+
+    # Prepare tensors for communication between CP ranks
+    # Each CP rank needs to send boundary elements to adjacent ranks
+    tensor_send_list = []
+    tensor_recv_list = []
+    for i in range(len(rolled_tensor_list)):
+        tensor_send_list.append(rolled_tensor_list[i].select(dims, shifts).contiguous())
+        empty_tensor = torch.empty(
+            tensor_send_list[i].shape,
+            dtype=tensor_send_list[i].dtype,
+            device=torch.cuda.current_device(),
+        )
+        tensor_recv_list.append(empty_tensor)
+
+    # Get the global rank of next and prev process in the cp group
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    next_rank = global_ranks[(local_rank + 1) % len(global_ranks)]
+    prev_rank = global_ranks[(local_rank - 1) % len(global_ranks)]
+
+    # Start send and recv ops
+    ops = []
+    if local_rank != 0:
+        req_send_first_part = torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank)
+        ops.append(req_send_first_part)
+        req_recv_second_part = torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank)
+        ops.append(req_recv_second_part)
+    else:
+        tensor_recv_list[1] = fill_value
+    if local_rank != len(global_ranks) - 1:
+        req_recv_first_part = torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank)
+        ops.append(req_recv_first_part)
+        req_send_second_part = torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank)
+        ops.append(req_send_second_part)
+    else:
+        # For the last CP rank, the removed elements of second part go into the first part
+        tensor_recv_list[0] = tensor_send_list[1]
+
+    # Wait for all communication operations to complete
+    for op in ops:
+        op.wait()
+
+    # Splicing: Replace boundary elements with received elements from adjacent ranks
+    # This ensures proper sequence continuity across CP boundaries
+    index = [slice(None)] * rolled_tensor_list[0].dim()
+    index[dims] = shifts
+    for i in range(len(rolled_tensor_list)):
+        rolled_tensor_list[i][tuple(index)] = tensor_recv_list[i]
+
+    # Concatenate the processed chunks back into a single tensor
+    rolled_tensor = torch.cat(rolled_tensor_list, dim=dims)
+
+    return rolled_tensor
+
+
+def _roll_tensors_packed_seq(
+    tensors: List[Tensor],
+    shifts: int,
+    dims: int,
+    packed_seq_params: PackedSeqParams,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    fill_values: List[Union[bool, int, float]],
+    roll_context: Optional[MTPSequenceRollContext],
+    sequence_fields: Optional[List[str]],
+    roll_depth: int,
+) -> List[Tensor]:
+    """Dispatch packed tensors to CP1, zigzag CP, or contiguous CP rolling."""
+    for tensor in tensors:
+        assert (
+            dims == -1 or dims == tensor.dim() - 1
+        ), "Packed sequence roll only supports the last dimension."
+    assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
+
+    # Prefer padded cumulative seqlens because CP's local THD layout uses the
+    # padded physical boundaries. Unpadded boundaries index the wrong local
+    # chunks when sequence lengths are not already divisible by 2 * cp_size.
+    cu_seqlens = _get_packed_roll_cu_seqlens(packed_seq_params)
+
+    cp_size = cp_group.size() if cp_group is not None else 1
+    if cp_size == 1:
+        if roll_context is not None and not isinstance(roll_context, LocalRollContext):
+            raise ValueError("A prepared sequence-roll context cannot be used for packed CP1.")
+        reference_tensor = tensors[0]
+        sequence_end_indices = _get_packed_seq_end_indices(
+            cu_seqlens, reference_tensor.device, reference_tensor.size(dims)
+        )
+        for tensor in tensors:
+            if tensor.device != reference_tensor.device:
+                raise ValueError("All packed CP1 tensors must be on the same device.")
+            if tensor.size(dims) != reference_tensor.size(dims):
+                raise ValueError("All packed CP1 tensors must have the same sequence length.")
+        return [
+            _roll_tensor_packed_seq_cp1(
+                tensor, shifts, dims, sequence_end_indices, fill_value=fill_value
+            )
+            for tensor, fill_value in zip(tensors, fill_values)
+        ]
+
+    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
+    if cp_partition_mode == 'zigzag':
+        if roll_context is not None and not isinstance(roll_context, ZigzagPackedCPRollContext):
+            raise ValueError(
+                "A prepared sequence-roll context is not supported for zigzag packed CP."
+            )
+        return [
+            _roll_tensor_packed_seq_zigzag_cp(
+                tensor, shifts, dims, cu_seqlens, cp_group, fill_value=fill_value
+            )
+            for tensor, fill_value in zip(tensors, fill_values)
+        ]
+    if cp_partition_mode == 'contiguous':
+        contiguous_roll_halos = None
+        if roll_context is None:
+            contiguous_roll_plan = _build_contiguous_packed_seq_roll_plan(
+                tensors[0], dims, cu_seqlens, cp_group
+            )
+        elif isinstance(roll_context, ContiguousPackedCPRollContext):
+            contiguous_roll_plan = roll_context.plan
+            contiguous_roll_halos = roll_context.halos
+        else:
+            raise ValueError(
+                "The prepared sequence-roll context does not support contiguous packed CP."
+            )
+        return _roll_tensors_packed_seq_contiguous_cp(
+            tensors,
+            dims,
+            fill_values,
+            contiguous_roll_plan,
+            contiguous_roll_halos,
+            sequence_fields,
+            roll_depth,
+        )
+    raise ValueError(f"Unsupported packed sequence CP partition mode: {cp_partition_mode}")
+
+
+def _roll_tensor_packed_seq_cp1(tensor, shifts, dims, sequence_end_indices, fill_value=0):
+    """Roll one CP1 packed tensor and fill every physical sequence end."""
+    # A full-buffer left roll is equivalent to rolling each packed sequence
+    # independently once the values that crossed sequence boundaries are filled.
+    rolled_tensor = torch.roll(tensor, shifts=shifts, dims=dims)
+    rolled_tensor.index_fill_(dims, sequence_end_indices, fill_value)
+    return rolled_tensor
+
+
+def _roll_tensor_packed_seq_zigzag_cp(tensor, shifts, dims, cu_seqlens, cp_group, fill_value=0):
+    """Roll a zigzag-CP THD shard without crossing packed sequence boundaries."""
+    cp_size = cp_group.size()
+    rolled_tensor = tensor.clone()
+
+    # CP enabled: each rank owns two chunks per sequence (front and mirrored tail).
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    next_rank = global_ranks[(local_rank + 1) % cp_size]
+    prev_rank = global_ranks[(local_rank - 1) % cp_size]
+
+    # Iterate over each sequence individually
+    for i in range(len(cu_seqlens) - 1):
+        start_idx = cu_seqlens[i]
+        end_idx = cu_seqlens[i + 1]
+
+        # the idx has been multiplied by cp_size, need to divide it by cp_size to get the local idx
+        local_start_idx = start_idx // cp_size
+        local_end_idx = end_idx // cp_size
+
+        # Skip empty sequences - this can happen when a sequence is very short and
+        # after dividing by cp_size, the local slice has zero length
+        local_seq_len = local_end_idx - local_start_idx
+        if local_seq_len == 0:
+            continue
+
+        tensor_slice = rolled_tensor[..., local_start_idx:local_end_idx].clone()
+
+        # The following code is very similar as the code in roll_tensor function
+        local_chunks = tensor_slice.chunk(2, dim=dims)
+        rolled_chunks = [torch.roll(chunk, shifts=shifts, dims=dims) for chunk in local_chunks]
+
+        tensor_send_list = []
+        tensor_recv_list = []
+        for chunk in rolled_chunks:
+            # Skip empty chunks that can occur when the sequence slice is very small
+            if chunk.size(dims) == 0:
+                tensor_send_list.append(
+                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                )
+                tensor_recv_list.append(
+                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                )
+                continue
+            boundary = chunk.select(dims, shifts).contiguous().clone()
+            tensor_send_list.append(boundary)
+            tensor_recv_list.append(torch.empty_like(boundary))
+
+        ops = []
+        if local_rank != 0:
+            ops.append(torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank))
+            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank))
+        else:
+            tensor_recv_list[1].fill_(fill_value)
+
+        if local_rank != cp_size - 1:
+            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank))
+            ops.append(torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank))
+        else:
+            tensor_recv_list[0].copy_(tensor_send_list[1])
+
+        for op in ops:
+            op.wait()
+
+        index = [slice(None)] * rolled_chunks[0].dim()
+        index[dims] = shifts
+        for chunk, recv in zip(rolled_chunks, tensor_recv_list):
+            # Skip empty chunks
+            if chunk.size(dims) == 0:
+                continue
+            chunk[tuple(index)] = recv
+
+        seq_result = torch.cat(rolled_chunks, dim=dims)
+
+        # update the rolled tensor
+        rolled_tensor[..., local_start_idx:local_end_idx] = seq_result
+
+    return rolled_tensor
+
+
+def _roll_tensors_packed_seq_contiguous_cp(
+    tensors: List[Tensor],
+    dims: int,
+    fill_values: List[Union[bool, int, float]],
+    contiguous_roll_plan: ContiguousPackedSeqRollPlan,
+    contiguous_roll_halos: Optional[ContiguousPackedCPRollHalos] = None,
+    sequence_fields: Optional[List[str]] = None,
+    roll_depth: int = 0,
+) -> List[Tensor]:
+    """Roll contiguous packed-CP tensors from halos or one grouped P2P exchange.
+
+    A prefetched halo is used only when every field in this grouped call is present.
+    Otherwise the entire call takes the grouped P2P fallback, keeping all CP ranks
+    on the same communication branch while supporting optional model inputs.
+    """
+    assert len(tensors) == len(fill_values)
+    if not tensors:
+        return []
+
+    for tensor in tensors:
+        assert (
+            dims == -1 or dims == tensor.dim() - 1
+        ), "Packed sequence roll only supports the last dimension."
+        if tensor.size(dims) != contiguous_roll_plan.sequence_length:
+            raise ValueError(
+                "All tensors sharing a packed-sequence roll plan must have the same "
+                "sequence length."
+            )
+        if tensor.device != contiguous_roll_plan.device:
+            raise ValueError(
+                "All tensors sharing a packed-sequence roll plan must be on the same device."
+            )
+
+    if contiguous_roll_plan.sequence_length == 0:
+        return [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+
+    if not contiguous_roll_plan.has_sequences:
+        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
+            rolled_tensor.fill_(fill_value)
+        return rolled_tensors
+
+    halo_tail_values = None
+    if contiguous_roll_halos is not None and sequence_fields is not None:
+        if len(sequence_fields) != len(tensors):
+            raise ValueError("Each rolled tensor must have a canonical sequence field.")
+
+        requested_halos = [contiguous_roll_halos.get(field) for field in sequence_fields]
+        if all(halo is not None for halo in requested_halos):
+            if roll_depth >= contiguous_roll_halos.width:
+                raise ValueError(
+                    f"roll_depth={roll_depth} exceeds the prefetched halo width "
+                    f"{contiguous_roll_halos.width}."
+                )
+
+            halo_tail_values = []
+            for tensor, sequence_field, fill_value, halo in zip(
+                tensors, sequence_fields, fill_values, requested_halos
+            ):
+                assert halo is not None
+                expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
+                if fill_value != expected_fill_value:
+                    raise ValueError(
+                        f"Halo field {sequence_field} requires boundary fill value "
+                        f"{expected_fill_value!r}, got {fill_value!r}."
+                    )
+                if halo.device != tensor.device:
+                    raise ValueError(
+                        f"Halo field {sequence_field} and its tensor must be on the same device."
+                    )
+                if halo.dtype != tensor.dtype:
+                    raise ValueError(
+                        f"Halo field {sequence_field} and its tensor must have the same dtype."
+                    )
+                if halo.dim() != tensor.dim() or halo.shape[:-1] != tensor.shape[:-1]:
+                    raise ValueError(
+                        f"Halo field {sequence_field} must match its tensor's leading dimensions."
+                    )
+                halo_tail_values.append(halo.select(dims, roll_depth))
+
+    if halo_tail_values is not None:
+        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+        for rolled_tensor, halo_tail, fill_value in zip(
+            rolled_tensors, halo_tail_values, fill_values
+        ):
+            rolled_tensor.select(dims, -1).copy_(halo_tail)
+            # Internal physical sequence ends are handled by the shared immediate
+            # boundary mask. Tail values for deeper rolls were sanitized before
+            # slicing because their validity depends on the requested depth.
+            rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
+        return rolled_tensors
+
+    recv_buffers: List[Optional[Tensor]] = [None] * len(tensors)
+    # Keep contiguous send buffers alive until every grouped work handle completes.
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+
+    if contiguous_roll_plan.recv_rank is not None:
+        # After a left roll, each local tail consumes the first element from the
+        # next contiguous CP shard.
+        for index, tensor in enumerate(tensors):
+            recv_buffer = torch.empty_like(tensor.select(dims, 0))
+            recv_buffers[index] = recv_buffer
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_buffer,
+                    contiguous_roll_plan.recv_rank,
+                    group=contiguous_roll_plan.cp_group,
+                )
+            )
+    if contiguous_roll_plan.send_rank is not None:
+        # This rank's first element becomes the previous shard's local tail.
+        for tensor in tensors:
+            send_buffer = tensor.select(dims, 0).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_buffer,
+                    contiguous_roll_plan.send_rank,
+                    group=contiguous_roll_plan.cp_group,
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+    for work in works:
+        work.wait()
+
+    for rolled_tensor, recv_buffer, fill_value in zip(rolled_tensors, recv_buffers, fill_values):
+        if recv_buffer is not None:
+            rolled_tensor.select(dims, -1).copy_(recv_buffer)
+        # Apply the shared boundary mask after installing the adjacent value so a
+        # physical packed-sequence end always wins over a cross-rank successor.
+        rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
+
+    return rolled_tensors

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -15,6 +15,8 @@ from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace
 from megatron.core.enums import Fp8Recipe
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.fusions.fused_mtp_prefix import mtp_e2e_prefix_objective
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -724,126 +726,6 @@ def _compute_mtp_acceptance_counts(
     return correct, total
 
 
-class _VocabParallelTVDistance(torch.autograd.Function):
-    """Full-vocabulary TV distance with a TP-aware analytical backward.
-
-    The implementation follows Algorithms 1 and 2 in the Bebop paper
-    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
-    distribution detached and returns gradients for draft logits only.
-
-    This PyTorch implementation establishes the mathematical contract. It does
-    not yet fuse the vocabulary passes into a dedicated GPU kernel.
-    """
-
-    @staticmethod
-    def forward(
-        ctx,
-        draft_logits: Tensor,
-        target_logits: Tensor,
-        tp_group: Optional[torch.distributed.ProcessGroup],
-        logits_are_vocab_sharded: bool,
-    ) -> Tensor:
-        """Compute the TV distance and save the draft-side backward state."""
-        if draft_logits.shape != target_logits.shape:
-            raise ValueError(
-                "Draft and target logits must have identical shapes, got "
-                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
-            )
-        if draft_logits.device != target_logits.device:
-            raise ValueError("Draft and target logits must be on the same device.")
-
-        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
-        if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
-            initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
-            if initialized_tp_size > 1:
-                raise ValueError(
-                    "tp_group must be provided for TV distance over vocab-sharded logits "
-                    f"when tensor parallel size is {initialized_tp_size}."
-                )
-
-        draft_logits_fp32 = draft_logits.float()
-        target_logits_fp32 = target_logits.float()
-        maxima = torch.stack(
-            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
-        )
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
-        draft_max, target_max = maxima.unbind(dim=0)
-
-        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
-        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
-        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(
-                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
-        draft_denominator, target_denominator = denominators.unbind(dim=0)
-
-        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
-        target_prob = target_exp / target_denominator.unsqueeze(-1)
-        draft_below_target = draft_prob <= target_prob
-        overlap_and_s = torch.stack(
-            (
-                torch.minimum(draft_prob, target_prob).sum(dim=-1),
-                (draft_prob * draft_below_target).sum(dim=-1),
-            )
-        )
-        if logits_are_vocab_sharded and tp_size > 1:
-            torch.distributed.all_reduce(
-                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
-        overlap, s = overlap_and_s.unbind(dim=0)
-
-        raw_tv_distance = 1.0 - overlap
-        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
-        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
-        ctx.save_for_backward(
-            draft_logits,
-            draft_max,
-            draft_denominator,
-            s,
-            draft_prob > target_prob,
-            clamp_gradient_mask,
-        )
-        return tv_distance
-
-    @staticmethod
-    def backward(ctx, grad_output: Tensor):
-        """Apply the analytical Bebop gradient to the draft logits only."""
-        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
-            ctx.saved_tensors
-        )
-
-        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
-        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
-        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
-        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
-        return grad_draft.to(draft_logits.dtype), None, None, None
-
-
-def vocab_parallel_tv_distance(
-    draft_logits: Tensor,
-    target_logits: Tensor,
-    tp_group: Optional[torch.distributed.ProcessGroup] = None,
-    logits_are_vocab_sharded: bool = True,
-) -> Tensor:
-    """Compute per-position full-vocabulary TV distance between draft and target logits.
-
-    Args:
-        draft_logits: Trainable draft logits with vocabulary in the last dimension.
-        target_logits: Detached target logits with the same local or global vocabulary layout.
-        tp_group: Tensor-parallel group owning vocabulary shards.
-        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
-
-    Returns:
-        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
-        ``draft_logits``.
-    """
-    return _VocabParallelTVDistance.apply(
-        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
-    )
-
-
 @dataclass
 class MultiTokenPredictionLayerSubmodules:
     """
@@ -1117,10 +999,11 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             draft_logits = scale_logits_fn(draft_logits)
+        aligned_target_logits = target_logits.permute(2, 0, 1)
         tv_distances.append(
             vocab_parallel_tv_distance(
                 draft_logits,
-                target_logits.permute(2, 0, 1),
+                aligned_target_logits,
                 tp_group=tp_group,
                 logits_are_vocab_sharded=logits_are_vocab_sharded,
             )
@@ -1128,9 +1011,7 @@ def _process_mtp_e2e_tv_loss(
 
     tv_distances_tensor = torch.stack(tv_distances, dim=0)
     per_step_acceptance = 1.0 - tv_distances_tensor
-    prefix_acceptance = torch.cumprod(per_step_acceptance, dim=0)
-    prefix_losses = 1.0 - prefix_acceptance
-    e2e_tv_loss = prefix_losses.mean(dim=0)
+    e2e_tv_loss, prefix_losses = mtp_e2e_prefix_objective(per_step_acceptance)
 
     chain_mask = chain_valid.transpose(0, 1).to(e2e_tv_loss.dtype)
     num_tokens = chain_mask.sum()

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -724,6 +724,126 @@ def _compute_mtp_acceptance_counts(
     return correct, total
 
 
+class _VocabParallelTVDistance(torch.autograd.Function):
+    """Full-vocabulary TV distance with a TP-aware analytical backward.
+
+    The implementation follows Algorithms 1 and 2 in the Bebop paper
+    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
+    distribution detached and returns gradients for draft logits only.
+
+    This PyTorch implementation establishes the mathematical contract. It does
+    not yet fuse the vocabulary passes into a dedicated GPU kernel.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Compute the TV distance and save the draft-side backward state."""
+        if draft_logits.shape != target_logits.shape:
+            raise ValueError(
+                "Draft and target logits must have identical shapes, got "
+                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+            )
+        if draft_logits.device != target_logits.device:
+            raise ValueError("Draft and target logits must be on the same device.")
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
+            initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
+            if initialized_tp_size > 1:
+                raise ValueError(
+                    "tp_group must be provided for TV distance over vocab-sharded logits "
+                    f"when tensor parallel size is {initialized_tp_size}."
+                )
+
+        draft_logits_fp32 = draft_logits.float()
+        target_logits_fp32 = target_logits.float()
+        maxima = torch.stack(
+            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        draft_max, target_max = maxima.unbind(dim=0)
+
+        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
+        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
+        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        draft_denominator, target_denominator = denominators.unbind(dim=0)
+
+        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
+        target_prob = target_exp / target_denominator.unsqueeze(-1)
+        draft_below_target = draft_prob <= target_prob
+        overlap_and_s = torch.stack(
+            (
+                torch.minimum(draft_prob, target_prob).sum(dim=-1),
+                (draft_prob * draft_below_target).sum(dim=-1),
+            )
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        overlap, s = overlap_and_s.unbind(dim=0)
+
+        raw_tv_distance = 1.0 - overlap
+        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
+        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
+        ctx.save_for_backward(
+            draft_logits,
+            draft_max,
+            draft_denominator,
+            s,
+            draft_prob > target_prob,
+            clamp_gradient_mask,
+        )
+        return tv_distance
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical Bebop gradient to the draft logits only."""
+        (draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask) = (
+            ctx.saved_tensors
+        )
+
+        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
+        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
+        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
+        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
+        return grad_draft.to(draft_logits.dtype), None, None, None
+
+
+def vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    logits_are_vocab_sharded: bool = True,
+) -> Tensor:
+    """Compute per-position full-vocabulary TV distance between draft and target logits.
+
+    Args:
+        draft_logits: Trainable draft logits with vocabulary in the last dimension.
+        target_logits: Detached target logits with the same local or global vocabulary layout.
+        tp_group: Tensor-parallel group owning vocabulary shards.
+        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+
+    Returns:
+        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
+        ``draft_logits``.
+    """
+    return _VocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )
+
+
 @dataclass
 class MultiTokenPredictionLayerSubmodules:
     """
@@ -929,9 +1049,127 @@ class MTPLossAutoScaler(torch.autograd.Function):
         MTPLossAutoScaler.main_loss_backward_scale = scale
 
 
+def _process_mtp_e2e_tv_loss(
+    hidden_states_list: tuple[Tensor, ...],
+    loss_mask: Tensor,
+    output_layer: Callable,
+    output_weight: Tensor,
+    runtime_gather_output: Optional[bool],
+    is_training: bool,
+    config: TransformerConfig,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    packed_seq_params: Optional[PackedSeqParams],
+    scale_logits_fn: Optional[Callable[[Tensor], Tensor]],
+    original_num_tokens: Tensor,
+) -> Tensor:
+    """Apply the end-to-end TV objective to MTP draft hidden states.
+
+    The frozen backbone is projected once. For depth ``i``, its target logits are
+    shifted by ``i + 1`` positions to align with the MTP draft distribution for
+    the same future token. Only start positions with a complete chain across all
+    configured MTP depths contribute to the objective.
+    """
+    hidden_states = hidden_states_list[0]
+    logits_are_vocab_sharded = _mtp_logits_are_vocab_sharded(output_layer, runtime_gather_output)
+
+    # Project the frozen backbone once, then align each target distribution by
+    # rolling logits. Re-projecting one shifted hidden tensor per MTP depth would
+    # add a full vocabulary GEMM for every draft step.
+    with torch.no_grad():
+        target_logits, _ = output_layer(
+            hidden_states.detach(),
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            target_logits = scale_logits_fn(target_logits)
+    # roll_tensor handles packed boundaries and CP communication along its last
+    # dimension. Keep vocabulary before sequence while preparing target alignment.
+    target_logits = target_logits.permute(1, 2, 0)
+    current_loss_mask = loss_mask
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    tv_distances = []
+
+    for mtp_layer_number in range(config.mtp_num_layers):
+        target_logits, _ = roll_tensor(
+            target_logits,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
+        )
+        current_loss_mask, _ = roll_tensor(
+            current_loss_mask,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=False,
+        )
+        chain_valid &= current_loss_mask.bool()
+
+        draft_logits, _ = output_layer(
+            hidden_states_list[mtp_layer_number + 1],
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            draft_logits = scale_logits_fn(draft_logits)
+        tv_distances.append(
+            vocab_parallel_tv_distance(
+                draft_logits,
+                target_logits.permute(2, 0, 1),
+                tp_group=tp_group,
+                logits_are_vocab_sharded=logits_are_vocab_sharded,
+            )
+        )
+
+    tv_distances_tensor = torch.stack(tv_distances, dim=0)
+    per_step_acceptance = 1.0 - tv_distances_tensor
+    prefix_acceptance = torch.cumprod(per_step_acceptance, dim=0)
+    prefix_losses = 1.0 - prefix_acceptance
+    e2e_tv_loss = prefix_losses.mean(dim=0)
+
+    chain_mask = chain_valid.transpose(0, 1).to(e2e_tv_loss.dtype)
+    num_tokens = chain_mask.sum()
+    masked_e2e_tv_loss = e2e_tv_loss * chain_mask
+
+    if is_training:
+        avg_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        for mtp_layer_number in range(config.mtp_num_layers):
+            loss_for_log = (
+                torch.sum(prefix_losses[mtp_layer_number] * chain_mask)
+                / num_tokens.clamp(min=1)
+            )
+            correct = torch.sum(per_step_acceptance[mtp_layer_number] * chain_mask)
+            MTPLossLoggingHelper.save_metrics_to_tracker(
+                loss_for_log,
+                correct,
+                num_tokens,
+                mtp_layer_number,
+                config.mtp_num_layers,
+                avg_group=avg_group,
+            )
+
+    assert config.mtp_loss_scaling_factor is not None
+    if config.calculate_per_token_loss:
+        normalized_loss = (
+            config.mtp_loss_scaling_factor
+            * masked_e2e_tv_loss
+            * (original_num_tokens / num_tokens.clamp(min=1))
+        )
+    else:
+        normalized_loss = (
+            config.mtp_loss_scaling_factor * masked_e2e_tv_loss / num_tokens.clamp(min=1)
+        )
+    return MTPLossAutoScaler.apply(hidden_states, normalized_loss)
+
+
 def process_mtp_loss(
     hidden_states: Tensor,
-    labels: Tensor,
+    labels: Optional[Tensor],
     loss_mask: Optional[Tensor],
     output_layer: Callable,
     output_weight: Optional[Tensor],
@@ -1008,6 +1246,23 @@ def process_mtp_loss(
     # when calculate_per_token_loss is enabled. This ensures MTP gradients are
     # correctly scaled relative to the main loss gradients in finalize_model_grads.
     original_num_tokens = loss_mask.sum()
+
+    if config.mtp_loss_type == "e2e_tv":
+        assert output_weight is not None
+        return _process_mtp_e2e_tv_loss(
+            hidden_states_list=hidden_states_list,
+            loss_mask=loss_mask,
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+            is_training=is_training,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            scale_logits_fn=scale_logits_fn,
+            original_num_tokens=original_num_tokens,
+        )
 
     for mtp_layer_number in range(config.mtp_num_layers):
         mtp_logits, _ = output_layer(

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1020,10 +1020,9 @@ def _process_mtp_e2e_tv_loss(
     if is_training:
         avg_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
         for mtp_layer_number in range(config.mtp_num_layers):
-            loss_for_log = (
-                torch.sum(prefix_losses[mtp_layer_number] * chain_mask)
-                / num_tokens.clamp(min=1)
-            )
+            loss_for_log = torch.sum(
+                prefix_losses[mtp_layer_number] * chain_mask
+            ) / num_tokens.clamp(min=1)
             correct = torch.sum(per_step_acceptance[mtp_layer_number] * chain_mask)
             MTPLossLoggingHelper.save_metrics_to_tracker(
                 loss_for_log,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -19,7 +19,7 @@ from megatron.core.fusions.fused_mtp_prefix import mtp_e2e_prefix_objective
 from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel import (
@@ -32,6 +32,12 @@ from megatron.core.tensor_parallel.inference_layers import (
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollContext,
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_fields,
+)
+from megatron.core.transformer.mtp_sequence_roll import roll_tensor as roll_tensors_with_context
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
@@ -943,7 +949,8 @@ def _process_mtp_e2e_tv_loss(
     tp_group: Optional[torch.distributed.ProcessGroup],
     packed_seq_params: Optional[PackedSeqParams],
     scale_logits_fn: Optional[Callable[[Tensor], Tensor]],
-    original_num_tokens: Tensor,
+    sequence_roll_context: Optional[MTPSequenceRollContext],
+    derived_labels_from_input_ids: bool,
 ) -> Tensor:
     """Apply the end-to-end TV objective to MTP draft hidden states.
 
@@ -966,30 +973,69 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             target_logits = scale_logits_fn(target_logits)
-    # roll_tensor handles packed boundaries and CP communication along its last
-    # dimension. Keep vocabulary before sequence while preparing target alignment.
-    target_logits = target_logits.permute(1, 2, 0)
-    current_loss_mask = loss_mask
+    num_depths = config.mtp_num_layers
+    max_offset = num_depths + int(derived_labels_from_input_ids)
+    tv_roll_context = prepare_mtp_sequence_roll_fields(
+        sequence_roll_context,
+        (
+            MTPSequenceRollField("target_logits", target_logits, 0, 1, 0),
+            MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0),
+        ),
+        max_offset=max_offset,
+    )
+    use_prepared_roll_rows = tv_roll_context is not None
+    if use_prepared_roll_rows:
+        assert tv_roll_context is not None
+        aligned_loss_masks = tv_roll_context.materialize_all("loss_mask")
+        current_loss_mask = loss_mask
+        original_loss_mask = aligned_loss_masks[0] if derived_labels_from_input_ids else loss_mask
+    else:
+        # Keep vocabulary before sequence for the established cumulative-roll path.
+        target_logits = target_logits.permute(1, 2, 0)
+        current_loss_mask = loss_mask
+        if derived_labels_from_input_ids:
+            current_loss_mask = roll_tensors_with_context(
+                [current_loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["loss_mask"],
+                roll_depth=0,
+            )[0]
+        original_loss_mask = current_loss_mask
+
+    original_num_tokens = original_loss_mask.sum()
     chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
     tv_distances = []
 
-    for mtp_layer_number in range(config.mtp_num_layers):
-        target_logits, _ = roll_tensor(
-            target_logits,
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            return_sum=False,
-        )
-        current_loss_mask, _ = roll_tensor(
-            current_loss_mask,
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            return_sum=False,
-        )
+    for mtp_layer_number in range(num_depths):
+        if use_prepared_roll_rows:
+            assert tv_roll_context is not None
+            target_address = tv_roll_context.address("target_logits", mtp_layer_number + 1)
+            current_loss_mask = aligned_loss_masks[
+                mtp_layer_number + int(derived_labels_from_input_ids)
+            ]
+        else:
+            target_logits = roll_tensors_with_context(
+                [target_logits],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                fill_values=[0],
+            )[0]
+            current_loss_mask = roll_tensors_with_context(
+                [current_loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["loss_mask"],
+                roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
+            )[0]
         chain_valid &= current_loss_mask.bool()
 
         draft_logits, _ = output_layer(
@@ -999,15 +1045,27 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             draft_logits = scale_logits_fn(draft_logits)
-        aligned_target_logits = target_logits.permute(2, 0, 1)
-        tv_distances.append(
-            vocab_parallel_tv_distance(
-                draft_logits,
-                aligned_target_logits,
-                tp_group=tp_group,
-                logits_are_vocab_sharded=logits_are_vocab_sharded,
+        if use_prepared_roll_rows:
+            tv_distances.append(
+                vocab_parallel_tv_distance(
+                    draft_logits,
+                    target_address.source,
+                    tp_group=tp_group,
+                    logits_are_vocab_sharded=logits_are_vocab_sharded,
+                    target_row_indices=target_address.row_indices,
+                    target_valid_rows=target_address.valid_rows,
+                    target_halo_logits=target_address.halo,
+                )
             )
-        )
+        else:
+            tv_distances.append(
+                vocab_parallel_tv_distance(
+                    draft_logits,
+                    target_logits.permute(2, 0, 1),
+                    tp_group=tp_group,
+                    logits_are_vocab_sharded=logits_are_vocab_sharded,
+                )
+            )
 
     tv_distances_tensor = torch.stack(tv_distances, dim=0)
     per_step_acceptance = 1.0 - tv_distances_tensor
@@ -1062,6 +1120,7 @@ def process_mtp_loss(
     packed_seq_params: Optional[PackedSeqParams] = None,
     scale_logits_fn: Optional[Callable[[Tensor], Tensor]] = None,
     input_ids: Optional[Tensor] = None,
+    sequence_roll_context: Optional[MTPSequenceRollContext] = None,
 ) -> Tensor:
     """Process Multi-Token Prediction (MTP) loss computation.
 
@@ -1087,6 +1146,8 @@ def process_mtp_loss(
             ``labels`` is None (e.g. RL training), by rolling left to match the SFT
             label convention (``label[i] = input_id[i + 1]``). Ignored when ``labels``
             is provided.
+        sequence_roll_context (Optional[MTPSequenceRollContext]): Layout-specific
+            metadata shared by MTP rolls in this microbatch.
 
     Returns:
         Tensor: Updated hidden states after MTP loss processing (first chunk only).
@@ -1094,38 +1155,22 @@ def process_mtp_loss(
     hidden_states_list = torch.chunk(hidden_states, 1 + config.mtp_num_layers, dim=0)
     hidden_states = hidden_states_list[0]
 
-    # When labels are not provided (e.g. RL training), derive them from input_ids by
-    # rolling left so that label[i] = input_id[i + 1], matching the SFT label format.
-    derived_labels_from_input_ids = False
-    if labels is None:
+    derived_labels_from_input_ids = labels is None
+    if derived_labels_from_input_ids:
         if input_ids is None:
             return hidden_states
-        labels, _ = roll_tensor(
-            input_ids, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
-        )
-        derived_labels_from_input_ids = True
+        if loss_mask is None:
+            loss_mask = torch.ones_like(input_ids)
+    elif loss_mask is None:
+        loss_mask = torch.ones_like(labels)
+
+    assert loss_mask is not None
 
     if config.mtp_detach_heads:
         if output_weight is not None:
             output_weight = output_weight.detach()
         else:
             output_weight = output_layer.weight.detach()
-
-    mtp_labels = labels.clone()
-    if loss_mask is None:
-        loss_mask = torch.ones_like(mtp_labels)
-    if derived_labels_from_input_ids:
-        # input_ids has no real token beyond the sequence window, so the last rolled-in
-        # label is fabricated (zeroed). Roll loss_mask in lockstep with the
-        # input_ids -> labels shift so that boundary position is masked.
-        loss_mask, _ = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
-        )
-
-    # Store the original number of tokens before rolling for proper normalization
-    # when calculate_per_token_loss is enabled. This ensures MTP gradients are
-    # correctly scaled relative to the main loss gradients in finalize_model_grads.
-    original_num_tokens = loss_mask.sum()
 
     if config.mtp_loss_type == "e2e_tv":
         assert output_weight is not None
@@ -1141,8 +1186,45 @@ def process_mtp_loss(
             tp_group=tp_group,
             packed_seq_params=packed_seq_params,
             scale_logits_fn=scale_logits_fn,
-            original_num_tokens=original_num_tokens,
+            sequence_roll_context=sequence_roll_context,
+            derived_labels_from_input_ids=derived_labels_from_input_ids,
         )
+
+    label_source = input_ids if derived_labels_from_input_ids else labels
+    assert label_source is not None
+    label_key = "input_ids" if derived_labels_from_input_ids else "labels"
+    max_offset = config.mtp_num_layers + int(derived_labels_from_input_ids)
+    loss_roll_context = prepare_mtp_sequence_roll_fields(
+        sequence_roll_context,
+        (
+            MTPSequenceRollField(label_key, label_source, -1, 0, 0),
+            MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0),
+        ),
+        max_offset=max_offset,
+    )
+    use_prepared_roll_rows = loss_roll_context is not None
+    if use_prepared_roll_rows:
+        assert loss_roll_context is not None
+        aligned_labels = loss_roll_context.materialize_all(label_key)
+        aligned_loss_masks = loss_roll_context.materialize_all("loss_mask")
+        original_loss_mask = aligned_loss_masks[0] if derived_labels_from_input_ids else loss_mask
+        mtp_labels = label_source
+    else:
+        mtp_labels = label_source
+        if derived_labels_from_input_ids:
+            mtp_labels, loss_mask = roll_tensors_with_context(
+                [mtp_labels, loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["input_ids", "loss_mask"],
+                roll_depth=0,
+            )
+        original_loss_mask = loss_mask
+
+    original_num_tokens = original_loss_mask.sum()
 
     for mtp_layer_number in range(config.mtp_num_layers):
         mtp_logits, _ = output_layer(
@@ -1152,12 +1234,23 @@ def process_mtp_loss(
         )
         if scale_logits_fn is not None:
             mtp_logits = scale_logits_fn(mtp_logits)
-        mtp_labels, _ = roll_tensor(
-            mtp_labels, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
-        )
-        loss_mask, num_tokens = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
-        )
+        if use_prepared_roll_rows:
+            offset_index = mtp_layer_number + int(derived_labels_from_input_ids)
+            mtp_labels = aligned_labels[offset_index]
+            loss_mask = aligned_loss_masks[offset_index]
+            num_tokens = loss_mask.sum()
+        else:
+            mtp_labels, loss_mask = roll_tensors_with_context(
+                [mtp_labels, loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=[label_key, "loss_mask"],
+                roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
+            )
+            num_tokens = loss_mask.sum()
 
         mtp_loss = compute_language_model_loss(mtp_labels, mtp_logits)
 
@@ -1394,6 +1487,9 @@ class MultiTokenPredictionLayer(MegatronModule):
         hidden_states: torch.Tensor,
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[torch.Tensor] = None,
+        sequence_roll_context: Optional[MTPSequenceRollContext] = None,
+        roll_depth: int = 0,
+        _inputs_pre_aligned: bool = False,
     ):
         """
         Preprocesses input data for the Multi-Token Prediction (MTP) layers.
@@ -1409,30 +1505,42 @@ class MultiTokenPredictionLayer(MegatronModule):
             hidden_states (torch.Tensor): hidden states tensor of shape [s, b, h] where s is the
                 sequence length, b is the batch size, and h is the hidden size.
             packed_seq_params (PackedSeqParams): Parameters for packed sequence processing.
+            sequence_roll_context: Layout-specific state shared by MTP rolls.
+            roll_depth: Zero-based prediction depth for the successor row.
+            _inputs_pre_aligned: Whether the block already materialized this absolute row.
         """
-        # Calc logits for the current Multi-Token Prediction (MTP) layers.
-        input_ids, _ = roll_tensor(
-            input_ids,
-            shifts=-1,
-            dims=-1,
-            cp_group=self.cp_group,
-            packed_seq_params=packed_seq_params,
-        )
-        position_ids, _ = roll_tensor(
-            position_ids,
-            shifts=-1,
-            dims=-1,
-            cp_group=self.cp_group,
-            packed_seq_params=packed_seq_params,
-        )
-        if padding_mask is not None:
-            padding_mask, _ = roll_tensor(
-                padding_mask,
+        if not _inputs_pre_aligned:
+            tensors_to_roll = [input_ids]
+            fill_values = [0]
+            sequence_fields = ["input_ids"]
+            roll_position_ids = getattr(embedding, "add_position_embedding", True)
+            if roll_position_ids:
+                tensors_to_roll.append(position_ids)
+                fill_values.append(0)
+                sequence_fields.append("position_ids")
+            if padding_mask is not None:
+                tensors_to_roll.append(padding_mask)
+                fill_values.append(True)
+                sequence_fields.append("padding_mask")
+
+            rolled_tensors = roll_tensors_with_context(
+                tensors_to_roll,
                 shifts=-1,
                 dims=-1,
-                cp_group=self.cp_group,
+                cp_group=resolve_cp_group(self.cp_group, packed_seq_params),
                 packed_seq_params=packed_seq_params,
+                fill_values=fill_values,
+                roll_context=sequence_roll_context,
+                sequence_fields=sequence_fields,
+                roll_depth=roll_depth,
             )
+            input_ids = rolled_tensors[0]
+            next_tensor = 1
+            if roll_position_ids:
+                position_ids = rolled_tensors[next_tensor]
+                next_tensor += 1
+            if padding_mask is not None:
+                padding_mask = rolled_tensors[next_tensor]
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
 
@@ -1802,6 +1910,9 @@ class MultiTokenPredictionLayer(MegatronModule):
         attention_bias: Optional[Tensor] = None,
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
+        sequence_roll_context: Optional[MTPSequenceRollContext] = None,
+        roll_depth: int = 0,
+        _inputs_pre_aligned: bool = False,
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
     ):
@@ -1820,6 +1931,9 @@ class MultiTokenPredictionLayer(MegatronModule):
             rotary_pos_emb (Tensor, optional): Rotary positional embeddings.
             rotary_pos_cos (Tensor, optional): Cosine component of rotary positional embeddings.
             rotary_pos_sin (Tensor, optional): Sine component of rotary positional embeddings.
+            sequence_roll_context: Layout-specific state shared by MTP rolls.
+            roll_depth: Zero-based prediction depth for this layer invocation.
+            _inputs_pre_aligned: Whether the block already selected this absolute row.
             sequence_len_offset (Tensor, optional): Offset for sequence length, if applicable.
             embedding (Callable): The embedding module from gpt model to compute the decoder input.
 
@@ -1835,6 +1949,9 @@ class MultiTokenPredictionLayer(MegatronModule):
             embedding=embedding,
             hidden_states=hidden_states,
             packed_seq_params=packed_seq_params,
+            sequence_roll_context=sequence_roll_context,
+            roll_depth=roll_depth,
+            _inputs_pre_aligned=_inputs_pre_aligned,
         )
 
         if self.config.recompute_granularity == 'full' and self.training:
@@ -1917,6 +2034,23 @@ class MultiTokenPredictionBlockSubmodules:
     """
 
     layer_specs: Optional[List[ModuleSpec]] = None
+
+
+def _scatter_mtp_padding_mask(
+    padding_mask: Optional[Tensor], *, sequence_parallel: bool, tp_group
+) -> Optional[Tensor]:
+    """Convert one globally aligned MTP routing mask to its TP-local layout."""
+    if padding_mask is None or not sequence_parallel:
+        return padding_mask
+    if tp_group is None:
+        raise ValueError("MTP sequence-parallel padding-mask scatter requires a TP group.")
+    return (
+        tensor_parallel.scatter_to_sequence_parallel_region(
+            padding_mask.transpose(0, 1).contiguous(), group=tp_group
+        )
+        .transpose(0, 1)
+        .contiguous()
+    )
 
 
 def _get_mtp_block_submodules(
@@ -2152,6 +2286,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         attention_bias: Optional[Tensor] = None,
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
+        sequence_roll_context: Optional[MTPSequenceRollContext] = None,
+        sequence_roll_padding_mask: Optional[Tensor] = None,
         sequence_len_offset: Optional[Tensor] = None,
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
@@ -2164,6 +2300,8 @@ class MultiTokenPredictionBlock(MegatronModule):
                 where s is the sequence length, b is the batch size, and h is the hidden size.
             attention_mask (Tensor): Boolean tensor of shape [1, 1, s, s] for masking
                 self-attention.
+            sequence_roll_context: Layout-specific metadata shared across all MTP depths.
+            sequence_roll_padding_mask: Unsharded padding-mask source for absolute rows.
 
         Returns:
             (Tensor): The mtp loss tensor of shape [b, s].
@@ -2180,8 +2318,41 @@ class MultiTokenPredictionBlock(MegatronModule):
         if hidden_state_mixing_enabled:
             hidden_state_history = [hidden_states]
 
+        if sequence_roll_padding_mask is not None and padding_mask is None:
+            raise ValueError(
+                "MTP sequence_roll_padding_mask requires the corresponding TP-local padding_mask."
+            )
+        roll_position_ids = getattr(embedding, "add_position_embedding", True)
+        roll_fields = [MTPSequenceRollField("input_ids", input_ids, -1, 0, 0)]
+        if roll_position_ids:
+            roll_fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+        if sequence_roll_padding_mask is not None:
+            roll_fields.append(
+                MTPSequenceRollField("padding_mask", sequence_roll_padding_mask, -1, 0, True)
+            )
+        prepared_roll_context = None
+        if padding_mask is None or sequence_roll_padding_mask is not None:
+            prepared_roll_context = prepare_mtp_sequence_roll_fields(
+                sequence_roll_context, roll_fields, max_offset=self.config.mtp_num_layers
+            )
+        aligned_rows = None
+        if prepared_roll_context is not None:
+            aligned_rows = {
+                field.key: prepared_roll_context.materialize_all(field.key) for field in roll_fields
+            }
+
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
+            if aligned_rows is not None:
+                input_ids = aligned_rows["input_ids"][iteration]
+                if roll_position_ids:
+                    position_ids = aligned_rows["position_ids"][iteration]
+                if sequence_roll_padding_mask is not None:
+                    padding_mask = _scatter_mtp_padding_mask(
+                        aligned_rows["padding_mask"][iteration],
+                        sequence_parallel=self.sequence_parallel,
+                        tp_group=getattr(self.layers[layer_idx], "tp_group", None),
+                    )
 
             # Older HSM entries predict earlier targets than the newest entry. Roll
             # them once per depth so all candidates correspond to the same target.
@@ -2258,6 +2429,9 @@ class MultiTokenPredictionBlock(MegatronModule):
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
                 packed_seq_params=packed_seq_params,
+                sequence_roll_context=sequence_roll_context,
+                roll_depth=iteration,
+                _inputs_pre_aligned=aligned_rows is not None,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
                 **(extra_block_kwargs or {}),

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -80,6 +80,14 @@ class TransformerConfig(ModelParallelConfig):
     which serves as an additional training objective.
     """
 
+    mtp_loss_type: str = "cross_entropy"
+    """Training objective for Multi-Token Prediction (MTP) heads.
+
+    Supported values are ``cross_entropy`` and ``e2e_tv``. The end-to-end total
+    variation objective directly optimizes the normalized expected acceptance
+    length under rejection-sampling verification.
+    """
+
     mtp_use_repeated_layer: bool = False
     """Use a single MTP layer repeatedly instead of multiple separate layers."""
 
@@ -1476,6 +1484,20 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.mtp_hsm and (self.mtp_num_layers is None or self.mtp_num_layers < 2):
             raise ValueError("mtp_hsm=True requires mtp_num_layers >= 2.")
+
+        if self.mtp_loss_type not in ("cross_entropy", "e2e_tv"):
+            raise ValueError(
+                "mtp_loss_type must be one of 'cross_entropy' or 'e2e_tv', "
+                f"got {self.mtp_loss_type!r}."
+            )
+        if self.mtp_loss_type == "e2e_tv":
+            if self.mtp_num_layers is None or self.mtp_num_layers < 1:
+                raise ValueError("mtp_loss_type='e2e_tv' requires mtp_num_layers >= 1.")
+            if not self.mtp_detach_heads:
+                raise ValueError(
+                    "mtp_loss_type='e2e_tv' requires mtp_detach_heads=True so the target "
+                    "distribution and shared backbone remain frozen."
+                )
 
         # When fp32 residual connections are enabled, pipeline parallel communication must
         # use fp32 to match the dtype of the residual stream between pipeline stages.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1446,14 +1446,6 @@ class TransformerConfig(ModelParallelConfig):
                 "Sequence-parallel CP layout conversion requires an even "
                 f"tensor-parallel size, got {self.tensor_model_parallel_size}."
             )
-        if (
-            self.linear_cp_layout == "contiguous"
-            and self.context_parallel_size > 1
-            and (self.mtp_num_layers or 0) > 0
-        ):
-            raise ValueError(
-                "linear_cp_layout='contiguous' with context parallelism does not yet support MTP."
-            )
 
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -976,7 +976,8 @@ def num_floating_point_operations(
                      gdn_qk_head_dim=128, gdn_v_head_dim=128,
                      gdn_num_qk_heads=16, gdn_num_v_heads=32,
                      gdn_conv_kernel_dim=4, gdn_use_gdn2=False,
-                     vocab_size=256000, mtp_num_layers=0):
+                     vocab_size=256000, mtp_num_layers=0,
+                     mtp_loss_type="cross_entropy"):
         """Calculate total FLOPs for the hybrid model."""
         mamba_flops = (
             gated_delta_product_layer_flops(total_tokens, hidden_size,
@@ -1004,7 +1005,14 @@ def num_floating_point_operations(
                                                   gdn_conv_kernel_dim, gdn_use_gdn2) +
                 (2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
         )
-        return flops_fwd * 3
+        # E2E TV projects the frozen backbone once to produce target logits.
+        # This projection has no backward pass because the target distribution
+        # is detached. Softmax/overlap elementwise work is omitted consistently
+        # with the existing cross-entropy FLOPs convention.
+        e2e_tv_target_projection_flops = (
+            2 * total_tokens * hidden_size * vocab_size if mtp_loss_type == "e2e_tv" else 0
+        )
+        return flops_fwd * 3 + e2e_tv_target_projection_flops
 
     def transformer_flops():
         """Calculate FLOPs for a standard Transformer model."""
@@ -1301,6 +1309,11 @@ def num_floating_point_operations(
                 * args.hidden_size
                 * args.padded_vocab_size
                 * (mtp_num_layers + 1)  # MTP + final logit
+                # E2E TV target distribution: one frozen forward-only output projection.
+                + fma_expansion_factor
+                * args.hidden_size
+                * args.padded_vocab_size
+                * int(getattr(args, "mtp_loss_type", "cross_entropy") == "e2e_tv")
             )
             # Self Attention (core L^2 part). For BSHD the default
             # ``seqlen_squared_sum_in_batch = batch_size * seq_length^2`` recovers the
@@ -1382,6 +1395,7 @@ def num_floating_point_operations(
             gdn_use_gdn2=(args.experimental_attention_variant == "gdn2"),
             vocab_size=args.padded_vocab_size,
             mtp_num_layers=mtp_num_layers,
+            mtp_loss_type=getattr(args, "mtp_loss_type", "cross_entropy"),
         )
     else:
         # Compute standard Transformer model FLOPs.

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -344,6 +344,7 @@ def forward_step(data_iterator, model: HybridModel):
             cp_group=hybrid_cp_group,
             total_tokens=total_tokens,
             tokens_per_sample=args.seq_length,
+            cp_partition_mode=args.linear_cp_layout,
         )
 
     timers('batch-generator').stop()

--- a/tests/unit_tests/context_parallel/test_layout.py
+++ b/tests/unit_tests/context_parallel/test_layout.py
@@ -175,6 +175,7 @@ def test_packed_zigzag_layout_uses_padded_metadata(monkeypatch):
         max_seqlen_q=9,
         max_seqlen_kv=9,
         total_tokens=16,
+        cp_partition_mode="contiguous",
     )
     plan = SimpleNamespace(
         cu_seqlens_padded=target_cu_seqlens_padded, max_seqlen_padded=16, pad_between_seqs=True
@@ -196,6 +197,7 @@ def test_packed_zigzag_layout_uses_padded_metadata(monkeypatch):
     assert zigzag_params.max_seqlen_q == 16
     assert zigzag_params.max_seqlen_kv == 16
     assert zigzag_params.pad_between_seqs
+    assert zigzag_params.cp_partition_mode == "zigzag"
     assert zigzag_params.total_tokens is None
     assert zigzag_params.seq_idx is None
 

--- a/tests/unit_tests/data/test_get_batch.py
+++ b/tests/unit_tests/data/test_get_batch.py
@@ -800,6 +800,7 @@ def test_forward_step_exposes_actual_thd_lengths_for_contiguous_cp(
     assert torch.equal(packed_seq_params.cu_seqlens_kv, expected_cu_seqlens)
     assert torch.equal(packed_seq_params.cu_seqlens_q_padded, padded_cu_seqlens[0])
     assert packed_seq_params.total_tokens == 8
+    assert packed_seq_params.cp_partition_mode == linear_cp_layout
 
 
 def create_pretrain_data_iterator(

--- a/tests/unit_tests/fusions/test_fused_mtp_prefix.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and graph-safety tests for the fused MTP prefix objective."""
+
+import pytest
+import torch
+
+from megatron.core.fusions.fused_mtp_prefix import (
+    fused_mtp_prefix_unavailable_reason,
+    mtp_e2e_prefix_objective,
+)
+
+
+def _native_prefix_objective(acceptances):
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses
+
+
+def _run_objective_and_gradient(function, acceptance_data, grad_output):
+    acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    output, prefix_losses = function(acceptances)
+    (output * grad_output).sum().backward()
+    return output.detach(), prefix_losses.detach(), acceptances.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("num_depths", [1, 2, 7])
+def test_fused_mtp_prefix_matches_native_forward_and_backward(num_depths):
+    """Dynamic draft depths match an independent cumprod oracle."""
+    torch.manual_seed(51 + num_depths)
+    acceptance_data = torch.rand(num_depths, 37, 2, device="cuda")
+    grad_output = torch.randn(37, 2, device="cuda")
+
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is None
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("zero_depth", [0, 3, 6])
+def test_fused_mtp_prefix_backward_is_zero_safe(zero_depth):
+    """Exact zero acceptance never produces division artifacts or nonfinite gradients."""
+    torch.manual_seed(71)
+    acceptance_data = torch.rand(7, 19, device="cuda")
+    acceptance_data[zero_depth] = 0
+    grad_output = torch.randn(19, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert torch.isfinite(actual_grad).all()
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_preserves_near_zero_loss():
+    """The fused mean must not cancel a one-ULP rejection near convergence."""
+    one = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    almost_one = torch.nextafter(one, torch.zeros_like(one))
+    acceptance_data = torch.stack((one, almost_one)).reshape(2, 1)
+    grad_output = torch.ones(1, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert actual.item() > 0.0
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=0, atol=0)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=0, atol=0)
+
+
+def test_mtp_prefix_unsupported_input_uses_reference_fallback(monkeypatch):
+    """CPU and noncontiguous inputs preserve the PyTorch reference path."""
+    acceptance_data = torch.rand(2, 5, 3).transpose(1, 2)
+    assert not acceptance_data.is_contiguous()
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    calls = 0
+    original_cumprod = torch.cumprod
+
+    def record_cumprod(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_cumprod(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "cumprod", record_cumprod)
+    actual = mtp_e2e_prefix_objective(acceptance_data)
+    reference = _native_prefix_objective(acceptance_data)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+    assert calls == 2
+
+
+def test_mtp_prefix_empty_rows_use_reference_fallback():
+    """An empty row dimension never dispatches a zero-program Triton grid."""
+    acceptance_data = torch.empty(7, 0)
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    if torch.cuda.is_available():
+        acceptance_data = acceptance_data.cuda()
+        assert fused_mtp_prefix_unavailable_reason(acceptance_data) == (
+            "acceptances must have at least one row"
+        )
+        actual, prefix_losses = mtp_e2e_prefix_objective(acceptance_data)
+        assert actual.shape == (0,)
+        assert prefix_losses.shape == (7, 0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mtp_prefix_bf16_acceptance_uses_reference_fallback():
+    """BF16 model logits still reach this primitive as FP32 fused-TV outputs."""
+    bf16_acceptances = torch.rand(2, 5, device="cuda", dtype=torch.bfloat16)
+    assert fused_mtp_prefix_unavailable_reason(bf16_acceptances) == (
+        "acceptance dtype torch.bfloat16 is not supported"
+    )
+    actual = mtp_e2e_prefix_objective(bf16_acceptances)
+    reference = _native_prefix_objective(bf16_acceptances)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_is_deterministic_and_cuda_graph_safe():
+    """Forward and analytical backward replay deterministically inside a CUDA Graph."""
+    torch.manual_seed(83)
+    acceptance_data = torch.rand(7, 67, device="cuda")
+    grad_output = torch.randn(67, device="cuda")
+    first = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    second = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    for first_tensor, second_tensor in zip(first, second):
+        assert torch.equal(first_tensor, second_tensor)
+
+    static_acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    static_acceptances.grad = torch.zeros_like(static_acceptances)
+    graph = torch.cuda.CUDAGraph()
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_acceptances.grad.zero_()
+            warmup_output, _ = mtp_e2e_prefix_objective(static_acceptances)
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    with torch.cuda.graph(graph):
+        static_acceptances.grad.zero_()
+        graph_output, graph_prefix_losses = mtp_e2e_prefix_objective(static_acceptances)
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, first[0], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(graph_prefix_losses, first[1], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_acceptances.grad, first[2], rtol=1e-5, atol=1e-6)

--- a/tests/unit_tests/fusions/test_fused_mtp_tv.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_tv.py
@@ -2,15 +2,28 @@
 
 """Numerical and dispatch tests for the fused MTP TV primitive."""
 
+import os
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from megatron.core import parallel_state
 from megatron.core.fusions import fused_mtp_tv as fused_mtp_tv_module
 from megatron.core.fusions.fused_mtp_tv import (
     fused_mtp_tv_unavailable_reason,
     vocab_parallel_tv_distance,
 )
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _select_torchrun_local_cuda_device():
+    """Keep Triton compilation and CUDA Graph capture on one device per process."""
+    if torch.cuda.is_available():
+        local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        torch.cuda.set_device(local_rank % torch.cuda.device_count())
+    yield
 
 
 def _native_tv_distance(draft_logits, target_logits):
@@ -160,6 +173,245 @@ def test_noncontiguous_target_is_packed_before_fused_dispatch(monkeypatch):
     torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
 
 
+def test_target_rows_use_reference_fallback_with_local_halo_and_invalid_fill(monkeypatch):
+    """CPU addressing gathers one target and safely maps invalid rows to zero logits."""
+    torch.manual_seed(23)
+    draft_data = torch.randn(4, 1, 7, dtype=torch.float32)
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, 1, 7, dtype=torch.float32, requires_grad=True)
+    target_row_indices = torch.tensor([[1], [4], [5], [99]], dtype=torch.int32)
+    target_valid_rows = torch.tensor([[True], [True], [False], [True]])
+    grad_output = torch.randn(4, 1, dtype=torch.float32)
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("CPU target-row addressing must use the reference fallback")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    materialized_target = torch.zeros_like(target_logits)
+    materialized_target[0].copy_(target_logits[1])
+    materialized_target[1].copy_(target_halo[0])
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_target_rows_flatten_sequence_and_batch_before_addressing():
+    """Address rows in canonical sequence-major order when the batch size exceeds one."""
+    torch.manual_seed(29)
+    sequence_length = 3
+    batch_size = 2
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, batch_size, vocab_size, device="cuda")
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, batch_size, vocab_size, device="cuda", requires_grad=True)
+    # Local rows flatten as ``sequence * batch_size + batch``; halo rows
+    # continue from ``sequence_length * batch_size`` using the same ordering.
+    target_row_indices = torch.tensor([[2, 3], [6, 7], [8, 9]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(sequence_length, batch_size, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    source_rows = target_logits.detach().reshape(-1, vocab_size)
+    halo_rows = target_halo.detach().reshape(-1, vocab_size)
+    materialized_target = torch.cat((source_rows, halo_rows), dim=0).index_select(
+        0, target_row_indices.reshape(-1).long()
+    )
+    materialized_target = materialized_target.view_as(draft_data)
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_target_rows_noncontiguous_source_uses_reference_fallback(monkeypatch):
+    """Addressing remains correct when a noncontiguous source disables fused dispatch."""
+    torch.manual_seed(31)
+    sequence_length = 3
+    batch_size = 2
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, batch_size, vocab_size, device="cuda")
+    target_logits = (
+        torch.randn(sequence_length, vocab_size, batch_size, device="cuda")
+        .transpose(1, 2)
+        .detach()
+        .requires_grad_(True)
+    )
+    target_halo = torch.randn(1, batch_size, vocab_size, device="cuda", requires_grad=True)
+    target_row_indices = torch.tensor([[2, 3], [4, 5], [6, 7]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(sequence_length, batch_size, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+    assert not target_logits.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) == "logits are not contiguous"
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("A noncontiguous addressed source must use the reference fallback")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    source_rows = target_logits.detach().reshape(-1, vocab_size)
+    halo_rows = target_halo.detach().reshape(-1, vocab_size)
+    materialized_target = torch.cat((source_rows, halo_rows), dim=0).index_select(
+        0, target_row_indices.reshape(-1).long()
+    )
+    materialized_target = materialized_target.view_as(draft_data)
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+def test_target_rows_dispatch_source_halo_and_metadata_without_materializing(monkeypatch):
+    """Fused dispatch receives the immutable source and compact halo directly."""
+    draft = torch.randn(3, 1, 7)
+    target = torch.randn_like(draft)
+    halo = torch.randn(1, 1, 7)
+    indices = torch.tensor([[1], [2], [3]], dtype=torch.int32)
+    valid = torch.ones(3, 1, dtype=torch.bool)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "fused_mtp_tv_unavailable_reason", lambda *_args: None)
+
+    def record_fused(draft_arg, target_arg, tp_group, vocab_sharded, **kwargs):
+        assert draft_arg is draft
+        assert target_arg is target
+        assert tp_group is None
+        assert vocab_sharded is False
+        assert kwargs["target_row_indices"] is indices
+        assert kwargs["target_valid_rows"] is valid
+        assert kwargs["target_halo_logits"] is halo
+        return torch.zeros(draft.shape[:-1], dtype=torch.float32)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", record_fused)
+    output = vocab_parallel_tv_distance(
+        draft,
+        target,
+        logits_are_vocab_sharded=False,
+        target_row_indices=indices,
+        target_valid_rows=valid,
+        target_halo_logits=halo,
+    )
+    assert output.shape == draft.shape[:-1]
+
+
+@pytest.mark.parametrize(
+    ("indices", "valid", "halo", "message"),
+    [
+        (None, torch.ones(2, 1, dtype=torch.bool), None, "provided together"),
+        (None, None, torch.randn(1, 1, 7), "require target row indices"),
+        (torch.ones(2, dtype=torch.int32), torch.ones(2, dtype=torch.bool), None, "leading"),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, dtype=torch.bool),
+            None,
+            "validity must match",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.float32),
+            torch.ones(2, 1, dtype=torch.bool),
+            None,
+            "int32 or torch.int64",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.int32),
+            None,
+            "torch.bool",
+        ),
+        (
+            torch.ones(2, 2, dtype=torch.int32)[:, :1],
+            torch.ones(2, 1, dtype=torch.bool),
+            None,
+            "metadata must be contiguous",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 1, 7, dtype=torch.float64),
+            "target-logits dtype",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 7),
+            "target-logits rank",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 2, 7),
+            "non-sequence target dimensions",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 1, 14)[..., ::2],
+            "halo logits must be contiguous",
+        ),
+    ],
+)
+def test_target_row_addressing_rejects_invalid_metadata(indices, valid, halo, message):
+    """Addressed dispatch rejects inconsistent metadata before any fused launch."""
+    draft = torch.randn(2, 1, 7)
+    target = torch.randn_like(draft)
+    with pytest.raises(ValueError, match=message):
+        vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=indices,
+            target_valid_rows=valid,
+            target_halo_logits=halo,
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_fused_mtp_tv_saves_only_compact_full_vocab_metadata():
     """Backward state must pack its only vocabulary-sized comparison mask."""
@@ -248,6 +500,177 @@ def test_fused_mtp_tv_is_cuda_graph_safe():
         graph_output = vocab_parallel_tv_distance(
             static_draft, target_logits, logits_are_vocab_sharded=False
         )
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, expected_output, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_draft.grad, expected_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_fused_mtp_tv_target_rows_match_materialized_local_halo_and_invalid(dtype, index_dtype):
+    """Direct Triton loads match local, halo, explicitly invalid, and OOB targets."""
+    torch.manual_seed(41)
+    sequence_length = 5
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, 1, vocab_size, device="cuda", dtype=dtype)
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, 1, vocab_size, device="cuda", dtype=dtype, requires_grad=True)
+    target_row_indices = torch.tensor([[1], [4], [5], [6], [99]], device="cuda", dtype=index_dtype)
+    target_valid_rows = torch.tensor(
+        [[True], [True], [True], [False], [True]], device="cuda", dtype=torch.bool
+    )
+    grad_output = torch.randn(sequence_length, 1, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            tp_group=None,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    materialized_target = torch.zeros_like(target_logits)
+    materialized_target[0].copy_(target_logits[1])
+    materialized_target[1].copy_(target_logits[4])
+    materialized_target[2].copy_(target_halo[0])
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    rtol = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    atol = 3e-3 if dtype == torch.bfloat16 else 1e-6
+    torch.testing.assert_close(actual, reference, rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=rtol, atol=atol)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.skipif(Utils.world_size < 2, reason="TP2 target-row addressing requires two ranks")
+def test_fused_mtp_tv_target_rows_match_global_oracle_with_tp2_sharded_vocab():
+    """TP2 addressed local, halo, invalid, and OOB rows match a global-vocab oracle."""
+    if Utils.world_size % 2 != 0:
+        pytest.skip("TP2 target-row addressing requires an even world size")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        torch.manual_seed(43)
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        sequence_length = 6
+        batch_size = 1
+        local_vocab_size = 257
+        global_vocab_size = 2 * local_vocab_size
+
+        global_draft_data = torch.randn(
+            sequence_length, batch_size, global_vocab_size, device="cuda"
+        )
+        global_target_logits = torch.randn_like(global_draft_data)
+        global_target_halo = torch.randn(2, batch_size, global_vocab_size, device="cuda")
+        vocab_start = tp_rank * local_vocab_size
+        vocab_end = vocab_start + local_vocab_size
+        local_draft_data = global_draft_data[..., vocab_start:vocab_end].contiguous()
+        local_target_logits = (
+            global_target_logits[..., vocab_start:vocab_end].contiguous().requires_grad_(True)
+        )
+        local_target_halo = (
+            global_target_halo[..., vocab_start:vocab_end].contiguous().requires_grad_(True)
+        )
+
+        target_row_indices = torch.tensor(
+            [[1], [5], [6], [7], [-1], [99]], device="cuda", dtype=torch.int32
+        )
+        target_valid_rows = torch.tensor(
+            [[True], [True], [True], [True], [False], [True]], device="cuda", dtype=torch.bool
+        )
+        grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+        def mapped_tp_tv(draft, target):
+            return vocab_parallel_tv_distance(
+                draft,
+                target,
+                tp_group=tp_group,
+                logits_are_vocab_sharded=True,
+                target_row_indices=target_row_indices,
+                target_valid_rows=target_valid_rows,
+                target_halo_logits=local_target_halo,
+            )
+
+        materialized_global_target = torch.zeros_like(global_target_logits)
+        materialized_global_target[0].copy_(global_target_logits[1])
+        materialized_global_target[1].copy_(global_target_logits[5])
+        materialized_global_target[2].copy_(global_target_halo[0])
+        materialized_global_target[3].copy_(global_target_halo[1])
+
+        actual, actual_grad = _run_tv_and_gradient(
+            mapped_tp_tv, local_draft_data, local_target_logits, grad_output
+        )
+        reference, reference_global_grad = _run_tv_and_gradient(
+            _native_tv_distance, global_draft_data, materialized_global_target, grad_output
+        )
+        reference_local_grad = reference_global_grad[..., vocab_start:vocab_end]
+
+        torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(actual_grad, reference_local_grad, rtol=1e-5, atol=1e-6)
+        assert local_target_logits.grad is None
+        assert local_target_halo.grad is None
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_target_rows_are_deterministic_and_cuda_graph_safe():
+    """Mapped source-plus-halo loads replay deterministically inside a CUDA Graph."""
+    torch.manual_seed(2037)
+    draft_data = torch.randn(4, 1, 1031, device="cuda")
+    target_logits = torch.randn_like(draft_data)
+    target_halo = torch.randn(1, 1, 1031, device="cuda")
+    target_row_indices = torch.tensor([[1], [2], [3], [4]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(4, 1, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(4, 1, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            tp_group=None,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    expected_output, expected_grad = _run_tv_and_gradient(
+        mapped_tv, draft_data, target_logits, grad_output
+    )
+    repeated_output, repeated_grad = _run_tv_and_gradient(
+        mapped_tv, draft_data, target_logits, grad_output
+    )
+    assert torch.equal(repeated_output, expected_output)
+    assert torch.equal(repeated_grad, expected_grad)
+
+    static_draft = draft_data.detach().clone().requires_grad_(True)
+    static_draft.grad = torch.zeros_like(static_draft)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_draft.grad.zero_()
+            warmup_output = mapped_tv(static_draft, target_logits)
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_draft.grad.zero_()
+        graph_output = mapped_tv(static_draft, target_logits)
         (graph_output * grad_output).sum().backward()
     graph.replay()
 

--- a/tests/unit_tests/fusions/test_fused_mtp_tv.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_tv.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and dispatch tests for the fused MTP TV primitive."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.fusions import fused_mtp_tv as fused_mtp_tv_module
+from megatron.core.fusions.fused_mtp_tv import (
+    fused_mtp_tv_unavailable_reason,
+    vocab_parallel_tv_distance,
+)
+
+
+def _native_tv_distance(draft_logits, target_logits):
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return (1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)).clamp(0.0, 1.0)
+
+
+def _run_tv_and_gradient(function, draft_data, target_logits, grad_output):
+    draft_logits = draft_data.detach().clone().requires_grad_(True)
+    output = function(draft_logits, target_logits)
+    (output * grad_output).sum().backward()
+    return output.detach(), draft_logits.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("vocab_size", [257, 154880])
+def test_fused_mtp_tv_matches_native_forward_and_backward(dtype, vocab_size):
+    """Cover an odd block tail and GLM-5.2's production vocabulary."""
+    torch.manual_seed(1234)
+    shape = (3, 2, vocab_size)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype, requires_grad=True)
+    grad_output = torch.randn(shape[:-1], device="cuda", dtype=torch.float32)
+
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) is None
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    assert actual.dtype == torch.float32
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    rtol = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    atol = 3e-3 if dtype == torch.bfloat16 else 1e-6
+    torch.testing.assert_close(actual, reference, rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=rtol, atol=atol)
+    assert target_logits.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_clamp_boundaries_and_zero_acceptance():
+    """The fused path preserves both clamp endpoints and finite gradients."""
+    vocab_size = 257
+    identical = torch.randn(2, vocab_size, device="cuda", dtype=torch.float32)
+    identical_output, identical_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        identical,
+        identical,
+        torch.ones(2, device="cuda"),
+    )
+    torch.testing.assert_close(
+        identical_output, torch.zeros_like(identical_output), atol=1e-6, rtol=0
+    )
+    torch.testing.assert_close(identical_grad, torch.zeros_like(identical_grad), atol=1e-6, rtol=0)
+
+    draft = torch.full((1, vocab_size), -100.0, device="cuda")
+    target = torch.full_like(draft, -100.0)
+    draft[:, 0] = 100.0
+    target[:, 1] = 100.0
+    output, gradient = _run_tv_and_gradient(
+        lambda draft_logits, target_logits: vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        ),
+        draft,
+        target,
+        torch.ones(1, device="cuda"),
+    )
+    torch.testing.assert_close(output, torch.ones_like(output), atol=1e-6, rtol=0)
+    assert torch.isfinite(gradient).all()
+    torch.testing.assert_close(gradient, torch.zeros_like(gradient), atol=1e-6, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_logits_use_reference_fallback(monkeypatch):
+    """Unsupported strides retain the PyTorch reference behavior."""
+    torch.manual_seed(17)
+    draft_data = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(draft_data.shape[:-1], device="cuda")
+    assert not draft_data.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) == "logits are not contiguous"
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("The fused kernel must not receive unsupported noncontiguous logits")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_target_is_packed_before_fused_dispatch(monkeypatch):
+    """A materialized-roll view is packed centrally when the draft supports Triton."""
+    torch.manual_seed(19)
+    draft_data = torch.randn(2, 3, 257, device="cuda")
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(2, 3, device="cuda")
+    assert draft_data.is_contiguous()
+    assert not target_logits.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, draft_data) is None
+
+    original_fused = fused_mtp_tv_module._fused_vocab_parallel_tv_distance
+    fused_calls = 0
+
+    def record_fused(draft, target, *args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        assert target.is_contiguous()
+        return original_fused(draft, target, *args, **kwargs)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", record_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    assert fused_calls == 1
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_saves_only_compact_full_vocab_metadata():
+    """Backward state must pack its only vocabulary-sized comparison mask."""
+    torch.manual_seed(29)
+    draft_logits = torch.randn(3, 2, 4097, device="cuda", requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+    saved_tensors = []
+
+    def pack_hook(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        output = vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        )
+        output.sum().backward()
+
+    full_vocab_tensors = [
+        tensor for tensor in saved_tensors if tensor.numel() == draft_logits.numel()
+    ]
+    assert len(full_vocab_tensors) == 1
+    assert full_vocab_tensors[0].data_ptr() == draft_logits.data_ptr()
+    packed_masks = [tensor for tensor in saved_tensors if tensor.dtype == torch.uint8]
+    assert [tuple(tensor.shape) for tensor in packed_masks] == [(6, (4097 + 7) // 8)]
+    assert not any(
+        tensor.dtype in (torch.bool, torch.uint8) and tensor.numel() == draft_logits.numel()
+        for tensor in saved_tensors
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_mtp_tv_is_deterministic(dtype):
+    """Repeated launches of the same implementation are bitwise stable."""
+    torch.manual_seed(2026)
+    draft_data = torch.randn(4, 1031, device="cuda", dtype=dtype)
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+
+    def function(draft, target):
+        return vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+
+    first_output, first_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    second_output, second_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    assert torch.equal(first_output, second_output)
+    assert torch.equal(first_grad, second_grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_is_cuda_graph_safe():
+    """The fused forward and analytical backward replay inside a CUDA Graph."""
+    torch.manual_seed(2031)
+    draft_data = torch.randn(4, 1031, device="cuda")
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+    expected_output, expected_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+
+    static_draft = draft_data.detach().clone().requires_grad_(True)
+    static_draft.grad = torch.zeros_like(static_draft)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_draft.grad.zero_()
+            warmup_output = vocab_parallel_tv_distance(
+                static_draft, target_logits, logits_are_vocab_sharded=False
+            )
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_draft.grad.zero_()
+        graph_output = vocab_parallel_tv_distance(
+            static_draft, target_logits, logits_are_vocab_sharded=False
+        )
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, expected_output, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_draft.grad, expected_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("shape", [(0, 257), (3, 0, 257)])
+def test_empty_row_logits_use_reference_fallback(shape):
+    """Empty leading dimensions never dispatch a zero-program Triton grid."""
+    draft = torch.empty(shape)
+    target = torch.empty_like(draft)
+    assert fused_mtp_tv_unavailable_reason(draft, target) is not None
+
+    if torch.cuda.is_available():
+        draft = draft.cuda()
+        target = target.cuda()
+        assert fused_mtp_tv_unavailable_reason(draft, target) == "logits must have at least one row"
+        actual = vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+        assert actual.shape == draft.shape[:-1]
+        assert actual.numel() == 0

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -126,6 +126,94 @@ class TestGPTModel:
         assert logits.shape[1] == sequence_length
         assert logits.shape[2] == self.gpt_model.vocab_size
 
+    @pytest.mark.parametrize("sequence_parallel", [False, True])
+    @pytest.mark.parametrize("has_padding_mask", [False, True])
+    def test_mtp_keeps_raw_padding_mask_after_decoder_preprocess(
+        self, sequence_parallel, has_padding_mask
+    ):
+        """Decoder SP transforms must not change the MTP sequence-roll source layout."""
+        input_ids = torch.arange(8, dtype=torch.long).view(2, 4)
+        position_ids = input_ids.clone()
+        raw_padding_mask = (
+            torch.tensor([[False, False, True, True], [False, True, False, True]])
+            if has_padding_mask
+            else None
+        )
+        transformed_padding_mask = raw_padding_mask
+        if sequence_parallel and raw_padding_mask is not None:
+            transformed_padding_mask = raw_padding_mask[:, :2].contiguous()
+        decoder_input = torch.zeros(4, 2, self.gpt_model.config.hidden_size)
+        decoder_output = torch.ones_like(decoder_input)
+        self.gpt_model.config.sequence_parallel = sequence_parallel
+
+        with (
+            patch.object(
+                self.gpt_model,
+                "_preprocess",
+                return_value=(decoder_input, None, None, None, None, transformed_padding_mask),
+            ),
+            patch.object(self.gpt_model.decoder, "forward", return_value=decoder_output) as decoder,
+            patch.object(
+                self.gpt_model, "_postprocess", return_value=decoder_output
+            ) as postprocess,
+        ):
+            self.gpt_model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                padding_mask=raw_padding_mask,
+            )
+
+        assert decoder.call_args.kwargs["padding_mask"] is transformed_padding_mask
+        assert postprocess.call_args.kwargs["padding_mask"] is transformed_padding_mask
+        assert postprocess.call_args.kwargs["mtp_padding_mask"] is raw_padding_mask
+
+    def test_postprocess_reuses_supplied_mtp_sequence_roll_context(self):
+        """Fine-grained callers can reuse one prepared context without rebuilding it."""
+
+        class RecordingMTP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.kwargs = None
+
+            def forward(self, **kwargs):
+                self.kwargs = kwargs
+                return kwargs["hidden_states"]
+
+        self.gpt_model.config.mtp_num_layers = 1
+        self.gpt_model.post_process = False
+        self.gpt_model.mtp = RecordingMTP()
+        supplied_context = object()
+        hidden_states = torch.zeros(4, 2, self.gpt_model.config.hidden_size)
+        input_ids = torch.zeros(2, 4, dtype=torch.long)
+        position_ids = torch.zeros_like(input_ids)
+        local_padding_mask = torch.zeros(2, 2, dtype=torch.bool)
+        raw_padding_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+
+        with patch(
+            "megatron.core.models.gpt.gpt_model.prepare_mtp_sequence_roll_context",
+            side_effect=AssertionError("A supplied MTP context must not be rebuilt."),
+        ):
+            output = self.gpt_model._postprocess(
+                hidden_states=hidden_states,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                labels=None,
+                rotary_pos_emb=None,
+                rotary_pos_cos=None,
+                rotary_pos_sin=None,
+                mtp_in_postprocess=True,
+                attention_mask=None,
+                padding_mask=local_padding_mask,
+                mtp_padding_mask=raw_padding_mask,
+                sequence_roll_context=supplied_context,
+            )
+
+        assert output is hidden_states
+        assert self.gpt_model.mtp.kwargs["sequence_roll_context"] is supplied_context
+        assert self.gpt_model.mtp.kwargs["padding_mask"] is local_padding_mask
+        assert self.gpt_model.mtp.kwargs["sequence_roll_padding_mask"] is raw_padding_mask
+
     @pytest.mark.internal
     def test_output_processor_forward(self):
         config: TransformerConfig = self.gpt_model.config

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -255,6 +255,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mtp_detach_heads": False,
     "mtp_hsm": False,
     "mtp_hybrid_override_pattern": None,
+    "mtp_loss_type": "cross_entropy",
     "mtp_loss_scaling_factor": 0.1,
     "mtp_num_layers": None,
     "mtp_standalone": False,

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -151,6 +151,26 @@ class TestBSHDBackwardCompat:
         assert default_flops == explicit_flops
 
 
+class TestMTPE2ETVFlops:
+    """E2E TV adds one frozen target-output projection to the FLOPs count."""
+
+    @pytest.mark.parametrize("hybrid", [False, True])
+    def test_counts_one_forward_only_target_projection(self, hybrid):
+        args = _make_hybrid_args() if hybrid else _make_gpt_args()
+        args.mtp_num_layers = 3
+        args.mtp_loss_type = "cross_entropy"
+        batch_size = 2
+        cross_entropy_flops = num_floating_point_operations(args, batch_size)
+
+        args.mtp_loss_type = "e2e_tv"
+        e2e_tv_flops = num_floating_point_operations(args, batch_size)
+
+        expected_extra = (
+            2 * batch_size * args.seq_length * args.hidden_size * args.padded_vocab_size
+        )
+        assert e2e_tv_flops - cross_entropy_flops == expected_extra
+
+
 class TestTHDScaling:
     """Only the L^2 attention term should depend on ``seqlen_squared_sum_in_batch``."""
 

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -14,9 +14,39 @@ from megatron.core.datasets.data_schedule import (
     get_batch_on_this_rank_for_sequence_packing,
     wrap_data_iterator,
 )
+from megatron.core.datasets.data_schedule_utils import build_packed_microbatches
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.training.global_vars import unset_global_variables
 from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize(("padded_lengths", "expected_min_chunk"), [((8, 12), 2), ((8, 10), 0)])
+def test_build_packed_microbatches_certifies_zigzag_chunk_size(padded_lengths, expected_min_chunk):
+    """The host schedule emits one conservative certificate per packed microbatch."""
+    samples = []
+    for padded_length in padded_lengths:
+        samples.append(
+            {
+                "tokens": torch.arange(padded_length, dtype=torch.int64),
+                "labels": torch.arange(padded_length, dtype=torch.int64),
+                "loss_mask": torch.ones(padded_length, dtype=torch.float32),
+                "position_ids": torch.arange(padded_length, dtype=torch.int64),
+                "original_seq_len": torch.tensor([padded_length - 1], dtype=torch.int32),
+                "padded_seq_len": torch.tensor([padded_length], dtype=torch.int32),
+            }
+        )
+    sample_id_groups = [[[0, 1], [0, 1]]]
+
+    packed = build_packed_microbatches(
+        [samples],
+        torch.device("cpu"),
+        sample_id_groups=sample_id_groups,
+        dcp_rank=0,
+        global_id_seqlens=list(enumerate(padded_lengths)),
+    )
+
+    assert len(packed) == 1
+    assert packed[0]["zigzag_cp_min_chunk_size"].item() == expected_min_chunk
 
 
 def test_scheduler_thd_padding_mask_from_cu_seqlens():

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import torch
 
+import megatron.core.datasets.data_schedule as data_schedule
 from megatron.core import parallel_state
 from megatron.core.datasets.data_schedule import (
     _build_thd_padding_mask,
@@ -18,6 +19,20 @@ from megatron.core.datasets.data_schedule_utils import build_packed_microbatches
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.training.global_vars import unset_global_variables
 from tests.unit_tests.test_utilities import Utils
+
+
+class _HostProcessGroup:
+    """Minimal rank/size interface for host-only batch metadata tests."""
+
+    def __init__(self, size=1, rank=0):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
 
 
 @pytest.mark.parametrize(("padded_lengths", "expected_min_chunk"), [((8, 12), 2), ((8, 10), 0)])
@@ -75,6 +90,96 @@ def test_scheduler_sanitizes_thd_padding_values():
     assert torch.equal(batch['labels'], torch.tensor([12, 13, 0, 22, 0]))
     assert torch.equal(batch['loss_mask'], torch.tensor([1.0, 1.0, 0.0, 1.0, 0.0]))
     assert torch.equal(batch['position_ids'], torch.tensor([0, 1, 0, 0, 0]))
+
+
+@pytest.mark.parametrize(
+    ("cuda_graph_impl", "expected_certificate"), [("none", 2), ("full_iteration", None)]
+)
+def test_sequence_packing_certificate_is_graph_safe(
+    monkeypatch, cuda_graph_impl, expected_certificate
+):
+    """Full-iteration capture must stay on the certificate-independent fallback path."""
+    group = _HostProcessGroup()
+    pg_collection = SimpleNamespace(tp=group, pp=group, cp=group)
+    batch = {
+        "tokens": torch.arange(8, dtype=torch.int64),
+        "position_ids": torch.arange(8, dtype=torch.int64),
+        "labels": torch.arange(8, dtype=torch.int64),
+        "loss_mask": torch.ones(8, dtype=torch.float32),
+        "cu_seqlens": torch.tensor([0, 8], dtype=torch.int32),
+        "cu_seqlens_padded": torch.tensor([0, 8], dtype=torch.int32),
+        "max_seqlen": torch.tensor([8], dtype=torch.int32),
+        "zigzag_cp_min_chunk_size": torch.tensor([2], dtype=torch.int32),
+    }
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _group: [0])
+    monkeypatch.setattr(
+        data_schedule, "broadcast_scalars", lambda values, *_args, **_kwargs: values
+    )
+    monkeypatch.setattr(data_schedule, "broadcast_tensor", lambda *_args, **_kwargs: None)
+
+    *_, packed_seq_params, _ = get_batch_on_this_rank_for_sequence_packing(
+        iter([batch]),
+        pg_collection=pg_collection,
+        config=SimpleNamespace(cuda_graph_impl=cuda_graph_impl),
+    )
+
+    assert packed_seq_params.zigzag_cp_min_chunk_size == expected_certificate
+
+
+@pytest.mark.parametrize(
+    ("pp_size", "pp_rank", "vpp_size", "vp_stage"),
+    [(3, 1, None, None), (2, 0, 2, 1)],
+    ids=["middle-pp", "middle-vpp"],
+)
+def test_sequence_packing_mtp_middle_stage_receives_cp_sliced_fields(
+    monkeypatch, pp_size, pp_rank, vpp_size, vp_stage
+):
+    """An MTP-only PP/VPP stage owns both model inputs and loss fields."""
+    tp_group = _HostProcessGroup()
+    pp_group = _HostProcessGroup(size=pp_size, rank=pp_rank)
+    cp_group = _HostProcessGroup(size=2, rank=0)
+    pg_collection = SimpleNamespace(tp=tp_group, pp=pp_group, cp=cp_group)
+    expected_indices = torch.tensor([0, 1, 6, 7], dtype=torch.int64)
+    batch = {
+        "tokens": torch.arange(8, dtype=torch.int64),
+        "position_ids": torch.arange(8, dtype=torch.int64),
+        "labels": torch.arange(8, dtype=torch.int64) + 1,
+        "loss_mask": torch.ones(8, dtype=torch.float32),
+        "cu_seqlens": torch.tensor([0, 8], dtype=torch.int32),
+        "cu_seqlens_padded": torch.tensor([0, 8], dtype=torch.int32),
+        "max_seqlen": torch.tensor([8], dtype=torch.int32),
+        "zigzag_cp_min_chunk_size": torch.tensor([2], dtype=torch.int32),
+    }
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _group: [0])
+    monkeypatch.setattr(
+        data_schedule, "broadcast_scalars", lambda values, *_args, **_kwargs: values
+    )
+    monkeypatch.setattr(data_schedule, "broadcast_tensor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        data_schedule,
+        "tex",
+        SimpleNamespace(thd_get_partitioned_indices=lambda *_args: expected_indices),
+    )
+
+    tokens, labels, loss_mask, _, position_ids, _, padding_mask = (
+        get_batch_on_this_rank_for_sequence_packing(
+            iter([batch]),
+            vpp_size=vpp_size,
+            mtp_on_this_rank=True,
+            vp_stage=vp_stage,
+            pg_collection=pg_collection,
+        )
+    )
+
+    assert torch.equal(tokens, torch.tensor([[0, 1, 6, 7]]))
+    assert torch.equal(position_ids, torch.tensor([[0, 1, 6, 7]]))
+    assert torch.equal(labels, torch.tensor([[1, 2, 7, 8]]))
+    assert torch.equal(loss_mask, torch.ones(1, 4))
+    assert torch.equal(padding_mask, torch.zeros(1, 4, dtype=torch.bool))
 
 
 class MockVariableLengthSequencePackingDataIterator:

--- a/tests/unit_tests/transformer/test_mtp_sequence_roll.py
+++ b/tests/unit_tests/transformer/test_mtp_sequence_roll.py
@@ -1,0 +1,1446 @@
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.packed_seq_params import PackedSeqParams, pad_sequence_for_thd
+from megatron.core.parallel_state import get_context_parallel_group
+from megatron.core.transformer import mtp_sequence_roll
+from megatron.core.transformer.mtp_sequence_roll import (
+    ContiguousPackedCPRollContext,
+    ContiguousPackedCPRollHalos,
+    ContiguousPackedSeqRollPlan,
+    LocalRollContext,
+    MTPSequenceRollField,
+    ZigzagPackedCPRollContext,
+    prepare_mtp_sequence_roll_context,
+    prepare_mtp_sequence_roll_fields,
+    roll_tensor,
+)
+from megatron.core.transformer.multi_token_prediction import (
+    MultiTokenPredictionBlock,
+    process_mtp_loss,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _packed_params(cu_seqlens, *, partition_mode="contiguous"):
+    return PackedSeqParams(
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        max_seqlen_q=8,
+        max_seqlen_kv=8,
+        qkv_format="thd",
+        cp_partition_mode=partition_mode,
+    )
+
+
+def _packed_absolute_reference(source, boundaries, offset, fill_value):
+    expected = torch.full_like(source, fill_value)
+    physical_ends = list(boundaries[1:])
+    if not physical_ends or physical_ends[-1] < source.size(-1):
+        physical_ends.append(source.size(-1))
+    start = 0
+    for end in physical_ends:
+        end = int(end)
+        if offset < end - start:
+            expected[..., start : end - offset] = source[..., start + offset : end]
+        start = end
+    return expected
+
+
+@pytest.mark.parametrize("offset", [1, 2, 7])
+def test_local_unpacked_absolute_rows_preserve_layout_and_source(offset):
+    ids = torch.arange(16, dtype=torch.long).view(2, 8)
+    hidden = torch.arange(48, dtype=torch.float32).view(8, 2, 3)
+    padding = torch.zeros_like(ids, dtype=torch.bool)
+    ids_before = ids.clone()
+    hidden_before = hidden.clone()
+
+    bare = prepare_mtp_sequence_roll_context(ids, None, None)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("ids", ids, -1, 0, 0),
+            MTPSequenceRollField("hidden", hidden, 0, 1, -1.0),
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+        ],
+        max_offset=7,
+    )
+
+    expected_ids = torch.zeros_like(ids)
+    expected_ids[:, : 8 - offset] = ids[:, offset:]
+    expected_hidden = torch.full_like(hidden, -1.0)
+    expected_hidden[: 8 - offset] = hidden[offset:]
+    expected_padding = torch.ones_like(padding)
+    expected_padding[:, : 8 - offset] = padding[:, offset:]
+
+    assert context.keys == ("ids", "hidden", "padding")
+    assert context.max_offset == 7
+    assert context.address("ids", offset).row_indices.dtype == torch.int32
+    assert context.address("ids", offset).halo is None
+    assert torch.equal(context.materialize("ids", offset), expected_ids)
+    assert torch.equal(context.materialize("hidden", offset), expected_hidden)
+    assert torch.equal(context.materialize("padding", offset), expected_padding)
+    assert context.materialize("ids", 0).data_ptr() == ids.data_ptr()
+    assert not hasattr(context._prepared_fields[0], "original")
+    assert torch.equal(context.materialize_all("ids")[offset - 1], expected_ids)
+    assert torch.equal(ids, ids_before)
+    assert torch.equal(hidden, hidden_before)
+
+
+@pytest.mark.parametrize("offset", [1, 2, 7])
+def test_local_packed_absolute_rows_respect_boundaries_and_implicit_tail(offset):
+    tokens = torch.arange(1, 11, dtype=torch.long).view(1, 10)
+    padding = torch.zeros_like(tokens, dtype=torch.bool)
+    cu_seqlens = torch.tensor([0, 3, 7], dtype=torch.int32)
+    packed = _packed_params(cu_seqlens)
+
+    bare = prepare_mtp_sequence_roll_context(tokens, None, packed)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("tokens", tokens, -1, 0, 0),
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+        ],
+        max_offset=7,
+    )
+
+    assert torch.equal(
+        context.materialize("tokens", offset),
+        _packed_absolute_reference(tokens, [0, 3, 7], offset, 0),
+    )
+    assert torch.equal(
+        context.materialize("padding", offset),
+        _packed_absolute_reference(padding, [0, 3, 7], offset, True),
+    )
+    address = context.address("tokens", offset)
+    assert address.row_indices.dtype == torch.int32
+    assert address.valid_rows.dtype == torch.bool
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_thd_cp1_prepared_rows_capture_and_replay():
+    """Packed CP1 row addressing remains data-driven across CUDA Graph replay."""
+    source = torch.arange(1, 9, dtype=torch.long, device="cuda").view(1, 8)
+    cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32, device="cuda")
+    packed = _packed_params(cu_seqlens)
+    bare = prepare_mtp_sequence_roll_context(source, None, packed)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields([MTPSequenceRollField("tokens", source, -1, 0, 0)], max_offset=3)
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            context.materialize_all("tokens")
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = context.materialize_all("tokens")
+    graph.replay()
+    torch.cuda.synchronize()
+    for offset, actual in enumerate(captured, 1):
+        assert torch.equal(actual, _packed_absolute_reference(source, [0, 3, 8], offset, 0))
+
+    source.copy_(torch.arange(21, 29, dtype=torch.long, device="cuda").view(1, 8))
+    graph.replay()
+    torch.cuda.synchronize()
+    for offset, actual in enumerate(captured, 1):
+        assert torch.equal(actual, _packed_absolute_reference(source, [0, 3, 8], offset, 0))
+
+
+def test_local_context_does_not_change_existing_roll_dispatch():
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6]], dtype=torch.long)
+    unpacked_context = prepare_mtp_sequence_roll_context(tokens, None, None)
+    expected_unpacked = roll_tensor([tokens], packed_seq_params=None)[0]
+    actual_unpacked = roll_tensor([tokens], packed_seq_params=None, roll_context=unpacked_context)[
+        0
+    ]
+    assert torch.equal(actual_unpacked, expected_unpacked)
+
+    cu_seqlens = torch.tensor([0, 2, 6], dtype=torch.int32)
+    packed = _packed_params(cu_seqlens)
+    packed_context = prepare_mtp_sequence_roll_context(tokens, None, packed)
+    expected_packed = roll_tensor([tokens], packed_seq_params=packed)[0]
+    actual_packed = roll_tensor([tokens], packed_seq_params=packed, roll_context=packed_context)[0]
+    assert torch.equal(actual_packed, expected_packed)
+
+
+def test_helper_keeps_unsupported_shapes_and_zigzag_on_fallback():
+    class FakeCPGroup:
+        def __init__(self, size):
+            self._size = size
+
+        def size(self):
+            return self._size
+
+    assert prepare_mtp_sequence_roll_context(torch.zeros(4), None, None) is None
+    packed = _packed_params(torch.tensor([0, 4], dtype=torch.int32), partition_mode="zigzag")
+    assert prepare_mtp_sequence_roll_context(torch.zeros((1, 4)), FakeCPGroup(2), packed) is None
+
+
+def test_contiguous_prepare_is_atomic_deterministic_and_one_hop(monkeypatch):
+    class FakeWork:
+        def wait(self):
+            return None
+
+    class FakeCPGroup:
+        pass
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.tensor([False, True, False, False]),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=FakeCPGroup(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(2, dtype=torch.long),
+    )
+    bare = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    padding = torch.zeros_like(ids, dtype=torch.bool)
+    grouped_calls = []
+
+    def fake_p2p_op(op, tensor, peer, group=None):
+        return SimpleNamespace(op=op, tensor=tensor, peer=peer, group=group)
+
+    def fake_batch_isend_irecv(ops):
+        grouped_calls.append(ops)
+        # Sorted key order is ids (long), then padding (bool), independent of the
+        # declaration order below.
+        recv_ops = [op for op in ops if op.op is torch.distributed.irecv]
+        assert [op.tensor.dtype for op in recv_ops] == [torch.long, torch.bool]
+        recv_ops[0].tensor.copy_(torch.tensor([[5], [6], [7]], dtype=torch.long))
+        recv_ops[1].tensor.zero_()
+        return [FakeWork() for _ in ops]
+
+    monkeypatch.setattr(torch.distributed, "P2POp", fake_p2p_op)
+    monkeypatch.setattr(torch.distributed, "batch_isend_irecv", fake_batch_isend_irecv)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+            MTPSequenceRollField("ids", ids, -1, 0, 0),
+        ],
+        max_offset=3,
+    )
+
+    assert len(grouped_calls) == 1
+    assert context.keys == ("padding", "ids")
+    assert context.address("ids", 3).halo is not None
+    expected_by_offset = (
+        torch.tensor([[2, 0, 4, 5]]),
+        torch.tensor([[0, 0, 5, 6]]),
+        torch.tensor([[0, 0, 6, 0]]),
+    )
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(context.materialize_all("ids"), expected_by_offset)
+    )
+
+    grouped_calls.clear()
+    unsupported = bare.prepare_fields([MTPSequenceRollField("ids", ids, -1, 0, 0)], max_offset=5)
+    assert unsupported is bare
+    assert grouped_calls == []
+
+
+def test_contiguous_validates_whole_group_before_p2p(monkeypatch):
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(3),
+    )
+    context = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Field validation must finish before P2P starts."),
+    )
+    with pytest.raises(ValueError, match="sequence length"):
+        context.prepare_fields(
+            [
+                MTPSequenceRollField("good", torch.zeros((1, 4)), -1, 0),
+                MTPSequenceRollField("bad", torch.zeros((1, 3)), -1, 0),
+            ],
+            max_offset=5,
+        )
+
+
+def test_contiguous_rejects_grad_fields_before_p2p(monkeypatch):
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(3),
+    )
+    context = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Gradient validation must finish before P2P starts."),
+    )
+    with pytest.raises(ValueError, match="does not support fields that require gradients"):
+        context.prepare_fields(
+            [MTPSequenceRollField("hidden", torch.zeros((1, 4), requires_grad=True), -1, 0)],
+            max_offset=5,
+        )
+
+
+def test_empty_prepare_replaces_fields_with_bare_sibling():
+    tokens = torch.arange(4, dtype=torch.long).view(1, 4)
+    local = LocalRollContext(
+        sequence_length=4, batch_size=1, device=torch.device("cpu")
+    ).prepare_fields([MTPSequenceRollField("tokens", tokens, -1, 0, 0)], max_offset=2)
+    cleared_local = local.prepare_fields([], max_offset=2)
+    assert cleared_local is not local
+    assert cleared_local.keys == ()
+    assert cleared_local.max_offset == 0
+    assert cleared_local.sequence_length == local.sequence_length
+    assert cleared_local.batch_size == local.batch_size
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=None,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(0),
+    )
+    halos = ContiguousPackedCPRollHalos(input_ids=torch.zeros((1, 2), dtype=torch.long))
+    contiguous = ContiguousPackedCPRollContext(plan=plan, halos=halos, batch_size=1).prepare_fields(
+        [MTPSequenceRollField("tokens", tokens, -1, 0, 0)], max_offset=2
+    )
+    cleared_contiguous = contiguous.prepare_fields([], max_offset=5)
+    assert cleared_contiguous is not contiguous
+    assert cleared_contiguous.keys == ()
+    assert cleared_contiguous.max_offset == 0
+    assert cleared_contiguous.plan is plan
+    assert cleared_contiguous.halos is halos
+    assert cleared_contiguous.batch_size == contiguous.batch_size
+
+
+def test_late_bound_siblings_reuse_local_and_contiguous_geometry(monkeypatch):
+    tokens = torch.arange(4, dtype=torch.long).view(1, 4)
+    mask = torch.zeros_like(tokens, dtype=torch.bool)
+
+    local = LocalRollContext(
+        sequence_length=4, batch_size=1, device=torch.device("cpu")
+    ).prepare_fields((MTPSequenceRollField("tokens", tokens, -1, 0, 0),), max_offset=3)
+    local_indices = local._roll_row_indices
+    local_valid = local._roll_valid_rows
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_local_roll_geometry",
+        lambda **_: pytest.fail("Local late binding should reuse row geometry."),
+    )
+    rebound_local = local.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+    assert rebound_local._roll_row_indices is local_indices
+    assert rebound_local._roll_valid_rows is local_valid
+    assert rebound_local.max_offset == 3
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=None,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(0),
+    )
+    contiguous = ContiguousPackedCPRollContext(plan=plan, batch_size=1).prepare_fields(
+        (MTPSequenceRollField("tokens", tokens, -1, 0, 0),), max_offset=3
+    )
+    contiguous_indices = contiguous._roll_row_indices
+    contiguous_valid = contiguous._roll_valid_rows
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_contiguous_packed_cp_roll_geometry",
+        lambda *_, **__: pytest.fail("Contiguous late binding should reuse row geometry."),
+    )
+    rebound_contiguous = contiguous.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+    assert rebound_contiguous._roll_row_indices is contiguous_indices
+    assert rebound_contiguous._roll_valid_rows is contiguous_valid
+    assert rebound_contiguous.max_offset == 3
+
+
+def test_source_identity_guard_reprepares_stale_fields_atomically():
+    stale = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    current = torch.tensor([[11, 12, 13, 14]], dtype=torch.long)
+    bare = prepare_mtp_sequence_roll_context(stale, None, None)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [MTPSequenceRollField("input_ids", stale, -1, 0, 0)], max_offset=2
+    )
+
+    assert context.is_prepared_for_fields([MTPSequenceRollField("input_ids", stale, -1, 0, 0)])
+    assert not context.is_prepared_for_fields(
+        [MTPSequenceRollField("input_ids", current, -1, 0, 0)]
+    )
+    rebound = prepare_mtp_sequence_roll_fields(
+        context, [MTPSequenceRollField("input_ids", current, -1, 0, 0)], max_offset=2
+    )
+    assert rebound is not None
+    assert rebound is not context
+    assert rebound.is_prepared_for_fields([MTPSequenceRollField("input_ids", current, -1, 0, 0)])
+    assert torch.equal(rebound.materialize("input_ids", 1), torch.tensor([[12, 13, 14, 0]]))
+
+    stale.add_(100)
+    assert not context.is_prepared_for_fields([MTPSequenceRollField("input_ids", stale, -1, 0, 0)])
+
+
+def test_source_identity_guard_safely_falls_back_for_inference_tensors():
+    with torch.inference_mode():
+        source = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        field = MTPSequenceRollField("input_ids", source, -1, 0, 0)
+        bare = prepare_mtp_sequence_roll_context(source, None, None)
+        assert isinstance(bare, LocalRollContext)
+        context = bare.prepare_fields([field], max_offset=2)
+
+        # Preparation itself remains useful, but an inference tensor has no
+        # version counter with which to prove that a later reuse is fresh.
+        assert torch.equal(context.materialize("input_ids", 1), torch.tensor([[2, 3, 4, 0]]))
+        assert not context.is_prepared_for_fields([field])
+        assert prepare_mtp_sequence_roll_fields(context, [field], max_offset=2) is None
+
+
+def _packed_global_aligned_rows(source, cu_seqlens, offset, fill_value):
+    """Return a global packed-sequence oracle for a left shift by ``offset``."""
+    expected = torch.full_like(source, fill_value)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        start = int(start)
+        end = int(end)
+        if offset < end - start:
+            expected[..., start : end - offset] = source[..., start + offset : end]
+    return expected
+
+
+def _materialize_address(address, fill_value):
+    """Materialize one public sequence-roll address without using context helpers."""
+    source = address.source
+    if address.halo is not None:
+        source = torch.cat((source, address.halo), dim=0)
+    payload_shape = source.shape[2:]
+    selected = source.reshape(-1, *payload_shape).index_select(
+        0, address.row_indices.reshape(-1).long()
+    )
+    selected = selected.reshape(*address.row_indices.shape, *payload_shape)
+    valid_rows = address.valid_rows
+    while valid_rows.dim() < selected.dim():
+        valid_rows = valid_rows.unsqueeze(-1)
+    return torch.where(valid_rows, selected, selected.new_full((), fill_value))
+
+
+class _FakeZigzagCPGroup:
+    """Minimal effective CP group for host-only certificate and route tests."""
+
+    def __init__(self, size):
+        self._size = size
+
+    def size(self):
+        return self._size
+
+
+def _certified_zigzag_params(cu_seqlens, cp_group, *, certificate, local_cp_size=None):
+    """Build zigzag packed-CP metadata with an explicit scheduler certificate."""
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=int(cu_seqlens[-1]),
+        max_seqlen_kv=int(cu_seqlens[-1]),
+        cp_partition_mode="zigzag",
+        local_cp_size=local_cp_size,
+        cp_group=cp_group,
+        zigzag_cp_min_chunk_size=certificate,
+    )
+
+
+def test_uncertified_and_zero_certificate_keep_zigzag_roll_fallback():
+    """Missing/zero certificates describe unsupported optimization, not invalid data."""
+    static_group = _FakeZigzagCPGroup(4)
+    dynamic_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    cu_seqlens = torch.tensor([0, 16], dtype=torch.int32)
+
+    for certificate in (None, 0):
+        packed = _certified_zigzag_params(
+            cu_seqlens, dynamic_group, certificate=certificate, local_cp_size=2
+        )
+        # The dynamic group carried by PackedSeqParams is the effective group;
+        # neither an absent nor a failed certificate creates a prepared context.
+        assert prepare_mtp_sequence_roll_context(source, static_group, packed) is None
+
+    negative = _certified_zigzag_params(cu_seqlens, dynamic_group, certificate=-1, local_cp_size=2)
+    with pytest.raises(ValueError, match="certificate cannot be negative"):
+        prepare_mtp_sequence_roll_context(source, static_group, negative)
+
+
+def test_zigzag_certificate_survives_padding_and_tightens_for_dummy_sequence():
+    """Appending a shorter physical sequence conservatively lowers the certificate."""
+    cu_seqlens = torch.tensor([0, 16], dtype=torch.int32)
+    packed = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens.clone(),
+        cu_seqlens_q_padded=cu_seqlens.clone(),
+        cu_seqlens_kv_padded=cu_seqlens.clone(),
+        max_seqlen_q=16,
+        max_seqlen_kv=16,
+        local_cp_size=2,
+        cp_partition_mode="zigzag",
+        zigzag_cp_min_chunk_size=4,
+    )
+
+    _, _, _, _, padded, _ = pad_sequence_for_thd(
+        torch.ones(1, 8),
+        None,
+        None,
+        None,
+        packed,
+        target_len=12,
+        tail_padding_policy="append_dummy_seq",
+        cp_size=2,
+        cp_rank=0,
+    )
+
+    assert padded.cu_seqlens_q_padded.tolist() == [0, 16, 24]
+    assert padded.zigzag_cp_min_chunk_size == 2
+
+
+def test_zigzag_certificate_is_ignored_by_cuda_graph_argument_matching():
+    """A scheduler runtime certificate must not select another graph runner."""
+    from megatron.core.transformer.cuda_graphs import ArgMetadata, _CudaGraphRunner
+
+    reference = PackedSeqParams(
+        qkv_format="thd", cp_partition_mode="zigzag", zigzag_cp_min_chunk_size=2
+    )
+    current = PackedSeqParams(
+        qkv_format="thd", cp_partition_mode="zigzag", zigzag_cp_min_chunk_size=8
+    )
+    runner = _CudaGraphRunner.__new__(_CudaGraphRunner)
+    runner.fwd_graph_input_arg_metas = [ArgMetadata(reference)]
+    runner.fwd_graph_input_kwarg_metas = {}
+
+    assert runner.get_mismatch_errors((current,), {}) == []
+    current.cp_partition_mode = "contiguous"
+    assert runner.get_mismatch_errors((current,), {})
+
+
+def test_certified_zigzag_rejects_effective_cp_group_mismatch():
+    source = torch.arange(8).view(1, 8)
+    dynamic_group = _FakeZigzagCPGroup(2)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 16], dtype=torch.int32), dynamic_group, certificate=4, local_cp_size=4
+    )
+
+    with pytest.raises(ValueError, match="must match the effective CP group size"):
+        prepare_mtp_sequence_roll_context(source, _FakeZigzagCPGroup(4), packed)
+
+
+@pytest.mark.parametrize(
+    ("boundaries", "message"),
+    [
+        ((1, 16), "must start at zero"),
+        ((0, 12, 8), "must be nondecreasing"),
+        ((0, 12), "must cover the physical buffer exactly"),
+        ((0, 14, 16), "physical chunk divisibility"),
+        ((0, 4, 16), "overstates the minimum physical chunk size"),
+    ],
+)
+def test_certified_zigzag_validates_runtime_metadata_before_p2p(monkeypatch, boundaries, message):
+    cp_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    packed = _certified_zigzag_params(
+        torch.tensor(boundaries, dtype=torch.int32), cp_group, certificate=2, local_cp_size=2
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda group: [0, 1])
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Invalid certified metadata must fail before P2P."),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        bare.prepare_fields((MTPSequenceRollField("tokens", source, -1, 0, 0),), max_offset=2)
+
+
+def test_certified_zigzag_multi_hop_fallback_is_atomic(monkeypatch):
+    """A consumer wider than the certificate performs no partial prepare or P2P."""
+    cp_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 16], dtype=torch.int32), cp_group, certificate=2, local_cp_size=2
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Unsupported multi-hop preparation must not start P2P."),
+    )
+
+    fields = (MTPSequenceRollField("tokens", source, -1, 0, 0),)
+    assert bare.prepare_fields(fields, max_offset=3) is bare
+    assert prepare_mtp_sequence_roll_fields(bare, fields, max_offset=3) is None
+    assert bare.keys == ()
+    assert bare.max_offset == 0
+
+
+def test_certified_zigzag_routes_and_late_binding_reuse_geometry(monkeypatch):
+    """Front/back routes use opposite peers and sibling fields share exact geometry."""
+
+    class FakeWork:
+        def wait(self):
+            return None
+
+    cp_group = _FakeZigzagCPGroup(4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 1)
+    monkeypatch.setattr(
+        torch.distributed, "get_process_group_ranks", lambda group: [10, 20, 30, 40]
+    )
+
+    captured_calls = []
+
+    def fake_p2p_op(op, tensor, peer, group=None):
+        return SimpleNamespace(op=op, tensor=tensor, peer=peer, group=group)
+
+    def fake_batch_isend_irecv(ops):
+        captured_calls.append(tuple(ops))
+        assert [(op.op, op.peer) for op in ops] == [
+            (torch.distributed.irecv, 30),
+            (torch.distributed.isend, 10),
+            (torch.distributed.irecv, 10),
+            (torch.distributed.isend, 30),
+        ]
+        recv_ops = [op for op in ops if op.op is torch.distributed.irecv]
+        if recv_ops[0].tensor.dtype == torch.long:
+            send_ops = [op for op in ops if op.op is torch.distributed.isend]
+            assert torch.equal(send_ops[0].tensor, torch.tensor([[4], [5], [6]], dtype=torch.long))
+            assert torch.equal(
+                send_ops[1].tensor, torch.tensor([[24], [25], [26]], dtype=torch.long)
+            )
+            recv_ops[0].tensor.copy_(torch.tensor([[8], [9], [10]], dtype=torch.long))
+            recv_ops[1].tensor.copy_(torch.tensor([[28], [29], [30]], dtype=torch.long))
+        else:
+            recv_ops[0].tensor.zero_()
+            recv_ops[1].tensor.zero_()
+        return [FakeWork() for _ in ops]
+
+    monkeypatch.setattr(torch.distributed, "P2POp", fake_p2p_op)
+    monkeypatch.setattr(torch.distributed, "batch_isend_irecv", fake_batch_isend_irecv)
+
+    # CP4 rank 1 owns global front chunk [4, 8) and mirrored back chunk [24, 28).
+    source = torch.tensor([[4, 5, 6, 7, 24, 25, 26, 27]], dtype=torch.long)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 32], dtype=torch.int32), cp_group, certificate=4, local_cp_size=4
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    prepared = bare.prepare_fields(
+        (MTPSequenceRollField("tokens", source, -1, 0, 0),), max_offset=3
+    )
+
+    assert torch.equal(
+        prepared.materialize("tokens", 1),
+        torch.tensor([[5, 6, 7, 8, 25, 26, 27, 28]], dtype=torch.long),
+    )
+    assert torch.equal(
+        prepared.materialize("tokens", 3),
+        torch.tensor([[7, 8, 9, 10, 27, 28, 29, 30]], dtype=torch.long),
+    )
+    first_indices = prepared._roll_row_indices
+    first_valid = prepared._roll_valid_rows
+    first_transport = prepared._roll_transport
+    assert first_indices is not None and first_valid is not None and first_transport is not None
+
+    # A late-bound TV/mask sibling with a smaller requested depth must reuse the
+    # already-built row map and route metadata rather than reconstruct either.
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_zigzag_packed_cp_roll_geometry",
+        lambda **_: pytest.fail("Late binding should reuse certified zigzag geometry."),
+    )
+    mask = torch.zeros_like(source, dtype=torch.bool)
+    rebound = prepared.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+
+    assert rebound.keys == ("mask",)
+    assert rebound.max_offset == 3
+    assert rebound._roll_row_indices is first_indices
+    assert rebound._roll_valid_rows is first_valid
+    assert rebound._roll_transport is first_transport
+    assert len(captured_calls) == 2
+
+
+def _canonical_mtp_test_layout(tensor, sequence_dim, batch_dim):
+    sequence_dim %= tensor.ndim
+    batch_dim %= tensor.ndim
+    remaining = tuple(dim for dim in range(tensor.ndim) if dim not in (sequence_dim, batch_dim))
+    return tensor.permute(sequence_dim, batch_dim, *remaining)
+
+
+def _restore_mtp_test_layout(tensor, source, sequence_dim, batch_dim):
+    sequence_dim %= source.ndim
+    batch_dim %= source.ndim
+    permutation = (sequence_dim, batch_dim) + tuple(
+        dim for dim in range(source.ndim) if dim not in (sequence_dim, batch_dim)
+    )
+    inverse = [0] * source.ndim
+    for canonical_dim, original_dim in enumerate(permutation):
+        inverse[original_dim] = canonical_dim
+    return tensor.permute(inverse)
+
+
+def _packed_sequence_roll_oracle(
+    source, offset, *, sequence_dim, batch_dim, fill_value, boundaries
+):
+    """Select global shifted rows without using production roll/address helpers."""
+    canonical = _canonical_mtp_test_layout(source, sequence_dim, batch_dim)
+    output = torch.full_like(canonical, fill_value)
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        valid_length = max(end - start - offset, 0)
+        if valid_length:
+            output[start : start + valid_length].copy_(
+                canonical[start + offset : start + offset + valid_length]
+            )
+    return _restore_mtp_test_layout(output, source, sequence_dim, batch_dim)
+
+
+def _zigzag_shard_oracle(source, boundaries, cp_size, cp_rank, *, sequence_dim, batch_dim):
+    """Produce one zigzag packed-CP shard without production partition helpers."""
+    canonical = _canonical_mtp_test_layout(source, sequence_dim, batch_dim)
+    local_segments = []
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        if start == end:
+            continue
+        segment = canonical[start:end]
+        assert segment.size(0) % (2 * cp_size) == 0
+        chunks = segment.chunk(2 * cp_size, dim=0)
+        local_segments.extend((chunks[cp_rank], chunks[2 * cp_size - cp_rank - 1]))
+    local = torch.cat(local_segments, dim=0).contiguous()
+    return _restore_mtp_test_layout(local, source, sequence_dim, batch_dim)
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_certified_zigzag_cp2_matches_global_oracle(monkeypatch):
+    """A real CP2 group validates both physical zigzag boundary directions."""
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = cp_group.size()
+        assert cp_size == 2
+        boundaries = (0, 16)
+        max_offset = 3
+        full_ids = torch.arange(1, 17, dtype=torch.long, device="cuda").view(1, -1)
+        full_mask = (full_ids % 3 == 0).to(torch.float32)
+        local_ids = _zigzag_shard_oracle(
+            full_ids, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_mask = _zigzag_shard_oracle(
+            full_mask, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        cu_seqlens = torch.tensor(boundaries, dtype=torch.int32, device="cuda")
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=16,
+            max_seqlen_kv=16,
+            cp_partition_mode="zigzag",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            zigzag_cp_min_chunk_size=4,
+        )
+        bare = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed)
+        assert isinstance(bare, ZigzagPackedCPRollContext)
+
+        original_batch_isend_irecv = torch.distributed.batch_isend_irecv
+        p2p_calls = []
+
+        def counted_batch_isend_irecv(ops):
+            p2p_calls.append(len(ops))
+            return original_batch_isend_irecv(ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        context = bare.prepare_fields(
+            (
+                MTPSequenceRollField("ids", local_ids, 1, 0, 0),
+                MTPSequenceRollField("mask", local_mask, 1, 0, 0),
+            ),
+            max_offset=max_offset,
+        )
+        assert p2p_calls == [4]
+
+        for offset in range(1, max_offset + 1):
+            for key, full_source, fill_value in (("ids", full_ids, 0), ("mask", full_mask, 0)):
+                global_expected = _packed_sequence_roll_oracle(
+                    full_source,
+                    offset,
+                    sequence_dim=1,
+                    batch_dim=0,
+                    fill_value=fill_value,
+                    boundaries=boundaries,
+                )
+                local_expected = _zigzag_shard_oracle(
+                    global_expected, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+                )
+                torch.testing.assert_close(
+                    context.materialize(key, offset), local_expected, rtol=0, atol=0
+                )
+        assert p2p_calls == [4]
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_certified_zigzag_cp4_dynamic_interleaved_group_matches_global_oracle(monkeypatch):
+    """A real interleaved CP4 group prepares all fields with one neighbor exchange."""
+    if Utils.world_size < 8 or Utils.world_size % 4 != 0:
+        pytest.skip("This test requires at least eight ranks and a world size divisible by four.")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1)
+    world_size = torch.distributed.get_world_size()
+    num_groups = world_size // 4
+    rank_lists = [
+        list(range(group_index, world_size, num_groups)) for group_index in range(num_groups)
+    ]
+    cp_groups = [torch.distributed.new_group(ranks) for ranks in rank_lists]
+    global_rank = torch.distributed.get_rank()
+    cp_group = cp_groups[global_rank % num_groups]
+    cp_rank = torch.distributed.get_rank(group=cp_group)
+    try:
+        cp_size = 4
+        max_offset = 2
+        valid_boundaries = (0, 13, 33, 33)
+        padded_boundaries = (0, 16, 40, 40)
+        global_sequence_length = padded_boundaries[-1]
+
+        full_padding = torch.ones((1, global_sequence_length), dtype=torch.bool, device="cuda")
+        for valid_start, valid_end, padded_start in zip(
+            valid_boundaries[:-1], valid_boundaries[1:], padded_boundaries[:-1]
+        ):
+            full_padding[:, padded_start : padded_start + valid_end - valid_start] = False
+        full_ids = torch.arange(1, global_sequence_length + 1, device="cuda").view(1, -1)
+        full_ids.masked_fill_(full_padding, 0)
+        full_target = (
+            torch.arange(global_sequence_length * 3, dtype=torch.float32, device="cuda")
+            .view(global_sequence_length, 1, 3)
+            .to(torch.bfloat16)
+        )
+        full_target.masked_fill_(full_padding.transpose(0, 1).unsqueeze(-1), 0)
+
+        local_ids = _zigzag_shard_oracle(
+            full_ids, padded_boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_padding = _zigzag_shard_oracle(
+            full_padding, padded_boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_target = _zigzag_shard_oracle(
+            full_target, padded_boundaries, cp_size, cp_rank, sequence_dim=0, batch_dim=1
+        )
+
+        cu_seqlens = torch.tensor(valid_boundaries, dtype=torch.int32, device="cuda")
+        padded_cu_seqlens = torch.tensor(padded_boundaries, dtype=torch.int32, device="cuda")
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=padded_cu_seqlens,
+            cu_seqlens_kv_padded=padded_cu_seqlens,
+            max_seqlen_q=24,
+            max_seqlen_kv=24,
+            cp_partition_mode="zigzag",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            zigzag_cp_min_chunk_size=2,
+        )
+        # The explicit group is deliberately unrelated: dynamic metadata must win.
+        static_cp_group = get_context_parallel_group()
+        bare = prepare_mtp_sequence_roll_context(local_ids, static_cp_group, packed)
+        assert isinstance(bare, ZigzagPackedCPRollContext)
+        assert bare.cp_group is cp_group
+
+        original_batch_isend_irecv = torch.distributed.batch_isend_irecv
+        p2p_calls = []
+
+        def counted_batch_isend_irecv(ops):
+            p2p_calls.append(len(ops))
+            return original_batch_isend_irecv(ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        fields = [
+            MTPSequenceRollField("ids", local_ids, 1, 0, 0),
+            MTPSequenceRollField("padding", local_padding, 1, 0, True),
+            MTPSequenceRollField("target", local_target, 0, 1, 0),
+        ]
+        if cp_rank % 2:
+            fields.reverse()
+        context = bare.prepare_fields(fields, max_offset=max_offset)
+
+        neighbor_count = int(cp_rank > 0) + int(cp_rank + 1 < cp_size)
+        assert p2p_calls == [2 * neighbor_count * len(fields)]
+        for offset in range(1, max_offset + 1):
+            for key, full_source, sequence_dim, batch_dim, fill_value in (
+                ("ids", full_ids, 1, 0, 0),
+                ("padding", full_padding, 1, 0, True),
+                ("target", full_target, 0, 1, 0),
+            ):
+                global_expected = _packed_sequence_roll_oracle(
+                    full_source,
+                    offset,
+                    sequence_dim=sequence_dim,
+                    batch_dim=batch_dim,
+                    fill_value=fill_value,
+                    boundaries=padded_boundaries,
+                )
+                local_expected = _zigzag_shard_oracle(
+                    global_expected,
+                    padded_boundaries,
+                    cp_size,
+                    cp_rank,
+                    sequence_dim=sequence_dim,
+                    batch_dim=batch_dim,
+                )
+                torch.testing.assert_close(
+                    context.materialize(key, offset), local_expected, rtol=0, atol=0
+                )
+
+        # Every depth consumes only the already-prepared row map and halos.
+        assert p2p_calls == [2 * neighbor_count * len(fields)]
+    finally:
+        torch.distributed.destroy_process_group(cp_group)
+        Utils.destroy_model_parallel()
+
+
+class TestContiguousPackedCPPreparedRollRowsDistributed:
+    """Real CP tests for generic sequence-roll fields and their legacy roll oracle."""
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def test_cp2_true_shards_mixed_dtype_one_grouped_exchange(self, monkeypatch):
+        """One preparation serves every absolute depth without another P2P.
+
+        Every CP rank receives a true contiguous slice of the same global packed
+        microbatch.  Ranks deliberately declare the two fields in opposite order;
+        transport therefore has to use the field-key order rather than declaration
+        order to pair the int64 and float32 messages safely.
+        """
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        assert cp_group.size() == cp_size
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        max_offset = local_sequence_length
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_ids = torch.stack((global_rows + 10, global_rows + 110)).to(torch.long)
+        global_scores = torch.stack(
+            (global_rows.to(torch.float32) + 0.25, global_rows.to(torch.float32) + 100.25)
+        )
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_ids = global_ids[:, local_slice].contiguous()
+        local_scores = global_scores[:, local_slice].contiguous()
+        source_ids = local_ids.clone()
+        source_scores = local_scores.clone()
+
+        # Three physical sequences [0, 5), [5, 9), [9, 12). The middle sequence
+        # crosses the CP boundary, while both ranks also own a local sequence end.
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        bare_context = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        batch_isend_irecv = torch.distributed.batch_isend_irecv
+        grouped_p2p_calls = 0
+        grouped_p2p_op_counts = []
+
+        def counted_batch_isend_irecv(p2p_ops):
+            nonlocal grouped_p2p_calls
+            grouped_p2p_calls += 1
+            grouped_p2p_op_counts.append(len(p2p_ops))
+            return batch_isend_irecv(p2p_ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        fields = [
+            MTPSequenceRollField("ids", local_ids, -1, 0, 0),
+            MTPSequenceRollField("scores", local_scores, -1, 0, -7.5),
+        ]
+        if cp_rank % 2:
+            fields.reverse()
+        context = bare_context.prepare_fields(fields, max_offset=max_offset)
+
+        assert context is not bare_context
+        assert context.keys == tuple(field.key for field in fields)
+        assert grouped_p2p_calls == 1
+        assert grouped_p2p_op_counts == [2]
+        assert context.max_offset == local_sequence_length
+
+        expected_ids_by_offset = []
+        expected_scores_by_offset = []
+        for offset in range(1, max_offset + 1):
+            expected_ids = _packed_global_aligned_rows(global_ids, cu_seqlens.tolist(), offset, 0)[
+                :, local_slice
+            ]
+            expected_scores = _packed_global_aligned_rows(
+                global_scores, cu_seqlens.tolist(), offset, -7.5
+            )[:, local_slice]
+            expected_ids_by_offset.append(expected_ids)
+            expected_scores_by_offset.append(expected_scores)
+
+            ids_address = context.address("ids", offset)
+            scores_address = context.address("scores", offset)
+            assert ids_address.row_indices.dtype == torch.int32
+            assert scores_address.row_indices.dtype == torch.int32
+            assert ids_address.valid_rows.dtype == torch.bool
+            assert scores_address.valid_rows.dtype == torch.bool
+            assert ids_address.halo is not None
+            assert scores_address.halo is not None
+            assert torch.equal(_materialize_address(ids_address, 0).permute(1, 0), expected_ids)
+            assert torch.equal(
+                _materialize_address(scores_address, -7.5).permute(1, 0), expected_scores
+            )
+            assert torch.equal(context.materialize("ids", offset), expected_ids)
+            assert torch.equal(context.materialize("scores", offset), expected_scores)
+
+        assert all(
+            torch.equal(actual, expected)
+            for actual, expected in zip(context.materialize_all("ids"), expected_ids_by_offset)
+        )
+        assert all(
+            torch.equal(actual, expected)
+            for actual, expected in zip(
+                context.materialize_all("scores"), expected_scores_by_offset
+            )
+        )
+        # Addressing and materialization are communication-free after prepare().
+        assert grouped_p2p_calls == 1
+
+        if cp_rank == cp_size - 1:
+            assert torch.equal(context.materialize("ids", max_offset), torch.zeros_like(local_ids))
+            assert torch.equal(
+                context.materialize("scores", max_offset), torch.full_like(local_scores, -7.5)
+            )
+
+        # The established cumulative roll path is an independent distributed
+        # oracle. It performs one grouped P2P per depth, unlike the prepared path.
+        grouped_p2p_calls = 0
+        grouped_p2p_op_counts.clear()
+        rolled_ids = local_ids
+        rolled_scores = local_scores
+        for offset in range(1, max_offset + 1):
+            rolled_ids, rolled_scores = roll_tensor(
+                [rolled_ids, rolled_scores],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                fill_values=[0, -7.5],
+                roll_context=bare_context,
+            )
+            assert torch.equal(rolled_ids, expected_ids_by_offset[offset - 1])
+            assert torch.equal(rolled_scores, expected_scores_by_offset[offset - 1])
+        assert grouped_p2p_calls == max_offset
+        assert grouped_p2p_op_counts == [2] * max_offset
+        assert torch.equal(local_ids, source_ids)
+        assert torch.equal(local_scores, source_scores)
+
+    def test_cp2_mtp_forward_direct_matches_legacy_roll(self):
+        """MTP block pre-alignment is identical to cumulative consumer rolling."""
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        num_depths = 3
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_ids = torch.stack((global_rows + 10, global_rows + 110)).long()
+        global_positions = torch.stack((global_rows, global_rows + 100)).long()
+        global_padding = torch.zeros(
+            (batch_size, global_sequence_length), dtype=torch.bool, device="cuda"
+        )
+        global_padding[0, 7] = True
+        global_padding[1, 10] = True
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_ids = global_ids[:, local_slice].contiguous()
+        local_positions = global_positions[:, local_slice].contiguous()
+        local_padding = global_padding[:, local_slice].contiguous()
+
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        bare_context = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+        direct_context = bare_context.prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", local_ids, -1, 0, 0),
+                MTPSequenceRollField("position_ids", local_positions, -1, 0, 0),
+                MTPSequenceRollField("padding_mask", local_padding, -1, 0, True),
+            ),
+            max_offset=num_depths,
+        )
+
+        class RollAwareLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def forward(
+                self,
+                hidden_states,
+                input_ids,
+                position_ids,
+                padding_mask,
+                packed_seq_params,
+                sequence_roll_context,
+                roll_depth,
+                _inputs_pre_aligned,
+                **kwargs,
+            ):
+                del kwargs
+                if not _inputs_pre_aligned:
+                    input_ids, position_ids, padding_mask = roll_tensor(
+                        [input_ids, position_ids, padding_mask],
+                        shifts=-1,
+                        dims=-1,
+                        cp_group=cp_group,
+                        packed_seq_params=packed_seq_params,
+                        fill_values=[0, 0, True],
+                        roll_context=sequence_roll_context,
+                        sequence_fields=["input_ids", "position_ids", "padding_mask"],
+                        roll_depth=roll_depth,
+                    )
+                self.calls.append(
+                    (
+                        input_ids.clone(),
+                        position_ids.clone(),
+                        padding_mask.clone(),
+                        _inputs_pre_aligned,
+                    )
+                )
+                aligned_value = input_ids.transpose(0, 1).unsqueeze(-1).to(hidden_states.dtype)
+                aligned_value = aligned_value + position_ids.transpose(0, 1).unsqueeze(-1).to(
+                    hidden_states.dtype
+                )
+                hidden_states = hidden_states + aligned_value
+                return hidden_states, input_ids, position_ids, padding_mask
+
+        def run(sequence_roll_context, sequence_roll_padding_mask=None):
+            config = SimpleNamespace(
+                pipeline_model_parallel_size=1, mtp_num_layers=num_depths, mtp_detach_heads=False
+            )
+            block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+            torch.nn.Module.__init__(block)
+            block.config = config
+            block.vp_stage = None
+            block.mtp_use_repeated_layer = False
+            block.layers = torch.nn.ModuleList(RollAwareLayer() for _ in range(num_depths))
+            output = block.forward(
+                input_ids=local_ids,
+                position_ids=local_positions,
+                hidden_states=torch.zeros(local_sequence_length, batch_size, 1, device="cuda"),
+                attention_mask=torch.empty(0, device="cuda"),
+                padding_mask=local_padding,
+                sequence_roll_padding_mask=sequence_roll_padding_mask,
+                packed_seq_params=packed_seq_params,
+                sequence_roll_context=sequence_roll_context,
+                embedding=SimpleNamespace(add_position_embedding=True),
+            )
+            calls = [layer.calls[0] for layer in block.layers]
+            return output, calls
+
+        legacy_output, legacy_calls = run(bare_context)
+        direct_output, direct_calls = run(direct_context, local_padding)
+        assert torch.equal(direct_output, legacy_output)
+        for depth, (legacy_call, direct_call) in enumerate(
+            zip(legacy_calls, direct_calls), start=1
+        ):
+            expected_ids = _packed_global_aligned_rows(global_ids, cu_seqlens.tolist(), depth, 0)[
+                :, local_slice
+            ]
+            expected_positions = _packed_global_aligned_rows(
+                global_positions, cu_seqlens.tolist(), depth, 0
+            )[:, local_slice]
+            expected_padding = _packed_global_aligned_rows(
+                global_padding, cu_seqlens.tolist(), depth, True
+            )[:, local_slice]
+            assert not legacy_call[3]
+            assert direct_call[3]
+            for legacy_value, direct_value, expected in zip(
+                legacy_call[:3],
+                direct_call[:3],
+                (expected_ids, expected_positions, expected_padding),
+            ):
+                assert torch.equal(legacy_value, expected)
+                assert torch.equal(direct_value, expected)
+
+    @pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+    def test_cp2_ce_direct_matches_legacy_roll(self, derived_labels):
+        """SFT and RL CE consumers preserve labels, masks, output, and gradients."""
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        num_depths = 3
+        hidden_size = 4
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_input_ids = torch.stack((global_rows + 10, global_rows + 110)).long()
+        global_labels = torch.stack((global_rows + 1010, global_rows + 1110)).long()
+        global_loss_mask = torch.ones(
+            (batch_size, global_sequence_length), dtype=torch.float32, device="cuda"
+        )
+        global_loss_mask[0, 3] = 0
+        global_loss_mask[1, 7] = 0
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_input_ids = global_input_ids[:, local_slice].contiguous()
+        local_labels = global_labels[:, local_slice].contiguous()
+        local_loss_mask = global_loss_mask[:, local_slice].contiguous()
+
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        reference = local_input_ids if derived_labels else local_labels
+        bare_context = prepare_mtp_sequence_roll_context(reference, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        config = TransformerConfig(
+            hidden_size=hidden_size, num_layers=2, num_attention_heads=2, mtp_num_layers=num_depths
+        )
+        config.mtp_loss_scaling_factor = 1.0
+        hidden_template = (
+            torch.arange(
+                (1 + num_depths) * local_sequence_length * batch_size * hidden_size,
+                dtype=torch.float32,
+                device="cuda",
+            ).view((1 + num_depths) * local_sequence_length, batch_size, hidden_size)
+            / 100.0
+            + 1.0
+        )
+
+        class OutputLayer:
+            gather_output = True
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                del weight, runtime_gather_output
+                return hidden, None
+
+        def run(sequence_roll_context):
+            hidden = hidden_template.clone().requires_grad_(True)
+            seen_labels = []
+
+            def compute_language_model_loss(current_labels, logits):
+                seen_labels.append(current_labels.clone())
+                return (
+                    logits.square().mean(dim=-1).transpose(0, 1)
+                    + current_labels.to(logits.dtype) * 1.0e-4
+                )
+
+            output = process_mtp_loss(
+                hidden_states=hidden,
+                labels=None if derived_labels else local_labels,
+                loss_mask=local_loss_mask,
+                output_layer=OutputLayer(),
+                output_weight=None,
+                runtime_gather_output=None,
+                is_training=False,
+                compute_language_model_loss=compute_language_model_loss,
+                config=config,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                input_ids=local_input_ids if derived_labels else None,
+                sequence_roll_context=sequence_roll_context,
+            )
+            output.sum().backward()
+            return output.detach(), hidden.grad.detach(), seen_labels
+
+        legacy_output, legacy_grad, legacy_labels = run(None)
+        direct_output, direct_grad, direct_labels = run(bare_context)
+        assert torch.equal(direct_output, legacy_output)
+        assert torch.equal(direct_grad, legacy_grad)
+        assert len(direct_labels) == num_depths
+
+        global_label_source = global_input_ids if derived_labels else global_labels
+        first_offset = 2 if derived_labels else 1
+        direct_grad_chunks = torch.chunk(direct_grad, 1 + num_depths, dim=0)
+        for depth, (legacy_current, direct_current) in enumerate(zip(legacy_labels, direct_labels)):
+            offset = first_offset + depth
+            expected_labels = _packed_global_aligned_rows(
+                global_label_source, cu_seqlens.tolist(), offset, 0
+            )[:, local_slice]
+            expected_mask = _packed_global_aligned_rows(
+                global_loss_mask, cu_seqlens.tolist(), offset, 0
+            )[:, local_slice]
+            assert torch.equal(legacy_current, expected_labels)
+            assert torch.equal(direct_current, expected_labels)
+            active_grad = direct_grad_chunks[depth + 1].abs().sum(dim=-1).transpose(0, 1) > 0
+            assert torch.equal(active_grad, expected_mask.bool())
+
+
+@pytest.mark.parametrize("sequence_parallel", [False, True])
+@pytest.mark.parametrize("has_padding_mask", [False, True])
+@pytest.mark.parametrize("prepared", [False, True], ids=["legacy", "prepared"])
+def test_mtp_block_scatters_only_prepared_global_padding_masks(
+    monkeypatch, sequence_parallel, has_padding_mask, prepared
+):
+    """Prepared rows scatter after alignment; legacy keeps its existing local mask."""
+    sequence_length = 8
+    local_sequence_length = 4 if sequence_parallel else sequence_length
+    input_ids = torch.arange(sequence_length).view(1, sequence_length)
+    position_ids = input_ids.clone()
+    raw_padding_mask = (
+        torch.tensor([[False, False, False, False, False, False, True, True]])
+        if has_padding_mask
+        else None
+    )
+    local_padding_mask = (
+        raw_padding_mask[:, :local_sequence_length].contiguous()
+        if raw_padding_mask is not None
+        else None
+    )
+    sequence_roll_context = None
+    if prepared:
+        bare_context = prepare_mtp_sequence_roll_context(input_ids, None, None)
+        fields = [
+            MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+            MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+        ]
+        if raw_padding_mask is not None:
+            fields.append(MTPSequenceRollField("padding_mask", raw_padding_mask, -1, 0, True))
+        sequence_roll_context = bare_context.prepare_fields(fields, max_offset=1)
+
+    tp_group = object()
+    scatter_calls = []
+
+    def fake_scatter(mask, group=None):
+        scatter_calls.append((mask.clone(), group))
+        return mask[:local_sequence_length]
+
+    monkeypatch.setattr(
+        "megatron.core.transformer.multi_token_prediction.tensor_parallel."
+        "scatter_to_sequence_parallel_region",
+        fake_scatter,
+    )
+
+    class RecordingLayer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.tp_group = tp_group
+            self.call = None
+
+        def forward(self, hidden_states, padding_mask=None, **kwargs):
+            self.call = (padding_mask, kwargs["_inputs_pre_aligned"])
+            return (hidden_states, kwargs["input_ids"], kwargs["position_ids"], padding_mask)
+
+    config = SimpleNamespace(
+        pipeline_model_parallel_size=1,
+        mtp_num_layers=1,
+        mtp_detach_heads=False,
+        sequence_parallel=sequence_parallel,
+    )
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = config
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = False
+    block.layers = torch.nn.ModuleList((RecordingLayer(),))
+
+    block.forward(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        hidden_states=torch.zeros(sequence_length, 1, 1),
+        attention_mask=torch.empty(0),
+        padding_mask=local_padding_mask,
+        sequence_roll_padding_mask=raw_padding_mask if prepared else None,
+        sequence_roll_context=sequence_roll_context,
+        embedding=SimpleNamespace(add_position_embedding=True),
+    )
+
+    seen_padding_mask, inputs_pre_aligned = block.layers[0].call
+    assert inputs_pre_aligned is prepared
+    if not has_padding_mask:
+        assert seen_padding_mask is None
+        assert scatter_calls == []
+    elif not prepared:
+        assert seen_padding_mask is local_padding_mask
+        assert scatter_calls == []
+    else:
+        expected_global = torch.ones_like(raw_padding_mask)
+        expected_global[:, :-1] = raw_padding_mask[:, 1:]
+        expected_local = expected_global[:, :local_sequence_length]
+        assert torch.equal(seen_padding_mask, expected_local)
+        if sequence_parallel:
+            assert len(scatter_calls) == 1
+            assert scatter_calls[0][1] is tp_group
+            assert torch.equal(scatter_calls[0][0], expected_global.transpose(0, 1))
+        else:
+            assert scatter_calls == []

--- a/tests/unit_tests/transformer/test_mtp_sequence_roll.py
+++ b/tests/unit_tests/transformer/test_mtp_sequence_roll.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from megatron.core.packed_seq_params import PackedSeqParams, pad_sequence_for_thd
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.parallel_state import get_context_parallel_group
 from megatron.core.transformer import mtp_sequence_roll
 from megatron.core.transformer.mtp_sequence_roll import (
@@ -499,38 +499,6 @@ def test_uncertified_and_zero_certificate_keep_zigzag_roll_fallback():
     negative = _certified_zigzag_params(cu_seqlens, dynamic_group, certificate=-1, local_cp_size=2)
     with pytest.raises(ValueError, match="certificate cannot be negative"):
         prepare_mtp_sequence_roll_context(source, static_group, negative)
-
-
-def test_zigzag_certificate_survives_padding_and_tightens_for_dummy_sequence():
-    """Appending a shorter physical sequence conservatively lowers the certificate."""
-    cu_seqlens = torch.tensor([0, 16], dtype=torch.int32)
-    packed = PackedSeqParams(
-        qkv_format="thd",
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_kv=cu_seqlens.clone(),
-        cu_seqlens_q_padded=cu_seqlens.clone(),
-        cu_seqlens_kv_padded=cu_seqlens.clone(),
-        max_seqlen_q=16,
-        max_seqlen_kv=16,
-        local_cp_size=2,
-        cp_partition_mode="zigzag",
-        zigzag_cp_min_chunk_size=4,
-    )
-
-    _, _, _, _, padded, _ = pad_sequence_for_thd(
-        torch.ones(1, 8),
-        None,
-        None,
-        None,
-        packed,
-        target_len=12,
-        tail_padding_policy="append_dummy_seq",
-        cp_size=2,
-        cp_rank=0,
-    )
-
-    assert padded.cu_seqlens_q_padded.tolist() == [0, 16, 24]
-    assert padded.zigzag_cp_min_chunk_size == 2
 
 
 def test_zigzag_certificate_is_ignored_by_cuda_graph_argument_matching():
@@ -1185,13 +1153,17 @@ class TestContiguousPackedCPPreparedRollRowsDistributed:
 
         def run(sequence_roll_context, sequence_roll_padding_mask=None):
             config = SimpleNamespace(
-                pipeline_model_parallel_size=1, mtp_num_layers=num_depths, mtp_detach_heads=False
+                pipeline_model_parallel_size=1,
+                mtp_num_layers=num_depths,
+                mtp_detach_heads=False,
+                mtp_hsm=False,
             )
             block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
             torch.nn.Module.__init__(block)
             block.config = config
             block.vp_stage = None
             block.mtp_use_repeated_layer = False
+            block.sequence_parallel = False
             block.layers = torch.nn.ModuleList(RollAwareLayer() for _ in range(num_depths))
             output = block.forward(
                 input_ids=local_ids,
@@ -1405,6 +1377,7 @@ def test_mtp_block_scatters_only_prepared_global_padding_masks(
         pipeline_model_parallel_size=1,
         mtp_num_layers=1,
         mtp_detach_heads=False,
+        mtp_hsm=False,
         sequence_parallel=sequence_parallel,
     )
     block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
@@ -1412,6 +1385,7 @@ def test_mtp_block_scatters_only_prepared_global_padding_masks(
     block.config = config
     block.vp_stage = None
     block.mtp_use_repeated_layer = False
+    block.sequence_parallel = sequence_parallel
     block.layers = torch.nn.ModuleList((RecordingLayer(),))
 
     block.forward(

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+from unittest import mock
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -9,6 +11,11 @@ from megatron.core.fusions import fused_mtp_tv as fused_tv_module
 from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
+from megatron.core.transformer.mtp_sequence_roll import (
+    ContiguousPackedCPRollContext,
+    ZigzagPackedCPRollContext,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler, process_mtp_loss
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -248,10 +255,14 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
 
     original_fused_tv = fused_tv_module._fused_vocab_parallel_tv_distance
 
-    def record_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded):
+    def record_fused_tv(
+        draft_logits, target_logits, tp_group, logits_are_vocab_sharded, **row_addressing
+    ):
         assert draft_logits.is_contiguous()
         assert target_logits.is_contiguous()
-        result = original_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded)
+        result = original_fused_tv(
+            draft_logits, target_logits, tp_group, logits_are_vocab_sharded, **row_addressing
+        )
         fused_tv_distances.append(result.detach().clone())
         return result
 
@@ -402,11 +413,35 @@ def test_process_mtp_e2e_tv_packed_zigzag_cp2_matches_global_reference(monkeypat
             qkv_format="thd",
         )
         local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
+        sequence_roll_context = prepare_mtp_sequence_roll_context(
+            tensor=local_loss_mask, cp_group=cp_group, packed_seq_params=packed_seq_params
+        )
+
         captured_target_steps = []
         tv_distance = mtp_module.vocab_parallel_tv_distance
 
         def capture_target(draft_logits, target_logits, **kwargs):
-            captured_target_steps.append(target_logits.detach().clone())
+            target_row_indices = kwargs.get("target_row_indices")
+            if target_row_indices is None:
+                captured_target = target_logits.detach().clone()
+            else:
+                target_valid_rows = kwargs["target_valid_rows"]
+                target_halo_logits = kwargs.get("target_halo_logits")
+                vocab_size = target_logits.size(-1)
+                target_rows = target_logits.detach().reshape(-1, vocab_size)
+                if target_halo_logits is not None:
+                    target_rows = torch.cat(
+                        (target_rows, target_halo_logits.detach().reshape(-1, vocab_size)), dim=0
+                    )
+                flat_indices = target_row_indices.reshape(-1).long()
+                flat_valid = target_valid_rows.reshape(-1)
+                flat_valid = flat_valid & (flat_indices >= 0) & (flat_indices < target_rows.size(0))
+                safe_indices = torch.where(flat_valid, flat_indices, 0)
+                captured_target = target_rows.index_select(0, safe_indices).view_as(draft_logits)
+                captured_target.masked_fill_(
+                    ~flat_valid.view_as(target_valid_rows).unsqueeze(-1), 0
+                )
+            captured_target_steps.append(captured_target)
             return tv_distance(draft_logits, target_logits, **kwargs)
 
         monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", capture_target)
@@ -426,6 +461,7 @@ def test_process_mtp_e2e_tv_packed_zigzag_cp2_matches_global_reference(monkeypat
             config=config,
             cp_group=cp_group,
             packed_seq_params=packed_seq_params,
+            sequence_roll_context=sequence_roll_context,
         )
         result.sum().backward()
 
@@ -512,3 +548,383 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference(logits_are_vocab_sha
         torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
     finally:
         Utils.destroy_model_parallel()
+
+
+def _zigzag_local_rows(global_tensor: torch.Tensor, cp_rank: int, cp_size: int) -> torch.Tensor:
+    """Shard a sequence-last tensor into MCore's front/mirrored-back zigzag layout."""
+    sequence_length = global_tensor.size(-1)
+    assert sequence_length % (2 * cp_size) == 0
+    chunk_length = sequence_length // (2 * cp_size)
+    chunks = global_tensor.split(chunk_length, dim=-1)
+    return torch.cat((chunks[cp_rank], chunks[2 * cp_size - cp_rank - 1]), dim=-1).contiguous()
+
+
+def _run_mtp_loss_and_grad(
+    *,
+    hidden_template: torch.Tensor,
+    labels: torch.Tensor | None,
+    loss_mask: torch.Tensor,
+    input_ids: torch.Tensor | None,
+    output_layer,
+    output_weight: torch.Tensor | None,
+    config: TransformerConfig,
+    cp_group=None,
+    tp_group=None,
+    packed_seq_params: PackedSeqParams | None = None,
+    sequence_roll_context=None,
+) -> tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor | None]:
+    """Return visible output, hidden/weight gradients, and losses passed to autograd."""
+    hidden = hidden_template.detach().clone().requires_grad_(True)
+    layer_weight = getattr(output_layer, "weight", None)
+    if isinstance(layer_weight, torch.Tensor) and layer_weight.grad is not None:
+        layer_weight.grad = None
+
+    def language_model_loss(current_labels, logits):
+        vocab_size = logits.size(-1)
+        sequence_major_loss = F.cross_entropy(
+            logits.reshape(-1, vocab_size),
+            current_labels.transpose(0, 1).reshape(-1),
+            reduction="none",
+        ).view(logits.shape[:-1])
+        return sequence_major_loss.transpose(0, 1).contiguous()
+
+    MTPLossAutoScaler.set_loss_scale(hidden.new_tensor(1.0))
+    normalized_losses = []
+    original_apply = MTPLossAutoScaler.apply
+
+    def record_loss(output, normalized_loss):
+        normalized_losses.append(normalized_loss.detach().clone())
+        return original_apply(output, normalized_loss)
+
+    with mock.patch.object(MTPLossAutoScaler, "apply", side_effect=record_loss):
+        output = process_mtp_loss(
+            hidden_states=hidden,
+            labels=labels,
+            loss_mask=loss_mask,
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=False if tp_group is not None else True,
+            is_training=False,
+            compute_language_model_loss=language_model_loss,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            input_ids=input_ids,
+            sequence_roll_context=sequence_roll_context,
+        )
+    output.sum().backward()
+    assert hidden.grad is not None
+    layer_weight_grad = getattr(layer_weight, "grad", None)
+    return (
+        output.detach(),
+        hidden.grad.detach(),
+        tuple(normalized_losses),
+        None if layer_weight_grad is None else layer_weight_grad.detach().clone(),
+    )
+
+
+def test_e2e_tv_direct_rows_compose_tp2_with_contiguous_cp2(monkeypatch):
+    """TP-sharded TV and contiguous-CP row addressing compose in one consumer."""
+    if Utils.world_size < 4:
+        pytest.skip("TP2 x CP2 direct TV requires at least four distributed ranks")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=2)
+    try:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        cp_group = parallel_state.get_context_parallel_group()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        num_depths = 2
+        global_sequence_length = 8
+        local_sequence_length = global_sequence_length // 2
+        hidden_size = 4
+        global_vocab_size = 10
+
+        torch.manual_seed(101)
+        global_hidden = torch.randn(
+            (1 + num_depths) * global_sequence_length, 1, hidden_size, device="cuda"
+        )
+        local_chunks = [
+            chunk.narrow(0, cp_rank * local_sequence_length, local_sequence_length).contiguous()
+            for chunk in torch.chunk(global_hidden, 1 + num_depths, dim=0)
+        ]
+        local_hidden = torch.cat(local_chunks, dim=0)
+        full_weight = torch.randn(global_vocab_size, hidden_size, device="cuda")
+        local_weight = full_weight.chunk(2, dim=0)[tp_rank].contiguous()
+
+        class ShardedOutputLayer:
+            gather_output = False
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                assert runtime_gather_output is False
+                return torch.matmul(hidden, weight.t()), None
+
+        config = _make_tv_config(num_depths, hidden_size)
+        cu_seqlens = torch.tensor([0, 6, 8], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=6,
+            max_seqlen_kv=6,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        local_labels = torch.zeros(1, local_sequence_length, dtype=torch.long, device="cuda")
+        local_loss_mask = torch.ones_like(local_labels, dtype=torch.float32)
+        bare_context = prepare_mtp_sequence_roll_context(local_labels, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        original_tv = mtp_module.vocab_parallel_tv_distance
+        addressed_calls = 0
+
+        def record_addressing(*args, **kwargs):
+            nonlocal addressed_calls
+            addressed_calls += int(kwargs.get("target_row_indices") is not None)
+            return original_tv(*args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", record_addressing)
+        direct_output, direct_grad, direct_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=None,
+            output_layer=ShardedOutputLayer(),
+            output_weight=local_weight,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=bare_context,
+        )
+
+        torch.distributed.barrier()
+        fallback_output, fallback_grad, fallback_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=None,
+            output_layer=ShardedOutputLayer(),
+            output_weight=local_weight,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=None,
+        )
+        # Keep rank-local assertions after every TP/CP collective in both paths;
+        # otherwise one failing rank can enter teardown while peers run fallback.
+        torch.distributed.barrier()
+        assert addressed_calls == num_depths
+        torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+        torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-5, atol=1e-6)
+        assert len(direct_losses) == len(fallback_losses) == 1
+        torch.testing.assert_close(direct_losses[0], fallback_losses[0], rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+def test_e2e_tv_certified_dynamic_zigzag_matches_roll_loss_and_gradient(
+    monkeypatch, derived_labels
+):
+    """Certified dynamic zigzag addressing preserves SFT/RL TV consumer semantics."""
+    if Utils.world_size < 2:
+        pytest.skip("Certified zigzag TV parity requires at least two distributed ranks")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = torch.distributed.get_world_size(group=cp_group)
+        num_depths = 2
+        global_sequence_length = 12
+        hidden_size = 5
+
+        torch.manual_seed(211)
+        global_hidden_chunks = torch.chunk(
+            torch.randn((1 + num_depths) * global_sequence_length, 1, hidden_size, device="cuda"),
+            1 + num_depths,
+            dim=0,
+        )
+        local_hidden = torch.cat(
+            [
+                _zigzag_local_rows(chunk.permute(1, 2, 0), cp_rank, cp_size).permute(2, 0, 1)
+                for chunk in global_hidden_chunks
+            ],
+            dim=0,
+        )
+        global_input_ids = torch.arange(global_sequence_length, device="cuda").view(1, -1)
+        global_labels = (global_input_ids + 1).remainder(hidden_size)
+        global_loss_mask = torch.ones(1, global_sequence_length, device="cuda")
+        global_loss_mask[:, 4] = 0
+        global_loss_mask[:, -1] = 0
+        local_input_ids = _zigzag_local_rows(global_input_ids, cp_rank, cp_size)
+        local_labels = _zigzag_local_rows(global_labels, cp_rank, cp_size)
+        local_loss_mask = _zigzag_local_rows(global_loss_mask, cp_rank, cp_size)
+
+        cu_seqlens = torch.tensor([0, global_sequence_length], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=global_sequence_length,
+            max_seqlen_kv=global_sequence_length,
+            qkv_format="thd",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            cp_partition_mode="zigzag",
+            zigzag_cp_min_chunk_size=global_sequence_length // (2 * cp_size),
+        )
+        source = local_input_ids if derived_labels else local_labels
+        bare_context = prepare_mtp_sequence_roll_context(source, None, packed_seq_params)
+        assert isinstance(bare_context, ZigzagPackedCPRollContext)
+        assert bare_context.cp_group is packed_seq_params.cp_group
+        config = _make_tv_config(num_depths, hidden_size)
+        output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+        original_tv = mtp_module.vocab_parallel_tv_distance
+        addressed_calls = 0
+
+        def record_addressing(*args, **kwargs):
+            nonlocal addressed_calls
+            addressed_calls += int(kwargs.get("target_row_indices") is not None)
+            return original_tv(*args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", record_addressing)
+
+        direct_output, direct_grad, direct_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=None if derived_labels else local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=local_input_ids if derived_labels else None,
+            output_layer=output_layer,
+            output_weight=None,
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=bare_context,
+        )
+        torch.distributed.barrier()
+        fallback_output, fallback_grad, fallback_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=None if derived_labels else local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=local_input_ids if derived_labels else None,
+            output_layer=output_layer,
+            output_weight=None,
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=None,
+        )
+        torch.distributed.barrier()
+        assert addressed_calls == num_depths
+        torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+        torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-5, atol=1e-6)
+        assert len(direct_losses) == len(fallback_losses) == 1
+        torch.testing.assert_close(direct_losses[0], fallback_losses[0], rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("loss_type", ["cross_entropy", "e2e_tv"], ids=["ce", "tv"])
+@pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+def test_aligned_rows_per_token_normalization_matches_roll(loss_type, derived_labels):
+    """Absolute rows preserve SFT/RL per-token scaling for CE and TV consumers."""
+    torch.manual_seed(307)
+    num_depths = 2
+    sequence_length = 7
+    hidden_size = 5
+    hidden_template = torch.randn(
+        (1 + num_depths) * sequence_length, 1, hidden_size, dtype=torch.float32
+    )
+    input_ids = torch.tensor([[0, 1, 2, 3, 4, 0, 1]], dtype=torch.long)
+    labels = torch.tensor([[1, 2, 3, 4, 0, 1, 2]], dtype=torch.long)
+    loss_mask = torch.tensor([[1, 1, 0, 1, 1, 0, 1]], dtype=torch.float32)
+
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=1,
+        mtp_num_layers=num_depths,
+        mtp_loss_type=loss_type,
+        mtp_detach_heads=loss_type == "e2e_tv",
+        mtp_loss_scaling_factor=0.75,
+        calculate_per_token_loss=True,
+        use_cpu_initialization=True,
+    )
+    output_weight = torch.eye(hidden_size)
+    direct_output_layer = _OutputLayer(output_weight.clone())
+    fallback_output_layer = _OutputLayer(output_weight.clone())
+    source = input_ids if derived_labels else labels
+    bare_context = prepare_mtp_sequence_roll_context(source, None, None)
+    assert bare_context is not None
+    original_prepare = mtp_module.prepare_mtp_sequence_roll_fields
+    original_roll = mtp_module.roll_tensor
+    original_tv = mtp_module.vocab_parallel_tv_distance
+    prepared_groups = 0
+    direct_roll_calls = 0
+    addressed_tv_calls = 0
+
+    def record_prepare(*args, **kwargs):
+        nonlocal prepared_groups
+        result = original_prepare(*args, **kwargs)
+        prepared_groups += int(result is not None)
+        return result
+
+    def record_roll(*args, **kwargs):
+        nonlocal direct_roll_calls
+        direct_roll_calls += 1
+        return original_roll(*args, **kwargs)
+
+    def record_tv(*args, **kwargs):
+        nonlocal addressed_tv_calls
+        addressed_tv_calls += int(kwargs.get("target_row_indices") is not None)
+        return original_tv(*args, **kwargs)
+
+    with (
+        mock.patch.object(
+            mtp_module, "prepare_mtp_sequence_roll_fields", side_effect=record_prepare
+        ),
+        mock.patch.object(mtp_module, "roll_tensor", side_effect=record_roll),
+        mock.patch.object(mtp_module, "vocab_parallel_tv_distance", side_effect=record_tv),
+    ):
+        direct_output, direct_grad, direct_losses, direct_weight_grad = _run_mtp_loss_and_grad(
+            hidden_template=hidden_template,
+            labels=None if derived_labels else labels,
+            loss_mask=loss_mask,
+            input_ids=input_ids if derived_labels else None,
+            output_layer=direct_output_layer,
+            output_weight=None,
+            config=config,
+            sequence_roll_context=bare_context,
+        )
+
+    fallback_output, fallback_grad, fallback_losses, fallback_weight_grad = _run_mtp_loss_and_grad(
+        hidden_template=hidden_template,
+        labels=None if derived_labels else labels,
+        loss_mask=loss_mask,
+        input_ids=input_ids if derived_labels else None,
+        output_layer=fallback_output_layer,
+        output_weight=None,
+        config=config,
+        sequence_roll_context=None,
+    )
+    assert prepared_groups > 0
+    assert direct_roll_calls == 0
+    assert addressed_tv_calls == (num_depths if loss_type == "e2e_tv" else 0)
+    torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+    torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-6, atol=1e-6)
+    assert len(direct_losses) == len(fallback_losses)
+    for direct_loss, fallback_loss in zip(direct_losses, fallback_losses):
+        torch.testing.assert_close(direct_loss, fallback_loss, rtol=1e-6, atol=1e-6)
+    if loss_type == "cross_entropy":
+        assert direct_weight_grad is not None
+        assert fallback_weight_grad is not None
+        torch.testing.assert_close(direct_weight_grad, fallback_weight_grad, rtol=1e-6, atol=1e-6)
+    else:
+        assert direct_weight_grad is None
+        assert fallback_weight_grad is None

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import parallel_state
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer import multi_token_prediction as mtp_module
+from megatron.core.transformer.multi_token_prediction import (
+    MTPLossAutoScaler,
+    process_mtp_loss,
+    vocab_parallel_tv_distance,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+_BEBOP_PAPER = "https://arxiv.org/abs/2606.12370"
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _native_tv_distance(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (10)."""
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return 1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)
+
+
+def _native_e2e_tv_loss(
+    draft_logits: list[torch.Tensor], target_logits: list[torch.Tensor]
+) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (13)."""
+    per_step_acceptance = torch.stack(
+        [
+            1.0 - _native_tv_distance(draft_step, target_step)
+            for draft_step, target_step in zip(draft_logits, target_logits)
+        ],
+        dim=0,
+    )
+    return 1.0 - torch.cumprod(per_step_acceptance, dim=0).mean(dim=0)
+
+
+def _native_roll_packed_sequence_first(
+    tensor: torch.Tensor, cu_seqlens: tuple[int, ...]
+) -> torch.Tensor:
+    """Independent packed left roll for tensors whose first dimension is sequence."""
+    rolled = torch.zeros_like(tensor)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        rolled[start : end - 1] = tensor[start + 1 : end]
+    return rolled
+
+
+def _cosine_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    return F.cosine_similarity(
+        a.flatten().double().unsqueeze(0), b.flatten().double().unsqueeze(0)
+    ).item()
+
+
+def _tensor_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    a, b = a.double(), b.double()
+    denom = (a * a + b * b).sum()
+    return (2.0 * (a * b).sum() / denom).item() if denom else 1.0
+
+
+def _assert_similarity(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-5):
+    assert torch.isfinite(a).all()
+    assert torch.isfinite(b).all()
+    assert _cosine_sim(a, b) > 1 - eps
+    assert _tensor_sim(a, b) > 1 - eps
+
+
+class _OutputLayer(torch.nn.Module):
+    """Small output projection with the same call contract as MCore's output layer."""
+
+    gather_output = True
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = torch.nn.Parameter(weight)
+
+    def forward(self, hidden, weight=None, runtime_gather_output=None):
+        del runtime_gather_output
+        weight = self.weight if weight is None else weight
+        return torch.matmul(hidden, weight.t()), None
+
+
+def _make_tv_config(mtp_num_layers: int, hidden_size: int) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=1,
+        mtp_num_layers=mtp_num_layers,
+        mtp_loss_type="e2e_tv",
+        mtp_loss_scaling_factor=1.0,
+        mtp_detach_heads=True,
+        use_cpu_initialization=True,
+    )
+
+
+def test_mtp_loss_type_validation():
+    default_config = TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=1)
+    assert default_config.mtp_loss_type == "cross_entropy"
+
+    with pytest.raises(ValueError, match="mtp_loss_type must be one of"):
+        TransformerConfig(
+            num_layers=1, hidden_size=8, num_attention_heads=1, mtp_loss_type="unknown"
+        )
+    with pytest.raises(ValueError, match="requires mtp_num_layers"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_loss_type="e2e_tv",
+            mtp_detach_heads=True,
+        )
+    with pytest.raises(ValueError, match="requires mtp_detach_heads=True"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_num_layers=2,
+            mtp_loss_type="e2e_tv",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_full_vocab_tv_forward_and_gradient_match_native_reference(dtype):
+    """Use GLM-5/5.2's production vocabulary size with paper-native math.
+
+    The reference is derived independently from Eq. (10) in ``_BEBOP_PAPER``;
+    it does not invoke MCore's analytical backward.
+    """
+    torch.manual_seed(1234)
+    shape = (2, 1, 128256)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype)
+    grad_weight = torch.tensor([[[0.25]], [[1.5]]], device="cuda")
+
+    draft_actual = draft_data.detach().clone().requires_grad_(True)
+    actual = vocab_parallel_tv_distance(draft_actual, target_logits, logits_are_vocab_sharded=False)
+    (actual * grad_weight.squeeze(-1)).sum().backward()
+
+    draft_reference = draft_data.detach().clone().requires_grad_(True)
+    reference = _native_tv_distance(draft_reference, target_logits)
+    (reference * grad_weight.squeeze(-1)).sum().backward()
+
+    tolerance = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(actual, reference, rtol=tolerance, atol=tolerance)
+    assert draft_actual.grad is not None
+    assert draft_reference.grad is not None
+    _assert_similarity(draft_actual.grad, draft_reference.grad, eps=tolerance)
+    assert target_logits.grad is None
+
+
+def test_process_mtp_e2e_tv_matches_native_alignment_and_gradient():
+    """Check shifted target alignment, Eq. (13), and draft-only gradients on CPU."""
+    torch.manual_seed(7)
+    mtp_num_layers = 2
+    seq_len = 6
+    batch_size = 1
+    hidden_size = 7
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+
+    hidden_data = torch.randn(
+        (1 + mtp_num_layers) * seq_len, batch_size, hidden_size, dtype=torch.float32
+    )
+    hidden_actual = hidden_data.detach().clone().requires_grad_(True)
+    labels = torch.zeros(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_actual,
+        labels=labels,
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    base_hidden, *draft_hidden = torch.chunk(hidden_data, 1 + mtp_num_layers, dim=0)
+    target_hidden = base_hidden.detach().permute(1, 2, 0)
+    target_logits = []
+    draft_logits = []
+    draft_references = []
+    reference_mask = loss_mask.clone()
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    for draft_hidden_step in draft_hidden:
+        target_hidden = torch.roll(target_hidden, shifts=-1, dims=-1)
+        target_hidden[..., -1] = 0
+        target_logits.append(target_hidden.permute(2, 0, 1))
+
+        draft_reference = draft_hidden_step.detach().clone().requires_grad_(True)
+        draft_references.append(draft_reference)
+        draft_logits.append(draft_reference)
+
+        reference_mask = torch.roll(reference_mask, shifts=-1, dims=-1)
+        reference_mask[..., -1] = 0
+        chain_valid &= reference_mask.bool()
+
+    chain_mask = chain_valid.transpose(0, 1).float()
+    reference_loss = _native_e2e_tv_loss(draft_logits, target_logits)
+    (reference_loss * chain_mask).sum().div(chain_mask.sum()).backward()
+
+    assert hidden_actual.grad is not None
+    actual_chunks = torch.chunk(hidden_actual.grad, 1 + mtp_num_layers, dim=0)
+    torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+    for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+        assert draft_reference.grad is not None
+        _assert_similarity(actual_grad, draft_reference.grad)
+        torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    assert output_layer.weight.grad is None
+
+
+def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
+    """A fixed-gamma objective must neither wrap nor train across THD segments."""
+    torch.manual_seed(17)
+    mtp_num_layers = 2
+    seq_len = 7
+    hidden_size = 5
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+    hidden_states = torch.randn((1 + mtp_num_layers) * seq_len, 1, hidden_size, requires_grad=True)
+    packed_seq_params = PackedSeqParams(
+        cu_seqlens_q=torch.tensor([0, 3, 7], dtype=torch.int32),
+        cu_seqlens_kv=torch.tensor([0, 3, 7], dtype=torch.int32),
+        max_seqlen_q=4,
+        max_seqlen_kv=4,
+        qkv_format="thd",
+    )
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, seq_len, dtype=torch.long),
+        loss_mask=torch.ones(1, seq_len),
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+        packed_seq_params=packed_seq_params,
+    )
+    result.sum().backward()
+
+    assert hidden_states.grad is not None
+    _, draft_0_grad, draft_1_grad = torch.chunk(hidden_states.grad, 3, dim=0)
+    expected_valid = torch.tensor([True, False, False, True, True, False, False])
+    assert torch.count_nonzero(draft_0_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_1_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_0_grad[expected_valid]) > 0
+    assert torch.count_nonzero(draft_1_grad[expected_valid]) > 0
+
+
+def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monkeypatch):
+    """Contiguous packed CP rolls target distributions without crossing segments."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        mtp_num_layers = 2
+        global_seq_len = 8
+        local_seq_len = global_seq_len // 2
+        hidden_size = 5
+        cu_seqlens = (0, 6, 8)
+
+        torch.manual_seed(23)
+        full_hidden = torch.randn(
+            (1 + mtp_num_layers) * global_seq_len, 1, hidden_size, device="cuda"
+        )
+        full_chunks = torch.chunk(full_hidden, 1 + mtp_num_layers, dim=0)
+        local_start = cp_rank * local_seq_len
+        local_chunks = [
+            chunk.narrow(0, local_start, local_seq_len).clone() for chunk in full_chunks
+        ]
+        local_hidden = torch.cat(local_chunks, dim=0).requires_grad_(True)
+        output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+        config = _make_tv_config(mtp_num_layers, hidden_size)
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens_tensor,
+            cu_seqlens_kv=cu_seqlens_tensor,
+            cu_seqlens_q_padded=cu_seqlens_tensor,
+            cu_seqlens_kv_padded=cu_seqlens_tensor,
+            max_seqlen_q=6,
+            max_seqlen_kv=6,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
+        captured_target_steps = []
+        tv_distance = mtp_module.vocab_parallel_tv_distance
+
+        def capture_target(draft_logits, target_logits, **kwargs):
+            captured_target_steps.append(target_logits.detach().clone())
+            return tv_distance(draft_logits, target_logits, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", capture_target)
+
+        MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+        result = process_mtp_loss(
+            hidden_states=local_hidden,
+            labels=torch.zeros(1, local_seq_len, dtype=torch.long, device="cuda"),
+            loss_mask=local_loss_mask,
+            output_layer=output_layer,
+            output_weight=None,
+            runtime_gather_output=True,
+            is_training=False,
+            compute_language_model_loss=lambda *_: pytest.fail(
+                "cross entropy must not run for e2e TV"
+            ),
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+        )
+        result.sum().backward()
+
+        reference_weight = output_layer.weight.detach()
+        target_logits = torch.matmul(full_chunks[0].detach(), reference_weight.t())
+        full_mask = torch.ones(global_seq_len, 1, device="cuda")
+        full_chain_valid = torch.ones_like(full_mask, dtype=torch.bool)
+        target_steps = []
+        draft_references = []
+        draft_steps = []
+        for full_draft in full_chunks[1:]:
+            target_logits = _native_roll_packed_sequence_first(target_logits, cu_seqlens)
+            target_steps.append(target_logits.narrow(0, local_start, local_seq_len))
+            full_mask = _native_roll_packed_sequence_first(full_mask, cu_seqlens)
+            full_chain_valid &= full_mask.bool()
+
+            draft_reference = (
+                full_draft.narrow(0, local_start, local_seq_len)
+                .detach()
+                .clone()
+                .requires_grad_(True)
+            )
+            draft_references.append(draft_reference)
+            draft_steps.append(torch.matmul(draft_reference, reference_weight.t()))
+
+        local_chain_mask = full_chain_valid.narrow(0, local_start, local_seq_len).float()
+        assert len(captured_target_steps) == mtp_num_layers
+        for captured_target, target_step in zip(captured_target_steps, target_steps):
+            torch.testing.assert_close(captured_target, target_step, rtol=0, atol=0)
+        reference_loss = _native_e2e_tv_loss(draft_steps, target_steps)
+        (reference_loss * local_chain_mask).sum().div(
+            local_chain_mask.sum().clamp(min=1)
+        ).backward()
+
+        assert local_hidden.grad is not None
+        actual_chunks = torch.chunk(local_hidden.grad, 1 + mtp_num_layers, dim=0)
+        torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+        for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+            assert draft_reference.grad is not None
+            torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
+    """TP-sharded forward and local gradients match a full-vocabulary reference."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        torch.manual_seed(2026)
+        full_shape = (2, 1, 128256)
+        full_draft_data = torch.randn(full_shape, dtype=torch.float32).cuda()
+        full_target = torch.randn(full_shape, dtype=torch.float32).cuda()
+        local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
+        local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+
+        local_draft = local_draft_data.detach().clone().requires_grad_(True)
+        actual = vocab_parallel_tv_distance(
+            local_draft, local_target, tp_group=tp_group, logits_are_vocab_sharded=True
+        )
+        actual.sum().backward()
+
+        full_draft = full_draft_data.detach().clone().requires_grad_(True)
+        reference = _native_tv_distance(full_draft, full_target)
+        reference.sum().backward()
+
+        torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+        assert local_draft.grad is not None
+        assert full_draft.grad is not None
+        expected_local_grad = full_draft.grad.chunk(2, dim=-1)[tp_rank]
+        _assert_similarity(local_draft.grad, expected_local_grad)
+        torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -9,10 +9,7 @@ from megatron.core.fusions import fused_mtp_tv as fused_tv_module
 from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
-from megatron.core.transformer.multi_token_prediction import (
-    MTPLossAutoScaler,
-    process_mtp_loss,
-)
+from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler, process_mtp_loss
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -265,15 +262,17 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
         fused_prefix_losses.append(prefix_losses.detach().clone())
         return objective, prefix_losses
 
-    def record_loss(loss_sum, num_tokens, layer_number, num_layers, **kwargs):
+    def record_metrics(loss, correct, total, layer_number, num_layers, **kwargs):
         assert num_layers == mtp_num_layers
         assert kwargs["avg_group"] is None
-        logged.append((loss_sum.detach().clone(), num_tokens.detach().clone(), layer_number))
+        logged.append(
+            (loss.detach().clone(), correct.detach().clone(), total.detach().clone(), layer_number)
+        )
 
     monkeypatch.setattr(fused_tv_module, "_fused_vocab_parallel_tv_distance", record_fused_tv)
     monkeypatch.setattr(mtp_module, "mtp_e2e_prefix_objective", record_prefix_objective)
     monkeypatch.setattr(parallel_state, "get_data_parallel_group", lambda **_: None)
-    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_loss_to_tracker", record_loss)
+    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_metrics_to_tracker", record_metrics)
 
     MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
     result = process_mtp_loss(
@@ -298,11 +297,19 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
     chain_mask = torch.zeros(sequence_length, 1, device="cuda")
     chain_mask[: sequence_length - mtp_num_layers] = 1
     assert len(logged) == mtp_num_layers
-    for layer_number, (loss_sum, num_tokens, logged_layer_number) in enumerate(logged):
+    expected_total = chain_mask.sum()
+    expected_acceptances = 1.0 - actual_tv_distances
+    for layer_number, (loss, correct, total, logged_layer_number) in enumerate(logged):
         assert logged_layer_number == layer_number
-        torch.testing.assert_close(num_tokens, chain_mask.sum(), rtol=0, atol=0)
+        torch.testing.assert_close(total, expected_total, rtol=0, atol=0)
         torch.testing.assert_close(
-            loss_sum, torch.sum(fused_prefix_losses[0][layer_number] * chain_mask), rtol=0, atol=0
+            loss,
+            torch.sum(fused_prefix_losses[0][layer_number] * chain_mask) / expected_total,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            correct, torch.sum(expected_acceptances[layer_number] * chain_mask), rtol=0, atol=0
         )
 
 
@@ -347,8 +354,8 @@ def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
     assert torch.count_nonzero(draft_1_grad[expected_valid]) > 0
 
 
-def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monkeypatch):
-    """Contiguous packed CP rolls target distributions without crossing segments."""
+def test_process_mtp_e2e_tv_packed_zigzag_cp2_matches_global_reference(monkeypatch):
+    """Two-chunk packed CP rolls target distributions without crossing segments."""
     if Utils.world_size < 2:
         pytest.skip("A distributed run with at least two ranks is required")
 
@@ -356,21 +363,32 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
     try:
         cp_group = parallel_state.get_context_parallel_group()
         cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = torch.distributed.get_world_size(group=cp_group)
         mtp_num_layers = 2
-        global_seq_len = 8
-        local_seq_len = global_seq_len // 2
+        global_seq_len = 12
         hidden_size = 5
-        cu_seqlens = (0, 6, 8)
+        cu_seqlens = (0, 8, 12)
+
+        # Main's CP layout gives each rank two chunks from every packed sequence:
+        # chunk ``rank`` and its mirrored tail chunk ``2 * cp_size - rank - 1``.
+        local_indices = []
+        for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+            sequence_length = end - start
+            assert sequence_length % (2 * cp_size) == 0
+            chunk_length = sequence_length // (2 * cp_size)
+            front_start = start + cp_rank * chunk_length
+            tail_start = start + (2 * cp_size - cp_rank - 1) * chunk_length
+            local_indices.extend(range(front_start, front_start + chunk_length))
+            local_indices.extend(range(tail_start, tail_start + chunk_length))
+        local_indices = torch.tensor(local_indices, dtype=torch.long, device="cuda")
+        local_seq_len = local_indices.numel()
 
         torch.manual_seed(23)
         full_hidden = torch.randn(
             (1 + mtp_num_layers) * global_seq_len, 1, hidden_size, device="cuda"
         )
         full_chunks = torch.chunk(full_hidden, 1 + mtp_num_layers, dim=0)
-        local_start = cp_rank * local_seq_len
-        local_chunks = [
-            chunk.narrow(0, local_start, local_seq_len).clone() for chunk in full_chunks
-        ]
+        local_chunks = [chunk.index_select(0, local_indices).clone() for chunk in full_chunks]
         local_hidden = torch.cat(local_chunks, dim=0).requires_grad_(True)
         output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
         config = _make_tv_config(mtp_num_layers, hidden_size)
@@ -379,12 +397,9 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         packed_seq_params = PackedSeqParams(
             cu_seqlens_q=cu_seqlens_tensor,
             cu_seqlens_kv=cu_seqlens_tensor,
-            cu_seqlens_q_padded=cu_seqlens_tensor,
-            cu_seqlens_kv_padded=cu_seqlens_tensor,
-            max_seqlen_q=6,
-            max_seqlen_kv=6,
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
             qkv_format="thd",
-            cp_partition_mode="contiguous",
         )
         local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
         captured_target_steps = []
@@ -423,20 +438,17 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         draft_steps = []
         for full_draft in full_chunks[1:]:
             target_logits = _native_roll_packed_sequence_first(target_logits, cu_seqlens)
-            target_steps.append(target_logits.narrow(0, local_start, local_seq_len))
+            target_steps.append(target_logits.index_select(0, local_indices))
             full_mask = _native_roll_packed_sequence_first(full_mask, cu_seqlens)
             full_chain_valid &= full_mask.bool()
 
             draft_reference = (
-                full_draft.narrow(0, local_start, local_seq_len)
-                .detach()
-                .clone()
-                .requires_grad_(True)
+                full_draft.index_select(0, local_indices).detach().clone().requires_grad_(True)
             )
             draft_references.append(draft_reference)
             draft_steps.append(torch.matmul(draft_reference, reference_weight.t()))
 
-        local_chain_mask = full_chain_valid.narrow(0, local_start, local_seq_len).float()
+        local_chain_mask = full_chain_valid.index_select(0, local_indices).float()
         assert len(captured_target_steps) == mtp_num_layers
         for captured_target, target_step in zip(captured_target_steps, target_steps):
             torch.testing.assert_close(captured_target, target_step, rtol=0, atol=0)

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -5,12 +5,13 @@ import torch
 import torch.nn.functional as F
 
 from megatron.core import parallel_state
+from megatron.core.fusions import fused_mtp_tv as fused_tv_module
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossAutoScaler,
     process_mtp_loss,
-    vocab_parallel_tv_distance,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -123,6 +124,19 @@ def test_mtp_loss_type_validation():
         )
 
 
+def test_process_mtp_e2e_tv_requires_tp_group_for_sharded_logits(monkeypatch):
+    """A missing explicit TP group cannot silently normalize each vocab shard."""
+    monkeypatch.setattr(parallel_state, "is_initialized", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 2)
+    draft_logits = torch.randn(2, 1, 7, requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+
+    with pytest.raises(ValueError, match="tp_group must be provided"):
+        vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group=None, logits_are_vocab_sharded=True
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_full_vocab_tv_forward_and_gradient_match_native_reference(dtype):
@@ -216,6 +230,80 @@ def test_process_mtp_e2e_tv_matches_native_alignment_and_gradient():
         _assert_similarity(actual_grad, draft_reference.grad)
         torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
     assert output_layer.weight.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch):
+    """The integrated materialized-roll path dispatches both fused objectives."""
+    torch.manual_seed(26)
+    mtp_num_layers = 2
+    sequence_length = 7
+    hidden_size = 257
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+    hidden_states = torch.randn(
+        (1 + mtp_num_layers) * sequence_length, 1, hidden_size, device="cuda", requires_grad=True
+    )
+    loss_mask = torch.ones(1, sequence_length, device="cuda")
+    fused_tv_distances = []
+    fused_prefix_losses = []
+    logged = []
+
+    original_fused_tv = fused_tv_module._fused_vocab_parallel_tv_distance
+
+    def record_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded):
+        assert draft_logits.is_contiguous()
+        assert target_logits.is_contiguous()
+        result = original_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded)
+        fused_tv_distances.append(result.detach().clone())
+        return result
+
+    original_prefix_objective = mtp_module.mtp_e2e_prefix_objective
+
+    def record_prefix_objective(acceptances):
+        objective, prefix_losses = original_prefix_objective(acceptances)
+        fused_prefix_losses.append(prefix_losses.detach().clone())
+        return objective, prefix_losses
+
+    def record_loss(loss_sum, num_tokens, layer_number, num_layers, **kwargs):
+        assert num_layers == mtp_num_layers
+        assert kwargs["avg_group"] is None
+        logged.append((loss_sum.detach().clone(), num_tokens.detach().clone(), layer_number))
+
+    monkeypatch.setattr(fused_tv_module, "_fused_vocab_parallel_tv_distance", record_fused_tv)
+    monkeypatch.setattr(mtp_module, "mtp_e2e_prefix_objective", record_prefix_objective)
+    monkeypatch.setattr(parallel_state, "get_data_parallel_group", lambda **_: None)
+    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_loss_to_tracker", record_loss)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, sequence_length, dtype=torch.long, device="cuda"),
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=True,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    assert len(fused_tv_distances) == mtp_num_layers
+    assert len(fused_prefix_losses) == 1
+    actual_tv_distances = torch.stack(fused_tv_distances)
+    expected_prefix_losses = 1.0 - torch.cumprod(1.0 - actual_tv_distances, dim=0)
+    torch.testing.assert_close(fused_prefix_losses[0], expected_prefix_losses, rtol=1e-5, atol=1e-6)
+
+    chain_mask = torch.zeros(sequence_length, 1, device="cuda")
+    chain_mask[: sequence_length - mtp_num_layers] = 1
+    assert len(logged) == mtp_num_layers
+    for layer_number, (loss_sum, num_tokens, logged_layer_number) in enumerate(logged):
+        assert logged_layer_number == layer_number
+        torch.testing.assert_close(num_tokens, chain_mask.sum(), rtol=0, atol=0)
+        torch.testing.assert_close(
+            loss_sum, torch.sum(fused_prefix_losses[0][layer_number] * chain_mask), rtol=0, atol=0
+        )
 
 
 def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
@@ -367,8 +455,9 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         Utils.destroy_model_parallel()
 
 
-def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
-    """TP-sharded forward and local gradients match a full-vocabulary reference."""
+@pytest.mark.parametrize("logits_are_vocab_sharded", [False, True], ids=["gathered", "sharded"])
+def test_vocab_parallel_tv_tp2_matches_full_vocab_reference(logits_are_vocab_sharded):
+    """TP gathered/sharded forward and local gradients match a full-vocabulary reference."""
     if Utils.world_size < 2:
         pytest.skip("A distributed run with at least two ranks is required")
     Utils.initialize_model_parallel(tensor_model_parallel_size=2)
@@ -379,12 +468,19 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
         full_shape = (2, 1, 128256)
         full_draft_data = torch.randn(full_shape, dtype=torch.float32).cuda()
         full_target = torch.randn(full_shape, dtype=torch.float32).cuda()
-        local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
-        local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+        if logits_are_vocab_sharded:
+            local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
+            local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+        else:
+            local_draft_data = full_draft_data
+            local_target = full_target
 
         local_draft = local_draft_data.detach().clone().requires_grad_(True)
         actual = vocab_parallel_tv_distance(
-            local_draft, local_target, tp_group=tp_group, logits_are_vocab_sharded=True
+            local_draft,
+            local_target,
+            tp_group=tp_group,
+            logits_are_vocab_sharded=logits_are_vocab_sharded,
         )
         actual.sum().backward()
 
@@ -395,7 +491,11 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference():
         torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
         assert local_draft.grad is not None
         assert full_draft.grad is not None
-        expected_local_grad = full_draft.grad.chunk(2, dim=-1)[tp_rank]
+        expected_local_grad = (
+            full_draft.grad.chunk(2, dim=-1)[tp_rank]
+            if logits_are_vocab_sharded
+            else full_draft.grad
+        )
         _assert_similarity(local_draft.grad, expected_local_grad)
         torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
     finally:

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -7,6 +7,7 @@ import torch
 from megatron.core.models.common import fine_grained_callables as common_callables
 from megatron.core.models.common import model_chunk_schedule_plan
 from megatron.core.models.common.fine_grained_callables import build_layer_callables
+from megatron.core.models.gpt import fine_grained_callables as gpt_callables
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
@@ -24,6 +25,71 @@ from tests.unit_tests.a2a_overlap.utils import (
     reset_model,
 )
 from tests.unit_tests.test_utilities import Utils
+
+
+def test_repeated_mtp_te_graph_owns_backward_dw_wrapper_per_logical_depth():
+    """Each logical use of a repeated MTP layer updates its own wgrad wrapper."""
+
+    class FakeBackwardDWWrapper:
+        def __init__(self):
+            self.graphed_backward_dw_callable = None
+
+        def set_graphed_backward_dw_callable(self, callable_):
+            self.graphed_backward_dw_callable = callable_
+
+    class FakeGraphableLayer(gpt_callables.GraphableMegatronModule):
+        def __init__(self):
+            torch.nn.Module.__init__(self)
+            self.config = SimpleNamespace(
+                moe_token_dispatcher_type="alltoall", moe_flex_dispatcher_backend=None
+            )
+            self.mlp = object()
+            self.cuda_graphs = [object()]
+            self.current_microbatch = 0
+            self.created_wrappers = []
+            self.graphed_dw_microbatches = []
+
+        def init_backward_dw_wrapper(self):
+            self.backward_dw_wrapper = FakeBackwardDWWrapper()
+            self.created_wrappers.append(self.backward_dw_wrapper)
+
+        def _te_cuda_graph_backward_dw_graph(self, microbatch):
+            self.graphed_dw_microbatches.append(microbatch)
+
+        @staticmethod
+        def _te_cuda_graph_replay(hidden_states, **_kwargs):
+            return hidden_states, None, None, None
+
+    layer = FakeGraphableLayer()
+    logical_callables = []
+    owned_wrappers = []
+    for _ in range(3):
+        forward_callables, backward_dw = gpt_callables.build_transformer_layer_callables(layer)
+        logical_callables.append(forward_callables[0])
+        owned_wrappers.append(backward_dw["pre_dispatch_computation"])
+
+    assert len({id(wrapper) for wrapper in owned_wrappers}) == 3
+    assert layer.backward_dw_wrapper is owned_wrappers[-1]
+
+    chunk_state = SimpleNamespace(
+        padding_mask=None,
+        attention_mask=None,
+        rotary_pos_emb=None,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        packed_seq_params=None,
+        sequence_len_offset=None,
+    )
+    hidden_states = torch.ones(2, 1, 4)
+    for logical_depth, callable_ in enumerate(logical_callables):
+        layer.current_microbatch = logical_depth
+        node = SimpleNamespace(chunk_state=chunk_state, layer_state=SimpleNamespace())
+        assert callable_(node, hidden_states) is hidden_states
+
+    assert all(wrapper.graphed_backward_dw_callable is not None for wrapper in owned_wrappers)
+    for wrapper in owned_wrappers:
+        wrapper.graphed_backward_dw_callable()
+    assert layer.graphed_dw_microbatches == [0, 1, 2]
 
 
 def run_model_ref_with_capture(model, input_tensors, iterations):

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from megatron.core.models.common import fine_grained_callables as common_callables
+from megatron.core.models.common import model_chunk_schedule_plan
 from megatron.core.models.common.fine_grained_callables import build_layer_callables
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
@@ -107,7 +110,8 @@ def test_mtp_pre_dispatch_applies_hybrid_empty_decoder_final_norm(monkeypatch):
 
     from megatron.core.models.hybrid.hybrid_model import HybridModel
 
-    def inner_pre_dispatch(_node, hidden_states):
+    def inner_pre_dispatch(_node, hidden_states, padding_mask=None):
+        del padding_mask
         return hidden_states
 
     def unused_forward(*_args, **_kwargs):
@@ -121,14 +125,24 @@ def test_mtp_pre_dispatch_applies_hybrid_empty_decoder_final_norm(monkeypatch):
 
     class FakeMTPConfig:
         sequence_parallel = False
+        mtp_num_layers = 1
 
     class FakeMTPLayer:
         config = FakeMTPConfig()
+        cp_group = None
+        tp_group = None
         eh_proj = object()
         mtp_model_layer = object()
 
         def _get_embeddings(
-            self, input_ids, position_ids, embedding, hidden_states, packed_seq_params, padding_mask
+            self,
+            input_ids,
+            position_ids,
+            embedding,
+            hidden_states,
+            packed_seq_params,
+            padding_mask,
+            **_kwargs,
         ):
             return input_ids, position_ids, padding_mask, None, hidden_states
 
@@ -141,6 +155,7 @@ def test_mtp_pre_dispatch_applies_hybrid_empty_decoder_final_norm(monkeypatch):
     monkeypatch.setattr(common_callables, "build_layer_callables", fake_build_layer_callables)
     monkeypatch.setattr(common_callables, "get_layer_moe_metadata", lambda _layer: (True, 1))
     monkeypatch.setattr(common_callables, "get_mtp_layer_offset", lambda _config, _vp_stage: 0)
+    monkeypatch.setattr(common_callables, "prepare_mtp_sequence_roll_context", lambda *_args: None)
 
     model = HybridModel.__new__(HybridModel)
     torch.nn.Module.__init__(model)
@@ -148,14 +163,23 @@ def test_mtp_pre_dispatch_applies_hybrid_empty_decoder_final_norm(monkeypatch):
     model.decoder.layers = []
     model.decoder.final_norm = lambda hidden_states: hidden_states + 4.0
     model.embedding = object()
+    model.post_process = False
     model.vp_stage = None
 
     node = DummyNode()
     node.chunk_state = DummyState()
     node.chunk_state.model = model
     node.chunk_state.context = None
+    node.chunk_state.input_ids = torch.zeros(1, 3, dtype=torch.long)
+    node.chunk_state.position_ids = torch.zeros(1, 3, dtype=torch.long)
+    node.chunk_state.labels = None
+    node.chunk_state.loss_mask = None
+    node.chunk_state.padding_mask = None
+    node.chunk_state.mtp_padding_mask = None
+    node.chunk_state.mtp_materialized_roll_rows = None
     node.chunk_state.packed_seq_params = None
     node.is_first_layer = True
+    node.mtp_absolute_depth = 1
 
     hidden_states = torch.arange(6, dtype=torch.float32).reshape(3, 1, 2).requires_grad_()
     expected = hidden_states + 4.0
@@ -165,6 +189,176 @@ def test_mtp_pre_dispatch_applies_hybrid_empty_decoder_final_norm(monkeypatch):
 
     torch.testing.assert_close(output, expected)
     torch.testing.assert_close(node.chunk_state.mtp_hidden_states[0], expected)
+
+
+def test_fine_grained_repeated_mtp_reuses_prepared_rows_by_absolute_depth(monkeypatch):
+    """One physical MTP layer consumes immutable rows for three logical depths."""
+    source_rows = {
+        "input_ids": tuple(torch.tensor([[depth, depth + 1, 0]]) for depth in (1, 2, 3)),
+        "position_ids": tuple(torch.tensor([[10 + depth, 11 + depth, 0]]) for depth in (1, 2, 3)),
+        "padding_mask": tuple(torch.tensor([[False, False, depth == 3]]) for depth in (1, 2, 3)),
+    }
+    materialize_calls = []
+
+    class FakeSequenceRollContext:
+        max_offset = 3
+        keys = tuple(source_rows)
+
+        @staticmethod
+        def is_prepared_for_fields(fields):
+            return {field.key for field in fields} == {
+                "input_ids",
+                "position_ids",
+                "labels",
+                "loss_mask",
+                "padding_mask",
+            }
+
+        def prepare_fields(self, fields, *, max_offset):
+            raise AssertionError("An already prepared context must be reused.")
+
+        @staticmethod
+        def materialize_all(key):
+            materialize_calls.append(key)
+            return source_rows[key]
+
+    sequence_roll_context = FakeSequenceRollContext()
+    prepare_calls = []
+
+    def fake_prepare(*args):
+        prepare_calls.append(args)
+        return sequence_roll_context
+
+    attn_calls = []
+
+    def fake_attn(node, hidden_states, padding_mask=None):
+        del node
+        attn_calls.append(padding_mask)
+        return hidden_states
+
+    def unused_callable(*args, **kwargs):
+        raise AssertionError("Only MTP attention/postprocess should run in this test.")
+
+    def fake_build_layer_callables(layer):
+        del layer
+        return [fake_attn, unused_callable, unused_callable, unused_callable, None], {
+            "pre_dispatch_computation": []
+        }
+
+    monkeypatch.setattr(common_callables, "build_layer_callables", fake_build_layer_callables)
+    monkeypatch.setattr(common_callables, "get_layer_moe_metadata", lambda _layer: (True, 1))
+    monkeypatch.setattr(common_callables, "prepare_mtp_sequence_roll_context", fake_prepare)
+    monkeypatch.setattr(common_callables, "resolve_cp_group", lambda group, packed: group)
+
+    embedding_calls = []
+
+    def get_embeddings(**kwargs):
+        embedding_calls.append(kwargs)
+        return (
+            kwargs["input_ids"],
+            kwargs["position_ids"],
+            kwargs["padding_mask"],
+            torch.zeros_like(kwargs["hidden_states"]),
+            kwargs["hidden_states"],
+        )
+
+    config = SimpleNamespace(sequence_parallel=False, mtp_num_layers=3)
+    layer = SimpleNamespace(
+        config=config,
+        cp_group=object(),
+        tp_group=object(),
+        layer_number=1,
+        mtp_model_layer=object(),
+        _get_embeddings=get_embeddings,
+        _concat_embeddings=lambda hidden_states, decoder_input: hidden_states + decoder_input,
+        _postprocess=lambda hidden_states: hidden_states,
+    )
+    callables = common_callables.build_mtp_layer_callables(layer)[0]
+    mtp_attn, mtp_postprocess = callables[0], callables[4]
+
+    input_ids = torch.tensor([[0, 1, 2]])
+    position_ids = torch.tensor([[10, 11, 12]])
+    padding_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+    packed_seq_params = SimpleNamespace(qkv_format="thd")
+    chunk_state = SimpleNamespace(
+        model=SimpleNamespace(
+            embedding=SimpleNamespace(add_position_embedding=True), post_process=True, vp_stage=None
+        ),
+        input_ids=input_ids,
+        position_ids=position_ids,
+        labels=input_ids + 1,
+        loss_mask=torch.ones_like(input_ids, dtype=torch.float32),
+        padding_mask=padding_mask,
+        mtp_padding_mask=padding_mask,
+        packed_seq_params=packed_seq_params,
+        context=None,
+        mtp_hidden_states=None,
+        mtp_sequence_roll_context=None,
+        mtp_materialized_roll_rows=None,
+    )
+    hidden_states = torch.ones(3, 1, 4)
+    current = hidden_states
+    for depth in range(1, 4):
+        node = SimpleNamespace(
+            is_first_layer=depth == 1,
+            is_last_layer=depth == 3,
+            mtp_absolute_depth=depth,
+            chunk_state=chunk_state,
+        )
+        current = mtp_attn(node, current)
+        current = mtp_postprocess(node, current)
+
+    assert current.shape[0] == 4 * hidden_states.shape[0]
+    assert len(prepare_calls) == 1
+    assert prepare_calls[0] == (input_ids, layer.cp_group, packed_seq_params)
+    assert materialize_calls == ["input_ids", "position_ids", "padding_mask"]
+    assert len(embedding_calls) == 3
+    for depth, call in enumerate(embedding_calls, 1):
+        assert call["input_ids"] is source_rows["input_ids"][depth - 1]
+        assert call["position_ids"] is source_rows["position_ids"][depth - 1]
+        assert call["padding_mask"] is source_rows["padding_mask"][depth - 1]
+        assert call["_inputs_pre_aligned"]
+        assert call["roll_depth"] == depth - 1
+        assert call["packed_seq_params"] is packed_seq_params
+    assert all(
+        actual is expected for actual, expected in zip(attn_calls, source_rows["padding_mask"])
+    )
+    assert chunk_state.input_ids is input_ids
+    assert chunk_state.position_ids is position_ids
+    assert chunk_state.padding_mask is padding_mask
+
+
+def test_repeated_mtp_schedule_expands_one_physical_layer_to_three_depths(monkeypatch):
+    """Fine-grained scheduling carries absolute depth without copying parameters."""
+    records = []
+
+    class RecordingLayerPlan:
+        def __init__(self, layer, event, chunk_state, comp_stream, comm_stream, extra_args):
+            del event, chunk_state, comp_stream, comm_stream
+            records.append((layer, dict(extra_args)))
+
+    monkeypatch.setattr(
+        model_chunk_schedule_plan, "TransformerLayerSchedulePlan", RecordingLayerPlan
+    )
+    config = SimpleNamespace(mtp_num_layers=3)
+    physical_layer = SimpleNamespace(layer_number=1)
+    module = SimpleNamespace(
+        layers=[physical_layer], config=config, mtp_use_repeated_layer=True, mtp_num_depths=0
+    )
+    owner = model_chunk_schedule_plan.TransformerModelChunkSchedulePlan.__new__(
+        model_chunk_schedule_plan.TransformerModelChunkSchedulePlan
+    )
+    owner._transformer_layers = []
+    owner._event = object()
+    owner._model_chunk_state = SimpleNamespace(model=SimpleNamespace(mtp=module))
+
+    owner._build_layer_schedule_plan(module, "compute", "communication")
+
+    assert len(records) == 3
+    assert all(layer is physical_layer for layer, _ in records)
+    assert [extra["mtp_absolute_depth"] for _, extra in records] == [1, 2, 3]
+    assert [extra["is_first_layer"] for _, extra in records] == [True, False, False]
+    assert [extra["is_last_layer"] for _, extra in records] == [False, False, True]
 
 
 class TestTransformerLayerSubmoduleCallables:

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -45,6 +45,21 @@ def test_batch_invariant_backend_rejects_unknown_value_at_construction():
         )
 
 
+def test_contiguous_cp_accepts_mtp_sequence_roll_support():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=4,
+        context_parallel_size=2,
+        linear_cp_layout="contiguous",
+        attention_cp_layout="zigzag",
+        mtp_num_layers=1,
+    )
+
+    assert config.linear_cp_layout == "contiguous"
+    assert config.mtp_num_layers == 1
+
+
 def test_gdp_num_householder_defaults_to_three():
     config = TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4)
 


### PR DESCRIPTION
## Summary

Main-branch counterpart of #6741.

- Add a layout-neutral sequence-roll context that aligns MTP fields from immutable source tensors using absolute offsets.
- Reuse the context across MTP forward inputs, learned positions, padding masks, CE/RL objectives, and E2E-TV targets.
- Support local CP1, contiguous packed CP, and scheduler-certified zigzag/dynamic CP while preserving the existing atomic fallback for unsupported layouts.
- Integrate the implementation with main-specific CP layout, HybridModel, fine-grained callable, and CUDA Graph APIs.

## Dependency

Depends on #6875, the main-branch counterpart of #6473.

This Draft currently targets `main` directly, so its diff includes the four E2E-TV commits from #6875 plus the four sequence-roll commits from this PR. Rebase this branch onto `main` after #6875 merges to narrow the diff to the sequence-roll increment.

## Test plan

- [x] Megatron autoformat check against the latest `main` (Black 26.3.0, isort, pylint, and Ruff).
- [x] `git diff --check`.
- [ ] Run `tests/unit_tests/transformer/test_mtp_sequence_roll.py`.
- [ ] Run focused MTP TV-loss, submodule-callable, sequence-packing, CP-layout, and TransformerConfig tests.
- [ ] Run distributed CP1/CP2/CP4 parity coverage on GPU.
- [ ] Run GitHub unit and integration CI.

## Related PR

- Dev counterpart: #6741
