### PR TITLE
feat(deepseek-v4): enable TP attention and CSA sequence-parallel paths

### DIFF
--- a/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
+++ b/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
@@ -219,7 +219,9 @@ def get_dsv4_hybrid_module_spec_for_backend(
         submodules=DSv4HybridSelfAttentionSubmodules(
             linear_q_down_proj=backend.linear(),
             linear_q_up_proj=backend.column_parallel_linear(),
-            linear_kv_proj=backend.column_parallel_linear(),
+            # DSv4 has one shared KV stream. DSv4HybridSelfAttention builds
+            # this TELinear in duplicated mode when TP>1.
+            linear_kv_proj=backend.linear(),
             core_attention=core_attention,
             linear_proj=backend.row_parallel_linear(),
             q_layernorm=qk_norm,

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -2107,6 +2107,9 @@ class CompressedSparseAttention(MegatronModule):
         packed_seq_params: PackedSeqParams = None,
         boundary_hidden: Optional[torch.Tensor] = None,
         boundary_kv: Optional[torch.Tensor] = None,
+        indexer_x_local: Optional[torch.Tensor] = None,
+        indexer_qr_local: Optional[torch.Tensor] = None,
+        tp_local_indexer_q: bool = False,
     ) -> torch.Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -2144,7 +2147,16 @@ class CompressedSparseAttention(MegatronModule):
                     query, key, x, qr, boundary_hidden, boundary_kv, packed_seq_params
                 )
             else:
-                output = self._forward_thd(query, key, x, qr, packed_seq_params)
+                output = self._forward_thd(
+                    query,
+                    key,
+                    x,
+                    qr,
+                    packed_seq_params,
+                    indexer_x_local=indexer_x_local,
+                    indexer_qr_local=indexer_qr_local,
+                    tp_local_indexer_q=tp_local_indexer_q,
+                )
             self.pg_collection.cp = _orig_cp_group
             nvtx_range_pop("compressed_sparse_attn")
             return output
@@ -2159,6 +2171,7 @@ class CompressedSparseAttention(MegatronModule):
         has_indexer_compressed = (
             self.compress_ratio > 1 and n_compressed > 0 and self.indexer is not None
         )
+        has_indexer_loss = (getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0) > 0
 
         indexer_loss = None
 
@@ -2174,7 +2187,12 @@ class CompressedSparseAttention(MegatronModule):
                 window_idxs,
                 packed_seq_params,
             )
-        elif has_indexer_compressed and self.training and torch.is_grad_enabled():
+        elif (
+            has_indexer_compressed
+            and self.training
+            and torch.is_grad_enabled()
+            and has_indexer_loss
+        ):
             output, indexer_loss = self._forward_fused_indexer_training(
                 query, x, qr, kv_full, n_compressed, offset, window_idxs, packed_seq_params
             )
@@ -2413,6 +2431,10 @@ class CompressedSparseAttention(MegatronModule):
         max_seqlen_q: int,
         max_seqlen_compressed_idx: int,
         max_seqlen_kv: int,
+        *,
+        indexer_x_local: Optional[torch.Tensor] = None,
+        indexer_qr_local: Optional[torch.Tensor] = None,
+        tp_local_indexer_q: bool = False,
     ) -> torch.Tensor:
         """Path C (THD): separate indexer forward (no loss) + fused sparse attn (compact).
 
@@ -2421,9 +2443,27 @@ class CompressedSparseAttention(MegatronModule):
         x_det = x.detach()
         qr_det = qr.detach()
 
-        q_indexer, k_indexer, weights_indexer, cu_seqlens_compressed_idx = (
-            self.indexer.forward_before_topk(x_det, qr_det, packed_seq_params)
-        )
+        # With a zero teacher-loss coefficient the Indexer route is a discrete
+        # routing decision only.  No Indexer activation can contribute a
+        # gradient, so do not build a parameter autograd graph for Q/K/weights.
+        with torch.no_grad():
+            if tp_local_indexer_q:
+                if indexer_x_local is None or indexer_qr_local is None:
+                    raise RuntimeError(
+                        "TP-local Indexer Q path requires local hidden and compressed-query inputs."
+                    )
+                q_indexer, weights_indexer = self._forward_indexer_q_weights_tp_local(
+                    indexer_x_local.detach(),
+                    indexer_qr_local.detach(),
+                    packed_seq_params,
+                )
+                k_indexer, cu_seqlens_compressed_idx = self.indexer.compressor(
+                    x_det, packed_seq_params=packed_seq_params
+                )
+            else:
+                q_indexer, k_indexer, weights_indexer, cu_seqlens_compressed_idx = (
+                    self.indexer.forward_before_topk(x_det, qr_det, packed_seq_params)
+                )
         q_thd = q_indexer.squeeze(1)
         w_thd = weights_indexer.squeeze(1)
         if k_indexer is None:
@@ -2474,6 +2514,73 @@ class CompressedSparseAttention(MegatronModule):
             is_thd=True,
         )
         return output.unsqueeze(1)
+
+    def _forward_indexer_q_weights_tp_local(
+        self,
+        x_local: torch.Tensor,
+        qr_local: torch.Tensor,
+        packed_seq_params: PackedSeqParams,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute duplicated Indexer Q/weights on TP-local sequence rows.
+
+        The Indexer compressor K remains on the legacy global-row path because
+        every TP rank needs the complete compressed-K buffer.  Q and weights are
+        token-wise and are only used to form a non-differentiable top-k when the
+        Indexer teacher-loss coefficient is zero, so computing them once on the
+        rank owning each sequence row and then gathering the results is exact.
+        """
+        tp_group = self.pg_collection.tp
+        if tp_group is None or tp_group.size() <= 1:
+            raise RuntimeError("TP-local Indexer Q path requires a TP group larger than one.")
+        if (getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0) > 0:
+            raise RuntimeError(
+                "TP-local Indexer Q is only enabled when dsa_indexer_loss_coeff == 0; "
+                "the teacher-loss gradient path still requires a dedicated implementation."
+            )
+
+        indexer = self.indexer
+        local_rows = x_local.shape[0]
+        if x_local.ndim != 3 or x_local.shape[1] != 1:
+            raise RuntimeError(
+                f"TP-local Indexer Q expects x_local [rows,1,hidden], got {tuple(x_local.shape)}"
+            )
+        cu_seqlens_q = (
+            packed_seq_params.cu_seqlens_q_padded
+            if packed_seq_params.cu_seqlens_q_padded is not None
+            else packed_seq_params.cu_seqlens_q
+        )
+        max_seqlen_q = int(packed_seq_params.max_seqlen_q)
+        with torch.no_grad():
+            q_indexer, _ = indexer.linear_wq_b(qr_local)
+            q_indexer = q_indexer.reshape(
+                local_rows, 1, indexer.index_n_heads, indexer.index_head_dim
+            )
+            # Gather the raw token-wise projection before RoPE.  Applying RoPE
+            # to local slices changes a few BF16 ulps in the fused kernel; the
+            # Indexer top-k is discrete and those ulps can flip many routes.
+            # Keeping the existing global RoPE call makes the top-k bitwise
+            # equivalent while still removing the duplicated GEMM work.
+            q_indexer = gather_from_sequence_parallel_region(q_indexer, group=tp_group)
+            q_indexer = _apply_rope(
+                q_indexer,
+                indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
+                indexer.qk_pos_emb_head_dim,
+                indexer.rotary_pos_emb,
+                self.config,
+                rotary_seq_len=q_indexer.shape[0],
+                ratio=1,
+                cp_group=self.pg_collection.cp,
+                cu_seqlens=cu_seqlens_q,
+                max_seqlen_rope=max_seqlen_q,
+            )
+            q_indexer = rotate_activation(q_indexer)
+            weights_indexer, _ = indexer.linear_weights_proj(x_local)
+            weights_indexer = weights_indexer * (indexer.index_n_heads**-0.5)
+
+            weights_indexer = gather_from_sequence_parallel_region(
+                weights_indexer, group=tp_group
+            )
+        return q_indexer, weights_indexer
 
     def _forward_fused_indexer_training_thd(
         self,
@@ -2784,7 +2891,13 @@ class CompressedSparseAttention(MegatronModule):
                     compressed_kv_local.squeeze(1), group=cp_group
                 )
 
-        use_indexer_loss = training_with_grad and compressed_topk is not None
+        # A zero coefficient still needs Indexer top-k for sparse attention,
+        # but it must not enter the dense/sparse teacher-loss autograd path.
+        # That path allocates large score/recompute workspaces even when its
+        # contribution is mathematically zero (especially at 256K).
+        use_indexer_loss = (
+            training_with_grad and compressed_topk is not None and indexer_loss_coeff > 0
+        )
         # ``use_indexer_loss`` implies the RS consumer edges above were built,
         # so the fused indexer-loss path always runs with backward overlap.
         overlap_cp_backward = use_indexer_loss and self.use_fused_kernels
@@ -2932,6 +3045,10 @@ class CompressedSparseAttention(MegatronModule):
         x: torch.Tensor,  # (total_q, 1, hidden_size)
         qr: torch.Tensor,  # (total_q, 1, q_lora_rank)
         packed_seq_params: PackedSeqParams,
+        *,
+        indexer_x_local: Optional[torch.Tensor] = None,
+        indexer_qr_local: Optional[torch.Tensor] = None,
+        tp_local_indexer_q: bool = False,
     ) -> torch.Tensor:
         """THD-packed branch of :meth:`forward`. See class docstring for layout.
 
@@ -3011,6 +3128,7 @@ class CompressedSparseAttention(MegatronModule):
         has_indexer = (
             self.compress_ratio > 1 and n_compressed_total > 0 and self.indexer is not None
         )
+        has_indexer_loss = (getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0) > 0
 
         indexer_loss = None
 
@@ -3033,7 +3151,7 @@ class CompressedSparseAttention(MegatronModule):
                 max_seqlen_compressed_idx,
                 packed_seq_params,
             )
-        elif has_indexer and is_training:
+        elif has_indexer and is_training and has_indexer_loss:
             output, indexer_loss = self._forward_fused_indexer_training_thd(
                 query,
                 x,
@@ -3065,6 +3183,9 @@ class CompressedSparseAttention(MegatronModule):
                 max_seqlen_q,
                 max_seqlen_compressed_idx,
                 max_seqlen_kv,
+                indexer_x_local=indexer_x_local,
+                indexer_qr_local=indexer_qr_local,
+                tp_local_indexer_q=tp_local_indexer_q,
             )
         else:
             output = self._forward_fused_no_indexer_thd(

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -2111,6 +2111,9 @@ class CompressedSparseAttention(MegatronModule):
         indexer_qr_local: Optional[torch.Tensor] = None,
         tp_local_indexer_q: bool = False,
         tp_local_indexer_topk: bool = False,
+        indexer_compressor_x_local: Optional[torch.Tensor] = None,
+        indexer_compressor_boundary_hidden: Optional[torch.Tensor] = None,
+        tp_local_indexer_compressor: bool = False,
         attention_compressor_x_local: Optional[torch.Tensor] = None,
         attention_compressor_boundary_hidden: Optional[torch.Tensor] = None,
         tp_local_attention_compressor: bool = False,
@@ -2164,6 +2167,9 @@ class CompressedSparseAttention(MegatronModule):
                     attention_compressor_x_local=attention_compressor_x_local,
                     attention_compressor_boundary_hidden=attention_compressor_boundary_hidden,
                     tp_local_attention_compressor=tp_local_attention_compressor,
+                    indexer_compressor_x_local=indexer_compressor_x_local,
+                    indexer_compressor_boundary_hidden=indexer_compressor_boundary_hidden,
+                    tp_local_indexer_compressor=tp_local_indexer_compressor,
                 )
             self.pg_collection.cp = _orig_cp_group
             nvtx_range_pop("compressed_sparse_attn")
@@ -2444,6 +2450,9 @@ class CompressedSparseAttention(MegatronModule):
         indexer_qr_local: Optional[torch.Tensor] = None,
         tp_local_indexer_q: bool = False,
         tp_local_indexer_topk: bool = False,
+        indexer_compressor_x_local: Optional[torch.Tensor] = None,
+        indexer_compressor_boundary_hidden: Optional[torch.Tensor] = None,
+        tp_local_indexer_compressor: bool = False,
     ) -> torch.Tensor:
         """Path C (THD): separate indexer forward (no loss) + fused sparse attn (compact).
 
@@ -2467,9 +2476,6 @@ class CompressedSparseAttention(MegatronModule):
                     packed_seq_params,
                     gather=False,
                 )
-                k_indexer, cu_seqlens_compressed_idx = self.indexer.compressor(
-                    x_det, packed_seq_params=packed_seq_params
-                )
             elif tp_local_indexer_q:
                 if indexer_x_local is None or indexer_qr_local is None:
                     raise RuntimeError(
@@ -2480,13 +2486,34 @@ class CompressedSparseAttention(MegatronModule):
                     indexer_qr_local.detach(),
                     packed_seq_params,
                 )
