### PR TITLE
Fix FSDP NCCL memory-pool ownership and teardown

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -50,6 +50,7 @@ from .uneven_dtensor import update_uneven_dtensor_chunk_metadata, validate_uneve
 from .utils import (
     _MODEL_PARALLEL_RNG_TRACKER_NAME,
     FSDPDistributedIndex,
+    GlobalMemoryBuffer,
     all_sharding_strategies_in,
     get_global_memory_buffer,
     get_mcore_tensor_parallel_partition_dim,
@@ -105,8 +106,6 @@ except ImportError:
         NCCL_ALLOCATOR = "APEX"
     except ImportError:
         nccl_allocator = None
-
-NCCL_MEMORY_POOL = None
 
 
 def _p_assert(cond: Any, s: str, raise_assertion_error: bool = True) -> None:
@@ -231,6 +230,16 @@ class MultiGroupUBRAllocator:
                 f"group.group_desc:{group.group_desc}",
             )
             backend.register_mem_pool(self.pool)
+
+
+class _ManualRegistrationState(Enum):
+    """Internal lifecycle of manual FSDP NCCL memory-pool registration."""
+
+    UNREGISTERED = "unregistered"
+    REGISTERING = "registering"
+    REGISTERED = "registered"
+    FAILED = "failed"
+    DEREGISTERED = "deregistered"
 
 
 @dataclasses.dataclass
@@ -693,12 +702,16 @@ class FixedPoolAllocator(TemporaryBucketAllocator):
         size: int = 2,
         dtype_fn: Callable[["ParameterGroup"], torch.dtype] = operator.attrgetter("dtype"),
         fallback_to_persistent_buffer: bool = False,
+        memory_buffer: GlobalMemoryBuffer | None = None,
     ):
         self.name = name
         self.fsdp_param_groups = fsdp_param_groups
         self.size = size  # Number of buffers in the pool (default is 2 for double buffering)
         self.allocation_tracker = {}  # tracking the global buffer allocation status
         self.dtype_fn = dtype_fn
+        self.memory_buffer = (
+            memory_buffer if memory_buffer is not None else get_global_memory_buffer()
+        )
 
         # Build a mapping from FSDP unit id to its associated bucket ids.
         fsdp_unit_buckets = defaultdict(dict)
@@ -875,7 +888,7 @@ class FixedPoolAllocator(TemporaryBucketAllocator):
                 bucket_id=bucket_id, size=size, dtype=dtype, device=device
             )
 
-        # Use buffer_name to get memory from global memory.
+        # Use buffer_name to get memory from this allocator's persistent arena.
         if mem_alloc_context is not None and mem_alloc_context != nullcontext:
             # Check if a new buffer allocation is required
             if (
@@ -886,7 +899,7 @@ class FixedPoolAllocator(TemporaryBucketAllocator):
                 self.allocation_tracker[(buffer_name, dtype)] = size
                 torch.cuda.synchronize()
         return Bucket(
-            data=get_global_memory_buffer().get_tensor(
+            data=self.memory_buffer.get_tensor(
                 [size], dtype=dtype, name=buffer_name, mem_alloc_context=mem_alloc_context
             )
         )
@@ -937,6 +950,7 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
         size: int = 2,
         dtype_fn: Callable[["ParameterGroup"], torch.dtype] = operator.attrgetter("dtype"),
         fallback_to_persistent_buffer: bool = False,
+        memory_buffer: GlobalMemoryBuffer | None = None,
     ):
         self.name = name
         self.fsdp_param_groups = fsdp_param_groups
@@ -945,6 +959,9 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
         self.bucket_alloc_index = {}  # map bucket ID to offset
         self.max_dtype_bucket_sizes = {}  # dtype -> [bucket sizes from smallest to largest]
         self.dtype_fn = dtype_fn
+        self.memory_buffer = (
+            memory_buffer if memory_buffer is not None else get_global_memory_buffer()
+        )
 
         # Build a mapping from FSDP unit id to its associated bucket ids.
         fsdp_unit_buckets = defaultdict(list)
@@ -1172,7 +1189,7 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
                 bucket_id=bucket_id, size=size, dtype=dtype, device=device
             )
 
