### PR TITLE
fix: make GTP weight rematerialization work end-to-end with tied embeddings and inference resharding

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1866,6 +1866,7 @@ class TELMHeadColumnParallelLinear(TEColumnParallelLinear):
         tp_comm_buffer_name: Optional[str] = None,
         disable_grad_reduce: bool = False,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
         output_dtype: Optional[torch.dtype] = None,
     ):
         from megatron.core.fp8_utils import is_mxfp8_output_proj_active
@@ -1905,6 +1906,7 @@ class TELMHeadColumnParallelLinear(TEColumnParallelLinear):
             skip_weight_param_allocation=skip_weight_param_allocation,
             tp_comm_buffer_name=tp_comm_buffer_name,
             tp_group=tp_group,
+            pg_collection=pg_collection,
             stride=stride,
         )
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -38,7 +38,6 @@ from megatron.core.quantization.quant_config import QuantizationConfig
 from megatron.core.quantization.utils import get_quant_config_or_none
 from megatron.core.tensor_parallel.layers import (
     _initialize_affine_weight_cpu,
-    copy_tensor_model_parallel_attributes,
     set_tensor_model_parallel_attributes,
 )
 from megatron.core.tensor_parallel.mappings import gather_from_tensor_model_parallel_region
@@ -87,9 +86,6 @@ except ImportError:
 
 _TE_CONFIG_TYPE_KEY = "transformer_engine_config_type"
 _EXPERT_PARAMETER_NAME_PATTERN = re.compile(r"(weight|bias)\d*")