-                k_indexer, cu_seqlens_compressed_idx = self.indexer.compressor(
-                    x_det, packed_seq_params=packed_seq_params
+            elif tp_local_indexer_compressor:
+                q_indexer, weights_indexer = self._forward_indexer_q_weights_global(
+                    x_det, qr_det, packed_seq_params
                 )
             else:
                 q_indexer, k_indexer, weights_indexer, cu_seqlens_compressed_idx = (
                     self.indexer.forward_before_topk(x_det, qr_det, packed_seq_params)
                 )
+            if tp_local_indexer_topk or tp_local_indexer_q or tp_local_indexer_compressor:
+                if tp_local_indexer_compressor:
+                    if (
+                        indexer_compressor_x_local is None
+                        or indexer_compressor_boundary_hidden is None
+                    ):
+                        raise RuntimeError(
+                            "TP-local Indexer compressor requires local hidden and boundary inputs."
+                        )
+                    k_indexer, cu_seqlens_compressed_idx = (
+                        self._forward_indexer_compressor_tp_local(
+                            indexer_compressor_x_local.detach(),
+                            indexer_compressor_boundary_hidden,
+                            packed_seq_params,
+                        )
+                    )
+                else:
+                    k_indexer, cu_seqlens_compressed_idx = self.indexer.compressor(
+                        x_det, packed_seq_params=packed_seq_params
+                    )
         if tp_local_indexer_topk:
             if k_indexer is None:
                 local_rows = indexer_x_local.shape[0]
@@ -2570,6 +2597,42 @@ class CompressedSparseAttention(MegatronModule):
             is_thd=True,
         )
         return output.unsqueeze(1)
+
+    def _forward_indexer_q_weights_global(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        packed_seq_params: PackedSeqParams,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute the global Indexer Q/weights without invoking its K compressor."""
+        indexer = self.indexer
+        cu_seqlens_q = (
+            packed_seq_params.cu_seqlens_q_padded
+            if packed_seq_params.cu_seqlens_q_padded is not None
+            else packed_seq_params.cu_seqlens_q
+        )
+        max_seqlen_q = int(packed_seq_params.max_seqlen_q)
+        q_indexer, _ = indexer.linear_wq_b(qr)
+        local_rows, bsz, _ = x.shape
+        q_indexer = q_indexer.reshape(
+            local_rows, bsz, indexer.index_n_heads, indexer.index_head_dim
+        )
+        q_indexer = _apply_rope(
+            q_indexer,
+            indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
+            indexer.qk_pos_emb_head_dim,
+            indexer.rotary_pos_emb,
+            self.config,
+            rotary_seq_len=local_rows,
+            ratio=1,
+            cp_group=self.pg_collection.cp,
+            cu_seqlens=cu_seqlens_q,
+            max_seqlen_rope=max_seqlen_q,
+        )
+        q_indexer = rotate_activation(q_indexer)
+        weights_indexer, _ = indexer.linear_weights_proj(x)
+        weights_indexer = weights_indexer * (indexer.index_n_heads**-0.5)
+        return q_indexer, weights_indexer
 
     def _forward_indexer_q_weights_tp_local(
         self,
@@ -3136,8 +3199,9 @@ class CompressedSparseAttention(MegatronModule):
             )
         return output.unsqueeze(1)
 
-    def _forward_attention_compressor_tp_local(
+    def _forward_compressor_tp_local(
         self,
+        compressor,
         x_local: torch.Tensor,
         boundary_hidden: torch.Tensor,
         packed_seq_params: PackedSeqParams,
@@ -3153,10 +3217,10 @@ class CompressedSparseAttention(MegatronModule):
         """
         tp_group = self.pg_collection.tp
         if tp_group is None or tp_group.size() <= 1:
-            raise RuntimeError("TP-local attention compressor requires a TP group larger than one.")
+            raise RuntimeError("TP-local compressor requires a TP group larger than one.")
         if x_local.ndim != 3 or x_local.shape[1] != 1:
             raise RuntimeError(
-                f"TP-local attention compressor expects [rows,1,hidden], got {tuple(x_local.shape)}"
+                f"TP-local compressor expects [rows,1,hidden], got {tuple(x_local.shape)}"
             )
         cu_seqlens = (
             packed_seq_params.cu_seqlens_q_padded
@@ -3165,7 +3229,7 @@ class CompressedSparseAttention(MegatronModule):
         )
         if packed_seq_params.max_seqlen_q is None:
             raise ValueError("TP-local attention compressor requires max_seqlen_q for THD metadata.")
-        ratio = int(self.compress_ratio)
+        ratio = int(compressor.compress_ratio)
         seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
         compressed_lens = torch.div(seq_lens, ratio, rounding_mode="floor")
         cu_seqlens_compressed = torch.cat(
@@ -3189,14 +3253,14 @@ class CompressedSparseAttention(MegatronModule):
                 ratio,
             )
         )
-        compressed_local, _ = self.compressor._forward_thd(
+        compressed_local, _ = compressor._forward_thd(
             hidden_compact,
             cu_seqlens,
             max_seqlen_q=int(packed_seq_params.max_seqlen_q),
             compressed_group_ids=compressed_group_ids,
         )
         if compressed_local is None:
-            raise RuntimeError("TP-local attention compressor unexpectedly returned no compressed rows.")
+            raise RuntimeError("TP-local compressor unexpectedly returned no compressed rows.")
         compressed_rank_major = gather_from_sequence_parallel_region(
             compressed_local.squeeze(1), group=tp_group
         )
@@ -3206,6 +3270,28 @@ class CompressedSparseAttention(MegatronModule):
             seq_to_rank_row.clamp_min(0).long(),
         )
         return compressed_global.unsqueeze(1), cu_seqlens_compressed
+
+    def _forward_attention_compressor_tp_local(
+        self,
+        x_local: torch.Tensor,
+        boundary_hidden: torch.Tensor,
+        packed_seq_params: PackedSeqParams,
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        """Compute the attention compressor through the generic local producer."""
+        return self._forward_compressor_tp_local(
+            self.compressor, x_local, boundary_hidden, packed_seq_params
+        )
+
+    def _forward_indexer_compressor_tp_local(
+        self,
+        x_local: torch.Tensor,
+        boundary_hidden: torch.Tensor,
+        packed_seq_params: PackedSeqParams,
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        """Compute the no-loss Indexer compressed-K producer on TP-local rows."""
+        return self._forward_compressor_tp_local(
+            self.indexer.compressor, x_local, boundary_hidden, packed_seq_params
+        )
 
     def _forward_thd(
         self,
@@ -3222,6 +3308,9 @@ class CompressedSparseAttention(MegatronModule):
         attention_compressor_x_local: Optional[torch.Tensor] = None,
         attention_compressor_boundary_hidden: Optional[torch.Tensor] = None,
         tp_local_attention_compressor: bool = False,
+        indexer_compressor_x_local: Optional[torch.Tensor] = None,
+        indexer_compressor_boundary_hidden: Optional[torch.Tensor] = None,
+        tp_local_indexer_compressor: bool = False,
     ) -> torch.Tensor:
         """THD-packed branch of :meth:`forward`. See class docstring for layout.
 
@@ -3376,6 +3465,9 @@ class CompressedSparseAttention(MegatronModule):
                 indexer_qr_local=indexer_qr_local,
                 tp_local_indexer_q=tp_local_indexer_q,
                 tp_local_indexer_topk=tp_local_indexer_topk,
+                indexer_compressor_x_local=indexer_compressor_x_local,
+                indexer_compressor_boundary_hidden=indexer_compressor_boundary_hidden,
+                tp_local_indexer_compressor=tp_local_indexer_compressor,
             )
         else:
             output = self._forward_fused_no_indexer_thd(

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -49,7 +49,12 @@ from megatron.core.transformer.experimental_attention_variant.dsa_kernels import
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import nvtx_range_pop, nvtx_range_push
+from megatron.core.utils import (
+    get_pg_size,
+    make_tp_sharded_tensor_for_checkpoint,
+    nvtx_range_pop,
+    nvtx_range_push,
+)
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -1747,7 +1752,13 @@ class CompressedSparseAttention(MegatronModule):
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
 
-        self.n_local_heads = config.num_attention_heads
+        tp_size = get_pg_size(pg_collection.tp)
+        if config.num_attention_heads % tp_size != 0:
+            raise ValueError(
+                "CSA query heads must be divisible by tensor model parallel size: "
+                f"{config.num_attention_heads} % {tp_size} != 0"
+            )
+        self.n_local_heads = config.num_attention_heads // tp_size
 
         if softmax_scale is None:
             softmax_scale = config.v_head_dim**-0.5
@@ -1803,6 +1814,18 @@ class CompressedSparseAttention(MegatronModule):
             self.compressor.backward_dw()
         if self.indexer is not None:
             self.indexer.backward_dw()
+
+    def sharded_state_dict(self, prefix: str = "", sharded_offsets: tuple = (), metadata=None):
+        """Shard the per-query-head attention sink along the TP head axis."""
+        state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        key = f"{prefix}attn_sink"
+        state_dict[key] = make_tp_sharded_tensor_for_checkpoint(
+            tensor=self.attn_sink,
+            key=key,
+            tp_axis=0,
+            prepend_offsets=sharded_offsets,
+        )
+        return state_dict
 
     # ------------------------------------------------------------------
     # Private helpers – each owns one logical slice of the forward pass.

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1902,7 +1902,7 @@ class CompressedSparseAttention(MegatronModule):
                     q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
                         x_det, qr_det, packed_seq_params
                     )
-                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0
                     key_for_loss = compressed_kv.unsqueeze(2).expand(-1, -1, np, -1)
                     weights_for_unfused = weights_indexer.float() * self.indexer.softmax_scale
                     non_compressed_lse = _compute_unfused_csa_non_compressed_lse(
@@ -2246,7 +2246,7 @@ class CompressedSparseAttention(MegatronModule):
 
                     key_for_loss_thd = compressed_kv.unsqueeze(1).expand(-1, np_, -1)
                     weights_for_unfused = w_thd * self.indexer.softmax_scale
-                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0
 
                     # Physical padded offsets define the packed address space;
                     # unpadded lengths identify the real rows within each segment.
@@ -2498,7 +2498,7 @@ class CompressedSparseAttention(MegatronModule):
         ``(total_q, 1, np * hn)``.
         """
         sparse_loss = getattr(self.config, "dsa_indexer_use_sparse_loss", True)
-        indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+        indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0
 
         x_det = x.detach()
         qr_det = qr.detach()

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -49,6 +49,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa_kernels import
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.tensor_parallel.layers import set_tensor_model_parallel_attributes
 from megatron.core.utils import (
     get_pg_size,
     make_tp_sharded_tensor_for_checkpoint,
@@ -1099,6 +1100,10 @@ class Compressor(MegatronModule):
         )
         config.init_method(_ape)
         self.ape = mark_keep_in_fp32(nn.Parameter(_ape))
+        if get_pg_size(pg_collection.tp) > 1 and config.sequence_parallel:
+            # APE is replicated, but its gradient is computed from sequence-
+            # parallel slices and must be reduced across the TP group.
+            setattr(self.ape, 'sequence_parallel', True)
 
         norm_config = copy.copy(config)
         norm_config.normalization = "RMSNorm"
@@ -1771,6 +1776,8 @@ class CompressedSparseAttention(MegatronModule):
         self.attn_sink = mark_keep_in_fp32(
             nn.Parameter(torch.zeros(self.n_local_heads, dtype=torch.float32))
         )
+        if tp_size > 1:
+            set_tensor_model_parallel_attributes(self.attn_sink, True, 0, 1)
 
         # Conditionally build Compressor (ratio > 1). ratio == 0 is window-only ('W'): not built.
         if self.compress_ratio > 1 and submodules.compressor is not None:

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -2110,6 +2110,10 @@ class CompressedSparseAttention(MegatronModule):
         indexer_x_local: Optional[torch.Tensor] = None,
         indexer_qr_local: Optional[torch.Tensor] = None,
         tp_local_indexer_q: bool = False,
+        tp_local_indexer_topk: bool = False,
+        attention_compressor_x_local: Optional[torch.Tensor] = None,
+        attention_compressor_boundary_hidden: Optional[torch.Tensor] = None,
+        tp_local_attention_compressor: bool = False,
     ) -> torch.Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -2156,6 +2160,10 @@ class CompressedSparseAttention(MegatronModule):
                     indexer_x_local=indexer_x_local,
                     indexer_qr_local=indexer_qr_local,
                     tp_local_indexer_q=tp_local_indexer_q,
+                    tp_local_indexer_topk=tp_local_indexer_topk,
+                    attention_compressor_x_local=attention_compressor_x_local,
+                    attention_compressor_boundary_hidden=attention_compressor_boundary_hidden,
+                    tp_local_attention_compressor=tp_local_attention_compressor,
                 )
             self.pg_collection.cp = _orig_cp_group
             nvtx_range_pop("compressed_sparse_attn")
@@ -2435,6 +2443,7 @@ class CompressedSparseAttention(MegatronModule):
         indexer_x_local: Optional[torch.Tensor] = None,
         indexer_qr_local: Optional[torch.Tensor] = None,
         tp_local_indexer_q: bool = False,
