### PR TITLE
[Dev][Fix] fix ncclep_static_shape bugs.

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -842,6 +842,7 @@ def ensure_nccl_ep_bootstrapped(
     max_tokens_per_rank,
     recv_capacity_per_rank,
     hidden_dim,
+    num_topk,
     num_sms=0,
     zero_copy=False,
 ):
@@ -857,9 +858,11 @@ def ensure_nccl_ep_bootstrapped(
         num_experts (int): Total experts across ``ep_group`` (global, not per-rank).
         max_tokens_per_rank (int): Upper bound on local input tokens per forward. Must be
             even (NCCL EP requires ``num_tokens_per_rank * inner_dim % 4 == 0``).
-        recv_capacity_per_rank (int): Per-rank receive-buffer capacity in tokens. Must be
-            ``>= max_tokens_per_rank``; runtime overflow hard-traps (no soft drop).
+        recv_capacity_per_rank (int, optional): Per-rank receive-buffer capacity in tokens.
+            When ``None``, TE uses eager mode and sizes the receive buffers from the per-step
+            routing result.
         hidden_dim (int): Token hidden size.
+        num_topk (int): Number of experts each token routes to.
         num_sms (int): SM cap passed to TE as ``max_num_sms`` (0 lets TE/NCCL choose).
     """
     if not HAVE_TE_EP:
@@ -875,6 +878,7 @@ def ensure_nccl_ep_bootstrapped(
         max_tokens_per_rank=max_tokens_per_rank,
         recv_capacity_per_rank=recv_capacity_per_rank,
         hidden_dim=hidden_dim,
+        num_topk=num_topk,
         max_num_sms=num_sms,
         zero_copy=zero_copy,
     )

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1714,11 +1714,11 @@ class _NCCLEPManager(_DispatchManager):
                 "TransformerEngine NCCL EP is unavailable. The 'ncclep' backend requires a "
                 "TransformerEngine build with NCCL EP support (NVTE_BUILD_WITH_NCCL_EP=1)."
             )
-        if self.rank_capacity_factor is None:
+        if self.static_shape and self.rank_capacity_factor is None:
             raise ValueError(
-                "The 'ncclep' backend requires moe_expert_rank_capacity_factor to be set: it "
-                "sizes the per-rank receive buffer. Exceeding the budget hard-traps, so set it "
-                "generously."
+                "The 'ncclep' backend with moe_ncclep_static_shape=True requires "
+                "moe_expert_rank_capacity_factor to be set: it sizes the per-rank receive buffer. "
+                "Exceeding the budget hard-traps, so set it generously."
             )
 
         # Fresh EpBuffer per dispatch, held until the matching combine consumes it. dispatch
@@ -1745,7 +1745,7 @@ class _NCCLEPManager(_DispatchManager):
         self.num_local_tokens = num_tokens
 
     def _ensure_bootstrap(self):
-        """Bootstrap NCCL EP and size the receive buffer on first use (static shapes)."""
+        """Bootstrap NCCL EP and size the receive buffer on first use."""
         if self._bootstrapped:
             return
         # NCCL EP's HT backend requires max_dispatch_tokens_per_rank to be a multiple of the HT
@@ -1757,10 +1757,16 @@ class _NCCLEPManager(_DispatchManager):
             // _HT_TOKENS_PER_CHUNK
             * _HT_TOKENS_PER_CHUNK
         )
-        budget = int(self._max_tokens_per_rank * self.router_topk * self.rank_capacity_factor)
-        if self.alignment != 0:
-            budget += -budget % self.alignment
-        self._recv_capacity = budget
+        if self.static_shape:
+            budget = int(self._max_tokens_per_rank * self.router_topk * self.rank_capacity_factor)
+            if self.alignment != 0:
+                budget += -budget % self.alignment
+            self._recv_capacity = budget
+        else:
+            # Dynamic-shape NCCL EP must use TE eager mode. Passing a fixed capacity here makes
+            # dispatch return a [capacity, H] tensor, and narrowing it before combine violates
+            # combine_bwd's reverse-dispatch shape contract.
+            self._recv_capacity = None
 
         ensure_nccl_ep_bootstrapped(
             self.group,
@@ -1768,6 +1774,7 @@ class _NCCLEPManager(_DispatchManager):
             max_tokens_per_rank=self._max_tokens_per_rank,
             recv_capacity_per_rank=self._recv_capacity,
             hidden_dim=self.hidden_dim,
+            num_topk=self.router_topk,
             num_sms=(
                 self.config.moe_flex_dispatcher_num_sms
                 if self.config.moe_flex_dispatcher_num_sms is not None
@@ -1825,16 +1832,8 @@ class _NCCLEPManager(_DispatchManager):
         return self.tokens_per_expert
 
     def get_restored_hidden_states_by_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        # TE ep_combine reads from the static [recv_capacity, H] buffer. static_shape=False path the
-        # experts ran on the narrowed [Σ, H] slice, so re-expand back to recv_capacity; in
-        # static_shape mode the output is already recv_capacity rows (no-op). Rows beyond the valid
-        # region map to no token and combine ignores them.
-        num_valid = hidden_states.shape[0]
-        pad_rows = self._recv_capacity - num_valid
-        if pad_rows > 0:
-            hidden_states = torch.cat(
-                [hidden_states, hidden_states.new_zeros(pad_rows, hidden_states.shape[-1])], dim=0
-            )
+        # TE ep_combine accepts the actual expert-major row count. Keeping the dynamic-shape
+        # [Σ, H] tensor avoids materializing a large zero-padded [recv_capacity, H] temporary.
         return hidden_states
 
     def combine(

--- a/tests/unit_tests/transformer/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/transformer/moe/test_token_dispatcher.py
@@ -8,10 +8,16 @@ import torch
 
 from megatron.core import config, parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
+from megatron.core.transformer.moe import fused_a2a
+from megatron.core.transformer.moe import token_dispatcher as token_dispatcher_module
 from megatron.core.transformer.moe.fused_a2a import HYBRIDEP_TOKEN_ALIGNMENT, reset_hybrid_ep_buffer
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.moe.moe_utils import get_capacity
-from megatron.core.transformer.moe.token_dispatcher import MoETokenDispatcher, _HybridEPManager
+from megatron.core.transformer.moe.token_dispatcher import (
+    MoETokenDispatcher,
+    _HybridEPManager,
+    _NCCLEPManager,
+)
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
@@ -106,6 +112,143 @@ def test_hybridep_variable_tokens_are_padded_to_group_max(monkeypatch):
     assert manager.token_probs.shape == (expected_num_tokens, manager.num_experts)
     assert not manager.routing_map[local_num_tokens:].any()
     assert not manager.token_probs[local_num_tokens:].any()
+
+
+def _make_ncclep_config(**overrides):
+    defaults = {
+        "hidden_size": 16,
+        "moe_expert_rank_capacity_factor": None,
+        "moe_flex_dispatcher_num_sms": None,
+        "moe_grouped_gemm": False,
+        "moe_latent_size": None,
+        "moe_ncclep_static_shape": False,
+        "moe_ncclep_use_symm_mem": False,
+        "use_transformer_engine_op_fuser": False,
+        "fp8": None,
+        "fp4": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_ensure_nccl_ep_bootstrapped_passes_num_topk(monkeypatch):
+    calls = []
+
+    class FakeTEEP:
+        _BOOTSTRAPPED = False
+
+        def ep_bootstrap(self, ep_group, **kwargs):
+            calls.append((ep_group, kwargs))
+
+    fake_te_ep = FakeTEEP()
+    monkeypatch.setattr(fused_a2a, "HAVE_TE_EP", True)
+    monkeypatch.setattr(fused_a2a, "te_ep", fake_te_ep, raising=False)
+
+    ep_group = object()
+    fused_a2a.ensure_nccl_ep_bootstrapped(
+        ep_group,
+        num_experts=8,
+        max_tokens_per_rank=64,
+        recv_capacity_per_rank=None,
+        hidden_dim=32,
+        num_topk=4,
+        num_sms=7,
+        zero_copy=True,
+    )
+
+    assert calls == [
+        (
+            ep_group,
+            {
+                "num_experts": 8,
+                "max_tokens_per_rank": 64,
+                "recv_capacity_per_rank": None,
+                "hidden_dim": 32,
+                "num_topk": 4,
+                "max_num_sms": 7,
+                "zero_copy": True,
+            },
+        )
+    ]
+
+
+def test_ncclep_dynamic_shape_allows_missing_rank_capacity_and_bootstraps_eager(monkeypatch):
+    calls = []
+
+    def fake_ensure_nccl_ep_bootstrapped(group, **kwargs):
+        calls.append((group, kwargs))
+
+    monkeypatch.setattr(token_dispatcher_module, "nccl_ep_dispatch", object())
+    monkeypatch.setattr(
+        token_dispatcher_module,
+        "ensure_nccl_ep_bootstrapped",
+        fake_ensure_nccl_ep_bootstrapped,
+    )
+
+    group = object()
+    manager = _NCCLEPManager(
+        group=group,
+        num_local_experts=2,
+        router_topk=3,
+        num_experts=8,
+        config=_make_ncclep_config(
+            hidden_size=32,
+            moe_expert_rank_capacity_factor=None,
+            moe_flex_dispatcher_num_sms=5,
+            moe_ncclep_static_shape=False,
+        ),
+    )
+    manager.num_local_tokens = 65
+
+    manager._ensure_bootstrap()
+
+    assert manager._max_tokens_per_rank == 128
+    assert manager._recv_capacity is None
+    assert manager._bootstrapped
+    assert calls == [
+        (
+            group,
+            {
+                "num_experts": 8,
+                "max_tokens_per_rank": 128,
+                "recv_capacity_per_rank": None,
+                "hidden_dim": 32,
+                "num_topk": 3,
+                "num_sms": 5,
+                "zero_copy": False,
+            },
+        )
+    ]
+
+
+def test_ncclep_dynamic_shape_restores_expert_rows_without_padding():
+    manager = object.__new__(_NCCLEPManager)
+    manager._recv_capacity = None
+    hidden_states = torch.randn(7, 16)
+
+    assert manager.get_restored_hidden_states_by_experts(hidden_states) is hidden_states
+
+
+def test_ncclep_static_shape_requires_rank_capacity_factor(monkeypatch):
+    monkeypatch.setattr(token_dispatcher_module, "nccl_ep_dispatch", object())
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (10, 0))
+    monkeypatch.setenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", "1")
+
+    with pytest.raises(
+        ValueError,
+        match="moe_ncclep_static_shape=True requires .*moe_expert_rank_capacity_factor",
+    ):
+        _NCCLEPManager(
+            group=object(),
+            num_local_experts=2,
+            router_topk=3,
+            num_experts=8,
+            config=_make_ncclep_config(
+                moe_expert_rank_capacity_factor=None,
+                moe_ncclep_static_shape=True,
+                use_transformer_engine_op_fuser=True,
+            ),
+        )
 
 
 class MoEModelTestContainer:


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Avoid an extra host synchronization in the dynamic-shape NCCL EP flex dispatcher path and clarify that `moe_expert_rank_capacity_factor` is only required for NCCL EP static-shape mode.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