-        # Use buffer_name to get memory from global memory.
+        # Use buffer_name to get memory from this allocator's persistent arena.
         if mem_alloc_context is not None and mem_alloc_context != nullcontext:
             # Check if a new buffer allocation is required. Mirror the logic in
             # GlobalMemoryBuffer.get_tensor() to ensure MALLOC synchronization.
@@ -1184,7 +1201,7 @@ class MaxPoolAllocator(TemporaryBucketAllocator):
                 self.allocation_tracker[(buffer_name, dtype)] = size
                 torch.cuda.synchronize()
         return Bucket(
-            data=get_global_memory_buffer().get_tensor(
+            data=self.memory_buffer.get_tensor(
                 [size], dtype=dtype, name=buffer_name, mem_alloc_context=mem_alloc_context
             )
         )
@@ -2108,7 +2125,10 @@ class ParamAndGradBuffer:
             reset_parameters_for_meta_device_init_module
         )
         self.ubr_groups = None
-        self.already_registered = False
+        self.nccl_mem_pool = None
+        self.persistent_memory_buffer = GlobalMemoryBuffer()
+        self._manual_registration_state = _ManualRegistrationState.UNREGISTERED
+        self._registered_ubr_groups = []
         # User buffer registration related settings
         if self.ddp_config.nccl_ub:
             assert nccl_allocator is not None, (
@@ -2119,10 +2139,9 @@ class ParamAndGradBuffer:
             # it always uses fsdp double buffer.
             self.ddp_config.fsdp_double_buffer = True
             # Initialize the NCCL memory pool.
-            global NCCL_MEMORY_POOL
             # Initialize NCCL allocator runtime if available
             nccl_allocator.init()
-            NCCL_MEMORY_POOL = nccl_allocator.create_nccl_mem_pool(
+            self.nccl_mem_pool = nccl_allocator.create_nccl_mem_pool(
                 symmetric=not self.ddp_config.disable_symmetric_registration
             )
             log_single_rank(
@@ -2236,7 +2255,7 @@ class ParamAndGradBuffer:
                 "To use user buffer registration, "
                 "either requires megatron.core.nccl_allocator or apex.contrib.nccl_allocator"
             )
-            global NCCL_MEMORY_POOL
+            assert self.nccl_mem_pool is not None, "NCCL memory pool is not initialized"
             if groups is None:
                 # data parallel group is a default group for user buffer registration
                 groups = [self.dist_index.get_fsdp_group(is_expert_parallel=False)]
@@ -2244,20 +2263,20 @@ class ParamAndGradBuffer:
             if NCCL_ALLOCATOR == "MCORE":
                 if self.ddp_config.fsdp_manual_registration:
                     return functools.partial(
-                        nccl_allocator.MemPoolAllocatorWithoutRegistration, NCCL_MEMORY_POOL
+                        nccl_allocator.MemPoolAllocatorWithoutRegistration, self.nccl_mem_pool
                     )
                 if len(groups) == 1:
                     # register buffers to the default group directly using nccl memory allocator
                     mem_alloc_context = functools.partial(
                         nccl_allocator.nccl_mem,
-                        NCCL_MEMORY_POOL,
+                        self.nccl_mem_pool,
                         group=groups[0],
                         symmetric=symmetric,
                     )
                 else:
                     mem_alloc_context = functools.partial(
                         nccl_allocator.MultiGroupMemPoolAllocator,
-                        NCCL_MEMORY_POOL,
+                        self.nccl_mem_pool,
                         groups=groups,
                         symmetric=symmetric,
                     )
@@ -2278,12 +2297,12 @@ class ParamAndGradBuffer:
                 if len(groups) == 1:
                     # register buffers to the default group directly using nccl memory allocator
                     mem_alloc_context = functools.partial(
-                        nccl_allocator.nccl_mem, NCCL_MEMORY_POOL, group=groups[0]
+                        nccl_allocator.nccl_mem, self.nccl_mem_pool, group=groups[0]
                     )
                 else:
                     # Supports multiple groups registration for APEX NCCL allocator.
                     mem_alloc_context = functools.partial(
-                        MultiGroupUBRAllocator, NCCL_MEMORY_POOL, groups=groups
+                        MultiGroupUBRAllocator, self.nccl_mem_pool, groups=groups
                     )
             else:
                 raise ValueError(f"Invalid NCCL allocator: {NCCL_ALLOCATOR}")
@@ -2291,40 +2310,89 @@ class ParamAndGradBuffer:
         else:
             return nullcontext
 
-    def manual_buffer_registration(self):
+    def manual_buffer_registration(self) -> None:
         """
         Manually register the FSDP communication buffers to NCCL user buffer.
         """
         assert self.ddp_config.nccl_ub, "NCCL UBR is not enabled"
         assert self.ddp_config.fsdp_double_buffer, "FSDP double buffer is not enabled"
         assert self.ddp_config.fsdp_manual_registration, "FSDP manual registration is not enabled"
-        assert not self.already_registered, "Mem pool is already registered"
+        assert self.nccl_mem_pool is not None, "NCCL memory pool is not initialized"
+        assert self._manual_registration_state == _ManualRegistrationState.UNREGISTERED, (
+            "Mem pool cannot be registered from state "
+            f"{self._manual_registration_state.value}"
+        )
 
-        self.already_registered = True
+        self._manual_registration_state = _ManualRegistrationState.REGISTERING
+        try:
+            torch.cuda.synchronize()
+            torch.distributed.barrier(async_op=False)
+            torch.cuda.synchronize()
+            for group in self.ubr_groups:
+                log_single_rank(
+                    logger,
+                    logging.INFO,
+                    f"[MCORE][FSDP][Manual REG] Registering mem pool to group {group},"
+                    f"group.group_desc:{group.group_desc}, group.size(): {group.size()}",
+                )
+                nccl_allocator.register_mem_pool(
+                    self.nccl_mem_pool,
+                    group,
+                    symmetric=not self.ddp_config.disable_symmetric_registration,
+                )
+                self._registered_ubr_groups.append(group)
+                log_single_rank(
+                    logger,
+                    logging.INFO,
+                    f"[MCORE][FSDP][Manual REG] Registered mem pool to group {group},"
+                    f"group.group_desc:{group.group_desc}, group.size(): {group.size()}",
+                )
+        except Exception:
+            # Registration is collective. Do not attempt rollback here because ranks may
+            # have failed at different groups; a rollback collective could deadlock.
+            self._manual_registration_state = _ManualRegistrationState.FAILED
+            raise
+        self._manual_registration_state = _ManualRegistrationState.REGISTERED
 
-        global NCCL_MEMORY_POOL
+    @property
+    def already_registered(self) -> bool:
+        """Whether the application completed registration for every expected group."""
+        return self._manual_registration_state == _ManualRegistrationState.REGISTERED
+
+    def manual_buffer_deregistration(self) -> None:
+        """Collectively deregister manually registered groups in reverse order.
+
+        All ranks in each registered group must call this method in the same sequence.
+        """
+        assert self.ddp_config.nccl_ub, "NCCL UBR is not enabled"
+        assert self.ddp_config.fsdp_double_buffer, "FSDP double buffer is not enabled"
+        assert self.ddp_config.fsdp_manual_registration, "FSDP manual registration is not enabled"
+        assert self.nccl_mem_pool is not None, "NCCL memory pool is not initialized"
+        if self._manual_registration_state == _ManualRegistrationState.DEREGISTERED:
+            return
+        if self._manual_registration_state == _ManualRegistrationState.UNREGISTERED:
+            return
+        if self._manual_registration_state != _ManualRegistrationState.REGISTERED:
+            raise RuntimeError(
+                "Cannot safely deregister an FSDP NCCL memory pool from state "
+                f"{self._manual_registration_state.value}; communicator teardown is required."
+            )
+
         torch.cuda.synchronize()
-        torch.distributed.barrier(async_op=False)
-        torch.cuda.synchronize()
+        try:
+            for group in reversed(self._registered_ubr_groups):
+                if NCCL_ALLOCATOR == "MCORE":
+                    nccl_allocator.deregister_mem_pool(self.nccl_mem_pool, group)
+                else:
+                    backend = group._get_backend(torch.device("cuda", torch.cuda.current_device()))
+                    if self.nccl_mem_pool.snapshot():
+                        backend.deregister_mem_pool(self.nccl_mem_pool)
+        except Exception:
+            self._manual_registration_state = _ManualRegistrationState.FAILED
+            raise
 
-        for group in self.ubr_groups:
-            log_single_rank(
-                logger,
-                logging.INFO,
-                f"[MCORE][FSDP][Manual REG] Registering mem pool to group {group},"
-                f"group.group_desc:{group.group_desc}, group.size(): {group.size()}",
-            )
-            nccl_allocator.register_mem_pool(
-                NCCL_MEMORY_POOL,
-                group,
-                symmetric=not self.ddp_config.disable_symmetric_registration,
-            )
-            log_single_rank(
-                logger,
-                logging.INFO,
-                f"[MCORE][FSDP][Manual REG] Registered mem pool to group {group},"
-                f"group.group_desc:{group.group_desc}, group.size(): {group.size()}",
-            )
+        self._registered_ubr_groups.clear()
+        self._manual_registration_state = _ManualRegistrationState.DEREGISTERED
 
     def _log_parameter_groups(self):
         """Compact log of FSDP parameter groups and their parameters."""
@@ -2588,12 +2656,14 @@ class ParamAndGradBuffer:
                 fsdp_param_groups=self.parameter_groups,
                 size=UB_BUFFER_NUM,
                 fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
+                memory_buffer=self.persistent_memory_buffer,
             )
             self.transpose_weight_alloc = FIXED_POOL_ALLOC_TYPE(
                 name="fsdp_fp8_transpose_params",
                 fsdp_param_groups=self.parameter_groups,
                 size=UB_BUFFER_NUM,
                 fallback_to_persistent_buffer=self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail,
+                memory_buffer=self.persistent_memory_buffer,
             )
             # Resolve gradient bucket dtype used for MaxPoolAllocator bucket allocation
             # planning and FixedPoolAllocator unit symmetries. Falls back to each
@@ -2611,6 +2681,7 @@ class ParamAndGradBuffer:
                 fallback_to_persistent_buffer=(
                     self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
                 ),
+                memory_buffer=self.persistent_memory_buffer,
             )
             if self.dist_index.use_hybrid_fsdp:
                 # Only required for custom communication dtype buffer allocation