+        tp_local_indexer_topk: bool = False,
     ) -> torch.Tensor:
         """Path C (THD): separate indexer forward (no loss) + fused sparse attn (compact).
 
@@ -2447,7 +2456,21 @@ class CompressedSparseAttention(MegatronModule):
         # routing decision only.  No Indexer activation can contribute a
         # gradient, so do not build a parameter autograd graph for Q/K/weights.
         with torch.no_grad():
-            if tp_local_indexer_q:
+            if tp_local_indexer_topk:
+                if indexer_x_local is None or indexer_qr_local is None:
+                    raise RuntimeError(
+                        "TP-local Indexer top-k path requires local hidden and compressed-query inputs."
+                    )
+                q_indexer, weights_indexer = self._forward_indexer_q_weights_tp_local(
+                    indexer_x_local.detach(),
+                    indexer_qr_local.detach(),
+                    packed_seq_params,
+                    gather=False,
+                )
+                k_indexer, cu_seqlens_compressed_idx = self.indexer.compressor(
+                    x_det, packed_seq_params=packed_seq_params
+                )
+            elif tp_local_indexer_q:
                 if indexer_x_local is None or indexer_qr_local is None:
                     raise RuntimeError(
                         "TP-local Indexer Q path requires local hidden and compressed-query inputs."
@@ -2464,24 +2487,57 @@ class CompressedSparseAttention(MegatronModule):
                 q_indexer, k_indexer, weights_indexer, cu_seqlens_compressed_idx = (
                     self.indexer.forward_before_topk(x_det, qr_det, packed_seq_params)
                 )
-        q_thd = q_indexer.squeeze(1)
-        w_thd = weights_indexer.squeeze(1)
-        if k_indexer is None:
-            topk_indices_cmp = torch.full((total_q, 0), -1, dtype=torch.int32, device=query.device)
-        else:
-            k_thd = k_indexer.squeeze(1)
-            topk_indices_cmp, _ = indexer_topk(
-                q_thd,
-                k_thd,
-                w_thd,
-                topk=self.indexer.index_topk,
-                ratio=self.compress_ratio,
-                indexer_softmax_scale=self.indexer.softmax_scale,
-                cu_seqlens_q=cu_seqlens_q,
-                cu_seqlens_kv=cu_seqlens_compressed_idx,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_kv=max_seqlen_compressed_idx,
+        if tp_local_indexer_topk:
+            if k_indexer is None:
+                local_rows = indexer_x_local.shape[0]
+                topk_indices_cmp = torch.full(
+                    (local_rows, 0), -1, dtype=torch.int32, device=query.device
+                )
+            else:
+                topk_indices_cmp, _ = cp_utils.compute_cp_indexer_topk(
+                    q_indexer,
+                    weights_indexer,
+                    k_indexer.squeeze(1),
+                    cu_seqlens_q,
+                    cu_seqlens_compressed_idx,
+                    self.pg_collection.tp.rank() * indexer_x_local.shape[0],
+                    self.compress_ratio,
+                    self.indexer.index_topk,
+                    self.indexer.softmax_scale,
+                    max_seqlen_q,
+                    use_fused=self.use_fused_kernels,
+                )
+                if topk_indices_cmp is None:
+                    topk_indices_cmp = torch.full(
+                        (indexer_x_local.shape[0], 0),
+                        -1,
+                        dtype=torch.int32,
+                        device=query.device,
+                    )
+            topk_indices_cmp = gather_from_sequence_parallel_region(
+                topk_indices_cmp, group=self.pg_collection.tp
             )
+        else:
+            q_thd = q_indexer.squeeze(1)
+            w_thd = weights_indexer.squeeze(1)
+            if k_indexer is None:
+                topk_indices_cmp = torch.full(
+                    (total_q, 0), -1, dtype=torch.int32, device=query.device
+                )
+            else:
+                k_thd = k_indexer.squeeze(1)
+                topk_indices_cmp, _ = indexer_topk(
+                    q_thd,
+                    k_thd,
+                    w_thd,
+                    topk=self.indexer.index_topk,
+                    ratio=self.compress_ratio,
+                    indexer_softmax_scale=self.indexer.softmax_scale,
+                    cu_seqlens_q=cu_seqlens_q,
+                    cu_seqlens_kv=cu_seqlens_compressed_idx,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_kv=max_seqlen_compressed_idx,
+                )
 
         # Shift into per-segment full-KV index space.
         if topk_indices_cmp.shape[-1] > 0:
@@ -2520,6 +2576,8 @@ class CompressedSparseAttention(MegatronModule):
         x_local: torch.Tensor,
         qr_local: torch.Tensor,
         packed_seq_params: PackedSeqParams,
+        *,
+        gather: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Compute duplicated Indexer Q/weights on TP-local sequence rows.
 
@@ -2528,6 +2586,7 @@ class CompressedSparseAttention(MegatronModule):
         token-wise and are only used to form a non-differentiable top-k when the
         Indexer teacher-loss coefficient is zero, so computing them once on the
         rank owning each sequence row and then gathering the results is exact.
+        ``gather=False`` keeps the results local for the local-top-k variant.
         """
         tp_group = self.pg_collection.tp
         if tp_group is None or tp_group.size() <= 1:
@@ -2550,36 +2609,75 @@ class CompressedSparseAttention(MegatronModule):
             else packed_seq_params.cu_seqlens_q
         )
         max_seqlen_q = int(packed_seq_params.max_seqlen_q)
+        global_start = tp_group.rank() * local_rows
         with torch.no_grad():
             q_indexer, _ = indexer.linear_wq_b(qr_local)
             q_indexer = q_indexer.reshape(
                 local_rows, 1, indexer.index_n_heads, indexer.index_head_dim
             )
-            # Gather the raw token-wise projection before RoPE.  Applying RoPE
-            # to local slices changes a few BF16 ulps in the fused kernel; the
-            # Indexer top-k is discrete and those ulps can flip many routes.
-            # Keeping the existing global RoPE call makes the top-k bitwise
-            # equivalent while still removing the duplicated GEMM work.
-            q_indexer = gather_from_sequence_parallel_region(q_indexer, group=tp_group)
-            q_indexer = _apply_rope(
-                q_indexer,
-                indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
-                indexer.qk_pos_emb_head_dim,
-                indexer.rotary_pos_emb,
-                self.config,
-                rotary_seq_len=q_indexer.shape[0],
-                ratio=1,
-                cp_group=self.pg_collection.cp,
-                cu_seqlens=cu_seqlens_q,
-                max_seqlen_rope=max_seqlen_q,
-            )
+            if gather:
+                # Gather the raw token-wise projection before RoPE. Applying
+                # RoPE to local slices changes a few BF16 ulps in the fused
+                # kernel; the Indexer top-k is discrete and those ulps can
+                # flip many routes. Keeping the existing global RoPE call
+                # makes the top-k numerically equivalent while still removing
+                # the duplicated GEMM work.
+                q_indexer = gather_from_sequence_parallel_region(
+                    q_indexer, group=tp_group
+                )
+                q_indexer = _apply_rope(
+                    q_indexer,
+                    indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
+                    indexer.qk_pos_emb_head_dim,
+                    indexer.rotary_pos_emb,
+                    self.config,
+                    rotary_seq_len=q_indexer.shape[0],
+                    ratio=1,
+                    cp_group=self.pg_collection.cp,
+                    cu_seqlens=cu_seqlens_q,
+                    max_seqlen_rope=max_seqlen_q,
+                )
+            else:
+                # Local top-k uses the same CP metadata as the existing CP
+                # implementation so causal visibility is based on the true
+                # global position rather than the local row number.
+                if self.config.apply_dsa_kernel_fusion:
+                    rotary_pos_cos, rotary_pos_sin = indexer.rotary_pos_emb.get_cached_cos_sin(
+                        max_seqlen_q, dtype=q_indexer.dtype, packed_seq=True, mscale=1.0
+                    )
+                    q_indexer = cp_utils.apply_thd_cp_local_rope_fused(
+                        q_indexer,
+                        rotary_pos_cos,
+                        rotary_pos_sin,
+                        indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
+                        indexer.qk_pos_emb_head_dim,
+                        cu_seqlens_q,
+                        global_start,
+                    )
+                else:
+                    rope_result = indexer.rotary_pos_emb(max_seqlen_q, packed_seq=True)
+                    rotary_pos_emb = (
+                        rope_result[0] if isinstance(rope_result, tuple) else rope_result
+                    )
+                    q_indexer = cp_utils.apply_thd_cp_local_rope_unfused(
+                        q_indexer,
+                        rotary_pos_emb,
+                        indexer.index_head_dim - indexer.qk_pos_emb_head_dim,
+                        indexer.qk_pos_emb_head_dim,
+                        cu_seqlens_q,
+                        global_start,
+                        self.config,
+                    )
             q_indexer = rotate_activation(q_indexer)
             weights_indexer, _ = indexer.linear_weights_proj(x_local)
             weights_indexer = weights_indexer * (indexer.index_n_heads**-0.5)
 
-            weights_indexer = gather_from_sequence_parallel_region(
-                weights_indexer, group=tp_group
-            )
+            if gather:
+                weights_indexer = gather_from_sequence_parallel_region(
+                    weights_indexer, group=tp_group
+                )
+        if not gather:
+            return q_indexer.squeeze(1), weights_indexer.squeeze(1)
         return q_indexer, weights_indexer
 
     def _forward_fused_indexer_training_thd(
@@ -3038,6 +3136,77 @@ class CompressedSparseAttention(MegatronModule):
             )
         return output.unsqueeze(1)
 