-# GEMM bias parameters ("bias", or "bias0".."biasN" on a grouped linear). Deliberately excludes
-# names like "layer_norm_bias", which are not sized off out_features.
-_BIAS_NAME_PATTERN = re.compile(r"bias\d*")
 
 
 def _set_expert_parameter_attributes(
@@ -448,7 +444,7 @@ def _gtp_pre_init(
     ), f"_gtp_pre_init: output_size={output_size} not divisible by out_split_size={out_split_size}"
     per_rank, pad_length = gtp_remat_shard_dim0(output_size // out_split_size, gtp_remat_group)
     shard_out = per_rank * out_split_size
-    gtp_ctx = (gtp_remat_group, pad_length, output_size, out_split_size)
+    gtp_ctx = (gtp_remat_group, pad_length, output_size)
 
     tracker_name = get_gtp_remat_rng_tracker_name(is_expert=is_expert)
     if rng_via_kwarg:
@@ -456,54 +452,6 @@ def _gtp_pre_init(
     else:
         module.rng_tracker_name = tracker_name
     return shard_out, gtp_ctx
-
-
-def _gtp_restore_presharded_bias(module, gtp_ctx, is_grouped=False):
-    """Re-allocate biases that the pre-sharded ``out_features`` of :func:`_gtp_pre_init` shrank.
-
-    GTP shards the WEIGHT along dim 0; a bias is GTP-REPLICATED (mcore's own
-    ``ColumnParallelLinear`` allocates it at the full per-TP size,
-    ``attach_gtp_to_presharded_module`` never wraps it, and
-    ``make_sharded_tensors_for_checkpoint_with_gtp_remat`` treats a non-GTP param under a GTP
-    module as replicated). TE, however, sizes its bias from the ``out_features``
-    it is constructed with, and :func:`_gtp_pre_init` deliberately passes the pre-sharded value —
-    so the bias silently comes out 1/gtp_remat too small. That breaks two things: the all-gathered
-    weight produces a full-width GEMM output the shard-sized bias cannot be added to, and
-    distributed checkpointing declares a global shape 1/gtp_remat of the real one (a plain
-    checkpoint then fails to load with "Global shape mismatch ... linear_qkv.bias").
-
-    Biases are zero-initialized by both TE and mcore, so re-allocating loses no state.
-    """
-    gtp_remat_group, pad_length, logical_out_features, out_split_size = gtp_ctx
-    gtp_remat_size = gtp_remat_group.size()
-    # Size TE gave the bias (its shard) vs. the logical size it should have had.
-    logical_numel = logical_out_features // out_split_size
-    shard_numel = (logical_numel + pad_length) // gtp_remat_size
-    if shard_numel == logical_numel:
-        return
-
-    bias_names = getattr(module, "bias_names", None)
-    if not bias_names:
-        bias_names = [f"bias{idx}" for idx in range(module.num_gemms)] if is_grouped else ["bias"]
-    # Only the GEMM biases; never a norm bias (``layer_norm_bias``), which is sized off
-    # in_features and is not affected by the out_features pre-shard.
-    bias_names = [name for name in bias_names if _BIAS_NAME_PATTERN.fullmatch(name)]
-    for name in bias_names:
-        bias = getattr(module, name, None)
-        # Only touch a bias TE actually sized off the pre-sharded out_features. Anything else
-        # (a zero-length placeholder for bias=False) is left alone.
-        if not isinstance(bias, Parameter) or bias.dim() != 1 or bias.numel() != shard_numel:
-            continue
-        restored = Parameter(
-            torch.zeros(logical_numel, dtype=bias.dtype, device=bias.device),
-            requires_grad=bias.requires_grad,
-        )
-        copy_tensor_model_parallel_attributes(restored, bias)
-        for attr in ("allreduce", "sequence_parallel", "partition_stride"):
-            if hasattr(bias, attr):
-                setattr(restored, attr, getattr(bias, attr))
-        delattr(module, name)
-        module._parameters[name] = restored
 
 
 def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, replica_group=None):
@@ -515,14 +463,11 @@ def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, replica_group=None)
     """
     from megatron.core.tensor_parallel.gtp_api import attach_gtp_to_presharded_module
 
-    gtp_remat_group, pad_length, logical_out_features, _ = gtp_ctx
+    gtp_remat_group, pad_length, logical_out_features = gtp_ctx
     # Restore the LOGICAL out_features (the sharded value was only needed to size the weight in
     # super().__init__): downstream code reads it, e.g. the grouped-MLP fusion gate checks
     # fc1.out_features == 2 * fc2.in_features (a shard-sized fc1 would silently disable fusion).
     module.out_features = logical_out_features
-    # Biases are replicated, not GTP-sharded: undo the pre-shard for them before the weights are
-    # wrapped (which is what makes the weights, and only the weights, GTP params).
-    _gtp_restore_presharded_bias(module, gtp_ctx, is_grouped=is_grouped)
     attach_gtp_to_presharded_module(
         module, gtp_remat_group, pad_length, is_grouped=is_grouped, replica_group=replica_group
     )

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -38,6 +38,7 @@ from megatron.core.quantization.quant_config import QuantizationConfig
 from megatron.core.quantization.utils import get_quant_config_or_none
 from megatron.core.tensor_parallel.layers import (
     _initialize_affine_weight_cpu,
+    copy_tensor_model_parallel_attributes,
     set_tensor_model_parallel_attributes,
 )
 from megatron.core.tensor_parallel.mappings import gather_from_tensor_model_parallel_region
@@ -86,6 +87,9 @@ except ImportError:
 
 _TE_CONFIG_TYPE_KEY = "transformer_engine_config_type"
 _EXPERT_PARAMETER_NAME_PATTERN = re.compile(r"(weight|bias)\d*")
+# GEMM bias parameters ("bias", or "bias0".."biasN" on a grouped linear). Deliberately excludes
+# names like "layer_norm_bias", which are not sized off out_features.
+_BIAS_NAME_PATTERN = re.compile(r"bias\d*")
 
 
 def _set_expert_parameter_attributes(
@@ -444,7 +448,7 @@ def _gtp_pre_init(
     ), f"_gtp_pre_init: output_size={output_size} not divisible by out_split_size={out_split_size}"
     per_rank, pad_length = gtp_remat_shard_dim0(output_size // out_split_size, gtp_remat_group)
     shard_out = per_rank * out_split_size
-    gtp_ctx = (gtp_remat_group, pad_length, output_size)
+    gtp_ctx = (gtp_remat_group, pad_length, output_size, out_split_size)
 
     tracker_name = get_gtp_remat_rng_tracker_name(is_expert=is_expert)
     if rng_via_kwarg:
@@ -452,6 +456,54 @@ def _gtp_pre_init(
     else:
         module.rng_tracker_name = tracker_name
     return shard_out, gtp_ctx
+
+
+def _gtp_restore_presharded_bias(module, gtp_ctx, is_grouped=False):
+    """Re-allocate biases that the pre-sharded ``out_features`` of :func:`_gtp_pre_init` shrank.
+
+    GTP shards the WEIGHT along dim 0; a bias is GTP-REPLICATED (mcore's own
+    ``ColumnParallelLinear`` allocates it at the full per-TP size,
+    ``attach_gtp_to_presharded_module`` never wraps it, and
+    ``make_sharded_tensors_for_checkpoint_with_gtp_remat`` treats a non-GTP param under a GTP
+    module as replicated). TE, however, sizes its bias from the ``out_features``
+    it is constructed with, and :func:`_gtp_pre_init` deliberately passes the pre-sharded value —
+    so the bias silently comes out 1/gtp_remat too small. That breaks two things: the all-gathered
+    weight produces a full-width GEMM output the shard-sized bias cannot be added to, and
+    distributed checkpointing declares a global shape 1/gtp_remat of the real one (a plain
+    checkpoint then fails to load with "Global shape mismatch ... linear_qkv.bias").
+
+    Biases are zero-initialized by both TE and mcore, so re-allocating loses no state.
+    """
+    gtp_remat_group, pad_length, logical_out_features, out_split_size = gtp_ctx
+    gtp_remat_size = gtp_remat_group.size()
+    # Size TE gave the bias (its shard) vs. the logical size it should have had.
+    logical_numel = logical_out_features // out_split_size
+    shard_numel = (logical_numel + pad_length) // gtp_remat_size
+    if shard_numel == logical_numel:
+        return
+
+    bias_names = getattr(module, "bias_names", None)
+    if not bias_names:
+        bias_names = [f"bias{idx}" for idx in range(module.num_gemms)] if is_grouped else ["bias"]
+    # Only the GEMM biases; never a norm bias (``layer_norm_bias``), which is sized off
+    # in_features and is not affected by the out_features pre-shard.
+    bias_names = [name for name in bias_names if _BIAS_NAME_PATTERN.fullmatch(name)]
+    for name in bias_names:
+        bias = getattr(module, name, None)
+        # Only touch a bias TE actually sized off the pre-sharded out_features. Anything else
+        # (a zero-length placeholder for bias=False) is left alone.
+        if not isinstance(bias, Parameter) or bias.dim() != 1 or bias.numel() != shard_numel:
+            continue
+        restored = Parameter(
+            torch.zeros(logical_numel, dtype=bias.dtype, device=bias.device),
+            requires_grad=bias.requires_grad,
+        )
+        copy_tensor_model_parallel_attributes(restored, bias)
+        for attr in ("allreduce", "sequence_parallel", "partition_stride"):
+            if hasattr(bias, attr):
+                setattr(restored, attr, getattr(bias, attr))
+        delattr(module, name)
+        module._parameters[name] = restored
 
 
 def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, replica_group=None):
@@ -463,11 +515,14 @@ def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, replica_group=None)
     """
     from megatron.core.tensor_parallel.gtp_api import attach_gtp_to_presharded_module
 
-    gtp_remat_group, pad_length, logical_out_features = gtp_ctx
+    gtp_remat_group, pad_length, logical_out_features, _ = gtp_ctx
     # Restore the LOGICAL out_features (the sharded value was only needed to size the weight in
     # super().__init__): downstream code reads it, e.g. the grouped-MLP fusion gate checks
     # fc1.out_features == 2 * fc2.in_features (a shard-sized fc1 would silently disable fusion).
     module.out_features = logical_out_features
+    # Biases are replicated, not GTP-sharded: undo the pre-shard for them before the weights are
+    # wrapped (which is what makes the weights, and only the weights, GTP params).
+    _gtp_restore_presharded_bias(module, gtp_ctx, is_grouped=is_grouped)
     attach_gtp_to_presharded_module(
         module, gtp_remat_group, pad_length, is_grouped=is_grouped, replica_group=replica_group
     )

--- a/megatron/core/inference/shards.py
+++ b/megatron/core/inference/shards.py
@@ -158,6 +158,14 @@ def build_inference_pg_collection(
         tp_ep_pp=tp_ep_pp_group,
         dp_cp=dp_cp_group,
         tp_dp_cp=tp_dp_cp_group,
+        # Declare the GTP_remat axes OFF rather than leaving them unset. An inference
+        # layout never rematerializes weights, and `resolve_gtp_remat_group` falls back
+        # to the MPU globals for a field that is absent from `vars(pg_collection)` --
+        # which would hand this collection the *training* GTP layout and build a
+        # GTP-sharded inference model. Passing None explicitly puts the field in
+        # `vars()`, so the fallback is not taken.
+        gtp_remat=None,
+        expt_gtp_remat=None,
     )
 
 

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -180,8 +180,6 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 position_embedding_type=position_embedding_type,
                 scatter_to_sequence_parallel=scatter_embedding_sequence_parallel,
                 tp_group=self.pg_collection.tp,
-                # Not just tp_group: VocabParallelEmbedding resolves its GTP_remat axis from
-                # the collection, and falls back to the MPU globals when it gets None.
                 pg_collection=self.pg_collection,
             )
 
