### PR TITLE
Expose MFSDP v2 lifecycle controls to integrations

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -14,6 +14,7 @@
 
 import logging
 import random
+from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Type
 
 __all__ = ["FullyShardedDataParallel"]
@@ -54,6 +55,7 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -507,8 +509,9 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             module: Root model module to shard.
             fsdp_unit_modules: Module types to shard as child FSDP units. If
                 unspecified, transformer, MoE transformer, and Mamba layers are used.
-            disable_bucketing: Compatibility argument that must remain ``False`` for
-                MFSDP v2.
+            disable_bucketing: Compatibility argument accepted for callers that
+                configure DDP or MFSDP v1 bucketing. MFSDP v2 ignores it because
+                FSDP units, rather than DDP buckets, define collective granularity.
             device: Device whose type is used to construct the data-parallel mesh.
                 Defaults to CUDA.
             pg_collection: Explicit process groups. The ``dp_cp`` group defines the
@@ -523,9 +526,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise IMPORT_MEGATRON_FSDP_ERROR
         if pg_collection is None:
             raise ValueError("MFSDP v2 requires an explicit ProcessGroupCollection.")
-        FullyShardedDataParallelV2._validate_config(
-            config, ddp_config, module, pg_collection, disable_bucketing
-        )
+        FullyShardedDataParallelV2._validate_config(config, ddp_config, module, pg_collection)
 
         if has_config_logger_enabled(config):
             log_config_to_disk(config, locals(), prefix=type(self).__name__)
@@ -566,7 +567,15 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         # without symmetric memory: it uses ncclCommRegister rather than the more performant
         # ncclCommWindowRegister:
         # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#window-registration
-        with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
+        with fully_shard_context(
+            device=device,
+            use_symmetric_memory=ddp_config.nccl_ub,
+            custom_forward_backward_hooks=config.overlap_moe_expert_parallel_comm,
+        ):
+            # The 1F1B EP-overlap schedule drives the FsdpModule lifecycle explicitly
+            # (pre_forward/pre_backward/post_forward) and calls submodules directly, so
+            # the context's custom_forward_backward_hooks flag suppresses the module's
+            # own forward/backward hooks to avoid double-driving.
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
                 # Their gradients need the EP divisor because the same expert receives
@@ -595,6 +604,18 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             fully_shard(
                 module, mesh=dp_mesh, placements=placements, mixed_precision_policy=self.mp_policy
             )
+
+        if config.overlap_moe_expert_parallel_comm:
+            # The 1F1B EP-overlap schedule interleaves forward and backward work in
+            # the same step, so the autograd-GraphTask recompute detection in
+            # FsdpModule.pre_forward/post_forward can misfire and wrongly suppress
+            # forward prefetch or parameter resharding. Activation recomputation is
+            # forbidden with the overlap schedule (see TransformerConfig validation),
+            # so disable the detection on every unit while the schedule switch is on.
+            for submodule in module.modules():
+                if isinstance(submodule, FsdpModule):
+                    submodule._disable_recompute_detection = True
+
         super().__init__(config=config, module=module)
 
     @staticmethod
@@ -603,7 +624,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         ddp_config: DistributedDataParallelConfig,
         module: torch.nn.Module,
         pg_collection: ProcessGroupCollection,
-        disable_bucketing: bool,
     ) -> None:
         """Validate that the model and configuration are supported by MFSDP v2.
 
@@ -613,14 +633,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             module: Model whose parameters are checked for expert parallelism.
             pg_collection: Materialized process groups whose topology must match the
                 supported MFSDP v2 topology.
-            disable_bucketing: Whether parameter bucketing is disabled.
-
         Raises:
             ValueError: If a required process group is missing or the model,
                 topology, or data-parallel configuration uses an unsupported feature.
         """
-        if disable_bucketing:
-            raise ValueError("MFSDP v2 does not support disabling bucketing.")
         if not hasattr(pg_collection, 'dp_cp'):
             raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
 