+    def _forward_attention_compressor_tp_local(
+        self,
+        x_local: torch.Tensor,
+        boundary_hidden: torch.Tensor,
+        packed_seq_params: PackedSeqParams,
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        """Compute the attention compressed-KV producer on TP-local rows.
+
+        Every TP rank still receives the complete compressed-KV tensor for its
+        global query rows, but the duplicated token-wise compressor GEMMs run
+        only on the rank owning each sequence interval.  ``prepare_cp...`` and
+        its autograd boundary exchange preserve compression groups that cross a
+        rank boundary; the final gather is rank-major and is reordered into the
+        original sequence-major compressed layout.
+        """
+        tp_group = self.pg_collection.tp
+        if tp_group is None or tp_group.size() <= 1:
+            raise RuntimeError("TP-local attention compressor requires a TP group larger than one.")
+        if x_local.ndim != 3 or x_local.shape[1] != 1:
+            raise RuntimeError(
+                f"TP-local attention compressor expects [rows,1,hidden], got {tuple(x_local.shape)}"
+            )
+        cu_seqlens = (
+            packed_seq_params.cu_seqlens_q_padded
+            if packed_seq_params.cu_seqlens_q_padded is not None
+            else packed_seq_params.cu_seqlens_q
+        )
+        if packed_seq_params.max_seqlen_q is None:
+            raise ValueError("TP-local attention compressor requires max_seqlen_q for THD metadata.")
+        ratio = int(self.compress_ratio)
+        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+        compressed_lens = torch.div(seq_lens, ratio, rounding_mode="floor")
+        cu_seqlens_compressed = torch.cat(
+            (
+                torch.zeros_like(cu_seqlens[:1]),
+                torch.cumsum(compressed_lens, dim=0, dtype=torch.int32),
+            )
+        )
+        if int(cu_seqlens_compressed[-1].item()) == 0:
+            return None, cu_seqlens_compressed
+
+        global_start = tp_group.rank() * x_local.shape[0]
+        hidden_compact, compressed_group_ids, seq_to_rank_row = (
+            cp_utils.prepare_cp_compressor_input(
+                x_local,
+                boundary_hidden,
+                cu_seqlens,
+                cu_seqlens_compressed,
+                global_start,
+                tp_group.size(),
+                ratio,
+            )
+        )
+        compressed_local, _ = self.compressor._forward_thd(
+            hidden_compact,
+            cu_seqlens,
+            max_seqlen_q=int(packed_seq_params.max_seqlen_q),
+            compressed_group_ids=compressed_group_ids,
+        )
+        if compressed_local is None:
+            raise RuntimeError("TP-local attention compressor unexpectedly returned no compressed rows.")
+        compressed_rank_major = gather_from_sequence_parallel_region(
+            compressed_local.squeeze(1), group=tp_group
+        )
+        compressed_global = torch.index_select(
+            compressed_rank_major,
+            0,
+            seq_to_rank_row.clamp_min(0).long(),
+        )
+        return compressed_global.unsqueeze(1), cu_seqlens_compressed
+
     def _forward_thd(
         self,
         query: torch.Tensor,  # (total_q, np, hn)        TE THD convention
@@ -3049,6 +3218,10 @@ class CompressedSparseAttention(MegatronModule):
         indexer_x_local: Optional[torch.Tensor] = None,
         indexer_qr_local: Optional[torch.Tensor] = None,
         tp_local_indexer_q: bool = False,
+        tp_local_indexer_topk: bool = False,
+        attention_compressor_x_local: Optional[torch.Tensor] = None,
+        attention_compressor_boundary_hidden: Optional[torch.Tensor] = None,
+        tp_local_attention_compressor: bool = False,
     ) -> torch.Tensor:
         """THD-packed branch of :meth:`forward`. See class docstring for layout.
 
@@ -3091,9 +3264,25 @@ class CompressedSparseAttention(MegatronModule):
 
         # ---- Step 2: per-segment compression --------------------------------
         if self.compressor is not None and self.compress_ratio > 1:
-            compressed_kv, cu_seqlens_compressed = self.compressor(
-                x, packed_seq_params=packed_seq_params
-            )
+            if tp_local_attention_compressor:
+                if (
+                    attention_compressor_x_local is None
+                    or attention_compressor_boundary_hidden is None
+                ):
+                    raise RuntimeError(
+                        "TP-local attention compressor requires local hidden and boundary inputs."
+                    )
+                compressed_kv, cu_seqlens_compressed = (
+                    self._forward_attention_compressor_tp_local(
+                        attention_compressor_x_local,
+                        attention_compressor_boundary_hidden,
+                        packed_seq_params,
+                    )
+                )
+            else:
+                compressed_kv, cu_seqlens_compressed = self.compressor(
+                    x, packed_seq_params=packed_seq_params
+                )
             # compressed_kv is (total_comp, 1, hn) or None
             if compressed_kv is not None:
                 compressed_kv = compressed_kv.squeeze(1)  # (total_comp, hn)
@@ -3186,6 +3375,7 @@ class CompressedSparseAttention(MegatronModule):
                 indexer_x_local=indexer_x_local,
                 indexer_qr_local=indexer_qr_local,
                 tp_local_indexer_q=tp_local_indexer_q,
+                tp_local_indexer_topk=tp_local_indexer_topk,
             )
         else:
             output = self._forward_fused_no_indexer_thd(

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -22,6 +22,7 @@ Public API (same shape as the old ``dsa_kernels`` package):
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from typing import Optional, Tuple
 
@@ -141,7 +142,29 @@ def _get_head_padding(num_heads: int) -> int:
     )
 
 
-def _csa_fwd_flash_mla(
+def _get_flash_mla_query_chunk_size() -> int:
+    """Return the optional row chunk size for TP head-padding mitigation.
+
+    The default keeps the historical one-shot path. A positive value makes the
+    wrapper split query rows before applying FlashMLA's supported-head padding.
+    This is an environment gate until the underlying FlashMLA/cuDNN interfaces
+    accept native TP-local head counts.
+    """
+    raw_value = os.environ.get('DSV4_FLASH_MLA_QUERY_CHUNK_SIZE', '0').strip()
+    if not raw_value:
+        return 0
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            'DSV4_FLASH_MLA_QUERY_CHUNK_SIZE must be a non-negative integer'
+        ) from exc
+    if value < 0:
+        raise ValueError('DSV4_FLASH_MLA_QUERY_CHUNK_SIZE must be non-negative')
+    return value
+
+
+def _csa_fwd_flash_mla_single(
     q: Tensor,
     kv: Tensor,
     topk_idxs: Tensor,
@@ -150,18 +173,14 @@ def _csa_fwd_flash_mla(
     attn_sink: Optional[Tensor] = None,
     topk_length: Optional[Tensor] = None,
     indexer_topk: int = 0,
+    compact_output: bool = False,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """DSA-shaped adapter around :func:`flash_mla.flash_mla_sparse_fwd`.
-
-    Accepts flat (unbatched) tensors with global indices; pads ``TopK`` to
-    the GPU-specific alignment; returns ``(out, lse, lse_indexer)``.
-    """
+    """Run one FlashMLA call for a flat query row range."""
     assert not (
         indexer_topk > 0 and topk_length is not None
     ), "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
     _ensure_flash_mla()
 
-    _total_S_q, _H, _D = q.shape
     TopK = topk_idxs.shape[-1]
     topk_align = _get_topk_alignment()
     TopK_padded = (TopK + topk_align - 1) // topk_align * topk_align
@@ -205,6 +224,13 @@ def _csa_fwd_flash_mla(
         lse = lse[:, :actual_num_heads]
         if lse_indexer is not None:
             lse_indexer = lse_indexer[:, :actual_num_heads]
+        if compact_output:
+            # A slice is a view into FlashMLA's padded storage. Make the result
+            # independent so autograd does not retain the padded buffer.
+            out = out.contiguous()
+            lse = lse.contiguous()
+            if lse_indexer is not None:
+                lse_indexer = lse_indexer.contiguous()
 
     if indexer_topk > 0:
         # When indexer_topk == total TopK, lse_indexer should equal lse but
@@ -213,6 +239,78 @@ def _csa_fwd_flash_mla(
             return out, lse, lse.clone()
         return out, lse, lse_indexer
     return out, lse, None
+
+
+def _csa_fwd_flash_mla(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Run FlashMLA, optionally chunking rows before TP head padding.
+
+    TP8 currently presents FlashMLA with a global query row count and only
+    eight local heads. On H200 the adapter pads those heads to 64, so a one-shot
+    64K call materializes a 64K x 64 buffer. Row chunking preserves global KV
+    and top-k indices while bounding that padded buffer by the configured size.
+    """
+    assert not (
+        indexer_topk > 0 and topk_length is not None
+    ), "indexer_topk > 0 requires non-compact mode (topk_length must be None)"
+
+    chunk_size = _get_flash_mla_query_chunk_size()
+    actual_num_heads = q.size(1)
+    padded_num_heads = _get_head_padding(actual_num_heads)
+    should_chunk = (
+        chunk_size > 0 and padded_num_heads > actual_num_heads and q.size(0) > chunk_size
+    )
+    if not should_chunk:
+        return _csa_fwd_flash_mla_single(
+            q,
+            kv,
+            topk_idxs,
+            softmax_scale,
+            d_v=d_v,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            indexer_topk=indexer_topk,
+            compact_output=chunk_size > 0 and padded_num_heads > actual_num_heads,
+        )
+
+    outputs = []
+    lses = []
+    lse_indexers = []
+    for start in range(0, q.size(0), chunk_size):
+        end = min(start + chunk_size, q.size(0))
+        chunk_output, chunk_lse, chunk_lse_indexer = _csa_fwd_flash_mla_single(
+            q[start:end],
+            kv,
+            topk_idxs[start:end],
+            softmax_scale,
+            d_v=d_v,
+            attn_sink=attn_sink,
+            topk_length=topk_length[start:end] if topk_length is not None else None,
+            indexer_topk=indexer_topk,
+            compact_output=True,
+        )
+        outputs.append(chunk_output)
+        lses.append(chunk_lse)
+        if indexer_topk > 0:
+            assert chunk_lse_indexer is not None
+            lse_indexers.append(chunk_lse_indexer)
+
+    output = torch.cat(outputs, dim=0)
+    lse = torch.cat(lses, dim=0)
+    if indexer_topk > 0:
+        lse_indexer = torch.cat(lse_indexers, dim=0)
+        if indexer_topk >= topk_idxs.shape[-1]:
+            return output, lse, lse.clone()
+        return output, lse, lse_indexer
+    return output, lse, None
 
 
 def _pad_sparse_backward_inputs(q, out, d_out, lse, attn_sink):
@@ -238,6 +336,77 @@ def _pad_sparse_backward_inputs(q, out, d_out, lse, attn_sink):
 def _unpad_head_gradient(gradient, actual_num_heads):
     """Remove FlashMLA-only query-head padding from a gradient tensor."""
     return gradient[:, :actual_num_heads, :].contiguous()
+
+
+def _sparse_attention_backward(
+    q: Tensor,
+    kv: Tensor,
+    out: Tensor,
+    d_out: Tensor,
+    lse: Tensor,
+    attn_sink: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    topk_length: Optional[Tensor],
+):
+    """Run cuDNN DSA backward, optionally in the same row chunks as forward."""
+    _ensure_dsa_namespace()
+    chunk_size = _get_flash_mla_query_chunk_size()
+    actual_num_heads = q.size(1)
+    padded_num_heads = _get_head_padding(actual_num_heads)
+    should_chunk = (
+        chunk_size > 0 and padded_num_heads > actual_num_heads and q.size(0) > chunk_size
+    )
+    if not should_chunk:
+        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = (
+            _pad_sparse_backward_inputs(q, out, d_out, lse, attn_sink)
+        )
+        result = _DSA.sparse_attention_backward_wrapper(
+            bwd_q,
+            kv,
+            bwd_out,
+            bwd_dO,
+            bwd_lse,
+            bwd_sink,
+            topk_idxs,
+            softmax_scale=softmax_scale,
+            topk_length=topk_length,
+        )
+        return (
+            _unpad_head_gradient(result['dq'], actual_num_heads),
+            result['dkv'],
+            result['d_sink'][:actual_num_heads],
+        )
+
+    grad_q = torch.empty_like(q)
+    grad_kv = torch.zeros_like(kv)
+    grad_sink = torch.zeros_like(attn_sink)
+    for start in range(0, q.size(0), chunk_size):
+        end = min(start + chunk_size, q.size(0))
+        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = (
+            _pad_sparse_backward_inputs(
+                q[start:end],
+                out[start:end],
+                d_out[start:end],
+                lse[start:end],
+                attn_sink,
+            )
+        )
+        result = _DSA.sparse_attention_backward_wrapper(
+            bwd_q,
+            kv,
+            bwd_out,
+            bwd_dO,
+            bwd_lse,
+            bwd_sink,
+            topk_idxs[start:end],
+            softmax_scale=softmax_scale,
+            topk_length=topk_length[start:end] if topk_length is not None else None,
+        )
+        grad_q[start:end].copy_(_unpad_head_gradient(result['dq'], actual_num_heads))
+        grad_kv.add_(result['dkv'])
+        grad_sink.add_(result['d_sink'][:actual_num_heads])
+    return grad_q, grad_kv, grad_sink
 
 
 def _ensure_dsa_namespace():
@@ -797,26 +966,18 @@ class CSASparseAttnFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dO, d_lse, d_lse_indexer):
         """Compute sparse-attention backward via cuDNN DSA wrapper."""
-        _ensure_dsa_namespace()
-
         q, kv, attn_sink, topk_idxs, out, lse = ctx.saved_tensors
-        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
-            q, out, dO, lse, attn_sink
-        )
-
-        result = _DSA.sparse_attention_backward_wrapper(
-            bwd_q,
+        dq, dkv, d_sink = _sparse_attention_backward(
+            q,
             kv,
-            bwd_out,
-            bwd_dO,
-            bwd_lse,
-            bwd_sink,
+            out,
+            dO,
+            lse,
+            attn_sink,
             topk_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=ctx.topk_length,
         )
-        dq = _unpad_head_gradient(result["dq"], actual_num_heads)
-        dkv, d_sink = result["dkv"], result["d_sink"][:actual_num_heads]
         return dq, dkv, d_sink, None, None, None, None
 
 
@@ -1916,27 +2077,20 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             dO_flat = dO_flat.masked_fill(ctx.padding_row_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.padding_row_mask[:, None], 0)
 
-        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
-            q_flat, out_flat, dO_flat, lse, attn_sink
-        )
-        attn_bwd = _DSA.sparse_attention_backward_wrapper(
-            bwd_q,
+        grad_query, grad_kv_full, d_sink = _sparse_attention_backward(
+            q_flat,
             kv_flat,
-            bwd_out,
-            bwd_dO,
-            bwd_lse,
-            bwd_sink,
+            out_flat,
+            dO_flat,
+            lse,
+            attn_sink,
             global_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=topk_length,
         )
-        if is_thd:
-            grad_query = _unpad_head_gradient(attn_bwd["dq"], actual_num_heads)
-            grad_kv_full = attn_bwd["dkv"]
-        else:
-            grad_query = _unpad_head_gradient(attn_bwd["dq"], actual_num_heads).reshape(sq, b, np_, d)
-            grad_kv_full = attn_bwd["dkv"].reshape(skv, b, d)
-        d_sink = attn_bwd["d_sink"][:actual_num_heads]
+        if not is_thd:
+            grad_query = grad_query.reshape(sq, b, np_, d)
+            grad_kv_full = grad_kv_full.reshape(skv, b, d)
 
         # ---- 2. Scale pre-computed indexer grads by grad_loss. ---------------
         grad_q_indexer = precomputed_grad_q_indexer * grad_loss
@@ -2260,17 +2414,14 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         if ctx.q_padding_mask is not None:
             dO_flat = dO_flat.masked_fill(ctx.q_padding_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.q_padding_mask[:, None], 0)
-        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
-            query, out_flat, dO_flat, lse, attn_sink
-        )
         nvtx_range_push("dsv4_cp_sparse_attention_backward")