@@ -296,8 +294,6 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 embedding_activation_buffer=self.embedding_activation_buffer,
                 grad_output_buffer=self.grad_output_buffer,
                 tp_group=self.pg_collection.tp,
-                # Not just tp_group: the column-parallel layer resolves its GTP_remat axis
-                # from the collection, and falls back to the MPU globals when it gets None.
                 pg_collection=self.pg_collection,
                 output_dtype=self.logit_dtype,
             )

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -180,6 +180,9 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 position_embedding_type=position_embedding_type,
                 scatter_to_sequence_parallel=scatter_embedding_sequence_parallel,
                 tp_group=self.pg_collection.tp,
+                # Not just tp_group: VocabParallelEmbedding resolves its GTP_remat axis from
+                # the collection, and falls back to the MPU globals when it gets None.
+                pg_collection=self.pg_collection,
             )
 
         if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
@@ -293,6 +296,9 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 embedding_activation_buffer=self.embedding_activation_buffer,
                 grad_output_buffer=self.grad_output_buffer,
                 tp_group=self.pg_collection.tp,
+                # Not just tp_group: the column-parallel layer resolves its GTP_remat axis
+                # from the collection, and falls back to the MPU globals when it gets None.
+                pg_collection=self.pg_collection,
                 output_dtype=self.logit_dtype,
             )
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -1271,22 +1271,13 @@ class ColumnParallelLinear(torch.nn.Module):
         else:
             # Check the weight passed in is the correct shape
             expected_shape = (self.output_size_per_partition, self.input_size)
