### PR TITLE
Exclude cuBLAS workspaces from the MFSDP peak-memory bound

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -154,7 +154,10 @@ def test_training_step_peak_memory_bounds_full_size_buffers(
         model(x).float().sum().backward()
         optimizer.step()
 
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+    # Warm up so cuBLAS's workspaces land in resting_allocated rather than in peak_delta,
+    # which would otherwise depend on whether an earlier test already allocated them.
+    train_step()
+
     resting_allocated = torch.cuda.memory_allocated(device)
     torch.cuda.reset_peak_memory_stats(device)
     train_step()
@@ -164,15 +167,16 @@ def test_training_step_peak_memory_bounds_full_size_buffers(
     # child also has a full wgrad until it is copied into a full reduce-scatter input.
     # With separate streams, their allocation cannot reuse the released full-weight
     # storage, for a four-buffer peak. With a unified stream, the release precedes the
-    # allocation on that stream, reducing the peak to three. Allow one additional buffer
-    # for cuBLAS workspace, allocator granularity, and small temporaries.
-    full_buffer_bound = 4 if unify_communication_stream else 5
-    bound_nbytes = full_buffer_bound * child_weight_nbytes
+    # allocation on that stream, reducing the peak to three. The slack on top covers
+    # allocator granularity and small temporaries, measured at ~169 KiB.
+    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+    full_buffer_bound = 3 if unify_communication_stream else 4
+    bound_nbytes = full_buffer_bound * child_weight_nbytes + 1024**2
 
     assert peak_delta < bound_nbytes, (
         "FSDP training-step peak memory exceeded the full-size-buffer bound: "
         f"rank={rank}, peak_delta={_mb(peak_delta)}, "
-        f"{full_buffer_bound}_full_child_buffers={_mb(bound_nbytes)}"
+        f"bound={_mb(bound_nbytes)} ({full_buffer_bound} full child buffers + 1.00 MB)"
     )
 
 


### PR DESCRIPTION
`test_training_step_peak_memory_bounds_full_size_buffers[separate_streams]` fails when `test_memory.py` is the first file in a pytest process:

```
peak_delta=160.17 MB, 5_full_child_buffers=160.00 MB
```

cuBLAS allocates its classic and Lt workspaces on first use and keeps them — 32 MiB each on sm90, a full child buffer apiece. Allocated inside the measured step, they inflate the delta. Run any other test file first and it passes, since they are already resting by then. `run_ci_test.sh` runs the whole `mfsdp_v2` bucket in one pytest process, which is why CI has never seen it. Not a regression either: it reproduces back to `54c7918b9`, the commit that added the file.

## Fix

Run one step before measuring, so the workspaces land in `resting_allocated` and drop out of `peak_delta`. This hides none of FSDP's own memory — clearing both workspaces after a step returns allocation exactly to its pre-warmup value.

With them excluded the peak is 3 child buffers + 169 KiB, reproducible to the byte, so the bounds tighten from 5/4 buffers to 4/3 buffers + 1 MiB. That takes `unified_stream` from ~32 MiB of headroom to 855 KiB.

## Verification

H100, 4 ranks:

| run | main | this PR |
|---|---|---|
| file alone | 1 failed, 9 passed | **10 passed** |
| after another file | 10 passed | **15 passed** |