### PR TITLE
Fuse FP32 MoE router weight gradient accumulation

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -3713,11 +3713,13 @@ try:
         out: Optional[torch.Tensor] = None,
         bias: Optional[torch.Tensor] = None,
         grad: bool = False,
+        accumulate: bool = False,
     ) -> List[torch.Tensor]:
         """
         Wrapper for TE's general_gemm function.
         It supports fp32, bf16, fp16, and fp8 GEMMs with TN, NN, and NT layouts.
         The output dtype can be specified by `out_dtype`.
+        When `accumulate` is True, the GEMM result is accumulated into `out`.
         Note: not all combinations of these settings are supported. If not supported,
         cublaslt will throw an error.
         """
@@ -3726,7 +3728,7 @@ try:
             quantization_params=None,
             gelu=None,
             gelu_in=None,
-            accumulate=False,
+            accumulate=accumulate,
             layout=layout,
             out=out,
             bias=bias,

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -33,6 +33,8 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import deprecated, internal_api, is_te_min_version
 
 if HAVE_TE:
+    from transformer_engine.pytorch.module.base import get_dummy_wgrad
+
     from megatron.core.extensions.transformer_engine import (
         fused_compute_score_for_moe_aux_loss,
         fused_moe_aux_loss,
@@ -58,6 +60,7 @@ else:
         fused_unpermute,
         te_general_gemm,
     ) = (None, None, None, None, None, None, None, None, None, None)
+    get_dummy_wgrad = None
 
 
 def switch_load_balancing_loss_func(
@@ -1366,6 +1369,7 @@ class RouterGatingLinearFunction(torch.autograd.Function):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         router_dtype: torch.dtype,
+        gradient_accumulation_fusion: bool,
     ) -> torch.Tensor:
         """
         Forward pass of the RouterGatingLinearFunction function.
@@ -1375,6 +1379,8 @@ class RouterGatingLinearFunction(torch.autograd.Function):
             weight (torch.Tensor): The weight tensor.
             bias (torch.Tensor): The bias tensor. Could be None.
             router_dtype (torch.dtype): The router dtype.
+            gradient_accumulation_fusion (bool): Whether to accumulate the weight gradient
+                directly into the parameter's main gradient buffer.
 
         Returns:
             torch.Tensor: The output tensor.
@@ -1383,6 +1389,14 @@ class RouterGatingLinearFunction(torch.autograd.Function):
         ctx.router_dtype = router_dtype
         ctx.input_dtype = inp.dtype
         ctx.weight_dtype = weight.dtype
+        main_grad = getattr(weight, "main_grad", None)
+        ctx.gradient_accumulation_fusion = (
+            gradient_accumulation_fusion
+            and te_general_gemm is not None
+            and router_dtype == torch.float32
+            and (main_grad is not None or hasattr(weight, "__fsdp_param__"))
+        )
+        ctx.main_grad = main_grad if ctx.gradient_accumulation_fusion else None
         inp_shape = inp.shape
         inp = inp.view(-1, inp_shape[-1])
 
@@ -1405,7 +1419,7 @@ class RouterGatingLinearFunction(torch.autograd.Function):
     @staticmethod
     def backward(
         ctx, grad_output: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], None]:
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], None, None]:
         """
         Backward pass of the RouterGatingLinearFunction function.
 
