### PR TITLE
[Dev] Fix DSA sparse attention backward empty rows

### DIFF
--- a/megatron/core/context_parallel_layout/routes.py
+++ b/megatron/core/context_parallel_layout/routes.py
@@ -19,23 +19,54 @@ if TYPE_CHECKING:
 _ThdLayoutSegment = Tuple[int, int, int]
 
 
-def _compact_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
+def _materialize_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
     if cu_seqlens.dim() != 1:
         raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}.")
+    return cu_seqlens.detach().to(device="cpu", dtype=torch.long).tolist()
 
-    cu = cu_seqlens.detach().to(device="cpu", dtype=torch.long).tolist()
+
+def _compact_thd_cu_seqlens_list(cu: List[int], source: torch.Tensor) -> List[int]:
     if not cu or cu[0] != 0:
-        raise ValueError(f"cu_seqlens must start at 0, got {cu_seqlens}.")
+        raise ValueError(f"cu_seqlens must start at 0, got {source}.")
 
     compact_cu: List[int] = [cu[0]]
     prev = cu[0]
     for value in cu[1:]:
         if value < prev:
-            raise ValueError(f"cu_seqlens must be nondecreasing, got {cu_seqlens}.")
+            raise ValueError(f"cu_seqlens must be nondecreasing, got {source}.")
         if value != prev:
             compact_cu.append(value)
         prev = value
     return compact_cu
+
+
+def _compact_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
+    return _compact_thd_cu_seqlens_list(_materialize_thd_cu_seqlens_to_list(cu_seqlens), cu_seqlens)
+
+
+def _materialize_compact_thd_qkv_cu_seqlens(
+    cu_q: torch.Tensor, cu_kv: Optional[torch.Tensor]
+) -> Tuple[List[int], List[int]]:
+    """Materialize compact Q/KV boundaries with one host transfer."""
+    if cu_kv is None or cu_kv is cu_q:
+        host_q = _compact_thd_cu_seqlens_to_list(cu_q)
+        return host_q, host_q
+
+    if cu_q.device != cu_kv.device:
+        # Preserve the pre-existing mixed-device behavior. Joint materialization is
+        # only possible for co-located tensors; otherwise copy each side separately.
+        return _compact_thd_cu_seqlens_to_list(cu_q), _compact_thd_cu_seqlens_to_list(cu_kv)
+    if cu_q.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_q.shape)}.")
+    if cu_kv.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_kv.shape)}.")
+
+    q_numel = cu_q.numel()
+    joint_cu = torch.cat((cu_q.detach(), cu_kv.detach()))
+    joint_host = _materialize_thd_cu_seqlens_to_list(joint_cu)
+    host_q = _compact_thd_cu_seqlens_list(joint_host[:q_numel], cu_q)
+    host_kv = _compact_thd_cu_seqlens_list(joint_host[q_numel:], cu_kv)
+    return host_q, host_kv
 
 
 def _validate_thd_route_partitioning(cu: List[int], cp_size: int) -> None:
@@ -145,6 +176,57 @@ def _build_thd_layout_side_route(
     return torch.tensor(row_order, device=device, dtype=torch.long), split_sizes
 
 
+def _build_thd_cp_partition_route_from_host(
+    cu: List[int], cp_size: int, cp_rank: int, *, device: torch.device
+) -> ThdCpRoute:
+    """Build a THD CP route from already compact host boundaries."""
+    _validate_thd_route_partitioning(cu, cp_size)
+
+    zigzag_segments_by_rank: List[List[_ThdLayoutSegment]] = []
+    zigzag_lengths: List[int] = []
+    contiguous_segments_by_rank: List[List[_ThdLayoutSegment]] = []
+    for rank in range(cp_size):
+        zigzag_segments, zigzag_length = _build_thd_layout_segments(cu, cp_size, rank, "zigzag")
+        contiguous_segments, contiguous_length = _build_thd_layout_segments(
+            cu, cp_size, rank, "contiguous"
+        )
+        if zigzag_length != contiguous_length:
+            raise ValueError(
+                "THD CP layout conversion must preserve local token count, "
+                f"got zigzag={zigzag_length}, contiguous={contiguous_length} "
+                f"for cp_size={cp_size}, rank={rank}."
+            )
+        zigzag_segments_by_rank.append(zigzag_segments)
+        zigzag_lengths.append(zigzag_length)
+        contiguous_segments_by_rank.append(contiguous_segments)
+
+    zigzag_index, zigzag_split_sizes = _build_thd_layout_side_route(
+        zigzag_segments_by_rank[cp_rank], contiguous_segments_by_rank, device=device
+    )
+    contiguous_index, contiguous_split_sizes = _build_thd_layout_side_route(
+        contiguous_segments_by_rank[cp_rank], zigzag_segments_by_rank, device=device
+    )
+
+    local_length = zigzag_lengths[cp_rank]
+    if sum(zigzag_split_sizes) != local_length:
+        raise ValueError(
+            "Zigzag THD CP route split sizes do not match the local token count: "
+            f"splits={zigzag_split_sizes}, local_length={local_length}."
+        )
+    if sum(contiguous_split_sizes) != local_length:
+        raise ValueError(
+            "Contiguous THD CP route split sizes do not match the local token count: "
+            f"splits={contiguous_split_sizes}, local_length={local_length}."
+        )
+
+    return ThdCpRoute(
+        zigzag_index=zigzag_index,
+        zigzag_split_sizes=zigzag_split_sizes,
+        contiguous_index=contiguous_index,
+        contiguous_split_sizes=contiguous_split_sizes,
+    )
+
+
 def build_thd_cp_partition_route(
     cu_seqlens: torch.Tensor, cp_size: int, cp_rank: int, *, device: Optional[torch.device] = None
 ) -> ThdCpRoute:
@@ -163,51 +245,7 @@ def build_thd_cp_partition_route(
 
     with nvtx_range("cp_layout/thd/route"):
         cu = _compact_thd_cu_seqlens_to_list(cu_seqlens)
-        _validate_thd_route_partitioning(cu, cp_size)
-
-        zigzag_segments_by_rank: List[List[_ThdLayoutSegment]] = []
-        zigzag_lengths: List[int] = []
-        contiguous_segments_by_rank: List[List[_ThdLayoutSegment]] = []
-        for rank in range(cp_size):
-            zigzag_segments, zigzag_length = _build_thd_layout_segments(cu, cp_size, rank, "zigzag")
-            contiguous_segments, contiguous_length = _build_thd_layout_segments(
-                cu, cp_size, rank, "contiguous"
-            )
-            if zigzag_length != contiguous_length:
-                raise ValueError(
-                    "THD CP layout conversion must preserve local token count, "
-                    f"got zigzag={zigzag_length}, contiguous={contiguous_length} "
-                    f"for cp_size={cp_size}, rank={rank}."
-                )
-            zigzag_segments_by_rank.append(zigzag_segments)
-            zigzag_lengths.append(zigzag_length)
-            contiguous_segments_by_rank.append(contiguous_segments)
-
-        zigzag_index, zigzag_split_sizes = _build_thd_layout_side_route(
-            zigzag_segments_by_rank[cp_rank], contiguous_segments_by_rank, device=device
-        )
-        contiguous_index, contiguous_split_sizes = _build_thd_layout_side_route(
-            contiguous_segments_by_rank[cp_rank], zigzag_segments_by_rank, device=device
-        )
-
-        local_length = zigzag_lengths[cp_rank]
-        if sum(zigzag_split_sizes) != local_length:
-            raise ValueError(
-                "Zigzag THD CP route split sizes do not match the local token count: "
-                f"splits={zigzag_split_sizes}, local_length={local_length}."
-            )
-        if sum(contiguous_split_sizes) != local_length:
-            raise ValueError(
-                "Contiguous THD CP route split sizes do not match the local token count: "
-                f"splits={contiguous_split_sizes}, local_length={local_length}."
-            )
-
-        return ThdCpRoute(
-            zigzag_index=zigzag_index,
-            zigzag_split_sizes=zigzag_split_sizes,
-            contiguous_index=contiguous_index,
-            contiguous_split_sizes=contiguous_split_sizes,
-        )
+        return _build_thd_cp_partition_route_from_host(cu, cp_size, cp_rank, device=device)
 
 
 def get_thd_cp_partition_route(
@@ -269,12 +307,33 @@ def prebuild_thd_cp_partition_routes(
         return
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
-    cu_seqlens = get_packed_seq_params_cp_partition_cu_seqlens(packed_seq_params)
-    if cu_seqlens is None:
+    if not 0 <= cp_rank < cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
+    cu_q = get_packed_seq_params_cp_partition_cu_seqlens(packed_seq_params)
+    if cu_q is None:
         return
     if device is None:
-        device = cu_seqlens.device
+        device = cu_q.device
 
-    packed_seq_params.cp_partition_route = build_thd_cp_partition_route(
-        cu_seqlens, cp_size, cp_rank, device=device
+    # Also expose the compacted cu_seqlens as host integer lists. Consumers that
+    # derive per-token layout metadata from them (e.g. the DSA packed-CP position
+    # builders) can then work entirely on the host instead of re-deriving the same
+    # spans on the device, where the data-dependent shapes force a
+    # device-to-host readback behind the whole queued iteration. Doing the copy
+    # here is cheap for the same reason the route build is: at batch-construction
+    # time the CUDA queue is still shallow.
+    # getattr: the pre-existing contract of this function (see the unit tests) is
+    # any object carrying the q-side fields, so the kv-side reads must not widen it.
+    cu_kv_padded = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+    cu_kv = (
+        cu_kv_padded
+        if cu_kv_padded is not None
+        else getattr(packed_seq_params, "cu_seqlens_kv", None)
     )
+    with nvtx_range("cp_layout/thd/route"):
+        host_q, host_kv = _materialize_compact_thd_qkv_cu_seqlens(cu_q, cu_kv)
+        route = _build_thd_cp_partition_route_from_host(host_q, cp_size, cp_rank, device=device)
+
+    packed_seq_params.cp_partition_route = route
+    packed_seq_params.thd_cp_host_cu_seqlens_q = host_q
+    packed_seq_params.thd_cp_host_cu_seqlens_kv = host_kv

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -666,11 +666,21 @@ def pad_sequence_for_thd(
             cu_seqlens_q_padded = cu_seqlens_q
         if cu_seqlens_kv_padded is None:
             cu_seqlens_kv_padded = cu_seqlens_kv
+        # Missing padded metadata inherits the valid-coordinate source. Re-evaluate
+        # the relationship after that inheritance so self-attention Q/K aliases are
+        # not split by the two allocating transforms below.
+        qkv_padded_share_view = qkv_padded_share_view or _same_tensor_view(
+            cu_seqlens_q_padded, cu_seqlens_kv_padded
+        )
         assert (
             cu_seqlens_q_padded is not None or cu_seqlens_kv_padded is not None
         ), "Non-dummy THD tail padding requires metadata for at least one real sequence."
         cu_seqlens_q_padded = _extend_last_padded_sequence(cu_seqlens_q_padded, global_target_len)
-        cu_seqlens_kv_padded = _extend_last_padded_sequence(cu_seqlens_kv_padded, global_target_len)
+        cu_seqlens_kv_padded = (
+            cu_seqlens_q_padded
+            if qkv_padded_share_view
+            else _extend_last_padded_sequence(cu_seqlens_kv_padded, global_target_len)
+        )
         last_padded_q_len = _last_padded_sequence_length(cu_seqlens_q_padded)
         last_padded_kv_len = _last_padded_sequence_length(cu_seqlens_kv_padded)
 

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -154,6 +154,36 @@ def _pad_cu_seqlens(cu_seqlens: Optional[Tensor], target_entries: int) -> Option
     return padded
 
 
+def _same_tensor_view(a: Optional[Tensor], b: Optional[Tensor]) -> bool:
+    """Return whether two real tensors describe the same logical view."""
+    if not isinstance(a, Tensor) or not isinstance(b, Tensor):
+        return False
+    if a is b:
+        return type(a) is Tensor and not a.is_meta and a.numel() > 0
+    # Distinct tensor subclasses and meta/empty tensors do not provide a
+    # reliable physical-storage identity. Fail closed instead of comparing
+    # sentinel pointers or invoking unsupported storage accessors.
+    if type(a) is not Tensor or type(b) is not Tensor or a.is_meta or b.is_meta:
+        return False
+    if a.numel() == 0 or b.numel() == 0:
+        return False
+    try:
+        if (
+            a.dtype != b.dtype
+            or a.device != b.device
+            or a.shape != b.shape
+            or a.stride() != b.stride()
+            or a.storage_offset() != b.storage_offset()
+        ):
+            return False
+        a_data_ptr = a.data_ptr()
+        b_data_ptr = b.data_ptr()
+    except (RuntimeError, NotImplementedError):
+        # Some nonstandard tensor backends do not expose storage/data pointers.
+        return False
+    return a_data_ptr != 0 and a_data_ptr == b_data_ptr
+
+
 def _append_dummy_seq(cu_seqlens: Optional[Tensor], dummy_end: int) -> Optional[Tensor]:
     """Append a dummy sequence boundary to a cu_seqlens tensor.
 
@@ -570,6 +600,8 @@ def pad_sequence_for_thd(
     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
     cu_seqlens_q_padded = packed_seq_params.cu_seqlens_q_padded
     cu_seqlens_kv_padded = packed_seq_params.cu_seqlens_kv_padded
+    qkv_valid_share_view = _same_tensor_view(cu_seqlens_q, cu_seqlens_kv)
+    qkv_padded_share_view = _same_tensor_view(cu_seqlens_q_padded, cu_seqlens_kv_padded)
 
     # Represent post-pack padding either as a dummy sequence or as physical
     # padding attached to the final real sequence.
@@ -648,6 +680,14 @@ def pad_sequence_for_thd(
         cu_seqlens_kv = _pad_cu_seqlens(cu_seqlens_kv, target_cu_entries)
         cu_seqlens_q_padded = _pad_cu_seqlens(cu_seqlens_q_padded, target_cu_entries)
         cu_seqlens_kv_padded = _pad_cu_seqlens(cu_seqlens_kv_padded, target_cu_entries)
+
+    # The packing scheduler intentionally supplies Q/K metadata as matching
+    # views. Preserve that contract across transforms that allocate new tensors,
+    # while keeping independently supplied metadata independent.
+    if qkv_valid_share_view:
+        cu_seqlens_kv = cu_seqlens_q
+    if qkv_padded_share_view:
+        cu_seqlens_kv_padded = cu_seqlens_q_padded
 
     # Rebuild PackedSeqParams with the padded tensor and metadata shapes.
     padded_params = PackedSeqParams(

--- a/megatron/core/transformer/cuda_graph_config.py
+++ b/megatron/core/transformer/cuda_graph_config.py
@@ -59,6 +59,110 @@ def validate_moe_cuda_graph_support(config) -> None:
     )
 
 
+PACKED_DSA_CP_CUDA_GRAPH_ERROR = (
+    "CUDA graph capture is not supported for this packed DSA context-parallel "
+    "configuration: the requested capture path cannot preserve or reconstruct the "
+    "per-sequence CP layout during warmup and replay. Full CUDA Graph support for "
+    "packed DSA+CP is deferred; set cuda_graph_impl='none'. Other unguarded capture "
+    "combinations remain experimental unless separately validated."
+)
+
+
+def is_packed_dsa_cp_cuda_graph_capture_unsupported(
+    *,
+    experimental_attention_variant: Optional[str],
+    dsa_kernel_backend: str,
+    sequence_packing_scheduler: Optional[str],
+    dynamic_context_parallel: bool,
+    context_parallel_size: int,
+    cuda_graph_impl: str,
+    cuda_graph_modules: Optional[List[CudaGraphModule]],
+    inference_cuda_graph_scope: InferenceCudaGraphScope,
+) -> bool:
+    """Return whether a packed DSA+CP graph combination is proven unsupported.
+
+    Keep this predicate limited to configurations covered by GPU evidence. The
+    static validation matrix exercised configured CP=2 and CP=4; the dynamic
+    matrix exercised configured CP=2 only. Combined local attention+MLP,
+    attention+Mamba, and TE attention+MLP scopes were measured only at static
+    CP=2. CP=3 failed during model construction before eager preflight or graph
+    capture, so it is not graph-specific evidence and remains outside this
+    guard. Dynamic CP with configured CP=1 is likewise not inferred from the
+    DP x CP pool because that neighboring topology did not reach capture.
+    Unmeasured MoE/Mamba partial scopes and full-iteration capture also remain
+    available until they are measured.
+    """
+
+    static_packing = sequence_packing_scheduler == "dp_balanced" and not dynamic_context_parallel
+    dynamic_packing = (
+        sequence_packing_scheduler == "default_dynamic_cp" and dynamic_context_parallel
+    )
+    if experimental_attention_variant != "dsa":
+        return False
+    if not (static_packing or dynamic_packing):
+        return False
+
+    # Capture scope execution uses membership checks, so repeated spellings such
+    # as ``attn,attn`` are the same effective scope as ``attn``.
+    modules = frozenset(cuda_graph_modules or [])
+    if dsa_kernel_backend == "cudnn":
+        if cuda_graph_impl == "local":
+            measured_scopes = set()
+            if static_packing and context_parallel_size in (2, 4):
+                measured_scopes.update(
+                    {
+                        frozenset(),
+                        frozenset({CudaGraphModule.attn}),
+                        frozenset({CudaGraphModule.mlp}),
+                    }
+                )
+                if context_parallel_size == 2:
+                    measured_scopes.update(
+                        {
+                            frozenset({CudaGraphModule.attn, CudaGraphModule.mlp}),
+                            frozenset({CudaGraphModule.attn, CudaGraphModule.mamba}),
+                        }
+                    )
+            elif dynamic_packing and context_parallel_size == 2:
+                measured_scopes.update(
+                    {
+                        frozenset(),
+                        frozenset({CudaGraphModule.attn}),
+                        frozenset({CudaGraphModule.mlp}),
+                    }
+                )
+
+            if modules not in measured_scopes:
+                return False
+            if not modules:
+                # ``block`` owns an inference-only TransformerBlock graph and
+                # skips the per-layer whole-scope manager exercised by the
+                # training validation matrix.
+                return inference_cuda_graph_scope == InferenceCudaGraphScope.layer
+            return True
+        if cuda_graph_impl == "transformer_engine":
+            measured_scopes = set()
+            if static_packing and context_parallel_size in (2, 4):
+                measured_scopes.update({frozenset(), frozenset({CudaGraphModule.attn})})
+                if context_parallel_size == 2:
+                    measured_scopes.add(frozenset({CudaGraphModule.attn, CudaGraphModule.mlp}))
+            elif dynamic_packing and context_parallel_size == 2:
+                measured_scopes.update({frozenset(), frozenset({CudaGraphModule.attn})})
+            return modules in measured_scopes
+
+    # The unfused scorer was measured only for static attention-only local
+    # capture. TileLang was unavailable in the validation image, and the
+    # remaining backend-none scopes were not measured, so keep them available.
+    if (
+        dsa_kernel_backend == "none"
+        and static_packing
+        and context_parallel_size == 2
+        and cuda_graph_impl == "local"
+    ):
+        return modules == {CudaGraphModule.attn}
+    return False
+
+
 def normalize_cuda_graph_modules(
     scopes: Optional[Union[str, CudaGraphModule, List[Union[str, CudaGraphModule]]]],
 ) -> Tuple[List[CudaGraphModule], List[Tuple[str, str, object]], bool]:

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -30,6 +30,12 @@ from megatron.core.transformer.experimental_attention_variant import (
     dsa_layout,
     dsa_masking,
 )
+from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_local_positions_from_host as _build_cp_positions_from_host,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_query_positions_and_key_reorder_from_host as _cp_reorder_from_host,
+)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1938,6 +1944,7 @@ class DSAttention(MegatronModule):
     requires_dsa_inputs = True
     _HOLDER_ATTR = "_dsa_index_share_topk_holder"
     _LENGTH_HOLDER_ATTR = "_dsa_index_share_topk_length_holder"
+    _LAYOUT_HOLDER_ATTR = "_dsa_packed_cp_layout_holder"
 
     def __init__(
         self,
@@ -2022,6 +2029,45 @@ class DSAttention(MegatronModule):
             holder = {}
             setattr(carrier, self._LENGTH_HOLDER_ATTR, holder)
         return holder
+
+    def _get_packed_cp_layout_cache(
+        self, packed_seq_params: Optional[PackedSeqParams]
+    ) -> Optional[dict]:
+        """Return the per-microbatch memo for packed-CP layout metadata, or None.
+
+        The CP query positions and key reorder indices depend only on
+        ``cu_seqlens_q``/``cu_seqlens_kv``, ``cp_size``, ``cp_rank`` and the
+        requested output sizes. All of those are identical for every layer in a
+        microbatch, yet each layer rebuilds them, and each rebuild loops
+        ``cp_size`` times over :func:`build_packed_allgather_cp_local_positions`,
+        whose boolean-mask indexing has data-dependent output shapes and so
+        forces a device-to-host size readback.
+
+        ``PackedSeqParams`` is the only carrier used here. It is constructed per
+        microbatch, so a memo hung on it cannot outlive the layout it describes
+        -- which matters under dynamic CP, where the layout changes between
+        microbatches. The index-share top-k holders fall back to
+        ``attention_mask``/``self.config``, but that is only safe because every
+        computing layer overwrites its slot before any sharing layer reads it. A
+        layout memo has no such write-before-read ordering and ``self.config``
+        outlives the microbatch, so caching there could serve a stale layout.
+        """
+        if packed_seq_params is None:
+            return None
+        cache = getattr(packed_seq_params, self._LAYOUT_HOLDER_ATTR, None)
+        if cache is None:
+            cache = {}
+            setattr(packed_seq_params, self._LAYOUT_HOLDER_ATTR, cache)
+        return cache
+
+    @staticmethod
+    def _memoized(cache: Optional[dict], key: tuple, build):
+        """Return ``cache[key]``, building it on first use. No-op when cache is None."""
+        if cache is None:
+            return build()
+        if key not in cache:
+            cache[key] = build()
+        return cache[key]
 
     def backward_dw(self):
         """Compute the deferred weight gradients (delay_wgrad_compute) of the indexer."""
@@ -2122,11 +2168,21 @@ class DSAttention(MegatronModule):
         nonpacked_query_positions = None
         kv_reorder_idx = None
         single_packed_thd_sequence = False
+        # Layout metadata is identical for every layer in a microbatch; memoize it on
+        # the per-microbatch PackedSeqParams so only the first DSA layer pays for it.
+        layout_cache = self._get_packed_cp_layout_cache(packed_seq_params)
         if packed_thd:
             cu_seqlens_q, cu_seqlens_kv = dsa_layout.get_packed_qk_cu_seqlens(packed_seq_params)
-            single_packed_thd_sequence = (
-                cp_size > 1 and cu_seqlens_q.numel() == 2 and cu_seqlens_kv.numel() == 2
-            )
+            # Host copies of the compacted cu_seqlens, stored by
+            # prebuild_thd_cp_partition_routes at batch-construction time. When
+            # present, the layout builders below run entirely on the host: no
+            # kernels, no device readbacks, one async copy of the finished table.
+            host_cu_q = getattr(packed_seq_params, "thd_cp_host_cu_seqlens_q", None)
+            host_cu_kv = getattr(packed_seq_params, "thd_cp_host_cu_seqlens_kv", None)
+            # Whether the pack holds one sequence is a fact about the pack, not about
+            # context parallelism; which kernels accept that layout is the scoring
+            # plan's decision. Consumers that genuinely need CP already test cp_size.
+            single_packed_thd_sequence = cu_seqlens_q.numel() == 2 and cu_seqlens_kv.numel() == 2
             packed_query_output_size = (
                 sequence_parallel_tp_full_rows if sequence_parallel_tp else sq
             )
@@ -2137,12 +2193,26 @@ class DSAttention(MegatronModule):
                     row_start, row_start + sq, dtype=torch.int64, device=query.device
                 )
             elif sequence_parallel_tp and cp_size > 1:
-                packed_query_positions_full = dsa_layout.build_packed_allgather_cp_local_positions(
-                    cu_seqlens_q,
-                    cp_size,
-                    cp_rank,
-                    query.device,
-                    output_size=packed_query_output_size,
+                packed_query_positions_full = self._memoized(
+                    layout_cache,
+                    ("local_positions", cp_size, cp_rank, packed_query_output_size),
+                    lambda: (
+                        _build_cp_positions_from_host(
+                            host_cu_q,
+                            cp_size,
+                            cp_rank,
+                            query.device,
+                            output_size=packed_query_output_size,
+                        )
+                        if host_cu_q is not None
+                        else dsa_layout.build_packed_allgather_cp_local_positions(
+                            cu_seqlens_q,
+                            cp_size,
+                            cp_rank,
+                            query.device,
+                            output_size=packed_query_output_size,
+                        )
+                    ),
                 )
                 if sequence_parallel_query_is_local:
                     row_start = sequence_parallel_tp_row_start
@@ -2162,19 +2232,45 @@ class DSAttention(MegatronModule):
                     and isinstance(packed_seq_params.max_seqlen_kv, int)
                     and packed_seq_params.max_seqlen_kv == packed_global_output_size
                 )
-                packed_query_positions, kv_reorder_idx = (
-                    dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
-                        cu_seqlens_q=cu_seqlens_q,
-                        cu_seqlens_kv=cu_seqlens_kv,
-                        cp_size=cp_size,
-                        cp_rank=cp_rank,
-                        device=query.device,
-                        local_output_size=packed_query_output_size,
-                        key_local_output_size=packed_query_output_size,
-                        global_output_size=packed_global_output_size,
-                        query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
-                        key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
-                    )
+                packed_query_positions, kv_reorder_idx = self._memoized(
+                    layout_cache,
+                    (
+                        "positions_and_reorder",
+                        cp_size,
+                        cp_rank,
+                        packed_query_output_size,
+                        packed_query_output_size,
+                        packed_global_output_size,
+                        query_cu_seqlens_cover_output,
+                        key_cu_seqlens_cover_output,
+                    ),
+                    lambda: (
+                        _cp_reorder_from_host(
+                            host_cu_q,
+                            host_cu_kv,
+                            cp_size=cp_size,
+                            cp_rank=cp_rank,
+                            device=query.device,
+                            local_output_size=packed_query_output_size,
+                            key_local_output_size=packed_query_output_size,
+                            global_output_size=packed_global_output_size,
+                            query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+                            key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+                        )
+                        if host_cu_q is not None and host_cu_kv is not None
+                        else dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
+                            cu_seqlens_q=cu_seqlens_q,
+                            cu_seqlens_kv=cu_seqlens_kv,
+                            cp_size=cp_size,
+                            cp_rank=cp_rank,
+                            device=query.device,
+                            local_output_size=packed_query_output_size,
+                            key_local_output_size=packed_query_output_size,
+                            global_output_size=packed_global_output_size,
+                            query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+                            key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+                        )
+                    ),
                 )
             if packed_query_positions is not None:
                 packed_query_positions = packed_query_positions.contiguous()
@@ -2182,7 +2278,6 @@ class DSAttention(MegatronModule):
             _validate_nonpacked_cp_uniform_length(
                 sq=sq, skv=key.size(0), cp_size=cp_size, cp_group=cp_group, device=query.device
             )
-
         if sequence_parallel_tp:
             if key.size(0) == local_sequence_rows:
                 key = gather_from_sequence_parallel_region(key, group=tp_group)
@@ -2215,15 +2310,45 @@ class DSAttention(MegatronModule):
             # Gather local-sequence tensors, then undo MCore's zigzag rank order.
             def _build_kv_reorder_idx(local_len):
                 if packed_thd:
-                    _, idx = dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
-                        cu_seqlens_q=cu_seqlens_q,
-                        cu_seqlens_kv=cu_seqlens_kv,
-                        cp_size=cp_size,
-                        cp_rank=cp_rank,
-                        device=query.device,
-                        local_output_size=local_len,
-                        key_local_output_size=local_len,
-                        global_output_size=local_len * cp_size,
+                    # Same memo key shape as the branch above, so when the output sizes
+                    # coincide this reuses that result instead of rerunning the cp_size loop.
+                    _, idx = self._memoized(
+                        layout_cache,
+                        (
+                            "positions_and_reorder",
+                            cp_size,
+                            cp_rank,
+                            local_len,
+                            local_len,
+                            local_len * cp_size,
+                            False,
+                            False,
+                        ),
+                        lambda: (
+                            _cp_reorder_from_host(
+                                host_cu_q,
+                                host_cu_kv,
+                                cp_size=cp_size,
+                                cp_rank=cp_rank,
+                                device=query.device,
+                                local_output_size=local_len,
+                                key_local_output_size=local_len,
+                                global_output_size=local_len * cp_size,
+                            )
+                            if host_cu_q is not None and host_cu_kv is not None
+                            else (
+                                dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder
+                            )(
+                                cu_seqlens_q=cu_seqlens_q,
+                                cu_seqlens_kv=cu_seqlens_kv,
+                                cp_size=cp_size,
+                                cp_rank=cp_rank,
+                                device=query.device,
+                                local_output_size=local_len,
+                                key_local_output_size=local_len,
+                                global_output_size=local_len * cp_size,
+                            )
+                        ),
                     )
                     return idx
                 return dsa_layout.build_zigzag_allgather_cp_key_reorder(
@@ -2328,9 +2453,11 @@ class DSAttention(MegatronModule):
         )
         use_fused_kernels = dsa_kernels.use_fused_dsa_kernels(self.config)
         sparse_indexer_loss = self.config.dsa_indexer_use_sparse_loss
+        # Reports a packed causal layout with identity key positions. CP size is an
+        # independent geometry fact; the scoring plan and packed metadata eligibility
+        # decide which executor can safely consume the layout.
         use_local_indexer_varlen = (
             packed_thd
-            and cp_size > 1
             and attn_mask_type == AttnMaskType.causal
             and varlen_starts is not None
             and varlen_ends is not None
@@ -2555,6 +2682,7 @@ class DSAttention(MegatronModule):
                     local_packed_cp_query_len=local_packed_cp_query_len,
                     packed_seq_params=packed_seq_params,
                     cp_size=cp_size,
+                    varlen_is_plain_causal=varlen_is_plain_causal,
                 )
                 if fused_topk_with_loss is not None:
                     topk_indices, topk_length, indexer_loss = fused_topk_with_loss
@@ -2601,6 +2729,7 @@ class DSAttention(MegatronModule):
                     local_packed_cp_query_len=local_packed_cp_query_len,
                     packed_seq_params=packed_seq_params,
                     cp_size=cp_size,
+                    varlen_is_plain_causal=varlen_is_plain_causal,
                 )
                 if fused_topk is not None:
                     topk_indices, topk_length = fused_topk

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -153,6 +153,7 @@ def _run_sparse_attention(
     varlen_ends: Optional[torch.Tensor],
     key_positions: Optional[torch.Tensor],
     topk_length: Optional[torch.Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> torch.Tensor:
     """Run sparse attention for absorbed and non-absorbed MLA paths."""
     if absorbed_mla:
@@ -180,6 +181,7 @@ def _run_sparse_attention(
                 softmax_scale,
                 latent_v_channels,
                 topk_length=topk_length,
+                all_topk_rows_nonempty=all_topk_rows_nonempty,
             )
         # Fused backends may decline unsupported shapes or layouts by returning
         # None, so keep the absorbed PyTorch path as the authoritative fallback.
@@ -2759,6 +2761,18 @@ class DSAttention(MegatronModule):
         # ===================================
         # Run sparse attention kernel
         # ===================================
+        all_topk_rows_nonempty = dsa_masking.can_prove_all_topk_rows_nonempty(
+            computes_topk=computes_topk,
+            indexer_topk=self.index_topk,
+            kv_sequence_length=skv,
+            attention_mask=attention_mask,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            use_local_indexer_varlen=use_local_indexer_varlen,
+            varlen_starts=varlen_starts,
+            varlen_ends=varlen_ends,
+            key_positions=key_positions,
+        )
         output = _run_sparse_attention(
             absorbed_mla=absorbed_mla,
             query=query,
@@ -2773,6 +2787,7 @@ class DSAttention(MegatronModule):
             varlen_starts=varlen_starts,
             varlen_ends=varlen_ends,
             key_positions=key_positions,
+            all_topk_rows_nonempty=all_topk_rows_nonempty,
         )
 
         if use_indexer_loss:

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -348,6 +348,16 @@ def _get_topk_alignment() -> int:
     raise RuntimeError(f"cudnn fused DSA requires SM90+ (Hopper or later), got SM{sm[0]}{sm[1]}.")
 
 
+def _get_score_recompute_topk_alignment() -> int:
+    """Minimum top-K alignment required by cuDNN sparse score recompute."""
+    sm = _current_sm()
+    if sm[0] >= 10:
+        return 64
+    if sm[0] >= 9:
+        return 128
+    raise RuntimeError(f"cudnn fused DSA requires SM90+ (Hopper or later), got SM{sm[0]}{sm[1]}.")
+
+
 def _flash_mla_head_padding(num_heads: int) -> Optional[int]:
     """Padded query-head count FlashMLA supports for ``num_heads``, or None if unsupported.
 
@@ -771,13 +781,30 @@ def _packed_thd_kernel_applicable(
         or packed_cu_seqlens_q.numel() < 2
     ):
         return False
+    same_view = packed_cu_seqlens_q.device == packed_cu_seqlens_k.device and (
+        packed_cu_seqlens_q is packed_cu_seqlens_k
+        or (
+            packed_cu_seqlens_q.data_ptr() == packed_cu_seqlens_k.data_ptr()
+            and packed_cu_seqlens_q.storage_offset() == packed_cu_seqlens_k.storage_offset()
+            and packed_cu_seqlens_q.stride() == packed_cu_seqlens_k.stride()
+        )
+    )
+    same_boundaries = same_view or (
+        not packed_cu_seqlens_q.is_cuda
+        and not packed_cu_seqlens_k.is_cuda
+        and torch.equal(packed_cu_seqlens_q, packed_cu_seqlens_k)
+    )
+    # The packed scorer restores sequence-local top-k indices with the Q-derived
+    # row bounds. Differing K boundaries would silently map selected columns into
+    # another packed sequence, so decline unless equality is provable without a
+    # CUDA synchronization. Canonical self-attention schedulers preserve aliases.
+    if not same_boundaries:
+        return False
     if cp_size > 1:
         return sk % (2 * cp_size) == 0
 
-    # The CP1 path forwards cu-seqlens directly to cuDNN, so prove both kernel
-    # readiness and equality without synchronizing a CUDA tensor. Q boundaries are
-    # also used to restore sequence-local top-k indices; differing K boundaries would
-    # therefore produce incorrect global indices.
+    # The CP1 path forwards cu-seqlens directly to cuDNN, so prove its stricter
+    # device, dtype, maximum-length, and contiguity requirements as well.
     if (
         packed_cu_seqlens_q.device != device
         or packed_cu_seqlens_k.device != device
@@ -789,14 +816,7 @@ def _packed_thd_kernel_applicable(
         or not packed_cu_seqlens_k.is_contiguous()
     ):
         return False
-    same_view = packed_cu_seqlens_q is packed_cu_seqlens_k or (
-        packed_cu_seqlens_q.data_ptr() == packed_cu_seqlens_k.data_ptr()
-        and packed_cu_seqlens_q.storage_offset() == packed_cu_seqlens_k.storage_offset()
-        and packed_cu_seqlens_q.stride() == packed_cu_seqlens_k.stride()
-    )
-    if same_view:
-        return True
-    return not packed_cu_seqlens_q.is_cuda and torch.equal(packed_cu_seqlens_q, packed_cu_seqlens_k)
+    return True
 
 
 def _indexer_topk_packed_thd(
@@ -1862,6 +1882,14 @@ def _compute_attn_target(
     """
     _ensure_dsa_namespace()
     q_attn_bshd, lse, qhead_per_kv_head = _pad_attn_target_heads(q_attn_bshd, lse)
+    logical_topk = topk_indices.size(-1)
+    if topk_indices.is_cuda:
+        topk_alignment = _get_score_recompute_topk_alignment()
+        padded_topk = round_up_to_nearest_multiple(logical_topk, topk_alignment)
+        if padded_topk != logical_topk:
+            topk_indices = torch.nn.functional.pad(
+                topk_indices, (0, padded_topk - logical_topk), value=-1
+            )
     kwargs = {"qhead_per_kv_head": qhead_per_kv_head, "topk_indices_global": False}
     if topk_length is not None:
         kwargs["topk_length"] = topk_length.to(dtype=torch.int32, device=topk_indices.device)
@@ -1873,7 +1901,7 @@ def _compute_attn_target(
         softmax_scale,
         **kwargs,
     )
-    return result["target"].contiguous()
+    return result["target"][..., :logical_topk].contiguous()
 
 
 def _dense_attn_lse_chunk_rows(b: int, qhead_per_kv_head: int, sk: int, sq: int) -> int:

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -254,10 +254,14 @@ def run_fused_dsa_attention(
         packed_thd_single_sequence=packed_thd_single_sequence,
     )
     _assert_supported_indexer_scoring(use_relu)
+    # A nonpositive top-k or empty KV has no valid slot for the fixed-shape
+    # backward safe tile, so decline instead of entering the fused path.
     if (
         not absorbed_mla
         or value is not None
         or attn_mask_type != AttnMaskType.causal
+        or indexer_topk <= 0
+        or key.size(0) == 0
         or key.size(2) != 1
     ):
         return None
@@ -2352,9 +2356,9 @@ def _run_sparse_attention_backward(
     d: int,
     skv: int,
     grad_output: Tensor,
-    all_rows_nonempty: bool = False,
+    all_topk_rows_nonempty: bool = False,
 ) -> Tuple[Tensor, Tensor]:
-    """Run sparse attention backward, skipping rows that have no valid top-k entries."""
+    """Run sparse attention backward with fixed-shape handling for empty top-k rows."""
     d_v = out_flat.shape[-1]
     dO_flat = grad_output.reshape(sq * b, num_heads, d_v)
 
@@ -2383,56 +2387,31 @@ def _run_sparse_attention_backward(
         bwd_attn_sink[:num_heads] = attn_sink
 
     _ensure_dsa_namespace()
-    if all_rows_nonempty:
-        attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-            bwd_q_flat,
-            kv_flat,
-            bwd_out_flat,
-            bwd_dO_flat,
-            bwd_lse,
-            bwd_attn_sink,
-            global_idxs,
-            softmax_scale=softmax_scale,
-            topk_length=topk_length,
-        )
-        grad_query_flat = attn_bwd["dq"]
-        if padded_num_heads != num_heads:
-            grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
-        grad_kv_flat = attn_bwd["dkv"]
-        grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
-        grad_kv_full = grad_kv_flat.reshape(skv, b, kv_flat.size(-1))
-        return grad_query, grad_kv_full
-
-    valid_row_indices = torch.nonzero(topk_length > 0, as_tuple=False).flatten()
-    dummy_row_index = torch.full(
-        (1,), bwd_q_flat.size(0), dtype=valid_row_indices.dtype, device=valid_row_indices.device
-    )
-    compact_row_indices = torch.cat((valid_row_indices, dummy_row_index), dim=0)
-
-    # Add one zero-gradient row so the cuDNN wrapper never receives an empty query batch.
-    bwd_q_flat = torch.cat((bwd_q_flat, torch.zeros_like(bwd_q_flat[:1])), dim=0)
-    bwd_out_flat = torch.cat((bwd_out_flat, torch.zeros_like(bwd_out_flat[:1])), dim=0)
-    bwd_dO_flat = torch.cat((bwd_dO_flat, torch.zeros_like(bwd_dO_flat[:1])), dim=0)
-    bwd_lse = torch.cat((bwd_lse, torch.zeros_like(bwd_lse[:1])), dim=0)
-    global_idxs = torch.cat((global_idxs, torch.zeros_like(global_idxs[:1])), dim=0)
-    topk_length = torch.cat((topk_length, torch.ones_like(topk_length[:1])), dim=0)
+    empty_rows = None
+    if not all_topk_rows_nonempty:
+        empty_rows = topk_length <= 0
+        topk_length = topk_length.masked_fill(empty_rows, 1)
+        bwd_dO_flat = bwd_dO_flat.masked_fill(empty_rows[:, None, None], 0)
+        # FlashMLA already returns zero output and LSE=+inf for empty rows. Preserve
+        # that LSE invariant after promoting them to one safe tile so probabilities stay zero.
+        bwd_lse = bwd_lse.masked_fill(empty_rows[:, None], float("inf"))
 
     attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-        bwd_q_flat.index_select(0, compact_row_indices).contiguous(),
+        bwd_q_flat,
         kv_flat,
-        bwd_out_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_dO_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_lse.index_select(0, compact_row_indices).contiguous(),
+        bwd_out_flat,
+        bwd_dO_flat,
+        bwd_lse,
         bwd_attn_sink,
-        global_idxs.index_select(0, compact_row_indices).contiguous(),
+        global_idxs,
         softmax_scale=softmax_scale,
-        topk_length=topk_length.index_select(0, compact_row_indices).contiguous(),
+        topk_length=topk_length,
     )
-    grad_query_valid = attn_bwd["dq"][:-1]
+    grad_query_flat = attn_bwd["dq"]
     if padded_num_heads != num_heads:
-        grad_query_valid = grad_query_valid[:, :num_heads, :].contiguous()
-    grad_query_flat = torch.zeros_like(q_flat)
-    grad_query_flat.index_copy_(0, valid_row_indices, grad_query_valid)
+        grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
+    if empty_rows is not None:
+        grad_query_flat.masked_fill_(empty_rows[:, None, None], 0)
     grad_kv_flat = attn_bwd["dkv"]
 
     grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
@@ -2540,6 +2519,28 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             )
         )
 
+        # Plain-causal bounds are normalized to None before this low-level entry;
+        # full fusion also implies the helper's computes-top-k and no-mask gates.
+        normalized_plain_causal = (
+            varlen_starts is None and varlen_ends is None and key_positions is None
+        )
+        all_topk_rows_nonempty = dsa_masking.can_prove_all_topk_rows_nonempty(
+            computes_topk=True,
+            indexer_topk=effective_topk,
+            kv_sequence_length=skv,
+            attention_mask=None,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=normalized_plain_causal,
+            use_local_indexer_varlen=use_local_indexer_varlen,
+            varlen_starts=varlen_starts,
+            varlen_ends=varlen_ends,
+            key_positions=key_positions,
+        )
+        if not all_topk_rows_nonempty:
+            # The dummy may reference any in-range global KV row: backward forces
+            # dO=0 and LSE=+inf, so this tile contributes no gradient across batches.
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
+
         if need_indexer_loss:
             if sparse_loss:
                 if indexer_score_payload is None:
@@ -2623,13 +2624,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
-        ctx.all_sparse_bwd_rows_nonempty = (
-            query_valid_rows is None
-            and use_local_indexer_varlen
-            and varlen_starts is not None
-            and varlen_ends is not None
-            and key_positions is None
-        )
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         output = out_flat.reshape(sq, b, num_heads, d_v).reshape(sq, b, num_heads * d_v)
         return output, indexer_loss
@@ -2667,7 +2662,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
-            all_rows_nonempty=ctx.all_sparse_bwd_rows_nonempty,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
         if ctx.has_precomputed_indexer_grads and grad_loss is not None:
@@ -2881,6 +2876,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         softmax_scale: float,
         d_v: int,
         topk_length: Optional[Tensor],
+        all_topk_rows_nonempty: bool,
     ) -> Tensor:
         """Run fused sparse attention for precomputed top-k metadata."""
         sq, b, num_heads, d = query.shape
@@ -2890,6 +2886,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
                 query, kv_full, topk_indices, softmax_scale, d_v, topk_length=topk_length
             )
         )
+        if not all_topk_rows_nonempty:
+            # The dummy may reference any in-range global KV row: backward forces
+            # dO=0 and LSE=+inf, so this tile contributes no gradient across batches.
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
 
         ctx.save_for_backward(q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse)
         ctx.softmax_scale = softmax_scale
@@ -2899,6 +2899,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         return out_flat.reshape(sq, b, num_heads, d_v)
 
@@ -2924,9 +2925,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
-        return grad_query, grad_kv_full, None, None, None, None
+        return grad_query, grad_kv_full, None, None, None, None, None
 
 
 def run_fused_absorbed_sparse_attention(
@@ -2936,11 +2938,13 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Run cuDNN/FlashMLA sparse attention using externally supplied top-k indices."""
     if query.ndim != 4 or key.ndim != 4 or topk_indices.ndim != 3:
         return None
-    if key.size(2) != 1 or v_channels <= 0:
+    # Empty KV or zero-width top-k cannot provide a valid fixed-shape backward safe tile.
+    if key.size(0) == 0 or key.size(2) != 1 or topk_indices.size(2) == 0 or v_channels <= 0:
         return None
     if query.size(0) != topk_indices.size(1) or query.size(1) != topk_indices.size(0):
         return None
@@ -2953,7 +2957,7 @@ def run_fused_absorbed_sparse_attention(
 
     kv_full = key.squeeze(2).contiguous()
     return FusedSparseAttentionFunc.apply(
-        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length
+        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length, all_topk_rows_nonempty
     )
 
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -11,10 +11,12 @@ import torch
 from torch import Tensor
 
 from megatron.core.transformer.enums import AttnMaskType
-from megatron.core.transformer.experimental_attention_variant import (
-    dsa_indexer_loss,
-    dsa_layout,
-    dsa_masking,
+from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_masking
+from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+    IndexerScoringDecision,
+    IndexerScoringPlan,
+    report_unfused_scoring_once,
+    resolve_indexer_scoring_plan,
 )
 from megatron.core.utils import get_pg_size, round_up_to_nearest_multiple
 
@@ -153,26 +155,29 @@ def _supports_flash_mla_value_layout(kv_width: int, d_v: int) -> bool:
     return d_v == _FLASH_MLA_REQUIRED_VALUE_DIM and kv_width >= _FLASH_MLA_REQUIRED_VALUE_DIM
 
 
-def _get_multi_packed_cp_thd_metadata(
-    use_local_indexer_varlen: bool,
-    packed_seq_params: Optional["PackedSeqParams"],
-    single_packed_thd_sequence: bool,
-    cp_size: int,
+def _get_packed_thd_metadata(
+    use_local_indexer_varlen: bool, packed_seq_params: Optional["PackedSeqParams"]
 ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[int], Optional[int]]:
-    """Return packed metadata needed by the cuDNN multi-sequence THD indexer."""
-    if (
-        not use_local_indexer_varlen
-        or packed_seq_params is None
-        or single_packed_thd_sequence
-        or cp_size <= 1
-    ):
+    """Return packed metadata needed by the general cuDNN THD indexer."""
+    if not use_local_indexer_varlen or packed_seq_params is None:
         return None, None, None, None
-    cu_seqlens_q, cu_seqlens_k = dsa_layout.get_packed_qk_cu_seqlens(packed_seq_params)
+    cu_seqlens_q = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+    if cu_seqlens_q is None:
+        cu_seqlens_q = getattr(packed_seq_params, "cu_seqlens_q", None)
+    cu_seqlens_k = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+    if cu_seqlens_k is None:
+        cu_seqlens_k = getattr(packed_seq_params, "cu_seqlens_kv", None)
+    if cu_seqlens_q is None:
+        cu_seqlens_q = cu_seqlens_k
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    if cu_seqlens_q is None:
+        return None, None, None, None
     return (
         cu_seqlens_q,
         cu_seqlens_k,
-        packed_seq_params.max_seqlen_q,
-        packed_seq_params.max_seqlen_kv,
+        getattr(packed_seq_params, "max_seqlen_q", None),
+        getattr(packed_seq_params, "max_seqlen_kv", None),
     )
 
 
@@ -224,19 +229,19 @@ def run_fused_dsa_attention(
         return None
     if not torch.is_grad_enabled():
         loss_coeff = 0.0
-    # build_dsattention_forward_mask emits explicit varlen bounds even for the plain (non-packed,
-    # non-CP) causal case and flags them via ``varlen_is_plain_causal``. Those bounds are exactly
-    # equivalent to the no-varlen causal path the dense fused indexer loss was written for, so
-    # normalize them back to None: plain causal then takes the same fused path (relying on the
-    # kernel's internal causal masking) it took before that mask change, instead of declining
-    # dense loss and falling back to the slow reference-loss path. The flag carries the mask
-    # builder's structural knowledge, so we avoid the per-forward host/device sync a ``torch.equal``
-    # bounds comparison would force on this common path. Genuine packed/CP/custom-position varlen
-    # is left untouched (``varlen_is_plain_causal`` is False there) and is gated below, where it
-    # would otherwise trip the padded-row assert in FusedIndexerSparseAttnFunc.forward.
-    if cp_size == 1 and packed_seq_params is None and varlen_is_plain_causal:
-        varlen_starts = None
-        varlen_ends = None
+    # Plain causal bounds are equivalent to the no-varlen causal path the dense fused indexer
+    # loss was written for, so normalize them away: plain causal then takes the same fused path
+    # (relying on the kernel's internal causal masking) it took before that mask change, instead
+    # of declining dense loss and falling back to the slow reference-loss path. Genuine
+    # packed/CP/custom-position varlen is left untouched and is gated below, where it would
+    # otherwise trip the padded-row assert in FusedIndexerSparseAttnFunc.forward.
+    varlen_starts, varlen_ends = _normalize_plain_causal_bounds(
+        varlen_starts,
+        varlen_ends,
+        cp_size=cp_size,
+        packed_seq_params=packed_seq_params,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+    )
     has_varlen = varlen_starts is not None or varlen_ends is not None or key_positions is not None
     if has_varlen:
         if varlen_starts is None or varlen_ends is None:
@@ -260,9 +265,7 @@ def run_fused_dsa_attention(
     sq, b, num_heads, _ = query.size()
     kv_full = key.squeeze(2).contiguous()
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     packed_thd_kwargs = {}
     if packed_cu_seqlens_q is not None:
@@ -413,6 +416,36 @@ def _bytes_to_chunk_rows(n_rows: int, bytes_per_row: int, max_bytes: int, alignm
 def _causal_seq_lens(q_positions: Tensor, ratio: int, sk: int) -> Tensor:
     """Per-query causal key length under the indexer ``ratio``, clamped to ``sk``."""
     return ((q_positions + 1) // ratio).clamp(max=sk)
+
+
+def _normalize_plain_causal_bounds(
+    starts: Optional[Tensor],
+    ends: Optional[Tensor],
+    *,
+    cp_size: int,
+    packed_seq_params: Optional["PackedSeqParams"],
+    varlen_is_plain_causal: bool,
+) -> Tuple[Optional[Tensor], Optional[Tensor]]:
+    """Drop plain-causal varlen bounds so the single-kernel indexer scorer stays reachable.
+
+    ``build_dsattention_forward_mask`` emits explicit bounds even for the plain
+    (non-packed, non-CP) causal case and flags them via ``varlen_is_plain_causal``.
+    Those bounds are ``starts = 0`` and ``ends = arange(1, sq + 1).clamp(max=sk)``,
+    which is exactly what :func:`_causal_seq_lens` reconstructs internally under
+    ``_INDEXER_RATIO == 1``. Returning ``None`` here is therefore a no-op on
+    semantics, but it lets :func:`_indexer_topk_bshd` take its ``starts is None``
+    branch, which reaches the fused single-kernel ``indexer_forward_wrapper``
+    instead of the per-head scoring loop in
+    :func:`_compute_indexer_scores_chunk_with_global_rows`.
+
+    The flag carries the mask builder's structural knowledge, so we avoid the
+    per-forward host/device sync that a ``torch.equal`` bounds comparison would
+    force on this common path. Genuine packed/CP/custom-position varlen is left
+    untouched (``varlen_is_plain_causal`` is False there).
+    """
+    if cp_size == 1 and packed_seq_params is None and varlen_is_plain_causal:
+        return None, None
+    return starts, ends
 
 
 def _topk_tie_break_bias(positions: Tensor, key_count: int, dtype: torch.dtype) -> Tensor:
@@ -695,7 +728,78 @@ def _pad_topk_result(
     return topk_indices, topk_scores
 
 
-def _indexer_topk_multi_packed_cp_thd(
+def _packed_thd_kernel_applicable(
+    *,
+    b: int,
+    sq: int,
+    sk: int,
+    device: torch.device,
+    packed_cu_seqlens_q: Optional[Tensor],
+    packed_cu_seqlens_k: Optional[Tensor],
+    packed_max_seqlen_q: Optional[int],
+    packed_max_seqlen_k: Optional[int],
+    cp_size: int,
+    cp_rank: int,
+    local_packed_cp_query_start: int,
+    local_packed_cp_query_len: Optional[int],
+) -> bool:
+    """Whether the general THD scorer can safely consume this metadata.
+
+    This check is intentionally limited to structural facts available without reading a
+    CUDA tensor on the host. Value-level validation remains the packed-layout builder's
+    responsibility; doing it here would put a synchronization back in the layer hot path.
+    """
+    if (
+        b != 1
+        or cp_size < 1
+        or not 0 <= cp_rank < cp_size
+        or sk != sq * cp_size
+        or local_packed_cp_query_start != 0
+        or local_packed_cp_query_len not in (None, sq)
+        or packed_cu_seqlens_q is None
+        or packed_cu_seqlens_k is None
+        or packed_max_seqlen_q is None
+        or packed_max_seqlen_k is None
+        or packed_max_seqlen_q <= 0
+        or packed_max_seqlen_k <= 0
+    ):
+        return False
+    if (
+        packed_cu_seqlens_q.ndim != 1
+        or packed_cu_seqlens_k.ndim != 1
+        or packed_cu_seqlens_q.shape != packed_cu_seqlens_k.shape
+        or packed_cu_seqlens_q.numel() < 2
+    ):
+        return False
+    if cp_size > 1:
+        return sk % (2 * cp_size) == 0
+
+    # The CP1 path forwards cu-seqlens directly to cuDNN, so prove both kernel
+    # readiness and equality without synchronizing a CUDA tensor. Q boundaries are
+    # also used to restore sequence-local top-k indices; differing K boundaries would
+    # therefore produce incorrect global indices.
+    if (
+        packed_cu_seqlens_q.device != device
+        or packed_cu_seqlens_k.device != device
+        or packed_cu_seqlens_q.dtype != torch.int32
+        or packed_cu_seqlens_k.dtype != torch.int32
+        or packed_max_seqlen_q != packed_max_seqlen_k
+        or packed_max_seqlen_q > sq
+        or not packed_cu_seqlens_q.is_contiguous()
+        or not packed_cu_seqlens_k.is_contiguous()
+    ):
+        return False
+    same_view = packed_cu_seqlens_q is packed_cu_seqlens_k or (
+        packed_cu_seqlens_q.data_ptr() == packed_cu_seqlens_k.data_ptr()
+        and packed_cu_seqlens_q.storage_offset() == packed_cu_seqlens_k.storage_offset()
+        and packed_cu_seqlens_q.stride() == packed_cu_seqlens_k.stride()
+    )
+    if same_view:
+        return True
+    return not packed_cu_seqlens_q.is_cuda and torch.equal(packed_cu_seqlens_q, packed_cu_seqlens_k)
+
+
+def _indexer_topk_packed_thd(
     q_bshd: Tensor,
     k_bshd: Tensor,
     w_bsh: Tensor,
@@ -709,72 +813,98 @@ def _indexer_topk_multi_packed_cp_thd(
     packed_max_seqlen_k: int,
     cp_size: int,
     cp_rank: int,
+    local_packed_cp_query_start: int,
+    local_packed_cp_query_len: Optional[int],
 ) -> Tuple[Tensor, Optional[Tensor]]:
-    """Run cuDNN's THD indexer on packed CP front/back query segments."""
+    """Run cuDNN's general THD indexer for packed sequences at any CP size.
+
+    At CP1 the original packed Q/K/W tensors and cu-seqlens are passed directly to
+    cuDNN in one call. CP>1 retains the front/back segmented representation required by
+    zigzag context parallelism. Top-k selection and sequence-local to global index
+    restoration are shared by both representations.
+    """
     b, sq, _idx_nh, _idx_hd = q_bshd.shape
     sk = k_bshd.size(1)
-    if b != 1 or cp_size <= 1 or not 0 <= cp_rank < cp_size:
-        raise RuntimeError("packed CP cuDNN THD indexer requires b=1 and a valid CP rank")
-    if packed_cu_seqlens_q.numel() < 3:
-        raise RuntimeError(
-            "multi-sequence packed CP cuDNN THD indexer requires at least two sequences"
-        )
-    if packed_cu_seqlens_q.shape != packed_cu_seqlens_k.shape:
-        raise RuntimeError("packed CP cuDNN THD query/key cu_seqlens shapes must match")
-    if packed_max_seqlen_q <= 0 or packed_max_seqlen_k <= 0:
-        raise RuntimeError("packed CP cuDNN THD indexer requires positive maximum sequence lengths")
-
-    segment_divisor = 2 * cp_size
-    device = q_bshd.device
-    layout = dsa_layout.build_packed_cp_indexer_layout(
-        packed_cu_seqlens_q.to(device=device),
-        packed_cu_seqlens_k.to(device=device),
+    if not _packed_thd_kernel_applicable(
+        b=b,
+        sq=sq,
+        sk=sk,
+        device=q_bshd.device,
+        packed_cu_seqlens_q=packed_cu_seqlens_q,
+        packed_cu_seqlens_k=packed_cu_seqlens_k,
+        packed_max_seqlen_q=packed_max_seqlen_q,
+        packed_max_seqlen_k=packed_max_seqlen_k,
         cp_size=cp_size,
         cp_rank=cp_rank,
-        key_size=sk,
-    )
-    segmented_k = k_bshd[0].index_select(0, layout.source_indices).contiguous()
+        local_packed_cp_query_start=local_packed_cp_query_start,
+        local_packed_cp_query_len=local_packed_cp_query_len,
+    ):
+        raise RuntimeError("general packed THD scorer received incompatible layout metadata")
 
-    max_segment_q = packed_max_seqlen_q // segment_divisor
-    max_k_half = packed_max_seqlen_k // segment_divisor
-    max_segment_k = max((cp_rank + 1) * max_k_half, packed_max_seqlen_k - cp_rank * max_k_half)
+    device = q_bshd.device
+    if cp_size == 1:
+        score_q = q_bshd[0]
+        score_k = k_bshd[0]
+        score_w = w_bsh[0]
+        score_cu_q = packed_cu_seqlens_q
+        score_cu_k = packed_cu_seqlens_k
+        max_score_q = packed_max_seqlen_q
+        max_score_k = packed_max_seqlen_k
+    else:
+        segment_divisor = 2 * cp_size
+        layout = dsa_layout.build_packed_cp_indexer_layout(
+            packed_cu_seqlens_q.to(device=device),
+            packed_cu_seqlens_k.to(device=device),
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            key_size=sk,
+        )
+        score_q = q_bshd[0]
+        score_k = k_bshd[0].index_select(0, layout.source_indices).contiguous()
+        score_w = w_bsh[0]
+        score_cu_q = layout.segment_cu_q.to(dtype=torch.int32)
+        score_cu_k = layout.segment_cu_k.to(dtype=torch.int32)
+        max_score_q = packed_max_seqlen_q // segment_divisor
+        max_k_half = packed_max_seqlen_k // segment_divisor
+        max_score_k = max((cp_rank + 1) * max_k_half, packed_max_seqlen_k - cp_rank * max_k_half)
+
     scores = _cudnn_dsa.indexer_forward_wrapper(
-        q_bshd[0],
-        segmented_k,
-        w_bsh[0],
+        score_q,
+        score_k,
+        score_w,
         ratio=_INDEXER_RATIO,
         sm_scale=_INDEXER_SOFTMAX_SCALE,
-        cu_seqlens_q=layout.segment_cu_q.to(dtype=torch.int32),
-        cu_seqlens_k=layout.segment_cu_k.to(dtype=torch.int32),
-        max_seqlen_q=max_segment_q,
-        max_seqlen_k=max_segment_k,
+        cu_seqlens_q=score_cu_q,
+        cu_seqlens_k=score_cu_k,
+        max_seqlen_q=max_score_q,
+        max_seqlen_k=max_score_k,
     )["scores"]
 
-    segment_topk = min(topk_k, max_segment_k)
-    if segment_topk == max_segment_k:
+    score_topk = min(topk_k, max_score_k)
+    if score_topk == max_score_k:
         # Ranking is unnecessary when K covers every score column. This also
         # avoids cuDNN FE's vectorized-output restriction for large odd K.
-        topk_indices = torch.arange(segment_topk, dtype=torch.int32, device=device).view(
-            1, 1, segment_topk
+        topk_indices = torch.arange(score_topk, dtype=torch.int32, device=device).view(
+            1, 1, score_topk
         ) + starts.view(1, sq, 1).to(dtype=torch.int32)
-        topk_scores = scores.view(1, sq, segment_topk) if return_topk_scores else None
+        topk_scores = scores.view(1, sq, score_topk) if return_topk_scores else None
         return _pad_topk_result(topk_indices, topk_scores, topk_k)
 
-    local_seq_lens = (ends - starts).clamp(max=max_segment_k).to(torch.int32).contiguous()
-    use_tie_break = _use_dense_indexer_topk_tie_break(scores, segment_topk)
+    local_seq_lens = (ends - starts).clamp(max=max_score_k).to(torch.int32).contiguous()
+    use_tie_break = _use_dense_indexer_topk_tie_break(scores, score_topk)
     scores_for_topk = _add_indexer_topk_tie_break(scores, inplace=True) if use_tie_break else scores
     tk_result = _indexer_top_k_wrapper_chunked(
-        scores_for_topk, local_seq_lens, topk_k=segment_topk, return_topk_scores=return_topk_scores
+        scores_for_topk, local_seq_lens, topk_k=score_topk, return_topk_scores=return_topk_scores
     )
-    topk_indices = tk_result["indices"].view(1, sq, segment_topk)
+    topk_indices = tk_result["indices"].view(1, sq, score_topk)
     topk_scores = None
     if return_topk_scores:
         topk_scores = tk_result["values"]
         if topk_scores is None:
             raise RuntimeError("cuDNN indexer_top_k_wrapper did not return values.")
-        topk_scores = topk_scores.view(1, sq, segment_topk)
+        topk_scores = topk_scores.view(1, sq, score_topk)
         if use_tie_break:
-            topk_scores = _remove_indexer_topk_tie_break(topk_scores, topk_indices, max_segment_k)
+            topk_scores = _remove_indexer_topk_tie_break(topk_scores, topk_indices, max_score_k)
 
     valid = topk_indices >= 0
     topk_indices = torch.where(
@@ -789,6 +919,7 @@ def _indexer_topk_single_packed_cp_segments(
     w_bsh: Tensor,
     topk_k: int,
     return_topk_scores: bool,
+    cp_size: int,
     local_packed_cp_rank: int,
     local_packed_cp_query_start: int = 0,
     local_packed_cp_query_len: Optional[int] = None,
@@ -799,19 +930,28 @@ def _indexer_topk_single_packed_cp_segments(
     local_query_len = local_packed_cp_query_len if local_packed_cp_query_len is not None else sq
     local_query_start = local_packed_cp_query_start
     local_query_end = local_query_start + sq
-    if b != 1 or local_query_len % 2 != 0 or _INDEXER_RATIO != 1:
+    # Halving is what the zigzag context-parallel layout needs: every rank owns a front
+    # and a back chunk of equal length. A rank holding the whole sequence has no zigzag
+    # to undo, so it needs neither the split nor the even length that the split implies.
+    if not _segment_kernel_applicable(
+        b,
+        sq,
+        sk,
+        local_packed_cp_query_len,
+        cp_size,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+    ):
         raise RuntimeError(
-            "single packed CP cuDNN fast path requires b=1, even local query length, ratio=1"
-        )
-    if local_query_start < 0 or local_query_end > local_query_len:
-        raise RuntimeError(
-            "single packed CP cuDNN fast path received an invalid query slice: "
-            f"start={local_query_start}, sq={sq}, local_query_len={local_query_len}"
+            "single packed THD segment scorer received incompatible CP/query/key geometry"
         )
 
     half = local_query_len // 2
-    if sk == local_query_len:
-        segment_specs = ((0, half, half), (half, local_query_len, local_query_len))
+    if cp_size == 1:
+        # One causal segment over the whole local sequence; per-row key lengths are still
+        # built from arange inside the loop, so this is the same masking as the split form
+        # and it does not require an even length.
+        segment_specs = ((0, local_query_len, local_query_len),)
     else:
         segment_specs = (
             (0, half, (local_packed_cp_rank + 1) * half),
@@ -828,7 +968,7 @@ def _indexer_topk_single_packed_cp_segments(
         row_end = row_end_global - local_query_start
         if key_end <= 0 or key_end > sk:
             raise RuntimeError(
-                "single packed CP cuDNN fast path derived invalid key prefix: "
+                "single packed THD segment scorer derived invalid key prefix: "
                 f"key_end={key_end}, sk={sk}, cp_rank={local_packed_cp_rank}, sq={sq}"
             )
         segment_topk = min(topk_k, key_end)
@@ -859,7 +999,7 @@ def _indexer_topk_single_packed_cp_segments(
 
     if not indices_chunks:
         raise RuntimeError(
-            "single packed CP cuDNN fast path query slice did not intersect any CP segment"
+            "single packed THD segment scorer query slice did not intersect any segment"
         )
 
     return (
@@ -1073,6 +1213,88 @@ def _topk_in_bounds(
     return in_range & valid_bounds
 
 
+def _segment_kernel_applicable(
+    b: int,
+    sq: int,
+    sk: int,
+    local_packed_cp_query_len: Optional[int],
+    cp_size: int,
+    cp_rank: int,
+    local_packed_cp_query_start: int,
+) -> bool:
+    """Whether ``_indexer_topk_single_packed_cp_segments`` can take this shape.
+
+    That kernel raises rather than returning None when its preconditions fail, so the
+    scoring plan has to ask before promising it. Kept next to the kernel so the two
+    cannot drift apart.
+    """
+    local_query_len = local_packed_cp_query_len if local_packed_cp_query_len is not None else sq
+    if (
+        b != 1
+        or _INDEXER_RATIO != 1
+        or cp_size < 1
+        or not 0 <= cp_rank < cp_size
+        or local_query_len <= 0
+        or local_packed_cp_query_start < 0
+        or local_packed_cp_query_start + sq > local_query_len
+    ):
+        return False
+    # An odd local length only rules out the halved zigzag form; a rank holding the whole
+    # sequence takes the single-segment form, which has no parity requirement.
+    expected_key_len = local_query_len if cp_size == 1 else local_query_len * cp_size
+    if sk != expected_key_len:
+        return False
+    whole_sequence_local = cp_size == 1
+    if not whole_sequence_local and local_query_len % 2 != 0:
+        return False
+    if cp_size > 1:
+        half = local_query_len // 2
+        if (cp_rank + 1) * half > sk or sk - cp_rank * half <= 0:
+            return False
+    return True
+
+
+def _resolve_scoring_plan_for_call(
+    *,
+    starts: Optional[Tensor],
+    ends: Optional[Tensor],
+    varlen_is_plain_causal: bool,
+    packed_thd: bool,
+    cp_size: int,
+    use_local_indexer_varlen: bool,
+    single_packed_thd_sequence: bool,
+    packed_metadata_available: bool,
+    segment_kernel_applicable: bool = True,
+) -> IndexerScoringDecision:
+    """Map this call's layout facts onto a scoring plan.
+
+    ``use_local_indexer_varlen`` encodes "packed, causal, identity key positions" -- it
+    is how the caller reports a layout the packed kernels can accept. CP size is an
+    independent geometry fact consumed by the selected executor.
+    It is unpacked here rather than re-tested downstream, so each resolver argument
+    keeps exactly one meaning.
+    """
+    no_explicit_bounds = starts is None and ends is None
+    return resolve_indexer_scoring_plan(
+        bounds_available=no_explicit_bounds or (starts is not None and ends is not None),
+        varlen_is_plain_causal=varlen_is_plain_causal or no_explicit_bounds,
+        packed_thd=packed_thd,
+        cp_size=cp_size,
+        # Non-packed callers cannot report their mask type from here; they are
+        # treated as causal, so a non-causal non-packed layout lands on the generic
+        # "not reconstructible" reason rather than the dedicated non-causal one.
+        # Likewise packed_thd below is inferred from what the packed kernels could
+        # consume, so a packed layout no packed kernel claims is diagnosed with the
+        # non-packed reason. The dispatch outcome (UNFUSED_BOUNDS) is the same in
+        # every such case; only the diagnostic wording is generic.
+        mask_is_causal=use_local_indexer_varlen or not packed_thd,
+        explicit_key_positions=False,
+        single_sequence_pack=single_packed_thd_sequence,
+        packed_metadata_available=packed_metadata_available,
+        segment_kernel_applicable=segment_kernel_applicable,
+    )
+
+
 def _indexer_topk_bshd(
     q_bshd: Tensor,
     k_bsd: Tensor,
@@ -1093,6 +1315,7 @@ def _indexer_topk_bshd(
     packed_max_seqlen_q: Optional[int] = None,
     packed_max_seqlen_k: Optional[int] = None,
     packed_cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
     """BSHD-layout indexer scoring and top-K selection.
 
@@ -1110,10 +1333,9 @@ def _indexer_topk_bshd(
         * ``score_payload``: full scores when ``return_scores=True``, top-k
           scores when ``return_topk_scores=True``, otherwise ``None``.
 
-    ``use_local_indexer_varlen`` is an optimized packed-CP path for a single
-    packed sequence. It scores the local query rows directly instead of
-    scattering them to their global query positions first, then applies the
-    explicit starts/ends mask before top-k selection.
+    ``use_local_indexer_varlen`` identifies a packed causal identity-key layout. The
+    selected packed executor scores compact local query rows directly, then restores
+    sequence-local top-k indices to the global packed key coordinate space.
     """
     _ensure_dsa_namespace()
 
@@ -1140,7 +1362,46 @@ def _indexer_topk_bshd(
 
     k_bshd = k_bsd.unsqueeze(2)  # (b, sk, 1, idx_hd)
 
-    if starts is None:
+    scoring_plan = _resolve_scoring_plan_for_call(
+        segment_kernel_applicable=_segment_kernel_applicable(
+            b,
+            sq,
+            sk,
+            local_packed_cp_query_len,
+            packed_cp_size,
+            local_packed_cp_rank,
+            local_packed_cp_query_start,
+        ),
+        starts=starts,
+        ends=ends,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        packed_thd=use_local_indexer_varlen or packed_cu_seqlens_q is not None,
+        cp_size=packed_cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_metadata_available=_packed_thd_kernel_applicable(
+            b=b,
+            sq=sq,
+            sk=sk,
+            device=device,
+            packed_cu_seqlens_q=packed_cu_seqlens_q,
+            packed_cu_seqlens_k=packed_cu_seqlens_k,
+            packed_max_seqlen_q=packed_max_seqlen_q,
+            packed_max_seqlen_k=packed_max_seqlen_k,
+            cp_size=packed_cp_size,
+            cp_rank=local_packed_cp_rank,
+            local_packed_cp_query_start=local_packed_cp_query_start,
+            local_packed_cp_query_len=local_packed_cp_query_len,
+        ),
+    )
+    plan = scoring_plan.plan
+    report_unfused_scoring_once(scoring_plan, "indexer scoring")
+    if plan is IndexerScoringPlan.DECLINE:
+        raise RuntimeError(f"invalid DSA scoring dispatch: {scoring_plan.reason}")
+
+    # PLAIN_CAUSAL means the bounds, if any, are the trivial whole-sequence causal ones
+    # that ``_causal_seq_lens`` rebuilds exactly, so the single-kernel scorer applies.
+    if starts is None or plan is IndexerScoringPlan.PLAIN_CAUSAL:
         q_idx = torch.arange(sq, device=device)
         seq_lens = _causal_seq_lens(q_idx, _INDEXER_RATIO, sk).to(torch.int32).repeat(b)
         if not return_scores:
@@ -1155,26 +1416,20 @@ def _indexer_topk_bshd(
             ]  # (b, sq, sk) fp32, -inf on masked positions
     else:
         seq_lens = ends.clamp(max=sk).to(torch.int32).repeat(b)
-        if not return_scores and use_local_indexer_varlen and single_packed_thd_sequence:
+        if not return_scores and plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS:
             topk_indices, topk_scores = _indexer_topk_single_packed_cp_segments(
                 q_bshd,
                 k_bshd,
                 w_bsh,
                 topk_k,
                 return_topk_scores,
+                packed_cp_size,
                 local_packed_cp_rank,
                 local_packed_cp_query_start,
                 local_packed_cp_query_len,
             )
-        elif (
-            not return_scores
-            and use_local_indexer_varlen
-            and packed_cu_seqlens_q is not None
-            and packed_cu_seqlens_k is not None
-            and packed_max_seqlen_q is not None
-            and packed_max_seqlen_k is not None
-        ):
-            topk_indices, topk_scores = _indexer_topk_multi_packed_cp_thd(
+        elif not return_scores and plan is IndexerScoringPlan.PACKED_THD_GENERAL:
+            topk_indices, topk_scores = _indexer_topk_packed_thd(
                 q_bshd,
                 k_bshd,
                 w_bsh,
@@ -1188,6 +1443,8 @@ def _indexer_topk_bshd(
                 packed_max_seqlen_k,
                 packed_cp_size,
                 local_packed_cp_rank,
+                local_packed_cp_query_start,
+                local_packed_cp_query_len,
             )
         elif not return_scores:
             topk_indices, topk_scores = _indexer_topk_from_score_chunks(
@@ -1330,6 +1587,7 @@ def run_fused_qk_topk(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Tensor]]:
     """Run the cuDNN fused indexer and return top-k indices for split DSA."""
     _assert_supported_indexer_scoring(use_relu)
@@ -1340,13 +1598,14 @@ def run_fused_qk_topk(
         return None
     if q.size(2) != weights.size(2) or q.size(3) != k.size(2):
         return None
+    # Bounds the caller could not build at all are a genuine decline, which is a
+    # different thing from bounds that exist but describe a layout a fused kernel can
+    # rebuild for itself. The scoring plan distinguishes the two.
     if starts is None or ends is None:
         return None
 
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     q_bshd, k_bsd, w_bsh = _sbhd_to_bshd_indexer_inputs(q, k, weights)
     topk_indices, topk_length, _score_payload = _indexer_topk_bshd(
@@ -1369,6 +1628,7 @@ def run_fused_qk_topk(
         packed_max_seqlen_q=packed_max_seqlen_q,
         packed_max_seqlen_k=packed_max_seqlen_k,
         packed_cp_size=cp_size,
+        varlen_is_plain_causal=varlen_is_plain_causal,
     )
     return topk_indices, topk_length
 
@@ -1397,6 +1657,7 @@ def run_fused_qk_topk_with_loss(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Tensor, Tensor]]:
     """Run cuDNN fused indexer and sparse indexer loss for split DSA."""
     del block_size
@@ -1416,6 +1677,9 @@ def run_fused_qk_topk_with_loss(
         return None
     if query.size(3) != key.size(3):
         return None
+    # Bounds the caller could not build at all are a genuine decline, which is a
+    # different thing from bounds that exist but describe a layout a fused kernel can
+    # rebuild for itself. The scoring plan distinguishes the two.
     if starts is None or ends is None:
         return None
 
@@ -1428,9 +1692,7 @@ def run_fused_qk_topk_with_loss(
         return None
 
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     return FusedQKTopKWithSparseLossFunc.apply(
         q.contiguous(),
@@ -1443,8 +1705,8 @@ def run_fused_qk_topk_with_loss(
         loss_coeff,
         calculate_per_token_loss,
         latent_v_channels,
-        starts.contiguous(),
-        ends.contiguous(),
+        starts.contiguous() if starts is not None else None,
+        ends.contiguous() if ends is not None else None,
         query_valid_rows,
         use_local_indexer_varlen,
         single_packed_thd_sequence,
@@ -1457,6 +1719,7 @@ def run_fused_qk_topk_with_loss(
         packed_max_seqlen_k,
         cp_size,
         tp_group,
+        varlen_is_plain_causal,
     )
 
 
@@ -2391,8 +2654,8 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         loss_coeff: float,
         calculate_per_token_loss: bool,
         d_v: int,
-        varlen_starts: Tensor,
-        varlen_ends: Tensor,
+        varlen_starts: Optional[Tensor],
+        varlen_ends: Optional[Tensor],
         query_valid_rows: Optional[Tensor],
         use_local_indexer_varlen: bool,
         single_packed_thd_sequence: bool,
@@ -2405,6 +2668,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         packed_max_seqlen_k: Optional[int],
         packed_cp_size: int,
         tp_group,
+        varlen_is_plain_causal: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """Compute shared attention top-k metadata and sparse indexer loss."""
         _ensure_dsa_namespace()
@@ -2435,6 +2699,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
             packed_max_seqlen_q=packed_max_seqlen_q,
             packed_max_seqlen_k=packed_max_seqlen_k,
             packed_cp_size=packed_cp_size,
+            varlen_is_plain_causal=varlen_is_plain_causal,
         )
 
         if indexer_score_payload is None:
@@ -2495,7 +2760,8 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         #   single_packed_thd_sequence, local_packed_cp_rank,
         #   local_packed_cp_query_start, local_packed_cp_query_len,
         #   packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q,
-        #   packed_max_seqlen_k, packed_cp_size, tp_group.
+        #   packed_max_seqlen_k, packed_cp_size, tp_group,
+        #   varlen_is_plain_causal.
         return (
             grad_q_indexer,
             grad_k_indexer,
@@ -2521,6 +2787,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
             None,
             None,
             None,
+            None,  # varlen_is_plain_causal
         )
 
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -11,7 +11,11 @@ import torch
 from torch import Tensor
 
 from megatron.core.transformer.enums import AttnMaskType
-from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_masking
+from megatron.core.transformer.experimental_attention_variant import (
+    dsa_indexer_loss,
+    dsa_layout,
+    dsa_masking,
+)
 from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
     IndexerScoringDecision,
     IndexerScoringPlan,
@@ -181,6 +185,28 @@ def _get_packed_thd_metadata(
     )
 
 
+def _resolve_packed_layout_flags(
+    *,
+    use_local_indexer_varlen: bool,
+    single_packed_thd_sequence: bool,
+    packed_thd_causal_identity_layout: Optional[bool],
+    packed_thd_single_sequence: Optional[bool],
+) -> Tuple[bool, bool]:
+    """Prefer the new CP-independent facts while accepting direct legacy calls."""
+    return (
+        (
+            use_local_indexer_varlen
+            if packed_thd_causal_identity_layout is None
+            else packed_thd_causal_identity_layout
+        ),
+        (
+            single_packed_thd_sequence
+            if packed_thd_single_sequence is None
+            else packed_thd_single_sequence
+        ),
+    )
+
+
 def run_fused_dsa_attention(
     *,
     config: TransformerConfig,
@@ -208,6 +234,8 @@ def run_fused_dsa_attention(
     use_relu: bool,
     use_local_indexer_varlen: bool = False,
     single_packed_thd_sequence: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
     local_packed_cp_rank: int = 0,
     local_packed_cp_query_start: int = 0,
     local_packed_cp_query_len: Optional[int] = None,
@@ -219,6 +247,12 @@ def run_fused_dsa_attention(
     ``use_fused_dsa_kernels`` before calling, so this hook assumes it was selected (matching
     the TileLang backend) and only validates that the requested shapes/layout are supported.
     """
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     _assert_supported_indexer_scoring(use_relu)
     if (
         not absorbed_mla
@@ -1608,8 +1642,16 @@ def run_fused_qk_topk(
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
     varlen_is_plain_causal: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
 ) -> Optional[Tuple[Tensor, Tensor]]:
     """Run the cuDNN fused indexer and return top-k indices for split DSA."""
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     _assert_supported_indexer_scoring(use_relu)
     del block_size
     if q.ndim != 4 or k.ndim != 3 or weights.ndim != 3:
@@ -1678,8 +1720,16 @@ def run_fused_qk_topk_with_loss(
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
     varlen_is_plain_causal: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
 ) -> Optional[Tuple[Tensor, Tensor, Tensor]]:
     """Run cuDNN fused indexer and sparse indexer loss for split DSA."""
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     del block_size
     tp_group = getattr(pg_collection, "tp", None)
     _assert_supported_indexer_scoring(use_relu)

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -26,7 +26,7 @@ _BACKEND_MODULE_NAME_BY_BACKEND = {
 _BACKEND: Optional[ModuleType] = None
 _BACKEND_SELECTION: Optional[str] = None
 _LOGGER = logging.getLogger(__name__)
-_HOOK_KWARG_SIGNATURE_CACHE: dict[int, tuple[object, Optional[frozenset[str]]]] = {}
+_HOOK_KWARG_SIGNATURE_CACHE: dict[int, tuple[object, Optional[frozenset[str]], bool]] = {}
 
 
 def _get_dsa_kernel_backend(config: TransformerConfig) -> str:
@@ -76,24 +76,30 @@ def _log_declined_hook(config: TransformerConfig, hook_name: str, reason: str) -
     )
 
 
-def _hook_kwargs_accepting(fn, **candidate_kwargs):
+def _hook_kwargs_accepting(fn, *, opaque_fallback_names: Tuple[str, ...] = (), **candidate_kwargs):
     """Keep only the kwargs ``fn`` can accept.
 
     Backend hooks are resolved dynamically and may live out of tree; passing a
     keyword an older backend does not know would fail with a TypeError at the
-    first fused call rather than a clean decline.
+    first fused call rather than a clean decline. Opaque C/pybind hooks receive
+    no newly introduced kwargs by default, but callers can name kwargs that
+    predate this filtering so an unavailable signature does not break an
+    existing hook contract.
     """
     cache_key = id(fn)
     cached = _HOOK_KWARG_SIGNATURE_CACHE.get(cache_key)
     if cached is not None and cached[0] is fn:
         accepted_names = cached[1]
+        signature_is_opaque = cached[2]
     else:
         try:
             sig = inspect.signature(fn)
         except (TypeError, ValueError):
             # Opaque C/pybind hooks cannot safely receive a newly introduced keyword.
             accepted_names = frozenset()
+            signature_is_opaque = True
         else:
+            signature_is_opaque = False
             if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
                 accepted_names = None
             else:
@@ -104,11 +110,38 @@ def _hook_kwargs_accepting(fn, **candidate_kwargs):
                     in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
                 )
         # Retain the callable so Python object-id reuse cannot apply a stale signature.
-        _HOOK_KWARG_SIGNATURE_CACHE[cache_key] = (fn, accepted_names)
+        _HOOK_KWARG_SIGNATURE_CACHE[cache_key] = (fn, accepted_names, signature_is_opaque)
 
     if accepted_names is None:
         return candidate_kwargs
+    if signature_is_opaque:
+        accepted_names = frozenset(opaque_fallback_names)
     return {k: v for k, v in candidate_kwargs.items() if k in accepted_names}
+
+
+def _packed_layout_hook_kwargs(
+    fn,
+    *,
+    varlen_is_plain_causal: bool,
+    packed_thd_causal_identity_layout: bool,
+    packed_thd_single_sequence: bool,
+    opaque_fallback_names: Tuple[str, ...] = (),
+):
+    """Offer CP-independent layout facts only to hooks that declare support."""
+    return _hook_kwargs_accepting(
+        fn,
+        opaque_fallback_names=opaque_fallback_names,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
+
+
+def _legacy_packed_cp_flags(
+    *, cp_size: int, use_local_indexer_varlen: bool, single_packed_thd_sequence: bool
+) -> Tuple[bool, bool]:
+    """Preserve the historical CP-only meaning of existing backend hook flags."""
+    return (use_local_indexer_varlen and cp_size > 1, single_packed_thd_sequence and cp_size > 1)
 
 
 def _resolve_fused_hook(config: TransformerConfig, hook_name: str):
@@ -155,16 +188,19 @@ def run_fused_qk_topk(
 ) -> Optional[Tuple[Tensor, Optional[Tensor]]]:
     """Optional fused indexer hook for backend-specific implementations.
 
-    Contract note (changed in this release): ``single_packed_thd_sequence`` and
-    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
-    and a packed causal layout with identity key positions -- and no longer imply
-    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
-    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
-    split with an even local length.
+    The existing ``single_packed_thd_sequence`` and ``use_local_indexer_varlen``
+    backend kwargs retain their historical CP-only meaning. CP-independent layout
+    facts are offered as optional, signature-filtered kwargs so older out-of-tree
+    hooks cannot silently enter a CP path for a CP=1 pack.
     """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         q=q,
         k=k,
@@ -174,14 +210,19 @@ def run_fused_qk_topk(
         ends=ends,
         block_size=block_size,
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
-        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+        ),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk", "backend returned None")
@@ -216,16 +257,17 @@ def run_fused_qk_topk_with_loss(
 ) -> Optional[Tuple[Tensor, Optional[Tensor], Tensor]]:
     """Optional fused indexer+loss hook for backend-specific implementations.
 
-    Contract note (changed in this release): ``single_packed_thd_sequence`` and
-    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
-    and a packed causal layout with identity key positions -- and no longer imply
-    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
-    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
-    split with an even local length.
+    The existing packed-layout kwargs retain their historical CP-only meaning;
+    CP-independent facts use optional, signature-filtered kwargs.
     """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk_with_loss")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         config=config,
         q=q,
@@ -243,14 +285,19 @@ def run_fused_qk_topk_with_loss(
         query_valid_rows=query_valid_rows,
         calculate_per_token_loss=calculate_per_token_loss,
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
-        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+        ),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk_with_loss", "backend returned None")
@@ -310,16 +357,17 @@ def run_fused_dsa_attention(
 ) -> Optional[Tuple[Tensor, Tensor]]:
     """Optional full fused DSA hook for backends that fuse indexer and attention together.
 
-    Contract note (changed in this release): ``single_packed_thd_sequence`` and
-    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
-    and a packed causal layout with identity key positions -- and no longer imply
-    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
-    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
-    split with an even local length.
+    The existing packed-layout kwargs retain their historical CP-only meaning;
+    CP-independent facts use optional, signature-filtered kwargs.
     """
     fn = _resolve_fused_hook(config, "run_fused_dsa_attention")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         config=config,
         query=query,
@@ -342,10 +390,18 @@ def run_fused_dsa_attention(
         varlen_ends=varlen_ends,
         key_positions=key_positions,
         query_valid_rows=query_valid_rows,
-        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+            # ``varlen_is_plain_causal`` was already part of the full-hook
+            # contract before optional kwarg filtering was introduced.
+            opaque_fallback_names=("varlen_is_plain_causal",),
+        ),
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from importlib import import_module
 from types import ModuleType
@@ -25,6 +26,7 @@ _BACKEND_MODULE_NAME_BY_BACKEND = {
 _BACKEND: Optional[ModuleType] = None
 _BACKEND_SELECTION: Optional[str] = None
 _LOGGER = logging.getLogger(__name__)
+_HOOK_KWARG_SIGNATURE_CACHE: dict[int, tuple[object, Optional[frozenset[str]]]] = {}
 
 
 def _get_dsa_kernel_backend(config: TransformerConfig) -> str:
@@ -74,6 +76,41 @@ def _log_declined_hook(config: TransformerConfig, hook_name: str, reason: str) -
     )
 
 
+def _hook_kwargs_accepting(fn, **candidate_kwargs):
+    """Keep only the kwargs ``fn`` can accept.
+
+    Backend hooks are resolved dynamically and may live out of tree; passing a
+    keyword an older backend does not know would fail with a TypeError at the
+    first fused call rather than a clean decline.
+    """
+    cache_key = id(fn)
+    cached = _HOOK_KWARG_SIGNATURE_CACHE.get(cache_key)
+    if cached is not None and cached[0] is fn:
+        accepted_names = cached[1]
+    else:
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):
+            # Opaque C/pybind hooks cannot safely receive a newly introduced keyword.
+            accepted_names = frozenset()
+        else:
+            if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+                accepted_names = None
+            else:
+                accepted_names = frozenset(
+                    name
+                    for name, parameter in sig.parameters.items()
+                    if parameter.kind
+                    in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+                )
+        # Retain the callable so Python object-id reuse cannot apply a stale signature.
+        _HOOK_KWARG_SIGNATURE_CACHE[cache_key] = (fn, accepted_names)
+
+    if accepted_names is None:
+        return candidate_kwargs
+    return {k: v for k, v in candidate_kwargs.items() if k in accepted_names}
+
+
 def _resolve_fused_hook(config: TransformerConfig, hook_name: str):
     """Return the selected backend's ``hook_name`` callable, or None if unavailable.
 
@@ -114,8 +151,17 @@ def run_fused_qk_topk(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional[PackedSeqParams] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Optional[Tensor]]]:
-    """Optional fused indexer hook for backend-specific implementations."""
+    """Optional fused indexer hook for backend-specific implementations.
+
+    Contract note (changed in this release): ``single_packed_thd_sequence`` and
+    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
+    and a packed causal layout with identity key positions -- and no longer imply
+    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
+    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
+    split with an even local length.
+    """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk")
     if fn is None:
         return None
@@ -135,6 +181,7 @@ def run_fused_qk_topk(
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
+        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk", "backend returned None")
@@ -165,8 +212,17 @@ def run_fused_qk_topk_with_loss(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional[PackedSeqParams] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Optional[Tensor], Tensor]]:
-    """Optional fused indexer+loss hook for backend-specific implementations."""
+    """Optional fused indexer+loss hook for backend-specific implementations.
+
+    Contract note (changed in this release): ``single_packed_thd_sequence`` and
+    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
+    and a packed causal layout with identity key positions -- and no longer imply
+    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
+    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
+    split with an even local length.
+    """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk_with_loss")
     if fn is None:
         return None
@@ -194,6 +250,7 @@ def run_fused_qk_topk_with_loss(
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
+        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk_with_loss", "backend returned None")
@@ -251,7 +308,15 @@ def run_fused_dsa_attention(
     local_packed_cp_query_len: Optional[int] = None,
     pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> Optional[Tuple[Tensor, Tensor]]:
-    """Optional full fused DSA hook for backends that fuse indexer and attention together."""
+    """Optional full fused DSA hook for backends that fuse indexer and attention together.
+
+    Contract note (changed in this release): ``single_packed_thd_sequence`` and
+    ``use_local_indexer_varlen`` describe the layout only -- a single-sequence pack
+    and a packed causal layout with identity key positions -- and no longer imply
+    ``cp_size > 1``. Backends deciding kernel applicability from them must consult
+    ``cp_size`` (and their own shape preconditions) rather than assume a zigzag
+    split with an even local length.
+    """
     fn = _resolve_fused_hook(config, "run_fused_dsa_attention")
     if fn is None:
         return None
@@ -277,7 +342,7 @@ def run_fused_dsa_attention(
         varlen_ends=varlen_ends,
         key_positions=key_positions,
         query_valid_rows=query_valid_rows,
-        varlen_is_plain_causal=varlen_is_plain_causal,
+        **_hook_kwargs_accepting(fn, varlen_is_plain_causal=varlen_is_plain_causal),
         use_relu=use_relu,
         use_local_indexer_varlen=use_local_indexer_varlen,
         single_packed_thd_sequence=single_packed_thd_sequence,

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -312,12 +312,21 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Optional fused sparse-attention hook for backend-specific implementations."""
     fn = _resolve_fused_hook(config, "run_fused_absorbed_sparse_attention")
     if fn is None:
         return None
-    result = fn(query, key, topk_indices, softmax_scale, v_channels, topk_length)
+    result = fn(
+        query,
+        key,
+        topk_indices,
+        softmax_scale,
+        v_channels,
+        topk_length,
+        **_hook_kwargs_accepting(fn, all_topk_rows_nonempty=all_topk_rows_nonempty),
+    )
     if result is None:
         _log_declined_hook(config, "run_fused_absorbed_sparse_attention", "backend returned None")
     return result

--- a/megatron/core/transformer/experimental_attention_variant/dsa_layout.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_layout.py
@@ -3,7 +3,7 @@
 """Layout helpers for DeepSeek sparse attention."""
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -22,6 +22,8 @@ __all__ = [
     "get_cp_positions_from_layout",
     "get_packed_qk_cu_seqlens",
     "normalize_cp_comm_type",
+    "build_packed_allgather_cp_local_positions_from_host",
+    "build_packed_allgather_cp_query_positions_and_key_reorder_from_host",
 ]
 
 
@@ -305,6 +307,102 @@ def build_packed_allgather_cp_local_positions(
     return segment_starts.index_select(0, segment_ids) + segment_offsets
 
 
+def build_packed_allgather_cp_all_rank_positions(
+    cu_seqlens: torch.Tensor,
+    cp_size: int,
+    device: torch.device,
+    output_size: Optional[int] = None,
+    *,
+    cu_seqlens_cover_output: bool = False,
+) -> torch.Tensor:
+    """Build every CP rank's local packed positions at once: ``[cp_size, output_size]``.
+
+    Row ``r`` is identical to
+    ``build_packed_allgather_cp_local_positions(..., cp_rank=r, ...)``.
+
+    Doing all ranks together is worth a separate function because every expensive
+    step is rank-invariant. ``cp_rank`` enters only through ``front_starts`` and
+    ``back_starts`` -- cheap elementwise expressions. In particular
+    ``segment_lens`` is ``stack(half, half)`` and so does not depend on the rank,
+    which means the ``nonzero``/``nonempty_segments`` boolean masks, and therefore
+    all of the data-dependent output shapes that force a device-to-host size
+    readback, are shared across ranks. The per-rank loop this replaces paid those
+    readbacks ``cp_size`` times over; here they are paid once.
+    """
+    cu_seqlens_i64 = cu_seqlens.to(device=device, dtype=torch.int64)
+    if cp_size <= 1:
+        return build_packed_allgather_cp_local_positions(
+            cu_seqlens,
+            cp_size,
+            0,
+            device,
+            output_size=output_size,
+            cu_seqlens_cover_output=cu_seqlens_cover_output,
+        ).unsqueeze(0)
+
+    seq_starts = cu_seqlens_i64[:-1]
+    seq_ends = cu_seqlens_i64[1:]
+    seq_lens = seq_ends - seq_starts
+    nonzero = seq_lens > 0
+    seq_starts = seq_starts[nonzero]
+    seq_ends = seq_ends[nonzero]
+    seq_lens = seq_lens[nonzero]
+    if seq_lens.numel() == 0:
+        return torch.empty((cp_size, 0), dtype=torch.int64, device=device)
+
+    # Host-side guard for CPU/test callers; mirrors the single-rank builder.
+    if cu_seqlens_i64.device.type == "cpu":
+        bad_divisible = seq_lens[seq_lens % cp_size != 0]
+        if bad_divisible.numel() > 0:
+            raise ValueError(
+                "Packed DSA CP expects per-sequence padded lengths divisible by cp_size, got "
+                f"seq_len={int(bad_divisible[0].item())}, cp_size={cp_size}"
+            )
+        bad_local = seq_lens[(seq_lens // cp_size) % 2 != 0]
+        if bad_local.numel() > 0:
+            seq_len = int(bad_local[0].item())
+            raise ValueError(
+                "Packed DSA CP expects per-rank packed sequence lengths divisible by 2, got "
+                f"local_seq_len={seq_len // cp_size}, seq_len={seq_len}, cp_size={cp_size}"
+            )
+
+    half_seq_lens = (seq_lens // cp_size) // 2
+    ranks = torch.arange(cp_size, dtype=torch.int64, device=device).unsqueeze(1)
+    # [cp_size, n_seq]
+    front_starts = seq_starts.unsqueeze(0) + ranks * half_seq_lens.unsqueeze(0)
+    back_starts = seq_ends.unsqueeze(0) - (ranks + 1) * half_seq_lens.unsqueeze(0)
+    # Interleave to [f0, b0, f1, b1, ...] per row, matching the single-rank builder.
+    segment_starts = torch.stack((front_starts, back_starts), dim=2).reshape(cp_size, -1)
+    segment_lens = torch.stack((half_seq_lens, half_seq_lens), dim=1).reshape(-1)
+    nonempty_segments = segment_lens > 0
+    segment_starts = segment_starts[:, nonempty_segments]
+    segment_lens = segment_lens[nonempty_segments]
+
+    if output_size is None:
+        output_size = int(segment_lens.sum().item())
+    if output_size == 0:
+        return torch.empty((cp_size, 0), dtype=torch.int64, device=device)
+    if not cu_seqlens_cover_output:
+        pad_len = (
+            torch.tensor(output_size, dtype=torch.int64, device=device) - segment_lens.sum()
+        ).clamp_min(0)
+        # Per-rank padding origin, matching cu_seqlens[-1] + cp_rank * output_size.
+        pad_start = cu_seqlens_i64[-1] + ranks.reshape(-1) * output_size
+        segment_starts = torch.cat((segment_starts, pad_start.unsqueeze(1)), dim=1)
+        segment_lens = torch.cat((segment_lens, pad_len.view(1)), dim=0)
+
+    segment_ids = torch.repeat_interleave(
+        torch.arange(segment_lens.numel(), dtype=torch.int64, device=device),
+        segment_lens,
+        output_size=output_size,
+    )
+    segment_offsets = torch.arange(output_size, dtype=torch.int64, device=device)
+    segment_offsets -= torch.repeat_interleave(
+        torch.cumsum(segment_lens, dim=0) - segment_lens, segment_lens, output_size=output_size
+    )
+    return segment_starts.index_select(1, segment_ids) + segment_offsets.unsqueeze(0)
+
+
 def build_packed_allgather_cp_query_positions_and_key_reorder(
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_kv: torch.Tensor,
@@ -336,18 +434,15 @@ def build_packed_allgather_cp_query_positions_and_key_reorder(
     )
     if key_local_output_size is None:
         key_local_output_size = local_output_size
-    gathered_key_positions = [
-        build_packed_allgather_cp_local_positions(
-            cu_seqlens_kv,
-            cp_size,
-            rank,
-            device,
-            output_size=key_local_output_size,
-            cu_seqlens_cover_output=key_cu_seqlens_cover_output,
-        )
-        for rank in range(cp_size)
-    ]
-    gathered_key_positions = torch.cat(gathered_key_positions, dim=0)
+    # All ranks in one batched build. Row-major flattening reproduces exactly the
+    # rank0-local, rank1-local, ... concatenation the gathered KV tensor is in.
+    gathered_key_positions = build_packed_allgather_cp_all_rank_positions(
+        cu_seqlens_kv,
+        cp_size,
+        device,
+        output_size=key_local_output_size,
+        cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+    ).reshape(-1)
     key_reorder_idx = torch.argsort(gathered_key_positions)
     if global_output_size is not None and key_reorder_idx.numel() != global_output_size:
         raise RuntimeError(
@@ -355,6 +450,161 @@ def build_packed_allgather_cp_query_positions_and_key_reorder(
             f"expected {global_output_size}"
         )
     return query_positions, key_reorder_idx
+
+
+def _host_packed_cp_spans(
+    host_cu_seqlens: List[int], cp_size: int, cp_rank: int
+) -> List[Tuple[int, int]]:
+    """One rank's zigzag layout as ``(global_start, length)`` spans, from host ints.
+
+    The span decomposition is the same maths as the device builders above, but on a
+    Python list there is nothing to synchronize on: every length is already known.
+    Zero-length sequences contribute no spans, matching the device builders' filter.
+    """
+    spans: List[Tuple[int, int]] = []
+    for seq_start, seq_end in zip(host_cu_seqlens[:-1], host_cu_seqlens[1:]):
+        seq_len = seq_end - seq_start
+        if seq_len == 0:
+            continue
+        # The zigzag layout requires it, and on host integers the check is free --
+        # unlike the device builders, which can only validate without a sync on CPU
+        # inputs. Without it, non-divisible lengths would silently drop tokens here
+        # and leave uninitialized slots in the reorder buffer downstream.
+        if seq_len % (2 * cp_size) != 0:
+            raise ValueError(
+                "Packed DSA CP expects per-sequence padded lengths divisible by "
+                f"2 * cp_size ({2 * cp_size}), got seq_len={seq_len}"
+            )
+        half = seq_len // cp_size // 2
+        if half <= 0:
+            continue
+        spans.append((seq_start + cp_rank * half, half))
+        spans.append((seq_end - (cp_rank + 1) * half, half))
+    return spans
+
+
+def _host_to_device(values: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """Move a freshly built host tensor to ``device`` without blocking the CPU."""
+    if device.type == "cuda":
+        return values.pin_memory().to(device, non_blocking=True)
+    return values.to(device)
+
+
+def build_packed_allgather_cp_local_positions_from_host(
+    host_cu_seqlens: List[int],
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+    output_size: Optional[int] = None,
+    *,
+    cu_seqlens_cover_output: bool = False,
+) -> torch.Tensor:
+    """Host-side equivalent of :func:`build_packed_allgather_cp_local_positions`.
+
+    The device builder runs ~20 kernels over a few dozen integers and pays two
+    device-to-host size readbacks for its boolean-mask filters. When the compacted
+    ``cu_seqlens`` are already on the host -- ``prebuild_thd_cp_partition_routes``
+    stores them on ``PackedSeqParams`` at batch-construction time, where the one
+    blocking copy is cheap because the CUDA queue is still shallow -- the whole
+    table is a closed form over Python ints: zero kernels, zero synchronization,
+    one asynchronous host-to-device copy of the finished table.
+    """
+    if cp_size <= 1:
+        # Mirror the device builder: at cp_size <= 1 the local layout is the identity,
+        # with no zigzag halving (and therefore no even-length requirement).
+        if output_size is None:
+            output_size = host_cu_seqlens[-1]
+        return _host_to_device(torch.arange(output_size, dtype=torch.int64), device)
+    spans = _host_packed_cp_spans(host_cu_seqlens, cp_size, cp_rank)
+    real = (
+        torch.cat([torch.arange(start, start + length) for start, length in spans])
+        if spans
+        else torch.empty(0, dtype=torch.int64)
+    )
+    total = real.numel()
+    if output_size is None:
+        output_size = total
+    positions = torch.empty(output_size, dtype=torch.int64)
+    n = min(total, output_size)
+    positions[:n] = real[:n]
+    if output_size > n:
+        # The cover flag only ever accompanies output_size == total (dsa.py derives it
+        # from host max-seqlen metadata), so this branch is the not-covered case; fill
+        # it unconditionally rather than leave torch.empty garbage if a caller lies.
+        pad_start = host_cu_seqlens[-1] + cp_rank * output_size
+        positions[n:] = torch.arange(pad_start, pad_start + (output_size - n))
+    return _host_to_device(positions, device)
+
+
+def build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+    host_cu_seqlens_q: List[int],
+    host_cu_seqlens_kv: List[int],
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+    local_output_size: Optional[int] = None,
+    key_local_output_size: Optional[int] = None,
+    global_output_size: Optional[int] = None,
+    *,
+    query_cu_seqlens_cover_output: bool = False,
+    key_cu_seqlens_cover_output: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Host-side equivalent of the query-positions + key-reorder wrapper.
+
+    Besides removing the device builders' synchronizations, this replaces the
+    ``argsort`` over the gathered key positions with a direct inverse permutation.
+    The sort is unnecessary because the real positions of all ranks tile
+    ``[0, total_tokens)`` exactly once (every padded sequence length is divisible
+    by ``2 * cp_size``), so the rank of a value in sorted order *is* the value;
+    and the padding pseudo-positions ``total + r * output_size + j`` are unique
+    and already ascending in ``(rank, j)`` order. Both facts are pinned by the
+    bit-equality tests against the device path.
+    """
+    query_positions = build_packed_allgather_cp_local_positions_from_host(
+        host_cu_seqlens_q,
+        cp_size,
+        cp_rank,
+        device,
+        output_size=local_output_size,
+        cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+    )
+    if key_local_output_size is None:
+        key_local_output_size = local_output_size
+
+    kv_total = host_cu_seqlens_kv[-1]
+    if cp_size <= 1:
+        # Identity layout: the gathered order is already the global order.
+        out = key_local_output_size if key_local_output_size is not None else kv_total
+        return query_positions, _host_to_device(torch.arange(out, dtype=torch.int64), device)
+    spans_by_rank = [
+        _host_packed_cp_spans(host_cu_seqlens_kv, cp_size, rank) for rank in range(cp_size)
+    ]
+    real_len = sum(length for _, length in spans_by_rank[0]) if spans_by_rank else 0
+    if real_len * cp_size != kv_total:
+        raise ValueError(
+            "Packed DSA CP spans do not tile the key stream: "
+            f"{cp_size} ranks x {real_len} real tokens != total {kv_total}"
+        )
+    out = key_local_output_size if key_local_output_size is not None else real_len
+    pad = max(0, out - real_len)
+    n = cp_size * out
+    if global_output_size is not None and n != global_output_size:
+        raise RuntimeError(
+            f"Packed DSA CP key reorder length mismatch: got {n}, " f"expected {global_output_size}"
+        )
+    key_reorder_idx = torch.empty(n, dtype=torch.int64)
+    for rank, spans in enumerate(spans_by_rank):
+        local = 0
+        for global_start, length in spans:
+            key_reorder_idx[global_start : global_start + length] = torch.arange(
+                rank * out + local, rank * out + local + length
+            )
+            local += length
+        if pad > 0:
+            key_reorder_idx[kv_total + rank * pad : kv_total + (rank + 1) * pad] = torch.arange(
+                rank * out + local, rank * out + out
+            )
+    return query_positions, _host_to_device(key_reorder_idx, device)
 
 
 def extract_query_positions_from_position_ids(

--- a/megatron/core/transformer/experimental_attention_variant/dsa_masking.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_masking.py
@@ -17,6 +17,7 @@ __all__ = [
     "build_dsattention_forward_mask",
     "build_fused_indexer_varlen_bounds",
     "build_valid_mask_from_starts_ends",
+    "can_prove_all_topk_rows_nonempty",
     "extract_query_valid_rows_from_packed_seq_params",
     "gather_sparse_topk_validity_and_bias",
     "generate_varlen_mask_params",
@@ -31,6 +32,46 @@ __all__ = [
     "scatter_topk_into_index_mask",
     "sort_topk_by_index",
 ]
+
+
+def can_prove_all_topk_rows_nonempty(
+    *,
+    computes_topk: bool,
+    indexer_topk: int,
+    kv_sequence_length: int,
+    attention_mask: Optional[torch.Tensor],
+    query_valid_rows: Optional[torch.Tensor],
+    varlen_is_plain_causal: bool,
+    use_local_indexer_varlen: bool,
+    varlen_starts: Optional[torch.Tensor],
+    varlen_ends: Optional[torch.Tensor],
+    key_positions: Optional[torch.Tensor],
+) -> bool:
+    """Return a host-side certificate that every query row has a selected key.
+
+    The packed-local branch is provenance-based: its bounds must come from DSA's internal
+    packed self-attention layout. Selected cumulative lengths (padded when available),
+    synthetic tail positions, and reordered KV cover every physical query row; checking
+    tensor values here would introduce a device sync. This proves geometric non-emptiness
+    only; real-token masking remains a separate concern.
+
+    Backend callers may pass their normalized plain-causal layout as
+    ``varlen_is_plain_causal=True`` after dropping the equivalent explicit bounds.
+    """
+    if (
+        not computes_topk
+        or indexer_topk <= 0
+        or kv_sequence_length <= 0
+        or attention_mask is not None
+        or query_valid_rows is not None
+    ):
+        return False
+    return varlen_is_plain_causal or (
+        use_local_indexer_varlen
+        and varlen_starts is not None
+        and varlen_ends is not None
+        and key_positions is None
+    )
 
 
 def build_causal_mask_from_positions(

--- a/megatron/core/transformer/experimental_attention_variant/dsa_scoring_plan.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_scoring_plan.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Decide once how DSA indexer scoring will run, instead of re-deriving it per call.
+
+Choosing between the fused indexer scorer and the per-head fallback loop used to be
+spread across two files: ``DSAttention.forward`` assembled a handful of booleans
+(``use_local_indexer_varlen``, ``single_packed_thd_sequence``, the packed ``cu_seqlens``
+metadata), threaded them through the kernel dispatcher, and the dispatcher re-combined
+them into a branch. The decision existed only as the emergent result of those
+conditions, so a configuration that no fused kernel claimed simply fell through to the
+slow path with nothing reported.
+
+This module makes the decision a value. :func:`resolve_indexer_scoring_plan` is total --
+every configuration maps to some :class:`IndexerScoringPlan`, including
+:attr:`IndexerScoringPlan.UNFUSED_BOUNDS` -- and carries the reason it landed there, so
+callers can surface an unfused configuration instead of silently paying for it.
+
+Splitting the decision from its execution also separates two questions that the old
+conditions conflated: *what layout is this* versus *which kernel do we happen to have*.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import torch
+
+
+class IndexerScoringPlan(Enum):
+    """How indexer scores and top-k are produced for one attention call."""
+
+    PLAIN_CAUSAL = "plain_causal"
+    """Whole-sequence causal bounds. Reconstructible, so the single-kernel scorer runs."""
+
+    PACKED_SINGLE_SEGMENTS = "packed_single_segments"
+    """One sequence per pack, scored as one or more causal query/key segments."""
+
+    PACKED_THD_GENERAL = "packed_thd_general"
+    """General packed THD scoring driven by query/key cu_seqlens metadata."""
+
+    UNFUSED_BOUNDS = "unfused_bounds"
+    """No fused kernel claims this layout; scoring falls back to the per-head loop."""
+
+    DECLINE = "decline"
+    """Bounds cannot be built at all, so the caller must not attempt fused scoring."""
+
+    @property
+    def is_fused(self) -> bool:
+        """Whether this plan reaches a fused scoring kernel."""
+        return self in (
+            IndexerScoringPlan.PLAIN_CAUSAL,
+            IndexerScoringPlan.PACKED_SINGLE_SEGMENTS,
+            IndexerScoringPlan.PACKED_THD_GENERAL,
+        )
+
+
+@dataclass(frozen=True)
+class IndexerScoringDecision:
+    """A resolved plan plus the reason it was chosen.
+
+    ``reason`` is meant to be read by a human staring at a slow run, so it names the
+    condition that decided the outcome rather than restating the plan.
+    """
+
+    plan: IndexerScoringPlan
+    reason: str
+
+    @property
+    def is_fused(self) -> bool:
+        """Whether the chosen plan reaches a fused scoring kernel."""
+        return self.plan.is_fused
+
+
+def resolve_indexer_scoring_plan(
+    *,
+    bounds_available: bool,
+    varlen_is_plain_causal: bool,
+    packed_thd: bool,
+    cp_size: int,
+    mask_is_causal: bool,
+    explicit_key_positions: bool,
+    single_sequence_pack: bool,
+    packed_metadata_available: bool,
+    segment_kernel_applicable: bool = True,
+) -> IndexerScoringDecision:
+    """Resolve how indexer scoring should run for one attention call.
+
+    The arguments are facts about the layout, not capability flags: whoever calls this
+    does not need to know which kernels exist. Ordering matters only in that the
+    earlier clauses describe strictly more specific layouts.
+
+    Args:
+        bounds_available: The caller managed to build ``(starts, ends)`` key bounds.
+        varlen_is_plain_causal: Those bounds are the trivial whole-sequence causal ones,
+            as flagged by the mask builder, so a kernel can rebuild them itself.
+        packed_thd: Sequences are packed into a THD buffer.
+        cp_size: Context-parallel world size.
+        mask_is_causal: The attention mask type is plain causal.
+        explicit_key_positions: Custom key positions are in play, so bounds alone do not
+            describe the layout.
+        single_sequence_pack: This microbatch's pack holds exactly one sequence. This is
+            the only input here that varies batch to batch.
+        packed_metadata_available: ``cu_seqlens`` and max-seqlen metadata are present.
+        segment_kernel_applicable: The single-sequence segment kernel's structural
+            preconditions hold for this call. It raises rather than declining when they
+            do not, so the plan must not promise it.
+
+    Returns:
+        The resolved plan and the reason for it.
+    """
+    if explicit_key_positions:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.DECLINE, "custom key positions are not expressible as bounds"
+        )
+    if not bounds_available:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.DECLINE, "key bounds could not be built for this mask"
+        )
+
+    if varlen_is_plain_causal and not packed_thd and cp_size == 1:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.PLAIN_CAUSAL, "whole-sequence causal bounds are reconstructible"
+        )
+
+    if packed_thd and mask_is_causal:
+        if single_sequence_pack and segment_kernel_applicable:
+            return IndexerScoringDecision(
+                IndexerScoringPlan.PACKED_SINGLE_SEGMENTS,
+                "one sequence per pack, scored as causal segments",
+            )
+        # General THD scoring is independent of context-parallel world size. It is the
+        # normal multi-sequence path and also the safe fallback when the specialized
+        # single-sequence segment executor cannot take this call's shape.
+        if packed_metadata_available:
+            return IndexerScoringDecision(
+                IndexerScoringPlan.PACKED_THD_GENERAL,
+                (
+                    "single-sequence pack falling back to cu_seqlens metadata"
+                    if single_sequence_pack
+                    else "multi-sequence pack with cu_seqlens metadata"
+                ),
+            )
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS,
+            (
+                "single-sequence pack whose segment shape is unsupported and whose "
+                "cu_seqlens metadata is unavailable or incompatible"
+                if single_sequence_pack
+                else "packed THD without compatible cu_seqlens metadata"
+            ),
+        )
+
+    # Everything below is a layout no fused kernel currently claims. Name the specific
+    # reason: these are the configurations worth widening a gate for.
+    if not packed_thd and cp_size > 1:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS,
+            "context parallelism without sequence packing has no fused scoring path",
+        )
+    if not mask_is_causal:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS, "non-causal mask has no fused scoring path"
+        )
+    return IndexerScoringDecision(
+        IndexerScoringPlan.UNFUSED_BOUNDS, "bounds are not reconstructible by any fused kernel"
+    )
+
+
+_REPORTED_UNFUSED: set = set()
+
+
+def report_unfused_scoring_once(decision: IndexerScoringDecision, context: str) -> Optional[str]:
+    """Log an unfused scoring plan the first time each distinct reason appears.
+
+    A configuration that misses every fused kernel is a throughput cliff with no other
+    symptom, so it should say so once rather than never. Returns the emitted message, or
+    ``None`` if this reason was already reported.
+    """
+    if decision.is_fused or decision.plan is IndexerScoringPlan.DECLINE:
+        return None
+    key = f"{context}|{decision.reason}"
+    if key in _REPORTED_UNFUSED:
+        return None
+    _REPORTED_UNFUSED.add(key)
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    message = (
+        f"DSA indexer scoring falls back to the unfused per-head loop ({context}, "
+        f"rank {rank}): {decision.reason}."
+    )
+    # Deliberately not rank-0-only: with heterogeneous packs a non-zero rank can sit
+    # on the unfused cliff while rank 0 stays fused, which is exactly the silent case
+    # this exists to surface. The once-per-reason set bounds the volume per process.
+    logging.getLogger(__name__).warning(message)
+    return message

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3357,6 +3357,26 @@ class TransformerConfig(ModelParallelConfig):
             and (not self.cuda_graph_modules or CudaGraphModule.attn in self.cuda_graph_modules)
         )
 
+        # Local graph warmup clones tensor kwargs into zero-initialized static inputs. Packed
+        # DSA with CP needs the real cu-seqlens to build its CP key reorder, so every local
+        # capture scope (including MLP-only) fails before capture with an empty reorder. CP=1
+        # does not need that layout and remains supported. Dynamic CP is already rejected with
+        # CUDA graphs by the training argument validation.
+        if (
+            self.experimental_attention_variant == "dsa"
+            and self.dsa_kernel_backend == "cudnn"
+            and self.sequence_packing_scheduler == "dp_balanced"
+            and self.context_parallel_size > 1
+            and self.cuda_graph_impl == "local"
+        ):
+            raise ValueError(
+                "Local CUDA graph capture is not supported for packed cuDNN DSA with context "
+                "parallelism: capture warmup cannot reconstruct the packed CP layout from its "
+                "zero-initialized cu-seqlens inputs. Full CUDA Graph support for packed DSA+CP "
+                "is deferred; set cuda_graph_impl='none' or choose a non-local graph "
+                "implementation supported by the requested capture scopes."
+            )
+
         cp_layout_conversion_required = is_gated_delta_net_variant(
             self.experimental_attention_variant
         )

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -15,7 +15,9 @@ from megatron.core.inference.moe import InferenceGroupedGemmBackend
 from megatron.core.quantization.quant_config import RecipeConfig
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
+    PACKED_DSA_CP_CUDA_GRAPH_ERROR,
     get_deprecated_cuda_graph_modules_migration,
+    is_packed_dsa_cp_cuda_graph_capture_unsupported,
     is_whole_moe_cuda_graph_scope,
     normalize_cuda_graph_modules,
     normalize_inference_cuda_graph_scope,
@@ -3357,25 +3359,17 @@ class TransformerConfig(ModelParallelConfig):
             and (not self.cuda_graph_modules or CudaGraphModule.attn in self.cuda_graph_modules)
         )
 
-        # Local graph warmup clones tensor kwargs into zero-initialized static inputs. Packed
-        # DSA with CP needs the real cu-seqlens to build its CP key reorder, so every local
-        # capture scope (including MLP-only) fails before capture with an empty reorder. CP=1
-        # does not need that layout and remains supported. Dynamic CP is already rejected with
-        # CUDA graphs by the training argument validation.
-        if (
-            self.experimental_attention_variant == "dsa"
-            and self.dsa_kernel_backend == "cudnn"
-            and self.sequence_packing_scheduler == "dp_balanced"
-            and self.context_parallel_size > 1
-            and self.cuda_graph_impl == "local"
+        if is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant=self.experimental_attention_variant,
+            dsa_kernel_backend=self.dsa_kernel_backend,
+            sequence_packing_scheduler=self.sequence_packing_scheduler,
+            dynamic_context_parallel=self.dynamic_context_parallel,
+            context_parallel_size=self.context_parallel_size,
+            cuda_graph_impl=self.cuda_graph_impl,
+            cuda_graph_modules=self.cuda_graph_modules,
+            inference_cuda_graph_scope=self.inference_cuda_graph_scope,
         ):
-            raise ValueError(
-                "Local CUDA graph capture is not supported for packed cuDNN DSA with context "
-                "parallelism: capture warmup cannot reconstruct the packed CP layout from its "
-                "zero-initialized cu-seqlens inputs. Full CUDA Graph support for packed DSA+CP "
-                "is deferred; set cuda_graph_impl='none' or choose a non-local graph "
-                "implementation supported by the requested capture scopes."
-            )
+            raise ValueError(PACKED_DSA_CP_CUDA_GRAPH_ERROR)
 
         cp_layout_conversion_required = is_gated_delta_net_variant(
             self.experimental_attention_variant

--- a/tests/unit_tests/test_context_parallel_layout.py
+++ b/tests/unit_tests/test_context_parallel_layout.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import megatron.core.context_parallel_layout.conversion as context_parallel_layout_conversion
+import megatron.core.context_parallel_layout.routes as context_parallel_layout_routes
 from megatron.core import parallel_state
 from megatron.core.context_parallel_layout import (
     CpPartitionModeConverter,
@@ -90,6 +91,18 @@ def _get_test_thd_token_indices(cu_seqlens, cp_size, cp_rank, cp_partition_mode)
         token_indices.extend(range(first_start, first_start + chunk_len))
         token_indices.extend(range(second_start, second_start + chunk_len))
     return torch.tensor(token_indices, dtype=torch.long)
+
+
+def _assert_thd_routes_equal(actual, expected):
+    for field in ("zigzag_index", "contiguous_index"):
+        actual_index = getattr(actual, field)
+        expected_index = getattr(expected, field)
+        if expected_index is None:
+            assert actual_index is None
+        else:
+            assert torch.equal(actual_index, expected_index)
+    assert actual.zigzag_split_sizes == expected.zigzag_split_sizes
+    assert actual.contiguous_split_sizes == expected.contiguous_split_sizes
 
 
 @pytest.mark.parametrize(
@@ -401,6 +414,108 @@ def test_prebuild_thd_cp_partition_routes_populates_direct_fields():
     assert same_route is route
     assert reverse_route is route
     assert packed_seq_params.cp_partition_route is route
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+
+
+def test_prebuild_thd_cp_partition_routes_materializes_aliased_qkv_once(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40, 40], dtype=torch.int32)
+    expected_route = build_thd_cp_partition_route(cu_q, cp_size=2, cp_rank=1)
+    materialized = []
+    original_materialize = context_parallel_layout_routes._materialize_thd_cu_seqlens_to_list
+
+    def track_materialize(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return original_materialize(cu_seqlens)
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_materialize_thd_cu_seqlens_to_list", track_materialize
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_q,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=1))
+
+    assert len(materialized) == 1
+    assert materialized[0] is cu_q
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+    _assert_thd_routes_equal(packed_seq_params.cp_partition_route, expected_route)
+
+
+def test_prebuild_thd_cp_partition_routes_materializes_distinct_qkv_jointly_once(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40, 40], dtype=torch.int32)
+    cu_kv = torch.tensor([0, 8, 40, 40], dtype=torch.int64)
+    expected_route = build_thd_cp_partition_route(cu_q, cp_size=2, cp_rank=0)
+    materialized = []
+    original_materialize = context_parallel_layout_routes._materialize_thd_cu_seqlens_to_list
+
+    def track_materialize(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return original_materialize(cu_seqlens)
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_materialize_thd_cu_seqlens_to_list", track_materialize
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=0))
+
+    assert len(materialized) == 1
+    assert torch.equal(materialized[0], torch.cat((cu_q, cu_kv)))
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv == [0, 8, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is not (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+    _assert_thd_routes_equal(packed_seq_params.cp_partition_route, expected_route)
+
+
+def test_prebuild_thd_cp_partition_routes_preserves_mixed_device_fallback(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40])
+    cu_kv = torch.empty(3, device="meta", dtype=torch.int32)
+    materialized = []
+
+    def fake_compact(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return [0, 16, 40] if cu_seqlens is cu_q else [0, 8, 40]
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_compact_thd_cu_seqlens_to_list", fake_compact
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=0))
+
+    assert len(materialized) == 2
+    assert materialized[0] is cu_q
+    assert materialized[1] is cu_kv
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv == [0, 8, 40]
 
 
 def test_prebuild_thd_cp_partition_routes_raises_route_errors():

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -18,7 +18,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.enums import AttnMaskType, CudaGraphModule
 from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_kernels
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
     AbsorbedMLASelfAttention,
@@ -3996,6 +3996,66 @@ class TestDSAModuleSpecDispatch:
             self._make_dsa_config(
                 experimental_attention_variant="dsa", context_parallel_size=2, cp_comm_type="p2p"
             )
+
+    def _make_packed_cudnn_dsa_graph_config(self, monkeypatch, **overrides):
+        monkeypatch.setattr(
+            "megatron.core.transformer.transformer_config."
+            "_validate_dsa_kernel_backend_dependencies",
+            lambda _backend: None,
+        )
+        monkeypatch.setattr(
+            "megatron.core.transformer.transformer_config.is_te_min_version", lambda _version: True
+        )
+        kwargs = {
+            "experimental_attention_variant": "dsa",
+            "dsa_kernel_backend": "cudnn",
+            "sequence_packing_scheduler": "dp_balanced",
+            "max_seqlen_per_dp_cp_rank": 128,
+            "pad_packed_seq_alignment": "max",
+            "thd_max_packed_sequences": 4,
+            "context_parallel_size": 2,
+            "cp_comm_type": "allgather",
+            "cuda_graph_impl": "local",
+            "cuda_graph_modules": [CudaGraphModule.attn],
+        }
+        kwargs.update(overrides)
+        return self._make_dsa_config(**kwargs)
+
+    @pytest.mark.parametrize(
+        "cuda_graph_modules",
+        [[], [CudaGraphModule.attn], [CudaGraphModule.mlp]],
+        ids=["whole_layer", "attention", "mlp_only"],
+    )
+    def test_packed_cudnn_dsa_cp_rejects_every_local_cuda_graph_scope(
+        self, monkeypatch, cuda_graph_modules
+    ):
+        """CP layout construction fails during local warmup even for MLP-only capture."""
+        with pytest.raises(ValueError, match="packed cuDNN DSA with context parallelism"):
+            self._make_packed_cudnn_dsa_graph_config(
+                monkeypatch, cuda_graph_modules=cuda_graph_modules
+            )
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"context_parallel_size": 1, "cp_comm_type": None},
+            {"experimental_attention_variant": None},
+            {"dsa_kernel_backend": "none"},
+            {
+                "sequence_packing_scheduler": None,
+                "max_seqlen_per_dp_cp_rank": None,
+                "pad_packed_seq_alignment": None,
+                "thd_max_packed_sequences": None,
+            },
+            {"cuda_graph_impl": "none"},
+            {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": [CudaGraphModule.mlp]},
+        ],
+        ids=["cp1", "non_dsa", "unfused_backend", "nonpacked", "cuda_graph_disabled", "te_mlp"],
+    )
+    def test_packed_cudnn_dsa_cp_local_cuda_graph_guard_is_narrow(self, monkeypatch, overrides):
+        """Changing any measured guard dimension leaves the neighboring config available."""
+        config = self._make_packed_cudnn_dsa_graph_config(monkeypatch, **overrides)
+        assert isinstance(config, MLATransformerConfig)
 
     def test_get_dsa_module_spec_for_backend(self):
         """get_dsa_module_spec_for_backend returns the correct full spec structure."""

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -18,7 +18,10 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.enums import AttnMaskType, CudaGraphModule
+from megatron.core.transformer.cuda_graph_config import (
+    is_packed_dsa_cp_cuda_graph_capture_unsupported,
+)
+from megatron.core.transformer.enums import AttnMaskType, CudaGraphModule, InferenceCudaGraphScope
 from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_kernels
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
     AbsorbedMLASelfAttention,
@@ -589,7 +592,9 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
         is expected_topk
     )
     assert seen["topk_kwargs"]["use_local_indexer_varlen"] is False
-    assert seen["topk_kwargs"]["single_packed_thd_sequence"] is True
+    assert seen["topk_kwargs"]["single_packed_thd_sequence"] is False
+    assert seen["topk_kwargs"]["packed_thd_causal_identity_layout"] is False
+    assert seen["topk_kwargs"]["packed_thd_single_sequence"] is True
     assert seen["topk_kwargs"]["local_packed_cp_rank"] == 3
     assert (
         dsa_kernels.run_fused_qk_topk_with_loss(
@@ -615,8 +620,10 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     )
     assert seen["loss_kwargs"]["config"] is Config
     assert seen["loss_kwargs"]["calculate_per_token_loss"] is True
-    assert seen["loss_kwargs"]["use_local_indexer_varlen"] is True
-    assert seen["loss_kwargs"]["single_packed_thd_sequence"] is True
+    assert seen["loss_kwargs"]["use_local_indexer_varlen"] is False
+    assert seen["loss_kwargs"]["single_packed_thd_sequence"] is False
+    assert seen["loss_kwargs"]["packed_thd_causal_identity_layout"] is True
+    assert seen["loss_kwargs"]["packed_thd_single_sequence"] is True
     assert seen["loss_kwargs"]["local_packed_cp_rank"] == 2
 
     topk_length = torch.ones((1, 1), dtype=torch.int32)
@@ -660,6 +667,8 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     assert seen["full_kwargs"]["varlen_starts"] is starts
     assert seen["full_kwargs"]["use_relu"] is False
     assert seen["full_kwargs"]["varlen_is_plain_causal"] is True
+    assert seen["full_kwargs"]["use_local_indexer_varlen"] is False
+    assert seen["full_kwargs"]["packed_thd_causal_identity_layout"] is True
 
 
 def test_dsa_kernel_dependency_validation(monkeypatch):
@@ -3997,7 +4006,7 @@ class TestDSAModuleSpecDispatch:
                 experimental_attention_variant="dsa", context_parallel_size=2, cp_comm_type="p2p"
             )
 
-    def _make_packed_cudnn_dsa_graph_config(self, monkeypatch, **overrides):
+    def _make_packed_dsa_graph_config(self, monkeypatch, **overrides):
         monkeypatch.setattr(
             "megatron.core.transformer.transformer_config."
             "_validate_dsa_kernel_backend_dependencies",
@@ -4022,25 +4031,91 @@ class TestDSAModuleSpecDispatch:
         return self._make_dsa_config(**kwargs)
 
     @pytest.mark.parametrize(
-        "cuda_graph_modules",
-        [[], [CudaGraphModule.attn], [CudaGraphModule.mlp]],
-        ids=["whole_layer", "attention", "mlp_only"],
+        ("context_parallel_size", "cuda_graph_impl", "cuda_graph_modules"),
+        [
+            (2, "local", []),
+            (2, "local", [CudaGraphModule.attn]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.attn]),
+            (2, "local", [CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.mlp, CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.mamba]),
+            (2, "transformer_engine", [CudaGraphModule.attn]),
+            (2, "transformer_engine", [CudaGraphModule.attn, CudaGraphModule.attn]),
+            (2, "transformer_engine", []),
+            (2, "transformer_engine", [CudaGraphModule.attn, CudaGraphModule.mlp]),
+            (4, "local", []),
+            (4, "local", [CudaGraphModule.attn]),
+            (4, "local", [CudaGraphModule.mlp]),
+            (4, "transformer_engine", [CudaGraphModule.attn]),
+            (4, "transformer_engine", []),
+        ],
+        ids=[
+            "cp2_local_whole_layer",
+            "cp2_local_attention",
+            "cp2_local_attention_repeated",
+            "cp2_local_mlp_only",
+            "cp2_local_mlp_only_repeated",
+            "cp2_local_attention_mlp",
+            "cp2_local_attention_mamba",
+            "cp2_te_attention",
+            "cp2_te_attention_repeated",
+            "cp2_te_whole_layer",
+            "cp2_te_attention_mlp",
+            "cp4_local_whole_layer",
+            "cp4_local_attention",
+            "cp4_local_mlp_only",
+            "cp4_te_attention",
+            "cp4_te_whole_layer",
+        ],
     )
-    def test_packed_cudnn_dsa_cp_rejects_every_local_cuda_graph_scope(
-        self, monkeypatch, cuda_graph_modules
+    def test_packed_cudnn_dsa_cp_rejects_measured_cuda_graph_scopes(
+        self, monkeypatch, context_parallel_size, cuda_graph_impl, cuda_graph_modules
     ):
-        """CP layout construction fails during local warmup even for MLP-only capture."""
-        with pytest.raises(ValueError, match="packed cuDNN DSA with context parallelism"):
-            self._make_packed_cudnn_dsa_graph_config(
-                monkeypatch, cuda_graph_modules=cuda_graph_modules
+        """Reject only packed CP graph scopes whose failure was reproduced on GPU."""
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(
+                monkeypatch,
+                context_parallel_size=context_parallel_size,
+                cuda_graph_impl=cuda_graph_impl,
+                cuda_graph_modules=cuda_graph_modules,
             )
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {
+                "cuda_graph_impl": "none",
+                "enable_cuda_graph": True,
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {
+                "cuda_graph_impl": "none",
+                "external_cuda_graph": True,
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {"cuda_graph_impl": "local", "cuda_graph_modules": "attn"},
+            {"cuda_graph_impl": "local", "cuda_graph_modules": "attn,attn"},
+        ],
+        ids=[
+            "deprecated_local_flag",
+            "deprecated_te_flag",
+            "string_scope",
+            "repeated_string_scope",
+        ],
+    )
+    def test_packed_cudnn_dsa_cp_graph_guard_follows_normalized_legacy_inputs(
+        self, monkeypatch, overrides
+    ):
+        """Legacy graph flags and string scopes must not bypass the measured guard."""
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(monkeypatch, **overrides)
 
     @pytest.mark.parametrize(
         "overrides",
         [
             {"context_parallel_size": 1, "cp_comm_type": None},
             {"experimental_attention_variant": None},
-            {"dsa_kernel_backend": "none"},
             {
                 "sequence_packing_scheduler": None,
                 "max_seqlen_per_dp_cp_rank": None,
@@ -4049,13 +4124,231 @@ class TestDSAModuleSpecDispatch:
             },
             {"cuda_graph_impl": "none"},
             {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": [CudaGraphModule.mlp]},
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 1,
+                "cp_comm_type": None,
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+            },
+            {"context_parallel_size": 3},
+            {
+                "context_parallel_size": 4,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 4,
+                "cuda_graph_modules": [CudaGraphModule.attn, CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 4,
+                "dsa_kernel_backend": "none",
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {"sequence_packing_scheduler": "default_dynamic_cp"},
+            {"cuda_graph_modules": [], "inference_cuda_graph_scope": InferenceCudaGraphScope.block},
+            {"cuda_graph_impl": "local", "cuda_graph_modules": [CudaGraphModule.mamba]},
+            {"cuda_graph_impl": "full_iteration", "cuda_graph_modules": []},
         ],
-        ids=["cp1", "non_dsa", "unfused_backend", "nonpacked", "cuda_graph_disabled", "te_mlp"],
+        ids=[
+            "cp1",
+            "non_dsa",
+            "nonpacked",
+            "cuda_graph_disabled",
+            "te_mlp",
+            "dynamic_te_mlp",
+            "dynamic_configured_cp1",
+            "configured_cp3_unmeasured",
+            "configured_cp4_te_mlp_passed",
+            "configured_cp4_combined_unmeasured",
+            "configured_cp4_unfused_unmeasured",
+            "dynamic_scheduler_without_dynamic_cp_unmeasured",
+            "block_inference_whole_scope_unmeasured",
+            "local_mamba_unmeasured",
+            "full_iteration_unmeasured",
+        ],
     )
-    def test_packed_cudnn_dsa_cp_local_cuda_graph_guard_is_narrow(self, monkeypatch, overrides):
+    def test_packed_cudnn_dsa_cp_cuda_graph_guard_is_narrow(self, monkeypatch, overrides):
         """Changing any measured guard dimension leaves the neighboring config available."""
-        config = self._make_packed_cudnn_dsa_graph_config(monkeypatch, **overrides)
+        config = self._make_packed_dsa_graph_config(monkeypatch, **overrides)
         assert isinstance(config, MLATransformerConfig)
+
+    def test_packed_cudnn_dsa_preserves_legacy_block_inference_scope(self, monkeypatch):
+        """The deprecated spelling maps to an unmeasured block-inference graph."""
+        with pytest.warns(DeprecationWarning, match="full_iteration_inference"):
+            config = self._make_packed_dsa_graph_config(
+                monkeypatch, cuda_graph_impl="local", cuda_graph_modules="full_iteration_inference"
+            )
+        assert config.cuda_graph_modules == []
+        assert config.inference_cuda_graph_scope == InferenceCudaGraphScope.block
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"dsa_kernel_backend": "none"},
+            {
+                "dsa_kernel_backend": "none",
+                "cuda_graph_modules": [CudaGraphModule.attn, CudaGraphModule.attn],
+            },
+            {"sequence_packing_scheduler": "default_dynamic_cp", "dynamic_context_parallel": True},
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_modules": [],
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [],
+            },
+        ],
+        ids=[
+            "static_unfused_local_attention",
+            "static_unfused_local_attention_repeated",
+            "dynamic_cudnn_local_attention",
+            "dynamic_cudnn_local_whole_layer",
+            "dynamic_cudnn_local_mlp",
+            "dynamic_cudnn_te_attention",
+            "dynamic_cudnn_te_whole_layer",
+        ],
+    )
+    def test_packed_dsa_cp_rejects_additional_measured_graph_configs(self, monkeypatch, overrides):
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(monkeypatch, **overrides)
+
+    @pytest.mark.parametrize(
+        (
+            "context_parallel_size",
+            "dsa_kernel_backend",
+            "sequence_packing_scheduler",
+            "dynamic_context_parallel",
+            "cuda_graph_impl",
+            "cuda_graph_modules",
+        ),
+        [
+            (2, "none", "dp_balanced", False, "local", []),
+            (2, "none", "dp_balanced", False, "local", [CudaGraphModule.mlp]),
+            (2, "none", "dp_balanced", False, "transformer_engine", [CudaGraphModule.attn]),
+            (2, "none", "default_dynamic_cp", True, "local", [CudaGraphModule.attn]),
+            (4, "none", "dp_balanced", False, "local", [CudaGraphModule.attn]),
+            (2, "tilelang", "dp_balanced", False, "local", [CudaGraphModule.attn]),
+            (
+                2,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.mlp, CudaGraphModule.mamba],
+            ),
+            (
+                4,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.attn, CudaGraphModule.mlp],
+            ),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.moe]),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.moe_router]),
+            (
+                2,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.moe_router, CudaGraphModule.moe_preprocess],
+            ),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.mamba]),
+            (2, "cudnn", "dp_balanced", False, "transformer_engine", [CudaGraphModule.mlp]),
+            (2, "cudnn", "dp_balanced", False, "transformer_engine", [CudaGraphModule.moe]),
+            (2, "cudnn", "dp_balanced", False, "full_iteration", []),
+        ],
+        ids=[
+            "cp2_backend_none_whole_layer",
+            "cp2_backend_none_mlp",
+            "cp2_backend_none_te_attention",
+            "cp2_backend_none_dynamic_attention",
+            "cp4_backend_none_attention",
+            "cp2_backend_tilelang",
+            "cp2_local_mlp_mamba_combined",
+            "cp4_local_attention_mlp_combined",
+            "cp2_local_moe",
+            "cp2_local_moe_router",
+            "cp2_local_moe_preprocess",
+            "cp2_local_mamba",
+            "cp2_te_mlp",
+            "cp2_te_moe",
+            "cp2_full_iteration",
+        ],
+    )
+    def test_packed_dsa_cp_cuda_graph_predicate_preserves_unmeasured_neighbors(
+        self,
+        context_parallel_size,
+        dsa_kernel_backend,
+        sequence_packing_scheduler,
+        dynamic_context_parallel,
+        cuda_graph_impl,
+        cuda_graph_modules,
+    ):
+        """Do not turn static reasoning about unmeasured neighbors into prohibitions."""
+        assert not is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant="dsa",
+            dsa_kernel_backend=dsa_kernel_backend,
+            sequence_packing_scheduler=sequence_packing_scheduler,
+            dynamic_context_parallel=dynamic_context_parallel,
+            context_parallel_size=context_parallel_size,
+            cuda_graph_impl=cuda_graph_impl,
+            cuda_graph_modules=cuda_graph_modules,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.layer,
+        )
+
+    @pytest.mark.parametrize(
+        ("context_parallel_size", "sequence_packing_scheduler", "dynamic_context_parallel"),
+        [
+            (3, "dp_balanced", False),
+            (3, "default_dynamic_cp", True),
+            (4, "default_dynamic_cp", True),
+            (2, "dp_balanced", True),
+            (2, "default_dynamic_cp", False),
+        ],
+        ids=[
+            "static_cp3",
+            "dynamic_cp3",
+            "dynamic_cp4",
+            "dynamic_flag_static_scheduler",
+            "dynamic_scheduler_without_flag",
+        ],
+    )
+    def test_packed_dsa_cuda_graph_predicate_preserves_unmeasured_topologies(
+        self, context_parallel_size, sequence_packing_scheduler, dynamic_context_parallel
+    ):
+        assert not is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant="dsa",
+            dsa_kernel_backend="cudnn",
+            sequence_packing_scheduler=sequence_packing_scheduler,
+            dynamic_context_parallel=dynamic_context_parallel,
+            context_parallel_size=context_parallel_size,
+            cuda_graph_impl="local",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            inference_cuda_graph_scope=InferenceCudaGraphScope.layer,
+        )
 
     def test_get_dsa_module_spec_for_backend(self):
         """get_dsa_module_spec_for_backend returns the correct full spec structure."""

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -40,8 +40,11 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     unfused_dsa_fn,
 )
 from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_all_rank_positions,
     build_packed_allgather_cp_local_positions,
+    build_packed_allgather_cp_local_positions_from_host,
     build_packed_allgather_cp_query_positions_and_key_reorder,
+    build_packed_allgather_cp_query_positions_and_key_reorder_from_host,
     build_zigzag_allgather_cp_key_reorder,
     extract_query_positions_from_position_ids,
     get_cp_positions_from_layout,
@@ -4019,3 +4022,264 @@ class TestDSAModuleSpecDispatch:
         config = self._make_dsa_config(qk_l2_norm=True)
         with pytest.raises(AssertionError, match="qk_l2_norm is not supported"):
             get_dsa_module_spec_for_backend(config, backend=None)
+
+
+class TestPackedCPAllRankPositions:
+    """The batched CP position builder must match the per-rank loop exactly."""
+
+    @staticmethod
+    def _cu_seqlens(seq_lens, cp_size):
+        """Pad each sequence to a multiple of 2 * cp_size and return cu_seqlens."""
+        multiple = 2 * cp_size
+        padded = [0 if s == 0 else -(-s // multiple) * multiple for s in seq_lens]
+        offsets = [0]
+        for p in padded:
+            offsets.append(offsets[-1] + p)
+        return torch.tensor(offsets, dtype=torch.int32)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8, 16, 64])
+    @pytest.mark.parametrize(
+        "seq_lens", [[512], [512, 1024], [256, 256, 512], [128, 384, 640, 896], [1024, 0, 2048]]
+    )
+    @pytest.mark.parametrize("cover", [True, False])
+    def test_matches_per_rank_loop(self, cp_size, seq_lens, cover):
+        """Row r of the batched build equals the single-rank build for cp_rank=r."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        output_size = total // cp_size
+
+        expected = torch.stack(
+            [
+                build_packed_allgather_cp_local_positions(
+                    cu_seqlens,
+                    cp_size,
+                    rank,
+                    device,
+                    output_size=output_size,
+                    cu_seqlens_cover_output=cover,
+                )
+                for rank in range(cp_size)
+            ],
+            dim=0,
+        )
+        actual = build_packed_allgather_cp_all_rank_positions(
+            cu_seqlens, cp_size, device, output_size=output_size, cu_seqlens_cover_output=cover
+        )
+        assert actual.shape == expected.shape
+        assert torch.equal(actual, expected)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8])
+    def test_padded_output_size(self, cp_size):
+        """Rows still match when output_size exceeds the packed token count."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens([512, 1024], cp_size)
+        output_size = int(cu_seqlens[-1]) // cp_size + 2 * cp_size
+        expected = torch.stack(
+            [
+                build_packed_allgather_cp_local_positions(
+                    cu_seqlens, cp_size, rank, device, output_size=output_size
+                )
+                for rank in range(cp_size)
+            ],
+            dim=0,
+        )
+        actual = build_packed_allgather_cp_all_rank_positions(
+            cu_seqlens, cp_size, device, output_size=output_size
+        )
+        assert torch.equal(actual, expected)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 16])
+    def test_key_reorder_unchanged(self, cp_size):
+        """The public reorder index is unchanged by the batched build."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens([512, 1024], cp_size)
+        total = int(cu_seqlens[-1])
+        output_size = total // cp_size
+
+        _, key_reorder_idx = build_packed_allgather_cp_query_positions_and_key_reorder(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cp_size=cp_size,
+            cp_rank=0,
+            device=device,
+            local_output_size=output_size,
+            key_local_output_size=output_size,
+            global_output_size=total,
+        )
+        reference = torch.argsort(
+            torch.cat(
+                [
+                    build_packed_allgather_cp_local_positions(
+                        cu_seqlens, cp_size, rank, device, output_size=output_size
+                    )
+                    for rank in range(cp_size)
+                ],
+                dim=0,
+            )
+        )
+        assert torch.equal(key_reorder_idx, reference)
+
+
+class TestHostSidePackedCpLayoutBuilders:
+    """The host builders must be bit-equal to the device builders they replace.
+
+    The host path consumes the compacted cu_seqlens list that
+    prebuild_thd_cp_partition_routes stores on PackedSeqParams; the device path
+    consumes the raw device tensor. e2e loss cannot discriminate here (the
+    training workload is not run-to-run reproducible), so bit equality of the
+    produced tables is the correctness contract.
+    """
+
+    @staticmethod
+    def _cu_seqlens(seq_lens, cp_size):
+        multiple = 2 * cp_size
+        padded = [0 if s == 0 else -(-s // multiple) * multiple for s in seq_lens]
+        offsets = [0]
+        for p in padded:
+            offsets.append(offsets[-1] + p)
+        return torch.tensor(offsets, dtype=torch.int32)
+
+    @staticmethod
+    def _host_list(cu_seqlens):
+        """Compacted host list, matching _compact_thd_cu_seqlens_to_list semantics."""
+        values = cu_seqlens.tolist()
+        compact = [values[0]]
+        for v in values[1:]:
+            if v != compact[-1]:
+                compact.append(v)
+        return compact
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 4, 8, 16])
+    @pytest.mark.parametrize(
+        "seq_lens", [[512], [512, 1024], [256, 256, 512], [128, 384, 640, 896], [1024, 0, 2048]]
+    )
+    @pytest.mark.parametrize("cover", [True, False])
+    def test_local_positions_match_device_builder(self, cp_size, seq_lens, cover):
+        """Every rank's host-built positions equal the device builder's output."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        output_size = total // cp_size
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected = build_packed_allgather_cp_local_positions(
+                cu_seqlens,
+                cp_size,
+                rank,
+                device,
+                output_size=output_size,
+                cu_seqlens_cover_output=cover,
+            )
+            actual = build_packed_allgather_cp_local_positions_from_host(
+                host_cu,
+                cp_size,
+                rank,
+                device,
+                output_size=output_size,
+                cu_seqlens_cover_output=cover,
+            )
+            assert torch.equal(actual, expected), f"rank {rank} differs"
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8])
+    @pytest.mark.parametrize("seq_lens", [[512], [256, 256, 512], [1024, 0, 2048]])
+    def test_padded_local_positions_match_device_builder(self, cp_size, seq_lens):
+        """Rows still match when output_size exceeds the packed token count."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        output_size = total // cp_size + 64
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected = build_packed_allgather_cp_local_positions(
+                cu_seqlens, cp_size, rank, device, output_size=output_size
+            )
+            actual = build_packed_allgather_cp_local_positions_from_host(
+                host_cu, cp_size, rank, device, output_size=output_size
+            )
+            assert torch.equal(actual, expected), f"rank {rank} differs"
+
+    @pytest.mark.parametrize("seq_lens", [[5], [7, 3], [1]])
+    def test_cp1_odd_lengths_match_device_identity(self, seq_lens):
+        """cp_size=1 has no zigzag halving, so odd lengths must stay identity.
+
+        The span form floors seq_len // 2 and would silently drop the middle token;
+        the builders take a dedicated identity path instead, mirroring the device
+        builder's cp_size <= 1 branch.
+        """
+        device = torch.device("cpu")
+        offsets = [0]
+        for length in seq_lens:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int32)
+        host_cu = offsets
+        total = offsets[-1]
+        expected = build_packed_allgather_cp_local_positions(
+            cu_seqlens, 1, 0, device, output_size=total
+        )
+        actual = build_packed_allgather_cp_local_positions_from_host(
+            host_cu, 1, 0, device, output_size=total
+        )
+        assert torch.equal(actual, expected)
+        _, reorder = build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+            host_cu,
+            host_cu,
+            cp_size=1,
+            cp_rank=0,
+            device=device,
+            local_output_size=total,
+            key_local_output_size=total,
+        )
+        assert torch.equal(reorder, torch.arange(total, dtype=torch.int64))
+
+    @pytest.mark.parametrize("cp_size", [2, 4])
+    def test_non_divisible_lengths_raise_on_host(self, cp_size):
+        """Host builders reject lengths not divisible by 2*cp_size instead of
+        silently dropping tokens; the check is free on host integers."""
+        bad_cu = [0, 2 * cp_size + 1]
+        with pytest.raises(ValueError, match="divisible"):
+            build_packed_allgather_cp_local_positions_from_host(
+                bad_cu, cp_size, 0, torch.device("cpu")
+            )
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8, 16])
+    @pytest.mark.parametrize("seq_lens", [[512], [512, 1024], [256, 256, 512], [1024, 0, 2048]])
+    @pytest.mark.parametrize("pad", [0, 64])
+    def test_query_and_reorder_match_device_wrapper(self, cp_size, seq_lens, pad):
+        """The host wrapper (direct inverse, no argsort) equals the device wrapper."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        local = total // cp_size + pad
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected_q, expected_r = build_packed_allgather_cp_query_positions_and_key_reorder(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=rank,
+                device=device,
+                local_output_size=local,
+                key_local_output_size=local,
+                global_output_size=local * cp_size,
+            )
+            actual_q, actual_r = (
+                build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+                    host_cu,
+                    host_cu,
+                    cp_size=cp_size,
+                    cp_rank=rank,
+                    device=device,
+                    local_output_size=local,
+                    key_local_output_size=local,
+                    global_output_size=local * cp_size,
+                )
+            )
+            assert torch.equal(actual_q, expected_q), f"rank {rank} query positions differ"
+            assert torch.equal(actual_r, expected_r), f"rank {rank} key reorder differs"

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -56,6 +56,8 @@ from megatron.core.transformer.experimental_attention_variant.dsa_masking import
     build_causal_mask_from_positions,
     build_dsattention_forward_mask,
     build_fused_indexer_varlen_bounds,
+    can_prove_all_topk_rows_nonempty,
+    extract_query_valid_rows_from_packed_seq_params,
     generate_varlen_mask_params_for_positions,
     masked_log_softmax,
     scatter_topk_into_index_mask,
@@ -407,6 +409,128 @@ def test_dsa_kernel_backend_loader_cache_and_import_errors(monkeypatch):
         dsa_kernels._load_backend(Config)
 
 
+def test_dsa_all_topk_rows_nonempty_certificate():
+    common = {
+        "computes_topk": True,
+        "indexer_topk": 2,
+        "kv_sequence_length": 4,
+        "attention_mask": None,
+        "query_valid_rows": None,
+        "varlen_is_plain_causal": True,
+        "use_local_indexer_varlen": False,
+        "varlen_starts": None,
+        "varlen_ends": None,
+        "key_positions": None,
+    }
+    assert can_prove_all_topk_rows_nonempty(**common)
+
+    packed_local = {
+        **common,
+        "varlen_is_plain_causal": False,
+        "use_local_indexer_varlen": True,
+        "varlen_starts": torch.tensor([0, 0]),
+        "varlen_ends": torch.tensor([1, 2]),
+    }
+    assert can_prove_all_topk_rows_nonempty(**packed_local)
+
+    unsupported = [
+        {"computes_topk": False},
+        {"indexer_topk": 0},
+        {"kv_sequence_length": 0},
+        {"attention_mask": torch.zeros((1, 1, 2, 4), dtype=torch.bool)},
+        {"query_valid_rows": torch.ones((1, 2), dtype=torch.bool)},
+        {"varlen_is_plain_causal": False},
+        {**packed_local, "key_positions": torch.arange(4)},
+        {**packed_local, "varlen_ends": None},
+    ]
+    for override in unsupported:
+        assert not can_prove_all_topk_rows_nonempty(**{**common, **override})
+
+
+def test_dsa_packed_cp_padding_preserves_nonempty_local_varlen_rows():
+    """Padded THD rows still have causal KV coverage without a real-token mask."""
+    device = torch.device("cpu")
+    cp_size = 2
+    global_rows = 12
+    local_rows = global_rows // cp_size
+    cu_seqlens = torch.tensor([0, 3, 7], dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.tensor([0, 4, 12], dtype=torch.int32, device=device)
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens_padded,
+        cu_seqlens_kv_padded=cu_seqlens_padded,
+        max_seqlen_q=8,
+        max_seqlen_kv=8,
+        pad_between_seqs=True,
+    )
+    query_valid_rows = extract_query_valid_rows_from_packed_seq_params(
+        packed_seq_params, b=1, sq=local_rows, device=device
+    )
+    assert query_valid_rows is None
+
+    padding_positions = torch.tensor([3, 8, 9, 10, 11], device=device)
+    all_query_positions = []
+    for cp_rank in range(cp_size):
+        query_positions = build_packed_allgather_cp_local_positions(
+            cu_seqlens_padded,
+            cp_size,
+            cp_rank,
+            device,
+            output_size=local_rows,
+            cu_seqlens_cover_output=True,
+        )
+        all_query_positions.append(query_positions)
+        float_mask, varlen_params, varlen_is_plain_causal = build_dsattention_forward_mask(
+            sq=local_rows,
+            skv=global_rows,
+            b=1,
+            device=device,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_comm_type="allgather",
+            cp_group=None,
+            attn_mask_type=AttnMaskType.causal,
+            attention_mask=None,
+            position_ids=None,
+            packed_seq_params=packed_seq_params,
+            packed_query_positions=query_positions,
+        )
+        assert float_mask is None
+        assert not varlen_is_plain_causal
+        assert varlen_params is not None
+        starts, ends, key_positions = varlen_params
+        assert key_positions is None
+
+        physical_key_positions = torch.arange(global_rows, device=device)
+        row_has_key = (
+            (physical_key_positions.unsqueeze(0) >= starts.unsqueeze(1))
+            & (physical_key_positions.unsqueeze(0) < ends.unsqueeze(1))
+        ).any(dim=1)
+        assert torch.all(row_has_key)
+        assert torch.any((query_positions.unsqueeze(1) == padding_positions).any(dim=1))
+        assert can_prove_all_topk_rows_nonempty(
+            computes_topk=True,
+            indexer_topk=2,
+            kv_sequence_length=global_rows,
+            attention_mask=None,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            use_local_indexer_varlen=True,
+            varlen_starts=starts,
+            varlen_ends=ends,
+            key_positions=key_positions,
+        )
+
+    torch.testing.assert_close(
+        torch.cat(all_query_positions).sort().values,
+        torch.arange(global_rows, device=device),
+        rtol=0,
+        atol=0,
+    )
+
+
 def test_dsa_kernel_hooks_return_none_without_backend_function(monkeypatch):
     class Config:
         attention_backend = "auto"
@@ -493,7 +617,9 @@ def test_dsa_kernel_hooks_log_declined_backend(monkeypatch, caplog):
         is None
     )
     assert (
-        dsa_kernels.run_fused_absorbed_sparse_attention(Config, q, q, starts.view(1, 1, 1), 1.0, 1)
+        dsa_kernels.run_fused_absorbed_sparse_attention(
+            Config, q, q, starts.view(1, 1, 1), 1.0, 1, all_topk_rows_nonempty=True
+        )
         is None
     )
     assert (
@@ -557,8 +683,9 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
         seen["loss_kwargs"] = kwargs
         return expected_topk_loss
 
-    def run_fused_absorbed_sparse_attention(*args):
+    def run_fused_absorbed_sparse_attention(*args, all_topk_rows_nonempty=False):
         seen["sparse_args"] = args
+        seen["all_topk_rows_nonempty"] = all_topk_rows_nonempty
         return expected_sparse
 
     def run_fused_dsa_attention(**kwargs):
@@ -629,11 +756,12 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     topk_length = torch.ones((1, 1), dtype=torch.int32)
     assert (
         dsa_kernels.run_fused_absorbed_sparse_attention(
-            Config, q, k, topk_indices, 1.0, 1, topk_length
+            Config, q, k, topk_indices, 1.0, 1, topk_length, all_topk_rows_nonempty=True
         )
         is expected_sparse
     )
     assert seen["sparse_args"][-1] is topk_length
+    assert seen["all_topk_rows_nonempty"] is True
 
     assert (
         dsa_kernels.run_fused_dsa_attention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Compatibility coverage for optional DSA backend hook kwargs."""
+
+import pytest
+
+from megatron.core.transformer.experimental_attention_variant import dsa_kernels
+
+
+@pytest.fixture(autouse=True)
+def _clear_hook_signature_cache():
+    dsa_kernels._HOOK_KWARG_SIGNATURE_CACHE.clear()
+    yield
+    dsa_kernels._HOOK_KWARG_SIGNATURE_CACHE.clear()
+
+
+def _run_split_hook(*, varlen_is_plain_causal=True):
+    marker = object()
+    result = dsa_kernels.run_fused_qk_topk(
+        object(),
+        marker,
+        marker,
+        marker,
+        8,
+        marker,
+        marker,
+        128,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+    )
+    return result, marker
+
+
+def _run_full_hook(*, varlen_is_plain_causal=True):
+    marker = object()
+    result = dsa_kernels.run_fused_dsa_attention(
+        config=object(),
+        query=marker,
+        key=marker,
+        value=None,
+        up_v_weight=None,
+        q_indexer=marker,
+        k_indexer=marker,
+        indexer_weights=marker,
+        indexer_topk=8,
+        softmax_scale=1.0,
+        loss_coeff=0.0,
+        sparse_loss=False,
+        calculate_per_token_loss=False,
+        absorbed_mla=True,
+        cp_size=1,
+        attn_mask_type=None,
+        packed_seq_params=None,
+        varlen_starts=None,
+        varlen_ends=None,
+        key_positions=None,
+        query_valid_rows=None,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        use_relu=True,
+    )
+    return result, marker
+
+
+def test_hook_kwarg_signature_is_inspected_once(monkeypatch):
+    inspected = []
+    original_signature = dsa_kernels.inspect.signature
+
+    def hook(*, varlen_is_plain_causal=False):
+        return varlen_is_plain_causal
+
+    def track_signature(fn):
+        inspected.append(fn)
+        return original_signature(fn)
+
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", track_signature)
+
+    expected = {"varlen_is_plain_causal": True}
+    assert (
+        dsa_kernels._hook_kwargs_accepting(hook, varlen_is_plain_causal=True, unsupported=True)
+        == expected
+    )
+    assert (
+        dsa_kernels._hook_kwargs_accepting(hook, varlen_is_plain_causal=True, unsupported=True)
+        == expected
+    )
+    assert inspected == [hook]
+
+
+def test_legacy_exact_split_hook_excludes_new_optional_kwarg(monkeypatch):
+    calls = []
+    expected = object()
+
+    def legacy_hook(
+        *,
+        q,
+        k,
+        weights,
+        index_topk,
+        starts,
+        ends,
+        block_size,
+        use_relu,
+        use_local_indexer_varlen,
+        single_packed_thd_sequence,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+        local_packed_cp_query_len,
+        packed_seq_params,
+        cp_size,
+    ):
+        calls.append((q, k, weights, index_topk, starts, ends, block_size, cp_size))
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: legacy_hook)
+
+    result, marker = _run_split_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert calls == [(marker, marker, marker, 8, marker, marker, 128, 1)]
+
+
+def test_kwargs_split_hook_receives_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def kwargs_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: kwargs_hook)
+
+    result, _ = _run_split_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+
+
+def test_opaque_split_hook_receives_no_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def opaque_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    result, _ = _run_split_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert "varlen_is_plain_causal" not in seen
+
+
+def test_split_hook_type_error_propagates_without_retry(monkeypatch):
+    calls = 0
+
+    def failing_hook(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise TypeError("backend implementation failed")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: failing_hook)
+
+    with pytest.raises(TypeError, match="backend implementation failed"):
+        _run_split_hook(varlen_is_plain_causal=True)
+    assert calls == 1
+
+
+def test_legacy_exact_full_hook_excludes_new_optional_kwarg(monkeypatch):
+    calls = []
+    expected = object()
+
+    def full_hook(
+        *,
+        config,
+        query,
+        key,
+        value,
+        up_v_weight,
+        q_indexer,
+        k_indexer,
+        indexer_weights,
+        indexer_topk,
+        softmax_scale,
+        loss_coeff,
+        sparse_loss,
+        calculate_per_token_loss,
+        absorbed_mla,
+        cp_size,
+        attn_mask_type,
+        packed_seq_params,
+        varlen_starts,
+        varlen_ends,
+        key_positions,
+        query_valid_rows,
+        use_relu,
+        use_local_indexer_varlen,
+        single_packed_thd_sequence,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+        local_packed_cp_query_len,
+        pg_collection,
+    ):
+        del (
+            config,
+            value,
+            up_v_weight,
+            softmax_scale,
+            loss_coeff,
+            sparse_loss,
+            calculate_per_token_loss,
+            absorbed_mla,
+            attn_mask_type,
+            packed_seq_params,
+            varlen_starts,
+            varlen_ends,
+            key_positions,
+            query_valid_rows,
+            use_relu,
+            use_local_indexer_varlen,
+            single_packed_thd_sequence,
+            local_packed_cp_rank,
+            local_packed_cp_query_start,
+            local_packed_cp_query_len,
+            pg_collection,
+        )
+        calls.append((query, key, q_indexer, k_indexer, indexer_weights, indexer_topk, cp_size))
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: full_hook)
+
+    result, marker = _run_full_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert calls == [(marker, marker, marker, marker, marker, 8, 1)]
+
+
+def test_kwargs_full_hook_receives_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def full_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: full_hook)
+
+    result, _ = _run_full_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
@@ -240,6 +240,49 @@ def test_split_hook_type_error_propagates_without_retry(monkeypatch):
     assert calls == 1
 
 
+def test_sparse_attention_hook_filters_static_row_certificate_for_legacy_signature(monkeypatch):
+    """The fixed-row certificate must not break an older exact backend hook."""
+    expected = object()
+
+    def legacy_hook(query, key, topk_indices, softmax_scale, v_channels, topk_length):
+        del query, key, topk_indices, softmax_scale, v_channels, topk_length
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: legacy_hook)
+
+    marker = object()
+    result = dsa_kernels.run_fused_absorbed_sparse_attention(
+        object(), marker, marker, marker, 1.0, 8, marker, all_topk_rows_nonempty=True
+    )
+
+    assert result is expected
+
+
+def test_opaque_sparse_attention_hook_receives_no_static_row_certificate(monkeypatch):
+    """An opaque out-of-tree hook receives only its established positional contract."""
+    calls = []
+    expected = object()
+
+    def opaque_hook(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    marker = object()
+    result = dsa_kernels.run_fused_absorbed_sparse_attention(
+        object(), marker, marker, marker, 1.0, 8, marker, all_topk_rows_nonempty=True
+    )
+
+    assert result is expected
+    assert len(calls[0][0]) == 6
+    assert calls[0][1] == {}
+
+
 def test_legacy_exact_full_hook_excludes_new_optional_kwarg(monkeypatch):
     calls = []
     expected = object()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from megatron.core.transformer.experimental_attention_variant import dsa_kernels
+from megatron.core.transformer.experimental_attention_variant import dsa_cudnn_kernels, dsa_kernels
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +14,13 @@ def _clear_hook_signature_cache():
     dsa_kernels._HOOK_KWARG_SIGNATURE_CACHE.clear()
 
 
-def _run_split_hook(*, varlen_is_plain_causal=True):
+def _run_split_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
     marker = object()
     result = dsa_kernels.run_fused_qk_topk(
         object(),
@@ -25,12 +31,21 @@ def _run_split_hook(*, varlen_is_plain_causal=True):
         marker,
         marker,
         128,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        cp_size=cp_size,
         varlen_is_plain_causal=varlen_is_plain_causal,
     )
     return result, marker
 
 
-def _run_full_hook(*, varlen_is_plain_causal=True):
+def _run_full_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
     marker = object()
     result = dsa_kernels.run_fused_dsa_attention(
         config=object(),
@@ -47,7 +62,7 @@ def _run_full_hook(*, varlen_is_plain_causal=True):
         sparse_loss=False,
         calculate_per_token_loss=False,
         absorbed_mla=True,
-        cp_size=1,
+        cp_size=cp_size,
         attn_mask_type=None,
         packed_seq_params=None,
         varlen_starts=None,
@@ -56,6 +71,38 @@ def _run_full_hook(*, varlen_is_plain_causal=True):
         query_valid_rows=None,
         varlen_is_plain_causal=varlen_is_plain_causal,
         use_relu=True,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
+    return result, marker
+
+
+def _run_split_loss_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
+    marker = object()
+    result = dsa_kernels.run_fused_qk_topk_with_loss(
+        object(),
+        marker,
+        marker,
+        marker,
+        8,
+        marker,
+        marker,
+        128,
+        marker,
+        marker,
+        1.0,
+        1.0,
+        marker,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        cp_size=cp_size,
+        varlen_is_plain_causal=varlen_is_plain_causal,
     )
     return result, marker
 
@@ -107,15 +154,33 @@ def test_legacy_exact_split_hook_excludes_new_optional_kwarg(monkeypatch):
         packed_seq_params,
         cp_size,
     ):
-        calls.append((q, k, weights, index_topk, starts, ends, block_size, cp_size))
+        calls.append(
+            (
+                q,
+                k,
+                weights,
+                index_topk,
+                starts,
+                ends,
+                block_size,
+                use_local_indexer_varlen,
+                single_packed_thd_sequence,
+                cp_size,
+            )
+        )
         return expected
 
     monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: legacy_hook)
 
-    result, marker = _run_split_hook(varlen_is_plain_causal=True)
+    result, marker = _run_split_hook(varlen_is_plain_causal=True, cp_size=1)
+    result_cp2, marker_cp2 = _run_split_hook(varlen_is_plain_causal=True, cp_size=2)
 
     assert result is expected
-    assert calls == [(marker, marker, marker, 8, marker, marker, 128, 1)]
+    assert result_cp2 is expected
+    assert calls == [
+        (marker, marker, marker, 8, marker, marker, 128, False, False, 1),
+        (marker_cp2, marker_cp2, marker_cp2, 8, marker_cp2, marker_cp2, 128, True, True, 2),
+    ]
 
 
 def test_kwargs_split_hook_receives_new_optional_kwarg(monkeypatch):
@@ -132,6 +197,10 @@ def test_kwargs_split_hook_receives_new_optional_kwarg(monkeypatch):
 
     assert result is expected
     assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
 
 
 def test_opaque_split_hook_receives_no_new_optional_kwarg(monkeypatch):
@@ -152,6 +221,8 @@ def test_opaque_split_hook_receives_no_new_optional_kwarg(monkeypatch):
 
     assert result is expected
     assert "varlen_is_plain_causal" not in seen
+    assert "packed_thd_causal_identity_layout" not in seen
+    assert "packed_thd_single_sequence" not in seen
 
 
 def test_split_hook_type_error_propagates_without_retry(monkeypatch):
@@ -220,22 +291,37 @@ def test_legacy_exact_full_hook_excludes_new_optional_kwarg(monkeypatch):
             key_positions,
             query_valid_rows,
             use_relu,
-            use_local_indexer_varlen,
-            single_packed_thd_sequence,
             local_packed_cp_rank,
             local_packed_cp_query_start,
             local_packed_cp_query_len,
             pg_collection,
         )
-        calls.append((query, key, q_indexer, k_indexer, indexer_weights, indexer_topk, cp_size))
+        calls.append(
+            (
+                query,
+                key,
+                q_indexer,
+                k_indexer,
+                indexer_weights,
+                indexer_topk,
+                use_local_indexer_varlen,
+                single_packed_thd_sequence,
+                cp_size,
+            )
+        )
         return expected
 
     monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: full_hook)
 
-    result, marker = _run_full_hook(varlen_is_plain_causal=True)
+    result, marker = _run_full_hook(varlen_is_plain_causal=True, cp_size=1)
+    result_cp2, marker_cp2 = _run_full_hook(varlen_is_plain_causal=True, cp_size=2)
 
     assert result is expected
-    assert calls == [(marker, marker, marker, marker, marker, 8, 1)]
+    assert result_cp2 is expected
+    assert calls == [
+        (marker, marker, marker, marker, marker, 8, False, False, 1),
+        (marker_cp2, marker_cp2, marker_cp2, marker_cp2, marker_cp2, 8, True, True, 2),
+    ]
 
 
 def test_kwargs_full_hook_receives_new_optional_kwarg(monkeypatch):
@@ -252,3 +338,66 @@ def test_kwargs_full_hook_receives_new_optional_kwarg(monkeypatch):
 
     assert result is expected
     assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
+
+
+def test_opaque_full_hook_preserves_existing_varlen_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def opaque_full_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_full_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    result, _ = _run_full_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert "packed_thd_causal_identity_layout" not in seen
+    assert "packed_thd_single_sequence" not in seen
+
+
+def test_kwargs_split_loss_hook_receives_compatible_layout_flags(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def loss_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: loss_hook)
+
+    result, _ = _run_split_loss_hook(cp_size=1)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
+
+
+def test_cudnn_hook_prefers_new_cp_independent_layout_flags():
+    assert dsa_cudnn_kernels._resolve_packed_layout_flags(
+        use_local_indexer_varlen=False,
+        single_packed_thd_sequence=False,
+        packed_thd_causal_identity_layout=True,
+        packed_thd_single_sequence=True,
+    ) == (True, True)
+    assert dsa_cudnn_kernels._resolve_packed_layout_flags(
+        use_local_indexer_varlen=True,
+        single_packed_thd_sequence=True,
+        packed_thd_causal_identity_layout=None,
+        packed_thd_single_sequence=None,
+    ) == (True, True)

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -2341,7 +2341,11 @@ def test_cudnn_sparse_backward_uses_batch_major_topk_indices_for_batched_kv(monk
 
 
 @pytest.mark.parametrize("source", ["full_fusion", "split_attention"])
-def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, source):
+@pytest.mark.parametrize(
+    "row_lengths", [(1, 2), (0, 2), (0, 0)], ids=["nonempty", "mixed", "all-empty"]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_keeps_fixed_rows(monkeypatch, source, row_lengths, dtype):
     seen = {}
 
     class FakeDSA:
@@ -2350,76 +2354,201 @@ def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, sour
             q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
         ):
             seen["bwd_q_shape"] = q.shape
+            seen["bwd_dO"] = dO.detach().clone()
+            seen["bwd_lse"] = lse.detach().clone()
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
-            return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
+            return {"dq": torch.ones_like(q), "dkv": torch.ones_like(kv) * dO.sum()}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
 
+    def make_topk(width):
+        topk = torch.full((1, 2, width), -1, dtype=torch.int32)
+        if row_lengths[0] > 0:
+            topk[0, 0, : row_lengths[0]] = torch.tensor([0, 3])[: row_lengths[0]]
+        if row_lengths[1] > 0:
+            topk[0, 1, : row_lengths[1]] = torch.tensor([1, 2])[: row_lengths[1]]
+        return topk
+
     def fake_indexer_topk(*args, **kwargs):
-        return (
-            torch.tensor([[[-1, -1, -1, -1], [1, 2, -1, -1]]], dtype=torch.int32),
-            torch.tensor([[0, 2]], dtype=torch.int32),
-            None,
-        )
+        return make_topk(4), torch.tensor([row_lengths], dtype=torch.int32), None
 
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         seen["fwd_topk"] = topk_idxs.detach().clone()
         seen["fwd_topk_length"] = topk_length.detach().clone()
-        return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
+        # Match FlashMLA's empty-row contract so the wrapper must preserve LSE=+inf.
+        lse = torch.tensor([[5.0], [6.0]], dtype=torch.float32, device=q.device)
+        lse[torch.tensor(row_lengths, device=q.device) <= 0] = float("inf")
+        return torch.zeros((2, 1, d_v), dtype=q.dtype, device=q.device), lse
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
 
     if source == "full_fusion":
-        query = torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, 1), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1), dtype=dtype, requires_grad=True)
         monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
         output, _indexer_loss = dsa_cudnn_kernels.fused_indexer_sparse_attn(
             query,
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16, requires_grad=True),
-            torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((2, 1, 1), dtype=torch.bfloat16),
+            key,
+            torch.zeros((2, 1, 1, 1), dtype=dtype),
+            torch.zeros((4, 1, 1), dtype=dtype),
+            torch.zeros((2, 1, 1), dtype=dtype),
             indexer_topk=4,
             softmax_scale=1.0,
             loss_coeff=0.0,
             sparse_loss=True,
             calculate_per_token_loss=False,
             d_v=1,
+            query_valid_rows=torch.tensor([[length > 0 for length in row_lengths]]),
         )
-        expected_fwd_topk = torch.tensor([[-1, -1, -1, -1], [1, 2, -1, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0, 0], [0, 0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(4).squeeze(0)
     else:
         value_dim = 512
-        query = torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
-        key = torch.zeros((4, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        input_topk = make_topk(3)
+        input_topk_length = torch.tensor([row_lengths], dtype=torch.int32)
+        original_topk = input_topk.clone()
+        original_topk_length = input_topk_length.clone()
         output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
             query=query,
             key=key,
-            topk_indices=torch.tensor([[[-1, -1, -1], [2, -1, 1]]], dtype=torch.int32),
+            topk_indices=input_topk,
             softmax_scale=1.0,
             v_channels=value_dim,
+            topk_length=input_topk_length,
         )
         assert output is not None
-        expected_fwd_topk = torch.tensor([[-1, -1, -1], [1, 2, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0], [0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(3).squeeze(0)
 
-    output.float().sum().backward()
+    empty_rows = torch.tensor(row_lengths) <= 0
+    grad_output = torch.ones_like(output)
+    grad_output[empty_rows] = float("nan")
+
+    def fail_nonzero(*_args, **_kwargs):
+        raise AssertionError("fixed-shape sparse backward must not call torch.nonzero")
+
+    monkeypatch.setattr(torch, "nonzero", fail_nonzero)
+    output.backward(grad_output, retain_graph=True)
 
     torch.testing.assert_close(seen["fwd_topk"], expected_fwd_topk)
-    torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([0, 2], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["fwd_topk_length"], torch.tensor(row_lengths, dtype=torch.int32)
+    )
     assert seen["bwd_q_shape"] == (query.size(0) * query.size(1), query.size(2), query.size(3))
-    # Backward compacts nonempty rows and appends one dummy row to avoid empty cuDNN launches.
+    expected_bwd_topk = expected_fwd_topk.clamp_min(0)
+    expected_bwd_topk[empty_rows, 0] = 0
     torch.testing.assert_close(seen["bwd_topk"], expected_bwd_topk)
-    torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([2, 1], dtype=torch.int32))
-    torch.testing.assert_close(query.grad[0], torch.zeros_like(query.grad[0]))
-    torch.testing.assert_close(query.grad[1], torch.ones_like(query.grad[1]))
+    torch.testing.assert_close(
+        seen["bwd_topk_length"],
+        torch.tensor([max(1, length) for length in row_lengths], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        seen["bwd_dO"][empty_rows], torch.zeros_like(seen["bwd_dO"][empty_rows])
+    )
+    torch.testing.assert_close(
+        seen["bwd_lse"][empty_rows], torch.full_like(seen["bwd_lse"][empty_rows], float("inf"))
+    )
+    if (~empty_rows).any():
+        torch.testing.assert_close(
+            seen["bwd_lse"][~empty_rows], torch.tensor([[5.0], [6.0]])[~empty_rows]
+        )
+    expected_query_grad = torch.ones_like(query.grad)
+    expected_query_grad[empty_rows] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_dkv = seen["bwd_dO"].sum().to(key.dtype)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
     if source == "split_attention":
-        torch.testing.assert_close(key.grad, torch.zeros_like(key.grad))
+        torch.testing.assert_close(input_topk, original_topk)
+        torch.testing.assert_close(input_topk_length, original_topk_length)
+
+    query.grad.zero_()
+    key.grad.zero_()
+    output.backward(grad_output)
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
 
 
-def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen(monkeypatch):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_dummy_rows_add_no_cross_batch_gradient(monkeypatch, dtype):
     seen = {}
+
+    class FakeDSA:
+        @staticmethod
+        def sparse_attention_backward_wrapper(
+            q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
+        ):
+            del out, lse, attn_sink, softmax_scale
+            seen["topk"] = topk_indices.detach().clone()
+            seen["topk_length"] = topk_length.detach().clone()
+            seen["dO"] = dO.detach().clone()
+            dkv = torch.zeros_like(kv)
+            for row in range(q.size(0)):
+                for column in range(int(topk_length[row])):
+                    dkv[topk_indices[row, column]] += dO[row].sum()
+            return {"dq": torch.ones_like(q), "dkv": dkv}
+
+    def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
+        del kv, softmax_scale, attn_sink
+        seen["forward_topk"] = topk_idxs.detach().clone()
+        seen["forward_topk_length"] = topk_length.detach().clone()
+        return torch.zeros((q.size(0), q.size(1), d_v), dtype=q.dtype), torch.ones(
+            (q.size(0), q.size(1)), dtype=torch.float32
+        )
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
+
+    value_dim = 512
+    query = torch.zeros((2, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    key = torch.zeros((3, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    topk_indices = torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    topk_length = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=query,
+        key=key,
+        topk_indices=topk_indices,
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=topk_length,
+    )
+    assert output is not None
+
+    grad_output = torch.zeros_like(output)
+    grad_output[0, 0, 0, 0] = float("nan")
+    grad_output[0, 1, 0, 0] = 2
+    grad_output[1, 0, 0, 0] = 3
+    grad_output[1, 1, 0, 0] = float("nan")
+    output.backward(grad_output)
+
+    torch.testing.assert_close(
+        seen["forward_topk_length"], torch.tensor([0, 1, 1, 0], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["topk_length"], torch.tensor([1, 1, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["topk"], torch.tensor([[0, 0], [3, 0], [4, 0], [0, 0]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["dO"][[0, 3]], torch.zeros_like(seen["dO"][[0, 3]]))
+
+    expected_query_grad = torch.ones_like(query)
+    expected_query_grad[0, 0] = 0
+    expected_query_grad[1, 1] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_key_grad = torch.zeros_like(key)
+    expected_key_grad[1, 1] = 2
+    expected_key_grad[2, 0] = 3
+    torch.testing.assert_close(key.grad, expected_key_grad)
+    torch.testing.assert_close(
+        topk_indices, torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    )
+
+
+@pytest.mark.parametrize("layout", ["plain_causal", "local_varlen"])
+def test_cudnn_full_fusion_uses_nonempty_layout_certificate(monkeypatch, layout):
+    seen = {}
+    use_local_varlen = layout == "local_varlen"
 
     class FakeDSA:
         @staticmethod
@@ -2430,13 +2559,14 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
             seen["bwd_q_shape"] = q.shape
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
+            seen["bwd_topk_length_ptr"] = topk_length.data_ptr()
             return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
 
     def fake_indexer_topk(*args, **kwargs):
-        assert kwargs["use_local_indexer_varlen"] is True
+        assert kwargs["use_local_indexer_varlen"] is use_local_varlen
         return (
             torch.tensor([[[0, -1, -1], [0, 1, -1]]], dtype=torch.int32),
             torch.tensor([[1, 2]], dtype=torch.int32),
@@ -2446,6 +2576,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         del kv, topk_idxs, softmax_scale, attn_sink
         seen["fwd_topk_length"] = topk_length.detach().clone()
+        seen["fwd_topk_length_ptr"] = topk_length.data_ptr()
         return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
@@ -2464,9 +2595,9 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
         sparse_loss=True,
         calculate_per_token_loss=False,
         d_v=1,
-        varlen_starts=torch.tensor([0, 0], dtype=torch.int64),
-        varlen_ends=torch.tensor([1, 2], dtype=torch.int64),
-        use_local_indexer_varlen=True,
+        varlen_starts=(torch.tensor([0, 0], dtype=torch.int64) if use_local_varlen else None),
+        varlen_ends=(torch.tensor([1, 2], dtype=torch.int64) if use_local_varlen else None),
+        use_local_indexer_varlen=use_local_varlen,
     )
 
     output.float().sum().backward()
@@ -2474,6 +2605,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     assert seen["bwd_q_shape"] == (2, 1, 1)
     torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
     torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
+    assert seen["bwd_topk_length_ptr"] == seen["fwd_topk_length_ptr"]
     torch.testing.assert_close(
         seen["bwd_topk"], torch.tensor([[0, 0, 0], [0, 1, 0]], dtype=torch.int32)
     )
@@ -2527,6 +2659,28 @@ def test_cudnn_sparse_attention_declines_unsupported_flashmla_value_dim(monkeypa
         topk_indices=torch.tensor([[[2, 1, -1], [-1, -1, -1]]], dtype=torch.int32),
         softmax_scale=1.0,
         v_channels=4,
+    )
+
+    assert output is None
+
+
+@pytest.mark.parametrize("empty_dimension", ["topk", "kv"])
+def test_cudnn_sparse_attention_declines_without_safe_backward_tile(monkeypatch, empty_dimension):
+    def fail_flash_mla(*_args, **_kwargs):
+        raise AssertionError("cuDNN must not run without a valid safe backward tile")
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fail_flash_mla)
+
+    value_dim = 512
+    kv_length = 0 if empty_dimension == "kv" else 4
+    topk_width = 0 if empty_dimension == "topk" else 2
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16),
+        key=torch.zeros((kv_length, 1, 1, value_dim), dtype=torch.bfloat16),
+        topk_indices=torch.empty((1, 2, topk_width), dtype=torch.int32),
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=torch.zeros((1, 2), dtype=torch.int32),
     )
 
     assert output is None
@@ -2639,7 +2793,7 @@ def test_cudnn_attention_backward_pads_small_local_head_count(monkeypatch):
         d=attn_dim,
         skv=skv,
         grad_output=torch.zeros((sq, batch_size, num_heads, value_dim), device="cuda"),
-        all_rows_nonempty=True,
+        all_topk_rows_nonempty=True,
     )
 
     assert seen["shapes"] == (

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -755,7 +755,7 @@ def test_cudnn_indexer_topk_multi_packed_cp1_real_kernel_matches_pytorch_gradien
     indexer_dim = 128
     attention_heads = 64
     attention_dim = 576
-    # SM100 sparse score recompute requires top-k to be a multiple of 64.
+    # Exercise the SM90 internal 128-slot padding while SM100 consumes 64 directly.
     topk = 64
     softmax_scale = attention_dim**-0.5
     loss_coeff = 0.01
@@ -964,6 +964,27 @@ def test_cudnn_general_thd_rejects_impossible_qk_geometry():
     assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=5, **common)
     mismatched_max = {**common, "packed_max_seqlen_k": 1}
     assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=3, **mismatched_max)
+
+
+def test_cudnn_general_thd_cp2_rejects_different_qk_boundaries():
+    """Q-relative index restoration is unsafe when packed K starts differ."""
+    cu_q = torch.tensor([0, 8, 24], dtype=torch.int32)
+    cu_k = torch.tensor([0, 16, 24], dtype=torch.int32)
+
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        b=1,
+        sq=12,
+        sk=24,
+        device=cu_q.device,
+        packed_cu_seqlens_q=cu_q,
+        packed_cu_seqlens_k=cu_k,
+        packed_max_seqlen_q=16,
+        packed_max_seqlen_k=16,
+        cp_size=2,
+        cp_rank=0,
+        local_packed_cp_query_start=0,
+        local_packed_cp_query_len=None,
+    )
 
 
 @pytest.mark.parametrize("max_segment_k", [5, 6], ids=["odd-k", "even-k"])
@@ -1804,6 +1825,13 @@ def test_flash_mla_topk_alignment_uses_sm100_block(monkeypatch):
         assert dsa_cudnn_kernels._get_topk_alignment() == 512
     finally:
         dsa_cudnn_kernels._device_sm.cache_clear()
+
+
+@pytest.mark.parametrize("sm, expected", [((9, 0), 128), ((10, 0), 64)])
+def test_sparse_score_recompute_topk_alignment(monkeypatch, sm, expected):
+    monkeypatch.setattr(dsa_cudnn_kernels, "_current_sm", lambda: sm)
+
+    assert dsa_cudnn_kernels._get_score_recompute_topk_alignment() == expected
 
 
 def test_dsa_fwd_flash_mla_pads_topk_to_flashmla_block(monkeypatch):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -557,6 +557,415 @@ def test_cudnn_indexer_topk_multi_packed_cp_uses_segmented_thd(monkeypatch):
     )
 
 
+def test_cudnn_indexer_topk_multi_packed_cp1_uses_direct_thd(monkeypatch):
+    """CP1 multi-sequence packs use one THD call without splitting Q or duplicating K."""
+    seen = {"calls": 0}
+
+    class FakeDSA:
+        @staticmethod
+        def indexer_forward_wrapper(
+            q, k, weights, ratio, sm_scale, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k
+        ):
+            seen["calls"] += 1
+            seen["q"] = q
+            seen["k"] = k
+            seen["weights"] = weights
+            seen["cu_q"] = cu_seqlens_q
+            seen["cu_k"] = cu_seqlens_k
+            seen["max_q"] = max_seqlen_q
+            seen["max_k"] = max_seqlen_k
+            del ratio, sm_scale
+            scores = torch.full((q.size(0), max_seqlen_k), float("-inf"))
+            for sequence in range(cu_seqlens_q.numel() - 1):
+                q_start = int(cu_seqlens_q[sequence])
+                q_end = int(cu_seqlens_q[sequence + 1])
+                for row in range(q_end - q_start):
+                    scores[q_start + row, : row + 1] = torch.arange(row + 1)
+            return {"scores": scores}
+
+        @staticmethod
+        def indexer_top_k_wrapper(scores, seq_lens, top_k, next_n, return_val):
+            del next_n
+            masked_scores = scores.clone()
+            key_ids = torch.arange(scores.size(1)).view(1, -1)
+            masked_scores.masked_fill_(key_ids >= seq_lens.view(-1, 1), float("-inf"))
+            values, indices = masked_scores.topk(top_k, dim=-1)
+            return {"indices": indices.to(torch.int32), "values": values if return_val else None}
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+
+    q = torch.ones((1, 8, 1, 1))
+    k = torch.ones((1, 8, 1))
+    weights = torch.ones((1, 8, 1))
+    cu_q = torch.tensor([0, 3, 8], dtype=torch.int32)
+    # Match the production dynamic-scheduler contract: self-attention Q/K
+    # boundaries alias, so equality is proven without a CUDA synchronization.
+    cu_k = cu_q
+    starts = torch.tensor([0, 0, 0, 3, 3, 3, 3, 3])
+    ends = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8])
+    topk_indices, topk_length, topk_scores = dsa_cudnn_kernels._indexer_topk_bshd(
+        q,
+        k,
+        weights,
+        topk=2,
+        varlen_starts=starts,
+        varlen_ends=ends,
+        return_scores=False,
+        return_topk_scores=True,
+        use_local_indexer_varlen=True,
+        packed_cu_seqlens_q=cu_q,
+        packed_cu_seqlens_k=cu_k,
+        packed_max_seqlen_q=5,
+        packed_max_seqlen_k=5,
+        packed_cp_size=1,
+        local_packed_cp_rank=0,
+    )
+
+    assert seen["calls"] == 1
+    assert seen["q"].shape == torch.Size([8, 1, 1])
+    assert seen["k"].shape == torch.Size([8, 1, 1])
+    assert seen["weights"].shape == torch.Size([8, 1])
+    assert seen["q"].data_ptr() == q.data_ptr()
+    assert seen["k"].data_ptr() == k.data_ptr()
+    assert seen["weights"].data_ptr() == weights.data_ptr()
+    assert seen["cu_q"] is cu_q
+    assert seen["cu_k"] is cu_k
+    assert (seen["max_q"], seen["max_k"]) == (5, 5)
+    torch.testing.assert_close(
+        topk_indices,
+        torch.tensor(
+            [[[0, -1], [1, 0], [2, 1], [3, -1], [4, 3], [5, 4], [6, 5], [7, 6]]], dtype=torch.int32
+        ),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        topk_length, torch.tensor([[1, 2, 2, 1, 2, 2, 2, 2]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        topk_scores,
+        torch.tensor(
+            [
+                [
+                    [0.0, torch.finfo(torch.float32).min],
+                    [1.0, 0.0],
+                    [2.0, 1.0],
+                    [0.0, torch.finfo(torch.float32).min],
+                    [1.0, 0.0],
+                    [2.0, 1.0],
+                    [3.0, 2.0],
+                    [4.0, 3.0],
+                ]
+            ]
+        ),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _pure_torch_packed_indexer_reference(
+    q_indexer, k_indexer, weights, query, key, starts, ends, *, topk, softmax_scale, loss_coeff
+):
+    """DeepSeek-V3.2 Section 2.1 indexer KL, expressed only with PyTorch ops.
+
+    Reference repository: https://github.com/deepseek-ai/DeepSeek-V3.2-Exp
+    Reference revision: 87e509a2e5a100d221c97df52c6e8be7835f0057, DeepSeek_V3_2.pdf
+    """
+    sq, batch, _indexer_heads, _indexer_dim = q_indexer.shape
+    sk = k_indexer.size(0)
+    key_ids = torch.arange(sk, device=q_indexer.device).view(1, 1, sk)
+    valid_bounds = (key_ids >= starts.view(1, sq, 1)) & (key_ids < ends.view(1, sq, 1))
+
+    # I(q, k) = sum_h w_h * relu(q_h dot k), from DeepSeek-V3.2 Section 2.1.
+    index_scores = torch.einsum("sbhd,tbd->sbht", q_indexer.float(), k_indexer.float())
+    index_scores = (torch.relu(index_scores) * weights.float().unsqueeze(-1)).sum(dim=2)
+    index_scores = index_scores.transpose(0, 1).masked_fill(~valid_bounds, float("-inf"))
+    selected_scores, selected_indices = index_scores.topk(min(topk, sk), dim=-1)
+    selected_valid = torch.isfinite(selected_scores)
+    selected_indices = selected_indices.masked_fill(~selected_valid, -1)
+    predict_log_probs = torch.log_softmax(
+        selected_scores.masked_fill(~selected_valid, float("-inf")), dim=-1
+    )
+
+    # The teacher is the head-summed attention probability over the same selected keys.
+    expanded_key = key.expand(-1, -1, query.size(2), -1)
+    attention_logits = (
+        torch.einsum("sbhd,tbhd->bhst", query.float(), expanded_key.float()) * softmax_scale
+    )
+    safe_indices = selected_indices.clamp_min(0)
+    selected_attention_logits = torch.gather(
+        attention_logits, dim=-1, index=safe_indices.unsqueeze(1).expand(-1, query.size(2), -1, -1)
+    ).masked_fill(~selected_valid.unsqueeze(1), float("-inf"))
+    teacher = torch.softmax(selected_attention_logits, dim=-1).sum(dim=1)
+    teacher = teacher / teacher.sum(dim=-1, keepdim=True).clamp_min(1.0e-10)
+    teacher = teacher.masked_fill(~selected_valid, 0.0).detach()
+
+    kl_terms = teacher * (torch.log(teacher.clamp_min(1.0e-10)) - predict_log_probs)
+    loss = kl_terms.masked_fill(~selected_valid, 0.0).sum() * (loss_coeff / (batch * sq))
+    return selected_indices, selected_valid.sum(dim=-1, dtype=torch.int32), loss
+
+
+def _assert_packed_indexer_gradient_parity(label, actual, expected):
+    """Check BF16 fused gradients with aggregate, scale-independent metrics."""
+    assert torch.isfinite(actual).all()
+    assert torch.isfinite(expected).all()
+    actual = actual.detach().double()
+    expected = expected.detach().double()
+    diff = actual - expected
+    actual_norm = actual.norm()
+    expected_norm = expected.norm()
+    tiny = torch.finfo(torch.float64).tiny
+    cosine = (actual * expected).sum() / (actual_norm * expected_norm).clamp_min(tiny)
+    tensor_similarity = (
+        2
+        * (actual * expected).sum()
+        / (actual.square().sum() + expected.square().sum()).clamp_min(tiny)
+    )
+    cosine_deficit = max(0.0, 1.0 - cosine.item())
+    tensor_deficit = max(0.0, 1.0 - tensor_similarity.item())
+    rel_l2 = (diff.norm() / expected_norm.clamp_min(tiny)).item()
+    norm_rel = (abs(actual_norm - expected_norm) / expected_norm.clamp_min(tiny)).item()
+    max_abs = diff.abs().max().item()
+    ref_rms = expected.square().mean().sqrt().item()
+    assert (
+        cosine_deficit <= 1.0e-4
+        and tensor_deficit <= 1.0e-4
+        and rel_l2 <= 1.2e-2
+        and norm_rel <= 1.0e-3
+    ), (
+        f"{label}: cosine_deficit={cosine_deficit:.9e}, "
+        f"tensor_deficit={tensor_deficit:.9e}, rel_l2={rel_l2:.9e}, "
+        f"norm_rel={norm_rel:.9e}, max_abs={max_abs:.9e}, ref_rms={ref_rms:.9e}"
+    )
+
+
+@pytest.mark.parametrize("seed", [6206, 6207, 6208])
+def test_cudnn_indexer_topk_multi_packed_cp1_real_kernel_matches_pytorch_gradients(seed):
+    """Odd-length CP1 THD scorer matches the independent Section 2.1 formula."""
+    _skip_if_fused_dsa_unavailable()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    device = torch.device("cuda")
+    sequence_lengths = (65, 67)
+    total_tokens = sum(sequence_lengths)
+    batch = 1
+    indexer_heads = 64
+    indexer_dim = 128
+    attention_heads = 64
+    attention_dim = 576
+    # SM100 sparse score recompute requires top-k to be a multiple of 64.
+    topk = 64
+    softmax_scale = attention_dim**-0.5
+    loss_coeff = 0.01
+
+    q_base = (
+        torch.randn(
+            total_tokens, batch, indexer_heads, indexer_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.125
+    )
+    k_base = (
+        torch.randn(total_tokens, batch, indexer_dim, device=device, dtype=torch.bfloat16) * 0.125
+    )
+    w_base = torch.randn(total_tokens, batch, indexer_heads, device=device, dtype=torch.bfloat16)
+    q_fused, q_ref = (q_base.clone().requires_grad_() for _ in range(2))
+    k_fused, k_ref = (k_base.clone().requires_grad_() for _ in range(2))
+    w_fused, w_ref = (w_base.clone().requires_grad_() for _ in range(2))
+
+    query = (
+        torch.randn(
+            total_tokens, batch, attention_heads, attention_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.125
+    )
+    key = (
+        torch.randn(total_tokens, batch, 1, attention_dim, device=device, dtype=torch.bfloat16)
+        * 0.125
+    )
+    cu_seqlens = torch.tensor([0, sequence_lengths[0], total_tokens], device=device).int()
+    starts = torch.tensor(
+        [0] * sequence_lengths[0] + [sequence_lengths[0]] * sequence_lengths[1],
+        device=device,
+        dtype=torch.int32,
+    )
+    ends = torch.cat(
+        (
+            torch.arange(1, sequence_lengths[0] + 1, device=device),
+            torch.arange(sequence_lengths[0] + 1, total_tokens + 1, device=device),
+        )
+    ).int()
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=max(sequence_lengths),
+        max_seqlen_kv=max(sequence_lengths),
+    )
+
+    fused_result = dsa_cudnn_kernels.run_fused_qk_topk_with_loss(
+        q=q_fused,
+        k=k_fused,
+        weights=w_fused,
+        index_topk=topk,
+        starts=starts,
+        ends=ends,
+        block_size=128,
+        query=query,
+        key=key,
+        softmax_scale=softmax_scale,
+        loss_coeff=loss_coeff,
+        pg_collection=_SingleRankProcessGroups(),
+        query_valid_rows=torch.ones((batch, total_tokens), dtype=torch.bool, device=device),
+        calculate_per_token_loss=False,
+        use_relu=True,
+        config=_PackedCpCudnnConfig(calculate_per_token_loss=False),
+        use_local_indexer_varlen=True,
+        single_packed_thd_sequence=False,
+        packed_seq_params=packed_seq_params,
+        cp_size=1,
+    )
+    assert fused_result is not None
+    fused_indices, fused_lengths, fused_loss = fused_result
+    ref_indices, ref_lengths, ref_loss = _pure_torch_packed_indexer_reference(
+        q_ref,
+        k_ref,
+        w_ref,
+        query,
+        key,
+        starts,
+        ends,
+        topk=topk,
+        softmax_scale=softmax_scale,
+        loss_coeff=loss_coeff,
+    )
+
+    # FlashMLA consumes sorted indices, while the pure top-k is score ordered.
+    sentinel = total_tokens
+    canonical_fused = torch.where(fused_indices >= 0, fused_indices, sentinel).sort(dim=-1).values
+    canonical_ref = (
+        torch.where(ref_indices >= 0, ref_indices, sentinel)
+        .sort(dim=-1)
+        .values.to(dtype=canonical_fused.dtype)
+    )
+    torch.testing.assert_close(canonical_fused, canonical_ref, rtol=0, atol=0)
+    torch.testing.assert_close(fused_lengths, ref_lengths, rtol=0, atol=0)
+    torch.testing.assert_close(fused_loss, ref_loss, rtol=1.0e-4, atol=1.0e-7)
+
+    fused_loss.backward()
+    ref_loss.backward()
+    for name, fused_grad, ref_grad in (
+        ("q_indexer", q_fused.grad, q_ref.grad),
+        ("k_indexer", k_fused.grad, k_ref.grad),
+        ("weights", w_fused.grad, w_ref.grad),
+    ):
+        _assert_packed_indexer_gradient_parity(name, fused_grad, ref_grad)
+
+
+def test_cudnn_indexer_topk_incompatible_packed_boundaries_fall_back(monkeypatch):
+    class FakeDSA:
+        @staticmethod
+        def indexer_forward_wrapper(q, k, weights, ratio, sm_scale, **packed_kwargs):
+            del weights, ratio, sm_scale
+            assert not packed_kwargs
+            return {
+                "scores": torch.arange(k.size(1), dtype=torch.float32)
+                .view(1, 1, -1)
+                .expand(q.size(0), q.size(1), -1)
+            }
+
+        @staticmethod
+        def indexer_top_k_wrapper(scores, seq_lens, top_k, next_n, return_val):
+            del next_n, return_val
+            masked_scores = scores.clone()
+            key_ids = torch.arange(scores.size(1)).view(1, -1)
+            masked_scores.masked_fill_(key_ids >= seq_lens.view(-1, 1), float("-inf"))
+            return {"indices": masked_scores.topk(top_k, dim=-1).indices.int(), "values": None}
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+    monkeypatch.setattr(
+        dsa_cudnn_kernels,
+        "_indexer_topk_packed_thd",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("incompatible boundaries must not reach the THD scorer")
+        ),
+    )
+
+    topk_indices, topk_length, _ = dsa_cudnn_kernels._indexer_topk_bshd(
+        torch.ones((1, 3, 1, 1)),
+        torch.ones((1, 3, 1)),
+        torch.ones((1, 3, 1)),
+        topk=2,
+        varlen_starts=torch.tensor([0, 0, 2]),
+        varlen_ends=torch.tensor([1, 2, 3]),
+        return_scores=False,
+        use_local_indexer_varlen=True,
+        packed_cu_seqlens_q=torch.tensor([0, 2, 3], dtype=torch.int32),
+        packed_cu_seqlens_k=torch.tensor([0, 1, 3], dtype=torch.int32),
+        packed_max_seqlen_q=2,
+        packed_max_seqlen_k=2,
+        packed_cp_size=1,
+    )
+
+    torch.testing.assert_close(
+        topk_indices, torch.tensor([[[0, -1], [0, 1], [2, -1]]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(topk_length, torch.tensor([[1, 2, 1]], dtype=torch.int32))
+
+
+def test_cudnn_general_thd_rejects_tp_query_slices():
+    """THD cu-seqlens describe full Q, so either TP-slice marker must decline."""
+    cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32)
+    common = dict(
+        b=1,
+        sq=8,
+        sk=8,
+        device=cu_seqlens.device,
+        packed_cu_seqlens_q=cu_seqlens,
+        packed_cu_seqlens_k=cu_seqlens,
+        packed_max_seqlen_q=5,
+        packed_max_seqlen_k=5,
+        cp_size=1,
+        cp_rank=0,
+    )
+
+    assert dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=0, local_packed_cp_query_len=None
+    )
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=1, local_packed_cp_query_len=9
+    )
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=0, local_packed_cp_query_len=16
+    )
+
+
+def test_cudnn_general_thd_rejects_impossible_qk_geometry():
+    cu_seqlens = torch.tensor([0, 1, 3], dtype=torch.int32)
+    common = dict(
+        b=1,
+        sq=3,
+        device=cu_seqlens.device,
+        packed_cu_seqlens_q=cu_seqlens,
+        packed_cu_seqlens_k=cu_seqlens,
+        packed_max_seqlen_q=2,
+        packed_max_seqlen_k=2,
+        cp_size=1,
+        cp_rank=0,
+        local_packed_cp_query_start=0,
+        local_packed_cp_query_len=None,
+    )
+
+    assert dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=3, **common)
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=5, **common)
+    mismatched_max = {**common, "packed_max_seqlen_k": 1}
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=3, **mismatched_max)
+
+
 @pytest.mark.parametrize("max_segment_k", [5, 6], ids=["odd-k", "even-k"])
 @pytest.mark.parametrize("return_topk_scores", [False, True], ids=["indices", "scores"])
 def test_cudnn_indexer_topk_multi_packed_cp_selects_all_segment_keys(
@@ -756,6 +1165,7 @@ def test_cudnn_indexer_topk_single_packed_cp_uses_absolute_seq_lens(monkeypatch)
         return_topk_scores=True,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
+        packed_cp_size=2,
         local_packed_cp_rank=1,
     )
 
@@ -808,7 +1218,6 @@ def test_cudnn_indexer_topk_single_packed_cp_prefix_crops_keys_per_chunk(monkeyp
         return_scores=False,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
-        local_packed_cp_rank=1,
         local_packed_cp_query_len=8,
     )
 
@@ -844,6 +1253,7 @@ def test_cudnn_indexer_topk_single_packed_cp_real_kernel_uses_bottom_right_align
         return_topk_scores=True,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
+        packed_cp_size=4,
         local_packed_cp_rank=1,
     )
 
@@ -1109,6 +1519,7 @@ def test_cudnn_split_topk_hook_uses_indexer_topk(monkeypatch):
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         seen["q_shape"] = q_bshd.shape
         seen["k_shape"] = k_bsd.shape
@@ -1124,6 +1535,7 @@ def test_cudnn_split_topk_hook_uses_indexer_topk(monkeypatch):
         seen["local_packed_cp_rank"] = local_packed_cp_rank
         seen["local_packed_cp_query_start"] = local_packed_cp_query_start
         seen["local_packed_cp_query_len"] = local_packed_cp_query_len
+        seen["varlen_is_plain_causal"] = varlen_is_plain_causal
         return (
             torch.tensor([[[1, 0, -1], [2, 1, 0]]], dtype=torch.int32),
             torch.tensor([[2, 3]], dtype=torch.int32),
@@ -1256,6 +1668,7 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         seen["return_scores"] = return_scores
         seen["return_topk_scores"] = return_topk_scores
@@ -1266,6 +1679,7 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         seen["local_packed_cp_rank"] = local_packed_cp_rank
         seen["local_packed_cp_query_start"] = local_packed_cp_query_start
         seen["local_packed_cp_query_len"] = local_packed_cp_query_len
+        seen["varlen_is_plain_causal"] = varlen_is_plain_causal
         return (
             torch.tensor([[[1, 0], [2, -1]]], dtype=torch.int32),
             torch.tensor([[2, 1]], dtype=torch.int32),
@@ -1307,8 +1721,8 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         k=k,
         weights=weights,
         index_topk=2,
-        starts=torch.tensor([0, 1], dtype=torch.int32),
-        ends=torch.tensor([2, 3], dtype=torch.int32),
+        starts=torch.tensor([0, 0], dtype=torch.int32),
+        ends=torch.tensor([1, 2], dtype=torch.int32),
         block_size=128,
         query=torch.zeros((2, 1, 1, Config.kv_lora_rank), dtype=torch.bfloat16),
         key=torch.zeros((3, 1, 1, Config.kv_lora_rank), dtype=torch.bfloat16),
@@ -1317,9 +1731,9 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         pg_collection=pg_collection,
         calculate_per_token_loss=False,
         use_relu=True,
-        use_local_indexer_varlen=True,
-        single_packed_thd_sequence=True,
-        local_packed_cp_rank=5,
+        use_local_indexer_varlen=False,
+        single_packed_thd_sequence=False,
+        varlen_is_plain_causal=True,
     )
 
     torch.testing.assert_close(topk_indices, torch.tensor([[[0, 1], [2, -1]]], dtype=torch.int32))
@@ -1327,9 +1741,10 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
     assert indexer_loss.item() == 4.0
     assert seen["return_scores"] is False
     assert seen["return_topk_scores"] is True
-    assert seen["use_local_indexer_varlen"] is True
-    assert seen["single_packed_thd_sequence"] is True
-    assert seen["local_packed_cp_rank"] == 5
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["local_packed_cp_rank"] == 0
+    assert seen["varlen_is_plain_causal"] is True
     assert seen["tp_group"] is pg_collection.tp
     assert seen["d_v"] == Config.kv_lora_rank
     torch.testing.assert_close(
@@ -1611,6 +2026,7 @@ def test_cudnn_sparse_loss_uses_selected_topk_scores(monkeypatch):
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         del (
             single_packed_thd_sequence,
@@ -1797,6 +2213,9 @@ def test_cudnn_sparse_loss_reduces_attention_target_across_tp(monkeypatch):
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
     monkeypatch.setattr(dsa_cudnn_kernels, "_compute_attn_target", fake_attn_target)
+    monkeypatch.setattr(
+        dsa_cudnn_kernels, "get_pg_size", lambda group: group.size() if group is not None else 1
+    )
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
     dsa_cudnn_kernels._compute_sparse_indexer_loss_and_grads(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_scoring_plan.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_scoring_plan.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for DSA indexer scoring plan resolution.
+
+The cases below mirror configurations whose actual branch was measured on GB200 with a
+branch-tracing build, so the resolver is pinned to observed behaviour rather than to a
+reading of the dispatcher.
+"""
+
+import pytest
+
+from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+    IndexerScoringPlan,
+    resolve_indexer_scoring_plan,
+)
+
+BASE = dict(
+    bounds_available=True,
+    varlen_is_plain_causal=False,
+    packed_thd=False,
+    cp_size=1,
+    mask_is_causal=True,
+    explicit_key_positions=False,
+    single_sequence_pack=False,
+    packed_metadata_available=False,
+    segment_kernel_applicable=True,
+)
+
+
+def _resolve(**overrides):
+    return resolve_indexer_scoring_plan(**{**BASE, **overrides})
+
+
+class TestIndexerScoringPlan:
+    """Plan resolution for each layout the dispatcher can encounter."""
+
+    def test_plain_causal_reaches_the_fused_scorer(self):
+        """Non-packed, no CP: bounds are reconstructible so the single kernel applies."""
+        decision = _resolve(varlen_is_plain_causal=True)
+        assert decision.plan is IndexerScoringPlan.PLAIN_CAUSAL
+        assert decision.is_fused
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 16])
+    def test_packed_single_sequence_uses_segment_specialization(self, cp_size):
+        """One sequence per pack uses segments independently of CP size."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=cp_size,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS
+        assert decision.is_fused
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 16])
+    def test_packed_multi_sequence_uses_general_thd(self, cp_size):
+        """Several sequences per pack take the general THD scorer at every CP size."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=cp_size,
+            single_sequence_pack=False,
+            packed_metadata_available=True,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert decision.is_fused
+
+    def test_packed_cp_multi_without_metadata_is_unfused(self):
+        """Without cu_seqlens the packed kernels cannot express the boundaries."""
+        decision = _resolve(
+            packed_thd=True, cp_size=16, single_sequence_pack=False, packed_metadata_available=False
+        )
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "cu_seqlens" in decision.reason
+
+    def test_single_sequence_pack_reaches_the_fused_scorer_without_cp(self):
+        """The segment kernel degenerates correctly when one rank holds the sequence."""
+        decision = _resolve(
+            packed_thd=True, single_sequence_pack=True, packed_metadata_available=True
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS
+        assert decision.is_fused
+
+    def test_multi_sequence_pack_without_cp_uses_general_thd(self):
+        """Pack cardinality is independent of CP geometry."""
+        decision = _resolve(packed_thd=True, packed_metadata_available=True)
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert decision.is_fused
+
+    def test_context_parallel_without_packing_is_unfused_and_says_why(self):
+        """CP without packing misses every fused kernel. Measured on GB200."""
+        decision = _resolve(cp_size=4)
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "packing" in decision.reason
+
+    def test_segment_kernel_preconditions_are_respected(self):
+        """The segment kernel raises rather than declining, so the plan must not promise it.
+
+        Widening the single-pack gate without this check routed a packed cp_size=1 run
+        into the kernel, which died with "requires b=1, even local query length,
+        ratio=1" instead of falling back.
+        """
+        decision = _resolve(
+            packed_thd=True,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert "falling back" in decision.reason
+
+    def test_segment_kernel_preconditions_apply_under_cp_too(self):
+        """The same shape guard is needed on the pre-existing CP>1 path."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=16,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+
+    def test_single_sequence_without_any_compatible_packed_kernel_is_unfused(self):
+        decision = _resolve(
+            packed_thd=True,
+            single_sequence_pack=True,
+            packed_metadata_available=False,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "incompatible" in decision.reason
+
+    def test_explicit_key_positions_declines(self):
+        """Custom key positions are not expressible as row-wise bounds at all."""
+        decision = _resolve(explicit_key_positions=True, varlen_is_plain_causal=True)
+        assert decision.plan is IndexerScoringPlan.DECLINE
+        assert not decision.is_fused
+
+    def test_missing_bounds_declines(self):
+        """A mask the caller could not turn into bounds must not reach fused scoring."""
+        decision = _resolve(bounds_available=False)
+        assert decision.plan is IndexerScoringPlan.DECLINE
+
+    def test_non_causal_mask_is_unfused(self):
+        """No fused scorer covers a non-causal mask."""
+        decision = _resolve(mask_is_causal=False)
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 8, 16])
+    @pytest.mark.parametrize("packed_thd", [False, True])
+    @pytest.mark.parametrize("single_sequence_pack", [False, True])
+    def test_resolution_is_total(self, cp_size, packed_thd, single_sequence_pack):
+        """Every configuration resolves to a plan carrying a non-empty reason.
+
+        Totality is the property that keeps a new layout from silently falling through
+        to the slow path the way it does today.
+        """
+        decision = _resolve(
+            cp_size=cp_size,
+            packed_thd=packed_thd,
+            single_sequence_pack=single_sequence_pack,
+            packed_metadata_available=packed_thd,
+        )
+        assert isinstance(decision.plan, IndexerScoringPlan)
+        assert decision.reason
+
+    def test_decline_is_not_reported_as_a_slow_fallback(self):
+        """A decline means fused scoring was never attempted, not that it was slow."""
+        from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+            report_unfused_scoring_once,
+        )
+
+        decision = _resolve(explicit_key_positions=True)
+        assert report_unfused_scoring_once(decision, "test-decline") is None
+
+    def test_unfused_plan_is_reported_once_per_reason(self):
+        """The warning exists so a throughput cliff is visible; it must not spam."""
+        from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+            report_unfused_scoring_once,
+        )
+
+        decision = _resolve(cp_size=4)
+        first = report_unfused_scoring_once(decision, "test-once")
+        second = report_unfused_scoring_once(decision, "test-once")
+        assert first is not None and decision.reason in first
+        assert second is None

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -411,6 +411,116 @@ class TestPadSequenceForThdAliasPreservation:
         assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
 
     @pytest.mark.internal
+    def test_extend_last_missing_padded_metadata_inherits_valid_qkv_view(self):
+        cu_q, cu_kv = _make_same_view_cu_pair([0, 3, 5])
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 5], dtype=torch.int32))
+        assert torch.equal(padded.cu_seqlens_q_padded, torch.tensor([0, 3, 8], dtype=torch.int32))
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_extend_last_missing_padded_metadata_keeps_distinct_valid_qkv_views(self):
+        cu_q = torch.tensor([0, 3, 5], dtype=torch.int32)
+        cu_kv = cu_q.clone()
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        expected = torch.tensor([0, 3, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected)
+        assert padded.cu_seqlens_q_padded is not padded.cu_seqlens_kv_padded
+        assert padded.cu_seqlens_q_padded.data_ptr() != padded.cu_seqlens_kv_padded.data_ptr()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_extend_last_missing_padded_metadata_keeps_cp1_thd_scorer_eligible(self):
+        from megatron.core.transformer.experimental_attention_variant import dsa_cudnn_kernels
+
+        storage = torch.tensor([-1, 0, 3, 5, -1], dtype=torch.int32, device="cuda")
+        cu_q = storage[1:-1]
+        cu_kv = storage[1:-1]
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert dsa_cudnn_kernels._packed_thd_kernel_applicable(
+            b=1,
+            sq=8,
+            sk=8,
+            device=torch.device("cuda"),
+            packed_cu_seqlens_q=padded.cu_seqlens_q_padded,
+            packed_cu_seqlens_k=padded.cu_seqlens_kv_padded,
+            packed_max_seqlen_q=padded.max_seqlen_q,
+            packed_max_seqlen_k=padded.max_seqlen_kv,
+            cp_size=1,
+            cp_rank=0,
+            local_packed_cp_query_start=0,
+            local_packed_cp_query_len=None,
+        )
+
+    @pytest.mark.internal
     def test_fixed_capacity_only_padding_preserves_qkv_views(self):
         psp = _make_same_view_psp([0, 3, 8], [0, 4, 8])
 

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
 Unit tests for THD format with CUDA Graph support.
@@ -34,6 +34,7 @@ from megatron.core.datasets.data_schedule import _build_thd_padding_mask
 from megatron.core.packed_seq_params import (
     PackedSeqParams,
     _resolve_thd_padding_lengths,
+    _same_tensor_view,
     extend_thd_padding_before_cp_slice,
     get_thd_padding_kwargs,
     pad_sequence_for_thd,
@@ -77,6 +78,47 @@ def _make_psp(seqlens):
         max_seqlen_q=max(seqlens),
         max_seqlen_kv=max(seqlens),
     )
+
+
+def _make_same_view_cu_pair(boundaries):
+    storage = torch.tensor([-1, *boundaries, -1], dtype=torch.int32)
+    q = storage[1:-1]
+    kv = storage[1:-1]
+    assert q is not kv
+    assert q.data_ptr() == kv.data_ptr()
+    return q, kv
+
+
+def _make_same_view_psp(valid_boundaries, padded_boundaries):
+    cu_q, cu_kv = _make_same_view_cu_pair(valid_boundaries)
+    cu_q_padded, cu_kv_padded = _make_same_view_cu_pair(padded_boundaries)
+    max_seqlen = max(
+        right - left
+        for boundaries in (valid_boundaries, padded_boundaries)
+        for left, right in zip(boundaries, boundaries[1:])
+    )
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_q_padded=cu_q_padded,
+        cu_seqlens_kv_padded=cu_kv_padded,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        pad_between_seqs=valid_boundaries != padded_boundaries,
+    )
+
+
+def _assert_qkv_views_are_shared(packed_seq_params):
+    for q, kv in (
+        (packed_seq_params.cu_seqlens_q, packed_seq_params.cu_seqlens_kv),
+        (packed_seq_params.cu_seqlens_q_padded, packed_seq_params.cu_seqlens_kv_padded),
+    ):
+        assert q is kv
+        assert q.data_ptr() == kv.data_ptr()
+        assert q.storage_offset() == kv.storage_offset()
+        assert q.shape == kv.shape
+        assert q.stride() == kv.stride()
 
 
 def _build_layer(H, nh, nkv, ffn, max_seqlen, max_num_seqs, tp=1, sp=False):
@@ -294,6 +336,140 @@ class TestResolveThdPaddingLengths:
             expected_global_target,
         )
         assert mask_device == psp.cu_seqlens_q.device
+
+
+class TestPadSequenceForThdAliasPreservation:
+
+    @pytest.mark.internal
+    def test_same_tensor_view_edge_cases_fail_closed(self):
+        base = torch.arange(6)
+        same_view = base[:4]
+        same_view_alias = base[:4]
+        assert _same_tensor_view(same_view, same_view)
+        assert _same_tensor_view(same_view, same_view_alias)
+        assert not _same_tensor_view(None, None)
+        assert not _same_tensor_view(same_view, None)
+
+        empty = torch.empty(0)
+        assert not _same_tensor_view(empty, empty)
+        assert not _same_tensor_view(empty, empty.view_as(empty))
+
+        meta = torch.empty(4, device="meta")
+        assert not _same_tensor_view(meta, meta)
+        assert not _same_tensor_view(meta, meta.view_as(meta))
+
+        assert not _same_tensor_view(same_view, base[1:5])
+        assert not _same_tensor_view(same_view, base[:3])
+
+    @pytest.mark.internal
+    def test_same_tensor_view_fake_tensor_fails_closed(self):
+        try:
+            from torch._subclasses.fake_tensor import FakeTensorMode
+        except ImportError:
+            pytest.skip("FakeTensorMode is not available in this PyTorch version.")
+
+        with FakeTensorMode():
+            fake = torch.empty(4, device="cuda")
+            fake_alias = fake.view_as(fake)
+
+        assert not _same_tensor_view(fake, fake)
+        assert not _same_tensor_view(fake, fake_alias)
+
+    @pytest.mark.internal
+    def test_append_dummy_sequence_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 5], [0, 3, 5])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5), None, None, None, psp, target_len=8, cp_size=1, cp_rank=0
+        )
+
+        expected = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q, expected)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_extend_last_sequence_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 5], [0, 4, 7])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 7),
+            None,
+            None,
+            None,
+            psp,
+            target_len=10,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 5], dtype=torch.int32))
+        assert torch.equal(padded.cu_seqlens_q_padded, torch.tensor([0, 4, 10], dtype=torch.int32))
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_fixed_capacity_only_padding_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 8], [0, 4, 8])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 8),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            max_num_seqs=5,
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 8, 8, 8, 8], dtype=torch.int32))
+        assert torch.equal(
+            padded.cu_seqlens_q_padded, torch.tensor([0, 4, 8, 8, 8, 8], dtype=torch.int32)
+        )
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_distinct_equal_qkv_views_remain_distinct(self):
+        cu_q = torch.tensor([0, 3, 5], dtype=torch.int32)
+        cu_kv = cu_q.clone()
+        cu_q_padded = cu_q.clone()
+        cu_kv_padded = cu_q.clone()
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=cu_q_padded,
+            cu_seqlens_kv_padded=cu_kv_padded,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            max_num_seqs=5,
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        expected = torch.tensor([0, 3, 5, 8, 8, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q, expected)
+        assert torch.equal(padded.cu_seqlens_kv, expected)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected)
+        assert padded.cu_seqlens_q is not padded.cu_seqlens_kv
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_kv.data_ptr()
+        assert padded.cu_seqlens_q_padded is not padded.cu_seqlens_kv_padded
+        assert padded.cu_seqlens_q_padded.data_ptr() != padded.cu_seqlens_kv_padded.data_ptr()
 
 
 class TestPadSequenceForThd:

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -509,7 +509,7 @@ class TestPadSequenceForThdAliasPreservation:
             b=1,
             sq=8,
             sk=8,
-            device=torch.device("cuda"),
+            device=padded.cu_seqlens_q_padded.device,
             packed_cu_seqlens_q=padded.cu_seqlens_q_padded,
             packed_cu_seqlens_k=padded.cu_seqlens_kv_padded,
             packed_max_seqlen_q=padded.max_seqlen_q,


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Main counterpart: #6939.

Depends on #6206. This PR is intentionally stacked on the upstream
`pull-request/6206` branch; review only the two commits above that branch. If
#6206 is updated, this branch will be rebased onto its new head. After #6206
merges, this PR will be rebased onto and retargeted to `dev`.

Keep ordinary DSA sparse-attention backward shapes static when top-k contains
empty query rows, removing its dynamic `nonzero`/compact/gather/scatter path.

The generic path replaces each empty row with a safe one-tile cuDNN invocation:
its first index is zero, its effective top-k length is one, and its `dO`/`LSE`
are zeroed before backward. The returned `dQ` is explicitly zeroed for those
rows, so the safe tile contributes neither query nor KV gradients. A conservative
host-side certificate retains the existing allocation-free fast path when all
rows are provably nonempty.

This covers both the combined fused path and the split path used by IndexShare
and MTP sharing. It does not change CSA, THD/CP layout, MTP sharing semantics,
configuration, or the full-iteration CUDA Graph validator.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Verification notes

- Unit/native parity: full and split paths; nonempty, mixed-empty, and all-empty
  rows; BF16/FP32; metadata immutability; zero-size rejection; batch isolation.
- H100 real cuDNN: split forward/backward and changing-pattern CUDA Graph replay
  passed. The combined cuDNN IndexerTopK forward is SM100-only and was covered on
  GB200.
- GB200 real cuDNN: split and combined eager/native parity and fixed-shape graph
  replay passed; no stale mask or replay allocation growth.
- 16-GPU GB200 GLM proxy ABBA: short THD 4K effective CP1 improved 2.38%; long
  THD 64K dynamic CP16 improved 3.19%; peak memory was unchanged in both cells.
- Nsight Systems 2026.4.1: candidate DSA backward traces contain no target
  `nonzero`, `index_select`, `index_copy`, or dynamic gather/scatter operations.
