### PR TITLE
[Dev] Reduce HybridEP dispatch pending frees with stream hand-back

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -303,7 +303,7 @@ class TransformerLayerSchedulePlan:
         extra_args["is_mtp"] = is_mtp
 
         # wrapper to help create TransformerLayerNode
-        def create_node(stream, module, name):
+        def create_node(stream, module, name, free_input_handback_stream=None):
             bwd_dw_callables = bwd_dw_callable_map.get(name, None)
             return TransformerLayerNode(
                 stream,
@@ -314,6 +314,7 @@ class TransformerLayerSchedulePlan:
                 name=name,
                 bwd_dw_callables=bwd_dw_callables,
                 extra_args=extra_args,
+                free_input_handback_stream=free_input_handback_stream,
             )
 
         (
@@ -328,7 +329,17 @@ class TransformerLayerSchedulePlan:
         # Create nodes for different operations in the layer
         # Each node type has a predefined name that determines its memory strategy
         self.attn = create_node(comp_stream, attn_module, "attn")
-        self.mlp = create_node(comp_stream, mlp_module, "mlp")
+        dispatch_output_handback_stream = (
+            comm_stream
+            if is_moe and self.config.moe_hybridep_use_manual_forward_stream_handback
+            else None
+        )
+        self.mlp = create_node(
+            comp_stream,
+            mlp_module,
+            "mlp",
+            free_input_handback_stream=dispatch_output_handback_stream,
+        )
         if is_moe:
             self.moe_dispatch = create_node(comm_stream, moe_dispatch_module, "moe_dispatch")
             self.moe_combine = create_node(comm_stream, moe_combine_module, "moe_combine")

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -333,6 +333,7 @@ class TransformerLayerNode(ScheduleNode):
         name="default",
         bwd_dw_callables=None,
         extra_args={},
+        free_input_handback_stream=None,
     ):
         """Initialize a transformer layer node.
 
@@ -346,6 +347,8 @@ class TransformerLayerNode(ScheduleNode):
             name (str): Node name, also used to determine memory strategy
             bwd_dw_callables (list): List of weight gradient functions for the layer.
             extra_args (dict): Extra arguments for the node: is_moe, config.
+            free_input_handback_stream (torch.cuda.Stream or callable, optional): Stream that
+                created a cross-stream input and should regain ownership after its last consumer.
         """
         # Determine whether to free input memory
         config = extra_args.get("config", None)
@@ -364,6 +367,7 @@ class TransformerLayerNode(ScheduleNode):
             event,
             weak_method(self.backward_impl),
             free_input=free_input,
+            free_input_handback_stream=free_input_handback_stream,
             name=name,
         )
         self.layer_state = layer_state

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -158,6 +158,7 @@ class ScheduleNode:
         name: str = "schedule_node",
         forward_nvtx_name: Optional[str] = None,
         backward_nvtx_name: Optional[str] = None,
+        free_input_handback_stream: Optional[torch.cuda.Stream | Callable] = None,
     ):
         """Initialize a schedule node.
 
@@ -174,6 +175,11 @@ class ScheduleNode:
             backward_func (callable, optional): Function for the backward pass.
             free_input (bool): Flag to indicate if the input should be freed after the
                 forward pass.
+            free_input_handback_stream (torch.cuda.Stream or callable, optional): The stream that
+                created a cross-stream input. Before releasing the input, enqueue a wait for this
+                node's last consumer on that stream instead of calling ``record_stream``. This is
+                only safe when the scheduler knows both the creation stream and the last consumer;
+                every released input must have been created on this same stream.
             name (str): Name of the node for debugging purposes.
             forward_nvtx_name (str, optional): Stable NVTX label for forward execution.
             backward_nvtx_name (str, optional): Stable NVTX label for backward execution.
@@ -186,6 +192,7 @@ class ScheduleNode:
         self.stream = stream
         self.event = event
         self.free_input = free_input
+        self.free_input_handback_stream = free_input_handback_stream
         self.inputs = None
         self.outputs = None
         # When True, the forward runs under torch.no_grad() so no autograd graph is
@@ -236,15 +243,36 @@ class ScheduleNode:
 
             self.output = data
 
-        # Immediately frees input tensors after they are used for nodes
-        # where inputs are no longer needed after computation.
-        if self.free_input:
-            for input in inputs:
-                if input is not None:
-                    input.record_stream(self.stream)
-                    input.untyped_storage().resize_(0)
+        self._free_forward_inputs(inputs)
 
         return self.output
+
+    def _free_forward_inputs(self, inputs):
+        """Release forward inputs after their final scheduled consumer.
+
+        ``record_stream`` is the general fallback for inputs created on another stream. When the
+        schedule provides the creation stream explicitly, the node's completion event can instead
+        be handed back to that stream before release. Subsequent allocations on the creation stream
+        are then ordered after the consumer without leaving the block pending on a side stream.
+        """
+        if not self.free_input:
+            return
+
+        handback_stream = self.free_input_handback_stream
+        if isinstance(handback_stream, Callable):
+            handback_stream = handback_stream()
+            self.free_input_handback_stream = handback_stream
+
+        if handback_stream is not None:
+            # stream_acquire_context records this event after the forward callable, so this wait
+            # is the precise last-consumer frontier for every input released below.
+            self.event.wait(handback_stream)
+
+        for input in inputs:
+            if input is not None:
+                if handback_stream is None:
+                    input.record_stream(self.stream)
+                input.untyped_storage().resize_(0)
 
     def get_output(self):
         """Get the forward output"""

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -975,6 +975,15 @@ class TransformerConfig(ModelParallelConfig):
     upstream and leave this option disabled.
     """
 
