### PR TITLE
Don't destroy the default process group in the EP test cleanup

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_expert_parallel.py
@@ -233,5 +233,8 @@ def test_ep_fsdp_matches_fullbatch_reference(distributed_setup):
     )
 
     # Destroy the groups this test created; leave the default (world) group for later tests.
+    # A mesh dim that spans every rank is backed by the default group rather than a fresh one
+    # (e.g. "ep" here when edp_size == 1).
     for group in (one, ep_group, expert_dp_group):
-        dist.destroy_process_group(group)
+        if group is not dist.group.WORLD:
+            dist.destroy_process_group(group)


### PR DESCRIPTION
At `world_size == ep_size`, `edp_size` is 1, so the `ep` mesh dim spans every rank and `DeviceMesh` returns the *default* group for it rather than a new one. Probing the groups at 4 ranks:

```
default(WORLD)   id=280745243688752  name='0'  size=4  ranks=[0,1,2,3]
ep_group         id=280745243688752  name='0'  size=4  ranks=[0,1,2,3]   <-- same object
expert_dp_group  id=280745243682736  name='1'  size=1  ranks=[0]
```

So the cleanup loop calls `destroy_process_group(WORLD)`, which per its docstring destroys *all* groups. Two consequences at 4 GPUs:

- the next iteration raises `ValueError: Invalid process group specified` on an invalidated handle, failing the test in cleanup though every assertion passed;
- the process is left with no distributed state, so any later test in it hangs on its first collective — which makes this file un-mergeable with any other.

CI runs this at 8 GPUs, where `edp_size == 2` and `ep` covers a real subset, so it only bites at 4.

Skip the default group, which is what the comment already claimed. On `main` at 4 GPUs: `ValueError` on all 4 ranks → `1 passed in 2.48s`.