@@ -2625,6 +2696,7 @@ class ParamAndGradBuffer:
                     fallback_to_persistent_buffer=(
                         self.ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
                     ),
+                    memory_buffer=self.persistent_memory_buffer,
                 )
             self.double_buf_units = self.weight_alloc.fsdp_double_buffer_units
         else:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1516,6 +1516,47 @@ def preprocess_common_state_dict(common_state_dict):
     return preprocessed_common_state_dict
 
 
+def _deregister_nccl_memory_pools(model: list[torch.nn.Module], args: argparse.Namespace) -> None:
+    """Deregister model-owned NCCL pools before process-group teardown.
+
+    ProcessGroupNCCL destruction may otherwise deregister retained symmetric handles again.
+    """
+    fsdp_buffers = []
+    ddp_buffers = []
+    for model_module in model:
+        if isinstance(model_module, (FullyShardedDataParallelV1, FullyShardedDataParallelV2)):
+            param_and_grad_buffer = model_module.param_and_grad_buffer
+            if (
+                param_and_grad_buffer.ddp_config.fsdp_manual_registration
+                and param_and_grad_buffer.nccl_mem_pool is not None
+            ):
+                fsdp_buffers.append(param_and_grad_buffer)
+
+        if isinstance(model_module, DDP):
+            ddp_buffers.extend(
+                buffer
+                for buffer in model_module.buffers + model_module.expert_parallel_buffers
+                if buffer.nccl_mem_pool is not None
+            )
+
+    gtp_registration_enabled = getattr(args, 'gtp_remat_nccl_ub', False) or getattr(
+        args, 'gtp_expert_remat_nccl_ub', False
+    )
+    if not gtp_registration_enabled and not fsdp_buffers and not ddp_buffers:
+        return
+
+    torch.distributed.barrier()
+    if gtp_registration_enabled:
+        from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
+
+        deregister_and_clear_gtp_symm_pools()
+
+    for param_and_grad_buffer in fsdp_buffers:
+        param_and_grad_buffer.manual_buffer_deregistration()
+    for buffer in ddp_buffers:
+        nccl_allocator.deregister_mem_pool(buffer.nccl_mem_pool, buffer.data_parallel_group)
+
+
 def pretrain(
     cfg_container: PretrainConfigContainer,
     train_valid_test_dataset_provider,
@@ -2161,12 +2202,7 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
-    if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'gtp_expert_remat_nccl_ub', False):
-        from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
-
-        # Deregister the GTP symmetric-memory pools: windows left registered when the
-        # process groups are destroyed make NCCL abort.
-        deregister_and_clear_gtp_symm_pools()
+    _deregister_nccl_memory_pools(model, args)
 
     ft_integration.shutdown()
     one_logger_utils.finish()