-        attn_bwd = _DSA.sparse_attention_backward_wrapper(
-            bwd_q,
+        grad_query, grad_kv_full, d_sink = _sparse_attention_backward(
+            query,
             kv_full,
-            bwd_out,
-            bwd_dO,
-            bwd_lse,
-            bwd_sink,
+            out_flat,
+            dO_flat,
+            lse,
+            attn_sink,
             topk_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=topk_length,
@@ -2287,7 +2438,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                     f"got {grad_k_indexer_rank_major.shape[0]} rows, "
                     f"expected {expected_indexer_rows}."
                 )
-            grad_compressed_kv = attn_bwd["dkv"][ctx.compressed_kv_start :]
+            grad_compressed_kv = grad_kv_full[ctx.compressed_kv_start :]
             expected_rows = ctx.local_compressed_kv_rows * cp_group.size()
             if grad_compressed_kv.shape[0] != expected_rows:
                 raise RuntimeError(
@@ -2332,9 +2483,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
             grad_k_indexer = None
 
         gradients = (
-            _unpad_head_gradient(attn_bwd["dq"], actual_num_heads),
-            attn_bwd["dkv"],
-            attn_bwd["d_sink"][:actual_num_heads],
+            grad_query,
+            grad_kv_full,
+            d_sink,
             None,
             grad_q_indexer,
             grad_k_indexer,

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -122,6 +122,25 @@ def _get_topk_alignment() -> int:
     return 128
 
 
+@lru_cache(maxsize=8)
+def _get_head_padding(num_heads: int) -> int:
+    """Return a FlashMLA-supported query-head count for local TP heads."""
+    sm = torch.cuda.get_device_capability()
+    if sm[0] >= 10:
+        supported = (64, 128)
+    elif sm[0] >= 9:
+        supported = (64, )
+    else:
+        raise RuntimeError(f"fused DSA requires SM90+, got SM{sm[0]}{sm[1]}")
+    for padded_heads in supported:
+        if padded_heads % num_heads == 0:
+            return padded_heads
+    raise RuntimeError(
+        "FlashMLA sparse prefill requires local query heads to divide a supported "
+        f"head count, got h_q={num_heads}"
+    )
+
+
 def _csa_fwd_flash_mla(
     q: Tensor,
     kv: Tensor,
@@ -150,6 +169,17 @@ def _csa_fwd_flash_mla(
         pad_width = TopK_padded - TopK
         topk_idxs = torch.nn.functional.pad(topk_idxs, (0, pad_width), value=-1)
 
+    actual_num_heads = q.size(1)
+    padded_num_heads = _get_head_padding(actual_num_heads)
+    if padded_num_heads != actual_num_heads:
+        q_padded = q.new_zeros((q.size(0), padded_num_heads, q.size(2)))
+        q_padded[:, :actual_num_heads, :] = q
+        q = q_padded
+        if attn_sink is not None:
+            attn_sink_padded = attn_sink.new_full((padded_num_heads,), float('-inf'))
+            attn_sink_padded[:actual_num_heads] = attn_sink
+            attn_sink = attn_sink_padded
+
     kv_3d = kv.unsqueeze(1)  # (total_S_kv, 1, D)  h_kv=1
     indices = topk_idxs.unsqueeze(1)  # (total_S_q, 1, TopK_padded) h_kv=1
 
@@ -170,6 +200,12 @@ def _csa_fwd_flash_mla(
             out, _max_logits, lse = res
             lse_indexer = None
 
+    if padded_num_heads != actual_num_heads:
+        out = out[:, :actual_num_heads, :]
+        lse = lse[:, :actual_num_heads]
+        if lse_indexer is not None:
+            lse_indexer = lse_indexer[:, :actual_num_heads]
+
     if indexer_topk > 0:
         # When indexer_topk == total TopK, lse_indexer should equal lse but
         # the kernel may not snapshot correctly; fall back to lse.
@@ -177,6 +213,31 @@ def _csa_fwd_flash_mla(
             return out, lse, lse.clone()
         return out, lse, lse_indexer
     return out, lse, None
+
+
+def _pad_sparse_backward_inputs(q, out, d_out, lse, attn_sink):
+    """Pad local TP query heads for the cuDNN sparse backward contract."""
+    actual_num_heads = q.shape[1]
+    padded_num_heads = _get_head_padding(actual_num_heads)
+    if padded_num_heads == actual_num_heads:
+        return q, out, d_out, lse, attn_sink, actual_num_heads
+
+    q_padded = q.new_zeros((q.size(0), padded_num_heads, q.size(2)))
+    q_padded[:, :actual_num_heads, :] = q
+    out_padded = out.new_zeros((out.size(0), padded_num_heads, out.size(2)))
+    out_padded[:, :actual_num_heads, :] = out
+    d_out_padded = d_out.new_zeros((d_out.size(0), padded_num_heads, d_out.size(2)))
+    d_out_padded[:, :actual_num_heads, :] = d_out
+    lse_padded = lse.new_zeros((lse.size(0), padded_num_heads))
+    lse_padded[:, :actual_num_heads] = lse
+    sink_padded = attn_sink.new_full((padded_num_heads,), float('-inf'))
+    sink_padded[:actual_num_heads] = attn_sink
+    return q_padded, out_padded, d_out_padded, lse_padded, sink_padded, actual_num_heads
+
+
+def _unpad_head_gradient(gradient, actual_num_heads):
+    """Remove FlashMLA-only query-head padding from a gradient tensor."""
+    return gradient[:, :actual_num_heads, :].contiguous()
 
 
 def _ensure_dsa_namespace():
@@ -739,19 +800,23 @@ class CSASparseAttnFunc(torch.autograd.Function):
         _ensure_dsa_namespace()
 
         q, kv, attn_sink, topk_idxs, out, lse = ctx.saved_tensors
+        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
+            q, out, dO, lse, attn_sink
+        )
 
         result = _DSA.sparse_attention_backward_wrapper(
-            q,
+            bwd_q,
             kv,
-            out,
-            dO,
-            lse,
-            attn_sink,
+            bwd_out,
+            bwd_dO,
+            bwd_lse,
+            bwd_sink,
             topk_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=ctx.topk_length,
         )
-        dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
+        dq = _unpad_head_gradient(result["dq"], actual_num_heads)
+        dkv, d_sink = result["dkv"], result["d_sink"][:actual_num_heads]
         return dq, dkv, d_sink, None, None, None, None
 
 
@@ -1851,24 +1916,27 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             dO_flat = dO_flat.masked_fill(ctx.padding_row_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.padding_row_mask[:, None], 0)
 
+        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
+            q_flat, out_flat, dO_flat, lse, attn_sink
+        )
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
-            q_flat,
+            bwd_q,
             kv_flat,
-            out_flat,
-            dO_flat,
-            lse,
-            attn_sink,
+            bwd_out,
+            bwd_dO,
+            bwd_lse,
+            bwd_sink,
             global_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=topk_length,
         )
         if is_thd:
-            grad_query = attn_bwd["dq"]
+            grad_query = _unpad_head_gradient(attn_bwd["dq"], actual_num_heads)
             grad_kv_full = attn_bwd["dkv"]
         else:
-            grad_query = attn_bwd["dq"].reshape(sq, b, np_, d)
+            grad_query = _unpad_head_gradient(attn_bwd["dq"], actual_num_heads).reshape(sq, b, np_, d)
             grad_kv_full = attn_bwd["dkv"].reshape(skv, b, d)
-        d_sink = attn_bwd["d_sink"]
+        d_sink = attn_bwd["d_sink"][:actual_num_heads]
 
         # ---- 2. Scale pre-computed indexer grads by grad_loss. ---------------
         grad_q_indexer = precomputed_grad_q_indexer * grad_loss
@@ -2192,14 +2260,17 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         if ctx.q_padding_mask is not None:
             dO_flat = dO_flat.masked_fill(ctx.q_padding_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.q_padding_mask[:, None], 0)
+        bwd_q, bwd_out, bwd_dO, bwd_lse, bwd_sink, actual_num_heads = _pad_sparse_backward_inputs(
+            query, out_flat, dO_flat, lse, attn_sink
+        )
         nvtx_range_push("dsv4_cp_sparse_attention_backward")
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
-            query,
+            bwd_q,
             kv_full,
-            out_flat,
-            dO_flat,
-            lse,
-            attn_sink,
+            bwd_out,
+            bwd_dO,
+            bwd_lse,
+            bwd_sink,
             topk_idxs,
             softmax_scale=ctx.softmax_scale,
             topk_length=topk_length,
@@ -2261,9 +2332,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
             grad_k_indexer = None
 
         gradients = (
-            attn_bwd["dq"],
+            _unpad_head_gradient(attn_bwd["dq"], actual_num_heads),
             attn_bwd["dkv"],
-            attn_bwd["d_sink"],
+            attn_bwd["d_sink"][:actual_num_heads],
             None,
             grad_q_indexer,
             grad_k_indexer,

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -102,6 +102,13 @@ class DSv4HybridAttention(Attention):
                     "o_groups must be divisible by tensor model parallel size: "
                     f"{self.config.o_groups} % {self.tp_size} != 0"
                 )
+            # The generic Attention base class treats num_query_groups=1 as
+            # GQA and assumes each TP rank initially owns all query heads.
+            # DSv4's custom q-up projection is already column-sharded, so its
+            # output is local-head shaped and must use the explicit TP-local
+            # head count here.
+            self.num_attention_heads_per_partition = self.config.num_attention_heads // self.tp_size
+            self.num_query_groups_per_partition = 1
 
         assert (
             not self.checkpoint_core_attention
@@ -287,10 +294,19 @@ class DSv4HybridAttention(Attention):
             raise ValueError("DSv4 THD CP requires a contiguous CP partition.")
         self.pg_collection.cp = cp_group
 
+        sequence_parallel_local_length = hidden_states.size(0)
+        core_hidden_states = hidden_states
+        if self.tp_size > 1 and self.config.sequence_parallel:
+            # q-up uses TE's standard SP all-gather. The duplicated KV path
+            # and CSA compressor need the same CP-local sequence explicitly.
+            core_hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
+                hidden_states, group=self.pg_collection.tp
+            )
+
         boundary_hidden = None
         if use_thd_cp:
             boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
-                hidden_states,
+                core_hidden_states,
                 self._dsv4_compress_ratio,
                 self.config.csa_window_size,
                 self.pg_collection.cp,
@@ -315,6 +331,16 @@ class DSv4HybridAttention(Attention):
             query, key, value, q_compressed, kv_compressed = qkv
             boundary_kv = None
 
+        core_q_compressed = q_compressed
+        if self.tp_size > 1 and self.config.sequence_parallel:
+            # q-down is duplicated and remains TP-local, while CSA's learned
+            # indexer consumes the same complete CP-local sequence as the
+            # gathered hidden states. Keep the local q-compressed tensor for
+            # q-up, and provide a gathered copy to the core-attention path.
+            core_q_compressed = tensor_parallel.gather_from_sequence_parallel_region(
+                q_compressed, group=self.pg_collection.tp
+            )
+
         # TODO: Currently, TE can only accept contiguous tensors for MLA
         query = query.contiguous()
         key = key.contiguous()
@@ -334,8 +360,8 @@ class DSv4HybridAttention(Attention):
                 value,
                 attention_mask,
                 packed_seq_params=packed_seq_params,
-                x=hidden_states,
-                qr=q_compressed,
+                x=core_hidden_states,
+                qr=core_q_compressed,
                 boundary_hidden=boundary_hidden,
                 boundary_kv=boundary_kv,
             )
@@ -492,6 +518,21 @@ class DSv4HybridAttention(Attention):
             output, bias = self.linear_proj(core_attn_out)
         output = attn_proj_manager.group_offload(output, forced_released_tensors=[core_attn_out])
 
+        # Some TE versions reduce the row-parallel output across TP but leave
+        # the sequence dimension gathered. Restore the standard
+        # sequence-parallel module contract (local sequence on return) when
+        # that backend behavior is observed; do not double-scatter versions
+        # that already return the local shape.
+        if (
+            self.tp_size > 1
+            and self.config.sequence_parallel
+            and output.size(0) != sequence_parallel_local_length
+            and output.size(0) % self.tp_size == 0
+        ):
+            output = tensor_parallel.scatter_to_sequence_parallel_region(
+                output, group=self.pg_collection.tp
+            )
+
         self.pg_collection.cp = _orig_cp_group
         return output, bias
 
@@ -569,7 +610,6 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             tp_group=pg_collection.tp,
             name=(name + ".linear_q_up_proj") if name is not None else None,
         )
-
         kv_proj_kwargs = {}
         kv_proj_tp_group = pg_collection.tp
         if submodules.linear_kv_proj is TELinear:
@@ -588,9 +628,9 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             self.config.v_head_dim,
             config=self.config,
             init_method=self.config.init_method,
-            gather_output=False,
             bias=False,
             skip_bias_add=False,
+            skip_weight_param_allocation=False,
             is_expert=False,
             tp_comm_buffer_name='kv_up_proj',
             tp_group=kv_proj_tp_group,
@@ -755,6 +795,33 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             q = q.view(*q.size()[:-1], self.num_attention_heads_per_partition, self.q_head_dim)
             q = _q_rms_norm(q, self.config.layernorm_epsilon)
 
+            # Column-parallel q-up is the first point at which the actual
+            # sequence-parallel local length is observable.  Slice the global
+            # (or CP-local) RoPE table to that q length; using the incoming
+            # hidden-state length is incorrect because q-down/q-up may perform
+            # sequence-parallel scatter/gather internally.
+            local_rotary_pos_emb = rotary_pos_emb
+            local_rotary_pos_cos = rotary_pos_cos
+            local_rotary_pos_sin = rotary_pos_sin
+            if self.tp_size > 1 and self.config.sequence_parallel and not packed_seq:
+                local_seq_len = q.size(0)
+                tp_rank = torch.distributed.get_rank(group=self.pg_collection.tp)
+                start = tp_rank * local_seq_len
+
+                def _slice_tp_rope(tensor):
+                    if tensor is None or tensor.size(0) == local_seq_len:
+                        return tensor
+                    if start + local_seq_len > tensor.size(0):
+                        raise RuntimeError(
+                            "DSv4 TP RoPE table is shorter than the local sequence slice: "
+                            f"table={tensor.size(0)}, start={start}, local={local_seq_len}"
+                        )
+                    return tensor.narrow(0, start, local_seq_len)
+
+                local_rotary_pos_emb = _slice_tp_rope(local_rotary_pos_emb)
+                local_rotary_pos_cos = _slice_tp_rope(local_rotary_pos_cos)
+                local_rotary_pos_sin = _slice_tp_rope(local_rotary_pos_sin)
+
             boundary_rows = 0
             if boundary_kv_compressed is not None:
                 boundary_rows = boundary_kv_compressed.shape[0]
@@ -764,6 +831,21 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
             kv, _ = self.linear_kv_proj(kv_projection_input)
             kv = self.kv_layernorm(kv)
+            if self.tp_size > 1 and self.config.sequence_parallel:
+                # q-up is a standard SP column-parallel projection and
+                # therefore sees the complete CP-local sequence. The V4 KV
+                # projection is duplicated, so gather its local output to the
+                # same sequence space before CSA/attention.
+                if boundary_rows:
+                    boundary_kv_part = kv[:boundary_rows]
+                    local_kv_part = tensor_parallel.gather_from_sequence_parallel_region(
+                        kv[boundary_rows:], group=self.pg_collection.tp
+                    )
+                    kv = torch.cat([boundary_kv_part, local_kv_part], dim=0)
+                else:
+                    kv = tensor_parallel.gather_from_sequence_parallel_region(
+                        kv, group=self.pg_collection.tp
+                    )
             boundary_kv = None
 
             # [num_tokens, qk_pos_emb_head_dim] -> [num_tokens, 1, qk_pos_emb_head_dim]
@@ -778,8 +860,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     global_start = cp_rank * q.shape[0]
                     query = cp_utils.apply_thd_cp_local_rope_fused(
                         q,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        local_rotary_pos_cos,
+                        local_rotary_pos_sin,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_q,
@@ -788,8 +870,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     kv = kv.unsqueeze(-2)
                     kv = cp_utils.apply_thd_cp_local_rope_fused(
                         kv,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        local_rotary_pos_cos,
+                        local_rotary_pos_sin,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_q,
@@ -802,8 +884,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     cp_rank = cp_group.rank()
                     query = fused_mla_rope_inplace(
                         q,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        local_rotary_pos_cos,
+                        local_rotary_pos_sin,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_q,
@@ -814,8 +896,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     kv = kv.unsqueeze(-2)
                     kv = fused_mla_rope_inplace(
                         kv,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        local_rotary_pos_cos,
+                        local_rotary_pos_sin,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_q,
@@ -830,7 +912,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     global_start = cp_group.rank() * q.shape[0]
                     query = cp_utils.apply_thd_cp_local_rope_unfused(
                         q,
-                        rotary_pos_emb,
+                        local_rotary_pos_emb,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_q,
@@ -839,7 +921,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     )
                     kv = cp_utils.apply_thd_cp_local_rope_unfused(
                         kv.unsqueeze(-2),
-                        rotary_pos_emb,
+                        local_rotary_pos_emb,
                         self.config.qk_head_dim,
                         self.config.qk_pos_emb_head_dim,
                         cu_seqlens_kv,
@@ -854,7 +936,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     q_len = q.size()[0]
                     # Shorten rotary_pos_emb to the sequence length when inference_params
                     # is not provided so direct forward accepts any sequence length.
-                    rotary_pos_emb = rotary_pos_emb[0:q_len]
+                    local_rotary_pos_emb = local_rotary_pos_emb[0:q_len]
 
                     # q_no_pe: [num_tokens, n, qk_head_dim]
                     # q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
@@ -866,7 +948,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     # q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                     q_pos_emb = apply_rotary_pos_emb(
                         q_pos_emb,
-                        rotary_pos_emb,
+                        local_rotary_pos_emb,
                         config=self.config,
                         cu_seqlens=cu_seqlens_q,
                         mscale=mscale,
@@ -884,7 +966,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
                     k_pos_emb = apply_rotary_pos_emb(
                         k_pos_emb,
-                        rotary_pos_emb,
+                        local_rotary_pos_emb,
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
                         mscale=mscale,

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -28,7 +28,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.typed_torch import apply_module
-from megatron.core.utils import get_pg_size, is_te_min_version
+from megatron.core.utils import get_pg_size, is_te_min_version, make_tp_sharded_tensor_for_checkpoint
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
@@ -87,9 +87,20 @@ class DSv4HybridAttention(Attention):
         )
         self.config: MLATransformerConfig
 
-        assert (
-            get_pg_size(self.pg_collection.tp) == 1
-        ), "DSv4 Hybrid Attention only supports TP size 1."
+        self.tp_size = get_pg_size(self.pg_collection.tp)
+        if self.tp_size > 1:
+            if not self.config.sequence_parallel:
+                raise ValueError("DSv4 Hybrid Attention with TP>1 requires sequence_parallel=True.")
+            if self.config.num_attention_heads % self.tp_size != 0:
+                raise ValueError(
+                    "num_attention_heads must be divisible by tensor model parallel size: "
+                    f"{self.config.num_attention_heads} % {self.tp_size} != 0"
+                )
+            if self.config.o_groups % self.tp_size != 0:
+                raise ValueError(
+                    "o_groups must be divisible by tensor model parallel size: "
+                    f"{self.config.o_groups} % {self.tp_size} != 0"
+                )
 
         assert (
             not self.checkpoint_core_attention
@@ -169,12 +180,14 @@ class DSv4HybridAttention(Attention):
         )
 
         # Output.
-        self.o_local_groups = self.config.o_groups
+        # Q heads are column-parallel. The manual grouped output projection
+        # therefore owns only the corresponding local groups on each TP rank.
+        self.o_local_groups = self.config.o_groups // self.tp_size
         assert (
             self.query_projection_size % self.config.o_groups == 0
         ), "num_attention_heads * v_head_dim must be divisible by o_groups"
         group_proj_in_size = self.query_projection_size // self.config.o_groups
-        group_proj_out_size = self.config.o_groups * self.config.o_lora_rank
+        group_proj_out_size = self.o_local_groups * self.config.o_lora_rank
 
         _linear_o_group_proj = torch.empty(
             group_proj_out_size,
@@ -554,6 +567,18 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             name=(name + ".linear_q_up_proj") if name is not None else None,
         )
 
+        kv_proj_kwargs = {}
+        kv_proj_tp_group = pg_collection.tp
+        if submodules.linear_kv_proj is TELinear:
+            # DSv4 has one shared KV stream. Replicate it across TP ranks while
+            # query heads and grouped output weights are sharded by TP.
+            kv_proj_kwargs['parallel_mode'] = 'duplicated'
+            kv_proj_tp_group = None
+        else:
+            raise ValueError(
+                f"Unsupported linear_kv_proj for TP-aware DSv4: {submodules.linear_kv_proj}"
+            )
+
         self.linear_kv_proj = build_module(
             submodules.linear_kv_proj,
             self.config.hidden_size,
@@ -565,8 +590,9 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             skip_bias_add=False,
             is_expert=False,
             tp_comm_buffer_name='kv_up_proj',
-            tp_group=pg_collection.tp,
+            tp_group=kv_proj_tp_group,
             name=(name + ".linear_kv_proj") if name is not None else None,
+            **kv_proj_kwargs,
         )
         self.kv_layernorm = submodules.kv_layernorm(
             hidden_size=self.config.v_head_dim,
@@ -579,6 +605,22 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             config=self.config,
             eps=self.config.layernorm_epsilon,
         )
+
+    def sharded_state_dict(self, prefix: str = "", sharded_offsets: tuple = (), metadata=None):
+        """Add TP metadata for the manually-created grouped output projection."""
+        state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        # The Bridge replaces this Parameter with TE GroupedLinear for FP8
+        # parameter-gather mode; that module supplies its own sharding metadata.
+        if not isinstance(self.linear_o_group_proj, torch.Tensor):
+            return state_dict
+        key = f"{prefix}linear_o_group_proj"
+        state_dict[key] = make_tp_sharded_tensor_for_checkpoint(
+            tensor=self.linear_o_group_proj,
+            key=key,
+            tp_axis=0,
+            prepend_offsets=sharded_offsets,
+        )
+        return state_dict
 
     def get_query_key_value_tensors(
         self,

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 
+import os
 from dataclasses import dataclass
 from typing import NoReturn, Optional, Union
 
@@ -280,8 +281,39 @@ class DSv4HybridAttention(Attention):
         # for recompute; the rest of this forward reads it from pg_collection.
         # Restore the static group before returning.
         _orig_cp_group = self.pg_collection.cp
-        cp_group = _orig_cp_group
-        if packed_seq_params is not None and packed_seq_params.local_cp_size is not None:
+        tp_local_csa_requested = (
+            os.environ.get('DSV4_TP_LOCAL_CSA', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+        )
+        tp_local_csa = (
+            tp_local_csa_requested
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+        )
+        if tp_local_csa and os.environ.get('DSV4_TP_LOCAL_CSA_UNSAFE', '0') != '1':
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_CSA is disabled: rank-distinct TP correctness failed. '
+                'Set DSV4_TP_LOCAL_CSA_UNSAFE=1 only to reproduce the negative experiment.'
+            )
+        tp_local_indexer_q = (
+            os.environ.get('DSV4_TP_LOCAL_INDEXER_Q', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+            and not tp_local_csa
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+        )
+        if tp_local_indexer_q and (getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0) > 0:
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_INDEXER_Q currently requires dsa_indexer_loss_coeff == 0.'
+            )
+        cp_group = self.pg_collection.tp if tp_local_csa else _orig_cp_group
+        if not tp_local_csa and packed_seq_params is not None and packed_seq_params.local_cp_size is not None:
             assert packed_seq_params.cp_group is not None, "cp_group must be set in dynamic-cp mode"
             cp_group = packed_seq_params.cp_group
 
@@ -296,7 +328,7 @@ class DSv4HybridAttention(Attention):
 
         sequence_parallel_local_length = hidden_states.size(0)
         core_hidden_states = hidden_states
-        if self.tp_size > 1 and self.config.sequence_parallel:
+        if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
             # q-up uses TE's standard SP all-gather. The duplicated KV path
             # and CSA compressor need the same CP-local sequence explicitly.
             core_hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
@@ -324,6 +356,7 @@ class DSv4HybridAttention(Attention):
             packed_seq_params,
             inference_context=inference_context,
             boundary_hidden=boundary_hidden,
+            tp_local_csa=tp_local_csa,
         )
         if use_thd_cp:
             query, key, value, q_compressed, kv_compressed, boundary_kv = qkv
@@ -331,8 +364,32 @@ class DSv4HybridAttention(Attention):
             query, key, value, q_compressed, kv_compressed = qkv
             boundary_kv = None
 
+        if tp_local_csa:
+            # TE may return a sequence-gathered q-up result even though its
+            # GEMM consumed local rows. The local CSA path only needs this
+            # rank's contiguous query rows.
+            tp_rank = torch.distributed.get_rank(group=self.pg_collection.tp)
+            local_start = tp_rank * sequence_parallel_local_length
+            global_rows = sequence_parallel_local_length * self.tp_size
+
+            def _take_tp_local_rows(tensor):
+                if tensor is None or tensor.size(0) == sequence_parallel_local_length:
+                    return tensor
+                if tensor.size(0) != global_rows:
+                    raise RuntimeError(
+                        "DSv4 TP local CSA received an unexpected sequence length: "
+                        f"shape={tuple(tensor.shape)}, local={sequence_parallel_local_length}, "
+                        f"tp={self.tp_size}"
+                    )
+                return tensor.narrow(0, local_start, sequence_parallel_local_length).contiguous()
+
+            query = _take_tp_local_rows(query)
+            key = _take_tp_local_rows(key)
+            value = _take_tp_local_rows(value)
+            q_compressed = _take_tp_local_rows(q_compressed)
+
         core_q_compressed = q_compressed
-        if self.tp_size > 1 and self.config.sequence_parallel:
+        if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
             # q-down is duplicated and remains TP-local, while CSA's learned
             # indexer consumes the same complete CP-local sequence as the
             # gathered hidden states. Keep the local q-compressed tensor for
@@ -364,6 +421,9 @@ class DSv4HybridAttention(Attention):
                 qr=core_q_compressed,
                 boundary_hidden=boundary_hidden,
                 boundary_kv=boundary_kv,
+                indexer_x_local=hidden_states if tp_local_indexer_q else None,
+                indexer_qr_local=q_compressed if tp_local_indexer_q else None,
+                tp_local_indexer_q=tp_local_indexer_q,
             )
         forced_released_tensors = [query, key, value]
         if boundary_kv is not None:
@@ -371,6 +431,15 @@ class DSv4HybridAttention(Attention):
         core_attn_out = core_attn_manager.group_offload(
             core_attn_out, forced_released_tensors=forced_released_tensors
         )
+        if tp_local_csa:
+            # The local CSA path computes only this rank's query rows. Restore
+            # the legacy global-row contract before inverse RoPE and the
+            # existing output projection; its backward reduce-scatters the
+            # output gradient back into the local CSA rows.
+            core_attn_out = tensor_parallel.gather_from_sequence_parallel_region(
+                core_attn_out, group=self.pg_collection.tp
+            )
+            self.pg_collection.cp = _orig_cp_group
 
         if packed_seq_params is not None and packed_seq_params.qkv_format == 'thd':
             # reshape to same output shape as unpacked case
@@ -426,7 +495,7 @@ class DSv4HybridAttention(Attention):
         else:
             rotary_pos_emb = self.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
         if self.config.apply_rope_fusion:
-            if use_thd_cp:
+            if use_thd_cp and not tp_local_csa:
                 global_start = self.pg_collection.cp.rank() * core_attn_out.shape[0]
                 core_attn_out = cp_utils.apply_thd_cp_local_rope_fused(
                     core_attn_out,
@@ -458,7 +527,7 @@ class DSv4HybridAttention(Attention):
                 )
                 if packed_seq:
                     core_attn_out = core_attn_out.unsqueeze(1)
-        elif use_thd_cp:
+        elif use_thd_cp and not tp_local_csa:
             global_start = self.pg_collection.cp.rank() * core_attn_out.shape[0]
             core_attn_out = cp_utils.apply_thd_cp_local_rope_unfused(
                 core_attn_out,
@@ -675,6 +744,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         *,
         inference_params=None,
         boundary_hidden=None,
+        tp_local_csa=False,
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
@@ -790,6 +860,16 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             # q_compressed: [num_tokens, q_lora_rank]
             # q: [num_tokens, n * (qk_head_dim + qk_pos_emb_head_dim)]
             q, _ = self.linear_q_up_proj(q_compressed)
+            if tp_local_csa and q.size(0) != q_compressed.size(0):
+                local_q_rows = q_compressed.size(0)
+                expected_global_rows = local_q_rows * cp_group.size()
+                if q.size(0) != expected_global_rows:
+                    raise RuntimeError(
+                        "DSv4 TP local CSA q-up returned an unexpected sequence length: "
+                        f"q_rows={q.size(0)}, local_rows={local_q_rows}, "
+                        f"tp={cp_group.size()}"
+                    )
+                q = q.narrow(0, cp_group.rank() * local_q_rows, local_q_rows).contiguous()
 
             # q: [num_tokens, n, q_head_dim]
             q = q.view(*q.size()[:-1], self.num_attention_heads_per_partition, self.q_head_dim)
@@ -831,7 +911,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
             kv, _ = self.linear_kv_proj(kv_projection_input)
             kv = self.kv_layernorm(kv)
-            if self.tp_size > 1 and self.config.sequence_parallel:
+            if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
                 # q-up is a standard SP column-parallel projection and
                 # therefore sees the complete CP-local sequence. The V4 KV
                 # projection is duplicated, so gather its local output to the

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -935,7 +935,16 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                 else:
                     q_len = q.size()[0]
                     # Shorten rotary_pos_emb to the sequence length when inference_params
-                    # is not provided so direct forward accepts any sequence length.
+                    # is not provided so direct forward accepts any sequence length.  A
+                    # TP/sequence-parallel projection may append alignment rows after
+                    # the table was created from the unpadded input length; regenerate
+                    # the table in that case instead of relying on a broadcast that
+                    # fails one row short in the BSHD path.
+                    if local_rotary_pos_emb is not None and local_rotary_pos_emb.size(0) < q_len:
+                        if self._dsv4_uses_yarn_rope:
+                            local_rotary_pos_emb, _ = self.rotary_pos_emb(q_len, packed_seq=packed_seq)
+                        else:
+                            local_rotary_pos_emb = self.rotary_pos_emb(q_len, packed_seq=packed_seq)
                     local_rotary_pos_emb = local_rotary_pos_emb[0:q_len]
 
                     # q_no_pe: [num_tokens, n, qk_head_dim]

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -352,6 +352,37 @@ class DSv4HybridAttention(Attention):
                 'DSV4_TP_LOCAL_ATTENTION_COMPRESSOR is disabled: rank-distinct backward '
                 'gradient correctness failed. Set ..._UNSAFE=1 only to reproduce the negative experiment.'
             )
+        tp_local_indexer_compressor = (
+            os.environ.get('DSV4_TP_LOCAL_INDEXER_COMPRESSOR', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+            and not tp_local_csa
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+            and self._dsv4_compress_ratio > 1
+        )
+        if tp_local_indexer_compressor and (
+            getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0
+        ) > 0:
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_INDEXER_COMPRESSOR currently requires dsa_indexer_loss_coeff == 0.'
+            )
+        fuse_csa_input_gather = (
+            os.environ.get('DSV4_FUSE_CSA_INPUT_GATHER', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+            and not tp_local_csa
+            and not tp_local_indexer_q
+            and not tp_local_indexer_topk
+            and not tp_local_attention_compressor
+            and not tp_local_indexer_compressor
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+        )
         cp_group = self.pg_collection.tp if tp_local_csa else _orig_cp_group
         if not tp_local_csa and packed_seq_params is not None and packed_seq_params.local_cp_size is not None:
             assert packed_seq_params.cp_group is not None, "cp_group must be set in dynamic-cp mode"
@@ -368,7 +399,12 @@ class DSv4HybridAttention(Attention):
 
         sequence_parallel_local_length = hidden_states.size(0)
         core_hidden_states = hidden_states
-        if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
+        if (
+            self.tp_size > 1
+            and self.config.sequence_parallel
+            and not tp_local_csa
+            and not fuse_csa_input_gather
+        ):
             # q-up uses TE's standard SP all-gather. The duplicated KV path
             # and CSA compressor need the same CP-local sequence explicitly.
             core_hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
@@ -383,9 +419,9 @@ class DSv4HybridAttention(Attention):
                 self.config.csa_window_size,
                 self.pg_collection.cp,
             )
-        attention_compressor_boundary_hidden = None
-        if tp_local_attention_compressor:
-            attention_compressor_boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
+        local_compressor_boundary_hidden = None
+        if tp_local_attention_compressor or tp_local_indexer_compressor:
+            local_compressor_boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
                 hidden_states,
                 self._dsv4_compress_ratio,
                 self.config.csa_window_size,
@@ -455,7 +491,23 @@ class DSv4HybridAttention(Attention):
                 )
 
         core_q_compressed = q_compressed
-        if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
+        if fuse_csa_input_gather:
+            q_compressed_3d = (
+                q_compressed.unsqueeze(1) if q_compressed.ndim == 2 else q_compressed
+            )
+            if q_compressed_3d.shape[0] != sequence_parallel_local_length:
+                raise RuntimeError(
+                    'DSV4 fused CSA input gather requires TP-local q-compressed rows: '
+                    f'shape={tuple(q_compressed_3d.shape)}, '
+                    f'local={sequence_parallel_local_length}'
+                )
+            fused_csa_inputs = tensor_parallel.gather_from_sequence_parallel_region(
+                torch.cat((hidden_states, q_compressed_3d), dim=-1),
+                group=self.pg_collection.tp,
+            )
+            core_hidden_states = fused_csa_inputs[..., : self.config.hidden_size]
+            core_q_compressed = fused_csa_inputs[..., self.config.hidden_size :].squeeze(1)
+        elif self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
             # q-down is duplicated and remains TP-local, while CSA's learned
             # indexer consumes the same complete CP-local sequence as the
             # gathered hidden states. Keep the local q-compressed tensor for
@@ -498,8 +550,13 @@ class DSv4HybridAttention(Attention):
                 attention_compressor_x_local=(
                     hidden_states if tp_local_attention_compressor else None
                 ),
-                attention_compressor_boundary_hidden=attention_compressor_boundary_hidden,
+                attention_compressor_boundary_hidden=local_compressor_boundary_hidden,
                 tp_local_attention_compressor=tp_local_attention_compressor,
+                indexer_compressor_x_local=(
+                    hidden_states if tp_local_indexer_compressor else None
+                ),
+                indexer_compressor_boundary_hidden=local_compressor_boundary_hidden,
+                tp_local_indexer_compressor=tp_local_indexer_compressor,
             )
         forced_released_tensors = [query, key, value]
         if boundary_kv is not None:

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -27,6 +27,7 @@ from megatron.core.transformer.experimental_attention_variant.csa_utils import c
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.tensor_parallel.layers import set_tensor_model_parallel_attributes
 from megatron.core.typed_torch import apply_module
 from megatron.core.utils import get_pg_size, is_te_min_version, make_tp_sharded_tensor_for_checkpoint
 
@@ -197,6 +198,8 @@ class DSv4HybridAttention(Attention):
         )
         self.config.init_method(_linear_o_group_proj)
         self.linear_o_group_proj = torch.nn.Parameter(_linear_o_group_proj)
+        if self.tp_size > 1:
+            set_tensor_model_parallel_attributes(self.linear_o_group_proj, True, 0, 1)
 
         linear_proj_in_size = self.config.o_groups * self.config.o_lora_rank
 

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -312,6 +312,46 @@ class DSv4HybridAttention(Attention):
             raise RuntimeError(
                 'DSV4_TP_LOCAL_INDEXER_Q currently requires dsa_indexer_loss_coeff == 0.'
             )
+        tp_local_indexer_topk = (
+            os.environ.get('DSV4_TP_LOCAL_INDEXER_TOPK', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+            and not tp_local_csa
+            and not tp_local_indexer_q
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+        )
+        if tp_local_indexer_topk and (getattr(self.config, 'dsa_indexer_loss_coeff', 0.0) or 0.0) > 0:
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_INDEXER_TOPK currently requires dsa_indexer_loss_coeff == 0.'
+            )
+        if tp_local_indexer_topk and os.environ.get('DSV4_TP_LOCAL_INDEXER_TOPK_UNSAFE', '0') != '1':
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_INDEXER_TOPK is disabled: local RoPE/top-k changed routes '
+                'beyond the legacy fused-kernel nondeterminism envelope. '
+                'Set DSV4_TP_LOCAL_INDEXER_TOPK_UNSAFE=1 only to reproduce the negative experiment.'
+            )
+        tp_local_attention_compressor = (
+            os.environ.get('DSV4_TP_LOCAL_ATTENTION_COMPRESSOR', '0').strip().lower()
+            in ('1', 'true', 'yes', 'on')
+            and not tp_local_csa
+            and self.tp_size > 1
+            and self.config.sequence_parallel
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == 'thd'
+            and _orig_cp_group.size() == 1
+            and self._dsv4_compress_ratio > 1
+        )
+        if (
+            tp_local_attention_compressor
+            and os.environ.get('DSV4_TP_LOCAL_ATTENTION_COMPRESSOR_UNSAFE', '0') != '1'
+        ):
+            raise RuntimeError(
+                'DSV4_TP_LOCAL_ATTENTION_COMPRESSOR is disabled: rank-distinct backward '
+                'gradient correctness failed. Set ..._UNSAFE=1 only to reproduce the negative experiment.'
+            )
         cp_group = self.pg_collection.tp if tp_local_csa else _orig_cp_group
         if not tp_local_csa and packed_seq_params is not None and packed_seq_params.local_cp_size is not None:
             assert packed_seq_params.cp_group is not None, "cp_group must be set in dynamic-cp mode"
@@ -342,6 +382,14 @@ class DSv4HybridAttention(Attention):
                 self._dsv4_compress_ratio,
                 self.config.csa_window_size,
                 self.pg_collection.cp,
+            )
+        attention_compressor_boundary_hidden = None
+        if tp_local_attention_compressor:
+            attention_compressor_boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
+                hidden_states,
+                self._dsv4_compress_ratio,
+                self.config.csa_window_size,
+                self.pg_collection.tp,
             )
 
         # =====================