@@ -1413,8 +1427,9 @@ class RouterGatingLinearFunction(torch.autograd.Function):
             grad_output (torch.Tensor): The gradient output.
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], None]:
-                The gradient input, gradient weight, gradient bias, and None.
+            Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], None, None]:
+                The input, weight, and bias gradients, followed by placeholders for the router
+                dtype and gradient accumulation fusion arguments.
         """
         inp, weight, bias = ctx.saved_tensors
         inp_shape = inp.shape
@@ -1426,22 +1441,57 @@ class RouterGatingLinearFunction(torch.autograd.Function):
             grad_input = te_general_gemm(
                 weight.to(ctx.router_dtype), grad_output, ctx.router_dtype, layout="NN", grad=True
             )
-            grad_weight = te_general_gemm(
-                inp.to(ctx.router_dtype), grad_output, ctx.router_dtype, layout="NT", grad=True
-            )
             grad_input = grad_input[0].to(ctx.input_dtype)
-            grad_weight = grad_weight[0].to(ctx.weight_dtype)
+            if ctx.gradient_accumulation_fusion:
+                if hasattr(weight, "__fsdp_param__"):
+                    weight.main_grad = weight.get_main_grad()
+                else:
+                    weight.main_grad = ctx.main_grad
+                te_general_gemm(
+                    inp.to(ctx.router_dtype),
+                    grad_output,
+                    out_dtype=weight.main_grad.dtype,
+                    layout="NT",
+                    out=weight.main_grad,
+                    grad=True,
+                    accumulate=not getattr(weight, "overwrite_main_grad", False),
+                )
+                if hasattr(weight, "overwrite_main_grad"):
+                    weight.overwrite_main_grad = False
+                if hasattr(weight, "grad_added_to_main_grad"):
+                    # Trigger the DDP post-hook so the parameter is registered as ready without
+                    # accumulating the gradient twice.
+                    if getattr(weight, "zero_out_wgrad", False):
+                        grad_weight = get_dummy_wgrad(
+                            list(weight.main_grad.shape), ctx.weight_dtype, zero=True
+                        )
+                    else:
+                        grad_weight = get_dummy_wgrad(
+                            list(weight.main_grad.shape), ctx.weight_dtype
+                        )
+                    weight.grad_added_to_main_grad = True
+                else:
+                    grad_weight = None
+            else:
+                grad_weight = te_general_gemm(
+                    inp.to(ctx.router_dtype), grad_output, ctx.router_dtype, layout="NT", grad=True
+                )
+                grad_weight = grad_weight[0].to(ctx.weight_dtype)
         else:
             grad_input = torch.mm(grad_output, weight.to(ctx.router_dtype)).to(ctx.input_dtype)
             grad_weight = torch.mm(grad_output.t(), inp.to(ctx.router_dtype)).to(ctx.weight_dtype)
 
         grad_bias = grad_output.sum(dim=0).to(ctx.weight_dtype) if bias is not None else None
         grad_input = grad_input.view(*inp_shape)
-        return grad_input, grad_weight, grad_bias, None
+        return grad_input, grad_weight, grad_bias, None, None
 
 
 def router_gating_linear(
-    inp: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor], router_dtype: torch.dtype
+    inp: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    router_dtype: torch.dtype,
+    gradient_accumulation_fusion: bool = False,
 ) -> torch.Tensor:
     """
     Customized linear layer for router gating.
