### PR TITLE
Rename all mimo args to have mimo-* prefix

### DIFF
--- a/examples/mimo/model_providers/nemotron_moe_vlm.py
+++ b/examples/mimo/model_providers/nemotron_moe_vlm.py
@@ -183,8 +183,8 @@ def language_model_spec(
         pp_rank = 0
         pp_size = get_grid_dim_size(llm_grid, "pp")
         tp_size = get_grid_dim_size(llm_grid, "tp")
-        ep_size = getattr(args, "llm_ep", 1)
-        expt_tp_size = getattr(args, "llm_expt_tp", None) or 1
+        ep_size = getattr(args, "mimo_llm_ep", 1)
+        expt_tp_size = getattr(args, "mimo_llm_expt_tp", None) or 1
     else:
         assert all(
             getattr(pg_collection, name, None) is not None for name in ("pp", "tp", "ep", "expt_tp")

--- a/examples/mimo/pretrain_mimo.py
+++ b/examples/mimo/pretrain_mimo.py
@@ -45,11 +45,11 @@ def extra_args_provider(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
 
 def _set_stock_parallel_args(args: argparse.Namespace) -> None:
     # validate_args and the stock training loop consume these fields.
-    args.tensor_model_parallel_size = args.llm_tp
-    args.pipeline_model_parallel_size = args.llm_pp
-    args.context_parallel_size = args.llm_cp
-    args.expert_model_parallel_size = args.llm_ep
-    args.expert_tensor_parallel_size = args.llm_expt_tp or 1
+    args.tensor_model_parallel_size = args.mimo_llm_tp
+    args.pipeline_model_parallel_size = args.mimo_llm_pp
+    args.context_parallel_size = args.mimo_llm_cp
+    args.expert_model_parallel_size = args.mimo_llm_ep
+    args.expert_tensor_parallel_size = args.mimo_llm_expt_tp or 1
 
 
 def _parse_and_validate() -> argparse.Namespace:
@@ -72,7 +72,10 @@ def _parse_and_validate() -> argparse.Namespace:
 
     if getattr(args, "padded_vocab_size", None) is None:
         args.padded_vocab_size = calculate_padded_vocab_size(
-            args.vocab_size, args.make_vocab_size_divisible_by, args.llm_tp, logging_enabled=False
+            args.vocab_size,
+            args.make_vocab_size_divisible_by,
+            args.mimo_llm_tp,
+            logging_enabled=False,
         )
     return args
 

--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -72,15 +72,15 @@ uv run --extra ssm python -m torch.distributed.run \
   --seq-length 8192 \
   --max-position-embeddings 8192 \
   --bf16 \
-  --encoder-tp 2 \
-  --encoder-dp 2 \
-  --llm-offset 4 \
-  --llm-tp 2 \
-  --llm-cp 1 \
-  --llm-pp 1 \
-  --llm-dp "${LLM_DP}" \
-  --llm-ep 2 \
-  --llm-expt-tp 1 \
+  --mimo-encoder-tp 2 \
+  --mimo-encoder-dp 2 \
+  --mimo-llm-offset 4 \
+  --mimo-llm-tp 2 \
+  --mimo-llm-cp 1 \
+  --mimo-llm-pp 1 \
+  --mimo-llm-dp "${LLM_DP}" \
+  --mimo-llm-ep 2 \
+  --mimo-llm-expt-tp 1 \
   --tensor-parallel-num-weight-shards 4 \
   --expert-tensor-parallel-num-weight-shards 2 \
   --vocab-size 131072 \
@@ -99,7 +99,7 @@ uv run --extra ssm python -m torch.distributed.run \
   --use-distributed-optimizer \
   --overlap-grad-reduce \
   --overlap-param-gather \
-  --encoder-ddp-overlap \
+  --mimo-encoder-ddp-overlap \
   --train-iters "${TRAIN_ITERS}" \
   --eval-interval "${EVAL_INTERVAL}" \
   --eval-iters "${EVAL_ITERS}" \

--- a/examples/mimo/training/args.py
+++ b/examples/mimo/training/args.py
@@ -17,40 +17,60 @@ def add_hetero_grid_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     grid = parser.add_argument_group("hetero module grids")
 
     # Single encoder grid; CP/PP stay fixed at 1.
-    grid.add_argument("--encoder-tp", type=int, default=2,
-                      help="Encoder tensor-model-parallel size.")
-    grid.add_argument("--encoder-dp", type=int, default=2,
-                      help="Encoder data-parallel size.")
+    grid.add_argument(
+        "--mimo-encoder-tp", type=int, default=2, help="Encoder tensor-model-parallel size."
+    )
+    grid.add_argument("--mimo-encoder-dp", type=int, default=2, help="Encoder data-parallel size.")
 
     # Language grid placement + factorization.
-    grid.add_argument("--llm-offset", type=int, default=4,
-                      help="First global rank of the language grid span.")
-    grid.add_argument("--llm-tp", type=int, default=2,
-                      help="Language tensor-model-parallel size.")
-    grid.add_argument("--llm-cp", type=int, default=1,
-                      help="Language context-parallel size (CP=1 only for now).")
-    grid.add_argument("--llm-pp", type=int, default=1,
-                      help="Language pipeline-model-parallel size.")
-    grid.add_argument("--llm-dp", type=int, default=2,
-                      help="Language data-parallel size. Global batch is keyed on this.")
+    grid.add_argument(
+        "--mimo-llm-offset",
+        type=int,
+        default=4,
+        help="First global rank of the language grid span.",
+    )
+    grid.add_argument(
+        "--mimo-llm-tp", type=int, default=2, help="Language tensor-model-parallel size."
+    )
+    grid.add_argument(
+        "--mimo-llm-cp",
+        type=int,
+        default=1,
+        help="Language context-parallel size (CP=1 only for now).",
+    )
+    grid.add_argument(
+        "--mimo-llm-pp", type=int, default=1, help="Language pipeline-model-parallel size."
+    )
+    grid.add_argument(
+        "--mimo-llm-dp",
+        type=int,
+        default=2,
+        help="Language data-parallel size. Global batch is keyed on this.",
+    )
     # MoE expert parallelism for the language grid.
-    grid.add_argument("--llm-ep", type=int, default=1,
-                      help="Language expert-model-parallel size (MoE).")
-    grid.add_argument("--llm-expt-tp", type=int, default=None,
-                      help="Language expert tensor-parallel size; defaults to 1 when unset "
-                           "(experts default to TP=1; the 20L MoE recipe passes --llm-expt-tp 1).")
+    grid.add_argument(
+        "--mimo-llm-ep", type=int, default=1, help="Language expert-model-parallel size (MoE)."
+    )
+    grid.add_argument(
+        "--mimo-llm-expt-tp",
+        type=int,
+        default=None,
+        help="Language expert tensor-parallel size; defaults to 1 when unset "
+        "(experts default to TP=1; the 20L MoE recipe passes "
+        "--mimo-llm-expt-tp 1).",
+    )
 
     grid.add_argument(
-        "--llm-only",
+        "--mimo-llm-only",
         action="store_true",
         help=(
             "Run only the MIMO language module on the LLM grid. Keeps the MIMO "
             "training/data path but creates no encoder ranks or bridge communicators; "
-            "requires --llm-offset 0 so the language grid covers WORLD_SIZE."
+            "requires --mimo-llm-offset 0 so the language grid covers WORLD_SIZE."
         ),
     )
     grid.add_argument(
-        "--encoder-ddp-overlap",
+        "--mimo-encoder-ddp-overlap",
         action="store_true",
         help=(
             "Apply the global grad-reduce and param-gather overlap settings to encoder DDP. "
@@ -63,52 +83,61 @@ def add_hetero_grid_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
 def validate_hetero_grid_args(args: argparse.Namespace, world_size: int) -> tuple[int, int]:
     """Validate the disjoint hetero grid layout; returns ``(encoder_size, llm_size)``."""
     gtp_weight_remat_size, _ = resolve_hetero_gtp_degrees(args)
-    if args.llm_cp != 1:
+    if args.mimo_llm_cp != 1:
         raise ValueError("hetero MIMO training currently supports CP=1 only")
 
-    if getattr(args, "encoder_ddp_overlap", False) and not getattr(
+    if getattr(args, "mimo_encoder_ddp_overlap", False) and not getattr(
         args, "overlap_grad_reduce", False
     ):
-        raise ValueError("--encoder-ddp-overlap requires --overlap-grad-reduce")
+        raise ValueError("--mimo-encoder-ddp-overlap requires --overlap-grad-reduce")
 
     # MoE expert count must divide evenly across the language grid's expert parallelism.
     num_experts = _num_experts(args)
-    if num_experts and num_experts % args.llm_ep != 0:
+    if num_experts and num_experts % args.mimo_llm_ep != 0:
         raise ValueError(
-            f"--num-experts ({num_experts}) must be divisible by --llm-ep ({args.llm_ep})"
+            f"--num-experts ({num_experts}) must be divisible by "
+            f"--mimo-llm-ep ({args.mimo_llm_ep})"
         )
 
-    llm_size = args.llm_tp * gtp_weight_remat_size * args.llm_cp * args.llm_pp * args.llm_dp
+    llm_size = (
+        args.mimo_llm_tp
+        * gtp_weight_remat_size
+        * args.mimo_llm_cp
+        * args.mimo_llm_pp
+        * args.mimo_llm_dp
+    )
 
-    if args.llm_only:
-        if getattr(args, "encoder_ddp_overlap", False):
-            raise ValueError("--encoder-ddp-overlap cannot be used with --llm-only")
-        if args.llm_offset != 0:
+    if args.mimo_llm_only:
+        if getattr(args, "mimo_encoder_ddp_overlap", False):
+            raise ValueError("--mimo-encoder-ddp-overlap cannot be used with --mimo-llm-only")
+        if args.mimo_llm_offset != 0:
             raise ValueError(
-                "--llm-only requires --llm-offset 0 so language ranks cover WORLD_SIZE"
+                "--mimo-llm-only requires --mimo-llm-offset 0 so language ranks cover WORLD_SIZE"
             )
-        llm_ranks = set(range(args.llm_offset, args.llm_offset + llm_size))
+        llm_ranks = set(range(args.mimo_llm_offset, args.mimo_llm_offset + llm_size))
         all_ranks = set(range(world_size))
         if llm_ranks != all_ranks:
             raise ValueError(
-                "--llm-only requires the language grid to cover every torchrun rank exactly "
-                f"once; covered={sorted(llm_ranks)}, world={sorted(all_ranks)}"
+                "--mimo-llm-only requires the language grid to cover every torchrun rank "
+                f"exactly once; covered={sorted(llm_ranks)}, world={sorted(all_ranks)}"
             )
+        args.mimo_llm_world_size = llm_size
         return 0, llm_size
 
     # Fan-out divisibility: the bridge splits every LLM data lane across
-    # encoder_dp encoder lanes; the split must be exact.
-    llm_data_parallel_size = args.llm_dp * gtp_weight_remat_size
-    if (args.micro_batch_size * llm_data_parallel_size) % args.encoder_dp != 0:
+    # mimo_encoder_dp encoder lanes; the split must be exact.
+    llm_data_parallel_size = args.mimo_llm_dp * gtp_weight_remat_size
+    if (args.micro_batch_size * llm_data_parallel_size) % args.mimo_encoder_dp != 0:
         raise ValueError(
-            "--micro-batch-size * --llm-dp * GTP must be divisible by --encoder-dp "
-            f"(got {args.micro_batch_size} * {args.llm_dp} * "
-            f"{gtp_weight_remat_size} % {args.encoder_dp} != 0)"
+            "--micro-batch-size * --mimo-llm-dp * GTP must be divisible by "
+            "--mimo-encoder-dp "
+            f"(got {args.micro_batch_size} * {args.mimo_llm_dp} * "
+            f"{gtp_weight_remat_size} % {args.mimo_encoder_dp} != 0)"
         )
 
-    encoder_size = args.encoder_tp * args.encoder_dp
+    encoder_size = args.mimo_encoder_tp * args.mimo_encoder_dp
     encoder_ranks = set(range(encoder_size))  # encoder span always starts at rank 0
-    llm_ranks = set(range(args.llm_offset, args.llm_offset + llm_size))
+    llm_ranks = set(range(args.mimo_llm_offset, args.mimo_llm_offset + llm_size))
     all_ranks = set(range(world_size))
 
     if not encoder_ranks.isdisjoint(llm_ranks):
@@ -122,6 +151,7 @@ def validate_hetero_grid_args(args: argparse.Namespace, world_size: int) -> tupl
             f"covered={sorted(encoder_ranks | llm_ranks)}, world={sorted(all_ranks)}"
         )
 
+    args.mimo_llm_world_size = llm_size
     return encoder_size, llm_size
 
 
@@ -135,23 +165,23 @@ def build_module_grid_specs(
     language_grid_spec = ModuleGridSpec(
         name=MIMO_LANGUAGE_MODULE_KEY,
         num_ranks=llm_size,
-        tp=args.llm_tp,
-        cp=args.llm_cp,
-        pp=args.llm_pp,
-        ep=args.llm_ep,
+        tp=args.mimo_llm_tp,
+        cp=args.mimo_llm_cp,
+        pp=args.mimo_llm_pp,
+        ep=args.mimo_llm_ep,
         gtp_remat=gtp_weight_remat_size,
-        rank_offset=args.llm_offset,
-        expt_tp=args.llm_expt_tp or 1,
+        rank_offset=args.mimo_llm_offset,
+        expt_tp=args.mimo_llm_expt_tp or 1,
         expt_gtp_remat=expert_gtp_weight_remat_size,
     )
 
-    if args.llm_only:
+    if args.mimo_llm_only:
         return [language_grid_spec]
 
     encoder_grid_spec = ModuleGridSpec(
         name=encoder_module_name,
         num_ranks=encoder_size,
-        tp=args.encoder_tp,
+        tp=args.mimo_encoder_tp,
         cp=1,
         pp=1,
         ep=1,
@@ -164,12 +194,12 @@ def build_module_grid_specs(
 def resolve_hetero_gtp_degrees(args: argparse.Namespace) -> tuple[int, int]:
     """Return the language dense and expert GTP degrees."""
     _, gtp_weight_remat_size = resolve_tensor_parallel_weight_shards(
-        args.llm_tp,
+        args.mimo_llm_tp,
         getattr(args, "tensor_parallel_num_weight_shards", None),
         getattr(args, "gtp_weight_remat_size", 1),
     )
     _, expert_gtp_weight_remat_size = resolve_tensor_parallel_weight_shards(
-        args.llm_expt_tp or 1,
+        args.mimo_llm_expt_tp or 1,
         getattr(args, "expert_tensor_parallel_num_weight_shards", None),
         getattr(args, "expert_gtp_weight_remat_size", 1),
         shards_field="expert_tensor_parallel_num_weight_shards",

--- a/examples/mimo/training/data.py
+++ b/examples/mimo/training/data.py
@@ -291,12 +291,14 @@ def build_train_valid_test_data_loaders(
         raise ValueError(f"unsupported dataset provider: {args.dataset_provider}")
 
     encoder_name = _encoder_name(topology)
-    llm_data_parallel_size = args.llm_dp * args.gtp_weight_remat_size
+    llm_data_parallel_size = args.mimo_llm_dp * args.gtp_weight_remat_size
     if (
         encoder_name is not None
-        and (args.micro_batch_size * llm_data_parallel_size) % args.encoder_dp
+        and (args.micro_batch_size * llm_data_parallel_size) % args.mimo_encoder_dp
     ):
-        raise ValueError("micro_batch_size * llm_dp * GTP must be divisible by encoder_dp")
+        raise ValueError(
+            "micro_batch_size * mimo_llm_dp * GTP must be divisible by mimo_encoder_dp"
+        )
 
     language_grid = topology.grids[MIMO_LANGUAGE_MODULE_KEY]
     language_pgc = topology.module_pgs[MIMO_LANGUAGE_MODULE_KEY]
@@ -316,7 +318,7 @@ def build_train_valid_test_data_loaders(
     if encoder_needs_data and language_needs_data:
         raise ValueError("the external DataLoader adapter requires non-colocated module grids")
     if encoder_needs_data:
-        encoder_mbs = args.micro_batch_size * llm_data_parallel_size // args.encoder_dp
+        encoder_mbs = args.micro_batch_size * llm_data_parallel_size // args.mimo_encoder_dp
         return _build_split_loaders(
             args,
             batch_size=encoder_mbs,

--- a/examples/mimo/training/encoder_prefetch.py
+++ b/examples/mimo/training/encoder_prefetch.py
@@ -51,10 +51,10 @@ def validate_encoder_prefetch_args(args) -> None:
     if args.freeze_projection:
         raise ValueError("encoder prefetch requires a trainable projection")
     for field, label in (
-        ("encoder_tp", "TP"),
-        ("encoder_cp", "CP"),
-        ("encoder_pp", "PP"),
-        ("encoder_ep", "EP"),
+        ("mimo_encoder_tp", "TP"),
+        ("mimo_encoder_cp", "CP"),
+        ("mimo_encoder_pp", "PP"),
+        ("mimo_encoder_ep", "EP"),
     ):
         if getattr(args, field, 1) != 1:
             raise ValueError(f"encoder prefetch requires encoder {label}=1")

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -128,7 +128,7 @@ def wrap_active_modules_with_ddp(
                 enc_config,
                 topology.module_pgs[name],
                 ddp_config=_ddp_config_for_role(
-                    ddp_config, enable_overlap=getattr(args, "encoder_ddp_overlap", False)
+                    ddp_config, enable_overlap=getattr(args, "mimo_encoder_ddp_overlap", False)
                 ),
                 data_parallel_random_init=data_parallel_random_init,
                 mixed_precision_wrapper=_EncoderFloat16Module,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3558,13 +3558,14 @@ def training_log(
 
         elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)
         elapsed_time_per_iteration = elapsed_time / total_iterations
+        llm_world_size = getattr(args, 'mimo_llm_world_size', args.world_size)
 
         throughput = num_floating_point_operations(
             args,
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
-        ) / (elapsed_time_per_iteration * 10**12 * args.world_size)
+        ) / (elapsed_time_per_iteration * 10**12 * llm_world_size)
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
 
@@ -3735,6 +3736,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     args = get_args()
     if args.save is None:
         return
+    llm_world_size = getattr(args, 'mimo_llm_world_size', args.world_size)
 
     # Compute job throughput.
     # args.num_floating_point_operations_so_far keeps track of floating-point operations
@@ -3742,7 +3744,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     global _TRAIN_START_TIME
     job_throughput = (
         num_floating_point_operations_so_far - args.num_floating_point_operations_so_far
-    ) / ((time.time() - _TRAIN_START_TIME) * 10**12 * args.world_size)
+    ) / ((time.time() - _TRAIN_START_TIME) * 10**12 * llm_world_size)
 
     # Compute cumulative throughput since jobs of this world size were launched.
     # `get_start_time_from_progress_log` returns start time and number of floating-point
@@ -3751,7 +3753,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     elapsed_time = (datetime.now() - start_time).total_seconds()
     cumulative_throughput = (
         num_floating_point_operations_so_far - start_num_floating_point_operations
-    ) / (elapsed_time * 10**12 * args.world_size)
+    ) / (elapsed_time * 10**12 * llm_world_size)
 
     tokens_so_far = args.consumed_train_samples * args.seq_length
     saved_ckpt_prefix = 'Saving async checkpoint' if args.async_save else 'Saved checkpoint'
@@ -4478,7 +4480,7 @@ def train(
             'total_flops_since_current_train_start': num_floating_point_operations_since_current_train_start,
             'num_floating_point_operations_so_far': num_floating_point_operations_so_far,
             'consumed_train_samples': args.consumed_train_samples,
-            'world_size': args.world_size,
+            'world_size': getattr(args, 'mimo_llm_world_size', args.world_size),
             'seq_length': args.seq_length,
         }
 

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -457,7 +457,7 @@ def get_mimo_model(
     if use_layer_wise_distributed_optimizer:
         wrap_active_modules_with_ddp(
             SimpleNamespace(
-                encoder_ddp_overlap=False,
+                mimo_encoder_ddp_overlap=False,
                 freeze_lm=False,
                 freeze_vit=False,
                 freeze_projection=False,

--- a/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
+++ b/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
@@ -31,7 +31,7 @@ def _args(**overrides):
         "mimo_encoder_prefetch_depth": 2,
         "freeze_vit": True,
         "freeze_projection": False,
-        "encoder_tp": 1,
+        "mimo_encoder_tp": 1,
         "rerun_mode": "disabled",
     }
     values.update(overrides)
@@ -43,10 +43,10 @@ def _args(**overrides):
     [
         ("freeze_vit", False, "freeze-vit"),
         ("freeze_projection", True, "trainable projection"),
-        ("encoder_tp", 2, "TP=1"),
-        ("encoder_cp", 2, "CP=1"),
-        ("encoder_pp", 2, "PP=1"),
-        ("encoder_ep", 2, "EP=1"),
+        ("mimo_encoder_tp", 2, "TP=1"),
+        ("mimo_encoder_cp", 2, "CP=1"),
+        ("mimo_encoder_pp", 2, "PP=1"),
+        ("mimo_encoder_ep", 2, "EP=1"),
         ("mimo_encoder_prefetch_depth", 0, "positive"),
         ("rerun_mode", "validate_results", "rerun"),
     ],

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_grid_args.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_grid_args.py
@@ -16,6 +16,19 @@ from examples.mimo.training.args import (
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
 WORLD_SIZE_8 = 8
+OLD_GRID_FLAGS = (
+    "--encoder-tp",
+    "--encoder-dp",
+    "--encoder-ddp-overlap",
+    "--llm-offset",
+    "--llm-tp",
+    "--llm-cp",
+    "--llm-pp",
+    "--llm-dp",
+    "--llm-ep",
+    "--llm-expt-tp",
+    "--llm-only",
+)
 
 
 def _parse(argv):
@@ -28,8 +41,9 @@ def _parse(argv):
 def _layout_8gpu_20l(**overrides):
     """Canonical 8-GPU layout: encoder 0-3 (tp2/dp2), llm 4-7 (tp2/pp1/dp2/ep4)."""
     argv = (
-        "--encoder-tp 2 --encoder-dp 2 "
-        "--llm-offset 4 --llm-tp 2 --llm-pp 1 --llm-dp 2 --llm-ep 4"
+        "--mimo-encoder-tp 2 --mimo-encoder-dp 2 "
+        "--mimo-llm-offset 4 --mimo-llm-tp 2 --mimo-llm-pp 1 "
+        "--mimo-llm-dp 2 --mimo-llm-ep 4"
     ).split()
     args = _parse(argv)
     # Stock args the validator reads but the grid parser does not own.
@@ -40,10 +54,40 @@ def _layout_8gpu_20l(**overrides):
     return args
 
 
+def test_parser_uses_mimo_prefixed_destinations():
+    args = _parse(
+        "--mimo-encoder-tp 3 --mimo-encoder-dp 4 --mimo-llm-offset 5 "
+        "--mimo-llm-tp 6 --mimo-llm-cp 1 --mimo-llm-pp 7 --mimo-llm-dp 8 "
+        "--mimo-llm-ep 9 --mimo-llm-expt-tp 10 --mimo-llm-only "
+        "--mimo-encoder-ddp-overlap".split()
+    )
+
+    assert vars(args) == {
+        "mimo_encoder_tp": 3,
+        "mimo_encoder_dp": 4,
+        "mimo_llm_offset": 5,
+        "mimo_llm_tp": 6,
+        "mimo_llm_cp": 1,
+        "mimo_llm_pp": 7,
+        "mimo_llm_dp": 8,
+        "mimo_llm_ep": 9,
+        "mimo_llm_expt_tp": 10,
+        "mimo_llm_only": True,
+        "mimo_encoder_ddp_overlap": True,
+    }
+
+
+@pytest.mark.parametrize("flag", OLD_GRID_FLAGS)
+def test_parser_rejects_unprefixed_grid_flags(flag):
+    with pytest.raises(SystemExit):
+        _parse([flag])
+
+
 def test_canonical_layout_validates_and_maps_specs():
     args = _layout_8gpu_20l()
     encoder_size, llm_size = validate_hetero_grid_args(args, WORLD_SIZE_8)
     assert (encoder_size, llm_size) == (4, 4)
+    assert args.mimo_llm_world_size == llm_size
 
     encoder_grid_spec, language_grid_spec = build_module_grid_specs(
         args, WORLD_SIZE_8, encoder_module_name="radio_encoder"
@@ -58,14 +102,14 @@ def test_canonical_layout_validates_and_maps_specs():
     assert language_grid_spec.num_ranks == 4
     assert language_grid_spec.rank_offset == 4
     assert language_grid_spec.dp == 2
-    # expt_tp defaults to 1 when --llm-expt-tp unset (ep=4 over 4 ranks needs expt_tp=1).
+    # expt_tp defaults to 1 when --mimo-llm-expt-tp is unset.
     assert language_grid_spec.expt_tp == 1
 
 
 def test_gtp_layout_validates_and_maps_weight_shard_axes():
     args = _layout_8gpu_20l(
-        llm_dp=1,
-        llm_ep=2,
+        mimo_llm_dp=1,
+        mimo_llm_ep=2,
         tensor_parallel_num_weight_shards=4,
         expert_tensor_parallel_num_weight_shards=2,
     )
@@ -90,8 +134,8 @@ def test_weight_shards_must_divide_language_tp():
 
 
 def test_overlapping_spans_raise():
-    # llm-offset 2 makes llm ranks {2,3,4,5} overlap encoder ranks {0,1,2,3}.
-    args = _layout_8gpu_20l(llm_offset=2)
+    # mimo_llm_offset 2 makes llm ranks {2,3,4,5} overlap encoder ranks {0,1,2,3}.
+    args = _layout_8gpu_20l(mimo_llm_offset=2)
     with pytest.raises(ValueError, match="disjoint"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
@@ -104,62 +148,67 @@ def test_non_covering_spans_raise():
 
 
 def test_fanout_divisibility_raises():
-    # mbs(1) * llm_dp(2) = 2 not divisible by encoder_dp(3).
-    args = _layout_8gpu_20l(encoder_dp=3, micro_batch_size=1, llm_dp=2)
-    with pytest.raises(ValueError, match="divisible by --encoder-dp"):
+    # mbs(1) * mimo_llm_dp(2) = 2 not divisible by mimo_encoder_dp(3).
+    args = _layout_8gpu_20l(mimo_encoder_dp=3, micro_batch_size=1, mimo_llm_dp=2)
+    with pytest.raises(ValueError, match="divisible by --mimo-encoder-dp"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
 def test_ep_divisibility_raises():
-    # num_experts 128 not divisible by llm_ep 3.
-    args = _layout_8gpu_20l(llm_ep=3, num_experts=128)
-    with pytest.raises(ValueError, match="divisible by --llm-ep"):
+    # num_experts 128 not divisible by mimo_llm_ep 3.
+    args = _layout_8gpu_20l(mimo_llm_ep=3, num_experts=128)
+    with pytest.raises(ValueError, match="divisible by --mimo-llm-ep"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
 def test_parser_does_not_expose_unsupported_grid_knobs():
     args = _parse([])
-    assert not hasattr(args, "encoder_cp")
-    assert not hasattr(args, "encoder_pp")
-    assert not hasattr(args, "llm_expt_dp")
+    assert not hasattr(args, "mimo_encoder_cp")
+    assert not hasattr(args, "mimo_encoder_pp")
+    assert not hasattr(args, "mimo_llm_expt_dp")
 
 
 def test_llm_cp_must_be_one():
-    args = _layout_8gpu_20l(llm_cp=2)
+    args = _layout_8gpu_20l(mimo_llm_cp=2)
     with pytest.raises(ValueError, match="CP=1 only"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
 def test_encoder_overlap_requires_grad_reduce():
-    args = _layout_8gpu_20l(encoder_ddp_overlap=True, overlap_grad_reduce=False)
+    args = _layout_8gpu_20l(mimo_encoder_ddp_overlap=True, overlap_grad_reduce=False)
     with pytest.raises(ValueError, match="requires --overlap-grad-reduce"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
 def test_encoder_overlap_accepts_uniform_participation_opt_in():
-    args = _layout_8gpu_20l(encoder_ddp_overlap=True, overlap_grad_reduce=True)
+    args = _layout_8gpu_20l(mimo_encoder_ddp_overlap=True, overlap_grad_reduce=True)
     assert validate_hetero_grid_args(args, WORLD_SIZE_8) == (4, 4)
 
 
 def test_llm_only_requires_offset_zero():
-    args = _layout_8gpu_20l(llm_only=True, llm_offset=4)
-    with pytest.raises(ValueError, match="--llm-only requires --llm-offset 0"):
+    args = _layout_8gpu_20l(mimo_llm_only=True, mimo_llm_offset=4)
+    with pytest.raises(ValueError, match="--mimo-llm-only requires --mimo-llm-offset 0"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
 def test_llm_only_rejects_encoder_overlap():
     args = _layout_8gpu_20l(
-        llm_only=True, llm_offset=0, llm_ep=2, encoder_ddp_overlap=True, overlap_grad_reduce=True
+        mimo_llm_only=True,
+        mimo_llm_offset=0,
+        mimo_llm_ep=2,
+        mimo_encoder_ddp_overlap=True,
+        overlap_grad_reduce=True,
     )
-    with pytest.raises(ValueError, match="cannot be used with --llm-only"):
+    with pytest.raises(ValueError, match="cannot be used with --mimo-llm-only"):
         validate_hetero_grid_args(args, 4)
 
 
 def test_llm_only_covers_world():
     # llm tp2/pp1/dp2 = 4 ranks at offset 0; world_size 4 -> covers exactly, no encoder spec.
-    args = _layout_8gpu_20l(llm_only=True, llm_offset=0, llm_ep=2, num_experts=128)
+    args = _layout_8gpu_20l(mimo_llm_only=True, mimo_llm_offset=0, mimo_llm_ep=2, num_experts=128)
     encoder_size, llm_size = validate_hetero_grid_args(args, 4)
     assert (encoder_size, llm_size) == (0, 4)
+    assert args.mimo_llm_world_size == llm_size
     specs = build_module_grid_specs(args, 4, encoder_module_name="radio_encoder")
     assert len(specs) == 1
     assert specs[0].name == MIMO_LANGUAGE_MODULE_KEY

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -135,7 +135,9 @@ def test_supplied_ddp_config_wins_over_global_args(mocker):
     mocker.patch("examples.mimo.training.runtime._module_config", return_value=mocker.MagicMock())
     mocker.patch("examples.mimo.training.runtime.print_rank_0")
 
-    args = _args(encoder_ddp_overlap=True, overlap_grad_reduce=False, overlap_param_gather=False)
+    args = _args(
+        mimo_encoder_ddp_overlap=True, overlap_grad_reduce=False, overlap_param_gather=False
+    )
     supplied_ddp_config = DistributedDataParallelConfig(
         overlap_grad_reduce=True, overlap_param_gather=True, bucket_size=1234
     )

--- a/tests/unit_tests/models/mimo/test_mimo_mock_data.py
+++ b/tests/unit_tests/models/mimo/test_mimo_mock_data.py
@@ -25,9 +25,9 @@ def _args():
         seed=123,
         dataset_provider="mock",
         micro_batch_size=2,
-        llm_dp=2,
+        mimo_llm_dp=2,
         gtp_weight_remat_size=1,
-        encoder_dp=1,
+        mimo_encoder_dp=1,
         seq_length=8,
         image_seq_length=4,
         vocab_size=64,
@@ -71,7 +71,7 @@ def adapter(monkeypatch):
 def test_dynamic_radio_loader_emits_patchified_cpu_metadata(adapter):
     args = _args()
     args.micro_batch_size = 2
-    args.llm_dp = 1
+    args.mimo_llm_dp = 1
     args.seq_length = 24
     args.image_seq_length = 12
     args.params_dtype = torch.bfloat16

--- a/tests/unit_tests/models/mimo/test_nemotron_moe_vlm_provider.py
+++ b/tests/unit_tests/models/mimo/test_nemotron_moe_vlm_provider.py
@@ -279,9 +279,13 @@ def test_language_model_spec_builds_mamba():
     from megatron.core.models.mamba.mamba_model import MambaModel
 
     args = _parse_validate(_build_argv(*_PRESET_20L))
+    args.mimo_llm_ep = 2
+    args.mimo_llm_expt_tp = 2
     spec = language_model_spec(args, pg_collection=None, llm_grid=None)
     assert spec.module is MambaModel
     assert spec.params["config"].num_layers == 20
+    assert spec.params["config"].expert_model_parallel_size == 2
+    assert spec.params["config"].expert_tensor_parallel_size == 2
     assert spec.params["max_sequence_length"] == args.seq_length
 
 

--- a/tests/unit_tests/models/mimo/test_nemotron_moe_vlm_provider.py
+++ b/tests/unit_tests/models/mimo/test_nemotron_moe_vlm_provider.py
@@ -281,6 +281,7 @@ def test_language_model_spec_builds_mamba():
     args = _parse_validate(_build_argv(*_PRESET_20L))
     args.mimo_llm_ep = 2
     args.mimo_llm_expt_tp = 2
+    args.expert_tensor_parallel_num_weight_shards = args.mimo_llm_expt_tp
     spec = language_model_spec(args, pg_collection=None, llm_grid=None)
     assert spec.module is MambaModel
     assert spec.params["config"].num_layers == 20


### PR DESCRIPTION
## Summary

- prefix all heterogeneous MIMO grid CLI options with `--mimo-`
- migrate the parsed namespace to `args.mimo_*` across topology validation, runtime, data, and model-provider consumers
- derive `args.mimo_llm_world_size` from the validated language grid and use it for FLOP-based throughput denominators, with `args.world_size` as the non-MIMO fallback
- update the 20-layer launcher and focused tests, including rejection of the legacy unprefixed options

## Validation

- dependency-free parser smoke check: all 11 `--mimo-*` flags map to `mimo_*` destinations and all 11 legacy flags are absent
- dependency-free topology smoke check: heterogeneous and LLM-only layouts both derive `mimo_llm_world_size=4`
- `black 26.3.0 --check` on the changed MIMO argument and test files
- `ruff check` on the incremental Python changes
- Python syntax compilation for the incremental Python changes
- `bash -n examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh`
- `git diff --check`
- H100 MIMO checkpoint round-trip: pending CI (`Run tests`)

The throughput numerator remains unchanged and continues to describe the language model. Only its denominator switches to the validated language-grid rank count for MIMO; physical `args.world_size` remains unchanged for job grouping, energy, and configuration metadata.

The existing `mimo_hetero_gtp_checkpoint_round_trip` functional test invokes the updated launcher for checkpoint save and load/resave, so it exercises the renamed options end to end.