### PR TITLE
Guard the module-level triton import in moe/ops/paged_stash.py

### DIFF
--- a/megatron/core/transformer/moe/ops/paged_stash.py
+++ b/megatron/core/transformer/moe/ops/paged_stash.py
@@ -1,8 +1,22 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Triton kernels for MoE paged stash."""
 
-import triton
-import triton.language as tl
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    from unittest.mock import MagicMock
+
+    from megatron.core.utils import null_decorator
+
+    HAVE_TRITON = False
+    triton = MagicMock()
+    triton.jit = null_decorator
+    triton.autotune = null_decorator
+    triton.heuristics = null_decorator
+    tl = MagicMock()
 
 GLOBAL_BLOCK_SIZE = 1024
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import importlib.util
 import logging
 import math
 import warnings
@@ -2317,6 +2318,11 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.moe_paged_stash:
+            if importlib.util.find_spec("triton") is None:
+                raise ValueError(
+                    "moe_paged_stash requires triton, which is not installed. "
+                    "Install triton or disable moe_paged_stash."
+                )
             if self.cpu_offloading:
                 raise ValueError("moe_paged_stash cannot be enabled with cpu_offloading.")
             if self.moe_expert_rank_capacity_factor is None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2318,6 +2318,10 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.moe_paged_stash:
+            # Without this the kernel is a mock (paged_stash.py guards the triton import), so the
+            # first launch raises TypeError: '_GeneratorContextManager' object is not
+            # subscriptable, mid-step and naming neither triton nor this flag. Nothing else
+            # rejects the combination.
             if importlib.util.find_spec("triton") is None:
                 raise ValueError(
                     "moe_paged_stash requires triton, which is not installed. "


### PR DESCRIPTION
### What

`import megatron.core` raises `ModuleNotFoundError: No module named 'triton'` on any install without triton, because `megatron/core/transformer/moe/ops/paged_stash.py:4` imports it at module scope on the unconditional package path: `megatron/core/__init__.py` → `distributed/__init__.py` → `distributed/finalize_model_grads.py` → `pipeline_parallel/__init__.py` → `pipeline_parallel/schedules.py:27` → `moe/paged_stash.py:12`.

triton is not a declared dependency (`["torch>=2.6.0", "numpy", "packaging>=24.2"]`), and torch's own marker is `platform_machine == "x86_64"` before 2.11 — so `pip install megatron-core torch==2.9.0` against the published manylinux **aarch64** wheel installs no triton and the package cannot be imported at all. `.github/workflows/install-test.yml` states the rule: *"For basic install, all imports need to either be successful or appropriately guarded."*

This applies the guard idiom already used by 27 other files in this tree. It also raises in `TransformerConfig`, where `moe_paged_stash` is already validated, because otherwise enabling the feature without triton fails later with `TypeError: '_GeneratorContextManager' object is not subscriptable` at `moe/paged_stash.py:227` — an error naming neither triton nor the flag. `moe_paged_stash` defaults to `False`, so nothing changes for anyone using the feature.

### Verified, on a machine with no triton installed

| | before | after |
|---|---|---|
| `python -c "import megatron.core"` | `ModuleNotFoundError` at `moe/ops/paged_stash.py:4` | succeeds |
| `TransformerConfig(..., moe_paged_stash=True)` | accepted, then fails mid-step | `ValueError: moe_paged_stash requires triton, which is not installed.` |

**No performance claim is made here and nothing was benchmarked** — this is an import-time fix, verified on a CPU-only machine.

### Out of scope, deliberately

`import megatron.training` is still blocked by the same pattern in `megatron/core/ssm/ops` — seven files, two of which read `triton.__version__` at module scope outside their try, so guarding those turns `ImportError` into `AttributeError`. Happy to send that separately.