@@ -388,6 +436,24 @@ class DSv4HybridAttention(Attention):
             value = _take_tp_local_rows(value)
             q_compressed = _take_tp_local_rows(q_compressed)
 
+        local_indexer_qr = q_compressed
+        if (tp_local_indexer_q or tp_local_indexer_topk) and q_compressed is not None:
+            # The duplicated q-down projection may return a sequence-gathered
+            # tensor under TE sequence-parallel mode.  Indexer Q is token-wise
+            # and only needs this rank's compressed-query rows.
+            global_rows = sequence_parallel_local_length * self.tp_size
+            if q_compressed.size(0) == global_rows:
+                tp_rank = torch.distributed.get_rank(group=self.pg_collection.tp)
+                local_indexer_qr = q_compressed.narrow(
+                    0, tp_rank * sequence_parallel_local_length, sequence_parallel_local_length
+                ).contiguous()
+            elif q_compressed.size(0) != sequence_parallel_local_length:
+                raise RuntimeError(
+                    "DSv4 TP-local Indexer received an unexpected compressed-query length: "
+                    f"shape={tuple(q_compressed.shape)}, local={sequence_parallel_local_length}, "
+                    f"tp={self.tp_size}"
+                )
+
         core_q_compressed = q_compressed
         if self.tp_size > 1 and self.config.sequence_parallel and not tp_local_csa:
             # q-down is duplicated and remains TP-local, while CSA's learned
