### PR TITLE
Support multiple CP layout batch views and fix THD+CP bug in MTP

### DIFF
--- a/megatron/core/context_parallel/__init__.py
+++ b/megatron/core/context_parallel/__init__.py
@@ -7,15 +7,20 @@ from .layout import (
     THDCPLayoutPlan,
     build_thd_cp_layout_plan,
     contiguous_to_zigzag,
+    convert_cp_layout,
     zigzag_to_contiguous,
 )
+from .utils import ContextParallelBatch, get_batches_on_this_cp_rank
 
 __all__ = [
     "CPLayout",
+    "ContextParallelBatch",
     "ContextParallelLayoutManager",
     "ContextParallelLayoutState",
     "THDCPLayoutPlan",
     "build_thd_cp_layout_plan",
     "contiguous_to_zigzag",
+    "convert_cp_layout",
+    "get_batches_on_this_cp_rank",
     "zigzag_to_contiguous",
 ]

--- a/megatron/core/context_parallel/layout.py
+++ b/megatron/core/context_parallel/layout.py
@@ -2,7 +2,7 @@
 
 """Context-parallel sequence-layout conversion."""
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Literal
 
@@ -34,15 +34,21 @@ class THDCPLayoutPlan:
 
     contiguous_local_token_count: int
     zigzag_local_token_count: int
-    cu_seqlens_padded: torch.Tensor
-    max_seqlen_padded: int
-    pad_between_seqs: bool
     forward_send_indices: torch.Tensor
     forward_receive_positions: torch.Tensor
     forward_input_split_sizes: tuple[int, ...]
     forward_output_split_sizes: tuple[int, ...]
     reverse_send_indices: torch.Tensor
     reverse_receive_indices: torch.Tensor
+
+
+@dataclass(frozen=True, eq=False)
+class _THDZigzagMetadata:
+    """Metadata describing the padded zigzag ordering of a packed token stream."""
+
+    rank_order_indices: torch.Tensor
+    cu_seqlens_padded: torch.Tensor
+    pad_between_seqs: bool
 
 
 @dataclass(frozen=True)
