### PR TITLE
Fix FSDP mixed-precision reset for fixed buffers

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1309,7 +1309,7 @@ class MegatronFSDP(torch.nn.Module):
         finally:
             self.reset_mixed_precision_policy(mp_policy_backup)
 
-    def reset_mixed_precision_policy(self, mixed_precision_policy: MixedPrecisionPolicy):
+    def reset_mixed_precision_policy(self, mixed_precision_policy: MixedPrecisionPolicy) -> None:
         """
         Re-configure MixedPrecisionPolicy for MegatronFSDP / ParamAndGradBuffer.
         """
@@ -1317,13 +1317,12 @@ class MegatronFSDP(torch.nn.Module):
             # Preserve the original main parameter + gradient data-type.
             main_params_dtype=self.mp_policy.main_params_dtype,
             main_grads_dtype=self.mp_policy.main_grads_dtype,
-            # Gradient communication data-type can only be reset
-            # if symmetric buffers / NCCL UB are not used, because
-            # inflates FixedPoolAllocator memory & breaks NCCL UBR.
+            # Fixed buffers are allocated for the initial communication dtype and cannot
+            # adopt a new dtype without rebuilding and, for NCCL UBR, re-registering them.
             grad_comm_dtype=(
-                mixed_precision_policy.grad_comm_dtype
+                self.mp_policy.grad_comm_dtype
                 if self.ddp_config.nccl_ub or self.ddp_config.fsdp_double_buffer
-                else self.mp_policy.grad_comm_dtype
+                else mixed_precision_policy.grad_comm_dtype
             ),
         )
         self.mp_policy = mp_policy_reset

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_mixed_precision_policy.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mfsdp_mixed_precision_policy.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.distributed.fsdp.src import megatron_fsdp
+
+
+@pytest.mark.parametrize(
+    ("nccl_ub", "fsdp_double_buffer", "expected_grad_comm_dtype"),
+    [(False, False, torch.float16), (True, True, torch.bfloat16), (False, True, torch.bfloat16)],
+)
+def test_mixed_precision_context_preserves_fixed_buffer_dtype_and_restores_policy(
+    nccl_ub, fsdp_double_buffer, expected_grad_comm_dtype
+):
+    original_policy = megatron_fsdp.MixedPrecisionPolicy(
+        main_params_dtype=torch.float32,
+        main_grads_dtype=torch.float32,
+        grad_comm_dtype=torch.bfloat16,
+    )
+    requested_policy = megatron_fsdp.MixedPrecisionPolicy(grad_comm_dtype=torch.float16)
+    param_and_grad_buffer = SimpleNamespace(mp_policy=original_policy)
+    fsdp = SimpleNamespace(
+        mp_policy=original_policy,
+        ddp_config=SimpleNamespace(nccl_ub=nccl_ub, fsdp_double_buffer=fsdp_double_buffer),
+        param_and_grad_buffer=param_and_grad_buffer,
+    )
+    fsdp.reset_mixed_precision_policy = MethodType(
+        megatron_fsdp.MegatronFSDP.reset_mixed_precision_policy, fsdp
+    )
+
+    with megatron_fsdp.MegatronFSDP.mixed_precision_context(fsdp, requested_policy):
+        assert fsdp.mp_policy.main_params_dtype == original_policy.main_params_dtype
+        assert fsdp.mp_policy.main_grads_dtype == original_policy.main_grads_dtype
+        assert fsdp.mp_policy.grad_comm_dtype == expected_grad_comm_dtype
+        assert param_and_grad_buffer.mp_policy is fsdp.mp_policy
+
+    assert fsdp.mp_policy.main_params_dtype == original_policy.main_params_dtype
+    assert fsdp.mp_policy.main_grads_dtype == original_policy.main_grads_dtype
+    assert fsdp.mp_policy.grad_comm_dtype == original_policy.grad_comm_dtype
+    assert param_and_grad_buffer.mp_policy is fsdp.mp_policy


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Correct the reversed gradient-communication dtype guard in `MegatronFSDP.reset_mixed_precision_policy()`.

## Why

`reset_mixed_precision_policy()` updates the active policy; it does not rebuild communication buffers. Without double buffering, gradient communication uses disposable temporary buckets whose dtype is selected from the active policy when each bucket is fetched, so the requested dtype can be adopted. Double buffering instead uses a fixed pool planned from the initial `grad_comm_dtype`; NCCL UBR requires double buffering and additionally registers its memory pool. Fixed buffers must therefore retain their allocated dtype unless they are rebuilt and, for UBR, re-registered.

The current ternary implements the opposite behavior:

| Buffer mode | Reset behavior |
| --- | --- |
| Dynamic | Adopt the requested communication dtype |
| FSDP double buffer | Preserve the allocated dtype |
| NCCL UBR | Preserve the allocated and registered dtype |

Merged PR #3067 provides the design provenance. The production change here is intentionally just the operand correction plus its explanatory comment.

## Validation

- In a paired direct policy-path probe in an H100 environment with PyTorch `2.10.0a0+b4e4ee81d3.nv25.12`, CUDA `13.1`, and NCCL `2.28.9`, baseline `4c9d3852e` failed all three policy cases: the dynamic-buffer case retained FP32 instead of adopting the requested BF16, while the double-buffer and NCCL UBR cases adopted BF16 instead of preserving their allocated FP32. Independent fix `ff3db8200` passed all three.
- The source-native regression test also passed on every rank in a single-node, eight-H100 `torch.distributed.run` at predecessor head `e7ae8b3a6`; it exercises the real context entry/`finally` path, policy propagation, and restoration.
- Current head `a575a5227a481edc2f4aa1b68518083e5cd562d2` is one signed commit directly on `b1fe7599e18a213292600177ad7ff290a1127160`. Ruff and isort passed before the comment-only amendment, and `git diff --check` passes on the current head. Current upstream CI is pending on this SHA.

## Issue tracking

Linked issue: N/A — focused correctness fix.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not needed for this policy-selection fix)
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation (no user-facing configuration changes)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR