### PR TITLE
Fix one-shot stream causing FSDP memory leaks

### DIFF
--- a/megatron/training/models/dist_utils.py
+++ b/megatron/training/models/dist_utils.py
@@ -337,14 +337,21 @@ def _ddp_wrap(
         # DistOpt-style buffer.
         tag_params_for_buffer_routing(model)
 
-    if get_model_config(model[0]).cuda_graph_impl == "full_iteration":
+    cuda_graph_impl = get_model_config(model[0]).cuda_graph_impl
+    current_stream = torch.cuda.current_stream()
+    if cuda_graph_impl == "full_iteration":
         # DDP initialization must use the full-iteration capture stream so its retained
         # AccumulateGrad nodes do not reference a different, non-capturing stream.
         ddp_stream = get_shared_capture_stream()
+    elif cuda_graph_impl == "none":
+        # Eager initialization is serialized with the current stream. A one-shot side stream
+        # can leave cached blocks unavailable to later allocations on the current stream.
+        ddp_stream = current_stream
     else:
         # Preserve a dedicated initialization stream for all other implementations.
         ddp_stream = torch.cuda.Stream()
-    ddp_stream.wait_stream(torch.cuda.current_stream())
+    if ddp_stream is not current_stream:
+        ddp_stream.wait_stream(current_stream)
 
     with torch.cuda.stream(ddp_stream):
         dp_init_kwargs = {}
@@ -403,8 +410,9 @@ def _ddp_wrap(
             wrapped_model.append(wrapped_chunk)
         model = wrapped_model
 
-    # Ensure initialization-stream work completes before touching params on the default stream.
-    torch.cuda.current_stream().wait_stream(ddp_stream)
+    # Ensure side-stream initialization completes before touching params on the current stream.
+    if ddp_stream is not current_stream:
+        current_stream.wait_stream(ddp_stream)
 
     # Broadcast params from data parallel src rank to other data parallel ranks.
     if data_parallel_random_init:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2514,14 +2514,20 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             for disable in per_chunk_disable_bucketing
         ]
 
+        current_stream = torch.cuda.current_stream()
         if config.cuda_graph_impl == "full_iteration":
             # DDP initialization must use the full-iteration capture stream so its retained
             # AccumulateGrad nodes do not reference a different, non-capturing stream.
             ddp_stream = get_shared_capture_stream()
+        elif config.cuda_graph_impl == "none":
+            # Eager initialization is serialized with the current stream. A one-shot side stream
+            # can leave cached blocks unavailable to later allocations on the current stream.
+            ddp_stream = current_stream
         else:
             # Preserve a dedicated initialization stream for all other implementations.
             ddp_stream = torch.cuda.Stream()
-        ddp_stream.wait_stream(torch.cuda.current_stream())
+        if ddp_stream is not current_stream:
+            ddp_stream.wait_stream(current_stream)
 
         with torch.cuda.stream(ddp_stream):
             model = wrap_model_chunks_with_ddp(
@@ -2539,8 +2545,9 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 bucket_sizes=per_chunk_bucket_sizes,
                 disable_bucketing_per_chunk=per_chunk_disable_bucketing,
             )
-        # Ensure initialization-stream work completes before touching params on the default stream.
-        torch.cuda.current_stream().wait_stream(ddp_stream)
+        # Ensure side-stream initialization completes before touching params on the current stream.
+        if ddp_stream is not current_stream:
+            current_stream.wait_stream(ddp_stream)
 
         # Broadcast params from data parallel src rank to other data parallel ranks.
         if args.data_parallel_random_init:

--- a/tests/unit_tests/training/models/test_dist_utils.py
+++ b/tests/unit_tests/training/models/test_dist_utils.py
@@ -522,7 +522,34 @@ class TestDdpWrap:
         mock_stream_context.assert_called_once_with(shared_stream)
         mock_current_stream.return_value.wait_stream.assert_called_once_with(shared_stream)
 
-    @pytest.mark.parametrize("cuda_graph_impl", ["none", "local", "transformer_engine"])
+    @patch("megatron.training.models.dist_utils.DistributedDataParallel")
+    @patch("megatron.training.models.dist_utils.get_model_config")
+    @patch("torch.cuda.stream", new_callable=MagicMock)
+    @patch("torch.cuda.current_stream")
+    @patch("torch.cuda.Stream")
+    @patch("megatron.training.models.dist_utils.get_shared_capture_stream")
+    def test_uses_current_stream_when_cuda_graph_is_disabled(
+        self,
+        mock_shared_stream,
+        mock_stream,
+        mock_current_stream,
+        mock_stream_context,
+        mock_config,
+        mock_ddp,
+    ):
+        mock_stream_context.return_value.__enter__ = Mock(return_value=None)
+        mock_stream_context.return_value.__exit__ = Mock(return_value=False)
+        current_stream = mock_current_stream.return_value
+        mock_config.return_value.cuda_graph_impl = "none"
+
+        _ddp_wrap(self.model, False, self.ddp_config, False, pg_collection=self.pg)
+
+        mock_shared_stream.assert_not_called()
+        mock_stream.assert_not_called()
+        mock_stream_context.assert_called_once_with(current_stream)
+        current_stream.wait_stream.assert_not_called()
+
+    @pytest.mark.parametrize("cuda_graph_impl", ["local", "transformer_engine"])
     @patch("megatron.training.models.dist_utils.DistributedDataParallel")
     @patch("megatron.training.models.dist_utils.get_model_config")
     @patch("torch.cuda.stream", new_callable=MagicMock)


### PR DESCRIPTION
## What

A one-shot stream, introduced by the CUDA Graph option, was used to initialize the DDP/FSDP wrapper even when the CUDA graph was not in use, causing an FSDP memory leak. This PR fix this bug.

## Why

Eager wrapper initialization is already serialized with the current stream. Creating a one-shot side stream can leave large cached blocks unavailable to later allocations on the current stream, inflating CUDA caching allocator reserved memory and device memory without increasing live tensor memory.

A matched 42-layer M-FSDP v2 workload showed:

| Initialization | Peak allocated | Peak reserved | Peak device used |
| --- | ---: | ---: | ---: |
| One-shot side stream | 203,503.89 MiB | 242,670 MiB | 250,401 MiB |
| Current stream | 203,503.89 MiB | 221,706 MiB | 229,437 MiB |

The change reduced peak reserved and device memory by 20,964 MiB (20.47 GiB), while peak allocated memory was unchanged. A standalone two-stream reproduction and allocator analysis are available in [this report](https://gist.github.com/shjwudp/fd71fd67ea9aa38ced500774b2319959).

## Tests

- `python -m torch.distributed.run --nproc-per-node=1 -m pytest -q` on the eager/current, full-iteration/shared, and local/TE/dedicated stream-selection tests: **4 passed**.
- `python3 -m py_compile` on the changed Python files.
- `ruff check` on the changed Python files.
- `git diff --check`.