@@ -1453,11 +1503,15 @@ def router_gating_linear(
         weight (torch.Tensor): The weight tensor.
         bias (torch.Tensor): The bias tensor. Could be None.
         router_dtype (torch.dtype): The router dtype.
+        gradient_accumulation_fusion (bool): Whether to accumulate the weight gradient directly
+            into the parameter's main gradient buffer.
 
     Returns:
         torch.Tensor: The output tensor.
     """
-    return RouterGatingLinearFunction.apply(inp, weight, bias, router_dtype)
+    return RouterGatingLinearFunction.apply(
+        inp, weight, bias, router_dtype, gradient_accumulation_fusion
+    )
 
 
 def get_align_size_for_quantization(config: TransformerConfig) -> int:

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -112,7 +112,9 @@ class Router(ABC, MegatronModule):
             router_dtype = torch.float32
         elif self.config.moe_router_dtype == 'fp64':
             router_dtype = torch.float64
-        logits = router_gating_linear(input, self.weight, self.bias, router_dtype)
+        logits = router_gating_linear(
+            input, self.weight, self.bias, router_dtype, self.config.gradient_accumulation_fusion
+        )
         return logits
 
     @abstractmethod

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -616,6 +616,50 @@ def test_router_gating_linear(router_dtype):
 
 @pytest.mark.internal
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("overwrite_main_grad", [False, True])
+def test_router_gating_linear_gradient_accumulation_fusion(overwrite_main_grad):
+    from megatron.core.extensions.transformer_engine import te_general_gemm
+
+    if te_general_gemm is None:
+        pytest.skip("TE general GEMM is not available")
+
+    num_tokens = 64
+    hidden_size = 128
+    num_experts = 32
+    weight = torch.randn(
+        (num_experts, hidden_size), dtype=torch.bfloat16, device="cuda", requires_grad=True
+    )
+    weight.main_grad = torch.randn_like(weight, dtype=torch.float32)
+    expected_main_grad = (
+        torch.zeros_like(weight.main_grad) if overwrite_main_grad else weight.main_grad.clone()
+    )
+    weight.grad_added_to_main_grad = False
+    if overwrite_main_grad:
+        weight.__fsdp_param__ = True
+        weight.overwrite_main_grad = True
+        weight.get_main_grad = lambda: weight.main_grad
+
+    for _ in range(2):
+        inp = torch.randn(
+            (num_tokens, hidden_size), dtype=torch.bfloat16, device="cuda", requires_grad=True
+        )
+        grad_output = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda")
+        expected_main_grad.add_(grad_output.t().matmul(inp.float()))
+
+        output = router_gating_linear(
+            inp, weight, bias=None, router_dtype=torch.float32, gradient_accumulation_fusion=True
+        )
+        output.backward(grad_output)
+
+        assert weight.grad_added_to_main_grad
+        weight.grad = None
+
+    assert not getattr(weight, "overwrite_main_grad", False)
+    torch.testing.assert_close(weight.main_grad, expected_main_grad, rtol=2.0e-3, atol=2.0e-2)
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("router_dtype", [torch.bfloat16, torch.float32, torch.float64])
 def test_router_gating_linear_bias(router_dtype):
     tols = dict(rtol=2.0e-2, atol=1.0e-3)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Fuse FP32 MoE router weight-gradient accumulation into Transformer Engine's GEMM output path.

## Issue tracking
Linked issue: N/A — this is a localized performance fix.

## Motivation

  The MoE router uses a custom autograd function to compute its weight gradient. When
  `gradient_accumulation_fusion` is enabled, tensor-parallel linear layers accumulate
  their weight gradients directly into `main_grad`, but the router previously returned
  a standalone `grad_weight`.

  As a result, the router weight gradient followed the unfused path:

  1. Compute a temporary FP32 weight gradient.
  2. Cast it to the router parameter dtype, typically BF16.
  3. Return it through autograd as `param.grad`.
  4. Accumulate it into the FP32 `main_grad` buffer from the DDP or FSDP hook.

  This produces an unnecessary temporary gradient, dtype conversion, and separate
  `main_grad.add_` operation.

  ## Changes

  - Pass `gradient_accumulation_fusion` to the router gating linear function.
  - Extend the Transformer Engine `general_gemm` wrapper with an `accumulate` argument.
  - Accumulate FP32 router weight gradients directly into `weight.main_grad`.
  - Return a dummy weight gradient so DDP and FSDP post-backward hooks still:
    - run on the main autograd thread;
    - register the parameter as ready for gradient synchronization;
    - avoid accumulating the weight gradient twice.
  - Honor Megatron-FSDP's `overwrite_main_grad` contract:
    - overwrite newly allocated sharded gradient buffers on their first use;
    - accumulate subsequent gradient contributions.
  - Preserve the existing unfused fallback for non-FP32 routers, unavailable TE GEMM,
    and parameters without a `main_grad` buffer.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-M/blob/main/tools/autoformat.sh) on my PR