@@ -5151,23 +5187,8 @@ def train(
 
     # If any exit conditions (signal handler, duration, iterations) have been reached, exit.
     if should_exit:
-        # Deregister NCCL user-buffer memory pools before exit.
-        # Without this, ProcessGroupNCCL's destructor calls abort() which uses
-        # ncclCommDeregister on handles created by ncclCommWindowRegister,
-        # causing "NCCL WARN Deregister: Could not find handle" and a crash.
-        torch.distributed.barrier()
-        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'gtp_expert_remat_nccl_ub', False):
-            from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
-
-            # Deregister the GTP symmetric-memory pools: windows left registered when the
-            # process groups are destroyed make NCCL abort.
-            deregister_and_clear_gtp_symm_pools()
-
-        for model_module in model:
-            if isinstance(model_module, DDP):
-                for buf in model_module.buffers + model_module.expert_parallel_buffers:
-                    if getattr(buf, 'nccl_mem_pool', None) is not None:
-                        nccl_allocator.deregister_mem_pool(buf.nccl_mem_pool, buf.data_parallel_group)
+        # Deregister retained pools before ProcessGroupNCCL destructors run.
+        _deregister_nccl_memory_pools(model, args)
         one_logger and one_logger.log_metrics(
             {'app_finish_time': one_logger_utils.get_timestamp_in_ms()}
         )

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mcore_fully_sharded_data_parallel.py
@@ -359,7 +359,6 @@ class TestFullyShardedDataParallel:
         from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
             FixedPoolAllocator,
         )