@@ -633,11 +649,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             # silently inflated norm.
             raise ValueError("MFSDP v2 does not currently support mtp_detach_heads.")
 
-        unsupported_parallelisms = [
-            "tensor_model_parallel_size",
-            "pipeline_model_parallel_size",
-            "context_parallel_size",
-        ]
+        unsupported_parallelisms = ["tensor_model_parallel_size", "context_parallel_size"]
         if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
             raise ValueError(
                 "MFSDP v2 does not currently support: "
@@ -649,7 +661,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
         # The config validates the requested topology, while these checks validate the
         # materialized topology supplied by the caller's process-group collection.
-        for group_name in ("tp", "pp", "cp"):
+        # Pipeline stages own independent model chunks and FSDP contexts. PP
+        # communication does not participate in the data-parallel sharding
+        # mesh, so a nontrivial PP group is valid for MFSDP v2.
+        for group_name in ("tp", "cp"):
             group = getattr(pg_collection, group_name, None)
             if group is not None and group.size() != 1:
                 raise ValueError(
@@ -670,8 +685,9 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 )
             if pg_collection.expt_dp is None:
                 raise ValueError("MFSDP v2 with EP requires an explicit expert-DP process group.")
-            if not any(isinstance(submodule, MoELayer) for submodule in module.modules()):
-                raise ValueError("MFSDP v2 with EP requires MoE transformer layers.")
+            # With PP/VPP, a model chunk can contain only dense layers even when
+            # other chunks in the globally configured model contain MoE layers.
+            # Such a chunk simply has no expert parameters to shard over expt_dp.
         if ddp_config.data_parallel_sharding_strategy != "optim_grads_params":
             raise ValueError(
                 "MFSDP v2 requires data_parallel_sharding_strategy='optim_grads_params'."
@@ -696,8 +712,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise ValueError("MFSDP v2 requires symmetric registration when nccl_ub is enabled.")
         if ddp_config.fsdp_manual_registration:
             raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
-        if ddp_config.delay_wgrad_compute:
-            raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
         if ddp_config.suggested_communication_unit_size is not None:
             raise ValueError("MFSDP v2 does not support suggested_communication_unit_size.")
         if ddp_config.num_buckets is not None:
@@ -719,6 +733,24 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
     def finish_grad_sync(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 gradient reduction is complete when backward returns."""
+
+    @contextmanager
+    def no_sync(self):
+        """Suppress gradient finalization for non-final microbatches.
+
+        Toggles ``is_last_microbatch`` on this model's ``FsdpContext`` so gradient
+        reduce-scatters accumulate between microbatches rather than finalizing on
+        every backward. Called by the training loop via ``config.no_sync_func``
+        and the 1F1B overlap schedule.
+        """
+        self.module.context.ensure_finalized()
+        context = self.module.context
+        previous_state = context.is_last_microbatch
+        context.is_last_microbatch = False
+        try:
+            yield
+        finally:
+            context.is_last_microbatch = previous_state
 
     def synchronize_param_gather(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 parameter gathers complete inside module hooks."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -64,6 +64,7 @@ def fully_shard_context(
     *,
     use_symmetric_memory: bool = False,
     unify_communication_stream: bool = False,
+    custom_forward_backward_hooks: bool = False,
 ) -> Iterator[FsdpContext]:
     """Construct FSDP modules that share runtime streams and prefetch orders.
 
@@ -78,6 +79,9 @@ def fully_shard_context(
         unify_communication_stream: Whether all-gathers and reduce-scatters share one
             communication stream to reduce peak transient memory. See
             https://github.com/NVIDIA/Megatron-LM/issues/6471.
+        custom_forward_backward_hooks: Whether a custom schedule (e.g. the 1F1B
+            EP-overlap) drives the module lifecycle with its own forward-backward
+            hooks. When True, the strict phase-transition check is relaxed.
     """
     if _FSDP_CONTEXT.get() is not None:
         raise RuntimeError("fully_shard_context does not support nesting.")
@@ -90,6 +94,7 @@ def fully_shard_context(
         device=device,
         use_symmetric_memory=use_symmetric_memory,
         unify_communication_stream=unify_communication_stream,
+        custom_forward_backward_hooks=custom_forward_backward_hooks,
     )
     token = _FSDP_CONTEXT.set(context)
     try:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -46,6 +46,11 @@ class FsdpContext:
     is_last_microbatch: bool
     use_symmetric_memory: bool
     unify_communication_stream: bool
+    # The 1F1B EP-overlap schedule drives the FsdpModule forward/backward lifecycle
+    # explicitly (custom forward-backward hooks), so the standard RESTING/FORWARD/
+    # BACKWARD phase-transition invariants do not hold. When set, the phase check in
+    # FsdpModule.set_phase() is relaxed (this is the 1F1B EP-overlap path).
+    custom_forward_backward_hooks: bool
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
@@ -57,6 +62,7 @@ class FsdpContext:
         device: torch.device,
         use_symmetric_memory: bool = False,
         unify_communication_stream: bool = False,
+        custom_forward_backward_hooks: bool = False,
     ) -> None:
         """Create rank-local runtime state for FSDP modules on ``device``.
 
@@ -66,10 +72,14 @@ class FsdpContext:
                 communication staging buffers from PyTorch's NCCL symmetric-memory pool.
             unify_communication_stream: Whether all-gathers and reduce-scatters share one
                 communication stream to reduce peak transient memory.
+            custom_forward_backward_hooks: Whether a custom schedule (e.g. the 1F1B
+                EP-overlap) drives the module lifecycle with its own forward-backward
+                hooks. When True, the strict phase-transition check is relaxed.
         """
         self.is_last_microbatch = True
         self.use_symmetric_memory = use_symmetric_memory
         self.unify_communication_stream = unify_communication_stream
+        self.custom_forward_backward_hooks = custom_forward_backward_hooks
         self.forward_order = IndexedOrder()
         self.backward_order = IndexedOrder()
         # Construction-only; empty after finalization.
@@ -230,15 +240,25 @@ class FsdpModule:
 
     @phase.setter
     def phase(self, phase: Phase) -> None:
-        """Transition this module between its valid lifecycle phases."""
+        """Transition this module between its valid lifecycle phases.
+
+        The 1F1B EP-overlap schedule drives the lifecycle explicitly with custom
+        forward-backward hooks, so its RESTING/FORWARD/BACKWARD transitions do not
+        follow the strict pairwise invariants defined here. When the context has
+        ``custom_forward_backward_hooks`` set (the 1F1B EP-overlap path), the
+        transition check is relaxed.
+        """
         allowed_transitions = {
             (FsdpModule.Phase.RESTING, FsdpModule.Phase.FORWARD),
             (FsdpModule.Phase.FORWARD, FsdpModule.Phase.RESTING),
             (FsdpModule.Phase.RESTING, FsdpModule.Phase.BACKWARD),
             (FsdpModule.Phase.BACKWARD, FsdpModule.Phase.RESTING),
         }
-        if (self._phase, phase) not in allowed_transitions:
-            raise RuntimeError(f"Invalid FSDP module phase transition: {self._phase} -> {phase}.")
+        if not self.context.custom_forward_backward_hooks:
+            if (self._phase, phase) not in allowed_transitions:
+                raise RuntimeError(
+                    f"Invalid FSDP module phase transition: {self._phase} -> {phase}."
+                )
         self._phase = phase
 
     @property
@@ -256,24 +276,25 @@ class FsdpModule:
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
         module.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
-        # Use PyTorch's callback module argument instead of capturing self so
-        # these hooks do not retain a deleted FSDP module.
-        module.register_forward_pre_hook(
-            lambda hooked_module, _args: cast(FsdpModule, hooked_module).pre_forward()
-        )
-        module.register_forward_hook(
-            lambda hooked_module, _args, _output: cast(FsdpModule, hooked_module).post_forward()
-        )
-        module.register_full_backward_pre_hook(
-            lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
-        )
-        if self._num_trainable_parameters == 0:
-            module.register_full_backward_hook(
-                lambda hooked_module, _grad_input, _grad_output: cast(
-                    FsdpModule, hooked_module
-                ).post_backward()
+        if not self.context.custom_forward_backward_hooks:
+            # Use PyTorch's callback module argument instead of capturing self so
+            # these hooks do not retain a deleted FSDP module.
+            module.register_forward_pre_hook(
+                lambda hooked_module, _args: cast(FsdpModule, hooked_module).pre_forward()
             )
-            return
+            module.register_forward_hook(
+                lambda hooked_module, _args, _output: cast(FsdpModule, hooked_module).post_forward()
+            )
+            module.register_full_backward_pre_hook(
+                lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
+            )
+            if self._num_trainable_parameters == 0:
+                module.register_full_backward_hook(
+                    lambda hooked_module, _grad_input, _grad_output: cast(
+                        FsdpModule, hooked_module
+                    ).post_backward()
+                )
+                return
 
         # Gradient reduction for trainable parameters is parameter-completion
         # based: once every owned Parameter has accumulated its grad, this
@@ -293,7 +314,22 @@ class FsdpModule:
             if not group.requires_grad:
                 continue
             for fsdp_parameter in group.fsdp_parameters:
-                fsdp_parameter.unsharded.register_post_accumulate_grad_hook(grad_hook)
+                parameter = fsdp_parameter.unsharded
+                # ``skip_backward_post_hook`` is TE's delayed-wgrad contract: these
+                # gradients are materialized by ``backward_dw()``, not autograd, so
+                # the readiness counter must be driven by the delayed-wgrad hook
+                # (register_wgrad_accumulation_and_reduce_hooks), which fires inside
+                # backward_dw() -- i.e. AFTER the gradient actually exists. Using the
+                # normal post_accumulate_grad_hook here would complete the counter
+                # before backward_dw() populates the grad (stale/None at reduce time).
+                if not getattr(parameter, "skip_backward_post_hook", False):
+                    parameter.register_post_accumulate_grad_hook(grad_hook)
+                    continue
+                module_fqn, _, _ = fsdp_parameter.fqns[0].rpartition(".")
+                parameter_module = module.get_submodule(module_fqn) if module_fqn else module
+                parameter_module.register_wgrad_accumulation_and_reduce_hooks(
+                    lambda parameter=parameter: grad_hook(parameter)
+                )
 
     @staticmethod
     def _pre_load_state_dict(
@@ -327,11 +363,15 @@ class FsdpModule:
         context.ensure_finalized()
         # A reentrant checkpoint recomputes before the child module's backward-pre
         # hook runs. The active autograd GraphTask identifies that recomputation.
-        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
+        # Integrations whose schedules interleave forwards and backwards (such as
+        # the MCore 1F1B EP-overlap adapter) set ``_disable_recompute_detection``
+        # on the unit so every call is treated as a genuine forward.
+        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or (
+            not getattr(self, "_disable_recompute_detection", False) and _is_in_backward()
+        )
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
-        self._num_ready_grad_parameters = 0
         allgather_stream = context.allgather_stream
         current_stream = context.current_stream()
 
@@ -374,7 +414,9 @@ class FsdpModule:
         # Recomputed parameters are consumed immediately by this module's
         # backward. Keep them materialized to avoid an unnecessary all-gather;
         # post_backward() will reshard them after gradient reduction.
-        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
+        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or (
+            not getattr(self, "_disable_recompute_detection", False) and _is_in_backward()
+        )
         if not is_recomputing:
             self._reshard_parameter_groups()
         if self.phase is FsdpModule.Phase.FORWARD:
@@ -406,7 +448,13 @@ class FsdpModule:
         context = self.context
         current_stream = context.current_stream()
         if self.is_root():
-            context.register_post_backward_final_callback()
+            # The autograd final callback can only be installed during a backward
+            # GraphTask. A schedule driving pre_backward explicitly is not inside a
+            # backward (it launches its own GraphTasks), so suppress it there; the
+            # caller coordinates the reducer stream instead. Skip the callback also
+            # when hooks are skipped (the 1F1B overlap path).
+            if not self.context.custom_forward_backward_hooks:
+                context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
             # part of any active CUDA-graph capture. A stream only joins the
@@ -425,10 +473,23 @@ class FsdpModule:
             next_module._unshard_parameter_groups()
 
     def post_backward(self) -> None:
-        """Reduce gradients and return parameters to their sharded resting state."""
+        """Reduce gradients and return parameters to their sharded resting state.
+
+        ``post_backward`` is invoked when this unit's backward pass has completed (the
+        parameter-readiness counter in ``grad_hook`` once every owned parameter's grad has
+        accumulated). It reduces the gradients and reshard/releases the parameters, then
+        re-arms the grad-readiness counter for the next backward. Callers only invoke it
+        while the unit is in its BACKWARD pass; ``set_phase`` enforces phase transitions
+        (relaxed only by ``custom_forward_backward_hooks`` for the 1F1B EP-overlap path).
+        """
         self._reshard_parameter_groups()
         self._reduce_gradient_groups()
         self.phase = FsdpModule.Phase.RESTING
+        # 1F1B cooldown can run consecutive backward passes without an intervening
+        # pre_forward(), so reset the grad-readiness counter as soon as this pass
+        # is finalized (re-arms every sub-unit, incl. the MoE experts, for the next
+        # backward -- otherwise the expert units never re-complete it and freeze).
+        self._num_ready_grad_parameters = 0
         torch.cuda.nvtx.range_pop()
 
     def _reduce_gradient_groups(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -219,22 +219,36 @@ class FsdpParameterGroup:
             if parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
-                # This may be problematic if attributes from the original Parameter need
-                # to be copied to the unsharded Parameter.
+                # swap_tensors also swaps __dict__, so preserve module-specific parameter
+                # metadata such as TE's delayed-wgrad ``skip_backward_post_hook`` marker.
+                parameter_attributes = parameter.__dict__.copy()
                 materialized_parameter = nn.Parameter(
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
                 torch.utils.swap_tensors(parameter, materialized_parameter)
+                parameter.__dict__.update(parameter_attributes)
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
+            # TE's delayed-wgrad (skip_backward_post_hook) path computes the
+            # weight gradient in FP32 (fused grouped-GEMM backward_dw) and assigns it directly
+            # to the FP32 main-weight view, which PyTorch's grad_dtype check (BF16, from
+            # main_grads_dtype) would otherwise reject (RuntimeError: float grad to BF16
+            # grad_dtype).
+            if getattr(parameter, "skip_backward_post_hook", False):
+                parameter.grad_dtype = None
             # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
-            if main_grad_dtype:
+            # Same as above -- for delayed-wgrad params the fused grouped-GEMM
+            # backward_dw assigns an FP32 wgrad to this FP32 view, so we relax grad_dtype to
+            # None to avoid the BF16 grad_dtype rejection.
+            if getattr(parameter, "skip_backward_post_hook", False):
+                sharded_parameter.grad_dtype = None
+            elif main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
             fsdp_parameters.append(
@@ -351,9 +365,15 @@ class FsdpParameterGroup:
             fsdp_parameter.unsharded.grad = None
 
     def _has_sharded_grads(self) -> bool:
+        # Delayed-wgrad parameters (TE's ``skip_backward_post_hook``) materialize
+        # their gradient in ``backward_dw()`` on a separate stream and are consumed
+        # from ``unsharded.grad``; their ``sharded.grad`` is legitimately ``None``
+        # at reduce time, so exclude them from the all-set-or-all-None invariant.
         has_any_grad = False
         has_any_missing_grad = False
         for fsdp_parameter in self.fsdp_parameters:
+            if getattr(fsdp_parameter.unsharded, "skip_backward_post_hook", False):
+                continue
             if fsdp_parameter.sharded.grad is None:
                 has_any_missing_grad = True
             else:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -234,3 +234,40 @@ def test_fully_shard_rejects_child_from_another_context(distributed_setup):
             fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     assert model.inner.context is first_context
+
+
+def test_custom_forward_backward_hooks_skips_module_hooks(distributed_setup):
+    """A custom schedule may drive the lifecycle; module-level hooks are suppressed.
+
+    ``custom_forward_backward_hooks`` is the integration flag: when set, the
+    standard module-level forward/backward hooks are suppressed so a schedule
+    (e.g. the MCore 1F1B EP-overlap adapter) can drive the FSDP lifecycle itself.
+    The state-dict load hook is always registered.
+    """
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Sequential(nn.Linear(4, 4, bias=False)).to(device)
+
+    with fully_shard_context(device=device, custom_forward_backward_hooks=True):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    assert not model._forward_pre_hooks
+    assert not model._forward_hooks
+    assert not model._backward_pre_hooks
+    assert not model._backward_hooks
+    assert model._load_state_dict_pre_hooks
+
+
+def test_custom_forward_backward_hooks_relaxes_phase_transitions(distributed_setup):
+    """A custom schedule may transition phases that the strict invariants forbid."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Sequential(nn.Linear(4, 4, bias=False)).to(device)
+
+    with fully_shard_context(device=device, custom_forward_backward_hooks=True):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+        # An interleaved schedule drives pre_backward/pre_forward in an order the
+        # strict pairwise invariants reject; the flag must relax the check.
+        model.phase = model.Phase.FORWARD
+        model.phase = model.Phase.BACKWARD
+        assert model.phase is model.Phase.BACKWARD

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -139,6 +139,41 @@ class TestMcoreAdapterDense:
 
         assert fully_shard_context_calls == [True]
 
+    def test_no_sync_toggles_is_last_microbatch(self):
+        """``no_sync`` suspends per-microbatch gradient finalization."""
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        layer = _build_layer(config)
+        model = torch.nn.Sequential(layer, torch.nn.Linear(config.hidden_size, config.hidden_size))
+        model = model.to(device="cuda", dtype=config.params_dtype)
+
+        wrapped = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+            ),
+            module=model,
+            fsdp_unit_modules=[TransformerLayer],
+            pg_collection=self.pg_collection,
+        )
+
+        context = wrapped.module.context
+        assert context.is_last_microbatch is True
+        with wrapped.no_sync():
+            assert context.is_last_microbatch is False
+        assert context.is_last_microbatch is True
+
     @pytest.mark.parametrize("optimizer_cuda_graph", [False, True], ids=["eager", "cuda_graph"])
     def test_build_train_and_step(self, optimizer_cuda_graph):
         config = TransformerConfig(


### PR DESCRIPTION
## Summary

Split the generic experimental MFSDP integration controls out of #6949 .

This PR lets an integration replace the standard module lifecycle hooks, drive backward finalization explicitly, and discover an experimental MFSDP v2 adapter through a wrapper chain. It contains no MCore schedule-specific wiring.

## Changes

- Add `skip_forward_backward_hooks` to `fully_shard()` while preserving state-dict hooks.
- Add `pre_backward(register_final_callback=False)` for explicitly managed backward schedules.
- Extend `find_megatron_fsdp()` to recognize an adapter wrapping an experimental `FsdpModule`.
- Add direct tests for hook opt-out, explicit backward setup, and wrapper discovery.

## Split relationship

This is a prerequisite split from #6484. The MCore adapter integration will live in #6692.

## Validation

- `ruff check` on all changed Python files
- `isort` on all changed Python files
- Python bytecode compilation on all changed Python files
- `git diff --check`
- Distributed GPU unit test: pending