-            # A GTP weight-remat shard legitimately arrives at its *local* shape: with tied
-            # embeddings, shared_embedding_or_output_weight() hands this layer the embedding's
-            # GTP-sharded parameter, and _forward_impl all-gathers it to the logical shape
-            # before the matmul (see the gtp_remat_size kwarg). Compare the logical shape so
-            # the guard still rejects a genuinely wrong weight.
             # Deferred to break the tensor_parallel package import cycle (gtp_api ->
             # generalized_tensor_parallelism -> tensor_parallel/__init__ -> layers).
             from megatron.core.tensor_parallel.gtp_api import is_gtp_param
 
-            if is_gtp_param(weight):
-                supplied_shape = weight._unsharded_shape
-            else:
-                supplied_shape = tuple(weight.shape)
-            if supplied_shape != expected_shape:
+            if weight.shape != expected_shape and not is_gtp_param(weight):
                 raise RuntimeError(
-                    f"supplied weight's shape is {supplied_shape}, "
+                    f"supplied weight's shape is {tuple(weight.shape)}, "
                     f"not {expected_shape} as expected"
                 )
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -1271,9 +1271,22 @@ class ColumnParallelLinear(torch.nn.Module):
         else:
             # Check the weight passed in is the correct shape
             expected_shape = (self.output_size_per_partition, self.input_size)
-            if weight.shape != expected_shape:
+            # A GTP weight-remat shard legitimately arrives at its *local* shape: with tied
+            # embeddings, shared_embedding_or_output_weight() hands this layer the embedding's
+            # GTP-sharded parameter, and _forward_impl all-gathers it to the logical shape
+            # before the matmul (see the gtp_remat_size kwarg). Compare the logical shape so
+            # the guard still rejects a genuinely wrong weight.
+            # Deferred to break the tensor_parallel package import cycle (gtp_api ->
+            # generalized_tensor_parallelism -> tensor_parallel/__init__ -> layers).
+            from megatron.core.tensor_parallel.gtp_api import is_gtp_param
+
+            if is_gtp_param(weight):
+                supplied_shape = weight._unsharded_shape
+            else:
+                supplied_shape = tuple(weight.shape)
+            if supplied_shape != expected_shape:
                 raise RuntimeError(
-                    f"supplied weight's shape is {tuple(weight.shape)}, "
+                    f"supplied weight's shape is {supplied_shape}, "
                     f"not {expected_shape} as expected"
                 )
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -84,21 +84,6 @@ class _FakeGroup:
         return self._rank
 
 
