### PR TITLE
Pad MLA's V to the QK width on the unpacked path

### DIFF
--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -83,12 +83,12 @@ if TYPE_CHECKING:
 
 
 def _prepare_mla_core_attention_value(parallel_attention, query, value, packed_seq_params):
-    """Prepare value tensor for MLA core attention THD execution."""
+    """Prepare value tensor for MLA core attention execution."""
     orig_v_dim = value.shape[-1] if value is not None else None
     padded_v_dim = orig_v_dim
+    is_thd = packed_seq_params is not None and packed_seq_params.qkv_format == "thd"
     need_v_pad = (
-        packed_seq_params is not None
-        and packed_seq_params.qkv_format == "thd"
+        (is_thd or parallel_attention.config.mla_pad_v_head_dim_unpacked)
         and parallel_attention.config.experimental_attention_variant is None
         and value is not None
         and query.shape[-1] != orig_v_dim
@@ -100,12 +100,16 @@ def _prepare_mla_core_attention_value(parallel_attention, query, value, packed_s
 
 
 def _trim_mla_core_attention_output(core_attn_out, need_v_pad, orig_v_dim, padded_v_dim):
-    """Trim THD MLA core attention output back to the original V dimension."""
-    if need_v_pad:
-        if core_attn_out.ndim == 2:
-            core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-1], -1, padded_v_dim)
-        core_attn_out = core_attn_out[..., :orig_v_dim]
-    return core_attn_out
+    """Trim MLA core attention output back to the original V dimension."""
+    if not need_v_pad:
+        return core_attn_out
+    if core_attn_out.ndim == 2:
+        core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-1], -1, padded_v_dim)
+        return core_attn_out[..., :orig_v_dim]
+    # [s, b, h * padded_v_dim]: split the head dim out, or the slice cuts across heads.
+    core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-1], -1, padded_v_dim)
+    core_attn_out = core_attn_out[..., :orig_v_dim]
+    return core_attn_out.reshape(*core_attn_out.shape[:-2], -1)
 
 
 @dataclass
@@ -260,7 +264,7 @@ class MultiLatentAttention(Attention):
         attn_mask_type=None,
         **extra_kwargs,
     ):
-        """Run MLA core attention with the THD value pad/trim workaround."""
+        """Run MLA core attention with the value pad/trim workaround."""
         value, need_v_pad, orig_v_dim, padded_v_dim = _prepare_mla_core_attention_value(
             self, query, value, packed_seq_params
         )

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3429,6 +3429,11 @@ class MLATransformerConfig(TransformerConfig):
     mscale_all_dim: float = 0.0
     """Mscale all dimensions for YaRN RoPE in Multi-Latent Attention, used by yarn."""
 
+    mla_pad_v_head_dim_unpacked: bool = False
+    """Pad V up to the QK head dim on the unpacked path, as the packed (thd) path already does.
+       Below compute capability 9.0 no attention backend has a kernel for unequal QK and V head
+       dims, so an unpadded MLA layer falls back to the unfused path."""
+
     cache_mla_latents: bool = False
     """Cache the low dimensional tensors for MLA rather than full KV cache.
        This is only for the dynamic inference backend and requires that 

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -438,6 +438,66 @@ class TestParallelMLAAttention:
                 assert output.shape[2] == transformer_config.hidden_size
                 assert bias.shape[0] == transformer_config.hidden_size
 
+    @pytest.mark.parametrize("pad_unpacked", [False, True])
+    def test_gpu_forward_qv_head_dim_mismatch_unpacked(self, pad_unpacked):
+        """Test the unpacked MLA path when q and v head dimensions differ."""
+        if is_te_min_version("1.10.0"):
+            transformer_config = MLATransformerConfig(
+                num_layers=2,
+                hidden_size=12,
+                num_attention_heads=4,
+                use_cpu_initialization=True,
+                q_lora_rank=32,
+                kv_lora_rank=32,
+                qk_head_dim=128,
+                v_head_dim=64,
+                qk_pos_emb_head_dim=64,
+                mla_pad_v_head_dim_unpacked=pad_unpacked,
+                rope_type=self.transformer_config.rope_type,
+                rotary_base=self.transformer_config.rotary_base,
+                original_max_position_embeddings=self.transformer_config.original_max_position_embeddings,
+            )
+            mismatch_attention = MLASelfAttention(
+                transformer_config,
+                get_mla_self_attn_submodules(),
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+            )
+
+            sequence_length = 32
+            micro_batch_size = 1
+
+            mismatch_attention.cuda().bfloat16()
+
+            # [sequence length, batch size, hidden size]
+            hidden_states = torch.ones(
+                (sequence_length, micro_batch_size, transformer_config.hidden_size)
+            )
+            hidden_states = hidden_states.cuda().bfloat16()
+
+            query, key, value, _, _ = mismatch_attention.get_query_key_value_tensors(
+                hidden_states, None, None, None, None
+            )
+            assert query.shape[-1] != value.shape[-1]
+
+            prepared_value, need_v_pad, orig_v_dim, padded_v_dim = (
+                mla_module._prepare_mla_core_attention_value(
+                    mismatch_attention, query, value, None
+                )
+            )
+            assert need_v_pad == pad_unpacked
+            assert prepared_value.shape[-1] == (
+                query.shape[-1] if pad_unpacked else value.shape[-1]
+            )
+            assert orig_v_dim == transformer_config.v_head_dim
+
+            output, bias = mismatch_attention(hidden_states, None)
+
+            assert output.shape[0] == sequence_length
+            assert output.shape[1] == micro_batch_size
+            assert output.shape[2] == transformer_config.hidden_size
+            assert bias.shape[0] == transformer_config.hidden_size
+
     def test_checkpointed_gpu_forward(self):
         if is_te_min_version("1.10.0"):
             transformer_config = self.transformer_config


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Extends MLA's V pad to the unpacked path, so the two paths handle unequal QK and V head dims the same way. Behind `MLATransformerConfig.mla_pad_v_head_dim_unpacked`, default `False`.

## Issue tracking

Related: #1698, fixed for `thd` in #3003.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

## Why

#3003 pads V up to the QK width because Transformer Engine has no fused backend when the two differ. That is a property of the geometry, not of the layout — but the fix landed in `_prepare_mla_core_attention_value` under `packed_seq_params.qkv_format == "thd"`, so the same MLA model reaching the same backend with the same head dims is padded when packed and not when unpacked.

For MLA the widths always differ: the RoPE dims ride on q/k but not on v. With DeepSeek-style dims — `qk_nope 128 + qk_rope 64` = 192 against `v_head_dim` 128 — below compute capability 9.0 neither cuDNN nor FlashAttention accepts the pair, and an unpacked layer selects nothing:

```
Disabling FusedAttention as no backend supports the provided input
Running with UnfusedDotProductAttention backend
```

This is the fallback #6241 warns about from the other side. Where it happens, the pad is what makes FlashAttention eligible, exactly as it already does for `thd`.

## What changes

`need_v_pad` gains the unpacked case behind the new flag; the `thd` condition and the `experimental_attention_variant` escape hatch are untouched.

`_trim_mla_core_attention_output` gains the unpacked layout. On `thd` the output arrives as `[t, h * padded_v_dim]` and the existing reshape splits the head dim out before the slice. On the unpacked path it arrives as `[s, b, h * padded_v_dim]`, so slicing the flat last dim would cut across heads rather than off the end of each one; the trim now splits the head dim out and flattens back.

Default is `False`: no existing model changes behaviour.

## What it is worth

Whole training step — forward, backward, Adam — on a small MLA model with DeepSeek-V2-Lite attention dims, 8 layers, hidden 2048, `ffn_hidden_size` 10944, bf16, `attention_dropout` 0, batch 1, unpacked. Median of 40 steps after 15 warmup, two rounds per cell with the arm order reversed. A100 80GB SXM4, torch 2.11.0+cu130, TE 2.15.0.

| tokens | unpadded | padded | padded faster by |
|---|---|---|---|
| 4096 | 133.0, 133.2 | 100.1, 100.1 | **24.8%** |
| 8192 | 469.8, 469.8 | 212.3, 212.2 | **54.8%** |
| 16384 | OOM, OOM | 532.9, 533.6 | — |

The gap widens with sequence length, which is what a change in attention should look like: attention is O(s²), so its share of the step grows and the unfused kernel costs more.

At 16384 the unpadded arm does not run at all: `UnfusedDotProductAttention` materializes `[b, h, s, s]` and asks for 16 GiB on top of a model that already fills the card. Both rounds OOM inside `forward_torch_softmax`; the padded arm completes.

## Correctness

Pad-then-trim is an identity — the padded columns are sums of zeros, so the trim discards nothing.

The pad and the trim were exercised directly over both layouts: with the flag set the prepared V widens 128 to 192 with a zero tail, the trim returns `[s, b, h * 128]` with each head's first 128 columns intact, and with the flag clear nothing is padded. The `thd` path produces the same `need_v_pad` and the same trimmed shape as before this change.

Where the two arms end up on different backends they agree to bf16 rounding rather than bit-exactly, since they are different kernels: worst relative drift 4.0e-3 on the geometry above.

## Test

`test_gpu_forward_qv_head_dim_mismatch_unpacked` is parametrized over both settings and asserts that the flag controls `need_v_pad`, that the prepared V has the expected width, and that the forward still produces correctly shaped output and bias. It sits next to `test_gpu_forward_thd_qv_head_dim_mismatch`, which covers the packed path.

## Notes for reviewers

The flag is the mirror of the one in #6241: that turns the pad off where the native width is already served, this turns it on where it is not. Together they cover both directions of the same decision, which is why neither is a default.

Deciding automatically — padding whenever the backend cannot take the native width — has the same obstacle noted there: the answer varies with TE version, compute capability and cuDNN version, and Megatron-Core cannot query TE's backend selection. This takes the smaller step; happy to rework it if you prefer the automatic route.

The measurement is on sm80, but the condition is compute capability below 9.0 rather than any one card — sm75, sm86 and sm89 select the same way. On sm90+ the native width is already served and the pad is a cost rather than a saving, which #6240 measures at 5.7% to 87.4%; that is why this defaults off. Happy to add an sm90+ row if it would help.
