### PR TITLE
Enable Black string normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ extend_skip = ["setup.py"]
 
 [tool.black]
 line_length = 100
-skip_string_normalization = true
 # recognized by future versions, disallows to reformat code with incompatible versions
 # Matches NeMO version so people working on both codebases don't need two different version of black installed
 required_version = "26"

--- a/tools/autoformat.sh
+++ b/tools/autoformat.sh
@@ -36,7 +36,7 @@ if [[ $SKIP_DOCS == true ]]; then
 fi
 
 if [[ -n "$CHANGED_FILES" ]]; then
-    black --skip-magic-trailing-comma --skip-string-normalization $ADDITIONAL_ARGS $ADDITIONAL_BLACK_ARGS --verbose $CHANGED_FILES
+    black --skip-magic-trailing-comma $ADDITIONAL_ARGS $ADDITIONAL_BLACK_ARGS --verbose $CHANGED_FILES
     isort $ADDITIONAL_ARGS $CHANGED_FILES
     pylint $ADDITIONAL_PYLINT_ARGS $CHANGED_FILES
     ruff check $ADDITIONAL_RUFF_ARGS $CHANGED_FILES


### PR DESCRIPTION
## Summary

- remove the opt-out that disabled Black string normalization
- stop the CI formatter from overriding Black’s default quote-normalization behavior

## Context

This follows [the review discussion between @wujingyue and @rapatel](https://github.com/NVIDIA/Megatron-LM/pull/6594#discussion_r3866641685).

## Validation

- parsed the Black configuration with Python `tomllib`
- `bash -n tools/autoformat.sh`
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
- `git diff --check`
- Black’s string normalizers identify 15,022 quote changes across 630 tracked Python files (no prefix-only changes)