### PR TITLE
Fix DSA sparse attention backward empty rows

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -127,6 +127,7 @@ def _run_sparse_attention(
     varlen_ends: Optional[torch.Tensor],
     key_positions: Optional[torch.Tensor],
     topk_length: Optional[torch.Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> torch.Tensor:
     """Run sparse attention for absorbed and non-absorbed MLA paths."""
     if absorbed_mla:
@@ -154,6 +155,7 @@ def _run_sparse_attention(
                 softmax_scale,
                 latent_v_channels,
                 topk_length=topk_length,
+                all_topk_rows_nonempty=all_topk_rows_nonempty,
             )
         # Fused backends may decline unsupported shapes or layouts by returning
         # None, so keep the absorbed PyTorch path as the authoritative fallback.
@@ -184,6 +186,36 @@ def _run_sparse_attention(
         varlen_starts=varlen_starts,
         varlen_ends=varlen_ends,
         key_positions=key_positions,
+    )
+
+
+def _can_prove_all_topk_rows_nonempty(
+    *,
+    computes_topk: bool,
+    indexer_topk: int,
+    kv_sequence_length: int,
+    attention_mask: Optional[torch.Tensor],
+    query_valid_rows: Optional[torch.Tensor],
+    varlen_is_plain_causal: bool,
+    use_local_indexer_varlen: bool,
+    varlen_starts: Optional[torch.Tensor],
+    varlen_ends: Optional[torch.Tensor],
+    key_positions: Optional[torch.Tensor],
+) -> bool:
+    """Return a host-side certificate that every query row has at least one selected key."""
+    if (
+        not computes_topk
+        or indexer_topk <= 0
+        or kv_sequence_length <= 0
+        or attention_mask is not None
+        or query_valid_rows is not None
+    ):
+        return False
+    return varlen_is_plain_causal or (
+        use_local_indexer_varlen
+        and varlen_starts is not None
+        and varlen_ends is not None
+        and key_positions is None
     )
 
 
@@ -2319,6 +2351,18 @@ class DSAttention(MegatronModule):
         # ===================================
         # Run sparse attention kernel
         # ===================================
+        all_topk_rows_nonempty = _can_prove_all_topk_rows_nonempty(
+            computes_topk=computes_topk,
+            indexer_topk=self.index_topk,
+            kv_sequence_length=skv,
+            attention_mask=attention_mask,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            use_local_indexer_varlen=use_local_indexer_varlen,
+            varlen_starts=varlen_starts,
+            varlen_ends=varlen_ends,
+            key_positions=key_positions,
+        )
         output = _run_sparse_attention(
             absorbed_mla=absorbed_mla,
             query=query,
@@ -2333,6 +2377,7 @@ class DSAttention(MegatronModule):
             varlen_starts=varlen_starts,
             varlen_ends=varlen_ends,
             key_positions=key_positions,
+            all_topk_rows_nonempty=all_topk_rows_nonempty,
         )
 
         if use_indexer_loss:

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -219,6 +219,8 @@ def run_fused_dsa_attention(
         not absorbed_mla
         or value is not None
         or attn_mask_type != AttnMaskType.causal
+        or indexer_topk <= 0
+        or key.size(0) == 0
         or key.size(2) != 1
     ):
         return None
@@ -2009,9 +2011,9 @@ def _run_sparse_attention_backward(
     d: int,
     skv: int,
     grad_output: Tensor,
-    all_rows_nonempty: bool = False,
+    all_topk_rows_nonempty: bool = False,
 ) -> Tuple[Tensor, Tensor]:
-    """Run sparse attention backward, skipping rows that have no valid top-k entries."""
+    """Run sparse attention backward with fixed-shape handling for empty top-k rows."""
     d_v = out_flat.shape[-1]
     dO_flat = grad_output.reshape(sq * b, num_heads, d_v)
 
@@ -2040,56 +2042,29 @@ def _run_sparse_attention_backward(
         bwd_attn_sink[:num_heads] = attn_sink
 
     _ensure_dsa_namespace()
-    if all_rows_nonempty:
-        attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-            bwd_q_flat,
-            kv_flat,
-            bwd_out_flat,
-            bwd_dO_flat,
-            bwd_lse,
-            bwd_attn_sink,
-            global_idxs,
-            softmax_scale=softmax_scale,
-            topk_length=topk_length,
-        )
-        grad_query_flat = attn_bwd["dq"]
-        if padded_num_heads != num_heads:
-            grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
-        grad_kv_flat = attn_bwd["dkv"]
-        grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
-        grad_kv_full = grad_kv_flat.reshape(skv, b, kv_flat.size(-1))
-        return grad_query, grad_kv_full
-
-    valid_row_indices = torch.nonzero(topk_length > 0, as_tuple=False).flatten()
-    dummy_row_index = torch.full(
-        (1,), bwd_q_flat.size(0), dtype=valid_row_indices.dtype, device=valid_row_indices.device
-    )
-    compact_row_indices = torch.cat((valid_row_indices, dummy_row_index), dim=0)
-
-    # Add one zero-gradient row so the cuDNN wrapper never receives an empty query batch.
-    bwd_q_flat = torch.cat((bwd_q_flat, torch.zeros_like(bwd_q_flat[:1])), dim=0)
-    bwd_out_flat = torch.cat((bwd_out_flat, torch.zeros_like(bwd_out_flat[:1])), dim=0)
-    bwd_dO_flat = torch.cat((bwd_dO_flat, torch.zeros_like(bwd_dO_flat[:1])), dim=0)
-    bwd_lse = torch.cat((bwd_lse, torch.zeros_like(bwd_lse[:1])), dim=0)
-    global_idxs = torch.cat((global_idxs, torch.zeros_like(global_idxs[:1])), dim=0)
-    topk_length = torch.cat((topk_length, torch.ones_like(topk_length[:1])), dim=0)
+    empty_rows = None
+    if not all_topk_rows_nonempty:
+        empty_rows = topk_length <= 0
+        topk_length = topk_length.masked_fill(empty_rows, 1)
+        bwd_dO_flat = bwd_dO_flat.masked_fill(empty_rows[:, None, None], 0)
+        bwd_lse = bwd_lse.masked_fill(empty_rows[:, None], 0)
 
     attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-        bwd_q_flat.index_select(0, compact_row_indices).contiguous(),
+        bwd_q_flat,
         kv_flat,
-        bwd_out_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_dO_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_lse.index_select(0, compact_row_indices).contiguous(),
+        bwd_out_flat,
+        bwd_dO_flat,
+        bwd_lse,
         bwd_attn_sink,
-        global_idxs.index_select(0, compact_row_indices).contiguous(),
+        global_idxs,
         softmax_scale=softmax_scale,
-        topk_length=topk_length.index_select(0, compact_row_indices).contiguous(),
+        topk_length=topk_length,
     )
-    grad_query_valid = attn_bwd["dq"][:-1]
+    grad_query_flat = attn_bwd["dq"]
     if padded_num_heads != num_heads:
-        grad_query_valid = grad_query_valid[:, :num_heads, :].contiguous()
-    grad_query_flat = torch.zeros_like(q_flat)
-    grad_query_flat.index_copy_(0, valid_row_indices, grad_query_valid)
+        grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
+    if empty_rows is not None:
+        grad_query_flat.masked_fill_(empty_rows[:, None, None], 0)
     grad_kv_flat = attn_bwd["dkv"]
 
     grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
@@ -2197,6 +2172,23 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             )
         )
 
+        all_topk_rows_nonempty = (
+            effective_topk > 0
+            and skv > 0
+            and query_valid_rows is None
+            and (
+                (varlen_starts is None and varlen_ends is None and key_positions is None)
+                or (
+                    use_local_indexer_varlen
+                    and varlen_starts is not None
+                    and varlen_ends is not None
+                    and key_positions is None
+                )
+            )
+        )
+        if not all_topk_rows_nonempty:
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
+
         if need_indexer_loss:
             if sparse_loss:
                 if indexer_score_payload is None:
@@ -2280,13 +2272,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
-        ctx.all_sparse_bwd_rows_nonempty = (
-            query_valid_rows is None
-            and use_local_indexer_varlen
-            and varlen_starts is not None
-            and varlen_ends is not None
-            and key_positions is None
-        )
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         output = out_flat.reshape(sq, b, num_heads, d_v).reshape(sq, b, num_heads * d_v)
         return output, indexer_loss
@@ -2324,7 +2310,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
-            all_rows_nonempty=ctx.all_sparse_bwd_rows_nonempty,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
         if ctx.has_precomputed_indexer_grads and grad_loss is not None:
@@ -2534,6 +2520,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         softmax_scale: float,
         d_v: int,
         topk_length: Optional[Tensor],
+        all_topk_rows_nonempty: bool,
     ) -> Tensor:
         """Run fused sparse attention for precomputed top-k metadata."""
         sq, b, num_heads, d = query.shape
@@ -2543,6 +2530,8 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
                 query, kv_full, topk_indices, softmax_scale, d_v, topk_length=topk_length
             )
         )
+        if not all_topk_rows_nonempty:
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
 
         ctx.save_for_backward(q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse)
         ctx.softmax_scale = softmax_scale
@@ -2552,6 +2541,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         return out_flat.reshape(sq, b, num_heads, d_v)
 
@@ -2577,9 +2567,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
-        return grad_query, grad_kv_full, None, None, None, None
+        return grad_query, grad_kv_full, None, None, None, None, None
 
 
 def run_fused_absorbed_sparse_attention(
@@ -2589,11 +2580,12 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Run cuDNN/FlashMLA sparse attention using externally supplied top-k indices."""
     if query.ndim != 4 or key.ndim != 4 or topk_indices.ndim != 3:
         return None
-    if key.size(2) != 1 or v_channels <= 0:
+    if key.size(0) == 0 or key.size(2) != 1 or topk_indices.size(2) == 0 or v_channels <= 0:
         return None
     if query.size(0) != topk_indices.size(1) or query.size(1) != topk_indices.size(0):
         return None
@@ -2606,7 +2598,7 @@ def run_fused_absorbed_sparse_attention(
 
     kv_full = key.squeeze(2).contiguous()
     return FusedSparseAttentionFunc.apply(
-        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length
+        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length, all_topk_rows_nonempty
     )
 
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
+from functools import lru_cache
 from importlib import import_module
 from types import ModuleType
 from typing import TYPE_CHECKING, Optional, Tuple
@@ -87,6 +89,29 @@ def _resolve_fused_hook(config: TransformerConfig, hook_name: str):
     if fn is None:
         _log_declined_hook(config, hook_name, "hook is not implemented")
     return fn
+
+
+@lru_cache(maxsize=None)
+def _hook_parameter_names(fn):
+    """Return a cached backend-hook signature, or ``None`` for ``**kwargs`` hooks."""
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return None
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return None
+    return frozenset(signature.parameters)
+
+
+def _hook_kwargs_accepting(fn, **candidate_kwargs):
+    """Keep only optional internal kwargs accepted by a backend hook."""
+    parameter_names = _hook_parameter_names(fn)
+    if parameter_names is None:
+        return candidate_kwargs
+    return {name: value for name, value in candidate_kwargs.items() if name in parameter_names}
 
 
 def use_fused_dsa_kernels(config: TransformerConfig) -> bool:
@@ -208,12 +233,21 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Optional fused sparse-attention hook for backend-specific implementations."""
     fn = _resolve_fused_hook(config, "run_fused_absorbed_sparse_attention")
     if fn is None:
         return None
-    result = fn(query, key, topk_indices, softmax_scale, v_channels, topk_length)
+    result = fn(
+        query,
+        key,
+        topk_indices,
+        softmax_scale,
+        v_channels,
+        topk_length,
+        **_hook_kwargs_accepting(fn, all_topk_rows_nonempty=all_topk_rows_nonempty),
+    )
     if result is None:
         _log_declined_hook(config, "run_fused_absorbed_sparse_attention", "backend returned None")
     return result

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -28,6 +28,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAttention,
     DSAttentionSubmodules,
     FusedDSAIndexerLoss,
+    _can_prove_all_topk_rows_nonempty,
     _compute_indexer_teacher_probabilities,
     _normalize_indexer_teacher_target,
     _run_sparse_attention,
@@ -403,6 +404,44 @@ def test_dsa_kernel_backend_loader_cache_and_import_errors(monkeypatch):
         dsa_kernels._load_backend(Config)
 
 
+def test_dsa_all_topk_rows_nonempty_certificate():
+    common = {
+        "computes_topk": True,
+        "indexer_topk": 2,
+        "kv_sequence_length": 4,
+        "attention_mask": None,
+        "query_valid_rows": None,
+        "varlen_is_plain_causal": True,
+        "use_local_indexer_varlen": False,
+        "varlen_starts": None,
+        "varlen_ends": None,
+        "key_positions": None,
+    }
+    assert _can_prove_all_topk_rows_nonempty(**common)
+
+    packed_local = {
+        **common,
+        "varlen_is_plain_causal": False,
+        "use_local_indexer_varlen": True,
+        "varlen_starts": torch.tensor([0, 0]),
+        "varlen_ends": torch.tensor([1, 2]),
+    }
+    assert _can_prove_all_topk_rows_nonempty(**packed_local)
+
+    unsupported = [
+        {"computes_topk": False},
+        {"indexer_topk": 0},
+        {"kv_sequence_length": 0},
+        {"attention_mask": torch.zeros((1, 1, 2, 4), dtype=torch.bool)},
+        {"query_valid_rows": torch.ones((1, 2), dtype=torch.bool)},
+        {"varlen_is_plain_causal": False},
+        {**packed_local, "key_positions": torch.arange(4)},
+        {**packed_local, "varlen_ends": None},
+    ]
+    for override in unsupported:
+        assert not _can_prove_all_topk_rows_nonempty(**{**common, **override})
+
+
 def test_dsa_kernel_hooks_return_none_without_backend_function(monkeypatch):
     class Config:
         attention_backend = "auto"
@@ -489,7 +528,9 @@ def test_dsa_kernel_hooks_log_declined_backend(monkeypatch, caplog):
         is None
     )
     assert (
-        dsa_kernels.run_fused_absorbed_sparse_attention(Config, q, q, starts.view(1, 1, 1), 1.0, 1)
+        dsa_kernels.run_fused_absorbed_sparse_attention(
+            Config, q, q, starts.view(1, 1, 1), 1.0, 1, all_topk_rows_nonempty=True
+        )
         is None
     )
     assert (
@@ -553,8 +594,9 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
         seen["loss_kwargs"] = kwargs
         return expected_topk_loss
 
-    def run_fused_absorbed_sparse_attention(*args):
+    def run_fused_absorbed_sparse_attention(*args, all_topk_rows_nonempty=False):
         seen["sparse_args"] = args
+        seen["all_topk_rows_nonempty"] = all_topk_rows_nonempty
         return expected_sparse
 
     def run_fused_dsa_attention(**kwargs):
@@ -621,11 +663,12 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     topk_length = torch.ones((1, 1), dtype=torch.int32)
     assert (
         dsa_kernels.run_fused_absorbed_sparse_attention(
-            Config, q, k, topk_indices, 1.0, 1, topk_length
+            Config, q, k, topk_indices, 1.0, 1, topk_length, all_topk_rows_nonempty=True
         )
         is expected_sparse
     )
     assert seen["sparse_args"][-1] is topk_length
+    assert seen["all_topk_rows_nonempty"] is True
 
     assert (
         dsa_kernels.run_fused_dsa_attention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -1891,7 +1891,11 @@ def test_cudnn_sparse_backward_uses_batch_major_topk_indices_for_batched_kv(monk
 
 
 @pytest.mark.parametrize("source", ["full_fusion", "split_attention"])
-def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, source):
+@pytest.mark.parametrize(
+    "row_lengths", [(1, 2), (0, 2), (0, 0)], ids=["nonempty", "mixed", "all-empty"]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_keeps_fixed_rows(monkeypatch, source, row_lengths, dtype):
     seen = {}
 
     class FakeDSA:
@@ -1900,75 +1904,195 @@ def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, sour
             q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
         ):
             seen["bwd_q_shape"] = q.shape
+            seen["bwd_dO"] = dO.detach().clone()
+            seen["bwd_lse"] = lse.detach().clone()
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
-            return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
+            return {"dq": torch.ones_like(q), "dkv": torch.ones_like(kv) * dO.sum()}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
 
+    def make_topk(width):
+        topk = torch.full((1, 2, width), -1, dtype=torch.int32)
+        if row_lengths[0] > 0:
+            topk[0, 0, : row_lengths[0]] = torch.tensor([0, 3])[: row_lengths[0]]
+        if row_lengths[1] > 0:
+            topk[0, 1, : row_lengths[1]] = torch.tensor([1, 2])[: row_lengths[1]]
+        return topk
+
     def fake_indexer_topk(*args, **kwargs):
-        return (
-            torch.tensor([[[-1, -1, -1, -1], [1, 2, -1, -1]]], dtype=torch.int32),
-            torch.tensor([[0, 2]], dtype=torch.int32),
-            None,
-        )
+        return make_topk(4), torch.tensor([row_lengths], dtype=torch.int32), None
 
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         seen["fwd_topk"] = topk_idxs.detach().clone()
         seen["fwd_topk_length"] = topk_length.detach().clone()
-        return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
+        return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.tensor([[5.0], [6.0]])
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
 
     if source == "full_fusion":
-        query = torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, 1), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1), dtype=dtype, requires_grad=True)
         monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
         output, _indexer_loss = dsa_cudnn_kernels.fused_indexer_sparse_attn(
             query,
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16, requires_grad=True),
-            torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((2, 1, 1), dtype=torch.bfloat16),
+            key,
+            torch.zeros((2, 1, 1, 1), dtype=dtype),
+            torch.zeros((4, 1, 1), dtype=dtype),
+            torch.zeros((2, 1, 1), dtype=dtype),
             indexer_topk=4,
             softmax_scale=1.0,
             loss_coeff=0.0,
             sparse_loss=True,
             calculate_per_token_loss=False,
             d_v=1,
+            query_valid_rows=torch.tensor([[length > 0 for length in row_lengths]]),
         )
-        expected_fwd_topk = torch.tensor([[-1, -1, -1, -1], [1, 2, -1, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0, 0], [0, 0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(4).squeeze(0)
     else:
         value_dim = 512
-        query = torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
-        key = torch.zeros((4, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        input_topk = make_topk(3)
+        input_topk_length = torch.tensor([row_lengths], dtype=torch.int32)
+        original_topk = input_topk.clone()
+        original_topk_length = input_topk_length.clone()
         output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
             query=query,
             key=key,
-            topk_indices=torch.tensor([[[-1, -1, -1], [2, -1, 1]]], dtype=torch.int32),
+            topk_indices=input_topk,
             softmax_scale=1.0,
             v_channels=value_dim,
+            topk_length=input_topk_length,
         )
         assert output is not None
-        expected_fwd_topk = torch.tensor([[-1, -1, -1], [1, 2, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0], [0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(3).squeeze(0)
 
-    output.float().sum().backward()
+    empty_rows = torch.tensor(row_lengths) <= 0
+    grad_output = torch.ones_like(output)
+    grad_output[empty_rows] = float("nan")
+
+    def fail_nonzero(*_args, **_kwargs):
+        raise AssertionError("fixed-shape sparse backward must not call torch.nonzero")
+
+    monkeypatch.setattr(torch, "nonzero", fail_nonzero)
+    output.backward(grad_output, retain_graph=True)
 
     torch.testing.assert_close(seen["fwd_topk"], expected_fwd_topk)
-    torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([0, 2], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["fwd_topk_length"], torch.tensor(row_lengths, dtype=torch.int32)
+    )
     assert seen["bwd_q_shape"] == (query.size(0) * query.size(1), query.size(2), query.size(3))
-    # Backward compacts nonempty rows and appends one dummy row to avoid empty cuDNN launches.
+    expected_bwd_topk = expected_fwd_topk.clamp_min(0)
+    expected_bwd_topk[empty_rows, 0] = 0
     torch.testing.assert_close(seen["bwd_topk"], expected_bwd_topk)
-    torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([2, 1], dtype=torch.int32))
-    torch.testing.assert_close(query.grad[0], torch.zeros_like(query.grad[0]))
-    torch.testing.assert_close(query.grad[1], torch.ones_like(query.grad[1]))
+    torch.testing.assert_close(
+        seen["bwd_topk_length"],
+        torch.tensor([max(1, length) for length in row_lengths], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        seen["bwd_dO"][empty_rows], torch.zeros_like(seen["bwd_dO"][empty_rows])
+    )
+    torch.testing.assert_close(
+        seen["bwd_lse"][empty_rows], torch.zeros_like(seen["bwd_lse"][empty_rows])
+    )
+    if (~empty_rows).any():
+        torch.testing.assert_close(
+            seen["bwd_lse"][~empty_rows], torch.tensor([[5.0], [6.0]])[~empty_rows]
+        )
+    expected_query_grad = torch.ones_like(query.grad)
+    expected_query_grad[empty_rows] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_dkv = seen["bwd_dO"].sum().to(key.dtype)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
     if source == "split_attention":
-        torch.testing.assert_close(key.grad, torch.zeros_like(key.grad))
+        torch.testing.assert_close(input_topk, original_topk)
+        torch.testing.assert_close(input_topk_length, original_topk_length)
+
+    query.grad.zero_()
+    key.grad.zero_()
+    output.backward(grad_output)
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
 
 
-def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen(monkeypatch):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_empty_rows_do_not_cross_batches(monkeypatch, dtype):
+    seen = {}
+
+    class FakeDSA:
+        @staticmethod
+        def sparse_attention_backward_wrapper(
+            q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
+        ):
+            del out, lse, attn_sink, softmax_scale
+            seen["topk"] = topk_indices.detach().clone()
+            seen["topk_length"] = topk_length.detach().clone()
+            seen["dO"] = dO.detach().clone()
+            dkv = torch.zeros_like(kv)
+            for row in range(q.size(0)):
+                for column in range(int(topk_length[row])):
+                    dkv[topk_indices[row, column]] += dO[row].sum()
+            return {"dq": torch.ones_like(q), "dkv": dkv}
+
+    def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
+        del kv, softmax_scale, attn_sink
+        seen["forward_topk"] = topk_idxs.detach().clone()
+        seen["forward_topk_length"] = topk_length.detach().clone()
+        return torch.zeros((q.size(0), q.size(1), d_v), dtype=q.dtype), torch.ones(
+            (q.size(0), q.size(1)), dtype=torch.float32
+        )
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
+
+    value_dim = 512
+    query = torch.zeros((2, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    key = torch.zeros((3, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    topk_indices = torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    topk_length = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=query,
+        key=key,
+        topk_indices=topk_indices,
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=topk_length,
+    )
+    assert output is not None
+
+    grad_output = torch.zeros_like(output)
+    grad_output[0, 0, 0, 0] = float("nan")
+    grad_output[0, 1, 0, 0] = 2
+    grad_output[1, 0, 0, 0] = 3
+    grad_output[1, 1, 0, 0] = float("nan")
+    output.backward(grad_output)
+
+    torch.testing.assert_close(
+        seen["forward_topk_length"], torch.tensor([0, 1, 1, 0], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["topk_length"], torch.tensor([1, 1, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["topk"], torch.tensor([[0, 0], [3, 0], [4, 0], [0, 0]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["dO"][[0, 3]], torch.zeros_like(seen["dO"][[0, 3]]))
+
+    expected_query_grad = torch.ones_like(query)
+    expected_query_grad[0, 0] = 0
+    expected_query_grad[1, 1] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_key_grad = torch.zeros_like(key)
+    expected_key_grad[1, 1] = 2
+    expected_key_grad[2, 0] = 3
+    torch.testing.assert_close(key.grad, expected_key_grad)
+    torch.testing.assert_close(
+        topk_indices, torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    )
+
+
+def test_cudnn_full_fusion_uses_nonempty_local_varlen_certificate(monkeypatch):
     seen = {}
 
     class FakeDSA:
@@ -1980,6 +2104,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
             seen["bwd_q_shape"] = q.shape
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
+            seen["bwd_topk_length_ptr"] = topk_length.data_ptr()
             return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
@@ -1996,6 +2121,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         del kv, topk_idxs, softmax_scale, attn_sink
         seen["fwd_topk_length"] = topk_length.detach().clone()
+        seen["fwd_topk_length_ptr"] = topk_length.data_ptr()
         return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
@@ -2024,6 +2150,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     assert seen["bwd_q_shape"] == (2, 1, 1)
     torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
     torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
+    assert seen["bwd_topk_length_ptr"] == seen["fwd_topk_length_ptr"]
     torch.testing.assert_close(
         seen["bwd_topk"], torch.tensor([[0, 0, 0], [0, 1, 0]], dtype=torch.int32)
     )
@@ -2077,6 +2204,28 @@ def test_cudnn_sparse_attention_declines_unsupported_flashmla_value_dim(monkeypa
         topk_indices=torch.tensor([[[2, 1, -1], [-1, -1, -1]]], dtype=torch.int32),
         softmax_scale=1.0,
         v_channels=4,
+    )
+
+    assert output is None
+
+
+@pytest.mark.parametrize("empty_dimension", ["topk", "kv"])
+def test_cudnn_sparse_attention_declines_without_safe_backward_tile(monkeypatch, empty_dimension):
+    def fail_flash_mla(*_args, **_kwargs):
+        raise AssertionError("cuDNN must not run without a valid safe backward tile")
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fail_flash_mla)
+
+    value_dim = 512
+    kv_length = 0 if empty_dimension == "kv" else 4
+    topk_width = 0 if empty_dimension == "topk" else 2
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16),
+        key=torch.zeros((kv_length, 1, 1, value_dim), dtype=torch.bfloat16),
+        topk_indices=torch.empty((1, 2, topk_width), dtype=torch.int32),
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=torch.zeros((1, 2), dtype=torch.int32),
     )
 
     assert output is None
@@ -2189,7 +2338,7 @@ def test_cudnn_attention_backward_pads_small_local_head_count(monkeypatch):
         d=attn_dim,
         skv=skv,
         grad_output=torch.zeros((sq, batch_size, num_heads, value_dim), device="cuda"),
-        all_rows_nonempty=True,
+        all_topk_rows_nonempty=True,
     )
 
     assert seen["shapes"] == (


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Main counterpart of #6910.

Keep ordinary DSA sparse-attention backward shapes static when top-k contains
empty query rows, removing its dynamic `nonzero`/compact/gather/scatter path.

The generic path replaces each empty row with a safe one-tile cuDNN invocation:
its first index is zero, its effective top-k length is one, and its `dO`/`LSE`
are zeroed before backward. The returned `dQ` is explicitly zeroed for those
rows, so the safe tile contributes neither query nor KV gradients. A conservative
host-side certificate retains the existing allocation-free fast path when all
rows are provably nonempty.

This covers both the combined fused path and the split path used by IndexShare
and MTP sharing. It does not change CSA, THD/CP layout, MTP sharing semantics,
configuration, or the full-iteration CUDA Graph validator.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Verification notes

- Unit/native parity: full and split paths; nonempty, mixed-empty, and all-empty
  rows; BF16/FP32; metadata immutability; zero-size rejection; batch isolation.
- H100 real cuDNN: split forward/backward and changing-pattern CUDA Graph replay
  passed. The combined cuDNN IndexerTopK forward is SM100-only and was covered on
  GB200.
- GB200 real cuDNN: split and combined eager/native parity and fixed-shape graph
  replay passed; no stale mask or replay allocation growth.
- 16-GPU GB200 GLM proxy ABBA: short THD 4K effective CP1 improved 2.38%; long
  THD 64K dynamic CP16 improved 3.19%; peak memory was unchanged in both cells.
- Nsight Systems 2026.4.1: candidate DSA backward traces contain no target
  `nonzero`, `index_select`, `index_copy`, or dynamic gather/scatter operations.