-class TestGTPReplicatedBias:
-    def test_bias_is_resized_in_place(self):
-        module = nn.Module()
-        module.bias = nn.Parameter(torch.ones(4))
-        module.bias.tensor_model_parallel = True
-        original_bias = module.bias
-
-        gtp_module._gtp_restore_replicated_bias(module, _FakeGroup(size=2), pad_length=1)
-
-        assert module.bias is original_bias
-        assert module.bias.shape == (7,)
-        assert torch.count_nonzero(module.bias) == 0
-        assert module.bias.tensor_model_parallel
-
-
 class TestGTPWeightCacheSchedulingDomain:
     @staticmethod
     def _make_param(group, chain_id):

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -84,6 +84,21 @@ class _FakeGroup:
         return self._rank
 
 
+class TestGTPReplicatedBias:
+    def test_bias_is_resized_in_place(self):
+        module = nn.Module()
+        module.bias = nn.Parameter(torch.ones(4))
+        module.bias.tensor_model_parallel = True
+        original_bias = module.bias
+
+        gtp_module._gtp_restore_replicated_bias(module, _FakeGroup(size=2), pad_length=1)
+
+        assert module.bias is original_bias
+        assert module.bias.shape == (7,)
+        assert torch.count_nonzero(module.bias) == 0
+        assert module.bias.tensor_model_parallel
+
+
 class TestGTPWeightCacheSchedulingDomain:
     @staticmethod
     def _make_param(group, chain_id):

--- a/tests/unit_tests/tensor_parallel/test_layers.py
+++ b/tests/unit_tests/tensor_parallel/test_layers.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from megatron.core.extensions.transformer_engine import te_general_gemm
 from megatron.core.tensor_parallel.layers import (
+    ColumnParallelLinear,
     copy_gtp_attributes,
     gtp_local_pad_zero_count,
     linear_with_frozen_weight,
@@ -112,6 +115,50 @@ class TestCopyGtpAttributes:
         expected = gtp_local_pad_zero_count(source, 0, source.numel())
         assert expected > 0, "test setup must exercise real padding"
         assert gtp_local_pad_zero_count(destination, 0, destination.numel()) == expected
+
+
+def _make_column_parallel_linear_for_weight_shape_check():
+    layer = ColumnParallelLinear.__new__(ColumnParallelLinear)
+    torch.nn.Module.__init__(layer)
+    layer.output_size_per_partition = 8
+    layer.input_size = 4
+    layer.bias = None
+    layer.skip_bias_add = False
+    layer.allreduce_dgrad = True
+    layer.sequence_parallel = False
+    layer.explicit_expert_comm = False
+    layer.disable_grad_reduce = False
+    layer.config = SimpleNamespace(
+        defer_embedding_wgrad_compute=False, _cpu_offloading_context=None
+    )
+    layer.gradient_accumulation_fusion = False
+    layer.grad_output_buffer = None
+    layer.tp_group = None
+    layer.gtp_remat_size = 2
+    layer.output_dtype = None
+    layer.gather_output = False
+    layer._forward_impl = lambda **kwargs: kwargs["input"]
+    return layer
+
+
+def test_column_parallel_linear_skips_shape_check_for_gtp_weight():
+    layer = _make_column_parallel_linear_for_weight_shape_check()
+    weight = torch.nn.Parameter(torch.zeros(4, 4))
+    weight.is_gtp_weight_remat = True
+    input_ = torch.zeros(2, 4)
+
+    output, output_bias = layer(input_, weight=weight)
+
+    assert output is input_
+    assert output_bias is None
+
+
+def test_column_parallel_linear_checks_shape_for_non_gtp_weight():
+    layer = _make_column_parallel_linear_for_weight_shape_check()
+    weight = torch.nn.Parameter(torch.zeros(4, 4))
+
+    with pytest.raises(RuntimeError, match="supplied weight's shape is"):
+        layer(torch.zeros(2, 4), weight=weight)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])


### PR DESCRIPTION
Found while validating GTP weight rematerialization (#6133, "Gtp refit support")
against the NeMo-RL Megatron functional suites on GB200 (4 GPUs), running GRPO
with a colocated Megatron generation backend at `TP=1`, `gtp_remat_size=2`, on
Qwen2.5-0.5B (which has `share_embeddings_and_output_weights=True`).

Before these four commits the configuration could not start. After them it runs
two full GRPO steps end-to-end: build → generate → reshard/refit → train.

Each commit is independent and stands on its own; three of them are one-liners.

## 1. `fix: restore GTP-replicated bias to its logical size in TE layers`

`_gtp_pre_init` passes a pre-sharded `out_features` to TE's constructor so the
*weight* comes out GTP-sharded. TE also sizes its **bias** off that same
`out_features`, so the bias silently comes out `1/gtp_remat` too small — but a
bias is GTP-replicated, not GTP-sharded (mcore's own `ColumnParallelLinear`
allocates it at the full per-TP size, `attach_gtp_to_presharded_module` never
wraps it, and `make_sharded_tensors_for_checkpoint_with_gtp_remat` treats a
non-GTP param under a GTP module as replicated).

Two consequences: the all-gathered weight produces a full-width GEMM output that
the shard-sized bias cannot be added to, and distributed checkpointing declares a
global shape `1/gtp_remat` of the real one, so a plain checkpoint fails to load
with `Global shape mismatch ... linear_qkv.bias`.

`_gtp_restore_presharded_bias` re-allocates the affected biases at their logical
size after `super().__init__`. Biases are zero-initialized by both TE and mcore,
so nothing is lost. It matches only GEMM biases (`bias`, `bias0..biasN`) — never
`layer_norm_bias`, which is sized off `in_features` — and only when the observed
numel is exactly the shard size, so it is a no-op on every non-GTP path.

## 2. `fix: resolve the GTP axis from GPTModel's own process groups`

`GPTModel` passed only `tp_group=self.pg_collection.tp` to `LanguageModelEmbedding`
and to the output layer. `resolve_gtp_remat_group` falls back to the **global MPU**
groups when it is given no collection, so those two layers picked up whatever GTP
layout `parallel_state` happened to hold rather than the model's own. Passing
`pg_collection` through makes the model self-describing, per the repo guidance on
avoiding new implicit `parallel_state` reads in `megatron/core`.

`TELMHeadColumnParallelLinear` did not accept `pg_collection` at all, so the
output-layer half of this was unreachable for TE LM heads; it now forwards it to
`TEColumnParallelLinear`.

## 3. `fix: declare the GTP axes off on inference process-group collections`

`build_inference_pg_collection` left `gtp_remat` / `expt_gtp_remat` unset.
`resolve_gtp_remat_group` inspects `vars(pg_collection)` and falls back to the
MPU globals for a field that is *absent*, so an inference collection built beside
a GTP-enabled training model inherited the **training** GTP layout and produced a
GTP-sharded inference model. An inference layout never rematerializes weights, so
the axes are now declared explicitly `None` — present in `vars()`, fallback not
taken.

This is what made a colocated reshard fail with
`supplied weight's shape is (75968, 896), not (151936, 896) as expected` while
building the dedicated inference model.

## 4. `fix: accept a GTP-sharded weight in ColumnParallelLinear's shape guard`

With tied embeddings, `shared_embedding_or_output_weight()` hands the output
layer the embedding's GTP-sharded parameter, and `_forward_impl` all-gathers it to
the logical shape before the matmul (via `gtp_remat_size`). The
`skip_weight_param_allocation` guard compared the *local* shape against the
logical one and rejected it, so the same
`supplied weight's shape is (75968, 896), not (151936, 896)` aborted the training
forward — this one independently of NeMo-RL or resharding, in any GTP run with
`share_embeddings_and_output_weights=True`.

The guard now compares `_unsharded_shape` for a GTP param, so it still rejects a
genuinely wrong weight.

## Validation

Rebased onto `main` at `5e2b1da45` and re-verified (each commit cherry-picked
clean; no conflicts with the merged #6133).

Validated as a set on GB200 (aarch64, 4 GPUs) with a GRPO functional test
configured `TP=1`, `gtp_remat_size=2`, NCCL refit, colocated Megatron generation:
without them the run aborts during model or inference-model construction; with
them it completes two full training steps.

## One thing this does *not* fix

That run's `train/token_mult_prob_error` measures **1.1011**, against a `< 1.05`
threshold the test inherited from its non-GTP sibling. The value is
bit-identical across repeated runs, so it is a deterministic train-vs-generation
logprob disagreement rather than noise.

I could not attribute it: the non-GTP control cannot exercise this code path (it
takes a different colocated-generation branch and hits an unrelated CUDA-graph
capture error), so there is no measured baseline for that threshold on this
configuration — it was never validated at 1.05 here. Several other non-vanilla
Megatron generation variants sit similarly above their own 1.05-class gates.

Flagging it rather than moving the threshold: whether the GTP path adds real
numerical error or the inherited threshold is simply wrong for it is a call for
whoever owns the GTP refit path.

---

Raised by an automated agent while testing #6133 against NeMo-RL. Draft — needs a
human review before merge.