### PR TITLE
Add optional norm before the LatentMoE up projection

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -60,9 +60,9 @@ except ImportError:
     HAVE_TRITON = False
 
 if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import TELinear, te_checkpoint
+    from megatron.core.extensions.transformer_engine import TELinear, TENorm, te_checkpoint
 else:
-    TELinear, te_checkpoint = None, None
+    TELinear, TENorm, te_checkpoint = None, None, None
 
 
 class ExpertsInterface(Protocol):
@@ -295,6 +295,12 @@ class MoELayer(BaseMoELayer):
                 name=(name + ".fc1_latent_proj") if name is not None else None,
                 **linear_gtp_kwargs,
             )
+            if self.config.moe_use_norm_before_up_proj:
+                self.fc2_norm = TENorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.layernorm_epsilon,
+                )
             self.fc2_latent_proj = linear_cls(
                 self.config.moe_latent_size,
                 self.config.hidden_size,
@@ -600,6 +606,8 @@ class MoELayer(BaseMoELayer):
 
         output = self.token_dispatcher.combine_postprocess(output)
         if self.config.moe_latent_size:
+            if self.config.moe_use_norm_before_up_proj:
+                output = apply_module(self.fc2_norm)(output)
             output, _ = self.fc2_latent_proj(output)
 
         if shared_expert_output is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -956,6 +956,10 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 
+    moe_use_norm_before_up_proj: bool = False
+    """Apply normalization before the latent-to-hidden MoE projection. Only effective when
+    ``moe_latent_size`` is set."""
+
     gtp_remat_opt_in_modules: list[str] = field(default_factory=list)
     """Extra modules to apply GTP_remat weight sharding to, beyond the default set (attention,
     Mamba, MLP, expert linears, embeddings). Allowed values:
@@ -1849,6 +1853,9 @@ class TransformerConfig(ModelParallelConfig):
                     "use_transformer_engine_op_fuser and moe_grouped_gemm: only the fused "
                     "grouped GEMM path consumes the pre-quantized MXFP8 GroupedTensor payload."
                 )
+
+        if self.moe_use_norm_before_up_proj and self.moe_latent_size is None:
+            raise ValueError("moe_use_norm_before_up_proj requires moe_latent_size to be set.")
 
         # moe_deepep_num_sms / moe_hybridep_num_sms are deprecated and unified into
         # moe_flex_dispatcher_num_sms. If either is set, route it (an explicit

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -957,8 +957,8 @@ class TransformerConfig(ModelParallelConfig):
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 
     moe_use_norm_before_up_proj: bool = False
-    """Apply normalization before the latent-to-hidden MoE projection. Only effective when
-    ``moe_latent_size`` is set."""
+    """Apply normalization before the latent-to-hidden MoE projection. Requires
+    ``moe_latent_size`` to be set."""
 
     gtp_remat_opt_in_modules: list[str] = field(default_factory=list)
     """Extra modules to apply GTP_remat weight sharding to, beyond the default set (attention,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1979,6 +1979,10 @@ def validate_args(args, defaults={}):
     if args.mla_down_proj_fusion:
         assert args.multi_latent_attention, "--mla-down-proj-fusion requires --multi-latent-attention"
 
+    assert (
+        not args.moe_use_norm_before_up_proj or args.moe_latent_size is not None
+    ), "--moe-use-norm-before-up-proj requires --moe-latent-size to be set."
+
     # MoE latent projections
     if args.moe_latent_size is not None:
         assert args.moe_latent_size > 0, "MoE latent projection dimension has to be greater than zero."

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2339,6 +2339,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
 
     # MoE latent projection.
     _set_arg('moe_latent_size', force=True)
+    _set_arg('moe_use_norm_before_up_proj', force=True)
 
     # Tokenizer args.
     if args.use_tokenizer_model_from_checkpoint_args:

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -206,6 +206,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_hybridep_num_blocks_unpermute": None,
     "moe_input_jitter_eps": None,
     "moe_latent_size": None,
+    "moe_use_norm_before_up_proj": False,
     "moe_layer_freq": 1,
     "moe_layer_recompute": False,
     "moe_ncclep_zero_copy": False,

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import signal
+import sys
 from argparse import ArgumentError, ArgumentParser, Namespace
 from dataclasses import dataclass, field
 from typing import Callable, Literal, Optional, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
@@ -16,7 +18,7 @@ from megatron.training.argument_utils import (
     core_transformer_config_from_args,
     pretrain_cfg_container_from_args,
 )
-from megatron.training.arguments import add_megatron_arguments
+from megatron.training.arguments import add_megatron_arguments, parse_args, validate_args
 from megatron.training.config import PretrainConfigContainer
 
 
@@ -62,11 +64,36 @@ def test_moe_norm_flag_reaches_transformer_config():
     assert default_args.moe_use_norm_before_up_proj is False
 
     enabled_args = parser.parse_args(["--moe-use-norm-before-up-proj"])
+    # params_dtype has no CLI flag of its own; validate_args normally derives it.
+    enabled_args.params_dtype = torch.float32
     config = core_transformer_config_from_args(
         enabled_args, config_class=CapturingTransformerConfig
     )
 
     assert config.moe_use_norm_before_up_proj is True
+
+
+def test_moe_norm_flag_requires_latent_size(monkeypatch):
+    """validate_args should reject the LatentMoE norm flag without a latent size."""
+    monkeypatch.setattr(sys, 'argv', ['test_argument_utils.py'])
+    args = parse_args()
+    args.num_layers = 2
+    args.hidden_size = 128
+    args.num_attention_heads = 4
+    args.max_position_embeddings = 1024
+    args.seq_length = 1024
+    args.micro_batch_size = 1
+    # Let validate_args derive a global batch size that is valid for the
+    # active data-parallel size in distributed unit-test jobs.
+    args.train_iters = 1
+    args.lr = 1e-4
+    args.tokenizer_type = 'NullTokenizer'
+    args.vocab_size = 1024
+    args.moe_use_norm_before_up_proj = True
+    args.moe_latent_size = None
+
+    with pytest.raises(AssertionError, match="--moe-use-norm-before-up-proj requires"):
+        validate_args(args)
 
 
 @dataclass

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -13,8 +13,10 @@ from megatron.core.optimizer import OptimizerConfig
 from megatron.training.argument_utils import (
     ArgumentGroupFactory,
     TypeInferenceError,
+    core_transformer_config_from_args,
     pretrain_cfg_container_from_args,
 )
+from megatron.training.arguments import add_megatron_arguments
 from megatron.training.config import PretrainConfigContainer
 
 
@@ -39,6 +41,32 @@ class DummyConfig:
 
     enum_setting: signal.Signals = signal.SIGTERM
     """Setting with enum type to test enum handling"""
+
+
+@dataclass(init=False)
+class CapturingTransformerConfig:
+    """Minimal config that records kwargs produced by core_transformer_config_from_args."""
+
+    moe_use_norm_before_up_proj: bool = False
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_moe_norm_flag_reaches_transformer_config():
+    """The generated LatentMoE norm flag should populate the model config."""
+    parser = ArgumentParser()
+    add_megatron_arguments(parser)
+
+    default_args = parser.parse_args([])
+    assert default_args.moe_use_norm_before_up_proj is False
+
+    enabled_args = parser.parse_args(["--moe-use-norm-before-up-proj"])
+    config = core_transformer_config_from_args(
+        enabled_args, config_class=CapturingTransformerConfig
+    )
+
+    assert config.moe_use_norm_before_up_proj is True
 
 
 @dataclass

--- a/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
@@ -147,6 +147,17 @@ class TestLatentMoELayer:
     def setup_method(self, method):
         pass
 
+    def test_norm_before_up_proj_requires_latent_moe(self):
+        with pytest.raises(
+            ValueError, match="moe_use_norm_before_up_proj requires moe_latent_size"
+        ):
+            TransformerConfig(
+                num_layers=1,
+                hidden_size=32,
+                num_attention_heads=4,
+                moe_use_norm_before_up_proj=True,
+            )
+
     @pytest.mark.skipif(
         not is_te_min_version("1.7.0.dev0"),
         reason="Expert with TE Linear is only supported in TE 1.7.0 and later.",
@@ -191,6 +202,8 @@ class TestLatentMoELayer:
         moe_layer.cuda()
         config = moe_layer.config
 
+        assert not hasattr(moe_layer, "fc2_norm")
+
         assert (
             moe_layer.shared_experts.linear_fc1.weight.shape[1] == config.hidden_size
         ), "Shared expert computation has to happen in hidden dimension."
@@ -226,4 +239,57 @@ class TestLatentMoELayer:
         output, _ = moe_layer(hidden_states)
         assert output.shape[2] == config.hidden_size
 
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not is_te_min_version("1.7.0.dev0"),
+        reason="Expert with TE Linear is only supported in TE 1.7.0 and later.",
+    )
+    def test_norm_before_latent_up_projection(self):
+        Utils.initialize_model_parallel(1, 1)
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            num_moe_experts=4,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type="alltoall",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=True,
+            moe_ffn_hidden_size=128,
+            activation_func=torch.nn.functional.silu,
+            gated_linear_unit=True,
+            add_bias_linear=False,
+            moe_latent_size=8,
+            moe_use_norm_before_up_proj=True,
+        )
+        transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
+            num_experts=config.num_moe_experts, moe_grouped_gemm=True
+        )
+        submodules = get_submodules(transformer_layer_submodules.mlp)
+        assert isinstance(submodules, MoESubmodules)
+        moe_layer = MoELayer(config, submodules).cuda()
+
+        assert moe_layer.fc2_norm.weight.shape == (config.moe_latent_size,)
+        norm_output = []
+        fc2_input = []
+        moe_layer.fc2_norm.register_forward_hook(
+            lambda _module, _inputs, output: norm_output.append(output.detach())
+        )
+        moe_layer.fc2_latent_proj.register_forward_pre_hook(
+            lambda _module, inputs: fc2_input.append(inputs[0].detach())
+        )
+
+        hidden_states = torch.randn(32, 2, config.hidden_size, device="cuda")
+        output, _ = moe_layer(hidden_states)
+
+        assert output.shape == hidden_states.shape
+        assert len(norm_output) == 1
+        assert len(fc2_input) == 1
+        torch.testing.assert_close(fc2_input[0], norm_output[0])
+
+        output.sum().backward()
+        assert moe_layer.fc2_norm.weight.grad is not None
         Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary

Adds a `moe_use_norm_before_up_proj` config flag that inserts a `TENorm` on the latent activations before `fc2_latent_proj`, so the latent-to-hidden projection in `MoELayer` sees normalized inputs. The flag defaults to `False`, is only valid when `moe_latent_size` is set (validated in both `TransformerConfig.__post_init__` and `validate_args`), and is restored from checkpoint args so resumed runs keep the same architecture.

The original change was authored by Roger Waleffe. The only conflict when porting it onto `main` was in `transformer_config.py`, where `gtp_remat_opt_in_modules` had been added immediately after `moe_latent_size`; both fields are kept.

## Test plan

- New `tests/unit_tests/transformer/moe/test_latent_moe_layer.py::TestLatentMoELayer::test_norm_before_latent_up_projection` checks that `fc2_norm` is built with the latent hidden size, that its output is exactly what `fc2_latent_proj` receives, and that it gets gradients.
- New `test_norm_before_up_proj_requires_latent_moe` checks the config-level validation error.
- Existing `test_latent_moe_layer` asserts no `fc2_norm` is created when the flag is off.
- New `tests/unit_tests/test_argument_utils.py::test_moe_norm_flag_reaches_transformer_config` checks the generated `--moe-use-norm-before-up-proj` CLI flag reaches the transformer config, and `test_moe_norm_flag_requires_latent_size` checks the `validate_args` guard.
- `tests/unit_tests/models/test_hybrid_moe_model.py` golden config updated with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)