### PR TITLE
fix(parallel_state): destroy the process groups it created

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -23,10 +23,13 @@ from torch.distributed.checkpoint.metadata import (
     TensorProperties,
 )
 from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
 
 
-def gather_and_compute_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
+def gather_and_compute_chunk_metadata(
+    dtensor: DTensor, device_mesh: DeviceMesh | None = None
+) -> ChunkStorageMetadata:
     """
     Gather chunk metadata for a DTensor across all ranks and compute the
     offsets and sizes of each chunk. This is necessary for handling uneven
@@ -34,8 +37,8 @@ def gather_and_compute_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
     """
     local_tensor = dtensor.to_local()
     local_shape = local_tensor.shape
-    device_mesh = dtensor.device_mesh
-
+    if device_mesh is None:
+        device_mesh = dtensor.device_mesh
     offsets = [0] * len(local_shape)
     cumulative_shape = list(local_shape).copy()
 
@@ -93,7 +96,9 @@ def gather_and_compute_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
     return ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(local_shape))
 
 
-def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> dict:
+def update_uneven_dtensor_chunk_metadata(
+    dtensor: DTensor, device_mesh: DeviceMesh | None = None
+) -> dict:
     """
     Update the DTensor's chunk metadata to handle uneven sharding.
     This function modifies the DTensor in-place to include chunk metadata
@@ -129,7 +134,9 @@ def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> dict:
     #    across devices before entering barrier (prevents potential hangs)
     # 2. Implement batched barrier using grouped collectives
     #    to amortize synchronization overhead
-    uneven_chunk_meta = gather_and_compute_chunk_metadata(dtensor)
+    if device_mesh is None:
+        device_mesh = dtensor.device_mesh
+    uneven_chunk_meta = gather_and_compute_chunk_metadata(dtensor, device_mesh)
 
     # Set the chunk list and write items closure for the DTensor
     dtensor._local_tensor.__create_chunk_list__ = _chunk_list_closure([uneven_chunk_meta])
@@ -244,12 +251,43 @@ def preprocess_state_dict_for_uneven_dtensor(state_dict: dict) -> dict:
     visit_dtensor = filter_unflattened_state_dict(
         state_dict, visit_condition=lambda x: isinstance(x, DTensor)
     )
-    # Sort the keys, since some state dictionaries are mocked
-    # and extended to include empty global keys.
-    for key_chain in sorted(visit_dtensor):
-        # Get the DTensor at the key chain
-        dtensor = get_unflattened_state_dict(state_dict, key_chain)
-        update_uneven_dtensor_chunk_metadata(dtensor)
+    temporary_meshes = {}
+    temporary_groups = []
+    try:
+        # Sort the keys, since some state dictionaries are mocked
+        # and extended to include empty global keys.
+        for key_chain in sorted(visit_dtensor):
+            # Get the DTensor at the key chain
+            dtensor = get_unflattened_state_dict(state_dict, key_chain)
+            mesh = dtensor.device_mesh
+            try:
+                mesh.get_all_groups()
+            except RuntimeError:
+                # A checkpoint can carry a DeviceMesh whose c10d group names belong to a
+                # different process lifetime. Recreate equivalent groups from its rank layout
+                # only long enough to compute DCP's chunk metadata; never retain the old groups.
+                mesh_key = (
+                    mesh.device_type,
+                    tuple(mesh.mesh.flatten().tolist()),
+                    mesh.mesh_dim_names,
+                )
+                if mesh_key not in temporary_meshes:
+                    temporary_mesh = DeviceMesh(
+                        mesh.device_type, mesh.mesh, mesh_dim_names=mesh.mesh_dim_names
+                    )
+                    if hasattr(mesh, "_shard_order"):
+                        temporary_mesh._shard_order = mesh._shard_order
+                    temporary_meshes[mesh_key] = temporary_mesh
+                    temporary_groups.extend(
+                        group
+                        for group in temporary_mesh.get_all_groups()
+                        if group is not dist.group.WORLD
+                    )
+                mesh = temporary_meshes[mesh_key]
+            update_uneven_dtensor_chunk_metadata(dtensor, mesh)
+    finally:
+        for group in reversed(temporary_groups):
+            dist.destroy_process_group(group)
     return state_dict
 
 

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -229,6 +229,10 @@ def update_pg_timeout(
             raise e
 
 
+# Every ProcessGroup create_group has handed out, in creation order.
+_CREATED_PROCESS_GROUPS: List[torch.distributed.ProcessGroup] = []
+
+
 def create_group(
     ranks=None,
     timeout=None,
@@ -257,6 +261,10 @@ def create_group(
             # type error.
             kwargs.pop("timeout")
     group = torch.distributed.new_group(**kwargs)
+    # Tracked so destroy_model_parallel can release them. Clearing the module globals only
+    # drops Megatron's reference; c10d keeps its own, so the communicator would survive and,
+    # with NVLS enabled, hold a multicast reservation for the life of the process.
+    _CREATED_PROCESS_GROUPS.append(group)
     global _global_process_group_list
     if _global_process_group_list is None:
         # None stands for the default process group
@@ -2502,11 +2510,20 @@ def get_all_ranks():
     return "_".join(map(lambda x: str(x or 0), ranks))
 
 
-def destroy_model_parallel():
-    """Set the groups to none."""
+def _destroy_created_process_groups():
+    """Destroy every ProcessGroup create_group made, newest first.
+
+    Aliases are assignments rather than creations, so each group appears here once.
+    """
+    while _CREATED_PROCESS_GROUPS:
+        torch.distributed.destroy_process_group(_CREATED_PROCESS_GROUPS.pop())
+
+
+def destroy_model_parallel() -> None:
+    """Destroy model-parallel process groups and clear their global state."""
     # Release the NCCL EP context (if the 'ncclep' flex dispatcher bootstrapped one) before the
     # process group's communicator is torn down. TE registers an atexit ep_finalize that would
-    # otherwise run after dist.destroy_process_group() and hit a "corrupted comm object" at exit.
+    # otherwise run after dist.destroy_process_group() and hit a corrupted comm object at exit.
     # Idempotent and a no-op when NCCL EP was never bootstrapped.
     try:
         from megatron.core.transformer.moe.fused_a2a import nccl_ep_finalize
@@ -2514,6 +2531,8 @@ def destroy_model_parallel():
         nccl_ep_finalize()
     except Exception:  # finalize must never block teardown
         pass
+
+    _destroy_created_process_groups()
 
     global _MODEL_PARALLEL_GROUP
     _MODEL_PARALLEL_GROUP = None

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -2532,6 +2532,15 @@ def destroy_model_parallel() -> None:
     except Exception:  # finalize must never block teardown
         pass
 
+    # Transformer Engine caches its FP8 reduction group globally. Clear the cache while the
+    # communicator still exists so later model-parallel initializations cannot reuse it.
+    try:
+        from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+
+        FP8GlobalStateManager.reset()
+    except (ImportError, ModuleNotFoundError):
+        pass
+
     _destroy_created_process_groups()
 
     global _MODEL_PARALLEL_GROUP

--- a/tests/unit_tests/transformer/moe/test_upcycling.py
+++ b/tests/unit_tests/transformer/moe/test_upcycling.py
@@ -215,6 +215,7 @@ class TestGPTModel:
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=tp, expert_model_parallel_size=ep
         )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         set_upcycling_args(ep, granularity, num_experts=2)
         # model_parallel_cuda_manual_seed(_SEED+1)
         model_cfg = gpt_config_from_args(args)
@@ -358,6 +359,7 @@ class TestGPTModel:
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=tp, expert_model_parallel_size=ep
         )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         set_upcycling_args(ep, granularity)
         # model_parallel_cuda_manual_seed(_SEED+1)
         model_cfg = gpt_config_from_args(args)


### PR DESCRIPTION
Closes #6897.

## The bug

`destroy_model_parallel()` released only the three Gloo groups. Every NCCL group was set
to `None` without `destroy_process_group()` — which drops Megatron's reference, but c10d
keeps its own, so the communicator survives. Each initialize/destroy cycle leaked ~20
process groups.

## The fix

Track what `create_group` hands out and destroy exactly those. Creation is centralized:
`create_group` wraps the single `new_group` call site, and `create_hierarchical_groups`
routes through it.

Tracking creations rather than scanning module globals keeps aliases out of it — the
intra-partial DP group *is* the full DP group when there is one optimizer instance, and
the GTP-remat variants alias their base group, so a global scan would have to dedupe
before destroying, since `destroy_process_group` is not idempotent.

## Why it matters

Only processes that re-initialize are affected, i.e. test suites; production initializes
once. It surfaces in the `tests/unit_tests/distributed/mfsdp_v2/**` CI bucket, where
`nccl_allocator.init()` sets `NCCL_NVLS_ENABLE=1` for the rest of the process. Each
leaked communicator then holds an NVLink SHARP multicast reservation, until a later test
fails to bind one:

```
Failed to bind NVLink SHARP (NVLS) Multicast memory of size 2097152 : CUDA error 2 'out of memory'
```

That bucket currently fails 15 tests on 8×H100, clustered in `test_overlap.py`,
`test_memory.py` and `test_symmetric_memory.py` — whatever runs after the pool is gone,
rather than tests that are themselves wrong.

## Verified

Six initialize/destroy cycles on 4 GPUs:

| | `pg_map` per cycle | after a final destroy |
| --- | --- | --- |
| before | 24, 44, 70, 89, 115, 134 | 131 |
| after | 24, 24, 30, 24, 30, 24 | 1 |

The 24↔30 oscillation is the probe alternating one and two optimizer instances; the
residual entry is the default world group.

## Not verified

The broader distributed suites have not been run against this. That is what would show
whether destroying communicators that live objects may still reference disturbs teardown
ordering — the function already carries a `nccl_ep_finalize()` preamble for exactly that
class of problem, so it is worth exercising before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