-        from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import get_global_memory_buffer
 
         fsdp_config = DistributedDataParallelConfig(
             data_parallel_sharding_strategy="optim_grads_params",
@@ -426,7 +425,7 @@ class TestFullyShardedDataParallel:
         torch.cuda.synchronize()
         fsdp_model.stop_communication()
 
-        gmb_buffer = get_global_memory_buffer().buffer
+        gmb_buffer = pgb.persistent_memory_buffer.buffer
         for alloc_attr in ("weight_alloc", "main_grad_alloc"):
             alloc = getattr(pgb, alloc_attr)
             persistent_keys = [

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_registration_ownership.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_registration_ownership.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp import param_and_grad_buffer
+from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
+    FixedPoolAllocator,
+    MaxPoolAllocator,
+    ParamAndGradBuffer,
+    _ManualRegistrationState,
+)
+from megatron.training import training
+
+pytestmark = pytest.mark.internal
+
+
+def _group(name):
+    return SimpleNamespace(group_desc=name, size=lambda: 2)
+
+
+def _manual_buffer(pool, groups):
+    buffer = ParamAndGradBuffer.__new__(ParamAndGradBuffer)
+    buffer.ddp_config = SimpleNamespace(
+        nccl_ub=True,
+        fsdp_double_buffer=True,
+        fsdp_manual_registration=True,
+        disable_symmetric_registration=False,
+    )
+    buffer.nccl_mem_pool = pool
+    buffer.ubr_groups = groups
+    buffer._manual_registration_state = _ManualRegistrationState.UNREGISTERED
+    buffer._registered_ubr_groups = []
+    return buffer
+
+
+def test_manual_registration_uses_each_wrappers_pool(monkeypatch):
+    pools = [object(), object()]
+    groups = [_group("first"), _group("second")]
+    buffers = [_manual_buffer(pool, [group]) for pool, group in zip(pools, groups)]
+    calls = []
+
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        param_and_grad_buffer.nccl_allocator,
+        "register_mem_pool",
+        lambda pool, group, symmetric: calls.append((pool, group)),
+    )
+
+    for buffer in buffers:
+        buffer.manual_buffer_registration()
+
+    assert calls == list(zip(pools, groups))
+    assert all(buffer.already_registered for buffer in buffers)
+    with pytest.raises(AssertionError, match="Mem pool cannot be registered"):
+        buffers[0].manual_buffer_registration()
+
+
+def test_partial_registration_failure_is_not_reported_as_success(monkeypatch):
+    groups = [_group("first"), _group("second")]
+    buffer = _manual_buffer(object(), groups)
+
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda *args, **kwargs: None)
+
+    def register_mem_pool(pool, group, symmetric):
+        if group is groups[1]:
+            raise RuntimeError("injected registration failure")
+
+    monkeypatch.setattr(
+        param_and_grad_buffer.nccl_allocator, "register_mem_pool", register_mem_pool
+    )
+
+    with pytest.raises(RuntimeError, match="injected registration failure"):
+        buffer.manual_buffer_registration()
+
+    assert buffer._manual_registration_state == _ManualRegistrationState.FAILED
+    assert buffer._registered_ubr_groups == groups[:1]
+    assert not buffer.already_registered
+
+
+def test_deregistration_is_reversed_and_idempotent(monkeypatch):
+    pool = object()
+    groups = [_group("first"), _group("second")]
+    buffer = _manual_buffer(pool, groups)
+    buffer._manual_registration_state = _ManualRegistrationState.REGISTERED
+    buffer._registered_ubr_groups = list(groups)
+    calls = []
+
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(param_and_grad_buffer, "NCCL_ALLOCATOR", "MCORE")
+    monkeypatch.setattr(
+        param_and_grad_buffer.nccl_allocator,
+        "deregister_mem_pool",
+        lambda call_pool, group: calls.append((call_pool, group)),
+    )
+
+    buffer.manual_buffer_deregistration()
+    buffer.manual_buffer_deregistration()
+
+    assert calls == [(pool, groups[1]), (pool, groups[0])]
+    assert buffer._manual_registration_state == _ManualRegistrationState.DEREGISTERED
+
+
+def test_training_teardown_deregisters_every_owned_pool(monkeypatch):
+    calls = []
+
+    class _FSDP:
+        def __init__(self, index, manual_registration=True):
+            self.param_and_grad_buffer = SimpleNamespace(
+                ddp_config=SimpleNamespace(fsdp_manual_registration=manual_registration),
+                nccl_mem_pool=object(),
+                manual_buffer_deregistration=lambda: calls.append(("fsdp", index)),
+            )
+
+    class _DDP:
+        def __init__(self, buffers, expert_parallel_buffers):
+            self.buffers = buffers
+            self.expert_parallel_buffers = expert_parallel_buffers
+
+    fsdp_modules = [_FSDP(0), _FSDP(1), _FSDP(2, manual_registration=False)]
+    dense_pool, expert_pool = object(), object()
+    dense_group, expert_group = object(), object()
+    ddp_module = _DDP(
+        buffers=[
+            SimpleNamespace(nccl_mem_pool=dense_pool, data_parallel_group=dense_group),
+            SimpleNamespace(nccl_mem_pool=None, data_parallel_group=object()),
+        ],
+        expert_parallel_buffers=[
+            SimpleNamespace(nccl_mem_pool=expert_pool, data_parallel_group=expert_group)
+        ],
+    )
+
+    monkeypatch.setattr(training, "DDP", _DDP)
+    monkeypatch.setattr(training, "FullyShardedDataParallelV1", _FSDP)
+    monkeypatch.setattr(training, "FullyShardedDataParallelV2", _FSDP)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: calls.append(("barrier", None)))
+    monkeypatch.setattr(
+        training.nccl_allocator,
+        "deregister_mem_pool",
+        lambda pool, group: calls.append(("ddp", pool, group)),
+    )
+
+    training._deregister_nccl_memory_pools(
+        [*fsdp_modules, ddp_module],
+        SimpleNamespace(gtp_remat_nccl_ub=False, gtp_expert_remat_nccl_ub=False),
+    )
+
+    assert calls == [
+        ("barrier", None),
+        ("fsdp", 0),
+        ("fsdp", 1),
+        ("ddp", dense_pool, dense_group),
+        ("ddp", expert_pool, expert_group),
+    ]
+
+
+@pytest.mark.parametrize("allocator_type", [FixedPoolAllocator, MaxPoolAllocator])
+def test_persistent_allocator_arenas_do_not_alias(allocator_type):
+    parameter_group = SimpleNamespace(
+        fsdp_unit_id=0, dtype=torch.float32, params=[torch.nn.Parameter(torch.empty(8))]
+    )
+    allocators = [
+        allocator_type(
+            name="wrapper-local-name",
+            fsdp_param_groups=[parameter_group],
+            size=1,
+            memory_buffer=param_and_grad_buffer.GlobalMemoryBuffer(),
+        )
+        for _ in range(2)
+    ]
+
+    buckets = [
+        allocator.allocate(bucket_id=0, size=8, dtype=torch.float32, device=torch.device("cuda"))
+        for allocator in allocators
+    ]
+
+    assert buckets[0].data.data_ptr() != buckets[1].data.data_ptr()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Give each MCore FSDP `ParamAndGradBuffer` ownership of its NCCL memory pool and persistent allocation arena, make manual registration failure-aware, and clean up manually registered pools on normal completion and early exit.

