### PR TITLE
fix: restore the post-load param all-gather for the layer-wise optimizer

### DIFF
--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -761,6 +761,17 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         if expt_dp_size == 1 or len(self.expt_dp_params_list[0]) == 0:
             self.expt_dp_params_list = None
 
+    def _unique_model_chunks(self) -> List[torch.nn.Module]:
+        """Model chunks for the per-chunk work in ChainedOptimizer.
+
+        The base class collects these from the chained children, but ours are
+        Float16OptimizerWithFloat16Params wrapping raw torch optimizers, which carry no
+        ``model_chunks`` -- so that scan returns [] and every per-chunk step becomes a silent
+        no-op, including the param all-gather after a checkpoint load. ``self.model_chunks`` is
+        assigned in ``__init__`` for exactly this reason; use it.
+        """
+        return list(self.model_chunks)
+
     def set_bucket_layerwise_params_list(self, model_chunks):
         """Map sharded params to DDP buckets for async all-gather.
 

--- a/tests/unit_tests/dist_checkpointing/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_layer_wise_optimizer.py
@@ -130,6 +130,36 @@ class TestLayerWiseOptimizer:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
+    def test_post_load_param_sync_reaches_the_model_chunks(self):
+        """The post-checkpoint-load refresh must be able to all-gather the params.
+
+        ``quantize_and_sync_model_params_from_main_params()`` gathers over
+        ``_unique_model_chunks()``, which ``ChainedOptimizer`` builds by scanning the chained
+        children for ``model_chunks``. ``LayerWiseDistributedOptimizer`` wraps raw torch
+        optimizers in ``Float16OptimizerWithFloat16Params``, which never set one, so the scan
+        returns [] and the gather silently never runs.
+        """
+        Utils.initialize_model_parallel(1, 1)
+        model, optimizer = setup_model_and_optimizer(
+            seed=2, tp=1, pp=1, dist_opt=True, optimizer='dist_muon', use_param_layout=True
+        )
+        # The outer chain is [LayerWiseDistributedOptimizer, DistributedOptimizer]; the latter
+        # does carry model_chunks, so the defect is only visible on the nested layer-wise one.
+        lw = next(
+            c for c in optimizer.chained_optimizers
+            if isinstance(c, LayerWiseDistributedOptimizer)
+        )
+
+        assert all(
+            not getattr(c, 'model_chunks', []) for c in lw.chained_optimizers
+        ), "a chained child grew model_chunks; the override may no longer be needed"
+
+        assert lw._unique_model_chunks(), (
+            f"_unique_model_chunks() is empty though {len(lw.model_chunks)} chunk(s) exist, so "
+            "start_param_sync never runs after a checkpoint load and each rank keeps only the "
+            "params it staged itself"
+        )
+
     def test_parameter_sharding(self):
         """Test that parameters are correctly sharded across DP ranks."""
         Utils.initialize_model_parallel(1, 1)


### PR DESCRIPTION
**A run resumed from a checkpoint under `--optimizer muon --use-distributed-optimizer` silently continues from a different model than the one it saved. Every model and optimizer state tensor is affected. There is no error and the loss curve looks normal.**

## Root cause

`ChainedOptimizer.quantize_and_sync_model_params_from_main_params()` runs after every checkpoint load. Staging main params into model params is per-rank; `start_param_sync(force_sync=True)` is what makes the ranks agree:

```python
model_chunks = self._unique_model_chunks()
for optimizer in self.chained_optimizers:
    optimizer._stage_model_params_from_main_params()   # per-rank, local
for model_chunk in model_chunks:                       # the cross-rank sync
    model_chunk.start_param_sync(force_sync=True)
```

`_unique_model_chunks()` collects `model_chunks` off the chained children. `LayerWiseDistributedOptimizer` wraps raw torch optimizers in `Float16OptimizerWithFloat16Params`, which never sets that attribute — so the list comes back empty and **the second loop never executes**. Instrumented on a live run:

```
_unique_model_chunks: from children=0  self.model_chunks=1
```

## Impact

Continuous run vs resumed run, same iteration, diffed key by key. The checkpoint has 5331 flattened leaves, but only 38 are model or optimizer state — the rest are RNG streams (48), scalars, and metadata that cannot differ:

```
tensors 108  ->  numel>1: 86  ->  48 rng_state (8 ranks x 6 streams)
                               ->  38 model + optimizer state
non-tensor 5223  (param-group hyperparams, step counters, shard metadata)
```

**37 of the 38 differ** (the only untouched one is `router.expert_bias`). Magnitudes, five steps after the resume:

| state | elems differing | max abs | relative |
|---|---|---|---|
| FP32 master params | 4194208 / 4194304 | 1.7e-02 | **4.6e-02 … 5.7e-02** | | muon `momentum_buffer` | 4194304 / 4194304 | 2.8e-06 | **8.1e-02 … 1.6e-01** | | adam `exp_avg` / `exp_avg_sq` | ~all | 8.5e-06 | 1.8e-02 |

So ~5% relative error on the master weights and up to 16% on muon momentum. Nothing is missing from the checkpoint — no key is absent on either side — the values are wrong.

At 120B this showed up as 0.2% loss error on the first resumed step, compounding to 19% by step 25.

> Measured with warmup disabled (`--lr 8.0e-3 --lr-warmup-samples 0`). On the stock schedule the
> first steps run at a few percent of peak LR, which shrinks the same corruption to ~1e-4 relative
> and lets two tensors round back to their original values — masking how total the damage is.

## Fix

``LayerWiseDistributedOptimizer`` already assigns ``self.model_chunks`` in ``__init__`` precisely because the base-class scan comes back empty (see the comment there). Use it:

```python
def _unique_model_chunks(self) -> List[torch.nn.Module]:
    return list(self.model_chunks)
```

``ChainedOptimizer`` is left untouched: its scan skips **stub** children, and stubs still carry ``model_chunks`` (set at ``distrib_optimizer.py:682``, before stub status at ``:700``) because frozen sub-models get a stub optimizer. Widening the base class would force-sync a frozen chunk nothing staged into.

``start_param_sync`` is the required sync here, not merely a workable one: this method only runs under ``--fp8-param-gather``/``--fp4-param-gather``, and it is the path that performs FP8 post-all-gather processing. The layer-wise ``allgather_params()`` cannot substitute -- it flattens with ``_flatten_dense_tensors``, which raises on MXFP8 tensors.

## Proof

120B-shaped MoE recipe: MXFP8 with `--fp8-param-gather` and `--reuse-grad-buf-for-mxfp8-param-ag`, expert parallelism, grouped experts, GTP weight shards. Three legs in one allocation — continuous, save-at-N, resume-from-N — comparing the resumed trajectory against the continuous one.

| | A/A | resume | checkpoint shards |
|---|---|---|---|
| 2 nodes, muon, before | IDENTICAL | **DIVERGED** | 8/8 differ | | 2 nodes, muon, after | IDENTICAL | IDENTICAL | 1/8 (rank 0's args blob) | | 2 nodes, adam, before / after | IDENTICAL | IDENTICAL | 1/8 — no regression | | 2 nodes, muon, `--no-use-layer-wise-param-layout`, after | IDENTICAL | IDENTICAL | 1/8 | | 64 nodes, muon, after | IDENTICAL | IDENTICAL | — |

The `--no-use-layer-wise-param-layout` row covers the legacy path, where DDP is built without the precomputed layout — the fix holds there too.

The A/A column is two fresh runs of the same config; it is IDENTICAL everywhere, including at the raised LR, so the divergence is attributable to the checkpoint round-trip and not to run-to-run noise. The 64-node row draws on two jobs: the A/A from a full three-leg run, and the resume from a resume-only rerun that loads the same checkpoint and compares against the same continuous leg that diverged before the fix -- a direct A/B rather than a fresh experiment. Both arms of every comparison are the same tree apart from this one method; the "before" arm ran from a separate worktree.

Key-level diff, same pair:

```
before:  5331 shared keys, 38 differ   (37 state tensors + the args blob)
after:   5331 shared keys,  1 differ   (the args blob alone -- the legs necessarily differ
                                        in --exit-interval / --save / --load)
```

## Scope

Needs the layer-wise optimizer **and** quantized param gather: the call site is gated on `args.fp8_param_gather or args.fp4_param_gather`, and `DistributedOptimizer` children do carry `model_chunks`, so the base-class scan works for them. Adam is unaffected, which the control rows confirm.

## Not established

Every measurement is taken several training steps after the resume, so it shows the settled difference rather than the error at the instant of load. The defect, the fix, and its effect are verified; the initial magnitude is not characterised.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
