### PR TITLE
fix: Copy gathered params into storage detached from the DDP parameter buffer

### DIFF
--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -61,6 +61,7 @@ from megatron.core.inference.utils import Counter, InferenceMode, await_process_
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import CudaGraphManager, delete_cuda_graphs
 from megatron.core.transformer.enums import InferenceCudaGraphScope
+from megatron.core.transformer.moe.experts import InferenceGroupedMLP
 from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
 from megatron.core.utils import (
     deprecate_args,
@@ -419,6 +420,10 @@ class DynamicInferenceEngine(AbstractEngine):
                         if isinstance(val, (int, float)) and int(val) > max_step:
                             max_step = int(val)
                     self.inference_step_offset = int(max_step)
+
+        # Repair expert aliases detached by conversion/load before the first capture;
+        # a new engine is already RUNNING, so resume() skips the refresh.
+        self._refresh_inference_grouped_mlp_weights()
 
         # Mark the inference engine as active. Cleared in `suspend()` and re-set in `resume()`.
         InferenceMode.set_active()
@@ -1238,6 +1243,14 @@ class DynamicInferenceEngine(AbstractEngine):
         if not self.use_coordinator:
             self.state = EngineState.SUSPENDED
 
+    @torch.no_grad()
+    def _refresh_inference_grouped_mlp_weights(self) -> None:
+        """Refresh materialized serving buffers after the caller has synchronized weights."""
+        model = unwrap_model(self.controller.inference_wrapped_model.model)
+        for module in model.modules():
+            if isinstance(module, InferenceGroupedMLP):
+                module.refresh_inference_weights()
+
     def resume(self):
         """Resume engine by reallocating context's GPU state."""
 
@@ -1253,6 +1266,7 @@ class DynamicInferenceEngine(AbstractEngine):
         # that spans the refit republishes under its original generation and is
         # unmatchable by new arrivals.
         self._weight_epoch += 1
+        self._refresh_inference_grouped_mlp_weights()
 
         InferenceMode.set_active()
 

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -346,6 +346,14 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Initialization options.
         self.controller = controller
+        # Snapshot for the resume-time weight refresh: it runs on the coordinator
+        # thread, so it must not traverse a module tree the caller may be mutating
+        # (e.g. toggling CUDA-graph wrappers). The set is fixed at model build.
+        self._inference_grouped_mlp_modules = [
+            module
+            for module in unwrap_model(controller.inference_wrapped_model.model).modules()
+            if isinstance(module, InferenceGroupedMLP)
+        ]
         self.context = context
 
         self.num_speculative_tokens = inference_config.num_speculative_tokens
@@ -1245,11 +1253,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
     @torch.no_grad()
     def _refresh_inference_grouped_mlp_weights(self) -> None:
-        """Refresh materialized serving buffers after the caller has synchronized weights."""
-        model = unwrap_model(self.controller.inference_wrapped_model.model)
-        for module in model.modules():
-            if isinstance(module, InferenceGroupedMLP):
-                module.refresh_inference_weights()
+        """Refresh materialized serving buffers after the caller has synchronized weights.
+
+        Iterates the snapshot taken at construction: this runs on the coordinator
+        thread, where traversing the live module tree races caller-side mutation.
+        """
+        for module in self._inference_grouped_mlp_modules:
+            module.refresh_inference_weights()
 
     def resume(self):
         """Resume engine by reallocating context's GPU state."""

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1163,6 +1163,8 @@ class InferenceGroupedMLP(TEGroupedMLP):
     - Inference + eager: torch.nn.functional.grouped_mm with GPU-resident cumsum offsets
     """
 
+    _serving_weights_canonical = False
+
     def __init__(
         self,
         num_local_experts: int,
@@ -1180,9 +1182,19 @@ class InferenceGroupedMLP(TEGroupedMLP):
             name=name,
         )
 
-        # Concatenated weights are built lazily on first forward to ensure
-        # checkpoint loading has already populated the per-expert parameters.
+        # Trainable models pack lazily after checkpoint loading.
         self._concatenated_weights_built = False
+
+        # Inference-only models share parameter and serving storage.
+        # MXFP8 retains high-precision parameters for refits.
+        self._serving_weights_canonical = config.inference_only and not (
+            config.fp8 and config.fp8_recipe == Fp8Recipe.mxfp8
+        )
+        if self._serving_weights_canonical and self.linear_fc1.weight0.device.type != 'meta':
+            # Pack in the caller's allocation region to support offloading and
+            # release the original expert storage before loading weights.
+            self._build_concatenated_weights()
+            self._concatenated_weights_built = True
 
         if HAVE_FLASHINFER:
             self._flashinfer_activation_type = self._resolve_flashinfer_activation_type()
@@ -1324,19 +1336,13 @@ class InferenceGroupedMLP(TEGroupedMLP):
         return True
 
     @torch.inference_mode(False)  # needed for non-colocated inference.
+    @torch.no_grad()
     def _build_concatenated_weights(self):
-        """Create big contiguous weight tensors that share storage with TE's per-expert parameters.
+        """Pack TE expert weights into serving buffers with stable CUDA-graph addresses.
 
-        Creates _fc1_weight and _fc2_weight as contiguous tensors of shape
-        [num_experts, out_features, in_features]. Instead of replacing TE's parameters
-        (which breaks TE's internal bookkeeping), we redirect each parameter's .data
-        to be a view into the contiguous buffer. The nn.Parameter objects themselves
-        remain untouched in TE's module, preserving FP8 scaling state, etc.
-
-        This allows:
-        - TE's forward to work correctly (same Parameter objects, same internal state)
-        - Training updates to flow through (param.data is a view into the big tensor)
-        - torch.nn.functional.grouped_mm / FlashInfer to use the big tensor directly
+        Trainable models retain optimizer/DDP-owned storage and copy on refresh.
+        Inference-only models alias parameters into the buffers, retaining one copy
+        without replacing TE's Parameter objects.
         """
         # Get device/dtype from existing TE weights
         device = self.linear_fc1.weight0.device
@@ -1349,23 +1355,71 @@ class InferenceGroupedMLP(TEGroupedMLP):
         _fc1_weight = torch.empty(self.num_local_experts, *fc1_shape, device=device, dtype=dtype)
         _fc2_weight = torch.empty(self.num_local_experts, *fc2_shape, device=device, dtype=dtype)
 
-        # Copy existing TE weights into big tensors, then point param.data to the views
-        for i in range(self.num_local_experts):
-            fc1_param = getattr(self.linear_fc1, f'weight{i}')
-            fc2_param = getattr(self.linear_fc2, f'weight{i}')
-
-            # Copy initialized data into contiguous buffer
-            _fc1_weight[i].copy_(fc1_param.data)
-            _fc2_weight[i].copy_(fc2_param.data)
-
-            # Redirect param.data to view into contiguous buffer.
-            # The nn.Parameter object stays the same — TE's internal state is preserved.
-            fc1_param.data = _fc1_weight[i]
-            fc2_param.data = _fc2_weight[i]
-
         # Register big tensors as non-persistent buffers (for .to() device movement, not saved)
         self.register_buffer('_fc1_weight', _fc1_weight, persistent=False)
         self.register_buffer('_fc2_weight', _fc2_weight, persistent=False)
+
+        if self._serving_weights_canonical:
+            self._attach_serving_views()
+        else:
+            # Preserve optimizer/DDP-owned parameter storage.
+            for i in range(self.num_local_experts):
+                _fc1_weight[i].copy_(getattr(self.linear_fc1, f'weight{i}'))
+                _fc2_weight[i].copy_(getattr(self.linear_fc2, f'weight{i}'))
+
+    @torch.no_grad()
+    def _attach_serving_views(self) -> bool:
+        """Copy detached parameters into the serving buffers and rebind them as views.
+
+        Returns:
+            Whether any parameter was reattached.
+        """
+        attached = False
+        for linear, serving_weight in (
+            (self.linear_fc1, self._fc1_weight),
+            (self.linear_fc2, self._fc2_weight),
+        ):
+            for i in range(self.num_local_experts):
+                param = getattr(linear, f'weight{i}')
+                serving_view = serving_weight[i]
+                if param.data.data_ptr() == serving_view.data_ptr():
+                    continue
+                serving_view.copy_(param)
+                param.data = serving_view
+                attached = True
+        return attached
+
+    @torch.inference_mode(False)  # needed for non-colocated inference.
+    @torch.no_grad()
+    def refresh_inference_weights(self) -> bool:
+        """Refresh serving weights in place, preserving CUDA-graph addresses.
+
+        Inference-only models reattach views detached by device/dtype conversion or
+        assigning checkpoint loads; already-attached parameters need no copy.
+
+        Returns:
+            Whether any weights were copied or parameter views reattached.
+        """
+        if not self._concatenated_weights_built:
+            return False
+
+        weight = self.linear_fc1.weight0
+        if isinstance(weight, MXFP8Tensor) or (
+            hasattr(weight, 'data') and isinstance(weight.data, MXFP8Tensor)
+        ):
+            return False
+
+        if self._serving_weights_canonical:
+            return self._attach_serving_views()
+
+        for linear, serving_weight in (
+            (self.linear_fc1, self._fc1_weight),
+            (self.linear_fc2, self._fc2_weight),
+        ):
+            for expert_idx in range(self.num_local_experts):
+                param = getattr(linear, f'weight{expert_idx}')
+                serving_weight[expert_idx].copy_(param)
+        return True
 
     def _flashinfer_forward(self, hidden_states, routing_map, probs):
         """FlashInfer fused MoE kernel for CUDA-graphed inference iterations."""

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1294,6 +1294,11 @@ class TransformerConfig(ModelParallelConfig):
     use_inference_optimized_layers: bool = False
     """If True, use inference optimized transformer layers during inference."""
 
+    inference_only: bool = False
+    """Guarantee this model is never DDP-wrapped or optimizer-owned.
+    Allows inference modules to share parameter and serving storage. This is a
+    lifetime ownership contract, not a transient eval()/inference mode."""
+
     inference_fuse_tp_communication: bool = False
     """ If true, uses a fused reduce-scatter-residual-norm-allgather kernel during inference. """
 

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -42,7 +42,10 @@ logger = logging.getLogger(__name__)
 
 
 def get_model_builder(
-    args: Namespace, provider: Optional[Literal["gpt", "hybrid", "mamba"]] = None
+    args: Namespace,
+    provider: Optional[Literal["gpt", "hybrid", "mamba"]] = None,
+    *,
+    inference_only: bool = False,
 ) -> ModelBuilder:
     """Construct a :class:`ModelBuilder` for the requested model provider.
 
@@ -57,6 +60,7 @@ def get_model_builder(
         provider: Optional override for the model provider name. Must be one of
             ``"gpt"``, ``"hybrid"``, or the deprecated ``"mamba"``. When omitted,
             falls back to ``args.model_provider`` (set by ``add_inference_args``).
+        inference_only: Whether the model will never be owned by DDP or an optimizer.
 
     Returns:
         A :class:`ModelBuilder` instance bound to a config derived from ``args``.
@@ -64,7 +68,9 @@ def get_model_builder(
     if provider is None:
         provider = args.model_provider
     if provider == "gpt":
-        return GPTModelBuilder(gpt_config_from_args(args))
+        config = gpt_config_from_args(args)
+        config.transformer.inference_only = inference_only
+        return GPTModelBuilder(config)
     if provider in ("hybrid", "mamba"):
         if provider == "mamba":
             warnings.warn(
@@ -72,7 +78,9 @@ def get_model_builder(
                 DeprecationWarning,
                 stacklevel=2,
             )
-        return HybridModelBuilder(hybrid_config_from_args(args))
+        config = hybrid_config_from_args(args)
+        config.transformer.inference_only = inference_only
+        return HybridModelBuilder(config)
     raise ValueError(f"Invalid model provider {provider}")
 
 
@@ -88,7 +96,7 @@ def get_model_for_inference() -> MegatronModule:
         # care of running the modelopt-checkpoint auto-detection side effect.
         model = _get_model(modelopt_gpt_hybrid_builder, wrap_with_ddp=False)
     else:
-        builder = get_model_builder(args)
+        builder = get_model_builder(args, inference_only=True)
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         model = builder.build_distributed_models(
             pg_collection=pg_collection, wrap_with_ddp=False

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -45,6 +45,7 @@ from torch.utils.tensorboard import SummaryWriter
 from wandb import wandb_run
 
 from megatron.core import mpu
+from megatron.core.distributed import DistributedDataParallel
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.inference.contexts.dynamic_context import HAVE_TORCH_MEMORY_SAVER
 from megatron.core.inference.inference_request import FinishedRequestRecord
@@ -2972,7 +2973,7 @@ def calculate_grpo_loss(
 @contextmanager
 def megatron_rl_inference_mode(
     model: list[LanguageModule],
-    optimizer: MegatronOptimizer,
+    optimizer: MegatronOptimizer | None,
     cuda_graph_impl: str,
     offload_optimizer_during_inference: bool,
     training_model: Optional[list[LanguageModule]] = None,
@@ -2981,7 +2982,7 @@ def megatron_rl_inference_mode(
 
     Args:
         model: model to prepare for inference (may be separate inference model).
-        optimizer: optimizer used to train the model.
+        optimizer: optimizer used to train the model, or None for optimizer-free inference.
         cuda_graph_impl: which cuda graph implementation to use.
         offload_optimizer_during_inference: move optimizer to cpu during inference or not.
         training_model: training model (if separate from inference model). Used to offload
@@ -3018,6 +3019,17 @@ def megatron_rl_inference_mode(
     model_core = unwrap_model(model[0])
     with nvtx_range("rl/prefetch-weights-to-gpu", time=True):
         _maybe_prefetch_separate_inference_model_weights(model_core, to_cpu=False)
+    if training_model is None and optimizer is not None:
+        # Gather canonical parameters before the engine refreshes serving buffers.
+        with torch.no_grad(), nvtx_range("rl/synchronize-inference-parameters", time=True):
+            optimizer.prepare_model_params_for_param_sync()
+            for model_chunk in model:
+                # Ordinary DDP already has complete parameters.
+                if (
+                    isinstance(model_chunk, DistributedDataParallel)
+                    and model_chunk.ddp_config.param_sync_via_bucket_group
+                ):
+                    model_chunk.start_param_sync(force_sync=True)
 
     rotary_module = getattr(lang_module, "rotary_pos_emb", None)
     # Vanilla RotaryEmbedding module has lru_cache decorator which breaks RL training

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1898,6 +1898,8 @@ def pretrain(
 
             # Build an isolated inference config so training config remains unchanged
             inference_config = copy.deepcopy(model_cfg)
+            # This separate model is never DDP-wrapped or optimizer-owned.
+            inference_config.inference_only = True
             if args.rl_inference_tensor_model_parallel_size is not None:
                 inference_config.tensor_model_parallel_size = args.rl_inference_tensor_model_parallel_size
             if args.rl_inference_pipeline_model_parallel_size is not None:

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -997,6 +997,10 @@ def test_post_process_eviction_requeues_prefix_cached_request_with_fresh_hashes(
     ],
 )
 def test_init_refreshes_inference_only_experts_before_first_capture(conversion, device):
+    if device == "cuda":
+        # PyTorch caches the capture stream on the first device used.
+        torch.cuda.set_device(Utils.local_rank)
+
     config = TransformerConfig(
         num_layers=1,
         hidden_size=4,

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -69,6 +69,7 @@ from megatron.core.ssm.gated_delta_net import HAVE_FLA
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.cuda_graphs import delete_cuda_graphs
 from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope
+from megatron.core.transformer.moe.experts import InferenceGroupedMLP, TEGroupedMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_fa_min_version, is_te_min_version
 from tests.unit_tests.inference.engines.ssm_test_helpers import (
@@ -985,6 +986,198 @@ def test_post_process_eviction_requeues_prefix_cached_request_with_fresh_hashes(
     _assert_prefix_cache_checkpoint(request, engine.get_request(request.request_id))
 
 
+@pytest.mark.parametrize(
+    "conversion,device",
+    [
+        ("dtype", "cpu"),
+        ("dtype", "cuda"),
+        ("device", "cuda"),
+        ("assign", "cpu"),
+        ("assign", "cuda"),
+    ],
+)
+def test_init_refreshes_inference_only_experts_before_first_capture(conversion, device):
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=4,
+        num_attention_heads=1,
+        activation_func=squared_relu,
+        inference_only=True,
+    )
+
+    def init_te_weights(module, num_local_experts, config, **kwargs):
+        # Stub only TE setup; packing, conversion, and checkpoint loading stay real.
+        torch.nn.Module.__init__(module)
+        module.config = config
+        module.num_local_experts = num_local_experts
+        initial_device = "cpu" if conversion == "device" else device
+        for name in ("linear_fc1", "linear_fc2"):
+            linear = torch.nn.Module()
+            for idx in range(num_local_experts):
+                linear.register_parameter(
+                    f"weight{idx}", torch.nn.Parameter(torch.ones(2, 3, device=initial_device))
+                )
+            setattr(module, name, linear)
+
+    with mock.patch.object(TEGroupedMLP, "__init__", init_te_weights):
+        experts = InferenceGroupedMLP(2, config, submodules=None)
+    assert experts._concatenated_weights_built
+    assert experts.linear_fc1.weight0.data_ptr() == experts._fc1_weight[0].data_ptr()
+    model = torch.nn.Sequential(experts)
+    model.config = config
+    if conversion == "dtype":
+        model.double()
+    elif conversion == "device":
+        model.cuda()
+    else:
+        model.load_state_dict(
+            {name: tensor.clone() for name, tensor in model.state_dict().items()}, assign=True
+        )
+    with torch.no_grad():
+        for param in model.parameters():
+            param.fill_(7)
+    assert experts.linear_fc1.weight0.data_ptr() != experts._fc1_weight[0].data_ptr()
+    torch.testing.assert_close(experts._fc1_weight, torch.ones_like(experts._fc1_weight))
+    serving_ptrs = (experts._fc1_weight.data_ptr(), experts._fc2_weight.data_ptr())
+
+    context = mock.Mock(
+        spec=DynamicInferenceContext,
+        config=InferenceConfig(
+            pg_collection=mock.sentinel.pg, async_sched_mode=AsyncScheduleMode.LEGACY
+        ),
+        max_sequence_length=16,
+    )
+    controller = mock.Mock(
+        spec=TextGenerationController,
+        inference_wrapped_model=types.SimpleNamespace(model=model),
+        _async_sched_logits=mock.Mock(),
+    )
+    graph = None
+    serving_sum = None
+
+    def check_weights_before_capture():
+        nonlocal graph, serving_sum
+        for linear, serving in (
+            (experts.linear_fc1, experts._fc1_weight),
+            (experts.linear_fc2, experts._fc2_weight),
+        ):
+            torch.testing.assert_close(serving, torch.full_like(serving, 7))
+            for idx in range(experts.num_local_experts):
+                assert getattr(linear, f"weight{idx}").data_ptr() == serving[idx].data_ptr()
+        assert (experts._fc1_weight.data_ptr(), experts._fc2_weight.data_ptr()) == serving_ptrs
+        if device == "cuda":
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                serving_sum = experts._fc1_weight.sum() + experts._fc2_weight.sum()
+
+    with (
+        mock.patch.object(torch.distributed, "get_rank", return_value=0),
+        mock.patch.object(torch.cuda, "Event") if device == "cpu" else nullcontext(),
+        mock.patch.object(InferenceMode, "set_active"),
+        mock.patch.object(
+            DynamicInferenceEngine, "create_cuda_graphs", side_effect=check_weights_before_capture
+        ) as capture,
+    ):
+        engine = DynamicInferenceEngine(controller, context)
+    capture.assert_called_once()
+    assert engine.state == EngineState.RUNNING
+    assert not experts.refresh_inference_weights()
+    # Subsequent in-place refits remain visible to the first captured graph.
+    with torch.no_grad():
+        for param in model.parameters():
+            param.fill_(9)
+    if graph is not None:
+        graph.replay()
+        torch.testing.assert_close(
+            serving_sum, experts._fc1_weight.sum() + experts._fc2_weight.sum()
+        )
+
+
+@pytest.mark.parametrize("wrapped_model", [False, True])
+def test_resume_refreshes_expert_weights_before_context_and_graphs(wrapped_model):
+    experts = InferenceGroupedMLP.__new__(InferenceGroupedMLP)
+    torch.nn.Module.__init__(experts)
+    experts.num_local_experts = 2
+    experts._concatenated_weights_built = False
+    for linear_name in ('linear_fc1', 'linear_fc2'):
+        linear = torch.nn.Module()
+        for idx in range(experts.num_local_experts):
+            linear.register_parameter(f'weight{idx}', torch.nn.Parameter(torch.ones(2, 3)))
+        setattr(experts, linear_name, linear)
+    experts._build_concatenated_weights()
+    experts._concatenated_weights_built = True
+    serving_ptrs = (experts._fc1_weight.data_ptr(), experts._fc2_weight.data_ptr())
+    parameter_ptrs = [param.data_ptr() for param in experts.parameters()]
+    with torch.no_grad():
+        for param in experts.parameters():
+            param.fill_(7)
+
+    model = torch.nn.Sequential(experts)
+    if wrapped_model:
+        wrapper = torch.nn.Module()
+        wrapper.module = model
+        model = wrapper
+    engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
+    engine.controller = types.SimpleNamespace(
+        inference_wrapped_model=types.SimpleNamespace(model=model)
+    )
+    engine.state = EngineState.SUSPENDED
+    engine._weight_epoch = 0
+    engine.unified_memory_level = 0
+    engine.use_coordinator = True
+    engine.requests = {}
+    engine.resume_request_ids = []
+    events = []
+    refresh_weights = experts.refresh_inference_weights
+
+    def refresh():
+        assert engine._weight_epoch == 1
+        events.append('refresh')
+        return refresh_weights()
+
+    def check_weights(event):
+        events.append(event)
+        torch.testing.assert_close(experts._fc1_weight, torch.full((2, 2, 3), 7.0))
+        torch.testing.assert_close(experts._fc2_weight, torch.full((2, 2, 3), 7.0))
+        assert (experts._fc1_weight.data_ptr(), experts._fc2_weight.data_ptr()) == serving_ptrs
+        assert [param.data_ptr() for param in experts.parameters()] == parameter_ptrs
+
+    engine.context = types.SimpleNamespace(
+        reinitialize_inference_state_buffers=lambda: check_weights('context'),
+        kv_cache_management_mode=KVCacheManagementMode.RECOMPUTE,
+        static_kv_memory_pointers=False,
+        chunked_prefill_request_id=-1,
+    )
+    engine.create_cuda_graphs = lambda: check_weights('graphs')
+    with (
+        mock.patch.object(experts, 'refresh_inference_weights', side_effect=refresh),
+        mock.patch.object(DynamicInferenceEngine, 'suspend_resume_ctx', return_value=nullcontext()),
+        mock.patch.object(InferenceMode, 'set_active'),
+        mock.patch.object(torch.cuda, 'synchronize'),
+    ):
+        engine.resume()
+
+    assert events == ['refresh', 'context', 'graphs']
+
+
+@pytest.mark.parametrize("has_experts", [False, True])
+def test_refresh_inference_weights_skips_unmaterialized_buffers(has_experts):
+    model = torch.nn.Sequential()
+    if has_experts:
+        experts = InferenceGroupedMLP.__new__(InferenceGroupedMLP)
+        torch.nn.Module.__init__(experts)
+        experts._concatenated_weights_built = False
+        model.append(experts)
+    engine = DynamicInferenceEngine.__new__(DynamicInferenceEngine)
+    engine.controller = types.SimpleNamespace(
+        inference_wrapped_model=types.SimpleNamespace(model=model)
+    )
+
+    engine._refresh_inference_grouped_mlp_weights()
+
+    assert list(model.buffers()) == []
+
+
 def test_recompute_suspend_resume_readds_prefix_cached_request_with_fresh_hashes():
     """RECOMPUTE suspend/resume must re-add the prefix-enabled checkpoint tail."""
     request = _make_prefix_cached_request_for_checkpoint(request_id=23)
@@ -999,7 +1192,10 @@ def test_recompute_suspend_resume_readds_prefix_cached_request_with_fresh_hashes
     )
     engine.requests = {request.request_id: types.SimpleNamespace(record=record)}
     engine.waiting_request_ids = deque()
-    engine.controller = types.SimpleNamespace(_async_sched_logits=mock.Mock())
+    engine.controller = types.SimpleNamespace(
+        _async_sched_logits=mock.Mock(),
+        inference_wrapped_model=types.SimpleNamespace(model=torch.nn.Sequential()),
+    )
     engine.state = EngineState.RUNNING
     engine.unified_memory_level = 0
     engine.use_coordinator = False

--- a/tests/unit_tests/inference/test_model_building_utils.py
+++ b/tests/unit_tests/inference/test_model_building_utils.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.inference import utils
+
+
+@pytest.mark.parametrize("provider", ["gpt", "hybrid"])
+@pytest.mark.parametrize("inference_only", [False, True])
+def test_get_model_builder_sets_expert_storage_ownership(provider, inference_only):
+    config = SimpleNamespace(transformer=SimpleNamespace(inference_only=False))
+    builder_name = "GPTModelBuilder" if provider == "gpt" else "HybridModelBuilder"
+    with (
+        mock.patch.object(utils, f"{provider}_config_from_args", return_value=config),
+        mock.patch.object(utils, builder_name) as builder,
+    ):
+        utils.get_model_builder(
+            SimpleNamespace(model_provider=provider), inference_only=inference_only
+        )
+
+    builder.assert_called_once_with(config)
+    assert config.transformer.inference_only is inference_only
+
+
+def test_get_model_for_inference_opts_into_single_copy_expert_storage():
+    args = SimpleNamespace(
+        load="checkpoint",
+        inference_ckpt_non_strict=False,
+        transformer_impl="inference_optimized",
+        fp8_recipe=None,
+    )
+    model = torch.nn.Linear(2, 2)
+    builder = mock.Mock()
+    builder.build_distributed_models.return_value = [model]
+    with (
+        mock.patch.object(utils, "get_args", return_value=args),
+        mock.patch.object(utils, "HAS_NVIDIA_MODELOPT", False),
+        mock.patch.object(utils, "get_model_builder", return_value=builder) as get_builder,
+        mock.patch.object(
+            utils.ProcessGroupCollection, "use_mpu_process_groups", return_value=mock.sentinel.pg
+        ),
+        mock.patch.object(utils, "load_checkpoint"),
+    ):
+        assert utils.get_model_for_inference() is model
+
+    get_builder.assert_called_once_with(args, inference_only=True)
+    builder.build_distributed_models.assert_called_once_with(
+        pg_collection=mock.sentinel.pg, wrap_with_ddp=False
+    )
+    assert not model.training

--- a/tests/unit_tests/inference/test_wandb_logging.py
+++ b/tests/unit_tests/inference/test_wandb_logging.py
@@ -219,7 +219,7 @@ class TestInferenceWandbLogging:
         mock_controller._async_sched_logits = Mock()
         # Set up nested mock structure
         mock_controller.inference_wrapped_model = Mock()
-        mock_controller.inference_wrapped_model.model = Mock()
+        mock_controller.inference_wrapped_model.model = torch.nn.Module()
         mock_controller.inference_wrapped_model.model.config = Mock()
         mock_controller.inference_wrapped_model.model.config.cuda_graph_impl = "none"
         mock_controller.inference_wrapped_model.model.config.moe_enable_routing_replay = False
@@ -275,7 +275,7 @@ class TestInferenceWandbLogging:
         mock_controller._async_sched_logits = Mock()
         # Set up nested mock structure
         mock_controller.inference_wrapped_model = Mock()
-        mock_controller.inference_wrapped_model.model = Mock()
+        mock_controller.inference_wrapped_model.model = torch.nn.Module()
         mock_controller.inference_wrapped_model.model.config = Mock()
         mock_controller.inference_wrapped_model.model.config.cuda_graph_impl = "none"
         mock_controller.inference_wrapped_model.model.config.moe_enable_routing_replay = False

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -162,6 +162,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "hierarchical_context_parallel_sizes": None,
     "high_priority_a2a_comm_stream": False,
     "inference_fuse_tp_communication": False,
+    "inference_only": False,
     "inference_rng_tracker": False,
     "inference_sampling_seed": 42,
     "init_method": {},

--- a/tests/unit_tests/rl/test_rl_utils.py
+++ b/tests/unit_tests/rl/test_rl_utils.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.distributed.param_and_grad_buffer import _ParamAndGradBucketGroup
 from megatron.core.enums import ModelType
 from megatron.core.inference.inference_request import FinishedRequestRecord
 from megatron.core.models.common.language_module.language_module import LanguageModule
@@ -500,8 +501,13 @@ class TestRLUtils:
         [pytest.param(True, id="shared-config"), pytest.param(False, id="distinct-config")],
     )
     @pytest.mark.parametrize("num_experts", [None, 8], ids=["dense", "moe"])
+    @pytest.mark.parametrize("separate_model", [False, True], ids=["colocated", "separate"])
+    @pytest.mark.parametrize(
+        "optimizer_mode",
+        ["none", "replicated", "distributed", "layerwise_overlap", "layerwise_mxfp8", "unwrapped"],
+    )
     def test_megatron_rl_inference_mode_restores_training_cuda_graph_state(
-        self, monkeypatch, share_config, num_experts
+        self, monkeypatch, share_config, num_experts, separate_model, optimizer_mode
     ):
         config = SimpleNamespace(
             cuda_graph_impl="none",
@@ -518,7 +524,50 @@ class TestRLUtils:
             )
         )
         lang_module = DummyLangModule(layer_config)
-        model = [SimpleNamespace(config=config, module=lang_module)]
+        events = []
+        needs_param_sync = optimizer_mode in {"distributed", "layerwise_overlap", "layerwise_mxfp8"}
+        param_sync = None
+        if optimizer_mode in {"none", "unwrapped"}:
+            # Optimizer-free and non-DDP models need not expose start_param_sync.
+            model_chunk = SimpleNamespace(config=config, module=lang_module)
+        else:
+            ddp_config = DistributedDataParallelConfig(
+                use_distributed_optimizer=optimizer_mode == "distributed",
+                overlap_param_gather=optimizer_mode == "layerwise_overlap",
+                reuse_grad_buf_for_mxfp8_param_ag=optimizer_mode == "layerwise_mxfp8",
+                fp8_param_gather=optimizer_mode == "layerwise_mxfp8",
+            )
+            # Exercise the real DDP/bucket-group entry points without allocating
+            # distributed buffers. A pending gather completes through force_sync.
+            bucket_group = _ParamAndGradBucketGroup.__new__(_ParamAndGradBucketGroup)
+            bucket_group.ddp_config = ddp_config
+            bucket_group.param_gather_handle = MagicMock()
+            bucket_group._post_param_sync = MagicMock()
+            model_chunk = DistributedDataParallel.__new__(DistributedDataParallel)
+            torch.nn.Module.__init__(model_chunk)
+            model_chunk.config = config
+            model_chunk.module = lang_module
+            model_chunk.ddp_config = ddp_config
+            model_chunk.bucket_groups = [bucket_group]
+            model_chunk.expert_parallel_bucket_groups = []
+            if not needs_param_sync:
+                # Establish the failure that an unconditional gather would cause.
+                with pytest.raises(AssertionError):
+                    model_chunk.start_param_sync(force_sync=True)
+            start_param_sync = model_chunk.start_param_sync
+
+            def sync(**kwargs):
+                events.append("param-sync")
+                start_param_sync(**kwargs)
+
+            param_sync = MagicMock(side_effect=sync)
+            model_chunk.start_param_sync = param_sync
+        model = [model_chunk]
+        optimizer = None if optimizer_mode == "none" else MagicMock()
+        if optimizer is not None:
+            optimizer.prepare_model_params_for_param_sync.side_effect = lambda: events.append(
+                "prepare"
+            )
         args = SimpleNamespace(
             rl_training_cuda_graphs=False,
             num_experts=num_experts,
@@ -528,15 +577,36 @@ class TestRLUtils:
             inference_cuda_graph_scope=InferenceCudaGraphScope.block,
         )
         interface, _ = self._patch_rl_inference_mode_deps(monkeypatch, args)
+        interface.resume.side_effect = lambda **_: events.append("resume")
         toggle_cuda_graphs = self._make_toggle_cuda_graphs_mock()
         monkeypatch.setattr(rl_utils, "toggle_cuda_graphs", toggle_cuda_graphs)
 
-        with rl_utils.megatron_rl_inference_mode(model, MagicMock(), "local", False) as result:
+        with rl_utils.megatron_rl_inference_mode(
+            model, optimizer, "local", False, training_model=model if separate_model else None
+        ) as result:
             assert result is interface
             for current_config in (config, layer_config):
                 assert current_config.cuda_graph_impl == "local"
                 assert current_config.cuda_graph_modules == []
                 assert current_config.inference_cuda_graph_scope == InferenceCudaGraphScope.block
+
+        should_prepare = not separate_model and optimizer is not None
+        should_sync = should_prepare and needs_param_sync
+        assert events == (
+            (["prepare"] if should_prepare else [])
+            + (["param-sync"] if should_sync else [])
+            + ["resume"]
+        )
+        if optimizer is not None:
+            if should_prepare:
+                optimizer.prepare_model_params_for_param_sync.assert_called_once_with()
+            else:
+                optimizer.prepare_model_params_for_param_sync.assert_not_called()
+        if param_sync is not None:
+            if should_sync:
+                param_sync.assert_called_once_with(force_sync=True)
+            else:
+                param_sync.assert_not_called()
 
         assert toggle_cuda_graphs.call_args_list == [
             call(lang_module, "local"),

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -163,9 +163,7 @@ def test_inference_only_grouped_mlp_retains_single_copy_of_expert_weights(device
 
     # In-place refit writes land in the serving buffers without a refresh.
     module.linear_fc1.weight0.data.fill_(33)
-    torch.testing.assert_close(
-        module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 33.0)
-    )
+    torch.testing.assert_close(module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 33.0))
 
     # Steady state: nothing to refresh, serving addresses unchanged.
     serving_ptrs = (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr())
@@ -193,12 +191,8 @@ def test_inference_only_grouped_mlp_reattaches_detached_parameters_on_refresh(de
 
     # Values landed at the original serving addresses; parameters are views again.
     assert (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr()) == serving_ptrs
-    torch.testing.assert_close(
-        module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 44.0)
-    )
-    torch.testing.assert_close(
-        module._fc2_weight[1], torch.full_like(module._fc2_weight[1], 55.0)
-    )
+    torch.testing.assert_close(module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 44.0))
+    torch.testing.assert_close(module._fc2_weight[1], torch.full_like(module._fc2_weight[1], 55.0))
     assert module.linear_fc1.weight0.data_ptr() == module._fc1_weight[0].data_ptr()
     assert module.linear_fc2.weight1.data_ptr() == module._fc2_weight[1].data_ptr()
     if device == "cuda":

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -16,7 +16,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.transformer.module import Float16Module
-from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.experts import InferenceGroupedMLP, TEGroupedMLP
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -92,6 +92,118 @@ def test_remove_glu_interleaving_restores_contiguous_gate_and_linear_halves():
     output = TEGroupedMLP._remove_glu_interleaving(interleaved, interleave_size=2)
 
     torch.testing.assert_close(output, expected)
+
+
+def _make_inference_grouped_mlp_skeleton(device, serving_weights_canonical=False):
+    module = InferenceGroupedMLP.__new__(InferenceGroupedMLP)
+    torch.nn.Module.__init__(module)
+    module.num_local_experts = 2
+    module._concatenated_weights_built = False
+    module._serving_weights_canonical = serving_weights_canonical
+
+    for linear_name, shape in (('linear_fc1', (4, 3)), ('linear_fc2', (3, 2))):
+        linear = torch.nn.Module()
+        for expert_idx in range(module.num_local_experts):
+            linear.register_parameter(
+                f'weight{expert_idx}',
+                torch.nn.Parameter(torch.full(shape, float(expert_idx + 1), device=device)),
+            )
+        setattr(module, linear_name, linear)
+    return module
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_inference_grouped_mlp_refreshes_serving_weights_without_redirecting_parameters(device):
+    module = _make_inference_grouped_mlp_skeleton(device)
+
+    parameter_ptrs = {name: param.data_ptr() for name, param in module.named_parameters()}
+    module._build_concatenated_weights()
+    module._concatenated_weights_built = True
+    serving_ptrs = (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr())
+
+    assert {name: param.data_ptr() for name, param in module.named_parameters()} == parameter_ptrs
+    assert module._fc1_weight.data_ptr() not in parameter_ptrs.values()
+    assert module._fc2_weight.data_ptr() not in parameter_ptrs.values()
+
+    if device == "cuda":
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            serving_sum = module._fc1_weight.sum() + module._fc2_weight.sum()
+
+    module.linear_fc1.weight0.data.fill_(11)
+    module.linear_fc2.weight1.data.fill_(22)
+
+    assert module.refresh_inference_weights()
+    assert (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr()) == serving_ptrs
+    torch.testing.assert_close(module._fc1_weight[0], module.linear_fc1.weight0)
+    torch.testing.assert_close(module._fc2_weight[1], module.linear_fc2.weight1)
+    if device == "cuda":
+        graph.replay()
+        torch.testing.assert_close(serving_sum, module._fc1_weight.sum() + module._fc2_weight.sum())
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_inference_only_grouped_mlp_retains_single_copy_of_expert_weights(device):
+    module = _make_inference_grouped_mlp_skeleton(device, serving_weights_canonical=True)
+
+    module._build_concatenated_weights()
+    module._concatenated_weights_built = True
+
+    # Every parameter is a view into the packed serving buffers: one retained copy.
+    for linear, serving_weight in (
+        (module.linear_fc1, module._fc1_weight),
+        (module.linear_fc2, module._fc2_weight),
+    ):
+        for expert_idx in range(module.num_local_experts):
+            param = getattr(linear, f'weight{expert_idx}')
+            assert param.data_ptr() == serving_weight[expert_idx].data_ptr()
+            torch.testing.assert_close(
+                serving_weight[expert_idx], torch.full_like(param, float(expert_idx + 1))
+            )
+
+    # In-place refit writes land in the serving buffers without a refresh.
+    module.linear_fc1.weight0.data.fill_(33)
+    torch.testing.assert_close(
+        module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 33.0)
+    )
+
+    # Steady state: nothing to refresh, serving addresses unchanged.
+    serving_ptrs = (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr())
+    assert not module.refresh_inference_weights()
+    assert (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr()) == serving_ptrs
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_inference_only_grouped_mlp_reattaches_detached_parameters_on_refresh(device):
+    module = _make_inference_grouped_mlp_skeleton(device, serving_weights_canonical=True)
+    module._build_concatenated_weights()
+    module._concatenated_weights_built = True
+    serving_ptrs = (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr())
+
+    if device == "cuda":
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            serving_sum = module._fc1_weight.sum() + module._fc2_weight.sum()
+
+    # Detach parameter storage without moving the captured serving buffers.
+    module.linear_fc1.weight0.data = torch.full_like(module.linear_fc1.weight0, 44.0)
+    module.linear_fc2.weight1.data = torch.full_like(module.linear_fc2.weight1, 55.0)
+
+    assert module.refresh_inference_weights()
+
+    # Values landed at the original serving addresses; parameters are views again.
+    assert (module._fc1_weight.data_ptr(), module._fc2_weight.data_ptr()) == serving_ptrs
+    torch.testing.assert_close(
+        module._fc1_weight[0], torch.full_like(module._fc1_weight[0], 44.0)
+    )
+    torch.testing.assert_close(
+        module._fc2_weight[1], torch.full_like(module._fc2_weight[1], 55.0)
+    )
+    assert module.linear_fc1.weight0.data_ptr() == module._fc1_weight[0].data_ptr()
+    assert module.linear_fc2.weight1.data_ptr() == module._fc2_weight[1].data_ptr()
+    if device == "cuda":
+        graph.replay()
+        torch.testing.assert_close(serving_sum, module._fc1_weight.sum() + module._fc2_weight.sum())
 
 
 def test_make_fused_ops_reuses_grouped_linear_weights_on_meta_device(monkeypatch):


### PR DESCRIPTION
Keep TE expert parameters attached to optimizer/DDP-owned storage and
refresh packed serving buffers in place before inference. Synchronize
parameters before engine resume.

Allow explicitly inference-only models to retain one expert-weight copy
by making packed buffers canonical and keeping TE parameters as views.
Pack inside the caller's allocation region and repair aliases detached
by conversion or assigning checkpoint loads before first graph capture.
Keep MXFP8 high-precision refit parameters separate.

- [x] I, the PR author, have personally reviewed every line of this PR.

### Notes
- [this wandb report ](https://wandb.ai/adlr/nano-v3-megatron-inference/reports/BUG-stale-expert-weights-PR-6931---VmlldzoxNzgxOTg4MQ)has RL runs with both buggy and fixed code