## Why

The current pool is module-global. Constructing wrapper B overwrites the handle later read when wrapper A performs manual registration, even though wrapper A allocated through its own captured pool. The persistent allocators also share a global `(name, dtype)` arena, so equal keys in concurrent wrappers can resolve to the same storage.

An eight-rank NCCL reproducer constructed two wrappers and then registered wrapper A: current `main` registered wrapper B's pool; this patch registered wrapper A's pool. Both variants completed the collective, so this is an ownership/registration-coverage defect rather than a numerical-corruption claim.

## Changes

- Store `nccl_mem_pool` and a persistent arena on the owning `ParamAndGradBuffer`.
- Inject that arena into fixed- and max-pool allocators while preserving their default constructor behavior.
- Mark manual registration successful only after every group completes; retain the completed prefix on failure without attempting rank-asymmetric rollback.
- Deregister manually registered groups in reverse order and make repeated cleanup a no-op.
- Use one synchronized teardown helper for GTP, manual MCore FSDP, and registered legacy-DDP pools.

The lifecycle state deliberately covers only `manual_buffer_registration()`. Automatic allocation-context registration is unchanged and is not claimed by `manual_buffer_deregistration()`; the training helper calls it only when `fsdp_manual_registration` is active.

## Related work

Drafts #6317, #6318, and #6665 address deterministic materialization and broader FSDP UBR scope, while #4399 moves allocator code. Those patches retain the module-global pool/arena and are complementary; any future composition should preserve per-wrapper ownership.

## Validation

- Gaia job `65270` passed the predecessor source-native ownership suite on every rank under eight-rank `torch.distributed.run` at `c2c23b2bc22b914bee0dc736c3c846a07d83a2e0`.
- The real eight-rank H100/NCCL 2.28.9 probe selected wrapper B's pool on current `main` and wrapper A's pool with the fix; both produced the expected all-reduce sum `36.0`.
- The same predecessor head completed full Megatron runs with explicit registration, registered-buffer reuse, and orderly pool cleanup on Gaia H100 and Blyris GB200, including two-node and four-node FSDP paths.
- Current head `24e7f9ba467becd95d2c60df3585d1c67dba2936` is one signed commit directly on `b1fe7599e18a213292600177ad7ff290a1127160`; Ruff, isort, and `git diff --check` pass. Current upstream CI is pending on this SHA.

## Issue tracking

Linked issue: N/A — focused correctness and lifecycle fix.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (the external NCCL/training runs are not committed recipes)
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation (no user-facing configuration changes)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR