### PR TITLE
Add HybridModel architecture guidance

### DIFF
--- a/megatron/core/models/hybrid/AGENTS.md
+++ b/megatron/core/models/hybrid/AGENTS.md
@@ -1,0 +1,5 @@
+For new or modified code, keep files directly under this directory generic and
+independent of any particular layer implementation. Put layer-specific behavior in
+`hybrid/layers/` or with the owning layer's code. Top-level files should contain shared
+`HybridModel` orchestration and only the minimal registration or dispatch needed to
+compose layers.

--- a/megatron/core/models/hybrid/AGENTS.md
+++ b/megatron/core/models/hybrid/AGENTS.md
@@ -2,4 +2,6 @@ For new or modified code, keep files directly under this directory generic and
 independent of any particular layer implementation. Put layer-specific behavior in
 `layers/` or with the owning layer's code. Top-level files should contain shared
 `HybridModel` orchestration and only the minimal registration or dispatch needed to
-compose layers.
+compose layers. Keep parallelization logic in this directory similarly minimal; place
+it in the appropriate parallelism package and retain only the integration needed by
+`HybridModel`.

--- a/megatron/core/models/hybrid/AGENTS.md
+++ b/megatron/core/models/hybrid/AGENTS.md
@@ -1,5 +1,5 @@
 For new or modified code, keep files directly under this directory generic and
 independent of any particular layer implementation. Put layer-specific behavior in
-`hybrid/layers/` or with the owning layer's code. Top-level files should contain shared
+`layers/` or with the owning layer's code. Top-level files should contain shared
 `HybridModel` orchestration and only the minimal registration or dispatch needed to
 compose layers.

--- a/megatron/core/models/hybrid/CLAUDE.md
+++ b/megatron/core/models/hybrid/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Better guide agents when they modify or add features to HybridModel.

Agents performed noticeably better on a "Balanced-hash MoE routing" task with the AGENTS.md vs without it.