@@ -255,13 +261,11 @@ def _build_layout_redistribution_plan(
 def _build_thd_cp_layout_plan_from_rank_order_indices(
     rank_order_indices: torch.Tensor,
     source_token_count: int,
-    cu_seqlens_padded: torch.Tensor,
     cp_size: int,
     cp_rank: int,
     tp_size: int = 1,
     tp_rank: int = 0,
     group_rank_by_logical_rank: tuple[int, ...] | None = None,
-    pad_between_seqs: bool | torch.Tensor = False,
 ) -> THDCPLayoutPlan:
     """Build a packed layout plan from source indices grouped by target logical rank.
 
@@ -332,28 +336,13 @@ def _build_thd_cp_layout_plan_from_rank_order_indices(
     forward_output_split_sizes = torch.zeros(
         group_size, dtype=torch.int64, device=rank_order_indices.device
     ).index_add_(0, source_group_ranks, torch.ones_like(source_group_ranks))
-    if not isinstance(pad_between_seqs, torch.Tensor):
-        pad_between_seqs = torch.tensor(
-            pad_between_seqs, dtype=torch.bool, device=rank_order_indices.device
-        )
-    plan_metadata = torch.cat(
-        (
-            forward_input_split_sizes,
-            forward_output_split_sizes,
-            (cu_seqlens_padded[1:] - cu_seqlens_padded[:-1]).max().to(torch.int64).view(1),
-            pad_between_seqs.to(dtype=torch.int64, device=rank_order_indices.device).view(1),
-        )
-    ).tolist()
+    plan_metadata = torch.cat((forward_input_split_sizes, forward_output_split_sizes)).tolist()
     forward_input_split_sizes = tuple(plan_metadata[:group_size])
     forward_output_split_sizes = tuple(plan_metadata[group_size : 2 * group_size])
-    max_seqlen_padded, pad_between_seqs = plan_metadata[-2:]
 
     return THDCPLayoutPlan(
         contiguous_local_token_count=contiguous_local_token_count,
         zigzag_local_token_count=zigzag_local_token_count,
-        cu_seqlens_padded=cu_seqlens_padded,
-        max_seqlen_padded=max_seqlen_padded,
-        pad_between_seqs=bool(pad_between_seqs),
         forward_send_indices=forward_send_indices,
         forward_receive_positions=forward_receive_positions,
         forward_input_split_sizes=forward_input_split_sizes,
@@ -363,14 +352,10 @@ def _build_thd_cp_layout_plan_from_rank_order_indices(
     )
 
 
-def _build_thd_rank_order_indices(
-    cu_seqlens: torch.Tensor,
-    cu_seqlens_padded: torch.Tensor | None,
-    cp_size: int,
-    tp_size: int,
-    expected_source_token_count: int | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Build padded dual-chunk attention order without Transformer Engine helpers."""
+def _build_thd_zigzag_metadata(
+    cu_seqlens: torch.Tensor, cu_seqlens_padded: torch.Tensor | None, cp_size: int, tp_size: int
+) -> _THDZigzagMetadata:
+    """Build padded dual-chunk metadata without Transformer Engine helpers."""
     if cu_seqlens.ndim != 1 or cu_seqlens.numel() < 2:
         raise ValueError("cu_seqlens must be one-dimensional with at least two entries")
     if cu_seqlens.dtype != torch.int32:
@@ -390,34 +375,29 @@ def _build_thd_rank_order_indices(
 
     source_lengths = source_cu_seqlens[1:] - source_cu_seqlens[:-1]
 
-    # The token counts are needed on the host to validate and allocate the route tensors.
     alignment = 2 * cp_size
     target_lengths = (
         torch.div(source_lengths + alignment - 1, alignment, rounding_mode="floor") * alignment
     )
-    source_token_count, target_token_count = torch.stack(
-        (source_cu_seqlens[-1].to(torch.int64), target_lengths.sum().to(torch.int64))
-    ).tolist()
-    if (
-        expected_source_token_count is not None
-        and source_token_count != expected_source_token_count
-    ):
-        raise ValueError(
-            "The packed token count does not match the physical cumulative sequence lengths, got "
-            f"{expected_source_token_count} and {source_token_count}"
-        )
 
     # CP attention needs two equal chunks per CP rank. Pad each sequence to that granularity,
     # then add only enough padding to the last sequence to split the batch evenly over TP.
-    local_target_token_count = target_token_count // cp_size
-    tp_padding = (-local_target_token_count) % tp_size
-    if tp_padding:
-        target_lengths = target_lengths.clone()
-        target_lengths[-1] += tp_padding * cp_size
-        target_token_count += tp_padding * cp_size
+    local_target_token_count = torch.div(target_lengths.sum(), cp_size, rounding_mode="floor")
+    tp_padding = torch.remainder(-local_target_token_count, tp_size)
+    target_lengths = target_lengths.clone()
+    target_lengths[-1] += tp_padding * cp_size
     target_cu_seqlens = torch.cat(
         (torch.zeros_like(cu_seqlens[:1]), target_lengths.cumsum(dim=0, dtype=torch.int32))
     )
+
+    # These values must be host-known by the route allocator and PackedSeqParams. Read them back
+    # together so target-layout metadata does not add another device synchronization.
+    target_token_count, pad_between_seqs = torch.stack(
+        (
+            target_cu_seqlens[-1].to(torch.int64),
+            torch.any(cu_seqlens != target_cu_seqlens).to(torch.int64),
+        )
+    ).tolist()
 
     target_positions = torch.arange(target_token_count, dtype=torch.int64, device=cu_seqlens.device)
     sequence_ids = torch.searchsorted(target_cu_seqlens[1:], target_positions, right=True)
@@ -448,26 +428,28 @@ def _build_thd_rank_order_indices(
     )
     rank_order_indices = torch.empty_like(source_indices)
     rank_order_indices.scatter_(0, rank_order_positions, source_indices)
-    return rank_order_indices, target_cu_seqlens
+    return _THDZigzagMetadata(
+        rank_order_indices=rank_order_indices,
+        cu_seqlens_padded=target_cu_seqlens,
+        pad_between_seqs=bool(pad_between_seqs),
+    )
 
 
 def build_thd_cp_layout_plan(
-    cu_seqlens: torch.Tensor,
-    total_tokens: int,
+    rank_order_indices: torch.Tensor,
+    source_token_count: int,
     cp_group: torch.distributed.ProcessGroup,
-    cu_seqlens_padded: torch.Tensor | None = None,
     sequence_parallel: bool = False,
     tp_group: torch.distributed.ProcessGroup | None = None,
     tp_cp_group: torch.distributed.ProcessGroup | None = None,
 ) -> THDCPLayoutPlan:
-    """Build a reusable packed sequence layout plan for attention.
+    """Build a reusable packed sequence layout-conversion plan.
 
     Args:
-        cu_seqlens: Global cumulative actual sequence lengths in ``torch.int32``.
-        total_tokens: Global token count in the contiguous residual stream.
+        rank_order_indices: Contiguous source indices in target rank order.
+        source_token_count: Global token count in the contiguous layout.
         cp_group: Context-parallel process group.
-        cu_seqlens_padded: Optional physical offsets already present in the input.
-        sequence_parallel: Whether the residual stream is also sharded over TP ranks.
+        sequence_parallel: Whether the contiguous input is also sharded over TP ranks.
         tp_group: Tensor-parallel process group, required with sequence parallelism.
         tp_cp_group: Combined TP x CP process group, required when TP size is greater than one.
 
@@ -475,30 +457,14 @@ def build_thd_cp_layout_plan(
         A rank-local plan reusable for both directions of the layout conversion.
     """
     context = _get_layout_parallel_context(cp_group, sequence_parallel, tp_group, tp_cp_group)
-    if total_tokens % context.group_size != 0:
-        raise ValueError(
-            "The packed token count must be divisible by CP * TP, got "
-            f"{total_tokens}, CP size {context.cp_size}, and TP size {context.tp_size}"
-        )
-
-    rank_order_indices, target_cu_seqlens_padded = _build_thd_rank_order_indices(
-        cu_seqlens,
-        cu_seqlens_padded,
-        context.cp_size,
-        context.tp_size,
-        expected_source_token_count=total_tokens,
-    )
-    pad_between_seqs = torch.any(cu_seqlens != target_cu_seqlens_padded)
     return _build_thd_cp_layout_plan_from_rank_order_indices(
         rank_order_indices,
-        source_token_count=total_tokens,
-        cu_seqlens_padded=target_cu_seqlens_padded,
+        source_token_count=source_token_count,
         cp_size=context.cp_size,
         cp_rank=context.cp_rank,
         tp_size=context.tp_size,
         tp_rank=context.tp_rank,
         group_rank_by_logical_rank=context.group_rank_by_logical_rank,
-        pad_between_seqs=pad_between_seqs,
     )
 
 
@@ -663,6 +629,30 @@ def zigzag_to_contiguous(
     )
 
 
+def convert_cp_layout(
+    input_: torch.Tensor,
+    source_layout: CPLayout,
+    target_layout: CPLayout,
+    cp_group: torch.distributed.ProcessGroup,
+    sequence_parallel: bool = False,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+    tp_cp_group: torch.distributed.ProcessGroup | None = None,
+    thd_plan: THDCPLayoutPlan | None = None,
+) -> torch.Tensor:
+    """Convert a tensor between physical CP layouts."""
+    if source_layout == target_layout or cp_group.size() == 1:
+        return input_
+    if source_layout == "contiguous" and target_layout == "zigzag":
+        return contiguous_to_zigzag(
+            input_, cp_group, sequence_parallel, tp_group, tp_cp_group, thd_plan
+        )
+    if source_layout == "zigzag" and target_layout == "contiguous":
+        return zigzag_to_contiguous(
+            input_, cp_group, sequence_parallel, tp_group, tp_cp_group, thd_plan
+        )
+    raise ValueError(f"Unsupported CP layout conversion: {source_layout} to {target_layout}")
+
+
 @dataclass(eq=False)
 class ContextParallelLayoutManager:
     """Manage CP layout transitions across a sequence of layers."""
@@ -688,27 +678,18 @@ class ContextParallelLayoutManager:
         target_layout: CPLayout,
         thd_plan: THDCPLayoutPlan | None = None,
     ) -> torch.Tensor:
-        if not self.requires_conversion or source_layout == target_layout:
+        if not self.requires_conversion:
             return hidden_states
-        if source_layout == "contiguous" and target_layout == "zigzag":
-            return contiguous_to_zigzag(
-                hidden_states,
-                self.cp_group,
-                self.sequence_parallel,
-                self.tp_group,
-                self.tp_cp_group,
-                thd_plan,
-            )
-        if source_layout == "zigzag" and target_layout == "contiguous":
-            return zigzag_to_contiguous(
-                hidden_states,
-                self.cp_group,
-                self.sequence_parallel,
-                self.tp_group,
-                self.tp_cp_group,
-                thd_plan,
-            )
-        raise ValueError(f"Unsupported CP layout conversion: {source_layout} to {target_layout}")
+        return convert_cp_layout(
+            hidden_states,
+            source_layout,
+            target_layout,
+            self.cp_group,
+            self.sequence_parallel,
+            self.tp_group,
+            self.tp_cp_group,
+            thd_plan,
+        )
 
     def prepare_layer_input(
         self, layer_index: int, hidden_states: torch.Tensor, thd_plan: THDCPLayoutPlan | None = None
@@ -731,66 +712,40 @@ class ContextParallelLayoutManager:
             hidden_states, self.layer_layouts[layer_index], self.boundary_layout, thd_plan
         )
 
-    def build_packed_zigzag_layout(
-        self, packed_seq_params: PackedSeqParams
-    ) -> tuple[THDCPLayoutPlan, PackedSeqParams]:
-        """Build one THD conversion plan and its zigzag-layout metadata."""
-        if packed_seq_params.qkv_format != "thd":
-            raise ValueError(
-                "Packed CP layout conversion requires packed_seq_params.qkv_format='thd'"
-            )
-
-        cu_seqlens = packed_seq_params.cu_seqlens_q
-        if cu_seqlens is None:
-            raise ValueError("Packed CP layout conversion requires actual query lengths")
-        if packed_seq_params.cu_seqlens_kv is not cu_seqlens:
-            raise ValueError("Packed CP layout conversion requires shared Q/KV sequence metadata")
-
-        cu_seqlens_padded = packed_seq_params.cu_seqlens_q_padded
-        if packed_seq_params.cu_seqlens_kv_padded is not cu_seqlens_padded:
-            raise ValueError("Packed CP layout conversion requires shared Q/KV padding metadata")
-
-        total_tokens = packed_seq_params.total_tokens
-        if total_tokens is None:
-            raise ValueError("Packed CP layout conversion requires total_tokens")
-        plan = build_thd_cp_layout_plan(
-            cu_seqlens,
-            total_tokens,
-            self.cp_group,
-            cu_seqlens_padded=cu_seqlens_padded,
-            sequence_parallel=self.sequence_parallel,
-            tp_group=self.tp_group,
-            tp_cp_group=self.tp_cp_group,
-        )
-        zigzag_packed_seq_params = replace(
-            packed_seq_params,
-            cu_seqlens_q_padded=plan.cu_seqlens_padded,
-            cu_seqlens_kv_padded=plan.cu_seqlens_padded,
-            max_seqlen_q=plan.max_seqlen_padded,
-            max_seqlen_kv=plan.max_seqlen_padded,
-            total_tokens=None,
-            seq_idx=None,
-            pad_between_seqs=plan.pad_between_seqs,
-        )
-        return plan, zigzag_packed_seq_params
-
     def build_forward_state(
-        self, packed_seq_params: PackedSeqParams | None
+        self,
+        packed_seq_params: PackedSeqParams | None,
+        packed_seq_params_by_layout: dict[CPLayout, PackedSeqParams | None] | None = None,
+        thd_plan: THDCPLayoutPlan | None = None,
     ) -> "ContextParallelLayoutState | None":
-        """Build the layout state for one forward pass."""
+        """Build the layout state for one forward pass.
+
+        Args:
+            packed_seq_params: Metadata for the stack's boundary layout.
+            packed_seq_params_by_layout: Prebuilt metadata for each physical layout.
+            thd_plan: Prebuilt route between packed contiguous and zigzag layouts.
+        """
         if not self.requires_conversion:
             return None
 
-        thd_plan = None
-        zigzag_packed_seq_params = packed_seq_params
+        if thd_plan is not None and packed_seq_params_by_layout is not None:
+            return ContextParallelLayoutState(
+                manager=self,
+                thd_plan=thd_plan,
+                contiguous_packed_seq_params=packed_seq_params_by_layout["contiguous"],
+                zigzag_packed_seq_params=packed_seq_params_by_layout["zigzag"],
+            )
+
         if packed_seq_params is not None:
-            thd_plan, zigzag_packed_seq_params = self.build_packed_zigzag_layout(packed_seq_params)
+            raise ValueError(
+                "Packed CP layout conversion requires prebuilt metadata for both layouts"
+            )
 
         return ContextParallelLayoutState(
             manager=self,
             thd_plan=thd_plan,
             contiguous_packed_seq_params=packed_seq_params,
-            zigzag_packed_seq_params=zigzag_packed_seq_params,
+            zigzag_packed_seq_params=packed_seq_params,
         )
 
 

--- a/megatron/core/context_parallel/utils.py
+++ b/megatron/core/context_parallel/utils.py
@@ -2,9 +2,54 @@
 
 """Context-parallel batch partitioning helpers."""
 
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable
 
 import torch
+
+from megatron.core.packed_seq_params import PackedSeqParams
+
+from .layout import CPLayout, THDCPLayoutPlan, _build_thd_zigzag_metadata, build_thd_cp_layout_plan
+
+
+@dataclass(eq=False)
+class ContextParallelBatch:
+    """Batch views and reusable metadata prepared for the requested CP layouts.
+
+    Entries with the same layout key in ``batches_by_layout`` and
+    ``packed_seq_params_by_layout`` describe the same token ordering. Dense attention masks are
+    the exception: their query rows remain zigzag because that is the layout consumed by softmax
+    attention. Accessors default to ``boundary_layout``, and ``thd_plan`` connects the two packed
+    token orderings.
+    """
+
+    boundary_layout: CPLayout
+    batches_by_layout: dict[CPLayout, Dict[str, Any]]
+    packed_seq_params_by_layout: dict[CPLayout, PackedSeqParams | None]
+    thd_plan: THDCPLayoutPlan | None = None
+
+    @classmethod
+    def from_single_layout(
+        cls, layout: CPLayout, batch: Dict[str, Any], packed_seq_params: PackedSeqParams | None
+    ) -> "ContextParallelBatch":
+        """Wrap an already-partitioned batch that has one physical CP layout."""
+        return cls(
+            boundary_layout=layout,
+            batches_by_layout={layout: batch},
+            packed_seq_params_by_layout={layout: packed_seq_params},
+        )
+
+    def get_batch(self, layout: CPLayout | None = None) -> Dict[str, Any]:
+        """Return the batch view for a layout, defaulting to the boundary layout."""
+        if layout is None:
+            layout = self.boundary_layout
+        return self.batches_by_layout[layout]
+
+    def get_packed_seq_params(self, layout: CPLayout | None = None) -> PackedSeqParams | None:
+        """Return packed metadata for a layout, defaulting to the boundary layout."""
+        if layout is None:
+            layout = self.boundary_layout
+        return self.packed_seq_params_by_layout[layout]
 
 
 def _get_batch_on_this_cp_rank_contiguous(
@@ -48,3 +93,222 @@ def _get_batch_on_this_cp_rank_contiguous(
         batch[key] = val.narrow(seq_dim, cp_rank * local_seq_len, local_seq_len).contiguous()
 
     return batch
+
+
+def _get_batch_on_this_cp_rank_padded_zigzag(
+    batch: Dict[str, Any],
+    cp_group: torch.distributed.ProcessGroup,
+    rank_order_indices: torch.Tensor,
+    target_cu_seqlens_padded: torch.Tensor,
+) -> Dict[str, Any]:
+    """Build a packed zigzag shard padded for TE context-parallel attention."""
+    cp_size = torch.distributed.get_world_size(cp_group)
+    cp_rank = torch.distributed.get_rank(cp_group)
+    if cp_size == 1:
+        return batch
+
+    sequence_tensor = None
+    for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+        sequence_tensor = batch.get(key)
+        if sequence_tensor is not None:
+            break
+    cu_seqlens = batch['cu_seqlens'].squeeze(0)
+    cu_seqlens_padded = batch.get('cu_seqlens_padded')
+    if cu_seqlens_padded is not None:
+        cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
+    physical_cu_seqlens = cu_seqlens if cu_seqlens_padded is None else cu_seqlens_padded
+    if sequence_tensor is not None:
+        source_positions = torch.arange(
+            sequence_tensor.size(1), dtype=physical_cu_seqlens.dtype, device=sequence_tensor.device
+        )
+        sequence_ids = torch.searchsorted(physical_cu_seqlens[1:], source_positions, right=True)
+        valid_ends = physical_cu_seqlens[:-1] + cu_seqlens[1:] - cu_seqlens[:-1]
+        source_valid = source_positions < valid_ends.index_select(0, sequence_ids)
+        index = rank_order_indices.view(cp_size, -1)[cp_rank]
+        valid_index = index.clamp_min(0)
+        padding = (index < 0) | ~source_valid.index_select(0, valid_index)
+        for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+            tensor = batch.get(key)
+            if tensor is not None:
+                local_tensor = tensor.index_select(1, valid_index)
+                batch[key] = local_tensor.masked_fill(padding.view(1, -1), 0)
+    batch['cu_seqlens_padded'] = target_cu_seqlens_padded.unsqueeze(0)
+    if batch.get('max_seqlen') is not None:
+        max_seqlen = (target_cu_seqlens_padded[1:] - target_cu_seqlens_padded[:-1]).max()
+        batch['max_seqlen'] = max_seqlen.reshape_as(batch['max_seqlen'])
+    return batch
+
+
+def _build_packed_seq_params(
+    batch: Dict[str, Any],
+    layout: CPLayout,
+    cp_size: int,
+    tokens_per_sample: int | None,
+    use_logical_qkv_seqlens: bool = False,
+    pad_between_seqs: bool | None = None,
+) -> PackedSeqParams | None:
+    """Build packed sequence metadata for one physical CP layout."""
+    cu_seqlens = batch.get('cu_seqlens')
+    if cu_seqlens is None:
+        return None
+
+    cu_seqlens = cu_seqlens.squeeze(0)
+    cu_seqlens_padded = batch.get('cu_seqlens_padded')
+    if cu_seqlens_padded is not None:
+        cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
+    physical_cu_seqlens = cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens
+    qkv_cu_seqlens = (
+        cu_seqlens
+        if (layout == "contiguous" and cp_size > 1) or use_logical_qkv_seqlens
+        else physical_cu_seqlens
+    )
+
+    max_seqlen = int(batch['max_seqlen'].item())
+    local_cp_size = batch.get('local_cp_size')
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=qkv_cu_seqlens,
+        cu_seqlens_kv=qkv_cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens_padded,
+        cu_seqlens_kv_padded=cu_seqlens_padded,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        local_cp_size=int(local_cp_size.item()) if local_cp_size is not None else None,
+        cp_group=batch.get('hybrid_cp_group'),
+        total_tokens=int(physical_cu_seqlens[-1].item()),
+        tokens_per_sample=tokens_per_sample,
+        pad_between_seqs=pad_between_seqs,
+    )
+
+
+def get_batches_on_this_cp_rank(
+    batch: Dict[str, Any],
+    boundary_layout: CPLayout,
+    is_hybrid_cp: bool,
+    cp_group: torch.distributed.ProcessGroup,
+    additional_layouts: Iterable[CPLayout] = (),
+    hybrid_cp_group_func: Callable[[int], torch.distributed.ProcessGroup] | None = None,
+    use_per_sequence_balancing: bool = False,
+    sequence_parallel: bool = False,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+    tp_cp_group: torch.distributed.ProcessGroup | None = None,
+    tokens_per_sample: int | None = None,
+) -> ContextParallelBatch:
+    """Partition a batch and prepare metadata for the requested CP layouts.
+
+    The input is already broadcast over TP but has not yet been partitioned over CP. A caller
+    may request additional physical views when different consumers need different layouts. The
+    boundary view is always included and is the default returned by ``ContextParallelBatch``.
+
+    Packed non-hybrid CP batches need special handling when layout conversion requires a padded
+    zigzag view or the standard sharder would balance the flattened sample instead of each
+    sequence. The same rank ordering is used to build the zigzag batch tensors and their
+    ``PackedSeqParams``. When both layouts are requested, it also defines the
+    activation-conversion plan. All other cases use the standard batch sharder.
+    """
+    from megatron.core.utils import get_batch_on_this_cp_rank
+
+    requested_layouts = set(additional_layouts)
+    requested_layouts.add(boundary_layout)
+    cp_size = torch.distributed.get_world_size(cp_group)
+
+    build_packed_zigzag_view = (
+        not is_hybrid_cp
+        and cp_size > 1
+        and batch.get('cu_seqlens') is not None
+        and "zigzag" in requested_layouts
+        and (use_per_sequence_balancing or "contiguous" in requested_layouts)
+    )
+    build_thd_plan = build_packed_zigzag_view and "contiguous" in requested_layouts
+
+    if build_packed_zigzag_view:
+        # Build the padded zigzag ordering directly from the unsharded batch metadata.
+        cu_seqlens = batch['cu_seqlens'].squeeze(0)
+        cu_seqlens_padded = batch.get('cu_seqlens_padded')
+        if cu_seqlens_padded is not None:
+            cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
+        tp_size = tp_group.size() if sequence_parallel else 1
+        zigzag_metadata = _build_thd_zigzag_metadata(
+            cu_seqlens, cu_seqlens_padded, cp_size, tp_size
+        )
+
+        batches_by_layout = {
+            "zigzag": _get_batch_on_this_cp_rank_padded_zigzag(
+                dict(batch),
+                cp_group=cp_group,
+                rank_order_indices=zigzag_metadata.rank_order_indices,
+                target_cu_seqlens_padded=zigzag_metadata.cu_seqlens_padded,
+            )
+        }
+        if build_thd_plan:
+            batches_by_layout["contiguous"] = get_batch_on_this_cp_rank(
+                dict(batch), is_hybrid_cp=False, cp_group=cp_group, use_contiguous_cp=True
+            )
+        packed_seq_params_by_layout = {
+            layout: _build_packed_seq_params(
+                layout_batch,
+                layout,
+                cp_size,
+                tokens_per_sample,
+                use_logical_qkv_seqlens=layout == "zigzag",
+                pad_between_seqs=(zigzag_metadata.pad_between_seqs if layout == "zigzag" else None),
+            )
+            for layout, layout_batch in batches_by_layout.items()
+        }
+
+        thd_plan = None
+        if build_thd_plan:
+            # The route is a separate artifact connecting the two completed layout views.
+            contiguous_packed_seq_params = packed_seq_params_by_layout["contiguous"]
+            assert contiguous_packed_seq_params is not None
+            assert contiguous_packed_seq_params.total_tokens is not None
+            thd_plan = build_thd_cp_layout_plan(
+                zigzag_metadata.rank_order_indices,
+                contiguous_packed_seq_params.total_tokens,
+                cp_group,
+                sequence_parallel,
+                tp_group,
+                tp_cp_group,
+            )
+        return ContextParallelBatch(
+            boundary_layout=boundary_layout,
+            batches_by_layout=batches_by_layout,
+            packed_seq_params_by_layout=packed_seq_params_by_layout,
+            thd_plan=thd_plan,
+        )
+
+    has_sequence_data = any(
+        batch.get(key) is not None
+        for key in ('tokens', 'labels', 'loss_mask', 'position_ids', 'attention_mask')
+    )
+    if has_sequence_data:
+        # Copy the dictionary because the CP sharder replaces sequence-valued entries in place.
+        batches_by_layout = {
+            layout: get_batch_on_this_cp_rank(
+                dict(batch),
+                is_hybrid_cp=is_hybrid_cp,
+                cp_group=cp_group,
+                hybrid_cp_group_func=hybrid_cp_group_func,
+                use_per_sequence_balancing=use_per_sequence_balancing,
+                use_contiguous_cp=layout == "contiguous",
+            )
+            for layout in requested_layouts
+        }
+    else:
+        # Intermediate PP stages receive activations rather than token-aligned tensors.
+        batches_by_layout = {layout: dict(batch) for layout in requested_layouts}
+
+    # No shared conversion route exists in this path, so build metadata from each physical batch
+    # view rather than deriving one layout's metadata from the other.
+    packed_seq_params_by_layout = {
+        layout: _build_packed_seq_params(
+            batches_by_layout[layout], layout, cp_size, tokens_per_sample
+        )
+        for layout in requested_layouts
+    }
+
+    return ContextParallelBatch(
+        boundary_layout=boundary_layout,
+        batches_by_layout=batches_by_layout,
+        packed_seq_params_by_layout=packed_seq_params_by_layout,
+    )

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 import torch
 from torch import Tensor, nn
 
-from megatron.core.context_parallel import ContextParallelLayoutManager
+from megatron.core.context_parallel import ContextParallelLayoutManager, CPLayout, THDCPLayoutPlan
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
@@ -96,6 +96,7 @@ class HybridStack(MegatronModule):
         pg_collection (ProcessGroupCollection): the required model communication
             process groups to use.
         is_mtp_layer (bool, optional): whether this is an MTP layer. Defaults to False.
+        boundary_layout (CPLayout, optional): CP layout at the stack boundary.
     """
 
     def __init__(
@@ -113,6 +114,7 @@ class HybridStack(MegatronModule):
         is_mtp_layer: bool = False,
         name: str | None = None,
         layer_config_list: Sequence[TransformerConfig] | None = None,
+        boundary_layout: CPLayout | None = None,
     ) -> None:
         """
         Args:
@@ -146,6 +148,9 @@ class HybridStack(MegatronModule):
         self.post_layer_norm = post_layer_norm
         self.post_process = post_process
         self.is_mtp_layer = is_mtp_layer
+        boundary_layout = (
+            self.config.linear_cp_layout if boundary_layout is None else boundary_layout
+        )
 
         assert pg_collection is not None, "pg_collection must be provided for HybridStack"
 
@@ -178,7 +183,7 @@ class HybridStack(MegatronModule):
             )
             self._cp_layout_manager = ContextParallelLayoutManager(
                 layer_layouts=layer_layouts,
-                boundary_layout=self.config.linear_cp_layout,
+                boundary_layout=boundary_layout,
                 sequence_parallel=self.config.sequence_parallel,
                 cp_group=self.cp_group,
                 tp_group=self.tp_group,
@@ -425,6 +430,8 @@ class HybridStack(MegatronModule):
         inference_params: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask=None,
+        packed_seq_params_by_layout: dict[CPLayout, PackedSeqParams | None] | None = None,
+        cp_layout_plan: THDCPLayoutPlan | None = None,
     ):
         """
         Forward function of the HybridStack class.
@@ -453,7 +460,11 @@ class HybridStack(MegatronModule):
 
         cp_layout_state = None
         if self._cp_layout_manager is not None:
-            cp_layout_state = self._cp_layout_manager.build_forward_state(packed_seq_params)
+            cp_layout_state = self._cp_layout_manager.build_forward_state(
+                packed_seq_params,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                thd_plan=cp_layout_plan,
+            )
 
         packed_sequence_cp_metadata = None
         if self._has_linear_layer_with_chunkwise_cp and packed_seq_params is not None:

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -8,6 +8,7 @@ from torch import Tensor
 
 from megatron.core import tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
+from megatron.core.context_parallel import ContextParallelBatch
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.common.embeddings.language_model_embedding import LanguageModelEmbedding
@@ -443,6 +444,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[Tensor] = None,
         compute_mtp_loss: bool = True,
+        cp_batch: ContextParallelBatch | None = None,
     ) -> Tensor:
         """Forward function of the Hybrid model. This function passes the input tensors
         through the embedding layer, and then the decoder and finally into the post
@@ -456,6 +458,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 loaded. This does not control speculative decoding. On post-process stages,
                 ``labels`` still determine whether the model returns loss or logits.
                 Defaults to True.
+            cp_batch: Input tensors and packed metadata keyed by CP layout.
         """
         # If decoder_input is provided (not None), then input_ids and position_ids are ignored.
         # Otherwise, apply embedding layer on input_ids and position_ids to get decoder_input.
@@ -535,6 +538,11 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         #   be None, so this assert will succeed.
         # assert attention_mask is None, "The attention mask is ignored and should be set to None"
 
+        packed_seq_params_by_layout = (
+            cp_batch.packed_seq_params_by_layout if cp_batch is not None else None
+        )
+        cp_layout_plan = cp_batch.thd_plan if cp_batch is not None else None
+
         # Run decoder.
         decoder_output = self.decoder(
             hidden_states=decoder_input,
@@ -543,6 +551,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             rotary_pos_emb=rotary_pos_emb,
             packed_seq_params=packed_seq_params,
             padding_mask=padding_mask,
+            packed_seq_params_by_layout=packed_seq_params_by_layout,
+            cp_layout_plan=cp_layout_plan,
         )
         if isinstance(decoder_output, tuple):
             hidden_states, mhc_multistream = decoder_output
@@ -567,22 +577,38 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         mtp_forward_ran = (
             self.mtp_process and not (in_inference_mode or is_spec_decode) and compute_mtp_loss
         )
+        mtp_hidden_states = hidden_states
+        mtp_inputs = None
         if mtp_forward_ran:
-            hidden_states = self.mtp(
+            mtp_inputs = self.mtp.prepare_cp_layout(
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,
                 mhc_multistream=mhc_multistream,
+                labels=labels,
+                loss_mask=loss_mask,
+                mtp_input_mask=mtp_input_mask,
+                packed_seq_params=packed_seq_params,
+                cp_batch=cp_batch,
+            )
+            assert mtp_inputs.input_ids is not None and mtp_inputs.position_ids is not None
+            mtp_hidden_states = self.mtp(
+                input_ids=mtp_inputs.input_ids,
+                position_ids=mtp_inputs.position_ids,
+                hidden_states=mtp_inputs.hidden_states,
+                mhc_multistream=mtp_inputs.mhc_multistream,
                 attention_mask=attention_mask,
                 inference_params=inference_params,
                 rotary_pos_emb=rotary_pos_emb,
-                packed_seq_params=packed_seq_params,
+                packed_seq_params=mtp_inputs.packed_seq_params,
                 embedding=self.embedding,
-                mtp_input_mask=mtp_input_mask,
+                mtp_input_mask=mtp_inputs.mtp_input_mask,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
             )
 
         if not self.post_process:
-            return hidden_states
+            return mtp_hidden_states if mtp_forward_ran else hidden_states
 
         if self.config.mtp_num_layers is not None and self.mtp_process:
             assert self.config.mtp_num_layers > 0
@@ -601,12 +627,13 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     # this back to None after reading to allow GC.
                     inference_context.mtp_decoder_hidden_states = hidden_states
             elif mtp_forward_ran:
+                assert mtp_inputs is not None
                 # For RL (labels is None), process_mtp_loss derives labels from
                 # input_ids to match the SFT label format.
                 hidden_states = process_mtp_loss(
-                    hidden_states=hidden_states,
-                    labels=labels,
-                    loss_mask=loss_mask,
+                    hidden_states=mtp_hidden_states,
+                    labels=mtp_inputs.labels,
+                    loss_mask=mtp_inputs.loss_mask,
                     output_layer=self.output_layer,
                     output_weight=output_weight,
                     runtime_gather_output=runtime_gather_output,
@@ -615,14 +642,15 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config=self.config,
                     cp_group=self.pg_collection.cp,
                     tp_group=self.tp_group,
-                    packed_seq_params=packed_seq_params,
+                    packed_seq_params=mtp_inputs.packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,
-                    input_ids=input_ids,
-                    mtp_input_mask=mtp_input_mask,
+                    input_ids=mtp_inputs.input_ids,
+                    mtp_input_mask=mtp_inputs.mtp_input_mask,
                     metric_avg_group=(
                         getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
                         or self.pg_collection.dp_cp
                     ),
+                    main_hidden_states=hidden_states,
                 )
         sequence_parallel_override = False
         if (

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
+from megatron.core.context_parallel import ContextParallelBatch, convert_cp_layout
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
@@ -46,6 +47,7 @@ from megatron.core.utils import (
 )
 
 if TYPE_CHECKING:
+    from megatron.core.context_parallel import CPLayout, THDCPLayoutPlan
     from megatron.core.models.hybrid.hybrid_block import HybridStackSubmodules
 
 if is_torch_min_version("1.13.0"):
@@ -334,6 +336,9 @@ def _roll_tensor_packed_seq(
     assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
     cu_seqlens = packed_seq_params.cu_seqlens_q
     assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
+    physical_cu_seqlens = packed_seq_params.cu_seqlens_q_padded
+    if physical_cu_seqlens is None:
+        physical_cu_seqlens = cu_seqlens
 
     rolled_tensor = tensor.clone()
 
@@ -341,13 +346,16 @@ def _roll_tensor_packed_seq(
     if cp_size == 1:
         # CP disabled: roll each packed sequence independently within its boundaries
         for i in range(len(cu_seqlens) - 1):
-            start_idx = cu_seqlens[i]
-            end_idx = cu_seqlens[i + 1]
+            start_idx = physical_cu_seqlens[i]
+            valid_length = cu_seqlens[i + 1] - cu_seqlens[i]
+            end_idx = start_idx + valid_length
+            physical_end_idx = physical_cu_seqlens[i + 1]
             seq_slice = tensor[..., start_idx:end_idx]
             rolled_seq = torch.roll(seq_slice, shifts=shifts, dims=dims)
             # Zero out the last position(s) that would cross sequence boundaries
             rolled_seq[..., shifts:] = 0
             rolled_tensor[..., start_idx:end_idx] = rolled_seq
+            rolled_tensor[..., end_idx:physical_end_idx] = 0
         rolled_sum = rolled_tensor.sum() if return_sum else None
         return rolled_tensor, rolled_sum
 
@@ -359,8 +367,8 @@ def _roll_tensor_packed_seq(
 
     # Iterate over each sequence individually
     for i in range(len(cu_seqlens) - 1):
-        start_idx = cu_seqlens[i]
-        end_idx = cu_seqlens[i + 1]
+        start_idx = physical_cu_seqlens[i]
+        end_idx = physical_cu_seqlens[i + 1]
 
         # the idx has been multiplied by cp_size, need to divide it by cp_size to get the local idx
         local_start_idx = start_idx // cp_size
@@ -993,6 +1001,7 @@ def process_mtp_loss(
     input_ids: Optional[Tensor] = None,
     mtp_input_mask: Optional[Tensor] = None,
     metric_avg_group: Optional[torch.distributed.ProcessGroup] = None,
+    main_hidden_states: Optional[Tensor] = None,
 ) -> Tensor:
     """Process Multi-Token Prediction (MTP) loss computation.
 
@@ -1022,12 +1031,14 @@ def process_mtp_loss(
             additional MTP conditioning inputs. The mask accumulates across prediction
             steps so a path stays masked after it reaches an invalid token.
         metric_avg_group (Optional[ProcessGroup]): Group used to average MTP logging metrics.
+        main_hidden_states (Optional[Tensor]): Hidden states returned to the main model.
+            Defaults to the first chunk of ``hidden_states``.
 
     Returns:
-        Tensor: Updated hidden states after MTP loss processing (first chunk only).
+        Tensor: Main-model hidden states with the MTP loss attached.
     """
     hidden_states_list = torch.chunk(hidden_states, 1 + config.mtp_num_layers, dim=0)
-    hidden_states = hidden_states_list[0]
+    hidden_states = hidden_states_list[0] if main_hidden_states is None else main_hidden_states
 
     # When labels are not provided (e.g. RL training), derive them from input_ids by
     # rolling left so that label[i] = input_id[i + 1], matching the SFT label format.
@@ -1363,6 +1374,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 post_process=True,  # MTP layer is self-contained
                 pg_collection=pg_collection,
                 is_mtp_layer=True,
+                boundary_layout=self.config.attention_cp_layout,
                 name=(name + ".mtp_model_layer") if name is not None else None,
             )
         elif self.config.mtp_num_layers is not None:
@@ -1586,6 +1598,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[torch.Tensor] = None,
+        packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
+        cp_layout_plan: Optional[THDCPLayoutPlan] = None,
     ) -> torch.Tensor:
         """
         Concatenates embeddings with hidden states and then applies transformer layer forward.
@@ -1621,6 +1635,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                         rotary_pos_emb=rotary_pos_emb,
                         inference_context=inference_params,
                         packed_seq_params=packed_seq_params,
+                        packed_seq_params_by_layout=packed_seq_params_by_layout,
+                        cp_layout_plan=cp_layout_plan,
                     )
                 else:
                     # GPT path: single TransformerLayer
@@ -1728,21 +1744,16 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
+        packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
+        cp_layout_plan: Optional[THDCPLayoutPlan] = None,
     ):
         """Forward through ``_proj_and_transformer_layer`` with activation
         recomputation.
 
         Mirrors ``transformer_block._checkpointed_forward``:
 
-        * Non-tensor objects (``attention_bias``, ``inference_params``,
-          ``packed_seq_params``) are captured by the ``custom_forward``
-          closure; only tensor / ``None`` arguments flow positionally
-          through the underlying checkpoint primitive. This is required
-          by both backends: ``tensor_parallel.checkpoint`` because its
-          ``save_for_backward`` only accepts tensors and ``None``, and
-          ``te_checkpoint`` because its reentrant implementation only
-          tracks positional tensor inputs as checkpoint inputs (kwarg
-          tensors are not represented in the recompute backward path).
+        * Non-tensor objects are captured by the ``custom_forward`` closure; only tensor / ``None``
+          arguments flow positionally through the underlying checkpoint primitive.
         * Quantized recipes (fp8, fp4) route through ``te_checkpoint``;
           everything else uses ``tensor_parallel.checkpoint``.
         * Only ``fp8 + delayed scaling`` needs an outer quantization
@@ -1776,6 +1787,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
             )
 
         # Decide the outer quantization context, matching
@@ -1825,8 +1838,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 # tensor_parallel.checkpoint stashes args via autograd's
                 # ``save_for_backward``, which only accepts tensors and ``None``.
                 # Pass tensor / ``None`` args positionally and capture the
-                # non-tensor objects (``attention_bias``, ``inference_params``,
-                # ``packed_seq_params``) via the ``custom_forward`` closure.
+                # non-tensor objects via the ``custom_forward`` closure.
                 return tensor_parallel.checkpoint(
                     custom_forward,
                     self.config.distribute_saved_activations,
@@ -1870,6 +1882,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
             )
         else:
             raise ValueError("Invalid activation recompute method.")
@@ -1894,6 +1908,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
         mtp_input_mask: Optional[Tensor] = None,
+        packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
+        cp_layout_plan: Optional[THDCPLayoutPlan] = None,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -1946,6 +1962,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
             )
         else:
             hidden_states = self._proj_and_transformer_layer(
@@ -1962,6 +1980,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
             )
 
         return hidden_states, input_ids, position_ids, padding_mask, mtp_input_mask
@@ -2011,6 +2031,20 @@ class MultiTokenPredictionBlockSubmodules:
     """
 
     layer_specs: Optional[List[ModuleSpec]] = None
+
+
+@dataclass(eq=False)
+class MultiTokenPredictionInputs:
+    """Inputs prepared in the CP layout consumed by an MTP block."""
+
+    input_ids: Tensor
+    position_ids: Tensor
+    hidden_states: Tensor
+    mhc_multistream: Optional[Tensor]
+    labels: Optional[Tensor]
+    loss_mask: Optional[Tensor]
+    mtp_input_mask: Optional[Tensor]
+    packed_seq_params: Optional[PackedSeqParams]
 
 
 def _get_mtp_block_submodules(
@@ -2132,6 +2166,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
+        self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)
         self.pp_rank = pg_collection.pp.rank()
         self.dp_group = pg_collection.dp if self.config.mtp_hsm else None
         self.hidden_state_mixing_rng_tracker_name = (
@@ -2145,6 +2180,69 @@ class MultiTokenPredictionBlock(MegatronModule):
             # Tag MTP params so the optimizer can clip their gradients separately.
             for param in self.parameters():
                 param.grad_norm_group = 'mtp'
+
+    def prepare_cp_layout(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        hidden_states: Tensor,
+        mhc_multistream: Optional[Tensor],
+        labels: Optional[Tensor],
+        loss_mask: Optional[Tensor],
+        mtp_input_mask: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        cp_batch: Optional[ContextParallelBatch],
+    ) -> MultiTokenPredictionInputs:
+        """Prepare activations and token-aligned inputs for the MTP block's CP layout."""
+        source_layout = (
+            cp_batch.boundary_layout if cp_batch is not None else self.config.linear_cp_layout
+        )
+        target_layout = self.config.attention_cp_layout
+        requires_conversion = self.cp_group.size() > 1 and source_layout != target_layout
+
+        if requires_conversion:
+            if mtp_input_mask is not None:
+                raise ValueError("mtp_input_mask is not supported with CP layout conversion")
+            if cp_batch is None:
+                raise ValueError("cp_batch is required when MTP uses a different CP layout")
+            hidden_states = convert_cp_layout(
+                hidden_states,
+                source_layout,
+                target_layout,
+                self.cp_group,
+                self.sequence_parallel,
+                self.tp_group,
+                self.tp_cp_group,
+                cp_batch.thd_plan,
+            )
+            if mhc_multistream is not None:
+                mhc_multistream = convert_cp_layout(
+                    mhc_multistream,
+                    source_layout,
+                    target_layout,
+                    self.cp_group,
+                    self.sequence_parallel,
+                    self.tp_group,
+                    self.tp_cp_group,
+                    cp_batch.thd_plan,
+                )
+            packed_seq_params = cp_batch.get_packed_seq_params(target_layout)
+            layout_batch = cp_batch.get_batch(target_layout)
+            input_ids = layout_batch["tokens"]
+            position_ids = layout_batch["position_ids"]
+            labels = layout_batch["labels"]
+            loss_mask = layout_batch["loss_mask"]
+
+        return MultiTokenPredictionInputs(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            mhc_multistream=mhc_multistream,
+            labels=labels,
+            loss_mask=loss_mask,
+            mtp_input_mask=mtp_input_mask,
+            packed_seq_params=packed_seq_params,
+        )
 
     def _build_layers(self, pg_collection):
         # Determine number of depths to build
@@ -2253,6 +2351,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         embedding=None,
         mtp_input_mask: Optional[Tensor] = None,
         mhc_multistream: Optional[Tensor] = None,
+        packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
+        cp_layout_plan: Optional[THDCPLayoutPlan] = None,
     ) -> Tensor:
         """
         Perform the forward pass through all of the MTP modules.
@@ -2365,6 +2465,8 @@ class MultiTokenPredictionBlock(MegatronModule):
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
                 packed_seq_params=packed_seq_params,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
                 mtp_input_mask=mtp_input_mask,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1495,6 +1495,14 @@ class TransformerConfig(ModelParallelConfig):
                 "hybrid_context_parallel is not supported with linear_cp_layout='contiguous'."
             )
         if (
+            self.sequence_packing_scheduler is not None
+            and self.context_parallel_size > 1
+            and self.linear_cp_layout != self.attention_cp_layout
+        ):
+            raise ValueError(
+                "The sequence-packing scheduler does not support CP layout conversion."
+            )
+        if (
             self.context_parallel_size > 1
             and self.linear_cp_layout != self.attention_cp_layout
             and self.sequence_parallel
@@ -1504,14 +1512,6 @@ class TransformerConfig(ModelParallelConfig):
             raise ValueError(
                 "Sequence-parallel CP layout conversion requires an even "
                 f"tensor-parallel size, got {self.tensor_model_parallel_size}."
-            )
-        if (
-            self.linear_cp_layout == "contiguous"
-            and self.context_parallel_size > 1
-            and (self.mtp_num_layers or 0) > 0
-        ):
-            raise ValueError(
-                "linear_cp_layout='contiguous' with context parallelism does not yet support MTP."
             )
 
     def __post_init__(self):

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -37,13 +37,13 @@ import torch
 
 from hybrid_builders import hybrid_builder
 from megatron.core import mpu
+from megatron.core.context_parallel import ContextParallelBatch, get_batches_on_this_cp_rank
 from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
 from megatron.core.datasets.data_schedule import get_batch_on_this_rank_for_sequence_packing
 from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig, MockGPTDataset
 from megatron.core.enums import ModelType
 from megatron.core.package_info import __version__ as mcore_version
 from megatron.core.models.hybrid.hybrid_model import HybridModel
-from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.parallel_state import (
     get_context_parallel_group,
     get_hybrid_data_context_parallel_groups,
@@ -57,7 +57,6 @@ from megatron.core.utils import (
     StragglerDetector,
     flatten_batch_for_packed_sequences,
     get_attr_wrapped_model,
-    get_batch_on_this_cp_rank,
     get_batch_on_this_tp_rank,
     get_te_version,
     get_torch_version,
@@ -93,8 +92,8 @@ except ImportError:
 
 stimer = StragglerDetector()
 
-# Canonical, ordered schema of the fields ``get_batch`` returns. Kept alphabetical
-# to match the historical ``sorted(batch.keys())`` order that callers unpack into.
+# Canonical, ordered batch schema. Kept alphabetical to match the
+# historical ``sorted(batch.keys())`` order.
 BATCH_KEYS = [
     "attention_mask",
     "cu_seqlens",
@@ -116,7 +115,15 @@ def get_batch(data_iterator, vp_stage=None):
     config = core_transformer_config_from_args(args)
 
     if args.sequence_packing_scheduler is not None:
-        return get_batch_on_this_rank_for_sequence_packing(
+        (
+            tokens,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            packed_seq_params,
+            padding_mask,
+        ) = get_batch_on_this_rank_for_sequence_packing(
             data_iterator,
             vpp_size=config.virtual_pipeline_model_parallel_size,
             mtp_on_this_rank=mtp_on_this_rank_func(
@@ -126,6 +133,18 @@ def get_batch(data_iterator, vp_stage=None):
                 vp_stage=vp_stage,
             ),
             vp_stage=vp_stage,
+        )
+        return ContextParallelBatch.from_single_layout(
+            config.linear_cp_layout,
+            {
+                "tokens": tokens,
+                "labels": labels,
+                "loss_mask": loss_mask,
+                "attention_mask": attention_mask,
+                "position_ids": position_ids,
+                "padding_mask": padding_mask,
+            },
+            packed_seq_params,
         )
 
     cp_size = args.context_parallel_size
@@ -146,7 +165,11 @@ def get_batch(data_iterator, vp_stage=None):
         and not mtp_on_this_rank
         and not has_cu_seqlens
     ):
-        return [None for _ in BATCH_KEYS]
+        return ContextParallelBatch(
+            boundary_layout=config.linear_cp_layout,
+            batches_by_layout={config.linear_cp_layout: dict.fromkeys(BATCH_KEYS)},
+            packed_seq_params_by_layout={config.linear_cp_layout: None},
+        )
 
     batch = {}
     if tp_rank == 0:
@@ -179,35 +202,33 @@ def get_batch(data_iterator, vp_stage=None):
 
     if not is_first_or_last_pipeline_stage(vp_stage) and not mtp_on_this_rank:
         assert has_cu_seqlens
-        return (
-            None,
-            batch['cu_seqlens'],
-            batch['cu_seqlens_padded'],
-            None,
-            None,
-            None,
-            None,
-            batch['max_seqlen'],
-            None,
-            None,
-        )
+        batch = {
+            **dict.fromkeys(BATCH_KEYS),
+            'cu_seqlens': batch['cu_seqlens'],
+            'cu_seqlens_padded': batch['cu_seqlens_padded'],
+            'max_seqlen': batch['max_seqlen'],
+        }
 
-    batch = get_batch_on_this_cp_rank(
+    additional_layouts = set()
+    if cp_size > 1 and config.linear_cp_layout != config.attention_cp_layout:
+        additional_layouts.add(config.attention_cp_layout)
+    return get_batches_on_this_cp_rank(
         batch,
+        boundary_layout=config.linear_cp_layout,
         is_hybrid_cp=is_hybrid_cp,
         cp_group=get_context_parallel_group(),
+        additional_layouts=additional_layouts,
         hybrid_cp_group_func=get_hybrid_data_context_parallel_groups,
         use_per_sequence_balancing=args.dataloader_inter_document_masking and not is_sft,
-        use_contiguous_cp=(config.linear_cp_layout == "contiguous" and cp_size > 1),
+        sequence_parallel=config.sequence_parallel,
+        tp_group=mpu.get_tensor_model_parallel_group(),
+        tp_cp_group=(
+            mpu.get_tensor_and_context_parallel_group()
+            if config.sequence_parallel and config.tensor_model_parallel_size > 1
+            else None
+        ),
+        tokens_per_sample=args.seq_length,
     )
-
-    # Return values in BATCH_KEYS order so callers can unpack into the fixed
-    # names regardless of any provenance fields wrappers like BlendedDataset
-    # add (e.g. "dataset_id"). The for-loop above already populates every
-    # BATCH_KEYS entry on tp_rank 0; other tp_ranks receive a fresh dict from
-    # get_batch_on_this_tp_rank. BATCH_KEYS is already alphabetical, matching
-    # the historical sorted(batch.keys()) order.
-    return [batch[key] for key in BATCH_KEYS]
 
 
 # define spiky loss as a loss that's 10x the max loss observed
@@ -320,65 +341,18 @@ def forward_step(data_iterator, model: HybridModel):
 
     with stimer(bdata=True):
         vp_stage = get_attr_wrapped_model(model, "vp_stage")
-        batch = get_batch(data_iterator, vp_stage)
-
-        if len(batch) == 7:
-            (
-                tokens,
-                labels,
-                loss_mask,
-                attention_mask,
-                position_ids,
-                packed_seq_params,
-                padding_mask,
-            ) = batch
-        elif len(batch) == 6:
-            tokens, labels, loss_mask, attention_mask, position_ids, packed_seq_params = batch
-            padding_mask = None
-        else:
-            (
-                attention_mask,
-                cu_seqlens,
-                cu_seqlens_padded,
-                hybrid_cp_group,
-                labels,
-                local_cp_size,
-                loss_mask,
-                max_seqlen,
-                position_ids,
-                tokens,
-            ) = batch
-
-            padding_mask = None
-            packed_seq_params = None
-            if cu_seqlens is not None:
-                # Squeeze the batch dim: the batch dict keeps cu_seqlens as (1, N)
-                # for consistency, but PackedSeqParams and TE expect 1-D.
-                cu_seqlens = cu_seqlens.squeeze(0)
-                if cu_seqlens_padded is not None:
-                    cu_seqlens_padded = cu_seqlens_padded.squeeze(0)
-                # Use real (unpadded) cu_seqlens to feed the FLOPs accounting: varlen
-                # attention only computes work for real tokens within each chunk.
-                update_seqlen_stats_from_cu_seqlens(cu_seqlens)
-                cu_seqlens_for_params = (
-                    cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens
-                )
-                total_tokens = int(cu_seqlens_for_params[-1].item())
-                if args.linear_cp_layout == "contiguous" and args.context_parallel_size > 1:
-                    cu_seqlens_for_params = cu_seqlens
-                packed_seq_params = PackedSeqParams(
-                    qkv_format="thd",
-                    cu_seqlens_q=cu_seqlens_for_params,
-                    cu_seqlens_kv=cu_seqlens_for_params,
-                    cu_seqlens_q_padded=cu_seqlens_padded,
-                    cu_seqlens_kv_padded=cu_seqlens_padded,
-                    max_seqlen_q=int(max_seqlen.item()),
-                    max_seqlen_kv=int(max_seqlen.item()),
-                    local_cp_size=int(local_cp_size.item()) if local_cp_size is not None else None,
-                    cp_group=hybrid_cp_group,
-                    total_tokens=total_tokens,
-                    tokens_per_sample=args.seq_length,
-                )
+        cp_batch = get_batch(data_iterator, vp_stage)
+        batch = cp_batch.get_batch()
+        attention_mask = batch.get("attention_mask")
+        cu_seqlens = batch.get("cu_seqlens")
+        labels = batch.get("labels")
+        loss_mask = batch.get("loss_mask")
+        position_ids = batch.get("position_ids")
+        tokens = batch.get("tokens")
+        packed_seq_params = cp_batch.get_packed_seq_params()
+        padding_mask = batch.get("padding_mask")
+        if cu_seqlens is not None:
+            update_seqlen_stats_from_cu_seqlens(cu_seqlens.squeeze(0))
 
     timers('batch-generator').stop()
 
@@ -391,6 +365,7 @@ def forward_step(data_iterator, model: HybridModel):
             packed_seq_params=packed_seq_params,
             loss_mask=loss_mask,
             padding_mask=padding_mask,
+            cp_batch=cp_batch,
         )
 
     # [ModelOpt]: model is needed to access ModelOpt distillation losses

--- a/tests/unit_tests/context_parallel/test_layout.py
+++ b/tests/unit_tests/context_parallel/test_layout.py
@@ -19,7 +19,7 @@ from megatron.core.context_parallel.layout import (
     _build_group_rank_by_logical_rank,
     _build_layout_redistribution_plan,
     _build_thd_cp_layout_plan_from_rank_order_indices,
-    _build_thd_rank_order_indices,
+    _build_thd_zigzag_metadata,
     _local_segment_ids,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -154,57 +154,28 @@ def test_matching_cp_layouts_do_not_convert(monkeypatch):
     assert manager.build_forward_state(None) is None
 
 
-def test_packed_zigzag_layout_uses_padded_metadata(monkeypatch):
-    cp_group = SimpleNamespace(size=lambda: 2)
-    tp_group = object()
-    tp_cp_group = object()
+def test_prebuilt_packed_layout_state_is_reused():
     manager = ContextParallelLayoutManager(
-        layer_layouts=("contiguous", "zigzag"),
+        layer_layouts=("zigzag",),
         boundary_layout="contiguous",
         sequence_parallel=False,
-        cp_group=cp_group,
-        tp_group=tp_group,
-        tp_cp_group=tp_cp_group,
+        cp_group=SimpleNamespace(size=lambda: 2),
+        tp_group=None,
+        tp_cp_group=None,
     )
-    cu_seqlens = torch.tensor((0, 7, 16), dtype=torch.int32)
-    target_cu_seqlens_padded = torch.tensor((0, 8, 24), dtype=torch.int32)
-    packed_seq_params = PackedSeqParams(
-        qkv_format="thd",
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_kv=cu_seqlens,
-        max_seqlen_q=9,
-        max_seqlen_kv=9,
-        total_tokens=16,
-    )
-    plan = SimpleNamespace(
-        cu_seqlens_padded=target_cu_seqlens_padded, max_seqlen_padded=16, pad_between_seqs=True
-    )
-    monkeypatch.setattr(
-        context_parallel_layout_module, "build_thd_cp_layout_plan", lambda *_args, **_kwargs: plan
+    contiguous_params = PackedSeqParams(qkv_format="thd")
+    zigzag_params = PackedSeqParams(qkv_format="thd")
+    plan = object()
+    packed_seq_params_by_layout = {"contiguous": contiguous_params, "zigzag": zigzag_params}
+
+    state = manager.build_forward_state(
+        contiguous_params, packed_seq_params_by_layout=packed_seq_params_by_layout, thd_plan=plan
     )
 
-    layout_state = manager.build_forward_state(packed_seq_params)
-
-    assert layout_state is not None
-    assert layout_state.thd_plan is plan
-    zigzag_params = layout_state.zigzag_packed_seq_params
-    assert zigzag_params is not None
-    assert zigzag_params.cu_seqlens_q is cu_seqlens
-    assert zigzag_params.cu_seqlens_kv is cu_seqlens
-    assert zigzag_params.cu_seqlens_q_padded is target_cu_seqlens_padded
-    assert zigzag_params.cu_seqlens_kv_padded is target_cu_seqlens_padded
-    assert zigzag_params.max_seqlen_q == 16
-    assert zigzag_params.max_seqlen_kv == 16
-    assert zigzag_params.pad_between_seqs
-    assert zigzag_params.total_tokens is None
-    assert zigzag_params.seq_idx is None
-
-    monkeypatch.setattr(manager, "prepare_layer_input", lambda _index, hidden, _plan: hidden)
-    hidden_states = torch.zeros(2, 1, 1)
-    _, layer_packed_seq_params = layout_state.prepare_layer(0, hidden_states)
-    assert layer_packed_seq_params is packed_seq_params
-    _, layer_packed_seq_params = layout_state.prepare_layer(1, hidden_states)
-    assert layer_packed_seq_params is zigzag_params
+    assert state is not None
+    assert state.thd_plan is plan
+    assert state.contiguous_packed_seq_params is contiguous_params
+    assert state.zigzag_packed_seq_params is zigzag_params
 
 
 @pytest.mark.parametrize(
@@ -285,14 +256,17 @@ def test_layout_redistribution_plan_restores_target_segments(
         )
 
 
-def test_thd_rank_order_indices_pad_uneven_sequences():
-    rank_order_indices, padded_cu_seqlens = _build_thd_rank_order_indices(
+def test_thd_zigzag_layout_pads_uneven_sequences():
+    metadata = _build_thd_zigzag_metadata(
         torch.tensor((0, 3, 8), dtype=torch.int32), None, cp_size=2, tp_size=1
     )
 
-    torch.testing.assert_close(padded_cu_seqlens, torch.tensor((0, 4, 12), dtype=torch.int32))
     torch.testing.assert_close(
-        rank_order_indices,
+        metadata.cu_seqlens_padded, torch.tensor((0, 4, 12), dtype=torch.int32)
+    )
+    assert metadata.pad_between_seqs
+    torch.testing.assert_close(
+        metadata.rank_order_indices,
         torch.tensor((0, -1, 3, 4, -1, -1, 1, 2, 5, 6, 7, -1), dtype=torch.int64),
     )
 
@@ -316,14 +290,12 @@ def test_thd_layout_plan_routes_per_sequence_zigzag_tokens(
         plan = _build_thd_cp_layout_plan_from_rank_order_indices(
             rank_order_indices,
             source_token_count=rank_order_indices.numel(),
-            cu_seqlens_padded=torch.tensor(cu_seqlens, dtype=torch.int32),
             cp_size=cp_size,
             cp_rank=cp_rank,
             tp_size=tp_size,
             tp_rank=tp_rank,
             group_rank_by_logical_rank=group_rank_by_logical_rank,
         )
-        assert not plan.pad_between_seqs
         plans_by_group_rank[group_rank] = (logical_rank, plan)
         contiguous_by_group_rank[group_rank] = torch.arange(
             logical_rank * local_sequence_length,
@@ -357,12 +329,13 @@ def test_thd_layout_plan_handles_padding(cp_size, tp_size, cu_seqlens, cu_seqlen
         if cu_seqlens_padded is not None
         else None
     )
-    rank_order_indices, target_cu_seqlens_padded = _build_thd_rank_order_indices(
+    metadata = _build_thd_zigzag_metadata(
         actual_cu_seqlens, source_cu_seqlens_padded, cp_size, tp_size
     )
-    assert target_cu_seqlens_padded.dtype == torch.int32
+    assert metadata.cu_seqlens_padded.dtype == torch.int32
+    assert metadata.pad_between_seqs
     if source_cu_seqlens_padded is not None:
-        torch.testing.assert_close(target_cu_seqlens_padded, source_cu_seqlens_padded)
+        torch.testing.assert_close(metadata.cu_seqlens_padded, source_cu_seqlens_padded)
     group_size = cp_size * tp_size
     source_token_count = (
         cu_seqlens[-1] if source_cu_seqlens_padded is None else cu_seqlens_padded[-1]
@@ -374,16 +347,13 @@ def test_thd_layout_plan_handles_padding(cp_size, tp_size, cu_seqlens, cu_seqlen
     for logical_rank in range(group_size):
         cp_rank, tp_rank = divmod(logical_rank, tp_size)
         plan = _build_thd_cp_layout_plan_from_rank_order_indices(
-            rank_order_indices,
+            metadata.rank_order_indices,
             source_token_count=source_token_count,
-            cu_seqlens_padded=target_cu_seqlens_padded,
             cp_size=cp_size,
             cp_rank=cp_rank,
             tp_size=tp_size,
             tp_rank=tp_rank,
-            pad_between_seqs=True,
         )
-        assert plan.pad_between_seqs
         plans_by_group_rank.append((logical_rank, plan))
         inputs_by_group_rank.append(
             torch.arange(
@@ -393,7 +363,7 @@ def test_thd_layout_plan_handles_padding(cp_size, tp_size, cu_seqlens, cu_seqlen
         )
 
     zigzag_by_group_rank = _simulate_thd_plan(plans_by_group_rank, inputs_by_group_rank)
-    torch.testing.assert_close(torch.cat(zigzag_by_group_rank), rank_order_indices)
+    torch.testing.assert_close(torch.cat(zigzag_by_group_rank), metadata.rank_order_indices)
 
     restored_by_group_rank = _simulate_thd_plan(
         plans_by_group_rank, zigzag_by_group_rank, reverse=True
@@ -507,23 +477,23 @@ def test_thd_layout_all_to_all_pads_and_round_trips(tp_size, cp_size):
             .clone()
             .requires_grad_(True)
         )
+        metadata = _build_thd_zigzag_metadata(cu_seqlens, None, cp_size, tp_size)
+        assert metadata.pad_between_seqs
         plan = build_thd_cp_layout_plan(
-            cu_seqlens,
+            metadata.rank_order_indices,
             total_tokens,
             cp_group,
             sequence_parallel=sequence_parallel,
             tp_group=tp_group,
             tp_cp_group=tp_cp_group,
         )
-        assert plan.pad_between_seqs
         zigzag = contiguous_to_zigzag(
             contiguous, cp_group, sequence_parallel, tp_group, tp_cp_group, plan
         )
-        rank_order_indices, _ = _build_thd_rank_order_indices(cu_seqlens, None, cp_size, tp_size)
         expected = global_values.new_zeros(
             (plan.zigzag_local_token_count, *global_values.shape[1:])
         )
-        expected_indices = rank_order_indices.view(group_size, -1)[logical_rank]
+        expected_indices = metadata.rank_order_indices.view(group_size, -1)[logical_rank]
         valid_positions = torch.nonzero(expected_indices >= 0, as_tuple=False).flatten()
         expected.index_copy_(
             0,

--- a/tests/unit_tests/data/test_get_batch.py
+++ b/tests/unit_tests/data/test_get_batch.py
@@ -10,8 +10,13 @@ import torch
 
 import pretrain_hybrid
 from megatron.core import mpu
-from megatron.core.context_parallel.utils import _get_batch_on_this_cp_rank_contiguous
+from megatron.core.context_parallel import get_batches_on_this_cp_rank
+from megatron.core.context_parallel.utils import (
+    _build_packed_seq_params,
+    _get_batch_on_this_cp_rank_contiguous,
+)
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.utils import (
     _get_batch_on_this_cp_rank_per_sequence_balancing,
     flatten_batch_for_packed_sequences,
@@ -167,7 +172,7 @@ def test_sft_batch(tp_size, pp_size, cp_size, seq_length):
         )
 
     global_batch_size = int(os.environ.get("WORLD_SIZE", 1)) // (tp_size * pp_size * cp_size)
-    initialize_test_environment(
+    args = initialize_test_environment(
         tp_size,
         pp_size,
         cp_size,
@@ -182,6 +187,9 @@ def test_sft_batch(tp_size, pp_size, cp_size, seq_length):
     if mpu.get_tensor_model_parallel_rank() == 0:
         data_iterator, num_real_tokens = create_sft_data_iterator(seq_length)
 
+    cp_batch = get_batch(data_iterator)
+    assert set(cp_batch.batches_by_layout) == {args.linear_cp_layout}
+    batch = cp_batch.get_batch()
     (
         attention_mask,
         cu_seqlens,
@@ -193,7 +201,7 @@ def test_sft_batch(tp_size, pp_size, cp_size, seq_length):
         max_seqlen,
         position_ids,
         tokens,
-    ) = get_batch(data_iterator)
+    ) = [batch[key] for key in pretrain_hybrid.BATCH_KEYS]
 
     is_first = mpu.is_pipeline_first_stage()
     is_last = mpu.is_pipeline_last_stage()
@@ -548,6 +556,8 @@ def test_inter_document_masking_batch(tp_size, pp_size, cp_size, seq_length):
     if mpu.get_tensor_model_parallel_rank() == 0:
         data_iterator, _ = create_sft_data_iterator(seq_length)
 
+    cp_batch = get_batch(data_iterator)
+    batch = cp_batch.get_batch()
     (
         attention_mask,
         cu_seqlens,
@@ -559,15 +569,19 @@ def test_inter_document_masking_batch(tp_size, pp_size, cp_size, seq_length):
         max_seqlen,
         position_ids,
         tokens,
-    ) = get_batch(data_iterator)
+    ) = [batch[key] for key in pretrain_hybrid.BATCH_KEYS]
 
     is_first = mpu.is_pipeline_first_stage()
     is_last = mpu.is_pipeline_last_stage()
 
-    # With CP > 1 and per-sequence balancing, sequence-dimension tensors
-    # are zigzag-partitioned to seq_length // cp_size while cu_seqlens
-    # and max_seqlen are left unchanged.
-    partitioned_seq_length = seq_length // cp_size
+    # Per-sequence zigzag balancing may pad each sequence to 2 * CP alignment, so the physical
+    # shard length comes from the padded metadata rather than the original sample length.
+    if cp_size > 1:
+        assert cu_seqlens_padded is not None
+        partitioned_seq_length = cu_seqlens_padded[0, -1].item() // cp_size
+    else:
+        assert cu_seqlens_padded is None
+        partitioned_seq_length = seq_length
 
     if pp_size == 1:
         assert tokens is not None
@@ -748,53 +762,193 @@ def test_get_batch_on_this_cp_rank_contiguous_keeps_attention_mask_zigzag(cp_siz
 
 
 @pytest.mark.parametrize(
+    ("cp_rank", "expected_indices"),
+    [
+        (0, [0, -1, 4, 5, 6, -1, -1, -1]),
+        (1, [1, -1, 7, 8, 9, -1, -1, -1]),
+        (2, [2, -1, 10, 11, 12, -1, -1, -1]),
+        (3, [3, -1, 13, 14, 15, -1, -1, -1]),
+    ],
+)
+@pytest.mark.parametrize("with_contiguous_layout", [False, True])
+def test_get_batch_on_this_cp_rank_zigzag_packed(cp_rank, expected_indices, with_contiguous_layout):
+    tokens = torch.arange(1, 17).view(1, 16)
+    loss_mask = torch.tensor([[1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+    batch = {
+        "tokens": tokens,
+        "labels": tokens + 100,
+        "loss_mask": loss_mask,
+        "position_ids": tokens - 1,
+        "cu_seqlens": torch.tensor([[0, 3, 13]], dtype=torch.int32),
+        "cu_seqlens_padded": torch.tensor([[0, 4, 16]], dtype=torch.int32),
+        "max_seqlen": torch.tensor([12], dtype=torch.int32),
+    }
+    parallel_context = SimpleNamespace(
+        cp_size=4,
+        cp_rank=cp_rank,
+        tp_size=4,
+        tp_rank=0,
+        group_size=16,
+        communication_group=MagicMock(),
+        group_rank_by_logical_rank=tuple(range(16)),
+    )
+    cp_group = MagicMock()
+    cp_group.size.return_value = 4
+    cp_group.rank.return_value = cp_rank
+    tp_group = MagicMock()
+    tp_group.size.return_value = 4
+    with (
+        patch("torch.distributed.get_world_size", return_value=4),
+        patch("torch.distributed.get_rank", return_value=cp_rank),
+        patch(
+            "megatron.core.context_parallel.layout._get_layout_parallel_context",
+            return_value=parallel_context,
+        ),
+    ):
+        cp_batch = get_batches_on_this_cp_rank(
+            batch,
+            boundary_layout="contiguous" if with_contiguous_layout else "zigzag",
+            is_hybrid_cp=False,
+            cp_group=cp_group,
+            additional_layouts=("zigzag",) if with_contiguous_layout else (),
+            use_per_sequence_balancing=True,
+            sequence_parallel=True,
+            tp_group=tp_group,
+            tp_cp_group=MagicMock(),
+            tokens_per_sample=16,
+        )
+        result = cp_batch.get_batch("zigzag")
+
+    indices = torch.tensor(expected_indices)
+    padding = indices < 0
+    gathered_indices = indices.clamp_min(0)
+    padding = padding | (gathered_indices == 3) | (gathered_indices >= 14)
+    expected_tokens = tokens.index_select(1, gathered_indices).masked_fill(padding.view(1, -1), 0)
+    expected_loss_mask = loss_mask.index_select(1, gathered_indices).masked_fill(
+        padding.view(1, -1), 0
+    )
+    torch.testing.assert_close(result["tokens"], expected_tokens)
+    torch.testing.assert_close(result["loss_mask"], expected_loss_mask)
+    torch.testing.assert_close(
+        result["cu_seqlens_padded"], torch.tensor([[0, 8, 32]], dtype=torch.int32)
+    )
+    assert result["max_seqlen"].item() == 24
+    assert (cp_batch.thd_plan is not None) == with_contiguous_layout
+    assert set(cp_batch.batches_by_layout) == (
+        {"contiguous", "zigzag"} if with_contiguous_layout else {"zigzag"}
+    )
+    zigzag_packed_seq_params = cp_batch.get_packed_seq_params("zigzag")
+    assert zigzag_packed_seq_params is not None
+    torch.testing.assert_close(
+        zigzag_packed_seq_params.cu_seqlens_q_padded, result["cu_seqlens_padded"].squeeze(0)
+    )
+    torch.testing.assert_close(
+        zigzag_packed_seq_params.cu_seqlens_q, batch["cu_seqlens"].squeeze(0)
+    )
+    assert zigzag_packed_seq_params.max_seqlen_q == 24
+    assert zigzag_packed_seq_params.pad_between_seqs
+    assert zigzag_packed_seq_params.total_tokens == 32
+    torch.testing.assert_close(
+        zigzag_packed_seq_params.seq_idx, torch.tensor([[0] * 8 + [1] * 24], dtype=torch.int32)
+    )
+
+
+def test_metadata_only_cp_batch_skips_sharding():
+    batch = dict.fromkeys(pretrain_hybrid.BATCH_KEYS)
+    batch["cu_seqlens"] = torch.tensor([[0, 3, 13]], dtype=torch.int32)
+    batch["cu_seqlens_padded"] = torch.tensor([[0, 4, 16]], dtype=torch.int32)
+    batch["max_seqlen"] = torch.tensor([12], dtype=torch.int32)
+
+    with (
+        patch("torch.distributed.get_world_size", return_value=4),
+        patch("megatron.core.utils.get_batch_on_this_cp_rank") as shard_batch,
+    ):
+        cp_batch = get_batches_on_this_cp_rank(
+            batch,
+            boundary_layout="zigzag",
+            is_hybrid_cp=False,
+            cp_group=MagicMock(),
+            tokens_per_sample=16,
+        )
+
+    shard_batch.assert_not_called()
+    assert cp_batch.get_batch()["tokens"] is None
+    assert cp_batch.get_packed_seq_params("zigzag") is not None
+
+
+def test_get_batch_builds_required_cp_layouts():
+    cp_size = 4
+    seq_length = 16
+    if int(os.environ.get("WORLD_SIZE", "1")) < cp_size:
+        pytest.skip(f"CP={cp_size} requires at least {cp_size} ranks")
+    global_batch_size = int(os.environ.get("WORLD_SIZE", "1")) // cp_size
+    args = initialize_test_environment(
+        tp_size=1,
+        pp_size=1,
+        cp_size=cp_size,
+        seq_length=seq_length,
+        micro_batch_size=1,
+        global_batch_size=global_batch_size,
+    )
+    args.linear_cp_layout = "contiguous"
+    args.attention_cp_layout = "zigzag"
+
+    tokens = torch.arange(seq_length, dtype=torch.int64).view(1, -1)
+    batch = {
+        "tokens": tokens,
+        "labels": tokens + 100,
+        "loss_mask": torch.ones_like(tokens, dtype=torch.float32),
+        "position_ids": tokens.clone(),
+    }
+    data_iterator = iter([batch]) if mpu.get_tensor_model_parallel_rank() == 0 else None
+
+    cp_batch = get_batch(data_iterator)
+    local_tokens = cp_batch.get_batch()["tokens"]
+
+    cp_rank = mpu.get_context_parallel_rank()
+    contiguous_indices = torch.arange(
+        cp_rank * (seq_length // cp_size), (cp_rank + 1) * (seq_length // cp_size), device="cuda"
+    )
+    segment_length = seq_length // (2 * cp_size)
+    zigzag_indices = torch.tensor(
+        [
+            *range(cp_rank * segment_length, (cp_rank + 1) * segment_length),
+            *range(
+                (2 * cp_size - cp_rank - 1) * segment_length,
+                (2 * cp_size - cp_rank) * segment_length,
+            ),
+        ],
+        device="cuda",
+    )
+    global_tokens = tokens.cuda()
+    torch.testing.assert_close(local_tokens, global_tokens.index_select(1, contiguous_indices))
+    assert set(cp_batch.batches_by_layout) == {"contiguous", "zigzag"}
+    torch.testing.assert_close(
+        cp_batch.get_batch("zigzag")["tokens"], global_tokens.index_select(1, zigzag_indices)
+    )
+
+
+@pytest.mark.parametrize(
     ("linear_cp_layout", "cp_size", "use_actual_lengths"),
     [("zigzag", 2, False), ("contiguous", 1, False), ("contiguous", 2, True)],
 )
-def test_forward_step_exposes_actual_thd_lengths_for_contiguous_cp(
-    monkeypatch, linear_cp_layout, cp_size, use_actual_lengths
+def test_packed_seq_params_expose_actual_thd_lengths_for_contiguous_cp(
+    linear_cp_layout, cp_size, use_actual_lengths
 ):
     actual_cu_seqlens = torch.tensor([[0, 3, 5]], dtype=torch.int32)
     padded_cu_seqlens = torch.tensor([[0, 4, 8]], dtype=torch.int32)
     max_seqlen = torch.tensor([4], dtype=torch.int32)
-    captured_kwargs = {}
-
-    monkeypatch.setattr(
-        pretrain_hybrid,
-        "args",
-        SimpleNamespace(
-            context_parallel_size=cp_size, linear_cp_layout=linear_cp_layout, seq_length=8
-        ),
-        raising=False,
+    batch = {
+        "cu_seqlens": actual_cu_seqlens,
+        "cu_seqlens_padded": padded_cu_seqlens,
+        "hybrid_cp_group": None,
+        "local_cp_size": None,
+        "max_seqlen": max_seqlen,
+    }
+    packed_seq_params = _build_packed_seq_params(
+        batch, linear_cp_layout, cp_size, tokens_per_sample=8
     )
-    monkeypatch.setattr(pretrain_hybrid, "get_timers", MagicMock(return_value=MagicMock()))
-    monkeypatch.setattr(pretrain_hybrid, "stimer", MagicMock())
-    monkeypatch.setattr(pretrain_hybrid, "get_attr_wrapped_model", lambda *_args: None)
-    monkeypatch.setattr(pretrain_hybrid, "update_seqlen_stats_from_cu_seqlens", lambda *_: None)
-    monkeypatch.setattr(
-        pretrain_hybrid,
-        "get_batch",
-        lambda *_args: (
-            None,
-            actual_cu_seqlens,
-            padded_cu_seqlens,
-            None,
-            torch.zeros(1, 8),
-            None,
-            torch.ones(1, 8),
-            max_seqlen,
-            torch.arange(8).unsqueeze(0),
-            torch.zeros(1, 8),
-        ),
-    )
-
-    def model(*_args, **kwargs):
-        captured_kwargs.update(kwargs)
-        return torch.tensor(0.0)
-
-    pretrain_hybrid.forward_step(None, model)
-
-    packed_seq_params = captured_kwargs["packed_seq_params"]
+    assert packed_seq_params is not None
     expected_cu_seqlens = actual_cu_seqlens[0] if use_actual_lengths else padded_cu_seqlens[0]
     assert torch.equal(packed_seq_params.cu_seqlens_q, expected_cu_seqlens)
     assert torch.equal(packed_seq_params.cu_seqlens_kv, expected_cu_seqlens)
@@ -831,6 +985,52 @@ def create_pretrain_data_iterator(
     return iter([batch])
 
 
+def test_sequence_packing_batch_uses_context_parallel_batch_interface():
+    tokens = torch.tensor([[1, 2]])
+    labels = torch.tensor([[2, 3]])
+    loss_mask = torch.ones(1, 2)
+    position_ids = torch.tensor([[0, 1]])
+    padding_mask = torch.zeros(1, 2, dtype=torch.bool)
+    packed_seq_params = PackedSeqParams(qkv_format="thd")
+    scheduler_batch = (
+        tokens,
+        labels,
+        loss_mask,
+        None,
+        position_ids,
+        packed_seq_params,
+        padding_mask,
+    )
+    args = SimpleNamespace(sequence_packing_scheduler="dp_balanced")
+    config = SimpleNamespace(
+        virtual_pipeline_model_parallel_size=None,
+        pipeline_model_parallel_layout=None,
+        mtp_num_layers=1,
+        linear_cp_layout="zigzag",
+    )
+
+    with (
+        patch.object(pretrain_hybrid, "get_args", return_value=args),
+        patch.object(pretrain_hybrid, "core_transformer_config_from_args", return_value=config),
+        patch.object(pretrain_hybrid, "mtp_on_this_rank_func", return_value=True),
+        patch.object(
+            pretrain_hybrid,
+            "get_batch_on_this_rank_for_sequence_packing",
+            return_value=scheduler_batch,
+        ),
+    ):
+        cp_batch = get_batch(None)
+
+    assert set(cp_batch.batches_by_layout) == {"zigzag"}
+    assert cp_batch.get_packed_seq_params() is packed_seq_params
+    batch = cp_batch.get_batch()
+    assert batch["tokens"] is tokens
+    assert batch["labels"] is labels
+    assert batch["loss_mask"] is loss_mask
+    assert batch["position_ids"] is position_ids
+    assert batch["padding_mask"] is padding_mask
+
+
 @pytest.mark.parametrize("tp_size", [1, 2, 4])
 @pytest.mark.parametrize("pp_size", [1, 2, 4])
 @pytest.mark.parametrize("cp_size", [1, 2, 4])
@@ -846,7 +1046,7 @@ def test_pretrain_batch(
         )
     dp_size = int(os.environ.get("WORLD_SIZE", 1)) // (tp_size * pp_size * cp_size)
     global_batch_size = micro_batch_size * dp_size
-    initialize_test_environment(
+    args = initialize_test_environment(
         tp_size,
         pp_size,
         cp_size,
@@ -865,6 +1065,8 @@ def test_pretrain_batch(
             create_attention_mask=create_attention_mask,
         )
 
+    cp_batch = get_batch(data_iterator)
+    batch = cp_batch.get_batch()
     (
         attention_mask,
         cu_seqlens,
@@ -876,7 +1078,7 @@ def test_pretrain_batch(
         max_seqlen,
         position_ids,
         tokens,
-    ) = get_batch(data_iterator)
+    ) = [batch[key] for key in pretrain_hybrid.BATCH_KEYS]
 
     is_first = mpu.is_pipeline_first_stage()
     is_last = mpu.is_pipeline_last_stage()
@@ -1078,7 +1280,7 @@ def test_hybrid_cp_batch(tp_size, cp_size, seq_length, create_attention_mask):
             f"Skipping test because tp_size * cp_size > torch.cuda.device_count() ({tp_size * cp_size} > {torch.cuda.device_count()})"
         )
 
-    initialize_test_environment(
+    args = initialize_test_environment(
         tp_size,
         1,
         cp_size,
@@ -1094,6 +1296,8 @@ def test_hybrid_cp_batch(tp_size, cp_size, seq_length, create_attention_mask):
     if mpu.get_tensor_model_parallel_rank() == 0:
         data_iterator = create_hybrid_cp_data_iterator(seq_length, cp_size=cp_size)
 
+    cp_batch = get_batch(data_iterator)
+    batch = cp_batch.get_batch()
     (
         attention_mask,
         cu_seqlens,
@@ -1105,7 +1309,7 @@ def test_hybrid_cp_batch(tp_size, cp_size, seq_length, create_attention_mask):
         max_seqlen,
         position_ids,
         tokens,
-    ) = get_batch(data_iterator)
+    ) = [batch[key] for key in pretrain_hybrid.BATCH_KEYS]
 
     # Presence checks
     assert tokens is not None
@@ -1265,6 +1469,8 @@ def test_inter_document_masking_multi_mbs_batch(tp_size, micro_batch_size, seq_l
             seq_length, micro_batch_size=micro_batch_size
         )
 
+    cp_batch = get_batch(data_iterator)
+    batch = cp_batch.get_batch()
     (
         attention_mask,
         cu_seqlens,
@@ -1276,7 +1482,7 @@ def test_inter_document_masking_multi_mbs_batch(tp_size, micro_batch_size, seq_l
         max_seqlen,
         position_ids,
         tokens,
-    ) = get_batch(data_iterator)
+    ) = [batch[key] for key in pretrain_hybrid.BATCH_KEYS]
 
     total_tokens = micro_batch_size * seq_length
 

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -310,6 +310,9 @@ class TestHybridModel:
                 super().__init__()
                 self.mtp_input_mask = None
 
+            def prepare_cp_layout(self, **kwargs):
+                return SimpleNamespace(**kwargs)
+
             def forward(self, **kwargs):
                 self.mtp_input_mask = kwargs["mtp_input_mask"]
                 hidden_states = kwargs["hidden_states"]

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -8,6 +8,7 @@ import types
 import pytest
 import torch
 
+from megatron.core.context_parallel import ContextParallelBatch
 from megatron.core.enums import ModelType
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.utils import InferenceMode
@@ -35,6 +36,7 @@ from megatron.core.transformer.hyper_connection import learned_output_contract
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
+    MultiTokenPredictionInputs,
     _initialize_hidden_state_mixing_rng_tracker,
     _mix_hidden_state_history,
     _mtp_logits_are_vocab_sharded,
@@ -792,6 +794,8 @@ class TestMultiTokenPredictionLayer:
             inference_params=None,
             packed_seq_params=None,
             sequence_len_offset=None,
+            packed_seq_params_by_layout=None,
+            cp_layout_plan=None,
         ):
             seen["padding_mask"] = padding_mask
             return hidden_states
@@ -1228,6 +1232,46 @@ class TestMultiTokenPredictionLayer:
         else:
             assert [shape[0] for shape, _ in rolled] == [1, 1, 1, 1]
             assert [return_sum for _, return_sum in rolled] == [False, True, False, True]
+
+    def test_process_mtp_loss_preserves_main_layout_hidden_states(self):
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            num_layers=2,
+            hidden_size=8,
+            num_attention_heads=2,
+            use_cpu_initialization=True,
+        )
+        seq_len = 4
+        mtp_hidden_states = torch.randn(
+            (1 + config.mtp_num_layers) * seq_len, 1, config.hidden_size, requires_grad=True
+        )
+        main_hidden_states = torch.randn(seq_len, 1, config.hidden_size, requires_grad=True)
+        output_weight = torch.nn.Parameter(torch.randn(16, config.hidden_size))
+
+        def output_layer(hidden, weight=None, runtime_gather_output=None):
+            return torch.matmul(hidden, weight.t()), None
+
+        def compute_language_model_loss(labels, logits):
+            return logits.square().sum(dim=-1).transpose(0, 1)
+
+        result = process_mtp_loss(
+            hidden_states=mtp_hidden_states,
+            labels=torch.arange(seq_len).unsqueeze(0),
+            loss_mask=torch.ones(1, seq_len),
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=compute_language_model_loss,
+            config=config,
+            main_hidden_states=main_hidden_states,
+        )
+        torch.testing.assert_close(result, main_hidden_states)
+
+        result.sum().backward()
+
+        torch.testing.assert_close(main_hidden_states.grad, torch.ones_like(main_hidden_states))
+        assert torch.count_nonzero(mtp_hidden_states.grad[seq_len:]) > 0
 
 
 class TestMTPHiddenStateRollUnderParallelism:
@@ -2877,6 +2921,64 @@ class TestMultiTokenPrediction:
 
         Utils.destroy_model_parallel()
 
+    def test_roll_tensor_with_attention_padded_packed_sequences_without_cp(self):
+        tensor = torch.arange(1, 25)
+        expected = torch.zeros_like(tensor)
+        expected[:2] = torch.tensor([2, 3])
+        expected[8:17] = torch.arange(10, 19)
+        cu_seqlens = torch.tensor([0, 3, 13], dtype=torch.int32)
+        cu_seqlens_padded = torch.tensor([0, 8, 24], dtype=torch.int32)
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            qkv_format="thd",
+        )
+
+        rolled, _ = roll_tensor(tensor, shifts=-1, dims=-1, packed_seq_params=packed_seq_params)
+
+        torch.testing.assert_close(rolled, expected)
+
+    def test_roll_tensor_with_attention_padded_packed_sequences(self):
+        cp = 4
+        if int(os.environ.get("WORLD_SIZE", "1")) < cp:
+            pytest.skip(f"CP={cp} requires at least {cp} ranks")
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp)
+        cp_group = get_context_parallel_group()
+        cp_rank = get_pg_rank(cp_group)
+
+        local_tensors = (
+            [1, 0, 5, 6, 0, 0],
+            [2, 0, 7, 8, 0, 0],
+            [3, 0, 9, 10, 0, 0],
+            [0, 0, 11, 12, 13, 14],
+        )
+        expected_tensors = (
+            [2, 0, 6, 7, 0, 0],
+            [3, 0, 8, 9, 0, 0],
+            [0, 0, 10, 11, 0, 0],
+            [0, 0, 12, 13, 14, 0],
+        )
+        tensor = torch.tensor(local_tensors[cp_rank], device="cuda")
+        expected = torch.tensor(expected_tensors[cp_rank], device="cuda")
+        cu_seqlens = torch.tensor([0, 3, 13], dtype=torch.int32, device="cuda")
+        cu_seqlens_padded = torch.tensor([0, 8, 24], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            qkv_format="thd",
+        )
+
+        rolled, _ = roll_tensor(
+            tensor, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+        )
+
+        torch.testing.assert_close(rolled, expected)
+        Utils.destroy_model_parallel()
+
 
 class TestMTPLossLoggingHelper:
     def setup_method(self, method):
@@ -3188,6 +3290,25 @@ class TestMultiTokenPredictionHybrid:
             decoder_hidden_states = kwargs["hidden_states"]
             return torch.cat((decoder_hidden_states, decoder_hidden_states + 100.0), dim=0)
 
+        class MTPStub:
+            def __init__(self):
+                self.forward_impl = mtp
+
+            def prepare_cp_layout(self, **kwargs):
+                return MultiTokenPredictionInputs(
+                    input_ids=kwargs["input_ids"],
+                    position_ids=kwargs["position_ids"],
+                    hidden_states=kwargs["hidden_states"],
+                    mhc_multistream=kwargs["mhc_multistream"],
+                    labels=kwargs["labels"],
+                    loss_mask=kwargs["loss_mask"],
+                    mtp_input_mask=kwargs["mtp_input_mask"],
+                    packed_seq_params=kwargs["packed_seq_params"],
+                )
+
+            def __call__(self, **kwargs):
+                return self.forward_impl(**kwargs)
+
         def output_layer(output, **kwargs):
             return output, None
 
@@ -3211,11 +3332,13 @@ class TestMultiTokenPredictionHybrid:
             share_embeddings_and_output_weights=False,
             mtp_process=True,
             embedding=None,
-            mtp=mtp,
+            mtp=MTPStub(),
             output_layer=output_layer,
             training=True,
             compute_language_model_loss=compute_language_model_loss,
-            pg_collection=types.SimpleNamespace(cp=None, dp_cp=metric_avg_group),
+            pg_collection=types.SimpleNamespace(
+                cp=None, tp=None, tp_cp=None, dp_cp=metric_avg_group
+            ),
             tp_group=None,
             _scale_logits=lambda logits: logits,
         )
@@ -3259,9 +3382,8 @@ class TestMultiTokenPredictionHybrid:
             assert kwargs["loss_mask"] is loss_mask
             assert kwargs["mtp_input_mask"] is mtp_input_mask
             assert kwargs["metric_avg_group"] is metric_avg_group
-            return torch.chunk(kwargs["hidden_states"], 1 + kwargs["config"].mtp_num_layers, dim=0)[
-                0
-            ]
+            assert kwargs["main_hidden_states"] is hidden_states
+            return kwargs["main_hidden_states"]
 
         monkeypatch.setattr(
             "megatron.core.models.hybrid.hybrid_model.process_mtp_loss", process_mtp_loss_spy
@@ -3290,6 +3412,128 @@ class TestMultiTokenPredictionHybrid:
             torch.testing.assert_close(output, labels.to(dtype=hidden_states.dtype) + 1000.0)
         else:
             torch.testing.assert_close(output, hidden_states.transpose(0, 1).contiguous())
+
+    def test_forward_uses_mtp_cp_layout_inputs(self, monkeypatch):
+        model, hidden_states, call_counts, metric_avg_group = self._make_forward_stub()
+        contiguous_packed_seq_params = object()
+        zigzag_packed_seq_params = object()
+        zigzag_hidden_states = hidden_states + 10.0
+        captured = {}
+
+        expected_packed_seq_params_by_layout = {
+            "contiguous": contiguous_packed_seq_params,
+            "zigzag": zigzag_packed_seq_params,
+        }
+        cp_layout_plan = object()
+        cp_group = types.SimpleNamespace(size=lambda: 2)
+        tp_group = object()
+        tp_cp_group = object()
+        model.pg_collection = types.SimpleNamespace(
+            cp=cp_group, tp=tp_group, tp_cp=tp_cp_group, dp_cp=metric_avg_group
+        )
+        model.mtp.config = types.SimpleNamespace(attention_cp_layout="zigzag")
+        model.mtp.cp_group = cp_group
+        model.mtp.tp_group = tp_group
+        model.mtp.tp_cp_group = tp_cp_group
+        model.mtp.sequence_parallel = True
+        model.mtp.prepare_cp_layout = types.MethodType(
+            MultiTokenPredictionBlock.prepare_cp_layout, model.mtp
+        )
+
+        def convert_cp_layout_spy(
+            layer_hidden_states,
+            source_layout,
+            target_layout,
+            passed_cp_group,
+            sequence_parallel,
+            passed_tp_group,
+            passed_tp_cp_group,
+            thd_plan,
+        ):
+            assert source_layout == "contiguous"
+            assert target_layout == "zigzag"
+            assert passed_cp_group is cp_group
+            assert sequence_parallel
+            assert passed_tp_group is tp_group
+            assert passed_tp_cp_group is tp_cp_group
+            assert thd_plan is cp_layout_plan
+            assert layer_hidden_states is hidden_states
+            return zigzag_hidden_states
+
+        monkeypatch.setattr(
+            "megatron.core.transformer.multi_token_prediction.convert_cp_layout",
+            convert_cp_layout_spy,
+        )
+
+        def mtp(**kwargs):
+            call_counts["mtp"] += 1
+            captured["mtp"] = kwargs
+            return torch.cat((kwargs["hidden_states"], kwargs["hidden_states"] + 100.0), dim=0)
+
+        model.mtp.forward_impl = mtp
+        input_ids = torch.tensor([[1, 2]])
+        position_ids = torch.tensor([[0, 1]])
+        labels = torch.tensor([[2, 3]])
+        loss_mask = torch.ones(1, 2)
+        zigzag_input_ids = torch.tensor([[4, 3]])
+        zigzag_position_ids = torch.tensor([[3, 2]])
+        zigzag_labels = torch.tensor([[5, 4]])
+        zigzag_loss_mask = torch.tensor([[1.0, 0.0]])
+        batches_by_layout = {
+            "contiguous": {
+                "tokens": input_ids,
+                "position_ids": position_ids,
+                "labels": labels,
+                "loss_mask": loss_mask,
+            },
+            "zigzag": {
+                "tokens": zigzag_input_ids,
+                "position_ids": zigzag_position_ids,
+                "labels": zigzag_labels,
+                "loss_mask": zigzag_loss_mask,
+            },
+        }
+        cp_batch = ContextParallelBatch(
+            boundary_layout="contiguous",
+            batches_by_layout=batches_by_layout,
+            packed_seq_params_by_layout=expected_packed_seq_params_by_layout,
+            thd_plan=cp_layout_plan,
+        )
+
+        def process_mtp_loss_spy(**kwargs):
+            call_counts["mtp_loss"] += 1
+            captured["mtp_loss"] = kwargs
+            return kwargs["main_hidden_states"]
+
+        monkeypatch.setattr(
+            "megatron.core.models.hybrid.hybrid_model.process_mtp_loss", process_mtp_loss_spy
+        )
+
+        output = HybridModel.forward(
+            model,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            decoder_input=hidden_states,
+            labels=labels,
+            loss_mask=loss_mask,
+            packed_seq_params=contiguous_packed_seq_params,
+            cp_batch=cp_batch,
+        )
+
+        assert captured["mtp"]["hidden_states"] is zigzag_hidden_states
+        assert captured["mtp"]["input_ids"] is zigzag_input_ids
+        assert captured["mtp"]["position_ids"] is zigzag_position_ids
+        assert captured["mtp"]["packed_seq_params"] is zigzag_packed_seq_params
+        assert (
+            captured["mtp"]["packed_seq_params_by_layout"] is expected_packed_seq_params_by_layout
+        )
+        assert captured["mtp"]["cp_layout_plan"] is cp_layout_plan
+        assert captured["mtp_loss"]["labels"] is zigzag_labels
+        assert captured["mtp_loss"]["loss_mask"] is zigzag_loss_mask
+        assert captured["mtp_loss"]["input_ids"] is zigzag_input_ids
+        assert captured["mtp_loss"]["main_hidden_states"] is hidden_states
+        torch.testing.assert_close(output, labels.to(dtype=hidden_states.dtype) + 1000.0)
 
     @pytest.mark.parametrize("compute_mtp_loss", [True, False])
     def test_compute_mtp_loss_does_not_control_speculative_decoding(


### PR DESCRIPTION
## Summary
- Fix upstream THD+CP, which incorrectly shards a packed batch as one flat sequence instead of partitioning each packed sequence independently. This produces token shards and PackedSeqParams that describe different physical layouts, especially when attention padding is required.
- Keep zigzag layout for MTP layers
- Optimize layout conversion by building one reusable THD redistribution plan during batch partitioning and reusing it throughout the forward pass.

## Tests
```
  python -m torch.distributed.run --nproc-per-node 4 -m pytest -q \
    tests/unit_tests/context_parallel/test_layout.py \
    tests/unit_tests/data/test_get_batch.py \
    tests/unit_tests/transformer/test_multi_token_prediction.py \
    tests/unit_tests/transformer/test_transformer_config.py
```