@@ -421,9 +487,19 @@ class DSv4HybridAttention(Attention):
                 qr=core_q_compressed,
                 boundary_hidden=boundary_hidden,
                 boundary_kv=boundary_kv,
-                indexer_x_local=hidden_states if tp_local_indexer_q else None,
-                indexer_qr_local=q_compressed if tp_local_indexer_q else None,
+                indexer_x_local=(
+                    hidden_states if (tp_local_indexer_q or tp_local_indexer_topk) else None
+                ),
+                indexer_qr_local=(
+                    local_indexer_qr if (tp_local_indexer_q or tp_local_indexer_topk) else None
+                ),
                 tp_local_indexer_q=tp_local_indexer_q,
+                tp_local_indexer_topk=tp_local_indexer_topk,
+                attention_compressor_x_local=(
+                    hidden_states if tp_local_attention_compressor else None
+                ),
+                attention_compressor_boundary_hidden=attention_compressor_boundary_hidden,
+                tp_local_attention_compressor=tp_local_attention_compressor,
             )
         forced_released_tensors = [query, key, value]
         if boundary_kv is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1838,9 +1838,18 @@ class TransformerConfig(ModelParallelConfig):
             assert all(
                 ratio in [0, 4, 128] for ratio in self.csa_compress_ratios
             ), "csa_compress_ratios must be 0, 4, or 128"
