### PR TITLE
Add per-module MFSDP prefetch budgets

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -639,6 +639,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         # without symmetric memory: it uses ncclCommRegister rather than the more performant
         # ncclCommWindowRegister:
         # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#window-registration
+        prefetch_kwargs = {
+            "forward_prefetch_size": ddp_config.suggested_communication_unit_size,
+            "backward_prefetch_size": ddp_config.suggested_communication_unit_size,
+        }
         with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
@@ -654,6 +658,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                             placements=expert_placements,
                             mixed_precision_policy=self.mp_policy,
                             grad_divisor=config.expert_model_parallel_size,
+                            **prefetch_kwargs,
                         )
             for submodule in reversed(list(module.modules())):
                 if submodule is module:
@@ -668,6 +673,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                         mesh=dp_mesh,
                         placements=dense_placements,
                         mixed_precision_policy=self.mp_policy,
+                        **prefetch_kwargs,
                     )
             if config.init_model_with_meta_device:
                 _materialize_owned_meta_modules(module, device)
@@ -676,6 +682,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 mesh=dp_mesh,
                 placements=dense_placements,
                 mixed_precision_policy=self.mp_policy,
+                **prefetch_kwargs,
             )
         super().__init__(config=config, module=module)
 
@@ -789,8 +796,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
         if ddp_config.delay_wgrad_compute:
             raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
-        if ddp_config.suggested_communication_unit_size is not None:
-            raise ValueError("MFSDP v2 does not support suggested_communication_unit_size.")
         if ddp_config.num_buckets is not None:
             raise ValueError("MFSDP v2 does not support num_buckets.")
         if ddp_config.megatron_fsdp_use_decoupled_grad:

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -52,6 +52,7 @@ try:
     )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
         Placements,
+        SchedulePolicy,
         fully_shard,
         fully_shard_context,
     )
@@ -639,10 +640,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         # without symmetric memory: it uses ncclCommRegister rather than the more performant
         # ncclCommWindowRegister:
         # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#window-registration
-        prefetch_kwargs = {
-            "forward_prefetch_size": ddp_config.suggested_communication_unit_size,
-            "backward_prefetch_size": ddp_config.suggested_communication_unit_size,
-        }
+        schedule_policy = SchedulePolicy(
+            forward_prefetch_size=ddp_config.suggested_communication_unit_size,
+            backward_prefetch_size=ddp_config.suggested_communication_unit_size,
+        )
         with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
@@ -658,7 +659,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                             placements=expert_placements,
                             mixed_precision_policy=self.mp_policy,
                             grad_divisor=config.expert_model_parallel_size,
-                            **prefetch_kwargs,
+                            schedule_policy=schedule_policy,
                         )
             for submodule in reversed(list(module.modules())):
                 if submodule is module:
@@ -673,7 +674,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                         mesh=dp_mesh,
                         placements=dense_placements,
                         mixed_precision_policy=self.mp_policy,
-                        **prefetch_kwargs,
+                        schedule_policy=schedule_policy,
                     )
             if config.init_model_with_meta_device:
                 _materialize_owned_meta_modules(module, device)
@@ -682,7 +683,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 mesh=dp_mesh,
                 placements=dense_placements,
                 mixed_precision_policy=self.mp_policy,
-                **prefetch_kwargs,
+                schedule_policy=schedule_policy,
             )
         super().__init__(config=config, module=module)
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -18,10 +18,12 @@ from .checkpoint import load_checkpoint, save_checkpoint
 from .dbuffer import DBuffer
 from .fully_shard import Placements, fully_shard, fully_shard_context, microbatch
 from .optimizer import fully_shard_optimizer