+    moe_hybridep_use_manual_forward_stream_handback: bool = False
+    """Hand forward HybridEP dispatch-output storage back to its communication stream after the
+    expert MLP consumes it on the compute stream. This avoids ``record_stream`` pending-free growth
+    when combined-1F1B enqueues several dispatches ahead of their GPU consumers. Backward dispatch
+    outputs keep the default lifetime path because an immediate hand-back would serialize the next
+    forward dispatch. This optimization is limited to the statically scheduled low-precision
+    HybridEP overlap path, where the creation stream and final consumer are both known.
+    """
+
     moe_per_layer_logging: bool = False
     """Enable per-layer logging for MoE, currently supports auxiliary loss and z loss."""
 
@@ -2123,6 +2132,33 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "moe_flex_dispatcher_backend='ncclep' requires "
                     "moe_token_dispatcher_type='flex'."
+                )
+
+        if self.moe_hybridep_use_manual_forward_stream_handback:
+            if not (
+                self.moe_token_dispatcher_type == "flex"
+                and self.moe_flex_dispatcher_backend == "hybridep"
+            ):
+                raise ValueError(
+                    "moe_hybridep_use_manual_forward_stream_handback requires the flex HybridEP "
+                    "backend."
+                )
+            if not self.overlap_moe_expert_parallel_comm:
+                raise ValueError(
+                    "moe_hybridep_use_manual_forward_stream_handback requires "
+                    "overlap_moe_expert_parallel_comm."
+                )
+            if self.fp8 is None and self.fp4 is None:
+                raise ValueError(
+                    "moe_hybridep_use_manual_forward_stream_handback requires fp8 or fp4 so the "
+                    "expert MLP can release its original dispatch input after the forward cast."
+                )
+            if self.fine_grained_activation_offloading and 'expert_fc1' in (
+                self.offload_modules or []
+            ):
+                raise ValueError(
+                    "moe_hybridep_use_manual_forward_stream_handback does not support offloading "
+                    "'expert_fc1', which retains the original dispatch input beyond MLP forward."
                 )
 
         # moe_deepep_num_sms / moe_hybridep_num_sms are deprecated and unified into

--- a/tests/unit_tests/pipeline_parallel/test_schedule_node_stream_handback.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedule_node_stream_handback.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from megatron.core.pipeline_parallel.utils import ScheduleNode
+
+
+class _FakeStorage:
+    def __init__(self, trace):
+        self.trace = trace
+
+    def resize_(self, size):
+        self.trace.append(("resize", size))
+
+
+class _FakeTensor:
+    def __init__(self, trace):
+        self.trace = trace
+        self.storage = _FakeStorage(trace)
+
+    def record_stream(self, stream):
+        self.trace.append(("record_stream", stream))
+
+    def untyped_storage(self):
+        return self.storage
+
+
+class _FakeEvent:
+    def __init__(self, trace):
+        self.trace = trace
+
+    def wait(self, stream):
+        self.trace.append(("wait", stream))
+
+
+def _make_node(trace, *, handback_stream=None):
+    return ScheduleNode(
+        forward_func=lambda: None,
+        stream="consumer",
+        event=_FakeEvent(trace),
+        free_input=True,
+        free_input_handback_stream=handback_stream,
+    )
+
+
+def test_free_forward_inputs_record_stream_fallback():
+    trace = []
+    node = _make_node(trace)
+
+    node._free_forward_inputs((_FakeTensor(trace), None))
+
+    assert trace == [("record_stream", "consumer"), ("resize", 0)]
+
+
+def test_handback_argument_preserves_positional_name_compatibility():
+    node = ScheduleNode(lambda: None, "consumer", _FakeEvent([]), None, True, "custom-name")
+
+    assert node.name == "custom-name"
+    assert node.free_input_handback_stream is None
+
+
+def test_free_forward_inputs_hands_back_before_release():
+    trace = []
+    creator_calls = []
+
+    def get_creator_stream():
+        creator_calls.append(True)
+        return "creator"
+
+    node = _make_node(trace, handback_stream=get_creator_stream)
+
+    node._free_forward_inputs((_FakeTensor(trace), None))
+    node._free_forward_inputs((_FakeTensor(trace),))
+
+    assert creator_calls == [True]
+    assert trace == [("wait", "creator"), ("resize", 0), ("wait", "creator"), ("resize", 0)]