-            assert (
-                self.tensor_model_parallel_size == 1
-            ), "DSv4 Hybrid Attention only supports TP size 1."
+            if self.tensor_model_parallel_size > 1:
+                assert self.sequence_parallel, (
+                    "DSv4 Hybrid Attention with TP>1 requires sequence_parallel=True."
+                )
+                assert self.num_attention_heads % self.tensor_model_parallel_size == 0, (
+                    "DSv4 Hybrid Attention requires num_attention_heads divisible by TP: "
+                    f"{self.num_attention_heads=} {self.tensor_model_parallel_size=}"
+                )
+                assert self.o_groups % self.tensor_model_parallel_size == 0, (
+                    "DSv4 Hybrid Attention requires o_groups divisible by TP: "
+                    f"{self.o_groups=} {self.tensor_model_parallel_size=}"
+                )
             assert not self.qk_clip, "QK clipping is not supported with DSv4 Hybrid Attention."
             self.hetereogenous_dist_checkpoint = True
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
@@ -44,6 +44,7 @@ from megatron.core.transformer.experimental_attention_variant.csa_utils.fused_sp
     _csa_fwd_flash_mla,
     _ensure_dsa_namespace,
     _ensure_flash_mla,
+    _get_head_padding,
     _get_topk_alignment,
     _kl_loss_from_dense_scores,
     _kl_loss_from_target_predict,
@@ -756,6 +757,36 @@ class TestGetTopkAlignment:
         sm = torch.cuda.get_device_capability()
         expected = 64 if sm[0] >= 10 else 128
         assert align == expected
+
+
+# ---------------------------------------------------------------------------
+# _get_head_padding
+# ---------------------------------------------------------------------------
+
+
+class TestHeadPadding:
+    """Architecture-dependent query-head padding for TP-local FlashMLA inputs."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_head_padding_cache(self):
+        _get_head_padding.cache_clear()
+        yield
+        _get_head_padding.cache_clear()
+
+    @pytest.mark.parametrize("sm_major", [9, 10])
+    def test_tp_local_heads_pad_to_flash_mla_supported_count(self, sm_major):
+        """TP8's eight local query heads must be padded to the 64-head kernel."""
+        with patch('torch.cuda.get_device_capability', return_value=(sm_major, 0)):
+            assert _get_head_padding(8) == 64
+            assert _get_head_padding(16) == 64
+            assert _get_head_padding(32) == 64
+            assert _get_head_padding(64) == 64
+
+    def test_unsupported_head_count_is_rejected(self):
+        """A non-divisor cannot be passed to FlashMLA by zero-padding."""
+        with patch('torch.cuda.get_device_capability', return_value=(9, 0)):
+            with pytest.raises(RuntimeError, match='local query heads'):
+                _get_head_padding(48)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_tp_query_chunking.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_tp_query_chunking.py
@@ -1,0 +1,113 @@
+"""Tests for the feature-gated TP query chunking adapter."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import torch
+
+from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+    fused_sparse_attention as dk,
+)
+
+
+class TestTPQueryChunking(unittest.TestCase):
+
+    def test_flash_mla_forward_chunks_rows_and_compacts_output(self):
+        """Chunking must preserve row order while padding one chunk at a time."""
+        calls = []
+
+        def flash_stub(q, kv, indices, scale, **kwargs):
+            calls.append((tuple(q.shape), tuple(indices.shape)))
+            out = q + 1
+            lse = torch.zeros(q.size(0), q.size(1), dtype=torch.float32)
+            return out, torch.empty(0), lse
+
+        with (
+            patch.dict(os.environ, {'DSV4_FLASH_MLA_QUERY_CHUNK_SIZE': '3'}),
+            patch.object(dk, '_get_head_padding', return_value=8),
+            patch.object(dk, '_get_topk_alignment', return_value=4),
+            patch.object(
+                dk.torch.cuda.nvtx, 'range', side_effect=lambda _name: nullcontext()
+            ),
+            patch.object(dk, '_flash_mla_sparse_fwd', flash_stub),
+        ):
+            q = torch.arange(7 * 4 * 2, dtype=torch.float32).reshape(7, 4, 2)
+            kv = torch.zeros(5, 2)
+            topk = torch.zeros(7, 4, dtype=torch.int32)
+            topk_length = torch.full((7,), 4, dtype=torch.int32)
+
+            out, lse, lse_indexer = dk._csa_fwd_flash_mla(
+                q,
+                kv,
+                topk,
+                softmax_scale=1.0,
+                attn_sink=torch.zeros(4),
+                topk_length=topk_length,
+            )
+
+        self.assertIsNone(lse_indexer)
+        self.assertEqual(
+            calls,
+            [((3, 8, 2), (3, 1, 4)), ((3, 8, 2), (3, 1, 4)), ((1, 8, 2), (1, 1, 4))],
+        )
+        self.assertTrue(torch.equal(out, q + 1))
+        self.assertEqual(out.shape, q.shape)
+        self.assertEqual(lse.shape, (7, 4))
+
+    def test_dsa_backward_chunks_and_accumulates_kv_gradient(self):
+        """Chunked DSA backward must concatenate dq and sum dkv/d_sink."""
+        calls = []
+
+        class FakeDSA:
+
+            def sparse_attention_backward_wrapper(
+                self, q, kv, out, d_out, lse, sink, indices, **kwargs
+            ):
+                rows = q.size(0)
+                calls.append(tuple(q.shape))
+                return {
+                    'dq': torch.full_like(q, rows),
+                    'dkv': torch.full_like(kv, rows),
+                    'd_sink': torch.full_like(sink, rows),
+                }
+
+        with (
+            patch.dict(os.environ, {'DSV4_FLASH_MLA_QUERY_CHUNK_SIZE': '3'}),
+            patch.object(dk, '_get_head_padding', return_value=8),
+            patch.object(dk, '_DSA', FakeDSA()),
+        ):
+            q = torch.zeros(7, 4, 2)
+            kv = torch.zeros(5, 2)
+            out = torch.zeros_like(q)
+            d_out = torch.zeros_like(q)
+            lse = torch.zeros(7, 4)
+            sink = torch.zeros(4)
+            topk = torch.zeros(7, 4, dtype=torch.int32)
+            topk_length = torch.full((7,), 4, dtype=torch.int32)
+
+            dq, dkv, d_sink = dk._sparse_attention_backward(
+                q,
+                kv,
+                out,
+                d_out,
+                lse,
+                sink,
+                topk,
+                softmax_scale=1.0,
+                topk_length=topk_length,
+            )
+
+        self.assertEqual(calls, [(3, 8, 2), (3, 8, 2), (1, 8, 2)])
+        self.assertTrue(torch.equal(dq[:3], torch.full_like(dq[:3], 3)))
+        self.assertTrue(torch.equal(dq[3:6], torch.full_like(dq[3:6], 3)))
+        self.assertTrue(torch.equal(dq[6:], torch.ones_like(dq[6:])))
+        self.assertTrue(torch.equal(dkv, torch.full_like(dkv, 7)))
+        self.assertTrue(torch.equal(d_sink, torch.full_like(d_sink, 7)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_tp.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_tp.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from tests.unit_tests.test_utilities import Utils
@@ -40,6 +41,7 @@ class TestDSv4HybridAttentionTP:
             dsa_indexer_n_heads=8,
             dsa_indexer_head_dim=32,
             dsa_indexer_topk=8,
+            num_query_groups=1,
         )
         request.cls.pg = ProcessGroupCollection.use_mpu_process_groups()
         yield
@@ -75,7 +77,21 @@ class TestDSv4HybridAttentionTP:
             device="cuda",
             requires_grad=True,
         )
-        output, bias = attn(hidden_states=hidden, attention_mask=None)
+        cu_seqlens = torch.tensor([0, local_seq], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=local_seq,
+            max_seqlen_kv=local_seq,
+        )
+        output, bias = attn(
+            hidden_states=hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+        )
         assert output.shape == hidden.shape
         assert torch.isfinite(output).all()
         output.float().square().mean().backward()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_tp.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_tp.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.transformer.experimental_attention_variant.test_dsv4_hybrid_attention import (
+    _SEED,
+    _build_attention,
+    _make_config,
+)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
+class TestDSv4HybridAttentionTP:
+    """Shape and one-layer backward gate for the experimental TP path."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_method(self, request):
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, pipeline_model_parallel_size=1)
+        torch.manual_seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        request.cls.config = _make_config(
+            num_layers=1,
+            hidden_size=256,
+            num_attention_heads=16,
+            v_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            q_lora_rank=64,
+            o_groups=8,
+            o_lora_rank=64,
+            csa_compress_ratios=[0],
+            csa_window_size=8,
+            tensor_model_parallel_size=2,
+            sequence_parallel=True,
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=32,
+            dsa_indexer_topk=8,
+        )
+        request.cls.pg = ProcessGroupCollection.use_mpu_process_groups()
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_tp_local_parameter_shapes(self):
+        attn = _build_attention(self.config, layer_number=1, pg_collection=self.pg).cuda()
+
+        assert attn.linear_q_up_proj.weight.shape == (
+            self.config.num_attention_heads * self.config.v_head_dim // 2,
+            self.config.q_lora_rank,
+        )
+        assert attn.linear_kv_proj.weight.shape == (
+            self.config.v_head_dim,
+            self.config.hidden_size,
+        )
+        assert attn.linear_o_group_proj.shape == (
+            self.config.o_groups * self.config.o_lora_rank // 2,
+            self.config.num_attention_heads * self.config.v_head_dim // self.config.o_groups,
+        )
+        assert attn.core_attention.attn_sink.shape == (
+            self.config.num_attention_heads // 2,
+        )
+
+    def test_tp_window_attention_forward_backward(self):
+        attn = _build_attention(self.config, layer_number=1, pg_collection=self.pg).cuda().train()
+        local_seq = 32
+        hidden = torch.randn(
+            local_seq,
+            1,
+            self.config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        output, bias = attn(hidden_states=hidden, attention_mask=None)
+        assert output.shape == hidden.shape
+        assert torch.isfinite(output).all()
+        output.float().square().mean().backward()
+        assert hidden.grad is not None
+        assert attn.linear_kv_proj.weight.grad is not None
+        assert attn.linear_q_up_proj.weight.grad is not None
+        assert attn.linear_o_group_proj.grad is not None


### PR DESCRIPTION
## Summary

Enable experimental TP>1 support for the DeepSeek-V4 Hybrid Attention MCore implementation.

- validate TP divisibility for query heads and `o_groups`;
- shard query heads, attention sink, grouped output projection, and checkpoint metadata;
- gather the duplicated KV stream and CSA hidden/q-compressed inputs in TP sequence-parallel mode;
- support THD CP contiguous boundary exchange and learned ratio-4 indexer paths;
- normalize a missing `dsa_indexer_loss_coeff` to `0.0` in unfused CSA paths.

## H200 evidence

- TP8/CP1/window-only module forward/backward: pass.
- TP8/CP1/ratio4 learned indexer module forward/backward: pass.
- TP4/CP2/window-only module forward/backward: pass.
- TP4/CP2/ratio4 learned indexer module forward/backward: pass.
- TP1<->TP8 same-weight BF16 numerical gate: pass; loss absolute difference `1.45346e-4`, output max absolute error `2.4414e-4`, max gradient absolute error `4.8828e-4`.

The full DeepSeek-V4 Flash one-step run and CPFS artifacts are documented in the companion ms-swift TP development PR.

## Limitations

This is an experimental implementation. TP8/PP2 end-to-end needs a 16-card window; the available TP2/PP2/EP2 full-model smoke was blocked by H200 all-to-all workspace OOM.