+from .schedule import SchedulePolicy
 
 __all__ = [
     "DBuffer",
     "Placements",
+    "SchedulePolicy",
     "fully_shard",
     "fully_shard_context",
     "fully_shard_optimizer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -26,6 +26,7 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
+from .schedule import SchedulePolicy
 
 _FSDP_CONTEXT = ContextVar[FsdpContext | None]("mfsdp_context", default=None)
 
@@ -108,8 +109,7 @@ def fully_shard(
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
     grad_divisor: int = 1,
-    forward_prefetch_size: int | None = None,
-    backward_prefetch_size: int | None = None,
+    schedule_policy: SchedulePolicy = SchedulePolicy(),
 ) -> None:
     """Apply FSDP to a module in place.
 
@@ -133,12 +133,7 @@ def fully_shard(
             the expert-data-parallel mesh alone therefore divides by too little, and
             ``grad_divisor=ep_size`` makes up the difference. Dense parameters see only
             their own rank's tokens and need no divisor.
-        forward_prefetch_size: Number of parameter elements to prefetch in forward order.
-            ``None`` prefetches one successor, preserving the default behavior. ``0``
-            disables prefetching.
-        backward_prefetch_size: Number of parameter elements to prefetch in backward order.
-            ``None`` prefetches one successor, preserving the default behavior. ``0``
-            disables prefetching.
+        schedule_policy: Communication scheduling policy for this FSDP module.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -167,8 +162,7 @@ def fully_shard(
             main_weight_placements=tuple(placements.optimizer),
             mixed_precision_policy=mixed_precision_policy,
             grad_divisor=grad_divisor,
-            forward_prefetch_size=forward_prefetch_size,
-            backward_prefetch_size=backward_prefetch_size,
+            schedule_policy=schedule_policy,
             use_symmetric_memory=context.use_symmetric_memory,
         )
     except Exception:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -108,6 +108,8 @@ def fully_shard(
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
     grad_divisor: int = 1,
+    forward_prefetch_size: int | None = None,
+    backward_prefetch_size: int | None = None,
 ) -> None:
     """Apply FSDP to a module in place.
 
@@ -131,6 +133,12 @@ def fully_shard(
             the expert-data-parallel mesh alone therefore divides by too little, and
             ``grad_divisor=ep_size`` makes up the difference. Dense parameters see only
             their own rank's tokens and need no divisor.
+        forward_prefetch_size: Number of parameter elements to prefetch in forward order.
+            ``None`` prefetches one successor, preserving the default behavior. ``0``
+            disables prefetching.
+        backward_prefetch_size: Number of parameter elements to prefetch in backward order.
+            ``None`` prefetches one successor, preserving the default behavior. ``0``
+            disables prefetching.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -159,6 +167,8 @@ def fully_shard(
             main_weight_placements=tuple(placements.optimizer),
             mixed_precision_policy=mixed_precision_policy,
             grad_divisor=grad_divisor,
+            forward_prefetch_size=forward_prefetch_size,
+            backward_prefetch_size=backward_prefetch_size,
             use_symmetric_memory=context.use_symmetric_memory,
         )
     except Exception:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -36,6 +36,13 @@ def _is_in_backward() -> bool:
     return torch._C._current_graph_task_id() != -1
 
 
+def _validate_prefetch_size(prefetch_size: int | None, name: str) -> int | None:
+    """Validate an optional non-negative parameter-element prefetch budget."""
+    if prefetch_size is not None and prefetch_size < 0:
+        raise ValueError(f"{name} must be non-negative, got {prefetch_size}.")
+    return prefetch_size
+
+
 class FsdpContext:
     """Runtime stream and prefetch state shared by FSDP roots constructed together."""
 
@@ -158,6 +165,9 @@ class FsdpModule:
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
     _is_root: bool
+    _num_trainable_parameters: int
+    _forward_prefetch_size: int | None
+    _backward_prefetch_size: int | None
     # Event recorded after this FsdpModule's full parameters are materialized.
     # ``None`` lets pre_forward enqueue an all-gather unless an earlier FsdpModule
     # already prefetched this module.
@@ -177,6 +187,8 @@ class FsdpModule:
         main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
+        forward_prefetch_size: int | None = None,
+        backward_prefetch_size: int | None = None,
         use_symmetric_memory: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
@@ -185,6 +197,12 @@ class FsdpModule:
         self._name = None
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
+        self._forward_prefetch_size = _validate_prefetch_size(
+            forward_prefetch_size, "forward_prefetch_size"
+        )
+        self._backward_prefetch_size = _validate_prefetch_size(
+            backward_prefetch_size, "backward_prefetch_size"
+        )
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -349,9 +367,24 @@ class FsdpModule:
         # prefetch the next module in forward order: its backward may already
         # be complete, so no later backward hook would reshard it.
         if not is_recomputing:
-            next_module = context.forward_order.next_item(self)
-            if next_module is not None:
-                next_module._unshard_parameter_groups()
+            self._prefetch_parameter_groups(context.forward_order, self._forward_prefetch_size)
+
+    def _prefetch_parameter_groups(
+        self, order: IndexedOrder["FsdpModule"], prefetch_size: int | None
+    ) -> None:
+        """Prefetch successors from ``order`` according to this module's budget."""
+        next_module = order.next_item(self)
+        if next_module is None or prefetch_size == 0:
+            return
+        if prefetch_size is None:
+            next_module._unshard_parameter_groups()
+            return
+
+        prefetched_size = 0
+        while next_module is not None and prefetched_size < prefetch_size:
+            next_module._unshard_parameter_groups()
+            prefetched_size += next_module.num_parameter_elements
+            next_module = order.next_item(next_module)
 
     def _unshard_parameter_groups(self) -> None:
         """Unshard this FsdpModule's parameter groups on the all-gather stream.
@@ -421,9 +454,7 @@ class FsdpModule:
         assert self._unshard_event is not None
         current_stream.wait_event(self._unshard_event)
 
-        next_module = context.backward_order.next_item(self)
-        if next_module is not None:
-            next_module._unshard_parameter_groups()
+        self._prefetch_parameter_groups(context.backward_order, self._backward_prefetch_size)
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
@@ -456,6 +487,15 @@ class FsdpModule:
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
         """Parameter groups owned by this FsdpModule."""
         return self._parameter_groups
+
+    @property
+    def num_parameter_elements(self) -> int:
+        """Return the number of unsharded parameter elements owned by this module."""
+        return sum(
+            parameter.unsharded.numel()
+            for group in self._parameter_groups
+            for parameter in group.fsdp_parameters
+        )
 
     def _nvtx_label(self, phase: Literal["forward", "backward"]) -> str:
         name = self.name if self.name else "<root>"

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -36,13 +36,6 @@ def _is_in_backward() -> bool:
     return torch._C._current_graph_task_id() != -1
 
 
-def _validate_prefetch_size(prefetch_size: int | None, name: str) -> int | None:
-    """Validate an optional non-negative parameter-element prefetch budget."""
-    if prefetch_size is not None and prefetch_size < 0:
-        raise ValueError(f"{name} must be non-negative, got {prefetch_size}.")
-    return prefetch_size
-
-
 class FsdpContext:
     """Runtime stream and prefetch state shared by FSDP roots constructed together."""
 
@@ -197,12 +190,16 @@ class FsdpModule:
         self._name = None
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
-        self._forward_prefetch_size = _validate_prefetch_size(
-            forward_prefetch_size, "forward_prefetch_size"
-        )
-        self._backward_prefetch_size = _validate_prefetch_size(
-            backward_prefetch_size, "backward_prefetch_size"
-        )
+        if forward_prefetch_size is not None and forward_prefetch_size < 0:
+            raise ValueError(
+                f"forward_prefetch_size must be non-negative, got {forward_prefetch_size}."
+            )
+        if backward_prefetch_size is not None and backward_prefetch_size < 0:
+            raise ValueError(
+                f"backward_prefetch_size must be non-negative, got {backward_prefetch_size}."
+            )
+        self._forward_prefetch_size = forward_prefetch_size
+        self._backward_prefetch_size = backward_prefetch_size
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -374,10 +371,9 @@ class FsdpModule:
     ) -> None:
         """Prefetch successors from ``order`` according to this module's budget."""
         next_module = order.next_item(self)
-        if next_module is None or prefetch_size == 0:
-            return
         if prefetch_size is None:
-            next_module._unshard_parameter_groups()
+            if next_module is not None:
+                next_module._unshard_parameter_groups()
             return
 
         prefetched_size = 0

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -29,6 +29,7 @@ from .countdown import Countdown
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Flat
+from .schedule import SchedulePolicy
 
 
 def _is_in_backward() -> bool:
@@ -159,8 +160,7 @@ class FsdpModule:
     _trainable_parameter_countdown: Countdown
     _is_root: bool
     _num_trainable_parameters: int
-    _forward_prefetch_size: int | None
-    _backward_prefetch_size: int | None
+    _schedule_policy: SchedulePolicy
     # Event recorded after this FsdpModule's full parameters are materialized.
     # ``None`` lets pre_forward enqueue an all-gather unless an earlier FsdpModule
     # already prefetched this module.
@@ -180,8 +180,7 @@ class FsdpModule:
         main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
-        forward_prefetch_size: int | None = None,
-        backward_prefetch_size: int | None = None,
+        schedule_policy: SchedulePolicy = SchedulePolicy(),
         use_symmetric_memory: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
@@ -190,16 +189,7 @@ class FsdpModule:
         self._name = None
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
-        if forward_prefetch_size is not None and forward_prefetch_size < 0:
-            raise ValueError(
-                f"forward_prefetch_size must be non-negative, got {forward_prefetch_size}."
-            )
-        if backward_prefetch_size is not None and backward_prefetch_size < 0:
-            raise ValueError(
-                f"backward_prefetch_size must be non-negative, got {backward_prefetch_size}."
-            )
-        self._forward_prefetch_size = forward_prefetch_size
-        self._backward_prefetch_size = backward_prefetch_size
+        self._schedule_policy = schedule_policy
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -364,7 +354,9 @@ class FsdpModule:
         # prefetch the next module in forward order: its backward may already
         # be complete, so no later backward hook would reshard it.
         if not is_recomputing:
-            self._prefetch_parameter_groups(context.forward_order, self._forward_prefetch_size)
+            self._prefetch_parameter_groups(
+                context.forward_order, self._schedule_policy.forward_prefetch_size
+            )
 
     def _prefetch_parameter_groups(
         self, order: IndexedOrder["FsdpModule"], prefetch_size: int | None
@@ -450,7 +442,9 @@ class FsdpModule:
         assert self._unshard_event is not None
         current_stream.wait_event(self._unshard_event)
 
-        self._prefetch_parameter_groups(context.backward_order, self._backward_prefetch_size)
+        self._prefetch_parameter_groups(
+            context.backward_order, self._schedule_policy.backward_prefetch_size
+        )
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/schedule.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/schedule.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scheduling configuration for the minimal Megatron-FSDP path."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SchedulePolicy:
+    """Control communication scheduling for one FSDP module.
+
+    ``None`` prefetches one successor, preserving the default behavior. ``0``
+    disables prefetching. Positive values specify parameter-element budgets.
+    """
+
+    forward_prefetch_size: int | None = None
+    backward_prefetch_size: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate non-negative prefetch budgets."""
+        if self.forward_prefetch_size is not None and self.forward_prefetch_size < 0:
+            raise ValueError(
+                "forward_prefetch_size must be non-negative, " f"got {self.forward_prefetch_size}."
+            )
+        if self.backward_prefetch_size is not None and self.backward_prefetch_size < 0:
+            raise ValueError(
+                "backward_prefetch_size must be non-negative, "
+                f"got {self.backward_prefetch_size}."
+            )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 import torch.distributed as dist
 from torch import nn
-from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import Partial, Replicate, Shard
 from torch.profiler import ProfilerActivity, profile
 
@@ -265,7 +265,7 @@ def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
     dtype = torch.bfloat16
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
-    mesh = DeviceMesh.from_group(dist.group.WORLD, device.type)
+    mesh = init_device_mesh(device.type, (world_size,))
     model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
     placements = _flat_placements()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -251,3 +251,61 @@ def test_overlaps_communication_and_compute(
 
     # Release the dedicated communicator so it does not leak into the shared session.
     dist.destroy_process_group(dp_group)
+
+
+@pytest.mark.flaky
+@pytest.mark.flaky_in_dev
+def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
+    """Zero per-module prefetch budgets should launch all-gathers before compute."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    dim = 16384
+    num_children = 4
+    dtype = torch.bfloat16
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    dp_group = dist.new_group(backend="nccl")
+    mesh = DeviceMesh.from_group(dp_group, device.type)
+    model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
+    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
+    placements = _flat_placements()
+    with fully_shard_context(device=device) as context:
+        for layer in model.layers:
+            fully_shard(
+                layer,
+                mesh=mesh,
+                placements=placements,
+                mixed_precision_policy=policy,
+                forward_prefetch_size=0,
+                backward_prefetch_size=0,
+            )
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, foreach=False)
+    fully_shard_optimizer(optimizer)
+    x = torch.randn(8192, dim, device=device, dtype=dtype, requires_grad=True)
+
+    def train_one_step() -> None:
+        optimizer.zero_grad(set_to_none=True)
+        for microbatch_index in range(2):
+            with microbatch(context, is_last=microbatch_index == 1):
+                model(x).sum().backward()
+        optimizer.step()
+
+    train_one_step()
+    torch.cuda.synchronize(device)
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        train_one_step()
+        torch.cuda.synchronize(device)
+
+    gemm_groups = collect_linked_event_groups(prof, _GEMM_OP_NAME_SUBSTRING)
+    allgather_groups = collect_linked_event_groups(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
+    assert len(allgather_groups) == 4 * num_children
+    assert all(
+        not any(event_groups_overlap(allgather, gemm) for gemm in gemm_groups)
+        for allgather in allgather_groups
+    ), "All-gathers overlapped GEMM compute despite zero prefetch budgets."
+
+    dist.destroy_process_group(dp_group)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -14,6 +14,7 @@ from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Placements,
+    SchedulePolicy,
     fully_shard,
     fully_shard_context,
     fully_shard_optimizer,
@@ -276,8 +277,7 @@ def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
                 mesh=mesh,
                 placements=placements,
                 mixed_precision_policy=policy,
-                forward_prefetch_size=0,
-                backward_prefetch_size=0,
+                schedule_policy=SchedulePolicy(forward_prefetch_size=0, backward_prefetch_size=0),
             )
 
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01, foreach=False)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -253,8 +253,6 @@ def test_overlaps_communication_and_compute(
     dist.destroy_process_group(dp_group)
 
 
-@pytest.mark.flaky
-@pytest.mark.flaky_in_dev
 def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
     """Zero per-module prefetch budgets should launch all-gathers before compute."""
     world_size = distributed_setup.world_size
@@ -267,8 +265,7 @@ def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
     dtype = torch.bfloat16
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
-    dp_group = dist.new_group(backend="nccl")
-    mesh = DeviceMesh.from_group(dp_group, device.type)
+    mesh = DeviceMesh.from_group(dist.group.WORLD, device.type)
     model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
     placements = _flat_placements()
@@ -307,5 +304,3 @@ def test_prefetch_size_zero_disables_allgather_overlap(distributed_setup):
         not any(event_groups_overlap(allgather, gemm) for gemm in gemm_groups)
         for allgather in allgather_groups
     ), "All-gathers overlapped GEMM compute despite zero prefetch budgets."
-
-    dist.destroy_process_group(dp_group)


### PR DESCRIPTION
## Summary

- add independent forward and backward prefetch element budgets to MFSDP v2 `fully_shard()`
- use `suggested_communication_unit_size` as the adapter-level value passed to each wrapped module
- verify zero budgets disable all-gather/GEMM overlap

## Testing

- `python -m torch.distributed.run --nproc-per-node=2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_overlap.py::test_prefetch_size_zero_disables_allgather_overlap`
- `isort --check-only ... && black --check ... && ruff check ...`