--- a/tests/unit_tests/pipeline_parallel/test_schedule_node_stream_handback.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedule_node_stream_handback.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import pytest
+import torch
+
 from megatron.core.pipeline_parallel.utils import ScheduleNode
 
 
@@ -72,3 +75,58 @@ def test_free_forward_inputs_hands_back_before_release():
 
     assert creator_calls == [True]
     assert trace == [("wait", "creator"), ("resize", 0), ("wait", "creator"), ("resize", 0)]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_handback_reuses_creator_stream_storage_without_corrupting_consumer():
+    """Exercise the real allocator while the consumer stream trails the producer."""
+
+    def run(use_handback):
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        creator = torch.cuda.Stream()
+        consumer = torch.cuda.Stream()
+        event = torch.cuda.Event()
+        shape = (4 * 1024 * 1024,)
+        outputs = []
+        expected = []
+        pointers = []
+
+        def consume(value):
+            # Force enough in-flight depth for record_stream to retain several
+            # blocks while keeping the test independent of GEMM libraries.
+            torch.cuda._sleep(10_000_000)
+            return value.sum(dtype=torch.float32)
+
+        node = ScheduleNode(
+            consume,
+            consumer,
+            event,
+            free_input=True,
+            free_input_handback_stream=creator if use_handback else None,
+        )
+
+        for index in range(16):
+            value = float(index + 1)
+            with torch.cuda.stream(creator):
+                tensor = torch.full(shape, value, dtype=torch.bfloat16, device="cuda")
+                pointers.append(tensor.data_ptr())
+                event.record(creator)
+            outputs.append(node.forward(tensor))
+            expected.append(value * shape[0])
+
+        torch.cuda.synchronize()
+        actual = torch.stack(outputs).cpu()
+        torch.testing.assert_close(
+            actual, torch.tensor(expected, dtype=torch.float32), rtol=0, atol=0
+        )
+        return actual, len(set(pointers)), torch.cuda.max_memory_reserved()
+
+    control_output, control_pointers, control_reserved = run(False)
+    handback_output, handback_pointers, handback_reserved = run(True)
+
+    torch.testing.assert_close(handback_output, control_output, rtol=0, atol=0)
+    assert handback_pointers < control_pointers
+    assert handback_reserved < control_reserved


### PR DESCRIPTION
## Summary

- add an optional creation-stream hand-back path to `ScheduleNode` so storage can be released without `record_stream()` once the final consumer event has been handed back
- enable the path only for HybridEP forward dispatch outputs consumed by the expert MLP; the default allocator lifetime behavior remains unchanged
- validate the supported HybridEP/A2A-overlap/FP8-or-FP4 configuration and preserve the existing positional `ScheduleNode` API
- add fake-ordering tests and a real CUDA two-stream allocator/data-integrity test

## Motivation

HybridEP creates dispatch outputs on its communication stream and the expert MLP consumes them on a compute stream. The existing `record_stream(compute_stream) + storage.resize_(0)` path correctly protects the asynchronous consumer, but it can retain one allocator block per in-flight layer as `active_pending_free`.

The fine-grained scheduler already knows the final forward consumer. This change records that consumer's completion event, makes the creation stream wait on it, and then releases the storage without `record_stream()`. Subsequent creation-stream allocations can therefore reuse the block in stream order.

The optimization is intentionally limited to forward dispatch. Applying an immediate hand-back to backward dispatch could make the communication stream wait for backward expert compute before enqueueing the next forward dispatch, reducing combined-1F1B overlap.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev ... bash tools/autoformat.sh`
  - Black, isort, pylint, and ruff passed
- `python tools/check_copyright.py <changed Python files>`
- real CUDA two-stream test with a deliberately delayed consumer:
  - identical output checksums
  - unique input pointers: 30 -> 1
  - peak reserved memory: 304 MiB -> 26 MiB
- 8-GPU GB200, HybridEP, full-iteration CUDA Graph proxy A/B:
  - forward dispatch pending-free: 15 x 48 MiB -> 0
  - peak physical live memory: 24,244.374 MiB -> 23,524.375 MiB (-720 MiB)
  - 30-step steady-state iteration time: 78.433 ms -> 78.300 ms (performance parity; the confidence interval includes zero)

## Scope and limitations

- opt-in and disabled by default
- does not change backward dispatch or grouped-GEMM output lifetimes
- does not require a caller-owned ring buffer or a DeepEP API change