### PR TITLE
[Dev] [DO NOT MERGE] GLM-5.2 integration stack and full-model benchmark tracker

### DIFF
--- a/docs/user-guide/features/cuda_graph.md
+++ b/docs/user-guide/features/cuda_graph.md
@@ -136,8 +136,8 @@ This implementation does not create inference CUDA graphs. For inference, use
 
 ### THD Sequence Packing (fixed schedule)
 
-Full-iteration capture is supported with the THD sequence packing scheduler
-(`--sequence-packing-scheduler dp_balanced`) under a fixed-schedule, static-shape contract:
+Full-iteration capture is supported with the THD sequence packing schedulers under a
+fixed-schedule, static-shape contract:
 
 - `num_microbatches` must stay constant across warmup, capture and replay. The packing scheduler
   and dataset must produce the same number of packed microbatches every step; a change after
@@ -153,8 +153,15 @@ Full-iteration capture is supported with the THD sequence packing scheduler
   exact boundaries and fails before capture/replay rather than reuse stale route metadata. At
   least one eager warmup step is required so consumers can materialize host-derived device layout
   caches before capture.
-- Dynamic context parallel (`--dynamic-context-parallel`) is not supported; the CP topology must
-  be static.
+- Dynamic context parallel remains disabled by default for full-iteration capture. A workload
+  whose realized schedule is deliberately invariant may opt in with
+  `--cuda-graph-static-dynamic-cp` together with `--dynamic-context-parallel` and
+  `--sequence-packing-scheduler default_dynamic_cp`. The flag does not make full-iteration
+  capture generally dynamic: every static microbatch slot must keep the same microbatch count,
+  effective CP size, process-group identity and ordered membership, partition mode, and (for
+  CP>1) exact packed boundaries and route-defining geometry. Layout changes are detected before
+  capture or replay and rejected by all ranks together. At effective CP1, tensor-backed
+  cu_seqlens and masks may change while the realized group remains fixed.
 - Pipeline parallel send/recv use the static CP-local token capacity instead of the per-step
   variable-shape handshake.
 - Validation/eval runs eager: a dedicated fixed-shape validation graph is not implemented yet.

--- a/docs/user-guide/features/cuda_graph.md
+++ b/docs/user-guide/features/cuda_graph.md
@@ -134,6 +134,31 @@ This implementation does not create inference CUDA graphs. For inference, use
 --no-check-for-nan-in-loss-and-grad
 ```
 
+### THD Sequence Packing (fixed schedule)
+
+Full-iteration capture is supported with the THD sequence packing scheduler
+(`--sequence-packing-scheduler dp_balanced`) under a fixed-schedule, static-shape contract:
+
+- `num_microbatches` must stay constant across warmup, capture and replay. The packing scheduler
+  and dataset must produce the same number of packed microbatches every step; a change after
+  capture raises a signature-mismatch error instead of silently replaying the stale graph.
+- `--pad-packed-seq-alignment max` (or a value equal to `--max-seqlen-per-dp-cp-rank`),
+  `--max-seqlen-per-dp-cp-rank` and `--thd-max-packed-sequences` are required. Every packed
+  microbatch is canonicalized outside the graph to the per-rank token capacity and a fixed
+  `thd_max_packed_sequences + 1` cu_seqlens width; the real sequence count, `cu_seqlens` content
+  and padding distribution may still change per step when context parallel size is 1.
+- With context parallel size greater than 1, each static microbatch slot must also keep identical
+  packed boundaries across eager warmup, capture and replay. CP routes contain Python split sizes
+  and host-derived layout metadata that are baked into the graph. The batch loader validates the
+  exact boundaries and fails before capture/replay rather than reuse stale route metadata. At
+  least one eager warmup step is required so consumers can materialize host-derived device layout
+  caches before capture.
+- Dynamic context parallel (`--dynamic-context-parallel`) is not supported; the CP topology must
+  be static.
+- Pipeline parallel send/recv use the static CP-local token capacity instead of the per-step
+  variable-shape handshake.
+- Validation/eval runs eager: a dedicated fixed-shape validation graph is not implemented yet.
+
 ---
 
 ## Common Configuration Examples

--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -29,6 +29,7 @@ The following table summarizes MTP configuration fields:
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
 | `mtp_use_repeated_layer` | Reuse one physical MTP layer for every prediction depth. Parameters are shared, while the hidden state, shifted token input, and query are recomputed at each iteration. Default: `False`. |
 | `dsa_mtp_index_kv_share` | For repeated-layer DSA MTP, compute latent KV and indexer top-k at iteration 0 and reuse them at later iterations. Queries and sparse attention are still evaluated at every iteration. The indexer loss is computed and tracked only at iteration 0, so `dsa_indexer_loss_coeff` may need retuning when switching from non-sharing. Default: `False`. |
+| `mtp_loss_type` | MTP training objective: `cross_entropy` or `e2e_tv`. Default: `cross_entropy`. |
 
 ## Repeated DSA MTP IndexShare and KVShare
 
@@ -41,6 +42,15 @@ Because the shared indexer runs only at iteration 0, its auxiliary loss is also 
 Selective activation recomputation with `core_attn` in `recompute_modules` is not supported when `dsa_mtp_index_kv_share` is enabled. Capturing the source key inside the core-attention checkpoint would detach consumer-iteration gradients, so use selective `mla_up_proj` recomputation, full activation recomputation, or disable sharing.
 
 The current implementation uses the split indexer-top-k and sparse-attention path because the combined DSA kernel does not expose top-k for reuse. When an eligible fused DSA backend is configured, enabling sharing logs a rank-0 warning that the combined kernel is bypassed; fused top-k and fused sparse-attention kernels remain available independently. Per-layer CUDA graph scopes that capture attention are not supported with MTP iteration sharing because they split the producer-consumer lifetime across separate graphs. MoE-only scopes and graph scopes that contain the complete MTP producer-consumer chain are compatible, subject to the prerequisites of the selected CUDA graph implementation.
+
+## End-to-End TV Loss
+
+Set `mtp_loss_type: e2e_tv` and `mtp_detach_heads: true` to enable the end-to-end
+TV objective. This mode requires `mtp_num_layers >= 1` and uses
+`mtp_loss_scaling_factor` to scale the auxiliary loss. To train only MTP parameters,
+the optimizer must additionally freeze the base model or select only MTP parameters;
+`mtp_detach_heads` does not change the optimizer parameter set. See
+[Bebop](https://arxiv.org/abs/2606.12370) for the objective definition.
 
 ## Pipeline Parallel Layout for MTP
 

--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -27,6 +27,20 @@ The following table summarizes MTP configuration fields:
 | --- | --- |
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
+| `mtp_use_repeated_layer` | Reuse one physical MTP layer for every prediction depth. Parameters are shared, while the hidden state, shifted token input, and query are recomputed at each iteration. Default: `False`. |
+| `dsa_mtp_index_kv_share` | For repeated-layer DSA MTP, compute latent KV and indexer top-k at iteration 0 and reuse them at later iterations. Queries and sparse attention are still evaluated at every iteration. The indexer loss is computed and tracked only at iteration 0, so `dsa_indexer_loss_coeff` may need retuning when switching from non-sharing. Default: `False`. |
+
+## Repeated DSA MTP IndexShare and KVShare
+
+Set `mtp_use_repeated_layer: true`, choose more than one MTP iteration, and enable `dsa_mtp_index_kv_share` to use GLM-5.2-style sharing across MTP iterations. The physical MTP layer must be a DSA indexer-compute layer under the model's `dsa_indexer_topk_freq` and `dsa_indexer_skip_topk_offset` schedule.
+
+Iteration 0 produces the post-RoPE, post-TP/CP-gather latent key and top-k indices. Later iterations reuse those tensors while recomputing the query and running sparse attention. The shared key remains attached to autograd. Under full activation recomputation it is an explicit checkpoint output from iteration 0 and an explicit checkpoint input to later iterations, so gradients from all sparse-attention consumers accumulate into the iteration-0 KV projection. Under selective `mla_up_proj` recompute, only the query up-projection is checkpointed; the source key is constructed outside that checkpoint and stays available to every consumer iteration.
+
+Because the shared indexer runs only at iteration 0, its auxiliary loss is also computed and added to the loss tracker only once, rather than once per MTP iteration as in the non-sharing path. This changes the effective indexer-loss weighting when sharing is enabled; retune `dsa_indexer_loss_coeff` if the training recipe should preserve a particular indexer-loss contribution.
+
+Selective activation recomputation with `core_attn` in `recompute_modules` is not supported when `dsa_mtp_index_kv_share` is enabled. Capturing the source key inside the core-attention checkpoint would detach consumer-iteration gradients, so use selective `mla_up_proj` recomputation, full activation recomputation, or disable sharing.
+
+The current implementation uses the split indexer-top-k and sparse-attention path because the combined DSA kernel does not expose top-k for reuse. When an eligible fused DSA backend is configured, enabling sharing logs a rank-0 warning that the combined kernel is bypassed; fused top-k and fused sparse-attention kernels remain available independently. Per-layer CUDA graph scopes that capture attention are not supported with MTP iteration sharing because they split the producer-consumer lifetime across separate graphs. MoE-only scopes and graph scopes that contain the complete MTP producer-consumer chain are compatible, subject to the prerequisites of the selected CUDA graph implementation.
 
 ## Pipeline Parallel Layout for MTP
 
@@ -55,4 +69,4 @@ Use `m` for MTP layers in the pipeline layout string. For example:
 
 ## Unsupported Combinations
 
-Context Parallel (CP), arbitrary `AttnMaskType`, and learned absolute position embeddings are not supported with MTP.
+Arbitrary `AttnMaskType` and learned absolute position embeddings are not supported with MTP. Context Parallel support is specific to the attention implementation. For repeated DSA sharing, the supported CP path is DSA with `cp_comm_type=allgather`; it reuses the iteration-0 global latent key within the same microbatch CP group. Speculative decoding is not yet supported with `dsa_mtp_index_kv_share`: its serial `compute_mtp_single_step` calls do not carry the iteration-0 tensors across prediction depths, so disable sharing or set `num_speculative_tokens=0`. Other attention implementations retain their existing MTP and CP capabilities.

--- a/gpt_builders.py
+++ b/gpt_builders.py
@@ -56,34 +56,30 @@ def gpt_builder(args, pre_process, post_process, vp_stage=None, config=None, pg_
     mtp_block_spec = None
     if args.mtp_num_layers is not None:
         assert not (config.transformer_impl == "inference_optimized")
-        if (
+        if args.experimental_attention_variant is not None:
+            # The MTP stage may contain no decoder layers. Build its inner layer from the
+            # global experimental-attention pattern rather than falling back to standard
+            # attention merely because the local decoder block is empty.
+            experimental_layer_specs = (
+                get_transformer_layer_with_experimental_attention_variant_spec(config=config)
+            )
+            transformer_layer_spec_for_mtp = experimental_layer_specs[-1]
+        elif (
             hasattr(transformer_layer_spec, 'layer_specs')
             and len(transformer_layer_spec.layer_specs) == 0
         ):
             # Get the decoder layer spec explicitly if no decoder layer in the last stage,
             # Only happens with block spec (TransformerBlockSubmodules) when using MoE.
             transformer_layer_spec_for_mtp = _get_transformer_layer_spec(use_te, config)
-        elif args.experimental_attention_variant is not None:
-            # get_gpt_decoder_layer_specs rejects experimental variants;
-            # build per-layer specs via the experimental entry point.
-            experimental_layer_specs = (
-                get_transformer_layer_with_experimental_attention_variant_spec(config=config)
-            )
-            transformer_layer_spec_for_mtp = experimental_layer_specs[-1]
         else:
             # Define the decoder block spec
-            if args.experimental_attention_variant is not None:
-                decoder_layer_specs = (
-                    get_transformer_layer_with_experimental_attention_variant_spec(config=config)
-                )
-            else:
-                decoder_layer_specs = get_gpt_decoder_layer_specs(
-                    config,
-                    use_transformer_engine=use_te,
-                    normalization=args.normalization,
-                    qk_l2_norm=args.qk_l2_norm,
-                    vp_stage=vp_stage,
-                )
+            decoder_layer_specs = get_gpt_decoder_layer_specs(
+                config,
+                use_transformer_engine=use_te,
+                normalization=args.normalization,
+                qk_l2_norm=args.qk_l2_norm,
+                vp_stage=vp_stage,
+            )
             transformer_layer_spec_for_mtp = decoder_layer_specs[-1]
         # Use spec of the last layer in decoder block as spec of the transformer layer in MTP
         mtp_block_spec = get_gpt_mtp_block_spec(

--- a/megatron/core/context_parallel_layout/routes.py
+++ b/megatron/core/context_parallel_layout/routes.py
@@ -19,23 +19,54 @@ if TYPE_CHECKING:
 _ThdLayoutSegment = Tuple[int, int, int]
 
 
-def _compact_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
+def _materialize_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
     if cu_seqlens.dim() != 1:
         raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}.")
+    return cu_seqlens.detach().to(device="cpu", dtype=torch.long).tolist()
 
-    cu = cu_seqlens.detach().to(device="cpu", dtype=torch.long).tolist()
+
+def _compact_thd_cu_seqlens_list(cu: List[int], source: torch.Tensor) -> List[int]:
     if not cu or cu[0] != 0:
-        raise ValueError(f"cu_seqlens must start at 0, got {cu_seqlens}.")
+        raise ValueError(f"cu_seqlens must start at 0, got {source}.")
 
     compact_cu: List[int] = [cu[0]]
     prev = cu[0]
     for value in cu[1:]:
         if value < prev:
-            raise ValueError(f"cu_seqlens must be nondecreasing, got {cu_seqlens}.")
+            raise ValueError(f"cu_seqlens must be nondecreasing, got {source}.")
         if value != prev:
             compact_cu.append(value)
         prev = value
     return compact_cu
+
+
+def _compact_thd_cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> List[int]:
+    return _compact_thd_cu_seqlens_list(_materialize_thd_cu_seqlens_to_list(cu_seqlens), cu_seqlens)
+
+
+def _materialize_compact_thd_qkv_cu_seqlens(
+    cu_q: torch.Tensor, cu_kv: Optional[torch.Tensor]
+) -> Tuple[List[int], List[int]]:
+    """Materialize compact Q/KV boundaries with one host transfer."""
+    if cu_kv is None or cu_kv is cu_q:
+        host_q = _compact_thd_cu_seqlens_to_list(cu_q)
+        return host_q, host_q
+
+    if cu_q.device != cu_kv.device:
+        # Preserve the pre-existing mixed-device behavior. Joint materialization is
+        # only possible for co-located tensors; otherwise copy each side separately.
+        return _compact_thd_cu_seqlens_to_list(cu_q), _compact_thd_cu_seqlens_to_list(cu_kv)
+    if cu_q.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_q.shape)}.")
+    if cu_kv.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_kv.shape)}.")
+
+    q_numel = cu_q.numel()
+    joint_cu = torch.cat((cu_q.detach(), cu_kv.detach()))
+    joint_host = _materialize_thd_cu_seqlens_to_list(joint_cu)
+    host_q = _compact_thd_cu_seqlens_list(joint_host[:q_numel], cu_q)
+    host_kv = _compact_thd_cu_seqlens_list(joint_host[q_numel:], cu_kv)
+    return host_q, host_kv
 
 
 def _validate_thd_route_partitioning(cu: List[int], cp_size: int) -> None:
@@ -145,6 +176,57 @@ def _build_thd_layout_side_route(
     return torch.tensor(row_order, device=device, dtype=torch.long), split_sizes
 
 
+def _build_thd_cp_partition_route_from_host(
+    cu: List[int], cp_size: int, cp_rank: int, *, device: torch.device
+) -> ThdCpRoute:
+    """Build a THD CP route from already compact host boundaries."""
+    _validate_thd_route_partitioning(cu, cp_size)
+
+    zigzag_segments_by_rank: List[List[_ThdLayoutSegment]] = []
+    zigzag_lengths: List[int] = []
+    contiguous_segments_by_rank: List[List[_ThdLayoutSegment]] = []
+    for rank in range(cp_size):
+        zigzag_segments, zigzag_length = _build_thd_layout_segments(cu, cp_size, rank, "zigzag")
+        contiguous_segments, contiguous_length = _build_thd_layout_segments(
+            cu, cp_size, rank, "contiguous"
+        )
+        if zigzag_length != contiguous_length:
+            raise ValueError(
+                "THD CP layout conversion must preserve local token count, "
+                f"got zigzag={zigzag_length}, contiguous={contiguous_length} "
+                f"for cp_size={cp_size}, rank={rank}."
+            )
+        zigzag_segments_by_rank.append(zigzag_segments)
+        zigzag_lengths.append(zigzag_length)
+        contiguous_segments_by_rank.append(contiguous_segments)
+
+    zigzag_index, zigzag_split_sizes = _build_thd_layout_side_route(
+        zigzag_segments_by_rank[cp_rank], contiguous_segments_by_rank, device=device
+    )
+    contiguous_index, contiguous_split_sizes = _build_thd_layout_side_route(
+        contiguous_segments_by_rank[cp_rank], zigzag_segments_by_rank, device=device
+    )
+
+    local_length = zigzag_lengths[cp_rank]
+    if sum(zigzag_split_sizes) != local_length:
+        raise ValueError(
+            "Zigzag THD CP route split sizes do not match the local token count: "
+            f"splits={zigzag_split_sizes}, local_length={local_length}."
+        )
+    if sum(contiguous_split_sizes) != local_length:
+        raise ValueError(
+            "Contiguous THD CP route split sizes do not match the local token count: "
+            f"splits={contiguous_split_sizes}, local_length={local_length}."
+        )
+
+    return ThdCpRoute(
+        zigzag_index=zigzag_index,
+        zigzag_split_sizes=zigzag_split_sizes,
+        contiguous_index=contiguous_index,
+        contiguous_split_sizes=contiguous_split_sizes,
+    )
+
+
 def build_thd_cp_partition_route(
     cu_seqlens: torch.Tensor, cp_size: int, cp_rank: int, *, device: Optional[torch.device] = None
 ) -> ThdCpRoute:
@@ -163,51 +245,7 @@ def build_thd_cp_partition_route(
 
     with nvtx_range("cp_layout/thd/route"):
         cu = _compact_thd_cu_seqlens_to_list(cu_seqlens)
-        _validate_thd_route_partitioning(cu, cp_size)
-
-        zigzag_segments_by_rank: List[List[_ThdLayoutSegment]] = []
-        zigzag_lengths: List[int] = []
-        contiguous_segments_by_rank: List[List[_ThdLayoutSegment]] = []
-        for rank in range(cp_size):
-            zigzag_segments, zigzag_length = _build_thd_layout_segments(cu, cp_size, rank, "zigzag")
-            contiguous_segments, contiguous_length = _build_thd_layout_segments(
-                cu, cp_size, rank, "contiguous"
-            )
-            if zigzag_length != contiguous_length:
-                raise ValueError(
-                    "THD CP layout conversion must preserve local token count, "
-                    f"got zigzag={zigzag_length}, contiguous={contiguous_length} "
-                    f"for cp_size={cp_size}, rank={rank}."
-                )
-            zigzag_segments_by_rank.append(zigzag_segments)
-            zigzag_lengths.append(zigzag_length)
-            contiguous_segments_by_rank.append(contiguous_segments)
-
-        zigzag_index, zigzag_split_sizes = _build_thd_layout_side_route(
-            zigzag_segments_by_rank[cp_rank], contiguous_segments_by_rank, device=device
-        )
-        contiguous_index, contiguous_split_sizes = _build_thd_layout_side_route(
-            contiguous_segments_by_rank[cp_rank], zigzag_segments_by_rank, device=device
-        )
-
-        local_length = zigzag_lengths[cp_rank]
-        if sum(zigzag_split_sizes) != local_length:
-            raise ValueError(
-                "Zigzag THD CP route split sizes do not match the local token count: "
-                f"splits={zigzag_split_sizes}, local_length={local_length}."
-            )
-        if sum(contiguous_split_sizes) != local_length:
-            raise ValueError(
-                "Contiguous THD CP route split sizes do not match the local token count: "
-                f"splits={contiguous_split_sizes}, local_length={local_length}."
-            )
-
-        return ThdCpRoute(
-            zigzag_index=zigzag_index,
-            zigzag_split_sizes=zigzag_split_sizes,
-            contiguous_index=contiguous_index,
-            contiguous_split_sizes=contiguous_split_sizes,
-        )
+        return _build_thd_cp_partition_route_from_host(cu, cp_size, cp_rank, device=device)
 
 
 def get_thd_cp_partition_route(
@@ -269,12 +307,33 @@ def prebuild_thd_cp_partition_routes(
         return
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
-    cu_seqlens = get_packed_seq_params_cp_partition_cu_seqlens(packed_seq_params)
-    if cu_seqlens is None:
+    if not 0 <= cp_rank < cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
+    cu_q = get_packed_seq_params_cp_partition_cu_seqlens(packed_seq_params)
+    if cu_q is None:
         return
     if device is None:
-        device = cu_seqlens.device
+        device = cu_q.device
 
-    packed_seq_params.cp_partition_route = build_thd_cp_partition_route(
-        cu_seqlens, cp_size, cp_rank, device=device
+    # Also expose the compacted cu_seqlens as host integer lists. Consumers that
+    # derive per-token layout metadata from them (e.g. the DSA packed-CP position
+    # builders) can then work entirely on the host instead of re-deriving the same
+    # spans on the device, where the data-dependent shapes force a
+    # device-to-host readback behind the whole queued iteration. Doing the copy
+    # here is cheap for the same reason the route build is: at batch-construction
+    # time the CUDA queue is still shallow.
+    # getattr: the pre-existing contract of this function (see the unit tests) is
+    # any object carrying the q-side fields, so the kv-side reads must not widen it.
+    cu_kv_padded = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+    cu_kv = (
+        cu_kv_padded
+        if cu_kv_padded is not None
+        else getattr(packed_seq_params, "cu_seqlens_kv", None)
     )
+    with nvtx_range("cp_layout/thd/route"):
+        host_q, host_kv = _materialize_compact_thd_qkv_cu_seqlens(cu_q, cu_kv)
+        route = _build_thd_cp_partition_route_from_host(host_q, cp_size, cp_rank, device=device)
+
+    packed_seq_params.cp_partition_route = route
+    packed_seq_params.thd_cp_host_cu_seqlens_q = host_q
+    packed_seq_params.thd_cp_host_cu_seqlens_kv = host_kv

--- a/megatron/core/context_parallel_layout/utils.py
+++ b/megatron/core/context_parallel_layout/utils.py
@@ -41,5 +41,6 @@ def finalize_packed_seq_params(
 
     cp_group = resolve_cp_group(get_context_parallel_group(), packed_seq_params)
     packed_seq_params.cp_group = cp_group
-    prebuild_thd_cp_partition_routes(packed_seq_params, cp_group)
+    if not getattr(packed_seq_params, '_full_cuda_graph_cp_metadata_prebuilt', False):
+        prebuild_thd_cp_partition_routes(packed_seq_params, cp_group)
     return packed_seq_params

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -79,6 +79,94 @@ def _build_thd_full_iteration_cp_metadata(packed_seq_params: PackedSeqParams) ->
     }
 
 
+def _build_thd_full_iteration_dynamic_cp_signature(
+    packed_seq_params: PackedSeqParams, *, config
+) -> Dict[str, Any]:
+    """Describe the exact realized dynamic-CP topology for one static slot.
+
+    The process-group identity is intentional. CUDA Graph capture binds
+    collectives to a particular communicator, so another ProcessGroup with the
+    same rank membership is not interchangeable with the captured object.
+    """
+    # This helper must be called before ``finalize_packed_seq_params``.  The
+    # finalizer deliberately falls back to the model's static CP group when the
+    # per-microbatch group is absent; that fallback is useful on ordinary eager
+    # paths, but it must not certify a dynamic-CP schedule that failed to
+    # provide its realized group.
+    cp_group = packed_seq_params.cp_group
+    local_cp_size = packed_seq_params.local_cp_size
+    validation_error = None
+    if cp_group is None or local_cp_size is None:
+        validation_error = (
+            "Static dynamic-CP full-iteration batches require both local_cp_size "
+            "and the realized CP process group."
+        )
+    else:
+        local_cp_size = int(local_cp_size)
+
+    cp_group_size = -1
+    cp_group_rank = -1
+    cp_group_global_ranks = ()
+    if cp_group is not None:
+        try:
+            cp_group_size = int(cp_group.size())
+            cp_group_rank = int(cp_group.rank())
+            cp_group_global_ranks = tuple(torch.distributed.get_process_group_ranks(cp_group))
+        except (AttributeError, RuntimeError, ValueError, TypeError) as exc:
+            if validation_error is None:
+                validation_error = (
+                    "Static dynamic-CP full-iteration batch could not inspect its "
+                    f"realized CP process group: {exc}"
+                )
+    if validation_error is None and local_cp_size != cp_group_size:
+        validation_error = (
+            "Static dynamic-CP full-iteration batch has inconsistent topology: "
+            f"local_cp_size={local_cp_size}, process-group size={cp_group_size}."
+        )
+    if validation_error is None and len(cp_group_global_ranks) != cp_group_size:
+        validation_error = (
+            "Static dynamic-CP full-iteration batch has inconsistent process-group "
+            f"membership: size={cp_group_size}, ranks={cp_group_global_ranks}."
+        )
+    if validation_error is None and not 0 <= cp_group_rank < cp_group_size:
+        validation_error = (
+            "Static dynamic-CP full-iteration batch has invalid process-group rank: "
+            f"rank={cp_group_rank}, size={cp_group_size}."
+        )
+    mtp_num_layers = int(getattr(config, 'mtp_num_layers', 0) or 0)
+    if (
+        validation_error is None
+        and mtp_num_layers > 0
+        and packed_seq_params.cp_partition_mode == 'zigzag'
+        and cp_group_size > 1
+    ):
+        # This data-layer certificate is shared by forward, SFT, and RL consumers.
+        # Reserve one additional future row so no consumer can silently fall back
+        # to the legacy cumulative-roll path during graph capture.
+        required_max_offset = mtp_num_layers + 1
+        min_chunk_size = packed_seq_params.zigzag_cp_min_chunk_size
+        if min_chunk_size is None or min_chunk_size < required_max_offset:
+            validation_error = (
+                "THD full-iteration CUDA graph with MTP and zigzag dynamic CP>1 requires "
+                "the final zigzag_cp_min_chunk_size scheduler certificate to be at least "
+                f"mtp_num_layers + 1 ({required_max_offset}), got {min_chunk_size}; the "
+                "legacy cumulative-roll fallback is not CUDA-graph safe."
+            )
+
+    # Do not raise a rank-local exception here. StaticBufferLoader records this
+    # marker and the wrapper performs one world-wide consensus after every rank
+    # has completed batch preparation, so no peer can enter capture/replay alone.
+    return {
+        'version': 1,
+        'validation_error': validation_error,
+        'local_cp_size': -1 if local_cp_size is None else local_cp_size,
+        'cp_group_identity': None if cp_group is None else id(cp_group),
+        'cp_group_global_ranks': cp_group_global_ranks,
+        'cp_group_rank': cp_group_rank,
+        'cp_partition_mode': packed_seq_params.cp_partition_mode,
+    }
+
+
 def _build_thd_full_iteration_cp_layout_signature(
     packed_seq_params: PackedSeqParams,
 ) -> Optional[Dict[str, Any]]:
@@ -110,6 +198,7 @@ def _build_thd_full_iteration_cp_layout_signature(
         'contiguous_split_sizes': tuple(route.contiguous_split_sizes),
         'thd_cp_host_cu_seqlens_q': None if host_cu_q is None else tuple(host_cu_q),
         'thd_cp_host_cu_seqlens_kv': None if host_cu_kv is None else tuple(host_cu_kv),
+        'zigzag_cp_min_chunk_size': packed_seq_params.zigzag_cp_min_chunk_size,
     }
 
 
@@ -146,13 +235,13 @@ def _unpack_thd_full_iteration_static_batch(batch: Dict[str, Any]):
     # Only CP>1 geometry is immutable across a static-buffer slot.  At CP1,
     # packed boundaries may change between replays, so do not retain consumer
     # caches attached to a PackedSeqParams instance from an earlier batch.
+    cp_metadata = batch[_THD_FULL_ITERATION_CP_METADATA_KEY]
     packed_seq_params = (
-        batch.get(_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY)
+        cp_metadata.get(_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY)
         if layout_metadata is not None
         else None
     )
     if packed_seq_params is None:
-        cp_metadata = batch[_THD_FULL_ITERATION_CP_METADATA_KEY]
         packed_seq_params = PackedSeqParams(
             qkv_format='thd',
             cu_seqlens_q=batch['cu_seqlens'],
@@ -161,10 +250,13 @@ def _unpack_thd_full_iteration_static_batch(batch: Dict[str, Any]):
             cu_seqlens_kv_padded=batch['cu_seqlens_padded'],
             max_seqlen_q=batch['max_seqlen'],
             max_seqlen_kv=batch['max_seqlen'],
-            local_cp_size=None,
+            local_cp_size=batch['local_cp_size'],
             cp_group=cp_metadata['cp_group'],
             cp_partition_mode=batch['cp_partition_mode'],
             pad_between_seqs=batch['pad_between_seqs'],
+            zigzag_cp_min_chunk_size=(
+                None if layout_metadata is None else layout_metadata.get('zigzag_cp_min_chunk_size')
+            ),
             cp_partition_route=_restore_thd_full_iteration_cp_route(cp_metadata, layout_metadata),
         )
         for name in ('thd_cp_host_cu_seqlens_q', 'thd_cp_host_cu_seqlens_kv'):
@@ -180,7 +272,11 @@ def _unpack_thd_full_iteration_static_batch(batch: Dict[str, Any]):
             # graph. In addition to preserving route tensor addresses, this
             # lets consumers populate per-layout caches during eager warmup and
             # reuse them during capture without rebuilding host-derived tensors.
-            batch[_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY] = packed_seq_params
+            # StaticBufferLoader returns a shallow top-level copy, while this
+            # nested metadata dict is shared with the captured slot; cache here
+            # so the object survives the next replay without exposing a mutable
+            # top-level entry to pipeline-stage batch tailoring.
+            cp_metadata[_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY] = packed_seq_params
     return (
         batch['tokens'],
         batch['labels'],
@@ -215,8 +311,9 @@ def prepare_thd_static_batch_for_full_iteration_cuda_graph(
     ``THD_FULL_ITERATION_STATIC_BATCH_KEY`` and reads the static tensors
     without further shape discovery.
     """
-    # Static-shape requirements (max_seqlen_per_dp_cp_rank, thd_max_packed_sequences,
-    # no dynamic CP) are validated once at TransformerConfig construction time.
+    # Static-shape requirements are validated once at TransformerConfig
+    # construction time. Dynamic CP additionally requires an explicit opt-in to
+    # this per-slot certificate path; ordinary dynamic schedules remain rejected.
     assert config is not None, "THD full-iteration batch preparation requires a config."
     assert getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration', (
         "prepare_thd_static_batch_for_full_iteration_cuda_graph requires "
@@ -224,6 +321,18 @@ def prepare_thd_static_batch_for_full_iteration_cuda_graph(
     )
     max_seqlen_per_dp_cp_rank = config.max_seqlen_per_dp_cp_rank
     thd_max_packed_sequences = config.thd_max_packed_sequences
+    dynamic_cp = bool(getattr(config, 'dynamic_context_parallel', False))
+    if dynamic_cp and not getattr(config, 'cuda_graph_static_dynamic_cp', False):
+        raise RuntimeError(
+            "THD full-iteration CUDA graph with dynamic context parallelism requires "
+            "cuda_graph_static_dynamic_cp=True so every realized schedule slot is "
+            "certified before replay."
+        )
+    if dynamic_cp and getattr(config, 'sequence_packing_scheduler', None) != 'default_dynamic_cp':
+        raise RuntimeError(
+            "Static-certified dynamic CP requires "
+            "sequence_packing_scheduler='default_dynamic_cp'."
+        )
 
     # Canonicalization mutates the batch dict in place (padding-mask insertion,
     # 2D views, sanitized values). Work on a shallow copy so callers that replay
@@ -241,20 +350,34 @@ def prepare_thd_static_batch_for_full_iteration_cuda_graph(
             vpp_size=vpp_size,
             mtp_on_this_rank=mtp_on_this_rank(config, ignore_virtual=False, vp_stage=vp_stage),
             vp_stage=vp_stage,
-            dynamic_cp=False,
+            dynamic_cp=dynamic_cp,
             pg_collection=pg_collection,
             config=config,
         )
     )
 
-    # CP route construction reads packed boundaries on the host and creates
-    # Python split metadata. Do it before StaticBufferLoader hands the batch to
-    # the captured forward, then preserve the resulting tensors and lists in
-    # the static slot. The exact CP>1 geometry is part of the graph contract;
-    # StaticBufferLoader rejects a later batch that would invalidate it.
-    finalize_packed_seq_params(packed_seq_params)
+    # Certify dynamic CP from the scheduler-produced metadata *before* the
+    # ordinary finalizer is allowed to resolve a missing group from the model's
+    # static CP group.  An invalid dynamic topology is kept as a deferred marker
+    # and deliberately not finalized; all ranks reject it together after batch
+    # preparation.
+    dynamic_cp_signature = (
+        _build_thd_full_iteration_dynamic_cp_signature(packed_seq_params, config=config)
+        if dynamic_cp
+        else None
+    )
+    if dynamic_cp_signature is None or dynamic_cp_signature['validation_error'] is None:
+        # CP route construction reads packed boundaries on the host and creates
+        # Python split metadata. Do it before StaticBufferLoader hands the batch
+        # to the captured forward, then preserve the resulting tensors and
+        # lists in the static slot.
+        finalize_packed_seq_params(packed_seq_params)
     cp_metadata = _build_thd_full_iteration_cp_metadata(packed_seq_params)
-    cp_layout_signature = _build_thd_full_iteration_cp_layout_signature(packed_seq_params)
+    cp_layout_signature = (
+        None
+        if dynamic_cp_signature is not None and dynamic_cp_signature['validation_error'] is not None
+        else _build_thd_full_iteration_cp_layout_signature(packed_seq_params)
+    )
 
     # Enforce the static-input contract before the tensors reach graph buffers.
     expected_entries = thd_max_packed_sequences + 1
@@ -298,12 +421,18 @@ def prepare_thd_static_batch_for_full_iteration_cuda_graph(
         'cu_seqlens': packed_seq_params.cu_seqlens_q,
         'cu_seqlens_padded': packed_seq_params.cu_seqlens_q_padded,
         'max_seqlen': packed_seq_params.max_seqlen_q,
+        'local_cp_size': packed_seq_params.local_cp_size,
         'cp_partition_mode': packed_seq_params.cp_partition_mode,
         'pad_between_seqs': packed_seq_params.pad_between_seqs,
         _THD_FULL_ITERATION_CP_METADATA_KEY: cp_metadata,
     }
+    static_metadata = {}
     if cp_layout_signature is not None:
-        static_batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY] = {'thd_cp_layout': cp_layout_signature}
+        static_metadata['thd_cp_layout'] = cp_layout_signature
+    if dynamic_cp_signature is not None:
+        static_metadata['thd_dynamic_cp'] = dynamic_cp_signature
+    if static_metadata:
+        static_batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY] = static_metadata
     return static_batch
 
 
@@ -1154,7 +1283,9 @@ def get_batch_on_this_rank_for_sequence_packing(
     max_seqlen = scalar_metadata_host[0]
     zigzag_cp_min_chunk_size = scalar_metadata_host[1]
     if zigzag_cp_min_chunk_size < 0 or (
-        config is not None and getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration'
+        not dynamic_cp
+        and config is not None
+        and getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration'
     ):
         zigzag_cp_min_chunk_size = None
     local_cp_size = scalar_metadata_host[2] if dynamic_cp else None

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -640,7 +640,12 @@ class DpBalancedScheduler(BasePackingScheduler):
 
             # Step 6: Build packed microbatches
             new_samples = build_packed_microbatches(
-                samples_this_rank_with_id, sample_id_groups, dcp_rank, dev, self.is_dynamic_cp
+                samples_this_rank_with_id,
+                sample_id_groups,
+                dcp_rank,
+                dev,
+                self.is_dynamic_cp,
+                global_id_seqlens,
             )
 
             # Step 7: Calculate FLOPs info
@@ -895,7 +900,7 @@ def get_batch_on_this_rank_for_sequence_packing(
     dev = torch.cuda.current_device()
 
     # data_iterator should return a batch including the following keys.
-    batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen']
+    batch_keys = ['cu_seqlens', 'cu_seqlens_padded', 'max_seqlen', 'zigzag_cp_min_chunk_size']
     if dynamic_cp:
         batch_keys.append('local_cp_size')
     if is_first_stage or mtp_on_this_rank:
@@ -909,6 +914,10 @@ def get_batch_on_this_rank_for_sequence_packing(
     if is_tp_rank_0:
         assert prefetched_batch is not None, "TP rank 0 requires a data_iterator"
         batch = prefetched_batch
+        # External iterators do not carry the optional scheduler certificate.
+        # Unknown geometry keeps MTP on its established zigzag packed-CP roll path.
+        if 'zigzag_cp_min_chunk_size' not in batch:
+            batch['zigzag_cp_min_chunk_size'] = torch.tensor(-1, dtype=torch.int32, device=dev)
         for key in batch_keys:
             assert key in batch, f"{key} is missing in current batch."
     else:
@@ -966,9 +975,10 @@ def get_batch_on_this_rank_for_sequence_packing(
         # sequence. Extend its global physical endpoint before CP slicing so
         # both zigzag indices and contiguous rank origins see the padded layout.
         if pad_alignment is not None and tail_padding_policy == 'extend_last':
+            original_cu_seqlens_padded = batch['cu_seqlens_padded']
             batch['cu_seqlens_padded'], batch['max_seqlen'], non_dummy_global_target_len = (
                 extend_thd_padding_before_cp_slice(
-                    batch['cu_seqlens_padded'],
+                    original_cu_seqlens_padded,
                     batch['max_seqlen'],
                     alignment=alignment,
                     target_len=(
@@ -978,6 +988,17 @@ def get_batch_on_this_rank_for_sequence_packing(
                     cp_partition_mode=cp_partition_mode,
                 )
             )
+            if batch['cu_seqlens_padded'] is not original_cu_seqlens_padded:
+                # Extending the final sequence can repair a previously
+                # non-divisible physical layout. The old zero certificate no
+                # longer describes it, so downgrade only that value to unknown.
+                certificate = batch['zigzag_cp_min_chunk_size']
+                if isinstance(certificate, torch.Tensor):
+                    batch['zigzag_cp_min_chunk_size'] = torch.where(
+                        certificate == 0, certificate.new_full(certificate.shape, -1), certificate
+                    )
+                elif certificate == 0:
+                    batch['zigzag_cp_min_chunk_size'] = -1
 
     # Partition sequence tensors for context parallelism. Padding mask is needed
     # on every PP stage, while data tensors are only needed on first/last/MTP stages.
@@ -1080,6 +1101,17 @@ def get_batch_on_this_rank_for_sequence_packing(
         batch['cu_seqlens_padded'] = torch.empty([cu_seqlen_size], dtype=torch.int32, device=dev)
         batch['max_seqlen'] = torch.empty(1, dtype=torch.int32, device=dev)
 
+    if is_tp_rank_0:
+        if type(batch['zigzag_cp_min_chunk_size']) == int:
+            batch['zigzag_cp_min_chunk_size'] = torch.tensor(
+                batch['zigzag_cp_min_chunk_size'], dtype=torch.int32, device=dev
+            )
+        else:
+            assert batch['zigzag_cp_min_chunk_size'].dtype == torch.int32
+            assert batch['zigzag_cp_min_chunk_size'].numel() == 1
+    else:
+        batch['zigzag_cp_min_chunk_size'] = torch.empty(1, dtype=torch.int32, device=dev)
+
     # Step5: Prepare "local_cp_size" if dynamic context parallel is enabled.
     if dynamic_cp:
         if is_tp_rank_0:
@@ -1104,6 +1136,7 @@ def get_batch_on_this_rank_for_sequence_packing(
     broadcast_tensor(batch['cu_seqlens'], tp_src_rank, tp_group)
     broadcast_tensor(batch['cu_seqlens_padded'], tp_src_rank, tp_group)
     broadcast_tensor(batch['max_seqlen'], tp_src_rank, tp_group)
+    broadcast_tensor(batch['zigzag_cp_min_chunk_size'], tp_src_rank, tp_group)
     broadcast_tensor(batch['local_cp_size'], tp_src_rank, tp_group)
 
     # Extract the data from batch after broadcasting.
@@ -1114,8 +1147,17 @@ def get_batch_on_this_rank_for_sequence_packing(
     padding_mask = batch['padding_mask']
     cu_seqlens = batch['cu_seqlens']
     cu_seqlens_padded = batch['cu_seqlens_padded']
-    max_seqlen = batch['max_seqlen'].item()
-    local_cp_size = batch['local_cp_size'].item() if dynamic_cp else None
+    scalar_metadata = [batch['max_seqlen'].reshape(1), batch['zigzag_cp_min_chunk_size'].reshape(1)]
+    if dynamic_cp:
+        scalar_metadata.append(batch['local_cp_size'].reshape(1))
+    scalar_metadata_host = torch.cat(scalar_metadata).cpu().tolist()
+    max_seqlen = scalar_metadata_host[0]
+    zigzag_cp_min_chunk_size = scalar_metadata_host[1]
+    if zigzag_cp_min_chunk_size < 0 or (
+        config is not None and getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration'
+    ):
+        zigzag_cp_min_chunk_size = None
+    local_cp_size = scalar_metadata_host[2] if dynamic_cp else None
     cp_group = (
         parallel_state.get_dynamic_data_context_parallel_groups(group_size=local_cp_size)
         if dynamic_cp
@@ -1138,6 +1180,7 @@ def get_batch_on_this_rank_for_sequence_packing(
         cp_group=cp_group,
         cp_partition_mode=cp_partition_mode,
         pad_between_seqs=True,
+        zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
     )
 
     # Dummy metadata is appended after CP slicing as an ordinary sequence.

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Type
 import torch
 
 from megatron.core import parallel_state
+from megatron.core.context_parallel_layout import ThdCpRoute, finalize_packed_seq_params
 from megatron.core.datasets.data_schedule_utils import (
     align_sample_id_groups,
     broadcast_scalars,
@@ -16,6 +17,7 @@ from megatron.core.datasets.data_schedule_utils import (
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
 )
+from megatron.core.full_cuda_graph import FULL_CUDA_GRAPH_STATIC_METADATA_KEY
 from megatron.core.packed_seq_params import (
     PackedSeqParams,
     extend_thd_padding_before_cp_slice,
@@ -26,6 +28,283 @@ from megatron.core.packed_seq_params import (
 from megatron.core.pipeline_parallel.hybrid_cp_schedule import BalancedCPScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.multi_token_prediction import mtp_on_this_rank
+
+# Sentinel key marking a batch that was already canonicalized to the THD
+# full-iteration CUDA graph static-input contract outside the captured region.
+THD_FULL_ITERATION_STATIC_BATCH_KEY = 'thd_full_iteration_static_batch'
+_THD_FULL_ITERATION_CP_METADATA_KEY = 'thd_full_iteration_cp_metadata'
+_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY = '_thd_full_iteration_packed_seq_params'
+
+
+def _materialize_thd_cp_layout_signatures(
+    packed_seq_params: PackedSeqParams,
+    host_cu_q: Optional[List[int]],
+    host_cu_kv: Optional[List[int]],
+):
+    """Return exact Q/KV CP boundaries with at most one normal host transfer."""
+    if host_cu_q is not None and host_cu_kv is not None:
+        return tuple(host_cu_q), tuple(host_cu_kv)
+
+    cu_q = (
+        packed_seq_params.cu_seqlens_q_padded
+        if packed_seq_params.cu_seqlens_q_padded is not None
+        else packed_seq_params.cu_seqlens_q
+    )
+    cu_kv = (
+        packed_seq_params.cu_seqlens_kv_padded
+        if packed_seq_params.cu_seqlens_kv_padded is not None
+        else packed_seq_params.cu_seqlens_kv
+    )
+    assert cu_q is not None and cu_kv is not None
+    if cu_q is cu_kv:
+        values = tuple(cu_q.detach().to(device='cpu', dtype=torch.int64).tolist())
+        return values, values
+    if cu_q.device != cu_kv.device:
+        return (
+            tuple(cu_q.detach().to(device='cpu', dtype=torch.int64).tolist()),
+            tuple(cu_kv.detach().to(device='cpu', dtype=torch.int64).tolist()),
+        )
+    q_numel = cu_q.numel()
+    values = torch.cat((cu_q.detach(), cu_kv.detach())).to(device='cpu', dtype=torch.int64).tolist()
+    return tuple(values[:q_numel]), tuple(values[q_numel:])
+
+
+def _build_thd_full_iteration_cp_metadata(packed_seq_params: PackedSeqParams) -> Dict[str, Any]:
+    """Serialize finalized CP tensor inputs into containers understood by StaticBufferLoader."""
+    route = packed_seq_params.cp_partition_route
+    return {
+        'cp_group': packed_seq_params.cp_group,
+        'zigzag_index': None if route is None else route.zigzag_index,
+        'contiguous_index': None if route is None else route.contiguous_index,
+    }
+
+
+def _build_thd_full_iteration_cp_layout_signature(
+    packed_seq_params: PackedSeqParams,
+) -> Optional[Dict[str, Any]]:
+    """Return the exact packed geometry baked into CP>1 Python route metadata."""
+    cp_group = packed_seq_params.cp_group
+    if cp_group is None or cp_group.size() <= 1:
+        return None
+    route = packed_seq_params.cp_partition_route
+    assert route is not None, "CP>1 THD static batches require a prebuilt partition route."
+
+    # PRs layered on top of the generic THD graph support may attach compact
+    # host boundaries for consumers such as DSA. Keep them in the immutable
+    # metadata certificate without making this module depend on those consumers.
+    host_cu_q = getattr(packed_seq_params, 'thd_cp_host_cu_seqlens_q', None)
+    host_cu_kv = getattr(packed_seq_params, 'thd_cp_host_cu_seqlens_kv', None)
+    cp_cu_q, cp_cu_kv = _materialize_thd_cp_layout_signatures(
+        packed_seq_params, host_cu_q, host_cu_kv
+    )
+    return {
+        'version': 1,
+        'cp_size': cp_group.size(),
+        'cp_rank': cp_group.rank(),
+        'cp_partition_mode': packed_seq_params.cp_partition_mode,
+        'cp_cu_seqlens_q': cp_cu_q,
+        'cp_cu_seqlens_kv': cp_cu_kv,
+        'zigzag_index_is_none': route.zigzag_index is None,
+        'zigzag_split_sizes': tuple(route.zigzag_split_sizes),
+        'contiguous_index_is_none': route.contiguous_index is None,
+        'contiguous_split_sizes': tuple(route.contiguous_split_sizes),
+        'thd_cp_host_cu_seqlens_q': None if host_cu_q is None else tuple(host_cu_q),
+        'thd_cp_host_cu_seqlens_kv': None if host_cu_kv is None else tuple(host_cu_kv),
+    }
+
+
+def _restore_thd_full_iteration_cp_route(
+    tensor_metadata: Dict[str, Any], layout_metadata: Optional[Dict[str, Any]]
+):
+    """Rebuild the lightweight route wrapper around static-buffer payloads."""
+    if layout_metadata is None:
+        return None
+    for layout in ('zigzag', 'contiguous'):
+        index = tensor_metadata[f'{layout}_index']
+        if (index is None) != layout_metadata[f'{layout}_index_is_none']:
+            raise RuntimeError(
+                f"THD full-iteration {layout} route index presence does not match its "
+                "graph-static metadata certificate."
+            )
+    return ThdCpRoute(
+        zigzag_index=tensor_metadata['zigzag_index'],
+        zigzag_split_sizes=list(layout_metadata['zigzag_split_sizes']),
+        contiguous_index=tensor_metadata['contiguous_index'],
+        contiguous_split_sizes=list(layout_metadata['contiguous_split_sizes']),
+    )
+
+
+def _unpack_thd_full_iteration_static_batch(batch: Dict[str, Any]):
+    """Rebuild ``get_batch`` outputs from a pre-canonicalized static batch.
+
+    Inside a captured full-iteration CUDA graph, batch tensors must be read
+    from fixed addresses without shape discovery, host synchronization, or
+    collective communication, so this only re-wraps the static tensors
+    prepared by ``prepare_thd_static_batch_for_full_iteration_cuda_graph``.
+    """
+    layout_metadata = batch.get(FULL_CUDA_GRAPH_STATIC_METADATA_KEY, {}).get('thd_cp_layout')
+    # Only CP>1 geometry is immutable across a static-buffer slot.  At CP1,
+    # packed boundaries may change between replays, so do not retain consumer
+    # caches attached to a PackedSeqParams instance from an earlier batch.
+    packed_seq_params = (
+        batch.get(_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY)
+        if layout_metadata is not None
+        else None
+    )
+    if packed_seq_params is None:
+        cp_metadata = batch[_THD_FULL_ITERATION_CP_METADATA_KEY]
+        packed_seq_params = PackedSeqParams(
+            qkv_format='thd',
+            cu_seqlens_q=batch['cu_seqlens'],
+            cu_seqlens_kv=batch['cu_seqlens'],
+            cu_seqlens_q_padded=batch['cu_seqlens_padded'],
+            cu_seqlens_kv_padded=batch['cu_seqlens_padded'],
+            max_seqlen_q=batch['max_seqlen'],
+            max_seqlen_kv=batch['max_seqlen'],
+            local_cp_size=None,
+            cp_group=cp_metadata['cp_group'],
+            cp_partition_mode=batch['cp_partition_mode'],
+            pad_between_seqs=batch['pad_between_seqs'],
+            cp_partition_route=_restore_thd_full_iteration_cp_route(cp_metadata, layout_metadata),
+        )
+        for name in ('thd_cp_host_cu_seqlens_q', 'thd_cp_host_cu_seqlens_kv'):
+            value = None if layout_metadata is None else layout_metadata.get(name)
+            if value is not None:
+                setattr(packed_seq_params, name, list(value))
+        # ``pretrain_{gpt,hybrid}.get_batch`` finalizes every ordinary THD
+        # batch. This marker makes that operation idempotent for metadata that
+        # was already finalized outside capture.
+        packed_seq_params._full_cuda_graph_cp_metadata_prebuilt = True
+        if layout_metadata is not None:
+            # The CP>1 static buffer owns this object for the lifetime of the
+            # graph. In addition to preserving route tensor addresses, this
+            # lets consumers populate per-layout caches during eager warmup and
+            # reuse them during capture without rebuilding host-derived tensors.
+            batch[_THD_FULL_ITERATION_PACKED_SEQ_PARAMS_KEY] = packed_seq_params
+    return (
+        batch['tokens'],
+        batch['labels'],
+        batch['loss_mask'],
+        None,
+        batch['position_ids'],
+        packed_seq_params,
+        batch['padding_mask'],
+    )
+
+
+def prepare_thd_static_batch_for_full_iteration_cuda_graph(
+    data_iterator,
+    vp_stage: Optional[int] = None,
+    *,
+    config,
+    vpp_size: Optional[int] = None,
+    pg_collection: Optional[ProcessGroupCollection] = None,
+) -> Dict[str, Any]:
+    """Canonicalize one packed THD microbatch outside the full-iteration graph.
+
+    Runs the eager THD batch path (padding-mask construction, CP slicing, TP
+    broadcast and static-shape padding) so every tensor reaches the fixed
+    shapes required for CUDA graph capture and replay: token-like tensors at
+    the per-rank token capacity ``max_seqlen_per_dp_cp_rank`` and cu_seqlens
+    tensors at ``thd_max_packed_sequences + 1`` entries, with
+    ``max_seqlen_q/kv`` pinned to the static config upper bound. This function
+    issues TP broadcasts, so all ranks must call it in the same order.
+
+    Returns a dict suitable for ``StaticBufferLoader``. The captured
+    ``get_batch_on_this_rank_for_sequence_packing`` path recognizes it via
+    ``THD_FULL_ITERATION_STATIC_BATCH_KEY`` and reads the static tensors
+    without further shape discovery.
+    """
+    # Static-shape requirements (max_seqlen_per_dp_cp_rank, thd_max_packed_sequences,
+    # no dynamic CP) are validated once at TransformerConfig construction time.
+    assert config is not None, "THD full-iteration batch preparation requires a config."
+    assert getattr(config, 'cuda_graph_impl', 'none') == 'full_iteration', (
+        "prepare_thd_static_batch_for_full_iteration_cuda_graph requires "
+        f"cuda_graph_impl='full_iteration', got {getattr(config, 'cuda_graph_impl', 'none')}."
+    )
+    max_seqlen_per_dp_cp_rank = config.max_seqlen_per_dp_cp_rank
+    thd_max_packed_sequences = config.thd_max_packed_sequences
+
+    # Canonicalization mutates the batch dict in place (padding-mask insertion,
+    # 2D views, sanitized values). Work on a shallow copy so callers that replay
+    # the same raw batch — e.g. the PagedStashRunner overflow fallback — can
+    # canonicalize it again.
+    if data_iterator is not None:
+        raw_batch = next(data_iterator)
+        if isinstance(raw_batch, dict):
+            raw_batch = dict(raw_batch)
+        data_iterator = iter([raw_batch])
+
+    tokens, labels, loss_mask, _, position_ids, packed_seq_params, padding_mask = (
+        get_batch_on_this_rank_for_sequence_packing(
+            data_iterator,
+            vpp_size=vpp_size,
+            mtp_on_this_rank=mtp_on_this_rank(config, ignore_virtual=False, vp_stage=vp_stage),
+            vp_stage=vp_stage,
+            dynamic_cp=False,
+            pg_collection=pg_collection,
+            config=config,
+        )
+    )
+
+    # CP route construction reads packed boundaries on the host and creates
+    # Python split metadata. Do it before StaticBufferLoader hands the batch to
+    # the captured forward, then preserve the resulting tensors and lists in
+    # the static slot. The exact CP>1 geometry is part of the graph contract;
+    # StaticBufferLoader rejects a later batch that would invalidate it.
+    finalize_packed_seq_params(packed_seq_params)
+    cp_metadata = _build_thd_full_iteration_cp_metadata(packed_seq_params)
+    cp_layout_signature = _build_thd_full_iteration_cp_layout_signature(packed_seq_params)
+
+    # Enforce the static-input contract before the tensors reach graph buffers.
+    expected_entries = thd_max_packed_sequences + 1
+    for name, cu in (
+        ('cu_seqlens', packed_seq_params.cu_seqlens_q),
+        ('cu_seqlens_padded', packed_seq_params.cu_seqlens_q_padded),
+    ):
+        assert cu is not None and cu.numel() == expected_entries, (
+            f"THD full-iteration static batch expects {name} with {expected_entries} entries "
+            f"(thd_max_packed_sequences + 1), got "
+            f"{None if cu is None else cu.numel()}."
+        )
+    for name, t in (
+        ('tokens', tokens),
+        ('labels', labels),
+        ('loss_mask', loss_mask),
+        ('position_ids', position_ids),
+        ('padding_mask', padding_mask),
+    ):
+        assert t is None or t.shape[-1] == max_seqlen_per_dp_cp_rank, (
+            f"THD full-iteration static batch expects {name} padded to the per-rank token "
+            f"capacity ({max_seqlen_per_dp_cp_rank}), got {t.shape[-1]}."
+        )
+    assert isinstance(packed_seq_params.max_seqlen_q, int), (
+        "THD full-iteration static batch expects a Python int max_seqlen (static upper bound), "
+        f"got {type(packed_seq_params.max_seqlen_q)}."
+    )
+    assert packed_seq_params.pad_between_seqs is True, (
+        "THD full-iteration static batch requires the batch-independent "
+        "pad_between_seqs=True contract, "
+        f"got {packed_seq_params.pad_between_seqs!r}."
+    )
+
+    static_batch = {
+        THD_FULL_ITERATION_STATIC_BATCH_KEY: True,
+        'tokens': tokens,
+        'labels': labels,
+        'loss_mask': loss_mask,
+        'position_ids': position_ids,
+        'padding_mask': padding_mask,
+        'cu_seqlens': packed_seq_params.cu_seqlens_q,
+        'cu_seqlens_padded': packed_seq_params.cu_seqlens_q_padded,
+        'max_seqlen': packed_seq_params.max_seqlen_q,
+        'cp_partition_mode': packed_seq_params.cp_partition_mode,
+        'pad_between_seqs': packed_seq_params.pad_between_seqs,
+        _THD_FULL_ITERATION_CP_METADATA_KEY: cp_metadata,
+    }
+    if cp_layout_signature is not None:
+        static_batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY] = {'thd_cp_layout': cp_layout_signature}
+    return static_batch
 
 
 def _build_thd_padding_mask(
@@ -583,6 +862,18 @@ def get_batch_on_this_rank_for_sequence_packing(
         packed_seq_params, padding_mask)
     """
 
+    # Full-iteration CUDA graph feeds every rank a pre-canonicalized static
+    # batch (see prepare_thd_static_batch_for_full_iteration_cuda_graph). The
+    # captured path must read those tensors from fixed addresses without shape
+    # discovery, host synchronization, or dynamic allocation.
+    prefetched_batch = None
+    if data_iterator is not None:
+        prefetched_batch = next(data_iterator)
+        if isinstance(prefetched_batch, dict) and prefetched_batch.get(
+            THD_FULL_ITERATION_STATIC_BATCH_KEY, False
+        ):
+            return _unpack_thd_full_iteration_static_batch(prefetched_batch)
+
     if pg_collection is None:
         tp_group = parallel_state.get_tensor_model_parallel_group()
         pp_group = parallel_state.get_pipeline_model_parallel_group()
@@ -616,8 +907,8 @@ def get_batch_on_this_rank_for_sequence_packing(
 
     # Get a batch from data_iterator or create an emtpy batch.
     if is_tp_rank_0:
-        assert data_iterator is not None
-        batch = next(data_iterator)
+        assert prefetched_batch is not None, "TP rank 0 requires a data_iterator"
+        batch = prefetched_batch
         for key in batch_keys:
             assert key in batch, f"{key} is missing in current batch."
     else:

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -235,6 +235,7 @@ def _pack_sequences(
     original_lengths: torch.Tensor,
     local_cp_size: Optional[torch.Tensor],
     dev: torch.device,
+    zigzag_cp_min_chunk_size: Optional[int] = None,
 ) -> Dict[str, torch.Tensor]:
     """Pack multiple samples into a single packed sample."""
 
@@ -265,6 +266,10 @@ def _pack_sequences(
 
     if local_cp_size is not None:
         new_sample["local_cp_size"] = local_cp_size
+    if zigzag_cp_min_chunk_size is not None:
+        new_sample["zigzag_cp_min_chunk_size"] = torch.tensor(
+            zigzag_cp_min_chunk_size, dtype=torch.int32, device=dev
+        )
 
     return new_sample
 
@@ -330,7 +335,12 @@ def create_data_iterator(
     ):
         vpp_size = config.virtual_pipeline_model_parallel_size
         if tp_group.rank() == 0:
-            metadata_keys = ["max_seqlen", "cu_seqlens", "cu_seqlens_padded"]
+            metadata_keys = [
+                "max_seqlen",
+                "cu_seqlens",
+                "cu_seqlens_padded",
+                "zigzag_cp_min_chunk_size",
+            ]
             if is_dynamic_cp:
                 metadata_keys.append("local_cp_size")
             new_data_iterator = []
@@ -478,6 +488,7 @@ def build_packed_microbatches(
     dcp_rank: int,
     dev: torch.device,
     is_dynamic_cp: bool = False,
+    global_id_seqlens: Optional[List[Tuple[int, int]]] = None,
 ) -> List[Dict[str, torch.Tensor]]:
     """Build packed samples for each microbatch.
 
@@ -488,6 +499,10 @@ def build_packed_microbatches(
         dcp_rank: This rank's index within the DP×CP group.
         dev: Target device.
         is_dynamic_cp: Whether dynamic context parallel is enabled.
+        global_id_seqlens: Optional host mapping from global sample ID to its
+            physical padded length. When present, it emits the minimum zigzag
+            half-chunk size without a model-forward D2H copy; zero means the
+            physical lengths do not admit one-hop certification.
     """
     num_micro_batches = len(sample_id_groups)
     seg_starts: List[int] = [0]
@@ -503,20 +518,16 @@ def build_packed_microbatches(
     ]
 
     local_cp_sizes_gpu = None
+    effective_cp_sizes_cpu: List[int] = []
+    for i in range(num_micro_batches):
+        sample_ids_this_group = sample_id_groups[i][dcp_rank]
+        effective_cp_sizes_cpu.append(
+            len([1 for sample_ids in sample_id_groups[i] if sample_ids_this_group[0] in sample_ids])
+        )
     if is_dynamic_cp:
-        local_cp_sizes_cpu: List[int] = []
-        for i in range(num_micro_batches):
-            sample_ids_this_group = sample_id_groups[i][dcp_rank]
-            local_cp_sizes_cpu.append(
-                len(
-                    [
-                        1
-                        for sample_ids in sample_id_groups[i]
-                        if sample_ids_this_group[0] in sample_ids
-                    ]
-                )
-            )
-        local_cp_sizes_gpu = torch.tensor(local_cp_sizes_cpu, dtype=torch.int32, device=dev)
+        local_cp_sizes_gpu = torch.tensor(effective_cp_sizes_cpu, dtype=torch.int32, device=dev)
+
+    padded_length_by_id = dict(global_id_seqlens) if global_id_seqlens is not None else None
 
     for i in range(num_micro_batches):
         samples = grouped_samples[i]
@@ -533,7 +544,24 @@ def build_packed_microbatches(
         lens_padded = padded_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
         lens_original = original_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
         local_cp_size = local_cp_sizes_gpu[i] if is_dynamic_cp else None
-        new_sample = _pack_sequences(samples, lens_padded, lens_original, local_cp_size, dev)
+        zigzag_cp_min_chunk_size = None
+        if padded_length_by_id is not None:
+            divisor = 2 * effective_cp_sizes_cpu[i]
+            padded_lengths_host = [
+                padded_length_by_id[sample_id] for sample_id in sample_id_groups[i][dcp_rank]
+            ]
+            if any(length % divisor != 0 for length in padded_lengths_host):
+                zigzag_cp_min_chunk_size = 0
+            else:
+                zigzag_cp_min_chunk_size = min(length // divisor for length in padded_lengths_host)
+        new_sample = _pack_sequences(
+            samples,
+            lens_padded,
+            lens_original,
+            local_cp_size,
+            dev,
+            zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
+        )
         new_samples.append(new_sample)
 
     return new_samples

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1756,13 +1756,13 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
 
         # These fields are MCore-only and should not be forwarded to TE attention.
         # total_tokens and seq_idx are only for Mamba; tokens_per_sample is only for
-        # MoE sequence-level aux loss reshaping; cp_partition_mode and cp_partition_route
-        # are MCore CP metadata.
+        # MoE sequence-level aux loss reshaping; the remaining fields are MCore CP metadata.
         self.kept_packed_seq_params.discard("total_tokens")
         self.kept_packed_seq_params.discard("seq_idx")
         self.kept_packed_seq_params.discard("tokens_per_sample")
         self.kept_packed_seq_params.discard("cp_partition_mode")
         self.kept_packed_seq_params.discard("cp_partition_route")
+        self.kept_packed_seq_params.discard("zigzag_cp_min_chunk_size")
 
         if config.qk_clip or config.log_max_attention_logit:
             # qk-clip is only supported in TE 2.9.0 and later

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -7,9 +7,20 @@ import logging
 
 import torch
 
-from megatron.core.tensor_parallel.random import get_all_rng_states
+from megatron.core.tensor_parallel.random import (
+    convert_cuda_rng_state,
+    get_all_rng_states,
+    get_cuda_rng_tracker,
+    is_graph_safe_cuda_rng_tracker,
+)
 
 logger = logging.getLogger(__name__)
+
+# Optional pure-Python metadata attached to an input batch whose values are baked
+# into the captured graph (for example, packed-CP route split sizes).  Tensor
+# payloads may change between replays, but this metadata must remain identical for
+# each static-buffer slot.
+FULL_CUDA_GRAPH_STATIC_METADATA_KEY = 'full_cuda_graph_static_metadata'
 
 # Process-wide handle so full-iter and optimizer graph captures share one pool and one
 # non-default stream (per-stream alloc segments can inflate memory_reserved; see
@@ -91,6 +102,12 @@ def clone_tensors_in_struct(tgt, src):
         if not isinstance(tgt, dict):
             return copy_tensors_in_struct(src)
         for k in src:
+            # This metadata was compared before any static-buffer update and is
+            # immutable for the lifetime of the graph.  Keep the captured copy
+            # instead of descending into pure-Python tuples such as CP split
+            # sizes and packed boundaries.
+            if k == FULL_CUDA_GRAPH_STATIC_METADATA_KEY:
+                continue
             if isinstance(src[k], (tuple, list, dict, torch.Tensor)):
                 clone_tensors_in_struct(tgt[k], src[k])
             else:
@@ -111,6 +128,17 @@ class StaticBufferLoader:
     def __init__(self):
         self.stream = torch.cuda.Stream()
 
+    @classmethod
+    def reset(cls, stage=None):
+        """Drop all static buffers (e.g. between models or tests).
+
+        Only call after the CUDA graphs referencing these buffers have been
+        destroyed via ``FullCudaGraphWrapper.reset_cuda_graph``.
+        """
+        for reset_stage in ('training', 'validation'):
+            if stage is None or stage == reset_stage:
+                cls.static_buffers[reset_stage] = []
+
     def __call__(self, inputs, stage, microbatch):
         assert stage in ['training', 'validation']
         assert microbatch <= len(StaticBufferLoader.static_buffers[stage])
@@ -123,6 +151,18 @@ class StaticBufferLoader:
             with torch.cuda.stream(self.stream):
                 StaticBufferLoader.static_buffers[stage].append(copy_tensors_in_struct(inputs))
         else:
+            incoming_static_metadata = inputs.get(FULL_CUDA_GRAPH_STATIC_METADATA_KEY)
+            captured_static_metadata = StaticBufferLoader.static_buffers[stage][microbatch].get(
+                FULL_CUDA_GRAPH_STATIC_METADATA_KEY
+            )
+            if incoming_static_metadata != captured_static_metadata:
+                raise RuntimeError(
+                    "Full-iteration CUDA graph static input metadata changed for "
+                    f"{stage} microbatch slot {microbatch}. The captured graph contains "
+                    "Python-derived layout values (such as packed-CP route/split metadata), "
+                    "so replay with a different layout would be incorrect. Keep the packed "
+                    "geometry fixed for each microbatch slot or reset and recapture the graph."
+                )
 
             for k in inputs.keys():
                 if k not in StaticBufferLoader.static_buffers[stage][microbatch]:
@@ -151,15 +191,118 @@ class FullCudaGraphWrapper:
     curr_iteration = {'training': 0, 'validation': 0}
     cuda_graph = {'training': None, 'validation': None}
     result = {'training': None, 'validation': None}
+    capture_signature = {'training': None, 'validation': None}
 
-    def __init__(self, forward_backward_func, cuda_graph_warmup_steps=1, use_single_mempool=False):
+    @staticmethod
+    def _get_graphable_rng_states():
+        """Validate and return the graph-safe generators used during capture."""
+        tracker = get_cuda_rng_tracker()
+        if not is_graph_safe_cuda_rng_tracker(tracker):
+            raise RuntimeError(
+                "Full-iteration CUDA graph capture requires a graph-safe CUDA RNG tracker. "
+                "Initialize the native tracker with use_cudagraphable_rng=True."
+            )
+
+        tracker_states = tracker.get_states()
+        invalid_states = {
+            name: type(state).__name__
+            for name, state in tracker_states.items()
+            if not isinstance(state, (torch.Tensor, torch.Generator))
+        }
+        if invalid_states:
+            raise RuntimeError(
+                "Full-iteration CUDA graph capture requires tensor or generator RNG states; "
+                f"tracker returned unsupported states: {invalid_states}."
+            )
+
+        if any(isinstance(state, torch.Tensor) for state in tracker_states.values()):
+            tracker_states = {
+                name: convert_cuda_rng_state(state, to_graphable=True)
+                for name, state in tracker_states.items()
+            }
+        # Besides updating the tracker, this synchronizes TE's process-global
+        # state registry and discards any states left by an older tracker.
+        tracker.set_states(tracker_states)
+        graphable_states = get_all_rng_states()
+
+        invalid_states = {
+            name: type(state).__name__
+            for name, state in graphable_states.items()
+            if not isinstance(state, torch.Generator)
+        }
+        if invalid_states:
+            raise RuntimeError(
+                "Full-iteration CUDA graph capture requires graphable RNG generators; "
+                f"tracker returned non-generator states: {invalid_states}."
+            )
+
+        detached_states = [
+            name
+            for name, state in graphable_states.items()
+            if tracker.get_states().get(name) is not state
+        ]
+        missing_states = set(tracker.get_states()) ^ set(graphable_states)
+        if detached_states or missing_states:
+            raise RuntimeError(
+                "Full-iteration CUDA graph capture requires the registered generators to be "
+                "owned by the active RNG tracker; "
+                f"detached states: {detached_states}, mismatched names: {sorted(missing_states)}."
+            )
+        return graphable_states
+
+    def __init__(
+        self,
+        forward_backward_func,
+        cuda_graph_warmup_steps=1,
+        use_single_mempool=False,
+        batch_preparation_fn=None,
+    ):
+        """
+        Args:
+            forward_backward_func: The pipeline-parallel forward-backward function to wrap.
+            cuda_graph_warmup_steps: Number of eager iterations to run before capture.
+            use_single_mempool: Share one memory pool across full-iter/optimizer captures.
+            batch_preparation_fn: Optional ``fn(data_iterator, vp_stage) -> dict`` hook that
+                canonicalizes one microbatch to graph-static shapes outside the captured
+                region (e.g. THD packed batches). It is called on every rank for every
+                (model chunk, microbatch) pair in the same order — even on ranks whose
+                data_iterator is None — so it may issue collectives such as TP broadcasts.
+        """
         self.forward_backward_func = forward_backward_func
         self.static_loader = StaticBufferLoader()
         self.cuda_graph_warmup_steps = cuda_graph_warmup_steps
         self.use_single_mempool = use_single_mempool
+        self.batch_preparation_fn = batch_preparation_fn
+
+    def _data_read_with_batch_preparation(self, data_iterator, model, stage, num_microbatches):
+        """Canonicalize each microbatch outside the graph, then load static buffers.
+
+        Every rank receives an iterator of static batches (the preparation
+        function broadcasts data to ranks without a data_iterator), and each
+        (model chunk, microbatch) pair gets its own static buffer slot.
+        """
+        num_chunks = len(model) if isinstance(model, list) else 1
+        if isinstance(data_iterator, list):
+            assert len(data_iterator) == num_chunks
+            iterators = data_iterator
+        else:
+            iterators = [data_iterator] * num_chunks
+        use_vp_stage = isinstance(model, list) and len(model) > 1
+        data_list = []
+        for i in range(num_chunks):
+            chunk_batches = []
+            for b in range(num_microbatches):
+                batch = self.batch_preparation_fn(iterators[i], i if use_vp_stage else None)
+                chunk_batches.append(self.static_loader(batch, stage, i * num_microbatches + b))
+            data_list.append(iter(chunk_batches))
+        return data_list
 
     def data_read(self, data_iterator, model, training, num_microbatches):
         """Read all microbatch inputs from Dataloader and copy to static buffers."""
+        if self.batch_preparation_fn is not None:
+            return self._data_read_with_batch_preparation(
+                data_iterator, model, 'training' if training else 'validation', num_microbatches
+            )
         if not isinstance(model, list) or len(model) == 1:
             assert not isinstance(data_iterator, list) or len(data_iterator) == 1
             iterator0 = data_iterator if not isinstance(data_iterator, list) else data_iterator[0]
@@ -210,10 +353,22 @@ class FullCudaGraphWrapper:
 
         training = not kwargs['forward_only']
         data_iterator = kwargs['data_iterator']
+        training_str = 'training' if training else 'validation'
+
+        # A captured graph bakes in the schedule topology; replaying it with a
+        # different signature would silently reuse stale shapes and buffers.
+        signature = {
+            'num_microbatches': num_microbatches,
+            'num_model_chunks': len(model) if isinstance(model, list) else 1,
+            'seq_length': kwargs.get('seq_length'),
+            'micro_batch_size': kwargs.get('micro_batch_size'),
+            'decoder_seq_length': kwargs.get('decoder_seq_length'),
+        }
+        self._check_capture_signature(training_str, signature)
+
         data_list = self.data_read(data_iterator, model, training, num_microbatches)
         kwargs['data_iterator'] = data_list
 
-        training_str = 'training' if training else 'validation'
         curr_iteration = self.curr_iter(training_str)
         if curr_iteration == self.cuda_graph_warmup_steps:
             logger.info(f'Capture CUDA graph for {training_str}!!!')
@@ -235,8 +390,10 @@ class FullCudaGraphWrapper:
             gc.collect()
             torch.cuda.empty_cache()
             assert FullCudaGraphWrapper.cuda_graph[training_str] is None
+            graphable_rng_states = self._get_graphable_rng_states()
+            FullCudaGraphWrapper.capture_signature[training_str] = signature
             FullCudaGraphWrapper.cuda_graph[training_str] = torch.cuda.CUDAGraph()
-            for _, state in get_all_rng_states().items():
+            for state in graphable_rng_states.values():
                 FullCudaGraphWrapper.cuda_graph[training_str].register_generator_state(state)
             torch.cuda.synchronize()
             capture_stream = get_shared_capture_stream()
@@ -259,6 +416,28 @@ class FullCudaGraphWrapper:
         self.next_iter(training_str)
         return FullCudaGraphWrapper.result[training_str]
 
+    def _check_capture_signature(self, stage, signature):
+        """Refuse to replay a captured graph whose call signature changed."""
+        captured = FullCudaGraphWrapper.capture_signature[stage]
+        if captured is None:
+            # No graph captured for this stage yet; nothing to enforce.
+            return
+        mismatches = {
+            key: (captured[key], signature[key])
+            for key in captured
+            if captured[key] != signature[key]
+        }
+        if mismatches:
+            details = ', '.join(
+                f"{key}: captured={old} vs current={new}" for key, (old, new) in mismatches.items()
+            )
+            raise RuntimeError(
+                f"Full-iteration CUDA graph signature mismatch for {stage} ({details}). "
+                "The captured graph bakes in the schedule topology (e.g. a fixed "
+                "num_microbatches), so these values must stay constant after capture. "
+                "Keep the schedule fixed or reset the graph via reset_cuda_graph()."
+            )
+
     def curr_iter(self, stage):
         """Return current training/validation iteration."""
         return FullCudaGraphWrapper.curr_iteration[stage]
@@ -267,18 +446,22 @@ class FullCudaGraphWrapper:
         """Increment current training/validation iteration."""
         FullCudaGraphWrapper.curr_iteration[stage] += 1
 
-    def reset_cuda_graph(self, stage=None):
-        """Reset CUDA graph."""
-        if stage is None or stage == 'training':
-            if FullCudaGraphWrapper.cuda_graph['training'] is not None:
-                del FullCudaGraphWrapper.cuda_graph['training']
-                FullCudaGraphWrapper.cuda_graph['training'] = None
-            FullCudaGraphWrapper.result['training'] = None
-            FullCudaGraphWrapper.curr_iteration['training'] = 0
-        if stage is None or stage == 'validation':
-            if FullCudaGraphWrapper.cuda_graph['validation'] is not None:
-                del FullCudaGraphWrapper.cuda_graph['validation']
-                FullCudaGraphWrapper.cuda_graph['validation'] = None
-            FullCudaGraphWrapper.result['validation'] = None
-            FullCudaGraphWrapper.curr_iteration['validation'] = 0
+    @classmethod
+    def reset_cuda_graph(cls, stage=None):
+        """Destroy captured CUDA graph(s) and reset the class-level state.
+
+        Must be called before tearing down the process groups whose collectives
+        were captured (e.g. PP P2P): a live graph keeps references to NCCL
+        resources and destroying the communicators first can hang shutdown.
+        """
+        for reset_stage in ('training', 'validation'):
+            if stage is not None and stage != reset_stage:
+                continue
+            if cls.cuda_graph[reset_stage] is not None:
+                del cls.cuda_graph[reset_stage]
+                cls.cuda_graph[reset_stage] = None
+            cls.result[reset_stage] = None
+            cls.curr_iteration[reset_stage] = 0
+            cls.capture_signature[reset_stage] = None
+            StaticBufferLoader.reset(stage=reset_stage)
         gc.collect()

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -127,6 +127,39 @@ class StaticBufferLoader:
 
     def __init__(self):
         self.stream = torch.cuda.Stream()
+        self.defer_static_metadata_mismatch = False
+        self.static_metadata_mismatch = None
+        self.batch_stage = None
+        self.batch_start_length = None
+        self.batch_dynamic_cp_metadata = []
+
+    def begin_batch(self, stage, *, defer_static_metadata_mismatch=False):
+        """Reset per-call metadata state before loading all static-buffer slots."""
+        assert stage in ('training', 'validation')
+        self.defer_static_metadata_mismatch = defer_static_metadata_mismatch
+        self.static_metadata_mismatch = None
+        self.batch_stage = stage
+        self.batch_start_length = len(StaticBufferLoader.static_buffers[stage])
+        self.batch_dynamic_cp_metadata = []
+
+    def rollback_batch(self):
+        """Discard only slots appended since ``begin_batch``.
+
+        Existing slots may already be owned by a captured CUDA graph and must
+        never be replaced or truncated after a rejected replay batch.
+        """
+        if self.batch_stage is None:
+            return
+        assert self.batch_start_length is not None
+        del StaticBufferLoader.static_buffers[self.batch_stage][self.batch_start_length :]
+
+    def end_batch(self):
+        """Clear per-call bookkeeping after consensus succeeds or fails."""
+        self.defer_static_metadata_mismatch = False
+        self.static_metadata_mismatch = None
+        self.batch_stage = None
+        self.batch_start_length = None
+        self.batch_dynamic_cp_metadata = []
 
     @classmethod
     def reset(cls, stage=None):
@@ -146,23 +179,54 @@ class StaticBufferLoader:
             inputs = inputs[0]
 
         assert isinstance(inputs, dict)
+        incoming_static_metadata = inputs.get(FULL_CUDA_GRAPH_STATIC_METADATA_KEY)
+        dynamic_cp_metadata = (
+            incoming_static_metadata.get('thd_dynamic_cp')
+            if isinstance(incoming_static_metadata, dict)
+            else None
+        )
+        if self.batch_stage is not None:
+            assert stage == self.batch_stage
+            self.batch_dynamic_cp_metadata.append(dynamic_cp_metadata)
+        validation_error = (
+            dynamic_cp_metadata.get('validation_error')
+            if isinstance(dynamic_cp_metadata, dict)
+            else None
+        )
+        if validation_error is not None:
+            message = (
+                "Full-iteration CUDA graph static input metadata is invalid for "
+                f"{stage} microbatch slot {microbatch}: {validation_error}"
+            )
+            if not self.defer_static_metadata_mismatch:
+                raise RuntimeError(message)
+            if self.static_metadata_mismatch is None:
+                self.static_metadata_mismatch = message
+
         if microbatch == len(StaticBufferLoader.static_buffers[stage]):
             self.stream.wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(self.stream):
                 StaticBufferLoader.static_buffers[stage].append(copy_tensors_in_struct(inputs))
         else:
-            incoming_static_metadata = inputs.get(FULL_CUDA_GRAPH_STATIC_METADATA_KEY)
             captured_static_metadata = StaticBufferLoader.static_buffers[stage][microbatch].get(
                 FULL_CUDA_GRAPH_STATIC_METADATA_KEY
             )
             if incoming_static_metadata != captured_static_metadata:
-                raise RuntimeError(
+                message = (
                     "Full-iteration CUDA graph static input metadata changed for "
                     f"{stage} microbatch slot {microbatch}. The captured graph contains "
                     "Python-derived layout values (such as packed-CP route/split metadata), "
                     "so replay with a different layout would be incorrect. Keep the packed "
                     "geometry fixed for each microbatch slot or reset and recapture the graph."
                 )
+                if not self.defer_static_metadata_mismatch:
+                    raise RuntimeError(message)
+                if self.static_metadata_mismatch is None:
+                    self.static_metadata_mismatch = message
+                # Do not mutate the captured slot. The wrapper performs one
+                # world-wide consensus after every rank has inspected all slots,
+                # then every rank fails together before capture or replay.
+                return StaticBufferLoader.static_buffers[stage][microbatch].copy()
 
             for k in inputs.keys():
                 if k not in StaticBufferLoader.static_buffers[stage][microbatch]:
@@ -256,6 +320,7 @@ class FullCudaGraphWrapper:
         cuda_graph_warmup_steps=1,
         use_single_mempool=False,
         batch_preparation_fn=None,
+        require_global_static_metadata_consensus=False,
     ):
         """
         Args:
@@ -267,12 +332,169 @@ class FullCudaGraphWrapper:
                 region (e.g. THD packed batches). It is called on every rank for every
                 (model chunk, microbatch) pair in the same order — even on ranks whose
                 data_iterator is None — so it may issue collectives such as TP broadcasts.
+            require_global_static_metadata_consensus: Defer local static-metadata mismatches
+                until all ranks perform one consensus outside capture. This guarantees that
+                a rank-local packed-layout change cannot leave peer ranks replaying a graph
+                whose collectives wait for the failed rank.
         """
         self.forward_backward_func = forward_backward_func
         self.static_loader = StaticBufferLoader()
         self.cuda_graph_warmup_steps = cuda_graph_warmup_steps
         self.use_single_mempool = use_single_mempool
         self.batch_preparation_fn = batch_preparation_fn
+        self.require_global_static_metadata_consensus = require_global_static_metadata_consensus
+
+    @staticmethod
+    def _encode_new_dynamic_cp_group_state(
+        dynamic_cp_metadata, mismatch_found, appended_count, world_size
+    ):
+        """Encode all per-slot DCP groups into one fixed-shape WORLD payload."""
+        encoded = [int(mismatch_found), len(dynamic_cp_metadata), appended_count]
+        for metadata in dynamic_cp_metadata:
+            if metadata is None:
+                encoded.extend([0, 0, -1])
+                encoded.extend([-1] * world_size)
+                continue
+
+            members = [int(rank) for rank in metadata.get('cp_group_global_ranks', ())]
+            # Preserve the reported group size separately.  If it exceeds the
+            # WORLD-sized membership field, the validator below rejects it on
+            # every rank rather than changing the collective shape.
+            group_size = int(metadata.get('local_cp_size', -1))
+            group_rank = int(metadata.get('cp_group_rank', -1))
+            encoded.extend([1, group_size, group_rank])
+            encoded.extend((members + [-1] * world_size)[:world_size])
+        return encoded
+
+    @staticmethod
+    def _validate_new_dynamic_cp_group_state(
+        gathered_state, slot_count, appended_count, world_size
+    ):
+        """Validate that every DCP group is an ordered membership equivalence class."""
+        rows = gathered_state.to(device='cpu').tolist()
+        if any(row[1] != slot_count for row in rows):
+            return "ranks prepared different numbers of static DCP microbatch slots"
+        if any(row[2] != appended_count for row in rows):
+            return "ranks appended different numbers of static DCP microbatch slots"
+
+        block_width = world_size + 3
+        for slot in range(slot_count):
+            start = 3 + slot * block_width
+            present = [bool(row[start]) for row in rows]
+            if not any(present):
+                continue
+            if not all(present):
+                return f"slot {slot} has dynamic-CP metadata on only a subset of ranks"
+
+            for reporter_rank, row in enumerate(rows):
+                group_size = row[start + 1]
+                group_rank = row[start + 2]
+                members = tuple(row[start + 3 : start + 3 + world_size])
+                if not 1 <= group_size <= world_size:
+                    return (
+                        f"slot {slot} rank {reporter_rank} reported invalid dynamic-CP "
+                        f"group size {group_size} for WORLD size {world_size}"
+                    )
+                members = members[:group_size]
+                if len(set(members)) != group_size or any(
+                    member < 0 or member >= world_size for member in members
+                ):
+                    return (
+                        f"slot {slot} rank {reporter_rank} reported invalid dynamic-CP "
+                        f"members {members}"
+                    )
+                if not 0 <= group_rank < group_size or members[group_rank] != reporter_rank:
+                    return (
+                        f"slot {slot} rank {reporter_rank} reported group rank {group_rank} "
+                        f"for ordered members {members}"
+                    )
+
+                for expected_group_rank, member in enumerate(members):
+                    peer_row = rows[member]
+                    peer_start = start
+                    peer_size = peer_row[peer_start + 1]
+                    peer_group_rank = peer_row[peer_start + 2]
+                    peer_members = tuple(peer_row[peer_start + 3 : peer_start + 3 + group_size])
+                    if (
+                        not bool(peer_row[peer_start])
+                        or peer_size != group_size
+                        or peer_group_rank != expected_group_rank
+                        or peer_members != members
+                    ):
+                        return (
+                            f"slot {slot} dynamic-CP membership is not coherent: rank "
+                            f"{reporter_rank} reports {members}, but member {member} reports "
+                            f"members={peer_members}, group_rank={peer_group_rank}"
+                        )
+        return None
+
+    def _check_new_dynamic_cp_group_consensus(self, mismatch_found, appended_count):
+        """Run the exact DCP membership check whenever new slots are created."""
+        world_size = torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
+        local_encoded = self._encode_new_dynamic_cp_group_state(
+            self.static_loader.batch_dynamic_cp_metadata, mismatch_found, appended_count, world_size
+        )
+        local_state = torch.tensor(
+            local_encoded, dtype=torch.int64, device=torch.cuda.current_device()
+        )
+        if world_size > 1:
+            gathered = torch.empty(
+                world_size * local_state.numel(), dtype=local_state.dtype, device=local_state.device
+            )
+            torch.distributed.all_gather_into_tensor(gathered, local_state)
+            gathered = gathered.view(world_size, local_state.numel())
+        else:
+            gathered = local_state.unsqueeze(0)
+
+        mismatch_found = bool(torch.any(gathered[:, 0] != 0).item())
+        group_error = self._validate_new_dynamic_cp_group_state(
+            gathered, len(self.static_loader.batch_dynamic_cp_metadata), appended_count, world_size
+        )
+        return mismatch_found or group_error is not None, group_error
+
+    def _check_global_static_metadata_consensus(self, stage):
+        """Make every rank fail together when any rank's static layout changes."""
+        assert self.static_loader.batch_stage == stage
+        assert self.static_loader.batch_start_length is not None
+        local_mismatch = self.static_loader.static_metadata_mismatch
+        mismatch_found = local_mismatch is not None
+        group_error = None
+        appended_count = (
+            len(StaticBufferLoader.static_buffers[stage]) - self.static_loader.batch_start_length
+        )
+        try:
+            if self.require_global_static_metadata_consensus:
+                if appended_count > 0:
+                    # Any batch that creates static slots validates all ordered
+                    # DCP memberships in the same fixed-shape WORLD all-gather
+                    # that propagates rank-local metadata failures.
+                    mismatch_found, group_error = self._check_new_dynamic_cp_group_consensus(
+                        mismatch_found, appended_count
+                    )
+                elif torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+                    mismatch_flag = torch.tensor(
+                        [int(mismatch_found)], dtype=torch.int32, device=torch.cuda.current_device()
+                    )
+                    torch.distributed.all_reduce(mismatch_flag, op=torch.distributed.ReduceOp.MAX)
+                    mismatch_found = bool(mismatch_flag.item())
+
+            if mismatch_found:
+                detail = (
+                    local_mismatch
+                    or group_error
+                    or ("Full-iteration CUDA graph static input metadata changed on another rank.")
+                )
+                raise RuntimeError(
+                    f"{detail} All ranks rejected the {stage} batch before capture or replay."
+                )
+        except Exception:
+            # Collective/runtime failures must not leave newly allocated slots
+            # behind either.  Existing graph-owned slots are preserved by the
+            # begin-batch boundary.
+            self.static_loader.rollback_batch()
+            raise
+        finally:
+            self.static_loader.end_batch()
 
     def _data_read_with_batch_preparation(self, data_iterator, model, stage, num_microbatches):
         """Canonicalize each microbatch outside the graph, then load static buffers.
@@ -366,7 +588,12 @@ class FullCudaGraphWrapper:
         }
         self._check_capture_signature(training_str, signature)
 
+        self.static_loader.begin_batch(
+            training_str,
+            defer_static_metadata_mismatch=self.require_global_static_metadata_consensus,
+        )
         data_list = self.data_read(data_iterator, model, training, num_microbatches)
+        self._check_global_static_metadata_consensus(training_str)
         kwargs['data_iterator'] = data_list
 
         curr_iteration = self.curr_iter(training_str)
@@ -457,17 +684,29 @@ class FullCudaGraphWrapper:
         return FullCudaGraphWrapper.result[training_str]
 
     def _check_capture_signature(self, stage, signature):
-        """Refuse to replay a captured graph whose call signature changed."""
+        """Refuse inconsistent or changed signatures before any rank reads data.
+
+        Static-certified dynamic CP may run different effective CP groups, but
+        full-iteration capture still requires one world-wide schedule signature.
+        Check that invariant collectively so one rank cannot fail locally while
+        its peers enter batch-preparation collectives or graph replay.
+        """
         captured = FullCudaGraphWrapper.capture_signature[stage]
-        if captured is None:
-            # No graph captured for this stage yet; nothing to enforce.
-            return
-        mismatches = {
-            key: (captured[key], signature[key])
-            for key in captured
-            if captured[key] != signature[key]
-        }
-        if mismatches:
+        mismatches = (
+            {}
+            if captured is None
+            else {
+                key: (captured[key], signature[key])
+                for key in captured
+                if captured[key] != signature[key]
+            }
+        )
+
+        if not self.require_global_static_metadata_consensus or not (
+            torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1
+        ):
+            if not mismatches:
+                return
             details = ', '.join(
                 f"{key}: captured={old} vs current={new}" for key, (old, new) in mismatches.items()
             )
@@ -477,6 +716,59 @@ class FullCudaGraphWrapper:
                 "num_microbatches), so these values must stay constant after capture. "
                 "Keep the schedule fixed or reset the graph via reset_cuda_graph()."
             )
+
+        signature_keys = (
+            'num_microbatches',
+            'num_model_chunks',
+            'seq_length',
+            'micro_batch_size',
+            'decoder_seq_length',
+        )
+        encoded_signature = [0 if stage == 'training' else 1]
+        encoded_signature.extend(
+            -1 if signature[key] is None else int(signature[key]) for key in signature_keys
+        )
+        # The buffer count decides whether the post-data path performs the
+        # one-time topology all-gather or the steady-state mismatch all-reduce.
+        # Certify it before data reads so all ranks select the same collective.
+        encoded_signature.append(len(StaticBufferLoader.static_buffers[stage]))
+        # Include graph-presence as well as the local captured-signature check.
+        # Otherwise one rank that lost/reset its graph could enter warmup while
+        # its peers replay, even if their current call signatures still match.
+        local_state = torch.tensor(
+            encoded_signature + [int(captured is not None), int(bool(mismatches))],
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        world_size = torch.distributed.get_world_size()
+        gathered = torch.empty(
+            world_size * local_state.numel(), dtype=local_state.dtype, device=local_state.device
+        )
+        torch.distributed.all_gather_into_tensor(gathered, local_state)
+        gathered = gathered.view(world_size, local_state.numel())
+
+        current_signature_differs = torch.any(gathered[:, :-2] != gathered[0, :-2])
+        graph_presence_differs = torch.any(gathered[:, -2] != gathered[0, -2])
+        captured_signature_mismatch = torch.any(gathered[:, -1] != 0)
+        if not bool(
+            (
+                current_signature_differs | graph_presence_differs | captured_signature_mismatch
+            ).item()
+        ):
+            return
+
+        details = (
+            ', '.join(
+                f"{key}: captured={old} vs current={new}" for key, (old, new) in mismatches.items()
+            )
+            if mismatches
+            else "the current signature, graph presence, or captured signature differs across ranks"
+        )
+        raise RuntimeError(
+            f"Full-iteration CUDA graph signature mismatch for {stage} ({details}). "
+            "All ranks rejected the call before reading data, capture, or replay. "
+            "Keep the schedule fixed across ranks or reset the graph via reset_cuda_graph()."
+        )
 
     def curr_iter(self, stage):
         """Return current training/validation iteration."""

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -371,6 +371,32 @@ class FullCudaGraphWrapper:
 
         curr_iteration = self.curr_iter(training_str)
         if curr_iteration == self.cuda_graph_warmup_steps:
+            from megatron.core.transformer.cuda_graphs import (
+                _prepare_dsa_metric_tracker_for_capture,
+                _restore_metric_tracker,
+                _snapshot_metric_tracker,
+            )
+            from megatron.core.transformer.experimental_attention_variant.dsa import (
+                DSAIndexerLossLoggingHelper,
+            )
+
+            pg_collection = kwargs.get('pg_collection')
+            prepare_dsa_tracker = True
+            if pg_collection is not None and hasattr(
+                pg_collection, "get_language_model_collection"
+            ):
+                prepare_dsa_tracker = pg_collection.has_language_model()
+                pp_group = (
+                    pg_collection.get_language_model_collection().pp
+                    if prepare_dsa_tracker
+                    else None
+                )
+            else:
+                pp_group = getattr(pg_collection, "pp", None)
+            if prepare_dsa_tracker:
+                _prepare_dsa_metric_tracker_for_capture(model, pp_group)
+            dsa_metric_tracker = DSAIndexerLossLoggingHelper.tracker
+            dsa_metric_snapshot = _snapshot_metric_tracker(dsa_metric_tracker)
             logger.info(f'Capture CUDA graph for {training_str}!!!')
             if hasattr(torch.autograd.graph, 'set_override_stale_capture_stream'):
                 torch.autograd.graph.set_override_stale_capture_stream(True)
@@ -408,6 +434,20 @@ class FullCudaGraphWrapper:
                 )
             torch.cuda.synchronize()
             torch.distributed.barrier()
+            captured_reduction_metadata = {
+                key: dsa_metric_tracker[key]
+                for key in ("reduce_group", "avg_group")
+                if key in dsa_metric_tracker
+            }
+            # Recording executes the graph body once. Restore the pre-capture metric values
+            # before the replay below so the capture iteration is accounted exactly once while
+            # retaining the storage referenced by the graph. With zero eager warmup, reduction
+            # groups are first discovered by Python during capture and must survive because
+            # replay only executes the recorded GPU work.
+            _restore_metric_tracker(dsa_metric_tracker, dsa_metric_snapshot)
+            for key, value in captured_reduction_metadata.items():
+                if dsa_metric_snapshot[1].get(key) is None:
+                    dsa_metric_tracker[key] = value
             logger.info(f'CUDA graph capture done for {training_str}!!!')
         if FullCudaGraphWrapper.cuda_graph[training_str] is None:
             FullCudaGraphWrapper.result[training_str] = self.forward_backward_func(*args, **kwargs)

--- a/megatron/core/fusions/fused_mtp_prefix.py
+++ b/megatron/core/fusions/fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Sync-free prefix objective for MTP end-to-end acceptance probabilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _mtp_prefix_forward_kernel(
+        acceptances,
+        output,
+        prefix_losses,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute the prefix losses and their mean."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        prefix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+        prefix_loss_sum = tl.zeros((BLOCK_SIZE,), tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_product *= acceptance
+            prefix_loss = 1.0 - prefix_product
+            prefix_loss_sum += prefix_loss
+            tl.store(prefix_losses + depth * num_rows + rows, prefix_loss, mask=row_mask)
+            depth += 1
+
+        tl.store(output + rows, prefix_loss_sum * inv_num_depths, mask=row_mask)
+
+    @triton.jit
+    def _mtp_prefix_backward_kernel(
+        acceptances,
+        grad_output,
+        grad_acceptances,
+        num_rows,
+        num_depths,
+        inv_num_depths,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Apply a zero-safe analytical gradient without dividing by acceptance."""
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_mask = rows < num_rows
+        output_gradient = tl.load(grad_output + rows, mask=row_mask, other=0.0).to(tl.float32)
+        prefix_before = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+
+        depth = 0
+        while depth < num_depths:
+            suffix_product = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_sum = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+            suffix_depth = depth + 1
+            while suffix_depth < num_depths:
+                suffix_acceptance = tl.load(
+                    acceptances + suffix_depth * num_rows + rows, mask=row_mask, other=1.0
+                ).to(tl.float32)
+                suffix_product *= suffix_acceptance
+                suffix_sum += suffix_product
+                suffix_depth += 1
+
+            gradient = -output_gradient * inv_num_depths * prefix_before * suffix_sum
+            tl.store(grad_acceptances + depth * num_rows + rows, gradient, mask=row_mask)
+            acceptance = tl.load(
+                acceptances + depth * num_rows + rows, mask=row_mask, other=1.0
+            ).to(tl.float32)
+            prefix_before *= acceptance
+            depth += 1
+
+
+def fused_mtp_prefix_unavailable_reason(acceptances: Tensor) -> Optional[str]:
+    """Return why the fused prefix objective cannot consume the input."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if not acceptances.is_cuda:
+        return "acceptances are not a CUDA tensor"
+    # The fused TV primitive produces FP32 acceptance probabilities for both
+    # BF16 and FP32 logits. Keep this internal contract narrow instead of
+    # introducing different BF16 prefix-rounding semantics that production
+    # cannot exercise.
+    if acceptances.dtype != torch.float32:
+        return f"acceptance dtype {acceptances.dtype} is not supported"
+    if acceptances.ndim == 0 or acceptances.size(0) == 0:
+        return "acceptances must have a non-empty depth dimension"
+    if acceptances.numel() == 0:
+        return "acceptances must have at least one row"
+    if not acceptances.is_contiguous():
+        return "acceptances are not contiguous"
+    return None
+
+
+class _FusedMTPPrefixObjective(torch.autograd.Function):
+    """Triton prefix objective with a zero-safe analytical backward."""
+
+    @staticmethod
+    def forward(ctx, acceptances: Tensor) -> tuple[Tensor, Tensor]:
+        """Compute the mean and per-depth rejection probabilities."""
+        num_depths = acceptances.size(0)
+        num_rows = acceptances.numel() // num_depths
+        inv_num_depths = float(num_depths**-1)
+        output = torch.empty(
+            acceptances.shape[1:], dtype=acceptances.dtype, device=acceptances.device
+        )
+        prefix_losses = torch.empty_like(acceptances)
+        _mtp_prefix_forward_kernel[(triton.cdiv(num_rows, 256),)](
+            acceptances,
+            output,
+            prefix_losses,
+            num_rows=num_rows,
+            num_depths=num_depths,
+            inv_num_depths=inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(acceptances)
+        ctx.num_depths = num_depths
+        ctx.num_rows = num_rows
+        ctx.inv_num_depths = inv_num_depths
+        ctx.mark_non_differentiable(prefix_losses)
+        return output, prefix_losses
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor, _grad_prefix_losses: Tensor) -> tuple[Tensor]:
+        """Return the analytical gradient for every acceptance probability."""
+        (acceptances,) = ctx.saved_tensors
+        grad_acceptances = torch.empty_like(acceptances)
+        _mtp_prefix_backward_kernel[(triton.cdiv(ctx.num_rows, 256),)](
+            acceptances,
+            grad_output.contiguous(),
+            grad_acceptances,
+            num_rows=ctx.num_rows,
+            num_depths=ctx.num_depths,
+            inv_num_depths=ctx.inv_num_depths,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        return (grad_acceptances,)
+
+
+def _reference_mtp_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Preserve the established PyTorch implementation as an oracle and fallback."""
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses.detach()
+
+
+def mtp_e2e_prefix_objective(acceptances: Tensor) -> tuple[Tensor, Tensor]:
+    """Compute mean and detached per-depth E2E-TV losses with automatic dispatch."""
+    if fused_mtp_prefix_unavailable_reason(acceptances) is None:
+        return _FusedMTPPrefixObjective.apply(acceptances)
+    return _reference_mtp_prefix_objective(acceptances)

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -31,8 +31,57 @@ _BLOCK_SIZE = 1024
 if HAVE_TRITON:
 
     @triton.jit
+    def _load_tv_target_values(
+        target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
+        row,
+        cols,
+        vocab_mask,
+        vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
+    ):
+        """Load one target row from local storage, a compact halo, or logical zeros."""
+        if HAS_TARGET_ROW_MAP:
+            target_row = tl.load(target_row_indices + row).to(tl.int64)
+            target_is_valid = tl.load(target_valid_rows + row)
+            target_is_valid = (
+                target_is_valid
+                & (target_row >= 0)
+                & (target_row < local_target_rows + target_halo_rows)
+            )
+            safe_target_row = tl.where(target_is_valid, target_row, 0)
+            target_row_ptr = tl.where(
+                safe_target_row < local_target_rows,
+                target + safe_target_row * vocab_size,
+                target_halo + (safe_target_row - local_target_rows) * vocab_size,
+            )
+            target_values = tl.load(
+                target_row_ptr + cols, mask=vocab_mask & target_is_valid, other=-float("inf")
+            )
+            return tl.where(target_is_valid, target_values.to(tl.float32), 0.0)
+
+        return tl.load(target + row * vocab_size + cols, mask=vocab_mask, other=-float("inf")).to(
+            tl.float32
+        )
+
+    @triton.jit
     def _tv_row_stats_kernel(
-        draft, target, maxima, denominators, vocab_size, BLOCK_SIZE: tl.constexpr
+        draft,
+        target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
+        maxima,
+        denominators,
+        vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
     ):
         """Compute stable local softmax maxima and denominators for one row."""
         row = tl.program_id(0).to(tl.int64)
@@ -48,8 +97,18 @@ if HAVE_TRITON:
             draft_values = tl.load(draft + row_start + cols, mask=mask, other=-float("inf")).to(
                 tl.float32
             )
-            target_values = tl.load(target + row_start + cols, mask=mask, other=-float("inf")).to(
-                tl.float32
+            target_values = _load_tv_target_values(
+                target,
+                target_halo,
+                target_row_indices,
+                target_valid_rows,
+                row,
+                cols,
+                mask,
+                vocab_size,
+                local_target_rows,
+                target_halo_rows,
+                HAS_TARGET_ROW_MAP,
             )
 
             draft_tile_max = tl.max(draft_values, axis=0)
@@ -95,12 +154,18 @@ if HAVE_TRITON:
     def _tv_overlap_kernel(
         draft,
         target,
+        target_halo,
+        target_row_indices,
+        target_valid_rows,
         maxima,
         denominators,
         overlap_and_s,
         draft_above_target_bits,
         vocab_size,
         packed_vocab_size,
+        local_target_rows,
+        target_halo_rows,
+        HAS_TARGET_ROW_MAP: tl.constexpr,
         BLOCK_SIZE: tl.constexpr,
     ):
         """Compute local overlap and the draft mass at or below the target."""
@@ -120,7 +185,19 @@ if HAVE_TRITON:
             cols = col_start + byte_offsets[:, None] * 8 + bit_offsets[None, :]
             mask = cols < vocab_size
             draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
-            target_values = tl.load(target + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            target_values = _load_tv_target_values(
+                target,
+                target_halo,
+                target_row_indices,
+                target_valid_rows,
+                row,
+                cols,
+                mask,
+                vocab_size,
+                local_target_rows,
+                target_halo_rows,
+                HAS_TARGET_ROW_MAP,
+            )
             draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
             target_prob = tl.exp(target_values - target_max) / target_denominator
             overlap += tl.sum(
@@ -217,6 +294,59 @@ def fused_mtp_tv_unavailable_reason(  # pylint: disable=too-many-return-statemen
     return None
 
 
+def _validate_target_row_addressing(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    target_row_indices: Optional[Tensor],
+    target_valid_rows: Optional[Tensor],
+    target_halo_logits: Optional[Tensor],
+) -> bool:
+    """Validate optional direct target-row addressing and return whether it is active."""
+    has_target_row_map = target_row_indices is not None
+    if has_target_row_map != (target_valid_rows is not None):
+        raise ValueError("Target row indices and validity must be provided together.")
+    if target_halo_logits is not None and not has_target_row_map:
+        raise ValueError("Target halo logits require target row indices and validity.")
+    if not has_target_row_map:
+        return False
+
+    assert target_row_indices is not None
+    assert target_valid_rows is not None
+    if target_row_indices.shape != draft_logits.shape[:-1]:
+        raise ValueError(
+            "Target row indices must match the draft leading dimensions, got "
+            f"{tuple(target_row_indices.shape)} and {tuple(draft_logits.shape[:-1])}."
+        )
+    if target_valid_rows.shape != target_row_indices.shape:
+        raise ValueError(
+            "Target row validity must match target row indices, got "
+            f"{tuple(target_valid_rows.shape)} and {tuple(target_row_indices.shape)}."
+        )
+    if target_row_indices.device != draft_logits.device:
+        raise ValueError("Target row indices must be on the logits device.")
+    if target_valid_rows.device != draft_logits.device:
+        raise ValueError("Target row validity must be on the logits device.")
+    if target_row_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Target row indices must use torch.int32 or torch.int64.")
+    if target_valid_rows.dtype != torch.bool:
+        raise ValueError("Target row validity must use torch.bool.")
+    if not target_row_indices.is_contiguous() or not target_valid_rows.is_contiguous():
+        raise ValueError("Target row metadata must be contiguous.")
+
+    if target_halo_logits is not None:
+        if target_halo_logits.device != target_logits.device:
+            raise ValueError("Target halo logits must be on the target-logits device.")
+        if target_halo_logits.dtype != target_logits.dtype:
+            raise ValueError("Target halo logits must use the target-logits dtype.")
+        if target_halo_logits.ndim != target_logits.ndim:
+            raise ValueError("Target halo logits must have the target-logits rank.")
+        if target_halo_logits.shape[1:] != target_logits.shape[1:]:
+            raise ValueError("Target halo logits must match non-sequence target dimensions.")
+        if not target_halo_logits.is_contiguous():
+            raise ValueError("Target halo logits must be contiguous.")
+    return True
+
+
 class _FusedVocabParallelTVDistance(torch.autograd.Function):
     """Triton TV distance with compact analytical-backward state."""
 
@@ -227,23 +357,44 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
         target_logits: Tensor,
         tp_group: Optional[torch.distributed.ProcessGroup],
         logits_are_vocab_sharded: bool,
+        target_row_indices: Optional[Tensor],
+        target_valid_rows: Optional[Tensor],
+        target_halo_logits: Optional[Tensor],
     ) -> Tensor:
         """Run fused forward passes and preserve compact backward state."""
         unavailable_reason = fused_mtp_tv_unavailable_reason(draft_logits, target_logits)
         if unavailable_reason is not None:
             raise RuntimeError(f"Fused MTP TV distance is unavailable: {unavailable_reason}.")
 
+        has_target_row_map = _validate_target_row_addressing(
+            draft_logits, target_logits, target_row_indices, target_valid_rows, target_halo_logits
+        )
         vocab_size = draft_logits.size(-1)
         output_shape = draft_logits.shape[:-1]
         num_rows = draft_logits.numel() // vocab_size
         maxima = torch.empty((2, num_rows), dtype=torch.float32, device=draft_logits.device)
         denominators = torch.empty_like(maxima)
+        target_row_indices_arg = target_row_indices if has_target_row_map else draft_logits
+        target_valid_rows_arg = target_valid_rows if has_target_row_map else draft_logits
+        target_halo_logits_arg = (
+            target_halo_logits if target_halo_logits is not None else target_logits
+        )
+        local_target_rows = target_logits.numel() // vocab_size
+        target_halo_rows = (
+            target_halo_logits.numel() // vocab_size if target_halo_logits is not None else 0
+        )
         _tv_row_stats_kernel[(num_rows,)](
             draft_logits,
             target_logits,
+            target_halo_logits_arg,
+            target_row_indices_arg,
+            target_valid_rows_arg,
             maxima,
             denominators,
             vocab_size=vocab_size,
+            local_target_rows=local_target_rows,
+            target_halo_rows=target_halo_rows,
+            HAS_TARGET_ROW_MAP=has_target_row_map,
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
@@ -274,12 +425,18 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
         _tv_overlap_kernel[(num_rows,)](
             draft_logits,
             target_logits,
+            target_halo_logits_arg,
+            target_row_indices_arg,
+            target_valid_rows_arg,
             maxima,
             denominators,
             overlap_and_s,
             draft_above_target_bits,
             vocab_size=vocab_size,
             packed_vocab_size=packed_vocab_size,
+            local_target_rows=local_target_rows,
+            target_halo_rows=target_halo_rows,
+            HAS_TARGET_ROW_MAP=has_target_row_map,
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
@@ -337,7 +494,7 @@ class _FusedVocabParallelTVDistance(torch.autograd.Function):
             BLOCK_SIZE=_BLOCK_SIZE,
             num_warps=8,
         )
-        return grad_draft, None, None, None
+        return grad_draft, None, None, None, None, None, None
 
 
 def _fused_vocab_parallel_tv_distance(
@@ -345,10 +502,20 @@ def _fused_vocab_parallel_tv_distance(
     target_logits: Tensor,
     tp_group: Optional[torch.distributed.ProcessGroup],
     logits_are_vocab_sharded: bool,
+    *,
+    target_row_indices: Optional[Tensor] = None,
+    target_valid_rows: Optional[Tensor] = None,
+    target_halo_logits: Optional[Tensor] = None,
 ) -> Tensor:
-    """Compute TV distance using Triton and TP collectives."""
+    """Compute TV distance using Triton, optional target-row addressing, and TP collectives."""
     return _FusedVocabParallelTVDistance.apply(
-        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+        draft_logits,
+        target_logits.detach(),
+        tp_group,
+        logits_are_vocab_sharded,
+        target_row_indices,
+        target_valid_rows,
+        target_halo_logits.detach() if target_halo_logits is not None else None,
     )
 
 
@@ -463,14 +630,23 @@ def vocab_parallel_tv_distance(
     target_logits: Tensor,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     logits_are_vocab_sharded: bool = True,
+    *,
+    target_row_indices: Optional[Tensor] = None,
+    target_valid_rows: Optional[Tensor] = None,
+    target_halo_logits: Optional[Tensor] = None,
 ) -> Tensor:
     """Compute full-vocabulary TV distance with automatic fused/reference dispatch.
 
     Args:
         draft_logits: Trainable draft logits with vocabulary in the last dimension.
-        target_logits: Detached target logits with the same local or global vocabulary layout.
+        target_logits: Detached local target-logit storage with the same vocabulary layout.
         tp_group: Tensor-parallel group owning vocabulary shards.
         logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+        target_row_indices: Optional flattened row in ``target_logits`` or its halo for each
+            draft row.
+        target_valid_rows: Validity mask paired with ``target_row_indices``. Invalid and
+            out-of-bounds rows select a safe all-zero target-logit vector.
+        target_halo_logits: Optional compact rows logically appended to ``target_logits``.
 
     Returns:
         A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
@@ -484,19 +660,60 @@ def vocab_parallel_tv_distance(
     if draft_logits.device != target_logits.device:
         raise ValueError("Draft and target logits must be on the same device.")
     _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+    has_target_row_map = _validate_target_row_addressing(
+        draft_logits, target_logits, target_row_indices, target_valid_rows, target_halo_logits
+    )
 
     # Materialized sequence rolls produce a noncontiguous target view. Pack only
     # that detached input when the trainable draft otherwise supports Triton.
     if (
-        not target_logits.is_contiguous()
+        not has_target_row_map
+        and not target_logits.is_contiguous()
         and fused_mtp_tv_unavailable_reason(draft_logits, draft_logits) is None
     ):
         target_logits = target_logits.detach().contiguous()
 
     if fused_mtp_tv_unavailable_reason(draft_logits, target_logits) is None:
         return _fused_vocab_parallel_tv_distance(
-            draft_logits, target_logits, tp_group, logits_are_vocab_sharded
+            draft_logits,
+            target_logits,
+            tp_group,
+            logits_are_vocab_sharded,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo_logits,
         )
+
+    if has_target_row_map:
+        assert target_row_indices is not None
+        assert target_valid_rows is not None
+        vocab_size = draft_logits.size(-1)
+        local_targets = target_logits.detach().reshape(-1, vocab_size)
+        flat_indices = target_row_indices.reshape(-1).long()
+        flat_valid = target_valid_rows.reshape(-1)
+        num_local_rows = local_targets.size(0)
+        halo_targets = None
+        num_halo_rows = 0
+        if target_halo_logits is not None:
+            halo_targets = target_halo_logits.detach().reshape(-1, vocab_size)
+            num_halo_rows = halo_targets.size(0)
+
+        num_addressable_rows = num_local_rows + num_halo_rows
+        flat_valid = flat_valid & (flat_indices >= 0) & (flat_indices < num_addressable_rows)
+        safe_local_indices = torch.where(
+            flat_valid & (flat_indices < num_local_rows), flat_indices, 0
+        )
+        materialized_target = local_targets.index_select(0, safe_local_indices)
+        if halo_targets is not None and num_halo_rows > 0:
+            selects_halo = flat_valid & (flat_indices >= num_local_rows)
+            safe_halo_indices = torch.where(selects_halo, flat_indices - num_local_rows, 0)
+            selected_halo = halo_targets.index_select(0, safe_halo_indices)
+            materialized_target = torch.where(
+                selects_halo.unsqueeze(1), selected_halo, materialized_target
+            )
+        materialized_target.masked_fill_(~flat_valid.unsqueeze(1), 0)
+        target_logits = materialized_target.view_as(draft_logits)
+
     return _VocabParallelTVDistance.apply(
         draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
     )

--- a/megatron/core/fusions/fused_mtp_tv.py
+++ b/megatron/core/fusions/fused_mtp_tv.py
@@ -1,0 +1,502 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Full-vocabulary TV distance with fused CUDA dispatch and a PyTorch fallback."""
+
+# Triton kernel signatures and programs naturally exceed the host-code lint limits.
+# pylint: disable=invalid-name,too-many-arguments,too-many-locals
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core import parallel_state
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAVE_TRITON = False
+
+
+_BLOCK_SIZE = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _tv_row_stats_kernel(
+        draft, target, maxima, denominators, vocab_size, BLOCK_SIZE: tl.constexpr
+    ):
+        """Compute stable local softmax maxima and denominators for one row."""
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = -float("inf")
+        target_max = -float("inf")
+        draft_sum = 0.0
+        target_sum = 0.0
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            target_values = tl.load(target + row_start + cols, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+
+            draft_tile_max = tl.max(draft_values, axis=0)
+            target_tile_max = tl.max(target_values, axis=0)
+            draft_new_max = tl.maximum(draft_max, draft_tile_max)
+            target_new_max = tl.maximum(target_max, target_tile_max)
+            draft_old_scale = tl.where(
+                draft_max == -float("inf"), 0.0, tl.exp(draft_max - draft_new_max)
+            )
+            target_old_scale = tl.where(
+                target_max == -float("inf"), 0.0, tl.exp(target_max - target_new_max)
+            )
+            draft_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(draft_values - draft_new_max), 0.0), axis=0
+            )
+            target_tile_sum = tl.sum(
+                tl.where(mask, tl.exp(target_values - target_new_max), 0.0), axis=0
+            )
+            draft_sum = draft_sum * draft_old_scale + draft_tile_sum
+            target_sum = target_sum * target_old_scale + target_tile_sum
+            draft_max = draft_new_max
+            target_max = target_new_max
+
+        num_rows = tl.num_programs(0)
+        tl.store(maxima + row, draft_max)
+        tl.store(maxima + num_rows + row, target_max)
+        tl.store(denominators + row, draft_sum)
+        tl.store(denominators + num_rows + row, target_sum)
+
+    @triton.jit
+    def _tv_rescale_denominators_kernel(
+        local_maxima, global_maxima, denominators, num_values, BLOCK_SIZE: tl.constexpr
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < num_values
+        local_max = tl.load(local_maxima + offsets, mask=mask)
+        global_max = tl.load(global_maxima + offsets, mask=mask)
+        denominator = tl.load(denominators + offsets, mask=mask)
+        denominator *= tl.exp(local_max - global_max)
+        tl.store(denominators + offsets, denominator, mask=mask)
+
+    @triton.jit
+    def _tv_overlap_kernel(
+        draft,
+        target,
+        maxima,
+        denominators,
+        overlap_and_s,
+        draft_above_target_bits,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Compute local overlap and the draft mass at or below the target."""
+        row = tl.program_id(0).to(tl.int64)
+        num_rows = tl.num_programs(0)
+        row_start = row * vocab_size
+        draft_max = tl.load(maxima + row)
+        target_max = tl.load(maxima + num_rows + row)
+        draft_denominator = tl.load(denominators + row)
+        target_denominator = tl.load(denominators + num_rows + row)
+        overlap = 0.0
+        draft_mass_below_target = 0.0
+
+        bit_offsets = tl.arange(0, 8)
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            byte_offsets = tl.arange(0, BLOCK_SIZE // 8)
+            cols = col_start + byte_offsets[:, None] * 8 + bit_offsets[None, :]
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            target_values = tl.load(target + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            target_prob = tl.exp(target_values - target_max) / target_denominator
+            overlap += tl.sum(
+                tl.sum(tl.where(mask, tl.minimum(draft_prob, target_prob), 0.0), axis=1), axis=0
+            )
+            draft_mass_below_target += tl.sum(
+                tl.sum(tl.where(mask & (draft_prob <= target_prob), draft_prob, 0.0), axis=1),
+                axis=0,
+            )
+            packed_above_target = tl.sum(
+                tl.where(mask & (draft_prob > target_prob), 1 << bit_offsets[None, :], 0), axis=1
+            )
+            packed_offsets = col_start // 8 + byte_offsets
+            tl.store(
+                draft_above_target_bits + row * packed_vocab_size + packed_offsets,
+                packed_above_target,
+                mask=packed_offsets < packed_vocab_size,
+            )
+
+        tl.store(overlap_and_s + row, overlap)
+        tl.store(overlap_and_s + num_rows + row, draft_mass_below_target)
+
+    @triton.jit
+    def _tv_finalize_kernel(
+        overlap, output, clamp_gradient_mask, num_rows, BLOCK_SIZE: tl.constexpr
+    ):
+        rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = rows < num_rows
+        raw_distance = 1.0 - tl.load(overlap + rows, mask=mask)
+        distance = tl.maximum(0.0, tl.minimum(1.0, raw_distance))
+        tl.store(output + rows, distance, mask=mask)
+        tl.store(
+            clamp_gradient_mask + rows, (raw_distance >= 0.0) & (raw_distance <= 1.0), mask=mask
+        )
+
+    @triton.jit
+    def _tv_backward_kernel(
+        draft,
+        draft_maxima,
+        draft_denominators,
+        draft_mass_below_target,
+        draft_above_target_bits,
+        clamp_gradient_mask,
+        grad_output,
+        grad_draft,
+        vocab_size,
+        packed_vocab_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        row = tl.program_id(0).to(tl.int64)
+        row_start = row * vocab_size
+        draft_max = tl.load(draft_maxima + row)
+        draft_denominator = tl.load(draft_denominators + row)
+        draft_mass = tl.load(draft_mass_below_target + row)
+        row_gradient = tl.load(grad_output + row).to(tl.float32)
+        row_gradient *= tl.load(clamp_gradient_mask + row).to(tl.float32)
+
+        for col_start in range(0, vocab_size, BLOCK_SIZE):
+            cols = col_start + tl.arange(0, BLOCK_SIZE)
+            mask = cols < vocab_size
+            draft_values = tl.load(draft + row_start + cols, mask=mask, other=0.0).to(tl.float32)
+            draft_prob = tl.exp(draft_values - draft_max) / draft_denominator
+            packed_above_target = tl.load(
+                draft_above_target_bits + row * packed_vocab_size + cols // 8, mask=mask, other=0
+            ).to(tl.int32)
+            draft_above_target = (packed_above_target >> (cols % 8)) & 1
+            gradient = draft_prob * (draft_mass - 1.0 + draft_above_target.to(tl.float32))
+            gradient *= row_gradient
+            tl.store(grad_draft + row_start + cols, gradient, mask=mask)
+
+
+def fused_mtp_tv_unavailable_reason(  # pylint: disable=too-many-return-statements
+    draft_logits: Tensor, target_logits: Tensor
+) -> Optional[str]:
+    """Return why the fused kernel cannot consume the two logits tensors."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if draft_logits.shape != target_logits.shape:
+        return "draft and target logits have different shapes"
+    if draft_logits.device != target_logits.device:
+        return "draft and target logits are on different devices"
+    if not draft_logits.is_cuda:
+        return "logits are not CUDA tensors"
+    if draft_logits.dtype not in (torch.bfloat16, torch.float32):
+        return f"draft dtype {draft_logits.dtype} is not supported"
+    if target_logits.dtype != draft_logits.dtype:
+        return "draft and target logits have different dtypes"
+    if draft_logits.ndim == 0 or draft_logits.size(-1) == 0:
+        return "logits must have a non-empty vocabulary dimension"
+    if draft_logits.numel() == 0:
+        return "logits must have at least one row"
+    if not draft_logits.is_contiguous() or not target_logits.is_contiguous():
+        return "logits are not contiguous"
+    return None
+
+
+class _FusedVocabParallelTVDistance(torch.autograd.Function):
+    """Triton TV distance with compact analytical-backward state."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Run fused forward passes and preserve compact backward state."""
+        unavailable_reason = fused_mtp_tv_unavailable_reason(draft_logits, target_logits)
+        if unavailable_reason is not None:
+            raise RuntimeError(f"Fused MTP TV distance is unavailable: {unavailable_reason}.")
+
+        vocab_size = draft_logits.size(-1)
+        output_shape = draft_logits.shape[:-1]
+        num_rows = draft_logits.numel() // vocab_size
+        maxima = torch.empty((2, num_rows), dtype=torch.float32, device=draft_logits.device)
+        denominators = torch.empty_like(maxima)
+        _tv_row_stats_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            vocab_size=vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        if logits_are_vocab_sharded and tp_size > 1:
+            local_maxima = maxima
+            maxima = local_maxima.clone()
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+            num_stats = maxima.numel()
+            _tv_rescale_denominators_kernel[(triton.cdiv(num_stats, 256),)](
+                local_maxima,
+                maxima,
+                denominators,
+                num_values=num_stats,
+                BLOCK_SIZE=256,
+                num_warps=4,
+            )
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        overlap_and_s = torch.empty_like(maxima)
+        packed_vocab_size = (vocab_size + 7) // 8
+        draft_above_target_bits = torch.empty(
+            (num_rows, packed_vocab_size), dtype=torch.uint8, device=draft_logits.device
+        )
+        _tv_overlap_kernel[(num_rows,)](
+            draft_logits,
+            target_logits,
+            maxima,
+            denominators,
+            overlap_and_s,
+            draft_above_target_bits,
+            vocab_size=vocab_size,
+            packed_vocab_size=packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+
+        output = torch.empty(num_rows, dtype=torch.float32, device=draft_logits.device)
+        clamp_gradient_mask = torch.empty(num_rows, dtype=torch.bool, device=draft_logits.device)
+        _tv_finalize_kernel[(triton.cdiv(num_rows, 256),)](
+            overlap_and_s,
+            output,
+            clamp_gradient_mask,
+            num_rows=num_rows,
+            BLOCK_SIZE=256,
+            num_warps=4,
+        )
+        ctx.save_for_backward(
+            draft_logits,
+            maxima[0],
+            denominators[0],
+            overlap_and_s[1],
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        )
+        ctx.vocab_size = vocab_size
+        ctx.packed_vocab_size = packed_vocab_size
+        return output.view(output_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical draft-logit gradient from packed metadata."""
+        (
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+        ) = ctx.saved_tensors
+        num_rows = draft_logits.numel() // ctx.vocab_size
+        grad_draft = torch.empty_like(draft_logits)
+        _tv_backward_kernel[(num_rows,)](
+            draft_logits,
+            draft_maxima,
+            draft_denominators,
+            draft_mass_below_target,
+            draft_above_target_bits,
+            clamp_gradient_mask,
+            grad_output.contiguous(),
+            grad_draft,
+            vocab_size=ctx.vocab_size,
+            packed_vocab_size=ctx.packed_vocab_size,
+            BLOCK_SIZE=_BLOCK_SIZE,
+            num_warps=8,
+        )
+        return grad_draft, None, None, None
+
+
+def _fused_vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    logits_are_vocab_sharded: bool,
+) -> Tensor:
+    """Compute TV distance using Triton and TP collectives."""
+    return _FusedVocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )
+
+
+def _validate_vocab_parallel_tv_group(
+    tp_group: Optional[torch.distributed.ProcessGroup], logits_are_vocab_sharded: bool
+) -> None:
+    """Reject vocab-sharded TV before a missing TP group can change its normalization."""
+    # Compatibility guard retained from the original MTP-local dispatcher. New
+    # callers should pass the explicit TP group instead of relying on MPU state.
+    if logits_are_vocab_sharded and tp_group is None and parallel_state.is_initialized():
+        initialized_tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        if initialized_tp_size > 1:
+            raise ValueError(
+                "tp_group must be provided for TV distance over vocab-sharded logits "
+                f"when tensor parallel size is {initialized_tp_size}."
+            )
+
+
+class _VocabParallelTVDistance(torch.autograd.Function):
+    """Full-vocabulary TV distance with a TP-aware analytical backward.
+
+    The implementation follows Algorithms 1 and 2 in the Bebop paper
+    (https://arxiv.org/abs/2606.12370). It intentionally keeps the target
+    distribution detached and returns gradients for draft logits only.
+
+    This PyTorch implementation establishes the mathematical contract and is
+    retained as the oracle and fallback for unsupported fused-kernel inputs.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        draft_logits: Tensor,
+        target_logits: Tensor,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        logits_are_vocab_sharded: bool,
+    ) -> Tensor:
+        """Compute the TV distance and save the draft-side backward state."""
+        if draft_logits.shape != target_logits.shape:
+            raise ValueError(
+                "Draft and target logits must have identical shapes, got "
+                f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+            )
+        if draft_logits.device != target_logits.device:
+            raise ValueError("Draft and target logits must be on the same device.")
+
+        tp_size = torch.distributed.get_world_size(group=tp_group) if tp_group is not None else 1
+        _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+        draft_logits_fp32 = draft_logits.float()
+        target_logits_fp32 = target_logits.float()
+        maxima = torch.stack(
+            (draft_logits_fp32.max(dim=-1).values, target_logits_fp32.max(dim=-1).values)
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(maxima, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        draft_max, target_max = maxima.unbind(dim=0)
+
+        draft_exp = torch.exp(draft_logits_fp32 - draft_max.unsqueeze(-1))
+        target_exp = torch.exp(target_logits_fp32 - target_max.unsqueeze(-1))
+        denominators = torch.stack((draft_exp.sum(dim=-1), target_exp.sum(dim=-1)))
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                denominators, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        draft_denominator, target_denominator = denominators.unbind(dim=0)
+
+        draft_prob = draft_exp / draft_denominator.unsqueeze(-1)
+        target_prob = target_exp / target_denominator.unsqueeze(-1)
+        draft_below_target = draft_prob <= target_prob
+        overlap_and_s = torch.stack(
+            (
+                torch.minimum(draft_prob, target_prob).sum(dim=-1),
+                (draft_prob * draft_below_target).sum(dim=-1),
+            )
+        )
+        if logits_are_vocab_sharded and tp_size > 1:
+            torch.distributed.all_reduce(
+                overlap_and_s, op=torch.distributed.ReduceOp.SUM, group=tp_group
+            )
+        overlap, s = overlap_and_s.unbind(dim=0)
+
+        raw_tv_distance = 1.0 - overlap
+        tv_distance = raw_tv_distance.clamp(min=0.0, max=1.0)
+        clamp_gradient_mask = (raw_tv_distance >= 0.0) & (raw_tv_distance <= 1.0)
+        ctx.save_for_backward(
+            draft_logits,
+            draft_max,
+            draft_denominator,
+            s,
+            draft_prob > target_prob,
+            clamp_gradient_mask,
+        )
+        return tv_distance
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Apply the analytical Bebop gradient to the draft logits only."""
+        draft_logits, draft_max, draft_denominator, s, draft_above_target, clamp_gradient_mask = (
+            ctx.saved_tensors
+        )
+
+        draft_prob = torch.exp(draft_logits.float() - draft_max.unsqueeze(-1))
+        draft_prob = draft_prob / draft_denominator.unsqueeze(-1)
+        grad_draft = draft_prob * (s.unsqueeze(-1) - 1.0 + draft_above_target.to(draft_prob.dtype))
+        grad_draft *= (grad_output * clamp_gradient_mask).unsqueeze(-1)
+        return grad_draft.to(draft_logits.dtype), None, None, None
+
+
+def vocab_parallel_tv_distance(
+    draft_logits: Tensor,
+    target_logits: Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    logits_are_vocab_sharded: bool = True,
+) -> Tensor:
+    """Compute full-vocabulary TV distance with automatic fused/reference dispatch.
+
+    Args:
+        draft_logits: Trainable draft logits with vocabulary in the last dimension.
+        target_logits: Detached target logits with the same local or global vocabulary layout.
+        tp_group: Tensor-parallel group owning vocabulary shards.
+        logits_are_vocab_sharded: Whether the last dimension is sharded across ``tp_group``.
+
+    Returns:
+        A FP32 tensor with the vocabulary dimension removed. Gradients flow only to
+        ``draft_logits``.
+    """
+    if draft_logits.shape != target_logits.shape:
+        raise ValueError(
+            "Draft and target logits must have identical shapes, got "
+            f"{tuple(draft_logits.shape)} and {tuple(target_logits.shape)}."
+        )
+    if draft_logits.device != target_logits.device:
+        raise ValueError("Draft and target logits must be on the same device.")
+    _validate_vocab_parallel_tv_group(tp_group, logits_are_vocab_sharded)
+
+    # Materialized sequence rolls produce a noncontiguous target view. Pack only
+    # that detached input when the trainable draft otherwise supports Triton.
+    if (
+        not target_logits.is_contiguous()
+        and fused_mtp_tv_unavailable_reason(draft_logits, draft_logits) is None
+    ):
+        target_logits = target_logits.detach().contiguous()
+
+    if fused_mtp_tv_unavailable_reason(draft_logits, target_logits) is None:
+        return _fused_vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group, logits_are_vocab_sharded
+        )
+    return _VocabParallelTVDistance.apply(
+        draft_logits, target_logits.detach(), tp_group, logits_are_vocab_sharded
+    )

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -112,6 +112,12 @@ class TextGenerationController:
         inference_config = self.inference_wrapped_model.inference_context.config
         self.tokenizer = tokenizer
         self.num_speculative_tokens = inference_config.num_speculative_tokens
+        if self.num_speculative_tokens and self.model_config.dsa_mtp_index_kv_share:
+            raise ValueError(
+                "dsa_mtp_index_kv_share is not supported with speculative decoding because "
+                "serial compute_mtp_single_step calls do not carry iteration-0 DSA KV/top-k "
+                "tensors. Disable dsa_mtp_index_kv_share or set num_speculative_tokens=0."
+            )
 
         pg_collection = inference_config.pg_collection
         if pg_collection is not None:
@@ -2443,7 +2449,7 @@ class TextGenerationController:
                 if sampling_params.num_tokens_to_generate > 0:
                     # Check end of generation status for each tensor
                     # and update generated sequence lengths
-                    (is_generation_done_tensor, generated_sequence_lengths) = (
+                    is_generation_done_tensor, generated_sequence_lengths = (
                         self.update_generation_status(
                             updated_prompts_tokens=batch_prompt_tokens,
                             generation_started=generation_started,

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -377,6 +377,16 @@ class ModelParallelConfig:
         should only be set if the sequence length varies by microbatch within a global batch.
     """
 
+    thd_static_pp_communication: bool = False
+    """Derived (do not set directly): THD full-iteration CUDA graph mode uses static PP shapes.
+        Set by TransformerConfig.__post_init__ when cuda_graph_impl='full_iteration' is combined
+        with a sequence packing scheduler. Overrides the variable_seq_lengths shape handshake:
+        packed batches are canonicalized to the static per-rank token capacity
+        max_seqlen_per_dp_cp_rank before entering the graph, so all PP send/recv tensors have a
+        fixed sequence dimension and the per-step shape negotiation (which is not
+        graph-capturable) is skipped.
+    """
+
     overlap_p2p_comm: bool = False
     """When True some of the peer to peer communication for pipeline parallelism will overlap with
        computation. Must be False if batch_p2p_comm is true.

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -687,6 +687,11 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self._model_chunk_state.loss_mask = loss_mask
         self._model_chunk_state.packed_seq_params = packed_seq_params
         self._model_chunk_state.padding_mask = padding_mask
+        # Keep the pre-transformer mask for MTP sequence-roll preparation. GPT
+        # preprocessing may sequence-parallel scatter ``padding_mask`` in place.
+        self._model_chunk_state.mtp_padding_mask = padding_mask
+        self._model_chunk_state.mtp_sequence_roll_context = None
+        self._model_chunk_state.mtp_materialized_roll_rows = None
         self._model_chunk_state.extra_block_kwargs = extra_block_kwargs
         self._model_chunk_state.runtime_gather_output = runtime_gather_output
         self._model_chunk_state.output_processor = output_processor
@@ -728,8 +733,28 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
         from megatron.core.tensor_parallel.random import MHCCheckpointManager
 
-        num_layers = len(module.layers)
         config = module.config
+        is_repeated_mtp = bool(
+            module_tag == "mtp" and getattr(module, "mtp_use_repeated_layer", False)
+        )
+        if is_repeated_mtp:
+            assert (
+                len(module.layers) == 1
+            ), "Repeated MTP fine-grained scheduling requires exactly one physical layer."
+            num_layers = int(getattr(module, "mtp_num_depths", 0) or config.mtp_num_layers or 0)
+            assert num_layers > 0, "Repeated MTP requires at least one logical prediction depth."
+            physical_layer = module.layers[0]
+            first_absolute_depth = physical_layer.layer_number
+            scheduled_layers = tuple(
+                (physical_layer, first_absolute_depth + logical_index)
+                for logical_index in range(num_layers)
+            )
+        else:
+            num_layers = len(module.layers)
+            scheduled_layers = tuple(
+                (layer, layer.layer_number if module_tag == "mtp" else None)
+                for layer in module.layers
+            )
         use_mhc_recompute = (
             module.training
             and torch.is_grad_enabled()
@@ -743,7 +768,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         )
         group_index = 0
 
-        for layer_idx in range(num_layers):
+        for layer_idx, (layer, mtp_absolute_depth) in enumerate(scheduled_layers):
             is_group_end = bool(
                 mhc_recompute_manager is not None
                 and (layer_idx == num_layers - 1 or (layer_idx + 1) % group_size == 0)
@@ -755,14 +780,10 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 "is_last_layer_in_mhc_recompute_group": is_group_end,
                 "mhc_recompute_group_index": group_index,
                 "mhc_recompute_module_tag": module_tag,
+                "mtp_absolute_depth": mtp_absolute_depth,
             }
             layer_plan = TransformerLayerSchedulePlan(
-                module.layers[layer_idx],
-                self.event,
-                self.state,
-                comp_stream,
-                comm_stream,
-                extra_args,
+                layer, self.event, self.state, comp_stream, comm_stream, extra_args
             )
             self._transformer_layers.append(layer_plan)
 
@@ -855,6 +876,8 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
     def release_state(self):
         """Release reference, this helps avoid memory leak."""
         self._recompute_segments = []
+        self._model_chunk_state.mtp_sequence_roll_context = None
+        self._model_chunk_state.mtp_materialized_roll_rows = None
         self._model_chunk_state.model = None
         self.pre_process.model_chunk_state = None
         self.pre_process = None

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -9,7 +9,7 @@ import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
-from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -17,8 +17,13 @@ from megatron.core.pipeline_parallel.utils import ScheduleNode, make_viewless
 from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.module import GraphableMegatronModule, float16_to_fp32
 from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionLayer,
+    _scatter_mtp_padding_mask,
     get_mtp_layer_offset,
 )
 from megatron.core.transformer.transformer_layer import (
@@ -310,6 +315,7 @@ class PostProcessNode(ScheduleNode):
             extra_block_kwargs=self.chunk_state.extra_block_kwargs,
             output_processor=self.chunk_state.output_processor,
             output_processor_context=self.chunk_state.output_processor_context,
+            sequence_roll_context=getattr(self.chunk_state, "mtp_sequence_roll_context", None),
         )
 
         # For now, 1f1b only supports fp16 module
@@ -372,6 +378,7 @@ class TransformerLayerNode(ScheduleNode):
         self.detached = tuple()
         self.before_detached = tuple()
         self.is_mtp = extra_args.get("is_mtp", False)
+        self.mtp_absolute_depth = extra_args.get("mtp_absolute_depth")
         self.mhc_recompute_manager = extra_args.get("mhc_recompute_manager")
         self.is_last_layer_in_mhc_recompute_group = extra_args.get(
             "is_last_layer_in_mhc_recompute_group", False
@@ -607,7 +614,16 @@ def build_transformer_layer_callables(layer: TransformerLayer):
     is_hyper_connection_layer = isinstance(layer, HyperConnectionTransformerLayer)
     is_mhc_layer = is_moe and is_hyper_connection_layer
 
-    def submodule_attn_forward(node: ScheduleNode, hidden_states: torch.Tensor):
+    # A repeated MTP layer builds one callable set per logical depth while sharing
+    # the same physical TransformerLayer. Keep the delayed-wgrad wrapper owned by
+    # this callable invocation; ``layer.backward_dw_wrapper`` is overwritten when
+    # the next logical depth is built.
+    layer.init_backward_dw_wrapper()
+    backward_dw_wrapper = layer.backward_dw_wrapper
+
+    def submodule_attn_forward(
+        node: ScheduleNode, hidden_states: torch.Tensor, padding_mask: Optional[Tensor] = None
+    ):
         """
         Performs same attnention forward logic as GPT Model and forward pass for
         computations between attention and dispatch:
@@ -618,6 +634,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         is_last_in_mhc_recompute_group = getattr(
             node, "is_last_layer_in_mhc_recompute_group", False
         )
+        effective_padding_mask = (
+            padding_mask if padding_mask is not None else node.chunk_state.padding_mask
+        )
         if mhc_recompute_manager is not None:
             mhc_recompute_manager.is_last_layer_in_recompute_block = is_last_in_mhc_recompute_group
 
@@ -627,7 +646,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             and layer.cuda_graphs
         )
         if using_cuda_graph_replay:
-            layer.set_te_cuda_graph_backward_dw_wrapper()
+            backward_dw_wrapper.set_graphed_backward_dw_callable(
+                partial(layer._te_cuda_graph_backward_dw_graph, layer.current_microbatch)
+            )
             # The fine-grained schedule calls _te_cuda_graph_replay directly,
             # bypassing TransformerLayer.__call__ where _mhc_recompute_manager is
             # normally set. Thread it here for every hyper-connection layer: the
@@ -648,6 +669,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 rotary_pos_sin: Optional[Tensor] = None,
                 packed_seq_params: Optional[PackedSeqParams] = None,
                 sequence_len_offset: Optional[Tensor] = None,
+                padding_mask: Optional[Tensor] = None,
                 mhc_recompute_manager=None,
             ):
                 attention_kwargs = dict(
@@ -708,7 +730,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)
                 probs, routing_map = layer.mlp.route(
-                    pre_mlp_layernorm_output, padding_mask=node.chunk_state.padding_mask
+                    pre_mlp_layernorm_output, padding_mask=padding_mask
                 )
                 local_tokens, probs = layer.mlp.preprocess(
                     pre_mlp_layernorm_output, probs, routing_map
@@ -733,6 +755,8 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             packed_seq_params=node.chunk_state.packed_seq_params,
             sequence_len_offset=node.chunk_state.sequence_len_offset,
         )
+        if is_moe and effective_padding_mask is not None:
+            forward_kwargs["padding_mask"] = effective_padding_mask
         if is_hyper_connection_layer and (
             not using_cuda_graph_replay
             or CudaGraphModule.attn not in layer.config.cuda_graph_modules
@@ -939,8 +963,6 @@ def build_transformer_layer_callables(layer: TransformerLayer):
     mlp_func = submodule_moe_forward if is_moe else mlp_wrapper
     combine_func = submodule_combine_forward if is_moe else raise_not_implemented
 
-    layer.init_backward_dw_wrapper()
-
     # mHC post runs the fused H_res/H_post bias-dropout-add, so it needs the
     # sequence-parallel RNG fork that this builder's other callables do not carry.
     # That omission on dispatch/mlp/combine predates this PR -- the overlap
@@ -953,7 +975,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
     )
 
     forward_funcs = [attn_func, dispatch_func, mlp_func, combine_func, None, mhc_post_func]
-    backward_dw = {"attn": layer.backward_dw_wrapper, "mlp": layer.mlp}
+    backward_dw = {"attn": backward_dw_wrapper, "mlp": layer.mlp}
     return forward_funcs, backward_dw
 
 
@@ -986,6 +1008,66 @@ def build_mtp_layer_callables(layer):
     is_moe = isinstance(layer.mtp_model_layer.mlp, MoELayer)
     assert is_moe, "MTP layer in a2a overlap only supports MoE layer for now."
 
+    def prepare_roll_rows(node):
+        """Prepare this microbatch's immutable MTP fields and materialize them once."""
+        chunk_state = node.chunk_state
+        materialized = getattr(chunk_state, "mtp_materialized_roll_rows", None)
+        if materialized is not None:
+            return materialized
+
+        model = chunk_state.model
+        input_ids = chunk_state.input_ids
+        labels = chunk_state.labels
+        reference = input_ids if input_ids is not None else labels
+        cp_group = resolve_cp_group(layer.cp_group, chunk_state.packed_seq_params)
+        sequence_roll_context = prepare_mtp_sequence_roll_context(
+            tensor=reference, cp_group=cp_group, packed_seq_params=chunk_state.packed_seq_params
+        )
+
+        fields = []
+        if input_ids is not None:
+            fields.append(MTPSequenceRollField("input_ids", input_ids, -1, 0, 0))
+        roll_position_ids = getattr(model.embedding, "add_position_embedding", True)
+        if roll_position_ids and chunk_state.position_ids is not None:
+            fields.append(MTPSequenceRollField("position_ids", chunk_state.position_ids, -1, 0, 0))
+        if model.post_process and labels is not None:
+            fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+        if model.post_process and chunk_state.loss_mask is not None:
+            fields.append(MTPSequenceRollField("loss_mask", chunk_state.loss_mask, -1, 0, 0))
+        mtp_padding_mask = getattr(chunk_state, "mtp_padding_mask", chunk_state.padding_mask)
+        if mtp_padding_mask is not None:
+            fields.append(MTPSequenceRollField("padding_mask", mtp_padding_mask, -1, 0, True))
+
+        max_offset = int(layer.config.mtp_num_layers or 0) + int(
+            model.post_process and labels is None
+        )
+        if sequence_roll_context is not None and fields and max_offset > 0:
+            if not (
+                sequence_roll_context.max_offset >= max_offset
+                and sequence_roll_context.is_prepared_for_fields(fields)
+            ):
+                sequence_roll_context = sequence_roll_context.prepare_fields(
+                    fields, max_offset=max_offset
+                )
+            if (
+                sequence_roll_context.max_offset >= max_offset
+                and sequence_roll_context.is_prepared_for_fields(fields)
+            ):
+                forward_keys = ("input_ids", "position_ids", "padding_mask")
+                materialized = {
+                    key: sequence_roll_context.materialize_all(key)
+                    for key in forward_keys
+                    if key in sequence_roll_context.keys
+                }
+            else:
+                materialized = {}
+        else:
+            materialized = {}
+
+        chunk_state.mtp_sequence_roll_context = sequence_roll_context
+        chunk_state.mtp_materialized_roll_rows = materialized
+        return materialized
+
     def submodule_mtp_attn_forward(node, hidden_states):
         # MTP Block Preprocess
         if node.is_first_layer:
@@ -997,26 +1079,55 @@ def build_mtp_layer_callables(layer):
             else:
                 hidden_states = node.chunk_state.mtp_hidden_states[offset]
 
+        materialized_rows = prepare_roll_rows(node)
+        absolute_depth = getattr(node, "mtp_absolute_depth", None) or layer.layer_number
+        use_prepared_rows = "input_ids" in materialized_rows
+        if use_prepared_rows:
+            input_ids = materialized_rows["input_ids"][absolute_depth - 1]
+            position_ids = (
+                materialized_rows["position_ids"][absolute_depth - 1]
+                if "position_ids" in materialized_rows
+                else node.chunk_state.position_ids
+            )
+            padding_mask = (
+                materialized_rows["padding_mask"][absolute_depth - 1]
+                if "padding_mask" in materialized_rows
+                else None
+            )
+        else:
+            input_ids = node.chunk_state.input_ids
+            position_ids = node.chunk_state.position_ids
+            padding_mask = node.chunk_state.padding_mask
+
         input_ids, position_ids, padding_mask, decoder_input, hidden_states = layer._get_embeddings(
-            input_ids=node.chunk_state.input_ids,
-            position_ids=node.chunk_state.position_ids,
+            input_ids=input_ids,
+            position_ids=position_ids,
             embedding=node.chunk_state.model.embedding,
             hidden_states=hidden_states,
             packed_seq_params=node.chunk_state.packed_seq_params,
-            padding_mask=node.chunk_state.padding_mask,
+            padding_mask=padding_mask,
+            sequence_roll_context=getattr(node.chunk_state, "mtp_sequence_roll_context", None),
+            roll_depth=absolute_depth - 1,
+            _inputs_pre_aligned=use_prepared_rows,
         )
-        node.chunk_state.input_ids = input_ids
-        node.chunk_state.position_ids = position_ids
-        node.chunk_state.padding_mask = padding_mask
+        if use_prepared_rows:
+            padding_mask = _scatter_mtp_padding_mask(
+                padding_mask,
+                sequence_parallel=layer.config.sequence_parallel,
+                tp_group=layer.tp_group,
+            )
+        else:
+            # Preserve the established cumulative-roll fallback for unsupported
+            # layouts. The prepared path keeps all source fields immutable.
+            node.chunk_state.input_ids = input_ids
+            node.chunk_state.position_ids = position_ids
+            node.chunk_state.padding_mask = padding_mask
 
         # MTP Layer Preprocess
         # norm, linear projection and transformer
         assert (
             node.chunk_state.context is None
         ), f"multi token prediction + cross attention is not yet supported."
-        assert (
-            node.chunk_state.packed_seq_params is None
-        ), f"multi token prediction + sequence packing is not yet supported."
 
         if layer.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()
@@ -1026,7 +1137,7 @@ def build_mtp_layer_callables(layer):
         # fp8 context is added in 1f1b schedule, so we don't need to add it here
         with rng_context:
             hidden_states = layer._concat_embeddings(hidden_states, decoder_input)
-            return attn_forward(node, hidden_states)
+            return attn_forward(node, hidden_states, padding_mask=padding_mask)
 
     def submodule_mtp_postprocess_forward(node, hidden_states):
         # Save pre-contraction multi-stream; _postprocess contracts for mtp_hidden_states.

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -30,10 +30,13 @@ from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 from megatron.core.transformer.enums import ModelType
 from megatron.core.transformer.linear_cross_entropy import LinearCrossEntropyModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     mtp_on_this_rank,
-    prepare_mtp_sequence_roll_context,
     process_mtp_loss,
 )
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -582,6 +585,10 @@ class GPTModel(LanguageModule):
             self.preprocess_for_paged_stash()
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
+        # MTP sequence-roll preparation operates on the unsharded batch layout. Keep
+        # the raw routing mask while _preprocess separately scatters the decoder's
+        # copy when sequence parallelism is enabled.
+        mtp_padding_mask = padding_mask
 
         preproc_output = self._preprocess(
             input_ids=input_ids,
@@ -643,6 +650,7 @@ class GPTModel(LanguageModule):
             decoder_input=decoder_input,
             attention_mask=attention_mask,
             padding_mask=padding_mask,
+            mtp_padding_mask=mtp_padding_mask,
             inference_params=inference_params,
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
@@ -668,6 +676,7 @@ class GPTModel(LanguageModule):
         decoder_input=None,
         attention_mask=None,
         padding_mask=None,
+        mtp_padding_mask=None,
         inference_params=None,
         packed_seq_params=None,
         sequence_len_offset=None,
@@ -677,6 +686,7 @@ class GPTModel(LanguageModule):
         mhc_multistream=None,
         output_processor=None,
         output_processor_context=None,
+        sequence_roll_context=None,
     ):
         """Postprocesses decoder hidden states to generate logits or compute loss.
 
@@ -697,37 +707,48 @@ class GPTModel(LanguageModule):
             and inference_context.num_speculative_tokens > 0
         )
         mtp_cp_group = None
-        sequence_roll_context = None
         if (
             self.config.mtp_num_layers
             and (mtp_in_postprocess or self.post_process)
             and not (in_inference_mode or is_spec_decode)
         ):
             mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
-            # Build layout-specific metadata once, then fetch every locally owned
-            # MTP field's compact successor rows in one grouped operation. The extra
-            # row covers RL's initial label derivation before the per-layer rolls.
-            sequence_roll_context = prepare_mtp_sequence_roll_context(
-                tensor=input_ids if input_ids is not None else labels,
-                cp_group=mtp_cp_group,
-                packed_seq_params=packed_seq_params,
-            )
-            if sequence_roll_context is not None:
-                roll_position_ids = mtp_in_postprocess and getattr(
-                    self.embedding, "add_position_embedding", True
+            if sequence_roll_context is None:
+                # Build layout-specific metadata once, then prepare every locally owned
+                # MTP field for absolute sequence-roll access in one grouped operation.
+                sequence_roll_context = prepare_mtp_sequence_roll_context(
+                    tensor=input_ids if input_ids is not None else labels,
+                    cp_group=mtp_cp_group,
+                    packed_seq_params=packed_seq_params,
                 )
-                sequence_roll_context = sequence_roll_context.prefetch_halos(
-                    width=self.config.mtp_num_layers + 1,
-                    input_ids=(
+                if sequence_roll_context is not None:
+                    roll_position_ids = mtp_in_postprocess and getattr(
+                        self.embedding, "add_position_embedding", True
+                    )
+                    fields = []
+                    input_source = (
                         input_ids
                         if mtp_in_postprocess or (self.post_process and labels is None)
                         else None
-                    ),
-                    position_ids=position_ids if roll_position_ids else None,
-                    labels=labels if self.post_process else None,
-                    loss_mask=loss_mask if self.post_process else None,
-                    padding_mask=padding_mask if mtp_in_postprocess else None,
-                )
+                    )
+                    if input_source is not None:
+                        fields.append(MTPSequenceRollField("input_ids", input_source, -1, 0, 0))
+                    if roll_position_ids and position_ids is not None:
+                        fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+                    if self.post_process and labels is not None:
+                        fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+                    if self.post_process and loss_mask is not None:
+                        fields.append(MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0))
+                    if mtp_in_postprocess and mtp_padding_mask is not None:
+                        fields.append(
+                            MTPSequenceRollField("padding_mask", mtp_padding_mask, -1, 0, True)
+                        )
+                    max_offset = self.config.mtp_num_layers + int(
+                        self.post_process and labels is None
+                    )
+                    sequence_roll_context = sequence_roll_context.prepare_fields(
+                        fields, max_offset=max_offset
+                    )
 
         # logits and loss
         output_weight = None
@@ -749,6 +770,7 @@ class GPTModel(LanguageModule):
                 sequence_roll_context=sequence_roll_context,
                 sequence_len_offset=sequence_len_offset,
                 padding_mask=padding_mask,
+                sequence_roll_padding_mask=mtp_padding_mask,
                 embedding=self.embedding,
                 **(extra_block_kwargs or {}),
             )

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -156,17 +156,21 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         if hasattr(layer, 'tp_group'):
             self.tp_group = layer.tp_group
 
-    def get_layer_static_inputs(self, seq_length, micro_batch_size):
+    def get_layer_static_inputs(self, seq_length, micro_batch_size, *, for_pipeline_prewarm=False):
         """Override to produce n-stream hidden_states of shape [s, b, n*C].
 
-        CUDA graph capture allocates static buffers sized by this method. The base
-        returns [s, b, C], but mHC layers carry n-stream hidden states [s, b, n*C].
+        CUDA graph capture and pipeline prewarm allocate synthetic buffers sized by this method.
+        The base returns [s, b, C], but mHC layers carry n-stream hidden states [s, b, n*C].
         Mirrors ``HyperConnectionTransformerLayer.get_layer_static_inputs``.
         """
         if hasattr(self.inner_layer, "get_layer_static_inputs"):
-            static_inputs = self.inner_layer.get_layer_static_inputs(seq_length, micro_batch_size)
+            static_inputs = self.inner_layer.get_layer_static_inputs(
+                seq_length, micro_batch_size, for_pipeline_prewarm=for_pipeline_prewarm
+            )
         else:
-            static_inputs = super().get_layer_static_inputs(seq_length, micro_batch_size)
+            static_inputs = super().get_layer_static_inputs(
+                seq_length, micro_batch_size, for_pipeline_prewarm=for_pipeline_prewarm
+            )
         hs = static_inputs["hidden_states"]
         n = self.config.num_residual_streams
         static_inputs["hidden_states"] = torch.ones(

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -24,10 +24,13 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.enums import InferenceCudaGraphScope, ModelType
 from megatron.core.transformer.module import GraphableMegatronModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     mtp_on_this_rank,
-    prepare_mtp_sequence_roll_context,
     process_mtp_loss,
 )
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -623,9 +626,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             and not (in_inference_mode or is_spec_decode)
         ):
             mtp_cp_group = resolve_cp_group(self.pg_collection.cp, packed_seq_params)
-            # Build layout-specific metadata once, then fetch every locally owned
-            # MTP field's compact successor rows in one grouped operation. The extra
-            # row covers RL's initial label derivation before the per-layer rolls.
+            # Build layout-specific metadata once, then prepare every locally owned
+            # MTP field for absolute sequence-roll access in one grouped operation.
             sequence_roll_context = prepare_mtp_sequence_roll_context(
                 tensor=input_ids if input_ids is not None else labels,
                 cp_group=mtp_cp_group,
@@ -633,13 +635,20 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             )
             if sequence_roll_context is not None:
                 roll_position_ids = getattr(self.embedding, "add_position_embedding", True)
-                sequence_roll_context = sequence_roll_context.prefetch_halos(
-                    width=self.config.mtp_num_layers + 1,
-                    input_ids=input_ids,
-                    position_ids=position_ids if roll_position_ids else None,
-                    labels=labels if self.post_process else None,
-                    loss_mask=loss_mask if self.post_process else None,
-                    padding_mask=padding_mask,
+                fields = []
+                if input_ids is not None:
+                    fields.append(MTPSequenceRollField("input_ids", input_ids, -1, 0, 0))
+                if roll_position_ids and position_ids is not None:
+                    fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+                if self.post_process and labels is not None:
+                    fields.append(MTPSequenceRollField("labels", labels, -1, 0, 0))
+                if self.post_process and loss_mask is not None:
+                    fields.append(MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0))
+                if padding_mask is not None:
+                    fields.append(MTPSequenceRollField("padding_mask", padding_mask, -1, 0, True))
+                max_offset = self.config.mtp_num_layers + int(self.post_process and labels is None)
+                sequence_roll_context = sequence_roll_context.prepare_fields(
+                    fields, max_offset=max_offset
                 )
 
         mtp_forward_ran = self.mtp_process and not (in_inference_mode or is_spec_decode)
@@ -656,6 +665,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 sequence_roll_context=sequence_roll_context,
                 embedding=self.embedding,
                 padding_mask=padding_mask,
+                sequence_roll_padding_mask=padding_mask,
             )
 
         if not self.post_process:

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -66,6 +66,8 @@ from .emerging_optimizers import (
     HAVE_EMERGING_OPTIMIZERS,
     _create_emerging_optimizer,
     _get_qkv_split_shapes,
+    _localize_qkv_split_shapes,
+    _qkv_split_groups_are_complete,
 )
 from .grad_scaler import ConstantGradScaler, DynamicGradScaler
 from .layer_wise_optimizer import LayerWiseDistributedOptimizer, is_managed_by_layer_wise_optimizer
@@ -768,6 +770,8 @@ def _get_megatron_emerging_optimizer(
         raise ValueError(f"Unsupported emerging optimizer: {eopt_name}")
     if config.fp16:
         raise ValueError('emerging optimizer with fp16 is not supported.')
+    if config.muon_split_qkv_per_head and not config.muon_split_qkv:
+        raise ValueError("muon_split_qkv_per_head requires muon_split_qkv=True")
 
     if pg_collection is None:
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
@@ -776,25 +780,70 @@ def _get_megatron_emerging_optimizer(
 
     # Tag parameters with optimizer-specific attributes (expert_tp, is_qkv).
     for model_chunk in model_chunks:
-        qkv_split_shapes = None
         for name, param in model_chunk.named_parameters():
             if not param.requires_grad:
                 continue
             if 'experts' in name and 'shared' not in name:
                 param.expert_tp = True
-            # TODO(deyuf): support MLA
-            if 'linear_qkv.weight' in name and len(param.shape) == 2:
-                if qkv_split_shapes is None:
-                    qkv_split_shapes = _get_qkv_split_shapes(model_chunk.config)
-                if param.shape[0] % sum(qkv_split_shapes) == 0:
-                    param.is_qkv = True
-                    param.qkv_split_shapes = qkv_split_shapes
+            qkv_layout = getattr(param, 'qkv_layout', None)
+            if (qkv_layout is not None or 'linear_qkv.weight' in name) and len(param.shape) == 2:
+                if qkv_layout is not None:
+                    qkv_split_shapes = _get_qkv_split_shapes(
+                        qkv_layout, split_qkv_per_head=config.muon_split_qkv_per_head
+                    )
+                    logical_split_shapes = (
+                        qkv_split_shapes
+                        if config.muon_split_qkv_per_head
+                        else qkv_split_shapes * qkv_layout.num_groups
+                    )
                 else:
+                    # Backward compatibility for custom QKV modules that do not annotate
+                    # their weight with the owning attention layer's logical layout.
+                    qkv_split_shapes = _get_qkv_split_shapes(
+                        model_chunk.config, split_qkv_per_head=config.muon_split_qkv_per_head
+                    )
+                    logical_split_shapes = (
+                        qkv_split_shapes
+                        if config.muon_split_qkv_per_head
+                        else qkv_split_shapes * model_chunk.config.num_query_groups
+                    )
+
+                tp_group = (
+                    pg_collection.expt_tp
+                    if getattr(param, 'expert_tp', False)
+                    else pg_collection.tp
+                )
+                tp_size = get_pg_size(tp_group)
+                tp_rank = get_pg_rank(tp_group)
+                local_rows = param.shape[0]
+                if local_rows * tp_size != sum(logical_split_shapes):
                     log_single_rank(
                         logger,
                         logging.DEBUG,
                         f"Emerging optimizer QKV split skipped for {name}: "
-                        f"shape={tuple(param.shape)}, split_shapes={qkv_split_shapes}",
+                        f"logical_rows={sum(logical_split_shapes)}, "
+                        f"local_rows={local_rows}, tp_size={tp_size}",
+                    )
+                    param.is_qkv = False
+                    param.qkv_split_shapes = None
+                    param.qkv_split_shapes_global = None
+                    param.qkv_split_groups_are_complete = False
+                    param.qkv_split_heads_are_complete = False
+                    continue
+
+                param.is_qkv = True
+                param.qkv_split_shapes_global = logical_split_shapes
+                local_start = tp_rank * local_rows
+                if config.muon_split_qkv_per_head:
+                    param.qkv_split_shapes, param.qkv_split_heads_are_complete = (
+                        _localize_qkv_split_shapes(
+                            qkv_split_shapes, local_start=local_start, local_rows=local_rows
+                        )
+                    )
+                else:
+                    param.qkv_split_shapes = qkv_split_shapes
+                    param.qkv_split_groups_are_complete = _qkv_split_groups_are_complete(
+                        qkv_split_shapes, local_start=local_start, local_rows=local_rows
                     )
 
     # Apply optimizer-specific default param overrides (e.g. muon: non-linear -> adam).

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -17,7 +17,7 @@ import torch
 from torch.optim.optimizer import ParamsT
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.utils import get_pg_size, log_single_rank
+from megatron.core.utils import get_pg_rank, get_pg_size, log_single_rank
 
 from .optimizer_config import ParamKey, ParamPredicate
 
@@ -32,7 +32,13 @@ try:
 
     # It is necessary to import optimizers for the registry to work.
     from emerging_optimizers.scalar_optimizers import Lion  # pylint: disable=unused-import
-    from emerging_optimizers.soap import SOAP  # pylint: disable=unused-import
+
+    try:
+        from emerging_optimizers.legacy_soap import SOAP  # pylint: disable=unused-import
+    except ModuleNotFoundError as exc:
+        if exc.name != "emerging_optimizers.legacy_soap":
+            raise
+        from emerging_optimizers.soap import SOAP  # pylint: disable=unused-import
 
     HAVE_EMERGING_OPTIMIZERS = True
 except ImportError:
@@ -130,11 +136,29 @@ def _is_nonlinear_or_embedding(param):
     return getattr(param, 'is_embedding_or_output_parameter', False) or len(param.shape) != 2
 
 
-def _get_qkv_split_shapes(model_cfg) -> list[int]:
-    """Compute QKV split shapes from model config."""
+def _get_qkv_split_shapes(model_cfg, split_qkv_per_head: bool = False) -> list[int]:
+    """Compute fused QKV split shapes from logical attention layout metadata.
+
+    Args:
+        model_cfg: Transformer config or an owning attention layer's ``QKVLayout`` metadata.
+        split_qkv_per_head: Return one split size per physical attention head. When false,
+            return the per-query-group Q, gate (if present), K, and V projection widths.
+    """
+    if hasattr(model_cfg, 'projection_split_shapes'):
+        if split_qkv_per_head:
+            return list(model_cfg.per_head_split_shapes) * model_cfg.num_groups
+        return list(model_cfg.projection_split_shapes)
+
     query_projection_size = (
         model_cfg.num_attention_heads // model_cfg.num_query_groups * model_cfg.kv_channels
     )
+    if split_qkv_per_head:
+        num_query_heads_per_group = model_cfg.num_attention_heads // model_cfg.num_query_groups
+        per_group_shapes = [model_cfg.kv_channels] * num_query_heads_per_group
+        if getattr(model_cfg, 'attention_output_gate', False):
+            per_group_shapes += [model_cfg.kv_channels] * num_query_heads_per_group
+        per_group_shapes += [model_cfg.kv_channels, model_cfg.kv_channels]
+        return per_group_shapes * model_cfg.num_query_groups
     if getattr(model_cfg, 'attention_output_gate', False):
         return [
             query_projection_size,
@@ -143,6 +167,46 @@ def _get_qkv_split_shapes(model_cfg) -> list[int]:
             model_cfg.kv_channels,
         ]
     return [query_projection_size, model_cfg.kv_channels, model_cfg.kv_channels]
+
+
+def _localize_qkv_split_shapes(
+    global_split_shapes: list[int], local_start: int, local_rows: int
+) -> tuple[list[int], bool]:
+    """Intersect global per-head split sizes with a rank-local contiguous row range.
+
+    Returns:
+        The physical rank-local split sizes and whether every intersected head is complete.
+    """
+    local_stop = local_start + local_rows
+    local_split_shapes = []
+    all_heads_complete = True
+    head_start = 0
+    for head_rows in global_split_shapes:
+        head_stop = head_start + head_rows
+        overlap_start = max(head_start, local_start)
+        overlap_stop = min(head_stop, local_stop)
+        if overlap_start < overlap_stop:
+            overlap_rows = overlap_stop - overlap_start
+            local_split_shapes.append(overlap_rows)
+            all_heads_complete &= overlap_rows == head_rows
+        head_start = head_stop
+
+    if sum(local_split_shapes) != local_rows:
+        raise RuntimeError(
+            f"Muon per-head QKV local range [{local_start}, {local_stop}) is outside "
+            f"the global split shape with {sum(global_split_shapes)} rows"
+        )
+    return local_split_shapes, all_heads_complete
+
+
+def _qkv_split_groups_are_complete(
+    split_shapes: list[int], local_start: int, local_rows: int
+) -> bool:
+    """Return whether a local row range contains only complete fused QKV groups."""
+    split_width = sum(split_shapes)
+    if split_width <= 0:
+        raise ValueError(f"Muon QKV split shapes must sum to a positive size: {split_shapes}")
+    return local_start % split_width == 0 and local_rows % split_width == 0
 
 
 # ===========================================================================
@@ -169,6 +233,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         weight_decay: float = 0.01,
         use_decoupled_weight_decay: bool = True,
         split_qkv: bool = False,
+        split_qkv_per_head: bool = False,
         is_qkv_fn: Callable[[torch.Tensor], bool] | None = None,
         qkv_split_shapes: list[int] | None = None,
         fp32_matmul_prec: str = "medium",
@@ -181,6 +246,8 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
     ) -> None:
         if num_ns_steps < 1:
             raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
+        if split_qkv_per_head and not split_qkv:
+            raise ValueError("split_qkv_per_head requires split_qkv=True")
 
         def scaled_orthogonalize_fn(
             grad: torch.Tensor,
@@ -211,8 +278,10 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         self.pg_collection = pg_collection
         self.tp_mode = tp_mode
         self.split_qkv = split_qkv
+        self.split_qkv_per_head = split_qkv_per_head
         self.is_qkv_fn = is_qkv_fn
         self.qkv_split_shapes = qkv_split_shapes
+        self._warned_distributed_qkv_fallback = False
 
         weight_decay_method = "decoupled" if use_decoupled_weight_decay else "l2"
         # Use explicit class call instead of super() so that subclasses with
@@ -229,6 +298,160 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             fp32_matmul_prec=fp32_matmul_prec,
             scaled_orthogonalize_fn=scaled_orthogonalize_fn,
         )
+
+    def _warn_distributed_qkv_fallback(self):
+        """Warn once when a QKV layout cannot use distributed Newton-Schulz."""
+        if self.tp_mode != "distributed" or self._warned_distributed_qkv_fallback:
+            return
+        log_single_rank(
+            logger,
+            logging.WARNING,
+            "muon_tp_mode='distributed' is not supported for per-head or fragmented "
+            "QKV splitting; falling back to non-TP Newton-Schulz.",
+        )
+        self._warned_distributed_qkv_fallback = True
+
+    @staticmethod
+    def _gather_qkv_grad(
+        param: torch.Tensor,
+        grad: torch.Tensor,
+        tp_group: torch.distributed.ProcessGroup | None,
+        expected_rows: int,
+    ) -> tuple[torch.Tensor, tuple[int, int] | None]:
+        """Reconstruct a row-sharded QKV gradient and record its local TP slice."""
+        if grad.shape[0] == expected_rows:
+            return grad, None
+
+        partition_dim = getattr(param, "partition_dim", None)
+        if partition_dim != 0 or tp_group is None:
+            raise RuntimeError(
+                f"Muon QKV split shape mismatch: grad_shape={tuple(grad.shape)}, "
+                f"expected_rows={expected_rows}, partition_dim={partition_dim}"
+            )
+        tp_size = get_pg_size(tp_group)
+        if grad.shape[0] * tp_size != expected_rows:
+            raise RuntimeError(
+                "Muon QKV split cannot reconstruct the global tensor: "
+                f"local_grad_shape={tuple(grad.shape)}, tp_size={tp_size}, "
+                f"expected_rows={expected_rows}"
+            )
+        tp_rank = get_pg_rank(tp_group)
+        tp_local_rows = grad.shape[0]
+        shards = [torch.empty_like(grad) for _ in range(tp_size)]
+        torch.distributed.all_gather(shards, grad, tp_group)
+        return torch.cat(shards, dim=0), (tp_rank, tp_local_rows)
+
+    @staticmethod
+    def _restore_local_qkv_grad(
+        gathered_grad: torch.Tensor, tp_slice: tuple[int, int] | None
+    ) -> torch.Tensor:
+        """Restore the TP shard recorded by :meth:`_gather_qkv_grad`."""
+        if tp_slice is None:
+            return gathered_grad
+        tp_rank, tp_local_rows = tp_slice
+        return gathered_grad[tp_rank * tp_local_rows : (tp_rank + 1) * tp_local_rows].contiguous()
+
+    def _orthogonalize_split_qkv(self, grad, split_shapes, orthogonalize_fn):
+        """Split and reconstruct Megatron's interleaved fused QKV update."""
+        if grad.ndim != 2:
+            raise RuntimeError(f"Muon QKV gradient must be 2D, got {grad.ndim}D")
+        if not split_shapes or any(size <= 0 for size in split_shapes):
+            raise RuntimeError(f"Muon QKV split shapes must be positive: {split_shapes}")
+        split_width = sum(split_shapes)
+        if self.split_qkv_per_head:
+            if grad.shape[0] != split_width:
+                raise RuntimeError(
+                    f"Muon per-head QKV split shape mismatch: grad_shape={tuple(grad.shape)}, "
+                    f"split_shapes={split_shapes}"
+                )
+            if len(set(split_shapes)) == 1:
+                # A 3D input selects Emerging-Optimizers' batched Newton-Schulz path.
+                head_rows = split_shapes[0]
+                return orthogonalize_fn(grad.view(len(split_shapes), head_rows, -1)).view_as(grad)
+            return torch.cat(
+                [orthogonalize_fn(head) for head in torch.split(grad, split_shapes, dim=0)], dim=0
+            )
+
+        if grad.shape[0] % split_width != 0:
+            raise RuntimeError(
+                f"Muon QKV split shape mismatch: grad_shape={tuple(grad.shape)}, "
+                f"split_shapes={split_shapes}"
+            )
+        num_query_groups = grad.shape[0] // split_width
+        grouped_grad = grad.view(num_query_groups, split_width, -1)
+        projection_grads = torch.split(grouped_grad, split_shapes, dim=1)
+        projection_grads = [
+            projection.reshape(-1, grad.shape[-1]) for projection in projection_grads
+        ]
+        projection_grads = [
+            orthogonalize_fn(projection).view(num_query_groups, -1, grad.shape[-1])
+            for projection in projection_grads
+        ]
+        return torch.cat(projection_grads, dim=1).view_as(grad)
+
+    def _orthogonalize_qkv_per_head(self, p, grad, tp_group):
+        """Orthogonalize every Q, gate, K, and V head independently.
+
+        Split sizes may describe complete heads in the local tensor or the global fused
+        QKV tensor. For a global layout, reconstruct TP dimension 0 before splitting so
+        heads crossing rank boundaries remain complete.
+        """
+        self._warn_distributed_qkv_fallback()
+        local_split_shapes = getattr(p, "qkv_split_shapes", None)
+        heads_are_complete = getattr(p, "qkv_split_heads_are_complete", None)
+        use_local_layout = heads_are_complete is True or (
+            heads_are_complete is None
+            and local_split_shapes is not None
+            and sum(local_split_shapes) == grad.shape[0]
+        )
+        if use_local_layout:
+            qkv_split_shapes = local_split_shapes
+        else:
+            qkv_split_shapes = getattr(p, "qkv_split_shapes_global", None)
+            if qkv_split_shapes is None:
+                qkv_split_shapes = self.qkv_split_shapes
+        if qkv_split_shapes is None:
+            raise RuntimeError("Muon per-head QKV split requested but qkv_split_shapes is not set")
+        if not qkv_split_shapes or any(size <= 0 for size in qkv_split_shapes):
+            raise RuntimeError(
+                f"Muon per-head QKV split shapes must be positive: {qkv_split_shapes}"
+            )
+
+        expected_rows = sum(qkv_split_shapes)
+        gathered_grad, tp_slice = self._gather_qkv_grad(p, grad, tp_group, expected_rows)
+
+        gathered_grad = self._orthogonalize_split_qkv(
+            gathered_grad,
+            qkv_split_shapes,
+            lambda head_grad: self.scaled_orthogonalize_fn(
+                head_grad, tp_group=None, partition_dim=None
+            ),
+        )
+
+        return self._restore_local_qkv_grad(gathered_grad, tp_slice)
+
+    def _orthogonalize_global_qkv(self, p, grad, tp_group, split_shapes):
+        """Orthogonalize projections after reconstructing their global QKV layout."""
+        self._warn_distributed_qkv_fallback()
+        global_split_shapes = getattr(p, "qkv_split_shapes_global", None)
+        if global_split_shapes is None:
+            raise RuntimeError("Muon global QKV split requires global split shapes")
+        expected_rows = sum(global_split_shapes)
+        if expected_rows % sum(split_shapes) != 0:
+            raise RuntimeError(
+                f"Muon global QKV layout does not contain complete query groups: "
+                f"global_split_shapes={global_split_shapes}, split_shapes={split_shapes}"
+            )
+
+        gathered_grad, tp_slice = self._gather_qkv_grad(p, grad, tp_group, expected_rows)
+        gathered_grad = self._orthogonalize_split_qkv(
+            gathered_grad,
+            split_shapes,
+            lambda projection_grad: self.scaled_orthogonalize_fn(
+                projection_grad, tp_group=None, partition_dim=None
+            ),
+        )
+        return self._restore_local_qkv_grad(gathered_grad, tp_slice)
 
     def orthogonalize(self, p: torch.Tensor, grad: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         """Orthogonalize the momentum.
@@ -256,36 +479,28 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             partition_dim = None
 
         if self.split_qkv and self.is_qkv_fn(p):  # type: ignore[misc]
-            grad_shape = grad.shape
+            if self.split_qkv_per_head:
+                return self._orthogonalize_qkv_per_head(p, grad, tp_group)
+
             qkv_split_shapes = getattr(p, "qkv_split_shapes", None)
             if qkv_split_shapes is None:
                 qkv_split_shapes = self.qkv_split_shapes
             if qkv_split_shapes is None:
                 raise RuntimeError("Muon QKV split requested but qkv_split_shapes is not set")
-            qkv_split_dim = sum(qkv_split_shapes)
-            if grad_shape[0] % qkv_split_dim != 0:
-                raise RuntimeError(
-                    f"Muon QKV split shape mismatch: grad_shape={tuple(grad_shape)}, "
-                    f"split_shapes={qkv_split_shapes}"
-                )
+            if getattr(p, "qkv_split_groups_are_complete", None) is False:
+                return self._orthogonalize_global_qkv(p, grad, tp_group, qkv_split_shapes)
             log_single_rank(
                 logger,
                 logging.DEBUG,
-                f'qkv split grad shape {grad_shape}, split shapes {qkv_split_shapes}',
+                f'qkv split grad shape {grad.shape}, split shapes {qkv_split_shapes}',
             )
-            num_query_groups = grad_shape[0] // qkv_split_dim
-            qkv_grads = torch.split(
-                grad.view(num_query_groups, qkv_split_dim, -1), qkv_split_shapes, dim=1
+            grad = self._orthogonalize_split_qkv(
+                grad,
+                qkv_split_shapes,
+                lambda projection_grad: self.scaled_orthogonalize_fn(
+                    projection_grad, tp_group, partition_dim
+                ),
             )
-            qkv_grads = [g.reshape(-1, grad_shape[-1]) for g in qkv_grads]
-
-            qkv_grads = [
-                self.scaled_orthogonalize_fn(g, tp_group, partition_dim).view(
-                    num_query_groups, -1, grad_shape[-1]
-                )
-                for g in qkv_grads
-            ]
-            grad = torch.cat(qkv_grads, dim=1).view(grad_shape)
         else:
             grad = self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
         return grad
@@ -308,6 +523,7 @@ class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):
         weight_decay: Weight decay coefficient.
         use_decoupled_weight_decay: Whether to use decoupled weight decay.
         split_qkv: Whether to split QKV weights for orthogonalization.
+        split_qkv_per_head: Whether to orthogonalize individual Q, gate, K, and V heads.
         is_qkv_fn: Function to determine if a tensor is a QKV weight.
         qkv_split_shapes: Shapes for splitting QKV weights.
         fp32_matmul_prec: Precision for FP32 matrix multiplication.
@@ -331,6 +547,7 @@ class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):
         weight_decay: float = 0.01,
         use_decoupled_weight_decay: bool = True,
         split_qkv: bool = False,
+        split_qkv_per_head: bool = False,
         is_qkv_fn: Callable[[torch.Tensor], bool] | None = None,
         qkv_split_shapes: list[int] | None = None,
         fp32_matmul_prec: str = "medium",
@@ -353,6 +570,7 @@ class TensorParallelAdaptiveMuon(TensorParallelMuon, AdaptiveMuon):
             weight_decay=weight_decay,
             use_decoupled_weight_decay=use_decoupled_weight_decay,
             split_qkv=split_qkv,
+            split_qkv_per_head=split_qkv_per_head,
             is_qkv_fn=is_qkv_fn,
             qkv_split_shapes=qkv_split_shapes,
             fp32_matmul_prec=fp32_matmul_prec,
@@ -402,7 +620,9 @@ def _muon_config_to_kwargs(config, model_chunks, pg_collection) -> Dict[str, Any
     """Convert OptimizerConfig to TensorParallelMuon constructor kwargs."""
     kwargs = _kwargs_from_config(TensorParallelMuon, "muon", config)
     kwargs["is_qkv_fn"] = lambda p: getattr(p, "is_qkv", False)
-    kwargs["qkv_split_shapes"] = _get_qkv_split_shapes(model_chunks[0].config)
+    kwargs["qkv_split_shapes"] = _get_qkv_split_shapes(
+        model_chunks[0].config, split_qkv_per_head=kwargs.get("split_qkv_per_head", False)
+    )
     kwargs["pg_collection"] = pg_collection
     return kwargs
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -263,6 +263,12 @@ class OptimizerConfig:
     muon_split_qkv: bool = True
     """Whether to split QKV parameters for Muon optimizer."""
 
+    muon_split_qkv_per_head: bool = False
+    """Whether to orthogonalize each Q, gate, K, and V head independently. Requires
+    ``muon_split_qkv``. Uniform head sizes use the batched Newton-Schulz implementation
+    from the Emerging-Optimizers revision pinned in ``pyproject.toml``. By default, Muon
+    orthogonalizes the Q, gate, K, and V projection matrices separately."""
+
     muon_nesterov: bool = False
     """Whether to use Nesterov-style momentum in the internal SGD."""
 
@@ -280,7 +286,9 @@ class OptimizerConfig:
     """The number of iteration steps to use in the Newton-Schulz iteration."""
 
     muon_tp_mode: str = "blockwise"
-    """How to perform NS calculation for tensor parallel weights. Defaults to "blockwise"."""
+    """How to perform NS calculation for tensor parallel weights. For QKV weights, ``distributed``
+    applies only to projection splits with complete local query groups; other QKV layouts fall back
+    to non-TP NS with a warning. Defaults to "blockwise"."""
 
     muon_extra_scale_factor: float = 1.0
     """Additional scale factor for the muon update."""

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -154,6 +154,36 @@ def _pad_cu_seqlens(cu_seqlens: Optional[Tensor], target_entries: int) -> Option
     return padded
 
 
+def _same_tensor_view(a: Optional[Tensor], b: Optional[Tensor]) -> bool:
+    """Return whether two real tensors describe the same logical view."""
+    if not isinstance(a, Tensor) or not isinstance(b, Tensor):
+        return False
+    if a is b:
+        return type(a) is Tensor and not a.is_meta and a.numel() > 0
+    # Distinct tensor subclasses and meta/empty tensors do not provide a
+    # reliable physical-storage identity. Fail closed instead of comparing
+    # sentinel pointers or invoking unsupported storage accessors.
+    if type(a) is not Tensor or type(b) is not Tensor or a.is_meta or b.is_meta:
+        return False
+    if a.numel() == 0 or b.numel() == 0:
+        return False
+    try:
+        if (
+            a.dtype != b.dtype
+            or a.device != b.device
+            or a.shape != b.shape
+            or a.stride() != b.stride()
+            or a.storage_offset() != b.storage_offset()
+        ):
+            return False
+        a_data_ptr = a.data_ptr()
+        b_data_ptr = b.data_ptr()
+    except (RuntimeError, NotImplementedError):
+        # Some nonstandard tensor backends do not expose storage/data pointers.
+        return False
+    return a_data_ptr != 0 and a_data_ptr == b_data_ptr
+
+
 def _append_dummy_seq(cu_seqlens: Optional[Tensor], dummy_end: int) -> Optional[Tensor]:
     """Append a dummy sequence boundary to a cu_seqlens tensor.
 
@@ -570,6 +600,8 @@ def pad_sequence_for_thd(
     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
     cu_seqlens_q_padded = packed_seq_params.cu_seqlens_q_padded
     cu_seqlens_kv_padded = packed_seq_params.cu_seqlens_kv_padded
+    qkv_valid_share_view = _same_tensor_view(cu_seqlens_q, cu_seqlens_kv)
+    qkv_padded_share_view = _same_tensor_view(cu_seqlens_q_padded, cu_seqlens_kv_padded)
 
     # Represent post-pack padding either as a dummy sequence or as physical
     # padding attached to the final real sequence.
@@ -634,11 +666,21 @@ def pad_sequence_for_thd(
             cu_seqlens_q_padded = cu_seqlens_q
         if cu_seqlens_kv_padded is None:
             cu_seqlens_kv_padded = cu_seqlens_kv
+        # Missing padded metadata inherits the valid-coordinate source. Re-evaluate
+        # the relationship after that inheritance so self-attention Q/K aliases are
+        # not split by the two allocating transforms below.
+        qkv_padded_share_view = qkv_padded_share_view or _same_tensor_view(
+            cu_seqlens_q_padded, cu_seqlens_kv_padded
+        )
         assert (
             cu_seqlens_q_padded is not None or cu_seqlens_kv_padded is not None
         ), "Non-dummy THD tail padding requires metadata for at least one real sequence."
         cu_seqlens_q_padded = _extend_last_padded_sequence(cu_seqlens_q_padded, global_target_len)
-        cu_seqlens_kv_padded = _extend_last_padded_sequence(cu_seqlens_kv_padded, global_target_len)
+        cu_seqlens_kv_padded = (
+            cu_seqlens_q_padded
+            if qkv_padded_share_view
+            else _extend_last_padded_sequence(cu_seqlens_kv_padded, global_target_len)
+        )
         last_padded_q_len = _last_padded_sequence_length(cu_seqlens_q_padded)
         last_padded_kv_len = _last_padded_sequence_length(cu_seqlens_kv_padded)
 
@@ -648,6 +690,14 @@ def pad_sequence_for_thd(
         cu_seqlens_kv = _pad_cu_seqlens(cu_seqlens_kv, target_cu_entries)
         cu_seqlens_q_padded = _pad_cu_seqlens(cu_seqlens_q_padded, target_cu_entries)
         cu_seqlens_kv_padded = _pad_cu_seqlens(cu_seqlens_kv_padded, target_cu_entries)
+
+    # The packing scheduler intentionally supplies Q/K metadata as matching
+    # views. Preserve that contract across transforms that allocate new tensors,
+    # while keeping independently supplied metadata independent.
+    if qkv_valid_share_view:
+        cu_seqlens_kv = cu_seqlens_q
+    if qkv_padded_share_view:
+        cu_seqlens_kv_padded = cu_seqlens_q_padded
 
     # Rebuild PackedSeqParams with the padded tensor and metadata shapes.
     padded_params = PackedSeqParams(

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
 import torch
@@ -37,6 +37,14 @@ class PackedSeqParams:
     cp_partition_mode: Literal["zigzag", "contiguous"] = "zigzag"
     tokens_per_sample: int = None
     cp_partition_route: Optional["ThdCpRoute"] = None
+    # Host-side certificate produced by the packing scheduler. None leaves
+    # zigzag packed-CP MTP on its established roll path. Zero records that the
+    # scheduler inspected the layout but could not certify one-hop addressing;
+    # a positive value proves the minimum non-empty half-chunk size. The
+    # certificate is runtime transport metadata, not part of a graph signature.
+    zigzag_cp_min_chunk_size: Optional[int] = field(
+        default=None, compare=False, metadata={"cuda_graph_ignore": True}
+    )
 
     def __post_init__(self):
         """Pre-compute seq_idx for Mamba mixer CUDA graph compatibility.
@@ -51,6 +59,12 @@ class PackedSeqParams:
         cu_seqlens_q_padded[-1] == max_seqlen then this additional sequence index will not be
         included.
         """
+        if self.zigzag_cp_min_chunk_size is not None and (
+            isinstance(self.zigzag_cp_min_chunk_size, bool)
+            or not isinstance(self.zigzag_cp_min_chunk_size, int)
+        ):
+            raise TypeError("zigzag_cp_min_chunk_size must be a host int or None.")
+
         cu_seqlens = (
             self.cu_seqlens_q_padded if self.cu_seqlens_q_padded is not None else self.cu_seqlens_q
         )
@@ -700,6 +714,19 @@ def pad_sequence_for_thd(
         cu_seqlens_kv_padded = cu_seqlens_q_padded
 
     # Rebuild PackedSeqParams with the padded tensor and metadata shapes.
+    zigzag_cp_min_chunk_size = packed_seq_params.zigzag_cp_min_chunk_size
+    if (
+        zigzag_cp_min_chunk_size is not None
+        and has_dummy_padding_seq
+        and packed_seq_params.cp_partition_mode == "zigzag"
+    ):
+        # The divisibility assertion above makes this an exact physical
+        # half-chunk length. Empty fixed-capacity cu_seqlens slots do not reduce
+        # the scheduler certificate.
+        dummy_chunk_size = dummy_seq_len // (2 * cp_size)
+        if dummy_chunk_size > 0:
+            zigzag_cp_min_chunk_size = min(zigzag_cp_min_chunk_size, dummy_chunk_size)
+
     padded_params = PackedSeqParams(
         qkv_format=packed_seq_params.qkv_format,
         cu_seqlens_q=cu_seqlens_q,
@@ -740,6 +767,7 @@ def pad_sequence_for_thd(
                 else (True if has_non_dummy_padding_tail else packed_seq_params.pad_between_seqs)
             )
         ),
+        zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
     )
 
     # True marks padded local token slots for routing/loss paths.

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -41,7 +41,9 @@ class PackedSeqParams:
     # zigzag packed-CP MTP on its established roll path. Zero records that the
     # scheduler inspected the layout but could not certify one-hop addressing;
     # a positive value proves the minimum non-empty half-chunk size. The
-    # certificate is runtime transport metadata, not part of a graph signature.
+    # certificate is runtime transport metadata ignored by layerwise graph
+    # argument matching. Full-iteration static inputs may certify it separately
+    # because replay must preserve the transport plan for each fixed slot.
     zigzag_cp_min_chunk_size: Optional[int] = field(
         default=None, compare=False, metadata={"cuda_graph_ignore": True}
     )

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -599,10 +599,8 @@ class PipelineOffloadManager:
         for chunk in self._cached_chunks_backward:
             for group in chunk.offload_groups:
                 if group.offload and keep_on_gpu_bytes > 0:
-                    debug_rank(
-                        f"group {group._name} offload {group.offload} \
-                        keep_on_gpu_bytes {keep_on_gpu_bytes}"
-                    )
+                    debug_rank(f"group {group._name} offload {group.offload} \
+                        keep_on_gpu_bytes {keep_on_gpu_bytes}")
                     keep_on_gpu_bytes -= group.total_offload_bytes
                     group.offload = False
         # Disable the later groups to meet the activation offload fraction.
@@ -918,18 +916,10 @@ class ChunkOffloadHandler:
         return self._max_group_size == 0
 
     def finish_all_groups(self, name=None) -> bool:
-        """Finish all groups."""
+        """Return whether this handler has no remaining group named ``name``."""
         debug_rank(
             f"------finish_all_groups {self} {self._max_group_size} {self._offloaded_group_index}"
         )
-        # TODO: check if this is correct
-        # Mark it as finished when there are no groups to offload or reload
-        if (
-            len(self._groups_to_reload) == 0
-            and len(self._groups_to_offload) == 0
-            and self._offloaded_group_index > 0
-        ):
-            return True
         assert name is not None, "Name is required"
         return (
             self.find_group_with_name(self.offload_groups, name, self._offloaded_group_index)

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -319,7 +319,11 @@ class P2PCommunicator:
         tensor_recv_prev_func = None
         tensor_recv_next_func = None
 
-        if config.variable_seq_lengths or config.mtp_standalone:
+        # THD full-iteration CUDA graph mode uses static P2P shapes, so the
+        # per-step shape handshake is skipped: it is not graph-capturable.
+        if (
+            config.variable_seq_lengths and not config.thd_static_pp_communication
+        ) or config.mtp_standalone:
             recv_prev_shape, recv_next_shape = self._communicate_shapes(
                 tensor_send_next, tensor_send_prev, recv_prev, recv_next
             )

--- a/megatron/core/pipeline_parallel/parallel_prewarm.py
+++ b/megatron/core/pipeline_parallel/parallel_prewarm.py
@@ -113,6 +113,8 @@ def _build_layer_inputs(
     micro_batch_size,
     rotary_pos_emb_cache,
     request_carrier_cache,
+    *,
+    is_mtp,
 ):
     """Build one eager synthetic sample for a local transformer layer."""
     if not hasattr(layer, 'get_layer_static_inputs'):
@@ -127,6 +129,10 @@ def _build_layer_inputs(
     kwargs = static_inputs
     _build_packed_seq_params(config, kwargs)
     _reuse_model_chunk_request_carriers(model_chunk, kwargs, request_carrier_cache)
+    if is_mtp and config.dsa_mtp_index_kv_share:
+        from megatron.core.transformer.multi_token_prediction import MTPDSAIterationContext
+
+        kwargs['mtp_dsa_context'] = MTPDSAIterationContext(iteration=0)
 
     if (
         getattr(model_chunk, 'position_embedding_type', None) == 'rope'
@@ -278,6 +284,7 @@ def prewarm_pipeline_model_parallel(
                         micro_batch_size,
                         rotary_pos_emb_cache,
                         request_carrier_cache,
+                        is_mtp=is_mtp,
                     )
                     inner_quantization_context = (
                         nullcontext()

--- a/megatron/core/pipeline_parallel/parallel_prewarm.py
+++ b/megatron/core/pipeline_parallel/parallel_prewarm.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Concurrent lazy-kernel initialization across pipeline stages."""
+
+import gc
+import logging
+import time
+from contextlib import ExitStack, nullcontext
+
+import torch
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.utils import get_attr_wrapped_model, log_on_each_pipeline_stage
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_differentiable_tensors(value):
+    """Flatten differentiable tensors from a nested layer output."""
+    if torch.is_tensor(value):
+        return [value] if value.requires_grad else []
+    if isinstance(value, dict):
+        tensors = []
+        for item in value.values():
+            tensors.extend(_collect_differentiable_tensors(item))
+        return tensors
+    if isinstance(value, (tuple, list)):
+        tensors = []
+        for item in value:
+            tensors.extend(_collect_differentiable_tensors(item))
+        return tensors
+    return []
+
+
+def _discover_local_layers(model):
+    """Return local decoder and MTP layers in PP/VPP model-chunk order."""
+    local_layers = []
+    for model_chunk in model:
+        try:
+            chunk_with_decoder = get_attr_wrapped_model(
+                model_chunk, 'decoder', allow_none=False, return_model_obj=True
+            )
+        except RuntimeError:
+            continue
+
+        for layer in chunk_with_decoder.decoder.layers:
+            local_layers.append((layer, False, chunk_with_decoder))
+        if hasattr(chunk_with_decoder, 'mtp'):
+            for mtp_layer in chunk_with_decoder.mtp.layers:
+                local_layers.append((mtp_layer.mtp_model_layer, True, chunk_with_decoder))
+    return local_layers
+
+
+def _get_quantization_context(layer, is_mtp):
+    """Return the per-layer FP8/FP4 context used by normal model execution."""
+    config = layer.config
+    layer_number = -1 if is_mtp else layer.layer_number - 1
+    if config.fp8:
+        from megatron.core.fp8_utils import get_fp8_context
+
+        return get_fp8_context(config, layer_number)
+    if config.fp4:
+        from megatron.core.fp4_utils import get_fp4_context
+
+        return get_fp4_context(config, layer_number)
+    return nullcontext()
+
+
+def _build_packed_seq_params(config, kwargs):
+    """Convert synthetic THD metadata tensors into eager PackedSeqParams."""
+    if 'cu_seqlens_q' not in kwargs:
+        return
+
+    max_seqlen = config.max_seqlen_per_dp_cp_rank * config.context_parallel_size
+    kwargs['packed_seq_params'] = PackedSeqParams(
+        qkv_format='thd',
+        cp_partition_mode=config.cp_partition_mode,
+        cu_seqlens_q=kwargs.pop('cu_seqlens_q'),
+        cu_seqlens_kv=kwargs.pop('cu_seqlens_kv'),
+        cu_seqlens_q_padded=kwargs.pop('cu_seqlens_q_padded'),
+        cu_seqlens_kv_padded=kwargs.pop('cu_seqlens_kv_padded'),
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        pad_between_seqs=True,
+    )
+
+
+def _reuse_model_chunk_request_carriers(model_chunk, kwargs, request_carrier_cache):
+    """Reuse per-request state carriers across layers in one model chunk.
+
+    Pipeline prewarm invokes local layers independently, but DSA IndexShare uses the
+    request's packed-sequence metadata (or its explicit attention mask for SBHD) to
+    carry top-k state from a computing layer to its sharing layers.  Reuse only those
+    carriers; layer-local activations and any MTP-specific context remain independent.
+    """
+    chunk_carriers = request_carrier_cache.setdefault(id(model_chunk), {})
+    for name in ('packed_seq_params', 'attention_mask'):
+        if name not in kwargs:
+            continue
+        if name in chunk_carriers:
+            kwargs[name] = chunk_carriers[name]
+        else:
+            chunk_carriers[name] = kwargs[name]
+
+
+def _build_layer_inputs(
+    layer,
+    model_chunk,
+    config,
+    seq_length,
+    micro_batch_size,
+    rotary_pos_emb_cache,
+    request_carrier_cache,
+):
+    """Build one eager synthetic sample for a local transformer layer."""
+    if not hasattr(layer, 'get_layer_static_inputs'):
+        raise TypeError(
+            f'Pipeline prewarm requires {type(layer).__name__}.get_layer_static_inputs().'
+        )
+
+    static_inputs = layer.get_layer_static_inputs(
+        seq_length, micro_batch_size, for_pipeline_prewarm=True
+    )
+    hidden_states = static_inputs.pop('hidden_states')
+    kwargs = static_inputs
+    _build_packed_seq_params(config, kwargs)
+    _reuse_model_chunk_request_carriers(model_chunk, kwargs, request_carrier_cache)
+
+    if (
+        getattr(model_chunk, 'position_embedding_type', None) == 'rope'
+        and not config.multi_latent_attention
+        and hasattr(model_chunk, 'rotary_pos_emb')
+    ):
+        rotary_seq_len = model_chunk.rotary_pos_emb.get_rotary_seq_len(
+            None, model_chunk.decoder, hidden_states, config, None
+        )
+        cache_key = (id(model_chunk), rotary_seq_len)
+        if cache_key not in rotary_pos_emb_cache:
+            rotary_pos_emb_cache[cache_key] = model_chunk.rotary_pos_emb(rotary_seq_len)
+        kwargs['rotary_pos_emb'] = rotary_pos_emb_cache[cache_key]
+
+    return (hidden_states,), kwargs
+
+
+def _reset_temporary_state(model, config, optimizers):
+    """Discard gradients and metric state produced by the synthetic pass."""
+    from megatron.core.distributed.finalize_model_grads import reset_model_temporary_tensors
+    from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
+
+    for model_chunk in model:
+        model_chunk.zero_grad_buffer()
+    for optimizer in optimizers:
+        optimizer.zero_grad()
+    get_moe_metrics_tracker().clear()
+    reset_model_temporary_tensors(config, model)
+
+
+def prewarm_pipeline_model_parallel(
+    model, config, seq_length, micro_batch_size, optimizers=(), pg_collection=None
+):
+    """Initialize local lazy kernels concurrently on all pipeline stages.
+
+    Every rank executes one eager forward/backward pass for each locally owned transformer layer.
+    The synthetic passes have no pipeline P2P edges, while collectives within each stage's
+    TP/CP/EP groups remain matched. This function neither captures nor replays CUDA Graphs.
+    """
+    if getattr(config, 'moe_paged_stash', False):
+        from megatron.core.transformer.moe.paged_stash import PagedStashManager
+
+        assert (
+            not PagedStashManager.get_instance().enabled
+        ), "Pipeline prewarm must run before the first Paged Stash schedule."
+
+    if pg_collection is None:
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    local_layers = _discover_local_layers(model)
+
+    torch.distributed.barrier()
+    torch.cuda.synchronize()
+    start_time = time.time()
+    log_on_each_pipeline_stage(
+        logger=logger,
+        tp_group=pg_collection.tp,
+        dp_cp_group=pg_collection.dp_cp,
+        level=logging.INFO,
+        msg=(
+            f'Rank {torch.distributed.get_rank()}: starting pipeline-parallel prewarm for '
+            f'{len(local_layers)} local layers.'
+        ),
+    )
+
+    buffer_backups = []
+    first_microbatch_backups = []
+    saved_quantization_tensors = None
+    offload_disabled = False
+
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossAutoScaler,
+        DSAIndexerLossLoggingHelper,
+    )
+    from megatron.core.transformer.moe.moe_utils import MoEAuxLossAutoScaler
+
+    dsa_tracker = DSAIndexerLossLoggingHelper.tracker
+    dsa_tracker_backup = {
+        key: value.clone() if torch.is_tensor(value) else value
+        for key, value in dsa_tracker.items()
+    }
+    loss_scale_backups = (
+        (DSAIndexerLossAutoScaler, DSAIndexerLossAutoScaler.main_loss_backward_scale),
+        (MoEAuxLossAutoScaler, MoEAuxLossAutoScaler.main_loss_backward_scale),
+    )
+
+    layers = [layer for layer, _is_mtp, _model_chunk in local_layers]
+    try:
+        seen_buffers = set()
+        seen_modules = set()
+        for layer in layers:
+            for module in layer.modules():
+                module_id = id(module)
+                if module_id not in seen_modules:
+                    seen_modules.add(module_id)
+                    if hasattr(module, 'is_first_microbatch'):
+                        first_microbatch_backups.append((module, module.is_first_microbatch))
+                        module.is_first_microbatch = True
+                for buffer in module.buffers(recurse=False):
+                    buffer_id = id(buffer)
+                    if buffer_id not in seen_buffers:
+                        seen_buffers.add(buffer_id)
+                        buffer_backups.append((buffer, buffer.clone()))
+
+        if config.fp8 or config.fp4:
+            from transformer_engine.pytorch.graph import save_fp8_tensors
+
+            if config.fp8:
+                from megatron.core.fp8_utils import get_fp8_recipe
+
+                recipe = get_fp8_recipe(config)
+            else:
+                from megatron.core.fp4_utils import get_fp4_recipe
+
+                recipe = get_fp4_recipe(config)
+            saved_quantization_tensors = save_fp8_tensors(layers, recipe)
+
+        if config.fine_grained_activation_offloading:
+            from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                FineGrainedActivationOffloadingInterface as off_interface,
+            )
+
+            off_interface.disable_offload()
+            offload_disabled = True
+
+        from megatron.core.fp8_utils import get_fp8_context
+        from megatron.core.tensor_parallel.random import _fork_rng
+
+        outer_quantization_context = (
+            get_fp8_context(config)
+            if config.fp8 and config.fp8_recipe == Fp8Recipe.delayed
+            else nullcontext()
+        )
+        rotary_pos_emb_cache = {}
+        request_carrier_cache = {}
+
+        with ExitStack() as stack:
+            for model_chunk in model:
+                no_sync = getattr(model_chunk, 'no_sync', None)
+                if callable(no_sync):
+                    stack.enter_context(no_sync())
+
+            with _fork_rng(), outer_quantization_context:
+                for layer, is_mtp, model_chunk in local_layers:
+                    args, kwargs = _build_layer_inputs(
+                        layer,
+                        model_chunk,
+                        config,
+                        seq_length,
+                        micro_batch_size,
+                        rotary_pos_emb_cache,
+                        request_carrier_cache,
+                    )
+                    inner_quantization_context = (
+                        nullcontext()
+                        if config.fp8 and config.fp8_recipe == Fp8Recipe.delayed
+                        else _get_quantization_context(layer, is_mtp)
+                    )
+                    with inner_quantization_context:
+                        outputs = layer.forward(*args, **kwargs)
+                    differentiable_outputs = _collect_differentiable_tensors(outputs)
+                    assert (
+                        differentiable_outputs
+                    ), "Pipeline prewarm must produce at least one differentiable tensor."
+                    torch.autograd.backward(
+                        differentiable_outputs,
+                        grad_tensors=[
+                            torch.zeros_like(output) for output in differentiable_outputs
+                        ],
+                    )
+                    del args, kwargs, outputs, differentiable_outputs
+
+        torch.cuda.synchronize()
+    finally:
+        if saved_quantization_tensors is not None:
+            from transformer_engine.pytorch.graph import restore_fp8_tensors
+
+            restore_fp8_tensors(layers, saved_quantization_tensors)
+        with torch.no_grad():
+            for buffer, backup in buffer_backups:
+                buffer.copy_(backup)
+        for module, is_first_microbatch in first_microbatch_backups:
+            module.is_first_microbatch = is_first_microbatch
+        if offload_disabled:
+            off_interface.enable_offload()
+        _reset_temporary_state(model, config, optimizers)
+        dsa_tracker.clear()
+        dsa_tracker.update(dsa_tracker_backup)
+        for loss_scaler, loss_scale in loss_scale_backups:
+            loss_scaler.main_loss_backward_scale = loss_scale
+
+        del buffer_backups
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    elapsed = time.time() - start_time
+    log_on_each_pipeline_stage(
+        logger=logger,
+        tp_group=pg_collection.tp,
+        dp_cp_group=pg_collection.dp_cp,
+        level=logging.INFO,
+        msg=(
+            f'Rank {torch.distributed.get_rank()}: pipeline-parallel prewarm completed '
+            f'{len(local_layers)} local layers in {elapsed:.2f}s.'
+        ),
+    )
+    torch.distributed.barrier()

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -1283,10 +1283,13 @@ def forward_backward_pipelining_with_interleaving(
         # Note: This is a simplified approach - proper VPP support may need more complex logic
         hidden_dim = config.hidden_size * getattr(config, 'num_residual_streams', 1)
 
-    tensor_shape = [seq_length, micro_batch_size, hidden_dim]
-    tensor_shape[0] = tensor_shape[0] // cp_group.size()
-    if config.sequence_parallel:
-        tensor_shape[0] = tensor_shape[0] // tp_group.size()
+    if config.thd_static_pp_communication:
+        tensor_shape = list(_thd_static_pp_tensor_shape(config, tp_group, hidden_dim))
+    else:
+        tensor_shape = [seq_length, micro_batch_size, hidden_dim]
+        tensor_shape[0] = tensor_shape[0] // cp_group.size()
+        if config.sequence_parallel:
+            tensor_shape[0] = tensor_shape[0] // tp_group.size()
 
     # Compute number of warmup and remaining microbatches.
     # seems only used for vpp
@@ -1743,7 +1746,7 @@ def forward_backward_pipelining_with_interleaving(
                 recv_next = True
                 if is_pp_last_stage(p2p_communicator.pp_group):
                     recv_next = False
-                (input_tensor, output_tensor_grad) = (
+                input_tensor, output_tensor_grad = (
                     p2p_communicator.send_forward_backward_recv_forward_backward(
                         output_tensor,
                         input_tensor_grad,
@@ -1807,7 +1810,7 @@ def forward_backward_pipelining_with_interleaving(
                 if is_pp_last_stage(p2p_communicator.pp_group):
                     recv_next = False
 
-                (bwd_recv_buffer[-1], bwd_wait_handles) = (
+                bwd_recv_buffer[-1], bwd_wait_handles = (
                     p2p_communicator.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
@@ -1960,7 +1963,7 @@ def forward_backward_pipelining_with_interleaving(
                     backward_k, forward=False
                 )
 
-                (bwd_recv_buffer[backward_k % bwd_recv_buffer_size], bwd_wait_handles) = (
+                bwd_recv_buffer[backward_k % bwd_recv_buffer_size], bwd_wait_handles = (
                     p2p_communicator.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
@@ -2033,7 +2036,7 @@ def forward_backward_pipelining_with_interleaving(
                 recv_prev = False
 
             # Communicate tensors.
-            (input_tensor, output_tensor_grad) = (
+            input_tensor, output_tensor_grad = (
                 p2p_communicator.send_forward_backward_recv_forward_backward(
                     output_tensor,
                     input_tensor_grad,
@@ -2214,6 +2217,19 @@ def forward_backward_pipelining_with_interleaving(
     return forward_data_store
 
 
+def _thd_static_pp_tensor_shape(config, tp_group, hidden_size):
+    """PP send/recv shape for THD full-iteration CUDA graph mode.
+
+    Packed batches are canonicalized to the static CP-local token capacity
+    before entering the graph, so PP shapes are fixed. The packed batch
+    dimension is always 1.
+    """
+    effective_seq_length = config.max_seqlen_per_dp_cp_rank
+    if config.sequence_parallel:
+        effective_seq_length = effective_seq_length // tp_group.size()
+    return (effective_seq_length, 1, hidden_size)
+
+
 def get_tensor_shapes(
     *,
     seq_length: int,
@@ -2241,6 +2257,9 @@ def get_tensor_shapes(
     tensor_shapes = []
 
     if config.variable_seq_lengths:
+        if config.thd_static_pp_communication:
+            tensor_shapes.append(_thd_static_pp_tensor_shape(config, tp_group, config.hidden_size))
+            return tensor_shapes
         # Shapes exchanged dynamically during P2P communication
         tensor_shapes.append(())
         return tensor_shapes

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -60,7 +60,11 @@ except ImportError:
 _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {
     "expert_tp": False,
     "is_qkv": False,
+    "qkv_layout": None,
     "qkv_split_shapes": None,
+    "qkv_split_shapes_global": None,
+    "qkv_split_groups_are_complete": False,
+    "qkv_split_heads_are_complete": False,
     "tensor_model_parallel": False,
     "partition_dim": -1,
     "partition_stride": 1,
@@ -235,7 +239,7 @@ class VocabParallelEmbedding(torch.nn.Module):
 
         self.tp_group = get_tensor_model_parallel_group_if_none(self.tp_group)
 
-        (self.vocab_start_index, self.vocab_end_index) = (
+        self.vocab_start_index, self.vocab_end_index = (
             VocabUtility.vocab_range_from_global_vocab_size(
                 self.num_embeddings, get_pg_rank(self.tp_group), get_pg_size(self.tp_group)
             )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -131,6 +131,49 @@ except ImportError:
     HAVE_FUSED_QKV_ROPE = False
 
 
+@dataclass(frozen=True)
+class QKVLayout:
+    """Logical row layout for a packed attention projection weight.
+
+    ``projection_split_shapes`` describes the projection slices repeated in every group.
+    ``per_head_split_shapes`` describes the independently orthogonalizable head slices in the
+    same group. Standard fused QKV has one group per query group, while MLA up-projections have
+    one group per attention head.
+    """
+
+    num_groups: int
+    projection_split_shapes: tuple[int, ...]
+    per_head_split_shapes: tuple[int, ...]
+
+    @classmethod
+    def from_transformer_config(cls, config: TransformerConfig) -> 'QKVLayout':
+        """Build the fused QKV row layout described by a transformer config."""
+        assert config.num_query_groups is not None
+        assert config.kv_channels is not None
+        num_query_heads_per_group = config.num_attention_heads // config.num_query_groups
+        projection_split_shapes = [num_query_heads_per_group * config.kv_channels]
+        per_head_split_shapes = [config.kv_channels] * num_query_heads_per_group
+        if config.attention_output_gate:
+            projection_split_shapes.append(num_query_heads_per_group * config.kv_channels)
+            per_head_split_shapes += [config.kv_channels] * num_query_heads_per_group
+        projection_split_shapes += [config.kv_channels, config.kv_channels]
+        per_head_split_shapes += [config.kv_channels, config.kv_channels]
+        return cls(
+            num_groups=config.num_query_groups,
+            projection_split_shapes=tuple(projection_split_shapes),
+            per_head_split_shapes=tuple(per_head_split_shapes),
+        )
+
+    @classmethod
+    def from_splits(cls, num_groups: int, split_shapes: tuple[int, ...]) -> 'QKVLayout':
+        """Build a layout whose projection slices are repeated once per attention head."""
+        return cls(
+            num_groups=num_groups,
+            projection_split_shapes=split_shapes,
+            per_head_split_shapes=split_shapes,
+        )
+
+
 class LinearQkvInterface(Protocol):
     """Interface for linear_qkv modules."""
 
@@ -1819,6 +1862,7 @@ class SelfAttention(Attention):
             tp_group=self.pg_collection.tp,
             name=(name + ".linear_qkv") if name is not None else None,
         )
+        self.linear_qkv.weight.qkv_layout = QKVLayout.from_transformer_config(self.config)
 
         # Resolve which norm class to use for Q and K.
         # Config selects the default norm class; spec overrides if set.

--- a/megatron/core/transformer/cuda_graph_config.py
+++ b/megatron/core/transformer/cuda_graph_config.py
@@ -59,6 +59,110 @@ def validate_moe_cuda_graph_support(config) -> None:
     )
 
 
+PACKED_DSA_CP_CUDA_GRAPH_ERROR = (
+    "CUDA graph capture is not supported for this packed DSA context-parallel "
+    "configuration: the requested capture path cannot preserve or reconstruct the "
+    "per-sequence CP layout during warmup and replay. Full CUDA Graph support for "
+    "packed DSA+CP is deferred; set cuda_graph_impl='none'. Other unguarded capture "
+    "combinations remain experimental unless separately validated."
+)
+
+
+def is_packed_dsa_cp_cuda_graph_capture_unsupported(
+    *,
+    experimental_attention_variant: Optional[str],
+    dsa_kernel_backend: str,
+    sequence_packing_scheduler: Optional[str],
+    dynamic_context_parallel: bool,
+    context_parallel_size: int,
+    cuda_graph_impl: str,
+    cuda_graph_modules: Optional[List[CudaGraphModule]],
+    inference_cuda_graph_scope: InferenceCudaGraphScope,
+) -> bool:
+    """Return whether a packed DSA+CP graph combination is proven unsupported.
+
+    Keep this predicate limited to configurations covered by GPU evidence. The
+    static validation matrix exercised configured CP=2 and CP=4; the dynamic
+    matrix exercised configured CP=2 only. Combined local attention+MLP,
+    attention+Mamba, and TE attention+MLP scopes were measured only at static
+    CP=2. CP=3 failed during model construction before eager preflight or graph
+    capture, so it is not graph-specific evidence and remains outside this
+    guard. Dynamic CP with configured CP=1 is likewise not inferred from the
+    DP x CP pool because that neighboring topology did not reach capture.
+    Unmeasured MoE/Mamba partial scopes and full-iteration capture also remain
+    available until they are measured.
+    """
+
+    static_packing = sequence_packing_scheduler == "dp_balanced" and not dynamic_context_parallel
+    dynamic_packing = (
+        sequence_packing_scheduler == "default_dynamic_cp" and dynamic_context_parallel
+    )
+    if experimental_attention_variant != "dsa":
+        return False
+    if not (static_packing or dynamic_packing):
+        return False
+
+    # Capture scope execution uses membership checks, so repeated spellings such
+    # as ``attn,attn`` are the same effective scope as ``attn``.
+    modules = frozenset(cuda_graph_modules or [])
+    if dsa_kernel_backend == "cudnn":
+        if cuda_graph_impl == "local":
+            measured_scopes = set()
+            if static_packing and context_parallel_size in (2, 4):
+                measured_scopes.update(
+                    {
+                        frozenset(),
+                        frozenset({CudaGraphModule.attn}),
+                        frozenset({CudaGraphModule.mlp}),
+                    }
+                )
+                if context_parallel_size == 2:
+                    measured_scopes.update(
+                        {
+                            frozenset({CudaGraphModule.attn, CudaGraphModule.mlp}),
+                            frozenset({CudaGraphModule.attn, CudaGraphModule.mamba}),
+                        }
+                    )
+            elif dynamic_packing and context_parallel_size == 2:
+                measured_scopes.update(
+                    {
+                        frozenset(),
+                        frozenset({CudaGraphModule.attn}),
+                        frozenset({CudaGraphModule.mlp}),
+                    }
+                )
+
+            if modules not in measured_scopes:
+                return False
+            if not modules:
+                # ``block`` owns an inference-only TransformerBlock graph and
+                # skips the per-layer whole-scope manager exercised by the
+                # training validation matrix.
+                return inference_cuda_graph_scope == InferenceCudaGraphScope.layer
+            return True
+        if cuda_graph_impl == "transformer_engine":
+            measured_scopes = set()
+            if static_packing and context_parallel_size in (2, 4):
+                measured_scopes.update({frozenset(), frozenset({CudaGraphModule.attn})})
+                if context_parallel_size == 2:
+                    measured_scopes.add(frozenset({CudaGraphModule.attn, CudaGraphModule.mlp}))
+            elif dynamic_packing and context_parallel_size == 2:
+                measured_scopes.update({frozenset(), frozenset({CudaGraphModule.attn})})
+            return modules in measured_scopes
+
+    # The unfused scorer was measured only for static attention-only local
+    # capture. TileLang was unavailable in the validation image, and the
+    # remaining backend-none scopes were not measured, so keep them available.
+    if (
+        dsa_kernel_backend == "none"
+        and static_packing
+        and context_parallel_size == 2
+        and cuda_graph_impl == "local"
+    ):
+        return modules == {CudaGraphModule.attn}
+    return False
+
+
 def normalize_cuda_graph_modules(
     scopes: Optional[Union[str, CudaGraphModule, List[Union[str, CudaGraphModule]]]],
 ) -> Tuple[List[CudaGraphModule], List[Tuple[str, str, object]], bool]:

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1388,6 +1388,8 @@ class _CudaGraphRunner(torch.nn.Module):
 
             elif is_dataclass(ref.value):
                 for field in dataclasses.fields(ref.value):
+                    if field.metadata.get("cuda_graph_ignore", False):
+                        continue
                     check(
                         ArgMetadata(getattr(val.value, field.name)),
                         ArgMetadata(getattr(ref.value, field.name)),

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -146,6 +146,99 @@ def _set_warmup_end():
     _IS_GRAPH_WARMUP = False
 
 
+def _snapshot_metric_tracker(tracker):
+    """Clone a tensor-valued metric tracker before graph warmup and capture."""
+    values = tracker.get("values")
+    metadata = {key: value for key, value in tracker.items() if key != "values"}
+    return (values.clone() if values is not None else None), metadata
+
+
+def _restore_metric_tracker(tracker, snapshot):
+    """Restore captured metric values in place so recorded graph storage stays live."""
+    cached_values, cached_metadata = snapshot
+    values = tracker.get("values")
+    if cached_values is None:
+        # A tracker first initialized during capture has no eager values to preserve. Keep its
+        # captured storage and reduction metadata, but discard warmup/capture contributions.
+        if values is not None:
+            values.zero_()
+        return
+    if values is None or values.shape != cached_values.shape:
+        raise RuntimeError("Metric tracker shape changed during CUDA Graph capture.")
+    values.copy_(cached_values)
+    for key in tuple(tracker):
+        if key != "values" and key not in cached_metadata:
+            del tracker[key]
+    tracker.update(cached_metadata)
+
+
+def _get_local_dsa_metric_tracker_size(model=None):
+    """Return the storage size required by local DSA/CSA modules before graph capture."""
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossLoggingHelper,
+    )
+
+    values = DSAIndexerLossLoggingHelper.tracker.get("values")
+    required_size = values.shape[0] if values is not None else 0
+    if model is None:
+        model_chunks = ()
+    elif isinstance(model, (list, tuple)):
+        model_chunks = model
+    else:
+        model_chunks = (model,)
+    for model_chunk in model_chunks:
+        for module in model_chunk.modules():
+            if not getattr(module, "logs_dsa_indexer_loss", False):
+                continue
+            layer_number = getattr(module, "layer_number", None)
+            if layer_number is not None:
+                required_size = max(required_size, layer_number)
+            config = getattr(module, "config", None)
+            if config is not None:
+                required_size = max(required_size, config.num_layers + (config.mtp_num_layers or 0))
+    return required_size
+
+
+def _prepare_dsa_metric_tracker_for_capture(model=None, pp_group=None):
+    """PP-negotiate and allocate the final DSA tracker storage before recording graphs."""
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAIndexerLossLoggingHelper,
+    )
+
+    tracker = DSAIndexerLossLoggingHelper.tracker
+    local_required_size = _get_local_dsa_metric_tracker_size(model)
+    capture_prepared_size = tracker.get("capture_prepared_size")
+    if capture_prepared_size is not None:
+        if local_required_size > capture_prepared_size:
+            raise RuntimeError(
+                "DSA metric tracker discovered a larger layer index after PP size agreement."
+            )
+        if capture_prepared_size > 0:
+            DSAIndexerLossLoggingHelper.ensure_tracker_size(capture_prepared_size)
+        return capture_prepared_size
+
+    # ``agreed_size`` may have been cached by an earlier eager metric reduction. It reflects
+    # only layers that wrote a loss in that step, whereas the model scan deliberately includes
+    # every potential graph writer. Negotiate once more at capture time instead of treating the
+    # eager value as final.
+    local_required_size = max(local_required_size, tracker.get("agreed_size") or 0)
+    size = local_required_size
+    if torch.distributed.is_initialized():
+        if pp_group is None and parallel_state.model_parallel_is_initialized():
+            pp_group = parallel_state.get_pipeline_model_parallel_group()
+        size_tensor = torch.tensor(
+            [local_required_size], device=torch.cuda.current_device(), dtype=torch.long
+        )
+        torch.distributed.all_reduce(size_tensor, op=torch.distributed.ReduceOp.MAX, group=pp_group)
+        size = int(size_tensor.item())
+
+    if size > 0:
+        DSAIndexerLossLoggingHelper.ensure_tracker_size(size)
+    tracker["agreed_size"] = size
+    tracker["capture_prepared_size"] = size
+    return size
+
+
 @dataclass
 class CudagraphBufferMetadata:
     """
@@ -381,6 +474,11 @@ class _CudagraphGlobalRecord:
                 "were already created!",
             )
             return
+
+        # Local capture follows one complete eager step, so the local tracker already reflects
+        # every local hybrid/MTP index. Negotiate its final size before any PP stage records a
+        # graph; otherwise the first metric reduction could grow another stage's captured tensor.
+        _prepare_dsa_metric_tracker_for_capture()
 
         # No cudagraphs have been created or recorded, so do nothing
         if len(cls.cudagraph_record) == 0:
@@ -847,6 +945,16 @@ class _CudaGraphRunner(torch.nn.Module):
             for name, entry in moe_metrics_tracker.metrics.items():
                 cached_aux_losses[name] = entry.values.clone()
 
+        # DSA indexer metrics are also accumulated from the forward path. Unlike MoE metrics,
+        # their tracker is shared across transformer layers, so every runner restores the exact
+        # eager state after its warmup/capture passes.
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossLoggingHelper,
+        )
+
+        dsa_metric_tracker = DSAIndexerLossLoggingHelper.tracker
+        dsa_metric_snapshot = _snapshot_metric_tracker(dsa_metric_tracker)
+
         self.fwd_graph = torch.cuda.CUDAGraph()
 
         # For cases with multiple active RNG states, e.g. TP.
@@ -1043,6 +1151,8 @@ class _CudaGraphRunner(torch.nn.Module):
                     name in moe_metrics_tracker.metrics
                 ), "cached metrics must be found in the tracker."
                 moe_metrics_tracker.metrics[name].values.copy_(cached_values)
+
+        _restore_metric_tracker(dsa_metric_tracker, dsa_metric_snapshot)
 
     def create_bwd_graph(self):
         """Create a bwd cudagraph for this runner. Should be called inside
@@ -2659,6 +2769,9 @@ class TECudaGraphHelper:
         Reset the model and optimizer state after capturing CUDA Graphs.
         """
         from megatron.core.distributed.finalize_model_grads import reset_model_temporary_tensors
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossLoggingHelper,
+        )
         from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 
         for model_chunk in self.model:
@@ -2666,6 +2779,8 @@ class TECudaGraphHelper:
         for optimizer in self.optimizers:
             optimizer.zero_grad()
         get_moe_metrics_tracker().clear()
+        if DSAIndexerLossLoggingHelper.tracker:
+            DSAIndexerLossLoggingHelper.clean_loss_in_tracker(preserve_groups=True)
         reset_model_temporary_tensors(self.config, self.model)
 
     def _finish_capturing(self, start_time):
@@ -2715,6 +2830,10 @@ class TECudaGraphHelper:
         Capture CUDA Graphs per TransformerLayer per microbatch.
         """
         validate_moe_cuda_graph_support(self.config)
+        # TE supports capture without eager warmup. Scan the full local model (including
+        # non-graphable hybrid/MTP internals), then PP-negotiate one final tracker storage before
+        # any layer graph records a pointer to it.
+        _prepare_dsa_metric_tracker_for_capture(self.model, self.pp_group)
         start_time = self._start_capturing()
 
         if not self.flattened_callables:

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -455,6 +455,7 @@ class AbsorbedMLASelfAttention(Attention):
         key_value_states=None,
         packed_seq_params=None,
         inference_context=None,
+        mtp_dsa_context=None,
         *,
         inference_params=None,
     ):
@@ -467,6 +468,14 @@ class AbsorbedMLASelfAttention(Attention):
         ), f"hidden_states should be 3D, [s, b, h], got {hidden_states.ndim}D"
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
+        shared_key = None
+        if mtp_dsa_context is not None and mtp_dsa_context.reuses_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            shared_key = mtp_dsa_context.shared_tensors.key
 
         # =========================================
         # Prepare RoPE and seqlen related params
@@ -538,36 +547,41 @@ class AbsorbedMLASelfAttention(Attention):
         #     kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim) / TP]
         # elif linear_kv_down_proj is Linear:
         #     kv_combined: [s / TP, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-        kv_combined, _ = self.linear_kv_down_proj(hidden_states)
-        if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
-            # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-            kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
-            # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if self.config.sequence_parallel:
+        if shared_key is None:
+            kv_combined, _ = self.linear_kv_down_proj(hidden_states)
+            if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
+                # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
+                kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
+                # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if self.config.sequence_parallel:
+                    # kv_compressed:[s / TP, b, kv_lora_rank]
+                    kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+            else:
                 # kv_compressed:[s / TP, b, kv_lora_rank]
-                kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+                # k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                    # k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                    k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
         else:
-            # kv_compressed:[s / TP, b, kv_lora_rank], k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-                # k_pos_emb: [s, b, qk_pos_emb_head_dim]
-                k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
+            kv_compressed = k_pos_emb = None
 
         if thd_packed_seq:
             assert q_compressed.ndim == 3 and q_compressed.size(1) == 1
-            assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
-            assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
             # If sequence packing, TE expect [t, h, d] shaped qkv input.
             # In Megatron-Core, the qkv shape is [t, 1, h, d].
             # So we need to reshape qkv from [t, 1, h, d] to [t, h, d].
             q_compressed = q_compressed.squeeze(1)
-            kv_compressed = kv_compressed.squeeze(1)
-            k_pos_emb = k_pos_emb.squeeze(1)
+            if shared_key is None:
+                assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
+                assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
+                kv_compressed = kv_compressed.squeeze(1)
+                k_pos_emb = k_pos_emb.squeeze(1)
 
         # =========================================
         # Apply norm
@@ -576,23 +590,36 @@ class AbsorbedMLASelfAttention(Attention):
             # q_compressed: [num_tokens, q_lora_rank]
             q_compressed = self.q_layernorm(q_compressed)
 
-        kv_compressed = self.kv_layernorm(kv_compressed)
-        # Because we won't apply V up projection to the compressed KV, so we need to gather it
-        # manually.
-        if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-            kv_compressed = gather_from_sequence_parallel_region(kv_compressed, group=self.tp_group)
+        if shared_key is None:
+            kv_compressed = self.kv_layernorm(kv_compressed)
+            # Because we won't apply V up projection to the compressed KV, so we need to gather it
+            # manually.
+            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                kv_compressed = gather_from_sequence_parallel_region(
+                    kv_compressed, group=self.tp_group
+                )
 
         # =========================================
         # QKV up projection and RoPE apply
         # =========================================
+        # Capture the active group by value because dynamic CP restores
+        # self.pg_collection.cp before checkpoint recomputation runs in backward.
+        active_cp_group = self.pg_collection.cp
 
-        def qkv_up_proj_and_rope_apply(q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb):
-            """
-            Apply the up projection and RoPE to the query and key.
-            When sequence packing enabled, the input tensors adopt a packed shape of [t, ...];
-            otherwise, they maintain the unpacked shape [s, b, ...]. In subsequent code comments,
-            we uniformly use [num_tokens, ...] to denote [s, b, ...] or [t, ...] for two cases.
-            """
+        def select_rotary_pos_emb(rotary_pos_emb, num_tokens):
+            """Select the RoPE rows used by both the query and key branches."""
+            if inference_context is not None:
+                sequence_start = inference_context.sequence_len_offset
+                sequence_end = sequence_start + num_tokens
+                return rotary_pos_emb[sequence_start:sequence_end]
+            if not thd_packed_seq or self.config.context_parallel_size == 1:
+                # Packed CP keeps the full embedding so every local segment can address its
+                # original positions. Other layouts use the local query length.
+                return rotary_pos_emb[:num_tokens]
+            return rotary_pos_emb
+
+        def q_up_proj_and_rope_apply(q_compressed, rotary_pos_emb):
+            """Apply Q up projection, K-weight absorption, and query RoPE."""
             if self.config.q_lora_rank is not None:
                 # q_compressed: [num_tokens, q_lora_rank]
                 # q: [num_tokens, n * (qk_head_dim + qk_pos_emb_head_dim)]
@@ -604,12 +631,6 @@ class AbsorbedMLASelfAttention(Attention):
 
             # q: [num_tokens, n, q_head_dim]
             q = q.view(*q.size()[:-1], self.num_attention_heads_per_partition, self.q_head_dim)
-
-            # [num_tokens, kv_lora_rank] -> [num_tokens, 1, kv_lora_rank]
-            kv_compressed = torch.unsqueeze(kv_compressed, -2)
-            # [num_tokens, qk_pos_emb_head_dim] -> [num_tokens, 1, qk_pos_emb_head_dim]
-            k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
-
             k_up_weight, _ = self._get_kv_up_weights()
 
             if use_fused_rope:
@@ -626,8 +647,8 @@ class AbsorbedMLASelfAttention(Attention):
                 assert q_absorbed.shape[:-1] == q.shape[:-1]
                 assert q_absorbed.size(-1) == self.config.kv_lora_rank
 
-                cp_rank = self.pg_collection.cp.rank()
-                cp_size = self.pg_collection.cp.size()
+                cp_rank = active_cp_group.rank()
+                cp_size = active_cp_group.size()
                 q_absorbed = fused_mla_rope_concat(
                     q_absorbed,
                     q_pos_emb,
@@ -637,33 +658,7 @@ class AbsorbedMLASelfAttention(Attention):
                     cp_rank,
                     cp_size,
                 )
-                kv_compressed = fused_mla_rope_concat(
-                    kv_compressed,
-                    k_pos_emb,
-                    rotary_pos_cos,
-                    rotary_pos_sin,
-                    cu_seqlens_kv,
-                    cp_rank,
-                    cp_size,
-                )
             else:
-                q_len = q.size()[0]
-                if inference_context is not None:
-                    # add offset to the sequence start for inference
-                    sequence_start = inference_context.sequence_len_offset
-                    sequence_end = sequence_start + q_len
-                    rotary_pos_emb = rotary_pos_emb[sequence_start:sequence_end]
-                elif not thd_packed_seq or self.config.context_parallel_size == 1:
-                    # Shorten rotary_pos_emb to the sequence length when inference_params
-                    # is not provided. This makes sure we can run forward directly with
-                    # any sequence length. During training, the sequence length is always
-                    # the full rotary_pos_emb length, except for sequence packing + CP.
-                    # When sequence packing and context parallel are both enabled, the
-                    # position embedding will not split rotary_pos_emb, so it may exceed
-                    # the sequence length on this CP rank, but we need the full rotary_pos_emb
-                    # to cover the full sequence, so we do not shorten it here.
-                    rotary_pos_emb = rotary_pos_emb[0:q_len]
-
                 # q_no_pe: [num_tokens, n, qk_head_dim]
                 # q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                 q_no_pe, q_pos_emb = torch.split(
@@ -681,33 +676,64 @@ class AbsorbedMLASelfAttention(Attention):
                 # Apply RoPE to q_pos_emb: [num_tokens, n, qk_pos_emb_head_dim]
                 q_pos_emb = apply_rotary_pos_emb(
                     q_pos_emb,
-                    rotary_pos_emb,
+                    select_rotary_pos_emb(rotary_pos_emb, q.size(0)),
                     config=self.config,
                     cu_seqlens=cu_seqlens_q,
                     mscale=mscale,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=active_cp_group,
                     mla_rotary_interleaved=True,
                     max_seqlen=rope_max_seqlen_q,
-                )
-                # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
-                k_pos_emb = apply_rotary_pos_emb(
-                    k_pos_emb,
-                    rotary_pos_emb,
-                    config=self.config,
-                    cu_seqlens=cu_seqlens_kv,
-                    mscale=mscale,
-                    cp_group=self.pg_collection.cp,
-                    mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_kv,
                 )
 
                 # query: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]
                 q_absorbed = torch.cat([q_absorbed, q_pos_emb], dim=-1)
-                # key: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
-                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
 
             assert q_absorbed.is_contiguous()
+            return q_absorbed
+
+        def key_rope_apply(kv_compressed, k_pos_emb, rotary_pos_emb, num_query_tokens):
+            """Assemble the latent attention key and apply key RoPE."""
+            # [num_tokens, dim] -> [num_tokens, 1, dim]
+            kv_compressed = torch.unsqueeze(kv_compressed, -2)
+            k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
+
+            if use_fused_rope:
+                cp_rank = active_cp_group.rank()
+                cp_size = active_cp_group.size()
+                kv_compressed = fused_mla_rope_concat(
+                    kv_compressed,
+                    k_pos_emb,
+                    rotary_pos_cos,
+                    rotary_pos_sin,
+                    cu_seqlens_kv,
+                    cp_rank,
+                    cp_size,
+                )
+            else:
+                k_pos_emb = apply_rotary_pos_emb(
+                    k_pos_emb,
+                    select_rotary_pos_emb(rotary_pos_emb, num_query_tokens),
+                    config=self.config,
+                    cu_seqlens=cu_seqlens_kv,
+                    mscale=mscale,
+                    cp_group=active_cp_group,
+                    mla_rotary_interleaved=True,
+                    max_seqlen=rope_max_seqlen_kv,
+                )
+                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
+
             assert kv_compressed.is_contiguous()
+            return kv_compressed
+
+        def qkv_up_proj_and_rope_apply(q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb):
+            """Compose the ordinary joint Q/K checkpoint path from shared primitives."""
+            q_absorbed = q_up_proj_and_rope_apply(q_compressed, rotary_pos_emb)
+            if shared_key is None:
+                kv_compressed = key_rope_apply(
+                    kv_compressed, k_pos_emb, rotary_pos_emb, q_absorbed.size(0)
+                )
+            else:
+                kv_compressed = shared_key
 
             return q_absorbed, kv_compressed
 
@@ -720,14 +746,35 @@ class AbsorbedMLASelfAttention(Attention):
             # and therefore identical between the forward pass and the replay.
             quantization = self.config.fp8 or self.config.fp4
             self.qkv_up_checkpoint = tensor_parallel.CheckpointWithoutOutput(fp8=quantization)
-            q_absorbed, kv_compressed = self.qkv_up_checkpoint.checkpoint(
-                qkv_up_proj_and_rope_apply, q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb
-            )
+            if mtp_dsa_context is not None:
+                # In sharing mode, the source K must outlive this attention call. Including
+                # it in CheckpointWithoutOutput would clear its storage after forward, so
+                # every sharing iteration checkpoints Q only and constructs/reuses K outside.
+                q_absorbed = self.qkv_up_checkpoint.checkpoint(
+                    q_up_proj_and_rope_apply, q_compressed, rotary_pos_emb
+                )
+                if shared_key is None:
+                    kv_compressed = key_rope_apply(
+                        kv_compressed, k_pos_emb, rotary_pos_emb, q_absorbed.size(0)
+                    )
+                else:
+                    kv_compressed = shared_key
+            else:
+                q_absorbed, kv_compressed = self.qkv_up_checkpoint.checkpoint(
+                    qkv_up_proj_and_rope_apply,
+                    q_compressed,
+                    kv_compressed,
+                    k_pos_emb,
+                    rotary_pos_emb,
+                )
         else:
             assert not self.cache_mla_latents, "cache_mla_latents is not supported for AbsorbedMLA"
             q_absorbed, kv_compressed = qkv_up_proj_and_rope_apply(
                 q_compressed, kv_compressed, k_pos_emb, rotary_pos_emb
             )
+
+        assert q_absorbed.is_contiguous()
+        assert kv_compressed.is_contiguous()
 
         return q_absorbed, kv_compressed, q_compressed
 
@@ -845,6 +892,7 @@ class AbsorbedMLASelfAttention(Attention):
         position_ids=None,
         attn_mask_type=None,
         packed_seq_params=None,
+        mtp_dsa_context=None,
     ):
         """Forward method with selective activation checkpointing."""
 
@@ -857,6 +905,9 @@ class AbsorbedMLASelfAttention(Attention):
             up_v_weight = inputs[5]
             attn_mask_type = inputs[6]
             attn_mask_type = AttnMaskType(attn_mask_type.item())
+            core_attention_kwargs = {}
+            if mtp_dsa_context is not None:
+                core_attention_kwargs["mtp_dsa_context"] = mtp_dsa_context
             output_ = self.core_attention(
                 q_absorbed,
                 k_compressed,
@@ -868,6 +919,7 @@ class AbsorbedMLASelfAttention(Attention):
                 position_ids=position_ids,
                 attn_mask_type=attn_mask_type,
                 packed_seq_params=packed_seq_params,
+                **core_attention_kwargs,
             )
             return output_
 
@@ -902,6 +954,7 @@ class AbsorbedMLASelfAttention(Attention):
         packed_seq_params=None,
         position_ids=None,
         sequence_len_offset=None,
+        mtp_dsa_context=None,
         *,
         inference_params=None,
     ):
@@ -942,7 +995,11 @@ class AbsorbedMLASelfAttention(Attention):
         # Query, Key, and Value
         # =====================
         q_absorbed, kv_compressed, q_compressed = self.get_query_key_value_tensors(
-            hidden_states, key_value_states, packed_seq_params, inference_context=inference_context
+            hidden_states,
+            key_value_states,
+            packed_seq_params,
+            inference_context=inference_context,
+            mtp_dsa_context=mtp_dsa_context,
         )
 
         assert q_absorbed.is_contiguous()
@@ -963,8 +1020,12 @@ class AbsorbedMLASelfAttention(Attention):
                 v_up_weight,
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
+                mtp_dsa_context=mtp_dsa_context,
             )
         else:
+            core_attention_kwargs = {}
+            if mtp_dsa_context is not None:
+                core_attention_kwargs["mtp_dsa_context"] = mtp_dsa_context
             core_attn_out = self.core_attention(
                 q_absorbed,
                 kv_compressed,
@@ -976,6 +1037,7 @@ class AbsorbedMLASelfAttention(Attention):
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
                 attn_mask_type=self.attn_mask_type,
+                **core_attention_kwargs,
             )
 
         # ==================================

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -35,7 +35,7 @@ from megatron.core.tensor_parallel.mappings import (
     gather_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
-from megatron.core.transformer.attention import Attention
+from megatron.core.transformer.attention import Attention, QKVLayout
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -415,6 +415,23 @@ class AbsorbedMLASelfAttention(Attention):
                 tp_comm_buffer_name='v_up_proj',
                 tp_group=pg_collection.tp,
                 name=(name + ".linear_v_up_proj") if name is not None else None,
+            )
+
+        q_up_proj = self.linear_q_proj if self.config.q_lora_rank is None else self.linear_q_up_proj
+        q_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+            self.config.num_attention_heads,
+            (self.config.qk_head_dim, self.config.qk_pos_emb_head_dim),
+        )
+        if self._uses_combined_kv_up_projection:
+            self.linear_kv_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+                self.config.num_attention_heads, (self.config.qk_head_dim, self.config.v_head_dim)
+            )
+        else:
+            self.linear_k_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+                self.config.num_attention_heads, (self.config.qk_head_dim,)
+            )
+            self.linear_v_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+                self.config.num_attention_heads, (self.config.v_head_dim,)
             )
 
         if self.config.q_lora_rank is not None:

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1712,6 +1712,8 @@ class CompressedSparseAttention(MegatronModule):
     * ``ratio == 128``: window + 128x compressed, attend to all (compressor built only)
     """
 
+    logs_dsa_indexer_loss = True
+
     def __init__(
         self,
         config: TransformerConfig,

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -30,6 +30,12 @@ from megatron.core.transformer.experimental_attention_variant import (
     dsa_layout,
     dsa_masking,
 )
+from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_local_positions_from_host as _build_cp_positions_from_host,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_query_positions_and_key_reorder_from_host as _cp_reorder_from_host,
+)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1938,6 +1944,7 @@ class DSAttention(MegatronModule):
     requires_dsa_inputs = True
     _HOLDER_ATTR = "_dsa_index_share_topk_holder"
     _LENGTH_HOLDER_ATTR = "_dsa_index_share_topk_length_holder"
+    _LAYOUT_HOLDER_ATTR = "_dsa_packed_cp_layout_holder"
 
     def __init__(
         self,
@@ -2022,6 +2029,45 @@ class DSAttention(MegatronModule):
             holder = {}
             setattr(carrier, self._LENGTH_HOLDER_ATTR, holder)
         return holder
+
+    def _get_packed_cp_layout_cache(
+        self, packed_seq_params: Optional[PackedSeqParams]
+    ) -> Optional[dict]:
+        """Return the per-microbatch memo for packed-CP layout metadata, or None.
+
+        The CP query positions and key reorder indices depend only on
+        ``cu_seqlens_q``/``cu_seqlens_kv``, ``cp_size``, ``cp_rank`` and the
+        requested output sizes. All of those are identical for every layer in a
+        microbatch, yet each layer rebuilds them, and each rebuild loops
+        ``cp_size`` times over :func:`build_packed_allgather_cp_local_positions`,
+        whose boolean-mask indexing has data-dependent output shapes and so
+        forces a device-to-host size readback.
+
+        ``PackedSeqParams`` is the only carrier used here. It is constructed per
+        microbatch, so a memo hung on it cannot outlive the layout it describes
+        -- which matters under dynamic CP, where the layout changes between
+        microbatches. The index-share top-k holders fall back to
+        ``attention_mask``/``self.config``, but that is only safe because every
+        computing layer overwrites its slot before any sharing layer reads it. A
+        layout memo has no such write-before-read ordering and ``self.config``
+        outlives the microbatch, so caching there could serve a stale layout.
+        """
+        if packed_seq_params is None:
+            return None
+        cache = getattr(packed_seq_params, self._LAYOUT_HOLDER_ATTR, None)
+        if cache is None:
+            cache = {}
+            setattr(packed_seq_params, self._LAYOUT_HOLDER_ATTR, cache)
+        return cache
+
+    @staticmethod
+    def _memoized(cache: Optional[dict], key: tuple, build):
+        """Return ``cache[key]``, building it on first use. No-op when cache is None."""
+        if cache is None:
+            return build()
+        if key not in cache:
+            cache[key] = build()
+        return cache[key]
 
     def backward_dw(self):
         """Compute the deferred weight gradients (delay_wgrad_compute) of the indexer."""
@@ -2122,11 +2168,21 @@ class DSAttention(MegatronModule):
         nonpacked_query_positions = None
         kv_reorder_idx = None
         single_packed_thd_sequence = False
+        # Layout metadata is identical for every layer in a microbatch; memoize it on
+        # the per-microbatch PackedSeqParams so only the first DSA layer pays for it.
+        layout_cache = self._get_packed_cp_layout_cache(packed_seq_params)
         if packed_thd:
             cu_seqlens_q, cu_seqlens_kv = dsa_layout.get_packed_qk_cu_seqlens(packed_seq_params)
-            single_packed_thd_sequence = (
-                cp_size > 1 and cu_seqlens_q.numel() == 2 and cu_seqlens_kv.numel() == 2
-            )
+            # Host copies of the compacted cu_seqlens, stored by
+            # prebuild_thd_cp_partition_routes at batch-construction time. When
+            # present, the layout builders below run entirely on the host: no
+            # kernels, no device readbacks, one async copy of the finished table.
+            host_cu_q = getattr(packed_seq_params, "thd_cp_host_cu_seqlens_q", None)
+            host_cu_kv = getattr(packed_seq_params, "thd_cp_host_cu_seqlens_kv", None)
+            # Whether the pack holds one sequence is a fact about the pack, not about
+            # context parallelism; which kernels accept that layout is the scoring
+            # plan's decision. Consumers that genuinely need CP already test cp_size.
+            single_packed_thd_sequence = cu_seqlens_q.numel() == 2 and cu_seqlens_kv.numel() == 2
             packed_query_output_size = (
                 sequence_parallel_tp_full_rows if sequence_parallel_tp else sq
             )
@@ -2137,12 +2193,26 @@ class DSAttention(MegatronModule):
                     row_start, row_start + sq, dtype=torch.int64, device=query.device
                 )
             elif sequence_parallel_tp and cp_size > 1:
-                packed_query_positions_full = dsa_layout.build_packed_allgather_cp_local_positions(
-                    cu_seqlens_q,
-                    cp_size,
-                    cp_rank,
-                    query.device,
-                    output_size=packed_query_output_size,
+                packed_query_positions_full = self._memoized(
+                    layout_cache,
+                    ("local_positions", cp_size, cp_rank, packed_query_output_size),
+                    lambda: (
+                        _build_cp_positions_from_host(
+                            host_cu_q,
+                            cp_size,
+                            cp_rank,
+                            query.device,
+                            output_size=packed_query_output_size,
+                        )
+                        if host_cu_q is not None
+                        else dsa_layout.build_packed_allgather_cp_local_positions(
+                            cu_seqlens_q,
+                            cp_size,
+                            cp_rank,
+                            query.device,
+                            output_size=packed_query_output_size,
+                        )
+                    ),
                 )
                 if sequence_parallel_query_is_local:
                     row_start = sequence_parallel_tp_row_start
@@ -2162,19 +2232,45 @@ class DSAttention(MegatronModule):
                     and isinstance(packed_seq_params.max_seqlen_kv, int)
                     and packed_seq_params.max_seqlen_kv == packed_global_output_size
                 )
-                packed_query_positions, kv_reorder_idx = (
-                    dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
-                        cu_seqlens_q=cu_seqlens_q,
-                        cu_seqlens_kv=cu_seqlens_kv,
-                        cp_size=cp_size,
-                        cp_rank=cp_rank,
-                        device=query.device,
-                        local_output_size=packed_query_output_size,
-                        key_local_output_size=packed_query_output_size,
-                        global_output_size=packed_global_output_size,
-                        query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
-                        key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
-                    )
+                packed_query_positions, kv_reorder_idx = self._memoized(
+                    layout_cache,
+                    (
+                        "positions_and_reorder",
+                        cp_size,
+                        cp_rank,
+                        packed_query_output_size,
+                        packed_query_output_size,
+                        packed_global_output_size,
+                        query_cu_seqlens_cover_output,
+                        key_cu_seqlens_cover_output,
+                    ),
+                    lambda: (
+                        _cp_reorder_from_host(
+                            host_cu_q,
+                            host_cu_kv,
+                            cp_size=cp_size,
+                            cp_rank=cp_rank,
+                            device=query.device,
+                            local_output_size=packed_query_output_size,
+                            key_local_output_size=packed_query_output_size,
+                            global_output_size=packed_global_output_size,
+                            query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+                            key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+                        )
+                        if host_cu_q is not None and host_cu_kv is not None
+                        else dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
+                            cu_seqlens_q=cu_seqlens_q,
+                            cu_seqlens_kv=cu_seqlens_kv,
+                            cp_size=cp_size,
+                            cp_rank=cp_rank,
+                            device=query.device,
+                            local_output_size=packed_query_output_size,
+                            key_local_output_size=packed_query_output_size,
+                            global_output_size=packed_global_output_size,
+                            query_cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+                            key_cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+                        )
+                    ),
                 )
             if packed_query_positions is not None:
                 packed_query_positions = packed_query_positions.contiguous()
@@ -2182,7 +2278,6 @@ class DSAttention(MegatronModule):
             _validate_nonpacked_cp_uniform_length(
                 sq=sq, skv=key.size(0), cp_size=cp_size, cp_group=cp_group, device=query.device
             )
-
         if sequence_parallel_tp:
             if key.size(0) == local_sequence_rows:
                 key = gather_from_sequence_parallel_region(key, group=tp_group)
@@ -2215,15 +2310,45 @@ class DSAttention(MegatronModule):
             # Gather local-sequence tensors, then undo MCore's zigzag rank order.
             def _build_kv_reorder_idx(local_len):
                 if packed_thd:
-                    _, idx = dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder(
-                        cu_seqlens_q=cu_seqlens_q,
-                        cu_seqlens_kv=cu_seqlens_kv,
-                        cp_size=cp_size,
-                        cp_rank=cp_rank,
-                        device=query.device,
-                        local_output_size=local_len,
-                        key_local_output_size=local_len,
-                        global_output_size=local_len * cp_size,
+                    # Same memo key shape as the branch above, so when the output sizes
+                    # coincide this reuses that result instead of rerunning the cp_size loop.
+                    _, idx = self._memoized(
+                        layout_cache,
+                        (
+                            "positions_and_reorder",
+                            cp_size,
+                            cp_rank,
+                            local_len,
+                            local_len,
+                            local_len * cp_size,
+                            False,
+                            False,
+                        ),
+                        lambda: (
+                            _cp_reorder_from_host(
+                                host_cu_q,
+                                host_cu_kv,
+                                cp_size=cp_size,
+                                cp_rank=cp_rank,
+                                device=query.device,
+                                local_output_size=local_len,
+                                key_local_output_size=local_len,
+                                global_output_size=local_len * cp_size,
+                            )
+                            if host_cu_q is not None and host_cu_kv is not None
+                            else (
+                                dsa_layout.build_packed_allgather_cp_query_positions_and_key_reorder
+                            )(
+                                cu_seqlens_q=cu_seqlens_q,
+                                cu_seqlens_kv=cu_seqlens_kv,
+                                cp_size=cp_size,
+                                cp_rank=cp_rank,
+                                device=query.device,
+                                local_output_size=local_len,
+                                key_local_output_size=local_len,
+                                global_output_size=local_len * cp_size,
+                            )
+                        ),
                     )
                     return idx
                 return dsa_layout.build_zigzag_allgather_cp_key_reorder(
@@ -2328,9 +2453,11 @@ class DSAttention(MegatronModule):
         )
         use_fused_kernels = dsa_kernels.use_fused_dsa_kernels(self.config)
         sparse_indexer_loss = self.config.dsa_indexer_use_sparse_loss
+        # Reports a packed causal layout with identity key positions. CP size is an
+        # independent geometry fact; the scoring plan and packed metadata eligibility
+        # decide which executor can safely consume the layout.
         use_local_indexer_varlen = (
             packed_thd
-            and cp_size > 1
             and attn_mask_type == AttnMaskType.causal
             and varlen_starts is not None
             and varlen_ends is not None
@@ -2555,6 +2682,7 @@ class DSAttention(MegatronModule):
                     local_packed_cp_query_len=local_packed_cp_query_len,
                     packed_seq_params=packed_seq_params,
                     cp_size=cp_size,
+                    varlen_is_plain_causal=varlen_is_plain_causal,
                 )
                 if fused_topk_with_loss is not None:
                     topk_indices, topk_length, indexer_loss = fused_topk_with_loss
@@ -2601,6 +2729,7 @@ class DSAttention(MegatronModule):
                     local_packed_cp_query_len=local_packed_cp_query_len,
                     packed_seq_params=packed_seq_params,
                     cp_size=cp_size,
+                    varlen_is_plain_causal=varlen_is_plain_causal,
                 )
                 if fused_topk is not None:
                     topk_indices, topk_length = fused_topk

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -43,6 +43,7 @@ from megatron.core.utils import ensure_params_ready, get_pg_size
 
 logger = logging.getLogger(__name__)
 _DSA_WEIGHTS_PROJ_TE_GEMM_FALLBACK_WARNED = False
+_warned_mtp_sharing_fused_bypass = False
 
 try:
     from transformer_engine.pytorch.module.base import get_dummy_wgrad
@@ -2047,6 +2048,29 @@ class DSAttention(MegatronModule):
         self.skip_topk = self.index_share and is_dsa_skip_topk_layer(
             self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
         )
+        self.mtp_index_share = self.config.dsa_mtp_index_kv_share and is_mtp_layer
+        global _warned_mtp_sharing_fused_bypass
+        if (
+            self.mtp_index_share
+            and dsa_kernels.use_fused_dsa_kernels(self.config)
+            and not _warned_mtp_sharing_fused_bypass
+        ):
+            _warned_mtp_sharing_fused_bypass = True
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                "dsa_mtp_index_kv_share=True requires reusable top-k indices, which the "
+                "combined fused DSA kernel does not expose. The repeated MTP layer therefore "
+                "uses the separable top-k and sparse-attention path; configured fused kernels "
+                "for those operations remain eligible. Benchmark this tradeoff for the target "
+                "MTP depth.",
+            )
+        if self.mtp_index_share and self.skip_topk:
+            raise ValueError(
+                "dsa_mtp_index_kv_share requires the repeated MTP layer to compute "
+                "its own top-k. Adjust dsa_indexer_skip_topk_offset/topk_freq so MTP layer "
+                f"{self.layer_number} is a computing layer."
+            )
         self.source_layer = (
             source_dsa_compute_layer(
                 self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
@@ -2163,6 +2187,7 @@ class DSAttention(MegatronModule):
         attention_bias: torch.Tensor = None,
         packed_seq_params: PackedSeqParams = None,
         up_v_weight: Optional[torch.Tensor] = None,
+        mtp_dsa_context=None,
     ):
         """
         Forward pass for Sparse Attention.
@@ -2182,6 +2207,18 @@ class DSAttention(MegatronModule):
         Returns:
             output: Output tensor [sq, b, hidden_size]
         """
+        if self.mtp_index_share and mtp_dsa_context is None:
+            raise RuntimeError(
+                "The repeated MTP DSA layer requires an explicit per-iteration sharing context. "
+                "Serial compute_mtp_single_step speculative inference does not provide this "
+                "context; disable dsa_mtp_index_kv_share or speculative decoding."
+            )
+        if not self.mtp_index_share and mtp_dsa_context is not None:
+            raise RuntimeError(
+                "Received an MTP DSA sharing context for an attention layer that is not "
+                "configured for MTP iteration sharing."
+            )
+        reuse_mtp_source = bool(mtp_dsa_context is not None and mtp_dsa_context.reuses_source)
         query, _ = dsa_layout.ensure_sbhd(query, "query")
         key, _ = dsa_layout.ensure_sbhd(key, "key")
         if value is not None:
@@ -2469,6 +2506,11 @@ class DSAttention(MegatronModule):
 
         skv = key.size(0)
 
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            source_key = key
+        else:
+            source_key = None
+
         if not packed_thd and sequence_parallel_query_is_local:
             nonpacked_query_positions = dsa_layout.extract_query_positions_from_position_ids(
                 position_ids, sq, query.device
@@ -2493,7 +2535,7 @@ class DSAttention(MegatronModule):
         qr = qr.detach()
 
         indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
-        computes_topk = not self.skip_topk
+        computes_topk = not self.skip_topk and not reuse_mtp_source
         use_indexer_loss = (
             self.training and torch.is_grad_enabled() and indexer_loss_coeff > 0 and computes_topk
         )
@@ -2565,7 +2607,15 @@ class DSAttention(MegatronModule):
             local_packed_cp_query_start = sequence_parallel_tp_row_start
             local_packed_cp_query_len = sequence_parallel_tp_full_rows
 
-        if self.skip_topk:
+        if reuse_mtp_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            topk_indices = mtp_dsa_context.shared_tensors.topk_indices
+            topk_length = mtp_dsa_context.shared_tensors.optional_topk_length()
+        elif self.skip_topk:
             assert topk_holder is not None
             if self.source_layer not in topk_holder:
                 raise RuntimeError(
@@ -2641,7 +2691,7 @@ class DSAttention(MegatronModule):
             )
 
         fused_output = None
-        if use_fused_kernels and not self.index_share:
+        if use_fused_kernels and not self.index_share and not self.mtp_index_share:
             assert q is not None and k is not None and weights is not None
             fused_output = dsa_kernels.run_fused_dsa_attention(
                 config=self.config,
@@ -2831,6 +2881,10 @@ class DSAttention(MegatronModule):
             topk_holder[self.layer_number] = topk_indices
             if topk_length_holder is not None and topk_length is not None:
                 topk_length_holder[self.layer_number] = topk_length
+
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            assert source_key is not None and topk_indices is not None
+            mtp_dsa_context.capture(source_key, topk_indices, topk_length)
 
         # ===================================
         # Run sparse attention kernel

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -340,6 +340,19 @@ class DSAIndexerLossLoggingHelper:
     tracker = {}
 
     @staticmethod
+    def ensure_tracker_size(num_layers: int) -> None:
+        """Ensure the tracker uses one storage large enough for all indexed layers."""
+        tracker = DSAIndexerLossLoggingHelper.tracker
+        if "values" not in tracker:
+            tracker["values"] = torch.zeros(num_layers, device=torch.cuda.current_device())
+        elif tracker["values"].shape[0] < num_layers:
+            grown = torch.zeros(
+                num_layers, device=tracker["values"].device, dtype=tracker["values"].dtype
+            )
+            grown[: tracker["values"].shape[0]] = tracker["values"]
+            tracker["values"] = grown
+
+    @staticmethod
     def save_loss_to_tracker(
         loss: torch.Tensor,
         layer_number: int,
@@ -366,14 +379,7 @@ class DSAIndexerLossLoggingHelper:
         # each MTP depth contains multiple hybrid layers) don't index out of bounds.
         # Grow lazily; with PP=1 every rank takes the same path, so sizes stay consistent.
         needed = max(num_layers, layer_number)
-        if "values" not in tracker:
-            tracker["values"] = torch.zeros(needed, device=torch.cuda.current_device())
-        elif tracker["values"].shape[0] < needed:
-            grown = torch.zeros(
-                needed, device=tracker["values"].device, dtype=tracker["values"].dtype
-            )
-            grown[: tracker["values"].shape[0]] = tracker["values"]
-            tracker["values"] = grown
+        DSAIndexerLossLoggingHelper.ensure_tracker_size(needed)
         tracker["values"][layer_number - 1] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group
@@ -390,7 +396,11 @@ class DSAIndexerLossLoggingHelper:
         tracker["avg_group"] = avg_group
 
     @staticmethod
-    def reduce_loss_in_tracker(num_layers: Optional[int] = None):
+    def reduce_loss_in_tracker(
+        num_layers: Optional[int] = None,
+        dynamic_cp_parent_group: Optional[torch.distributed.ProcessGroup] = None,
+        configured_cp_size: Optional[int] = None,
+    ):
         """Collect and reduce the indexer losses across ranks.
 
         Cross-PP `all_reduce` must be invoked on every rank in the pipeline-parallel group,
@@ -401,9 +411,19 @@ class DSAIndexerLossLoggingHelper:
         Args:
             num_layers: Total number of decoder layers; required to lazily initialize the
                 tracker on ranks where no indexer layer ran.
+            dynamic_cp_parent_group: Stable physical DP x CP group for Dynamic-CP metrics.
+                Supplying it on every PP rank makes stages without indexer layers use the
+                same reduction domain after the PP reduction.
+            configured_cp_size: Configured/static CP width. Dynamic CP accumulates raw local
+                token sums, so multiplying by this value before the physical DP x CP average
+                preserves the nominal global-batch weighting of static CP-SUM then DP-AVG.
         """
         tracker = DSAIndexerLossLoggingHelper.tracker
         pp_group = parallel_state.get_pipeline_model_parallel_group()
+        if dynamic_cp_parent_group is not None and (
+            configured_cp_size is None or configured_cp_size < 1
+        ):
+            raise ValueError("configured_cp_size must be positive for Dynamic CP logging.")
 
         # Agree on a consistent tracker size across the PP group BEFORE the collective.
         # Ranks owning indexer layers may have grown the tracker via save_loss_to_tracker
@@ -439,18 +459,24 @@ class DSAIndexerLossLoggingHelper:
         values = tracker["values"]
 
         torch.distributed.all_reduce(values, group=pp_group)
-        # Reduce indexer losses across ranks.
-        if tracker.get('reduce_group') is not None:
-            torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
-        if tracker.get('avg_group') is not None:
+        if dynamic_cp_parent_group is not None:
+            values.mul_(configured_cp_size)
             torch.distributed.all_reduce(
-                values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                values, group=dynamic_cp_parent_group, op=torch.distributed.ReduceOp.AVG
             )
-        torch.distributed.all_reduce(
-            values,
-            group=parallel_state.get_data_parallel_group(with_context_parallel=False),
-            op=torch.distributed.ReduceOp.AVG,
-        )
+        else:
+            # Reduce indexer losses across ranks.
+            if tracker.get('reduce_group') is not None:
+                torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
+            if tracker.get('avg_group') is not None:
+                torch.distributed.all_reduce(
+                    values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                )
+            torch.distributed.all_reduce(
+                values,
+                group=parallel_state.get_data_parallel_group(with_context_parallel=False),
+                op=torch.distributed.ReduceOp.AVG,
+            )
 
     @staticmethod
     def track_indexer_metrics(
@@ -463,6 +489,8 @@ class DSAIndexerLossLoggingHelper:
         num_layers: Optional[int] = None,
         num_indexer_layers: Optional[int] = None,
         preserve_groups: bool = False,
+        dynamic_cp_parent_group: Optional[torch.distributed.ProcessGroup] = None,
+        configured_cp_size: Optional[int] = None,
     ):
         """Track the sparse attention indexer metrics for logging.
 
@@ -477,8 +505,16 @@ class DSAIndexerLossLoggingHelper:
             num_indexer_layers: Number of layers that own an indexer. Defaults to
                 the tracker size when every tracked layer owns one.
             preserve_groups: Keep reduction groups after logging for CUDA Graph runs.
+            dynamic_cp_parent_group: Stable physical DP x CP group used by every PP rank
+                when Dynamic CP is enabled.
+            configured_cp_size: Configured/static CP width used to normalize Dynamic-CP
+                raw local token sums.
         """
-        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=num_layers)
+        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(
+            num_layers=num_layers,
+            dynamic_cp_parent_group=dynamic_cp_parent_group,
+            configured_cp_size=configured_cp_size,
+        )
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
             return
@@ -1981,6 +2017,7 @@ class DSAttention(MegatronModule):
 
     consumes_absorbed_v_up_projection = True
     requires_dsa_inputs = True
+    logs_dsa_indexer_loss = True
     _HOLDER_ATTR = "_dsa_index_share_topk_holder"
     _LENGTH_HOLDER_ATTR = "_dsa_index_share_topk_length_holder"
     _LAYOUT_HOLDER_ATTR = "_dsa_packed_cp_layout_holder"

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -153,6 +153,7 @@ def _run_sparse_attention(
     varlen_ends: Optional[torch.Tensor],
     key_positions: Optional[torch.Tensor],
     topk_length: Optional[torch.Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> torch.Tensor:
     """Run sparse attention for absorbed and non-absorbed MLA paths."""
     if absorbed_mla:
@@ -180,6 +181,7 @@ def _run_sparse_attention(
                 softmax_scale,
                 latent_v_channels,
                 topk_length=topk_length,
+                all_topk_rows_nonempty=all_topk_rows_nonempty,
             )
         # Fused backends may decline unsupported shapes or layouts by returning
         # None, so keep the absorbed PyTorch path as the authoritative fallback.
@@ -210,6 +212,43 @@ def _run_sparse_attention(
         varlen_starts=varlen_starts,
         varlen_ends=varlen_ends,
         key_positions=key_positions,
+    )
+
+
+def _can_prove_all_topk_rows_nonempty(
+    *,
+    computes_topk: bool,
+    indexer_topk: int,
+    kv_sequence_length: int,
+    attention_mask: Optional[torch.Tensor],
+    query_valid_rows: Optional[torch.Tensor],
+    varlen_is_plain_causal: bool,
+    use_local_indexer_varlen: bool,
+    varlen_starts: Optional[torch.Tensor],
+    varlen_ends: Optional[torch.Tensor],
+    key_positions: Optional[torch.Tensor],
+) -> bool:
+    """Return a host-side certificate that every query row has at least one selected key.
+
+    The packed-local branch is provenance-based: its bounds must come from DSA's internal
+    packed self-attention layout. Selected cumulative lengths (padded when available),
+    synthetic tail positions, and reordered KV cover every physical query row; checking
+    tensor values here would introduce a device sync. This proves geometric non-emptiness
+    only; real-token masking remains a separate concern.
+    """
+    if (
+        not computes_topk
+        or indexer_topk <= 0
+        or kv_sequence_length <= 0
+        or attention_mask is not None
+        or query_valid_rows is not None
+    ):
+        return False
+    return varlen_is_plain_causal or (
+        use_local_indexer_varlen
+        and varlen_starts is not None
+        and varlen_ends is not None
+        and key_positions is None
     )
 
 
@@ -2759,6 +2798,18 @@ class DSAttention(MegatronModule):
         # ===================================
         # Run sparse attention kernel
         # ===================================
+        all_topk_rows_nonempty = _can_prove_all_topk_rows_nonempty(
+            computes_topk=computes_topk,
+            indexer_topk=self.index_topk,
+            kv_sequence_length=skv,
+            attention_mask=attention_mask,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            use_local_indexer_varlen=use_local_indexer_varlen,
+            varlen_starts=varlen_starts,
+            varlen_ends=varlen_ends,
+            key_positions=key_positions,
+        )
         output = _run_sparse_attention(
             absorbed_mla=absorbed_mla,
             query=query,
@@ -2773,6 +2824,7 @@ class DSAttention(MegatronModule):
             varlen_starts=varlen_starts,
             varlen_ends=varlen_ends,
             key_positions=key_positions,
+            all_topk_rows_nonempty=all_topk_rows_nonempty,
         )
 
         if use_indexer_loss:

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -16,6 +16,12 @@ from megatron.core.transformer.experimental_attention_variant import (
     dsa_layout,
     dsa_masking,
 )
+from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+    IndexerScoringDecision,
+    IndexerScoringPlan,
+    report_unfused_scoring_once,
+    resolve_indexer_scoring_plan,
+)
 from megatron.core.utils import get_pg_size, round_up_to_nearest_multiple
 
 if TYPE_CHECKING:
@@ -153,26 +159,51 @@ def _supports_flash_mla_value_layout(kv_width: int, d_v: int) -> bool:
     return d_v == _FLASH_MLA_REQUIRED_VALUE_DIM and kv_width >= _FLASH_MLA_REQUIRED_VALUE_DIM
 
 
-def _get_multi_packed_cp_thd_metadata(
-    use_local_indexer_varlen: bool,
-    packed_seq_params: Optional["PackedSeqParams"],
-    single_packed_thd_sequence: bool,
-    cp_size: int,
+def _get_packed_thd_metadata(
+    use_local_indexer_varlen: bool, packed_seq_params: Optional["PackedSeqParams"]
 ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[int], Optional[int]]:
-    """Return packed metadata needed by the cuDNN multi-sequence THD indexer."""
-    if (
-        not use_local_indexer_varlen
-        or packed_seq_params is None
-        or single_packed_thd_sequence
-        or cp_size <= 1
-    ):
+    """Return packed metadata needed by the general cuDNN THD indexer."""
+    if not use_local_indexer_varlen or packed_seq_params is None:
         return None, None, None, None
-    cu_seqlens_q, cu_seqlens_k = dsa_layout.get_packed_qk_cu_seqlens(packed_seq_params)
+    cu_seqlens_q = getattr(packed_seq_params, "cu_seqlens_q_padded", None)
+    if cu_seqlens_q is None:
+        cu_seqlens_q = getattr(packed_seq_params, "cu_seqlens_q", None)
+    cu_seqlens_k = getattr(packed_seq_params, "cu_seqlens_kv_padded", None)
+    if cu_seqlens_k is None:
+        cu_seqlens_k = getattr(packed_seq_params, "cu_seqlens_kv", None)
+    if cu_seqlens_q is None:
+        cu_seqlens_q = cu_seqlens_k
+    if cu_seqlens_k is None:
+        cu_seqlens_k = cu_seqlens_q
+    if cu_seqlens_q is None:
+        return None, None, None, None
     return (
         cu_seqlens_q,
         cu_seqlens_k,
-        packed_seq_params.max_seqlen_q,
-        packed_seq_params.max_seqlen_kv,
+        getattr(packed_seq_params, "max_seqlen_q", None),
+        getattr(packed_seq_params, "max_seqlen_kv", None),
+    )
+
+
+def _resolve_packed_layout_flags(
+    *,
+    use_local_indexer_varlen: bool,
+    single_packed_thd_sequence: bool,
+    packed_thd_causal_identity_layout: Optional[bool],
+    packed_thd_single_sequence: Optional[bool],
+) -> Tuple[bool, bool]:
+    """Prefer the new CP-independent facts while accepting direct legacy calls."""
+    return (
+        (
+            use_local_indexer_varlen
+            if packed_thd_causal_identity_layout is None
+            else packed_thd_causal_identity_layout
+        ),
+        (
+            single_packed_thd_sequence
+            if packed_thd_single_sequence is None
+            else packed_thd_single_sequence
+        ),
     )
 
 
@@ -203,6 +234,8 @@ def run_fused_dsa_attention(
     use_relu: bool,
     use_local_indexer_varlen: bool = False,
     single_packed_thd_sequence: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
     local_packed_cp_rank: int = 0,
     local_packed_cp_query_start: int = 0,
     local_packed_cp_query_len: Optional[int] = None,
@@ -214,6 +247,12 @@ def run_fused_dsa_attention(
     ``use_fused_dsa_kernels`` before calling, so this hook assumes it was selected (matching
     the TileLang backend) and only validates that the requested shapes/layout are supported.
     """
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     _assert_supported_indexer_scoring(use_relu)
     if (
         not absorbed_mla
@@ -224,19 +263,19 @@ def run_fused_dsa_attention(
         return None
     if not torch.is_grad_enabled():
         loss_coeff = 0.0
-    # build_dsattention_forward_mask emits explicit varlen bounds even for the plain (non-packed,
-    # non-CP) causal case and flags them via ``varlen_is_plain_causal``. Those bounds are exactly
-    # equivalent to the no-varlen causal path the dense fused indexer loss was written for, so
-    # normalize them back to None: plain causal then takes the same fused path (relying on the
-    # kernel's internal causal masking) it took before that mask change, instead of declining
-    # dense loss and falling back to the slow reference-loss path. The flag carries the mask
-    # builder's structural knowledge, so we avoid the per-forward host/device sync a ``torch.equal``
-    # bounds comparison would force on this common path. Genuine packed/CP/custom-position varlen
-    # is left untouched (``varlen_is_plain_causal`` is False there) and is gated below, where it
-    # would otherwise trip the padded-row assert in FusedIndexerSparseAttnFunc.forward.
-    if cp_size == 1 and packed_seq_params is None and varlen_is_plain_causal:
-        varlen_starts = None
-        varlen_ends = None
+    # Plain causal bounds are equivalent to the no-varlen causal path the dense fused indexer
+    # loss was written for, so normalize them away: plain causal then takes the same fused path
+    # (relying on the kernel's internal causal masking) it took before that mask change, instead
+    # of declining dense loss and falling back to the slow reference-loss path. Genuine
+    # packed/CP/custom-position varlen is left untouched and is gated below, where it would
+    # otherwise trip the padded-row assert in FusedIndexerSparseAttnFunc.forward.
+    varlen_starts, varlen_ends = _normalize_plain_causal_bounds(
+        varlen_starts,
+        varlen_ends,
+        cp_size=cp_size,
+        packed_seq_params=packed_seq_params,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+    )
     has_varlen = varlen_starts is not None or varlen_ends is not None or key_positions is not None
     if has_varlen:
         if varlen_starts is None or varlen_ends is None:
@@ -260,9 +299,7 @@ def run_fused_dsa_attention(
     sq, b, num_heads, _ = query.size()
     kv_full = key.squeeze(2).contiguous()
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     packed_thd_kwargs = {}
     if packed_cu_seqlens_q is not None:
@@ -345,6 +382,16 @@ def _get_topk_alignment() -> int:
     raise RuntimeError(f"cudnn fused DSA requires SM90+ (Hopper or later), got SM{sm[0]}{sm[1]}.")
 
 
+def _get_score_recompute_topk_alignment() -> int:
+    """Minimum top-K alignment required by cuDNN sparse score recompute."""
+    sm = _current_sm()
+    if sm[0] >= 10:
+        return 64
+    if sm[0] >= 9:
+        return 128
+    raise RuntimeError(f"cudnn fused DSA requires SM90+ (Hopper or later), got SM{sm[0]}{sm[1]}.")
+
+
 def _flash_mla_head_padding(num_heads: int) -> Optional[int]:
     """Padded query-head count FlashMLA supports for ``num_heads``, or None if unsupported.
 
@@ -413,6 +460,36 @@ def _bytes_to_chunk_rows(n_rows: int, bytes_per_row: int, max_bytes: int, alignm
 def _causal_seq_lens(q_positions: Tensor, ratio: int, sk: int) -> Tensor:
     """Per-query causal key length under the indexer ``ratio``, clamped to ``sk``."""
     return ((q_positions + 1) // ratio).clamp(max=sk)
+
+
+def _normalize_plain_causal_bounds(
+    starts: Optional[Tensor],
+    ends: Optional[Tensor],
+    *,
+    cp_size: int,
+    packed_seq_params: Optional["PackedSeqParams"],
+    varlen_is_plain_causal: bool,
+) -> Tuple[Optional[Tensor], Optional[Tensor]]:
+    """Drop plain-causal varlen bounds so the single-kernel indexer scorer stays reachable.
+
+    ``build_dsattention_forward_mask`` emits explicit bounds even for the plain
+    (non-packed, non-CP) causal case and flags them via ``varlen_is_plain_causal``.
+    Those bounds are ``starts = 0`` and ``ends = arange(1, sq + 1).clamp(max=sk)``,
+    which is exactly what :func:`_causal_seq_lens` reconstructs internally under
+    ``_INDEXER_RATIO == 1``. Returning ``None`` here is therefore a no-op on
+    semantics, but it lets :func:`_indexer_topk_bshd` take its ``starts is None``
+    branch, which reaches the fused single-kernel ``indexer_forward_wrapper``
+    instead of the per-head scoring loop in
+    :func:`_compute_indexer_scores_chunk_with_global_rows`.
+
+    The flag carries the mask builder's structural knowledge, so we avoid the
+    per-forward host/device sync that a ``torch.equal`` bounds comparison would
+    force on this common path. Genuine packed/CP/custom-position varlen is left
+    untouched (``varlen_is_plain_causal`` is False there).
+    """
+    if cp_size == 1 and packed_seq_params is None and varlen_is_plain_causal:
+        return None, None
+    return starts, ends
 
 
 def _topk_tie_break_bias(positions: Tensor, key_count: int, dtype: torch.dtype) -> Tensor:
@@ -695,7 +772,88 @@ def _pad_topk_result(
     return topk_indices, topk_scores
 
 
-def _indexer_topk_multi_packed_cp_thd(
+def _packed_thd_kernel_applicable(
+    *,
+    b: int,
+    sq: int,
+    sk: int,
+    device: torch.device,
+    packed_cu_seqlens_q: Optional[Tensor],
+    packed_cu_seqlens_k: Optional[Tensor],
+    packed_max_seqlen_q: Optional[int],
+    packed_max_seqlen_k: Optional[int],
+    cp_size: int,
+    cp_rank: int,
+    local_packed_cp_query_start: int,
+    local_packed_cp_query_len: Optional[int],
+) -> bool:
+    """Whether the general THD scorer can safely consume this metadata.
+
+    This check is intentionally limited to structural facts available without reading a
+    CUDA tensor on the host. Value-level validation remains the packed-layout builder's
+    responsibility; doing it here would put a synchronization back in the layer hot path.
+    """
+    if (
+        b != 1
+        or cp_size < 1
+        or not 0 <= cp_rank < cp_size
+        or sk != sq * cp_size
+        or local_packed_cp_query_start != 0
+        or local_packed_cp_query_len not in (None, sq)
+        or packed_cu_seqlens_q is None
+        or packed_cu_seqlens_k is None
+        or packed_max_seqlen_q is None
+        or packed_max_seqlen_k is None
+        or packed_max_seqlen_q <= 0
+        or packed_max_seqlen_k <= 0
+    ):
+        return False
+    if (
+        packed_cu_seqlens_q.ndim != 1
+        or packed_cu_seqlens_k.ndim != 1
+        or packed_cu_seqlens_q.shape != packed_cu_seqlens_k.shape
+        or packed_cu_seqlens_q.numel() < 2
+    ):
+        return False
+    same_view = packed_cu_seqlens_q.device == packed_cu_seqlens_k.device and (
+        packed_cu_seqlens_q is packed_cu_seqlens_k
+        or (
+            packed_cu_seqlens_q.data_ptr() == packed_cu_seqlens_k.data_ptr()
+            and packed_cu_seqlens_q.storage_offset() == packed_cu_seqlens_k.storage_offset()
+            and packed_cu_seqlens_q.stride() == packed_cu_seqlens_k.stride()
+        )
+    )
+    same_boundaries = same_view or (
+        not packed_cu_seqlens_q.is_cuda
+        and not packed_cu_seqlens_k.is_cuda
+        and torch.equal(packed_cu_seqlens_q, packed_cu_seqlens_k)
+    )
+    # The packed scorer restores sequence-local top-k indices with the Q-derived
+    # row bounds. Differing K boundaries would silently map selected columns into
+    # another packed sequence, so decline unless equality is provable without a
+    # CUDA synchronization. Canonical self-attention schedulers preserve aliases.
+    if not same_boundaries:
+        return False
+    if cp_size > 1:
+        return sk % (2 * cp_size) == 0
+
+    # The CP1 path forwards cu-seqlens directly to cuDNN, so prove its stricter
+    # device, dtype, maximum-length, and contiguity requirements as well.
+    if (
+        packed_cu_seqlens_q.device != device
+        or packed_cu_seqlens_k.device != device
+        or packed_cu_seqlens_q.dtype != torch.int32
+        or packed_cu_seqlens_k.dtype != torch.int32
+        or packed_max_seqlen_q != packed_max_seqlen_k
+        or packed_max_seqlen_q > sq
+        or not packed_cu_seqlens_q.is_contiguous()
+        or not packed_cu_seqlens_k.is_contiguous()
+    ):
+        return False
+    return True
+
+
+def _indexer_topk_packed_thd(
     q_bshd: Tensor,
     k_bshd: Tensor,
     w_bsh: Tensor,
@@ -709,72 +867,98 @@ def _indexer_topk_multi_packed_cp_thd(
     packed_max_seqlen_k: int,
     cp_size: int,
     cp_rank: int,
+    local_packed_cp_query_start: int,
+    local_packed_cp_query_len: Optional[int],
 ) -> Tuple[Tensor, Optional[Tensor]]:
-    """Run cuDNN's THD indexer on packed CP front/back query segments."""
+    """Run cuDNN's general THD indexer for packed sequences at any CP size.
+
+    At CP1 the original packed Q/K/W tensors and cu-seqlens are passed directly to
+    cuDNN in one call. CP>1 retains the front/back segmented representation required by
+    zigzag context parallelism. Top-k selection and sequence-local to global index
+    restoration are shared by both representations.
+    """
     b, sq, _idx_nh, _idx_hd = q_bshd.shape
     sk = k_bshd.size(1)
-    if b != 1 or cp_size <= 1 or not 0 <= cp_rank < cp_size:
-        raise RuntimeError("packed CP cuDNN THD indexer requires b=1 and a valid CP rank")
-    if packed_cu_seqlens_q.numel() < 3:
-        raise RuntimeError(
-            "multi-sequence packed CP cuDNN THD indexer requires at least two sequences"
-        )
-    if packed_cu_seqlens_q.shape != packed_cu_seqlens_k.shape:
-        raise RuntimeError("packed CP cuDNN THD query/key cu_seqlens shapes must match")
-    if packed_max_seqlen_q <= 0 or packed_max_seqlen_k <= 0:
-        raise RuntimeError("packed CP cuDNN THD indexer requires positive maximum sequence lengths")
-
-    segment_divisor = 2 * cp_size
-    device = q_bshd.device
-    layout = dsa_layout.build_packed_cp_indexer_layout(
-        packed_cu_seqlens_q.to(device=device),
-        packed_cu_seqlens_k.to(device=device),
+    if not _packed_thd_kernel_applicable(
+        b=b,
+        sq=sq,
+        sk=sk,
+        device=q_bshd.device,
+        packed_cu_seqlens_q=packed_cu_seqlens_q,
+        packed_cu_seqlens_k=packed_cu_seqlens_k,
+        packed_max_seqlen_q=packed_max_seqlen_q,
+        packed_max_seqlen_k=packed_max_seqlen_k,
         cp_size=cp_size,
         cp_rank=cp_rank,
-        key_size=sk,
-    )
-    segmented_k = k_bshd[0].index_select(0, layout.source_indices).contiguous()
+        local_packed_cp_query_start=local_packed_cp_query_start,
+        local_packed_cp_query_len=local_packed_cp_query_len,
+    ):
+        raise RuntimeError("general packed THD scorer received incompatible layout metadata")
 
-    max_segment_q = packed_max_seqlen_q // segment_divisor
-    max_k_half = packed_max_seqlen_k // segment_divisor
-    max_segment_k = max((cp_rank + 1) * max_k_half, packed_max_seqlen_k - cp_rank * max_k_half)
+    device = q_bshd.device
+    if cp_size == 1:
+        score_q = q_bshd[0]
+        score_k = k_bshd[0]
+        score_w = w_bsh[0]
+        score_cu_q = packed_cu_seqlens_q
+        score_cu_k = packed_cu_seqlens_k
+        max_score_q = packed_max_seqlen_q
+        max_score_k = packed_max_seqlen_k
+    else:
+        segment_divisor = 2 * cp_size
+        layout = dsa_layout.build_packed_cp_indexer_layout(
+            packed_cu_seqlens_q.to(device=device),
+            packed_cu_seqlens_k.to(device=device),
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            key_size=sk,
+        )
+        score_q = q_bshd[0]
+        score_k = k_bshd[0].index_select(0, layout.source_indices).contiguous()
+        score_w = w_bsh[0]
+        score_cu_q = layout.segment_cu_q.to(dtype=torch.int32)
+        score_cu_k = layout.segment_cu_k.to(dtype=torch.int32)
+        max_score_q = packed_max_seqlen_q // segment_divisor
+        max_k_half = packed_max_seqlen_k // segment_divisor
+        max_score_k = max((cp_rank + 1) * max_k_half, packed_max_seqlen_k - cp_rank * max_k_half)
+
     scores = _cudnn_dsa.indexer_forward_wrapper(
-        q_bshd[0],
-        segmented_k,
-        w_bsh[0],
+        score_q,
+        score_k,
+        score_w,
         ratio=_INDEXER_RATIO,
         sm_scale=_INDEXER_SOFTMAX_SCALE,
-        cu_seqlens_q=layout.segment_cu_q.to(dtype=torch.int32),
-        cu_seqlens_k=layout.segment_cu_k.to(dtype=torch.int32),
-        max_seqlen_q=max_segment_q,
-        max_seqlen_k=max_segment_k,
+        cu_seqlens_q=score_cu_q,
+        cu_seqlens_k=score_cu_k,
+        max_seqlen_q=max_score_q,
+        max_seqlen_k=max_score_k,
     )["scores"]
 
-    segment_topk = min(topk_k, max_segment_k)
-    if segment_topk == max_segment_k:
+    score_topk = min(topk_k, max_score_k)
+    if score_topk == max_score_k:
         # Ranking is unnecessary when K covers every score column. This also
         # avoids cuDNN FE's vectorized-output restriction for large odd K.
-        topk_indices = torch.arange(segment_topk, dtype=torch.int32, device=device).view(
-            1, 1, segment_topk
+        topk_indices = torch.arange(score_topk, dtype=torch.int32, device=device).view(
+            1, 1, score_topk
         ) + starts.view(1, sq, 1).to(dtype=torch.int32)
-        topk_scores = scores.view(1, sq, segment_topk) if return_topk_scores else None
+        topk_scores = scores.view(1, sq, score_topk) if return_topk_scores else None
         return _pad_topk_result(topk_indices, topk_scores, topk_k)
 
-    local_seq_lens = (ends - starts).clamp(max=max_segment_k).to(torch.int32).contiguous()
-    use_tie_break = _use_dense_indexer_topk_tie_break(scores, segment_topk)
+    local_seq_lens = (ends - starts).clamp(max=max_score_k).to(torch.int32).contiguous()
+    use_tie_break = _use_dense_indexer_topk_tie_break(scores, score_topk)
     scores_for_topk = _add_indexer_topk_tie_break(scores, inplace=True) if use_tie_break else scores
     tk_result = _indexer_top_k_wrapper_chunked(
-        scores_for_topk, local_seq_lens, topk_k=segment_topk, return_topk_scores=return_topk_scores
+        scores_for_topk, local_seq_lens, topk_k=score_topk, return_topk_scores=return_topk_scores
     )
-    topk_indices = tk_result["indices"].view(1, sq, segment_topk)
+    topk_indices = tk_result["indices"].view(1, sq, score_topk)
     topk_scores = None
     if return_topk_scores:
         topk_scores = tk_result["values"]
         if topk_scores is None:
             raise RuntimeError("cuDNN indexer_top_k_wrapper did not return values.")
-        topk_scores = topk_scores.view(1, sq, segment_topk)
+        topk_scores = topk_scores.view(1, sq, score_topk)
         if use_tie_break:
-            topk_scores = _remove_indexer_topk_tie_break(topk_scores, topk_indices, max_segment_k)
+            topk_scores = _remove_indexer_topk_tie_break(topk_scores, topk_indices, max_score_k)
 
     valid = topk_indices >= 0
     topk_indices = torch.where(
@@ -789,6 +973,7 @@ def _indexer_topk_single_packed_cp_segments(
     w_bsh: Tensor,
     topk_k: int,
     return_topk_scores: bool,
+    cp_size: int,
     local_packed_cp_rank: int,
     local_packed_cp_query_start: int = 0,
     local_packed_cp_query_len: Optional[int] = None,
@@ -799,19 +984,28 @@ def _indexer_topk_single_packed_cp_segments(
     local_query_len = local_packed_cp_query_len if local_packed_cp_query_len is not None else sq
     local_query_start = local_packed_cp_query_start
     local_query_end = local_query_start + sq
-    if b != 1 or local_query_len % 2 != 0 or _INDEXER_RATIO != 1:
+    # Halving is what the zigzag context-parallel layout needs: every rank owns a front
+    # and a back chunk of equal length. A rank holding the whole sequence has no zigzag
+    # to undo, so it needs neither the split nor the even length that the split implies.
+    if not _segment_kernel_applicable(
+        b,
+        sq,
+        sk,
+        local_packed_cp_query_len,
+        cp_size,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+    ):
         raise RuntimeError(
-            "single packed CP cuDNN fast path requires b=1, even local query length, ratio=1"
-        )
-    if local_query_start < 0 or local_query_end > local_query_len:
-        raise RuntimeError(
-            "single packed CP cuDNN fast path received an invalid query slice: "
-            f"start={local_query_start}, sq={sq}, local_query_len={local_query_len}"
+            "single packed THD segment scorer received incompatible CP/query/key geometry"
         )
 
     half = local_query_len // 2
-    if sk == local_query_len:
-        segment_specs = ((0, half, half), (half, local_query_len, local_query_len))
+    if cp_size == 1:
+        # One causal segment over the whole local sequence; per-row key lengths are still
+        # built from arange inside the loop, so this is the same masking as the split form
+        # and it does not require an even length.
+        segment_specs = ((0, local_query_len, local_query_len),)
     else:
         segment_specs = (
             (0, half, (local_packed_cp_rank + 1) * half),
@@ -828,7 +1022,7 @@ def _indexer_topk_single_packed_cp_segments(
         row_end = row_end_global - local_query_start
         if key_end <= 0 or key_end > sk:
             raise RuntimeError(
-                "single packed CP cuDNN fast path derived invalid key prefix: "
+                "single packed THD segment scorer derived invalid key prefix: "
                 f"key_end={key_end}, sk={sk}, cp_rank={local_packed_cp_rank}, sq={sq}"
             )
         segment_topk = min(topk_k, key_end)
@@ -859,7 +1053,7 @@ def _indexer_topk_single_packed_cp_segments(
 
     if not indices_chunks:
         raise RuntimeError(
-            "single packed CP cuDNN fast path query slice did not intersect any CP segment"
+            "single packed THD segment scorer query slice did not intersect any segment"
         )
 
     return (
@@ -1073,6 +1267,88 @@ def _topk_in_bounds(
     return in_range & valid_bounds
 
 
+def _segment_kernel_applicable(
+    b: int,
+    sq: int,
+    sk: int,
+    local_packed_cp_query_len: Optional[int],
+    cp_size: int,
+    cp_rank: int,
+    local_packed_cp_query_start: int,
+) -> bool:
+    """Whether ``_indexer_topk_single_packed_cp_segments`` can take this shape.
+
+    That kernel raises rather than returning None when its preconditions fail, so the
+    scoring plan has to ask before promising it. Kept next to the kernel so the two
+    cannot drift apart.
+    """
+    local_query_len = local_packed_cp_query_len if local_packed_cp_query_len is not None else sq
+    if (
+        b != 1
+        or _INDEXER_RATIO != 1
+        or cp_size < 1
+        or not 0 <= cp_rank < cp_size
+        or local_query_len <= 0
+        or local_packed_cp_query_start < 0
+        or local_packed_cp_query_start + sq > local_query_len
+    ):
+        return False
+    # An odd local length only rules out the halved zigzag form; a rank holding the whole
+    # sequence takes the single-segment form, which has no parity requirement.
+    expected_key_len = local_query_len if cp_size == 1 else local_query_len * cp_size
+    if sk != expected_key_len:
+        return False
+    whole_sequence_local = cp_size == 1
+    if not whole_sequence_local and local_query_len % 2 != 0:
+        return False
+    if cp_size > 1:
+        half = local_query_len // 2
+        if (cp_rank + 1) * half > sk or sk - cp_rank * half <= 0:
+            return False
+    return True
+
+
+def _resolve_scoring_plan_for_call(
+    *,
+    starts: Optional[Tensor],
+    ends: Optional[Tensor],
+    varlen_is_plain_causal: bool,
+    packed_thd: bool,
+    cp_size: int,
+    use_local_indexer_varlen: bool,
+    single_packed_thd_sequence: bool,
+    packed_metadata_available: bool,
+    segment_kernel_applicable: bool = True,
+) -> IndexerScoringDecision:
+    """Map this call's layout facts onto a scoring plan.
+
+    ``use_local_indexer_varlen`` encodes "packed, causal, identity key positions" -- it
+    is how the caller reports a layout the packed kernels can accept. CP size is an
+    independent geometry fact consumed by the selected executor.
+    It is unpacked here rather than re-tested downstream, so each resolver argument
+    keeps exactly one meaning.
+    """
+    no_explicit_bounds = starts is None and ends is None
+    return resolve_indexer_scoring_plan(
+        bounds_available=no_explicit_bounds or (starts is not None and ends is not None),
+        varlen_is_plain_causal=varlen_is_plain_causal or no_explicit_bounds,
+        packed_thd=packed_thd,
+        cp_size=cp_size,
+        # Non-packed callers cannot report their mask type from here; they are
+        # treated as causal, so a non-causal non-packed layout lands on the generic
+        # "not reconstructible" reason rather than the dedicated non-causal one.
+        # Likewise packed_thd below is inferred from what the packed kernels could
+        # consume, so a packed layout no packed kernel claims is diagnosed with the
+        # non-packed reason. The dispatch outcome (UNFUSED_BOUNDS) is the same in
+        # every such case; only the diagnostic wording is generic.
+        mask_is_causal=use_local_indexer_varlen or not packed_thd,
+        explicit_key_positions=False,
+        single_sequence_pack=single_packed_thd_sequence,
+        packed_metadata_available=packed_metadata_available,
+        segment_kernel_applicable=segment_kernel_applicable,
+    )
+
+
 def _indexer_topk_bshd(
     q_bshd: Tensor,
     k_bsd: Tensor,
@@ -1093,6 +1369,7 @@ def _indexer_topk_bshd(
     packed_max_seqlen_q: Optional[int] = None,
     packed_max_seqlen_k: Optional[int] = None,
     packed_cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
     """BSHD-layout indexer scoring and top-K selection.
 
@@ -1110,10 +1387,9 @@ def _indexer_topk_bshd(
         * ``score_payload``: full scores when ``return_scores=True``, top-k
           scores when ``return_topk_scores=True``, otherwise ``None``.
 
-    ``use_local_indexer_varlen`` is an optimized packed-CP path for a single
-    packed sequence. It scores the local query rows directly instead of
-    scattering them to their global query positions first, then applies the
-    explicit starts/ends mask before top-k selection.
+    ``use_local_indexer_varlen`` identifies a packed causal identity-key layout. The
+    selected packed executor scores compact local query rows directly, then restores
+    sequence-local top-k indices to the global packed key coordinate space.
     """
     _ensure_dsa_namespace()
 
@@ -1140,7 +1416,46 @@ def _indexer_topk_bshd(
 
     k_bshd = k_bsd.unsqueeze(2)  # (b, sk, 1, idx_hd)
 
-    if starts is None:
+    scoring_plan = _resolve_scoring_plan_for_call(
+        segment_kernel_applicable=_segment_kernel_applicable(
+            b,
+            sq,
+            sk,
+            local_packed_cp_query_len,
+            packed_cp_size,
+            local_packed_cp_rank,
+            local_packed_cp_query_start,
+        ),
+        starts=starts,
+        ends=ends,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        packed_thd=use_local_indexer_varlen or packed_cu_seqlens_q is not None,
+        cp_size=packed_cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_metadata_available=_packed_thd_kernel_applicable(
+            b=b,
+            sq=sq,
+            sk=sk,
+            device=device,
+            packed_cu_seqlens_q=packed_cu_seqlens_q,
+            packed_cu_seqlens_k=packed_cu_seqlens_k,
+            packed_max_seqlen_q=packed_max_seqlen_q,
+            packed_max_seqlen_k=packed_max_seqlen_k,
+            cp_size=packed_cp_size,
+            cp_rank=local_packed_cp_rank,
+            local_packed_cp_query_start=local_packed_cp_query_start,
+            local_packed_cp_query_len=local_packed_cp_query_len,
+        ),
+    )
+    plan = scoring_plan.plan
+    report_unfused_scoring_once(scoring_plan, "indexer scoring")
+    if plan is IndexerScoringPlan.DECLINE:
+        raise RuntimeError(f"invalid DSA scoring dispatch: {scoring_plan.reason}")
+
+    # PLAIN_CAUSAL means the bounds, if any, are the trivial whole-sequence causal ones
+    # that ``_causal_seq_lens`` rebuilds exactly, so the single-kernel scorer applies.
+    if starts is None or plan is IndexerScoringPlan.PLAIN_CAUSAL:
         q_idx = torch.arange(sq, device=device)
         seq_lens = _causal_seq_lens(q_idx, _INDEXER_RATIO, sk).to(torch.int32).repeat(b)
         if not return_scores:
@@ -1155,26 +1470,20 @@ def _indexer_topk_bshd(
             ]  # (b, sq, sk) fp32, -inf on masked positions
     else:
         seq_lens = ends.clamp(max=sk).to(torch.int32).repeat(b)
-        if not return_scores and use_local_indexer_varlen and single_packed_thd_sequence:
+        if not return_scores and plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS:
             topk_indices, topk_scores = _indexer_topk_single_packed_cp_segments(
                 q_bshd,
                 k_bshd,
                 w_bsh,
                 topk_k,
                 return_topk_scores,
+                packed_cp_size,
                 local_packed_cp_rank,
                 local_packed_cp_query_start,
                 local_packed_cp_query_len,
             )
-        elif (
-            not return_scores
-            and use_local_indexer_varlen
-            and packed_cu_seqlens_q is not None
-            and packed_cu_seqlens_k is not None
-            and packed_max_seqlen_q is not None
-            and packed_max_seqlen_k is not None
-        ):
-            topk_indices, topk_scores = _indexer_topk_multi_packed_cp_thd(
+        elif not return_scores and plan is IndexerScoringPlan.PACKED_THD_GENERAL:
+            topk_indices, topk_scores = _indexer_topk_packed_thd(
                 q_bshd,
                 k_bshd,
                 w_bsh,
@@ -1188,6 +1497,8 @@ def _indexer_topk_bshd(
                 packed_max_seqlen_k,
                 packed_cp_size,
                 local_packed_cp_rank,
+                local_packed_cp_query_start,
+                local_packed_cp_query_len,
             )
         elif not return_scores:
             topk_indices, topk_scores = _indexer_topk_from_score_chunks(
@@ -1330,8 +1641,17 @@ def run_fused_qk_topk(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
 ) -> Optional[Tuple[Tensor, Tensor]]:
     """Run the cuDNN fused indexer and return top-k indices for split DSA."""
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     _assert_supported_indexer_scoring(use_relu)
     del block_size
     if q.ndim != 4 or k.ndim != 3 or weights.ndim != 3:
@@ -1340,13 +1660,14 @@ def run_fused_qk_topk(
         return None
     if q.size(2) != weights.size(2) or q.size(3) != k.size(2):
         return None
+    # Bounds the caller could not build at all are a genuine decline, which is a
+    # different thing from bounds that exist but describe a layout a fused kernel can
+    # rebuild for itself. The scoring plan distinguishes the two.
     if starts is None or ends is None:
         return None
 
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     q_bshd, k_bsd, w_bsh = _sbhd_to_bshd_indexer_inputs(q, k, weights)
     topk_indices, topk_length, _score_payload = _indexer_topk_bshd(
@@ -1369,6 +1690,7 @@ def run_fused_qk_topk(
         packed_max_seqlen_q=packed_max_seqlen_q,
         packed_max_seqlen_k=packed_max_seqlen_k,
         packed_cp_size=cp_size,
+        varlen_is_plain_causal=varlen_is_plain_causal,
     )
     return topk_indices, topk_length
 
@@ -1397,8 +1719,17 @@ def run_fused_qk_topk_with_loss(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional["PackedSeqParams"] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
+    packed_thd_causal_identity_layout: Optional[bool] = None,
+    packed_thd_single_sequence: Optional[bool] = None,
 ) -> Optional[Tuple[Tensor, Tensor, Tensor]]:
     """Run cuDNN fused indexer and sparse indexer loss for split DSA."""
+    use_local_indexer_varlen, single_packed_thd_sequence = _resolve_packed_layout_flags(
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
     del block_size
     tp_group = getattr(pg_collection, "tp", None)
     _assert_supported_indexer_scoring(use_relu)
@@ -1416,6 +1747,9 @@ def run_fused_qk_topk_with_loss(
         return None
     if query.size(3) != key.size(3):
         return None
+    # Bounds the caller could not build at all are a genuine decline, which is a
+    # different thing from bounds that exist but describe a layout a fused kernel can
+    # rebuild for itself. The scoring plan distinguishes the two.
     if starts is None or ends is None:
         return None
 
@@ -1428,9 +1762,7 @@ def run_fused_qk_topk_with_loss(
         return None
 
     packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q, packed_max_seqlen_k = (
-        _get_multi_packed_cp_thd_metadata(
-            use_local_indexer_varlen, packed_seq_params, single_packed_thd_sequence, cp_size
-        )
+        _get_packed_thd_metadata(use_local_indexer_varlen, packed_seq_params)
     )
     return FusedQKTopKWithSparseLossFunc.apply(
         q.contiguous(),
@@ -1443,8 +1775,8 @@ def run_fused_qk_topk_with_loss(
         loss_coeff,
         calculate_per_token_loss,
         latent_v_channels,
-        starts.contiguous(),
-        ends.contiguous(),
+        starts.contiguous() if starts is not None else None,
+        ends.contiguous() if ends is not None else None,
         query_valid_rows,
         use_local_indexer_varlen,
         single_packed_thd_sequence,
@@ -1457,6 +1789,7 @@ def run_fused_qk_topk_with_loss(
         packed_max_seqlen_k,
         cp_size,
         tp_group,
+        varlen_is_plain_causal,
     )
 
 
@@ -1599,6 +1932,14 @@ def _compute_attn_target(
     """
     _ensure_dsa_namespace()
     q_attn_bshd, lse, qhead_per_kv_head = _pad_attn_target_heads(q_attn_bshd, lse)
+    logical_topk = topk_indices.size(-1)
+    if topk_indices.is_cuda:
+        topk_alignment = _get_score_recompute_topk_alignment()
+        padded_topk = round_up_to_nearest_multiple(logical_topk, topk_alignment)
+        if padded_topk != logical_topk:
+            topk_indices = torch.nn.functional.pad(
+                topk_indices, (0, padded_topk - logical_topk), value=-1
+            )
     kwargs = {"qhead_per_kv_head": qhead_per_kv_head, "topk_indices_global": False}
     if topk_length is not None:
         kwargs["topk_length"] = topk_length.to(dtype=torch.int32, device=topk_indices.device)
@@ -1610,7 +1951,7 @@ def _compute_attn_target(
         softmax_scale,
         **kwargs,
     )
-    return result["target"].contiguous()
+    return result["target"][..., :logical_topk].contiguous()
 
 
 def _dense_attn_lse_chunk_rows(b: int, qhead_per_kv_head: int, sk: int, sq: int) -> int:
@@ -2391,8 +2732,8 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         loss_coeff: float,
         calculate_per_token_loss: bool,
         d_v: int,
-        varlen_starts: Tensor,
-        varlen_ends: Tensor,
+        varlen_starts: Optional[Tensor],
+        varlen_ends: Optional[Tensor],
         query_valid_rows: Optional[Tensor],
         use_local_indexer_varlen: bool,
         single_packed_thd_sequence: bool,
@@ -2405,6 +2746,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         packed_max_seqlen_k: Optional[int],
         packed_cp_size: int,
         tp_group,
+        varlen_is_plain_causal: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """Compute shared attention top-k metadata and sparse indexer loss."""
         _ensure_dsa_namespace()
@@ -2435,6 +2777,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
             packed_max_seqlen_q=packed_max_seqlen_q,
             packed_max_seqlen_k=packed_max_seqlen_k,
             packed_cp_size=packed_cp_size,
+            varlen_is_plain_causal=varlen_is_plain_causal,
         )
 
         if indexer_score_payload is None:
@@ -2495,7 +2838,8 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
         #   single_packed_thd_sequence, local_packed_cp_rank,
         #   local_packed_cp_query_start, local_packed_cp_query_len,
         #   packed_cu_seqlens_q, packed_cu_seqlens_k, packed_max_seqlen_q,
-        #   packed_max_seqlen_k, packed_cp_size, tp_group.
+        #   packed_max_seqlen_k, packed_cp_size, tp_group,
+        #   varlen_is_plain_causal.
         return (
             grad_q_indexer,
             grad_k_indexer,
@@ -2521,6 +2865,7 @@ class FusedQKTopKWithSparseLossFunc(torch.autograd.Function):
             None,
             None,
             None,
+            None,  # varlen_is_plain_causal
         )
 
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -254,10 +254,14 @@ def run_fused_dsa_attention(
         packed_thd_single_sequence=packed_thd_single_sequence,
     )
     _assert_supported_indexer_scoring(use_relu)
+    # A nonpositive top-k or empty KV has no valid slot for the fixed-shape
+    # backward safe tile, so decline instead of entering the fused path.
     if (
         not absorbed_mla
         or value is not None
         or attn_mask_type != AttnMaskType.causal
+        or indexer_topk <= 0
+        or key.size(0) == 0
         or key.size(2) != 1
     ):
         return None
@@ -2352,9 +2356,9 @@ def _run_sparse_attention_backward(
     d: int,
     skv: int,
     grad_output: Tensor,
-    all_rows_nonempty: bool = False,
+    all_topk_rows_nonempty: bool = False,
 ) -> Tuple[Tensor, Tensor]:
-    """Run sparse attention backward, skipping rows that have no valid top-k entries."""
+    """Run sparse attention backward with fixed-shape handling for empty top-k rows."""
     d_v = out_flat.shape[-1]
     dO_flat = grad_output.reshape(sq * b, num_heads, d_v)
 
@@ -2383,56 +2387,31 @@ def _run_sparse_attention_backward(
         bwd_attn_sink[:num_heads] = attn_sink
 
     _ensure_dsa_namespace()
-    if all_rows_nonempty:
-        attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-            bwd_q_flat,
-            kv_flat,
-            bwd_out_flat,
-            bwd_dO_flat,
-            bwd_lse,
-            bwd_attn_sink,
-            global_idxs,
-            softmax_scale=softmax_scale,
-            topk_length=topk_length,
-        )
-        grad_query_flat = attn_bwd["dq"]
-        if padded_num_heads != num_heads:
-            grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
-        grad_kv_flat = attn_bwd["dkv"]
-        grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
-        grad_kv_full = grad_kv_flat.reshape(skv, b, kv_flat.size(-1))
-        return grad_query, grad_kv_full
-
-    valid_row_indices = torch.nonzero(topk_length > 0, as_tuple=False).flatten()
-    dummy_row_index = torch.full(
-        (1,), bwd_q_flat.size(0), dtype=valid_row_indices.dtype, device=valid_row_indices.device
-    )
-    compact_row_indices = torch.cat((valid_row_indices, dummy_row_index), dim=0)
-
-    # Add one zero-gradient row so the cuDNN wrapper never receives an empty query batch.
-    bwd_q_flat = torch.cat((bwd_q_flat, torch.zeros_like(bwd_q_flat[:1])), dim=0)
-    bwd_out_flat = torch.cat((bwd_out_flat, torch.zeros_like(bwd_out_flat[:1])), dim=0)
-    bwd_dO_flat = torch.cat((bwd_dO_flat, torch.zeros_like(bwd_dO_flat[:1])), dim=0)
-    bwd_lse = torch.cat((bwd_lse, torch.zeros_like(bwd_lse[:1])), dim=0)
-    global_idxs = torch.cat((global_idxs, torch.zeros_like(global_idxs[:1])), dim=0)
-    topk_length = torch.cat((topk_length, torch.ones_like(topk_length[:1])), dim=0)
+    empty_rows = None
+    if not all_topk_rows_nonempty:
+        empty_rows = topk_length <= 0
+        topk_length = topk_length.masked_fill(empty_rows, 1)
+        bwd_dO_flat = bwd_dO_flat.masked_fill(empty_rows[:, None, None], 0)
+        # FlashMLA already returns zero output and LSE=+inf for empty rows. Preserve
+        # that LSE invariant after promoting them to one safe tile so probabilities stay zero.
+        bwd_lse = bwd_lse.masked_fill(empty_rows[:, None], float("inf"))
 
     attn_bwd = _cudnn_dsa.sparse_attention_backward_wrapper(
-        bwd_q_flat.index_select(0, compact_row_indices).contiguous(),
+        bwd_q_flat,
         kv_flat,
-        bwd_out_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_dO_flat.index_select(0, compact_row_indices).contiguous(),
-        bwd_lse.index_select(0, compact_row_indices).contiguous(),
+        bwd_out_flat,
+        bwd_dO_flat,
+        bwd_lse,
         bwd_attn_sink,
-        global_idxs.index_select(0, compact_row_indices).contiguous(),
+        global_idxs,
         softmax_scale=softmax_scale,
-        topk_length=topk_length.index_select(0, compact_row_indices).contiguous(),
+        topk_length=topk_length,
     )
-    grad_query_valid = attn_bwd["dq"][:-1]
+    grad_query_flat = attn_bwd["dq"]
     if padded_num_heads != num_heads:
-        grad_query_valid = grad_query_valid[:, :num_heads, :].contiguous()
-    grad_query_flat = torch.zeros_like(q_flat)
-    grad_query_flat.index_copy_(0, valid_row_indices, grad_query_valid)
+        grad_query_flat = grad_query_flat[:, :num_heads, :].contiguous()
+    if empty_rows is not None:
+        grad_query_flat.masked_fill_(empty_rows[:, None, None], 0)
     grad_kv_flat = attn_bwd["dkv"]
 
     grad_query = grad_query_flat.reshape(sq, b, num_heads, d)
@@ -2540,6 +2519,28 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             )
         )
 
+        # Backend-normalized counterpart of dsa._can_prove_all_topk_rows_nonempty:
+        # plain-causal bounds are None here, while dispatch already implies the
+        # helper's attention-mask and computes-topk gates.
+        all_topk_rows_nonempty = (
+            effective_topk > 0
+            and skv > 0
+            and query_valid_rows is None
+            and (
+                (varlen_starts is None and varlen_ends is None and key_positions is None)
+                or (
+                    use_local_indexer_varlen
+                    and varlen_starts is not None
+                    and varlen_ends is not None
+                    and key_positions is None
+                )
+            )
+        )
+        if not all_topk_rows_nonempty:
+            # The dummy may reference any in-range global KV row: backward forces
+            # dO=0 and LSE=+inf, so this tile contributes no gradient across batches.
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
+
         if need_indexer_loss:
             if sparse_loss:
                 if indexer_score_payload is None:
@@ -2623,13 +2624,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
-        ctx.all_sparse_bwd_rows_nonempty = (
-            query_valid_rows is None
-            and use_local_indexer_varlen
-            and varlen_starts is not None
-            and varlen_ends is not None
-            and key_positions is None
-        )
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         output = out_flat.reshape(sq, b, num_heads, d_v).reshape(sq, b, num_heads * d_v)
         return output, indexer_loss
@@ -2667,7 +2662,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
-            all_rows_nonempty=ctx.all_sparse_bwd_rows_nonempty,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
         if ctx.has_precomputed_indexer_grads and grad_loss is not None:
@@ -2881,6 +2876,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         softmax_scale: float,
         d_v: int,
         topk_length: Optional[Tensor],
+        all_topk_rows_nonempty: bool,
     ) -> Tensor:
         """Run fused sparse attention for precomputed top-k metadata."""
         sq, b, num_heads, d = query.shape
@@ -2890,6 +2886,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
                 query, kv_full, topk_indices, softmax_scale, d_v, topk_length=topk_length
             )
         )
+        if not all_topk_rows_nonempty:
+            # The dummy may reference any in-range global KV row: backward forces
+            # dO=0 and LSE=+inf, so this tile contributes no gradient across batches.
+            global_idxs[:, 0].masked_fill_(topk_length_flat <= 0, 0)
 
         ctx.save_for_backward(q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse)
         ctx.softmax_scale = softmax_scale
@@ -2899,6 +2899,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
         ctx.num_heads = num_heads
         ctx.d = d
         ctx.skv = skv
+        ctx.all_topk_rows_nonempty = all_topk_rows_nonempty
 
         return out_flat.reshape(sq, b, num_heads, d_v)
 
@@ -2924,9 +2925,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
             d=d,
             skv=skv,
             grad_output=grad_output,
+            all_topk_rows_nonempty=ctx.all_topk_rows_nonempty,
         )
 
-        return grad_query, grad_kv_full, None, None, None, None
+        return grad_query, grad_kv_full, None, None, None, None, None
 
 
 def run_fused_absorbed_sparse_attention(
@@ -2936,11 +2938,13 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Run cuDNN/FlashMLA sparse attention using externally supplied top-k indices."""
     if query.ndim != 4 or key.ndim != 4 or topk_indices.ndim != 3:
         return None
-    if key.size(2) != 1 or v_channels <= 0:
+    # Empty KV or zero-width top-k cannot provide a valid fixed-shape backward safe tile.
+    if key.size(0) == 0 or key.size(2) != 1 or topk_indices.size(2) == 0 or v_channels <= 0:
         return None
     if query.size(0) != topk_indices.size(1) or query.size(1) != topk_indices.size(0):
         return None
@@ -2953,7 +2957,7 @@ def run_fused_absorbed_sparse_attention(
 
     kv_full = key.squeeze(2).contiguous()
     return FusedSparseAttentionFunc.apply(
-        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length
+        query, kv_full, topk_indices, softmax_scale, v_channels, topk_length, all_topk_rows_nonempty
     )
 
 

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -312,12 +312,21 @@ def run_fused_absorbed_sparse_attention(
     softmax_scale: float,
     v_channels: int,
     topk_length: Optional[Tensor] = None,
+    all_topk_rows_nonempty: bool = False,
 ) -> Optional[Tensor]:
     """Optional fused sparse-attention hook for backend-specific implementations."""
     fn = _resolve_fused_hook(config, "run_fused_absorbed_sparse_attention")
     if fn is None:
         return None
-    result = fn(query, key, topk_indices, softmax_scale, v_channels, topk_length)
+    result = fn(
+        query,
+        key,
+        topk_indices,
+        softmax_scale,
+        v_channels,
+        topk_length,
+        **_hook_kwargs_accepting(fn, all_topk_rows_nonempty=all_topk_rows_nonempty),
+    )
     if result is None:
         _log_declined_hook(config, "run_fused_absorbed_sparse_attention", "backend returned None")
     return result

--- a/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_kernels.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from importlib import import_module
 from types import ModuleType
@@ -25,6 +26,7 @@ _BACKEND_MODULE_NAME_BY_BACKEND = {
 _BACKEND: Optional[ModuleType] = None
 _BACKEND_SELECTION: Optional[str] = None
 _LOGGER = logging.getLogger(__name__)
+_HOOK_KWARG_SIGNATURE_CACHE: dict[int, tuple[object, Optional[frozenset[str]], bool]] = {}
 
 
 def _get_dsa_kernel_backend(config: TransformerConfig) -> str:
@@ -74,6 +76,74 @@ def _log_declined_hook(config: TransformerConfig, hook_name: str, reason: str) -
     )
 
 
+def _hook_kwargs_accepting(fn, *, opaque_fallback_names: Tuple[str, ...] = (), **candidate_kwargs):
+    """Keep only the kwargs ``fn`` can accept.
+
+    Backend hooks are resolved dynamically and may live out of tree; passing a
+    keyword an older backend does not know would fail with a TypeError at the
+    first fused call rather than a clean decline. Opaque C/pybind hooks receive
+    no newly introduced kwargs by default, but callers can name kwargs that
+    predate this filtering so an unavailable signature does not break an
+    existing hook contract.
+    """
+    cache_key = id(fn)
+    cached = _HOOK_KWARG_SIGNATURE_CACHE.get(cache_key)
+    if cached is not None and cached[0] is fn:
+        accepted_names = cached[1]
+        signature_is_opaque = cached[2]
+    else:
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):
+            # Opaque C/pybind hooks cannot safely receive a newly introduced keyword.
+            accepted_names = frozenset()
+            signature_is_opaque = True
+        else:
+            signature_is_opaque = False
+            if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+                accepted_names = None
+            else:
+                accepted_names = frozenset(
+                    name
+                    for name, parameter in sig.parameters.items()
+                    if parameter.kind
+                    in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+                )
+        # Retain the callable so Python object-id reuse cannot apply a stale signature.
+        _HOOK_KWARG_SIGNATURE_CACHE[cache_key] = (fn, accepted_names, signature_is_opaque)
+
+    if accepted_names is None:
+        return candidate_kwargs
+    if signature_is_opaque:
+        accepted_names = frozenset(opaque_fallback_names)
+    return {k: v for k, v in candidate_kwargs.items() if k in accepted_names}
+
+
+def _packed_layout_hook_kwargs(
+    fn,
+    *,
+    varlen_is_plain_causal: bool,
+    packed_thd_causal_identity_layout: bool,
+    packed_thd_single_sequence: bool,
+    opaque_fallback_names: Tuple[str, ...] = (),
+):
+    """Offer CP-independent layout facts only to hooks that declare support."""
+    return _hook_kwargs_accepting(
+        fn,
+        opaque_fallback_names=opaque_fallback_names,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        packed_thd_causal_identity_layout=packed_thd_causal_identity_layout,
+        packed_thd_single_sequence=packed_thd_single_sequence,
+    )
+
+
+def _legacy_packed_cp_flags(
+    *, cp_size: int, use_local_indexer_varlen: bool, single_packed_thd_sequence: bool
+) -> Tuple[bool, bool]:
+    """Preserve the historical CP-only meaning of existing backend hook flags."""
+    return (use_local_indexer_varlen and cp_size > 1, single_packed_thd_sequence and cp_size > 1)
+
+
 def _resolve_fused_hook(config: TransformerConfig, hook_name: str):
     """Return the selected backend's ``hook_name`` callable, or None if unavailable.
 
@@ -114,11 +184,23 @@ def run_fused_qk_topk(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional[PackedSeqParams] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Optional[Tensor]]]:
-    """Optional fused indexer hook for backend-specific implementations."""
+    """Optional fused indexer hook for backend-specific implementations.
+
+    The existing ``single_packed_thd_sequence`` and ``use_local_indexer_varlen``
+    backend kwargs retain their historical CP-only meaning. CP-independent layout
+    facts are offered as optional, signature-filtered kwargs so older out-of-tree
+    hooks cannot silently enter a CP path for a CP=1 pack.
+    """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         q=q,
         k=k,
@@ -128,13 +210,19 @@ def run_fused_qk_topk(
         ends=ends,
         block_size=block_size,
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+        ),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk", "backend returned None")
@@ -165,11 +253,21 @@ def run_fused_qk_topk_with_loss(
     local_packed_cp_query_len: Optional[int] = None,
     packed_seq_params: Optional[PackedSeqParams] = None,
     cp_size: int = 1,
+    varlen_is_plain_causal: bool = False,
 ) -> Optional[Tuple[Tensor, Optional[Tensor], Tensor]]:
-    """Optional fused indexer+loss hook for backend-specific implementations."""
+    """Optional fused indexer+loss hook for backend-specific implementations.
+
+    The existing packed-layout kwargs retain their historical CP-only meaning;
+    CP-independent facts use optional, signature-filtered kwargs.
+    """
     fn = _resolve_fused_hook(config, "run_fused_qk_topk_with_loss")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         config=config,
         q=q,
@@ -187,13 +285,19 @@ def run_fused_qk_topk_with_loss(
         query_valid_rows=query_valid_rows,
         calculate_per_token_loss=calculate_per_token_loss,
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,
         packed_seq_params=packed_seq_params,
         cp_size=cp_size,
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+        ),
     )
     if result is None:
         _log_declined_hook(config, "run_fused_qk_topk_with_loss", "backend returned None")
@@ -251,10 +355,19 @@ def run_fused_dsa_attention(
     local_packed_cp_query_len: Optional[int] = None,
     pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> Optional[Tuple[Tensor, Tensor]]:
-    """Optional full fused DSA hook for backends that fuse indexer and attention together."""
+    """Optional full fused DSA hook for backends that fuse indexer and attention together.
+
+    The existing packed-layout kwargs retain their historical CP-only meaning;
+    CP-independent facts use optional, signature-filtered kwargs.
+    """
     fn = _resolve_fused_hook(config, "run_fused_dsa_attention")
     if fn is None:
         return None
+    legacy_local_varlen, legacy_single_sequence = _legacy_packed_cp_flags(
+        cp_size=cp_size,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
     result = fn(
         config=config,
         query=query,
@@ -277,10 +390,18 @@ def run_fused_dsa_attention(
         varlen_ends=varlen_ends,
         key_positions=key_positions,
         query_valid_rows=query_valid_rows,
-        varlen_is_plain_causal=varlen_is_plain_causal,
+        **_packed_layout_hook_kwargs(
+            fn,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            packed_thd_causal_identity_layout=use_local_indexer_varlen,
+            packed_thd_single_sequence=single_packed_thd_sequence,
+            # ``varlen_is_plain_causal`` was already part of the full-hook
+            # contract before optional kwarg filtering was introduced.
+            opaque_fallback_names=("varlen_is_plain_causal",),
+        ),
         use_relu=use_relu,
-        use_local_indexer_varlen=use_local_indexer_varlen,
-        single_packed_thd_sequence=single_packed_thd_sequence,
+        use_local_indexer_varlen=legacy_local_varlen,
+        single_packed_thd_sequence=legacy_single_sequence,
         local_packed_cp_rank=local_packed_cp_rank,
         local_packed_cp_query_start=local_packed_cp_query_start,
         local_packed_cp_query_len=local_packed_cp_query_len,

--- a/megatron/core/transformer/experimental_attention_variant/dsa_layout.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_layout.py
@@ -3,7 +3,7 @@
 """Layout helpers for DeepSeek sparse attention."""
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -22,6 +22,8 @@ __all__ = [
     "get_cp_positions_from_layout",
     "get_packed_qk_cu_seqlens",
     "normalize_cp_comm_type",
+    "build_packed_allgather_cp_local_positions_from_host",
+    "build_packed_allgather_cp_query_positions_and_key_reorder_from_host",
 ]
 
 
@@ -305,6 +307,102 @@ def build_packed_allgather_cp_local_positions(
     return segment_starts.index_select(0, segment_ids) + segment_offsets
 
 
+def build_packed_allgather_cp_all_rank_positions(
+    cu_seqlens: torch.Tensor,
+    cp_size: int,
+    device: torch.device,
+    output_size: Optional[int] = None,
+    *,
+    cu_seqlens_cover_output: bool = False,
+) -> torch.Tensor:
+    """Build every CP rank's local packed positions at once: ``[cp_size, output_size]``.
+
+    Row ``r`` is identical to
+    ``build_packed_allgather_cp_local_positions(..., cp_rank=r, ...)``.
+
+    Doing all ranks together is worth a separate function because every expensive
+    step is rank-invariant. ``cp_rank`` enters only through ``front_starts`` and
+    ``back_starts`` -- cheap elementwise expressions. In particular
+    ``segment_lens`` is ``stack(half, half)`` and so does not depend on the rank,
+    which means the ``nonzero``/``nonempty_segments`` boolean masks, and therefore
+    all of the data-dependent output shapes that force a device-to-host size
+    readback, are shared across ranks. The per-rank loop this replaces paid those
+    readbacks ``cp_size`` times over; here they are paid once.
+    """
+    cu_seqlens_i64 = cu_seqlens.to(device=device, dtype=torch.int64)
+    if cp_size <= 1:
+        return build_packed_allgather_cp_local_positions(
+            cu_seqlens,
+            cp_size,
+            0,
+            device,
+            output_size=output_size,
+            cu_seqlens_cover_output=cu_seqlens_cover_output,
+        ).unsqueeze(0)
+
+    seq_starts = cu_seqlens_i64[:-1]
+    seq_ends = cu_seqlens_i64[1:]
+    seq_lens = seq_ends - seq_starts
+    nonzero = seq_lens > 0
+    seq_starts = seq_starts[nonzero]
+    seq_ends = seq_ends[nonzero]
+    seq_lens = seq_lens[nonzero]
+    if seq_lens.numel() == 0:
+        return torch.empty((cp_size, 0), dtype=torch.int64, device=device)
+
+    # Host-side guard for CPU/test callers; mirrors the single-rank builder.
+    if cu_seqlens_i64.device.type == "cpu":
+        bad_divisible = seq_lens[seq_lens % cp_size != 0]
+        if bad_divisible.numel() > 0:
+            raise ValueError(
+                "Packed DSA CP expects per-sequence padded lengths divisible by cp_size, got "
+                f"seq_len={int(bad_divisible[0].item())}, cp_size={cp_size}"
+            )
+        bad_local = seq_lens[(seq_lens // cp_size) % 2 != 0]
+        if bad_local.numel() > 0:
+            seq_len = int(bad_local[0].item())
+            raise ValueError(
+                "Packed DSA CP expects per-rank packed sequence lengths divisible by 2, got "
+                f"local_seq_len={seq_len // cp_size}, seq_len={seq_len}, cp_size={cp_size}"
+            )
+
+    half_seq_lens = (seq_lens // cp_size) // 2
+    ranks = torch.arange(cp_size, dtype=torch.int64, device=device).unsqueeze(1)
+    # [cp_size, n_seq]
+    front_starts = seq_starts.unsqueeze(0) + ranks * half_seq_lens.unsqueeze(0)
+    back_starts = seq_ends.unsqueeze(0) - (ranks + 1) * half_seq_lens.unsqueeze(0)
+    # Interleave to [f0, b0, f1, b1, ...] per row, matching the single-rank builder.
+    segment_starts = torch.stack((front_starts, back_starts), dim=2).reshape(cp_size, -1)
+    segment_lens = torch.stack((half_seq_lens, half_seq_lens), dim=1).reshape(-1)
+    nonempty_segments = segment_lens > 0
+    segment_starts = segment_starts[:, nonempty_segments]
+    segment_lens = segment_lens[nonempty_segments]
+
+    if output_size is None:
+        output_size = int(segment_lens.sum().item())
+    if output_size == 0:
+        return torch.empty((cp_size, 0), dtype=torch.int64, device=device)
+    if not cu_seqlens_cover_output:
+        pad_len = (
+            torch.tensor(output_size, dtype=torch.int64, device=device) - segment_lens.sum()
+        ).clamp_min(0)
+        # Per-rank padding origin, matching cu_seqlens[-1] + cp_rank * output_size.
+        pad_start = cu_seqlens_i64[-1] + ranks.reshape(-1) * output_size
+        segment_starts = torch.cat((segment_starts, pad_start.unsqueeze(1)), dim=1)
+        segment_lens = torch.cat((segment_lens, pad_len.view(1)), dim=0)
+
+    segment_ids = torch.repeat_interleave(
+        torch.arange(segment_lens.numel(), dtype=torch.int64, device=device),
+        segment_lens,
+        output_size=output_size,
+    )
+    segment_offsets = torch.arange(output_size, dtype=torch.int64, device=device)
+    segment_offsets -= torch.repeat_interleave(
+        torch.cumsum(segment_lens, dim=0) - segment_lens, segment_lens, output_size=output_size
+    )
+    return segment_starts.index_select(1, segment_ids) + segment_offsets.unsqueeze(0)
+
+
 def build_packed_allgather_cp_query_positions_and_key_reorder(
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_kv: torch.Tensor,
@@ -336,18 +434,15 @@ def build_packed_allgather_cp_query_positions_and_key_reorder(
     )
     if key_local_output_size is None:
         key_local_output_size = local_output_size
-    gathered_key_positions = [
-        build_packed_allgather_cp_local_positions(
-            cu_seqlens_kv,
-            cp_size,
-            rank,
-            device,
-            output_size=key_local_output_size,
-            cu_seqlens_cover_output=key_cu_seqlens_cover_output,
-        )
-        for rank in range(cp_size)
-    ]
-    gathered_key_positions = torch.cat(gathered_key_positions, dim=0)
+    # All ranks in one batched build. Row-major flattening reproduces exactly the
+    # rank0-local, rank1-local, ... concatenation the gathered KV tensor is in.
+    gathered_key_positions = build_packed_allgather_cp_all_rank_positions(
+        cu_seqlens_kv,
+        cp_size,
+        device,
+        output_size=key_local_output_size,
+        cu_seqlens_cover_output=key_cu_seqlens_cover_output,
+    ).reshape(-1)
     key_reorder_idx = torch.argsort(gathered_key_positions)
     if global_output_size is not None and key_reorder_idx.numel() != global_output_size:
         raise RuntimeError(
@@ -355,6 +450,161 @@ def build_packed_allgather_cp_query_positions_and_key_reorder(
             f"expected {global_output_size}"
         )
     return query_positions, key_reorder_idx
+
+
+def _host_packed_cp_spans(
+    host_cu_seqlens: List[int], cp_size: int, cp_rank: int
+) -> List[Tuple[int, int]]:
+    """One rank's zigzag layout as ``(global_start, length)`` spans, from host ints.
+
+    The span decomposition is the same maths as the device builders above, but on a
+    Python list there is nothing to synchronize on: every length is already known.
+    Zero-length sequences contribute no spans, matching the device builders' filter.
+    """
+    spans: List[Tuple[int, int]] = []
+    for seq_start, seq_end in zip(host_cu_seqlens[:-1], host_cu_seqlens[1:]):
+        seq_len = seq_end - seq_start
+        if seq_len == 0:
+            continue
+        # The zigzag layout requires it, and on host integers the check is free --
+        # unlike the device builders, which can only validate without a sync on CPU
+        # inputs. Without it, non-divisible lengths would silently drop tokens here
+        # and leave uninitialized slots in the reorder buffer downstream.
+        if seq_len % (2 * cp_size) != 0:
+            raise ValueError(
+                "Packed DSA CP expects per-sequence padded lengths divisible by "
+                f"2 * cp_size ({2 * cp_size}), got seq_len={seq_len}"
+            )
+        half = seq_len // cp_size // 2
+        if half <= 0:
+            continue
+        spans.append((seq_start + cp_rank * half, half))
+        spans.append((seq_end - (cp_rank + 1) * half, half))
+    return spans
+
+
+def _host_to_device(values: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """Move a freshly built host tensor to ``device`` without blocking the CPU."""
+    if device.type == "cuda":
+        return values.pin_memory().to(device, non_blocking=True)
+    return values.to(device)
+
+
+def build_packed_allgather_cp_local_positions_from_host(
+    host_cu_seqlens: List[int],
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+    output_size: Optional[int] = None,
+    *,
+    cu_seqlens_cover_output: bool = False,
+) -> torch.Tensor:
+    """Host-side equivalent of :func:`build_packed_allgather_cp_local_positions`.
+
+    The device builder runs ~20 kernels over a few dozen integers and pays two
+    device-to-host size readbacks for its boolean-mask filters. When the compacted
+    ``cu_seqlens`` are already on the host -- ``prebuild_thd_cp_partition_routes``
+    stores them on ``PackedSeqParams`` at batch-construction time, where the one
+    blocking copy is cheap because the CUDA queue is still shallow -- the whole
+    table is a closed form over Python ints: zero kernels, zero synchronization,
+    one asynchronous host-to-device copy of the finished table.
+    """
+    if cp_size <= 1:
+        # Mirror the device builder: at cp_size <= 1 the local layout is the identity,
+        # with no zigzag halving (and therefore no even-length requirement).
+        if output_size is None:
+            output_size = host_cu_seqlens[-1]
+        return _host_to_device(torch.arange(output_size, dtype=torch.int64), device)
+    spans = _host_packed_cp_spans(host_cu_seqlens, cp_size, cp_rank)
+    real = (
+        torch.cat([torch.arange(start, start + length) for start, length in spans])
+        if spans
+        else torch.empty(0, dtype=torch.int64)
+    )
+    total = real.numel()
+    if output_size is None:
+        output_size = total
+    positions = torch.empty(output_size, dtype=torch.int64)
+    n = min(total, output_size)
+    positions[:n] = real[:n]
+    if output_size > n:
+        # The cover flag only ever accompanies output_size == total (dsa.py derives it
+        # from host max-seqlen metadata), so this branch is the not-covered case; fill
+        # it unconditionally rather than leave torch.empty garbage if a caller lies.
+        pad_start = host_cu_seqlens[-1] + cp_rank * output_size
+        positions[n:] = torch.arange(pad_start, pad_start + (output_size - n))
+    return _host_to_device(positions, device)
+
+
+def build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+    host_cu_seqlens_q: List[int],
+    host_cu_seqlens_kv: List[int],
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+    local_output_size: Optional[int] = None,
+    key_local_output_size: Optional[int] = None,
+    global_output_size: Optional[int] = None,
+    *,
+    query_cu_seqlens_cover_output: bool = False,
+    key_cu_seqlens_cover_output: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Host-side equivalent of the query-positions + key-reorder wrapper.
+
+    Besides removing the device builders' synchronizations, this replaces the
+    ``argsort`` over the gathered key positions with a direct inverse permutation.
+    The sort is unnecessary because the real positions of all ranks tile
+    ``[0, total_tokens)`` exactly once (every padded sequence length is divisible
+    by ``2 * cp_size``), so the rank of a value in sorted order *is* the value;
+    and the padding pseudo-positions ``total + r * output_size + j`` are unique
+    and already ascending in ``(rank, j)`` order. Both facts are pinned by the
+    bit-equality tests against the device path.
+    """
+    query_positions = build_packed_allgather_cp_local_positions_from_host(
+        host_cu_seqlens_q,
+        cp_size,
+        cp_rank,
+        device,
+        output_size=local_output_size,
+        cu_seqlens_cover_output=query_cu_seqlens_cover_output,
+    )
+    if key_local_output_size is None:
+        key_local_output_size = local_output_size
+
+    kv_total = host_cu_seqlens_kv[-1]
+    if cp_size <= 1:
+        # Identity layout: the gathered order is already the global order.
+        out = key_local_output_size if key_local_output_size is not None else kv_total
+        return query_positions, _host_to_device(torch.arange(out, dtype=torch.int64), device)
+    spans_by_rank = [
+        _host_packed_cp_spans(host_cu_seqlens_kv, cp_size, rank) for rank in range(cp_size)
+    ]
+    real_len = sum(length for _, length in spans_by_rank[0]) if spans_by_rank else 0
+    if real_len * cp_size != kv_total:
+        raise ValueError(
+            "Packed DSA CP spans do not tile the key stream: "
+            f"{cp_size} ranks x {real_len} real tokens != total {kv_total}"
+        )
+    out = key_local_output_size if key_local_output_size is not None else real_len
+    pad = max(0, out - real_len)
+    n = cp_size * out
+    if global_output_size is not None and n != global_output_size:
+        raise RuntimeError(
+            f"Packed DSA CP key reorder length mismatch: got {n}, " f"expected {global_output_size}"
+        )
+    key_reorder_idx = torch.empty(n, dtype=torch.int64)
+    for rank, spans in enumerate(spans_by_rank):
+        local = 0
+        for global_start, length in spans:
+            key_reorder_idx[global_start : global_start + length] = torch.arange(
+                rank * out + local, rank * out + local + length
+            )
+            local += length
+        if pad > 0:
+            key_reorder_idx[kv_total + rank * pad : kv_total + (rank + 1) * pad] = torch.arange(
+                rank * out + local, rank * out + out
+            )
+    return query_positions, _host_to_device(key_reorder_idx, device)
 
 
 def extract_query_positions_from_position_ids(

--- a/megatron/core/transformer/experimental_attention_variant/dsa_scoring_plan.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_scoring_plan.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Decide once how DSA indexer scoring will run, instead of re-deriving it per call.
+
+Choosing between the fused indexer scorer and the per-head fallback loop used to be
+spread across two files: ``DSAttention.forward`` assembled a handful of booleans
+(``use_local_indexer_varlen``, ``single_packed_thd_sequence``, the packed ``cu_seqlens``
+metadata), threaded them through the kernel dispatcher, and the dispatcher re-combined
+them into a branch. The decision existed only as the emergent result of those
+conditions, so a configuration that no fused kernel claimed simply fell through to the
+slow path with nothing reported.
+
+This module makes the decision a value. :func:`resolve_indexer_scoring_plan` is total --
+every configuration maps to some :class:`IndexerScoringPlan`, including
+:attr:`IndexerScoringPlan.UNFUSED_BOUNDS` -- and carries the reason it landed there, so
+callers can surface an unfused configuration instead of silently paying for it.
+
+Splitting the decision from its execution also separates two questions that the old
+conditions conflated: *what layout is this* versus *which kernel do we happen to have*.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import torch
+
+
+class IndexerScoringPlan(Enum):
+    """How indexer scores and top-k are produced for one attention call."""
+
+    PLAIN_CAUSAL = "plain_causal"
+    """Whole-sequence causal bounds. Reconstructible, so the single-kernel scorer runs."""
+
+    PACKED_SINGLE_SEGMENTS = "packed_single_segments"
+    """One sequence per pack, scored as one or more causal query/key segments."""
+
+    PACKED_THD_GENERAL = "packed_thd_general"
+    """General packed THD scoring driven by query/key cu_seqlens metadata."""
+
+    UNFUSED_BOUNDS = "unfused_bounds"
+    """No fused kernel claims this layout; scoring falls back to the per-head loop."""
+
+    DECLINE = "decline"
+    """Bounds cannot be built at all, so the caller must not attempt fused scoring."""
+
+    @property
+    def is_fused(self) -> bool:
+        """Whether this plan reaches a fused scoring kernel."""
+        return self in (
+            IndexerScoringPlan.PLAIN_CAUSAL,
+            IndexerScoringPlan.PACKED_SINGLE_SEGMENTS,
+            IndexerScoringPlan.PACKED_THD_GENERAL,
+        )
+
+
+@dataclass(frozen=True)
+class IndexerScoringDecision:
+    """A resolved plan plus the reason it was chosen.
+
+    ``reason`` is meant to be read by a human staring at a slow run, so it names the
+    condition that decided the outcome rather than restating the plan.
+    """
+
+    plan: IndexerScoringPlan
+    reason: str
+
+    @property
+    def is_fused(self) -> bool:
+        """Whether the chosen plan reaches a fused scoring kernel."""
+        return self.plan.is_fused
+
+
+def resolve_indexer_scoring_plan(
+    *,
+    bounds_available: bool,
+    varlen_is_plain_causal: bool,
+    packed_thd: bool,
+    cp_size: int,
+    mask_is_causal: bool,
+    explicit_key_positions: bool,
+    single_sequence_pack: bool,
+    packed_metadata_available: bool,
+    segment_kernel_applicable: bool = True,
+) -> IndexerScoringDecision:
+    """Resolve how indexer scoring should run for one attention call.
+
+    The arguments are facts about the layout, not capability flags: whoever calls this
+    does not need to know which kernels exist. Ordering matters only in that the
+    earlier clauses describe strictly more specific layouts.
+
+    Args:
+        bounds_available: The caller managed to build ``(starts, ends)`` key bounds.
+        varlen_is_plain_causal: Those bounds are the trivial whole-sequence causal ones,
+            as flagged by the mask builder, so a kernel can rebuild them itself.
+        packed_thd: Sequences are packed into a THD buffer.
+        cp_size: Context-parallel world size.
+        mask_is_causal: The attention mask type is plain causal.
+        explicit_key_positions: Custom key positions are in play, so bounds alone do not
+            describe the layout.
+        single_sequence_pack: This microbatch's pack holds exactly one sequence. This is
+            the only input here that varies batch to batch.
+        packed_metadata_available: ``cu_seqlens`` and max-seqlen metadata are present.
+        segment_kernel_applicable: The single-sequence segment kernel's structural
+            preconditions hold for this call. It raises rather than declining when they
+            do not, so the plan must not promise it.
+
+    Returns:
+        The resolved plan and the reason for it.
+    """
+    if explicit_key_positions:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.DECLINE, "custom key positions are not expressible as bounds"
+        )
+    if not bounds_available:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.DECLINE, "key bounds could not be built for this mask"
+        )
+
+    if varlen_is_plain_causal and not packed_thd and cp_size == 1:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.PLAIN_CAUSAL, "whole-sequence causal bounds are reconstructible"
+        )
+
+    if packed_thd and mask_is_causal:
+        if single_sequence_pack and segment_kernel_applicable:
+            return IndexerScoringDecision(
+                IndexerScoringPlan.PACKED_SINGLE_SEGMENTS,
+                "one sequence per pack, scored as causal segments",
+            )
+        # General THD scoring is independent of context-parallel world size. It is the
+        # normal multi-sequence path and also the safe fallback when the specialized
+        # single-sequence segment executor cannot take this call's shape.
+        if packed_metadata_available:
+            return IndexerScoringDecision(
+                IndexerScoringPlan.PACKED_THD_GENERAL,
+                (
+                    "single-sequence pack falling back to cu_seqlens metadata"
+                    if single_sequence_pack
+                    else "multi-sequence pack with cu_seqlens metadata"
+                ),
+            )
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS,
+            (
+                "single-sequence pack whose segment shape is unsupported and whose "
+                "cu_seqlens metadata is unavailable or incompatible"
+                if single_sequence_pack
+                else "packed THD without compatible cu_seqlens metadata"
+            ),
+        )
+
+    # Everything below is a layout no fused kernel currently claims. Name the specific
+    # reason: these are the configurations worth widening a gate for.
+    if not packed_thd and cp_size > 1:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS,
+            "context parallelism without sequence packing has no fused scoring path",
+        )
+    if not mask_is_causal:
+        return IndexerScoringDecision(
+            IndexerScoringPlan.UNFUSED_BOUNDS, "non-causal mask has no fused scoring path"
+        )
+    return IndexerScoringDecision(
+        IndexerScoringPlan.UNFUSED_BOUNDS, "bounds are not reconstructible by any fused kernel"
+    )
+
+
+_REPORTED_UNFUSED: set = set()
+
+
+def report_unfused_scoring_once(decision: IndexerScoringDecision, context: str) -> Optional[str]:
+    """Log an unfused scoring plan the first time each distinct reason appears.
+
+    A configuration that misses every fused kernel is a throughput cliff with no other
+    symptom, so it should say so once rather than never. Returns the emitted message, or
+    ``None`` if this reason was already reported.
+    """
+    if decision.is_fused or decision.plan is IndexerScoringPlan.DECLINE:
+        return None
+    key = f"{context}|{decision.reason}"
+    if key in _REPORTED_UNFUSED:
+        return None
+    _REPORTED_UNFUSED.add(key)
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    message = (
+        f"DSA indexer scoring falls back to the unfused per-head loop ({context}, "
+        f"rank {rank}): {decision.reason}."
+    )
+    # Deliberately not rank-0-only: with heterogeneous packs a non-zero rank can sit
+    # on the unfused cliff while rank 0 stays fused, which is exactly the silent case
+    # this exists to surface. The once-per-reason set bounds the volume per process.
+    logging.getLogger(__name__).warning(message)
+    return message

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -281,15 +281,15 @@ class GraphableMegatronModule(MegatronModule):
             and self.config.cuda_graph_impl != "none"
         )
 
-    def get_layer_static_inputs(self, seq_length, micro_batch_size):
+    def get_layer_static_inputs(self, seq_length, micro_batch_size, *, for_pipeline_prewarm=False):
         """
-        Get the static inputs for the layer.
+        Get synthetic inputs for the layer.
         We assume that the module has one hidden_states input, whose shape is inferred
         from the seq_length, micro_batch_size, and parallel config.
         Override this method if the module has other inputs.
 
-        For THD + CUDA Graph, hidden_states uses the padded max sequence length with
-        micro_batch_size=1 (packed sequence format).
+        For THD CUDA Graph capture or pipeline prewarm, hidden_states uses the padded maximum
+        sequence length with micro_batch_size=1 (packed sequence format).
 
         Returns:
             Dict[str, torch.Tensor]: A dictionary containing the static inputs for the layer.
@@ -299,11 +299,15 @@ class GraphableMegatronModule(MegatronModule):
         sequence_parallel = self.config.sequence_parallel
         tensor_model_parallel_size = self.config.tensor_model_parallel_size
 
-        if self._is_thd_cuda_graph():
-            # THD + CUDA Graph: pre-padded packed-sequence buffer, batch dim = 1.
+        use_padded_thd = self._is_thd_cuda_graph() or (
+            for_pipeline_prewarm
+            and getattr(self.config, 'sequence_packing_scheduler', None) is not None
+        )
+        if use_padded_thd:
+            # THD static execution: pre-padded packed-sequence buffer, batch dim = 1.
             assert (
                 self.config.max_seqlen_per_dp_cp_rank is not None
-            ), "max_seqlen_per_dp_cp_rank must be set when using THD format with CUDA Graph."
+            ), "max_seqlen_per_dp_cp_rank must be set for padded THD synthetic inputs."
             slen_full = self.config.max_seqlen_per_dp_cp_rank
             batch = 1
         else:

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -1354,6 +1354,15 @@ class PagedStashRunner:
                 f"{self._te_graph_runtime_num_microbatches}, got {num_microbatches}."
             )
 
+    def _restore_full_iteration_paged_stash_replay_state(self, training: bool) -> None:
+        """Restore stash enablement when full-iteration replay skips the Python schedule."""
+
+        if not isinstance(self.forward_backward_func, FullCudaGraphWrapper):
+            return
+        stage = "training" if training else "validation"
+        if FullCudaGraphWrapper.cuda_graph[stage] is not None:
+            self.stash_manager.enabled = training and self.config.moe_paged_stash
+
     def prepare_for_rerun(self, is_training=True):
         """Prepare for rerun"""
         log_single_rank(
@@ -1449,6 +1458,7 @@ class PagedStashRunner:
 
         training = not kwargs['forward_only']
         data_iterator = kwargs['data_iterator']
+        self._restore_full_iteration_paged_stash_replay_state(training)
         self._validate_te_whole_moe_graph_runtime(training, num_microbatches)
         saved_moe_paged_stash = self.config.moe_paged_stash
         num_tries = 0

--- a/megatron/core/transformer/mtp_sequence_roll.py
+++ b/megatron/core/transformer/mtp_sequence_roll.py
@@ -1,0 +1,1935 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
+
+_MTP_SEQUENCE_FIELD_FILL_VALUES = {
+    "input_ids": 0,
+    "position_ids": 0,
+    "labels": 0,
+    "loss_mask": 0,
+    "padding_mask": True,
+}
+
+
+# Shared field state and addressing.
+
+
+@dataclass(frozen=True)
+class MTPSequenceRollField:
+    """One immutable field descriptor for absolute sequence-roll access.
+
+    ``sequence_dim`` and ``batch_dim`` describe the logical row layout. All
+    remaining dimensions are payload dimensions and are preserved when a shifted
+    row is materialized. The context never modifies the source tensor; external
+    mutation is detected through the tensor version when available.
+    """
+
+    key: str
+    tensor: Tensor
+    sequence_dim: int
+    batch_dim: int
+    fill_value: Union[bool, int, float] = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.key, str) or not self.key:
+            raise ValueError("An MTP sequence-roll field key must be a non-empty string.")
+        if not isinstance(self.tensor, Tensor):
+            raise TypeError("An MTP sequence-roll field payload must be a tensor.")
+        if self.tensor.dim() < 2:
+            raise ValueError("An MTP sequence-roll field needs sequence and batch dimensions.")
+        sequence_dim = _normalize_mtp_sequence_roll_dim(
+            self.sequence_dim, self.tensor.dim(), name=f"{self.key}.sequence_dim"
+        )
+        batch_dim = _normalize_mtp_sequence_roll_dim(
+            self.batch_dim, self.tensor.dim(), name=f"{self.key}.batch_dim"
+        )
+        if sequence_dim == batch_dim:
+            raise ValueError(
+                f"MTP sequence-roll field {self.key!r} uses one dimension for sequence and batch."
+            )
+
+
+@dataclass(frozen=True)
+class MTPSequenceRollAddress:
+    """Canonical source-plus-halo address for one absolute roll offset.
+
+    Roll offset zero denotes the source row, and roll offset ``k`` denotes its
+    ``k``-th successor. A legacy cumulative ``roll_depth=d`` therefore consumes
+    absolute roll offset ``d + 1``.
+    """
+
+    source: Tensor
+    halo: Optional[Tensor]
+    row_indices: Tensor
+    valid_rows: Tensor
+
+
+@dataclass(frozen=True)
+class _PreparedMTPSequenceRollField:
+    """Canonical ``[sequence, batch, ...]`` field and layout restoration state."""
+
+    key: str
+    source: Tensor
+    source_id: int
+    source_version: Optional[int]
+    inverse_permutation: Tuple[int, ...]
+    halo: Optional[Tensor]
+    fill_value: Union[bool, int, float]
+    fill_tensor: Tensor
+
+    def restore(self, canonical: Tensor) -> Tensor:
+        """Restore a canonical sequence-roll tensor to its declared layout."""
+        return canonical.permute(self.inverse_permutation)
+
+
+def _normalize_mtp_sequence_roll_dim(dim: int, ndim: int, *, name: str) -> int:
+    """Normalize a field dimension while rejecting out-of-range indexing."""
+    if not isinstance(dim, int) or not -ndim <= dim < ndim:
+        raise ValueError(f"{name}={dim!r} is invalid for a {ndim}-dimensional tensor.")
+    return dim % ndim
+
+
+def _get_mtp_sequence_roll_source_version(tensor: Tensor) -> Optional[int]:
+    """Return the mutation version, or ``None`` for inference tensors."""
+    try:
+        return tensor._version
+    except RuntimeError:
+        # Inference tensors intentionally do not carry version counters. They
+        # may still be prepared, but a context cannot safely prove reuse.
+        return None
+
+
+def _canonicalize_mtp_sequence_roll_field(
+    field: MTPSequenceRollField, *, sequence_length: int, batch_size: int, device: torch.device
+) -> _PreparedMTPSequenceRollField:
+    """Validate one field and expose it as ``[sequence, batch, ...]``."""
+    sequence_dim = _normalize_mtp_sequence_roll_dim(
+        field.sequence_dim, field.tensor.dim(), name=f"{field.key}.sequence_dim"
+    )
+    batch_dim = _normalize_mtp_sequence_roll_dim(
+        field.batch_dim, field.tensor.dim(), name=f"{field.key}.batch_dim"
+    )
+    if sequence_dim == batch_dim:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} uses one dimension for sequence and batch."
+        )
+    permutation = (sequence_dim, batch_dim) + tuple(
+        dim for dim in range(field.tensor.dim()) if dim not in (sequence_dim, batch_dim)
+    )
+    inverse_permutation = tuple(permutation.index(dim) for dim in range(field.tensor.dim()))
+    source = field.tensor.permute(permutation)
+    if source.size(0) != sequence_length:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} has sequence length {source.size(0)}, "
+            f"expected {sequence_length}."
+        )
+    if source.size(1) != batch_size:
+        raise ValueError(
+            f"MTP sequence-roll field {field.key!r} has batch size {source.size(1)}, "
+            f"expected {batch_size}."
+        )
+    if source.device != device:
+        raise ValueError("All fields sharing an MTP sequence-roll context must use its device.")
+    return _PreparedMTPSequenceRollField(
+        key=field.key,
+        source=source,
+        source_id=id(field.tensor),
+        source_version=_get_mtp_sequence_roll_source_version(field.tensor),
+        inverse_permutation=inverse_permutation,
+        halo=None,
+        fill_value=field.fill_value,
+        fill_tensor=field.tensor.new_full((), field.fill_value),
+    )
+
+
+def _validate_mtp_sequence_roll_fields(
+    fields: Sequence[MTPSequenceRollField],
+    *,
+    sequence_length: int,
+    batch_size: int,
+    device: torch.device,
+) -> Tuple[_PreparedMTPSequenceRollField, ...]:
+    """Validate a complete replacement field group before any communication."""
+    fields = tuple(fields)
+    keys = [field.key for field in fields]
+    if len(set(keys)) != len(keys):
+        raise ValueError("Each MTP sequence-roll field key may be prepared only once.")
+    return tuple(
+        _canonicalize_mtp_sequence_roll_field(
+            field, sequence_length=sequence_length, batch_size=batch_size, device=device
+        )
+        for field in fields
+    )
+
+
+def _get_mtp_sequence_roll_field(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...], key: str
+) -> _PreparedMTPSequenceRollField:
+    """Return one prepared field or raise a precise lookup error."""
+    for prepared in prepared_fields:
+        if prepared.key == key:
+            return prepared
+    raise KeyError(f"MTP sequence-roll field {key!r} has not been prepared.")
+
+
+def _mtp_sequence_roll_field_matches_source(
+    prepared: _PreparedMTPSequenceRollField, field: MTPSequenceRollField
+) -> bool:
+    """Return whether a prepared field still describes this exact tensor source."""
+    source_version = _get_mtp_sequence_roll_source_version(field.tensor)
+    if (
+        prepared.key != field.key
+        or prepared.source_id != id(field.tensor)
+        or prepared.source_version is None
+        or source_version is None
+        or prepared.source_version != source_version
+        or prepared.fill_value != field.fill_value
+    ):
+        return False
+    try:
+        candidate = _canonicalize_mtp_sequence_roll_field(
+            field,
+            sequence_length=prepared.source.size(0),
+            batch_size=prepared.source.size(1),
+            device=prepared.source.device,
+        )
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    try:
+        return (
+            candidate.inverse_permutation == prepared.inverse_permutation
+            and candidate.source.shape == prepared.source.shape
+            and candidate.source.stride() == prepared.source.stride()
+            and candidate.source.storage_offset() == prepared.source.storage_offset()
+            and candidate.source.data_ptr() == prepared.source.data_ptr()
+            and candidate.source.dtype == prepared.source.dtype
+            and candidate.source.layout == prepared.source.layout
+        )
+    except RuntimeError:
+        return False
+
+
+def _materialize_mtp_sequence_roll_rows(
+    prepared: _PreparedMTPSequenceRollField, row_indices: Tensor, valid_rows: Tensor
+) -> Tensor:
+    """Materialize canonical rows through safe indices, then apply boundary fills."""
+    source = prepared.source
+    sequence_length, batch_size = source.shape[:2]
+    payload_shape = source.shape[2:]
+    output_shape = tuple(row_indices.shape) + tuple(payload_shape)
+    if row_indices.numel() == 0:
+        return source.new_empty(output_shape)
+
+    flat_source = source.reshape(sequence_length * batch_size, *payload_shape)
+    if prepared.halo is not None:
+        halo = prepared.halo
+        flat_halo = halo.reshape(-1, *payload_shape)
+        flat_source = torch.cat((flat_source, flat_halo), dim=0)
+    gathered = flat_source.index_select(0, row_indices.reshape(-1)).reshape(output_shape)
+    expanded_valid = valid_rows.reshape(tuple(valid_rows.shape) + (1,) * len(payload_shape))
+    return torch.where(expanded_valid, gathered, prepared.fill_tensor)
+
+
+# Layout-neutral context API.
+
+
+class MTPSequenceRollContext:
+    """Base type for layout-specific state shared by MTP sequence rolls.
+
+    The public MTP call chain passes one context without knowing the physical
+    sequence layout. Concrete subtypes own their row geometry, halo transport,
+    and prepared field state while exposing the same roll and addressing API.
+    """
+
+    @property
+    def keys(self) -> Tuple[str, ...]:
+        """Return prepared field keys in their declaration order."""
+        prepared_fields = getattr(self, "_prepared_fields", ())
+        return tuple(prepared.key for prepared in prepared_fields)
+
+    @property
+    def max_offset(self) -> int:
+        """Return the largest prepared roll offset; offset zero denotes the source row."""
+        return getattr(self, "_prepared_max_offset", 0)
+
+    def is_prepared_for_fields(self, fields: Sequence[MTPSequenceRollField]) -> bool:
+        """Return whether prepared payloads still correspond to the current sources."""
+        fields = tuple(fields)
+        if not fields or len({field.key for field in fields}) != len(fields):
+            return False
+        prepared_fields = getattr(self, "_prepared_fields", ())
+        for field in fields:
+            try:
+                prepared = _get_mtp_sequence_roll_field(prepared_fields, field.key)
+            except KeyError:
+                return False
+            if not _mtp_sequence_roll_field_matches_source(prepared, field):
+                return False
+        return True
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare absolute shifted rows when this layout supports them.
+
+        The base implementation is the atomic fallback: unsupported layout
+        contexts remain unchanged and retain their established roll behavior.
+        """
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        return self
+
+    def _validate_prepared_offset(self, offset: int) -> None:
+        if not isinstance(offset, int):
+            raise TypeError("MTP sequence-roll offset must be an integer.")
+        if not 0 <= offset <= self.max_offset:
+            raise ValueError(
+                f"MTP sequence-roll offset {offset} is outside [0, {self.max_offset}]."
+            )
+
+    def address(self, key: str, offset: int) -> MTPSequenceRollAddress:
+        """Return canonical direct-address metadata for one absolute offset."""
+        self._validate_prepared_offset(offset)
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        row_indices = getattr(self, "_roll_row_indices", None)
+        valid_rows = getattr(self, "_roll_valid_rows", None)
+        if row_indices is None or valid_rows is None:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        return MTPSequenceRollAddress(
+            source=prepared.source,
+            halo=prepared.halo,
+            row_indices=row_indices[offset],
+            valid_rows=valid_rows[offset],
+        )
+
+    def materialize(self, key: str, offset: int) -> Tensor:
+        """Materialize one absolute roll offset in the field's declared layout."""
+        self._validate_prepared_offset(offset)
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        if offset == 0:
+            return prepared.restore(prepared.source)
+        address = self.address(key, offset)
+        canonical = _materialize_mtp_sequence_roll_rows(
+            prepared, address.row_indices, address.valid_rows
+        )
+        return prepared.restore(canonical)
+
+    def materialize_all(self, key: str) -> Tuple[Tensor, ...]:
+        """Materialize absolute offsets ``1..max_offset`` with one indexed gather."""
+        prepared = _get_mtp_sequence_roll_field(getattr(self, "_prepared_fields", ()), key)
+        if self.max_offset <= 0:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        row_indices = getattr(self, "_roll_row_indices", None)
+        valid_rows = getattr(self, "_roll_valid_rows", None)
+        if row_indices is None or valid_rows is None:
+            raise RuntimeError("This MTP sequence-roll context has no prepared shifted rows.")
+        canonical = _materialize_mtp_sequence_roll_rows(prepared, row_indices[1:], valid_rows[1:])
+        return tuple(prepared.restore(canonical[offset]) for offset in range(self.max_offset))
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Return a context with successor rows prepared for repeated MTP rolls.
+
+        Layout-specific contexts implement the communication and boundary rules.
+        Keeping this operation on the context lets model entry points remain layout
+        neutral while each concrete subtype uses its own transport strategy.
+        Optional fields that are not consumed on this pipeline stage can be omitted.
+
+        Args:
+            width: Number of successor rows required by repeated MTP rolls.
+            input_ids: Local token IDs used by MTP embedding or RL label derivation.
+            position_ids: Local learned-absolute position IDs, when rolled by MTP.
+            labels: Local SFT labels consumed by MTP loss.
+            loss_mask: Local MTP loss mask.
+            padding_mask: Local padding flags rolled by MTP embedding.
+
+        Returns:
+            A context containing the prepared layout-specific halo payload.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support halo prefetch.")
+
+
+# Local CP1 layout.
+
+
+@dataclass(frozen=True, eq=False)
+class LocalRollContext(MTPSequenceRollContext):
+    """Absolute sequence-roll geometry for two-dimensional CP1 sequence fields.
+
+    This subtype adds no communication. A bare context preserves the existing CP1
+    fallback; consumers that prepare fields use absolute roll offsets. Packed
+    boundaries are shared by every batch row; an omitted physical tail is treated
+    as one final sequence, matching the established roll helper.
+    """
+
+    sequence_length: int
+    batch_size: int
+    device: torch.device
+    packed_cu_seqlens: Optional[Tensor] = None
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Return this local context; CP1 has no remote successor halos."""
+        if width <= 0:
+            raise ValueError("Local MTP sequence-roll width must be positive.")
+        return self
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Return an immutable sibling containing local absolute shifted rows."""
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+        if not prepared_fields:
+            return LocalRollContext(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                device=self.device,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+        )
+        if reuse_geometry:
+            prepared_max_offset = self._prepared_max_offset
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+        else:
+            prepared_max_offset = max_offset
+            row_indices, valid_rows = _build_local_roll_geometry(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                max_offset=prepared_max_offset,
+                device=self.device,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        return LocalRollContext(
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+            packed_cu_seqlens=self.packed_cu_seqlens,
+            _prepared_fields=prepared_fields,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+        )
+
+
+def _build_local_roll_geometry(
+    *,
+    sequence_length: int,
+    batch_size: int,
+    max_offset: int,
+    device: torch.device,
+    packed_cu_seqlens: Optional[Tensor],
+) -> Tuple[Tensor, Tensor]:
+    """Build compact int32 row maps for a local CP1 microbatch."""
+    rows = torch.arange(sequence_length, device=device, dtype=torch.long)
+    offsets = torch.arange(max_offset + 1, device=device, dtype=torch.long).unsqueeze(1)
+    targets = rows.unsqueeze(0) + offsets
+    valid = targets < sequence_length
+    if packed_cu_seqlens is not None and sequence_length > 0:
+        cu = packed_cu_seqlens.to(device=device, dtype=torch.long)
+        # Appending the physical capacity also models the legal implicit tail;
+        # a duplicate final endpoint is harmless with right-biased bucketization.
+        boundaries = torch.cat((cu[1:], cu.new_full((1,), sequence_length)))
+        sequence_slots = torch.bucketize(rows, boundaries, right=True).clamp(
+            max=max(boundaries.numel() - 1, 0)
+        )
+        sequence_ends = boundaries.index_select(0, sequence_slots)
+        valid &= targets < sequence_ends.unsqueeze(0)
+
+    safe_targets = targets.clamp(min=0, max=max(sequence_length - 1, 0))
+    batches = torch.arange(batch_size, device=device, dtype=torch.long)
+    row_indices = safe_targets.unsqueeze(-1) * batch_size + batches
+    row_indices = row_indices.to(torch.int32).contiguous()
+    valid_rows = valid.unsqueeze(-1).expand(-1, -1, batch_size).contiguous()
+    return row_indices, valid_rows
+
+
+# Contiguous packed-CP layout.
+
+
+@dataclass(frozen=True)
+class ContiguousPackedSeqRollPlan:
+    """Per-microbatch metadata for one-token contiguous-CP packed-sequence rolls.
+
+    A one-token left roll is local except at the end of a CP shard, where the
+    replacement value may be the first element owned by the next CP rank. Packed
+    sequences add another constraint: positions at a physical packed-sequence
+    boundary must receive a field-specific fill value instead of a value from the
+    following sequence.
+
+    The CP neighbors and boundary mask depend only on the physical packed layout,
+    not on tensor dtype or payload. One context can therefore reuse this plan for
+    input IDs, learned-absolute position IDs, padding masks, labels, and loss masks
+    throughout a microbatch. When prefetched halos are present, the neighbor ranks
+    remain recorded for validation and fallback but no rolling P2P is issued.
+
+    Reuse is valid only for tensors on the recorded device, with the recorded local
+    sequence length, using the recorded CP group. Do not cache a plan across
+    microbatches unless those layout invariants are guaranteed to remain unchanged.
+
+    Attributes:
+        invalid_next: One-dimensional boolean mask over the local sequence axis.
+            True means that the corresponding global position has no immediate
+            physical successor in the same packed sequence. Repeated local rolls
+            propagate fills at internal boundaries; prefetched tail halos are
+            separately sanitized for every prediction depth.
+        sequence_length: Length of the local contiguous CP shard.
+        device: Device on which the boundary mask and compatible payload tensors
+            reside.
+        cp_group: Effective CP process group for this microbatch. This may be the
+            dynamic group injected into PackedSeqParams rather than the model's
+            statically configured CP group.
+        recv_rank: Global rank of the next contiguous CP shard, used by the P2P
+            fallback when no prefetched halo is supplied. None on the last CP rank.
+        send_rank: Global rank of the previous contiguous CP shard, used by the P2P
+            fallback. None on the first CP rank.
+        has_sequences: Whether de-duplicated cumulative sequence lengths describe at
+            least one physical packed sequence.
+        right_halo_valid_count: Number of successor rows after the local final row
+            that remain in the same physical packed sequence. This device scalar
+            sanitizes an arbitrary small halo width without rebuilding packed
+            metadata.
+    """
+
+    invalid_next: Tensor
+    sequence_length: int
+    device: torch.device
+    cp_group: torch.distributed.ProcessGroup
+    recv_rank: Optional[int]
+    send_rank: Optional[int]
+    has_sequences: bool
+    right_halo_valid_count: Tensor
+
+
+def _get_packed_roll_cu_seqlens(packed_seq_params: PackedSeqParams) -> Tensor:
+    """Return the physical packed-sequence boundaries used by MTP rolling."""
+    cu_seqlens = (
+        packed_seq_params.cu_seqlens_q_padded
+        if getattr(packed_seq_params, 'cu_seqlens_q_padded', None) is not None
+        else packed_seq_params.cu_seqlens_q
+    )
+    assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
+    return cu_seqlens
+
+
+def _get_packed_seq_end_indices(
+    cu_seqlens: Tensor, device: torch.device, sequence_length: int
+) -> Tensor:
+    """Return the ends of explicit packed sequences and any implicit tail.
+
+    PackedSeqParams permits the physical tensor to be longer than the final
+    cumulative sequence length. In that case, the remaining buffer is an
+    implicit tail sequence whose final element must also be filled after the
+    full-buffer roll. Duplicate end indices are safe because index_fill_ is
+    idempotent.
+    """
+    sequence_end_indices = cu_seqlens[1:].to(device=device, dtype=torch.long) - 1
+    if sequence_length == 0:
+        return sequence_end_indices.new_empty((0,))
+    implicit_tail_end = sequence_end_indices.new_full((1,), sequence_length - 1)
+    return torch.cat((sequence_end_indices, implicit_tail_end))
+
+
+def _build_contiguous_packed_seq_roll_plan(
+    tensor: Tensor, dims: int, cu_seqlens: Tensor, cp_group: torch.distributed.ProcessGroup
+) -> ContiguousPackedSeqRollPlan:
+    """Build reusable boundary and neighbor metadata for a contiguous-CP shard."""
+    assert (
+        dims == -1 or dims == tensor.dim() - 1
+    ), "Packed sequence roll only supports the last dimension."
+
+    local_seq_len = tensor.size(dims)
+    cp_size = cp_group.size()
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+
+    cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
+    if cu.numel() > 1:
+        # Static packed metadata can repeat its final boundary to pad the number
+        # of cu_seqlens entries. Remove duplicates before assigning positions to
+        # packed intervals so every retained interval has a nonzero length.
+        nonduplicate_boundaries = torch.ones(cu.numel(), device=cu.device, dtype=torch.bool)
+        nonduplicate_boundaries[1:] = cu[1:] != cu[:-1]
+        cu = cu[nonduplicate_boundaries]
+
+    has_sequences = cu.numel() > 1
+    if local_seq_len == 0 or not has_sequences:
+        invalid_next = torch.ones(local_seq_len, device=tensor.device, dtype=torch.bool)
+        right_halo_valid_count = torch.zeros((), device=tensor.device, dtype=cu.dtype)
+    else:
+        global_start = local_rank * local_seq_len
+        global_positions = global_start + torch.arange(
+            local_seq_len, device=tensor.device, dtype=cu.dtype
+        )
+        seq_idx = torch.bucketize(global_positions, cu[1:], right=True).clamp(max=cu.numel() - 2)
+        seq_ends = cu[1:][seq_idx]
+        # This deliberately stays true at the local shard's final position when
+        # the same packed sequence continues on the next CP rank. A prefetched
+        # halo or grouped P2P supplies that successor; only physical ends are masked.
+        valid_next = (global_positions < cu[-1]) & (global_positions + 1 < seq_ends)
+        invalid_next = ~valid_next
+
+        # Successor rows are valid only until the physical sequence containing
+        # this shard's final row ends. Keeping the count as a device scalar avoids
+        # a host synchronization and lets halo preparation build any small width.
+        local_tail = global_positions[-1]
+        right_halo_valid_count = torch.where(
+            local_tail < cu[-1],
+            (seq_ends[-1] - local_tail - 1).clamp_min(0),
+            torch.zeros((), device=tensor.device, dtype=cu.dtype),
+        )
+
+    # A left roll receives from the next contiguous shard and sends the first
+    # local element to the previous shard. Store global ranks because PyTorch's
+    # P2P API interprets peer ranks globally even when a process group is passed.
+    return ContiguousPackedSeqRollPlan(
+        invalid_next=invalid_next,
+        sequence_length=local_seq_len,
+        device=tensor.device,
+        cp_group=cp_group,
+        recv_rank=global_ranks[local_rank + 1] if local_rank < cp_size - 1 else None,
+        send_rank=global_ranks[local_rank - 1] if local_rank > 0 else None,
+        has_sequences=has_sequences,
+        right_halo_valid_count=right_halo_valid_count,
+    )
+
+
+class MTPSequenceRollHalos:
+    """Base type for layout-specific successor rows prepared before MTP.
+
+    Halo storage is owned by the corresponding roll context and never travels through
+    the model's public forward signature. Concrete layouts can choose how to acquire
+    and represent their successor rows without changing GPT, Hybrid, or MTP layers.
+    """
+
+
+@dataclass(frozen=True)
+class ContiguousPackedCPRollHalos(MTPSequenceRollHalos):
+    """Compact successor rows prefetched across contiguous CP ranks.
+
+    Each tensor stores only a small right halo, never a view of the full packed
+    microbatch. Halo index zero is the immediate successor of this CP rank's local
+    final row; halo index d is used by the d-th repeated left roll. Values that cross
+    a physical packed-sequence boundary are replaced with the field's normal
+    boundary fill value once, before MTP starts.
+
+    The explicit optional fields keep this dataclass friendly to CUDA-graph input
+    traversal and make the supported payload contract visible. A pipeline stage
+    may omit fields it does not own.
+
+    Attributes:
+        input_ids: Successor token IDs (the data batch calls this field 'tokens').
+        position_ids: Successor learned-absolute position IDs.
+        labels: Successor SFT labels.
+        loss_mask: Successor loss-mask values.
+        padding_mask: Successor padding flags, with True marking padding.
+    """
+
+    input_ids: Optional[Tensor] = None
+    position_ids: Optional[Tensor] = None
+    labels: Optional[Tensor] = None
+    loss_mask: Optional[Tensor] = None
+    padding_mask: Optional[Tensor] = None
+
+    def __post_init__(self):
+        present_halos = [
+            halo
+            for halo in (
+                self.input_ids,
+                self.position_ids,
+                self.labels,
+                self.loss_mask,
+                self.padding_mask,
+            )
+            if halo is not None
+        ]
+        if not present_halos:
+            raise ValueError("A contiguous packed-CP halo payload must contain at least one field.")
+        widths = {halo.size(-1) for halo in present_halos}
+        if len(widths) != 1:
+            raise ValueError("All contiguous packed-CP halo fields must have the same width.")
+
+    @property
+    def width(self) -> int:
+        """Return the number of prefetched successor rows."""
+        for halo in (
+            self.input_ids,
+            self.position_ids,
+            self.labels,
+            self.loss_mask,
+            self.padding_mask,
+        ):
+            if halo is not None:
+                return halo.size(-1)
+        raise AssertionError("ContiguousPackedCPRollHalos requires at least one field.")
+
+    def get(self, sequence_field: str) -> Optional[Tensor]:
+        """Return the halo for a canonical MTP sequence field."""
+        if sequence_field not in {
+            "input_ids",
+            "position_ids",
+            "labels",
+            "loss_mask",
+            "padding_mask",
+        }:
+            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
+        return getattr(self, sequence_field)
+
+
+@dataclass(frozen=True, eq=False)
+class ContiguousPackedCPRollContext(MTPSequenceRollContext):
+    """State reused by all contiguous packed-CP rolls in one microbatch.
+
+    Attributes:
+        plan: Boundary and CP-neighbor metadata shared by every field and depth.
+        halos: Optional compact successor rows prefetched immediately before MTP.
+            None retains grouped P2P as a correctness fallback for direct callers.
+    """
+
+    plan: ContiguousPackedSeqRollPlan
+    halos: Optional[ContiguousPackedCPRollHalos] = None
+    batch_size: int = 1
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare one field group with a single one-hop grouped P2P exchange.
+
+        A width larger than the local shard would need more than one neighbor hop;
+        that legal but unsupported case returns this context unchanged so callers
+        can atomically retain the established roll fallback.
+        """
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.plan.sequence_length,
+            batch_size=self.batch_size,
+            device=self.plan.device,
+        )
+        if not prepared_fields:
+            return ContiguousPackedCPRollContext(
+                plan=self.plan, halos=self.halos, batch_size=self.batch_size
+            )
+        if any(prepared.source.requires_grad for prepared in prepared_fields):
+            raise ValueError(
+                "Contiguous-CP sequence-roll preparation does not support fields that "
+                "require gradients."
+            )
+        if max_offset > self.plan.sequence_length:
+            return self
+
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+        )
+        if reuse_geometry:
+            prepared_max_offset = self._prepared_max_offset
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+        else:
+            prepared_max_offset = max_offset
+            row_indices, valid_rows = _build_contiguous_packed_cp_roll_geometry(
+                self.plan, batch_size=self.batch_size, max_offset=prepared_max_offset
+            )
+        halos = _exchange_contiguous_packed_cp_roll_field_halos(
+            prepared_fields, max_offset=prepared_max_offset, plan=self.plan
+        )
+        prepared_with_halos = tuple(
+            _PreparedMTPSequenceRollField(
+                key=prepared.key,
+                source=prepared.source,
+                source_id=prepared.source_id,
+                source_version=prepared.source_version,
+                inverse_permutation=prepared.inverse_permutation,
+                halo=halos[prepared.key],
+                fill_value=prepared.fill_value,
+                fill_tensor=prepared.fill_tensor,
+            )
+            for prepared in prepared_fields
+        )
+        return ContiguousPackedCPRollContext(
+            plan=self.plan,
+            halos=self.halos,
+            batch_size=self.batch_size,
+            _prepared_fields=prepared_with_halos,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+        )
+
+    def prefetch_halos(
+        self,
+        width: int,
+        *,
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        labels: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> MTPSequenceRollContext:
+        """Prefetch contiguous-CP successor rows in one grouped P2P operation.
+
+        The returned context is immutable and shares this context's roll plan. The
+        payload contains only width rows per present field, so it does not retain or
+        copy a full packed microbatch. Missing optional fields keep their later
+        grouped roll calls on the communication fallback.
+
+        Args:
+            width: Number of successor rows required by repeated MTP rolls.
+            input_ids: Local token IDs used by MTP embedding or RL label derivation.
+            position_ids: Local learned-absolute position IDs, when rolled by MTP.
+            labels: Local SFT labels consumed by MTP loss.
+            loss_mask: Local MTP loss mask.
+            padding_mask: Local padding flags rolled by MTP embedding.
+
+        Returns:
+            A new context with compact halos, or this context when prefetch is not
+            applicable to the local shard or no fields are present.
+        """
+        if self.halos is not None:
+            raise ValueError("Contiguous packed-CP halos have already been prefetched.")
+        if width <= 0:
+            raise ValueError("Contiguous packed-CP halo width must be positive.")
+        if width > self.plan.sequence_length:
+            # One neighbor exchange cannot supply rows spanning multiple CP shards.
+            # Keep the established per-roll grouped P2P path for these tiny shards.
+            return self
+
+        tensors_by_field = {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "padding_mask": padding_mask,
+        }
+        sequence_fields = []
+        present_tensors: List[Tensor] = []
+        for field, tensor in tensors_by_field.items():
+            if tensor is not None:
+                sequence_fields.append(field)
+                present_tensors.append(tensor)
+        if not sequence_fields:
+            return self
+
+        return ContiguousPackedCPRollContext(
+            plan=self.plan,
+            halos=_prefetch_contiguous_packed_cp_roll_halos(
+                tensors=present_tensors,
+                sequence_fields=sequence_fields,
+                fill_values=[_MTP_SEQUENCE_FIELD_FILL_VALUES[field] for field in sequence_fields],
+                width=width,
+                plan=self.plan,
+            ),
+            batch_size=self.batch_size,
+            _prepared_fields=self._prepared_fields,
+            _prepared_max_offset=self._prepared_max_offset,
+            _roll_row_indices=self._roll_row_indices,
+            _roll_valid_rows=self._roll_valid_rows,
+        )
+
+
+def _build_contiguous_packed_cp_roll_geometry(
+    plan: ContiguousPackedSeqRollPlan, *, batch_size: int, max_offset: int
+) -> Tuple[Tensor, Tensor]:
+    """Build one-hop absolute row maps from the existing contiguous roll plan."""
+    sequence_length = plan.sequence_length
+    rows = torch.arange(sequence_length, device=plan.device, dtype=torch.long)
+    offsets = torch.arange(max_offset + 1, device=plan.device, dtype=torch.long).unsqueeze(1)
+    targets = rows.unsqueeze(0) + offsets
+
+    # A target is valid only if every traversed local edge is valid. The compact
+    # right-halo count covers the remaining edges after the local final row.
+    invalid_prefix = torch.cat(
+        (
+            torch.zeros(1, device=plan.device, dtype=torch.int32),
+            plan.invalid_next.to(torch.int32).cumsum(0),
+        )
+    )
+    local_edge_end = targets.clamp(max=sequence_length)
+    crossed_invalid = invalid_prefix.index_select(0, local_edge_end.reshape(-1)).reshape(
+        targets.shape
+    ) - invalid_prefix[:-1].unsqueeze(0)
+    halo_rows = (targets - sequence_length).clamp_min(0)
+    halo_valid = (targets < sequence_length) | (halo_rows < plan.right_halo_valid_count)
+    valid = (crossed_invalid == 0) & halo_valid
+
+    addressed_rows = torch.where(targets < sequence_length, targets, sequence_length + halo_rows)
+    addressed_rows = addressed_rows.clamp(min=0, max=max(sequence_length + max_offset - 1, 0))
+    batches = torch.arange(batch_size, device=plan.device, dtype=torch.long)
+    row_indices = addressed_rows.unsqueeze(-1) * batch_size + batches
+    return (
+        row_indices.to(torch.int32).contiguous(),
+        valid.unsqueeze(-1).expand(-1, -1, batch_size).contiguous(),
+    )
+
+
+def _exchange_contiguous_packed_cp_roll_field_halos(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...],
+    *,
+    max_offset: int,
+    plan: ContiguousPackedSeqRollPlan,
+) -> dict[str, Tensor]:
+    """Acquire all generic field halos in one deterministic grouped P2P."""
+    # Sort only the transport order. The returned context preserves declaration
+    # order, while peers that supplied the same keys in a different order still
+    # match send and receive operations deterministically.
+    transport_fields = sorted(prepared_fields, key=lambda prepared: prepared.key)
+    halos = {
+        prepared.key: prepared.source.new_full(
+            (max_offset,) + tuple(prepared.source.shape[1:]), prepared.fill_value
+        )
+        for prepared in transport_fields
+    }
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+    if plan.has_sequences and plan.recv_rank is not None:
+        for prepared in transport_fields:
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    halos[prepared.key],
+                    plan.recv_rank,
+                    group=plan.cp_group,
+                )
+            )
+    if plan.has_sequences and plan.send_rank is not None:
+        for prepared in transport_fields:
+            send_buffer = prepared.source.narrow(0, 0, max_offset).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+    return halos
+
+
+def _prefetch_contiguous_packed_cp_roll_halos(
+    tensors: List[Tensor],
+    sequence_fields: List[str],
+    fill_values: List[Union[bool, int, float]],
+    width: int,
+    plan: ContiguousPackedSeqRollPlan,
+) -> ContiguousPackedCPRollHalos:
+    """Fetch compact right halos for contiguous packed CP in one grouped P2P.
+
+    Each rank sends the first width rows of every requested field to its
+    predecessor and receives the corresponding rows from its successor. Received
+    rows are sanitized once using the physical packed boundary that contains this
+    rank's local final row. Repeated MTP rolls can then consume halo offsets without
+    further communication.
+
+    Args:
+        tensors: Local MTP fields sharing the plan's sequence axis.
+        sequence_fields: Canonical names corresponding to tensors.
+        fill_values: Per-field physical-boundary fill values.
+        width: Number of successor rows required by all MTP prediction depths.
+        plan: Reusable contiguous packed-CP layout and neighbor metadata.
+
+    Returns:
+        Compact, independently allocated successor rows keyed by MTP field.
+
+    Raises:
+        ValueError: If the field metadata is inconsistent with the roll plan.
+    """
+    if width <= 0:
+        raise ValueError("Contiguous packed-CP halo width must be positive.")
+    if len(tensors) != len(sequence_fields) or len(tensors) != len(fill_values):
+        raise ValueError("Each halo tensor must have a canonical field and fill value.")
+    if len(set(sequence_fields)) != len(sequence_fields):
+        raise ValueError("Each contiguous packed-CP halo field may be prefetched only once.")
+    if width > plan.sequence_length:
+        raise ValueError(
+            f"Contiguous packed-CP halo width {width} exceeds local sequence length "
+            f"{plan.sequence_length}."
+        )
+
+    halos: List[Tensor] = []
+    for tensor, sequence_field, fill_value in zip(tensors, sequence_fields, fill_values):
+        if sequence_field not in _MTP_SEQUENCE_FIELD_FILL_VALUES:
+            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
+        expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
+        if fill_value != expected_fill_value:
+            raise ValueError(
+                f"Halo field {sequence_field} requires boundary fill value "
+                f"{expected_fill_value!r}, got {fill_value!r}."
+            )
+        if tensor.device != plan.device:
+            raise ValueError("All halo tensors sharing a roll plan must be on the same device.")
+        if tensor.size(-1) != plan.sequence_length:
+            raise ValueError(
+                "All halo tensors sharing a roll plan must have the same sequence length."
+            )
+
+        halo_shape = list(tensor.shape)
+        halo_shape[-1] = width
+        halos.append(tensor.new_full(halo_shape, fill_value))
+
+    # Retain contiguous send slices until every grouped work handle completes.
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+    if plan.has_sequences and plan.recv_rank is not None:
+        for halo in halos:
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv, halo, plan.recv_rank, group=plan.cp_group
+                )
+            )
+    if plan.has_sequences and plan.send_rank is not None:
+        for tensor in tensors:
+            send_buffer = tensor.narrow(-1, 0, width).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+
+    # Offset d is valid only when the local tail and its (d + 1)-th successor
+    # belong to the same physical packed sequence. Broadcasting this small mask
+    # sanitizes every field without retaining the full packed metadata.
+    invalid_halo = (
+        torch.arange(width, device=plan.device, dtype=plan.right_halo_valid_count.dtype)
+        >= plan.right_halo_valid_count
+    )
+    for halo, fill_value in zip(halos, fill_values):
+        halo.masked_fill_(invalid_halo, fill_value)
+
+    halo_by_field = dict(zip(sequence_fields, halos))
+    return ContiguousPackedCPRollHalos(
+        input_ids=halo_by_field.get("input_ids"),
+        position_ids=halo_by_field.get("position_ids"),
+        labels=halo_by_field.get("labels"),
+        loss_mask=halo_by_field.get("loss_mask"),
+        padding_mask=halo_by_field.get("padding_mask"),
+    )
+
+
+# Zigzag packed-CP layout.
+
+
+@dataclass(frozen=True)
+class _ZigzagPackedCPRollTransport:
+    """Compact prefix rows exchanged with the two physical zigzag neighbors."""
+
+    front_prefix_rows: Tensor
+    back_prefix_rows: Tensor
+    prefix_valid: Tensor
+
+
+@dataclass(frozen=True, eq=False)
+class ZigzagPackedCPRollContext(MTPSequenceRollContext):
+    """One-hop absolute rows for scheduler-certified zigzag packed CP.
+
+    This subtype extends the base sequence-roll interface while preserving the
+    established zigzag dispatcher as the fallback. A positive scheduler certificate
+    proves that every requested roll offset crosses at most one physical half-chunk.
+    If a consumer asks for a wider offset, field preparation leaves this context
+    bare and that consumer atomically uses the original cumulative-roll path.
+    """
+
+    sequence_length: int
+    batch_size: int
+    device: torch.device
+    cp_group: torch.distributed.ProcessGroup
+    packed_cu_seqlens: Tensor
+    min_chunk_size: int
+    _prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...] = ()
+    _prepared_max_offset: int = 0
+    _roll_row_indices: Optional[Tensor] = None
+    _roll_valid_rows: Optional[Tensor] = None
+    _roll_transport: Optional[_ZigzagPackedCPRollTransport] = None
+
+    def prepare_fields(
+        self, fields: Sequence[MTPSequenceRollField], *, max_offset: int
+    ) -> MTPSequenceRollContext:
+        """Prepare one field group after validating its one-hop certificate."""
+        if not isinstance(max_offset, int) or max_offset <= 0:
+            raise ValueError("MTP sequence-roll max_offset must be a positive integer.")
+        prepared_fields = _validate_mtp_sequence_roll_fields(
+            fields,
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+        if not prepared_fields:
+            return ZigzagPackedCPRollContext(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                device=self.device,
+                cp_group=self.cp_group,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+                min_chunk_size=self.min_chunk_size,
+            )
+        if any(prepared.source.requires_grad for prepared in prepared_fields):
+            raise ValueError(
+                "One-hop zigzag packed-CP sequence-roll preparation does not support "
+                "fields that require gradients."
+            )
+        if max_offset > self.min_chunk_size:
+            return self
+
+        reuse_geometry = (
+            self._prepared_max_offset >= max_offset
+            and self._roll_row_indices is not None
+            and self._roll_valid_rows is not None
+            and self._roll_transport is not None
+        )
+        prepared_max_offset = self._prepared_max_offset if reuse_geometry else max_offset
+        if reuse_geometry:
+            row_indices = self._roll_row_indices
+            valid_rows = self._roll_valid_rows
+            transport = self._roll_transport
+            assert transport is not None
+        else:
+            row_indices, valid_rows, transport = _build_zigzag_packed_cp_roll_geometry(
+                sequence_length=self.sequence_length,
+                batch_size=self.batch_size,
+                max_offset=prepared_max_offset,
+                device=self.device,
+                cp_group=self.cp_group,
+                packed_cu_seqlens=self.packed_cu_seqlens,
+            )
+        halos = _exchange_zigzag_packed_cp_roll_field_halos(
+            prepared_fields, cp_group=self.cp_group, transport=transport
+        )
+        prepared_with_halos = tuple(
+            _PreparedMTPSequenceRollField(
+                key=prepared.key,
+                source=prepared.source,
+                source_id=prepared.source_id,
+                source_version=prepared.source_version,
+                inverse_permutation=prepared.inverse_permutation,
+                halo=halos[prepared.key],
+                fill_value=prepared.fill_value,
+                fill_tensor=prepared.fill_tensor,
+            )
+            for prepared in prepared_fields
+        )
+        return ZigzagPackedCPRollContext(
+            sequence_length=self.sequence_length,
+            batch_size=self.batch_size,
+            device=self.device,
+            cp_group=self.cp_group,
+            packed_cu_seqlens=self.packed_cu_seqlens,
+            min_chunk_size=self.min_chunk_size,
+            _prepared_fields=prepared_with_halos,
+            _prepared_max_offset=prepared_max_offset,
+            _roll_row_indices=row_indices,
+            _roll_valid_rows=valid_rows,
+            _roll_transport=transport,
+        )
+
+
+def _build_zigzag_packed_cp_roll_geometry(
+    *,
+    sequence_length: int,
+    batch_size: int,
+    max_offset: int,
+    device: torch.device,
+    cp_group: torch.distributed.ProcessGroup,
+    packed_cu_seqlens: Tensor,
+) -> Tuple[Tensor, Tensor, _ZigzagPackedCPRollTransport]:
+    """Build exact one-hop row maps and transport for a certified zigzag packed-CP microbatch."""
+    cp_size = cp_group.size()
+    cu = packed_cu_seqlens.to(device=device, dtype=torch.long)
+    if cu.ndim != 1 or cu.numel() < 2:
+        raise ValueError(
+            "Zigzag packed-CP MTP metadata requires one-dimensional cu_seqlens with at least "
+            "two entries."
+        )
+    torch._assert_async(cu[0] == 0, "Zigzag packed-CP MTP cumulative lengths must start at zero.")
+    torch._assert_async(
+        torch.all(cu[1:] >= cu[:-1]),
+        "Zigzag packed-CP MTP cumulative lengths must be nondecreasing.",
+    )
+    torch._assert_async(
+        cu[-1] == sequence_length * cp_size,
+        "Zigzag packed-CP MTP metadata must cover the physical buffer exactly.",
+    )
+
+    physical_lengths = cu[1:] - cu[:-1]
+    divisor = 2 * cp_size
+    torch._assert_async(
+        torch.all((physical_lengths == 0) | (physical_lengths.remainder(divisor) == 0)),
+        "Zigzag packed-CP MTP certificate contradicts physical chunk divisibility.",
+    )
+    local_cu = torch.div(cu, cp_size, rounding_mode="floor")
+    chunk_lengths = torch.div(physical_lengths, divisor, rounding_mode="floor")
+    torch._assert_async(
+        torch.all((physical_lengths == 0) | (chunk_lengths >= max_offset)),
+        "Zigzag packed-CP MTP certificate overstates the minimum physical chunk size.",
+    )
+
+    num_sequence_slots = chunk_lengths.numel()
+    prefix_offsets = torch.arange(max_offset, device=device, dtype=torch.long).unsqueeze(0)
+    prefix_valid = prefix_offsets < chunk_lengths.unsqueeze(1)
+    front_prefix_rows = (local_cu[:-1].unsqueeze(1) + prefix_offsets).clamp(
+        min=0, max=max(sequence_length - 1, 0)
+    )
+    back_prefix_rows = (
+        local_cu[:-1].unsqueeze(1) + chunk_lengths.unsqueeze(1) + prefix_offsets
+    ).clamp(min=0, max=max(sequence_length - 1, 0))
+
+    local_rows = torch.arange(sequence_length, device=device, dtype=torch.long)
+    sequence_slots = torch.bucketize(local_rows, local_cu[1:], right=True).clamp(
+        max=max(num_sequence_slots - 1, 0)
+    )
+    sequence_starts = local_cu[:-1].index_select(0, sequence_slots)
+    row_chunk_lengths = chunk_lengths.index_select(0, sequence_slots)
+    offsets_in_local_sequence = local_rows - sequence_starts
+    is_front_chunk = offsets_in_local_sequence < row_chunk_lengths
+    offsets_in_chunk = torch.where(
+        is_front_chunk, offsets_in_local_sequence, offsets_in_local_sequence - row_chunk_lengths
+    )
+
+    offsets = torch.arange(1, max_offset + 1, device=device, dtype=torch.long).unsqueeze(1)
+    advanced_offsets = offsets_in_chunk.unsqueeze(0) + offsets
+    crosses_chunk = advanced_offsets >= row_chunk_lengths.unsqueeze(0)
+    halo_offsets = advanced_offsets - row_chunk_lengths.unsqueeze(0)
+    local_targets = local_rows.unsqueeze(0) + offsets
+
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    if local_rank == cp_size - 1:
+        front_cross_targets = (
+            sequence_starts.unsqueeze(0) + row_chunk_lengths.unsqueeze(0) + halo_offsets
+        )
+    else:
+        front_cross_targets = (
+            sequence_length + sequence_slots.unsqueeze(0) * max_offset + halo_offsets
+        )
+    if local_rank == 0:
+        back_cross_targets = torch.zeros_like(halo_offsets)
+    else:
+        back_cross_targets = (
+            sequence_length
+            + num_sequence_slots * max_offset
+            + sequence_slots.unsqueeze(0) * max_offset
+            + halo_offsets
+        )
+    cross_targets = torch.where(
+        is_front_chunk.unsqueeze(0), front_cross_targets, back_cross_targets
+    )
+    addressed_rows = torch.where(crosses_chunk, cross_targets, local_targets)
+    valid = ~(crosses_chunk & ~is_front_chunk.unsqueeze(0) & (local_rank == 0))
+
+    batches = torch.arange(batch_size, device=device, dtype=torch.long)
+    shifted_indices = addressed_rows.unsqueeze(-1) * batch_size + batches
+    identity = local_rows.unsqueeze(-1) * batch_size + batches
+    row_indices = torch.cat((identity.unsqueeze(0), shifted_indices), dim=0)
+    valid_rows = torch.cat(
+        (
+            torch.ones((1, sequence_length, batch_size), device=device, dtype=torch.bool),
+            valid.unsqueeze(-1).expand(-1, -1, batch_size),
+        ),
+        dim=0,
+    )
+    return (
+        row_indices.to(torch.int32).contiguous(),
+        valid_rows.contiguous(),
+        _ZigzagPackedCPRollTransport(
+            front_prefix_rows=front_prefix_rows.flatten().contiguous(),
+            back_prefix_rows=back_prefix_rows.flatten().contiguous(),
+            prefix_valid=prefix_valid.flatten().contiguous(),
+        ),
+    )
+
+
+def _exchange_zigzag_packed_cp_roll_field_halos(
+    prepared_fields: Tuple[_PreparedMTPSequenceRollField, ...],
+    *,
+    cp_group: torch.distributed.ProcessGroup,
+    transport: _ZigzagPackedCPRollTransport,
+) -> dict[str, Tensor]:
+    """Exchange both zigzag prefix tapes for every field in one P2P batch."""
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    cp_size = cp_group.size()
+    transport_fields = sorted(prepared_fields, key=lambda prepared: prepared.key)
+    next_rank = global_ranks[local_rank + 1] if local_rank < cp_size - 1 else None
+    previous_rank = global_ranks[local_rank - 1] if local_rank > 0 else None
+    # Halo segment zero is the next rank's front prefix; segment one is
+    # the previous rank's back prefix. Keep send and receive peers explicit so
+    # each route has one unambiguous semantic even when every P2P uses tag zero.
+    route_specs = (
+        (transport.front_prefix_rows, previous_rank, next_rank),
+        (transport.back_prefix_rows, next_rank, previous_rank),
+    )
+    segments = {prepared.key: [] for prepared in transport_fields}
+    send_buffers = []
+    p2p_ops = []
+    for send_rows, send_rank, recv_rank in route_specs:
+        for prepared in transport_fields:
+            valid_shape = (-1,) + (1,) * (prepared.source.dim() - 1)
+            send = prepared.source.index_select(0, send_rows)
+            send = send.masked_fill(
+                ~transport.prefix_valid.view(valid_shape), prepared.fill_value
+            ).contiguous()
+            send_buffers.append(send)
+            recv = prepared.source.new_full(send.shape, prepared.fill_value)
+            segments[prepared.key].append(recv)
+            if recv_rank is not None:
+                p2p_ops.append(
+                    torch.distributed.P2POp(
+                        torch.distributed.irecv, recv, recv_rank, group=cp_group
+                    )
+                )
+            if send_rank is not None:
+                p2p_ops.append(
+                    torch.distributed.P2POp(
+                        torch.distributed.isend, send, send_rank, group=cp_group
+                    )
+                )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    for work in works:
+        work.wait()
+    return {
+        key: torch.cat(field_segments, dim=0).contiguous()
+        for key, field_segments in segments.items()
+    }
+
+
+# Public preparation entry points.
+
+
+def prepare_mtp_sequence_roll_context(
+    tensor: Tensor | None,
+    cp_group: torch.distributed.ProcessGroup | None,
+    packed_seq_params: PackedSeqParams | None,
+    dims: int = -1,
+) -> MTPSequenceRollContext | None:
+    """Prepare layout-specific state shared by MTP rolls in one microbatch.
+
+    The public boundary is layout neutral. Two-dimensional CP1 inputs receive a
+    local context capable of optional absolute addressing while retaining the legacy
+    roll helper as fallback. Contiguous packed CP retains its existing plan and halo
+    behavior while also supporting explicit one-hop sequence-roll preparation. A
+    scheduler-certified zigzag packed-CP microbatch receives the same absolute-row
+    interface with two compact neighbor tapes. Uncertified and unsupported layouts
+    return None and keep their established paths.
+
+    Args:
+        tensor: Reference payload that establishes local sequence length and device.
+        cp_group: Effective context-parallel process group for the microbatch.
+        packed_seq_params: Physical packed-sequence layout metadata.
+        dims: Sequence dimension; packed rolling supports only the final dimension.
+
+    Returns:
+        A layout-specific roll context, or None when no prepared state is needed.
+    """
+    if tensor is None:
+        return None
+
+    cp_group = resolve_cp_group(cp_group, packed_seq_params)
+    cp_size = cp_group.size() if cp_group is not None else 1
+    if cp_size <= 1:
+        if tensor.dim() != 2:
+            return None
+        sequence_dim = _normalize_mtp_sequence_roll_dim(dims, tensor.dim(), name="dims")
+        # Packed rolling supports only the final dimension. Do not create a
+        # context that the established dispatcher would reject.
+        if packed_seq_params is not None and sequence_dim != tensor.dim() - 1:
+            return None
+        batch_dim = 1 - sequence_dim
+        return LocalRollContext(
+            sequence_length=tensor.size(sequence_dim),
+            batch_size=tensor.size(batch_dim),
+            device=tensor.device,
+            packed_cu_seqlens=(
+                _get_packed_roll_cu_seqlens(packed_seq_params)
+                if packed_seq_params is not None
+                else None
+            ),
+        )
+
+    if packed_seq_params is None or cp_group is None:
+        return None
+
+    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
+    if cp_partition_mode == "zigzag":
+        min_chunk_size = packed_seq_params.zigzag_cp_min_chunk_size
+        if min_chunk_size is None or min_chunk_size == 0:
+            # Zero is a scheduler-produced "not certifiable" result, not
+            # malformed packed metadata. Preserve the established zigzag roll
+            # path exactly as for an absent certificate.
+            return None
+        if min_chunk_size < 0:
+            raise ValueError("Zigzag packed-CP MTP scheduler certificate cannot be negative.")
+        if (
+            packed_seq_params.local_cp_size is not None
+            and int(packed_seq_params.local_cp_size) != cp_size
+        ):
+            raise ValueError(
+                "Zigzag packed-CP MTP metadata local_cp_size must match "
+                "the effective CP group size."
+            )
+        if (
+            packed_seq_params.qkv_format != "thd"
+            or tensor.dim() != 2
+            or tensor.size(0) != 1
+            or (
+                _normalize_mtp_sequence_roll_dim(dims, tensor.dim(), name="dims")
+                != tensor.dim() - 1
+            )
+        ):
+            return None
+        return ZigzagPackedCPRollContext(
+            sequence_length=tensor.size(-1),
+            batch_size=tensor.size(0),
+            device=tensor.device,
+            cp_group=cp_group,
+            packed_cu_seqlens=_get_packed_roll_cu_seqlens(packed_seq_params),
+            min_chunk_size=min_chunk_size,
+        )
+    if cp_partition_mode != 'contiguous':
+        return None
+
+    return ContiguousPackedCPRollContext(
+        plan=_build_contiguous_packed_seq_roll_plan(
+            tensor, dims, _get_packed_roll_cu_seqlens(packed_seq_params), cp_group
+        ),
+        batch_size=tensor.size(0) if tensor.dim() == 2 else 1,
+    )
+
+
+def prepare_mtp_sequence_roll_fields(
+    sequence_roll_context: Optional[MTPSequenceRollContext],
+    fields: Sequence[MTPSequenceRollField],
+    *,
+    max_offset: int,
+) -> Optional[MTPSequenceRollContext]:
+    """Return one atomically prepared consumer field group when supported.
+
+    A context already containing the complete group for these exact source
+    tensors is reused. Otherwise the fields are late-bound as one replacement
+    group. Unsupported layouts return ``None`` so the caller takes its complete
+    legacy cumulative-roll path; a consumer never mixes addressed and rolled fields.
+    """
+    if sequence_roll_context is None:
+        return None
+    if (
+        sequence_roll_context.max_offset >= max_offset
+        and sequence_roll_context.is_prepared_for_fields(fields)
+    ):
+        return sequence_roll_context
+    prepared_context = sequence_roll_context.prepare_fields(fields, max_offset=max_offset)
+    if prepared_context.max_offset >= max_offset and prepared_context.is_prepared_for_fields(
+        fields
+    ):
+        return prepared_context
+    return None
+
+
+# Cumulative-roll compatibility path.
+
+
+def roll_tensor(
+    tensors: List[Tensor],
+    shifts: int = -1,
+    dims: int = -1,
+    cp_group: torch.distributed.ProcessGroup | None = None,
+    packed_seq_params: PackedSeqParams | None = None,
+    fill_values: List[Union[bool, int, float]] | None = None,
+    roll_context: MTPSequenceRollContext | None = None,
+    sequence_fields: List[str] | None = None,
+    roll_depth: int = 0,
+) -> List[Tensor]:
+    """Roll one or more MTP tensor fields along the sequence dimension.
+
+    All tensors in one call share the same physical sequence layout. Grouping them
+    allows contiguous packed CP to share metadata and use one P2P batch. When a
+    contiguous context owns prefetched halos, the same dispatcher replaces each
+    local tail from the requested field/depth and issues no rolling P2P.
+
+    Args:
+        tensors: Tensor fields to roll together.
+        shifts: Shift along the sequence dimension.
+        dims: Sequence dimension.
+        cp_group: Effective context-parallel process group.
+        packed_seq_params: Packed-sequence layout metadata, when applicable.
+        fill_values: Per-field values written at physical sequence boundaries.
+        roll_context: Layout-specific state prepared for this microbatch. None
+            retains the regular dispatcher and communication fallback.
+        sequence_fields: Canonical source fields corresponding to tensors. These
+            identify prefetched halo payloads and are required only when the
+            context contains halos.
+        roll_depth: Zero-based repeated-roll depth. Depth zero consumes the
+            immediate successor; depth d consumes halo offset d.
+
+    Returns:
+        Rolled tensors in the same order as tensors.
+
+    Raises:
+        ValueError: If field counts, depth, or roll-context arguments are inconsistent.
+    """
+    if not tensors:
+        return []
+    if roll_depth < 0:
+        raise ValueError("roll_depth must be non-negative.")
+    if fill_values is None:
+        fill_values = [0] * len(tensors)
+    if len(tensors) != len(fill_values):
+        raise ValueError("Each tensor must have a corresponding roll fill value.")
+    if sequence_fields is not None and len(tensors) != len(sequence_fields):
+        raise ValueError("Each tensor must have a corresponding canonical sequence field.")
+
+    if packed_seq_params is None:
+        if roll_context is not None and not isinstance(roll_context, LocalRollContext):
+            raise ValueError("A prepared sequence-roll context requires packed parameters.")
+        return _roll_tensors_unpacked(tensors, shifts, dims, cp_group, fill_values)
+
+    return _roll_tensors_packed_seq(
+        tensors,
+        shifts,
+        dims,
+        packed_seq_params,
+        cp_group,
+        fill_values,
+        roll_context,
+        sequence_fields,
+        roll_depth,
+    )
+
+
+def _roll_tensors_unpacked(
+    tensors: List[Tensor],
+    shifts: int,
+    dims: int,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    fill_values: List[Union[bool, int, float]],
+) -> List[Tensor]:
+    """Roll unpacked tensors for CP1 or the standard zigzag CP layout."""
+    if cp_group is None or cp_group.size() == 1:
+        rolled_tensors = [torch.roll(tensor, shifts=shifts, dims=dims) for tensor in tensors]
+        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
+            rolled_tensor.select(dims, shifts).fill_(fill_value)
+        return rolled_tensors
+
+    return [
+        _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=fill_value)
+        for tensor, fill_value in zip(tensors, fill_values)
+    ]
+
+
+def _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=0):
+    """Roll one unpacked tensor in the standard two-chunk zigzag CP layout."""
+    # This matches the batch splitting logic in get_batch_on_this_cp_rank().
+    tensor_list = tensor.chunk(2, dim=dims)
+    rolled_tensor_list = []
+    for i in range(len(tensor_list)):
+        rolled_tensor_list.append(torch.roll(tensor_list[i], shifts=shifts, dims=dims))
+
+    # Prepare tensors for communication between CP ranks
+    # Each CP rank needs to send boundary elements to adjacent ranks
+    tensor_send_list = []
+    tensor_recv_list = []
+    for i in range(len(rolled_tensor_list)):
+        tensor_send_list.append(rolled_tensor_list[i].select(dims, shifts).contiguous())
+        empty_tensor = torch.empty(
+            tensor_send_list[i].shape,
+            dtype=tensor_send_list[i].dtype,
+            device=torch.cuda.current_device(),
+        )
+        tensor_recv_list.append(empty_tensor)
+
+    # Get the global rank of next and prev process in the cp group
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    next_rank = global_ranks[(local_rank + 1) % len(global_ranks)]
+    prev_rank = global_ranks[(local_rank - 1) % len(global_ranks)]
+
+    # Start send and recv ops
+    ops = []
+    if local_rank != 0:
+        req_send_first_part = torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank)
+        ops.append(req_send_first_part)
+        req_recv_second_part = torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank)
+        ops.append(req_recv_second_part)
+    else:
+        tensor_recv_list[1] = fill_value
+    if local_rank != len(global_ranks) - 1:
+        req_recv_first_part = torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank)
+        ops.append(req_recv_first_part)
+        req_send_second_part = torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank)
+        ops.append(req_send_second_part)
+    else:
+        # For the last CP rank, the removed elements of second part go into the first part
+        tensor_recv_list[0] = tensor_send_list[1]
+
+    # Wait for all communication operations to complete
+    for op in ops:
+        op.wait()
+
+    # Splicing: Replace boundary elements with received elements from adjacent ranks
+    # This ensures proper sequence continuity across CP boundaries
+    index = [slice(None)] * rolled_tensor_list[0].dim()
+    index[dims] = shifts
+    for i in range(len(rolled_tensor_list)):
+        rolled_tensor_list[i][tuple(index)] = tensor_recv_list[i]
+
+    # Concatenate the processed chunks back into a single tensor
+    rolled_tensor = torch.cat(rolled_tensor_list, dim=dims)
+
+    return rolled_tensor
+
+
+def _roll_tensors_packed_seq(
+    tensors: List[Tensor],
+    shifts: int,
+    dims: int,
+    packed_seq_params: PackedSeqParams,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    fill_values: List[Union[bool, int, float]],
+    roll_context: Optional[MTPSequenceRollContext],
+    sequence_fields: Optional[List[str]],
+    roll_depth: int,
+) -> List[Tensor]:
+    """Dispatch packed tensors to CP1, zigzag CP, or contiguous CP rolling."""
+    for tensor in tensors:
+        assert (
+            dims == -1 or dims == tensor.dim() - 1
+        ), "Packed sequence roll only supports the last dimension."
+    assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
+
+    # Prefer padded cumulative seqlens because CP's local THD layout uses the
+    # padded physical boundaries. Unpadded boundaries index the wrong local
+    # chunks when sequence lengths are not already divisible by 2 * cp_size.
+    cu_seqlens = _get_packed_roll_cu_seqlens(packed_seq_params)
+
+    cp_size = cp_group.size() if cp_group is not None else 1
+    if cp_size == 1:
+        if roll_context is not None and not isinstance(roll_context, LocalRollContext):
+            raise ValueError("A prepared sequence-roll context cannot be used for packed CP1.")
+        reference_tensor = tensors[0]
+        sequence_end_indices = _get_packed_seq_end_indices(
+            cu_seqlens, reference_tensor.device, reference_tensor.size(dims)
+        )
+        for tensor in tensors:
+            if tensor.device != reference_tensor.device:
+                raise ValueError("All packed CP1 tensors must be on the same device.")
+            if tensor.size(dims) != reference_tensor.size(dims):
+                raise ValueError("All packed CP1 tensors must have the same sequence length.")
+        return [
+            _roll_tensor_packed_seq_cp1(
+                tensor, shifts, dims, sequence_end_indices, fill_value=fill_value
+            )
+            for tensor, fill_value in zip(tensors, fill_values)
+        ]
+
+    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
+    if cp_partition_mode == 'zigzag':
+        if roll_context is not None and not isinstance(roll_context, ZigzagPackedCPRollContext):
+            raise ValueError(
+                "A prepared sequence-roll context is not supported for zigzag packed CP."
+            )
+        return [
+            _roll_tensor_packed_seq_zigzag_cp(
+                tensor, shifts, dims, cu_seqlens, cp_group, fill_value=fill_value
+            )
+            for tensor, fill_value in zip(tensors, fill_values)
+        ]
+    if cp_partition_mode == 'contiguous':
+        contiguous_roll_halos = None
+        if roll_context is None:
+            contiguous_roll_plan = _build_contiguous_packed_seq_roll_plan(
+                tensors[0], dims, cu_seqlens, cp_group
+            )
+        elif isinstance(roll_context, ContiguousPackedCPRollContext):
+            contiguous_roll_plan = roll_context.plan
+            contiguous_roll_halos = roll_context.halos
+        else:
+            raise ValueError(
+                "The prepared sequence-roll context does not support contiguous packed CP."
+            )
+        return _roll_tensors_packed_seq_contiguous_cp(
+            tensors,
+            dims,
+            fill_values,
+            contiguous_roll_plan,
+            contiguous_roll_halos,
+            sequence_fields,
+            roll_depth,
+        )
+    raise ValueError(f"Unsupported packed sequence CP partition mode: {cp_partition_mode}")
+
+
+def _roll_tensor_packed_seq_cp1(tensor, shifts, dims, sequence_end_indices, fill_value=0):
+    """Roll one CP1 packed tensor and fill every physical sequence end."""
+    # A full-buffer left roll is equivalent to rolling each packed sequence
+    # independently once the values that crossed sequence boundaries are filled.
+    rolled_tensor = torch.roll(tensor, shifts=shifts, dims=dims)
+    rolled_tensor.index_fill_(dims, sequence_end_indices, fill_value)
+    return rolled_tensor
+
+
+def _roll_tensor_packed_seq_zigzag_cp(tensor, shifts, dims, cu_seqlens, cp_group, fill_value=0):
+    """Roll a zigzag-CP THD shard without crossing packed sequence boundaries."""
+    cp_size = cp_group.size()
+    rolled_tensor = tensor.clone()
+
+    # CP enabled: each rank owns two chunks per sequence (front and mirrored tail).
+    local_rank = torch.distributed.get_rank(group=cp_group)
+    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
+    next_rank = global_ranks[(local_rank + 1) % cp_size]
+    prev_rank = global_ranks[(local_rank - 1) % cp_size]
+
+    # Iterate over each sequence individually
+    for i in range(len(cu_seqlens) - 1):
+        start_idx = cu_seqlens[i]
+        end_idx = cu_seqlens[i + 1]
+
+        # the idx has been multiplied by cp_size, need to divide it by cp_size to get the local idx
+        local_start_idx = start_idx // cp_size
+        local_end_idx = end_idx // cp_size
+
+        # Skip empty sequences - this can happen when a sequence is very short and
+        # after dividing by cp_size, the local slice has zero length
+        local_seq_len = local_end_idx - local_start_idx
+        if local_seq_len == 0:
+            continue
+
+        tensor_slice = rolled_tensor[..., local_start_idx:local_end_idx].clone()
+
+        # The following code is very similar as the code in roll_tensor function
+        local_chunks = tensor_slice.chunk(2, dim=dims)
+        rolled_chunks = [torch.roll(chunk, shifts=shifts, dims=dims) for chunk in local_chunks]
+
+        tensor_send_list = []
+        tensor_recv_list = []
+        for chunk in rolled_chunks:
+            # Skip empty chunks that can occur when the sequence slice is very small
+            if chunk.size(dims) == 0:
+                tensor_send_list.append(
+                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                )
+                tensor_recv_list.append(
+                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                )
+                continue
+            boundary = chunk.select(dims, shifts).contiguous().clone()
+            tensor_send_list.append(boundary)
+            tensor_recv_list.append(torch.empty_like(boundary))
+
+        ops = []
+        if local_rank != 0:
+            ops.append(torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank))
+            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank))
+        else:
+            tensor_recv_list[1].fill_(fill_value)
+
+        if local_rank != cp_size - 1:
+            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank))
+            ops.append(torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank))
+        else:
+            tensor_recv_list[0].copy_(tensor_send_list[1])
+
+        for op in ops:
+            op.wait()
+
+        index = [slice(None)] * rolled_chunks[0].dim()
+        index[dims] = shifts
+        for chunk, recv in zip(rolled_chunks, tensor_recv_list):
+            # Skip empty chunks
+            if chunk.size(dims) == 0:
+                continue
+            chunk[tuple(index)] = recv
+
+        seq_result = torch.cat(rolled_chunks, dim=dims)
+
+        # update the rolled tensor
+        rolled_tensor[..., local_start_idx:local_end_idx] = seq_result
+
+    return rolled_tensor
+
+
+def _roll_tensors_packed_seq_contiguous_cp(
+    tensors: List[Tensor],
+    dims: int,
+    fill_values: List[Union[bool, int, float]],
+    contiguous_roll_plan: ContiguousPackedSeqRollPlan,
+    contiguous_roll_halos: Optional[ContiguousPackedCPRollHalos] = None,
+    sequence_fields: Optional[List[str]] = None,
+    roll_depth: int = 0,
+) -> List[Tensor]:
+    """Roll contiguous packed-CP tensors from halos or one grouped P2P exchange.
+
+    A prefetched halo is used only when every field in this grouped call is present.
+    Otherwise the entire call takes the grouped P2P fallback, keeping all CP ranks
+    on the same communication branch while supporting optional model inputs.
+    """
+    assert len(tensors) == len(fill_values)
+    if not tensors:
+        return []
+
+    for tensor in tensors:
+        assert (
+            dims == -1 or dims == tensor.dim() - 1
+        ), "Packed sequence roll only supports the last dimension."
+        if tensor.size(dims) != contiguous_roll_plan.sequence_length:
+            raise ValueError(
+                "All tensors sharing a packed-sequence roll plan must have the same "
+                "sequence length."
+            )
+        if tensor.device != contiguous_roll_plan.device:
+            raise ValueError(
+                "All tensors sharing a packed-sequence roll plan must be on the same device."
+            )
+
+    if contiguous_roll_plan.sequence_length == 0:
+        return [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+
+    if not contiguous_roll_plan.has_sequences:
+        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
+            rolled_tensor.fill_(fill_value)
+        return rolled_tensors
+
+    halo_tail_values = None
+    if contiguous_roll_halos is not None and sequence_fields is not None:
+        if len(sequence_fields) != len(tensors):
+            raise ValueError("Each rolled tensor must have a canonical sequence field.")
+
+        requested_halos = [contiguous_roll_halos.get(field) for field in sequence_fields]
+        if all(halo is not None for halo in requested_halos):
+            if roll_depth >= contiguous_roll_halos.width:
+                raise ValueError(
+                    f"roll_depth={roll_depth} exceeds the prefetched halo width "
+                    f"{contiguous_roll_halos.width}."
+                )
+
+            halo_tail_values = []
+            for tensor, sequence_field, fill_value, halo in zip(
+                tensors, sequence_fields, fill_values, requested_halos
+            ):
+                assert halo is not None
+                expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
+                if fill_value != expected_fill_value:
+                    raise ValueError(
+                        f"Halo field {sequence_field} requires boundary fill value "
+                        f"{expected_fill_value!r}, got {fill_value!r}."
+                    )
+                if halo.device != tensor.device:
+                    raise ValueError(
+                        f"Halo field {sequence_field} and its tensor must be on the same device."
+                    )
+                if halo.dtype != tensor.dtype:
+                    raise ValueError(
+                        f"Halo field {sequence_field} and its tensor must have the same dtype."
+                    )
+                if halo.dim() != tensor.dim() or halo.shape[:-1] != tensor.shape[:-1]:
+                    raise ValueError(
+                        f"Halo field {sequence_field} must match its tensor's leading dimensions."
+                    )
+                halo_tail_values.append(halo.select(dims, roll_depth))
+
+    if halo_tail_values is not None:
+        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+        for rolled_tensor, halo_tail, fill_value in zip(
+            rolled_tensors, halo_tail_values, fill_values
+        ):
+            rolled_tensor.select(dims, -1).copy_(halo_tail)
+            # Internal physical sequence ends are handled by the shared immediate
+            # boundary mask. Tail values for deeper rolls were sanitized before
+            # slicing because their validity depends on the requested depth.
+            rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
+        return rolled_tensors
+
+    recv_buffers: List[Optional[Tensor]] = [None] * len(tensors)
+    # Keep contiguous send buffers alive until every grouped work handle completes.
+    send_buffers: List[Tensor] = []
+    p2p_ops = []
+
+    if contiguous_roll_plan.recv_rank is not None:
+        # After a left roll, each local tail consumes the first element from the
+        # next contiguous CP shard.
+        for index, tensor in enumerate(tensors):
+            recv_buffer = torch.empty_like(tensor.select(dims, 0))
+            recv_buffers[index] = recv_buffer
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    recv_buffer,
+                    contiguous_roll_plan.recv_rank,
+                    group=contiguous_roll_plan.cp_group,
+                )
+            )
+    if contiguous_roll_plan.send_rank is not None:
+        # This rank's first element becomes the previous shard's local tail.
+        for tensor in tensors:
+            send_buffer = tensor.select(dims, 0).contiguous()
+            send_buffers.append(send_buffer)
+            p2p_ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    send_buffer,
+                    contiguous_roll_plan.send_rank,
+                    group=contiguous_roll_plan.cp_group,
+                )
+            )
+
+    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
+    rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
+    for work in works:
+        work.wait()
+
+    for rolled_tensor, recv_buffer, fill_value in zip(rolled_tensors, recv_buffers, fill_values):
+        if recv_buffer is not None:
+            rolled_tensor.select(dims, -1).copy_(recv_buffer)
+        # Apply the shared boundary mask after installing the adjacent value so a
+        # physical packed-sequence end always wins over a cross-rank successor.
+        rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
+
+    return rolled_tensors

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -37,7 +37,7 @@ from megatron.core.tensor_parallel.mappings import (
     gather_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
-from megatron.core.transformer.attention import Attention, LinearProjBuilder
+from megatron.core.transformer.attention import Attention, LinearProjBuilder, QKVLayout
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -736,6 +736,15 @@ class MLASelfAttention(MultiLatentAttention):
             tp_comm_buffer_name='kv_up_proj',
             tp_group=pg_collection.tp,
             name=(name + ".linear_kv_up_proj") if name is not None else None,
+        )
+
+        q_up_proj = self.linear_q_proj if self.config.q_lora_rank is None else self.linear_q_up_proj
+        q_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+            self.config.num_attention_heads,
+            (self.config.qk_head_dim, self.config.qk_pos_emb_head_dim),
+        )
+        self.linear_kv_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+            self.config.num_attention_heads, (self.config.qk_head_dim, self.config.v_head_dim)
         )
 
         if self.config.q_lora_rank is not None:
@@ -1457,6 +1466,14 @@ class FusedMLASelfAttention(MLASelfAttention):
             tp_comm_buffer_name='kv_up_proj',
             tp_group=pg_collection.tp,
             name=(name + ".linear_kv_up_proj") if name is not None else None,
+        )
+
+        self.linear_q_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+            self.config.num_attention_heads,
+            (self.config.qk_head_dim, self.config.qk_pos_emb_head_dim),
+        )
+        self.linear_kv_up_proj.weight.qkv_layout = QKVLayout.from_splits(
+            self.config.num_attention_heads, (self.config.qk_head_dim, self.config.v_head_dim)
         )
 
         self.q_layernorm = layer_classes["q_layernorm"](

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1286,9 +1286,16 @@ class MTPLossLoggingHelper:
             )
 
     @staticmethod
-    def clean_loss_in_tracker():
-        """Clear per-step MTP loss and acceptance counters."""
+    def clean_loss_in_tracker(preserve_groups: bool = False):
+        """Clear per-step MTP loss and acceptance counters.
+
+        Args:
+            preserve_groups: Keep reduction groups for CUDA Graph replay, which
+                updates the captured tracker buffers without rerunning Python setup.
+        """
         tracker = MTPLossLoggingHelper.tracker
+        reduce_group = tracker.get("reduce_group") if preserve_groups else None
+        avg_group = tracker.get("avg_group") if preserve_groups else None
         if "loss_sums" in tracker:
             tracker["loss_sums"].zero_()
         if "num_tokens" in tracker:
@@ -1297,8 +1304,8 @@ class MTPLossLoggingHelper:
             tracker["values"].zero_()
         if "loss_values" in tracker:
             tracker["loss_values"].zero_()
-        tracker["reduce_group"] = None
-        tracker["avg_group"] = None
+        tracker["reduce_group"] = reduce_group
+        tracker["avg_group"] = avg_group
         MTPLossLoggingHelper._clean_acceptance_in_tracker()
 
     @staticmethod
@@ -1331,8 +1338,19 @@ class MTPLossLoggingHelper:
         tracker["values"] = values
 
     @staticmethod
-    def track_mtp_metrics(loss_scale, iteration, writer, wandb_writer=None, total_loss_dict=None):
-        """Track per-step MTP loss and acceptance metrics."""
+    def track_mtp_metrics(
+        loss_scale,
+        iteration,
+        writer,
+        wandb_writer=None,
+        total_loss_dict=None,
+        preserve_groups: bool = False,
+    ):
+        """Track per-step MTP loss and acceptance metrics.
+
+        Args:
+            preserve_groups: Keep reduction groups after logging for CUDA Graph replay.
+        """
         MTPLossLoggingHelper.reduce_loss_in_tracker()
         MTPLossLoggingHelper.reduce_metrics_in_tracker()
         tracker = MTPLossLoggingHelper.tracker
@@ -1394,7 +1412,7 @@ class MTPLossLoggingHelper:
                     wandb_writer.log({f"{step_acc_name}": step_rate}, iteration)
                     wandb_writer.log({f"{cum_acc_name}": cum_rate}, iteration)
 
-        MTPLossLoggingHelper.clean_loss_in_tracker()
+        MTPLossLoggingHelper.clean_loss_in_tracker(preserve_groups=preserve_groups)
 
 
 def _mtp_logits_are_vocab_sharded(

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -464,6 +464,54 @@ else:
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
 
+@dataclass(frozen=True)
+class MTPDSASharedTensors:
+    """DSA tensors produced by the first repeated MTP iteration and reused thereafter."""
+
+    key: Tensor
+    topk_indices: Tensor
+    topk_length: Tensor
+
+    def optional_topk_length(self) -> Optional[Tensor]:
+        """Return ``None`` when the producer did not emit per-row top-k lengths."""
+        return None if self.topk_length.numel() == 0 else self.topk_length
+
+
+@dataclass
+class MTPDSAIterationContext:
+    """Per-iteration carrier for explicit MTP DSA IndexShare and KVShare tensors."""
+
+    iteration: int
+    shared_tensors: Optional[MTPDSASharedTensors] = None
+    produced_tensors: Optional[MTPDSASharedTensors] = None
+
+    @property
+    def is_source(self) -> bool:
+        """Whether this iteration computes the shared tensors."""
+        return self.iteration == 0
+
+    @property
+    def reuses_source(self) -> bool:
+        """Whether this iteration consumes tensors from the source iteration."""
+        return self.iteration > 0
+
+    def capture(self, key: Tensor, topk_indices: Tensor, topk_length: Optional[Tensor]) -> None:
+        """Capture source tensors without detaching their autograd graph."""
+        if not self.is_source:
+            raise RuntimeError("Only MTP iteration 0 may produce shared DSA tensors.")
+        if topk_length is None:
+            # Checkpoint backends require a stable tensor-only output schema. An empty
+            # int32 tensor represents the optional per-row length tensor in that schema.
+            topk_length = topk_indices.new_empty((0,), dtype=torch.int32)
+        self.produced_tensors = MTPDSASharedTensors(key, topk_indices, topk_length)
+
+    def require_source_tensors(self) -> MTPDSASharedTensors:
+        """Return the tensors captured by iteration 0 or fail at the producer boundary."""
+        if self.produced_tensors is None:
+            raise RuntimeError("MTP iteration 0 did not produce DSA KV/top-k tensors.")
+        return self.produced_tensors
+
+
 def tie_word_embeddings_state_dict(
     sharded_state_dict: ShardedStateDict,
     word_emb_weight: Tensor,
@@ -1939,6 +1987,11 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if self.config.dsa_mtp_index_kv_share and mtp_layer_pattern is not None:
+            raise ValueError(
+                "dsa_mtp_index_kv_share currently supports the GPT MTP path only, "
+                "not a hybrid MTP layer pattern."
+            )
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -2249,6 +2302,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[torch.Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ) -> torch.Tensor:
         """
         Concatenates embeddings with hidden states and then applies transformer layer forward.
@@ -2302,6 +2356,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                         sequence_len_offset=sequence_len_offset,
                         padding_mask=padding_mask,
                         input_ids=input_ids,
+                        mtp_dsa_context=mtp_dsa_context,
                     )
 
         if not self.mhc_enabled:
@@ -2395,6 +2450,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         inference_params: Optional[InferenceParams] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ):
         """Forward a legacy GPT MTP layer with activation recomputation.
 
@@ -2431,8 +2487,22 @@ class MultiTokenPredictionLayer(MegatronModule):
             rotary_pos_cos,
             rotary_pos_sin,
             sequence_len_offset,
+            shared_key,
+            shared_topk_indices,
+            shared_topk_length,
         ):
-            return self._proj_and_transformer_layer(
+            recompute_context = None
+            if mtp_dsa_context is not None:
+                shared_tensors = None
+                if mtp_dsa_context.reuses_source:
+                    shared_tensors = MTPDSASharedTensors(
+                        shared_key, shared_topk_indices, shared_topk_length
+                    )
+                recompute_context = MTPDSAIterationContext(
+                    iteration=mtp_dsa_context.iteration, shared_tensors=shared_tensors
+                )
+
+            outputs = self._proj_and_transformer_layer(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
                 input_ids=input_ids,
@@ -2447,7 +2517,24 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                mtp_dsa_context=recompute_context,
             )
+            if recompute_context is not None and recompute_context.is_source:
+                produced = recompute_context.require_source_tensors()
+                return outputs, produced.key, produced.topk_indices, produced.topk_length
+            return outputs
+
+        if mtp_dsa_context is not None and mtp_dsa_context.reuses_source:
+            if mtp_dsa_context.shared_tensors is None:
+                raise RuntimeError(
+                    f"MTP iteration {mtp_dsa_context.iteration} requires iteration-0 "
+                    "DSA KV/top-k tensors."
+                )
+            shared_key = mtp_dsa_context.shared_tensors.key
+            shared_topk_indices = mtp_dsa_context.shared_tensors.topk_indices
+            shared_topk_length = mtp_dsa_context.shared_tensors.topk_length
+        else:
+            shared_key = shared_topk_indices = shared_topk_length = None
 
         # Decide the outer quantization context, matching
         # ``transformer_block._checkpointed_forward``. Only ``fp8 + delayed
@@ -2492,6 +2579,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
+                    shared_key,
+                    shared_topk_indices,
+                    shared_topk_length,
                 )
             else:
                 # tensor_parallel.checkpoint stashes args via autograd's
@@ -2513,6 +2603,9 @@ class MultiTokenPredictionLayer(MegatronModule):
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
+                    shared_key,
+                    shared_topk_indices,
+                    shared_topk_length,
                 )
 
         if self.config.recompute_method == 'uniform':
@@ -2522,6 +2615,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             ), "recompute_num_layers must be 1 for MTP recompute"
             with outer_quantization_context:
                 outputs = checkpoint_handler()
+            used_checkpoint = True
         elif self.config.recompute_method == 'block':
             # TODO: implement block-based recompute for MTP
             warnings.warn(
@@ -2542,10 +2636,23 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                mtp_dsa_context=mtp_dsa_context,
             )
+            used_checkpoint = False
         else:
             raise ValueError("Invalid activation recompute method.")
 
+        if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+            if not used_checkpoint:
+                # Block recompute is currently skipped, so the direct forward has already
+                # captured the source tensors in the caller-owned context.
+                mtp_dsa_context.require_source_tensors()
+                return outputs
+            hidden_states, shared_key, shared_topk_indices, shared_topk_length = outputs
+            # Expose the graph-connected checkpoint outputs through the existing context
+            # without changing MultiTokenPredictionLayer.forward's public return schema.
+            mtp_dsa_context.capture(shared_key, shared_topk_indices, shared_topk_length)
+            return hidden_states
         return outputs
 
     def forward(
@@ -2567,6 +2674,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         roll_depth: int = 0,
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -2589,10 +2697,14 @@ class MultiTokenPredictionLayer(MegatronModule):
                 successor row for this repeated roll.
             sequence_len_offset (Tensor, optional): Offset for sequence length, if applicable.
             embedding (Callable): The embedding module from gpt model to compute the decoder input.
+            mtp_dsa_context (MTPDSAIterationContext, optional): Per-iteration carrier for the
+                latent key and indexer top-k tensors shared by repeated-layer DSA MTP. Iteration
+                0 produces the tensors, and later iterations reuse them.
 
         Returns:
-            Union[Tensor, Tuple[Tensor, Tensor]]: The output hidden states tensor of shape
-            [s, b, h], and optionally the updated context tensor if cross-attention is used.
+            Tuple[Tensor, Tensor, Tensor, Optional[Tensor]]: Updated hidden states, shifted input
+            IDs, position IDs, and padding mask. Shared DSA tensors are carried through
+            ``mtp_dsa_context`` without changing this return schema.
         """
         assert context is None, "multi token prediction + cross attention is not yet supported."
         _orig_cp_group = self.cp_group
@@ -2607,6 +2719,10 @@ class MultiTokenPredictionLayer(MegatronModule):
             sequence_roll_context=sequence_roll_context,
             roll_depth=roll_depth,
         )
+
+        mtp_dsa_kwargs = {}
+        if mtp_dsa_context is not None:
+            mtp_dsa_kwargs["mtp_dsa_context"] = mtp_dsa_context
 
         # Legacy GPT MTP owns one outer checkpoint around its projection and Transformer
         # layer. Hybrid MTP instead delegates full recompute to the nested HybridStack so
@@ -2632,6 +2748,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                **mtp_dsa_kwargs,
             )
         else:
             hidden_states = self._proj_and_transformer_layer(
@@ -2649,6 +2766,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+                **mtp_dsa_kwargs,
             )
 
         self.cp_group = _orig_cp_group
@@ -2965,9 +3083,17 @@ class MultiTokenPredictionBlock(MegatronModule):
         if self.config.mtp_detach_heads:
             hidden_states = hidden_states.detach()
 
+        shared_dsa_tensors = None
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
+            mtp_dsa_context = None
+            mtp_dsa_kwargs = {}
+            if self.config.dsa_mtp_index_kv_share:
+                mtp_dsa_context = MTPDSAIterationContext(
+                    iteration=iteration, shared_tensors=shared_dsa_tensors
+                )
+                mtp_dsa_kwargs["mtp_dsa_context"] = mtp_dsa_context
+            layer_outputs = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,
@@ -2982,8 +3108,12 @@ class MultiTokenPredictionBlock(MegatronModule):
                 roll_depth=iteration,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
+                **mtp_dsa_kwargs,
                 **(extra_block_kwargs or {}),
             )
+            hidden_states, input_ids, position_ids, padding_mask = layer_outputs
+            if mtp_dsa_context is not None and mtp_dsa_context.is_source:
+                shared_dsa_tensors = mtp_dsa_context.require_source_tensors()
 
             if mhc_multistream is not None:
                 mhc_chunks.append(hidden_states)

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -16,6 +16,8 @@ from megatron.core.dist_checkpointing.utils import apply_prefix_mapping, replace
 from megatron.core.enums import Fp8Recipe
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.fusions.fused_mtp_prefix import mtp_e2e_prefix_objective
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.models.backends import BackendSpecProvider, LocalSpecProvider
 from megatron.core.packed_seq_params import PackedSeqParams, resolve_cp_group
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
@@ -1759,6 +1761,131 @@ class MTPLossAutoScaler(torch.autograd.Function):
         MTPLossAutoScaler.main_loss_backward_scale = scale
 
 
+def _process_mtp_e2e_tv_loss(
+    hidden_states_list: tuple[Tensor, ...],
+    loss_mask: Tensor,
+    output_layer: Callable,
+    output_weight: Tensor,
+    runtime_gather_output: Optional[bool],
+    is_training: bool,
+    config: TransformerConfig,
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    tp_group: Optional[torch.distributed.ProcessGroup],
+    packed_seq_params: Optional[PackedSeqParams],
+    scale_logits_fn: Optional[Callable[[Tensor], Tensor]],
+    sequence_roll_context: Optional[MTPSequenceRollContext],
+    derived_labels_from_input_ids: bool,
+    original_num_tokens: Optional[Tensor],
+) -> Tensor:
+    """Apply the end-to-end TV objective to MTP draft hidden states.
+
+    The frozen backbone is projected once. For depth ``i``, its target logits are
+    shifted by ``i + 1`` positions to align with the MTP draft distribution for
+    the same future token. Only start positions with a complete chain across all
+    configured MTP depths contribute to the objective.
+    """
+    hidden_states = hidden_states_list[0]
+    logits_are_vocab_sharded = _mtp_logits_are_vocab_sharded(output_layer, runtime_gather_output)
+
+    # Project the frozen backbone once, then align each target distribution by
+    # rolling logits. Re-projecting one shifted hidden tensor per MTP depth would
+    # add a full vocabulary GEMM for every draft step.
+    with torch.no_grad():
+        target_logits, _ = output_layer(
+            hidden_states.detach(),
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            target_logits = scale_logits_fn(target_logits)
+    # roll_tensor handles packed boundaries and CP communication along its last
+    # dimension. Keep vocabulary before sequence while preparing target alignment.
+    target_logits = target_logits.permute(1, 2, 0)
+    current_loss_mask = loss_mask
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    tv_distances = []
+
+    for mtp_layer_number in range(config.mtp_num_layers):
+        target_logits = roll_tensor(
+            [target_logits],
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            fill_values=[0],
+        )[0]
+        current_loss_mask = roll_tensor(
+            [current_loss_mask],
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            roll_context=sequence_roll_context,
+            sequence_fields=["loss_mask"],
+            roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
+        )[0]
+        chain_valid &= current_loss_mask.bool()
+
+        draft_logits, _ = output_layer(
+            hidden_states_list[mtp_layer_number + 1],
+            weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+        )
+        if scale_logits_fn is not None:
+            draft_logits = scale_logits_fn(draft_logits)
+        aligned_target_logits = target_logits.permute(2, 0, 1)
+        tv_distances.append(
+            vocab_parallel_tv_distance(
+                draft_logits,
+                aligned_target_logits,
+                tp_group=tp_group,
+                logits_are_vocab_sharded=logits_are_vocab_sharded,
+            )
+        )
+
+    tv_distances_tensor = torch.stack(tv_distances, dim=0)
+    per_step_acceptance = 1.0 - tv_distances_tensor
+    e2e_tv_loss, prefix_losses = mtp_e2e_prefix_objective(per_step_acceptance)
+
+    chain_mask = chain_valid.transpose(0, 1).to(e2e_tv_loss.dtype)
+    num_tokens = chain_mask.sum()
+    masked_e2e_tv_loss = e2e_tv_loss * chain_mask
+
+    if is_training:
+        collect_acceptance = MTPLossLoggingHelper.should_collect_acceptance()
+        avg_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        for mtp_layer_number in range(config.mtp_num_layers):
+            correct = None
+            total = None
+            if collect_acceptance:
+                correct = torch.sum(per_step_acceptance[mtp_layer_number] * chain_mask)
+                total = num_tokens
+            MTPLossLoggingHelper.save_loss_to_tracker(
+                torch.sum(prefix_losses[mtp_layer_number] * chain_mask),
+                num_tokens,
+                mtp_layer_number,
+                config.mtp_num_layers,
+                correct=correct,
+                total=total,
+                avg_group=avg_group,
+                calculate_per_token_loss=config.calculate_per_token_loss,
+            )
+
+    assert config.mtp_loss_scaling_factor is not None
+    if config.calculate_per_token_loss:
+        assert original_num_tokens is not None
+        normalized_loss = (
+            config.mtp_loss_scaling_factor
+            * masked_e2e_tv_loss
+            * (original_num_tokens / num_tokens.clamp(min=1))
+        )
+    else:
+        normalized_loss = (
+            config.mtp_loss_scaling_factor * masked_e2e_tv_loss / num_tokens.clamp(min=1)
+        )
+    return MTPLossAutoScaler.apply(hidden_states, normalized_loss)
+
+
 def process_mtp_loss(
     hidden_states: Tensor,
     labels: Optional[Tensor],
@@ -1845,6 +1972,25 @@ def process_mtp_loss(
     # when calculate_per_token_loss is enabled. This ensures MTP gradients are
     # correctly scaled relative to the main loss gradients in finalize_model_grads.
     original_num_tokens = loss_mask.sum() if config.calculate_per_token_loss else None
+
+    if config.mtp_loss_type == "e2e_tv":
+        assert output_weight is not None
+        return _process_mtp_e2e_tv_loss(
+            hidden_states_list=hidden_states_list,
+            loss_mask=loss_mask,
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=runtime_gather_output,
+            is_training=is_training,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            scale_logits_fn=scale_logits_fn,
+            sequence_roll_context=sequence_roll_context,
+            derived_labels_from_input_ids=derived_labels_from_input_ids,
+            original_num_tokens=original_num_tokens,
+        )
 
     fuse_linear_cross_entropy = (
         config.cross_entropy_loss_fusion and config.cross_entropy_fusion_impl == "linear"

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -32,6 +32,17 @@ from megatron.core.tensor_parallel.inference_layers import (
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.hyper_connection import learned_output_contract
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
+from megatron.core.transformer.mtp_sequence_roll import (  # for backward compatibility; pylint: disable=unused-import
+    ContiguousPackedCPRollContext,
+    ContiguousPackedCPRollHalos,
+    ContiguousPackedSeqRollPlan,
+    MTPSequenceRollContext,
+    MTPSequenceRollField,
+    MTPSequenceRollHalos,
+    prepare_mtp_sequence_roll_context,
+    prepare_mtp_sequence_roll_fields,
+    roll_tensor,
+)
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
@@ -58,404 +69,6 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
-
-
-_MTP_SEQUENCE_FIELD_FILL_VALUES = {
-    "input_ids": 0,
-    "position_ids": 0,
-    "labels": 0,
-    "loss_mask": 0,
-    "padding_mask": True,
-}
-
-
-class MTPSequenceRollHalos:
-    """Base type for layout-specific successor rows prepared before MTP.
-
-    Halo storage is owned by the corresponding roll context and never travels through
-    the model's public forward signature. Concrete layouts can choose how to acquire
-    and represent their successor rows without changing GPT, Hybrid, or MTP layers.
-    """
-
-
-@dataclass(frozen=True)
-class ContiguousPackedCPRollHalos(MTPSequenceRollHalos):
-    """Compact successor rows prefetched across contiguous CP ranks.
-
-    Each tensor stores only a small right halo, never a view of the full packed
-    microbatch. Offset zero is the immediate successor of this CP rank's local
-    final row; offset d is used by the d-th repeated left roll. Values that cross
-    a physical packed-sequence boundary are replaced with the field's normal
-    boundary fill value once, before MTP starts.
-
-    The explicit optional fields keep this dataclass friendly to CUDA-graph input
-    traversal and make the supported payload contract visible. A pipeline stage
-    may omit fields it does not own.
-
-    Attributes:
-        input_ids: Successor token IDs (the data batch calls this field 'tokens').
-        position_ids: Successor learned-absolute position IDs.
-        labels: Successor SFT labels.
-        loss_mask: Successor loss-mask values.
-        padding_mask: Successor padding flags, with True marking padding.
-    """
-
-    input_ids: Optional[Tensor] = None
-    position_ids: Optional[Tensor] = None
-    labels: Optional[Tensor] = None
-    loss_mask: Optional[Tensor] = None
-    padding_mask: Optional[Tensor] = None
-
-    def __post_init__(self):
-        present_halos = [
-            halo
-            for halo in (
-                self.input_ids,
-                self.position_ids,
-                self.labels,
-                self.loss_mask,
-                self.padding_mask,
-            )
-            if halo is not None
-        ]
-        if not present_halos:
-            raise ValueError("A contiguous packed-CP halo payload must contain at least one field.")
-        widths = {halo.size(-1) for halo in present_halos}
-        if len(widths) != 1:
-            raise ValueError("All contiguous packed-CP halo fields must have the same width.")
-
-    @property
-    def width(self) -> int:
-        """Return the number of prefetched successor rows."""
-        for halo in (
-            self.input_ids,
-            self.position_ids,
-            self.labels,
-            self.loss_mask,
-            self.padding_mask,
-        ):
-            if halo is not None:
-                return halo.size(-1)
-        raise AssertionError("ContiguousPackedCPRollHalos requires at least one field.")
-
-    def get(self, sequence_field: str) -> Optional[Tensor]:
-        """Return the halo for a canonical MTP sequence field."""
-        if sequence_field not in {
-            "input_ids",
-            "position_ids",
-            "labels",
-            "loss_mask",
-            "padding_mask",
-        }:
-            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
-        return getattr(self, sequence_field)
-
-
-class MTPSequenceRollContext:
-    """Base type for layout-specific state shared by MTP sequence rolls.
-
-    The public MTP call chain passes this marker without knowing the physical
-    sequence layout. A roll dispatcher inspects the concrete subtype and extracts
-    the plan and optional prefetched payload needed by that layout. Future layouts
-    can add a subtype without adding another layout-specific argument to GPT,
-    Hybrid, or MTP layers.
-    """
-
-    def prefetch_halos(
-        self,
-        width: int,
-        *,
-        input_ids: Tensor | None = None,
-        position_ids: Tensor | None = None,
-        labels: Tensor | None = None,
-        loss_mask: Tensor | None = None,
-        padding_mask: Tensor | None = None,
-    ) -> MTPSequenceRollContext:
-        """Return a context with successor rows prepared for repeated MTP rolls.
-
-        Layout-specific contexts implement the communication and boundary rules.
-        Keeping this operation on the context lets model entry points remain layout
-        neutral while a future zigzag implementation can use a different strategy.
-        Optional fields that are not consumed on this pipeline stage can be omitted.
-
-        Args:
-            width: Number of successor rows required by repeated MTP rolls.
-            input_ids: Local token IDs used by MTP embedding or RL label derivation.
-            position_ids: Local learned-absolute position IDs, when rolled by MTP.
-            labels: Local SFT labels consumed by MTP loss.
-            loss_mask: Local MTP loss mask.
-            padding_mask: Local padding flags rolled by MTP embedding.
-
-        Returns:
-            A context containing the prepared layout-specific halo payload.
-        """
-        raise NotImplementedError(f"{type(self).__name__} does not support halo prefetch.")
-
-
-@dataclass(frozen=True)
-class ContiguousPackedSeqRollPlan:
-    """Per-microbatch metadata for one-token contiguous-CP packed-sequence rolls.
-
-    A one-token left roll is local except at the end of a CP shard, where the
-    replacement value may be the first element owned by the next CP rank. Packed
-    sequences add another constraint: positions at a physical packed-sequence
-    boundary must receive a field-specific fill value instead of a value from the
-    following sequence.
-
-    The CP neighbors and boundary mask depend only on the physical packed layout,
-    not on tensor dtype or payload. One context can therefore reuse this plan for
-    input IDs, learned-absolute position IDs, padding masks, labels, and loss masks
-    throughout a microbatch. When prefetched halos are present, the neighbor ranks
-    remain recorded for validation and fallback but no rolling P2P is issued.
-
-    Reuse is valid only for tensors on the recorded device, with the recorded local
-    sequence length, using the recorded CP group. Do not cache a plan across
-    microbatches unless those layout invariants are guaranteed to remain unchanged.
-
-    Attributes:
-        invalid_next: One-dimensional boolean mask over the local sequence axis.
-            True means that the corresponding global position has no immediate
-            physical successor in the same packed sequence. Repeated local rolls
-            propagate fills at internal boundaries; prefetched tail halos are
-            separately sanitized for every prediction depth.
-        sequence_length: Length of the local contiguous CP shard.
-        device: Device on which the boundary mask and compatible payload tensors
-            reside.
-        cp_group: Effective CP process group for this microbatch. This may be the
-            dynamic group injected into PackedSeqParams rather than the model's
-            statically configured CP group.
-        recv_rank: Global rank of the next contiguous CP shard, used by the P2P
-            fallback when no prefetched halo is supplied. None on the last CP rank.
-        send_rank: Global rank of the previous contiguous CP shard, used by the P2P
-            fallback. None on the first CP rank.
-        has_sequences: Whether de-duplicated cumulative sequence lengths describe at
-            least one physical packed sequence.
-        right_halo_valid_count: Number of successor rows after the local final row
-            that remain in the same physical packed sequence. This device scalar
-            sanitizes an arbitrary small halo width without rebuilding packed
-            metadata.
-    """
-
-    invalid_next: Tensor
-    sequence_length: int
-    device: torch.device
-    cp_group: torch.distributed.ProcessGroup
-    recv_rank: Optional[int]
-    send_rank: Optional[int]
-    has_sequences: bool
-    right_halo_valid_count: Tensor
-
-
-@dataclass(frozen=True)
-class ContiguousPackedCPRollContext(MTPSequenceRollContext):
-    """State reused by all contiguous packed-CP rolls in one microbatch.
-
-    Attributes:
-        plan: Boundary and CP-neighbor metadata shared by every field and depth.
-        halos: Optional compact successor rows prefetched immediately before MTP.
-            None retains grouped P2P as a correctness fallback for direct callers.
-    """
-
-    plan: ContiguousPackedSeqRollPlan
-    halos: Optional[ContiguousPackedCPRollHalos] = None
-
-    def prefetch_halos(
-        self,
-        width: int,
-        *,
-        input_ids: Tensor | None = None,
-        position_ids: Tensor | None = None,
-        labels: Tensor | None = None,
-        loss_mask: Tensor | None = None,
-        padding_mask: Tensor | None = None,
-    ) -> MTPSequenceRollContext:
-        """Prefetch contiguous-CP successor rows in one grouped P2P operation.
-
-        The returned context is immutable and shares this context's roll plan. The
-        payload contains only width rows per present field, so it does not retain or
-        copy a full packed microbatch. Missing optional fields keep their later
-        grouped roll calls on the communication fallback.
-
-        Args:
-            width: Number of successor rows required by repeated MTP rolls.
-            input_ids: Local token IDs used by MTP embedding or RL label derivation.
-            position_ids: Local learned-absolute position IDs, when rolled by MTP.
-            labels: Local SFT labels consumed by MTP loss.
-            loss_mask: Local MTP loss mask.
-            padding_mask: Local padding flags rolled by MTP embedding.
-
-        Returns:
-            A new context with compact halos, or this context when prefetch is not
-            applicable to the local shard or no fields are present.
-        """
-        if self.halos is not None:
-            raise ValueError("Contiguous packed-CP halos have already been prefetched.")
-        if width <= 0:
-            raise ValueError("Contiguous packed-CP halo width must be positive.")
-        if width > self.plan.sequence_length:
-            # One neighbor exchange cannot supply rows spanning multiple CP shards.
-            # Keep the established per-roll grouped P2P path for these tiny shards.
-            return self
-
-        tensors_by_field = {
-            "input_ids": input_ids,
-            "position_ids": position_ids,
-            "labels": labels,
-            "loss_mask": loss_mask,
-            "padding_mask": padding_mask,
-        }
-        sequence_fields = []
-        present_tensors: List[Tensor] = []
-        for field, tensor in tensors_by_field.items():
-            if tensor is not None:
-                sequence_fields.append(field)
-                present_tensors.append(tensor)
-        if not sequence_fields:
-            return self
-
-        return ContiguousPackedCPRollContext(
-            plan=self.plan,
-            halos=_prefetch_contiguous_packed_cp_roll_halos(
-                tensors=present_tensors,
-                sequence_fields=sequence_fields,
-                fill_values=[_MTP_SEQUENCE_FIELD_FILL_VALUES[field] for field in sequence_fields],
-                width=width,
-                plan=self.plan,
-            ),
-        )
-
-
-def _get_packed_roll_cu_seqlens(packed_seq_params: PackedSeqParams) -> Tensor:
-    """Return the physical packed-sequence boundaries used by MTP rolling."""
-    cu_seqlens = (
-        packed_seq_params.cu_seqlens_q_padded
-        if getattr(packed_seq_params, 'cu_seqlens_q_padded', None) is not None
-        else packed_seq_params.cu_seqlens_q
-    )
-    assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
-    return cu_seqlens
-
-
-def _get_packed_seq_end_indices(
-    cu_seqlens: Tensor, device: torch.device, sequence_length: int
-) -> Tensor:
-    """Return the ends of explicit packed sequences and any implicit tail.
-
-    PackedSeqParams permits the physical tensor to be longer than the final
-    cumulative sequence length. In that case, the remaining buffer is an
-    implicit tail sequence whose final element must also be filled after the
-    full-buffer roll. Duplicate end indices are safe because index_fill_ is
-    idempotent.
-    """
-    sequence_end_indices = cu_seqlens[1:].to(device=device, dtype=torch.long) - 1
-    if sequence_length == 0:
-        return sequence_end_indices.new_empty((0,))
-    implicit_tail_end = sequence_end_indices.new_full((1,), sequence_length - 1)
-    return torch.cat((sequence_end_indices, implicit_tail_end))
-
-
-def _build_contiguous_packed_seq_roll_plan(
-    tensor: Tensor, dims: int, cu_seqlens: Tensor, cp_group: torch.distributed.ProcessGroup
-) -> ContiguousPackedSeqRollPlan:
-    """Build reusable boundary and neighbor metadata for a contiguous-CP shard."""
-    assert (
-        dims == -1 or dims == tensor.dim() - 1
-    ), "Packed sequence roll only supports the last dimension."
-
-    local_seq_len = tensor.size(dims)
-    cp_size = cp_group.size()
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
-
-    cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
-    if cu.numel() > 1:
-        # Static packed metadata can repeat its final boundary to pad the number
-        # of cu_seqlens entries. Remove duplicates before assigning positions to
-        # packed intervals so every retained interval has a nonzero length.
-        nonduplicate_boundaries = torch.ones(cu.numel(), device=cu.device, dtype=torch.bool)
-        nonduplicate_boundaries[1:] = cu[1:] != cu[:-1]
-        cu = cu[nonduplicate_boundaries]
-
-    has_sequences = cu.numel() > 1
-    if local_seq_len == 0 or not has_sequences:
-        invalid_next = torch.ones(local_seq_len, device=tensor.device, dtype=torch.bool)
-        right_halo_valid_count = torch.zeros((), device=tensor.device, dtype=cu.dtype)
-    else:
-        global_start = local_rank * local_seq_len
-        global_positions = global_start + torch.arange(
-            local_seq_len, device=tensor.device, dtype=cu.dtype
-        )
-        seq_idx = torch.bucketize(global_positions, cu[1:], right=True).clamp(max=cu.numel() - 2)
-        seq_ends = cu[1:][seq_idx]
-        # This deliberately stays true at the local shard's final position when
-        # the same packed sequence continues on the next CP rank. A prefetched
-        # halo or grouped P2P supplies that successor; only physical ends are masked.
-        valid_next = (global_positions < cu[-1]) & (global_positions + 1 < seq_ends)
-        invalid_next = ~valid_next
-
-        # Successor rows are valid only until the physical sequence containing
-        # this shard's final row ends. Keeping the count as a device scalar avoids
-        # a host synchronization and lets halo preparation build any small width.
-        local_tail = global_positions[-1]
-        right_halo_valid_count = torch.where(
-            local_tail < cu[-1],
-            (seq_ends[-1] - local_tail - 1).clamp_min(0),
-            torch.zeros((), device=tensor.device, dtype=cu.dtype),
-        )
-
-    # A left roll receives from the next contiguous shard and sends the first
-    # local element to the previous shard. Store global ranks because PyTorch's
-    # P2P API interprets peer ranks globally even when a process group is passed.
-    return ContiguousPackedSeqRollPlan(
-        invalid_next=invalid_next,
-        sequence_length=local_seq_len,
-        device=tensor.device,
-        cp_group=cp_group,
-        recv_rank=global_ranks[local_rank + 1] if local_rank < cp_size - 1 else None,
-        send_rank=global_ranks[local_rank - 1] if local_rank > 0 else None,
-        has_sequences=has_sequences,
-        right_halo_valid_count=right_halo_valid_count,
-    )
-
-
-def prepare_mtp_sequence_roll_context(
-    tensor: Tensor | None,
-    cp_group: torch.distributed.ProcessGroup | None,
-    packed_seq_params: PackedSeqParams | None,
-    dims: int = -1,
-) -> MTPSequenceRollContext | None:
-    """Prepare layout-specific state shared by MTP rolls in one microbatch.
-
-    The public boundary is layout neutral. Contiguous packed CP is currently the
-    only backend with prepared state; CP1, zigzag CP, unpacked layouts, and missing
-    tensors return None and retain their established roll paths. The returned
-    context can prefetch layout-specific halos immediately before MTP without
-    modifying PackedSeqParams or the model's public forward inputs.
-
-    Args:
-        tensor: Reference payload that establishes local sequence length and device.
-        cp_group: Effective context-parallel process group for the microbatch.
-        packed_seq_params: Physical packed-sequence layout metadata.
-        dims: Sequence dimension; packed rolling supports only the final dimension.
-
-    Returns:
-        A layout-specific roll context, or None when no prepared state is needed.
-    """
-    needs_no_context = (
-        tensor is None or packed_seq_params is None or cp_group is None or cp_group.size() <= 1
-    )
-    if needs_no_context:
-        return None
-
-    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
-    if cp_partition_mode != 'contiguous':
-        return None
-
-    return ContiguousPackedCPRollContext(
-        plan=_build_contiguous_packed_seq_roll_plan(
-            tensor, dims, _get_packed_roll_cu_seqlens(packed_seq_params), cp_group
-        )
-    )
 
 
 if HAVE_TE:
@@ -582,570 +195,6 @@ def tie_output_layer_state_dict(
         tp_group=tp_group,
         dp_cp_group=dp_cp_group,
     )
-
-
-def roll_tensor(
-    tensors: List[Tensor],
-    shifts: int = -1,
-    dims: int = -1,
-    cp_group: torch.distributed.ProcessGroup | None = None,
-    packed_seq_params: PackedSeqParams | None = None,
-    fill_values: List[Union[bool, int, float]] | None = None,
-    roll_context: MTPSequenceRollContext | None = None,
-    sequence_fields: List[str] | None = None,
-    roll_depth: int = 0,
-) -> List[Tensor]:
-    """Roll one or more MTP tensor fields along the sequence dimension.
-
-    All tensors in one call share the same physical sequence layout. Grouping them
-    allows contiguous packed CP to share metadata and use one P2P batch. When a
-    contiguous context owns prefetched halos, the same dispatcher replaces each
-    local tail from the requested field/depth and issues no rolling P2P.
-
-    Args:
-        tensors: Tensor fields to roll together.
-        shifts: Shift along the sequence dimension.
-        dims: Sequence dimension.
-        cp_group: Effective context-parallel process group.
-        packed_seq_params: Packed-sequence layout metadata, when applicable.
-        fill_values: Per-field values written at physical sequence boundaries.
-        roll_context: Layout-specific state prepared for this microbatch. None
-            retains the regular dispatcher and communication fallback.
-        sequence_fields: Canonical source fields corresponding to tensors. These
-            identify prefetched halo payloads and are required only when the
-            context contains halos.
-        roll_depth: Zero-based repeated-roll depth. Depth zero consumes the
-            immediate successor; depth d consumes halo offset d.
-
-    Returns:
-        Rolled tensors in the same order as tensors.
-
-    Raises:
-        ValueError: If field counts, depth, or roll-context arguments are inconsistent.
-    """
-    if not tensors:
-        return []
-    if roll_depth < 0:
-        raise ValueError("roll_depth must be non-negative.")
-    if fill_values is None:
-        fill_values = [0] * len(tensors)
-    if len(tensors) != len(fill_values):
-        raise ValueError("Each tensor must have a corresponding roll fill value.")
-    if sequence_fields is not None and len(tensors) != len(sequence_fields):
-        raise ValueError("Each tensor must have a corresponding canonical sequence field.")
-
-    if packed_seq_params is None:
-        if roll_context is not None:
-            raise ValueError("A prepared sequence-roll context requires packed parameters.")
-        return _roll_tensors_unpacked(tensors, shifts, dims, cp_group, fill_values)
-
-    return _roll_tensors_packed_seq(
-        tensors,
-        shifts,
-        dims,
-        packed_seq_params,
-        cp_group,
-        fill_values,
-        roll_context,
-        sequence_fields,
-        roll_depth,
-    )
-
-
-def _roll_tensors_unpacked(
-    tensors: List[Tensor],
-    shifts: int,
-    dims: int,
-    cp_group: Optional[torch.distributed.ProcessGroup],
-    fill_values: List[Union[bool, int, float]],
-) -> List[Tensor]:
-    """Roll unpacked tensors for CP1 or the standard zigzag CP layout."""
-    if cp_group is None or cp_group.size() == 1:
-        rolled_tensors = [torch.roll(tensor, shifts=shifts, dims=dims) for tensor in tensors]
-        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
-            rolled_tensor.select(dims, shifts).fill_(fill_value)
-        return rolled_tensors
-
-    return [
-        _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=fill_value)
-        for tensor, fill_value in zip(tensors, fill_values)
-    ]
-
-
-def _roll_tensor_unpacked_zigzag_cp(tensor, shifts, dims, cp_group, fill_value=0):
-    """Roll one unpacked tensor in the standard two-chunk zigzag CP layout."""
-    # This matches the batch splitting logic in get_batch_on_this_cp_rank().
-    tensor_list = tensor.chunk(2, dim=dims)
-    rolled_tensor_list = []
-    for i in range(len(tensor_list)):
-        rolled_tensor_list.append(torch.roll(tensor_list[i], shifts=shifts, dims=dims))
-
-    # Prepare tensors for communication between CP ranks
-    # Each CP rank needs to send boundary elements to adjacent ranks
-    tensor_send_list = []
-    tensor_recv_list = []
-    for i in range(len(rolled_tensor_list)):
-        tensor_send_list.append(rolled_tensor_list[i].select(dims, shifts).contiguous())
-        empty_tensor = torch.empty(
-            tensor_send_list[i].shape,
-            dtype=tensor_send_list[i].dtype,
-            device=torch.cuda.current_device(),
-        )
-        tensor_recv_list.append(empty_tensor)
-
-    # Get the global rank of next and prev process in the cp group
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    next_rank = global_ranks[(local_rank + 1) % len(global_ranks)]
-    prev_rank = global_ranks[(local_rank - 1) % len(global_ranks)]
-
-    # Start send and recv ops
-    ops = []
-    if local_rank != 0:
-        req_send_first_part = torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank)
-        ops.append(req_send_first_part)
-        req_recv_second_part = torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank)
-        ops.append(req_recv_second_part)
-    else:
-        tensor_recv_list[1] = fill_value
-    if local_rank != len(global_ranks) - 1:
-        req_recv_first_part = torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank)
-        ops.append(req_recv_first_part)
-        req_send_second_part = torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank)
-        ops.append(req_send_second_part)
-    else:
-        # For the last CP rank, the removed elements of second part go into the first part
-        tensor_recv_list[0] = tensor_send_list[1]
-
-    # Wait for all communication operations to complete
-    for op in ops:
-        op.wait()
-
-    # Splicing: Replace boundary elements with received elements from adjacent ranks
-    # This ensures proper sequence continuity across CP boundaries
-    index = [slice(None)] * rolled_tensor_list[0].dim()
-    index[dims] = shifts
-    for i in range(len(rolled_tensor_list)):
-        rolled_tensor_list[i][tuple(index)] = tensor_recv_list[i]
-
-    # Concatenate the processed chunks back into a single tensor
-    rolled_tensor = torch.cat(rolled_tensor_list, dim=dims)
-
-    return rolled_tensor
-
-
-def _roll_tensors_packed_seq(
-    tensors: List[Tensor],
-    shifts: int,
-    dims: int,
-    packed_seq_params: PackedSeqParams,
-    cp_group: Optional[torch.distributed.ProcessGroup],
-    fill_values: List[Union[bool, int, float]],
-    roll_context: Optional[MTPSequenceRollContext],
-    sequence_fields: Optional[List[str]],
-    roll_depth: int,
-) -> List[Tensor]:
-    """Dispatch packed tensors to CP1, zigzag CP, or contiguous CP rolling."""
-    for tensor in tensors:
-        assert (
-            dims == -1 or dims == tensor.dim() - 1
-        ), "Packed sequence roll only supports the last dimension."
-    assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
-
-    # Prefer padded cumulative seqlens because CP's local THD layout uses the
-    # padded physical boundaries. Unpadded boundaries index the wrong local
-    # chunks when sequence lengths are not already divisible by 2 * cp_size.
-    cu_seqlens = _get_packed_roll_cu_seqlens(packed_seq_params)
-
-    cp_size = cp_group.size() if cp_group is not None else 1
-    if cp_size == 1:
-        if roll_context is not None:
-            raise ValueError("A prepared sequence-roll context cannot be used for packed CP1.")
-        reference_tensor = tensors[0]
-        sequence_end_indices = _get_packed_seq_end_indices(
-            cu_seqlens, reference_tensor.device, reference_tensor.size(dims)
-        )
-        for tensor in tensors:
-            if tensor.device != reference_tensor.device:
-                raise ValueError("All packed CP1 tensors must be on the same device.")
-            if tensor.size(dims) != reference_tensor.size(dims):
-                raise ValueError("All packed CP1 tensors must have the same sequence length.")
-        return [
-            _roll_tensor_packed_seq_cp1(
-                tensor, shifts, dims, sequence_end_indices, fill_value=fill_value
-            )
-            for tensor, fill_value in zip(tensors, fill_values)
-        ]
-
-    cp_partition_mode = getattr(packed_seq_params, 'cp_partition_mode', 'zigzag')
-    if cp_partition_mode == 'zigzag':
-        if roll_context is not None:
-            raise ValueError(
-                "A prepared sequence-roll context is not supported for packed zigzag CP."
-            )
-        return [
-            _roll_tensor_packed_seq_zigzag_cp(
-                tensor, shifts, dims, cu_seqlens, cp_group, fill_value=fill_value
-            )
-            for tensor, fill_value in zip(tensors, fill_values)
-        ]
-    if cp_partition_mode == 'contiguous':
-        contiguous_roll_halos = None
-        if roll_context is None:
-            contiguous_roll_plan = _build_contiguous_packed_seq_roll_plan(
-                tensors[0], dims, cu_seqlens, cp_group
-            )
-        elif isinstance(roll_context, ContiguousPackedCPRollContext):
-            contiguous_roll_plan = roll_context.plan
-            contiguous_roll_halos = roll_context.halos
-        else:
-            raise ValueError(
-                "The prepared sequence-roll context does not support contiguous packed CP."
-            )
-        return _roll_tensors_packed_seq_contiguous_cp(
-            tensors,
-            dims,
-            fill_values,
-            contiguous_roll_plan,
-            contiguous_roll_halos,
-            sequence_fields,
-            roll_depth,
-        )
-    raise ValueError(f"Unsupported packed sequence CP partition mode: {cp_partition_mode}")
-
-
-def _roll_tensor_packed_seq_cp1(tensor, shifts, dims, sequence_end_indices, fill_value=0):
-    """Roll one CP1 packed tensor and fill every physical sequence end."""
-    # A full-buffer left roll is equivalent to rolling each packed sequence
-    # independently once the values that crossed sequence boundaries are filled.
-    rolled_tensor = torch.roll(tensor, shifts=shifts, dims=dims)
-    rolled_tensor.index_fill_(dims, sequence_end_indices, fill_value)
-    return rolled_tensor
-
-
-def _roll_tensor_packed_seq_zigzag_cp(tensor, shifts, dims, cu_seqlens, cp_group, fill_value=0):
-    """Roll a zigzag-CP THD shard without crossing packed sequence boundaries."""
-    cp_size = cp_group.size()
-    rolled_tensor = tensor.clone()
-
-    # CP enabled: each rank owns two chunks per sequence (front and mirrored tail).
-    local_rank = torch.distributed.get_rank(group=cp_group)
-    global_ranks = torch.distributed.get_process_group_ranks(group=cp_group)
-    next_rank = global_ranks[(local_rank + 1) % cp_size]
-    prev_rank = global_ranks[(local_rank - 1) % cp_size]
-
-    # Iterate over each sequence individually
-    for i in range(len(cu_seqlens) - 1):
-        start_idx = cu_seqlens[i]
-        end_idx = cu_seqlens[i + 1]
-
-        # the idx has been multiplied by cp_size, need to divide it by cp_size to get the local idx
-        local_start_idx = start_idx // cp_size
-        local_end_idx = end_idx // cp_size
-
-        # Skip empty sequences - this can happen when a sequence is very short and
-        # after dividing by cp_size, the local slice has zero length
-        local_seq_len = local_end_idx - local_start_idx
-        if local_seq_len == 0:
-            continue
-
-        tensor_slice = rolled_tensor[..., local_start_idx:local_end_idx].clone()
-
-        # The following code is very similar as the code in roll_tensor function
-        local_chunks = tensor_slice.chunk(2, dim=dims)
-        rolled_chunks = [torch.roll(chunk, shifts=shifts, dims=dims) for chunk in local_chunks]
-
-        tensor_send_list = []
-        tensor_recv_list = []
-        for chunk in rolled_chunks:
-            # Skip empty chunks that can occur when the sequence slice is very small
-            if chunk.size(dims) == 0:
-                tensor_send_list.append(
-                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
-                )
-                tensor_recv_list.append(
-                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
-                )
-                continue
-            boundary = chunk.select(dims, shifts).contiguous().clone()
-            tensor_send_list.append(boundary)
-            tensor_recv_list.append(torch.empty_like(boundary))
-
-        ops = []
-        if local_rank != 0:
-            ops.append(torch.distributed.isend(tensor=tensor_send_list[0], dst=prev_rank))
-            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[1], src=prev_rank))
-        else:
-            tensor_recv_list[1].fill_(fill_value)
-
-        if local_rank != cp_size - 1:
-            ops.append(torch.distributed.irecv(tensor=tensor_recv_list[0], src=next_rank))
-            ops.append(torch.distributed.isend(tensor=tensor_send_list[1], dst=next_rank))
-        else:
-            tensor_recv_list[0].copy_(tensor_send_list[1])
-
-        for op in ops:
-            op.wait()
-
-        index = [slice(None)] * rolled_chunks[0].dim()
-        index[dims] = shifts
-        for chunk, recv in zip(rolled_chunks, tensor_recv_list):
-            # Skip empty chunks
-            if chunk.size(dims) == 0:
-                continue
-            chunk[tuple(index)] = recv
-
-        seq_result = torch.cat(rolled_chunks, dim=dims)
-
-        # update the rolled tensor
-        rolled_tensor[..., local_start_idx:local_end_idx] = seq_result
-
-    return rolled_tensor
-
-
-def _prefetch_contiguous_packed_cp_roll_halos(
-    tensors: List[Tensor],
-    sequence_fields: List[str],
-    fill_values: List[Union[bool, int, float]],
-    width: int,
-    plan: ContiguousPackedSeqRollPlan,
-) -> ContiguousPackedCPRollHalos:
-    """Fetch compact right halos for contiguous packed CP in one grouped P2P.
-
-    Each rank sends the first width rows of every requested field to its
-    predecessor and receives the corresponding rows from its successor. Received
-    rows are sanitized once using the physical packed boundary that contains this
-    rank's local final row. Repeated MTP rolls can then consume halo offsets without
-    further communication.
-
-    Args:
-        tensors: Local MTP fields sharing the plan's sequence axis.
-        sequence_fields: Canonical names corresponding to tensors.
-        fill_values: Per-field physical-boundary fill values.
-        width: Number of successor rows required by all MTP prediction depths.
-        plan: Reusable contiguous packed-CP layout and neighbor metadata.
-
-    Returns:
-        Compact, independently allocated successor rows keyed by MTP field.
-
-    Raises:
-        ValueError: If the field metadata is inconsistent with the roll plan.
-    """
-    if width <= 0:
-        raise ValueError("Contiguous packed-CP halo width must be positive.")
-    if len(tensors) != len(sequence_fields) or len(tensors) != len(fill_values):
-        raise ValueError("Each halo tensor must have a canonical field and fill value.")
-    if len(set(sequence_fields)) != len(sequence_fields):
-        raise ValueError("Each contiguous packed-CP halo field may be prefetched only once.")
-    if width > plan.sequence_length:
-        raise ValueError(
-            f"Contiguous packed-CP halo width {width} exceeds local sequence length "
-            f"{plan.sequence_length}."
-        )
-
-    halos: List[Tensor] = []
-    for tensor, sequence_field, fill_value in zip(tensors, sequence_fields, fill_values):
-        if sequence_field not in _MTP_SEQUENCE_FIELD_FILL_VALUES:
-            raise ValueError(f"Unsupported MTP sequence halo field: {sequence_field}.")
-        expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
-        if fill_value != expected_fill_value:
-            raise ValueError(
-                f"Halo field {sequence_field} requires boundary fill value "
-                f"{expected_fill_value!r}, got {fill_value!r}."
-            )
-        if tensor.device != plan.device:
-            raise ValueError("All halo tensors sharing a roll plan must be on the same device.")
-        if tensor.size(-1) != plan.sequence_length:
-            raise ValueError(
-                "All halo tensors sharing a roll plan must have the same sequence length."
-            )
-
-        halo_shape = list(tensor.shape)
-        halo_shape[-1] = width
-        halos.append(tensor.new_full(halo_shape, fill_value))
-
-    # Retain contiguous send slices until every grouped work handle completes.
-    send_buffers: List[Tensor] = []
-    p2p_ops = []
-    if plan.has_sequences and plan.recv_rank is not None:
-        for halo in halos:
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.irecv, halo, plan.recv_rank, group=plan.cp_group
-                )
-            )
-    if plan.has_sequences and plan.send_rank is not None:
-        for tensor in tensors:
-            send_buffer = tensor.narrow(-1, 0, width).contiguous()
-            send_buffers.append(send_buffer)
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.isend, send_buffer, plan.send_rank, group=plan.cp_group
-                )
-            )
-
-    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
-    for work in works:
-        work.wait()
-
-    # Offset d is valid only when the local tail and its (d + 1)-th successor
-    # belong to the same physical packed sequence. Broadcasting this small mask
-    # sanitizes every field without retaining the full packed metadata.
-    invalid_halo = (
-        torch.arange(width, device=plan.device, dtype=plan.right_halo_valid_count.dtype)
-        >= plan.right_halo_valid_count
-    )
-    for halo, fill_value in zip(halos, fill_values):
-        halo.masked_fill_(invalid_halo, fill_value)
-
-    halo_by_field = dict(zip(sequence_fields, halos))
-    return ContiguousPackedCPRollHalos(
-        input_ids=halo_by_field.get("input_ids"),
-        position_ids=halo_by_field.get("position_ids"),
-        labels=halo_by_field.get("labels"),
-        loss_mask=halo_by_field.get("loss_mask"),
-        padding_mask=halo_by_field.get("padding_mask"),
-    )
-
-
-def _roll_tensors_packed_seq_contiguous_cp(
-    tensors: List[Tensor],
-    dims: int,
-    fill_values: List[Union[bool, int, float]],
-    contiguous_roll_plan: ContiguousPackedSeqRollPlan,
-    contiguous_roll_halos: Optional[ContiguousPackedCPRollHalos] = None,
-    sequence_fields: Optional[List[str]] = None,
-    roll_depth: int = 0,
-) -> List[Tensor]:
-    """Roll contiguous packed-CP tensors from halos or one grouped P2P exchange.
-
-    A prefetched halo is used only when every field in this grouped call is present.
-    Otherwise the entire call takes the grouped P2P fallback, keeping all CP ranks
-    on the same communication branch while supporting optional model inputs.
-    """
-    assert len(tensors) == len(fill_values)
-    if not tensors:
-        return []
-
-    for tensor in tensors:
-        assert (
-            dims == -1 or dims == tensor.dim() - 1
-        ), "Packed sequence roll only supports the last dimension."
-        if tensor.size(dims) != contiguous_roll_plan.sequence_length:
-            raise ValueError(
-                "All tensors sharing a packed-sequence roll plan must have the same "
-                "sequence length."
-            )
-        if tensor.device != contiguous_roll_plan.device:
-            raise ValueError(
-                "All tensors sharing a packed-sequence roll plan must be on the same device."
-            )
-
-    if contiguous_roll_plan.sequence_length == 0:
-        return [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
-
-    if not contiguous_roll_plan.has_sequences:
-        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
-        for rolled_tensor, fill_value in zip(rolled_tensors, fill_values):
-            rolled_tensor.fill_(fill_value)
-        return rolled_tensors
-
-    halo_tail_values = None
-    if contiguous_roll_halos is not None and sequence_fields is not None:
-        if len(sequence_fields) != len(tensors):
-            raise ValueError("Each rolled tensor must have a canonical sequence field.")
-
-        requested_halos = [contiguous_roll_halos.get(field) for field in sequence_fields]
-        if all(halo is not None for halo in requested_halos):
-            if roll_depth >= contiguous_roll_halos.width:
-                raise ValueError(
-                    f"roll_depth={roll_depth} exceeds the prefetched halo width "
-                    f"{contiguous_roll_halos.width}."
-                )
-
-            halo_tail_values = []
-            for tensor, sequence_field, fill_value, halo in zip(
-                tensors, sequence_fields, fill_values, requested_halos
-            ):
-                assert halo is not None
-                expected_fill_value = _MTP_SEQUENCE_FIELD_FILL_VALUES[sequence_field]
-                if fill_value != expected_fill_value:
-                    raise ValueError(
-                        f"Halo field {sequence_field} requires boundary fill value "
-                        f"{expected_fill_value!r}, got {fill_value!r}."
-                    )
-                if halo.device != tensor.device:
-                    raise ValueError(
-                        f"Halo field {sequence_field} and its tensor must be on the same device."
-                    )
-                if halo.dtype != tensor.dtype:
-                    raise ValueError(
-                        f"Halo field {sequence_field} and its tensor must have the same dtype."
-                    )
-                if halo.dim() != tensor.dim() or halo.shape[:-1] != tensor.shape[:-1]:
-                    raise ValueError(
-                        f"Halo field {sequence_field} must match its tensor's leading dimensions."
-                    )
-                halo_tail_values.append(halo.select(dims, roll_depth))
-
-    if halo_tail_values is not None:
-        rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
-        for rolled_tensor, halo_tail, fill_value in zip(
-            rolled_tensors, halo_tail_values, fill_values
-        ):
-            rolled_tensor.select(dims, -1).copy_(halo_tail)
-            # Internal physical sequence ends are handled by the shared immediate
-            # boundary mask. Tail values for deeper rolls were sanitized before
-            # slicing because their validity depends on the requested depth.
-            rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
-        return rolled_tensors
-
-    recv_buffers: List[Optional[Tensor]] = [None] * len(tensors)
-    # Keep contiguous send buffers alive until every grouped work handle completes.
-    send_buffers: List[Tensor] = []
-    p2p_ops = []
-
-    if contiguous_roll_plan.recv_rank is not None:
-        # After a left roll, each local tail consumes the first element from the
-        # next contiguous CP shard.
-        for index, tensor in enumerate(tensors):
-            recv_buffer = torch.empty_like(tensor.select(dims, 0))
-            recv_buffers[index] = recv_buffer
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.irecv,
-                    recv_buffer,
-                    contiguous_roll_plan.recv_rank,
-                    group=contiguous_roll_plan.cp_group,
-                )
-            )
-    if contiguous_roll_plan.send_rank is not None:
-        # This rank's first element becomes the previous shard's local tail.
-        for tensor in tensors:
-            send_buffer = tensor.select(dims, 0).contiguous()
-            send_buffers.append(send_buffer)
-            p2p_ops.append(
-                torch.distributed.P2POp(
-                    torch.distributed.isend,
-                    send_buffer,
-                    contiguous_roll_plan.send_rank,
-                    group=contiguous_roll_plan.cp_group,
-                )
-            )
-
-    works = torch.distributed.batch_isend_irecv(p2p_ops) if p2p_ops else []
-    rolled_tensors = [torch.roll(tensor, shifts=-1, dims=dims) for tensor in tensors]
-    for work in works:
-        work.wait()
-
-    for rolled_tensor, recv_buffer, fill_value in zip(rolled_tensors, recv_buffers, fill_values):
-        if recv_buffer is not None:
-            rolled_tensor.select(dims, -1).copy_(recv_buffer)
-        # Apply the shared boundary mask after installing the adjacent value so a
-        # physical packed-sequence end always wins over a cross-rank successor.
-        rolled_tensor[..., contiguous_roll_plan.invalid_next] = fill_value
-
-    return rolled_tensors
 
 
 class MTPLossLoggingHelper:
@@ -1775,7 +824,6 @@ def _process_mtp_e2e_tv_loss(
     scale_logits_fn: Optional[Callable[[Tensor], Tensor]],
     sequence_roll_context: Optional[MTPSequenceRollContext],
     derived_labels_from_input_ids: bool,
-    original_num_tokens: Optional[Tensor],
 ) -> Tensor:
     """Apply the end-to-end TV objective to MTP draft hidden states.
 
@@ -1798,32 +846,72 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             target_logits = scale_logits_fn(target_logits)
-    # roll_tensor handles packed boundaries and CP communication along its last
-    # dimension. Keep vocabulary before sequence while preparing target alignment.
-    target_logits = target_logits.permute(1, 2, 0)
-    current_loss_mask = loss_mask
+    num_depths = config.mtp_num_layers
+    max_offset = num_depths + int(derived_labels_from_input_ids)
+    tv_roll_context = prepare_mtp_sequence_roll_fields(
+        sequence_roll_context,
+        (
+            MTPSequenceRollField("target_logits", target_logits, 0, 1, 0),
+            MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0),
+        ),
+        max_offset=max_offset,
+    )
+    use_prepared_roll_rows = tv_roll_context is not None
+
+    # The legacy path keeps vocabulary before sequence because roll_tensor
+    # operates on the final dimension. The addressed path leaves target logits
+    # in their native [sequence, batch, vocab] layout and reads them directly.
+    if use_prepared_roll_rows:
+        assert tv_roll_context is not None
+        aligned_loss_masks = tv_roll_context.materialize_all("loss_mask")
+        current_loss_mask = loss_mask
+        original_loss_mask = aligned_loss_masks[0] if derived_labels_from_input_ids else loss_mask
+    else:
+        target_logits = target_logits.permute(1, 2, 0)
+        current_loss_mask = loss_mask
+        if derived_labels_from_input_ids:
+            current_loss_mask = roll_tensor(
+                [current_loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["loss_mask"],
+                roll_depth=0,
+            )[0]
+        original_loss_mask = current_loss_mask
+
+    original_num_tokens = original_loss_mask.sum() if config.calculate_per_token_loss else None
     chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
     tv_distances = []
 
-    for mtp_layer_number in range(config.mtp_num_layers):
-        target_logits = roll_tensor(
-            [target_logits],
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            fill_values=[0],
-        )[0]
-        current_loss_mask = roll_tensor(
-            [current_loss_mask],
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            roll_context=sequence_roll_context,
-            sequence_fields=["loss_mask"],
-            roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
-        )[0]
+    for mtp_layer_number in range(num_depths):
+        if use_prepared_roll_rows:
+            assert tv_roll_context is not None
+            target_address = tv_roll_context.address("target_logits", mtp_layer_number + 1)
+            current_loss_mask = aligned_loss_masks[
+                mtp_layer_number + int(derived_labels_from_input_ids)
+            ]
+        else:
+            target_logits = roll_tensor(
+                [target_logits],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                fill_values=[0],
+            )[0]
+            current_loss_mask = roll_tensor(
+                [current_loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["loss_mask"],
+                roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
+            )[0]
         chain_valid &= current_loss_mask.bool()
 
         draft_logits, _ = output_layer(
@@ -1833,15 +921,28 @@ def _process_mtp_e2e_tv_loss(
         )
         if scale_logits_fn is not None:
             draft_logits = scale_logits_fn(draft_logits)
-        aligned_target_logits = target_logits.permute(2, 0, 1)
-        tv_distances.append(
-            vocab_parallel_tv_distance(
-                draft_logits,
-                aligned_target_logits,
-                tp_group=tp_group,
-                logits_are_vocab_sharded=logits_are_vocab_sharded,
+        if use_prepared_roll_rows:
+            tv_distances.append(
+                vocab_parallel_tv_distance(
+                    draft_logits,
+                    target_address.source,
+                    tp_group=tp_group,
+                    logits_are_vocab_sharded=logits_are_vocab_sharded,
+                    target_row_indices=target_address.row_indices,
+                    target_valid_rows=target_address.valid_rows,
+                    target_halo_logits=target_address.halo,
+                )
             )
-        )
+        else:
+            aligned_target_logits = target_logits.permute(2, 0, 1)
+            tv_distances.append(
+                vocab_parallel_tv_distance(
+                    draft_logits,
+                    aligned_target_logits,
+                    tp_group=tp_group,
+                    logits_are_vocab_sharded=logits_are_vocab_sharded,
+                )
+            )
 
     tv_distances_tensor = torch.stack(tv_distances, dim=0)
     per_step_acceptance = 1.0 - tv_distances_tensor
@@ -1936,28 +1037,15 @@ def process_mtp_loss(
     hidden_states_list = torch.chunk(hidden_states, 1 + config.mtp_num_layers, dim=0)
     hidden_states = hidden_states_list[0]
 
-    # When labels are not provided (e.g. RL training), derive them from input_ids by
-    # rolling left so that label[i] = input_id[i + 1], matching the SFT label format.
     derived_labels_from_input_ids = labels is None
     if derived_labels_from_input_ids:
         if input_ids is None:
             return hidden_states
         if loss_mask is None:
             loss_mask = torch.ones_like(input_ids)
-        labels, loss_mask = roll_tensor(
-            [input_ids, loss_mask],
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            roll_context=sequence_roll_context,
-            sequence_fields=["input_ids", "loss_mask"],
-            roll_depth=0,
-        )
     elif loss_mask is None:
         loss_mask = torch.ones_like(labels)
 
-    assert labels is not None
     assert loss_mask is not None
 
     if config.mtp_detach_heads:
@@ -1965,13 +1053,6 @@ def process_mtp_loss(
             output_weight = output_weight.detach()
         else:
             output_weight = output_layer.weight.detach()
-
-    mtp_labels = labels
-
-    # Store the original number of tokens before rolling for proper normalization
-    # when calculate_per_token_loss is enabled. This ensures MTP gradients are
-    # correctly scaled relative to the main loss gradients in finalize_model_grads.
-    original_num_tokens = loss_mask.sum() if config.calculate_per_token_loss else None
 
     if config.mtp_loss_type == "e2e_tv":
         assert output_weight is not None
@@ -1989,26 +1070,65 @@ def process_mtp_loss(
             scale_logits_fn=scale_logits_fn,
             sequence_roll_context=sequence_roll_context,
             derived_labels_from_input_ids=derived_labels_from_input_ids,
-            original_num_tokens=original_num_tokens,
         )
+
+    label_source = input_ids if derived_labels_from_input_ids else labels
+    assert label_source is not None
+    label_key = "input_ids" if derived_labels_from_input_ids else "labels"
+    max_offset = config.mtp_num_layers + int(derived_labels_from_input_ids)
+    loss_roll_context = prepare_mtp_sequence_roll_fields(
+        sequence_roll_context,
+        (
+            MTPSequenceRollField(label_key, label_source, -1, 0, 0),
+            MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0),
+        ),
+        max_offset=max_offset,
+    )
+    use_prepared_roll_rows = loss_roll_context is not None
+    if use_prepared_roll_rows:
+        assert loss_roll_context is not None
+        aligned_labels = loss_roll_context.materialize_all(label_key)
+        aligned_loss_masks = loss_roll_context.materialize_all("loss_mask")
+        original_loss_mask = aligned_loss_masks[0] if derived_labels_from_input_ids else loss_mask
+        mtp_labels = label_source
+    else:
+        # Preserve the original cumulative-roll path exactly. RL first derives
+        # SFT-format labels/mask at offset one; every MTP depth then rolls once.
+        mtp_labels = label_source
+        if derived_labels_from_input_ids:
+            mtp_labels, loss_mask = roll_tensor(
+                [mtp_labels, loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=["input_ids", "loss_mask"],
+                roll_depth=0,
+            )
+        original_loss_mask = loss_mask
+
+    original_num_tokens = original_loss_mask.sum() if config.calculate_per_token_loss else None
 
     fuse_linear_cross_entropy = (
         config.cross_entropy_loss_fusion and config.cross_entropy_fusion_impl == "linear"
     )
     for mtp_layer_number in range(config.mtp_num_layers):
-        mtp_labels, loss_mask = roll_tensor(
-            [mtp_labels, loss_mask],
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            roll_context=sequence_roll_context,
-            sequence_fields=[
-                "input_ids" if derived_labels_from_input_ids else "labels",
-                "loss_mask",
-            ],
-            roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
-        )
+        if use_prepared_roll_rows:
+            offset_index = mtp_layer_number + int(derived_labels_from_input_ids)
+            mtp_labels = aligned_labels[offset_index]
+            loss_mask = aligned_loss_masks[offset_index]
+        else:
+            mtp_labels, loss_mask = roll_tensor(
+                [mtp_labels, loss_mask],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                roll_context=sequence_roll_context,
+                sequence_fields=[label_key, "loss_mask"],
+                roll_depth=mtp_layer_number + int(derived_labels_from_input_ids),
+            )
         num_tokens = loss_mask.sum()
         if fuse_linear_cross_entropy:
             mtp_loss = output_layer(
@@ -2303,6 +1423,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         padding_mask: Optional[torch.Tensor] = None,
         sequence_roll_context: Optional[MTPSequenceRollContext] = None,
         roll_depth: int = 0,
+        _inputs_pre_aligned: bool = False,
     ):
         """Roll MTP inputs once and compute the next-depth token embeddings.
 
@@ -2317,40 +1438,44 @@ class MultiTokenPredictionLayer(MegatronModule):
                 in this microbatch.
             roll_depth: Zero-based prediction depth selecting the prefetched
                 successor row for this repeated roll.
+            _inputs_pre_aligned: Internal block-to-layer contract indicating that
+                input, learned position, and padding fields already represent the
+                absolute shifted row for this depth.
         """
-        cp_group = resolve_cp_group(self.cp_group, packed_seq_params)
+        if not _inputs_pre_aligned:
+            cp_group = resolve_cp_group(self.cp_group, packed_seq_params)
 
-        tensors_to_roll = [input_ids]
-        fill_values = [0]
-        sequence_fields = ["input_ids"]
-        roll_position_ids = getattr(embedding, 'add_position_embedding', True)
-        if roll_position_ids:
-            tensors_to_roll.append(position_ids)
-            fill_values.append(0)
-            sequence_fields.append("position_ids")
-        if padding_mask is not None:
-            tensors_to_roll.append(padding_mask)
-            fill_values.append(True)
-            sequence_fields.append("padding_mask")
+            tensors_to_roll = [input_ids]
+            fill_values = [0]
+            sequence_fields = ["input_ids"]
+            roll_position_ids = getattr(embedding, 'add_position_embedding', True)
+            if roll_position_ids:
+                tensors_to_roll.append(position_ids)
+                fill_values.append(0)
+                sequence_fields.append("position_ids")
+            if padding_mask is not None:
+                tensors_to_roll.append(padding_mask)
+                fill_values.append(True)
+                sequence_fields.append("padding_mask")
 
-        rolled_tensors = roll_tensor(
-            tensors_to_roll,
-            shifts=-1,
-            dims=-1,
-            cp_group=cp_group,
-            packed_seq_params=packed_seq_params,
-            fill_values=fill_values,
-            roll_context=sequence_roll_context,
-            sequence_fields=sequence_fields,
-            roll_depth=roll_depth,
-        )
-        input_ids = rolled_tensors[0]
-        next_rolled_tensor = 1
-        if roll_position_ids:
-            position_ids = rolled_tensors[next_rolled_tensor]
-            next_rolled_tensor += 1
-        if padding_mask is not None:
-            padding_mask = rolled_tensors[next_rolled_tensor]
+            rolled_tensors = roll_tensor(
+                tensors_to_roll,
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                fill_values=fill_values,
+                roll_context=sequence_roll_context,
+                sequence_fields=sequence_fields,
+                roll_depth=roll_depth,
+            )
+            input_ids = rolled_tensors[0]
+            next_rolled_tensor = 1
+            if roll_position_ids:
+                position_ids = rolled_tensors[next_rolled_tensor]
+                next_rolled_tensor += 1
+            if padding_mask is not None:
+                padding_mask = rolled_tensors[next_rolled_tensor]
 
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
 
@@ -2821,6 +1946,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
         mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
+        _inputs_pre_aligned: bool = False,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -2841,6 +1967,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                 in this microbatch.
             roll_depth: Zero-based prediction depth selecting the prefetched
                 successor row for this repeated roll.
+            _inputs_pre_aligned: Internal block-to-layer contract indicating that
+                sequence fields are already aligned to this absolute depth.
             sequence_len_offset (Tensor, optional): Offset for sequence length, if applicable.
             embedding (Callable): The embedding module from gpt model to compute the decoder input.
             mtp_dsa_context (MTPDSAIterationContext, optional): Per-iteration carrier for the
@@ -2864,6 +1992,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             packed_seq_params=packed_seq_params,
             sequence_roll_context=sequence_roll_context,
             roll_depth=roll_depth,
+            _inputs_pre_aligned=_inputs_pre_aligned,
         )
 
         mtp_dsa_kwargs = {}
@@ -2963,6 +2092,23 @@ class MultiTokenPredictionBlockSubmodules:
     """
 
     layer_specs: Optional[List[ModuleSpec]] = None
+
+
+def _scatter_mtp_padding_mask(
+    padding_mask: Optional[Tensor], *, sequence_parallel: bool, tp_group
+) -> Optional[Tensor]:
+    """Convert one globally aligned MTP routing mask to its TP-local layout."""
+    if padding_mask is None or not sequence_parallel:
+        return padding_mask
+    if tp_group is None:
+        raise ValueError("MTP sequence-parallel padding-mask scatter requires a TP group.")
+    return (
+        tensor_parallel.scatter_to_sequence_parallel_region(
+            padding_mask.transpose(0, 1).contiguous(), group=tp_group
+        )
+        .transpose(0, 1)
+        .contiguous()
+    )
 
 
 def _get_mtp_block_submodules(
@@ -3195,6 +2341,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
         mhc_multistream: Optional[Tensor] = None,
+        sequence_roll_padding_mask: Optional[Tensor] = None,
     ) -> Tensor:
         """
         Perform the forward pass through all of the MTP modules.
@@ -3208,8 +2355,11 @@ class MultiTokenPredictionBlock(MegatronModule):
             attention_mask (Tensor): Boolean tensor of shape [1, 1, s, s] for masking
                 self-attention.
             padding_mask (Tensor, optional): Padding mask for MoE routing (True = padded).
-                Each MTP layer rolls this mask in sync with input_ids/position_ids using
-                a True field fill value so boundary positions are marked as padded.
+                This is already TP-local under sequence parallelism and remains the
+                source for the cumulative-roll fallback.
+            sequence_roll_padding_mask (Tensor, optional): Unsharded padding-mask source
+                used to prepare and materialize absolute roll rows. Each row is scattered
+                to the MTP layer's TP-local layout after materialization.
             sequence_roll_context: Layout-specific metadata shared across all MTP
                 depths.
 
@@ -3230,8 +2380,54 @@ class MultiTokenPredictionBlock(MegatronModule):
             hidden_states = hidden_states.detach()
 
         shared_dsa_tensors = None
+        if sequence_roll_padding_mask is not None and padding_mask is None:
+            raise ValueError(
+                "MTP sequence_roll_padding_mask requires the corresponding TP-local padding_mask."
+            )
+
+        roll_position_ids = getattr(embedding, "add_position_embedding", True)
+        roll_fields = [MTPSequenceRollField("input_ids", input_ids, -1, 0, 0)]
+        if roll_position_ids:
+            roll_fields.append(MTPSequenceRollField("position_ids", position_ids, -1, 0, 0))
+        if sequence_roll_padding_mask is not None:
+            roll_fields.append(
+                MTPSequenceRollField("padding_mask", sequence_roll_padding_mask, -1, 0, True)
+            )
+        # A local padding mask without its unsharded source cannot participate in
+        # absolute addressing. Fall back the complete consumer group so input IDs,
+        # positions, and padding retain the established cumulative-roll semantics.
+        prepared_roll_context = None
+        if padding_mask is None or sequence_roll_padding_mask is not None:
+            prepared_roll_context = prepare_mtp_sequence_roll_fields(
+                sequence_roll_context, roll_fields, max_offset=self.config.mtp_num_layers
+            )
+        use_prepared_roll_rows = prepared_roll_context is not None
+        aligned_rows = None
+        if use_prepared_roll_rows:
+            assert prepared_roll_context is not None
+            # Materialize the complete group before invoking any MTP layer. A
+            # depth therefore either consumes only absolute rows or stays wholly
+            # on the established cumulative-roll path.
+            aligned_rows = {
+                field.key: prepared_roll_context.materialize_all(field.key) for field in roll_fields
+            }
+
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
+            if aligned_rows is not None:
+                input_ids = aligned_rows["input_ids"][iteration]
+                if roll_position_ids:
+                    position_ids = aligned_rows["position_ids"][iteration]
+                if sequence_roll_padding_mask is not None:
+                    padding_mask = aligned_rows["padding_mask"][iteration]
+                    padding_mask = _scatter_mtp_padding_mask(
+                        padding_mask,
+                        sequence_parallel=getattr(self.config, "sequence_parallel", False),
+                        tp_group=getattr(self.layers[layer_idx], "tp_group", None),
+                    )
+            alignment_kwargs = {}
+            if aligned_rows is not None:
+                alignment_kwargs["_inputs_pre_aligned"] = True
             mtp_dsa_context = None
             mtp_dsa_kwargs = {}
             if self.config.dsa_mtp_index_kv_share:
@@ -3254,6 +2450,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                 roll_depth=iteration,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
+                **alignment_kwargs,
                 **mtp_dsa_kwargs,
                 **(extra_block_kwargs or {}),
             )

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -87,6 +87,14 @@ class TransformerConfig(ModelParallelConfig):
     which serves as an additional training objective.
     """
 
+    mtp_loss_type: str = "cross_entropy"
+    """Training objective for Multi-Token Prediction (MTP) heads.
+
+    Supported values are ``cross_entropy`` and ``e2e_tv``. The end-to-end total
+    variation objective directly optimizes the normalized expected acceptance
+    length under rejection-sampling verification.
+    """
+
     mtp_use_repeated_layer: bool = False
     """Use a single MTP layer repeatedly instead of multiple separate layers."""
 
@@ -1538,6 +1546,20 @@ class TransformerConfig(ModelParallelConfig):
             is_gated_delta_net_variant,
             normalize_experimental_attention_variant,
         )
+
+        if self.mtp_loss_type not in ("cross_entropy", "e2e_tv"):
+            raise ValueError(
+                "mtp_loss_type must be one of 'cross_entropy' or 'e2e_tv', "
+                f"got {self.mtp_loss_type!r}."
+            )
+        if self.mtp_loss_type == "e2e_tv":
+            if self.mtp_num_layers is None or self.mtp_num_layers < 1:
+                raise ValueError("mtp_loss_type='e2e_tv' requires mtp_num_layers >= 1.")
+            if not self.mtp_detach_heads:
+                raise ValueError(
+                    "mtp_loss_type='e2e_tv' requires mtp_detach_heads=True so the target "
+                    "distribution and shared backbone remain frozen."
+                )
 
         # When fp32 residual connections are enabled, pipeline parallel communication must
         # use fp32 to match the dtype of the residual stream between pipeline stages.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1142,6 +1142,18 @@ class TransformerConfig(ModelParallelConfig):
     the linear-attention kernel on the full sequence for a shard of heads. Correct but memory-heavy.
     """
 
+    #############################
+    # Pipeline Parallel Prewarm
+    #############################
+    pipeline_model_parallel_prewarm: bool = False
+    """Initialize lazy kernels concurrently across pipeline stages before training.
+
+    Each PP rank runs one synthetic eager forward/backward pass for every transformer layer in
+    its local PP/VPP model chunks. The passes do not use pipeline P2P communication, so pipeline
+    stages can initialize their local kernels concurrently. This does not capture or replay CUDA
+    Graphs and can be used independently of ``cuda_graph_impl``.
+    """
+
     ##################
     # Cuda Graphs
     ##################
@@ -3444,6 +3456,11 @@ class TransformerConfig(ModelParallelConfig):
                 "that capture attention. Use a MoE-only scope or a graph scope that "
                 "contains the complete MTP producer-consumer chain."
             )
+
+        if self.pipeline_model_parallel_prewarm:
+            assert (
+                self.pipeline_model_parallel_size > 1
+            ), "pipeline_model_parallel_prewarm requires pipeline_model_parallel_size > 1."
 
         if self.cuda_graph_impl != "none":
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -15,7 +15,9 @@ from megatron.core.inference.moe import InferenceGroupedGemmBackend
 from megatron.core.quantization.quant_config import RecipeConfig
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
+    PACKED_DSA_CP_CUDA_GRAPH_ERROR,
     get_deprecated_cuda_graph_modules_migration,
+    is_packed_dsa_cp_cuda_graph_capture_unsupported,
     is_whole_moe_cuda_graph_scope,
     normalize_cuda_graph_modules,
     normalize_inference_cuda_graph_scope,
@@ -3356,6 +3358,18 @@ class TransformerConfig(ModelParallelConfig):
             self.cuda_graph_impl in ("local", "transformer_engine")
             and (not self.cuda_graph_modules or CudaGraphModule.attn in self.cuda_graph_modules)
         )
+
+        if is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant=self.experimental_attention_variant,
+            dsa_kernel_backend=self.dsa_kernel_backend,
+            sequence_packing_scheduler=self.sequence_packing_scheduler,
+            dynamic_context_parallel=self.dynamic_context_parallel,
+            context_parallel_size=self.context_parallel_size,
+            cuda_graph_impl=self.cuda_graph_impl,
+            cuda_graph_modules=self.cuda_graph_modules,
+            inference_cuda_graph_scope=self.inference_cuda_graph_scope,
+        ):
+            raise ValueError(PACKED_DSA_CP_CUDA_GRAPH_ERROR)
 
         cp_layout_conversion_required = is_gated_delta_net_variant(
             self.experimental_attention_variant

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3863,6 +3863,43 @@ class TransformerConfig(ModelParallelConfig):
                 "or --pad-packed-seq-alignment equal to max_seqlen_per_dp_cp_rank "
                 f"({self.max_seqlen_per_dp_cp_rank}), got {self.pad_packed_seq_alignment}."
             )
+            if self.cuda_graph_impl == "full_iteration":
+                # The full-iteration graph captures the whole forward_backward_func,
+                # so the entire batch path must satisfy the THD static-input
+                # contract: fixed per-rank token capacity, fixed cu_seqlens width,
+                # a fixed num_microbatches per step, and a static CP topology.
+                assert self.sequence_packing_scheduler is not None, (
+                    "THD full-iteration CUDA graph is only supported with a "
+                    "sequence packing scheduler."
+                )
+                assert not self.dynamic_context_parallel, (
+                    "THD full-iteration CUDA graph does not support dynamic context "
+                    "parallel; use a static CP topology."
+                )
+                assert self.max_seqlen_per_dp_cp_rank is not None, (
+                    "THD full-iteration CUDA graph requires --max-seqlen-per-dp-cp-rank "
+                    "to define the static per-rank token capacity."
+                )
+                assert (
+                    self.thd_max_packed_sequences is not None and self.thd_max_packed_sequences > 0
+                ), (
+                    "THD full-iteration CUDA graph requires a positive "
+                    "--thd-max-packed-sequences to define the static cu_seqlens width."
+                )
+                assert not self.mtp_standalone, (
+                    "THD full-iteration CUDA graph does not support standalone MTP: "
+                    "its PP shape handshake is not graph-capturable."
+                )
+                if self.context_parallel_size > 1:
+                    assert self.cuda_graph_warmup_steps > 0, (
+                        "THD full-iteration CUDA graph with context parallelism requires "
+                        "cuda_graph_warmup_steps > 0 so consumers can materialize "
+                        "host-derived device layout caches before graph capture."
+                    )
+                # Batches are canonicalized to the static per-rank token capacity
+                # before entering the graph, so PP communication uses static shapes
+                # instead of the (non-capturable) variable-seq-length handshake.
+                self.thd_static_pp_communication = True
 
         # 'extend_last' THD tail padding with context parallelism requires the
         # global metadata to be extended before CP slicing, which only the

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1273,6 +1273,17 @@ class TransformerConfig(ModelParallelConfig):
     packing, capture uses a conservative upper bound on the packed microbatch count so graph
     replay can cover iterations whose real packed microbatch count changes."""
 
+    cuda_graph_static_dynamic_cp: bool = False
+    """Allow dynamic CP with a full-iteration graph only through the static-certificate path.
+
+    This is an explicit fail-closed opt-in, not general dynamic-CP CUDA Graph support. The
+    dynamic scheduler still runs eagerly before every iteration, while each realized
+    microbatch slot must retain the captured microbatch count, effective CP size, process-group
+    identity and rank membership, partition mode, and (for CP>1) exact packed boundaries and
+    route-defining geometry. Any mismatch is rejected before replay. This option is only valid for the
+    full-iteration CUDA Graph implementation; layer/chunk implementations reject it.
+    """
+
     ####################
     # Hyper-Connection Configuration
     ####################
@@ -3544,6 +3555,13 @@ class TransformerConfig(ModelParallelConfig):
                     "2 cuda_graph_warmup_steps to record the pipeline schedule before capture."
                 )
 
+            if self.cuda_graph_impl == "full_iteration" and self.moe_paged_stash:
+                assert self.cuda_graph_warmup_steps >= 2, (
+                    "Full-iteration CUDA graphs with paged stash require at least two eager "
+                    "warmup steps to discover the stash schedule and allocate its buffers "
+                    "before capture."
+                )
+
             if self.recompute_granularity:
                 if self.recompute_granularity != "selective":
                     assert (
@@ -3934,6 +3952,19 @@ class TransformerConfig(ModelParallelConfig):
                 self.attention_backend == AttnBackend.flash
             ), "Batch invariant mode only supports FlashAttention"
 
+        if self.cuda_graph_static_dynamic_cp:
+            assert self.cuda_graph_impl == "full_iteration", (
+                "--cuda-graph-static-dynamic-cp is only valid with "
+                "cuda_graph_impl='full_iteration'."
+            )
+            assert (
+                self.dynamic_context_parallel
+            ), "--cuda-graph-static-dynamic-cp requires --dynamic-context-parallel."
+            assert self.sequence_packing_scheduler == 'default_dynamic_cp', (
+                "--cuda-graph-static-dynamic-cp requires "
+                "sequence_packing_scheduler='default_dynamic_cp'."
+            )
+
         if self.cuda_graph_impl != "none" and (
             self.sequence_packing_scheduler is not None or self.dynamic_context_parallel
         ):
@@ -3959,10 +3990,13 @@ class TransformerConfig(ModelParallelConfig):
                     "THD full-iteration CUDA graph is only supported with a "
                     "sequence packing scheduler."
                 )
-                assert not self.dynamic_context_parallel, (
-                    "THD full-iteration CUDA graph does not support dynamic context "
-                    "parallel; use a static CP topology."
-                )
+                if self.dynamic_context_parallel:
+                    assert self.cuda_graph_static_dynamic_cp, (
+                        "THD full-iteration CUDA graph with dynamic context parallelism "
+                        "requires --cuda-graph-static-dynamic-cp. This explicit opt-in "
+                        "enables per-slot realized-schedule certification; it does not "
+                        "permit the schedule topology to change after capture."
+                    )
                 assert self.max_seqlen_per_dp_cp_rank is not None, (
                     "THD full-iteration CUDA graph requires --max-seqlen-per-dp-cp-rank "
                     "to define the static per-rank token capacity."
@@ -3977,7 +4011,7 @@ class TransformerConfig(ModelParallelConfig):
                     "THD full-iteration CUDA graph does not support standalone MTP: "
                     "its PP shape handshake is not graph-capturable."
                 )
-                if self.context_parallel_size > 1:
+                if self.context_parallel_size > 1 or self.dynamic_context_parallel:
                     assert self.cuda_graph_warmup_steps > 0, (
                         "THD full-iteration CUDA graph with context parallelism requires "
                         "cuda_graph_warmup_steps > 0 so consumers can materialize "

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -355,6 +355,9 @@ class TransformerConfig(ModelParallelConfig):
     dsa_indexer_skip_topk_offset: int = 0
     """Layer offset for DSA cross-layer top-k sharing."""
 
+    dsa_mtp_index_kv_share: bool = False
+    """Reuse iteration-0 DSA top-k indices and latent KV across repeated MTP iterations."""
+
     dsa_indexer_loss_coeff: Optional[float] = None
     """Coefficient for the DSA indexer KL divergence loss. Set to 0 to disable indexer loss."""
 
@@ -1764,6 +1767,11 @@ class TransformerConfig(ModelParallelConfig):
                 "Use dsa_kernel_backend='tilelang' or 'none'."
             )
 
+        if self.dsa_mtp_index_kv_share and self.experimental_attention_variant != "dsa":
+            raise ValueError(
+                "dsa_mtp_index_kv_share requires experimental_attention_variant='dsa'."
+            )
+
         if is_gated_delta_net_variant(self.experimental_attention_variant):
             if not self.is_hybrid_model:
                 assert (
@@ -1861,6 +1869,11 @@ class TransformerConfig(ModelParallelConfig):
                     "dsa_indexer_skip_topk_offset must be non-negative, got "
                     f"{self.dsa_indexer_skip_topk_offset}."
                 )
+            if self.dsa_mtp_index_kv_share:
+                if not self.mtp_use_repeated_layer:
+                    raise ValueError("dsa_mtp_index_kv_share requires mtp_use_repeated_layer=True.")
+                if self.mtp_num_layers is None or self.mtp_num_layers <= 1:
+                    raise ValueError("dsa_mtp_index_kv_share requires mtp_num_layers > 1.")
             if self.context_parallel_size > 1:
                 cp_comm_types = (
                     self.cp_comm_type
@@ -2338,6 +2351,17 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.recompute_modules is None:
             self.recompute_modules = ["core_attn"]
+
+        if (
+            self.dsa_mtp_index_kv_share
+            and self.recompute_granularity == "selective"
+            and "core_attn" in self.recompute_modules
+        ):
+            raise ValueError(
+                "dsa_mtp_index_kv_share does not yet support selective recompute with "
+                "'core_attn' in recompute_modules. Use selective 'mla_up_proj' recompute, "
+                "full activation recompute, or disable MTP DSA sharing."
+            )
 
         if self.recompute_granularity == "selective":
             if len(self.recompute_modules) > 0:
@@ -3387,6 +3411,16 @@ class TransformerConfig(ModelParallelConfig):
                 f"(experimental_attention_variant={self.experimental_attention_variant!r}, "
                 f"cuda_graph_impl={self.cuda_graph_impl!r}, "
                 f"cuda_graph_modules={self.cuda_graph_modules!r})."
+            )
+        if (
+            self.dsa_mtp_index_kv_share
+            and cuda_graph_captures_attention
+            and self.cuda_graph_impl != "full_iteration"
+        ):
+            raise ValueError(
+                "dsa_mtp_index_kv_share does not support per-layer CUDA graph scopes "
+                "that capture attention. Use a MoE-only scope or a graph scope that "
+                "contains the complete MTP producer-consumer chain."
             )
 
         if self.cuda_graph_impl != "none":

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1267,43 +1267,57 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         return self.self_attention.linear_qkv.layer_norm_weight.data
 
-    def get_layer_static_inputs(self, seq_length, micro_batch_size):
+    def get_layer_static_inputs(self, seq_length, micro_batch_size, *, for_pipeline_prewarm=False):
         """
-        Get the static inputs for the transformer layer. Besides the hidden_states that is
+        Get synthetic inputs for the transformer layer. Besides the hidden_states that is
         generated in GraphableMegatronModule, we also add the attention_mask.
 
-        For THD + CUDA Graph: generates cu_seqlens and padding_mask static tensors
-        instead of attention_mask.
+        For padded THD execution, generates cu_seqlens and padding_mask tensors instead of an
+        attention_mask.
 
         Returns:
             Dict[str, torch.Tensor]: A dictionary containing the static inputs for the layer.
         """
-        static_inputs = super().get_layer_static_inputs(seq_length, micro_batch_size)
+        static_inputs = super().get_layer_static_inputs(
+            seq_length, micro_batch_size, for_pipeline_prewarm=for_pipeline_prewarm
+        )
         device = torch.cuda.current_device()
 
-        # Captured forward needs attention-side static input only when this
-        # layer's attention is inside the captured scope.
-        attn_in_graph = not isinstance(self.self_attention, IdentityOp) and (
-            not self.config.cuda_graph_modules
+        # Pipeline prewarm executes the full layer. CUDA Graph capture only needs attention-side
+        # inputs when attention belongs to the configured capture scope.
+        attention_is_executed = not isinstance(self.self_attention, IdentityOp) and (
+            for_pipeline_prewarm
+            or not self.config.cuda_graph_modules
             or CudaGraphModule.attn in self.config.cuda_graph_modules
         )
+        use_padded_thd = self._is_thd_cuda_graph() or (
+            for_pipeline_prewarm and self.config.sequence_packing_scheduler is not None
+        )
 
-        if self._is_thd_cuda_graph():
-            if attn_in_graph:
+        if use_padded_thd:
+            if attention_is_executed:
                 # Static cu_seqlens shaped [thd_max_packed_sequences + 1]. We seed it as
                 # one full-length sequence (covers the worst case at capture):
                 #   cu_seqlens = [0, max_T, max_T, ..., max_T]
                 # which represents a single packed sequence followed by zero-length
-                # entries. cu_seqlens_q / kv / *_padded all share this layout.
+                # entries. Pipeline prewarm aliases Q/K metadata because fused DSA
+                # scoring recognizes self-attention through tensor identity. CUDA Graph
+                # capture retains independent buffers so replay can update them separately.
                 max_T = self.config.max_seqlen_per_dp_cp_rank * self.config.context_parallel_size
-                max_num_seqs = self.config.thd_max_packed_sequences
+                max_num_seqs = self.config.thd_max_packed_sequences or 1
                 cu_seqlens = torch.zeros(max_num_seqs + 1, dtype=torch.int32, device=device)
                 cu_seqlens[1:] = max_T
 
                 static_inputs["cu_seqlens_q"] = cu_seqlens
-                static_inputs["cu_seqlens_kv"] = cu_seqlens.clone()
-                static_inputs["cu_seqlens_q_padded"] = cu_seqlens.clone()
-                static_inputs["cu_seqlens_kv_padded"] = cu_seqlens.clone()
+                if for_pipeline_prewarm:
+                    padded_cu_seqlens = cu_seqlens.clone()
+                    static_inputs["cu_seqlens_kv"] = cu_seqlens
+                    static_inputs["cu_seqlens_q_padded"] = padded_cu_seqlens
+                    static_inputs["cu_seqlens_kv_padded"] = padded_cu_seqlens
+                else:
+                    static_inputs["cu_seqlens_kv"] = cu_seqlens.clone()
+                    static_inputs["cu_seqlens_q_padded"] = cu_seqlens.clone()
+                    static_inputs["cu_seqlens_kv_padded"] = cu_seqlens.clone()
 
             slen_for_mask = self.config.max_seqlen_per_dp_cp_rank
             if self.config.sequence_parallel:
@@ -1311,7 +1325,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             static_inputs["padding_mask"] = torch.zeros(
                 1, slen_for_mask, dtype=torch.bool, device=device
             )
-        elif attn_in_graph:
+        elif attention_is_executed:
             if not self.config.create_attention_mask_in_dataloader:
                 if self.self_attention.attn_mask_type not in (
                     AttnMaskType.causal,
@@ -1321,7 +1335,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     log_single_rank(
                         logger,
                         logging.WARNING,
-                        "TE CUDA graph capture is omitting attention_mask because "
+                        "Synthetic layer execution is omitting attention_mask because "
                         "create_attention_mask_in_dataloader is False, but "
                         f"attn_mask_type={self.self_attention.attn_mask_type.name} may require "
                         "an explicit mask. Ensure this is intended for the current workload.",
@@ -1335,7 +1349,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     .tile(micro_batch_size, 1, 1, 1)
                 )
 
-        # Add input_ids for hash-based MoE routing under CUDA graphs.
+        # Add input_ids for hash-based MoE routing.
         # Only add for layers that actually use hash routing,
         # since other layers (e.g. on later PP stages) receive input_ids=None.
         if (
@@ -1345,7 +1359,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         ):
             input_ids_shape = (
                 (1, self.config.max_seqlen_per_dp_cp_rank)
-                if self._is_thd_cuda_graph()
+                if use_padded_thd
                 else (micro_batch_size, seq_length)
             )
             static_inputs["input_ids"] = torch.zeros(
@@ -2022,15 +2036,17 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 "output arity."
             )
 
-    def get_layer_static_inputs(self, seq_length, micro_batch_size):
+    def get_layer_static_inputs(self, seq_length, micro_batch_size, *, for_pipeline_prewarm=False):
         """Override to produce n-stream hidden_states of shape [s, b, n*C].
 
-        CUDA graph capture creates static buffers whose shapes are determined by
-        this method. The base class returns [s, b, C], but mHC layers operate on
-        n-stream hidden states of shape [s, b, n*C].
+        CUDA graph capture and pipeline prewarm create synthetic buffers whose shapes are
+        determined by this method. The base class returns [s, b, C], but mHC layers operate
+        on n-stream hidden states of shape [s, b, n*C].
         """
-        static_inputs = super().get_layer_static_inputs(seq_length, micro_batch_size)
-        if self._uses_mhc_recompute_attn_cuda_graph_split():
+        static_inputs = super().get_layer_static_inputs(
+            seq_length, micro_batch_size, for_pipeline_prewarm=for_pipeline_prewarm
+        )
+        if not for_pipeline_prewarm and self._uses_mhc_recompute_attn_cuda_graph_split():
             # The captured callable begins at the attention consumer, after the
             # eager mHC producer has reduced n streams to one hidden-size tensor.
             return static_inputs

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, Union
 
 if TYPE_CHECKING:
     from megatron.core.tensor_parallel.random import MHCCheckpointManager
+    from megatron.core.transformer.multi_token_prediction import MTPDSAIterationContext
 
 import torch
 import torch.distributed
@@ -711,6 +712,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
         input_ids: Optional[Tensor] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -778,6 +780,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         # Self attention.
         nvtx_range_push(suffix="self_attention")
+        attention_variant_kwargs = {}
+        if mtp_dsa_context is not None:
+            attention_variant_kwargs["mtp_dsa_context"] = mtp_dsa_context
         attention_output_with_bias = self.self_attention(
             input_layernorm_output,
             attention_mask=attention_mask,
@@ -789,6 +794,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             attention_bias=attention_bias,
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
+            **attention_variant_kwargs,
         )
         nvtx_range_pop(suffix="self_attention")
 
@@ -2220,6 +2226,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         padding_mask: Optional[Tensor] = None,
         input_ids: Optional[Tensor] = None,
         mhc_recompute_manager: Optional['MHCCheckpointManager'] = None,
+        mtp_dsa_context: Optional[MTPDSAIterationContext] = None,
         *,
         inference_params: Optional[Any] = None,
     ):
@@ -2253,6 +2260,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
 
         # Self attention.
         nvtx_range_push(suffix="self_attention")
+        attention_variant_kwargs = {}
+        if mtp_dsa_context is not None:
+            attention_variant_kwargs["mtp_dsa_context"] = mtp_dsa_context
         attention_output_with_bias = self.self_attention(
             input_layernorm_output,
             attention_mask=attention_mask,
@@ -2264,6 +2274,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             attention_bias=attention_bias,
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
+            **attention_variant_kwargs,
         )
         nvtx_range_pop(suffix="self_attention")
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3290,6 +3290,14 @@ def _add_regularization_args(parser):
         help='Whether to split QKV parameters for Muon optimizer',
     )
     group.add_argument(
+        '--muon-split-qkv-per-head',
+        action='store_true',
+        help='Orthogonalize each Q, gate, K, and V head independently. '
+        'Uniform head sizes use the batched Newton-Schulz implementation from '
+        'the emerging-optimizers revision pinned in pyproject.toml. By default, '
+        'Q, gate, K, and V projections are orthogonalized separately',
+    )
+    group.add_argument(
         '--muon-nesterov',
         action='store_true',
         help='Whether to use Nesterov-style momentum in the internal SGD',
@@ -3330,7 +3338,9 @@ def _add_regularization_args(parser):
         type=str,
         default='blockwise',
         choices=['blockwise', 'duplicated', 'distributed'],
-        help='How to perform NS calculation for tensor model parallel weights',
+        help='How to perform NS calculation for tensor model parallel weights. '
+        'For QKV weights, distributed mode applies only to projection splits with '
+        'complete local query groups; other layouts fall back to non-TP NS',
     )
     group.add_argument(
         '--muon-extra-scale-factor',

--- a/megatron/training/datasets/data_samplers.py
+++ b/megatron/training/datasets/data_samplers.py
@@ -2,7 +2,6 @@
 
 """Dataloaders."""
 
-
 import random
 
 import numpy as np
@@ -20,6 +19,12 @@ def build_pretraining_data_loader(dataset, consumed_samples):
 
     if dataset is None:
         return None
+    # Empty split (e.g. valid/test when --eval-iters 0): return null loader
+    try:
+        if len(dataset) == 0:
+            return None
+    except TypeError:
+        pass
     args = get_args()
 
     if hasattr(dataset, 'split'):

--- a/megatron/training/models/gpt.py
+++ b/megatron/training/models/gpt.py
@@ -10,6 +10,7 @@ from megatron.core.distributed.distributed_data_parallel_config import Distribut
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
     get_transformer_block_with_experimental_attention_variant_spec,
+    get_transformer_layer_with_experimental_attention_variant_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.models.gpt.heterogeneous.heterogeneous_layer_specs import (
@@ -437,7 +438,16 @@ def mtp_block_spec(
     if config.transformer.mtp_num_layers is not None:
         from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
 
-        if (
+        if transformer_cfg.experimental_attention_variant is not None:
+            # An MTP-only pipeline stage has no local decoder spec to copy. Preserve the
+            # configured experimental attention variant instead of selecting standard attention.
+            experimental_layer_specs = (
+                get_transformer_layer_with_experimental_attention_variant_spec(
+                    config=transformer_cfg
+                )
+            )
+            spec = experimental_layer_specs[-1]
+        elif (
             hasattr(transformer_layer_spec, "layer_specs")
             and len(transformer_layer_spec.layer_specs) == 0
         ):

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3493,6 +3493,11 @@ def training_log(
     # Track sparse attention indexer loss.
     if args.dsa_indexer_loss_coeff is not None and args.dsa_indexer_loss_coeff > 0:
         indexer_loss_scale = 1 / get_num_microbatches()
+        dynamic_cp_parent_group = None
+        if args.dynamic_context_parallel:
+            dynamic_cp_parent_group = getattr(pg_collection, "dp_cp", None)
+            if dynamic_cp_parent_group is None:
+                dynamic_cp_parent_group = mpu.get_data_parallel_group(with_context_parallel=True)
         DSAIndexerLossLoggingHelper.track_indexer_metrics(
             loss_scale=indexer_loss_scale,
             iteration=iteration,
@@ -3506,6 +3511,8 @@ def training_log(
                 else None
             ),
             preserve_groups=args.cuda_graph_impl != "none",
+            dynamic_cp_parent_group=dynamic_cp_parent_group,
+            configured_cp_size=args.context_parallel_size,
         )
 
     # Dump memory snapshot and print metrics to stdout.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -42,7 +42,10 @@ _LEGACY_TRAIN_START_TIME = time.time()  # NOTE(asolergi-nv): Legacy timestamp
 
 # First-party.
 from megatron.core import mpu, nccl_allocator, tensor_parallel
-from megatron.core.datasets.data_schedule import wrap_data_iterator
+from megatron.core.datasets.data_schedule import (
+    prepare_thd_static_batch_for_full_iteration_cuda_graph,
+    wrap_data_iterator,
+)
 from megatron.core.distributed import DistributedDataParallel as DDP
 from megatron.core.distributed import (
     DistributedDataParallelConfig,
@@ -2041,6 +2044,13 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
+    if args.cuda_graph_impl == "full_iteration":
+        # Captured graphs (including graph-captured NCCL P2P for PP) must be
+        # destroyed before communicator/process teardown, otherwise interpreter
+        # shutdown can hang until the NCCL watchdog aborts the process.
+        torch.cuda.synchronize()
+        FullCudaGraphWrapper.reset_cuda_graph()
+
     ft_integration.shutdown()
     one_logger_utils.finish()
 
@@ -3472,7 +3482,12 @@ def training_log(
             # by the scheduled microbatch count for this step.
             mtp_loss_scale = 1 / (num_microbatches or get_num_microbatches())
         MTPLossLoggingHelper.track_mtp_metrics(
-            mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict
+            mtp_loss_scale,
+            iteration,
+            writer,
+            wandb_writer,
+            total_loss_dict,
+            preserve_groups=args.cuda_graph_impl != "none",
         )
 
     # Track sparse attention indexer loss.
@@ -3998,6 +4013,16 @@ def checkpoint_and_decide_exit(
     return False
 
 
+def _resolve_thd_static_batch_pg_collection(pg_collection):
+    """Resolve the language-model process groups used by THD batch preparation."""
+    if isinstance(pg_collection, MultiModuleProcessGroupCollection):
+        raise ValueError(
+            "THD full-iteration batch preparation does not support "
+            "MultiModuleProcessGroupCollection."
+        )
+    return pg_collection
+
+
 def train(
     forward_step_func,
     model,
@@ -4270,10 +4295,24 @@ def train(
     # Wrap forward_backward_func for Full iteration CUDA graph
     forward_backward_func = get_forward_backward_func(schedule_pg_collection=pg_collection)
     if args.cuda_graph_impl == "full_iteration":
+        thd_batch_preparation_fn = None
+        if args.sequence_packing_scheduler is not None:
+            # THD full-iteration graphs require every packed microbatch to be
+            # canonicalized to graph-static shapes outside the captured region
+            # (this path issues TP broadcasts), and a fixed num_microbatches
+            # per step (enforced via the wrapper's capture signature).
+            thd_pg_collection = _resolve_thd_static_batch_pg_collection(pg_collection)
+            thd_batch_preparation_fn = functools.partial(
+                prepare_thd_static_batch_for_full_iteration_cuda_graph,
+                config=config,
+                vpp_size=config.virtual_pipeline_model_parallel_size,
+                pg_collection=thd_pg_collection,
+            )
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,
             cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
             use_single_mempool=config.cuda_graph_use_single_mempool,
+            batch_preparation_fn=thd_batch_preparation_fn,
         )
     # Wrap forward_backward_func for overflow handling with moe_expert_rank_capacity_factor
     if args.moe_expert_rank_capacity_factor is not None:
@@ -4883,7 +4922,11 @@ def evaluate(
     eval_pgc = get_attr_wrapped_model(model[0], "pg_collection")
     if eval_pgc is None:
         eval_pgc = ProcessGroupCollection.use_mpu_process_groups()
-    if args.cuda_graph_impl == "full_iteration":
+    if args.cuda_graph_impl == "full_iteration" and args.sequence_packing_scheduler is None:
+        # THD sequence packing keeps validation eager: a dedicated fixed-shape
+        # validation graph is not implemented yet, and the packed validation
+        # schedule may use a different num_microbatches than the captured
+        # training graph.
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,
             cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
@@ -4924,7 +4967,7 @@ def evaluate(
             ft_integration.on_eval_step_start()
             if getattr(config, 'sequence_packing_scheduler', None) is not None:
                 try:
-                    (packed_data_iterator, scheduled_eval_num_microbatches, _, _) = (
+                    packed_data_iterator, scheduled_eval_num_microbatches, _, _ = (
                         wrap_data_iterator(data_iterator, config, eval_num_microbatches)
                     )
                 except StopIteration:
@@ -5222,7 +5265,7 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     args = get_args()
 
-    (train_dataloader, valid_dataloaders, test_dataloader) = (None, None, None)
+    train_dataloader, valid_dataloaders, test_dataloader = (None, None, None)
 
     print_rank_0('> building train, validation, and test datasets ...')
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -100,8 +100,8 @@ from megatron.core.parallel_state import (
     update_pg_timeout,
 )
 from megatron.core.pipeline_parallel import get_forward_backward_func
-from megatron.core.pipeline_parallel.parallel_prewarm import prewarm_pipeline_model_parallel
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
+from megatron.core.pipeline_parallel.parallel_prewarm import prewarm_pipeline_model_parallel
 from megatron.core.pipeline_parallel.utils import (
     is_pp_first_stage,
     is_pp_last_stage,
@@ -1503,8 +1503,7 @@ def num_floating_point_operations(
         # ``kw_args``, never back onto ``args``), so the attribute alone misses
         # exactly the runs this guard exists for.
         assert (
-            args.experimental_attention_variant != "dsa"
-            and layer_counts[Symbols.DS_ATTENTION] == 0
+            args.experimental_attention_variant != "dsa" and layer_counts[Symbols.DS_ATTENTION] == 0
         ), (
             "num_floating_point_operations does not support DSA "
             "('D' layers / experimental_attention_variant='dsa') on the "
@@ -4517,6 +4516,7 @@ def train(
             cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
             use_single_mempool=config.cuda_graph_use_single_mempool,
             batch_preparation_fn=thd_batch_preparation_fn,
+            require_global_static_metadata_consensus=config.cuda_graph_static_dynamic_cp,
         )
     # Wrap forward_backward_func for overflow handling with moe_expert_rank_capacity_factor
     if args.moe_expert_rank_capacity_factor is not None:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -895,6 +895,7 @@ def num_floating_point_operations(
         kda_conv_kernel_dim=4,
         vocab_size=256000,
         mtp_num_layers=0,
+        mtp_loss_type="cross_entropy",
         q_lora_rank=None,
         kv_lora_rank=0,
         qk_head_dim=0,
@@ -1019,7 +1020,14 @@ def num_floating_point_operations(
             2 * mtp_num_layers * (3 * hidden_size + 2 * hidden_size * hidden_size) * total_tokens
             + 2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers)
         )
-        return flops_fwd * 3
+        # E2E TV projects the frozen backbone once to produce target logits.
+        # This projection has no backward pass because the target distribution
+        # is detached. Softmax/overlap elementwise work is omitted consistently
+        # with the existing cross-entropy FLOPs convention.
+        e2e_tv_target_projection_flops = (
+            2 * total_tokens * hidden_size * vocab_size if mtp_loss_type == "e2e_tv" else 0
+        )
+        return flops_fwd * 3 + e2e_tv_target_projection_flops
 
     def transformer_flops():
         """Calculate FLOPs for a standard Transformer model."""
@@ -1433,6 +1441,11 @@ def num_floating_point_operations(
                 * args.hidden_size
                 * args.padded_vocab_size
                 * (mtp_num_layers + 1)  # MTP + final logit
+                # E2E TV target distribution: one frozen forward-only output projection.
+                + fma_expansion_factor
+                * args.hidden_size
+                * args.padded_vocab_size
+                * int(getattr(args, "mtp_loss_type", "cross_entropy") == "e2e_tv")
             )
             # Self Attention (core L^2 part). For BSHD the default
             # ``seqlen_squared_sum_in_batch = batch_size * seq_length^2`` recovers the
@@ -1547,6 +1560,7 @@ def num_floating_point_operations(
             kda_conv_kernel_dim=args.linear_conv_kernel_dim or 4,
             vocab_size=args.padded_vocab_size,
             mtp_num_layers=mtp_num_layers,
+            mtp_loss_type=getattr(args, "mtp_loss_type", "cross_entropy"),
             q_lora_rank=args.q_lora_rank,
             kv_lora_rank=args.kv_lora_rank,
             qk_head_dim=args.qk_head_dim,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -100,6 +100,7 @@ from megatron.core.parallel_state import (
     update_pg_timeout,
 )
 from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.pipeline_parallel.parallel_prewarm import prewarm_pipeline_model_parallel
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import (
     is_pp_first_stage,
@@ -4605,6 +4606,15 @@ def train(
         ), "Parameter hashes not matching across DP replicas"
         torch.distributed.barrier()
         print_rank_0(f">>> Weight hashes match after {iteration} iterations...")
+
+    if config.pipeline_model_parallel_prewarm:
+        prewarm_pipeline_model_parallel(
+            model=model,
+            config=config,
+            seq_length=args.seq_length,
+            micro_batch_size=args.micro_batch_size,
+            optimizers=[optimizer],
+        )
 
     # Initialize CUDA Graphs helper.
     if args.cuda_graph_impl == "transformer_engine":

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -119,7 +119,10 @@ from megatron.core.rerun_state_machine import (
 )
 from megatron.core.resharding.refit import swap_model_weights
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
-from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    DSAIndexerLossLoggingHelper,
+    is_dsa_skip_topk_layer,
+)
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.moe import upcycling_utils
 from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
@@ -386,6 +389,114 @@ def consume_seqlen_stats_in_iteration() -> Tuple[Optional[float], Optional[float
     t.zero_()
     _seqlen_stats_active = False
     return total_real_tokens / dedup, seqlen_squared_sum / dedup
+
+
+def _dsa_sparse_core_scale(total_real_tokens, seqlen_squared_sum, dsa_indexer_topk):
+    """Fraction of dense causal (query, key) pairs that DSA actually attends to.
+
+    A DSA layer scores every past position with the indexer but runs attention
+    only over the ``dsa_indexer_topk`` highest-scoring keys, so its core
+    attention cost is ``sum_i(min(i, topk))`` pairs per sequence instead of the
+    dense causal ``L^2 / 2``. Returns the ratio between the two, i.e. the
+    factor the dense core-attention coefficient must be scaled by.
+
+    The caller only has the batch aggregates ``sum_i(L_i)`` and
+    ``sum_i(L_i ** 2)``, not the individual sequence lengths, so the ratio is
+    evaluated at the length-weighted mean ``sum(L^2) / sum(L)``. That is exact
+    when every sequence in the batch has the same length (the usual packed-THD
+    benchmark case) and, for ragged batches, weights toward the long sequences
+    that dominate attention cost. Collapses to ``1.0`` when the sequences are
+    no longer than ``topk``, where top-k selects everything and attention is
+    dense.
+    """
+    if not dsa_indexer_topk or total_real_tokens <= 0 or seqlen_squared_sum <= 0:
+        return 1.0
+    mean_seqlen = seqlen_squared_sum / total_real_tokens
+    # Average attended KV entries per query: ``min(i, topk)`` averaged over the
+    # sequence, approximated as ``eff * (1 - eff / (2 * L))`` with
+    # ``eff = min(topk, floor(L))``. The exact discrete average has ``eff - 1``
+    # in the correction term; the O(1/L) difference is below the precision of
+    # this estimate.
+    eff = min(dsa_indexer_topk, math.floor(mean_seqlen))
+    attended = eff * (1 - eff / (2 * mean_seqlen))
+    # Dense causal attention averages ~``mean_seqlen / 2`` keys per query.
+    return attended / (mean_seqlen / 2)
+
+
+def _dsa_indexer_flops(
+    *, hidden_size, q_lora_rank, n_heads, head_dim, num_indexer_layers, indexer_loss_coeff
+):
+    """DSA lightning-indexer FLOPs coefficients, fwd/bwd expansion included.
+
+    Counts the indexer's projections (a Q projection off the shared ``q_lora``
+    residual, the ``linear_wk`` key path, and the per-head ``weights_proj``)
+    plus its dense scoring pass of every query against every past token under
+    a causal mask. Scoring is ``O(L^2)`` even though the attention consuming
+    it is sparse. The indexer KL loss (``dsa_indexer_loss_coeff``) and the
+    top-k selection itself are NOT counted: like everywhere else in this file
+    only the model's defining GEMMs enter the estimate, not auxiliary-loss or
+    sorting work.
+
+    Only ``num_indexer_layers`` layers pay: with cross-layer index sharing
+    (``dsa_indexer_topk_freq``) the layers in between reuse the most recent
+    top-k (see ``is_dsa_skip_topk_layer``).
+
+    The indexer does NOT get the global fwd+bwd factor of 3. It is trained
+    only by its own KL loss, so ``DSAttention.forward`` runs it under
+    ``torch.no_grad()`` unless ``dsa_indexer_loss_coeff > 0`` (which defaults
+    to None), and even then ``x`` / ``qr`` are detached so no gradient leaves
+    the indexer:
+
+      * loss off -> forward only, everything is 1x.
+      * loss on  -> the projections (wq_b / wk / weights_proj) read a detached
+        input, so autograd skips their dgrad and they pay fwd + wgrad = 2x.
+        The scoring GEMM has two activation operands that both need gradients
+        to reach those weights, so it pays fwd + dq + dk = 3x.
+
+    Whether the indexer is trained is part of the training procedure rather
+    than the kernel schedule, so it belongs in this model-FLOPs count. (With
+    ``dsa_indexer_use_sparse_loss`` the scoring backward only covers the top-k
+    entries, which the 3x does not model; it defaults to False.)
+
+    Returns ``(token_linear, core)`` INCLUDING the fwd/bwd and FMA factors.
+    Multiply ``token_linear`` by the real token count and ``core`` by
+    ``sum_i(L_i ** 2)``.
+    """
+    if num_indexer_layers <= 0:
+        return 0, 0
+    if q_lora_rank is None:
+        # Mirrors DSAIndexer's own fallback when the model has no q lora rank.
+        q_lora_rank = hidden_size
+    index_dim = n_heads * head_dim
+    token_linear = num_indexer_layers * (
+        q_lora_rank * index_dim  # wq_b
+        + hidden_size * head_dim  # wk
+        + hidden_size * n_heads  # weights_proj
+    )
+    # Scoring each query against every past token under a causal mask (/2).
+    core = num_indexer_layers * index_dim / 2
+    fma_expansion_factor = 2
+    loss_enabled = (indexer_loss_coeff or 0.0) > 0
+    return (
+        (2 if loss_enabled else 1) * fma_expansion_factor * token_linear,
+        (3 if loss_enabled else 1) * fma_expansion_factor * core,
+    )
+
+
+def _num_dsa_indexer_layers(num_layers, skip_topk_offset, topk_freq):
+    """Count layers that compute their own DSA index (the rest reuse one).
+
+    On the standard-model path every layer is a DSA attention layer (MTP
+    layers included -- ``DSAttention.__init__`` numbers them
+    ``layer_number + config.num_layers``, which is exactly how the caller
+    extends ``num_layers``), so the predicate runs over the whole
+    ``1..num_layers`` range.
+    """
+    return sum(
+        1
+        for layer_number in range(1, num_layers + 1)
+        if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset or 0, topk_freq or 1)
+    )
 
 
 def _dsv4_hybrid_self_attention_flops(
@@ -1097,6 +1208,8 @@ def num_floating_point_operations(
 
         dsv4_hybrid_extra_term = 0
         dsv4_hybrid_extra_core_term = 0
+        dsa_extra_term = 0
+        dsa_extra_core_term = 0
         if is_linear_attention_variant(args.experimental_attention_variant):
             # Calculate number of dense and MoE Transformer MLPs.
             if isinstance(args.linear_attention_freq, int):
@@ -1203,6 +1316,51 @@ def num_floating_point_operations(
             dsv4_hybrid_extra_core_term = (
                 forward_backward_expansion_factor * fma_expansion_factor * dsv4_core_term
             )
+        elif args.experimental_attention_variant == "dsa":
+            # DSA (e.g. GLM-5.2). The MLA projections are unchanged -- absorption
+            # relocates the same W_UK/W_UV GEMMs (per-token K/V up-projection
+            # becomes per-token q-side and output-side absorption of identical
+            # cost) -- so the standard token-linear term computed above still
+            # applies. Core attention differs from plain MLA in two ways:
+            #   * DSA always executes the absorbed-MLA path
+            #     (``AbsorbedMLASelfAttention``): ``QK^T`` is formed over the
+            #     compressed KV latent, spanning
+            #     ``kv_lora_rank + qk_pos_emb_head_dim`` per head, and ``AV``
+            #     spans ``kv_lora_rank`` -- not the up-projected
+            #     (``qk_head_dim``, ``v_head_dim``) counted for plain MLA
+            #     above. Each branch counts the form its variant executes.
+            #   * Attention runs over the indexer's top-k keys instead of the
+            #     full causal mask, so the dense causal coefficient is scaled
+            #     down to the top-k pair count.
+            # The indexer itself adds projections plus its own dense O(L^2)
+            # scoring pass; it carries its own (KL-loss-dependent) fwd/bwd
+            # expansion instead of the global factor of 3 -- see
+            # ``_dsa_indexer_flops``.
+            num_linear_attention_layers = 0
+            linear_self_attn_term = 0
+            num_standard_attention_layers = num_layers
+
+            standard_self_attn_core_term = (
+                forward_backward_expansion_factor
+                * fma_expansion_factor
+                * (
+                    args.num_attention_heads * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2
+                    + args.num_attention_heads * args.kv_lora_rank / 2
+                )
+                * _dsa_sparse_core_scale(
+                    total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
+                )
+            )
+            dsa_extra_term, dsa_extra_core_term = _dsa_indexer_flops(
+                hidden_size=args.hidden_size,
+                q_lora_rank=args.q_lora_rank,
+                n_heads=args.dsa_indexer_n_heads,
+                head_dim=args.dsa_indexer_head_dim,
+                num_indexer_layers=_num_dsa_indexer_layers(
+                    num_layers, args.dsa_indexer_skip_topk_offset, args.dsa_indexer_topk_freq
+                ),
+                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+            )
         else:
             num_linear_attention_layers = 0
             linear_self_attn_term = 0
@@ -1214,12 +1372,16 @@ def num_floating_point_operations(
             linear_self_attn_term * num_linear_attention_layers
             + standard_self_attn_term * num_standard_attention_layers
             + dsv4_hybrid_extra_term
+            + dsa_extra_term
         )
         # Core attention (L^2) FLOPs. Standard attention has a uniform per-layer
         # coefficient; DSv4 sparse attention varies by layer type and is pre-summed.
+        # For DSA the standard coefficient is already the top-k-scaled absorbed
+        # form, and the extra term carries the indexer's dense scoring.
         self_attn_core_term = (
             standard_self_attn_core_term * num_standard_attention_layers
             + dsv4_hybrid_extra_core_term
+            + dsa_extra_core_term
         )
 
         # Token-linear FLOPs scale with the real (unpadded) token count.
@@ -1315,6 +1477,26 @@ def num_floating_point_operations(
                 f"got {num_attn_layers} attention layers but only "
                 f"{dsv4_n_layers_r0 + dsv4_n_layers_r4 + dsv4_n_layers_r128} are W/C/H."
             )
+
+        # DSA accounting (top-k sparse core attention + indexer) is only
+        # implemented on the standard-model path in ``transformer_flops``. A
+        # 'D' pattern here would silently fall through to the dense full-MLA
+        # estimate below -- overcounting core attention at long context and
+        # dropping the indexer entirely -- so fail loud instead. Key off the
+        # layer pattern itself, not just ``args.experimental_attention_variant``:
+        # on the hybrid path a 'D' pattern sets the variant only in the config
+        # kwargs (``arguments.py``/``argument_utils.py`` write it into
+        # ``kw_args``, never back onto ``args``), so the attribute alone misses
+        # exactly the runs this guard exists for.
+        assert (
+            args.experimental_attention_variant != "dsa"
+            and layer_counts[Symbols.DS_ATTENTION] == 0
+        ), (
+            "num_floating_point_operations does not support DSA "
+            "('D' layers / experimental_attention_variant='dsa') on the "
+            "hybrid-model path (--hybrid-layer-pattern); express the model "
+            "without a layer pattern."
+        )
 
         mtp_num_layers = args.mtp_num_layers
         if mtp_num_layers is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,7 +228,7 @@ flash_mla = [
 nvidia-cudnn-frontend = { git = "https://github.com/NVIDIA/cudnn-frontend.git", rev = "0a14b7181d129d30e7bad34b8c3ed0a0c995e23d" }
 transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "f031cf87bd054c7558b887df7bed93975456667f" }
 nemo-run = { git = "https://github.com/NVIDIA-NeMo/Run.git", rev = "17ae86b64d7f75653351664f5d8c9e466faede00" }
-emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git", rev = "v0.3.0" }
+emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git", rev = "a44d1f83a4950b445f2a77ca71177c5f033d45d5" }
 fast-hadamard-transform = { git = "https://github.com/Dao-AILab/fast-hadamard-transform.git", rev = "f134af63deb2df17e1171a9ec1ea4a7d8604d5ca" }
 
 [tool.isort]

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -855,6 +855,33 @@ def test_unpack_batch_slices_prepacked_cu_seqlens_samples():
 # ----------------------------------------------------------------------------
 
 
+def test_zero_length_dataset_does_not_build_dataloader(monkeypatch):
+    from megatron.training.datasets import data_samplers
+
+    def unexpected_get_args():
+        raise AssertionError("empty datasets must return before reading dataloader arguments")
+
+    monkeypatch.setattr(data_samplers, "get_args", unexpected_get_args)
+    dataset = torch.utils.data.TensorDataset(torch.empty(0))
+
+    assert data_samplers.build_pretraining_data_loader(dataset, consumed_samples=0) is None
+
+
+def test_external_iterable_without_length_is_passed_through(monkeypatch):
+    from megatron.training.datasets import data_samplers
+
+    class ExternalIterable:
+        def __iter__(self):
+            return iter(())
+
+    monkeypatch.setattr(
+        data_samplers, "get_args", lambda: SimpleNamespace(dataloader_type="external")
+    )
+    dataset = ExternalIterable()
+
+    assert data_samplers.build_pretraining_data_loader(dataset, consumed_samples=0) is dataset
+
+
 def _build_varlen_for_loader(items, config, num_samples):
     from megatron.core.datasets.utils import Split
 

--- a/tests/unit_tests/distributed/mfsdp_v1/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v1/test_mcore_fully_sharded_data_parallel.py
@@ -16,7 +16,7 @@ from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import HAVE_TE_MXFP8TENSOR
 from megatron.core.fp8_utils import HAVE_TE
-from megatron.core.full_cuda_graph import FullCudaGraphWrapper, StaticBufferLoader
+from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.optimizer import OptimizerConfig
@@ -1007,13 +1007,8 @@ class TestMegatronFSDPE2E:
 
     @staticmethod
     def _reset_full_cuda_graph_static_state():
-        """Reset class-level state on FullCudaGraphWrapper / StaticBufferLoader
-        so a test that uses the wrapper does not see leftovers from a previous
-        test in this process."""
-        FullCudaGraphWrapper.curr_iteration = {'training': 0, 'validation': 0}
-        FullCudaGraphWrapper.cuda_graph = {'training': None, 'validation': None}
-        FullCudaGraphWrapper.result = {'training': None, 'validation': None}
-        StaticBufferLoader.static_buffers = {'training': [], 'validation': []}
+        """Reset full-iteration graph state so it cannot leak across tests."""
+        FullCudaGraphWrapper.reset_cuda_graph()
 
     @staticmethod
     def _reset_cuda_rng_tracker():
@@ -1057,8 +1052,8 @@ class TestMegatronFSDPE2E:
             outer-DP sharding strategy ``optim``.
 
         Asserts:
-          1. ``FullCudaGraphWrapper.cuda_graph['training']`` is populated by
-             the end of training (i.e. capture happened).
+          1. ``FullCudaGraphWrapper.cuda_graph['training']`` is observed before
+             the optimizer step and before pretrain teardown destroys it.
           2. Decoupled gradients are globally present before every
              ``optimizer.step``.
           3. Loss decreases across the run.
@@ -1119,6 +1114,7 @@ class TestMegatronFSDPE2E:
         # Test loss and gradients when using full-iter CG with FSDP.
         losses: list[torch.Tensor] = []
         grads_present_steps: list[bool] = []
+        cuda_graph_was_captured = False
 
         orig_forward_step = _pretrain_gpt.forward_step
 
@@ -1150,6 +1146,8 @@ class TestMegatronFSDPE2E:
         # precision-aware optimizer the FusedAdam reads from
         # ``param.decoupled_grad``.
         def pre_step_hook(optimizer, args_, kwargs_):
+            nonlocal cuda_graph_was_captured
+            cuda_graph_was_captured |= FullCudaGraphWrapper.cuda_graph.get("training") is not None
             local_present = any(
                 getattr(p, "decoupled_grad", None) is not None
                 and (
@@ -1168,7 +1166,6 @@ class TestMegatronFSDPE2E:
             grads_present_steps.append(any(gathered))
 
         hook_handle = register_optimizer_step_pre_hook(pre_step_hook)
-        cuda_graph_was_captured = False
 
         try:
             # Setup argument overrides for FSDP <> CG test.
@@ -1194,8 +1191,6 @@ class TestMegatronFSDPE2E:
                 wrapped_forward_step,
                 get_embedding_ranks=_pretrain_gpt.get_embedding_ranks,
             )
-            # Validate CUDA graph was captured and thus replayed.
-            cuda_graph_was_captured = FullCudaGraphWrapper.cuda_graph.get("training") is not None
         finally:
             hook_handle.remove()
             TestMegatronFSDPE2E._reset_full_cuda_graph_static_state()

--- a/tests/unit_tests/fusions/test_fused_mtp_prefix.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_prefix.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and graph-safety tests for the fused MTP prefix objective."""
+
+import pytest
+import torch
+
+from megatron.core.fusions.fused_mtp_prefix import (
+    fused_mtp_prefix_unavailable_reason,
+    mtp_e2e_prefix_objective,
+)
+
+
+def _native_prefix_objective(acceptances):
+    prefix_losses = 1.0 - torch.cumprod(acceptances, dim=0)
+    return prefix_losses.mean(dim=0), prefix_losses
+
+
+def _run_objective_and_gradient(function, acceptance_data, grad_output):
+    acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    output, prefix_losses = function(acceptances)
+    (output * grad_output).sum().backward()
+    return output.detach(), prefix_losses.detach(), acceptances.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("num_depths", [1, 2, 7])
+def test_fused_mtp_prefix_matches_native_forward_and_backward(num_depths):
+    """Dynamic draft depths match an independent cumprod oracle."""
+    torch.manual_seed(51 + num_depths)
+    acceptance_data = torch.rand(num_depths, 37, 2, device="cuda")
+    grad_output = torch.randn(37, 2, device="cuda")
+
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is None
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("zero_depth", [0, 3, 6])
+def test_fused_mtp_prefix_backward_is_zero_safe(zero_depth):
+    """Exact zero acceptance never produces division artifacts or nonfinite gradients."""
+    torch.manual_seed(71)
+    acceptance_data = torch.rand(7, 19, device="cuda")
+    acceptance_data[zero_depth] = 0
+    grad_output = torch.randn(19, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert torch.isfinite(actual_grad).all()
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_preserves_near_zero_loss():
+    """The fused mean must not cancel a one-ULP rejection near convergence."""
+    one = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    almost_one = torch.nextafter(one, torch.zeros_like(one))
+    acceptance_data = torch.stack((one, almost_one)).reshape(2, 1)
+    grad_output = torch.ones(1, device="cuda")
+
+    actual, actual_prefix_losses, actual_grad = _run_objective_and_gradient(
+        mtp_e2e_prefix_objective, acceptance_data, grad_output
+    )
+    reference, reference_prefix_losses, reference_grad = _run_objective_and_gradient(
+        _native_prefix_objective, acceptance_data, grad_output
+    )
+
+    assert actual.item() > 0.0
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+    torch.testing.assert_close(actual_prefix_losses, reference_prefix_losses, rtol=0, atol=0)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=0, atol=0)
+
+
+def test_mtp_prefix_unsupported_input_uses_reference_fallback(monkeypatch):
+    """CPU and noncontiguous inputs preserve the PyTorch reference path."""
+    acceptance_data = torch.rand(2, 5, 3).transpose(1, 2)
+    assert not acceptance_data.is_contiguous()
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    calls = 0
+    original_cumprod = torch.cumprod
+
+    def record_cumprod(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_cumprod(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "cumprod", record_cumprod)
+    actual = mtp_e2e_prefix_objective(acceptance_data)
+    reference = _native_prefix_objective(acceptance_data)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+    assert calls == 2
+
+
+def test_mtp_prefix_empty_rows_use_reference_fallback():
+    """An empty row dimension never dispatches a zero-program Triton grid."""
+    acceptance_data = torch.empty(7, 0)
+    assert fused_mtp_prefix_unavailable_reason(acceptance_data) is not None
+
+    if torch.cuda.is_available():
+        acceptance_data = acceptance_data.cuda()
+        assert fused_mtp_prefix_unavailable_reason(acceptance_data) == (
+            "acceptances must have at least one row"
+        )
+        actual, prefix_losses = mtp_e2e_prefix_objective(acceptance_data)
+        assert actual.shape == (0,)
+        assert prefix_losses.shape == (7, 0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mtp_prefix_bf16_acceptance_uses_reference_fallback():
+    """BF16 model logits still reach this primitive as FP32 fused-TV outputs."""
+    bf16_acceptances = torch.rand(2, 5, device="cuda", dtype=torch.bfloat16)
+    assert fused_mtp_prefix_unavailable_reason(bf16_acceptances) == (
+        "acceptance dtype torch.bfloat16 is not supported"
+    )
+    actual = mtp_e2e_prefix_objective(bf16_acceptances)
+    reference = _native_prefix_objective(bf16_acceptances)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_prefix_is_deterministic_and_cuda_graph_safe():
+    """Forward and analytical backward replay deterministically inside a CUDA Graph."""
+    torch.manual_seed(83)
+    acceptance_data = torch.rand(7, 67, device="cuda")
+    grad_output = torch.randn(67, device="cuda")
+    first = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    second = _run_objective_and_gradient(mtp_e2e_prefix_objective, acceptance_data, grad_output)
+    for first_tensor, second_tensor in zip(first, second):
+        assert torch.equal(first_tensor, second_tensor)
+
+    static_acceptances = acceptance_data.detach().clone().requires_grad_(True)
+    static_acceptances.grad = torch.zeros_like(static_acceptances)
+    graph = torch.cuda.CUDAGraph()
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_acceptances.grad.zero_()
+            warmup_output, _ = mtp_e2e_prefix_objective(static_acceptances)
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    with torch.cuda.graph(graph):
+        static_acceptances.grad.zero_()
+        graph_output, graph_prefix_losses = mtp_e2e_prefix_objective(static_acceptances)
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, first[0], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(graph_prefix_losses, first[1], rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_acceptances.grad, first[2], rtol=1e-5, atol=1e-6)

--- a/tests/unit_tests/fusions/test_fused_mtp_tv.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_tv.py
@@ -2,15 +2,28 @@
 
 """Numerical and dispatch tests for the fused MTP TV primitive."""
 
+import os
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from megatron.core import parallel_state
 from megatron.core.fusions import fused_mtp_tv as fused_mtp_tv_module
 from megatron.core.fusions.fused_mtp_tv import (
     fused_mtp_tv_unavailable_reason,
     vocab_parallel_tv_distance,
 )
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _select_torchrun_local_cuda_device():
+    """Keep Triton compilation and CUDA Graph capture on one device per process."""
+    if torch.cuda.is_available():
+        local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        torch.cuda.set_device(local_rank % torch.cuda.device_count())
+    yield
 
 
 def _native_tv_distance(draft_logits, target_logits):
@@ -160,6 +173,245 @@ def test_noncontiguous_target_is_packed_before_fused_dispatch(monkeypatch):
     torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
 
 
+def test_target_rows_use_reference_fallback_with_local_halo_and_invalid_fill(monkeypatch):
+    """CPU addressing gathers one target and safely maps invalid rows to zero logits."""
+    torch.manual_seed(23)
+    draft_data = torch.randn(4, 1, 7, dtype=torch.float32)
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, 1, 7, dtype=torch.float32, requires_grad=True)
+    target_row_indices = torch.tensor([[1], [4], [5], [99]], dtype=torch.int32)
+    target_valid_rows = torch.tensor([[True], [True], [False], [True]])
+    grad_output = torch.randn(4, 1, dtype=torch.float32)
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("CPU target-row addressing must use the reference fallback")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    materialized_target = torch.zeros_like(target_logits)
+    materialized_target[0].copy_(target_logits[1])
+    materialized_target[1].copy_(target_halo[0])
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_target_rows_flatten_sequence_and_batch_before_addressing():
+    """Address rows in canonical sequence-major order when the batch size exceeds one."""
+    torch.manual_seed(29)
+    sequence_length = 3
+    batch_size = 2
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, batch_size, vocab_size, device="cuda")
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, batch_size, vocab_size, device="cuda", requires_grad=True)
+    # Local rows flatten as ``sequence * batch_size + batch``; halo rows
+    # continue from ``sequence_length * batch_size`` using the same ordering.
+    target_row_indices = torch.tensor([[2, 3], [6, 7], [8, 9]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(sequence_length, batch_size, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    source_rows = target_logits.detach().reshape(-1, vocab_size)
+    halo_rows = target_halo.detach().reshape(-1, vocab_size)
+    materialized_target = torch.cat((source_rows, halo_rows), dim=0).index_select(
+        0, target_row_indices.reshape(-1).long()
+    )
+    materialized_target = materialized_target.view_as(draft_data)
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_target_rows_noncontiguous_source_uses_reference_fallback(monkeypatch):
+    """Addressing remains correct when a noncontiguous source disables fused dispatch."""
+    torch.manual_seed(31)
+    sequence_length = 3
+    batch_size = 2
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, batch_size, vocab_size, device="cuda")
+    target_logits = (
+        torch.randn(sequence_length, vocab_size, batch_size, device="cuda")
+        .transpose(1, 2)
+        .detach()
+        .requires_grad_(True)
+    )
+    target_halo = torch.randn(1, batch_size, vocab_size, device="cuda", requires_grad=True)
+    target_row_indices = torch.tensor([[2, 3], [4, 5], [6, 7]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(sequence_length, batch_size, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+    assert not target_logits.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) == "logits are not contiguous"
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("A noncontiguous addressed source must use the reference fallback")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    source_rows = target_logits.detach().reshape(-1, vocab_size)
+    halo_rows = target_halo.detach().reshape(-1, vocab_size)
+    materialized_target = torch.cat((source_rows, halo_rows), dim=0).index_select(
+        0, target_row_indices.reshape(-1).long()
+    )
+    materialized_target = materialized_target.view_as(draft_data)
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+def test_target_rows_dispatch_source_halo_and_metadata_without_materializing(monkeypatch):
+    """Fused dispatch receives the immutable source and compact halo directly."""
+    draft = torch.randn(3, 1, 7)
+    target = torch.randn_like(draft)
+    halo = torch.randn(1, 1, 7)
+    indices = torch.tensor([[1], [2], [3]], dtype=torch.int32)
+    valid = torch.ones(3, 1, dtype=torch.bool)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "fused_mtp_tv_unavailable_reason", lambda *_args: None)
+
+    def record_fused(draft_arg, target_arg, tp_group, vocab_sharded, **kwargs):
+        assert draft_arg is draft
+        assert target_arg is target
+        assert tp_group is None
+        assert vocab_sharded is False
+        assert kwargs["target_row_indices"] is indices
+        assert kwargs["target_valid_rows"] is valid
+        assert kwargs["target_halo_logits"] is halo
+        return torch.zeros(draft.shape[:-1], dtype=torch.float32)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", record_fused)
+    output = vocab_parallel_tv_distance(
+        draft,
+        target,
+        logits_are_vocab_sharded=False,
+        target_row_indices=indices,
+        target_valid_rows=valid,
+        target_halo_logits=halo,
+    )
+    assert output.shape == draft.shape[:-1]
+
+
+@pytest.mark.parametrize(
+    ("indices", "valid", "halo", "message"),
+    [
+        (None, torch.ones(2, 1, dtype=torch.bool), None, "provided together"),
+        (None, None, torch.randn(1, 1, 7), "require target row indices"),
+        (torch.ones(2, dtype=torch.int32), torch.ones(2, dtype=torch.bool), None, "leading"),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, dtype=torch.bool),
+            None,
+            "validity must match",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.float32),
+            torch.ones(2, 1, dtype=torch.bool),
+            None,
+            "int32 or torch.int64",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.int32),
+            None,
+            "torch.bool",
+        ),
+        (
+            torch.ones(2, 2, dtype=torch.int32)[:, :1],
+            torch.ones(2, 1, dtype=torch.bool),
+            None,
+            "metadata must be contiguous",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 1, 7, dtype=torch.float64),
+            "target-logits dtype",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 7),
+            "target-logits rank",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 2, 7),
+            "non-sequence target dimensions",
+        ),
+        (
+            torch.ones(2, 1, dtype=torch.int32),
+            torch.ones(2, 1, dtype=torch.bool),
+            torch.randn(1, 1, 14)[..., ::2],
+            "halo logits must be contiguous",
+        ),
+    ],
+)
+def test_target_row_addressing_rejects_invalid_metadata(indices, valid, halo, message):
+    """Addressed dispatch rejects inconsistent metadata before any fused launch."""
+    draft = torch.randn(2, 1, 7)
+    target = torch.randn_like(draft)
+    with pytest.raises(ValueError, match=message):
+        vocab_parallel_tv_distance(
+            draft,
+            target,
+            logits_are_vocab_sharded=False,
+            target_row_indices=indices,
+            target_valid_rows=valid,
+            target_halo_logits=halo,
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_fused_mtp_tv_saves_only_compact_full_vocab_metadata():
     """Backward state must pack its only vocabulary-sized comparison mask."""
@@ -248,6 +500,177 @@ def test_fused_mtp_tv_is_cuda_graph_safe():
         graph_output = vocab_parallel_tv_distance(
             static_draft, target_logits, logits_are_vocab_sharded=False
         )
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, expected_output, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_draft.grad, expected_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_fused_mtp_tv_target_rows_match_materialized_local_halo_and_invalid(dtype, index_dtype):
+    """Direct Triton loads match local, halo, explicitly invalid, and OOB targets."""
+    torch.manual_seed(41)
+    sequence_length = 5
+    vocab_size = 257
+    draft_data = torch.randn(sequence_length, 1, vocab_size, device="cuda", dtype=dtype)
+    target_logits = torch.randn_like(draft_data, requires_grad=True)
+    target_halo = torch.randn(2, 1, vocab_size, device="cuda", dtype=dtype, requires_grad=True)
+    target_row_indices = torch.tensor([[1], [4], [5], [6], [99]], device="cuda", dtype=index_dtype)
+    target_valid_rows = torch.tensor(
+        [[True], [True], [True], [False], [True]], device="cuda", dtype=torch.bool
+    )
+    grad_output = torch.randn(sequence_length, 1, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            tp_group=None,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    materialized_target = torch.zeros_like(target_logits)
+    materialized_target[0].copy_(target_logits[1])
+    materialized_target[1].copy_(target_logits[4])
+    materialized_target[2].copy_(target_halo[0])
+    actual, actual_grad = _run_tv_and_gradient(mapped_tv, draft_data, target_logits, grad_output)
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, materialized_target, grad_output
+    )
+
+    rtol = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    atol = 3e-3 if dtype == torch.bfloat16 else 1e-6
+    torch.testing.assert_close(actual, reference, rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=rtol, atol=atol)
+    assert target_logits.grad is None
+    assert target_halo.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.skipif(Utils.world_size < 2, reason="TP2 target-row addressing requires two ranks")
+def test_fused_mtp_tv_target_rows_match_global_oracle_with_tp2_sharded_vocab():
+    """TP2 addressed local, halo, invalid, and OOB rows match a global-vocab oracle."""
+    if Utils.world_size % 2 != 0:
+        pytest.skip("TP2 target-row addressing requires an even world size")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        torch.manual_seed(43)
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        sequence_length = 6
+        batch_size = 1
+        local_vocab_size = 257
+        global_vocab_size = 2 * local_vocab_size
+
+        global_draft_data = torch.randn(
+            sequence_length, batch_size, global_vocab_size, device="cuda"
+        )
+        global_target_logits = torch.randn_like(global_draft_data)
+        global_target_halo = torch.randn(2, batch_size, global_vocab_size, device="cuda")
+        vocab_start = tp_rank * local_vocab_size
+        vocab_end = vocab_start + local_vocab_size
+        local_draft_data = global_draft_data[..., vocab_start:vocab_end].contiguous()
+        local_target_logits = (
+            global_target_logits[..., vocab_start:vocab_end].contiguous().requires_grad_(True)
+        )
+        local_target_halo = (
+            global_target_halo[..., vocab_start:vocab_end].contiguous().requires_grad_(True)
+        )
+
+        target_row_indices = torch.tensor(
+            [[1], [5], [6], [7], [-1], [99]], device="cuda", dtype=torch.int32
+        )
+        target_valid_rows = torch.tensor(
+            [[True], [True], [True], [True], [False], [True]], device="cuda", dtype=torch.bool
+        )
+        grad_output = torch.randn(sequence_length, batch_size, device="cuda")
+
+        def mapped_tp_tv(draft, target):
+            return vocab_parallel_tv_distance(
+                draft,
+                target,
+                tp_group=tp_group,
+                logits_are_vocab_sharded=True,
+                target_row_indices=target_row_indices,
+                target_valid_rows=target_valid_rows,
+                target_halo_logits=local_target_halo,
+            )
+
+        materialized_global_target = torch.zeros_like(global_target_logits)
+        materialized_global_target[0].copy_(global_target_logits[1])
+        materialized_global_target[1].copy_(global_target_logits[5])
+        materialized_global_target[2].copy_(global_target_halo[0])
+        materialized_global_target[3].copy_(global_target_halo[1])
+
+        actual, actual_grad = _run_tv_and_gradient(
+            mapped_tp_tv, local_draft_data, local_target_logits, grad_output
+        )
+        reference, reference_global_grad = _run_tv_and_gradient(
+            _native_tv_distance, global_draft_data, materialized_global_target, grad_output
+        )
+        reference_local_grad = reference_global_grad[..., vocab_start:vocab_end]
+
+        torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(actual_grad, reference_local_grad, rtol=1e-5, atol=1e-6)
+        assert local_target_logits.grad is None
+        assert local_target_halo.grad is None
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_target_rows_are_deterministic_and_cuda_graph_safe():
+    """Mapped source-plus-halo loads replay deterministically inside a CUDA Graph."""
+    torch.manual_seed(2037)
+    draft_data = torch.randn(4, 1, 1031, device="cuda")
+    target_logits = torch.randn_like(draft_data)
+    target_halo = torch.randn(1, 1, 1031, device="cuda")
+    target_row_indices = torch.tensor([[1], [2], [3], [4]], device="cuda", dtype=torch.int32)
+    target_valid_rows = torch.ones(4, 1, device="cuda", dtype=torch.bool)
+    grad_output = torch.randn(4, 1, device="cuda")
+
+    def mapped_tv(draft, target):
+        return vocab_parallel_tv_distance(
+            draft,
+            target,
+            tp_group=None,
+            logits_are_vocab_sharded=False,
+            target_row_indices=target_row_indices,
+            target_valid_rows=target_valid_rows,
+            target_halo_logits=target_halo,
+        )
+
+    expected_output, expected_grad = _run_tv_and_gradient(
+        mapped_tv, draft_data, target_logits, grad_output
+    )
+    repeated_output, repeated_grad = _run_tv_and_gradient(
+        mapped_tv, draft_data, target_logits, grad_output
+    )
+    assert torch.equal(repeated_output, expected_output)
+    assert torch.equal(repeated_grad, expected_grad)
+
+    static_draft = draft_data.detach().clone().requires_grad_(True)
+    static_draft.grad = torch.zeros_like(static_draft)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_draft.grad.zero_()
+            warmup_output = mapped_tv(static_draft, target_logits)
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_draft.grad.zero_()
+        graph_output = mapped_tv(static_draft, target_logits)
         (graph_output * grad_output).sum().backward()
     graph.replay()
 

--- a/tests/unit_tests/fusions/test_fused_mtp_tv.py
+++ b/tests/unit_tests/fusions/test_fused_mtp_tv.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical and dispatch tests for the fused MTP TV primitive."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.fusions import fused_mtp_tv as fused_mtp_tv_module
+from megatron.core.fusions.fused_mtp_tv import (
+    fused_mtp_tv_unavailable_reason,
+    vocab_parallel_tv_distance,
+)
+
+
+def _native_tv_distance(draft_logits, target_logits):
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return (1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)).clamp(0.0, 1.0)
+
+
+def _run_tv_and_gradient(function, draft_data, target_logits, grad_output):
+    draft_logits = draft_data.detach().clone().requires_grad_(True)
+    output = function(draft_logits, target_logits)
+    (output * grad_output).sum().backward()
+    return output.detach(), draft_logits.grad.detach()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("vocab_size", [257, 154880])
+def test_fused_mtp_tv_matches_native_forward_and_backward(dtype, vocab_size):
+    """Cover an odd block tail and GLM-5.2's production vocabulary."""
+    torch.manual_seed(1234)
+    shape = (3, 2, vocab_size)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype, requires_grad=True)
+    grad_output = torch.randn(shape[:-1], device="cuda", dtype=torch.float32)
+
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) is None
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    assert actual.dtype == torch.float32
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    rtol = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    atol = 3e-3 if dtype == torch.bfloat16 else 1e-6
+    torch.testing.assert_close(actual, reference, rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=rtol, atol=atol)
+    assert target_logits.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_clamp_boundaries_and_zero_acceptance():
+    """The fused path preserves both clamp endpoints and finite gradients."""
+    vocab_size = 257
+    identical = torch.randn(2, vocab_size, device="cuda", dtype=torch.float32)
+    identical_output, identical_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        identical,
+        identical,
+        torch.ones(2, device="cuda"),
+    )
+    torch.testing.assert_close(
+        identical_output, torch.zeros_like(identical_output), atol=1e-6, rtol=0
+    )
+    torch.testing.assert_close(identical_grad, torch.zeros_like(identical_grad), atol=1e-6, rtol=0)
+
+    draft = torch.full((1, vocab_size), -100.0, device="cuda")
+    target = torch.full_like(draft, -100.0)
+    draft[:, 0] = 100.0
+    target[:, 1] = 100.0
+    output, gradient = _run_tv_and_gradient(
+        lambda draft_logits, target_logits: vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        ),
+        draft,
+        target,
+        torch.ones(1, device="cuda"),
+    )
+    torch.testing.assert_close(output, torch.ones_like(output), atol=1e-6, rtol=0)
+    assert torch.isfinite(gradient).all()
+    torch.testing.assert_close(gradient, torch.zeros_like(gradient), atol=1e-6, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_logits_use_reference_fallback(monkeypatch):
+    """Unsupported strides retain the PyTorch reference behavior."""
+    torch.manual_seed(17)
+    draft_data = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(draft_data.shape[:-1], device="cuda")
+    assert not draft_data.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, target_logits) == "logits are not contiguous"
+
+    def fail_if_fused(*_args, **_kwargs):
+        pytest.fail("The fused kernel must not receive unsupported noncontiguous logits")
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", fail_if_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_noncontiguous_target_is_packed_before_fused_dispatch(monkeypatch):
+    """A materialized-roll view is packed centrally when the draft supports Triton."""
+    torch.manual_seed(19)
+    draft_data = torch.randn(2, 3, 257, device="cuda")
+    target_logits = torch.randn(2, 257, 3, device="cuda").transpose(1, 2)
+    grad_output = torch.randn(2, 3, device="cuda")
+    assert draft_data.is_contiguous()
+    assert not target_logits.is_contiguous()
+    assert fused_mtp_tv_unavailable_reason(draft_data, draft_data) is None
+
+    original_fused = fused_mtp_tv_module._fused_vocab_parallel_tv_distance
+    fused_calls = 0
+
+    def record_fused(draft, target, *args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        assert target.is_contiguous()
+        return original_fused(draft, target, *args, **kwargs)
+
+    monkeypatch.setattr(fused_mtp_tv_module, "_fused_vocab_parallel_tv_distance", record_fused)
+    actual, actual_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+    reference, reference_grad = _run_tv_and_gradient(
+        _native_tv_distance, draft_data, target_logits, grad_output
+    )
+
+    assert fused_calls == 1
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_saves_only_compact_full_vocab_metadata():
+    """Backward state must pack its only vocabulary-sized comparison mask."""
+    torch.manual_seed(29)
+    draft_logits = torch.randn(3, 2, 4097, device="cuda", requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+    saved_tensors = []
+
+    def pack_hook(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        output = vocab_parallel_tv_distance(
+            draft_logits, target_logits, logits_are_vocab_sharded=False
+        )
+        output.sum().backward()
+
+    full_vocab_tensors = [
+        tensor for tensor in saved_tensors if tensor.numel() == draft_logits.numel()
+    ]
+    assert len(full_vocab_tensors) == 1
+    assert full_vocab_tensors[0].data_ptr() == draft_logits.data_ptr()
+    packed_masks = [tensor for tensor in saved_tensors if tensor.dtype == torch.uint8]
+    assert [tuple(tensor.shape) for tensor in packed_masks] == [(6, (4097 + 7) // 8)]
+    assert not any(
+        tensor.dtype in (torch.bool, torch.uint8) and tensor.numel() == draft_logits.numel()
+        for tensor in saved_tensors
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_mtp_tv_is_deterministic(dtype):
+    """Repeated launches of the same implementation are bitwise stable."""
+    torch.manual_seed(2026)
+    draft_data = torch.randn(4, 1031, device="cuda", dtype=dtype)
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+
+    def function(draft, target):
+        return vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+
+    first_output, first_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    second_output, second_grad = _run_tv_and_gradient(
+        function, draft_data, target_logits, grad_output
+    )
+    assert torch.equal(first_output, second_output)
+    assert torch.equal(first_grad, second_grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_mtp_tv_is_cuda_graph_safe():
+    """The fused forward and analytical backward replay inside a CUDA Graph."""
+    torch.manual_seed(2031)
+    draft_data = torch.randn(4, 1031, device="cuda")
+    target_logits = torch.randn_like(draft_data)
+    grad_output = torch.randn(4, device="cuda")
+    expected_output, expected_grad = _run_tv_and_gradient(
+        lambda draft, target: vocab_parallel_tv_distance(
+            draft, target, logits_are_vocab_sharded=False
+        ),
+        draft_data,
+        target_logits,
+        grad_output,
+    )
+
+    static_draft = draft_data.detach().clone().requires_grad_(True)
+    static_draft.grad = torch.zeros_like(static_draft)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            static_draft.grad.zero_()
+            warmup_output = vocab_parallel_tv_distance(
+                static_draft, target_logits, logits_are_vocab_sharded=False
+            )
+            (warmup_output * grad_output).sum().backward()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_draft.grad.zero_()
+        graph_output = vocab_parallel_tv_distance(
+            static_draft, target_logits, logits_are_vocab_sharded=False
+        )
+        (graph_output * grad_output).sum().backward()
+    graph.replay()
+
+    torch.testing.assert_close(graph_output, expected_output, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(static_draft.grad, expected_grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("shape", [(0, 257), (3, 0, 257)])
+def test_empty_row_logits_use_reference_fallback(shape):
+    """Empty leading dimensions never dispatch a zero-program Triton grid."""
+    draft = torch.empty(shape)
+    target = torch.empty_like(draft)
+    assert fused_mtp_tv_unavailable_reason(draft, target) is not None
+
+    if torch.cuda.is_available():
+        draft = draft.cuda()
+        target = target.cuda()
+        assert fused_mtp_tv_unavailable_reason(draft, target) == "logits must have at least one row"
+        actual = vocab_parallel_tv_distance(draft, target, logits_are_vocab_sharded=False)
+        assert actual.shape == draft.shape[:-1]
+        assert actual.numel() == 0

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -518,6 +518,19 @@ def test_async_generate_output_tokens_dynamic_batch_assertions(mode, expected_me
         asyncio.run(controller.async_generate_output_tokens_dynamic_batch(skip_bookkeeping=True))
 
 
+@pytest.mark.launch_on_gb200
+def test_dsa_mtp_sharing_rejects_speculative_decoding_before_distributed_setup():
+    model_config = SimpleNamespace(dsa_mtp_index_kv_share=True)
+    inference_config = SimpleNamespace(num_speculative_tokens=1)
+    inference_wrapped_model = SimpleNamespace(
+        model=SimpleNamespace(config=model_config),
+        inference_context=SimpleNamespace(config=inference_config),
+    )
+
+    with pytest.raises(ValueError, match="do not carry iteration-0 DSA KV/top-k tensors"):
+        TextGenerationController(inference_wrapped_model, tokenizer=None)
+
+
 class TestTextGenerationController(TextGenerationControllerTestBase):
 
     @classmethod

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -114,6 +114,94 @@ class TestGPTModel:
         assert logits.shape[1] == sequence_length
         assert logits.shape[2] == self.gpt_model.vocab_size
 
+    @pytest.mark.parametrize("sequence_parallel", [False, True])
+    @pytest.mark.parametrize("has_padding_mask", [False, True])
+    def test_mtp_keeps_raw_padding_mask_after_decoder_preprocess(
+        self, sequence_parallel, has_padding_mask
+    ):
+        """Decoder SP transforms must not change the MTP sequence-roll source layout."""
+        input_ids = torch.arange(8, dtype=torch.long).view(2, 4)
+        position_ids = input_ids.clone()
+        raw_padding_mask = (
+            torch.tensor([[False, False, True, True], [False, True, False, True]])
+            if has_padding_mask
+            else None
+        )
+        transformed_padding_mask = raw_padding_mask
+        if sequence_parallel and raw_padding_mask is not None:
+            transformed_padding_mask = raw_padding_mask[:, :2].contiguous()
+        decoder_input = torch.zeros(4, 2, self.gpt_model.config.hidden_size)
+        decoder_output = torch.ones_like(decoder_input)
+        self.gpt_model.config.sequence_parallel = sequence_parallel
+
+        with (
+            patch.object(
+                self.gpt_model,
+                "_preprocess",
+                return_value=(decoder_input, None, None, None, None, transformed_padding_mask),
+            ),
+            patch.object(self.gpt_model.decoder, "forward", return_value=decoder_output) as decoder,
+            patch.object(
+                self.gpt_model, "_postprocess", return_value=decoder_output
+            ) as postprocess,
+        ):
+            self.gpt_model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                padding_mask=raw_padding_mask,
+            )
+
+        assert decoder.call_args.kwargs["padding_mask"] is transformed_padding_mask
+        assert postprocess.call_args.kwargs["padding_mask"] is transformed_padding_mask
+        assert postprocess.call_args.kwargs["mtp_padding_mask"] is raw_padding_mask
+
+    def test_postprocess_reuses_supplied_mtp_sequence_roll_context(self):
+        """Fine-grained callers can reuse one prepared context without rebuilding it."""
+
+        class RecordingMTP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.kwargs = None
+
+            def forward(self, **kwargs):
+                self.kwargs = kwargs
+                return kwargs["hidden_states"]
+
+        self.gpt_model.config.mtp_num_layers = 1
+        self.gpt_model.post_process = False
+        self.gpt_model.mtp = RecordingMTP()
+        supplied_context = object()
+        hidden_states = torch.zeros(4, 2, self.gpt_model.config.hidden_size)
+        input_ids = torch.zeros(2, 4, dtype=torch.long)
+        position_ids = torch.zeros_like(input_ids)
+        local_padding_mask = torch.zeros(2, 2, dtype=torch.bool)
+        raw_padding_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+
+        with patch(
+            "megatron.core.models.gpt.gpt_model.prepare_mtp_sequence_roll_context",
+            side_effect=AssertionError("A supplied MTP context must not be rebuilt."),
+        ):
+            output = self.gpt_model._postprocess(
+                hidden_states=hidden_states,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                labels=None,
+                rotary_pos_emb=None,
+                rotary_pos_cos=None,
+                rotary_pos_sin=None,
+                mtp_in_postprocess=True,
+                attention_mask=None,
+                padding_mask=local_padding_mask,
+                mtp_padding_mask=raw_padding_mask,
+                sequence_roll_context=supplied_context,
+            )
+
+        assert output is hidden_states
+        assert self.gpt_model.mtp.kwargs["sequence_roll_context"] is supplied_context
+        assert self.gpt_model.mtp.kwargs["padding_mask"] is local_padding_mask
+        assert self.gpt_model.mtp.kwargs["sequence_roll_padding_mask"] is raw_padding_mask
+
     @pytest.mark.internal
     def test_output_processor_forward(self):
         config: TransformerConfig = self.gpt_model.config

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -690,3 +690,41 @@ def test_get_transformer_layer_spec_forwards_use_te_activation_func():
         assert (
             call_kwargs.get('use_te_activation_func') is True
         ), "use_te_activation_func must be forwarded from config"
+
+
+def test_gpt_builder_uses_experimental_mtp_spec_for_empty_decoder_stage():
+    """An MTP-only PP stage must not fall back to standard attention."""
+    args = MagicMock()
+    args.yaml_cfg = None
+    args.spec = None
+    args.transformer_impl = "transformer_engine"
+    args.experimental_attention_variant = "dsa"
+    args.mtp_num_layers = 7
+    config = MagicMock()
+    config.transformer_impl = "transformer_engine"
+
+    empty_block = MagicMock()
+    empty_block.layer_specs = []
+    expected_spec = MagicMock()
+
+    with (
+        patch('gpt_builders.core_transformer_config_from_args', return_value=config),
+        patch(
+            'gpt_builders.get_transformer_block_with_experimental_attention_variant_spec',
+            return_value=empty_block,
+        ),
+        patch(
+            'gpt_builders.get_transformer_layer_with_experimental_attention_variant_spec',
+            return_value=[MagicMock(), expected_spec],
+        ) as mock_experimental_specs,
+        patch('gpt_builders._get_transformer_layer_spec') as mock_generic_spec,
+        patch('gpt_builders.get_gpt_mtp_block_spec', return_value=MagicMock()) as mock_get_mtp,
+        patch('gpt_builders.GPTModel', return_value=MagicMock()),
+    ):
+        from gpt_builders import gpt_builder
+
+        gpt_builder(args, pre_process=False, post_process=True, vp_stage=None)
+
+    mock_experimental_specs.assert_called_once_with(config=config)
+    mock_generic_spec.assert_not_called()
+    assert mock_get_mtp.call_args.args[1] is expected_spec

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -81,6 +81,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "cuda_graph_modules": [],
     "cuda_graph_use_single_mempool": True,
     "cuda_graph_dynamic_microbatches": False,
+    "cuda_graph_static_dynamic_cp": False,
     "cuda_graph_scope": None,
     "cuda_graph_warmup_steps": 3,
     "deallocate_pipeline_outputs": True,

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -108,6 +108,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "dsa_indexer_topk_freq": 1,
     "dsa_indexer_weights_proj_use_quantization": True,
     "dsa_kernel_backend": "none",
+    "dsa_mtp_index_kv_share": False,
     "embedding_init_method": {},
     "embedding_init_method_std": 0.014,
     "enable_autocast": False,

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -310,6 +310,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "tensor_model_parallel_size": 2,
     "test_mode": False,
     "thd_max_packed_sequences": None,
+    "thd_static_pp_communication": False,
     "timers": None,
     "tp_comm_atomic_ag": False,
     "tp_comm_atomic_rs": False,

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -261,6 +261,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mup_width_mult": 1.0,
     "mtp_detach_heads": False,
     "mtp_hybrid_override_pattern": None,
+    "mtp_loss_type": "cross_entropy",
     "mtp_loss_scaling_factor": 0.1,
     "mtp_num_layers": None,
     "mtp_standalone": False,

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -204,6 +204,137 @@ def _run_one_iter_and_capture(
     return logits.detach().float().cpu(), grads, peak_bytes
 
 
+def _build_one_layer_vpp_models(*, seed: int) -> List[GPTModel]:
+    """Build PP=2/VPP=2 GPT chunks with exactly one TransformerLayer per chunk."""
+    from megatron.core import parallel_state
+    from megatron.core.enums import ModelType
+
+    model_parallel_cuda_manual_seed(seed)
+    torch.manual_seed(seed)
+    config = TransformerConfig(
+        num_layers=4,
+        hidden_size=128,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        attention_backend=AttnBackend.unfused,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+        virtual_pipeline_model_parallel_size=2,
+        fine_grained_activation_offloading=True,
+        offload_modules=["core_attn", "attn_proj"],
+        min_offloaded_tensor_size=1,
+    )
+
+    models = []
+    for vp_stage in range(2):
+        model = (
+            GPTModel(
+                config=config,
+                transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(),
+                vocab_size=128,
+                max_sequence_length=32,
+                pre_process=parallel_state.is_pipeline_first_stage(
+                    ignore_virtual=False, vp_stage=vp_stage
+                ),
+                post_process=parallel_state.is_pipeline_last_stage(
+                    ignore_virtual=False, vp_stage=vp_stage
+                ),
+                position_embedding_type="rope",
+                vp_stage=vp_stage,
+                share_embeddings_and_output_weights=False,
+            )
+            .bfloat16()
+            .cuda()
+        )
+        model.model_type = ModelType.encoder_or_decoder
+        model.train()
+        assert len(model.decoder.layers) == 1
+        models.append(model)
+    return models
+
+
+def _run_one_vpp_iteration(models: List[GPTModel]) -> List[Dict[str, torch.Tensor]]:
+    """Run one complete interleaved pipeline forward/backward iteration."""
+    from megatron.core.pipeline_parallel import get_forward_backward_func
+
+    seq_length = 32
+    micro_batch_size = 1
+    num_microbatches = 4
+
+    def forward_step_func(data_iterator, model):
+        next(data_iterator)
+        tokens = torch.arange(seq_length, dtype=torch.long, device="cuda").unsqueeze(0)
+        position_ids = torch.arange(seq_length, dtype=torch.long, device="cuda").unsqueeze(0)
+        labels = tokens.clone()
+        output = model(tokens, position_ids, None, labels=labels)
+
+        def loss_func(output_tensor):
+            loss = output_tensor.float().mean()
+            return loss, {"lm loss": loss.detach()}
+
+        return output, loss_func
+
+    losses = get_forward_backward_func()(
+        forward_step_func=forward_step_func,
+        data_iterator=[iter(range(num_microbatches)) for _ in models],
+        model=models,
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+    )
+    torch.cuda.synchronize()
+    return losses
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")
+def test_one_layer_vpp_chunk_runs_full_iteration_with_activation_offload():
+    """Do not advance a one-layer VPP chunk before its later offload group.
+
+    The warmup iteration records the real group layout for four TransformerLayers.
+    The second iteration executes the PP=2/VPP=2 interleaved 1F1B schedule, including
+    the immediate backward whose preceding virtual chunk contains only one layer.
+    """
+    from megatron.core import parallel_state
+
+    if Utils.world_size < 2 or Utils.world_size % 2 != 0:
+        pytest.skip("PP=2 requires an even WORLD_SIZE of at least 2.")
+
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        virtual_pipeline_model_parallel_size=2,
+    )
+    off_interface.reset_instance()
+
+    try:
+        models = _build_one_layer_vpp_models(seed=123)
+
+        # Build the real cached ChunkOffloadHandlers, then run one steady-state iteration.
+        _run_one_vpp_iteration(models)
+        for model in models:
+            for param in model.parameters():
+                if param.grad is not None:
+                    param.grad.zero_()
+        losses = _run_one_vpp_iteration(models)
+
+        grads = [
+            param.grad for model in models for param in model.parameters() if param.grad is not None
+        ]
+        assert grads, "Expected the interleaved schedule to produce parameter gradients."
+        assert all(torch.isfinite(grad).all() for grad in grads)
+        if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+            assert len(losses) == 4
+            assert all(torch.isfinite(item["lm loss"]) for item in losses)
+    finally:
+        off_interface.reset_instance()
+        Utils.destroy_model_parallel()
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")
 @pytest.mark.parametrize(
     "is_moe, is_mla, offload_modules",
@@ -825,6 +956,266 @@ def _run_iters_with_cuda_graph(
     destroy_num_microbatches_calculator()
 
     return logits.detach().float().cpu(), grads, peak_bytes
+
+
+def _build_partial_cg_pipeline_model(
+    *, seed: int, num_layers: int, moe_layer_freq, offload_modules: List[str]
+) -> GPTModel:
+    """Build one PP=2 model chunk with graph-scoped attention and eager experts."""
+    from megatron.core import parallel_state
+    from megatron.core.enums import ModelType
+    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+
+    model_parallel_cuda_manual_seed(seed)
+    torch.manual_seed(seed)
+    config = TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=256,
+        num_attention_heads=8,
+        use_cpu_initialization=True,
+        attention_backend=AttnBackend.unfused,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+        recompute_modules=["layernorm", "moe_act"],
+        recompute_granularity="selective",
+        num_moe_experts=4,
+        moe_grouped_gemm=True,
+        moe_layer_freq=moe_layer_freq,
+        fine_grained_activation_offloading=True,
+        offload_modules=offload_modules,
+        min_offloaded_tensor_size=1,
+        delay_offload_until_cuda_graph=False,
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_modules=["attn", "moe_router"],
+        cuda_graph_warmup_steps=3,
+        use_te_rng_tracker=True,
+    )
+    model = (
+        GPTModel(
+            config=config,
+            transformer_layer_spec=get_gpt_decoder_block_spec(
+                config=config, use_transformer_engine=True
+            ),
+            vocab_size=128,
+            max_sequence_length=128,
+            pre_process=parallel_state.is_pipeline_first_stage(),
+            post_process=parallel_state.is_pipeline_last_stage(),
+            position_embedding_type="rope",
+            share_embeddings_and_output_weights=False,
+        )
+        .bfloat16()
+        .cuda()
+    )
+    model.model_type = ModelType.encoder_or_decoder
+    model.train()
+    model.zero_grad_buffer = lambda: None
+    return model
+
+
+def _run_partial_cg_pipeline_iteration(model: GPTModel) -> List[Dict[str, torch.Tensor]]:
+    """Run one PP=2 pipeline iteration with four live CUDA-graph microbatch slots."""
+    from megatron.core.pipeline_parallel import get_forward_backward_func
+
+    seq_length = 128
+    micro_batch_size = 1
+    num_microbatches = 4
+
+    def forward_step_func(data_iterator, model):
+        microbatch_id = next(data_iterator)
+        tokens = (
+            (torch.arange(seq_length, dtype=torch.long, device="cuda") + microbatch_id)
+            .remainder(128)
+            .unsqueeze(0)
+        )
+        position_ids = torch.arange(seq_length, dtype=torch.long, device="cuda").unsqueeze(0)
+        output = model(tokens, position_ids, None, labels=tokens.clone())
+
+        def loss_func(output_tensor):
+            loss = output_tensor.float().mean()
+            return loss, {"lm loss": loss.detach()}
+
+        return output, loss_func
+
+    return get_forward_backward_func()(
+        forward_step_func=forward_step_func,
+        data_iterator=[iter(range(num_microbatches))],
+        model=[model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+    )
+
+
+def _run_partial_cg_offload_case(
+    *, num_layers: int, moe_layer_freq, offload_modules: List[str]
+) -> None:
+    """Validate one real PP=2 partial-CG/offload configuration."""
+    from megatron.core import parallel_state
+    from megatron.core.num_microbatches_calculator import (
+        destroy_num_microbatches_calculator,
+        init_num_microbatches_calculator,
+    )
+    from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+        PipelineOffloadManager,
+    )
+    from megatron.core.tensor_parallel.random import initialize_rng_tracker
+    from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+    from megatron.core.transformer.enums import CudaGraphModule
+    from megatron.core.transformer.moe.moe_layer import MoELayer
+
+    os.environ.pop("NVTE_FUSED_ATTN", None)
+    os.environ.pop("NVTE_FLASH_ATTN", None)
+    os.environ.pop("NVTE_UNFUSED_ATTN", None)
+
+    initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=2)
+    off_interface.reset_instance()
+    destroy_num_microbatches_calculator()
+    data_parallel_size = parallel_state.get_data_parallel_world_size()
+    init_num_microbatches_calculator(
+        rank=torch.distributed.get_rank(),
+        rampup_batch_size=None,
+        global_batch_size=4 * data_parallel_size,
+        micro_batch_size=1,
+        data_parallel_size=data_parallel_size,
+        decrease_batch_size_if_needed=False,
+    )
+    original_cuda_stream = torch.cuda.current_stream()
+    te_side_stream = torch.cuda.Stream()
+    te_side_stream.wait_stream(original_cuda_stream)
+    torch.cuda.set_stream(te_side_stream)
+
+    try:
+        model = _build_partial_cg_pipeline_model(
+            seed=123,
+            num_layers=num_layers,
+            moe_layer_freq=moe_layer_freq,
+            offload_modules=offload_modules,
+        )
+        local_num_layers = num_layers // 2
+        assert len(model.decoder.layers) == local_num_layers
+
+        if isinstance(moe_layer_freq, int):
+            global_moe_pattern = [
+                1 if layer_idx % moe_layer_freq == 0 else 0 for layer_idx in range(num_layers)
+            ]
+        else:
+            global_moe_pattern = moe_layer_freq
+        local_layer_offset = parallel_state.get_pipeline_model_parallel_rank() * local_num_layers
+        expected_local_moe_pattern = global_moe_pattern[
+            local_layer_offset : local_layer_offset + local_num_layers
+        ]
+        actual_local_moe_pattern = [
+            int(isinstance(layer.mlp, MoELayer)) for layer in model.decoder.layers
+        ]
+        assert actual_local_moe_pattern == expected_local_moe_pattern
+
+        assert model.config.cuda_graph_modules == [CudaGraphModule.attn, CudaGraphModule.moe_router]
+        attention_offload_modules = {"qkv_linear", "core_attn", "attn_proj"}
+        expected_offload_in_graph = bool(attention_offload_modules & set(offload_modules))
+        assert all(
+            layer.offload_module_in_cuda_graph == expected_offload_in_graph
+            for layer in model.decoder.layers
+        )
+        cuda_graph_helper = TECudaGraphHelper(
+            model=[model], config=model.config, seq_length=128, micro_batch_size=1, optimizers=[]
+        )
+
+        # Record real handlers and stabilize grad buffers before graph capture.
+        for _ in range(3):
+            for param in model.parameters():
+                if param.grad is not None:
+                    param.grad.zero_()
+            eager_losses = _run_partial_cg_pipeline_iteration(model)
+
+        eager_grads = {
+            name: param.grad.detach().float().cpu().clone()
+            for name, param in model.named_parameters()
+            if param.grad is not None
+        }
+        eager_loss_values = [item["lm loss"].float().cpu() for item in eager_losses]
+        offload_summary = PipelineOffloadManager.get_instance().offload_summary_bytes
+        for offload_module in offload_modules:
+            global_offload_bytes = torch.tensor(
+                offload_summary.get(offload_module, 0), dtype=torch.int64, device="cuda"
+            )
+            torch.distributed.all_reduce(global_offload_bytes)
+            assert global_offload_bytes.item() > 0, offload_summary
+
+        cuda_graph_helper.create_cudagraphs()
+        assert cuda_graph_helper.num_microbatches == 4
+        assert cuda_graph_helper.graphs_created()
+
+        for param in model.parameters():
+            if param.grad is not None:
+                param.grad.zero_()
+        losses = _run_partial_cg_pipeline_iteration(model)
+        torch.cuda.synchronize()
+
+        graph_grads = {
+            name: param.grad.detach().float().cpu()
+            for name, param in model.named_parameters()
+            if param.grad is not None
+        }
+        assert graph_grads.keys() == eager_grads.keys()
+        for name, eager_grad in eager_grads.items():
+            assert torch.allclose(graph_grads[name], eager_grad, rtol=1e-2, atol=1e-2), name
+        if parallel_state.is_pipeline_last_stage():
+            assert len(losses) == 4
+            graph_loss_values = [item["lm loss"].float().cpu() for item in losses]
+            assert all(
+                torch.allclose(graph_loss, eager_loss, rtol=1e-2, atol=1e-2)
+                for graph_loss, eager_loss in zip(graph_loss_values, eager_loss_values)
+            )
+    finally:
+        if "cuda_graph_helper" in locals() and cuda_graph_helper.graphs_created():
+            cuda_graph_helper.delete_cuda_graphs()
+        original_cuda_stream.wait_stream(te_side_stream)
+        torch.cuda.set_stream(original_cuda_stream)
+        destroy_num_microbatches_calculator()
+        off_interface.reset_instance()
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")
+@pytest.mark.skipif(
+    not is_te_min_version("2.14.0"), reason="Partial CUDA graph offloading requires TE >= 2.14.0"
+)
+def test_partial_cuda_graph_mixed_scope_offload_runs_full_iteration():
+    """Run graph-scoped core_attn and eager moe_act offload in one real iteration."""
+    _run_partial_cg_offload_case(
+        num_layers=4, moe_layer_freq=1, offload_modules=["core_attn", "moe_act"]
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")
+@pytest.mark.skipif(
+    not is_te_min_version("2.14.0"), reason="Partial CUDA graph offloading requires TE >= 2.14.0"
+)
+@pytest.mark.parametrize(
+    "offload_modules",
+    [
+        pytest.param(["moe_act"], id="moe-act-only"),
+        pytest.param(["expert_fc1", "moe_act"], id="moe-stack"),
+        pytest.param(["core_attn"], id="attention-core-only"),
+        pytest.param(["qkv_linear", "core_attn", "attn_proj"], id="attention-stack"),
+        pytest.param(["core_attn", "moe_act"], id="attention-and-moe-act"),
+        pytest.param(
+            ["qkv_linear", "core_attn", "attn_proj", "expert_fc1", "moe_act"],
+            id="attention-and-moe-stack",
+        ),
+    ],
+)
+def test_hybrid_dense_moe_partial_cuda_graph_offload_variants(offload_modules: List[str]):
+    """Exercise DeepSeek-V3-like dense-to-MoE layers across offload group subsets."""
+    _run_partial_cg_offload_case(
+        num_layers=6, moe_layer_freq=[0, 0, 1, 1, 1, 1], offload_modules=offload_modules
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offloading tests.")

--- a/tests/unit_tests/pipeline_parallel/test_parallel_prewarm.py
+++ b/tests/unit_tests/pipeline_parallel/test_parallel_prewarm.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.core.pipeline_parallel.parallel_prewarm import _build_layer_inputs
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+
+class _SyntheticLayer:
+    def __init__(self, *, packed, marker):
+        self.packed = packed
+        self.marker = marker
+
+    def get_layer_static_inputs(self, _seq_length, _micro_batch_size, **_kwargs):
+        inputs = {
+            'hidden_states': torch.full(
+                (2, 1, 4), self.marker, dtype=torch.float32, requires_grad=True
+            ),
+            'mtp_dsa_context': object(),
+        }
+        if self.packed:
+            cu_seqlens = torch.tensor([0, 2], dtype=torch.int32)
+            inputs.update(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                cu_seqlens_q_padded=cu_seqlens.clone(),
+                cu_seqlens_kv_padded=cu_seqlens.clone(),
+            )
+        else:
+            inputs['attention_mask'] = torch.full((1, 1, 2, 2), self.marker, dtype=torch.bool)
+        return inputs
+
+
+def _build_inputs(layer, model_chunk, request_carrier_cache):
+    config = SimpleNamespace(
+        context_parallel_size=1,
+        cp_partition_mode='contiguous',
+        max_seqlen_per_dp_cp_rank=2,
+        multi_latent_attention=True,
+    )
+    return _build_layer_inputs(
+        layer,
+        model_chunk,
+        config,
+        seq_length=2,
+        micro_batch_size=1,
+        rotary_pos_emb_cache={},
+        request_carrier_cache=request_carrier_cache,
+    )
+
+
+def test_pipeline_prewarm_reuses_thd_carrier_within_model_chunk():
+    chunk = object()
+    other_chunk = object()
+    cache = {}
+
+    first_args, first_kwargs = _build_inputs(_SyntheticLayer(packed=True, marker=1), chunk, cache)
+    second_args, second_kwargs = _build_inputs(_SyntheticLayer(packed=True, marker=2), chunk, cache)
+    other_args, other_kwargs = _build_inputs(
+        _SyntheticLayer(packed=True, marker=3), other_chunk, cache
+    )
+
+    assert first_kwargs['packed_seq_params'] is second_kwargs['packed_seq_params']
+    assert first_kwargs['packed_seq_params'] is not other_kwargs['packed_seq_params']
+    assert first_args[0] is not second_args[0]
+    assert second_args[0] is not other_args[0]
+    assert first_kwargs['mtp_dsa_context'] is not second_kwargs['mtp_dsa_context']
+
+
+def test_pipeline_prewarm_reuses_sbhd_carrier_within_model_chunk():
+    chunk = object()
+    other_chunk = object()
+    cache = {}
+
+    first_args, first_kwargs = _build_inputs(_SyntheticLayer(packed=False, marker=1), chunk, cache)
+    second_args, second_kwargs = _build_inputs(
+        _SyntheticLayer(packed=False, marker=0), chunk, cache
+    )
+    _, other_kwargs = _build_inputs(_SyntheticLayer(packed=False, marker=1), other_chunk, cache)
+
+    assert first_kwargs['attention_mask'] is second_kwargs['attention_mask']
+    assert first_kwargs['attention_mask'] is not other_kwargs['attention_mask']
+    assert first_args[0] is not second_args[0]
+    assert first_kwargs['mtp_dsa_context'] is not second_kwargs['mtp_dsa_context']
+
+
+def _make_thd_transformer_layer(*, cuda_graph_impl):
+    layer = object.__new__(TransformerLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(
+        bf16=True,
+        context_parallel_size=1,
+        create_attention_mask_in_dataloader=False,
+        cuda_graph_impl=cuda_graph_impl,
+        cuda_graph_modules=[],
+        fp16=False,
+        hidden_size=4,
+        max_seqlen_per_dp_cp_rank=4,
+        sequence_packing_scheduler=object(),
+        sequence_parallel=False,
+        tensor_model_parallel_size=1,
+        thd_max_packed_sequences=2,
+    )
+    layer.self_attention = SimpleNamespace(attn_mask_type=AttnMaskType.causal)
+    layer.is_moe_layer = False
+    return layer
+
+
+def test_pipeline_prewarm_aliases_thd_qk_metadata_only_for_prewarm(monkeypatch):
+    monkeypatch.setattr(torch.cuda, 'current_device', lambda: torch.device('cpu'))
+
+    prewarm_inputs = _make_thd_transformer_layer(cuda_graph_impl='none').get_layer_static_inputs(
+        4, 1, for_pipeline_prewarm=True
+    )
+    assert prewarm_inputs['cu_seqlens_q'] is prewarm_inputs['cu_seqlens_kv']
+    assert prewarm_inputs['cu_seqlens_q_padded'] is prewarm_inputs['cu_seqlens_kv_padded']
+    assert prewarm_inputs['cu_seqlens_q'] is not prewarm_inputs['cu_seqlens_q_padded']
+
+    graph_inputs = _make_thd_transformer_layer(cuda_graph_impl='local').get_layer_static_inputs(
+        4, 1, for_pipeline_prewarm=False
+    )
+    qk_metadata = [
+        graph_inputs['cu_seqlens_q'],
+        graph_inputs['cu_seqlens_kv'],
+        graph_inputs['cu_seqlens_q_padded'],
+        graph_inputs['cu_seqlens_kv_padded'],
+    ]
+    assert len({tensor.data_ptr() for tensor in qk_metadata}) == 4

--- a/tests/unit_tests/pipeline_parallel/test_parallel_prewarm.py
+++ b/tests/unit_tests/pipeline_parallel/test_parallel_prewarm.py
@@ -49,6 +49,7 @@ def _build_inputs(layer, model_chunk, request_carrier_cache):
         micro_batch_size=1,
         rotary_pos_emb_cache={},
         request_carrier_cache=request_carrier_cache,
+        is_mtp=False,
     )
 
 

--- a/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
+++ b/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
@@ -9,6 +9,7 @@ from megatron.core.tensor_parallel.layers import (
     VocabParallelEmbedding,
     copy_tensor_model_parallel_attributes,
 )
+from megatron.core.transformer.attention import QKVLayout
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -90,13 +91,25 @@ class TestTPAttributesWithoutInitialization:
         assert hasattr(w, "partition_stride") and w.partition_stride == 1
 
 
-def test_copy_tensor_model_parallel_attributes_preserves_qkv_split_shapes():
+def test_copy_tensor_model_parallel_attributes_preserves_qkv_metadata():
     source = torch.empty(4, 4)
     destination = torch.empty_like(source)
     source.is_qkv = True
-    source.qkv_split_shapes = [256, 64, 64]
+    source.qkv_layout = QKVLayout(
+        num_groups=2,
+        projection_split_shapes=(256, 64, 64),
+        per_head_split_shapes=(64, 64, 64, 64, 64, 64),
+    )
+    source.qkv_split_shapes = [2, 2]
+    source.qkv_split_shapes_global = [2] * 4
+    source.qkv_split_groups_are_complete = True
+    source.qkv_split_heads_are_complete = True
 
     copy_tensor_model_parallel_attributes(destination, source)
 
     assert destination.is_qkv is True
+    assert destination.qkv_layout == source.qkv_layout
     assert destination.qkv_split_shapes == source.qkv_split_shapes
+    assert destination.qkv_split_shapes_global == source.qkv_split_shapes_global
+    assert destination.qkv_split_groups_are_complete is True
+    assert destination.qkv_split_heads_are_complete is True

--- a/tests/unit_tests/test_context_parallel_layout.py
+++ b/tests/unit_tests/test_context_parallel_layout.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import megatron.core.context_parallel_layout.conversion as context_parallel_layout_conversion
+import megatron.core.context_parallel_layout.routes as context_parallel_layout_routes
 from megatron.core import parallel_state
 from megatron.core.context_parallel_layout import (
     CpPartitionModeConverter,
@@ -90,6 +91,18 @@ def _get_test_thd_token_indices(cu_seqlens, cp_size, cp_rank, cp_partition_mode)
         token_indices.extend(range(first_start, first_start + chunk_len))
         token_indices.extend(range(second_start, second_start + chunk_len))
     return torch.tensor(token_indices, dtype=torch.long)
+
+
+def _assert_thd_routes_equal(actual, expected):
+    for field in ("zigzag_index", "contiguous_index"):
+        actual_index = getattr(actual, field)
+        expected_index = getattr(expected, field)
+        if expected_index is None:
+            assert actual_index is None
+        else:
+            assert torch.equal(actual_index, expected_index)
+    assert actual.zigzag_split_sizes == expected.zigzag_split_sizes
+    assert actual.contiguous_split_sizes == expected.contiguous_split_sizes
 
 
 @pytest.mark.parametrize(
@@ -401,6 +414,108 @@ def test_prebuild_thd_cp_partition_routes_populates_direct_fields():
     assert same_route is route
     assert reverse_route is route
     assert packed_seq_params.cp_partition_route is route
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+
+
+def test_prebuild_thd_cp_partition_routes_materializes_aliased_qkv_once(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40, 40], dtype=torch.int32)
+    expected_route = build_thd_cp_partition_route(cu_q, cp_size=2, cp_rank=1)
+    materialized = []
+    original_materialize = context_parallel_layout_routes._materialize_thd_cu_seqlens_to_list
+
+    def track_materialize(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return original_materialize(cu_seqlens)
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_materialize_thd_cu_seqlens_to_list", track_materialize
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_q,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=1))
+
+    assert len(materialized) == 1
+    assert materialized[0] is cu_q
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+    _assert_thd_routes_equal(packed_seq_params.cp_partition_route, expected_route)
+
+
+def test_prebuild_thd_cp_partition_routes_materializes_distinct_qkv_jointly_once(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40, 40], dtype=torch.int32)
+    cu_kv = torch.tensor([0, 8, 40, 40], dtype=torch.int64)
+    expected_route = build_thd_cp_partition_route(cu_q, cp_size=2, cp_rank=0)
+    materialized = []
+    original_materialize = context_parallel_layout_routes._materialize_thd_cu_seqlens_to_list
+
+    def track_materialize(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return original_materialize(cu_seqlens)
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_materialize_thd_cu_seqlens_to_list", track_materialize
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=0))
+
+    assert len(materialized) == 1
+    assert torch.equal(materialized[0], torch.cat((cu_q, cu_kv)))
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv == [0, 8, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv is not (
+        packed_seq_params.thd_cp_host_cu_seqlens_q
+    )
+    _assert_thd_routes_equal(packed_seq_params.cp_partition_route, expected_route)
+
+
+def test_prebuild_thd_cp_partition_routes_preserves_mixed_device_fallback(monkeypatch):
+    cu_q = torch.tensor([0, 16, 40])
+    cu_kv = torch.empty(3, device="meta", dtype=torch.int32)
+    materialized = []
+
+    def fake_compact(cu_seqlens):
+        materialized.append(cu_seqlens)
+        return [0, 16, 40] if cu_seqlens is cu_q else [0, 8, 40]
+
+    monkeypatch.setattr(
+        context_parallel_layout_routes, "_compact_thd_cu_seqlens_to_list", fake_compact
+    )
+    packed_seq_params = SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_kv_padded=None,
+        cp_partition_route=None,
+    )
+
+    prebuild_thd_cp_partition_routes(packed_seq_params, _FakeGroup(size=2, rank=0))
+
+    assert len(materialized) == 2
+    assert materialized[0] is cu_q
+    assert materialized[1] is cu_kv
+    assert packed_seq_params.thd_cp_host_cu_seqlens_q == [0, 16, 40]
+    assert packed_seq_params.thd_cp_host_cu_seqlens_kv == [0, 8, 40]
 
 
 def test_prebuild_thd_cp_partition_routes_raises_route_errors():

--- a/tests/unit_tests/test_emerging_optimizers.py
+++ b/tests/unit_tests/test_emerging_optimizers.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import json
+import logging
 import os
 
 import pytest
@@ -10,23 +12,40 @@ from packaging.version import Version
 
 from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_spec,
+    get_gpt_layer_with_transformer_engine_spec,
+)
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.gpt.heterogeneous.heterogeneous_layer_specs import (
+    get_gpt_heterogeneous_layer_spec,
+)
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.emerging_optimizers import (
     HAVE_EMERGING_OPTIMIZERS,
     TensorParallelAdaptiveMuon,
     TensorParallelMuon,
     _get_qkv_split_shapes,
+    _localize_qkv_split_shapes,
+    _qkv_split_groups_are_complete,
     get_supported_coefficient_types,
     validate_coefficient_type,
 )
 from megatron.core.optimizer.muon import get_megatron_muon_optimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.transformer import TransformerConfig
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import MLATransformerConfig, TransformerConfig
+from megatron.core.transformer.attention import QKVLayout
+from megatron.core.transformer.heterogeneous.heterogeneous_config import (
+    HeterogeneousTransformerConfig,
+)
 from tests.unit_tests.test_utilities import Utils
 
 if HAVE_EMERGING_OPTIMIZERS:
+    from emerging_optimizers import utils as emerging_optimizer_utils
     from emerging_optimizers.scalar_optimizers import Lion
-    from emerging_optimizers.soap import SOAP
+
+    from megatron.core.optimizer.emerging_optimizers import SOAP
 else:
     SOAP = None
     Lion = None
@@ -80,6 +99,44 @@ def test_muon_qkv_split_shapes():
 
     assert _get_qkv_split_shapes(config) == [128, 64, 64]
     assert _get_qkv_split_shapes(gated_config) == [128, 128, 64, 64]
+    assert _get_qkv_split_shapes(config, split_qkv_per_head=True) == [64] * 32
+    assert _get_qkv_split_shapes(gated_config, split_qkv_per_head=True) == [64] * 48
+
+    mla_layout = QKVLayout.from_splits(4, (128, 64))
+    assert _get_qkv_split_shapes(mla_layout) == [128, 64]
+    assert _get_qkv_split_shapes(mla_layout, split_qkv_per_head=True) == [128, 64] * 4
+
+
+def test_muon_local_qkv_head_split_shapes_can_differ_by_tp_rank():
+    """Rank-local per-head layouts report complete and fragmented heads."""
+    global_split_shapes = [64] * 20
+
+    rank_0_shapes, rank_0_complete = _localize_qkv_split_shapes(
+        global_split_shapes, local_start=0, local_rows=160
+    )
+    rank_1_shapes, rank_1_complete = _localize_qkv_split_shapes(
+        global_split_shapes, local_start=160, local_rows=160
+    )
+    aligned_shapes, aligned_complete = _localize_qkv_split_shapes(
+        global_split_shapes, local_start=0, local_rows=640
+    )
+
+    assert rank_0_shapes == [64, 64, 32]
+    assert rank_1_shapes == [32, 64, 64]
+    assert not rank_0_complete
+    assert not rank_1_complete
+    assert aligned_shapes == [64] * 10
+    assert aligned_complete
+
+
+def test_muon_qkv_query_group_layout_localization():
+    """Projection splitting detects query groups fragmented by TP row ranges."""
+    split_shapes = [256, 64, 64]
+
+    assert _qkv_split_groups_are_complete(split_shapes, local_start=0, local_rows=384)
+    assert _qkv_split_groups_are_complete(split_shapes, local_start=384, local_rows=768)
+    assert not _qkv_split_groups_are_complete(split_shapes, local_start=0, local_rows=192)
+    assert not _qkv_split_groups_are_complete(split_shapes, local_start=192, local_rows=192)
 
 
 def test_muon_optimizer_smoke():
@@ -475,6 +532,245 @@ class TestMuonOptimizerMultiRankTP:
 
         return model, optimizer
 
+    def test_optimizer_factory_tags_qkv_when_tp_exceeds_query_groups(self):
+        """The public optimizer factory tags query groups fragmented across TP ranks."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_size = pg_collection.tp.size()
+        assert tp_size == 2
+        model_parallel_cuda_manual_seed(123)
+        transformer_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=2,
+            num_query_groups=1,
+            kv_channels=4,
+            tensor_model_parallel_size=tp_size,
+            use_cpu_initialization=False,
+            add_bias_linear=False,
+        )
+        model = GPTModel(
+            config=transformer_config,
+            transformer_layer_spec=get_gpt_layer_local_spec(),
+            vocab_size=32,
+            max_sequence_length=8,
+            pre_process=False,
+            post_process=False,
+            pg_collection=pg_collection,
+        )
+        optimizer_config = OptimizerConfig(
+            optimizer='muon',
+            lr=0.01,
+            use_distributed_optimizer=False,
+            muon_split_qkv=True,
+            muon_tp_mode="blockwise",
+        )
+
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config,
+            model_chunks=[model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+
+        qkv_weight = model.decoder.layers[0].self_attention.linear_qkv.weight
+        assert optimizer is not None
+        assert qkv_weight.shape[0] == 8
+        assert qkv_weight.is_qkv
+        assert qkv_weight.qkv_split_shapes == [8, 4, 4]
+        assert qkv_weight.qkv_split_shapes_global == [8, 4, 4]
+        assert not qkv_weight.qkv_split_groups_are_complete
+
+    @pytest.mark.parametrize("split_per_head", [False, True])
+    def test_optimizer_factory_uses_heterogeneous_layer_qkv_layout(self, split_per_head):
+        """Each heterogeneous attention layer supplies its own logical QKV layout."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_size = pg_collection.tp.size()
+        assert tp_size == 2
+        model_parallel_cuda_manual_seed(123)
+        block_configs = {
+            "block_configs": [
+                {
+                    "attention": {
+                        "no_op": False,
+                        "replace_with_linear": False,
+                        "num_query_groups": 2,
+                    },
+                    "mlp": {"no_op": False, "replace_with_linear": False, "ffn_hidden_size": 16},
+                },
+                {
+                    "attention": {
+                        "no_op": False,
+                        "replace_with_linear": False,
+                        "num_query_groups": 1,
+                    },
+                    "mlp": {"no_op": False, "replace_with_linear": False, "ffn_hidden_size": 16},
+                },
+            ]
+        }
+        transformer_config = HeterogeneousTransformerConfig(
+            num_layers=2,
+            hidden_size=8,
+            num_attention_heads=2,
+            kv_channels=4,
+            tensor_model_parallel_size=tp_size,
+            use_cpu_initialization=False,
+            add_bias_linear=False,
+            heterogeneous_layers_config_encoded_json=json.dumps(block_configs),
+        )
+        model = GPTModel(
+            config=transformer_config,
+            transformer_layer_spec=get_gpt_heterogeneous_layer_spec(transformer_config),
+            vocab_size=32,
+            max_sequence_length=8,
+            pre_process=False,
+            post_process=False,
+            pg_collection=pg_collection,
+        )
+        optimizer_config = OptimizerConfig(
+            optimizer='muon',
+            lr=0.01,
+            use_distributed_optimizer=False,
+            muon_split_qkv=True,
+            muon_split_qkv_per_head=split_per_head,
+            muon_tp_mode="blockwise",
+        )
+
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config,
+            model_chunks=[model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+
+        first_qkv = model.decoder.layers[0].self_attention.linear_qkv.weight
+        second_qkv = model.decoder.layers[1].self_attention.linear_qkv.weight
+        assert optimizer is not None
+        assert transformer_config.num_query_groups == 2
+        assert first_qkv.qkv_layout.num_groups == 2
+        assert second_qkv.qkv_layout.num_groups == 1
+        assert first_qkv.shape[0] == 12
+        assert second_qkv.shape[0] == 8
+        assert first_qkv.is_qkv
+        assert second_qkv.is_qkv
+        if split_per_head:
+            assert first_qkv.qkv_split_shapes_global == [4] * 6
+            assert second_qkv.qkv_split_shapes_global == [4] * 4
+            assert first_qkv.qkv_split_heads_are_complete
+            assert second_qkv.qkv_split_heads_are_complete
+        else:
+            assert first_qkv.qkv_split_shapes_global == [4, 4, 4] * 2
+            assert second_qkv.qkv_split_shapes_global == [8, 4, 4]
+            assert first_qkv.qkv_split_groups_are_complete
+            assert not second_qkv.qkv_split_groups_are_complete
+
+    @pytest.mark.parametrize("split_per_head", [False, True])
+    @pytest.mark.parametrize("q_lora_rank", [None, 4])
+    def test_optimizer_factory_uses_mla_up_projection_layouts(self, split_per_head, q_lora_rank):
+        """MLA up-projections use module-owned layouts with TP-aware Muon splitting."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_size = pg_collection.tp.size()
+        assert tp_size == 2
+        model_parallel_cuda_manual_seed(123)
+        transformer_config = MLATransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=2,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=4,
+            qk_head_dim=4,
+            qk_pos_emb_head_dim=2,
+            v_head_dim=3,
+            tensor_model_parallel_size=tp_size,
+            use_cpu_initialization=False,
+            add_bias_linear=False,
+            multi_latent_attention=True,
+            rope_type="rope",
+            rotary_base=10000,
+            original_max_position_embeddings=8,
+        )
+        model = GPTModel(
+            config=transformer_config,
+            transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(
+                multi_latent_attention=True
+            ),
+            vocab_size=32,
+            max_sequence_length=8,
+            pre_process=False,
+            post_process=False,
+            pg_collection=pg_collection,
+        )
+        optimizer_config = OptimizerConfig(
+            optimizer='muon',
+            lr=0.01,
+            use_distributed_optimizer=False,
+            muon_split_qkv=True,
+            muon_split_qkv_per_head=split_per_head,
+            muon_tp_mode="blockwise",
+        )
+
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config,
+            model_chunks=[model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+
+        attention = model.decoder.layers[0].self_attention
+        q_up_weight = (
+            attention.linear_q_proj.weight
+            if q_lora_rank is None
+            else attention.linear_q_up_proj.weight
+        )
+        kv_up_weight = attention.linear_kv_up_proj.weight
+        assert optimizer is not None
+        assert q_up_weight.is_qkv
+        assert kv_up_weight.is_qkv
+        assert q_up_weight.qkv_split_shapes_global == [4, 2] * 2
+        assert kv_up_weight.qkv_split_shapes_global == [4, 3] * 2
+        if split_per_head:
+            assert q_up_weight.qkv_split_heads_are_complete
+            assert kv_up_weight.qkv_split_heads_are_complete
+        else:
+            assert q_up_weight.qkv_split_groups_are_complete
+            assert kv_up_weight.qkv_split_groups_are_complete
+        if q_lora_rank is not None:
+            assert not getattr(attention.linear_q_down_proj.weight, 'is_qkv', False)
+        assert not getattr(attention.linear_kv_down_proj.weight, 'is_qkv', False)
+
+    def test_optimizer_factory_skips_mismatched_qkv_layout(self):
+        """A QKV layout mismatch falls back to whole-matrix Muon orthogonalization."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_size = pg_collection.tp.size()
+        transformer_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=2,
+            num_query_groups=1,
+            kv_channels=4,
+            tensor_model_parallel_size=tp_size,
+        )
+        model = torch.nn.Module()
+        model.config = transformer_config
+        model.linear_qkv = torch.nn.Linear(8, 7, bias=False, dtype=torch.float32, device='cuda')
+        model.linear_qkv.weight.tensor_model_parallel = True
+        model.linear_qkv.weight.partition_dim = 0
+        optimizer_config = OptimizerConfig(
+            optimizer='muon', lr=0.01, use_distributed_optimizer=False, muon_split_qkv=True
+        )
+
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config,
+            model_chunks=[model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+
+        qkv_weight = model.linear_qkv.weight
+        assert optimizer is not None
+        assert not qkv_weight.is_qkv
+        assert qkv_weight.qkv_split_shapes is None
+        assert qkv_weight.qkv_split_shapes_global is None
+
     @pytest.mark.parametrize("mode", ["duplicated", "distributed"])
     def test_muon_optimizer_modes_multirank_same_result(self, mode):
         """Test that duplicated and distributed modes produce same results with TP > 1."""
@@ -515,6 +811,148 @@ class TestMuonOptimizerMultiRankTP:
         assert not torch.equal(
             model.weight.data, original_weight
         ), "Weight should be updated with mode=blockwise"
+
+    def test_muon_optimizer_per_head_split_gathers_fragmented_heads(self):
+        """Per-head splitting reconstructs heads that cross TP rank boundaries."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_group = pg_collection.tp
+        tp_rank = tp_group.rank()
+        local_grad = torch.arange(12, dtype=torch.float32, device='cuda').view(3, 4)
+        local_grad = local_grad + tp_rank * local_grad.numel()
+        param = torch.nn.Parameter(torch.zeros_like(local_grad))
+        param.partition_dim = 0
+        param.is_qkv = True
+        param.qkv_split_shapes = [2, 2]
+        param.qkv_split_shapes_global = [2, 2, 2]
+        param.qkv_split_heads_are_complete = False
+
+        optimizer = TensorParallelMuon(
+            params=[param],
+            split_qkv=True,
+            split_qkv_per_head=True,
+            is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+            qkv_split_shapes=[2, 2, 2],
+            pg_collection=pg_collection,
+            tp_mode="blockwise",
+        )
+
+        def center_rows(x, tp_group=None, partition_dim=None):
+            del tp_group, partition_dim
+            return x - x.mean(dim=-2, keepdim=True)
+
+        optimizer.scaled_orthogonalize_fn = center_rows
+        actual = optimizer.orthogonalize(param, local_grad)
+
+        shards = [torch.empty_like(local_grad) for _ in range(tp_group.size())]
+        torch.distributed.all_gather(shards, local_grad, tp_group)
+        global_grad = torch.cat(shards, dim=0)
+        expected_global = torch.cat(
+            [center_rows(head) for head in torch.split(global_grad, [2, 2, 2], dim=0)], dim=0
+        )
+        expected = expected_global[tp_rank * 3 : (tp_rank + 1) * 3]
+        torch.testing.assert_close(actual, expected)
+
+    @pytest.mark.parametrize("split_shapes", ([4, 2, 2], [4, 4, 2, 2], [3, 5]))
+    def test_muon_optimizer_projection_split_gathers_fragmented_query_group(self, split_shapes):
+        """Projection splitting reconstructs a query group split over TP ranks."""
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        tp_group = pg_collection.tp
+        tp_rank = tp_group.rank()
+        global_rows = sum(split_shapes)
+        assert global_rows % tp_group.size() == 0
+        local_rows = global_rows // tp_group.size()
+        local_grad = torch.arange(local_rows * 4, dtype=torch.float32, device='cuda').view(
+            local_rows, 4
+        )
+        local_grad = local_grad + tp_rank * local_grad.numel()
+        param = torch.nn.Parameter(torch.zeros_like(local_grad))
+        param.partition_dim = 0
+        param.is_qkv = True
+        param.qkv_split_shapes = split_shapes
+        param.qkv_split_shapes_global = split_shapes
+        param.qkv_split_groups_are_complete = False
+
+        optimizer = TensorParallelMuon(
+            params=[param],
+            split_qkv=True,
+            is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+            qkv_split_shapes=split_shapes,
+            pg_collection=pg_collection,
+            tp_mode="blockwise",
+        )
+
+        def center_rows(x, tp_group=None, partition_dim=None):
+            del tp_group, partition_dim
+            return x - x.mean(dim=-2, keepdim=True)
+
+        optimizer.scaled_orthogonalize_fn = center_rows
+        actual = optimizer.orthogonalize(param, local_grad)
+
+        shards = [torch.empty_like(local_grad) for _ in range(tp_group.size())]
+        torch.distributed.all_gather(shards, local_grad, tp_group)
+        global_grad = torch.cat(shards, dim=0)
+        expected_global = torch.cat(
+            [
+                center_rows(projection)
+                for projection in torch.split(global_grad, split_shapes, dim=0)
+            ],
+            dim=0,
+        )
+        expected = expected_global[tp_rank * local_rows : (tp_rank + 1) * local_rows]
+        torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("layout", "expects_fallback"),
+    (("local_projection", False), ("per_head", True), ("fragmented", True)),
+)
+def test_muon_qkv_distributed_mode_routing_warns_once(monkeypatch, layout, expects_fallback):
+    """Only complete local projection splits retain distributed NS."""
+    grad = torch.arange(16, dtype=torch.float32, device='cuda').view(4, 4)
+    param = torch.nn.Parameter(torch.zeros_like(grad))
+    param.partition_dim = 0
+    param.is_qkv = True
+    param.qkv_split_shapes = [2, 1, 1]
+    param.qkv_split_shapes_global = [2, 1, 1]
+    param.qkv_split_groups_are_complete = layout != "fragmented"
+    param.qkv_split_heads_are_complete = True
+
+    optimizer = TensorParallelMuon(
+        params=[param],
+        split_qkv=True,
+        split_qkv_per_head=layout == "per_head",
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[2, 1, 1],
+        pg_collection=None,
+        tp_mode="distributed",
+    )
+    orthogonalize_args = []
+    log_records = []
+
+    def passthrough(x, tp_group=None, partition_dim=None):
+        orthogonalize_args.append((tp_group, partition_dim))
+        return x
+
+    def record_log(_logger, level, message):
+        log_records.append((level, message))
+
+    optimizer.scaled_orthogonalize_fn = passthrough
+    monkeypatch.setattr("megatron.core.optimizer.emerging_optimizers.log_single_rank", record_log)
+
+    torch.testing.assert_close(optimizer.orthogonalize(param, grad), grad)
+    torch.testing.assert_close(optimizer.orthogonalize(param, grad), grad)
+
+    warning_messages = [message for level, message in log_records if level == logging.WARNING]
+    if expects_fallback:
+        assert len(warning_messages) == 1
+        assert "falling back to non-TP Newton-Schulz" in warning_messages[0]
+        assert all(
+            tp_group is None and partition_dim is None
+            for tp_group, partition_dim in orthogonalize_args
+        )
+    else:
+        assert warning_messages == []
+        assert all(partition_dim == 0 for _, partition_dim in orthogonalize_args)
 
 
 # All non-custom coefficient types supported by emerging_optimizers.
@@ -718,6 +1156,148 @@ def test_muon_optimizer_qkv_split():
     assert not torch.equal(
         weight_with_split, weight_without_split
     ), "Weights should be different between split_qkv=True and split_qkv=False"
+
+
+def test_muon_optimizer_qkv_split_per_head_is_opt_in():
+    """Per-head splitting is guarded and differs from projection splitting."""
+    grad = torch.arange(48, dtype=torch.float32, device='cuda').view(16, 3)
+    projection_param = torch.nn.Parameter(torch.zeros_like(grad))
+    projection_param.is_qkv = True
+    projection_param.qkv_split_shapes = [4, 2, 2]
+    head_param = torch.nn.Parameter(torch.zeros_like(grad))
+    head_param.is_qkv = True
+    head_param.qkv_split_shapes = [2] * 8
+    orthogonalize_call_shapes = []
+
+    def center_rows(x, tp_group=None, partition_dim=None):
+        del tp_group, partition_dim
+        orthogonalize_call_shapes.append(tuple(x.shape))
+        return x - x.mean(dim=-2, keepdim=True)
+
+    projection_optimizer = TensorParallelMuon(
+        params=[projection_param],
+        split_qkv=True,
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[4, 2, 2],
+        pg_collection=None,
+    )
+    projection_optimizer.scaled_orthogonalize_fn = center_rows
+    projection_out = projection_optimizer.orthogonalize(projection_param, grad)
+    orthogonalize_call_shapes.clear()
+
+    head_optimizer = TensorParallelMuon(
+        params=[head_param],
+        split_qkv=True,
+        split_qkv_per_head=True,
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[2] * 8,
+        pg_collection=None,
+    )
+    head_optimizer.scaled_orthogonalize_fn = center_rows
+    head_out = head_optimizer.orthogonalize(head_param, grad)
+    assert orthogonalize_call_shapes == [(8, 2, 3)]
+
+    expected_head_out = torch.cat(
+        [center_rows(head) for head in torch.split(grad, [2] * 8, dim=0)], dim=0
+    )
+    torch.testing.assert_close(head_out, expected_head_out)
+    assert not torch.equal(projection_out, head_out)
+
+
+def test_muon_optimizer_qkv_split_per_head_requires_split_qkv():
+    """The per-head switch cannot enable QKV splitting by itself."""
+    param = torch.nn.Parameter(torch.zeros(4, 4, dtype=torch.float32, device='cuda'))
+    with pytest.raises(ValueError, match="split_qkv_per_head requires split_qkv=True"):
+        TensorParallelMuon(
+            params=[param], split_qkv=False, split_qkv_per_head=True, pg_collection=None
+        )
+
+
+def test_muon_optimizer_uniform_per_head_splits_use_batched_ns():
+    """Uniform per-head splits use Emerging-Optimizers' batched Newton-Schulz path."""
+    grad = torch.arange(16, dtype=torch.float32, device='cuda').view(4, 4)
+    param = torch.nn.Parameter(torch.zeros_like(grad))
+    param.is_qkv = True
+    param.qkv_split_shapes = [2, 2]
+    optimizer = TensorParallelMuon(
+        params=[param],
+        split_qkv=True,
+        split_qkv_per_head=True,
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[2, 2],
+        pg_collection=None,
+    )
+    call_shapes = []
+
+    def center_rows(x, tp_group=None, partition_dim=None):
+        del tp_group, partition_dim
+        call_shapes.append(tuple(x.shape))
+        return x - x.mean(dim=-2, keepdim=True)
+
+    optimizer.scaled_orthogonalize_fn = center_rows
+    actual = optimizer.orthogonalize(param, grad)
+    assert call_shapes == [(2, 2, 4)]
+    expected = torch.cat(
+        [head - head.mean(dim=-2, keepdim=True) for head in torch.split(grad, [2, 2])]
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_muon_optimizer_batched_per_head_ns_matches_individual_heads():
+    """The pinned Emerging-Optimizers 3D Newton-Schulz path matches 2D head calls."""
+    torch.manual_seed(42)
+    grad = torch.randn(8, 16, dtype=torch.float32, device='cuda')
+    param = torch.nn.Parameter(torch.zeros_like(grad))
+    param.is_qkv = True
+    param.qkv_split_shapes = [2] * 4
+    optimizer = TensorParallelMuon(
+        params=[param],
+        split_qkv=True,
+        split_qkv_per_head=True,
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[2] * 4,
+        fp32_matmul_prec="highest",
+        num_ns_steps=2,
+        pg_collection=None,
+    )
+
+    with emerging_optimizer_utils.fp32_matmul_precision(optimizer.fp32_matmul_prec):
+        actual = optimizer.orthogonalize(param, grad)
+        expected = torch.cat(
+            [
+                optimizer.scaled_orthogonalize_fn(head, tp_group=None, partition_dim=None)
+                for head in torch.split(grad, [2] * 4)
+            ]
+        )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_muon_optimizer_nonuniform_per_head_splits_use_unbatched_ns():
+    """Nonuniform per-head splits keep using individual Newton-Schulz calls."""
+    grad = torch.arange(12, dtype=torch.float32, device='cuda').view(3, 4)
+    param = torch.nn.Parameter(torch.zeros_like(grad))
+    param.is_qkv = True
+    param.qkv_split_shapes = [2, 1]
+    optimizer = TensorParallelMuon(
+        params=[param],
+        split_qkv=True,
+        split_qkv_per_head=True,
+        is_qkv_fn=lambda p: getattr(p, 'is_qkv', False),
+        qkv_split_shapes=[2, 1],
+        pg_collection=None,
+    )
+    call_shapes = []
+
+    def center_rows(x, tp_group=None, partition_dim=None):
+        del tp_group, partition_dim
+        call_shapes.append(tuple(x.shape))
+        return x - x.mean(dim=-2, keepdim=True)
+
+    optimizer.scaled_orthogonalize_fn = center_rows
+    actual = optimizer.orthogonalize(param, grad)
+    assert call_shapes == [(2, 4), (1, 4)]
+    expected = torch.cat([center_rows(head) for head in torch.split(grad, [2, 1])])
+    torch.testing.assert_close(actual, expected)
 
 
 def test_muon_optimizer_extra_scale_factor():

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -177,6 +177,26 @@ class TestBSHDBackwardCompat:
         assert default_flops == explicit_flops
 
 
+class TestMTPE2ETVFlops:
+    """E2E TV adds one frozen target-output projection to the FLOPs count."""
+
+    @pytest.mark.parametrize("hybrid", [False, True])
+    def test_counts_one_forward_only_target_projection(self, hybrid):
+        args = _make_hybrid_args() if hybrid else _make_gpt_args()
+        args.mtp_num_layers = 3
+        args.mtp_loss_type = "cross_entropy"
+        batch_size = 2
+        cross_entropy_flops = num_floating_point_operations(args, batch_size)
+
+        args.mtp_loss_type = "e2e_tv"
+        e2e_tv_flops = num_floating_point_operations(args, batch_size)
+
+        expected_extra = (
+            2 * batch_size * args.seq_length * args.hidden_size * args.padded_vocab_size
+        )
+        assert e2e_tv_flops - cross_entropy_flops == expected_extra
+
+
 class TestTHDScaling:
     """Only the L^2 attention term should depend on ``seqlen_squared_sum_in_batch``."""
 

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -1172,3 +1172,265 @@ class TestDSv4HybridMatchesStandard:
         std_flops = num_floating_point_operations(standard, batch_size)
         hyb_flops = num_floating_point_operations(hybrid, batch_size)
         assert hyb_flops == std_flops
+
+
+def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
+    """Minimal MLA + DSA args (GLM-5.2 style, small scale).
+
+    Uses ``dsa_indexer_topk_freq=1`` and ``dsa_indexer_skip_topk_offset=0``
+    so every layer computes its own top-k index -- the golden reference can
+    set ``num_indexer_layers = num_layers`` without importing the skip-layer
+    predicate from megatron.core.
+
+    ``dsa_indexer_loss_coeff`` drives the indexer's fwd/bwd expansion: the
+    indexer only has a backward pass when its KL loss is enabled. The default
+    here matches the in-tree functional test configs.
+    """
+    args = _make_gpt_args(
+        num_layers=4,
+        hidden_size=512,
+        num_attention_heads=8,
+        seq_length=256,
+        ffn_hidden_size=2048,
+        padded_vocab_size=1024,
+    )
+    args.multi_latent_attention = True
+    args.group_query_attention = False
+    args.q_lora_rank = 128
+    args.kv_lora_rank = 64
+    args.qk_head_dim = 48
+    args.qk_pos_emb_head_dim = 16
+    args.v_head_dim = 64
+    args.experimental_attention_variant = "dsa"
+    args.dsa_indexer_n_heads = 4
+    args.dsa_indexer_head_dim = 32
+    args.dsa_indexer_topk = 16
+    args.dsa_indexer_topk_freq = 1
+    args.dsa_indexer_skip_topk_offset = 0
+    args.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+    return args
+
+
+def _dsa_golden_flops(args, total_tokens, seqlen_squared_sum, num_indexer_layers=None):
+    """Independent golden calculator for DSA FLOPs.
+
+    Reimplements the formula from ``num_floating_point_operations`` so that
+    the test does not just call the same code twice. Assumes no MoE / MTP.
+    ``num_indexer_layers`` defaults to every layer, which is what
+    ``dsa_indexer_topk_freq=1`` / ``dsa_indexer_skip_topk_offset=0`` give;
+    cross-layer sharing cases pass the expected count explicitly.
+    """
+    fwd_bwd = 3
+    fma = 2
+    ffn_exp = 3 if args.swiglu else 2
+    num_layers = args.num_layers
+    nh = args.num_attention_heads
+
+    # ---- MLA projections (token-linear, per layer) ----
+    q_term = args.q_lora_rank * (
+        args.hidden_size + nh * (args.qk_head_dim + args.qk_pos_emb_head_dim) + 1
+    )
+    kv_term = (
+        args.kv_lora_rank * (args.hidden_size + nh * (args.qk_head_dim + args.v_head_dim) + 1)
+        + args.hidden_size * args.qk_pos_emb_head_dim
+    )
+    o_term = nh * args.v_head_dim * args.hidden_size
+    mla_proj_per_layer = fwd_bwd * fma * (q_term + kv_term + o_term)
+
+    # ---- Core attention: absorbed-MLA cost scaled down to top-k sparse pairs.
+    # DSA executes ``AbsorbedMLASelfAttention``: QK^T over the compressed KV
+    # latent (kv_lora_rank + rope per head) and AV over kv_lora_rank.
+    raw_core = nh * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2 + nh * args.kv_lora_rank / 2
+    mean_seqlen = seqlen_squared_sum / total_tokens
+    topk = args.dsa_indexer_topk
+    if mean_seqlen <= topk:
+        sparse_scale = 1.0
+    else:
+        dense_pairs = mean_seqlen * mean_seqlen / 2
+        topk_pairs = topk * mean_seqlen - topk * topk / 2
+        sparse_scale = topk_pairs / dense_pairs
+    sparse_core_per_layer = fwd_bwd * fma * raw_core * sparse_scale
+
+    # ---- DSA indexer: only layers that compute their own top-k index ----
+    if num_indexer_layers is None:
+        num_indexer_layers = num_layers
+    idx_dim = args.dsa_indexer_n_heads * args.dsa_indexer_head_dim
+    idx_token = num_indexer_layers * (
+        args.q_lora_rank * idx_dim  # wq_b
+        + args.hidden_size * args.dsa_indexer_head_dim  # wk
+        + args.hidden_size * args.dsa_indexer_n_heads  # weights_proj
+    )
+    idx_core = num_indexer_layers * idx_dim / 2
+    # The indexer only runs a backward pass when its KL loss is on, and its
+    # inputs are detached: projections pay fwd + wgrad, scoring pays fwd + dq + dk.
+    if (args.dsa_indexer_loss_coeff or 0.0) > 0:
+        idx_token_expansion, idx_core_expansion = 2, 3
+    else:
+        idx_token_expansion, idx_core_expansion = 1, 1
+    dsa_extra_token = idx_token_expansion * fma * idx_token
+    dsa_extra_core = idx_core_expansion * fma * idx_core
+
+    # ---- Aggregation ----
+    mlp = fwd_bwd * fma * args.hidden_size * (args.ffn_hidden_size * ffn_exp * num_layers)
+    logit = fwd_bwd * fma * args.hidden_size * args.padded_vocab_size
+    self_attn_term = mla_proj_per_layer * num_layers + dsa_extra_token
+    self_attn_core_term = sparse_core_per_layer * num_layers + dsa_extra_core
+
+    return total_tokens * (mlp + self_attn_term + logit) + seqlen_squared_sum * self_attn_core_term
+
+
+class TestDSA:
+    """DSA sparse-attention FLOPs against an independent golden calculator."""
+
+    def test_bshd(self):
+        """BSHD (uniform sequences) must match the golden calculator."""
+        args = _make_dsa_args()
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        flops = num_floating_point_operations(args, batch_size)
+        expected = _dsa_golden_flops(args, total_tokens, sum_sq)
+        assert flops == expected
+
+    def test_thd(self):
+        """THD (packed variable-length subsequences) must match the golden
+        calculator and be strictly less than BSHD due to the L^2 terms
+        (indexer scoring and sparse core attention)."""
+        args = _make_dsa_args()
+        batch_size = 2
+        packed_lengths = [64, 64, 128, 256]
+        total_tokens = sum(packed_lengths)
+        thd_sum_sq = sum(L**2 for L in packed_lengths)
+
+        flops = num_floating_point_operations(
+            args,
+            batch_size,
+            seqlen_squared_sum_in_batch=thd_sum_sq,
+            total_real_tokens_in_batch=total_tokens,
+        )
+        expected = _dsa_golden_flops(args, total_tokens, thd_sum_sq)
+        assert flops == expected
+        # THD must be strictly less than BSHD.
+        bshd_flops = num_floating_point_operations(args, batch_size)
+        assert flops < bshd_flops
+
+    @pytest.mark.parametrize("loss_coeff", [0.0, None])
+    def test_indexer_without_loss_is_forward_only(self, loss_coeff):
+        """With the indexer KL loss disabled the indexer has no backward pass.
+
+        ``DSAttention.forward`` runs it under ``torch.no_grad()`` in that case,
+        so its terms must drop from 2x/3x to 1x rather than keep the global
+        fwd+bwd factor. Everything outside the indexer is unchanged.
+        """
+        args = _make_dsa_args(dsa_indexer_loss_coeff=loss_coeff)
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        flops = num_floating_point_operations(args, batch_size)
+        assert flops == _dsa_golden_flops(args, total_tokens, sum_sq)
+        # A frozen indexer must cost strictly less than a trained one.
+        assert flops < num_floating_point_operations(_make_dsa_args(0.01), batch_size)
+
+    def test_cross_layer_index_sharing(self):
+        """Only layers that compute their own top-k index pay for the indexer.
+
+        ``dsa_indexer_topk_freq=1`` makes ``is_dsa_skip_topk_layer``
+        unconditionally False, so the layer-counting logic is only actually
+        exercised with sharing on. Here ``freq=4, offset=1`` leaves layers 1 and
+        5 computing out of 8, and ``_num_dsa_indexer_layers`` has to stay in
+        lockstep with the predicate in megatron.core.
+        """
+        args = _make_dsa_args()
+        args.num_layers = 8
+        args.dsa_indexer_topk_freq = 4
+        args.dsa_indexer_skip_topk_offset = 1
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        # Layers 1..8 compute when (max(L - 1, 0) % 4) == 0, i.e. layers 1 and 5.
+        expected = _dsa_golden_flops(args, total_tokens, sum_sq, num_indexer_layers=2)
+        assert num_floating_point_operations(args, batch_size) == expected
+
+        # Sharing must be cheaper than every layer running its own indexer.
+        no_sharing = _make_dsa_args()
+        no_sharing.num_layers = 8
+        assert num_floating_point_operations(args, batch_size) < num_floating_point_operations(
+            no_sharing, batch_size
+        )
+
+    def test_topk_caps_long_context_growth(self):
+        """Pin the bug: a long sequence must not be charged dense ``L^2 / 2``.
+
+        With ``seq_length`` well past ``dsa_indexer_topk`` the old behaviour
+        (plain dense MLA core, no top-k scaling) grows quadratically; the
+        corrected sparse core term is capped by top-k and only the indexer's
+        dense scoring keeps a (much smaller) quadratic component.
+        """
+        args = _make_dsa_args()
+        args.seq_length = 8192
+        batch_size = 1
+
+        corrected = num_floating_point_operations(args, batch_size)
+
+        # Same model reading as plain MLA (the branch DSA used to fall into).
+        dense = SimpleNamespace(**vars(args))
+        dense.experimental_attention_variant = None
+        assert corrected < num_floating_point_operations(dense, batch_size)
+
+
+class TestDSAHelperEdgeCases:
+    """Direct coverage of the helper guards and the hybrid rejection."""
+
+    def test_indexer_flops_zero_layers(self):
+        """No indexer layers contribute nothing."""
+        from megatron.training.training import _dsa_indexer_flops
+
+        assert _dsa_indexer_flops(
+            hidden_size=512,
+            q_lora_rank=128,
+            n_heads=4,
+            head_dim=32,
+            num_indexer_layers=0,
+            indexer_loss_coeff=0.01,
+        ) == (0, 0)
+
+    def test_sparse_core_scale_degenerate_inputs(self):
+        """Zero tokens or an unset top-k fall back to the dense scale of 1.0."""
+        from megatron.training.training import _dsa_sparse_core_scale
+
+        assert _dsa_sparse_core_scale(0, 0, 2048) == 1.0
+        assert _dsa_sparse_core_scale(512, 512 * 4096, None) == 1.0
+
+    def test_hybrid_dsa_rejected(self):
+        """A hybrid layer pattern with DSA must fail loud, not fall through
+        to the dense full-MLA estimate (which overcounts core attention and
+        drops the indexer)."""
+        args = _make_dsa_args()
+        args.hybrid_layer_pattern = "D-D-"
+        args.mamba_state_dim = 128
+        args.mamba_head_dim = 64
+        args.mamba_num_groups = 8
+        args.mamba_num_heads = 128
+
+        with pytest.raises(AssertionError, match="hybrid-model path"):
+            num_floating_point_operations(args, 2)
+
+    def test_hybrid_dsa_rejected_without_variant_attribute(self):
+        """The guard must key off the 'D' symbols in the layer pattern, not
+        just ``args.experimental_attention_variant``: on the hybrid path a
+        'D' pattern sets the variant only in the config kwargs (never back
+        onto ``args``), so a real ``--hybrid-layer-pattern "D..."`` launch
+        reaches this code with the attribute still ``None``."""
+        args = _make_dsa_args()
+        args.experimental_attention_variant = None
+        args.hybrid_layer_pattern = "D-D-"
+        args.mamba_state_dim = 128
+        args.mamba_head_dim = 64
+        args.mamba_num_groups = 8
+        args.mamba_num_heads = 128
+
+        with pytest.raises(AssertionError, match="hybrid-model path"):
+            num_floating_point_operations(args, 2)

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -18,6 +18,7 @@ from megatron.core.datasets.data_schedule import (
     wrap_data_iterator,
 )
 from megatron.core.datasets.data_schedule_utils import (
+    build_packed_microbatches,
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
 )
@@ -52,6 +53,38 @@ def test_scheduler_max_real_num_seqs_rejects_dummy_without_capacity():
 
     with pytest.raises(ValueError, match="includes that dummy sequence"):
         _get_scheduler_max_real_num_seqs(config)
+
+
+@pytest.mark.parametrize("dynamic_cp", [False, True])
+@pytest.mark.parametrize(("padded_lengths", "expected_min_chunk"), [((8, 12), 2), ((8, 10), 0)])
+def test_build_packed_microbatches_certifies_zigzag_chunk_size(
+    dynamic_cp, padded_lengths, expected_min_chunk
+):
+    """The host schedule emits one conservative certificate for each packed batch."""
+    samples = {
+        sample_id: {
+            "original_seq_len": torch.tensor([padded_length - 1], dtype=torch.int32),
+            "padded_seq_len": torch.tensor([padded_length], dtype=torch.int32),
+        }
+        for sample_id, padded_length in enumerate(padded_lengths)
+    }
+    sample_id_groups = [[[0, 1], [0, 1]]]
+
+    packed = build_packed_microbatches(
+        samples,
+        sample_id_groups,
+        dcp_rank=0,
+        dev=torch.device("cpu"),
+        is_dynamic_cp=dynamic_cp,
+        global_id_seqlens=list(enumerate(padded_lengths)),
+    )
+
+    assert len(packed) == 1
+    assert packed[0]["zigzag_cp_min_chunk_size"].item() == expected_min_chunk
+    if dynamic_cp:
+        assert packed[0]["local_cp_size"].item() == 2
+    else:
+        assert "local_cp_size" not in packed[0]
 
 
 def test_scheduler_thd_padding_mask_from_cu_seqlens():

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -214,6 +214,72 @@ def test_training_log_resets_first_iteration_when_log_interval_is_one(monkeypatc
     assert " alignment loss: 4.000000E+00 |" not in log_lines[-1]
 
 
+def test_training_log_uses_nominal_microbatches_and_dynamic_cp_parent(monkeypatch):
+    """DSA metrics use the stable physical parent and nominal microbatch divisor."""
+    parent_dp_cp_group = object()
+    recorded = []
+    args = SimpleNamespace(
+        consumed_train_samples=0,
+        context_parallel_size=4,
+        csa_compress_ratios=None,
+        cuda_graph_impl="none",
+        data_parallel_size=2,
+        dsa_indexer_loss_coeff=0.1,
+        dynamic_context_parallel=True,
+        freeze_all_layers=False,
+        log_interval=100,
+        micro_batch_size=1,
+        mtp_num_layers=None,
+        num_experts=None,
+        num_layers=4,
+        perform_rl_step=False,
+        seq_length=4096,
+        skipped_train_samples=0,
+        timing_log_level=0,
+        world_size=8,
+    )
+
+    monkeypatch.setattr(training_module, "get_args", lambda: args)
+    monkeypatch.setattr(training_module, "get_timers", mock.MagicMock)
+    monkeypatch.setattr(training_module, "get_tensorboard_writer", lambda: None)
+    monkeypatch.setattr(training_module, "get_wandb_writer", lambda: None)
+    monkeypatch.setattr(training_module, "get_one_logger", lambda: None)
+    monkeypatch.setattr(training_module, "get_energy_monitor", lambda: None)
+    monkeypatch.setattr(training_module, "get_num_microbatches", lambda: 7)
+    monkeypatch.setattr(
+        training_module,
+        "reduce_max_stat_across_model_parallel_group",
+        lambda value, group=None: value,
+    )
+    monkeypatch.setattr(training_module.one_logger_utils, "track_app_tag", lambda *a: None)
+    monkeypatch.setattr(
+        training_module.DSAIndexerLossLoggingHelper,
+        "track_indexer_metrics",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    training_module.training_log(
+        {},
+        {},
+        learning_rate=1.0e-4,
+        iteration=1,
+        loss_scale=1.0,
+        report_memory_flag=False,
+        skipped_iter=0,
+        grad_norm=None,
+        params_norm=None,
+        num_zeros_in_grad=None,
+        max_attention_logit=None,
+        pg_collection=SimpleNamespace(dp_cp=parent_dp_cp_group, mp=None),
+    )
+
+    assert len(recorded) == 1
+    assert recorded[0]["loss_scale"] == 1 / 7
+    assert recorded[0]["dynamic_cp_parent_group"] is parent_dp_cp_group
+    assert recorded[0]["configured_cp_size"] == 4
+    assert recorded[0]["num_layers"] == 4
+
+
 class TestGetModelBucketSizingPgCollection:
     """The DDP-bucket-sizing path in get_model must read world size / rank from the
     explicitly passed pg_collection (pg_collection.dp_cp / pg_collection.pp) rather

--- a/tests/unit_tests/training/models/test_gpt_builder.py
+++ b/tests/unit_tests/training/models/test_gpt_builder.py
@@ -836,6 +836,7 @@ class TestMtpBlockSpec:
         config.transformer.transformer_impl = transformer_impl
         config.transformer.normalization = "LayerNorm"
         config.transformer.qk_l2_norm = False
+        config.transformer.experimental_attention_variant = None
         return config
 
     def test_returns_none_when_mtp_num_layers_is_none(self):
@@ -878,6 +879,28 @@ class TestMtpBlockSpec:
         mock_te_or_local.assert_called_once_with(config, 4)
         passed_spec = mock_get_mtp.call_args.args[1]
         assert passed_spec is fallback_spec
+
+    @patch("megatron.training.models.gpt._te_or_local_layer_spec")
+    @patch(
+        "megatron.training.models.gpt.get_transformer_layer_with_experimental_attention_variant_spec"
+    )
+    @patch("megatron.core.models.gpt.gpt_layer_specs.get_gpt_mtp_block_spec")
+    def test_experimental_attention_precedes_empty_stage_fallback(
+        self, mock_get_mtp, mock_experimental_specs, mock_te_or_local
+    ):
+        config = self._make_config(mtp_num_layers=7)
+        config.transformer.experimental_attention_variant = "dsa"
+        empty_block = Mock()
+        empty_block.layer_specs = []
+        expected_spec = Mock(spec=ModuleSpec)
+        mock_experimental_specs.return_value = [Mock(spec=ModuleSpec), expected_spec]
+        mock_get_mtp.return_value = Mock(spec=ModuleSpec)
+
+        mtp_block_spec(config, empty_block, vp_stage=3)
+
+        mock_experimental_specs.assert_called_once_with(config=config.transformer)
+        mock_te_or_local.assert_not_called()
+        assert mock_get_mtp.call_args.args[1] is expected_spec
 
     @patch("megatron.core.models.gpt.gpt_layer_specs.get_gpt_mtp_block_spec")
     def test_passes_vp_stage_and_use_te_to_get_gpt_mtp_block_spec(self, mock_get_mtp):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -13,6 +13,11 @@ from megatron.core import parallel_state
 from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
 from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.optimizer import (
+    HAVE_EMERGING_OPTIMIZERS,
+    OptimizerConfig,
+    get_megatron_optimizer,
+)
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -309,6 +314,75 @@ def get_mla_submodules(
 # TODO: Add test case to cover TP > 1 but SP = False.
 
 
+@pytest.mark.parametrize("split_per_head", [False, True])
+@pytest.mark.skipif(
+    not HAVE_EMERGING_OPTIMIZERS, reason="emerging_optimizers package is not installed"
+)
+def test_split_kv_up_projections_are_tagged_for_muon(split_per_head):
+    """The dev-only split K/V layout is consumed by Muon's QKV split path."""
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = get_mock_mla_config(
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+            sequence_parallel=False,
+            recompute_mla_up_proj=False,
+        )
+        config.hidden_size = 16
+        config.num_attention_heads = 4
+        config.num_query_groups = 4
+        config.q_lora_rank = 8
+        config.kv_lora_rank = 4
+        config.qk_head_dim = 4
+        config.qk_pos_emb_head_dim = 2
+        config.v_head_dim = 3
+        attention = AbsorbedMLASelfAttention(
+            config=config,
+            submodules=get_absorbed_mla_submodules(
+                down_proj_use_column_parallel=False,
+                qk_layernorm=True,
+                rms_norm=True,
+                combined_kv_up_projection=False,
+            ),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=None,
+        ).cuda()
+        optimizer_config = OptimizerConfig(
+            optimizer='muon',
+            lr=0.01,
+            bf16=True,
+            use_distributed_optimizer=False,
+            muon_split_qkv=True,
+            muon_split_qkv_per_head=split_per_head,
+        )
+
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config, model_chunks=[attention], use_gloo_process_groups=False
+        )
+
+        k_weight = attention.linear_k_up_proj.weight
+        v_weight = attention.linear_v_up_proj.weight
+        assert optimizer is not None
+        assert k_weight.is_qkv
+        assert v_weight.is_qkv
+        assert k_weight.qkv_split_shapes_global == [config.qk_head_dim] * 4
+        assert v_weight.qkv_split_shapes_global == [config.v_head_dim] * 4
+        if split_per_head:
+            assert k_weight.qkv_split_shapes == [config.qk_head_dim] * 4
+            assert v_weight.qkv_split_shapes == [config.v_head_dim] * 4
+            assert k_weight.qkv_split_heads_are_complete
+            assert v_weight.qkv_split_heads_are_complete
+        else:
+            assert k_weight.qkv_split_shapes == [config.qk_head_dim]
+            assert v_weight.qkv_split_shapes == [config.v_head_dim]
+            assert k_weight.qkv_split_groups_are_complete
+            assert v_weight.qkv_split_groups_are_complete
+        assert not getattr(attention.linear_kv_down_proj.weight, 'is_qkv', False)
+    finally:
+        Utils.destroy_model_parallel()
+
+
 def _run_functionality(
     tp_cp_sp: List,
     qkv_format: str,
@@ -362,6 +436,19 @@ def _run_functionality(
         cp_comm_type="all_gather" if cp_size > 1 else None,
         pg_collection=None,
     ).cuda()
+    assert absorbed_mla.linear_q_up_proj.weight.qkv_layout.num_groups == config.num_attention_heads
+    if combined_kv_up_projection:
+        assert absorbed_mla.linear_kv_up_proj.weight.qkv_layout.projection_split_shapes == (
+            config.qk_head_dim,
+            config.v_head_dim,
+        )
+    else:
+        assert absorbed_mla.linear_k_up_proj.weight.qkv_layout.projection_split_shapes == (
+            config.qk_head_dim,
+        )
+        assert absorbed_mla.linear_v_up_proj.weight.qkv_layout.projection_split_shapes == (
+            config.v_head_dim,
+        )
 
     assert absorbed_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
     assert absorbed_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -132,6 +132,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
 
@@ -154,6 +155,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
         attention = DSAttention(
@@ -180,6 +182,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            dsa_mtp_index_kv_share=False,
             kv_channels=16,
         )
         attention = DSAttention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -33,6 +33,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAttention,
     DSAttentionSubmodules,
     FusedDSAIndexerLoss,
+    _can_prove_all_topk_rows_nonempty,
     _run_sparse_attention,
     _validate_nonpacked_cp_uniform_length,
     compute_dsa_indexer_loss,
@@ -56,6 +57,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa_masking import
     build_causal_mask_from_positions,
     build_dsattention_forward_mask,
     build_fused_indexer_varlen_bounds,
+    extract_query_valid_rows_from_packed_seq_params,
     generate_varlen_mask_params_for_positions,
     masked_log_softmax,
     scatter_topk_into_index_mask,
@@ -407,6 +409,128 @@ def test_dsa_kernel_backend_loader_cache_and_import_errors(monkeypatch):
         dsa_kernels._load_backend(Config)
 
 
+def test_dsa_all_topk_rows_nonempty_certificate():
+    common = {
+        "computes_topk": True,
+        "indexer_topk": 2,
+        "kv_sequence_length": 4,
+        "attention_mask": None,
+        "query_valid_rows": None,
+        "varlen_is_plain_causal": True,
+        "use_local_indexer_varlen": False,
+        "varlen_starts": None,
+        "varlen_ends": None,
+        "key_positions": None,
+    }
+    assert _can_prove_all_topk_rows_nonempty(**common)
+
+    packed_local = {
+        **common,
+        "varlen_is_plain_causal": False,
+        "use_local_indexer_varlen": True,
+        "varlen_starts": torch.tensor([0, 0]),
+        "varlen_ends": torch.tensor([1, 2]),
+    }
+    assert _can_prove_all_topk_rows_nonempty(**packed_local)
+
+    unsupported = [
+        {"computes_topk": False},
+        {"indexer_topk": 0},
+        {"kv_sequence_length": 0},
+        {"attention_mask": torch.zeros((1, 1, 2, 4), dtype=torch.bool)},
+        {"query_valid_rows": torch.ones((1, 2), dtype=torch.bool)},
+        {"varlen_is_plain_causal": False},
+        {**packed_local, "key_positions": torch.arange(4)},
+        {**packed_local, "varlen_ends": None},
+    ]
+    for override in unsupported:
+        assert not _can_prove_all_topk_rows_nonempty(**{**common, **override})
+
+
+def test_dsa_packed_cp_padding_preserves_nonempty_local_varlen_rows():
+    """Padded THD rows still have causal KV coverage without a real-token mask."""
+    device = torch.device("cpu")
+    cp_size = 2
+    global_rows = 12
+    local_rows = global_rows // cp_size
+    cu_seqlens = torch.tensor([0, 3, 7], dtype=torch.int32, device=device)
+    cu_seqlens_padded = torch.tensor([0, 4, 12], dtype=torch.int32, device=device)
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens_padded,
+        cu_seqlens_kv_padded=cu_seqlens_padded,
+        max_seqlen_q=8,
+        max_seqlen_kv=8,
+        pad_between_seqs=True,
+    )
+    query_valid_rows = extract_query_valid_rows_from_packed_seq_params(
+        packed_seq_params, b=1, sq=local_rows, device=device
+    )
+    assert query_valid_rows is None
+
+    padding_positions = torch.tensor([3, 8, 9, 10, 11], device=device)
+    all_query_positions = []
+    for cp_rank in range(cp_size):
+        query_positions = build_packed_allgather_cp_local_positions(
+            cu_seqlens_padded,
+            cp_size,
+            cp_rank,
+            device,
+            output_size=local_rows,
+            cu_seqlens_cover_output=True,
+        )
+        all_query_positions.append(query_positions)
+        float_mask, varlen_params, varlen_is_plain_causal = build_dsattention_forward_mask(
+            sq=local_rows,
+            skv=global_rows,
+            b=1,
+            device=device,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            cp_comm_type="allgather",
+            cp_group=None,
+            attn_mask_type=AttnMaskType.causal,
+            attention_mask=None,
+            position_ids=None,
+            packed_seq_params=packed_seq_params,
+            packed_query_positions=query_positions,
+        )
+        assert float_mask is None
+        assert not varlen_is_plain_causal
+        assert varlen_params is not None
+        starts, ends, key_positions = varlen_params
+        assert key_positions is None
+
+        physical_key_positions = torch.arange(global_rows, device=device)
+        row_has_key = (
+            (physical_key_positions.unsqueeze(0) >= starts.unsqueeze(1))
+            & (physical_key_positions.unsqueeze(0) < ends.unsqueeze(1))
+        ).any(dim=1)
+        assert torch.all(row_has_key)
+        assert torch.any((query_positions.unsqueeze(1) == padding_positions).any(dim=1))
+        assert _can_prove_all_topk_rows_nonempty(
+            computes_topk=True,
+            indexer_topk=2,
+            kv_sequence_length=global_rows,
+            attention_mask=None,
+            query_valid_rows=query_valid_rows,
+            varlen_is_plain_causal=varlen_is_plain_causal,
+            use_local_indexer_varlen=True,
+            varlen_starts=starts,
+            varlen_ends=ends,
+            key_positions=key_positions,
+        )
+
+    torch.testing.assert_close(
+        torch.cat(all_query_positions).sort().values,
+        torch.arange(global_rows, device=device),
+        rtol=0,
+        atol=0,
+    )
+
+
 def test_dsa_kernel_hooks_return_none_without_backend_function(monkeypatch):
     class Config:
         attention_backend = "auto"
@@ -493,7 +617,9 @@ def test_dsa_kernel_hooks_log_declined_backend(monkeypatch, caplog):
         is None
     )
     assert (
-        dsa_kernels.run_fused_absorbed_sparse_attention(Config, q, q, starts.view(1, 1, 1), 1.0, 1)
+        dsa_kernels.run_fused_absorbed_sparse_attention(
+            Config, q, q, starts.view(1, 1, 1), 1.0, 1, all_topk_rows_nonempty=True
+        )
         is None
     )
     assert (
@@ -557,8 +683,9 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
         seen["loss_kwargs"] = kwargs
         return expected_topk_loss
 
-    def run_fused_absorbed_sparse_attention(*args):
+    def run_fused_absorbed_sparse_attention(*args, all_topk_rows_nonempty=False):
         seen["sparse_args"] = args
+        seen["all_topk_rows_nonempty"] = all_topk_rows_nonempty
         return expected_sparse
 
     def run_fused_dsa_attention(**kwargs):
@@ -629,11 +756,12 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     topk_length = torch.ones((1, 1), dtype=torch.int32)
     assert (
         dsa_kernels.run_fused_absorbed_sparse_attention(
-            Config, q, k, topk_indices, 1.0, 1, topk_length
+            Config, q, k, topk_indices, 1.0, 1, topk_length, all_topk_rows_nonempty=True
         )
         is expected_sparse
     )
     assert seen["sparse_args"][-1] is topk_length
+    assert seen["all_topk_rows_nonempty"] is True
 
     assert (
         dsa_kernels.run_fused_dsa_attention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -18,7 +18,10 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.cuda_graph_config import (
+    is_packed_dsa_cp_cuda_graph_capture_unsupported,
+)
+from megatron.core.transformer.enums import AttnMaskType, CudaGraphModule, InferenceCudaGraphScope
 from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_kernels
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
     AbsorbedMLASelfAttention,
@@ -40,8 +43,11 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     unfused_dsa_fn,
 )
 from megatron.core.transformer.experimental_attention_variant.dsa_layout import (
+    build_packed_allgather_cp_all_rank_positions,
     build_packed_allgather_cp_local_positions,
+    build_packed_allgather_cp_local_positions_from_host,
     build_packed_allgather_cp_query_positions_and_key_reorder,
+    build_packed_allgather_cp_query_positions_and_key_reorder_from_host,
     build_zigzag_allgather_cp_key_reorder,
     extract_query_positions_from_position_ids,
     get_cp_positions_from_layout,
@@ -586,7 +592,9 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
         is expected_topk
     )
     assert seen["topk_kwargs"]["use_local_indexer_varlen"] is False
-    assert seen["topk_kwargs"]["single_packed_thd_sequence"] is True
+    assert seen["topk_kwargs"]["single_packed_thd_sequence"] is False
+    assert seen["topk_kwargs"]["packed_thd_causal_identity_layout"] is False
+    assert seen["topk_kwargs"]["packed_thd_single_sequence"] is True
     assert seen["topk_kwargs"]["local_packed_cp_rank"] == 3
     assert (
         dsa_kernels.run_fused_qk_topk_with_loss(
@@ -612,8 +620,10 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     )
     assert seen["loss_kwargs"]["config"] is Config
     assert seen["loss_kwargs"]["calculate_per_token_loss"] is True
-    assert seen["loss_kwargs"]["use_local_indexer_varlen"] is True
-    assert seen["loss_kwargs"]["single_packed_thd_sequence"] is True
+    assert seen["loss_kwargs"]["use_local_indexer_varlen"] is False
+    assert seen["loss_kwargs"]["single_packed_thd_sequence"] is False
+    assert seen["loss_kwargs"]["packed_thd_causal_identity_layout"] is True
+    assert seen["loss_kwargs"]["packed_thd_single_sequence"] is True
     assert seen["loss_kwargs"]["local_packed_cp_rank"] == 2
 
     topk_length = torch.ones((1, 1), dtype=torch.int32)
@@ -657,6 +667,8 @@ def test_dsa_kernel_hooks_dispatch_to_backend(monkeypatch):
     assert seen["full_kwargs"]["varlen_starts"] is starts
     assert seen["full_kwargs"]["use_relu"] is False
     assert seen["full_kwargs"]["varlen_is_plain_causal"] is True
+    assert seen["full_kwargs"]["use_local_indexer_varlen"] is False
+    assert seen["full_kwargs"]["packed_thd_causal_identity_layout"] is True
 
 
 def test_dsa_kernel_dependency_validation(monkeypatch):
@@ -3994,6 +4006,350 @@ class TestDSAModuleSpecDispatch:
                 experimental_attention_variant="dsa", context_parallel_size=2, cp_comm_type="p2p"
             )
 
+    def _make_packed_dsa_graph_config(self, monkeypatch, **overrides):
+        monkeypatch.setattr(
+            "megatron.core.transformer.transformer_config."
+            "_validate_dsa_kernel_backend_dependencies",
+            lambda _backend: None,
+        )
+        monkeypatch.setattr(
+            "megatron.core.transformer.transformer_config.is_te_min_version", lambda _version: True
+        )
+        kwargs = {
+            "experimental_attention_variant": "dsa",
+            "dsa_kernel_backend": "cudnn",
+            "sequence_packing_scheduler": "dp_balanced",
+            "max_seqlen_per_dp_cp_rank": 128,
+            "pad_packed_seq_alignment": "max",
+            "thd_max_packed_sequences": 4,
+            "context_parallel_size": 2,
+            "cp_comm_type": "allgather",
+            "cuda_graph_impl": "local",
+            "cuda_graph_modules": [CudaGraphModule.attn],
+        }
+        kwargs.update(overrides)
+        return self._make_dsa_config(**kwargs)
+
+    @pytest.mark.parametrize(
+        ("context_parallel_size", "cuda_graph_impl", "cuda_graph_modules"),
+        [
+            (2, "local", []),
+            (2, "local", [CudaGraphModule.attn]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.attn]),
+            (2, "local", [CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.mlp, CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.mlp]),
+            (2, "local", [CudaGraphModule.attn, CudaGraphModule.mamba]),
+            (2, "transformer_engine", [CudaGraphModule.attn]),
+            (2, "transformer_engine", [CudaGraphModule.attn, CudaGraphModule.attn]),
+            (2, "transformer_engine", []),
+            (2, "transformer_engine", [CudaGraphModule.attn, CudaGraphModule.mlp]),
+            (4, "local", []),
+            (4, "local", [CudaGraphModule.attn]),
+            (4, "local", [CudaGraphModule.mlp]),
+            (4, "transformer_engine", [CudaGraphModule.attn]),
+            (4, "transformer_engine", []),
+        ],
+        ids=[
+            "cp2_local_whole_layer",
+            "cp2_local_attention",
+            "cp2_local_attention_repeated",
+            "cp2_local_mlp_only",
+            "cp2_local_mlp_only_repeated",
+            "cp2_local_attention_mlp",
+            "cp2_local_attention_mamba",
+            "cp2_te_attention",
+            "cp2_te_attention_repeated",
+            "cp2_te_whole_layer",
+            "cp2_te_attention_mlp",
+            "cp4_local_whole_layer",
+            "cp4_local_attention",
+            "cp4_local_mlp_only",
+            "cp4_te_attention",
+            "cp4_te_whole_layer",
+        ],
+    )
+    def test_packed_cudnn_dsa_cp_rejects_measured_cuda_graph_scopes(
+        self, monkeypatch, context_parallel_size, cuda_graph_impl, cuda_graph_modules
+    ):
+        """Reject only packed CP graph scopes whose failure was reproduced on GPU."""
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(
+                monkeypatch,
+                context_parallel_size=context_parallel_size,
+                cuda_graph_impl=cuda_graph_impl,
+                cuda_graph_modules=cuda_graph_modules,
+            )
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {
+                "cuda_graph_impl": "none",
+                "enable_cuda_graph": True,
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {
+                "cuda_graph_impl": "none",
+                "external_cuda_graph": True,
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {"cuda_graph_impl": "local", "cuda_graph_modules": "attn"},
+            {"cuda_graph_impl": "local", "cuda_graph_modules": "attn,attn"},
+        ],
+        ids=[
+            "deprecated_local_flag",
+            "deprecated_te_flag",
+            "string_scope",
+            "repeated_string_scope",
+        ],
+    )
+    def test_packed_cudnn_dsa_cp_graph_guard_follows_normalized_legacy_inputs(
+        self, monkeypatch, overrides
+    ):
+        """Legacy graph flags and string scopes must not bypass the measured guard."""
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(monkeypatch, **overrides)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"context_parallel_size": 1, "cp_comm_type": None},
+            {"experimental_attention_variant": None},
+            {
+                "sequence_packing_scheduler": None,
+                "max_seqlen_per_dp_cp_rank": None,
+                "pad_packed_seq_alignment": None,
+                "thd_max_packed_sequences": None,
+            },
+            {"cuda_graph_impl": "none"},
+            {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": [CudaGraphModule.mlp]},
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 1,
+                "cp_comm_type": None,
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+            },
+            {"context_parallel_size": 3},
+            {
+                "context_parallel_size": 4,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 4,
+                "cuda_graph_modules": [CudaGraphModule.attn, CudaGraphModule.mlp],
+            },
+            {
+                "context_parallel_size": 4,
+                "dsa_kernel_backend": "none",
+                "cuda_graph_modules": [CudaGraphModule.attn],
+            },
+            {"sequence_packing_scheduler": "default_dynamic_cp"},
+            {"cuda_graph_modules": [], "inference_cuda_graph_scope": InferenceCudaGraphScope.block},
+            {"cuda_graph_impl": "local", "cuda_graph_modules": [CudaGraphModule.mamba]},
+            {"cuda_graph_impl": "full_iteration", "cuda_graph_modules": []},
+        ],
+        ids=[
+            "cp1",
+            "non_dsa",
+            "nonpacked",
+            "cuda_graph_disabled",
+            "te_mlp",
+            "dynamic_te_mlp",
+            "dynamic_configured_cp1",
+            "configured_cp3_unmeasured",
+            "configured_cp4_te_mlp_passed",
+            "configured_cp4_combined_unmeasured",
+            "configured_cp4_unfused_unmeasured",
+            "dynamic_scheduler_without_dynamic_cp_unmeasured",
+            "block_inference_whole_scope_unmeasured",
+            "local_mamba_unmeasured",
+            "full_iteration_unmeasured",
+        ],
+    )
+    def test_packed_cudnn_dsa_cp_cuda_graph_guard_is_narrow(self, monkeypatch, overrides):
+        """Changing any measured guard dimension leaves the neighboring config available."""
+        config = self._make_packed_dsa_graph_config(monkeypatch, **overrides)
+        assert isinstance(config, MLATransformerConfig)
+
+    def test_packed_cudnn_dsa_preserves_legacy_block_inference_scope(self, monkeypatch):
+        """The deprecated spelling maps to an unmeasured block-inference graph."""
+        with pytest.warns(DeprecationWarning, match="full_iteration_inference"):
+            config = self._make_packed_dsa_graph_config(
+                monkeypatch, cuda_graph_impl="local", cuda_graph_modules="full_iteration_inference"
+            )
+        assert config.cuda_graph_modules == []
+        assert config.inference_cuda_graph_scope == InferenceCudaGraphScope.block
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"dsa_kernel_backend": "none"},
+            {
+                "dsa_kernel_backend": "none",
+                "cuda_graph_modules": [CudaGraphModule.attn, CudaGraphModule.attn],
+            },
+            {"sequence_packing_scheduler": "default_dynamic_cp", "dynamic_context_parallel": True},
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_modules": [],
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_modules": [CudaGraphModule.mlp],
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+            },
+            {
+                "sequence_packing_scheduler": "default_dynamic_cp",
+                "dynamic_context_parallel": True,
+                "cuda_graph_impl": "transformer_engine",
+                "cuda_graph_modules": [],
+            },
+        ],
+        ids=[
+            "static_unfused_local_attention",
+            "static_unfused_local_attention_repeated",
+            "dynamic_cudnn_local_attention",
+            "dynamic_cudnn_local_whole_layer",
+            "dynamic_cudnn_local_mlp",
+            "dynamic_cudnn_te_attention",
+            "dynamic_cudnn_te_whole_layer",
+        ],
+    )
+    def test_packed_dsa_cp_rejects_additional_measured_graph_configs(self, monkeypatch, overrides):
+        with pytest.raises(ValueError, match="packed DSA context-parallel configuration"):
+            self._make_packed_dsa_graph_config(monkeypatch, **overrides)
+
+    @pytest.mark.parametrize(
+        (
+            "context_parallel_size",
+            "dsa_kernel_backend",
+            "sequence_packing_scheduler",
+            "dynamic_context_parallel",
+            "cuda_graph_impl",
+            "cuda_graph_modules",
+        ),
+        [
+            (2, "none", "dp_balanced", False, "local", []),
+            (2, "none", "dp_balanced", False, "local", [CudaGraphModule.mlp]),
+            (2, "none", "dp_balanced", False, "transformer_engine", [CudaGraphModule.attn]),
+            (2, "none", "default_dynamic_cp", True, "local", [CudaGraphModule.attn]),
+            (4, "none", "dp_balanced", False, "local", [CudaGraphModule.attn]),
+            (2, "tilelang", "dp_balanced", False, "local", [CudaGraphModule.attn]),
+            (
+                2,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.mlp, CudaGraphModule.mamba],
+            ),
+            (
+                4,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.attn, CudaGraphModule.mlp],
+            ),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.moe]),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.moe_router]),
+            (
+                2,
+                "cudnn",
+                "dp_balanced",
+                False,
+                "local",
+                [CudaGraphModule.moe_router, CudaGraphModule.moe_preprocess],
+            ),
+            (2, "cudnn", "dp_balanced", False, "local", [CudaGraphModule.mamba]),
+            (2, "cudnn", "dp_balanced", False, "transformer_engine", [CudaGraphModule.mlp]),
+            (2, "cudnn", "dp_balanced", False, "transformer_engine", [CudaGraphModule.moe]),
+            (2, "cudnn", "dp_balanced", False, "full_iteration", []),
+        ],
+        ids=[
+            "cp2_backend_none_whole_layer",
+            "cp2_backend_none_mlp",
+            "cp2_backend_none_te_attention",
+            "cp2_backend_none_dynamic_attention",
+            "cp4_backend_none_attention",
+            "cp2_backend_tilelang",
+            "cp2_local_mlp_mamba_combined",
+            "cp4_local_attention_mlp_combined",
+            "cp2_local_moe",
+            "cp2_local_moe_router",
+            "cp2_local_moe_preprocess",
+            "cp2_local_mamba",
+            "cp2_te_mlp",
+            "cp2_te_moe",
+            "cp2_full_iteration",
+        ],
+    )
+    def test_packed_dsa_cp_cuda_graph_predicate_preserves_unmeasured_neighbors(
+        self,
+        context_parallel_size,
+        dsa_kernel_backend,
+        sequence_packing_scheduler,
+        dynamic_context_parallel,
+        cuda_graph_impl,
+        cuda_graph_modules,
+    ):
+        """Do not turn static reasoning about unmeasured neighbors into prohibitions."""
+        assert not is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant="dsa",
+            dsa_kernel_backend=dsa_kernel_backend,
+            sequence_packing_scheduler=sequence_packing_scheduler,
+            dynamic_context_parallel=dynamic_context_parallel,
+            context_parallel_size=context_parallel_size,
+            cuda_graph_impl=cuda_graph_impl,
+            cuda_graph_modules=cuda_graph_modules,
+            inference_cuda_graph_scope=InferenceCudaGraphScope.layer,
+        )
+
+    @pytest.mark.parametrize(
+        ("context_parallel_size", "sequence_packing_scheduler", "dynamic_context_parallel"),
+        [
+            (3, "dp_balanced", False),
+            (3, "default_dynamic_cp", True),
+            (4, "default_dynamic_cp", True),
+            (2, "dp_balanced", True),
+            (2, "default_dynamic_cp", False),
+        ],
+        ids=[
+            "static_cp3",
+            "dynamic_cp3",
+            "dynamic_cp4",
+            "dynamic_flag_static_scheduler",
+            "dynamic_scheduler_without_flag",
+        ],
+    )
+    def test_packed_dsa_cuda_graph_predicate_preserves_unmeasured_topologies(
+        self, context_parallel_size, sequence_packing_scheduler, dynamic_context_parallel
+    ):
+        assert not is_packed_dsa_cp_cuda_graph_capture_unsupported(
+            experimental_attention_variant="dsa",
+            dsa_kernel_backend="cudnn",
+            sequence_packing_scheduler=sequence_packing_scheduler,
+            dynamic_context_parallel=dynamic_context_parallel,
+            context_parallel_size=context_parallel_size,
+            cuda_graph_impl="local",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            inference_cuda_graph_scope=InferenceCudaGraphScope.layer,
+        )
+
     def test_get_dsa_module_spec_for_backend(self):
         """get_dsa_module_spec_for_backend returns the correct full spec structure."""
         from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
@@ -4019,3 +4375,264 @@ class TestDSAModuleSpecDispatch:
         config = self._make_dsa_config(qk_l2_norm=True)
         with pytest.raises(AssertionError, match="qk_l2_norm is not supported"):
             get_dsa_module_spec_for_backend(config, backend=None)
+
+
+class TestPackedCPAllRankPositions:
+    """The batched CP position builder must match the per-rank loop exactly."""
+
+    @staticmethod
+    def _cu_seqlens(seq_lens, cp_size):
+        """Pad each sequence to a multiple of 2 * cp_size and return cu_seqlens."""
+        multiple = 2 * cp_size
+        padded = [0 if s == 0 else -(-s // multiple) * multiple for s in seq_lens]
+        offsets = [0]
+        for p in padded:
+            offsets.append(offsets[-1] + p)
+        return torch.tensor(offsets, dtype=torch.int32)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8, 16, 64])
+    @pytest.mark.parametrize(
+        "seq_lens", [[512], [512, 1024], [256, 256, 512], [128, 384, 640, 896], [1024, 0, 2048]]
+    )
+    @pytest.mark.parametrize("cover", [True, False])
+    def test_matches_per_rank_loop(self, cp_size, seq_lens, cover):
+        """Row r of the batched build equals the single-rank build for cp_rank=r."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        output_size = total // cp_size
+
+        expected = torch.stack(
+            [
+                build_packed_allgather_cp_local_positions(
+                    cu_seqlens,
+                    cp_size,
+                    rank,
+                    device,
+                    output_size=output_size,
+                    cu_seqlens_cover_output=cover,
+                )
+                for rank in range(cp_size)
+            ],
+            dim=0,
+        )
+        actual = build_packed_allgather_cp_all_rank_positions(
+            cu_seqlens, cp_size, device, output_size=output_size, cu_seqlens_cover_output=cover
+        )
+        assert actual.shape == expected.shape
+        assert torch.equal(actual, expected)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8])
+    def test_padded_output_size(self, cp_size):
+        """Rows still match when output_size exceeds the packed token count."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens([512, 1024], cp_size)
+        output_size = int(cu_seqlens[-1]) // cp_size + 2 * cp_size
+        expected = torch.stack(
+            [
+                build_packed_allgather_cp_local_positions(
+                    cu_seqlens, cp_size, rank, device, output_size=output_size
+                )
+                for rank in range(cp_size)
+            ],
+            dim=0,
+        )
+        actual = build_packed_allgather_cp_all_rank_positions(
+            cu_seqlens, cp_size, device, output_size=output_size
+        )
+        assert torch.equal(actual, expected)
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 16])
+    def test_key_reorder_unchanged(self, cp_size):
+        """The public reorder index is unchanged by the batched build."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens([512, 1024], cp_size)
+        total = int(cu_seqlens[-1])
+        output_size = total // cp_size
+
+        _, key_reorder_idx = build_packed_allgather_cp_query_positions_and_key_reorder(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cp_size=cp_size,
+            cp_rank=0,
+            device=device,
+            local_output_size=output_size,
+            key_local_output_size=output_size,
+            global_output_size=total,
+        )
+        reference = torch.argsort(
+            torch.cat(
+                [
+                    build_packed_allgather_cp_local_positions(
+                        cu_seqlens, cp_size, rank, device, output_size=output_size
+                    )
+                    for rank in range(cp_size)
+                ],
+                dim=0,
+            )
+        )
+        assert torch.equal(key_reorder_idx, reference)
+
+
+class TestHostSidePackedCpLayoutBuilders:
+    """The host builders must be bit-equal to the device builders they replace.
+
+    The host path consumes the compacted cu_seqlens list that
+    prebuild_thd_cp_partition_routes stores on PackedSeqParams; the device path
+    consumes the raw device tensor. e2e loss cannot discriminate here (the
+    training workload is not run-to-run reproducible), so bit equality of the
+    produced tables is the correctness contract.
+    """
+
+    @staticmethod
+    def _cu_seqlens(seq_lens, cp_size):
+        multiple = 2 * cp_size
+        padded = [0 if s == 0 else -(-s // multiple) * multiple for s in seq_lens]
+        offsets = [0]
+        for p in padded:
+            offsets.append(offsets[-1] + p)
+        return torch.tensor(offsets, dtype=torch.int32)
+
+    @staticmethod
+    def _host_list(cu_seqlens):
+        """Compacted host list, matching _compact_thd_cu_seqlens_to_list semantics."""
+        values = cu_seqlens.tolist()
+        compact = [values[0]]
+        for v in values[1:]:
+            if v != compact[-1]:
+                compact.append(v)
+        return compact
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 4, 8, 16])
+    @pytest.mark.parametrize(
+        "seq_lens", [[512], [512, 1024], [256, 256, 512], [128, 384, 640, 896], [1024, 0, 2048]]
+    )
+    @pytest.mark.parametrize("cover", [True, False])
+    def test_local_positions_match_device_builder(self, cp_size, seq_lens, cover):
+        """Every rank's host-built positions equal the device builder's output."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        output_size = total // cp_size
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected = build_packed_allgather_cp_local_positions(
+                cu_seqlens,
+                cp_size,
+                rank,
+                device,
+                output_size=output_size,
+                cu_seqlens_cover_output=cover,
+            )
+            actual = build_packed_allgather_cp_local_positions_from_host(
+                host_cu,
+                cp_size,
+                rank,
+                device,
+                output_size=output_size,
+                cu_seqlens_cover_output=cover,
+            )
+            assert torch.equal(actual, expected), f"rank {rank} differs"
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8])
+    @pytest.mark.parametrize("seq_lens", [[512], [256, 256, 512], [1024, 0, 2048]])
+    def test_padded_local_positions_match_device_builder(self, cp_size, seq_lens):
+        """Rows still match when output_size exceeds the packed token count."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        output_size = total // cp_size + 64
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected = build_packed_allgather_cp_local_positions(
+                cu_seqlens, cp_size, rank, device, output_size=output_size
+            )
+            actual = build_packed_allgather_cp_local_positions_from_host(
+                host_cu, cp_size, rank, device, output_size=output_size
+            )
+            assert torch.equal(actual, expected), f"rank {rank} differs"
+
+    @pytest.mark.parametrize("seq_lens", [[5], [7, 3], [1]])
+    def test_cp1_odd_lengths_match_device_identity(self, seq_lens):
+        """cp_size=1 has no zigzag halving, so odd lengths must stay identity.
+
+        The span form floors seq_len // 2 and would silently drop the middle token;
+        the builders take a dedicated identity path instead, mirroring the device
+        builder's cp_size <= 1 branch.
+        """
+        device = torch.device("cpu")
+        offsets = [0]
+        for length in seq_lens:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int32)
+        host_cu = offsets
+        total = offsets[-1]
+        expected = build_packed_allgather_cp_local_positions(
+            cu_seqlens, 1, 0, device, output_size=total
+        )
+        actual = build_packed_allgather_cp_local_positions_from_host(
+            host_cu, 1, 0, device, output_size=total
+        )
+        assert torch.equal(actual, expected)
+        _, reorder = build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+            host_cu,
+            host_cu,
+            cp_size=1,
+            cp_rank=0,
+            device=device,
+            local_output_size=total,
+            key_local_output_size=total,
+        )
+        assert torch.equal(reorder, torch.arange(total, dtype=torch.int64))
+
+    @pytest.mark.parametrize("cp_size", [2, 4])
+    def test_non_divisible_lengths_raise_on_host(self, cp_size):
+        """Host builders reject lengths not divisible by 2*cp_size instead of
+        silently dropping tokens; the check is free on host integers."""
+        bad_cu = [0, 2 * cp_size + 1]
+        with pytest.raises(ValueError, match="divisible"):
+            build_packed_allgather_cp_local_positions_from_host(
+                bad_cu, cp_size, 0, torch.device("cpu")
+            )
+
+    @pytest.mark.parametrize("cp_size", [2, 4, 8, 16])
+    @pytest.mark.parametrize("seq_lens", [[512], [512, 1024], [256, 256, 512], [1024, 0, 2048]])
+    @pytest.mark.parametrize("pad", [0, 64])
+    def test_query_and_reorder_match_device_wrapper(self, cp_size, seq_lens, pad):
+        """The host wrapper (direct inverse, no argsort) equals the device wrapper."""
+        device = torch.device("cpu")
+        cu_seqlens = self._cu_seqlens(seq_lens, cp_size)
+        total = int(cu_seqlens[-1])
+        if total == 0:
+            pytest.skip("degenerate all-empty case")
+        local = total // cp_size + pad
+        host_cu = self._host_list(cu_seqlens)
+        for rank in range(cp_size):
+            expected_q, expected_r = build_packed_allgather_cp_query_positions_and_key_reorder(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=rank,
+                device=device,
+                local_output_size=local,
+                key_local_output_size=local,
+                global_output_size=local * cp_size,
+            )
+            actual_q, actual_r = (
+                build_packed_allgather_cp_query_positions_and_key_reorder_from_host(
+                    host_cu,
+                    host_cu,
+                    cp_size=cp_size,
+                    cp_rank=rank,
+                    device=device,
+                    local_output_size=local,
+                    key_local_output_size=local,
+                    global_output_size=local * cp_size,
+                )
+            )
+            assert torch.equal(actual_q, expected_q), f"rank {rank} query positions differ"
+            assert torch.equal(actual_r, expected_r), f"rank {rank} key reorder differs"

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Compatibility coverage for optional DSA backend hook kwargs."""
+
+import pytest
+
+from megatron.core.transformer.experimental_attention_variant import dsa_cudnn_kernels, dsa_kernels
+
+
+@pytest.fixture(autouse=True)
+def _clear_hook_signature_cache():
+    dsa_kernels._HOOK_KWARG_SIGNATURE_CACHE.clear()
+    yield
+    dsa_kernels._HOOK_KWARG_SIGNATURE_CACHE.clear()
+
+
+def _run_split_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
+    marker = object()
+    result = dsa_kernels.run_fused_qk_topk(
+        object(),
+        marker,
+        marker,
+        marker,
+        8,
+        marker,
+        marker,
+        128,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        cp_size=cp_size,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+    )
+    return result, marker
+
+
+def _run_full_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
+    marker = object()
+    result = dsa_kernels.run_fused_dsa_attention(
+        config=object(),
+        query=marker,
+        key=marker,
+        value=None,
+        up_v_weight=None,
+        q_indexer=marker,
+        k_indexer=marker,
+        indexer_weights=marker,
+        indexer_topk=8,
+        softmax_scale=1.0,
+        loss_coeff=0.0,
+        sparse_loss=False,
+        calculate_per_token_loss=False,
+        absorbed_mla=True,
+        cp_size=cp_size,
+        attn_mask_type=None,
+        packed_seq_params=None,
+        varlen_starts=None,
+        varlen_ends=None,
+        key_positions=None,
+        query_valid_rows=None,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+        use_relu=True,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+    )
+    return result, marker
+
+
+def _run_split_loss_hook(
+    *,
+    varlen_is_plain_causal=True,
+    use_local_indexer_varlen=True,
+    single_packed_thd_sequence=True,
+    cp_size=1,
+):
+    marker = object()
+    result = dsa_kernels.run_fused_qk_topk_with_loss(
+        object(),
+        marker,
+        marker,
+        marker,
+        8,
+        marker,
+        marker,
+        128,
+        marker,
+        marker,
+        1.0,
+        1.0,
+        marker,
+        use_local_indexer_varlen=use_local_indexer_varlen,
+        single_packed_thd_sequence=single_packed_thd_sequence,
+        cp_size=cp_size,
+        varlen_is_plain_causal=varlen_is_plain_causal,
+    )
+    return result, marker
+
+
+def test_hook_kwarg_signature_is_inspected_once(monkeypatch):
+    inspected = []
+    original_signature = dsa_kernels.inspect.signature
+
+    def hook(*, varlen_is_plain_causal=False):
+        return varlen_is_plain_causal
+
+    def track_signature(fn):
+        inspected.append(fn)
+        return original_signature(fn)
+
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", track_signature)
+
+    expected = {"varlen_is_plain_causal": True}
+    assert (
+        dsa_kernels._hook_kwargs_accepting(hook, varlen_is_plain_causal=True, unsupported=True)
+        == expected
+    )
+    assert (
+        dsa_kernels._hook_kwargs_accepting(hook, varlen_is_plain_causal=True, unsupported=True)
+        == expected
+    )
+    assert inspected == [hook]
+
+
+def test_legacy_exact_split_hook_excludes_new_optional_kwarg(monkeypatch):
+    calls = []
+    expected = object()
+
+    def legacy_hook(
+        *,
+        q,
+        k,
+        weights,
+        index_topk,
+        starts,
+        ends,
+        block_size,
+        use_relu,
+        use_local_indexer_varlen,
+        single_packed_thd_sequence,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+        local_packed_cp_query_len,
+        packed_seq_params,
+        cp_size,
+    ):
+        calls.append(
+            (
+                q,
+                k,
+                weights,
+                index_topk,
+                starts,
+                ends,
+                block_size,
+                use_local_indexer_varlen,
+                single_packed_thd_sequence,
+                cp_size,
+            )
+        )
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: legacy_hook)
+
+    result, marker = _run_split_hook(varlen_is_plain_causal=True, cp_size=1)
+    result_cp2, marker_cp2 = _run_split_hook(varlen_is_plain_causal=True, cp_size=2)
+
+    assert result is expected
+    assert result_cp2 is expected
+    assert calls == [
+        (marker, marker, marker, 8, marker, marker, 128, False, False, 1),
+        (marker_cp2, marker_cp2, marker_cp2, 8, marker_cp2, marker_cp2, 128, True, True, 2),
+    ]
+
+
+def test_kwargs_split_hook_receives_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def kwargs_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: kwargs_hook)
+
+    result, _ = _run_split_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
+
+
+def test_opaque_split_hook_receives_no_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def opaque_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    result, _ = _run_split_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert "varlen_is_plain_causal" not in seen
+    assert "packed_thd_causal_identity_layout" not in seen
+    assert "packed_thd_single_sequence" not in seen
+
+
+def test_split_hook_type_error_propagates_without_retry(monkeypatch):
+    calls = 0
+
+    def failing_hook(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise TypeError("backend implementation failed")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: failing_hook)
+
+    with pytest.raises(TypeError, match="backend implementation failed"):
+        _run_split_hook(varlen_is_plain_causal=True)
+    assert calls == 1
+
+
+def test_legacy_exact_full_hook_excludes_new_optional_kwarg(monkeypatch):
+    calls = []
+    expected = object()
+
+    def full_hook(
+        *,
+        config,
+        query,
+        key,
+        value,
+        up_v_weight,
+        q_indexer,
+        k_indexer,
+        indexer_weights,
+        indexer_topk,
+        softmax_scale,
+        loss_coeff,
+        sparse_loss,
+        calculate_per_token_loss,
+        absorbed_mla,
+        cp_size,
+        attn_mask_type,
+        packed_seq_params,
+        varlen_starts,
+        varlen_ends,
+        key_positions,
+        query_valid_rows,
+        use_relu,
+        use_local_indexer_varlen,
+        single_packed_thd_sequence,
+        local_packed_cp_rank,
+        local_packed_cp_query_start,
+        local_packed_cp_query_len,
+        pg_collection,
+    ):
+        del (
+            config,
+            value,
+            up_v_weight,
+            softmax_scale,
+            loss_coeff,
+            sparse_loss,
+            calculate_per_token_loss,
+            absorbed_mla,
+            attn_mask_type,
+            packed_seq_params,
+            varlen_starts,
+            varlen_ends,
+            key_positions,
+            query_valid_rows,
+            use_relu,
+            local_packed_cp_rank,
+            local_packed_cp_query_start,
+            local_packed_cp_query_len,
+            pg_collection,
+        )
+        calls.append(
+            (
+                query,
+                key,
+                q_indexer,
+                k_indexer,
+                indexer_weights,
+                indexer_topk,
+                use_local_indexer_varlen,
+                single_packed_thd_sequence,
+                cp_size,
+            )
+        )
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: full_hook)
+
+    result, marker = _run_full_hook(varlen_is_plain_causal=True, cp_size=1)
+    result_cp2, marker_cp2 = _run_full_hook(varlen_is_plain_causal=True, cp_size=2)
+
+    assert result is expected
+    assert result_cp2 is expected
+    assert calls == [
+        (marker, marker, marker, marker, marker, 8, False, False, 1),
+        (marker_cp2, marker_cp2, marker_cp2, marker_cp2, marker_cp2, 8, True, True, 2),
+    ]
+
+
+def test_kwargs_full_hook_receives_new_optional_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def full_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: full_hook)
+
+    result, _ = _run_full_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
+
+
+def test_opaque_full_hook_preserves_existing_varlen_kwarg(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def opaque_full_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_full_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    result, _ = _run_full_hook(varlen_is_plain_causal=True)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert "packed_thd_causal_identity_layout" not in seen
+    assert "packed_thd_single_sequence" not in seen
+
+
+def test_kwargs_split_loss_hook_receives_compatible_layout_flags(monkeypatch):
+    seen = {}
+    expected = object()
+
+    def loss_hook(**kwargs):
+        seen.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: loss_hook)
+
+    result, _ = _run_split_loss_hook(cp_size=1)
+
+    assert result is expected
+    assert seen["varlen_is_plain_causal"] is True
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["packed_thd_causal_identity_layout"] is True
+    assert seen["packed_thd_single_sequence"] is True
+
+
+def test_cudnn_hook_prefers_new_cp_independent_layout_flags():
+    assert dsa_cudnn_kernels._resolve_packed_layout_flags(
+        use_local_indexer_varlen=False,
+        single_packed_thd_sequence=False,
+        packed_thd_causal_identity_layout=True,
+        packed_thd_single_sequence=True,
+    ) == (True, True)
+    assert dsa_cudnn_kernels._resolve_packed_layout_flags(
+        use_local_indexer_varlen=True,
+        single_packed_thd_sequence=True,
+        packed_thd_causal_identity_layout=None,
+        packed_thd_single_sequence=None,
+    ) == (True, True)

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_hook_kwarg_compat.py
@@ -240,6 +240,49 @@ def test_split_hook_type_error_propagates_without_retry(monkeypatch):
     assert calls == 1
 
 
+def test_sparse_attention_hook_filters_static_row_certificate_for_legacy_signature(monkeypatch):
+    """The fixed-row certificate must not break an older exact backend hook."""
+    expected = object()
+
+    def legacy_hook(query, key, topk_indices, softmax_scale, v_channels, topk_length):
+        del query, key, topk_indices, softmax_scale, v_channels, topk_length
+        return expected
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: legacy_hook)
+
+    marker = object()
+    result = dsa_kernels.run_fused_absorbed_sparse_attention(
+        object(), marker, marker, marker, 1.0, 8, marker, all_topk_rows_nonempty=True
+    )
+
+    assert result is expected
+
+
+def test_opaque_sparse_attention_hook_receives_no_static_row_certificate(monkeypatch):
+    """An opaque out-of-tree hook receives only its established positional contract."""
+    calls = []
+    expected = object()
+
+    def opaque_hook(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    def fail_signature(_fn):
+        raise ValueError("opaque callable")
+
+    monkeypatch.setattr(dsa_kernels, "_resolve_fused_hook", lambda _config, _name: opaque_hook)
+    monkeypatch.setattr(dsa_kernels.inspect, "signature", fail_signature)
+
+    marker = object()
+    result = dsa_kernels.run_fused_absorbed_sparse_attention(
+        object(), marker, marker, marker, 1.0, 8, marker, all_topk_rows_nonempty=True
+    )
+
+    assert result is expected
+    assert len(calls[0][0]) == 6
+    assert calls[0][1] == {}
+
+
 def test_legacy_exact_full_hook_excludes_new_optional_kwarg(monkeypatch):
     calls = []
     expected = object()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -33,7 +33,11 @@ from megatron.training.arguments import _add_experimental_attention_variant_args
 
 def _index_share_config():
     return SimpleNamespace(
-        dsa_indexer_topk=8, dsa_indexer_topk_freq=4, dsa_indexer_skip_topk_offset=1, kv_channels=16
+        dsa_indexer_topk=8,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=1,
+        dsa_mtp_index_kv_share=False,
+        kv_channels=16,
     )
 
 
@@ -68,6 +72,7 @@ def test_mtp_layer_number_offsets_index_share_schedule():
         dsa_indexer_topk=4,
         dsa_indexer_topk_freq=4,
         dsa_indexer_skip_topk_offset=1,
+        dsa_mtp_index_kv_share=False,
         kv_channels=16,
     )
     pg_collection = SimpleNamespace(tp=object(), cp=object())
@@ -323,9 +328,19 @@ def test_absorbed_mla_forward_uses_and_restores_dynamic_cp_group():
     v_up_weight = torch.randn(2, 3, 2)
 
     def get_query_key_value_tensors(
-        hidden_states_arg, key_value_states, packed_seq_params, inference_context=None
+        hidden_states_arg,
+        key_value_states,
+        packed_seq_params,
+        inference_context=None,
+        mtp_dsa_context=None,
     ):
-        del hidden_states_arg, key_value_states, packed_seq_params, inference_context
+        del (
+            hidden_states_arg,
+            key_value_states,
+            packed_seq_params,
+            inference_context,
+            mtp_dsa_context,
+        )
         observed_groups.append(pg_collection.cp)
         return q_absorbed, kv_compressed, q_compressed
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -454,6 +454,169 @@ def test_indexer_loss_tracker_grows_for_mtp_layer_numbers():
         helper.tracker.clear()
 
 
+def test_dynamic_cp_parent_average_preserves_nominal_global_batch_weighting():
+    """Mixed effective CP sizes retain equal sample weight after nominal-MB scaling."""
+    configured_cp_size = 4
+    parent_size = 8
+    configured_dp_size = parent_size // configured_cp_size
+    # The scheduler repacks fourteen nominal samples into four physical microbatches:
+    # eight CP1 samples, four CP2 samples, then two CP8 samples. CP8 intentionally exceeds
+    # the configured/static CP width and proves the multiplier is not effective logical CP.
+    cp1_local_sums = torch.arange(1, 9, dtype=torch.float32)
+    cp2_local_sums = torch.arange(1, 9, dtype=torch.float32)
+    cp8_first_local_sums = torch.arange(1, 9, dtype=torch.float32)
+    cp8_second_local_sums = torch.arange(2, 10, dtype=torch.float32)
+    scheduled_local_sums = (
+        cp1_local_sums,
+        cp2_local_sums,
+        cp8_first_local_sums,
+        cp8_second_local_sums,
+    )
+    expected_sample_sums = torch.cat(
+        (
+            cp1_local_sums,
+            cp2_local_sums.reshape(-1, 2).sum(dim=1),
+            cp8_first_local_sums.sum().reshape(1),
+            cp8_second_local_sums.sum().reshape(1),
+        )
+    )
+
+    tracker_sum = sum(
+        (local_sums * configured_cp_size).sum() / parent_size for local_sums in scheduled_local_sums
+    )
+    nominal_num_microbatches = expected_sample_sums.numel() // configured_dp_size
+
+    torch.testing.assert_close(tracker_sum / nominal_num_microbatches, expected_sample_sums.mean())
+
+
+def test_static_indexer_logging_preserves_group_updates():
+    """Static logging retains its historical last-writer group behavior."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    first_group = object()
+    second_group = object()
+    helper.tracker.clear()
+
+    try:
+        helper.save_loss_to_tracker(
+            loss=torch.tensor(1.0, device="cuda"),
+            layer_number=1,
+            num_layers=1,
+            avg_group=first_group,
+        )
+        helper.save_loss_to_tracker(
+            loss=torch.tensor(1.0, device="cuda"),
+            layer_number=1,
+            num_layers=1,
+            avg_group=second_group,
+        )
+
+        torch.testing.assert_close(
+            helper.tracker["values"], helper.tracker["values"].new_tensor([2.0])
+        )
+        assert helper.tracker["avg_group"] is second_group
+    finally:
+        helper.tracker.clear()
+
+
+def test_dynamic_cp_indexer_reduction_ignores_stale_logical_groups(monkeypatch):
+    """Dynamic reduction always uses the stable parent rather than last-writer metadata."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    pp_group = object()
+    parent_dp_cp_group = object()
+    stale_logical_cp_group = object()
+    dp_group = object()
+    calls = []
+    helper.tracker.clear()
+    helper.tracker.update(
+        {
+            "values": torch.tensor([3.0]),
+            "agreed_size": 1,
+            # Dynamic reduction must ignore last-writer metadata from either DSA or CSA.
+            "reduce_group": stale_logical_cp_group,
+            "avg_group": stale_logical_cp_group,
+        }
+    )
+
+    monkeypatch.setattr(
+        dsa_module.parallel_state, "get_pipeline_model_parallel_group", lambda: pp_group
+    )
+    monkeypatch.setattr(
+        dsa_module.parallel_state, "get_data_parallel_group", lambda with_context_parallel: dp_group
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_reduce",
+        lambda tensor, op=None, group=None: calls.append((group, op)),
+    )
+
+    try:
+        helper.reduce_loss_in_tracker(
+            num_layers=1, dynamic_cp_parent_group=parent_dp_cp_group, configured_cp_size=4
+        )
+
+        torch.testing.assert_close(helper.tracker["values"], torch.tensor([12.0]))
+        assert [group for group, _ in calls] == [pp_group, parent_dp_cp_group]
+        assert calls[1][1] == torch.distributed.ReduceOp.AVG
+        assert all(group is not dp_group for group, _ in calls)
+        assert all(group is not stale_logical_cp_group for group, _ in calls)
+    finally:
+        helper.tracker.clear()
+
+
+def test_dynamic_cp_indexer_reduction_initializes_empty_pp_stage(monkeypatch):
+    """A PP stage without indexer layers contributes a correctly shaped zero tensor."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    pp_group = object()
+    parent_dp_cp_group = object()
+    calls = []
+    helper.tracker.clear()
+
+    monkeypatch.setattr(
+        dsa_module.parallel_state, "get_pipeline_model_parallel_group", lambda: pp_group
+    )
+
+    def all_reduce(tensor, op=None, group=None):
+        calls.append((group, op, tuple(tensor.shape)))
+        if op == torch.distributed.ReduceOp.MAX:
+            tensor.fill_(3)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+
+    try:
+        helper.reduce_loss_in_tracker(
+            num_layers=2, dynamic_cp_parent_group=parent_dp_cp_group, configured_cp_size=4
+        )
+
+        assert calls == [
+            (pp_group, torch.distributed.ReduceOp.MAX, (1,)),
+            (pp_group, None, (3,)),
+            (parent_dp_cp_group, torch.distributed.ReduceOp.AVG, (3,)),
+        ]
+        torch.testing.assert_close(
+            helper.tracker["values"], torch.zeros_like(helper.tracker["values"])
+        )
+        assert helper.tracker["agreed_size"] == 3
+    finally:
+        helper.tracker.clear()
+
+
+@pytest.mark.parametrize("configured_cp_size", (None, 0))
+def test_dynamic_cp_indexer_reduction_rejects_invalid_configured_cp_size(
+    monkeypatch, configured_cp_size
+):
+    """The Dynamic-CP normalization factor must be a positive configured CP width."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    helper.tracker.clear()
+    monkeypatch.setattr(
+        dsa_module.parallel_state, "get_pipeline_model_parallel_group", lambda: object()
+    )
+
+    with pytest.raises(ValueError, match="configured_cp_size must be positive"):
+        helper.reduce_loss_in_tracker(
+            num_layers=1, dynamic_cp_parent_group=object(), configured_cp_size=configured_cp_size
+        )
+
+
 def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count(monkeypatch):
     """CUDA Graph reuse keeps groups, and only ratio-4 DSv4 layers enter the average."""
     helper = dsa_module.DSAIndexerLossLoggingHelper
@@ -474,13 +637,27 @@ def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count
         def add_scalar(name, value, iteration):
             recorded.append((name, value.clone(), iteration))
 
-    monkeypatch.setattr(helper, "reduce_loss_in_tracker", lambda num_layers=None: None)
+    reduced_with = []
+    monkeypatch.setattr(
+        helper,
+        "reduce_loss_in_tracker",
+        lambda num_layers=None, dynamic_cp_parent_group=None, configured_cp_size=None: reduced_with.append(
+            (dynamic_cp_parent_group, configured_cp_size)
+        ),
+    )
 
     try:
         helper.track_indexer_metrics(
-            loss_scale=0.5, iteration=7, writer=Writer(), num_indexer_layers=2, preserve_groups=True
+            loss_scale=0.5,
+            iteration=7,
+            writer=Writer(),
+            num_indexer_layers=2,
+            preserve_groups=True,
+            dynamic_cp_parent_group=avg_group,
+            configured_cp_size=4,
         )
 
+        assert reduced_with == [(avg_group, 4)]
         assert len(recorded) == 1
         name, value, iteration = recorded[0]
         assert name == "indexer loss"

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -557,6 +557,436 @@ def test_cudnn_indexer_topk_multi_packed_cp_uses_segmented_thd(monkeypatch):
     )
 
 
+def test_cudnn_indexer_topk_multi_packed_cp1_uses_direct_thd(monkeypatch):
+    """CP1 multi-sequence packs use one THD call without splitting Q or duplicating K."""
+    seen = {"calls": 0}
+
+    class FakeDSA:
+        @staticmethod
+        def indexer_forward_wrapper(
+            q, k, weights, ratio, sm_scale, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k
+        ):
+            seen["calls"] += 1
+            seen["q"] = q
+            seen["k"] = k
+            seen["weights"] = weights
+            seen["cu_q"] = cu_seqlens_q
+            seen["cu_k"] = cu_seqlens_k
+            seen["max_q"] = max_seqlen_q
+            seen["max_k"] = max_seqlen_k
+            del ratio, sm_scale
+            scores = torch.full((q.size(0), max_seqlen_k), float("-inf"))
+            for sequence in range(cu_seqlens_q.numel() - 1):
+                q_start = int(cu_seqlens_q[sequence])
+                q_end = int(cu_seqlens_q[sequence + 1])
+                for row in range(q_end - q_start):
+                    scores[q_start + row, : row + 1] = torch.arange(row + 1)
+            return {"scores": scores}
+
+        @staticmethod
+        def indexer_top_k_wrapper(scores, seq_lens, top_k, next_n, return_val):
+            del next_n
+            masked_scores = scores.clone()
+            key_ids = torch.arange(scores.size(1)).view(1, -1)
+            masked_scores.masked_fill_(key_ids >= seq_lens.view(-1, 1), float("-inf"))
+            values, indices = masked_scores.topk(top_k, dim=-1)
+            return {"indices": indices.to(torch.int32), "values": values if return_val else None}
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+
+    q = torch.ones((1, 8, 1, 1))
+    k = torch.ones((1, 8, 1))
+    weights = torch.ones((1, 8, 1))
+    cu_q = torch.tensor([0, 3, 8], dtype=torch.int32)
+    # Match the production dynamic-scheduler contract: self-attention Q/K
+    # boundaries alias, so equality is proven without a CUDA synchronization.
+    cu_k = cu_q
+    starts = torch.tensor([0, 0, 0, 3, 3, 3, 3, 3])
+    ends = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8])
+    topk_indices, topk_length, topk_scores = dsa_cudnn_kernels._indexer_topk_bshd(
+        q,
+        k,
+        weights,
+        topk=2,
+        varlen_starts=starts,
+        varlen_ends=ends,
+        return_scores=False,
+        return_topk_scores=True,
+        use_local_indexer_varlen=True,
+        packed_cu_seqlens_q=cu_q,
+        packed_cu_seqlens_k=cu_k,
+        packed_max_seqlen_q=5,
+        packed_max_seqlen_k=5,
+        packed_cp_size=1,
+        local_packed_cp_rank=0,
+    )
+
+    assert seen["calls"] == 1
+    assert seen["q"].shape == torch.Size([8, 1, 1])
+    assert seen["k"].shape == torch.Size([8, 1, 1])
+    assert seen["weights"].shape == torch.Size([8, 1])
+    assert seen["q"].data_ptr() == q.data_ptr()
+    assert seen["k"].data_ptr() == k.data_ptr()
+    assert seen["weights"].data_ptr() == weights.data_ptr()
+    assert seen["cu_q"] is cu_q
+    assert seen["cu_k"] is cu_k
+    assert (seen["max_q"], seen["max_k"]) == (5, 5)
+    torch.testing.assert_close(
+        topk_indices,
+        torch.tensor(
+            [[[0, -1], [1, 0], [2, 1], [3, -1], [4, 3], [5, 4], [6, 5], [7, 6]]], dtype=torch.int32
+        ),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        topk_length, torch.tensor([[1, 2, 2, 1, 2, 2, 2, 2]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        topk_scores,
+        torch.tensor(
+            [
+                [
+                    [0.0, torch.finfo(torch.float32).min],
+                    [1.0, 0.0],
+                    [2.0, 1.0],
+                    [0.0, torch.finfo(torch.float32).min],
+                    [1.0, 0.0],
+                    [2.0, 1.0],
+                    [3.0, 2.0],
+                    [4.0, 3.0],
+                ]
+            ]
+        ),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _pure_torch_packed_indexer_reference(
+    q_indexer, k_indexer, weights, query, key, starts, ends, *, topk, softmax_scale, loss_coeff
+):
+    """DeepSeek-V3.2 Section 2.1 indexer KL, expressed only with PyTorch ops.
+
+    Reference repository: https://github.com/deepseek-ai/DeepSeek-V3.2-Exp
+    Reference revision: 87e509a2e5a100d221c97df52c6e8be7835f0057, DeepSeek_V3_2.pdf
+    """
+    sq, batch, _indexer_heads, _indexer_dim = q_indexer.shape
+    sk = k_indexer.size(0)
+    key_ids = torch.arange(sk, device=q_indexer.device).view(1, 1, sk)
+    valid_bounds = (key_ids >= starts.view(1, sq, 1)) & (key_ids < ends.view(1, sq, 1))
+
+    # I(q, k) = sum_h w_h * relu(q_h dot k), from DeepSeek-V3.2 Section 2.1.
+    index_scores = torch.einsum("sbhd,tbd->sbht", q_indexer.float(), k_indexer.float())
+    index_scores = (torch.relu(index_scores) * weights.float().unsqueeze(-1)).sum(dim=2)
+    index_scores = index_scores.transpose(0, 1).masked_fill(~valid_bounds, float("-inf"))
+    selected_scores, selected_indices = index_scores.topk(min(topk, sk), dim=-1)
+    selected_valid = torch.isfinite(selected_scores)
+    selected_indices = selected_indices.masked_fill(~selected_valid, -1)
+    predict_log_probs = torch.log_softmax(
+        selected_scores.masked_fill(~selected_valid, float("-inf")), dim=-1
+    )
+
+    # The teacher is the head-summed attention probability over the same selected keys.
+    expanded_key = key.expand(-1, -1, query.size(2), -1)
+    attention_logits = (
+        torch.einsum("sbhd,tbhd->bhst", query.float(), expanded_key.float()) * softmax_scale
+    )
+    safe_indices = selected_indices.clamp_min(0)
+    selected_attention_logits = torch.gather(
+        attention_logits, dim=-1, index=safe_indices.unsqueeze(1).expand(-1, query.size(2), -1, -1)
+    ).masked_fill(~selected_valid.unsqueeze(1), float("-inf"))
+    teacher = torch.softmax(selected_attention_logits, dim=-1).sum(dim=1)
+    teacher = teacher / teacher.sum(dim=-1, keepdim=True).clamp_min(1.0e-10)
+    teacher = teacher.masked_fill(~selected_valid, 0.0).detach()
+
+    kl_terms = teacher * (torch.log(teacher.clamp_min(1.0e-10)) - predict_log_probs)
+    loss = kl_terms.masked_fill(~selected_valid, 0.0).sum() * (loss_coeff / (batch * sq))
+    return selected_indices, selected_valid.sum(dim=-1, dtype=torch.int32), loss
+
+
+def _assert_packed_indexer_gradient_parity(label, actual, expected):
+    """Check BF16 fused gradients with aggregate, scale-independent metrics."""
+    assert torch.isfinite(actual).all()
+    assert torch.isfinite(expected).all()
+    actual = actual.detach().double()
+    expected = expected.detach().double()
+    diff = actual - expected
+    actual_norm = actual.norm()
+    expected_norm = expected.norm()
+    tiny = torch.finfo(torch.float64).tiny
+    cosine = (actual * expected).sum() / (actual_norm * expected_norm).clamp_min(tiny)
+    tensor_similarity = (
+        2
+        * (actual * expected).sum()
+        / (actual.square().sum() + expected.square().sum()).clamp_min(tiny)
+    )
+    cosine_deficit = max(0.0, 1.0 - cosine.item())
+    tensor_deficit = max(0.0, 1.0 - tensor_similarity.item())
+    rel_l2 = (diff.norm() / expected_norm.clamp_min(tiny)).item()
+    norm_rel = (abs(actual_norm - expected_norm) / expected_norm.clamp_min(tiny)).item()
+    max_abs = diff.abs().max().item()
+    ref_rms = expected.square().mean().sqrt().item()
+    assert (
+        cosine_deficit <= 1.0e-4
+        and tensor_deficit <= 1.0e-4
+        and rel_l2 <= 1.2e-2
+        and norm_rel <= 1.0e-3
+    ), (
+        f"{label}: cosine_deficit={cosine_deficit:.9e}, "
+        f"tensor_deficit={tensor_deficit:.9e}, rel_l2={rel_l2:.9e}, "
+        f"norm_rel={norm_rel:.9e}, max_abs={max_abs:.9e}, ref_rms={ref_rms:.9e}"
+    )
+
+
+@pytest.mark.parametrize("seed", [6206, 6207, 6208])
+def test_cudnn_indexer_topk_multi_packed_cp1_real_kernel_matches_pytorch_gradients(seed):
+    """Odd-length CP1 THD scorer matches the independent Section 2.1 formula."""
+    _skip_if_fused_dsa_unavailable()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    device = torch.device("cuda")
+    sequence_lengths = (65, 67)
+    total_tokens = sum(sequence_lengths)
+    batch = 1
+    indexer_heads = 64
+    indexer_dim = 128
+    attention_heads = 64
+    attention_dim = 576
+    # Exercise the SM90 internal 128-slot padding while SM100 consumes 64 directly.
+    topk = 64
+    softmax_scale = attention_dim**-0.5
+    loss_coeff = 0.01
+
+    q_base = (
+        torch.randn(
+            total_tokens, batch, indexer_heads, indexer_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.125
+    )
+    k_base = (
+        torch.randn(total_tokens, batch, indexer_dim, device=device, dtype=torch.bfloat16) * 0.125
+    )
+    w_base = torch.randn(total_tokens, batch, indexer_heads, device=device, dtype=torch.bfloat16)
+    q_fused, q_ref = (q_base.clone().requires_grad_() for _ in range(2))
+    k_fused, k_ref = (k_base.clone().requires_grad_() for _ in range(2))
+    w_fused, w_ref = (w_base.clone().requires_grad_() for _ in range(2))
+
+    query = (
+        torch.randn(
+            total_tokens, batch, attention_heads, attention_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.125
+    )
+    key = (
+        torch.randn(total_tokens, batch, 1, attention_dim, device=device, dtype=torch.bfloat16)
+        * 0.125
+    )
+    cu_seqlens = torch.tensor([0, sequence_lengths[0], total_tokens], device=device).int()
+    starts = torch.tensor(
+        [0] * sequence_lengths[0] + [sequence_lengths[0]] * sequence_lengths[1],
+        device=device,
+        dtype=torch.int32,
+    )
+    ends = torch.cat(
+        (
+            torch.arange(1, sequence_lengths[0] + 1, device=device),
+            torch.arange(sequence_lengths[0] + 1, total_tokens + 1, device=device),
+        )
+    ).int()
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=max(sequence_lengths),
+        max_seqlen_kv=max(sequence_lengths),
+    )
+
+    fused_result = dsa_cudnn_kernels.run_fused_qk_topk_with_loss(
+        q=q_fused,
+        k=k_fused,
+        weights=w_fused,
+        index_topk=topk,
+        starts=starts,
+        ends=ends,
+        block_size=128,
+        query=query,
+        key=key,
+        softmax_scale=softmax_scale,
+        loss_coeff=loss_coeff,
+        pg_collection=_SingleRankProcessGroups(),
+        query_valid_rows=torch.ones((batch, total_tokens), dtype=torch.bool, device=device),
+        calculate_per_token_loss=False,
+        use_relu=True,
+        config=_PackedCpCudnnConfig(calculate_per_token_loss=False),
+        use_local_indexer_varlen=True,
+        single_packed_thd_sequence=False,
+        packed_seq_params=packed_seq_params,
+        cp_size=1,
+    )
+    assert fused_result is not None
+    fused_indices, fused_lengths, fused_loss = fused_result
+    ref_indices, ref_lengths, ref_loss = _pure_torch_packed_indexer_reference(
+        q_ref,
+        k_ref,
+        w_ref,
+        query,
+        key,
+        starts,
+        ends,
+        topk=topk,
+        softmax_scale=softmax_scale,
+        loss_coeff=loss_coeff,
+    )
+
+    # FlashMLA consumes sorted indices, while the pure top-k is score ordered.
+    sentinel = total_tokens
+    canonical_fused = torch.where(fused_indices >= 0, fused_indices, sentinel).sort(dim=-1).values
+    canonical_ref = (
+        torch.where(ref_indices >= 0, ref_indices, sentinel)
+        .sort(dim=-1)
+        .values.to(dtype=canonical_fused.dtype)
+    )
+    torch.testing.assert_close(canonical_fused, canonical_ref, rtol=0, atol=0)
+    torch.testing.assert_close(fused_lengths, ref_lengths, rtol=0, atol=0)
+    torch.testing.assert_close(fused_loss, ref_loss, rtol=1.0e-4, atol=1.0e-7)
+
+    fused_loss.backward()
+    ref_loss.backward()
+    for name, fused_grad, ref_grad in (
+        ("q_indexer", q_fused.grad, q_ref.grad),
+        ("k_indexer", k_fused.grad, k_ref.grad),
+        ("weights", w_fused.grad, w_ref.grad),
+    ):
+        _assert_packed_indexer_gradient_parity(name, fused_grad, ref_grad)
+
+
+def test_cudnn_indexer_topk_incompatible_packed_boundaries_fall_back(monkeypatch):
+    class FakeDSA:
+        @staticmethod
+        def indexer_forward_wrapper(q, k, weights, ratio, sm_scale, **packed_kwargs):
+            del weights, ratio, sm_scale
+            assert not packed_kwargs
+            return {
+                "scores": torch.arange(k.size(1), dtype=torch.float32)
+                .view(1, 1, -1)
+                .expand(q.size(0), q.size(1), -1)
+            }
+
+        @staticmethod
+        def indexer_top_k_wrapper(scores, seq_lens, top_k, next_n, return_val):
+            del next_n, return_val
+            masked_scores = scores.clone()
+            key_ids = torch.arange(scores.size(1)).view(1, -1)
+            masked_scores.masked_fill_(key_ids >= seq_lens.view(-1, 1), float("-inf"))
+            return {"indices": masked_scores.topk(top_k, dim=-1).indices.int(), "values": None}
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+    monkeypatch.setattr(
+        dsa_cudnn_kernels,
+        "_indexer_topk_packed_thd",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("incompatible boundaries must not reach the THD scorer")
+        ),
+    )
+
+    topk_indices, topk_length, _ = dsa_cudnn_kernels._indexer_topk_bshd(
+        torch.ones((1, 3, 1, 1)),
+        torch.ones((1, 3, 1)),
+        torch.ones((1, 3, 1)),
+        topk=2,
+        varlen_starts=torch.tensor([0, 0, 2]),
+        varlen_ends=torch.tensor([1, 2, 3]),
+        return_scores=False,
+        use_local_indexer_varlen=True,
+        packed_cu_seqlens_q=torch.tensor([0, 2, 3], dtype=torch.int32),
+        packed_cu_seqlens_k=torch.tensor([0, 1, 3], dtype=torch.int32),
+        packed_max_seqlen_q=2,
+        packed_max_seqlen_k=2,
+        packed_cp_size=1,
+    )
+
+    torch.testing.assert_close(
+        topk_indices, torch.tensor([[[0, -1], [0, 1], [2, -1]]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(topk_length, torch.tensor([[1, 2, 1]], dtype=torch.int32))
+
+
+def test_cudnn_general_thd_rejects_tp_query_slices():
+    """THD cu-seqlens describe full Q, so either TP-slice marker must decline."""
+    cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32)
+    common = dict(
+        b=1,
+        sq=8,
+        sk=8,
+        device=cu_seqlens.device,
+        packed_cu_seqlens_q=cu_seqlens,
+        packed_cu_seqlens_k=cu_seqlens,
+        packed_max_seqlen_q=5,
+        packed_max_seqlen_k=5,
+        cp_size=1,
+        cp_rank=0,
+    )
+
+    assert dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=0, local_packed_cp_query_len=None
+    )
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=1, local_packed_cp_query_len=9
+    )
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        **common, local_packed_cp_query_start=0, local_packed_cp_query_len=16
+    )
+
+
+def test_cudnn_general_thd_rejects_impossible_qk_geometry():
+    cu_seqlens = torch.tensor([0, 1, 3], dtype=torch.int32)
+    common = dict(
+        b=1,
+        sq=3,
+        device=cu_seqlens.device,
+        packed_cu_seqlens_q=cu_seqlens,
+        packed_cu_seqlens_k=cu_seqlens,
+        packed_max_seqlen_q=2,
+        packed_max_seqlen_k=2,
+        cp_size=1,
+        cp_rank=0,
+        local_packed_cp_query_start=0,
+        local_packed_cp_query_len=None,
+    )
+
+    assert dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=3, **common)
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=5, **common)
+    mismatched_max = {**common, "packed_max_seqlen_k": 1}
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(sk=3, **mismatched_max)
+
+
+def test_cudnn_general_thd_cp2_rejects_different_qk_boundaries():
+    """Q-relative index restoration is unsafe when packed K starts differ."""
+    cu_q = torch.tensor([0, 8, 24], dtype=torch.int32)
+    cu_k = torch.tensor([0, 16, 24], dtype=torch.int32)
+
+    assert not dsa_cudnn_kernels._packed_thd_kernel_applicable(
+        b=1,
+        sq=12,
+        sk=24,
+        device=cu_q.device,
+        packed_cu_seqlens_q=cu_q,
+        packed_cu_seqlens_k=cu_k,
+        packed_max_seqlen_q=16,
+        packed_max_seqlen_k=16,
+        cp_size=2,
+        cp_rank=0,
+        local_packed_cp_query_start=0,
+        local_packed_cp_query_len=None,
+    )
+
+
 @pytest.mark.parametrize("max_segment_k", [5, 6], ids=["odd-k", "even-k"])
 @pytest.mark.parametrize("return_topk_scores", [False, True], ids=["indices", "scores"])
 def test_cudnn_indexer_topk_multi_packed_cp_selects_all_segment_keys(
@@ -756,6 +1186,7 @@ def test_cudnn_indexer_topk_single_packed_cp_uses_absolute_seq_lens(monkeypatch)
         return_topk_scores=True,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
+        packed_cp_size=2,
         local_packed_cp_rank=1,
     )
 
@@ -808,7 +1239,6 @@ def test_cudnn_indexer_topk_single_packed_cp_prefix_crops_keys_per_chunk(monkeyp
         return_scores=False,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
-        local_packed_cp_rank=1,
         local_packed_cp_query_len=8,
     )
 
@@ -844,6 +1274,7 @@ def test_cudnn_indexer_topk_single_packed_cp_real_kernel_uses_bottom_right_align
         return_topk_scores=True,
         use_local_indexer_varlen=True,
         single_packed_thd_sequence=True,
+        packed_cp_size=4,
         local_packed_cp_rank=1,
     )
 
@@ -1109,6 +1540,7 @@ def test_cudnn_split_topk_hook_uses_indexer_topk(monkeypatch):
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         seen["q_shape"] = q_bshd.shape
         seen["k_shape"] = k_bsd.shape
@@ -1124,6 +1556,7 @@ def test_cudnn_split_topk_hook_uses_indexer_topk(monkeypatch):
         seen["local_packed_cp_rank"] = local_packed_cp_rank
         seen["local_packed_cp_query_start"] = local_packed_cp_query_start
         seen["local_packed_cp_query_len"] = local_packed_cp_query_len
+        seen["varlen_is_plain_causal"] = varlen_is_plain_causal
         return (
             torch.tensor([[[1, 0, -1], [2, 1, 0]]], dtype=torch.int32),
             torch.tensor([[2, 3]], dtype=torch.int32),
@@ -1256,6 +1689,7 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         seen["return_scores"] = return_scores
         seen["return_topk_scores"] = return_topk_scores
@@ -1266,6 +1700,7 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         seen["local_packed_cp_rank"] = local_packed_cp_rank
         seen["local_packed_cp_query_start"] = local_packed_cp_query_start
         seen["local_packed_cp_query_len"] = local_packed_cp_query_len
+        seen["varlen_is_plain_causal"] = varlen_is_plain_causal
         return (
             torch.tensor([[[1, 0], [2, -1]]], dtype=torch.int32),
             torch.tensor([[2, 1]], dtype=torch.int32),
@@ -1307,8 +1742,8 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         k=k,
         weights=weights,
         index_topk=2,
-        starts=torch.tensor([0, 1], dtype=torch.int32),
-        ends=torch.tensor([2, 3], dtype=torch.int32),
+        starts=torch.tensor([0, 0], dtype=torch.int32),
+        ends=torch.tensor([1, 2], dtype=torch.int32),
         block_size=128,
         query=torch.zeros((2, 1, 1, Config.kv_lora_rank), dtype=torch.bfloat16),
         key=torch.zeros((3, 1, 1, Config.kv_lora_rank), dtype=torch.bfloat16),
@@ -1317,9 +1752,9 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
         pg_collection=pg_collection,
         calculate_per_token_loss=False,
         use_relu=True,
-        use_local_indexer_varlen=True,
-        single_packed_thd_sequence=True,
-        local_packed_cp_rank=5,
+        use_local_indexer_varlen=False,
+        single_packed_thd_sequence=False,
+        varlen_is_plain_causal=True,
     )
 
     torch.testing.assert_close(topk_indices, torch.tensor([[[0, 1], [2, -1]]], dtype=torch.int32))
@@ -1327,9 +1762,10 @@ def test_cudnn_split_topk_with_loss_returns_precomputed_indexer_grads(monkeypatc
     assert indexer_loss.item() == 4.0
     assert seen["return_scores"] is False
     assert seen["return_topk_scores"] is True
-    assert seen["use_local_indexer_varlen"] is True
-    assert seen["single_packed_thd_sequence"] is True
-    assert seen["local_packed_cp_rank"] == 5
+    assert seen["use_local_indexer_varlen"] is False
+    assert seen["single_packed_thd_sequence"] is False
+    assert seen["local_packed_cp_rank"] == 0
+    assert seen["varlen_is_plain_causal"] is True
     assert seen["tp_group"] is pg_collection.tp
     assert seen["d_v"] == Config.kv_lora_rank
     torch.testing.assert_close(
@@ -1389,6 +1825,13 @@ def test_flash_mla_topk_alignment_uses_sm100_block(monkeypatch):
         assert dsa_cudnn_kernels._get_topk_alignment() == 512
     finally:
         dsa_cudnn_kernels._device_sm.cache_clear()
+
+
+@pytest.mark.parametrize("sm, expected", [((9, 0), 128), ((10, 0), 64)])
+def test_sparse_score_recompute_topk_alignment(monkeypatch, sm, expected):
+    monkeypatch.setattr(dsa_cudnn_kernels, "_current_sm", lambda: sm)
+
+    assert dsa_cudnn_kernels._get_score_recompute_topk_alignment() == expected
 
 
 def test_dsa_fwd_flash_mla_pads_topk_to_flashmla_block(monkeypatch):
@@ -1611,6 +2054,7 @@ def test_cudnn_sparse_loss_uses_selected_topk_scores(monkeypatch):
         packed_max_seqlen_q=None,
         packed_max_seqlen_k=None,
         packed_cp_size=1,
+        varlen_is_plain_causal=False,
     ):
         del (
             single_packed_thd_sequence,
@@ -1797,6 +2241,9 @@ def test_cudnn_sparse_loss_reduces_attention_target_across_tp(monkeypatch):
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
     monkeypatch.setattr(dsa_cudnn_kernels, "_compute_attn_target", fake_attn_target)
+    monkeypatch.setattr(
+        dsa_cudnn_kernels, "get_pg_size", lambda group: group.size() if group is not None else 1
+    )
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
     dsa_cudnn_kernels._compute_sparse_indexer_loss_and_grads(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -2341,7 +2341,11 @@ def test_cudnn_sparse_backward_uses_batch_major_topk_indices_for_batched_kv(monk
 
 
 @pytest.mark.parametrize("source", ["full_fusion", "split_attention"])
-def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, source):
+@pytest.mark.parametrize(
+    "row_lengths", [(1, 2), (0, 2), (0, 0)], ids=["nonempty", "mixed", "all-empty"]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_keeps_fixed_rows(monkeypatch, source, row_lengths, dtype):
     seen = {}
 
     class FakeDSA:
@@ -2350,75 +2354,198 @@ def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, sour
             q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
         ):
             seen["bwd_q_shape"] = q.shape
+            seen["bwd_dO"] = dO.detach().clone()
+            seen["bwd_lse"] = lse.detach().clone()
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
-            return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
+            return {"dq": torch.ones_like(q), "dkv": torch.ones_like(kv) * dO.sum()}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
     monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
 
+    def make_topk(width):
+        topk = torch.full((1, 2, width), -1, dtype=torch.int32)
+        if row_lengths[0] > 0:
+            topk[0, 0, : row_lengths[0]] = torch.tensor([0, 3])[: row_lengths[0]]
+        if row_lengths[1] > 0:
+            topk[0, 1, : row_lengths[1]] = torch.tensor([1, 2])[: row_lengths[1]]
+        return topk
+
     def fake_indexer_topk(*args, **kwargs):
-        return (
-            torch.tensor([[[-1, -1, -1, -1], [1, 2, -1, -1]]], dtype=torch.int32),
-            torch.tensor([[0, 2]], dtype=torch.int32),
-            None,
-        )
+        return make_topk(4), torch.tensor([row_lengths], dtype=torch.int32), None
 
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         seen["fwd_topk"] = topk_idxs.detach().clone()
         seen["fwd_topk_length"] = topk_length.detach().clone()
-        return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
+        # Match FlashMLA's empty-row contract so the wrapper must preserve LSE=+inf.
+        lse = torch.tensor([[5.0], [6.0]], dtype=torch.float32, device=q.device)
+        lse[torch.tensor(row_lengths, device=q.device) <= 0] = float("inf")
+        return torch.zeros((2, 1, d_v), dtype=q.dtype, device=q.device), lse
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
 
     if source == "full_fusion":
-        query = torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, 1), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1), dtype=dtype, requires_grad=True)
         monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
         output, _indexer_loss = dsa_cudnn_kernels.fused_indexer_sparse_attn(
             query,
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16, requires_grad=True),
-            torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((2, 1, 1), dtype=torch.bfloat16),
+            key,
+            torch.zeros((2, 1, 1, 1), dtype=dtype),
+            torch.zeros((4, 1, 1), dtype=dtype),
+            torch.zeros((2, 1, 1), dtype=dtype),
             indexer_topk=4,
             softmax_scale=1.0,
             loss_coeff=0.0,
             sparse_loss=True,
             calculate_per_token_loss=False,
             d_v=1,
+            query_valid_rows=torch.tensor([[length > 0 for length in row_lengths]]),
         )
-        expected_fwd_topk = torch.tensor([[-1, -1, -1, -1], [1, 2, -1, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0, 0], [0, 0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(4).squeeze(0)
     else:
         value_dim = 512
-        query = torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
-        key = torch.zeros((4, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
+        query = torch.zeros((2, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        key = torch.zeros((4, 1, 1, value_dim), dtype=dtype, requires_grad=True)
+        input_topk = make_topk(3)
+        input_topk_length = torch.tensor([row_lengths], dtype=torch.int32)
+        original_topk = input_topk.clone()
+        original_topk_length = input_topk_length.clone()
         output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
             query=query,
             key=key,
-            topk_indices=torch.tensor([[[-1, -1, -1], [2, -1, 1]]], dtype=torch.int32),
+            topk_indices=input_topk,
             softmax_scale=1.0,
             v_channels=value_dim,
+            topk_length=input_topk_length,
         )
         assert output is not None
-        expected_fwd_topk = torch.tensor([[-1, -1, -1], [1, 2, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0], [0, 0, 0]], dtype=torch.int32)
+        expected_fwd_topk = make_topk(3).squeeze(0)
 
-    output.float().sum().backward()
+    empty_rows = torch.tensor(row_lengths) <= 0
+    grad_output = torch.ones_like(output)
+    grad_output[empty_rows] = float("nan")
+
+    def fail_nonzero(*_args, **_kwargs):
+        raise AssertionError("fixed-shape sparse backward must not call torch.nonzero")
+
+    monkeypatch.setattr(torch, "nonzero", fail_nonzero)
+    output.backward(grad_output, retain_graph=True)
 
     torch.testing.assert_close(seen["fwd_topk"], expected_fwd_topk)
-    torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([0, 2], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["fwd_topk_length"], torch.tensor(row_lengths, dtype=torch.int32)
+    )
     assert seen["bwd_q_shape"] == (query.size(0) * query.size(1), query.size(2), query.size(3))
-    # Backward compacts nonempty rows and appends one dummy row to avoid empty cuDNN launches.
+    expected_bwd_topk = expected_fwd_topk.clamp_min(0)
+    expected_bwd_topk[empty_rows, 0] = 0
     torch.testing.assert_close(seen["bwd_topk"], expected_bwd_topk)
-    torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([2, 1], dtype=torch.int32))
-    torch.testing.assert_close(query.grad[0], torch.zeros_like(query.grad[0]))
-    torch.testing.assert_close(query.grad[1], torch.ones_like(query.grad[1]))
+    torch.testing.assert_close(
+        seen["bwd_topk_length"],
+        torch.tensor([max(1, length) for length in row_lengths], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        seen["bwd_dO"][empty_rows], torch.zeros_like(seen["bwd_dO"][empty_rows])
+    )
+    torch.testing.assert_close(
+        seen["bwd_lse"][empty_rows], torch.full_like(seen["bwd_lse"][empty_rows], float("inf"))
+    )
+    if (~empty_rows).any():
+        torch.testing.assert_close(
+            seen["bwd_lse"][~empty_rows], torch.tensor([[5.0], [6.0]])[~empty_rows]
+        )
+    expected_query_grad = torch.ones_like(query.grad)
+    expected_query_grad[empty_rows] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_dkv = seen["bwd_dO"].sum().to(key.dtype)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
     if source == "split_attention":
-        torch.testing.assert_close(key.grad, torch.zeros_like(key.grad))
+        torch.testing.assert_close(input_topk, original_topk)
+        torch.testing.assert_close(input_topk_length, original_topk_length)
+
+    query.grad.zero_()
+    key.grad.zero_()
+    output.backward(grad_output)
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    torch.testing.assert_close(key.grad, torch.ones_like(key.grad) * expected_dkv)
 
 
-def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen(monkeypatch):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_attention_backward_dummy_rows_add_no_cross_batch_gradient(monkeypatch, dtype):
+    seen = {}
+
+    class FakeDSA:
+        @staticmethod
+        def sparse_attention_backward_wrapper(
+            q, kv, out, dO, lse, attn_sink, topk_indices, softmax_scale, topk_length
+        ):
+            del out, lse, attn_sink, softmax_scale
+            seen["topk"] = topk_indices.detach().clone()
+            seen["topk_length"] = topk_length.detach().clone()
+            seen["dO"] = dO.detach().clone()
+            dkv = torch.zeros_like(kv)
+            for row in range(q.size(0)):
+                for column in range(int(topk_length[row])):
+                    dkv[topk_indices[row, column]] += dO[row].sum()
+            return {"dq": torch.ones_like(q), "dkv": dkv}
+
+    def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
+        del kv, softmax_scale, attn_sink
+        seen["forward_topk"] = topk_idxs.detach().clone()
+        seen["forward_topk_length"] = topk_length.detach().clone()
+        return torch.zeros((q.size(0), q.size(1), d_v), dtype=q.dtype), torch.ones(
+            (q.size(0), q.size(1)), dtype=torch.float32
+        )
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_cudnn_dsa", FakeDSA)
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
+
+    value_dim = 512
+    query = torch.zeros((2, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    key = torch.zeros((3, 2, 1, value_dim), dtype=dtype, requires_grad=True)
+    topk_indices = torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    topk_length = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=query,
+        key=key,
+        topk_indices=topk_indices,
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=topk_length,
+    )
+    assert output is not None
+
+    grad_output = torch.zeros_like(output)
+    grad_output[0, 0, 0, 0] = float("nan")
+    grad_output[0, 1, 0, 0] = 2
+    grad_output[1, 0, 0, 0] = 3
+    grad_output[1, 1, 0, 0] = float("nan")
+    output.backward(grad_output)
+
+    torch.testing.assert_close(
+        seen["forward_topk_length"], torch.tensor([0, 1, 1, 0], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["topk_length"], torch.tensor([1, 1, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(
+        seen["topk"], torch.tensor([[0, 0], [3, 0], [4, 0], [0, 0]], dtype=torch.int32)
+    )
+    torch.testing.assert_close(seen["dO"][[0, 3]], torch.zeros_like(seen["dO"][[0, 3]]))
+
+    expected_query_grad = torch.ones_like(query)
+    expected_query_grad[0, 0] = 0
+    expected_query_grad[1, 1] = 0
+    torch.testing.assert_close(query.grad, expected_query_grad)
+    expected_key_grad = torch.zeros_like(key)
+    expected_key_grad[1, 1] = 2
+    expected_key_grad[2, 0] = 3
+    torch.testing.assert_close(key.grad, expected_key_grad)
+    torch.testing.assert_close(
+        topk_indices, torch.tensor([[[-1, -1], [2, -1]], [[1, -1], [-1, -1]]], dtype=torch.int32)
+    )
+
+
+def test_cudnn_full_fusion_uses_nonempty_local_varlen_certificate(monkeypatch):
     seen = {}
 
     class FakeDSA:
@@ -2430,6 +2557,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
             seen["bwd_q_shape"] = q.shape
             seen["bwd_topk"] = topk_indices.detach().clone()
             seen["bwd_topk_length"] = topk_length.detach().clone()
+            seen["bwd_topk_length_ptr"] = topk_length.data_ptr()
             return {"dq": torch.ones_like(q), "dkv": torch.zeros_like(kv)}
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_ensure_dsa_namespace", lambda: None)
@@ -2446,6 +2574,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         del kv, topk_idxs, softmax_scale, attn_sink
         seen["fwd_topk_length"] = topk_length.detach().clone()
+        seen["fwd_topk_length_ptr"] = topk_length.data_ptr()
         return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
@@ -2474,6 +2603,7 @@ def test_cudnn_full_fusion_skips_sparse_bwd_compaction_for_nonempty_local_varlen
     assert seen["bwd_q_shape"] == (2, 1, 1)
     torch.testing.assert_close(seen["fwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
     torch.testing.assert_close(seen["bwd_topk_length"], torch.tensor([1, 2], dtype=torch.int32))
+    assert seen["bwd_topk_length_ptr"] == seen["fwd_topk_length_ptr"]
     torch.testing.assert_close(
         seen["bwd_topk"], torch.tensor([[0, 0, 0], [0, 1, 0]], dtype=torch.int32)
     )
@@ -2527,6 +2657,28 @@ def test_cudnn_sparse_attention_declines_unsupported_flashmla_value_dim(monkeypa
         topk_indices=torch.tensor([[[2, 1, -1], [-1, -1, -1]]], dtype=torch.int32),
         softmax_scale=1.0,
         v_channels=4,
+    )
+
+    assert output is None
+
+
+@pytest.mark.parametrize("empty_dimension", ["topk", "kv"])
+def test_cudnn_sparse_attention_declines_without_safe_backward_tile(monkeypatch, empty_dimension):
+    def fail_flash_mla(*_args, **_kwargs):
+        raise AssertionError("cuDNN must not run without a valid safe backward tile")
+
+    monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fail_flash_mla)
+
+    value_dim = 512
+    kv_length = 0 if empty_dimension == "kv" else 4
+    topk_width = 0 if empty_dimension == "topk" else 2
+    output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+        query=torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16),
+        key=torch.zeros((kv_length, 1, 1, value_dim), dtype=torch.bfloat16),
+        topk_indices=torch.empty((1, 2, topk_width), dtype=torch.int32),
+        softmax_scale=1.0,
+        v_channels=value_dim,
+        topk_length=torch.zeros((1, 2), dtype=torch.int32),
     )
 
     assert output is None
@@ -2639,7 +2791,7 @@ def test_cudnn_attention_backward_pads_small_local_head_count(monkeypatch):
         d=attn_dim,
         skv=skv,
         grad_output=torch.zeros((sq, batch_size, num_heads, value_dim), device="cuda"),
-        all_rows_nonempty=True,
+        all_topk_rows_nonempty=True,
     )
 
     assert seen["shapes"] == (

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_scoring_plan.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_scoring_plan.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for DSA indexer scoring plan resolution.
+
+The cases below mirror configurations whose actual branch was measured on GB200 with a
+branch-tracing build, so the resolver is pinned to observed behaviour rather than to a
+reading of the dispatcher.
+"""
+
+import pytest
+
+from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+    IndexerScoringPlan,
+    resolve_indexer_scoring_plan,
+)
+
+BASE = dict(
+    bounds_available=True,
+    varlen_is_plain_causal=False,
+    packed_thd=False,
+    cp_size=1,
+    mask_is_causal=True,
+    explicit_key_positions=False,
+    single_sequence_pack=False,
+    packed_metadata_available=False,
+    segment_kernel_applicable=True,
+)
+
+
+def _resolve(**overrides):
+    return resolve_indexer_scoring_plan(**{**BASE, **overrides})
+
+
+class TestIndexerScoringPlan:
+    """Plan resolution for each layout the dispatcher can encounter."""
+
+    def test_plain_causal_reaches_the_fused_scorer(self):
+        """Non-packed, no CP: bounds are reconstructible so the single kernel applies."""
+        decision = _resolve(varlen_is_plain_causal=True)
+        assert decision.plan is IndexerScoringPlan.PLAIN_CAUSAL
+        assert decision.is_fused
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 16])
+    def test_packed_single_sequence_uses_segment_specialization(self, cp_size):
+        """One sequence per pack uses segments independently of CP size."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=cp_size,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS
+        assert decision.is_fused
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 16])
+    def test_packed_multi_sequence_uses_general_thd(self, cp_size):
+        """Several sequences per pack take the general THD scorer at every CP size."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=cp_size,
+            single_sequence_pack=False,
+            packed_metadata_available=True,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert decision.is_fused
+
+    def test_packed_cp_multi_without_metadata_is_unfused(self):
+        """Without cu_seqlens the packed kernels cannot express the boundaries."""
+        decision = _resolve(
+            packed_thd=True, cp_size=16, single_sequence_pack=False, packed_metadata_available=False
+        )
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "cu_seqlens" in decision.reason
+
+    def test_single_sequence_pack_reaches_the_fused_scorer_without_cp(self):
+        """The segment kernel degenerates correctly when one rank holds the sequence."""
+        decision = _resolve(
+            packed_thd=True, single_sequence_pack=True, packed_metadata_available=True
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_SINGLE_SEGMENTS
+        assert decision.is_fused
+
+    def test_multi_sequence_pack_without_cp_uses_general_thd(self):
+        """Pack cardinality is independent of CP geometry."""
+        decision = _resolve(packed_thd=True, packed_metadata_available=True)
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert decision.is_fused
+
+    def test_context_parallel_without_packing_is_unfused_and_says_why(self):
+        """CP without packing misses every fused kernel. Measured on GB200."""
+        decision = _resolve(cp_size=4)
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "packing" in decision.reason
+
+    def test_segment_kernel_preconditions_are_respected(self):
+        """The segment kernel raises rather than declining, so the plan must not promise it.
+
+        Widening the single-pack gate without this check routed a packed cp_size=1 run
+        into the kernel, which died with "requires b=1, even local query length,
+        ratio=1" instead of falling back.
+        """
+        decision = _resolve(
+            packed_thd=True,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+        assert "falling back" in decision.reason
+
+    def test_segment_kernel_preconditions_apply_under_cp_too(self):
+        """The same shape guard is needed on the pre-existing CP>1 path."""
+        decision = _resolve(
+            packed_thd=True,
+            cp_size=16,
+            single_sequence_pack=True,
+            packed_metadata_available=True,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.PACKED_THD_GENERAL
+
+    def test_single_sequence_without_any_compatible_packed_kernel_is_unfused(self):
+        decision = _resolve(
+            packed_thd=True,
+            single_sequence_pack=True,
+            packed_metadata_available=False,
+            segment_kernel_applicable=False,
+        )
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+        assert "incompatible" in decision.reason
+
+    def test_explicit_key_positions_declines(self):
+        """Custom key positions are not expressible as row-wise bounds at all."""
+        decision = _resolve(explicit_key_positions=True, varlen_is_plain_causal=True)
+        assert decision.plan is IndexerScoringPlan.DECLINE
+        assert not decision.is_fused
+
+    def test_missing_bounds_declines(self):
+        """A mask the caller could not turn into bounds must not reach fused scoring."""
+        decision = _resolve(bounds_available=False)
+        assert decision.plan is IndexerScoringPlan.DECLINE
+
+    def test_non_causal_mask_is_unfused(self):
+        """No fused scorer covers a non-causal mask."""
+        decision = _resolve(mask_is_causal=False)
+        assert decision.plan is IndexerScoringPlan.UNFUSED_BOUNDS
+
+    @pytest.mark.parametrize("cp_size", [1, 2, 8, 16])
+    @pytest.mark.parametrize("packed_thd", [False, True])
+    @pytest.mark.parametrize("single_sequence_pack", [False, True])
+    def test_resolution_is_total(self, cp_size, packed_thd, single_sequence_pack):
+        """Every configuration resolves to a plan carrying a non-empty reason.
+
+        Totality is the property that keeps a new layout from silently falling through
+        to the slow path the way it does today.
+        """
+        decision = _resolve(
+            cp_size=cp_size,
+            packed_thd=packed_thd,
+            single_sequence_pack=single_sequence_pack,
+            packed_metadata_available=packed_thd,
+        )
+        assert isinstance(decision.plan, IndexerScoringPlan)
+        assert decision.reason
+
+    def test_decline_is_not_reported_as_a_slow_fallback(self):
+        """A decline means fused scoring was never attempted, not that it was slow."""
+        from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+            report_unfused_scoring_once,
+        )
+
+        decision = _resolve(explicit_key_positions=True)
+        assert report_unfused_scoring_once(decision, "test-decline") is None
+
+    def test_unfused_plan_is_reported_once_per_reason(self):
+        """The warning exists so a throughput cliff is visible; it must not spam."""
+        from megatron.core.transformer.experimental_attention_variant.dsa_scoring_plan import (
+            report_unfused_scoring_once,
+        )
+
+        decision = _resolve(cp_size=4)
+        first = report_unfused_scoring_once(decision, "test-once")
+        second = report_unfused_scoring_once(decision, "test-once")
+        assert first is not None and decision.reason in first
+        assert second is None

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
@@ -1,0 +1,1235 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Native parity coverage for repeated-MTP DSA IndexShare and KVShare."""
+
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import megatron.core.parallel_state as parallel_state
+from megatron.core.enums import Fp8Recipe
+from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+    get_dsa_module_spec_for_backend,
+    get_transformer_layer_with_experimental_attention_variant_spec,
+)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.random import (
+    CheckpointWithoutOutput,
+    model_parallel_cuda_manual_seed,
+)
+from megatron.core.transformer.enums import AttnBackend, AttnMaskType, CudaGraphModule
+from megatron.core.transformer.experimental_attention_variant import dsa as dsa_module
+from megatron.core.transformer.multi_token_prediction import (
+    MTPDSAIterationContext,
+    MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
+)
+from megatron.core.transformer.spec_utils import build_module
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.utils import init_method_normal, scaled_init_method_normal
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _make_config(**overrides) -> MLATransformerConfig:
+    kwargs = dict(
+        num_layers=2,
+        mtp_num_layers=7,
+        mtp_use_repeated_layer=True,
+        dsa_mtp_index_kv_share=True,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_query_groups=4,
+        kv_channels=8,
+        multi_latent_attention=True,
+        experimental_attention_variant="dsa",
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_head_dim=8,
+        qk_pos_emb_head_dim=4,
+        v_head_dim=8,
+        dsa_indexer_n_heads=4,
+        dsa_indexer_head_dim=8,
+        dsa_indexer_topk=4,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=3,
+        dsa_indexer_loss_coeff=0.0,
+        dsa_indexer_rotate_activation=False,
+        dsa_indexer_scoring_relu=False,
+        dsa_kernel_backend="none",
+        attention_backend=AttnBackend.unfused,
+        add_bias_linear=False,
+        qk_layernorm=True,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        sequence_parallel=False,
+        apply_rope_fusion=False,
+        rope_type="rope",
+        rotary_base=10000,
+        gradient_accumulation_fusion=False,
+        init_method=init_method_normal(0.02),
+        output_layer_init_method=scaled_init_method_normal(0.02, 2, multiplier=2.0),
+        use_cpu_initialization=False,
+        perform_initialization=True,
+    )
+    kwargs.update(overrides)
+    return MLATransformerConfig(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"experimental_attention_variant": None}, "requires experimental_attention_variant"),
+        ({"mtp_use_repeated_layer": False}, "requires mtp_use_repeated_layer"),
+        ({"mtp_num_layers": 1}, "requires mtp_num_layers > 1"),
+        (
+            {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": ["attn"]},
+            "does not support per-layer CUDA graph scopes that capture attention",
+        ),
+        (
+            {"cuda_graph_impl": "local", "cuda_graph_modules": []},
+            "does not support per-layer CUDA graph scopes that capture attention",
+        ),
+    ],
+)
+def test_iteration_sharing_rejects_incompatible_config(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _make_config(**overrides)
+
+
+def test_iteration_sharing_accepts_moe_only_cuda_graph_scope():
+    config = _make_config(
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_modules=["moe_router", "moe_preprocess"],
+        num_moe_experts=4,
+    )
+
+    assert config.cuda_graph_modules == [CudaGraphModule.moe_router, CudaGraphModule.moe_preprocess]
+
+
+def test_iteration_sharing_accepts_full_iteration_cuda_graph_scope():
+    config = _make_config(cuda_graph_impl="full_iteration", cuda_graph_modules=[])
+
+    assert config.cuda_graph_impl == "full_iteration"
+
+
+def test_iteration_sharing_accepts_selective_mla_up_projection_recompute():
+    config = _make_config(recompute_granularity="selective", recompute_modules=["mla_up_proj"])
+
+    assert config.recompute_modules == ["mla_up_proj"]
+
+
+@pytest.mark.parametrize(
+    ("is_mtp_layer", "fused_enabled", "expected_log_count"),
+    [(True, True, 1), (True, False, 0), (False, True, 0)],
+    ids=["sharing-fused", "sharing-unfused", "non-mtp-fused"],
+)
+def test_iteration_sharing_logs_when_combined_fused_dsa_is_disabled(
+    monkeypatch, is_mtp_layer, fused_enabled, expected_log_count
+):
+    logged_messages = []
+    monkeypatch.setattr(dsa_module, "_warned_mtp_sharing_fused_bypass", False)
+    monkeypatch.setattr(
+        dsa_module.dsa_kernels, "use_fused_dsa_kernels", lambda _config: fused_enabled
+    )
+    monkeypatch.setattr(
+        dsa_module,
+        "log_single_rank",
+        lambda _logger, _level, message: logged_messages.append(message),
+    )
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    config = _make_config()
+    submodules = dsa_module.DSAttentionSubmodules(indexer=None)
+    pg_collection = SimpleNamespace()
+
+    for _ in range(2):
+        dsa_module.DSAttention(
+            config=config,
+            submodules=submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=pg_collection,
+            is_mtp_layer=is_mtp_layer,
+        )
+
+    fallback_messages = [
+        message
+        for message in logged_messages
+        if "combined fused DSA kernel does not expose" in message
+    ]
+    assert len(fallback_messages) == expected_log_count
+
+
+def test_iteration_sharing_rejects_default_selective_core_attention_recompute():
+    with pytest.raises(ValueError, match="does not yet support selective recompute"):
+        _make_config(recompute_granularity="selective")
+
+
+def test_nonsharing_accepts_default_selective_core_attention_recompute():
+    config = _make_config(dsa_mtp_index_kv_share=False, recompute_granularity="selective")
+
+    assert config.recompute_modules == ["core_attn"]
+
+
+def test_nonsharing_selective_mla_up_projection_keeps_joint_qk_checkpoint(monkeypatch):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(1122)
+        config = _make_config(
+            dsa_mtp_index_kv_share=False,
+            recompute_granularity="selective",
+            recompute_modules=["mla_up_proj"],
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = build_module(attention_spec, config=config, layer_number=1).bfloat16().cuda()
+
+        checkpoint_output_arities = []
+        original_checkpoint = CheckpointWithoutOutput.checkpoint
+
+        def observed_checkpoint(checkpoint, run_function, *args):
+            outputs = original_checkpoint(checkpoint, run_function, *args)
+            checkpoint_output_arities.append(
+                1 if isinstance(outputs, torch.Tensor) else len(outputs)
+            )
+            return outputs
+
+        monkeypatch.setattr(CheckpointWithoutOutput, "checkpoint", observed_checkpoint)
+
+        total_tokens = 9
+        hidden_states = torch.randn(
+            total_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+
+        output, _ = attention(hidden_states, attention_mask=attention_mask)
+        output.float().square().mean().backward()
+
+        assert checkpoint_output_arities == [2]
+        assert hidden_states.grad is not None and torch.isfinite(hidden_states.grad).all()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def _rope_positions(total_tokens: int, segment_lengths: list[int] | None, device) -> torch.Tensor:
+    if segment_lengths is None:
+        return torch.arange(total_tokens, device=device)
+    return torch.cat([torch.arange(length, device=device) for length in segment_lengths])
+
+
+def _apply_rope(
+    x: torch.Tensor, positions: torch.Tensor, base: float, interleaved: bool
+) -> torch.Tensor:
+    dtype = x.dtype
+    dim = x.size(-1)
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=x.device) / dim))
+    freqs = torch.outer(positions.float(), freqs)
+    freqs = torch.polar(torch.ones_like(freqs), freqs).view(x.size(0), 1, 1, -1)
+    if interleaved:
+        x_pairs = x.float().reshape(*x.shape[:-1], -1, 2)
+    else:
+        x_pairs = x.float().reshape(*x.shape[:-1], 2, -1).transpose(-1, -2).contiguous()
+    x_complex = torch.view_as_complex(x_pairs)
+    output = torch.view_as_real(x_complex * freqs).flatten(-2)
+    if not interleaved:
+        output = torch.cat([output[..., 0::2], output[..., 1::2]], dim=-1)
+    return output.to(dtype=dtype)
+
+
+def _causal_segment_mask(
+    total_tokens: int, segment_lengths: list[int] | None, device
+) -> torch.Tensor:
+    valid = torch.zeros((total_tokens, total_tokens), dtype=torch.bool, device=device)
+    start = 0
+    for length in segment_lengths or [total_tokens]:
+        valid[start : start + length, start : start + length] = torch.tril(
+            torch.ones((length, length), dtype=torch.bool, device=device)
+        )
+        start += length
+    return valid
+
+
+class _NativeSharedAbsorbedDSA(nn.Module):
+    """Pure-PyTorch repeated-iteration DSA oracle with explicit source tensor reuse."""
+
+    _PARAMETER_MAP = {
+        "q_down_weight": "linear_q_down_proj.weight",
+        "q_norm_weight": "q_layernorm.weight",
+        "q_up_weight": "linear_q_up_proj.weight",
+        "kv_down_weight": "linear_kv_down_proj.weight",
+        "kv_norm_weight": "kv_layernorm.weight",
+        "kv_up_weight": "linear_kv_up_proj.weight",
+        "output_weight": "linear_proj.weight",
+        "index_q_weight": "core_attention.indexer.linear_wq_b.weight",
+        "index_k_weight": "core_attention.indexer.linear_wk.weight",
+        "index_k_norm_weight": "core_attention.indexer.k_norm.weight",
+        "index_k_norm_bias": "core_attention.indexer.k_norm.bias",
+        "index_weight_proj": "core_attention.indexer.linear_weights_proj.weight",
+    }
+
+    def __init__(self, real_attention, config: MLATransformerConfig):
+        super().__init__()
+        self.config = config
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in self._PARAMETER_MAP.items():
+            setattr(self, native_name, nn.Parameter(real_parameters[real_name].detach().clone()))
+
+    def _project_query(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        qr = F.linear(hidden_states, self.q_down_weight)
+        qr = F.rms_norm(
+            qr, (self.config.q_lora_rank,), self.q_norm_weight, self.config.layernorm_epsilon
+        )
+        query = F.linear(qr, self.q_up_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.qk_pos_emb_head_dim,
+        )
+        query_nope, query_rope = torch.split(
+            query, [self.config.qk_head_dim, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=True)
+
+        kv_up = self.kv_up_weight.view(
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.v_head_dim,
+            self.config.kv_lora_rank,
+        )
+        k_up = kv_up[:, : self.config.qk_head_dim]
+        query_absorbed = torch.einsum("sbhd,hdc->sbhc", query_nope, k_up)
+        return torch.cat([query_absorbed, query_rope], dim=-1), qr, kv_up
+
+    def _project_key(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        kv_combined = F.linear(hidden_states, self.kv_down_weight)
+        kv_latent, key_rope = torch.split(
+            kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        kv_latent = F.rms_norm(
+            kv_latent,
+            (self.config.kv_lora_rank,),
+            self.kv_norm_weight,
+            self.config.layernorm_epsilon,
+        )
+        key_rope = _apply_rope(
+            key_rope.unsqueeze(2), positions, self.config.rotary_base, interleaved=True
+        )
+        return torch.cat([kv_latent.unsqueeze(2), key_rope], dim=-1)
+
+    def _compute_topk(
+        self,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+    ) -> torch.Tensor:
+        source = hidden_states.detach()
+        qr = qr.detach()
+        query = F.linear(qr, self.index_q_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.dsa_indexer_n_heads,
+            self.config.dsa_indexer_head_dim,
+        )
+        query_rope, query_nope = torch.split(
+            query,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=False)
+        query = torch.cat([query_rope, query_nope], dim=-1)
+
+        key = F.linear(source, self.index_k_weight)
+        key = F.layer_norm(
+            key,
+            (self.config.dsa_indexer_head_dim,),
+            self.index_k_norm_weight,
+            self.index_k_norm_bias,
+            self.config.dsa_indexer_k_norm_epsilon or self.config.layernorm_epsilon,
+        )
+        key = key.unsqueeze(2)
+        key_rope, key_nope = torch.split(
+            key,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        key_rope = _apply_rope(key_rope, positions, self.config.rotary_base, interleaved=False)
+        key = torch.cat([key_rope, key_nope], dim=-1).squeeze(2)
+
+        weights = F.linear(source, self.index_weight_proj)
+        weights = weights * (self.config.dsa_indexer_n_heads**-0.5)
+        weights = weights * (self.config.dsa_indexer_head_dim**-0.5)
+        scores = torch.einsum("sbhd,tbd->bsht", query.float(), key.float())
+        scores = (scores * weights.transpose(0, 1).unsqueeze(-1)).sum(dim=2)
+        scores = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
+        topk_scores, topk = scores.topk(min(self.config.dsa_indexer_topk, key.size(0)), dim=-1)
+        return topk.masked_fill(topk_scores == float("-inf"), -1)
+
+    def forward_iteration(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+        shared_key: torch.Tensor | None,
+        shared_topk: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        query, qr, kv_up = self._project_query(hidden_states, positions)
+        key = self._project_key(hidden_states, positions) if shared_key is None else shared_key
+        topk = (
+            self._compute_topk(hidden_states, qr, positions, valid)
+            if shared_topk is None
+            else shared_topk
+        )
+
+        scores = torch.einsum("sbhd,tbnd->bhst", query.float(), key.float())
+        scores = scores * (self.config.qk_head_dim + self.config.qk_pos_emb_head_dim) ** -0.5
+        selected = torch.zeros_like(valid, dtype=torch.int32).unsqueeze(0)
+        selected.scatter_add_(-1, topk.clamp_min(0), (topk >= 0).to(dtype=selected.dtype))
+        sparse_valid = valid.unsqueeze(0) & (selected > 0)
+        scores = scores.masked_fill(~sparse_valid.unsqueeze(1), float("-inf"))
+        probabilities = torch.softmax(scores, dim=-1).to(dtype=key.dtype)
+        latent_value = key[..., : self.config.kv_lora_rank]
+        latent_output = torch.einsum("bhst,tbnd->sbhd", probabilities, latent_value)
+        v_up = kv_up[:, self.config.qk_head_dim :]
+        output = torch.einsum("sbhc,hdc->sbhd", latent_output, v_up)
+        output = F.linear(output.reshape(*hidden_states.shape[:-1], -1), self.output_weight)
+        return output, key, topk
+
+
+def _cosine_similarity(left: torch.Tensor, right: torch.Tensor) -> float:
+    return F.cosine_similarity(
+        left.flatten().double().unsqueeze(0), right.flatten().double().unsqueeze(0)
+    ).item()
+
+
+def _tensor_similarity(left: torch.Tensor, right: torch.Tensor) -> float:
+    left = left.double()
+    right = right.double()
+    denominator = (left.square() + right.square()).sum()
+    if denominator == 0:
+        return 1.0
+    return (2.0 * (left * right).sum() / denominator).item()
+
+
+def _assert_similarity(left: torch.Tensor, right: torch.Tensor, tolerance: float = 2e-2):
+    assert torch.isfinite(left).all()
+    assert torch.isfinite(right).all()
+    assert _cosine_similarity(left, right) > 1 - tolerance
+    assert _tensor_similarity(left, right) > 1 - tolerance
+
+
+@pytest.mark.parametrize("segment_lengths", [None, [5, 4]])
+@pytest.mark.parametrize("recompute_up_proj", [False, True])
+@pytest.mark.parametrize("apply_rope_fusion", [False, True], ids=["unfused-rope", "fused-rope"])
+def test_repeated_mtp_dsa_index_and_kv_share_native_parity(
+    monkeypatch, segment_lengths, recompute_up_proj, apply_rope_fusion
+):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(1234)
+        torch.manual_seed(1234)
+        torch.cuda.manual_seed(1234)
+
+        recompute_overrides = {}
+        if recompute_up_proj:
+            recompute_overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["mla_up_proj"],
+            }
+        config = _make_config(apply_rope_fusion=apply_rope_fusion, **recompute_overrides)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        real_attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        native_attention = _NativeSharedAbsorbedDSA(real_attention, config).bfloat16().cuda()
+
+        total_tokens = sum(segment_lengths) if segment_lengths is not None else 9
+        positions = _rope_positions(total_tokens, segment_lengths, device="cuda")
+        valid = _causal_segment_mask(total_tokens, segment_lengths, device="cuda")
+        if segment_lengths is None:
+            attention_mask = torch.zeros(
+                (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+            ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+            packed_seq_params = None
+        else:
+            cu_seqlens = torch.tensor(
+                [0, segment_lengths[0], total_tokens], dtype=torch.int32, device="cuda"
+            )
+            attention_mask = None
+            packed_seq_params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(segment_lengths),
+                max_seqlen_kv=max(segment_lengths),
+            )
+
+        call_counts = {"q": 0, "kv": 0, "indexer": 0, "sparse": 0}
+        checkpoint_output_arities = []
+        original_checkpoint = CheckpointWithoutOutput.checkpoint
+
+        def observed_checkpoint(checkpoint, run_function, *args):
+            outputs = original_checkpoint(checkpoint, run_function, *args)
+            checkpoint_output_arities.append(
+                1 if isinstance(outputs, torch.Tensor) else len(outputs)
+            )
+            return outputs
+
+        monkeypatch.setattr(CheckpointWithoutOutput, "checkpoint", observed_checkpoint)
+        hooks = [
+            real_attention.linear_q_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("q", call_counts["q"] + 1)
+            ),
+            real_attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            real_attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        real_inputs = [
+            torch.randn(
+                total_tokens,
+                1,
+                config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+                requires_grad=True,
+            )
+            for _ in range(config.mtp_num_layers)
+        ]
+        native_inputs = [value.detach().clone().requires_grad_(True) for value in real_inputs]
+        output_grads = [torch.randn_like(value) for value in real_inputs]
+
+        real_outputs = []
+        native_outputs = []
+        real_shared = None
+        native_key = native_topk = None
+        for iteration in range(config.mtp_num_layers):
+            context = MTPDSAIterationContext(iteration, shared_tensors=real_shared)
+            real_output, _ = real_attention(
+                real_inputs[iteration],
+                attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
+                mtp_dsa_context=context,
+            )
+            if context.is_source:
+                real_shared = context.require_source_tensors()
+            real_outputs.append(real_output)
+
+            native_output, current_key, current_topk = native_attention.forward_iteration(
+                native_inputs[iteration], positions, valid, native_key, native_topk
+            )
+            if iteration == 0:
+                native_key, native_topk = current_key, current_topk
+            native_outputs.append(native_output)
+
+        assert real_shared is not None
+        assert real_shared.key.untyped_storage().nbytes() > 0
+        assert torch.equal(real_shared.topk_indices, native_topk)
+        for row, indices in enumerate(real_shared.topk_indices[0]):
+            indices = indices[indices >= 0]
+            assert valid[row, indices].all()
+        for output, reference in zip(real_outputs, native_outputs):
+            _assert_similarity(output, reference)
+
+        torch.autograd.backward(real_outputs, output_grads)
+        torch.autograd.backward(native_outputs, output_grads)
+        for real_input, native_input in zip(real_inputs, native_inputs):
+            _assert_similarity(real_input.grad, native_input.grad)
+
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in native_attention._PARAMETER_MAP.items():
+            native_parameter = getattr(native_attention, native_name)
+            real_parameter = real_parameters[real_name]
+            if native_parameter.grad is None or real_parameter.grad is None:
+                assert native_parameter.grad is None and real_parameter.grad is None
+                continue
+            _assert_similarity(real_parameter.grad, native_parameter.grad)
+
+        assert call_counts == {"q": 7, "kv": 1, "indexer": 1, "sparse": 7}
+        assert checkpoint_output_arities == ([1] * 7 if recompute_up_proj else [])
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("share_mtp_index_kv", [True, False], ids=["sharing", "nonsharing"])
+def test_repeated_mtp_indexer_loss_charge_count(monkeypatch, share_mtp_index_kv):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(2345)
+        torch.manual_seed(2345)
+        torch.cuda.manual_seed(2345)
+
+        config = _make_config(dsa_indexer_loss_coeff=0.1, dsa_mtp_index_kv_share=share_mtp_index_kv)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        tracked_losses = []
+        monkeypatch.setattr(
+            dsa_module.DSAIndexerLossLoggingHelper,
+            "save_loss_to_tracker",
+            staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
+        )
+
+        total_tokens = 9
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+        shared = None
+        outputs = []
+        for iteration in range(config.mtp_num_layers):
+            context = None
+            attention_kwargs = {}
+            if share_mtp_index_kv:
+                context = MTPDSAIterationContext(iteration, shared_tensors=shared)
+                attention_kwargs["mtp_dsa_context"] = context
+            hidden_states = torch.randn(
+                total_tokens,
+                1,
+                config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+                requires_grad=True,
+            )
+            output, _ = attention(hidden_states, attention_mask=attention_mask, **attention_kwargs)
+            if context is not None and context.is_source:
+                shared = context.require_source_tensors()
+            outputs.append(output)
+
+        sum(output.float().sum() for output in outputs).backward()
+
+        expected_loss_count = 1 if share_mtp_index_kv else config.mtp_num_layers
+        assert len(tracked_losses) == expected_loss_count
+        assert all(loss.requires_grad for loss in tracked_losses)
+        for name in ("linear_wq_b.weight", "linear_wk.weight", "linear_weights_proj.weight"):
+            parameter = dict(attention.core_attention.indexer.named_parameters())[name]
+            assert parameter.grad is not None
+            assert torch.isfinite(parameter.grad).all()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_source_indexer_loss_and_gradients_match_unshared_oracle(monkeypatch):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(3456)
+        torch.manual_seed(3456)
+        torch.cuda.manual_seed(3456)
+
+        shared_config = _make_config(dsa_indexer_loss_coeff=0.1)
+        oracle_config = _make_config(dsa_indexer_loss_coeff=0.1, dsa_mtp_index_kv_share=False)
+        shared_spec = get_dsa_module_spec_for_backend(shared_config, backend=TESpecProvider())
+        oracle_spec = get_dsa_module_spec_for_backend(oracle_config, backend=TESpecProvider())
+        shared_attention = (
+            build_module(shared_spec, config=shared_config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        oracle_attention = (
+            build_module(oracle_spec, config=oracle_config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        oracle_attention.load_state_dict(shared_attention.state_dict())
+
+        tracked_losses = []
+        monkeypatch.setattr(
+            dsa_module.DSAIndexerLossLoggingHelper,
+            "save_loss_to_tracker",
+            staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
+        )
+
+        total_tokens = 9
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+        source_input = torch.randn(
+            total_tokens, 1, shared_config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        )
+
+        shared_tensors = None
+        shared_outputs = []
+        for iteration in range(shared_config.mtp_num_layers):
+            context = MTPDSAIterationContext(iteration, shared_tensors=shared_tensors)
+            hidden_states = (
+                source_input.detach().clone() if iteration == 0 else torch.randn_like(source_input)
+            ).requires_grad_(True)
+            output, _ = shared_attention(
+                hidden_states, attention_mask=attention_mask, mtp_dsa_context=context
+            )
+            if context.is_source:
+                shared_tensors = context.require_source_tensors()
+            shared_outputs.append(output)
+
+        oracle_input = source_input.detach().clone().requires_grad_(True)
+        oracle_output, _ = oracle_attention(oracle_input, attention_mask=attention_mask)
+
+        assert len(tracked_losses) == 2
+        torch.testing.assert_close(tracked_losses[0], tracked_losses[1], rtol=0, atol=0)
+
+        sum(output.float().sum() for output in shared_outputs).backward()
+        oracle_output.float().sum().backward()
+
+        shared_indexer_parameters = dict(shared_attention.core_attention.indexer.named_parameters())
+        oracle_indexer_parameters = dict(oracle_attention.core_attention.indexer.named_parameters())
+        for name in ("linear_wq_b.weight", "linear_wk.weight", "linear_weights_proj.weight"):
+            shared_grad = shared_indexer_parameters[name].grad
+            oracle_grad = oracle_indexer_parameters[name].grad
+            assert shared_grad is not None and oracle_grad is not None
+            torch.testing.assert_close(shared_grad, oracle_grad, rtol=0, atol=0)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("dynamic_cp", [False, True])
+@pytest.mark.parametrize("recompute_up_proj", [False, True])
+def test_cp2_reuses_global_source_kv_and_topk_with_gradient_flow(
+    monkeypatch, dynamic_cp, recompute_up_proj
+):
+    if Utils.world_size < 2:
+        pytest.skip("CP2 MTP DSA sharing requires at least two distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        model_parallel_cuda_manual_seed(3456)
+        torch.manual_seed(3456 + parallel_state.get_context_parallel_rank())
+        torch.cuda.manual_seed(3456 + parallel_state.get_context_parallel_rank())
+
+        recompute_overrides = {}
+        if recompute_up_proj:
+            recompute_overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["mla_up_proj"],
+            }
+        config = _make_config(
+            context_parallel_size=2, cp_comm_type="all_gather", **recompute_overrides
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(
+                attention_spec,
+                config=config,
+                layer_number=1,
+                cp_comm_type=config.cp_comm_type,
+                is_mtp_layer=True,
+            )
+            .bfloat16()
+            .cuda()
+        )
+        call_counts = {
+            "kv": 0,
+            "indexer": 0,
+            "sparse": 0,
+            "kv_cp_gather": 0,
+            "indexer_cp_gather": 0,
+        }
+        hooks = [
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+        original_gather = dsa_module.gather_from_sequence_parallel_region
+
+        def counted_cp_gather(tensor, group=None, **kwargs):
+            if group is parallel_state.get_context_parallel_group():
+                if tensor.size(-1) == config.kv_lora_rank + config.qk_pos_emb_head_dim:
+                    call_counts["kv_cp_gather"] += 1
+                elif tensor.size(-1) == config.dsa_indexer_head_dim:
+                    call_counts["indexer_cp_gather"] += 1
+            return original_gather(tensor, group=group, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "gather_from_sequence_parallel_region", counted_cp_gather)
+
+        local_tokens = 8
+        global_tokens = local_tokens * 2
+        cu_seqlens = torch.tensor([0, global_tokens], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens.clone(),
+            cu_seqlens_kv_padded=cu_seqlens.clone(),
+            max_seqlen_q=global_tokens,
+            max_seqlen_kv=global_tokens,
+            local_cp_size=2 if dynamic_cp else None,
+            cp_group=(parallel_state.get_context_parallel_group() if dynamic_cp else None),
+        )
+        source_hidden = torch.randn(
+            local_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        consumer_hidden = torch.randn_like(source_hidden, requires_grad=True)
+
+        source_context = MTPDSAIterationContext(iteration=0)
+        attention(
+            source_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=source_context,
+        )
+        shared = source_context.require_source_tensors()
+        source_key_data_ptr = shared.key.data_ptr()
+        assert shared.key.untyped_storage().nbytes() > 0
+        consumer_context = MTPDSAIterationContext(iteration=1, shared_tensors=shared)
+        consumer_output, _ = attention(
+            consumer_hidden,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+            mtp_dsa_context=consumer_context,
+        )
+        consumer_output.float().square().mean().backward()
+
+        assert shared.key.size(0) == global_tokens
+        assert shared.key.data_ptr() == source_key_data_ptr
+        assert shared.key.untyped_storage().nbytes() > 0
+        assert torch.all(shared.topk_indices >= -1)
+        assert torch.all(shared.topk_indices < global_tokens)
+        assert source_hidden.grad is not None and source_hidden.grad.float().norm() > 0
+        assert consumer_hidden.grad is not None and consumer_hidden.grad.float().norm() > 0
+        assert torch.isfinite(source_hidden.grad).all()
+        assert torch.isfinite(consumer_hidden.grad).all()
+        assert call_counts == {
+            "kv": 1,
+            "indexer": 1,
+            "sparse": 2,
+            "kv_cp_gather": 1,
+            "indexer_cp_gather": 1,
+        }
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_tp2_sequence_parallel_reuses_global_source_kv_and_topk(monkeypatch):
+    if Utils.world_size < 2:
+        pytest.skip("TP2 MTP DSA sharing requires at least two distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(3789)
+        torch.manual_seed(3789 + parallel_state.get_tensor_model_parallel_rank())
+        torch.cuda.manual_seed(3789 + parallel_state.get_tensor_model_parallel_rank())
+
+        config = _make_config(tensor_model_parallel_size=2, sequence_parallel=True)
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        call_counts = {"kv": 0, "indexer": 0, "sparse": 0}
+        hooks = [
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        local_tokens = 8
+        global_tokens = local_tokens * 2
+        source_hidden = torch.randn(
+            local_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        consumer_hidden = torch.randn_like(source_hidden, requires_grad=True)
+        valid = _causal_segment_mask(global_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, global_tokens, global_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, global_tokens, global_tokens), float("-inf"))
+        position_ids = torch.arange(global_tokens, device="cuda").view(1, global_tokens)
+
+        source_context = MTPDSAIterationContext(iteration=0)
+        attention(
+            source_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            mtp_dsa_context=source_context,
+        )
+        shared = source_context.require_source_tensors()
+        consumer_context = MTPDSAIterationContext(iteration=1, shared_tensors=shared)
+        consumer_output, _ = attention(
+            consumer_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            mtp_dsa_context=consumer_context,
+        )
+        consumer_output.float().square().mean().backward()
+
+        assert shared.key.size(0) == global_tokens
+        # Absorbed MLA gathers the sequence before its Q up-projection, so DSA sees
+        # global query rows even though the TransformerLayer input/output remain SP-local.
+        assert shared.topk_indices.size(1) == global_tokens
+        assert torch.all(shared.topk_indices >= -1)
+        assert torch.all(shared.topk_indices < global_tokens)
+        assert source_hidden.grad is not None and source_hidden.grad.float().norm() > 0
+        assert consumer_hidden.grad is not None and consumer_hidden.grad.float().norm() > 0
+        assert torch.isfinite(source_hidden.grad).all()
+        assert torch.isfinite(consumer_hidden.grad).all()
+        assert call_counts == {"kv": 1, "indexer": 1, "sparse": 2}
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize(
+    ("recompute_method", "use_mxfp8"),
+    [("uniform", False), ("uniform", True), ("block", False)],
+    ids=["uniform-native", "uniform-te-mxfp8", "block-fallback"],
+)
+def test_recompute_path_threads_shared_kv_through_iteration_context(recompute_method, use_mxfp8):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(4321)
+        scale = nn.Parameter(torch.tensor(1.25, device="cuda"))
+        dummy_layer = SimpleNamespace(
+            config=SimpleNamespace(
+                fp8="e4m3" if use_mxfp8 else None,
+                fp8_recipe=Fp8Recipe.mxfp8 if use_mxfp8 else None,
+                fp4=False,
+                distribute_saved_activations=False,
+                recompute_method=recompute_method,
+                recompute_num_layers=1,
+            ),
+            scale=scale,
+        )
+
+        def projected_forward(self, hidden_states, decoder_input, mtp_dsa_context=None, **_kwargs):
+            combined = hidden_states + decoder_input
+            if mtp_dsa_context.is_source:
+                key = combined * self.scale
+                topk = torch.zeros(
+                    (1, combined.size(0), 1), dtype=torch.int64, device=combined.device
+                )
+                mtp_dsa_context.capture(key, topk, None)
+                return combined.square()
+            return combined + 3 * mtp_dsa_context.shared_tensors.key
+
+        dummy_layer._proj_and_transformer_layer = types.MethodType(projected_forward, dummy_layer)
+
+        hidden = [torch.randn(4, 1, 3, device="cuda", requires_grad=True) for _ in range(3)]
+        decoder = [torch.randn_like(value) for value in hidden]
+        shared = None
+        source_context = None
+        outputs = []
+        for iteration in range(3):
+            context = MTPDSAIterationContext(iteration, shared_tensors=shared)
+            if recompute_method == "block":
+                with pytest.warns(UserWarning, match="is not supported for MTP"):
+                    output = MultiTokenPredictionLayer._checkpointed_forward(
+                        dummy_layer,
+                        hidden_states=hidden[iteration],
+                        decoder_input=decoder[iteration],
+                        mtp_dsa_context=context,
+                    )
+            else:
+                output = MultiTokenPredictionLayer._checkpointed_forward(
+                    dummy_layer,
+                    hidden_states=hidden[iteration],
+                    decoder_input=decoder[iteration],
+                    mtp_dsa_context=context,
+                )
+            assert isinstance(output, torch.Tensor)
+            if context.is_source:
+                source_context = context
+                shared = context.require_source_tensors()
+            outputs.append(output)
+
+        source_shared = shared
+        assert source_shared is not None
+        source_key_ptr = source_shared.key.data_ptr()
+        sum(output.sum() for output in outputs).backward()
+
+        reference_scale = nn.Parameter(scale.detach().clone())
+        reference_hidden = [value.detach().clone().requires_grad_(True) for value in hidden]
+        source = (reference_hidden[0] + decoder[0]) * reference_scale
+        reference_outputs = [
+            (reference_hidden[0] + decoder[0]).square(),
+            reference_hidden[1] + decoder[1] + 3 * source,
+            reference_hidden[2] + decoder[2] + 3 * source,
+        ]
+        sum(output.sum() for output in reference_outputs).backward()
+
+        assert source_context is not None
+        assert source_context.require_source_tensors() is source_shared
+        assert source_shared.key.data_ptr() == source_key_ptr
+        assert source_shared.key.grad_fn is not None
+        torch.testing.assert_close(scale.grad, reference_scale.grad)
+        for actual, expected in zip(hidden, reference_hidden):
+            torch.testing.assert_close(actual.grad, expected.grad)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_mtp_block_passes_one_source_state_through_all_repeated_iterations():
+    observed = []
+    sequence_roll_context = object()
+
+    class FakeRepeatedLayer:
+        def __call__(
+            self,
+            input_ids,
+            position_ids,
+            hidden_states,
+            padding_mask=None,
+            sequence_roll_context=None,
+            roll_depth=0,
+            mtp_dsa_context=None,
+            **_kwargs,
+        ):
+            assert mtp_dsa_context is not None
+            observed.append(
+                (
+                    mtp_dsa_context.iteration,
+                    mtp_dsa_context.shared_tensors,
+                    sequence_roll_context,
+                    roll_depth,
+                )
+            )
+            if mtp_dsa_context.is_source:
+                topk = torch.zeros((1, hidden_states.size(0), 1), dtype=torch.int64)
+                mtp_dsa_context.capture(hidden_states * 2, topk, None)
+            return hidden_states + 1, input_ids, position_ids, padding_mask
+
+    block = SimpleNamespace(
+        config=SimpleNamespace(
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=7,
+            mtp_detach_heads=False,
+            dsa_mtp_index_kv_share=True,
+        ),
+        vp_stage=None,
+        mtp_use_repeated_layer=True,
+        layers=[FakeRepeatedLayer()],
+    )
+    hidden_states = torch.randn(4, 1, 3)
+    output = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=torch.arange(4).view(1, 4),
+        position_ids=torch.arange(4).view(1, 4),
+        hidden_states=hidden_states,
+        attention_mask=None,
+        sequence_roll_context=sequence_roll_context,
+    )
+
+    assert output.shape == (32, 1, 3)
+    assert [iteration for iteration, *_ in observed] == list(range(7))
+    source_state = observed[1][1]
+    assert source_state is not None
+    assert observed[0][1] is None
+    assert all(shared is source_state for _, shared, *_ in observed[1:])
+    assert all(context is sequence_roll_context for *_, context, _ in observed)
+    assert [roll_depth for *_, roll_depth in observed] == list(range(7))
+
+
+def test_mtp_block_preserves_legacy_layer_signature_when_sharing_is_disabled():
+    observed_depths = []
+
+    class LegacyRepeatedLayer:
+        def __call__(
+            self,
+            *,
+            input_ids,
+            position_ids,
+            hidden_states,
+            attention_mask,
+            padding_mask,
+            inference_params,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            packed_seq_params,
+            sequence_roll_context,
+            roll_depth,
+            sequence_len_offset,
+            embedding,
+        ):
+            observed_depths.append(roll_depth)
+            return hidden_states + 1, input_ids, position_ids, padding_mask
+
+    block = SimpleNamespace(
+        config=SimpleNamespace(
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=2,
+            mtp_detach_heads=False,
+            dsa_mtp_index_kv_share=False,
+        ),
+        vp_stage=None,
+        mtp_use_repeated_layer=True,
+        layers=[LegacyRepeatedLayer()],
+    )
+    hidden_states = torch.randn(4, 1, 3)
+    output = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=torch.arange(4).view(1, 4),
+        position_ids=torch.arange(4).view(1, 4),
+        hidden_states=hidden_states,
+        attention_mask=None,
+    )
+
+    assert output.shape == (12, 1, 3)
+    assert observed_depths == [0, 1]
+
+
+@pytest.mark.parametrize("full_recompute", [False, True])
+def test_real_mtp_block_threads_sharing_through_transformer_and_absorbed_dsa(
+    monkeypatch, full_recompute
+):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(5678)
+        torch.manual_seed(5678)
+        torch.cuda.manual_seed(5678)
+
+        recompute_overrides = {}
+        if full_recompute:
+            recompute_overrides = {
+                "recompute_granularity": "full",
+                "recompute_method": "uniform",
+                "recompute_num_layers": 1,
+            }
+        config = _make_config(**recompute_overrides)
+        decoder_layer_specs = get_transformer_layer_with_experimental_attention_variant_spec(
+            config=config, backend=TESpecProvider()
+        )
+        mtp_spec = get_gpt_mtp_block_spec(
+            config=config, spec=decoder_layer_specs[-1], use_transformer_engine=True
+        )
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_spec).bfloat16().cuda()
+        attention = mtp.layers[0].mtp_model_layer.self_attention
+
+        call_counts = {"q": 0, "kv": 0, "indexer": 0, "sparse": 0}
+        hooks = [
+            attention.linear_q_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("q", call_counts["q"] + 1)
+            ),
+            attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        total_tokens = 9
+        embedding = nn.Embedding(32, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+
+        def embed(input_ids, position_ids):
+            del position_ids
+            return embedding(input_ids).transpose(0, 1).contiguous()
+
+        input_ids = torch.arange(total_tokens, device="cuda").view(1, total_tokens)
+        position_ids = input_ids.clone()
+        hidden_states = torch.randn(
+            total_tokens,
+            1,
+            config.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        valid = _causal_segment_mask(total_tokens, None, device="cuda")
+        attention_mask = torch.zeros(
+            (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+        ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+
+        output = mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            embedding=embed,
+        )
+        output[total_tokens:].float().square().mean().backward()
+
+        assert output.shape == (total_tokens * (config.mtp_num_layers + 1), 1, config.hidden_size)
+        assert hidden_states.grad is not None and torch.isfinite(hidden_states.grad).all()
+        assert embedding.weight.grad is not None and torch.isfinite(embedding.weight.grad).all()
+        recompute_multiplier = 2 if full_recompute else 1
+        assert call_counts == {
+            "q": 7 * recompute_multiplier,
+            "kv": 1 * recompute_multiplier,
+            "indexer": 1 * recompute_multiplier,
+            "sparse": 7 * recompute_multiplier,
+        }
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_iteration_sharing.py
@@ -19,12 +19,17 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 )
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.pipeline_parallel.parallel_prewarm import _build_layer_inputs
 from megatron.core.tensor_parallel.random import (
     CheckpointWithoutOutput,
     model_parallel_cuda_manual_seed,
 )
 from megatron.core.transformer.enums import AttnBackend, AttnMaskType, CudaGraphModule
 from megatron.core.transformer.experimental_attention_variant import dsa as dsa_module
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+)
 from megatron.core.transformer.multi_token_prediction import (
     MTPDSAIterationContext,
     MultiTokenPredictionBlock,
@@ -124,6 +129,40 @@ def test_iteration_sharing_accepts_full_iteration_cuda_graph_scope():
     config = _make_config(cuda_graph_impl="full_iteration", cuda_graph_modules=[])
 
     assert config.cuda_graph_impl == "full_iteration"
+
+
+@pytest.mark.parametrize(("is_mtp", "sharing"), [(True, True), (True, False), (False, True)])
+def test_pipeline_prewarm_builds_source_context_only_for_shared_mtp(is_mtp, sharing):
+    hidden_states = torch.zeros(2, 1, 4)
+
+    class StaticInputLayer:
+        def get_layer_static_inputs(
+            self, seq_length, micro_batch_size, *, for_pipeline_prewarm=False
+        ):
+            assert (seq_length, micro_batch_size) == (2, 1)
+            assert for_pipeline_prewarm
+            return {"hidden_states": hidden_states}
+
+    args, kwargs = _build_layer_inputs(
+        StaticInputLayer(),
+        SimpleNamespace(position_embedding_type=None),
+        SimpleNamespace(dsa_mtp_index_kv_share=sharing, multi_latent_attention=True),
+        2,
+        1,
+        {},
+        {},
+        is_mtp=is_mtp,
+    )
+
+    assert args[0] is hidden_states
+    context = kwargs.pop("mtp_dsa_context", None)
+    assert (context is not None) == (is_mtp and sharing)
+    if context is not None:
+        assert isinstance(context, MTPDSAIterationContext)
+        assert context.iteration == 0
+        assert context.is_source and not context.reuses_source
+        assert context.produced_tensors is None
+    assert kwargs == {}
 
 
 def test_iteration_sharing_accepts_selective_mla_up_projection_recompute():
@@ -961,6 +1000,7 @@ def test_recompute_path_threads_shared_kv_through_iteration_context(recompute_me
                 recompute_method=recompute_method,
                 recompute_num_layers=1,
             ),
+            mtp_layer_pattern=None,
             scale=scale,
         )
 
@@ -1033,7 +1073,19 @@ def test_recompute_path_threads_shared_kv_through_iteration_context(recompute_me
 
 def test_mtp_block_passes_one_source_state_through_all_repeated_iterations():
     observed = []
-    sequence_roll_context = object()
+    input_ids = torch.arange(4).view(1, 4)
+    position_ids = torch.arange(4).view(1, 4)
+    sequence_roll_context = prepare_mtp_sequence_roll_context(
+        tensor=input_ids, cp_group=None, packed_seq_params=None
+    )
+    assert sequence_roll_context is not None
+    sequence_roll_context = sequence_roll_context.prepare_fields(
+        (
+            MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+            MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+        ),
+        max_offset=7,
+    )
 
     class FakeRepeatedLayer:
         def __call__(
@@ -1075,8 +1127,8 @@ def test_mtp_block_passes_one_source_state_through_all_repeated_iterations():
     hidden_states = torch.randn(4, 1, 3)
     output = MultiTokenPredictionBlock.forward(
         block,
-        input_ids=torch.arange(4).view(1, 4),
-        position_ids=torch.arange(4).view(1, 4),
+        input_ids=input_ids,
+        position_ids=position_ids,
         hidden_states=hidden_states,
         attention_mask=None,
         sequence_roll_context=sequence_roll_context,

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from megatron.core import config
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.moe.moe_layer import MoELayer
@@ -285,6 +286,25 @@ def test_te_whole_moe_paged_stash_requires_fixed_runtime_microbatch_count(cuda_g
     with pytest.raises(RuntimeError, match="expected 2, got 3"):
         runner._validate_te_whole_moe_graph_runtime(training=True, num_microbatches=3)
     runner._validate_te_whole_moe_graph_runtime(training=True, num_microbatches=2)
+
+
+def test_full_iteration_graph_replay_restores_paged_stash_enablement(monkeypatch):
+    runner = PagedStashRunner.__new__(PagedStashRunner)
+    runner.config = SimpleNamespace(moe_paged_stash=True)
+    runner.stash_manager = SimpleNamespace(enabled=False)
+    runner.forward_backward_func = object.__new__(FullCudaGraphWrapper)
+    monkeypatch.setitem(FullCudaGraphWrapper.cuda_graph, "training", object())
+    monkeypatch.setitem(FullCudaGraphWrapper.cuda_graph, "validation", object())
+
+    runner._restore_full_iteration_paged_stash_replay_state(training=True)
+    assert runner.stash_manager.enabled
+
+    runner._restore_full_iteration_paged_stash_replay_state(training=False)
+    assert not runner.stash_manager.enabled
+
+    runner.config.moe_paged_stash = False
+    runner._restore_full_iteration_paged_stash_replay_state(training=True)
+    assert not runner.stash_manager.enabled
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -281,6 +281,39 @@ class TestCudaGraphConfigAndArguments:
                 cuda_graph_impl='full_iteration', cuda_graph_modules=[CudaGraphModule.attn]
             )
 
+    def test_thd_full_iteration_cp_requires_eager_warmup(self):
+        with pytest.raises(
+            AssertionError,
+            match=(
+                "THD full-iteration CUDA graph with context parallelism requires "
+                "cuda_graph_warmup_steps > 0"
+            ),
+        ):
+            _base_cuda_graph_config(
+                cuda_graph_impl='full_iteration',
+                cuda_graph_modules=[],
+                cuda_graph_warmup_steps=0,
+                context_parallel_size=2,
+                sequence_packing_scheduler='dp_balanced',
+                pad_packed_seq_alignment='max',
+                max_seqlen_per_dp_cp_rank=64,
+                thd_max_packed_sequences=8,
+            )
+
+    def test_thd_full_iteration_cp1_allows_zero_warmup(self):
+        cfg = _base_cuda_graph_config(
+            cuda_graph_impl='full_iteration',
+            cuda_graph_modules=[],
+            cuda_graph_warmup_steps=0,
+            context_parallel_size=1,
+            sequence_packing_scheduler='dp_balanced',
+            pad_packed_seq_alignment='max',
+            max_seqlen_per_dp_cp_rank=64,
+            thd_max_packed_sequences=8,
+        )
+
+        assert cfg.thd_static_pp_communication
+
     def test_full_iteration_scope_string_in_config_migrated(self):
         with pytest.warns(DeprecationWarning, match="deprecated"):
             cfg = _base_cuda_graph_config(

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -4,6 +4,7 @@ import gc
 import os
 import sys
 from contextlib import nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -40,6 +41,9 @@ from megatron.core.transformer.cuda_graphs import (
     TECudaGraphHelper,
     _CudagraphGlobalRecord,
     _layer_is_graphable,
+    _prepare_dsa_metric_tracker_for_capture,
+    _restore_metric_tracker,
+    _snapshot_metric_tracker,
 )
 from megatron.core.transformer.enums import CudaGraphModule, CudaGraphScope, InferenceCudaGraphScope
 from megatron.core.transformer.mlp import MLPSubmodules
@@ -115,6 +119,134 @@ def _validated_cuda_graph_cli_args(monkeypatch, cli_args=None, **overrides):
 
 
 class TestCudaGraphConfigAndArguments:
+    def test_graph_capture_preallocates_pp_agreed_dsa_tracker(self, monkeypatch):
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossLoggingHelper,
+        )
+
+        class MetricModule(torch.nn.Module):
+            logs_dsa_indexer_loss = True
+
+            def __init__(self):
+                super().__init__()
+                self.layer_number = 5
+                self.config = SimpleNamespace(num_layers=2, mtp_num_layers=1)
+
+        model = torch.nn.Module()
+        model.add_module("metric", MetricModule())
+        pp_group = object()
+        calls = []
+        tracker = {"values": torch.zeros(2, device="cuda"), "agreed_size": 2}
+        monkeypatch.setattr(DSAIndexerLossLoggingHelper, "tracker", tracker)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+
+        def pp_max(tensor, op=None, group=None):
+            calls.append((op, group))
+            tensor.fill_(7)
+
+        monkeypatch.setattr(torch.distributed, "all_reduce", pp_max)
+
+        assert _prepare_dsa_metric_tracker_for_capture([model], pp_group) == 7
+        assert calls == [(torch.distributed.ReduceOp.MAX, pp_group)]
+        assert tracker["values"].shape == (7,)
+        assert tracker["agreed_size"] == 7
+        assert tracker["capture_prepared_size"] == 7
+
+        captured_storage = tracker["values"]
+        assert _prepare_dsa_metric_tracker_for_capture([model], pp_group) == 7
+        assert tracker["values"] is captured_storage
+        assert len(calls) == 1
+
+    def test_local_capture_restores_existing_metric_tracker_in_place(self):
+        reduce_group = object()
+        values = torch.tensor([3.0, 5.0])
+        tracker = {"values": values, "reduce_group": reduce_group, "agreed_size": 2}
+        snapshot = _snapshot_metric_tracker(tracker)
+
+        tracker["values"].add_(7.0)
+        tracker["reduce_group"] = object()
+        tracker["capture_only"] = True
+        _restore_metric_tracker(tracker, snapshot)
+
+        assert tracker["values"] is values
+        torch.testing.assert_close(values, torch.tensor([3.0, 5.0]))
+        assert tracker["reduce_group"] is reduce_group
+        assert tracker["agreed_size"] == 2
+        assert "capture_only" not in tracker
+
+    def test_local_capture_zeros_new_metric_tracker_storage(self):
+        tracker = {}
+        snapshot = _snapshot_metric_tracker(tracker)
+
+        values = torch.tensor([7.0, 11.0])
+        avg_group = object()
+        tracker.update({"values": values, "avg_group": avg_group})
+        _restore_metric_tracker(tracker, snapshot)
+
+        assert tracker["values"] is values
+        torch.testing.assert_close(values, torch.zeros(2))
+        assert tracker["avg_group"] is avg_group
+
+    def test_reset_after_capture_cleans_dsa_loss_tracker(self, monkeypatch):
+        from importlib import import_module
+
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossLoggingHelper,
+        )
+        from megatron.core.transformer.moe import moe_logging
+
+        finalize_model_grads_module = import_module(
+            "megatron.core.distributed.finalize_model_grads"
+        )
+
+        reduce_group = object()
+        avg_group = object()
+        values = torch.tensor([7.0, 11.0])
+        dsa_tracker = {
+            'values': values,
+            'reduce_group': reduce_group,
+            'avg_group': avg_group,
+            'agreed_size': 2,
+        }
+        calls = []
+
+        class FakeModelChunk:
+            @staticmethod
+            def zero_grad_buffer():
+                calls.append('zero_grad_buffer')
+
+        class FakeOptimizer:
+            @staticmethod
+            def zero_grad():
+                calls.append('zero_grad')
+
+        helper = object.__new__(TECudaGraphHelper)
+        helper.model = [FakeModelChunk()]
+        helper.optimizers = [FakeOptimizer()]
+        helper.config = SimpleNamespace()
+
+        monkeypatch.setattr(DSAIndexerLossLoggingHelper, 'tracker', dsa_tracker)
+        monkeypatch.setattr(
+            moe_logging,
+            'get_moe_metrics_tracker',
+            lambda: SimpleNamespace(clear=lambda: calls.append('clear_moe_tracker')),
+        )
+        monkeypatch.setattr(
+            finalize_model_grads_module,
+            'reset_model_temporary_tensors',
+            lambda config, model: calls.append(('reset_model_temporary_tensors', config, model)),
+        )
+
+        helper._reset_after_capture()
+
+        assert calls[:3] == ['zero_grad_buffer', 'zero_grad', 'clear_moe_tracker']
+        assert calls[3] == ('reset_model_temporary_tensors', helper.config, helper.model)
+        assert dsa_tracker['values'] is values
+        assert torch.equal(dsa_tracker['values'], torch.zeros(2))
+        assert dsa_tracker['reduce_group'] is reduce_group
+        assert dsa_tracker['avg_group'] is avg_group
+        assert dsa_tracker['agreed_size'] == 2
+
     def test_local_impl_defaults_to_layer_scope(self):
         cfg = _base_cuda_graph_config(cuda_graph_impl='local')
         assert cfg.inference_cuda_graph_scope == InferenceCudaGraphScope.layer

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -28,6 +28,7 @@ from megatron.core.num_microbatches_calculator import (
     destroy_num_microbatches_calculator,
     init_num_microbatches_calculator,
 )
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.schedules import set_current_microbatch
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
@@ -49,6 +50,7 @@ from megatron.core.transformer.enums import CudaGraphModule, CudaGraphScope, Inf
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
 from megatron.core.transformer.moe.fused_a2a import reset_hybrid_ep_buffer
+from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler
 from megatron.core.transformer.spec_utils import ModuleSpec, get_submodules
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1973,6 +1975,145 @@ class TestPartialCudaGraph:
             self.cuda_graph_helper = None
 
         return torch.tensor(loss_list)
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("2.10.0")),
+        reason="Partial CUDA graph UT support requires TransformerEngine version >= 2.10.0",
+    )
+    def test_mtp_thd_partial_cudagraph_replay_changed_boundaries(self):
+        """TE partial replay refreshes same-shape THD boundaries for prepared MTP rows."""
+        self.seq_length = 32
+        self.micro_batch_size = 1
+        self.tp_size = 1
+        self.cp_size = 1
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, context_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        boundaries_per_step = ([0, 8, 16, 32], [0, 4, 16, 32], [0, 8, 16, 32])
+
+        def position_ids_for(boundaries):
+            position_ids = torch.empty(self.seq_length, dtype=torch.int64, device="cuda")
+            for start, end in zip(boundaries, boundaries[1:]):
+                position_ids[start:end] = torch.arange(end - start, device="cuda")
+            return position_ids.unsqueeze(0)
+
+        def run(cuda_graph_impl):
+            args = self.create_test_args(
+                cuda_graph_impl,
+                [CudaGraphModule.attn] if cuda_graph_impl == "transformer_engine" else None,
+                0,
+                1,
+                global_batch_size=torch.distributed.get_world_size(),
+                max_position_embeddings=32,
+                max_seqlen_per_dp_cp_rank=32,
+                mtp_num_layers=3,
+                fp8=None,
+                first_last_layers_bf16=False,
+                create_attention_mask_in_dataloader=False,
+                sequence_packing_scheduler="dp_balanced",
+                moe_token_dispatcher_type="alltoall",
+                pad_packed_seq_alignment="max",
+                thd_max_packed_sequences=3,
+                transformer_impl="transformer_engine",
+            )
+            set_args(args)
+            torch.manual_seed(123)
+            model_parallel_cuda_manual_seed(123)
+            input_ids = torch.arange(self.seq_length, dtype=torch.int64, device="cuda").unsqueeze(0)
+            labels = (input_ids + 1).clone()
+            loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+            padding_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+            gpt_model, optimizer, _ = setup_model_and_optimizer(
+                ModelType.encoder_or_decoder, self.model_provider
+            )
+            assert len(gpt_model) == 1
+            MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+
+            if cuda_graph_impl == "transformer_engine":
+                self.cuda_graph_helper = TECudaGraphHelper(
+                    model=gpt_model,
+                    config=gpt_model[0].config,
+                    seq_length=self.seq_length,
+                    micro_batch_size=self.micro_batch_size,
+                    optimizers=[optimizer],
+                )
+                self.cuda_graph_helper.create_cudagraphs()
+                assert self.cuda_graph_helper.graphs_created()
+
+            named_parameters = tuple(gpt_model[0].named_parameters())
+            mtp_grad_parameters = [
+                next(
+                    param
+                    for name, param in named_parameters
+                    if f"mtp.layers.{depth}." in name and param.requires_grad
+                )
+                for depth in range(3)
+            ]
+            results = []
+            for boundaries in boundaries_per_step:
+                gpt_model[0].zero_grad_buffer()
+                optimizer.zero_grad()
+                set_current_microbatch(gpt_model[0], 0)
+                gpt_model[0].set_is_first_microbatch()
+                cu_seqlens = torch.tensor(boundaries, dtype=torch.int32, device="cuda")
+                packed_seq_params = PackedSeqParams(
+                    qkv_format="thd",
+                    cu_seqlens_q=cu_seqlens.clone(),
+                    cu_seqlens_kv=cu_seqlens.clone(),
+                    cu_seqlens_q_padded=cu_seqlens.clone(),
+                    cu_seqlens_kv_padded=cu_seqlens.clone(),
+                    max_seqlen_q=32,
+                    max_seqlen_kv=32,
+                    pad_between_seqs=True,
+                )
+                output = gpt_model[0].forward(
+                    input_ids=input_ids,
+                    position_ids=position_ids_for(boundaries),
+                    attention_mask=None,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                    padding_mask=padding_mask,
+                    packed_seq_params=packed_seq_params,
+                )
+                loss = output.mean()
+                loss.backward()
+                assert all(param.main_grad is not None for param in mtp_grad_parameters)
+                results.append(
+                    (
+                        output.detach().cpu().clone(),
+                        loss.detach().cpu().clone(),
+                        tuple(
+                            param.main_grad.detach().cpu().clone() for param in mtp_grad_parameters
+                        ),
+                    )
+                )
+
+            if self.cuda_graph_helper is not None and self.cuda_graph_helper.graphs_created():
+                self.cuda_graph_helper.delete_cuda_graphs()
+                self.cuda_graph_helper = None
+            return results
+
+        try:
+            eager_results = run("none")
+            graph_results = run("transformer_engine")
+            for eager, graph in zip(eager_results, graph_results):
+                for eager_value, graph_value in zip(eager[:2], graph[:2]):
+                    assert torch.equal(graph_value, eager_value)
+                for eager_grad, graph_grad in zip(eager[2], graph[2], strict=True):
+                    assert torch.equal(graph_grad, eager_grad)
+            for results in (eager_results, graph_results):
+                assert torch.equal(results[0][0], results[2][0])
+                assert not torch.equal(results[0][0], results[1][0])
+                for depth in range(3):
+                    assert torch.equal(results[0][2][depth], results[2][2][depth])
+                    assert not torch.equal(results[0][2][depth], results[1][2][depth])
+                    assert results[0][2][depth].ne(0).any()
+        finally:
+            if self.cuda_graph_helper is not None and self.cuda_graph_helper.graphs_created():
+                self.cuda_graph_helper.delete_cuda_graphs()
+                self.cuda_graph_helper = None
+            Utils.destroy_model_parallel()
 
     @pytest.mark.flaky
     @pytest.mark.flaky_in_dev

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -366,6 +366,20 @@ class TestCudaGraphConfigAndArguments:
                 cuda_graph_modules=cuda_graph_modules, cuda_graph_warmup_steps=warmup_steps
             )
 
+    def test_full_iteration_paged_stash_requires_two_warmup_steps(self):
+        kwargs = dict(
+            cuda_graph_impl="full_iteration",
+            cuda_graph_modules=[],
+            moe_expert_capacity_factor=1.0,
+            moe_pad_expert_input_to_capacity=True,
+        )
+        for warmup_steps in (0, 1):
+            with pytest.raises(AssertionError, match="at least two eager warmup steps"):
+                _te_whole_moe_paged_stash_config(cuda_graph_warmup_steps=warmup_steps, **kwargs)
+
+        config = _te_whole_moe_paged_stash_config(cuda_graph_warmup_steps=2, **kwargs)
+        assert config.cuda_graph_warmup_steps == 2
+
     @pytest.mark.parametrize(
         "cuda_graph_modules", [[CudaGraphModule.moe], []], ids=["explicit-moe", "full-layer"]
     )
@@ -447,6 +461,93 @@ class TestCudaGraphConfigAndArguments:
         )
 
         assert cfg.thd_static_pp_communication
+
+    def test_thd_full_iteration_dynamic_cp_requires_static_certificate_opt_in(self):
+        with pytest.raises(AssertionError, match="requires --cuda-graph-static-dynamic-cp"):
+            _base_cuda_graph_config(
+                cuda_graph_impl='full_iteration',
+                cuda_graph_modules=[],
+                cuda_graph_warmup_steps=1,
+                context_parallel_size=2,
+                dynamic_context_parallel=True,
+                sequence_packing_scheduler='default_dynamic_cp',
+                pad_packed_seq_alignment='max',
+                max_seqlen_per_dp_cp_rank=64,
+                thd_max_packed_sequences=8,
+            )
+
+    def test_thd_full_iteration_dynamic_cp_allows_static_certificate_path(self):
+        cfg = _base_cuda_graph_config(
+            cuda_graph_impl='full_iteration',
+            cuda_graph_modules=[],
+            cuda_graph_warmup_steps=1,
+            context_parallel_size=2,
+            dynamic_context_parallel=True,
+            sequence_packing_scheduler='default_dynamic_cp',
+            cuda_graph_static_dynamic_cp=True,
+            pad_packed_seq_alignment='max',
+            max_seqlen_per_dp_cp_rank=64,
+            thd_max_packed_sequences=8,
+        )
+
+        assert cfg.dynamic_context_parallel
+        assert cfg.cuda_graph_static_dynamic_cp
+        assert cfg.thd_static_pp_communication
+
+    def test_thd_full_iteration_static_dynamic_cp_flag_requires_dynamic_cp(self):
+        with pytest.raises(AssertionError, match="requires --dynamic-context-parallel"):
+            _base_cuda_graph_config(
+                cuda_graph_impl='full_iteration',
+                cuda_graph_modules=[],
+                cuda_graph_warmup_steps=1,
+                sequence_packing_scheduler='dp_balanced',
+                cuda_graph_static_dynamic_cp=True,
+                pad_packed_seq_alignment='max',
+                max_seqlen_per_dp_cp_rank=64,
+                thd_max_packed_sequences=8,
+            )
+
+    def test_static_dynamic_cp_flag_requires_default_dynamic_cp_scheduler(self):
+        # ModelParallelConfig owns the dynamic-CP scheduler contract and runs
+        # before the full-iteration-specific validation below.
+        with pytest.raises(
+            ValueError,
+            match="Dynamic context parallelism requires sequence_packing_scheduler=default_dynamic_cp",
+        ):
+            _base_cuda_graph_config(
+                cuda_graph_impl='full_iteration',
+                cuda_graph_modules=[],
+                cuda_graph_warmup_steps=1,
+                context_parallel_size=2,
+                dynamic_context_parallel=True,
+                sequence_packing_scheduler='dp_balanced',
+                cuda_graph_static_dynamic_cp=True,
+                pad_packed_seq_alignment='max',
+                max_seqlen_per_dp_cp_rank=64,
+                thd_max_packed_sequences=8,
+            )
+
+    @pytest.mark.parametrize('cuda_graph_impl', ['none', 'local'])
+    def test_static_dynamic_cp_flag_rejects_non_full_iteration_impl(self, cuda_graph_impl):
+        with pytest.raises(
+            AssertionError, match="only valid with cuda_graph_impl='full_iteration'"
+        ):
+            _base_cuda_graph_config(
+                cuda_graph_impl=cuda_graph_impl,
+                cuda_graph_modules=[],
+                context_parallel_size=2,
+                dynamic_context_parallel=True,
+                sequence_packing_scheduler='default_dynamic_cp',
+                cuda_graph_static_dynamic_cp=True,
+                pad_packed_seq_alignment='max',
+                max_seqlen_per_dp_cp_rank=64,
+                thd_max_packed_sequences=8,
+            )
+
+    def test_static_dynamic_cp_cli_is_explicit_opt_in(self, monkeypatch):
+        monkeypatch.setattr(sys, 'argv', ['test_cuda_graphs.py', '--cuda-graph-static-dynamic-cp'])
+        args = parse_args()
+        assert args.cuda_graph_static_dynamic_cp
 
     def test_full_iteration_scope_string_in_config_migrated(self):
         with pytest.warns(DeprecationWarning, match="deprecated"):

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -204,6 +204,112 @@ def test_full_cuda_graph_capture_counts_dsa_metric_once():
     not (HAVE_TE and is_te_min_version("1.5.0")),
     reason="full-iteration MTP test requires TransformerEngine RNG tracking",
 )
+def test_repeated_mtp_bshd_training_with_full_cuda_graph():
+    """Capture and replay a full iteration with one MTP layer repeated to depth three."""
+    from megatron.core.pipeline_parallel import get_forward_backward_func
+
+    initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)
+    model_parallel_cuda_manual_seed(123)
+
+    sequence_length = 16
+    micro_batch_size = 1
+    vocab_size = 128
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=64,
+        ffn_hidden_size=128,
+        num_attention_heads=4,
+        mtp_num_layers=3,
+        mtp_use_repeated_layer=True,
+        mtp_loss_scaling_factor=0.1,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        cuda_graph_impl="full_iteration",
+        cuda_graph_modules=[],
+    )
+    layer_spec = get_gpt_layer_with_transformer_engine_spec()
+    mtp_block_spec = get_gpt_mtp_block_spec(
+        config=config, spec=layer_spec, use_transformer_engine=True
+    )
+    model = GPTModel(
+        config=config,
+        transformer_layer_spec=layer_spec,
+        mtp_block_spec=mtp_block_spec,
+        vocab_size=vocab_size,
+        max_sequence_length=sequence_length,
+        position_embedding_type="rope",
+    ).cuda()
+    model.train()
+    assert model.mtp_process
+
+    tokens = torch.arange(sequence_length, dtype=torch.int64).repeat(micro_batch_size, 1)
+    batch = {
+        'tokens': tokens,
+        'labels': (tokens + 1) % vocab_size,
+        'loss_mask': torch.ones_like(tokens, dtype=torch.float32),
+        'position_ids': torch.arange(sequence_length, dtype=torch.int64).repeat(
+            micro_batch_size, 1
+        ),
+    }
+
+    def forward_step_func(data_iterator, model):
+        microbatch = next(data_iterator)
+        output = model(
+            input_ids=microbatch['tokens'],
+            position_ids=microbatch['position_ids'],
+            attention_mask=None,
+            labels=microbatch['labels'],
+            loss_mask=microbatch['loss_mask'],
+            packed_seq_params=None,
+        )
+
+        def loss_func(output_tensor):
+            loss_mask = microbatch['loss_mask']
+            loss = (output_tensor.float() * loss_mask).sum() / loss_mask.sum()
+            return loss, {'lm loss': loss.detach()}
+
+        return output, loss_func
+
+    forward_backward_func = FullCudaGraphWrapper(
+        get_forward_backward_func(), cuda_graph_warmup_steps=1
+    )
+    losses = []
+    for _ in range(3):
+        model.zero_grad(set_to_none=False)
+        reduced = forward_backward_func(
+            forward_step_func=forward_step_func,
+            data_iterator=[iter([batch])],
+            model=[model],
+            num_microbatches=1,
+            seq_length=sequence_length,
+            micro_batch_size=micro_batch_size,
+            forward_only=False,
+        )
+        assert len(reduced) == 1
+        losses.append(reduced[0]['lm loss'].detach().clone())
+
+    assert FullCudaGraphWrapper.cuda_graph['training'] is not None
+    assert all(torch.isfinite(loss) for loss in losses)
+    torch.testing.assert_close(losses[1], losses[0], rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(losses[2], losses[0], rtol=1e-3, atol=1e-3)
+
+    mtp_grads = [
+        parameter.grad for parameter in model.mtp.parameters() if parameter.grad is not None
+    ]
+    assert mtp_grads
+    assert all(torch.isfinite(grad).all() for grad in mtp_grads)
+    assert any(torch.count_nonzero(grad).item() > 0 for grad in mtp_grads)
+
+
+@pytest.mark.skipif(
+    not (HAVE_TE and is_te_min_version("1.5.0")),
+    reason="full-iteration MTP test requires TransformerEngine RNG tracking",
+)
 def test_mtp_bshd_training_with_full_cuda_graph():
     """Capture and replay a full forward-backward iteration containing MTP BSHD rolls."""
     from megatron.core.pipeline_parallel import get_forward_backward_func

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -20,6 +20,7 @@ from megatron.core.tensor_parallel.random import (
     initialize_rng_tracker,
     model_parallel_cuda_manual_seed,
 )
+from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
@@ -38,11 +39,13 @@ def reset_full_cuda_graph_state():
     """Keep the full-iteration wrapper's class state isolated per test."""
     _reset_full_cuda_graph_state()
     MTPLossLoggingHelper.tracker = {}
+    DSAIndexerLossLoggingHelper.tracker = {}
     yield
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     _reset_full_cuda_graph_state()
     MTPLossLoggingHelper.tracker = {}
+    DSAIndexerLossLoggingHelper.tracker = {}
     Utils.destroy_model_parallel()
     gc.collect()
 
@@ -157,6 +160,44 @@ def test_forward_backward_func_with_full_cuda_graph(mocker):
         print(losses_reduced)
         assert i['loss_reduced'] == j['loss_reduced']
     Utils.destroy_model_parallel()
+
+
+def test_full_cuda_graph_capture_counts_dsa_metric_once():
+    """Discard capture-time DSA metric writes before replaying the real iteration."""
+    initialize_rng_tracker(force_reset=True)
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)
+
+    values = torch.zeros(1, device="cuda")
+    DSAIndexerLossLoggingHelper.tracker = {
+        "values": values,
+        "reduce_group": None,
+        "avg_group": None,
+    }
+    reduce_group = object()
+    avg_group = object()
+
+    def forward_backward_func(**kwargs):
+        del kwargs
+        DSAIndexerLossLoggingHelper.tracker["reduce_group"] = reduce_group
+        DSAIndexerLossLoggingHelper.tracker["avg_group"] = avg_group
+        DSAIndexerLossLoggingHelper.tracker["values"].add_(1.0)
+        return [DSAIndexerLossLoggingHelper.tracker["values"]]
+
+    model = torch.nn.Linear(1, 1).cuda()
+    wrapped = FullCudaGraphWrapper(forward_backward_func, cuda_graph_warmup_steps=0)
+    result = wrapped(
+        data_iterator=[iter([{"tokens": torch.ones(1)}])],
+        model=[model],
+        num_microbatches=1,
+        seq_length=1,
+        forward_only=True,
+    )
+
+    assert DSAIndexerLossLoggingHelper.tracker["values"] is values
+    torch.testing.assert_close(values, torch.ones_like(values))
+    torch.testing.assert_close(result[0], torch.ones_like(result[0]))
+    assert DSAIndexerLossLoggingHelper.tracker["reduce_group"] is reduce_group
+    assert DSAIndexerLossLoggingHelper.tracker["avg_group"] is avg_group
 
 
 @pytest.mark.skipif(

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -9,7 +9,7 @@ from pytest_mock import mocker
 
 import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core import ModelParallelConfig
-from megatron.core.full_cuda_graph import FullCudaGraphWrapper, StaticBufferLoader
+from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
     get_gpt_mtp_block_spec,
@@ -30,10 +30,7 @@ rank = Utils.rank
 
 def _reset_full_cuda_graph_state():
     """Drop process-global graph inputs and outputs between unit tests."""
-    FullCudaGraphWrapper.curr_iteration = {'training': 0, 'validation': 0}
-    FullCudaGraphWrapper.cuda_graph = {'training': None, 'validation': None}
-    FullCudaGraphWrapper.result = {'training': None, 'validation': None}
-    StaticBufferLoader.static_buffers = {'training': [], 'validation': []}
+    FullCudaGraphWrapper.reset_cuda_graph()
 
 
 @pytest.fixture(autouse=True)
@@ -282,7 +279,7 @@ def test_full_cuda_graph_training_with_mhc_recompute():
     recompute, and storage rebind captured inside the graph replay correctly.
     """
     from megatron.core.enums import ModelType
-    from megatron.core.full_cuda_graph import StaticBufferLoader, get_shared_capture_stream
+    from megatron.core.full_cuda_graph import get_shared_capture_stream
     from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
     from megatron.core.models.gpt.gpt_model import GPTModel
     from megatron.core.pipeline_parallel import get_forward_backward_func
@@ -296,10 +293,7 @@ def test_full_cuda_graph_training_with_mhc_recompute():
     Utils.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)
 
     def reset_wrapper_state():
-        FullCudaGraphWrapper.cuda_graph = {'training': None, 'validation': None}
-        FullCudaGraphWrapper.result = {'training': None, 'validation': None}
-        FullCudaGraphWrapper.curr_iteration = {'training': 0, 'validation': 0}
-        StaticBufferLoader.static_buffers = {'training': [], 'validation': []}
+        FullCudaGraphWrapper.reset_cuda_graph()
 
     def build_model():
         model_parallel_cuda_manual_seed(123, te_rng_tracker=True, force_reset_rng=True)
@@ -429,9 +423,5 @@ def test_full_cuda_graph_training_with_mhc_recompute():
                 compared += 1
         assert compared > 0, "no gradients were compared"
     finally:
-        try:
-            FullCudaGraphWrapper.cuda_graph['training'] = None
-            FullCudaGraphWrapper.cuda_graph['validation'] = None
-        finally:
-            reset_wrapper_state()
-            Utils.destroy_model_parallel()
+        reset_wrapper_state()
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_full_cuda_graph_distributed_consensus.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph_distributed_consensus.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Real-NCCL protocol tests for full-iteration CUDA graph consensus.
+
+Run this module through ``torchrun`` with at least two local GPUs.  These tests
+deliberately use the WORLD process group for the wrapper's safety collectives;
+rank-local mocks cannot detect mismatched collective selection or asymmetric
+failure behavior.
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.datasets.data_schedule import _build_thd_full_iteration_dynamic_cp_signature
+from megatron.core.full_cuda_graph import (
+    FULL_CUDA_GRAPH_STATIC_METADATA_KEY,
+    FullCudaGraphWrapper,
+    StaticBufferLoader,
+)
+from megatron.core.packed_seq_params import PackedSeqParams
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+    pytest.mark.skipif(Utils.world_size < 2, reason="requires torchrun with at least two ranks"),
+    pytest.mark.timeout(60),
+]
+
+
+@pytest.fixture(autouse=True)
+def _distributed_wrapper_state():
+    """Keep every test/rank at the same process-group and wrapper lifecycle."""
+    Utils.initialize_distributed()
+    torch.distributed.barrier()
+    FullCudaGraphWrapper.reset_cuda_graph()
+    yield
+    torch.distributed.barrier()
+    FullCudaGraphWrapper.reset_cuda_graph()
+    torch.distributed.barrier()
+
+
+@dataclass
+class _CallCounts:
+    data_read: int = 0
+    forward: int = 0
+
+
+class _CountingWrapper(FullCudaGraphWrapper):
+    """Minimal wrapper probe whose eager body contains no distributed work."""
+
+    def __init__(self, *, batch_supplier=None):
+        self.counts = _CallCounts()
+        self._batch_supplier = batch_supplier
+        super().__init__(
+            self._forward_backward,
+            cuda_graph_warmup_steps=100,
+            batch_preparation_fn=(None if batch_supplier is None else self._prepare_batch),
+            require_global_static_metadata_consensus=True,
+        )
+
+    def _prepare_batch(self, data_iterator, vp_stage):
+        return self._batch_supplier()
+
+    def data_read(self, data_iterator, model, training, num_microbatches):
+        self.counts.data_read += 1
+        return super().data_read(data_iterator, model, training, num_microbatches)
+
+    def _forward_backward(self, **kwargs):
+        self.counts.forward += 1
+        return torch.ones((), device=torch.cuda.current_device())
+
+
+def _call_kwargs(*, num_microbatches=1, forward_only=False):
+    return {
+        'model': torch.nn.Identity().cuda(),
+        'data_iterator': None,
+        'num_microbatches': num_microbatches,
+        'seq_length': 64,
+        'micro_batch_size': 1,
+        'forward_only': forward_only,
+    }
+
+
+def _capture_signature(*, num_microbatches=1):
+    return {
+        'num_microbatches': num_microbatches,
+        'num_model_chunks': 1,
+        'seq_length': 64,
+        'micro_batch_size': 1,
+        'decoder_seq_length': None,
+    }
+
+
+def _invoke(call):
+    try:
+        return call(), None
+    except Exception as exc:  # The collective outcome is asserted on every rank below.
+        return None, exc
+
+
+def _gather_ints(*values):
+    local = torch.tensor(values, dtype=torch.int64, device=torch.cuda.current_device())
+    world_size = torch.distributed.get_world_size()
+    gathered = torch.empty(world_size * local.numel(), dtype=local.dtype, device=local.device)
+    torch.distributed.all_gather_into_tensor(gathered, local)
+    return gathered.view(world_size, local.numel()).cpu()
+
+
+def _assert_collective_rejection(error, wrapper, *, message, expected_data_reads, stage='training'):
+    outcomes = _gather_ints(
+        isinstance(error, RuntimeError),
+        message in str(error),
+        wrapper.counts.data_read,
+        wrapper.counts.forward,
+        len(StaticBufferLoader.static_buffers[stage]),
+        FullCudaGraphWrapper.curr_iteration[stage],
+        wrapper.static_loader.batch_stage is None,
+        wrapper.static_loader.batch_start_length is None,
+        not wrapper.static_loader.batch_dynamic_cp_metadata,
+    )
+    assert torch.all(outcomes[:, 0] == 1), str(error)
+    assert torch.all(outcomes[:, 1] == 1), str(error)
+    assert torch.all(outcomes[:, 2] == expected_data_reads), outcomes
+    assert torch.all(outcomes[:, 3:] == torch.tensor([0, 0, 0, 1, 1, 1])), outcomes
+
+
+def _dynamic_cp_batch(cp_group, local_cp_size):
+    params = PackedSeqParams(
+        qkv_format='thd', local_cp_size=local_cp_size, cp_group=cp_group, cp_partition_mode='zigzag'
+    )
+    return {
+        'tokens': torch.tensor(
+            [torch.distributed.get_rank()], dtype=torch.int64, device=torch.cuda.current_device()
+        ),
+        FULL_CUDA_GRAPH_STATIC_METADATA_KEY: {
+            'thd_dynamic_cp': _build_thd_full_iteration_dynamic_cp_signature(
+                params, config=SimpleNamespace(mtp_num_layers=0)
+            )
+        },
+    }
+
+
+def test_rank_zero_only_current_signature_mismatch_fails_before_data_read():
+    """One rank changing N cannot leave peers entering batch preparation."""
+    rank = torch.distributed.get_rank()
+    wrapper = _CountingWrapper()
+
+    _, error = _invoke(lambda: wrapper(**_call_kwargs(num_microbatches=2 if rank == 0 else 1)))
+
+    _assert_collective_rejection(
+        error, wrapper, message='before reading data, capture, or replay', expected_data_reads=0
+    )
+
+
+def test_stage_mismatch_fails_before_data_read():
+    """Training/validation disagreement is part of the WORLD signature."""
+    rank = torch.distributed.get_rank()
+    wrapper = _CountingWrapper()
+
+    _, error = _invoke(lambda: wrapper(**_call_kwargs(forward_only=(rank != 0))))
+
+    # The local stage differs, so inspect both stage-local state vectors rather
+    # than assuming every process indexed the training dictionaries.
+    local_stage = 'training' if rank == 0 else 'validation'
+    _assert_collective_rejection(
+        error,
+        wrapper,
+        message='before reading data, capture, or replay',
+        expected_data_reads=0,
+        stage=local_stage,
+    )
+
+
+def test_rank_zero_only_captured_signature_mismatch_fails_before_data_read():
+    """A stale captured signature on one rank must reject the whole WORLD."""
+    rank = torch.distributed.get_rank()
+    wrapper = _CountingWrapper()
+    FullCudaGraphWrapper.capture_signature['training'] = _capture_signature(
+        num_microbatches=2 if rank == 0 else 1
+    )
+
+    _, error = _invoke(lambda: wrapper(**_call_kwargs(num_microbatches=1)))
+
+    _assert_collective_rejection(
+        error, wrapper, message='before reading data, capture, or replay', expected_data_reads=0
+    )
+
+
+def test_first_batch_rejects_incoherent_dynamic_cp_topology():
+    """Overlapping, non-reciprocal DCP memberships fail before eager forward."""
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    # All ranks must create subgroups in the same order.  Only rank zero uses
+    # this singleton; peers report WORLD, creating an incoherent overlap.
+    singleton = torch.distributed.new_group(ranks=[0], backend='nccl')
+    cp_group = singleton if rank == 0 else torch.distributed.group.WORLD
+    local_cp_size = 1 if rank == 0 else world_size
+    batch = _dynamic_cp_batch(cp_group, local_cp_size)
+    wrapper = _CountingWrapper(batch_supplier=lambda: batch)
+
+    _, error = _invoke(lambda: wrapper(**_call_kwargs()))
+
+    _assert_collective_rejection(
+        error, wrapper, message='before capture or replay', expected_data_reads=1
+    )
+
+
+def test_invalid_first_batch_rolls_back_then_valid_retry_succeeds():
+    """A rejected first slot must not poison the next valid static batch."""
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    current = {
+        'batch': _dynamic_cp_batch(torch.distributed.group.WORLD, 1 if rank == 0 else world_size)
+    }
+    wrapper = _CountingWrapper(batch_supplier=lambda: current['batch'])
+
+    _, first_error = _invoke(lambda: wrapper(**_call_kwargs()))
+    _assert_collective_rejection(
+        first_error, wrapper, message='before capture or replay', expected_data_reads=1
+    )
+
+    torch.distributed.barrier()
+    current['batch'] = _dynamic_cp_batch(torch.distributed.group.WORLD, world_size)
+    _, retry_error = _invoke(lambda: wrapper(**_call_kwargs()))
+
+    outcomes = _gather_ints(
+        retry_error is None,
+        wrapper.counts.data_read,
+        wrapper.counts.forward,
+        len(StaticBufferLoader.static_buffers['training']),
+        FullCudaGraphWrapper.curr_iteration['training'],
+        wrapper.static_loader.batch_stage is None,
+        wrapper.static_loader.batch_start_length is None,
+        not wrapper.static_loader.batch_dynamic_cp_metadata,
+    )
+    assert torch.all(outcomes == torch.tensor([1, 2, 1, 1, 1, 1, 1, 1])), (retry_error, outcomes)

--- a/tests/unit_tests/transformer/test_mtp_sequence_roll.py
+++ b/tests/unit_tests/transformer/test_mtp_sequence_roll.py
@@ -1203,7 +1203,10 @@ class TestContiguousPackedCPPreparedRollRowsDistributed:
 
         def run(sequence_roll_context, sequence_roll_padding_mask=None):
             config = SimpleNamespace(
-                pipeline_model_parallel_size=1, mtp_num_layers=num_depths, mtp_detach_heads=False
+                pipeline_model_parallel_size=1,
+                mtp_num_layers=num_depths,
+                mtp_detach_heads=False,
+                dsa_mtp_index_kv_share=False,
             )
             block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
             torch.nn.Module.__init__(block)
@@ -1428,6 +1431,7 @@ def test_mtp_block_scatters_only_prepared_global_padding_masks(
         mtp_num_layers=1,
         mtp_detach_heads=False,
         sequence_parallel=sequence_parallel,
+        dsa_mtp_index_kv_share=False,
     )
     block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
     torch.nn.Module.__init__(block)

--- a/tests/unit_tests/transformer/test_mtp_sequence_roll.py
+++ b/tests/unit_tests/transformer/test_mtp_sequence_roll.py
@@ -1,0 +1,1469 @@
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.packed_seq_params import PackedSeqParams, pad_sequence_for_thd
+from megatron.core.parallel_state import get_context_parallel_group
+from megatron.core.transformer import mtp_sequence_roll
+from megatron.core.transformer import multi_token_prediction as multi_token_prediction_module
+from megatron.core.transformer.mtp_sequence_roll import (
+    ContiguousPackedCPRollContext,
+    ContiguousPackedCPRollHalos,
+    ContiguousPackedSeqRollPlan,
+    LocalRollContext,
+    MTPSequenceRollField,
+    ZigzagPackedCPRollContext,
+    prepare_mtp_sequence_roll_context,
+    prepare_mtp_sequence_roll_fields,
+    roll_tensor,
+)
+from megatron.core.transformer.multi_token_prediction import (
+    MultiTokenPredictionBlock,
+    process_mtp_loss,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.launch_on_gb200
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "MTPSequenceRollHalos",
+        "ContiguousPackedCPRollHalos",
+        "MTPSequenceRollContext",
+        "ContiguousPackedSeqRollPlan",
+        "ContiguousPackedCPRollContext",
+        "prepare_mtp_sequence_roll_context",
+        "roll_tensor",
+    ],
+)
+def test_sequence_roll_legacy_exports(name):
+    """Moving the implementation must preserve the established import path."""
+    assert getattr(multi_token_prediction_module, name) is getattr(mtp_sequence_roll, name)
+
+
+def _packed_params(cu_seqlens, *, partition_mode="contiguous"):
+    return PackedSeqParams(
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        max_seqlen_q=8,
+        max_seqlen_kv=8,
+        qkv_format="thd",
+        cp_partition_mode=partition_mode,
+    )
+
+
+def _packed_absolute_reference(source, boundaries, offset, fill_value):
+    expected = torch.full_like(source, fill_value)
+    physical_ends = list(boundaries[1:])
+    if not physical_ends or physical_ends[-1] < source.size(-1):
+        physical_ends.append(source.size(-1))
+    start = 0
+    for end in physical_ends:
+        end = int(end)
+        if offset < end - start:
+            expected[..., start : end - offset] = source[..., start + offset : end]
+        start = end
+    return expected
+
+
+@pytest.mark.parametrize("offset", [1, 2, 7])
+def test_local_unpacked_absolute_rows_preserve_layout_and_source(offset):
+    ids = torch.arange(16, dtype=torch.long).view(2, 8)
+    hidden = torch.arange(48, dtype=torch.float32).view(8, 2, 3)
+    padding = torch.zeros_like(ids, dtype=torch.bool)
+    ids_before = ids.clone()
+    hidden_before = hidden.clone()
+
+    bare = prepare_mtp_sequence_roll_context(ids, None, None)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("ids", ids, -1, 0, 0),
+            MTPSequenceRollField("hidden", hidden, 0, 1, -1.0),
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+        ],
+        max_offset=7,
+    )
+
+    expected_ids = torch.zeros_like(ids)
+    expected_ids[:, : 8 - offset] = ids[:, offset:]
+    expected_hidden = torch.full_like(hidden, -1.0)
+    expected_hidden[: 8 - offset] = hidden[offset:]
+    expected_padding = torch.ones_like(padding)
+    expected_padding[:, : 8 - offset] = padding[:, offset:]
+
+    assert context.keys == ("ids", "hidden", "padding")
+    assert context.max_offset == 7
+    assert context.address("ids", offset).row_indices.dtype == torch.int32
+    assert context.address("ids", offset).halo is None
+    assert torch.equal(context.materialize("ids", offset), expected_ids)
+    assert torch.equal(context.materialize("hidden", offset), expected_hidden)
+    assert torch.equal(context.materialize("padding", offset), expected_padding)
+    assert context.materialize("ids", 0).data_ptr() == ids.data_ptr()
+    assert not hasattr(context._prepared_fields[0], "original")
+    assert torch.equal(context.materialize_all("ids")[offset - 1], expected_ids)
+    assert torch.equal(ids, ids_before)
+    assert torch.equal(hidden, hidden_before)
+
+
+@pytest.mark.parametrize("offset", [1, 2, 7])
+def test_local_packed_absolute_rows_respect_boundaries_and_implicit_tail(offset):
+    tokens = torch.arange(1, 11, dtype=torch.long).view(1, 10)
+    padding = torch.zeros_like(tokens, dtype=torch.bool)
+    cu_seqlens = torch.tensor([0, 3, 7], dtype=torch.int32)
+    packed = _packed_params(cu_seqlens)
+
+    bare = prepare_mtp_sequence_roll_context(tokens, None, packed)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("tokens", tokens, -1, 0, 0),
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+        ],
+        max_offset=7,
+    )
+
+    assert torch.equal(
+        context.materialize("tokens", offset),
+        _packed_absolute_reference(tokens, [0, 3, 7], offset, 0),
+    )
+    assert torch.equal(
+        context.materialize("padding", offset),
+        _packed_absolute_reference(padding, [0, 3, 7], offset, True),
+    )
+    address = context.address("tokens", offset)
+    assert address.row_indices.dtype == torch.int32
+    assert address.valid_rows.dtype == torch.bool
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_thd_cp1_prepared_rows_capture_and_replay():
+    """Packed CP1 row addressing remains data-driven across CUDA Graph replay."""
+    source = torch.arange(1, 9, dtype=torch.long, device="cuda").view(1, 8)
+    cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32, device="cuda")
+    packed = _packed_params(cu_seqlens)
+    bare = prepare_mtp_sequence_roll_context(source, None, packed)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields([MTPSequenceRollField("tokens", source, -1, 0, 0)], max_offset=3)
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            context.materialize_all("tokens")
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = context.materialize_all("tokens")
+    graph.replay()
+    torch.cuda.synchronize()
+    for offset, actual in enumerate(captured, 1):
+        assert torch.equal(actual, _packed_absolute_reference(source, [0, 3, 8], offset, 0))
+
+    source.copy_(torch.arange(21, 29, dtype=torch.long, device="cuda").view(1, 8))
+    graph.replay()
+    torch.cuda.synchronize()
+    for offset, actual in enumerate(captured, 1):
+        assert torch.equal(actual, _packed_absolute_reference(source, [0, 3, 8], offset, 0))
+
+
+def test_local_context_does_not_change_existing_roll_dispatch():
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6]], dtype=torch.long)
+    unpacked_context = prepare_mtp_sequence_roll_context(tokens, None, None)
+    expected_unpacked = roll_tensor([tokens], packed_seq_params=None)[0]
+    actual_unpacked = roll_tensor([tokens], packed_seq_params=None, roll_context=unpacked_context)[
+        0
+    ]
+    assert torch.equal(actual_unpacked, expected_unpacked)
+
+    cu_seqlens = torch.tensor([0, 2, 6], dtype=torch.int32)
+    packed = _packed_params(cu_seqlens)
+    packed_context = prepare_mtp_sequence_roll_context(tokens, None, packed)
+    expected_packed = roll_tensor([tokens], packed_seq_params=packed)[0]
+    actual_packed = roll_tensor([tokens], packed_seq_params=packed, roll_context=packed_context)[0]
+    assert torch.equal(actual_packed, expected_packed)
+
+
+def test_helper_keeps_unsupported_shapes_and_zigzag_on_fallback():
+    class FakeCPGroup:
+        def __init__(self, size):
+            self._size = size
+
+        def size(self):
+            return self._size
+
+    assert prepare_mtp_sequence_roll_context(torch.zeros(4), None, None) is None
+    packed = _packed_params(torch.tensor([0, 4], dtype=torch.int32), partition_mode="zigzag")
+    assert prepare_mtp_sequence_roll_context(torch.zeros((1, 4)), FakeCPGroup(2), packed) is None
+
+
+def test_contiguous_prepare_is_atomic_deterministic_and_one_hop(monkeypatch):
+    class FakeWork:
+        def wait(self):
+            return None
+
+    class FakeCPGroup:
+        pass
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.tensor([False, True, False, False]),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=FakeCPGroup(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(2, dtype=torch.long),
+    )
+    bare = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    padding = torch.zeros_like(ids, dtype=torch.bool)
+    grouped_calls = []
+
+    def fake_p2p_op(op, tensor, peer, group=None):
+        return SimpleNamespace(op=op, tensor=tensor, peer=peer, group=group)
+
+    def fake_batch_isend_irecv(ops):
+        grouped_calls.append(ops)
+        # Sorted key order is ids (long), then padding (bool), independent of the
+        # declaration order below.
+        recv_ops = [op for op in ops if op.op is torch.distributed.irecv]
+        assert [op.tensor.dtype for op in recv_ops] == [torch.long, torch.bool]
+        recv_ops[0].tensor.copy_(torch.tensor([[5], [6], [7]], dtype=torch.long))
+        recv_ops[1].tensor.zero_()
+        return [FakeWork() for _ in ops]
+
+    monkeypatch.setattr(torch.distributed, "P2POp", fake_p2p_op)
+    monkeypatch.setattr(torch.distributed, "batch_isend_irecv", fake_batch_isend_irecv)
+    context = bare.prepare_fields(
+        [
+            MTPSequenceRollField("padding", padding, -1, 0, True),
+            MTPSequenceRollField("ids", ids, -1, 0, 0),
+        ],
+        max_offset=3,
+    )
+
+    assert len(grouped_calls) == 1
+    assert context.keys == ("padding", "ids")
+    assert context.address("ids", 3).halo is not None
+    expected_by_offset = (
+        torch.tensor([[2, 0, 4, 5]]),
+        torch.tensor([[0, 0, 5, 6]]),
+        torch.tensor([[0, 0, 6, 0]]),
+    )
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(context.materialize_all("ids"), expected_by_offset)
+    )
+
+    grouped_calls.clear()
+    unsupported = bare.prepare_fields([MTPSequenceRollField("ids", ids, -1, 0, 0)], max_offset=5)
+    assert unsupported is bare
+    assert grouped_calls == []
+
+
+def test_contiguous_validates_whole_group_before_p2p(monkeypatch):
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(3),
+    )
+    context = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Field validation must finish before P2P starts."),
+    )
+    with pytest.raises(ValueError, match="sequence length"):
+        context.prepare_fields(
+            [
+                MTPSequenceRollField("good", torch.zeros((1, 4)), -1, 0),
+                MTPSequenceRollField("bad", torch.zeros((1, 3)), -1, 0),
+            ],
+            max_offset=5,
+        )
+
+
+def test_contiguous_rejects_grad_fields_before_p2p(monkeypatch):
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=1,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(3),
+    )
+    context = ContiguousPackedCPRollContext(plan=plan, batch_size=1)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Gradient validation must finish before P2P starts."),
+    )
+    with pytest.raises(ValueError, match="does not support fields that require gradients"):
+        context.prepare_fields(
+            [MTPSequenceRollField("hidden", torch.zeros((1, 4), requires_grad=True), -1, 0)],
+            max_offset=5,
+        )
+
+
+def test_empty_prepare_replaces_fields_with_bare_sibling():
+    tokens = torch.arange(4, dtype=torch.long).view(1, 4)
+    local = LocalRollContext(
+        sequence_length=4, batch_size=1, device=torch.device("cpu")
+    ).prepare_fields([MTPSequenceRollField("tokens", tokens, -1, 0, 0)], max_offset=2)
+    cleared_local = local.prepare_fields([], max_offset=2)
+    assert cleared_local is not local
+    assert cleared_local.keys == ()
+    assert cleared_local.max_offset == 0
+    assert cleared_local.sequence_length == local.sequence_length
+    assert cleared_local.batch_size == local.batch_size
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=None,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(0),
+    )
+    halos = ContiguousPackedCPRollHalos(input_ids=torch.zeros((1, 2), dtype=torch.long))
+    contiguous = ContiguousPackedCPRollContext(plan=plan, halos=halos, batch_size=1).prepare_fields(
+        [MTPSequenceRollField("tokens", tokens, -1, 0, 0)], max_offset=2
+    )
+    cleared_contiguous = contiguous.prepare_fields([], max_offset=5)
+    assert cleared_contiguous is not contiguous
+    assert cleared_contiguous.keys == ()
+    assert cleared_contiguous.max_offset == 0
+    assert cleared_contiguous.plan is plan
+    assert cleared_contiguous.halos is halos
+    assert cleared_contiguous.batch_size == contiguous.batch_size
+
+
+def test_late_bound_siblings_reuse_local_and_contiguous_geometry(monkeypatch):
+    tokens = torch.arange(4, dtype=torch.long).view(1, 4)
+    mask = torch.zeros_like(tokens, dtype=torch.bool)
+
+    local = LocalRollContext(
+        sequence_length=4, batch_size=1, device=torch.device("cpu")
+    ).prepare_fields((MTPSequenceRollField("tokens", tokens, -1, 0, 0),), max_offset=3)
+    local_indices = local._roll_row_indices
+    local_valid = local._roll_valid_rows
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_local_roll_geometry",
+        lambda **_: pytest.fail("Local late binding should reuse row geometry."),
+    )
+    rebound_local = local.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+    assert rebound_local._roll_row_indices is local_indices
+    assert rebound_local._roll_valid_rows is local_valid
+    assert rebound_local.max_offset == 3
+
+    plan = ContiguousPackedSeqRollPlan(
+        invalid_next=torch.zeros(4, dtype=torch.bool),
+        sequence_length=4,
+        device=torch.device("cpu"),
+        cp_group=object(),
+        recv_rank=None,
+        send_rank=None,
+        has_sequences=True,
+        right_halo_valid_count=torch.tensor(0),
+    )
+    contiguous = ContiguousPackedCPRollContext(plan=plan, batch_size=1).prepare_fields(
+        (MTPSequenceRollField("tokens", tokens, -1, 0, 0),), max_offset=3
+    )
+    contiguous_indices = contiguous._roll_row_indices
+    contiguous_valid = contiguous._roll_valid_rows
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_contiguous_packed_cp_roll_geometry",
+        lambda *_, **__: pytest.fail("Contiguous late binding should reuse row geometry."),
+    )
+    rebound_contiguous = contiguous.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+    assert rebound_contiguous._roll_row_indices is contiguous_indices
+    assert rebound_contiguous._roll_valid_rows is contiguous_valid
+    assert rebound_contiguous.max_offset == 3
+
+
+def test_source_identity_guard_reprepares_stale_fields_atomically():
+    stale = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    current = torch.tensor([[11, 12, 13, 14]], dtype=torch.long)
+    bare = prepare_mtp_sequence_roll_context(stale, None, None)
+    assert isinstance(bare, LocalRollContext)
+    context = bare.prepare_fields(
+        [MTPSequenceRollField("input_ids", stale, -1, 0, 0)], max_offset=2
+    )
+
+    assert context.is_prepared_for_fields([MTPSequenceRollField("input_ids", stale, -1, 0, 0)])
+    assert not context.is_prepared_for_fields(
+        [MTPSequenceRollField("input_ids", current, -1, 0, 0)]
+    )
+    rebound = prepare_mtp_sequence_roll_fields(
+        context, [MTPSequenceRollField("input_ids", current, -1, 0, 0)], max_offset=2
+    )
+    assert rebound is not None
+    assert rebound is not context
+    assert rebound.is_prepared_for_fields([MTPSequenceRollField("input_ids", current, -1, 0, 0)])
+    assert torch.equal(rebound.materialize("input_ids", 1), torch.tensor([[12, 13, 14, 0]]))
+
+    stale.add_(100)
+    assert not context.is_prepared_for_fields([MTPSequenceRollField("input_ids", stale, -1, 0, 0)])
+
+
+def test_source_identity_guard_safely_falls_back_for_inference_tensors():
+    with torch.inference_mode():
+        source = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        field = MTPSequenceRollField("input_ids", source, -1, 0, 0)
+        bare = prepare_mtp_sequence_roll_context(source, None, None)
+        assert isinstance(bare, LocalRollContext)
+        context = bare.prepare_fields([field], max_offset=2)
+
+        # Preparation itself remains useful, but an inference tensor has no
+        # version counter with which to prove that a later reuse is fresh.
+        assert torch.equal(context.materialize("input_ids", 1), torch.tensor([[2, 3, 4, 0]]))
+        assert not context.is_prepared_for_fields([field])
+        assert prepare_mtp_sequence_roll_fields(context, [field], max_offset=2) is None
+
+
+def _packed_global_aligned_rows(source, cu_seqlens, offset, fill_value):
+    """Return a global packed-sequence oracle for a left shift by ``offset``."""
+    expected = torch.full_like(source, fill_value)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        start = int(start)
+        end = int(end)
+        if offset < end - start:
+            expected[..., start : end - offset] = source[..., start + offset : end]
+    return expected
+
+
+def _materialize_address(address, fill_value):
+    """Materialize one public sequence-roll address without using context helpers."""
+    source = address.source
+    if address.halo is not None:
+        source = torch.cat((source, address.halo), dim=0)
+    payload_shape = source.shape[2:]
+    selected = source.reshape(-1, *payload_shape).index_select(
+        0, address.row_indices.reshape(-1).long()
+    )
+    selected = selected.reshape(*address.row_indices.shape, *payload_shape)
+    valid_rows = address.valid_rows
+    while valid_rows.dim() < selected.dim():
+        valid_rows = valid_rows.unsqueeze(-1)
+    return torch.where(valid_rows, selected, selected.new_full((), fill_value))
+
+
+class _FakeZigzagCPGroup:
+    """Minimal effective CP group for host-only certificate and route tests."""
+
+    def __init__(self, size):
+        self._size = size
+
+    def size(self):
+        return self._size
+
+
+def _certified_zigzag_params(cu_seqlens, cp_group, *, certificate, local_cp_size=None):
+    """Build zigzag packed-CP metadata with an explicit scheduler certificate."""
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=int(cu_seqlens[-1]),
+        max_seqlen_kv=int(cu_seqlens[-1]),
+        cp_partition_mode="zigzag",
+        local_cp_size=local_cp_size,
+        cp_group=cp_group,
+        zigzag_cp_min_chunk_size=certificate,
+    )
+
+
+def test_uncertified_and_zero_certificate_keep_zigzag_roll_fallback():
+    """Missing/zero certificates describe unsupported optimization, not invalid data."""
+    static_group = _FakeZigzagCPGroup(4)
+    dynamic_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    cu_seqlens = torch.tensor([0, 16], dtype=torch.int32)
+
+    for certificate in (None, 0):
+        packed = _certified_zigzag_params(
+            cu_seqlens, dynamic_group, certificate=certificate, local_cp_size=2
+        )
+        # The dynamic group carried by PackedSeqParams is the effective group;
+        # neither an absent nor a failed certificate creates a prepared context.
+        assert prepare_mtp_sequence_roll_context(source, static_group, packed) is None
+
+    negative = _certified_zigzag_params(cu_seqlens, dynamic_group, certificate=-1, local_cp_size=2)
+    with pytest.raises(ValueError, match="certificate cannot be negative"):
+        prepare_mtp_sequence_roll_context(source, static_group, negative)
+
+
+def test_zigzag_certificate_survives_padding_and_tightens_for_dummy_sequence():
+    """Appending a shorter physical sequence conservatively lowers the certificate."""
+    cu_seqlens = torch.tensor([0, 16], dtype=torch.int32)
+    packed = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens.clone(),
+        cu_seqlens_q_padded=cu_seqlens.clone(),
+        cu_seqlens_kv_padded=cu_seqlens.clone(),
+        max_seqlen_q=16,
+        max_seqlen_kv=16,
+        local_cp_size=2,
+        cp_partition_mode="zigzag",
+        zigzag_cp_min_chunk_size=4,
+    )
+
+    _, _, _, _, padded, _ = pad_sequence_for_thd(
+        torch.ones(1, 8),
+        None,
+        None,
+        None,
+        packed,
+        target_len=12,
+        tail_padding_policy="append_dummy_seq",
+        cp_size=2,
+        cp_rank=0,
+    )
+
+    assert padded.cu_seqlens_q_padded.tolist() == [0, 16, 24]
+    assert padded.zigzag_cp_min_chunk_size == 2
+
+
+def test_zigzag_certificate_is_ignored_by_cuda_graph_argument_matching():
+    """A scheduler runtime certificate must not select another graph runner."""
+    from megatron.core.transformer.cuda_graphs import ArgMetadata, _CudaGraphRunner
+
+    reference = PackedSeqParams(
+        qkv_format="thd", cp_partition_mode="zigzag", zigzag_cp_min_chunk_size=2
+    )
+    current = PackedSeqParams(
+        qkv_format="thd", cp_partition_mode="zigzag", zigzag_cp_min_chunk_size=8
+    )
+    runner = _CudaGraphRunner.__new__(_CudaGraphRunner)
+    runner.fwd_graph_input_arg_metas = [ArgMetadata(reference)]
+    runner.fwd_graph_input_kwarg_metas = {}
+
+    assert runner.get_mismatch_errors((current,), {}) == []
+    current.cp_partition_mode = "contiguous"
+    assert runner.get_mismatch_errors((current,), {})
+
+
+def test_certified_zigzag_rejects_effective_cp_group_mismatch():
+    source = torch.arange(8).view(1, 8)
+    dynamic_group = _FakeZigzagCPGroup(2)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 16], dtype=torch.int32), dynamic_group, certificate=4, local_cp_size=4
+    )
+
+    with pytest.raises(ValueError, match="must match the effective CP group size"):
+        prepare_mtp_sequence_roll_context(source, _FakeZigzagCPGroup(4), packed)
+
+
+@pytest.mark.parametrize(
+    ("boundaries", "message"),
+    [
+        ((1, 16), "must start at zero"),
+        ((0, 12, 8), "must be nondecreasing"),
+        ((0, 12), "must cover the physical buffer exactly"),
+        ((0, 14, 16), "physical chunk divisibility"),
+        ((0, 4, 16), "overstates the minimum physical chunk size"),
+    ],
+)
+def test_certified_zigzag_validates_runtime_metadata_before_p2p(monkeypatch, boundaries, message):
+    cp_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    packed = _certified_zigzag_params(
+        torch.tensor(boundaries, dtype=torch.int32), cp_group, certificate=2, local_cp_size=2
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda group: [0, 1])
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Invalid certified metadata must fail before P2P."),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        bare.prepare_fields((MTPSequenceRollField("tokens", source, -1, 0, 0),), max_offset=2)
+
+
+def test_certified_zigzag_multi_hop_fallback_is_atomic(monkeypatch):
+    """A consumer wider than the certificate performs no partial prepare or P2P."""
+    cp_group = _FakeZigzagCPGroup(2)
+    source = torch.arange(8).view(1, 8)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 16], dtype=torch.int32), cp_group, certificate=2, local_cp_size=2
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    monkeypatch.setattr(
+        torch.distributed,
+        "batch_isend_irecv",
+        lambda _: pytest.fail("Unsupported multi-hop preparation must not start P2P."),
+    )
+
+    fields = (MTPSequenceRollField("tokens", source, -1, 0, 0),)
+    assert bare.prepare_fields(fields, max_offset=3) is bare
+    assert prepare_mtp_sequence_roll_fields(bare, fields, max_offset=3) is None
+    assert bare.keys == ()
+    assert bare.max_offset == 0
+
+
+def test_certified_zigzag_routes_and_late_binding_reuse_geometry(monkeypatch):
+    """Front/back routes use opposite peers and sibling fields share exact geometry."""
+
+    class FakeWork:
+        def wait(self):
+            return None
+
+    cp_group = _FakeZigzagCPGroup(4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 1)
+    monkeypatch.setattr(
+        torch.distributed, "get_process_group_ranks", lambda group: [10, 20, 30, 40]
+    )
+
+    captured_calls = []
+
+    def fake_p2p_op(op, tensor, peer, group=None):
+        return SimpleNamespace(op=op, tensor=tensor, peer=peer, group=group)
+
+    def fake_batch_isend_irecv(ops):
+        captured_calls.append(tuple(ops))
+        assert [(op.op, op.peer) for op in ops] == [
+            (torch.distributed.irecv, 30),
+            (torch.distributed.isend, 10),
+            (torch.distributed.irecv, 10),
+            (torch.distributed.isend, 30),
+        ]
+        recv_ops = [op for op in ops if op.op is torch.distributed.irecv]
+        if recv_ops[0].tensor.dtype == torch.long:
+            send_ops = [op for op in ops if op.op is torch.distributed.isend]
+            assert torch.equal(send_ops[0].tensor, torch.tensor([[4], [5], [6]], dtype=torch.long))
+            assert torch.equal(
+                send_ops[1].tensor, torch.tensor([[24], [25], [26]], dtype=torch.long)
+            )
+            recv_ops[0].tensor.copy_(torch.tensor([[8], [9], [10]], dtype=torch.long))
+            recv_ops[1].tensor.copy_(torch.tensor([[28], [29], [30]], dtype=torch.long))
+        else:
+            recv_ops[0].tensor.zero_()
+            recv_ops[1].tensor.zero_()
+        return [FakeWork() for _ in ops]
+
+    monkeypatch.setattr(torch.distributed, "P2POp", fake_p2p_op)
+    monkeypatch.setattr(torch.distributed, "batch_isend_irecv", fake_batch_isend_irecv)
+
+    # CP4 rank 1 owns global front chunk [4, 8) and mirrored back chunk [24, 28).
+    source = torch.tensor([[4, 5, 6, 7, 24, 25, 26, 27]], dtype=torch.long)
+    packed = _certified_zigzag_params(
+        torch.tensor([0, 32], dtype=torch.int32), cp_group, certificate=4, local_cp_size=4
+    )
+    bare = prepare_mtp_sequence_roll_context(source, cp_group, packed)
+    assert isinstance(bare, ZigzagPackedCPRollContext)
+    prepared = bare.prepare_fields(
+        (MTPSequenceRollField("tokens", source, -1, 0, 0),), max_offset=3
+    )
+
+    assert torch.equal(
+        prepared.materialize("tokens", 1),
+        torch.tensor([[5, 6, 7, 8, 25, 26, 27, 28]], dtype=torch.long),
+    )
+    assert torch.equal(
+        prepared.materialize("tokens", 3),
+        torch.tensor([[7, 8, 9, 10, 27, 28, 29, 30]], dtype=torch.long),
+    )
+    first_indices = prepared._roll_row_indices
+    first_valid = prepared._roll_valid_rows
+    first_transport = prepared._roll_transport
+    assert first_indices is not None and first_valid is not None and first_transport is not None
+
+    # A late-bound TV/mask sibling with a smaller requested depth must reuse the
+    # already-built row map and route metadata rather than reconstruct either.
+    monkeypatch.setattr(
+        mtp_sequence_roll,
+        "_build_zigzag_packed_cp_roll_geometry",
+        lambda **_: pytest.fail("Late binding should reuse certified zigzag geometry."),
+    )
+    mask = torch.zeros_like(source, dtype=torch.bool)
+    rebound = prepared.prepare_fields(
+        (MTPSequenceRollField("mask", mask, -1, 0, True),), max_offset=2
+    )
+
+    assert rebound.keys == ("mask",)
+    assert rebound.max_offset == 3
+    assert rebound._roll_row_indices is first_indices
+    assert rebound._roll_valid_rows is first_valid
+    assert rebound._roll_transport is first_transport
+    assert len(captured_calls) == 2
+
+
+def _canonical_mtp_test_layout(tensor, sequence_dim, batch_dim):
+    sequence_dim %= tensor.ndim
+    batch_dim %= tensor.ndim
+    remaining = tuple(dim for dim in range(tensor.ndim) if dim not in (sequence_dim, batch_dim))
+    return tensor.permute(sequence_dim, batch_dim, *remaining)
+
+
+def _restore_mtp_test_layout(tensor, source, sequence_dim, batch_dim):
+    sequence_dim %= source.ndim
+    batch_dim %= source.ndim
+    permutation = (sequence_dim, batch_dim) + tuple(
+        dim for dim in range(source.ndim) if dim not in (sequence_dim, batch_dim)
+    )
+    inverse = [0] * source.ndim
+    for canonical_dim, original_dim in enumerate(permutation):
+        inverse[original_dim] = canonical_dim
+    return tensor.permute(inverse)
+
+
+def _packed_sequence_roll_oracle(
+    source, offset, *, sequence_dim, batch_dim, fill_value, boundaries
+):
+    """Select global shifted rows without using production roll/address helpers."""
+    canonical = _canonical_mtp_test_layout(source, sequence_dim, batch_dim)
+    output = torch.full_like(canonical, fill_value)
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        valid_length = max(end - start - offset, 0)
+        if valid_length:
+            output[start : start + valid_length].copy_(
+                canonical[start + offset : start + offset + valid_length]
+            )
+    return _restore_mtp_test_layout(output, source, sequence_dim, batch_dim)
+
+
+def _zigzag_shard_oracle(source, boundaries, cp_size, cp_rank, *, sequence_dim, batch_dim):
+    """Produce one zigzag packed-CP shard without production partition helpers."""
+    canonical = _canonical_mtp_test_layout(source, sequence_dim, batch_dim)
+    local_segments = []
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        if start == end:
+            continue
+        segment = canonical[start:end]
+        assert segment.size(0) % (2 * cp_size) == 0
+        chunks = segment.chunk(2 * cp_size, dim=0)
+        local_segments.extend((chunks[cp_rank], chunks[2 * cp_size - cp_rank - 1]))
+    local = torch.cat(local_segments, dim=0).contiguous()
+    return _restore_mtp_test_layout(local, source, sequence_dim, batch_dim)
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_certified_zigzag_cp2_matches_global_oracle(monkeypatch):
+    """A real CP2 group validates both physical zigzag boundary directions."""
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = cp_group.size()
+        assert cp_size == 2
+        boundaries = (0, 16)
+        max_offset = 3
+        full_ids = torch.arange(1, 17, dtype=torch.long, device="cuda").view(1, -1)
+        full_mask = (full_ids % 3 == 0).to(torch.float32)
+        local_ids = _zigzag_shard_oracle(
+            full_ids, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_mask = _zigzag_shard_oracle(
+            full_mask, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        cu_seqlens = torch.tensor(boundaries, dtype=torch.int32, device="cuda")
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=16,
+            max_seqlen_kv=16,
+            cp_partition_mode="zigzag",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            zigzag_cp_min_chunk_size=4,
+        )
+        bare = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed)
+        assert isinstance(bare, ZigzagPackedCPRollContext)
+
+        original_batch_isend_irecv = torch.distributed.batch_isend_irecv
+        p2p_calls = []
+
+        def counted_batch_isend_irecv(ops):
+            p2p_calls.append(len(ops))
+            return original_batch_isend_irecv(ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        context = bare.prepare_fields(
+            (
+                MTPSequenceRollField("ids", local_ids, 1, 0, 0),
+                MTPSequenceRollField("mask", local_mask, 1, 0, 0),
+            ),
+            max_offset=max_offset,
+        )
+        assert p2p_calls == [4]
+
+        for offset in range(1, max_offset + 1):
+            for key, full_source, fill_value in (("ids", full_ids, 0), ("mask", full_mask, 0)):
+                global_expected = _packed_sequence_roll_oracle(
+                    full_source,
+                    offset,
+                    sequence_dim=1,
+                    batch_dim=0,
+                    fill_value=fill_value,
+                    boundaries=boundaries,
+                )
+                local_expected = _zigzag_shard_oracle(
+                    global_expected, boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+                )
+                torch.testing.assert_close(
+                    context.materialize(key, offset), local_expected, rtol=0, atol=0
+                )
+        assert p2p_calls == [4]
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_certified_zigzag_cp4_dynamic_interleaved_group_matches_global_oracle(monkeypatch):
+    """A real interleaved CP4 group prepares all fields with one neighbor exchange."""
+    if Utils.world_size < 8 or Utils.world_size % 4 != 0:
+        pytest.skip("This test requires at least eight ranks and a world size divisible by four.")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1)
+    world_size = torch.distributed.get_world_size()
+    num_groups = world_size // 4
+    rank_lists = [
+        list(range(group_index, world_size, num_groups)) for group_index in range(num_groups)
+    ]
+    cp_groups = [torch.distributed.new_group(ranks) for ranks in rank_lists]
+    global_rank = torch.distributed.get_rank()
+    cp_group = cp_groups[global_rank % num_groups]
+    cp_rank = torch.distributed.get_rank(group=cp_group)
+    try:
+        cp_size = 4
+        max_offset = 2
+        valid_boundaries = (0, 13, 33, 33)
+        padded_boundaries = (0, 16, 40, 40)
+        global_sequence_length = padded_boundaries[-1]
+
+        full_padding = torch.ones((1, global_sequence_length), dtype=torch.bool, device="cuda")
+        for valid_start, valid_end, padded_start in zip(
+            valid_boundaries[:-1], valid_boundaries[1:], padded_boundaries[:-1]
+        ):
+            full_padding[:, padded_start : padded_start + valid_end - valid_start] = False
+        full_ids = torch.arange(1, global_sequence_length + 1, device="cuda").view(1, -1)
+        full_ids.masked_fill_(full_padding, 0)
+        full_target = (
+            torch.arange(global_sequence_length * 3, dtype=torch.float32, device="cuda")
+            .view(global_sequence_length, 1, 3)
+            .to(torch.bfloat16)
+        )
+        full_target.masked_fill_(full_padding.transpose(0, 1).unsqueeze(-1), 0)
+
+        local_ids = _zigzag_shard_oracle(
+            full_ids, padded_boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_padding = _zigzag_shard_oracle(
+            full_padding, padded_boundaries, cp_size, cp_rank, sequence_dim=1, batch_dim=0
+        )
+        local_target = _zigzag_shard_oracle(
+            full_target, padded_boundaries, cp_size, cp_rank, sequence_dim=0, batch_dim=1
+        )
+
+        cu_seqlens = torch.tensor(valid_boundaries, dtype=torch.int32, device="cuda")
+        padded_cu_seqlens = torch.tensor(padded_boundaries, dtype=torch.int32, device="cuda")
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=padded_cu_seqlens,
+            cu_seqlens_kv_padded=padded_cu_seqlens,
+            max_seqlen_q=24,
+            max_seqlen_kv=24,
+            cp_partition_mode="zigzag",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            zigzag_cp_min_chunk_size=2,
+        )
+        # The explicit group is deliberately unrelated: dynamic metadata must win.
+        static_cp_group = get_context_parallel_group()
+        bare = prepare_mtp_sequence_roll_context(local_ids, static_cp_group, packed)
+        assert isinstance(bare, ZigzagPackedCPRollContext)
+        assert bare.cp_group is cp_group
+
+        original_batch_isend_irecv = torch.distributed.batch_isend_irecv
+        p2p_calls = []
+
+        def counted_batch_isend_irecv(ops):
+            p2p_calls.append(len(ops))
+            return original_batch_isend_irecv(ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        fields = [
+            MTPSequenceRollField("ids", local_ids, 1, 0, 0),
+            MTPSequenceRollField("padding", local_padding, 1, 0, True),
+            MTPSequenceRollField("target", local_target, 0, 1, 0),
+        ]
+        if cp_rank % 2:
+            fields.reverse()
+        context = bare.prepare_fields(fields, max_offset=max_offset)
+
+        neighbor_count = int(cp_rank > 0) + int(cp_rank + 1 < cp_size)
+        assert p2p_calls == [2 * neighbor_count * len(fields)]
+        for offset in range(1, max_offset + 1):
+            for key, full_source, sequence_dim, batch_dim, fill_value in (
+                ("ids", full_ids, 1, 0, 0),
+                ("padding", full_padding, 1, 0, True),
+                ("target", full_target, 0, 1, 0),
+            ):
+                global_expected = _packed_sequence_roll_oracle(
+                    full_source,
+                    offset,
+                    sequence_dim=sequence_dim,
+                    batch_dim=batch_dim,
+                    fill_value=fill_value,
+                    boundaries=padded_boundaries,
+                )
+                local_expected = _zigzag_shard_oracle(
+                    global_expected,
+                    padded_boundaries,
+                    cp_size,
+                    cp_rank,
+                    sequence_dim=sequence_dim,
+                    batch_dim=batch_dim,
+                )
+                torch.testing.assert_close(
+                    context.materialize(key, offset), local_expected, rtol=0, atol=0
+                )
+
+        # Every depth consumes only the already-prepared row map and halos.
+        assert p2p_calls == [2 * neighbor_count * len(fields)]
+    finally:
+        torch.distributed.destroy_process_group(cp_group)
+        Utils.destroy_model_parallel()
+
+
+class TestContiguousPackedCPPreparedRollRowsDistributed:
+    """Real CP tests for generic sequence-roll fields and their legacy roll oracle."""
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def test_cp2_true_shards_mixed_dtype_one_grouped_exchange(self, monkeypatch):
+        """One preparation serves every absolute depth without another P2P.
+
+        Every CP rank receives a true contiguous slice of the same global packed
+        microbatch.  Ranks deliberately declare the two fields in opposite order;
+        transport therefore has to use the field-key order rather than declaration
+        order to pair the int64 and float32 messages safely.
+        """
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        assert cp_group.size() == cp_size
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        max_offset = local_sequence_length
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_ids = torch.stack((global_rows + 10, global_rows + 110)).to(torch.long)
+        global_scores = torch.stack(
+            (global_rows.to(torch.float32) + 0.25, global_rows.to(torch.float32) + 100.25)
+        )
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_ids = global_ids[:, local_slice].contiguous()
+        local_scores = global_scores[:, local_slice].contiguous()
+        source_ids = local_ids.clone()
+        source_scores = local_scores.clone()
+
+        # Three physical sequences [0, 5), [5, 9), [9, 12). The middle sequence
+        # crosses the CP boundary, while both ranks also own a local sequence end.
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        bare_context = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        batch_isend_irecv = torch.distributed.batch_isend_irecv
+        grouped_p2p_calls = 0
+        grouped_p2p_op_counts = []
+
+        def counted_batch_isend_irecv(p2p_ops):
+            nonlocal grouped_p2p_calls
+            grouped_p2p_calls += 1
+            grouped_p2p_op_counts.append(len(p2p_ops))
+            return batch_isend_irecv(p2p_ops)
+
+        monkeypatch.setattr(torch.distributed, "batch_isend_irecv", counted_batch_isend_irecv)
+        fields = [
+            MTPSequenceRollField("ids", local_ids, -1, 0, 0),
+            MTPSequenceRollField("scores", local_scores, -1, 0, -7.5),
+        ]
+        if cp_rank % 2:
+            fields.reverse()
+        context = bare_context.prepare_fields(fields, max_offset=max_offset)
+
+        assert context is not bare_context
+        assert context.keys == tuple(field.key for field in fields)
+        assert grouped_p2p_calls == 1
+        assert grouped_p2p_op_counts == [2]
+        assert context.max_offset == local_sequence_length
+
+        expected_ids_by_offset = []
+        expected_scores_by_offset = []
+        for offset in range(1, max_offset + 1):
+            expected_ids = _packed_global_aligned_rows(global_ids, cu_seqlens.tolist(), offset, 0)[
+                :, local_slice
+            ]
+            expected_scores = _packed_global_aligned_rows(
+                global_scores, cu_seqlens.tolist(), offset, -7.5
+            )[:, local_slice]
+            expected_ids_by_offset.append(expected_ids)
+            expected_scores_by_offset.append(expected_scores)
+
+            ids_address = context.address("ids", offset)
+            scores_address = context.address("scores", offset)
+            assert ids_address.row_indices.dtype == torch.int32
+            assert scores_address.row_indices.dtype == torch.int32
+            assert ids_address.valid_rows.dtype == torch.bool
+            assert scores_address.valid_rows.dtype == torch.bool
+            assert ids_address.halo is not None
+            assert scores_address.halo is not None
+            assert torch.equal(_materialize_address(ids_address, 0).permute(1, 0), expected_ids)
+            assert torch.equal(
+                _materialize_address(scores_address, -7.5).permute(1, 0), expected_scores
+            )
+            assert torch.equal(context.materialize("ids", offset), expected_ids)
+            assert torch.equal(context.materialize("scores", offset), expected_scores)
+
+        assert all(
+            torch.equal(actual, expected)
+            for actual, expected in zip(context.materialize_all("ids"), expected_ids_by_offset)
+        )
+        assert all(
+            torch.equal(actual, expected)
+            for actual, expected in zip(
+                context.materialize_all("scores"), expected_scores_by_offset
+            )
+        )
+        # Addressing and materialization are communication-free after prepare().
+        assert grouped_p2p_calls == 1
+
+        if cp_rank == cp_size - 1:
+            assert torch.equal(context.materialize("ids", max_offset), torch.zeros_like(local_ids))
+            assert torch.equal(
+                context.materialize("scores", max_offset), torch.full_like(local_scores, -7.5)
+            )
+
+        # The established cumulative roll path is an independent distributed
+        # oracle. It performs one grouped P2P per depth, unlike the prepared path.
+        grouped_p2p_calls = 0
+        grouped_p2p_op_counts.clear()
+        rolled_ids = local_ids
+        rolled_scores = local_scores
+        for offset in range(1, max_offset + 1):
+            rolled_ids, rolled_scores = roll_tensor(
+                [rolled_ids, rolled_scores],
+                shifts=-1,
+                dims=-1,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                fill_values=[0, -7.5],
+                roll_context=bare_context,
+            )
+            assert torch.equal(rolled_ids, expected_ids_by_offset[offset - 1])
+            assert torch.equal(rolled_scores, expected_scores_by_offset[offset - 1])
+        assert grouped_p2p_calls == max_offset
+        assert grouped_p2p_op_counts == [2] * max_offset
+        assert torch.equal(local_ids, source_ids)
+        assert torch.equal(local_scores, source_scores)
+
+    def test_cp2_mtp_forward_direct_matches_legacy_roll(self):
+        """MTP block pre-alignment is identical to cumulative consumer rolling."""
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        num_depths = 3
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_ids = torch.stack((global_rows + 10, global_rows + 110)).long()
+        global_positions = torch.stack((global_rows, global_rows + 100)).long()
+        global_padding = torch.zeros(
+            (batch_size, global_sequence_length), dtype=torch.bool, device="cuda"
+        )
+        global_padding[0, 7] = True
+        global_padding[1, 10] = True
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_ids = global_ids[:, local_slice].contiguous()
+        local_positions = global_positions[:, local_slice].contiguous()
+        local_padding = global_padding[:, local_slice].contiguous()
+
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        bare_context = prepare_mtp_sequence_roll_context(local_ids, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+        direct_context = bare_context.prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", local_ids, -1, 0, 0),
+                MTPSequenceRollField("position_ids", local_positions, -1, 0, 0),
+                MTPSequenceRollField("padding_mask", local_padding, -1, 0, True),
+            ),
+            max_offset=num_depths,
+        )
+
+        class RollAwareLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def forward(
+                self,
+                hidden_states,
+                input_ids,
+                position_ids,
+                padding_mask,
+                packed_seq_params,
+                sequence_roll_context,
+                roll_depth,
+                _inputs_pre_aligned=False,
+                **kwargs,
+            ):
+                del kwargs
+                if not _inputs_pre_aligned:
+                    input_ids, position_ids, padding_mask = roll_tensor(
+                        [input_ids, position_ids, padding_mask],
+                        shifts=-1,
+                        dims=-1,
+                        cp_group=cp_group,
+                        packed_seq_params=packed_seq_params,
+                        fill_values=[0, 0, True],
+                        roll_context=sequence_roll_context,
+                        sequence_fields=["input_ids", "position_ids", "padding_mask"],
+                        roll_depth=roll_depth,
+                    )
+                self.calls.append(
+                    (
+                        input_ids.clone(),
+                        position_ids.clone(),
+                        padding_mask.clone(),
+                        _inputs_pre_aligned,
+                    )
+                )
+                aligned_value = input_ids.transpose(0, 1).unsqueeze(-1).to(hidden_states.dtype)
+                aligned_value = aligned_value + position_ids.transpose(0, 1).unsqueeze(-1).to(
+                    hidden_states.dtype
+                )
+                hidden_states = hidden_states + aligned_value
+                return hidden_states, input_ids, position_ids, padding_mask
+
+        def run(sequence_roll_context, sequence_roll_padding_mask=None):
+            config = SimpleNamespace(
+                pipeline_model_parallel_size=1, mtp_num_layers=num_depths, mtp_detach_heads=False
+            )
+            block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+            torch.nn.Module.__init__(block)
+            block.config = config
+            block.vp_stage = None
+            block.mtp_use_repeated_layer = False
+            block.layers = torch.nn.ModuleList(RollAwareLayer() for _ in range(num_depths))
+            output = block.forward(
+                input_ids=local_ids,
+                position_ids=local_positions,
+                hidden_states=torch.zeros(local_sequence_length, batch_size, 1, device="cuda"),
+                attention_mask=torch.empty(0, device="cuda"),
+                padding_mask=local_padding,
+                sequence_roll_padding_mask=sequence_roll_padding_mask,
+                packed_seq_params=packed_seq_params,
+                sequence_roll_context=sequence_roll_context,
+                embedding=SimpleNamespace(add_position_embedding=True),
+            )
+            calls = [layer.calls[0] for layer in block.layers]
+            return output, calls
+
+        legacy_output, legacy_calls = run(bare_context)
+        direct_output, direct_calls = run(direct_context, local_padding)
+        assert torch.equal(direct_output, legacy_output)
+        for depth, (legacy_call, direct_call) in enumerate(
+            zip(legacy_calls, direct_calls), start=1
+        ):
+            expected_ids = _packed_global_aligned_rows(global_ids, cu_seqlens.tolist(), depth, 0)[
+                :, local_slice
+            ]
+            expected_positions = _packed_global_aligned_rows(
+                global_positions, cu_seqlens.tolist(), depth, 0
+            )[:, local_slice]
+            expected_padding = _packed_global_aligned_rows(
+                global_padding, cu_seqlens.tolist(), depth, True
+            )[:, local_slice]
+            assert not legacy_call[3]
+            assert direct_call[3]
+            for legacy_value, direct_value, expected in zip(
+                legacy_call[:3],
+                direct_call[:3],
+                (expected_ids, expected_positions, expected_padding),
+            ):
+                assert torch.equal(legacy_value, expected)
+                assert torch.equal(direct_value, expected)
+
+    @pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+    def test_cp2_ce_direct_matches_legacy_roll(self, derived_labels):
+        """SFT and RL CE consumers preserve labels, masks, output, and gradients."""
+        cp_size = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp_size)
+        cp_group = get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+
+        batch_size = 2
+        local_sequence_length = 6
+        global_sequence_length = cp_size * local_sequence_length
+        num_depths = 3
+        hidden_size = 4
+        global_rows = torch.arange(global_sequence_length, device="cuda")
+        global_input_ids = torch.stack((global_rows + 10, global_rows + 110)).long()
+        global_labels = torch.stack((global_rows + 1010, global_rows + 1110)).long()
+        global_loss_mask = torch.ones(
+            (batch_size, global_sequence_length), dtype=torch.float32, device="cuda"
+        )
+        global_loss_mask[0, 3] = 0
+        global_loss_mask[1, 7] = 0
+        local_slice = slice(cp_rank * local_sequence_length, (cp_rank + 1) * local_sequence_length)
+        local_input_ids = global_input_ids[:, local_slice].contiguous()
+        local_labels = global_labels[:, local_slice].contiguous()
+        local_loss_mask = global_loss_mask[:, local_slice].contiguous()
+
+        cu_seqlens = torch.tensor([0, 5, 9, 12], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=5,
+            max_seqlen_kv=5,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        reference = local_input_ids if derived_labels else local_labels
+        bare_context = prepare_mtp_sequence_roll_context(reference, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        config = TransformerConfig(
+            hidden_size=hidden_size, num_layers=2, num_attention_heads=2, mtp_num_layers=num_depths
+        )
+        config.mtp_loss_scaling_factor = 1.0
+        hidden_template = (
+            torch.arange(
+                (1 + num_depths) * local_sequence_length * batch_size * hidden_size,
+                dtype=torch.float32,
+                device="cuda",
+            ).view((1 + num_depths) * local_sequence_length, batch_size, hidden_size)
+            / 100.0
+            + 1.0
+        )
+
+        class OutputLayer:
+            gather_output = True
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                del weight, runtime_gather_output
+                return hidden, None
+
+        def run(sequence_roll_context):
+            hidden = hidden_template.clone().requires_grad_(True)
+            seen_labels = []
+
+            def compute_language_model_loss(current_labels, logits):
+                seen_labels.append(current_labels.clone())
+                return (
+                    logits.square().mean(dim=-1).transpose(0, 1)
+                    + current_labels.to(logits.dtype) * 1.0e-4
+                )
+
+            output = process_mtp_loss(
+                hidden_states=hidden,
+                labels=None if derived_labels else local_labels,
+                loss_mask=local_loss_mask,
+                output_layer=OutputLayer(),
+                output_weight=None,
+                runtime_gather_output=None,
+                is_training=False,
+                compute_language_model_loss=compute_language_model_loss,
+                config=config,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                input_ids=local_input_ids if derived_labels else None,
+                sequence_roll_context=sequence_roll_context,
+            )
+            output.sum().backward()
+            return output.detach(), hidden.grad.detach(), seen_labels
+
+        legacy_output, legacy_grad, legacy_labels = run(None)
+        direct_output, direct_grad, direct_labels = run(bare_context)
+        assert torch.equal(direct_output, legacy_output)
+        assert torch.equal(direct_grad, legacy_grad)
+        assert len(direct_labels) == num_depths
+
+        global_label_source = global_input_ids if derived_labels else global_labels
+        first_offset = 2 if derived_labels else 1
+        direct_grad_chunks = torch.chunk(direct_grad, 1 + num_depths, dim=0)
+        for depth, (legacy_current, direct_current) in enumerate(zip(legacy_labels, direct_labels)):
+            offset = first_offset + depth
+            expected_labels = _packed_global_aligned_rows(
+                global_label_source, cu_seqlens.tolist(), offset, 0
+            )[:, local_slice]
+            expected_mask = _packed_global_aligned_rows(
+                global_loss_mask, cu_seqlens.tolist(), offset, 0
+            )[:, local_slice]
+            assert torch.equal(legacy_current, expected_labels)
+            assert torch.equal(direct_current, expected_labels)
+            active_grad = direct_grad_chunks[depth + 1].abs().sum(dim=-1).transpose(0, 1) > 0
+            assert torch.equal(active_grad, expected_mask.bool())
+
+
+@pytest.mark.parametrize("sequence_parallel", [False, True])
+@pytest.mark.parametrize("has_padding_mask", [False, True])
+@pytest.mark.parametrize("prepared", [False, True], ids=["legacy", "prepared"])
+def test_mtp_block_scatters_only_prepared_global_padding_masks(
+    monkeypatch, sequence_parallel, has_padding_mask, prepared
+):
+    """Prepared rows scatter after alignment; legacy keeps its existing local mask."""
+    sequence_length = 8
+    local_sequence_length = 4 if sequence_parallel else sequence_length
+    input_ids = torch.arange(sequence_length).view(1, sequence_length)
+    position_ids = input_ids.clone()
+    raw_padding_mask = (
+        torch.tensor([[False, False, False, False, False, False, True, True]])
+        if has_padding_mask
+        else None
+    )
+    local_padding_mask = (
+        raw_padding_mask[:, :local_sequence_length].contiguous()
+        if raw_padding_mask is not None
+        else None
+    )
+    sequence_roll_context = None
+    if prepared:
+        bare_context = prepare_mtp_sequence_roll_context(input_ids, None, None)
+        fields = [
+            MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+            MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+        ]
+        if raw_padding_mask is not None:
+            fields.append(MTPSequenceRollField("padding_mask", raw_padding_mask, -1, 0, True))
+        sequence_roll_context = bare_context.prepare_fields(fields, max_offset=1)
+
+    tp_group = object()
+    scatter_calls = []
+
+    def fake_scatter(mask, group=None):
+        scatter_calls.append((mask.clone(), group))
+        return mask[:local_sequence_length]
+
+    monkeypatch.setattr(
+        "megatron.core.transformer.multi_token_prediction.tensor_parallel."
+        "scatter_to_sequence_parallel_region",
+        fake_scatter,
+    )
+
+    class RecordingLayer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.tp_group = tp_group
+            self.call = None
+
+        def forward(self, hidden_states, padding_mask=None, **kwargs):
+            self.call = (
+                padding_mask,
+                kwargs.get("_inputs_pre_aligned", False),
+                "_inputs_pre_aligned" in kwargs,
+            )
+            return (hidden_states, kwargs["input_ids"], kwargs["position_ids"], padding_mask)
+
+    config = SimpleNamespace(
+        pipeline_model_parallel_size=1,
+        mtp_num_layers=1,
+        mtp_detach_heads=False,
+        sequence_parallel=sequence_parallel,
+    )
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = config
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = False
+    block.layers = torch.nn.ModuleList((RecordingLayer(),))
+
+    block.forward(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        hidden_states=torch.zeros(sequence_length, 1, 1),
+        attention_mask=torch.empty(0),
+        padding_mask=local_padding_mask,
+        sequence_roll_padding_mask=raw_padding_mask if prepared else None,
+        sequence_roll_context=sequence_roll_context,
+        embedding=SimpleNamespace(add_position_embedding=True),
+    )
+
+    seen_padding_mask, inputs_pre_aligned, has_pre_aligned_kwarg = block.layers[0].call
+    assert inputs_pre_aligned is prepared
+    assert has_pre_aligned_kwarg is prepared
+    if not has_padding_mask:
+        assert seen_padding_mask is None
+        assert scatter_calls == []
+    elif not prepared:
+        assert seen_padding_mask is local_padding_mask
+        assert scatter_calls == []
+    else:
+        expected_global = torch.ones_like(raw_padding_mask)
+        expected_global[:, :-1] = raw_padding_mask[:, 1:]
+        expected_local = expected_global[:, :local_sequence_length]
+        assert torch.equal(seen_padding_mask, expected_local)
+        if sequence_parallel:
+            assert len(scatter_calls) == 1
+            assert scatter_calls[0][1] is tp_group
+            assert torch.equal(scatter_calls[0][0], expected_global.transpose(0, 1))
+        else:
+            assert scatter_calls == []

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -1,0 +1,508 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import parallel_state
+from megatron.core.fusions import fused_mtp_tv as fused_tv_module
+from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer import multi_token_prediction as mtp_module
+from megatron.core.transformer.multi_token_prediction import (
+    MTPLossAutoScaler,
+    prepare_mtp_sequence_roll_context,
+    process_mtp_loss,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+_BEBOP_PAPER = "https://arxiv.org/abs/2606.12370"
+pytestmark = pytest.mark.launch_on_gb200
+
+
+def _native_tv_distance(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (10)."""
+    draft_prob = F.softmax(draft_logits.float(), dim=-1)
+    target_prob = F.softmax(target_logits.detach().float(), dim=-1)
+    return 1.0 - torch.minimum(draft_prob, target_prob).sum(dim=-1)
+
+
+def _native_e2e_tv_loss(
+    draft_logits: list[torch.Tensor], target_logits: list[torch.Tensor]
+) -> torch.Tensor:
+    """Independent PyTorch reference for Bebop Eq. (13)."""
+    per_step_acceptance = torch.stack(
+        [
+            1.0 - _native_tv_distance(draft_step, target_step)
+            for draft_step, target_step in zip(draft_logits, target_logits)
+        ],
+        dim=0,
+    )
+    return 1.0 - torch.cumprod(per_step_acceptance, dim=0).mean(dim=0)
+
+
+def _native_roll_packed_sequence_first(
+    tensor: torch.Tensor, cu_seqlens: tuple[int, ...]
+) -> torch.Tensor:
+    """Independent packed left roll for tensors whose first dimension is sequence."""
+    rolled = torch.zeros_like(tensor)
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        rolled[start : end - 1] = tensor[start + 1 : end]
+    return rolled
+
+
+def _cosine_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    return F.cosine_similarity(
+        a.flatten().double().unsqueeze(0), b.flatten().double().unsqueeze(0)
+    ).item()
+
+
+def _tensor_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    a, b = a.double(), b.double()
+    denom = (a * a + b * b).sum()
+    return (2.0 * (a * b).sum() / denom).item() if denom else 1.0
+
+
+def _assert_similarity(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-5):
+    assert torch.isfinite(a).all()
+    assert torch.isfinite(b).all()
+    assert _cosine_sim(a, b) > 1 - eps
+    assert _tensor_sim(a, b) > 1 - eps
+
+
+class _OutputLayer(torch.nn.Module):
+    """Small output projection with the same call contract as MCore's output layer."""
+
+    gather_output = True
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = torch.nn.Parameter(weight)
+
+    def forward(self, hidden, weight=None, runtime_gather_output=None):
+        del runtime_gather_output
+        weight = self.weight if weight is None else weight
+        return torch.matmul(hidden, weight.t()), None
+
+
+def _make_tv_config(mtp_num_layers: int, hidden_size: int) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=1,
+        mtp_num_layers=mtp_num_layers,
+        mtp_loss_type="e2e_tv",
+        mtp_loss_scaling_factor=1.0,
+        mtp_detach_heads=True,
+        use_cpu_initialization=True,
+    )
+
+
+def test_mtp_loss_type_validation():
+    default_config = TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=1)
+    assert default_config.mtp_loss_type == "cross_entropy"
+
+    with pytest.raises(ValueError, match="mtp_loss_type must be one of"):
+        TransformerConfig(
+            num_layers=1, hidden_size=8, num_attention_heads=1, mtp_loss_type="unknown"
+        )
+    with pytest.raises(ValueError, match="requires mtp_num_layers"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_loss_type="e2e_tv",
+            mtp_detach_heads=True,
+        )
+    with pytest.raises(ValueError, match="requires mtp_detach_heads=True"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            mtp_num_layers=2,
+            mtp_loss_type="e2e_tv",
+        )
+
+
+def test_process_mtp_e2e_tv_requires_tp_group_for_sharded_logits(monkeypatch):
+    """A missing explicit TP group cannot silently normalize each vocab shard."""
+    monkeypatch.setattr(parallel_state, "is_initialized", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 2)
+    draft_logits = torch.randn(2, 1, 7, requires_grad=True)
+    target_logits = torch.randn_like(draft_logits)
+
+    with pytest.raises(ValueError, match="tp_group must be provided"):
+        vocab_parallel_tv_distance(
+            draft_logits, target_logits, tp_group=None, logits_are_vocab_sharded=True
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_full_vocab_tv_forward_and_gradient_match_native_reference(dtype):
+    """Use GLM-5/5.2's production vocabulary size with paper-native math.
+
+    The reference is derived independently from Eq. (10) in ``_BEBOP_PAPER``;
+    it does not invoke MCore's analytical backward.
+    """
+    torch.manual_seed(1234)
+    shape = (2, 1, 128256)
+    draft_data = torch.randn(shape, device="cuda", dtype=dtype)
+    target_logits = torch.randn(shape, device="cuda", dtype=dtype)
+    grad_weight = torch.tensor([[[0.25]], [[1.5]]], device="cuda")
+
+    draft_actual = draft_data.detach().clone().requires_grad_(True)
+    actual = vocab_parallel_tv_distance(draft_actual, target_logits, logits_are_vocab_sharded=False)
+    (actual * grad_weight.squeeze(-1)).sum().backward()
+
+    draft_reference = draft_data.detach().clone().requires_grad_(True)
+    reference = _native_tv_distance(draft_reference, target_logits)
+    (reference * grad_weight.squeeze(-1)).sum().backward()
+
+    tolerance = 3e-3 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(actual, reference, rtol=tolerance, atol=tolerance)
+    assert draft_actual.grad is not None
+    assert draft_reference.grad is not None
+    _assert_similarity(draft_actual.grad, draft_reference.grad, eps=tolerance)
+    assert target_logits.grad is None
+
+
+def test_process_mtp_e2e_tv_matches_native_alignment_and_gradient():
+    """Check shifted target alignment, Eq. (13), and draft-only gradients on CPU."""
+    torch.manual_seed(7)
+    mtp_num_layers = 2
+    seq_len = 6
+    batch_size = 1
+    hidden_size = 7
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+
+    hidden_data = torch.randn(
+        (1 + mtp_num_layers) * seq_len, batch_size, hidden_size, dtype=torch.float32
+    )
+    hidden_actual = hidden_data.detach().clone().requires_grad_(True)
+    labels = torch.zeros(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_actual,
+        labels=labels,
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    base_hidden, *draft_hidden = torch.chunk(hidden_data, 1 + mtp_num_layers, dim=0)
+    target_hidden = base_hidden.detach().permute(1, 2, 0)
+    target_logits = []
+    draft_logits = []
+    draft_references = []
+    reference_mask = loss_mask.clone()
+    chain_valid = torch.ones_like(loss_mask, dtype=torch.bool)
+    for draft_hidden_step in draft_hidden:
+        target_hidden = torch.roll(target_hidden, shifts=-1, dims=-1)
+        target_hidden[..., -1] = 0
+        target_logits.append(target_hidden.permute(2, 0, 1))
+
+        draft_reference = draft_hidden_step.detach().clone().requires_grad_(True)
+        draft_references.append(draft_reference)
+        draft_logits.append(draft_reference)
+
+        reference_mask = torch.roll(reference_mask, shifts=-1, dims=-1)
+        reference_mask[..., -1] = 0
+        chain_valid &= reference_mask.bool()
+
+    chain_mask = chain_valid.transpose(0, 1).float()
+    reference_loss = _native_e2e_tv_loss(draft_logits, target_logits)
+    (reference_loss * chain_mask).sum().div(chain_mask.sum()).backward()
+
+    assert hidden_actual.grad is not None
+    actual_chunks = torch.chunk(hidden_actual.grad, 1 + mtp_num_layers, dim=0)
+    torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+    for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+        assert draft_reference.grad is not None
+        _assert_similarity(actual_grad, draft_reference.grad)
+        torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    assert output_layer.weight.grad is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch):
+    """The integrated materialized-roll path dispatches both fused objectives."""
+    torch.manual_seed(26)
+    mtp_num_layers = 2
+    sequence_length = 7
+    hidden_size = 257
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+    hidden_states = torch.randn(
+        (1 + mtp_num_layers) * sequence_length, 1, hidden_size, device="cuda", requires_grad=True
+    )
+    loss_mask = torch.ones(1, sequence_length, device="cuda")
+    fused_tv_distances = []
+    fused_prefix_losses = []
+    logged = []
+
+    original_fused_tv = fused_tv_module._fused_vocab_parallel_tv_distance
+
+    def record_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded):
+        assert draft_logits.is_contiguous()
+        assert target_logits.is_contiguous()
+        result = original_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded)
+        fused_tv_distances.append(result.detach().clone())
+        return result
+
+    original_prefix_objective = mtp_module.mtp_e2e_prefix_objective
+
+    def record_prefix_objective(acceptances):
+        objective, prefix_losses = original_prefix_objective(acceptances)
+        fused_prefix_losses.append(prefix_losses.detach().clone())
+        return objective, prefix_losses
+
+    def record_loss(loss_sum, num_tokens, layer_number, num_layers, **kwargs):
+        assert num_layers == mtp_num_layers
+        assert kwargs["avg_group"] is None
+        logged.append((loss_sum.detach().clone(), num_tokens.detach().clone(), layer_number))
+
+    monkeypatch.setattr(fused_tv_module, "_fused_vocab_parallel_tv_distance", record_fused_tv)
+    monkeypatch.setattr(mtp_module, "mtp_e2e_prefix_objective", record_prefix_objective)
+    monkeypatch.setattr(parallel_state, "get_data_parallel_group", lambda **_: None)
+    monkeypatch.setattr(mtp_module.MTPLossLoggingHelper, "save_loss_to_tracker", record_loss)
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, sequence_length, dtype=torch.long, device="cuda"),
+        loss_mask=loss_mask,
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=True,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+    )
+    result.sum().backward()
+
+    assert len(fused_tv_distances) == mtp_num_layers
+    assert len(fused_prefix_losses) == 1
+    actual_tv_distances = torch.stack(fused_tv_distances)
+    expected_prefix_losses = 1.0 - torch.cumprod(1.0 - actual_tv_distances, dim=0)
+    torch.testing.assert_close(fused_prefix_losses[0], expected_prefix_losses, rtol=1e-5, atol=1e-6)
+
+    chain_mask = torch.zeros(sequence_length, 1, device="cuda")
+    chain_mask[: sequence_length - mtp_num_layers] = 1
+    assert len(logged) == mtp_num_layers
+    for layer_number, (loss_sum, num_tokens, logged_layer_number) in enumerate(logged):
+        assert logged_layer_number == layer_number
+        torch.testing.assert_close(num_tokens, chain_mask.sum(), rtol=0, atol=0)
+        torch.testing.assert_close(
+            loss_sum, torch.sum(fused_prefix_losses[0][layer_number] * chain_mask), rtol=0, atol=0
+        )
+
+
+def test_process_mtp_e2e_tv_masks_incomplete_packed_chains():
+    """A fixed-gamma objective must neither wrap nor train across THD segments."""
+    torch.manual_seed(17)
+    mtp_num_layers = 2
+    seq_len = 7
+    hidden_size = 5
+    config = _make_tv_config(mtp_num_layers, hidden_size)
+    output_layer = _OutputLayer(torch.eye(hidden_size))
+    hidden_states = torch.randn((1 + mtp_num_layers) * seq_len, 1, hidden_size, requires_grad=True)
+    packed_seq_params = PackedSeqParams(
+        cu_seqlens_q=torch.tensor([0, 3, 7], dtype=torch.int32),
+        cu_seqlens_kv=torch.tensor([0, 3, 7], dtype=torch.int32),
+        max_seqlen_q=4,
+        max_seqlen_kv=4,
+        qkv_format="thd",
+    )
+
+    MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0))
+    result = process_mtp_loss(
+        hidden_states=hidden_states,
+        labels=torch.zeros(1, seq_len, dtype=torch.long),
+        loss_mask=torch.ones(1, seq_len),
+        output_layer=output_layer,
+        output_weight=None,
+        runtime_gather_output=True,
+        is_training=False,
+        compute_language_model_loss=lambda *_: pytest.fail("cross entropy must not run for e2e TV"),
+        config=config,
+        packed_seq_params=packed_seq_params,
+    )
+    result.sum().backward()
+
+    assert hidden_states.grad is not None
+    _, draft_0_grad, draft_1_grad = torch.chunk(hidden_states.grad, 3, dim=0)
+    expected_valid = torch.tensor([True, False, False, True, True, False, False])
+    assert torch.count_nonzero(draft_0_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_1_grad[~expected_valid]) == 0
+    assert torch.count_nonzero(draft_0_grad[expected_valid]) > 0
+    assert torch.count_nonzero(draft_1_grad[expected_valid]) > 0
+
+
+def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monkeypatch):
+    """Contiguous packed CP rolls target distributions without crossing segments."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        mtp_num_layers = 2
+        global_seq_len = 8
+        local_seq_len = global_seq_len // 2
+        hidden_size = 5
+        cu_seqlens = (0, 6, 8)
+
+        torch.manual_seed(23)
+        full_hidden = torch.randn(
+            (1 + mtp_num_layers) * global_seq_len, 1, hidden_size, device="cuda"
+        )
+        full_chunks = torch.chunk(full_hidden, 1 + mtp_num_layers, dim=0)
+        local_start = cp_rank * local_seq_len
+        local_chunks = [
+            chunk.narrow(0, local_start, local_seq_len).clone() for chunk in full_chunks
+        ]
+        local_hidden = torch.cat(local_chunks, dim=0).requires_grad_(True)
+        output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+        config = _make_tv_config(mtp_num_layers, hidden_size)
+
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens_tensor,
+            cu_seqlens_kv=cu_seqlens_tensor,
+            cu_seqlens_q_padded=cu_seqlens_tensor,
+            cu_seqlens_kv_padded=cu_seqlens_tensor,
+            max_seqlen_q=6,
+            max_seqlen_kv=6,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        local_loss_mask = torch.ones(1, local_seq_len, device="cuda")
+        sequence_roll_context = prepare_mtp_sequence_roll_context(
+            tensor=local_loss_mask, cp_group=cp_group, packed_seq_params=packed_seq_params
+        )
+
+        captured_target_steps = []
+        tv_distance = mtp_module.vocab_parallel_tv_distance
+
+        def capture_target(draft_logits, target_logits, **kwargs):
+            captured_target_steps.append(target_logits.detach().clone())
+            return tv_distance(draft_logits, target_logits, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", capture_target)
+
+        MTPLossAutoScaler.set_loss_scale(torch.tensor(1.0, device="cuda"))
+        result = process_mtp_loss(
+            hidden_states=local_hidden,
+            labels=torch.zeros(1, local_seq_len, dtype=torch.long, device="cuda"),
+            loss_mask=local_loss_mask,
+            output_layer=output_layer,
+            output_weight=None,
+            runtime_gather_output=True,
+            is_training=False,
+            compute_language_model_loss=lambda *_: pytest.fail(
+                "cross entropy must not run for e2e TV"
+            ),
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=sequence_roll_context,
+        )
+        result.sum().backward()
+
+        reference_weight = output_layer.weight.detach()
+        target_logits = torch.matmul(full_chunks[0].detach(), reference_weight.t())
+        full_mask = torch.ones(global_seq_len, 1, device="cuda")
+        full_chain_valid = torch.ones_like(full_mask, dtype=torch.bool)
+        target_steps = []
+        draft_references = []
+        draft_steps = []
+        for full_draft in full_chunks[1:]:
+            target_logits = _native_roll_packed_sequence_first(target_logits, cu_seqlens)
+            target_steps.append(target_logits.narrow(0, local_start, local_seq_len))
+            full_mask = _native_roll_packed_sequence_first(full_mask, cu_seqlens)
+            full_chain_valid &= full_mask.bool()
+
+            draft_reference = (
+                full_draft.narrow(0, local_start, local_seq_len)
+                .detach()
+                .clone()
+                .requires_grad_(True)
+            )
+            draft_references.append(draft_reference)
+            draft_steps.append(torch.matmul(draft_reference, reference_weight.t()))
+
+        local_chain_mask = full_chain_valid.narrow(0, local_start, local_seq_len).float()
+        assert len(captured_target_steps) == mtp_num_layers
+        for captured_target, target_step in zip(captured_target_steps, target_steps):
+            torch.testing.assert_close(captured_target, target_step, rtol=0, atol=0)
+        reference_loss = _native_e2e_tv_loss(draft_steps, target_steps)
+        (reference_loss * local_chain_mask).sum().div(
+            local_chain_mask.sum().clamp(min=1)
+        ).backward()
+
+        assert local_hidden.grad is not None
+        actual_chunks = torch.chunk(local_hidden.grad, 1 + mtp_num_layers, dim=0)
+        torch.testing.assert_close(actual_chunks[0], torch.ones_like(actual_chunks[0]))
+        for actual_grad, draft_reference in zip(actual_chunks[1:], draft_references):
+            assert draft_reference.grad is not None
+            torch.testing.assert_close(actual_grad, draft_reference.grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("logits_are_vocab_sharded", [False, True], ids=["gathered", "sharded"])
+def test_vocab_parallel_tv_tp2_matches_full_vocab_reference(logits_are_vocab_sharded):
+    """TP gathered/sharded forward and local gradients match a full-vocabulary reference."""
+    if Utils.world_size < 2:
+        pytest.skip("A distributed run with at least two ranks is required")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2)
+    try:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        torch.manual_seed(2026)
+        full_shape = (2, 1, 128256)
+        full_draft_data = torch.randn(full_shape, dtype=torch.float32).cuda()
+        full_target = torch.randn(full_shape, dtype=torch.float32).cuda()
+        if logits_are_vocab_sharded:
+            local_draft_data = full_draft_data.chunk(2, dim=-1)[tp_rank].contiguous()
+            local_target = full_target.chunk(2, dim=-1)[tp_rank].contiguous()
+        else:
+            local_draft_data = full_draft_data
+            local_target = full_target
+
+        local_draft = local_draft_data.detach().clone().requires_grad_(True)
+        actual = vocab_parallel_tv_distance(
+            local_draft,
+            local_target,
+            tp_group=tp_group,
+            logits_are_vocab_sharded=logits_are_vocab_sharded,
+        )
+        actual.sum().backward()
+
+        full_draft = full_draft_data.detach().clone().requires_grad_(True)
+        reference = _native_tv_distance(full_draft, full_target)
+        reference.sum().backward()
+
+        torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-6)
+        assert local_draft.grad is not None
+        assert full_draft.grad is not None
+        expected_local_grad = (
+            full_draft.grad.chunk(2, dim=-1)[tp_rank]
+            if logits_are_vocab_sharded
+            else full_draft.grad
+        )
+        _assert_similarity(local_draft.grad, expected_local_grad)
+        torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_mtp_tv_loss.py
+++ b/tests/unit_tests/transformer/test_mtp_tv_loss.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+from unittest import mock
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -9,11 +11,12 @@ from megatron.core.fusions import fused_mtp_tv as fused_tv_module
 from megatron.core.fusions.fused_mtp_tv import vocab_parallel_tv_distance
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import multi_token_prediction as mtp_module
-from megatron.core.transformer.multi_token_prediction import (
-    MTPLossAutoScaler,
+from megatron.core.transformer.mtp_sequence_roll import (
+    ContiguousPackedCPRollContext,
+    ZigzagPackedCPRollContext,
     prepare_mtp_sequence_roll_context,
-    process_mtp_loss,
 )
+from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler, process_mtp_loss
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -252,10 +255,14 @@ def test_process_mtp_e2e_tv_uses_fused_tv_prefix_and_logs_each_depth(monkeypatch
 
     original_fused_tv = fused_tv_module._fused_vocab_parallel_tv_distance
 
-    def record_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded):
+    def record_fused_tv(
+        draft_logits, target_logits, tp_group, logits_are_vocab_sharded, **row_addressing
+    ):
         assert draft_logits.is_contiguous()
         assert target_logits.is_contiguous()
-        result = original_fused_tv(draft_logits, target_logits, tp_group, logits_are_vocab_sharded)
+        result = original_fused_tv(
+            draft_logits, target_logits, tp_group, logits_are_vocab_sharded, **row_addressing
+        )
         fused_tv_distances.append(result.detach().clone())
         return result
 
@@ -396,7 +403,27 @@ def test_process_mtp_e2e_tv_contiguous_packed_cp2_matches_global_reference(monke
         tv_distance = mtp_module.vocab_parallel_tv_distance
 
         def capture_target(draft_logits, target_logits, **kwargs):
-            captured_target_steps.append(target_logits.detach().clone())
+            target_row_indices = kwargs.get("target_row_indices")
+            if target_row_indices is None:
+                captured_target = target_logits.detach().clone()
+            else:
+                target_valid_rows = kwargs["target_valid_rows"]
+                target_halo_logits = kwargs.get("target_halo_logits")
+                vocab_size = target_logits.size(-1)
+                target_rows = target_logits.detach().reshape(-1, vocab_size)
+                if target_halo_logits is not None:
+                    target_rows = torch.cat(
+                        (target_rows, target_halo_logits.detach().reshape(-1, vocab_size)), dim=0
+                    )
+                flat_indices = target_row_indices.reshape(-1).long()
+                flat_valid = target_valid_rows.reshape(-1)
+                flat_valid = flat_valid & (flat_indices >= 0) & (flat_indices < target_rows.size(0))
+                safe_indices = torch.where(flat_valid, flat_indices, 0)
+                captured_target = target_rows.index_select(0, safe_indices).view_as(draft_logits)
+                captured_target.masked_fill_(
+                    ~flat_valid.view_as(target_valid_rows).unsqueeze(-1), 0
+                )
+            captured_target_steps.append(captured_target)
             return tv_distance(draft_logits, target_logits, **kwargs)
 
         monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", capture_target)
@@ -506,3 +533,383 @@ def test_vocab_parallel_tv_tp2_matches_full_vocab_reference(logits_are_vocab_sha
         torch.testing.assert_close(local_draft.grad, expected_local_grad, rtol=1e-5, atol=1e-6)
     finally:
         Utils.destroy_model_parallel()
+
+
+def _zigzag_local_rows(global_tensor: torch.Tensor, cp_rank: int, cp_size: int) -> torch.Tensor:
+    """Shard a sequence-last tensor into MCore's front/mirrored-back zigzag layout."""
+    sequence_length = global_tensor.size(-1)
+    assert sequence_length % (2 * cp_size) == 0
+    chunk_length = sequence_length // (2 * cp_size)
+    chunks = global_tensor.split(chunk_length, dim=-1)
+    return torch.cat((chunks[cp_rank], chunks[2 * cp_size - cp_rank - 1]), dim=-1).contiguous()
+
+
+def _run_mtp_loss_and_grad(
+    *,
+    hidden_template: torch.Tensor,
+    labels: torch.Tensor | None,
+    loss_mask: torch.Tensor,
+    input_ids: torch.Tensor | None,
+    output_layer,
+    output_weight: torch.Tensor | None,
+    config: TransformerConfig,
+    cp_group=None,
+    tp_group=None,
+    packed_seq_params: PackedSeqParams | None = None,
+    sequence_roll_context=None,
+) -> tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor | None]:
+    """Return visible output, hidden/weight gradients, and losses passed to autograd."""
+    hidden = hidden_template.detach().clone().requires_grad_(True)
+    layer_weight = getattr(output_layer, "weight", None)
+    if isinstance(layer_weight, torch.Tensor) and layer_weight.grad is not None:
+        layer_weight.grad = None
+
+    def language_model_loss(current_labels, logits):
+        vocab_size = logits.size(-1)
+        sequence_major_loss = F.cross_entropy(
+            logits.reshape(-1, vocab_size),
+            current_labels.transpose(0, 1).reshape(-1),
+            reduction="none",
+        ).view(logits.shape[:-1])
+        return sequence_major_loss.transpose(0, 1).contiguous()
+
+    MTPLossAutoScaler.set_loss_scale(hidden.new_tensor(1.0))
+    normalized_losses = []
+    original_apply = MTPLossAutoScaler.apply
+
+    def record_loss(output, normalized_loss):
+        normalized_losses.append(normalized_loss.detach().clone())
+        return original_apply(output, normalized_loss)
+
+    with mock.patch.object(MTPLossAutoScaler, "apply", side_effect=record_loss):
+        output = process_mtp_loss(
+            hidden_states=hidden,
+            labels=labels,
+            loss_mask=loss_mask,
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=False if tp_group is not None else True,
+            is_training=False,
+            compute_language_model_loss=language_model_loss,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            input_ids=input_ids,
+            sequence_roll_context=sequence_roll_context,
+        )
+    output.sum().backward()
+    assert hidden.grad is not None
+    layer_weight_grad = getattr(layer_weight, "grad", None)
+    return (
+        output.detach(),
+        hidden.grad.detach(),
+        tuple(normalized_losses),
+        None if layer_weight_grad is None else layer_weight_grad.detach().clone(),
+    )
+
+
+def test_e2e_tv_direct_rows_compose_tp2_with_contiguous_cp2(monkeypatch):
+    """TP-sharded TV and contiguous-CP row addressing compose in one consumer."""
+    if Utils.world_size < 4:
+        pytest.skip("TP2 x CP2 direct TV requires at least four distributed ranks")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=2)
+    try:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        cp_group = parallel_state.get_context_parallel_group()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        num_depths = 2
+        global_sequence_length = 8
+        local_sequence_length = global_sequence_length // 2
+        hidden_size = 4
+        global_vocab_size = 10
+
+        torch.manual_seed(101)
+        global_hidden = torch.randn(
+            (1 + num_depths) * global_sequence_length, 1, hidden_size, device="cuda"
+        )
+        local_chunks = [
+            chunk.narrow(0, cp_rank * local_sequence_length, local_sequence_length).contiguous()
+            for chunk in torch.chunk(global_hidden, 1 + num_depths, dim=0)
+        ]
+        local_hidden = torch.cat(local_chunks, dim=0)
+        full_weight = torch.randn(global_vocab_size, hidden_size, device="cuda")
+        local_weight = full_weight.chunk(2, dim=0)[tp_rank].contiguous()
+
+        class ShardedOutputLayer:
+            gather_output = False
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                assert runtime_gather_output is False
+                return torch.matmul(hidden, weight.t()), None
+
+        config = _make_tv_config(num_depths, hidden_size)
+        cu_seqlens = torch.tensor([0, 6, 8], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=6,
+            max_seqlen_kv=6,
+            qkv_format="thd",
+            cp_partition_mode="contiguous",
+        )
+        local_labels = torch.zeros(1, local_sequence_length, dtype=torch.long, device="cuda")
+        local_loss_mask = torch.ones_like(local_labels, dtype=torch.float32)
+        bare_context = prepare_mtp_sequence_roll_context(local_labels, cp_group, packed_seq_params)
+        assert isinstance(bare_context, ContiguousPackedCPRollContext)
+
+        original_tv = mtp_module.vocab_parallel_tv_distance
+        addressed_calls = 0
+
+        def record_addressing(*args, **kwargs):
+            nonlocal addressed_calls
+            addressed_calls += int(kwargs.get("target_row_indices") is not None)
+            return original_tv(*args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", record_addressing)
+        direct_output, direct_grad, direct_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=None,
+            output_layer=ShardedOutputLayer(),
+            output_weight=local_weight,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=bare_context,
+        )
+
+        torch.distributed.barrier()
+        fallback_output, fallback_grad, fallback_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=None,
+            output_layer=ShardedOutputLayer(),
+            output_weight=local_weight,
+            config=config,
+            cp_group=cp_group,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=None,
+        )
+        # Keep rank-local assertions after every TP/CP collective in both paths;
+        # otherwise one failing rank can enter teardown while peers run fallback.
+        torch.distributed.barrier()
+        assert addressed_calls == num_depths
+        torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+        torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-5, atol=1e-6)
+        assert len(direct_losses) == len(fallback_losses) == 1
+        torch.testing.assert_close(direct_losses[0], fallback_losses[0], rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+def test_e2e_tv_certified_dynamic_zigzag_matches_roll_loss_and_gradient(
+    monkeypatch, derived_labels
+):
+    """Certified dynamic zigzag addressing preserves SFT/RL TV consumer semantics."""
+    if Utils.world_size < 2:
+        pytest.skip("Certified zigzag TV parity requires at least two distributed ranks")
+
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+        cp_size = torch.distributed.get_world_size(group=cp_group)
+        num_depths = 2
+        global_sequence_length = 12
+        hidden_size = 5
+
+        torch.manual_seed(211)
+        global_hidden_chunks = torch.chunk(
+            torch.randn((1 + num_depths) * global_sequence_length, 1, hidden_size, device="cuda"),
+            1 + num_depths,
+            dim=0,
+        )
+        local_hidden = torch.cat(
+            [
+                _zigzag_local_rows(chunk.permute(1, 2, 0), cp_rank, cp_size).permute(2, 0, 1)
+                for chunk in global_hidden_chunks
+            ],
+            dim=0,
+        )
+        global_input_ids = torch.arange(global_sequence_length, device="cuda").view(1, -1)
+        global_labels = (global_input_ids + 1).remainder(hidden_size)
+        global_loss_mask = torch.ones(1, global_sequence_length, device="cuda")
+        global_loss_mask[:, 4] = 0
+        global_loss_mask[:, -1] = 0
+        local_input_ids = _zigzag_local_rows(global_input_ids, cp_rank, cp_size)
+        local_labels = _zigzag_local_rows(global_labels, cp_rank, cp_size)
+        local_loss_mask = _zigzag_local_rows(global_loss_mask, cp_rank, cp_size)
+
+        cu_seqlens = torch.tensor([0, global_sequence_length], dtype=torch.int32, device="cuda")
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=global_sequence_length,
+            max_seqlen_kv=global_sequence_length,
+            qkv_format="thd",
+            local_cp_size=cp_size,
+            cp_group=cp_group,
+            cp_partition_mode="zigzag",
+            zigzag_cp_min_chunk_size=global_sequence_length // (2 * cp_size),
+        )
+        source = local_input_ids if derived_labels else local_labels
+        bare_context = prepare_mtp_sequence_roll_context(source, None, packed_seq_params)
+        assert isinstance(bare_context, ZigzagPackedCPRollContext)
+        assert bare_context.cp_group is packed_seq_params.cp_group
+        config = _make_tv_config(num_depths, hidden_size)
+        output_layer = _OutputLayer(torch.eye(hidden_size, device="cuda"))
+        original_tv = mtp_module.vocab_parallel_tv_distance
+        addressed_calls = 0
+
+        def record_addressing(*args, **kwargs):
+            nonlocal addressed_calls
+            addressed_calls += int(kwargs.get("target_row_indices") is not None)
+            return original_tv(*args, **kwargs)
+
+        monkeypatch.setattr(mtp_module, "vocab_parallel_tv_distance", record_addressing)
+
+        direct_output, direct_grad, direct_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=None if derived_labels else local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=local_input_ids if derived_labels else None,
+            output_layer=output_layer,
+            output_weight=None,
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=bare_context,
+        )
+        torch.distributed.barrier()
+        fallback_output, fallback_grad, fallback_losses, _ = _run_mtp_loss_and_grad(
+            hidden_template=local_hidden,
+            labels=None if derived_labels else local_labels,
+            loss_mask=local_loss_mask,
+            input_ids=local_input_ids if derived_labels else None,
+            output_layer=output_layer,
+            output_weight=None,
+            config=config,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            sequence_roll_context=None,
+        )
+        torch.distributed.barrier()
+        assert addressed_calls == num_depths
+        torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+        torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-5, atol=1e-6)
+        assert len(direct_losses) == len(fallback_losses) == 1
+        torch.testing.assert_close(direct_losses[0], fallback_losses[0], rtol=1e-5, atol=1e-6)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("loss_type", ["cross_entropy", "e2e_tv"], ids=["ce", "tv"])
+@pytest.mark.parametrize("derived_labels", [False, True], ids=["sft", "rl"])
+def test_aligned_rows_per_token_normalization_matches_roll(loss_type, derived_labels):
+    """Absolute rows preserve SFT/RL per-token scaling for CE and TV consumers."""
+    torch.manual_seed(307)
+    num_depths = 2
+    sequence_length = 7
+    hidden_size = 5
+    hidden_template = torch.randn(
+        (1 + num_depths) * sequence_length, 1, hidden_size, dtype=torch.float32
+    )
+    input_ids = torch.tensor([[0, 1, 2, 3, 4, 0, 1]], dtype=torch.long)
+    labels = torch.tensor([[1, 2, 3, 4, 0, 1, 2]], dtype=torch.long)
+    loss_mask = torch.tensor([[1, 1, 0, 1, 1, 0, 1]], dtype=torch.float32)
+
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=1,
+        mtp_num_layers=num_depths,
+        mtp_loss_type=loss_type,
+        mtp_detach_heads=loss_type == "e2e_tv",
+        mtp_loss_scaling_factor=0.75,
+        calculate_per_token_loss=True,
+        use_cpu_initialization=True,
+    )
+    output_weight = torch.eye(hidden_size)
+    direct_output_layer = _OutputLayer(output_weight.clone())
+    fallback_output_layer = _OutputLayer(output_weight.clone())
+    source = input_ids if derived_labels else labels
+    bare_context = prepare_mtp_sequence_roll_context(source, None, None)
+    assert bare_context is not None
+    original_prepare = mtp_module.prepare_mtp_sequence_roll_fields
+    original_roll = mtp_module.roll_tensor
+    original_tv = mtp_module.vocab_parallel_tv_distance
+    prepared_groups = 0
+    direct_roll_calls = 0
+    addressed_tv_calls = 0
+
+    def record_prepare(*args, **kwargs):
+        nonlocal prepared_groups
+        result = original_prepare(*args, **kwargs)
+        prepared_groups += int(result is not None)
+        return result
+
+    def record_roll(*args, **kwargs):
+        nonlocal direct_roll_calls
+        direct_roll_calls += 1
+        return original_roll(*args, **kwargs)
+
+    def record_tv(*args, **kwargs):
+        nonlocal addressed_tv_calls
+        addressed_tv_calls += int(kwargs.get("target_row_indices") is not None)
+        return original_tv(*args, **kwargs)
+
+    with (
+        mock.patch.object(
+            mtp_module, "prepare_mtp_sequence_roll_fields", side_effect=record_prepare
+        ),
+        mock.patch.object(mtp_module, "roll_tensor", side_effect=record_roll),
+        mock.patch.object(mtp_module, "vocab_parallel_tv_distance", side_effect=record_tv),
+    ):
+        direct_output, direct_grad, direct_losses, direct_weight_grad = _run_mtp_loss_and_grad(
+            hidden_template=hidden_template,
+            labels=None if derived_labels else labels,
+            loss_mask=loss_mask,
+            input_ids=input_ids if derived_labels else None,
+            output_layer=direct_output_layer,
+            output_weight=None,
+            config=config,
+            sequence_roll_context=bare_context,
+        )
+
+    fallback_output, fallback_grad, fallback_losses, fallback_weight_grad = _run_mtp_loss_and_grad(
+        hidden_template=hidden_template,
+        labels=None if derived_labels else labels,
+        loss_mask=loss_mask,
+        input_ids=input_ids if derived_labels else None,
+        output_layer=fallback_output_layer,
+        output_weight=None,
+        config=config,
+        sequence_roll_context=None,
+    )
+    assert prepared_groups > 0
+    assert direct_roll_calls == 0
+    assert addressed_tv_calls == (num_depths if loss_type == "e2e_tv" else 0)
+    torch.testing.assert_close(direct_output, fallback_output, rtol=0, atol=0)
+    torch.testing.assert_close(direct_grad, fallback_grad, rtol=1e-6, atol=1e-6)
+    assert len(direct_losses) == len(fallback_losses)
+    for direct_loss, fallback_loss in zip(direct_losses, fallback_losses):
+        torch.testing.assert_close(direct_loss, fallback_loss, rtol=1e-6, atol=1e-6)
+    if loss_type == "cross_entropy":
+        assert direct_weight_grad is not None
+        assert fallback_weight_grad is not None
+        torch.testing.assert_close(direct_weight_grad, fallback_weight_grad, rtol=1e-6, atol=1e-6)
+    else:
+        assert direct_weight_grad is None
+        assert fallback_weight_grad is None

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -168,6 +168,16 @@ class TestParallelMLAAttention:
     def test_constructor(self):
         assert isinstance(self.parallel_attention, MLASelfAttention)
         assert self.parallel_attention.layer_number == 1
+        assert self.parallel_attention.linear_q_up_proj.weight.qkv_layout.num_groups == 4
+        assert (
+            self.parallel_attention.linear_q_up_proj.weight.qkv_layout.projection_split_shapes
+            == (128, 64)
+        )
+        assert self.parallel_attention.linear_kv_up_proj.weight.qkv_layout.num_groups == 4
+        assert (
+            self.parallel_attention.linear_kv_up_proj.weight.qkv_layout.projection_split_shapes
+            == (128, 128)
+        )
 
         num_weights = sum([p.numel() for p in self.parallel_attention.parameters()])
         assert num_weights == 65036
@@ -1853,6 +1863,9 @@ class TestFusedMLASelfAttention:
         assert isinstance(self.fused_attention, MLASelfAttention)
         assert self.fused_attention.layer_number == 1
         assert hasattr(self.fused_attention, 'linear_qkv_down_proj')
+        assert self.fused_attention.linear_q_up_proj.weight.qkv_layout.num_groups == 4
+        assert self.fused_attention.linear_kv_up_proj.weight.qkv_layout.num_groups == 4
+        assert getattr(self.fused_attention.linear_qkv_down_proj.weight, 'qkv_layout', None) is None
 
     def test_attention_latent_norm_epsilon_on_fused_projections(self):
         config = MLATransformerConfig(

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -76,6 +76,7 @@ def test_mtp_forward_signatures_preserve_positional_compatibility():
         "roll_depth",
         "sequence_len_offset",
         "embedding",
+        "mtp_dsa_context",
         "_inputs_pre_aligned",
     )
 
@@ -1399,7 +1400,10 @@ class TestMultiTokenPrediction:
                 return hidden_states, input_ids, position_ids, padding_mask
 
         config = types.SimpleNamespace(
-            pipeline_model_parallel_size=1, mtp_num_layers=2, mtp_detach_heads=False
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=2,
+            mtp_detach_heads=False,
+            dsa_mtp_index_kv_share=False,
         )
         block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
         torch.nn.Module.__init__(block)
@@ -1492,7 +1496,10 @@ class TestMultiTokenPrediction:
                 return hidden_states, input_ids, position_ids, padding_mask
 
         config = types.SimpleNamespace(
-            pipeline_model_parallel_size=1, mtp_num_layers=1, mtp_detach_heads=False
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=1,
+            mtp_detach_heads=False,
+            dsa_mtp_index_kv_share=False,
         )
         block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
         torch.nn.Module.__init__(block)
@@ -1540,6 +1547,88 @@ class TestMultiTokenPrediction:
                 sequence_roll_context=context,
                 embedding=embedding,
             )
+
+    def test_prepared_rows_and_repeated_dsa_context_share_are_composable(self):
+        """Absolute row alignment and iteration-scoped DSA sharing use independent carriers."""
+
+        shared_key = torch.tensor([101.0])
+        shared_topk = torch.tensor([[2]], dtype=torch.int32)
+        shared_topk_length = torch.tensor([1], dtype=torch.int32)
+
+        class SharingLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def forward(
+                self,
+                hidden_states,
+                input_ids,
+                position_ids,
+                padding_mask,
+                mtp_dsa_context,
+                **kwargs,
+            ):
+                self.calls.append(
+                    (
+                        input_ids.clone(),
+                        position_ids.clone(),
+                        kwargs["_inputs_pre_aligned"],
+                        mtp_dsa_context,
+                    )
+                )
+                if mtp_dsa_context.is_source:
+                    mtp_dsa_context.capture(shared_key, shared_topk, shared_topk_length)
+                else:
+                    assert mtp_dsa_context.reuses_source
+                    assert mtp_dsa_context.shared_tensors.key is shared_key
+                    assert mtp_dsa_context.shared_tensors.topk_indices is shared_topk
+                    assert mtp_dsa_context.shared_tensors.topk_length is shared_topk_length
+                return hidden_states, input_ids, position_ids, padding_mask
+
+        config = types.SimpleNamespace(
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=2,
+            mtp_detach_heads=False,
+            dsa_mtp_index_kv_share=True,
+        )
+        block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+        torch.nn.Module.__init__(block)
+        block.config = config
+        block.vp_stage = None
+        block.mtp_use_repeated_layer = True
+        layer = SharingLayer()
+        block.layers = torch.nn.ModuleList((layer,))
+
+        input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+        position_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        sequence_roll_context = prepare_mtp_sequence_roll_context(input_ids, None, None)
+        sequence_roll_context = sequence_roll_context.prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+                MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+            ),
+            max_offset=2,
+        )
+
+        block.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=torch.zeros(4, 1, 2),
+            attention_mask=None,
+            sequence_roll_context=sequence_roll_context,
+            embedding=types.SimpleNamespace(add_position_embedding=True),
+        )
+
+        assert len(layer.calls) == 2
+        assert torch.equal(layer.calls[0][0], torch.tensor([[20, 30, 40, 0]]))
+        assert torch.equal(layer.calls[1][0], torch.tensor([[30, 40, 0, 0]]))
+        assert torch.equal(layer.calls[0][1], torch.tensor([[1, 2, 3, 0]]))
+        assert torch.equal(layer.calls[1][1], torch.tensor([[2, 3, 0, 0]]))
+        assert all(call[2] for call in layer.calls)
+        assert layer.calls[0][3].is_source
+        assert layer.calls[1][3].reuses_source
+        assert layer.calls[1][3].shared_tensors is layer.calls[0][3].produced_tensors
 
     @pytest.mark.parametrize(
         (

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import inspect
 import os
 import sys
 import types
@@ -10,12 +11,14 @@ from torch import Tensor
 
 from megatron.core.enums import ModelType
 from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.models.gpt import gpt_model as gpt_model_module
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_layer_with_transformer_engine_spec,
     get_gpt_mtp_block_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid import hybrid_model as hybrid_model_module
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
@@ -24,17 +27,21 @@ from megatron.core.parallel_state import get_context_parallel_group
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.hyper_connection import learned_output_contract
-from megatron.core.transformer.multi_token_prediction import (
+from megatron.core.transformer.mtp_sequence_roll import (
     ContiguousPackedCPRollContext,
     ContiguousPackedCPRollHalos,
     ContiguousPackedSeqRollPlan,
+    LocalRollContext,
+    MTPSequenceRollField,
+    prepare_mtp_sequence_roll_context,
+    roll_tensor,
+)
+from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
     MultiTokenPredictionLayer,
     _mtp_logits_are_vocab_sharded,
-    prepare_mtp_sequence_roll_context,
     process_mtp_loss,
-    roll_tensor,
 )
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -58,6 +65,30 @@ else:
     TEColumnParallelGroupedLinear = None
 
 _SEED = 42
+
+
+def test_mtp_forward_signatures_preserve_positional_compatibility():
+    """New sequence-roll arguments must not shift established positional slots."""
+    layer_parameters = tuple(inspect.signature(MultiTokenPredictionLayer.forward).parameters)
+    layer_tail = layer_parameters[layer_parameters.index("sequence_roll_context") :]
+    assert layer_tail == (
+        "sequence_roll_context",
+        "roll_depth",
+        "sequence_len_offset",
+        "embedding",
+        "_inputs_pre_aligned",
+    )
+
+    block_parameters = tuple(inspect.signature(MultiTokenPredictionBlock.forward).parameters)
+    block_tail = block_parameters[block_parameters.index("sequence_roll_context") :]
+    assert block_tail == (
+        "sequence_roll_context",
+        "sequence_len_offset",
+        "extra_block_kwargs",
+        "embedding",
+        "mhc_multistream",
+        "sequence_roll_padding_mask",
+    )
 
 
 class TestMultiTokenPredictionLayer:
@@ -1222,6 +1253,574 @@ class TestMultiTokenPrediction:
         assert seen['labels'] is not None, "loss should be computed in RL mode"
         assert torch.equal(seen['labels'], torch.tensor([[30, 40, 50, 0, 0]], dtype=torch.long))
 
+    @pytest.mark.parametrize("derived_labels", [False, True])
+    def test_process_mtp_loss_aligned_rows_match_cumulative_roll(self, derived_labels):
+        """Absolute CE alignment preserves SFT and RL cumulative-roll semantics."""
+        config = TransformerConfig(
+            hidden_size=4, num_layers=2, num_attention_heads=2, mtp_num_layers=2
+        )
+        config.mtp_loss_scaling_factor = 1.0
+        sequence_length = 6
+        hidden_states = torch.arange(
+            (1 + config.mtp_num_layers) * sequence_length * config.hidden_size, dtype=torch.float32
+        ).view((1 + config.mtp_num_layers) * sequence_length, 1, config.hidden_size)
+        input_ids = torch.tensor([[10, 20, 30, 40, 50, 60]], dtype=torch.long)
+        labels = torch.tensor([[11, 21, 31, 41, 51, 61]], dtype=torch.long)
+        loss_mask = torch.tensor([[1, 1, 1, 1, 0, 0]], dtype=torch.float32)
+        source = input_ids if derived_labels else labels
+        label_key = "input_ids" if derived_labels else "labels"
+        max_offset = config.mtp_num_layers + int(derived_labels)
+
+        bare_context = prepare_mtp_sequence_roll_context(source, None, None)
+        assert bare_context is not None
+        prepared_context = bare_context.prepare_fields(
+            (
+                MTPSequenceRollField(label_key, source, -1, 0, 0),
+                MTPSequenceRollField("loss_mask", loss_mask, -1, 0, 0),
+            ),
+            max_offset=max_offset,
+        )
+
+        class OutputLayer:
+            gather_output = True
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                del weight, runtime_gather_output
+                return hidden, None
+
+        def run(context):
+            seen_labels = []
+
+            def compute_language_model_loss(current_labels, logits):
+                seen_labels.append(current_labels.clone())
+                return torch.ones_like(current_labels, dtype=logits.dtype)
+
+            process_mtp_loss(
+                hidden_states=hidden_states.clone(),
+                labels=None if derived_labels else labels,
+                loss_mask=loss_mask,
+                output_layer=OutputLayer(),
+                output_weight=None,
+                runtime_gather_output=None,
+                is_training=False,
+                compute_language_model_loss=compute_language_model_loss,
+                config=config,
+                input_ids=input_ids if derived_labels else None,
+                sequence_roll_context=context,
+            )
+            return seen_labels
+
+        fallback_labels = run(None)
+        addressed_labels = run(prepared_context)
+        assert len(addressed_labels) == config.mtp_num_layers
+        for actual, expected in zip(addressed_labels, fallback_labels):
+            assert torch.equal(actual, expected)
+
+        first_offset = 2 if derived_labels else 1
+        for depth, actual in enumerate(addressed_labels):
+            offset = first_offset + depth
+            expected = torch.zeros_like(source)
+            expected[:, : sequence_length - offset] = source[:, offset:]
+            assert torch.equal(actual, expected)
+
+    @pytest.mark.parametrize("derived_labels", [False, True])
+    def test_e2e_tv_aligned_rows_match_cumulative_roll_gradient(self, derived_labels):
+        """Direct TV target addressing preserves SFT/RL loss and gradient semantics."""
+        torch.manual_seed(_SEED)
+        config = TransformerConfig(
+            hidden_size=4, num_layers=2, num_attention_heads=2, mtp_num_layers=2
+        )
+        config.mtp_loss_scaling_factor = 0.5
+        config.mtp_loss_type = "e2e_tv"
+        sequence_length = 6
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6]], dtype=torch.long)
+        labels = torch.tensor([[2, 3, 4, 5, 6, 0]], dtype=torch.long)
+        loss_mask = torch.tensor([[1, 1, 1, 1, 0, 0]], dtype=torch.float32)
+        output_weight = torch.randn(7, config.hidden_size)
+
+        source = input_ids if derived_labels else labels
+        bare_context = prepare_mtp_sequence_roll_context(source, None, None)
+        assert bare_context is not None
+
+        class OutputLayer:
+            gather_output = True
+
+            def __call__(self, hidden, weight=None, runtime_gather_output=None):
+                del runtime_gather_output
+                return torch.matmul(hidden, weight.t()), None
+
+        def run(context):
+            local_hidden = torch.randn(
+                (1 + config.mtp_num_layers) * sequence_length,
+                1,
+                config.hidden_size,
+                generator=torch.Generator().manual_seed(_SEED + 1),
+                requires_grad=True,
+            )
+            result = process_mtp_loss(
+                hidden_states=local_hidden,
+                labels=None if derived_labels else labels,
+                loss_mask=loss_mask,
+                output_layer=OutputLayer(),
+                output_weight=output_weight,
+                runtime_gather_output=None,
+                is_training=False,
+                compute_language_model_loss=lambda *_: pytest.fail(
+                    "CE must not run for the TV objective"
+                ),
+                config=config,
+                input_ids=input_ids if derived_labels else None,
+                sequence_roll_context=context,
+            )
+            result.sum().backward()
+            return local_hidden.grad
+
+        fallback_grad = run(None)
+        addressed_grad = run(bare_context)
+        torch.testing.assert_close(addressed_grad, fallback_grad, rtol=1e-6, atol=1e-6)
+
+    def test_mtp_block_aligned_rows_are_atomic_and_pre_aligned(self):
+        """The block materializes all forward fields before entering any MTP depth."""
+
+        class FakeLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def forward(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
+                self.calls.append(
+                    (
+                        input_ids.clone(),
+                        position_ids.clone(),
+                        padding_mask.clone(),
+                        kwargs["_inputs_pre_aligned"],
+                    )
+                )
+                return hidden_states, input_ids, position_ids, padding_mask
+
+        config = types.SimpleNamespace(
+            pipeline_model_parallel_size=1, mtp_num_layers=2, mtp_detach_heads=False
+        )
+        block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+        torch.nn.Module.__init__(block)
+        block.config = config
+        block.vp_stage = None
+        block.mtp_use_repeated_layer = False
+        block.layers = torch.nn.ModuleList((FakeLayer(), FakeLayer()))
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        position_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        padding_mask = torch.tensor([[False, False, False, False]])
+        bare_context = prepare_mtp_sequence_roll_context(input_ids, None, None)
+        assert bare_context is not None
+        context = bare_context.prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+                MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+                MTPSequenceRollField("padding_mask", padding_mask, -1, 0, True),
+            ),
+            max_offset=2,
+        )
+
+        class Embedding:
+            add_position_embedding = True
+
+        block.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=torch.zeros(4, 1, 4),
+            attention_mask=torch.ones(1, 1, 4, 4, dtype=torch.bool),
+            padding_mask=padding_mask,
+            sequence_roll_padding_mask=padding_mask,
+            sequence_roll_context=context,
+            embedding=Embedding(),
+        )
+
+        expected_inputs = context.materialize_all("input_ids")
+        expected_positions = context.materialize_all("position_ids")
+        expected_padding = context.materialize_all("padding_mask")
+        for depth, layer in enumerate(block.layers):
+            seen_input, seen_position, seen_padding, pre_aligned = layer.calls[0]
+            assert pre_aligned
+            assert torch.equal(seen_input, expected_inputs[depth])
+            assert torch.equal(seen_position, expected_positions[depth])
+            assert torch.equal(seen_padding, expected_padding[depth])
+
+        stale_context = bare_context.prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", input_ids + 100, -1, 0, 0),
+                MTPSequenceRollField("position_ids", position_ids + 100, -1, 0, 0),
+                MTPSequenceRollField("padding_mask", ~padding_mask, -1, 0, True),
+            ),
+            max_offset=2,
+        )
+        for layer in block.layers:
+            layer.calls.clear()
+        block.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=torch.zeros(4, 1, 4),
+            attention_mask=torch.ones(1, 1, 4, 4, dtype=torch.bool),
+            padding_mask=padding_mask,
+            sequence_roll_padding_mask=padding_mask,
+            sequence_roll_context=stale_context,
+            embedding=Embedding(),
+        )
+        for depth, layer in enumerate(block.layers):
+            seen_input, seen_position, seen_padding, pre_aligned = layer.calls[0]
+            assert pre_aligned
+            assert torch.equal(seen_input, expected_inputs[depth])
+            assert torch.equal(seen_position, expected_positions[depth])
+            assert torch.equal(seen_padding, expected_padding[depth])
+
+    def test_mtp_block_padding_sources_are_atomic(self):
+        """A consumer never mixes addressed token rows with cumulative padding rolls."""
+
+        class RecordingLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.call = None
+
+            def forward(self, input_ids, position_ids, hidden_states, padding_mask, **kwargs):
+                assert "_inputs_pre_aligned" not in kwargs
+                self.call = (
+                    input_ids,
+                    position_ids,
+                    padding_mask,
+                    kwargs.get("_inputs_pre_aligned", False),
+                )
+                return hidden_states, input_ids, position_ids, padding_mask
+
+        config = types.SimpleNamespace(
+            pipeline_model_parallel_size=1, mtp_num_layers=1, mtp_detach_heads=False
+        )
+        block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+        torch.nn.Module.__init__(block)
+        block.config = config
+        block.vp_stage = None
+        block.mtp_use_repeated_layer = False
+        block.layers = torch.nn.ModuleList((RecordingLayer(),))
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        position_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        padding_mask = torch.tensor([[False, False, False, True]])
+        context = prepare_mtp_sequence_roll_context(input_ids, None, None).prepare_fields(
+            (
+                MTPSequenceRollField("input_ids", input_ids, -1, 0, 0),
+                MTPSequenceRollField("position_ids", position_ids, -1, 0, 0),
+                MTPSequenceRollField("padding_mask", padding_mask, -1, 0, True),
+            ),
+            max_offset=1,
+        )
+        embedding = types.SimpleNamespace(add_position_embedding=True)
+
+        block.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=torch.zeros(4, 1, 4),
+            attention_mask=None,
+            padding_mask=padding_mask,
+            sequence_roll_context=context,
+            embedding=embedding,
+        )
+        seen_input, seen_position, seen_padding, pre_aligned = block.layers[0].call
+        assert not pre_aligned
+        assert seen_input is input_ids
+        assert seen_position is position_ids
+        assert seen_padding is padding_mask
+
+        with pytest.raises(ValueError, match="sequence_roll_padding_mask requires"):
+            block.forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=torch.zeros(4, 1, 4),
+                attention_mask=None,
+                padding_mask=None,
+                sequence_roll_padding_mask=padding_mask,
+                sequence_roll_context=context,
+                embedding=embedding,
+            )
+
+    @pytest.mark.parametrize(
+        (
+            "mtp_in_postprocess",
+            "post_process",
+            "labels_present",
+            "loss_mask_present",
+            "padding_present",
+            "expected_keys",
+            "expected_max_offset",
+            "expect_mtp",
+            "expect_loss",
+        ),
+        (
+            (
+                True,
+                False,
+                True,
+                True,
+                True,
+                ("input_ids", "position_ids", "padding_mask"),
+                2,
+                True,
+                False,
+            ),
+            (
+                True,
+                True,
+                True,
+                True,
+                True,
+                ("input_ids", "position_ids", "labels", "loss_mask", "padding_mask"),
+                2,
+                True,
+                True,
+            ),
+            (
+                True,
+                True,
+                True,
+                False,
+                False,
+                ("input_ids", "position_ids", "labels"),
+                2,
+                True,
+                True,
+            ),
+            (False, True, True, True, True, ("labels", "loss_mask"), 2, False, True),
+            (False, True, False, False, False, ("input_ids",), 3, False, True),
+            (True, True, False, False, False, ("input_ids", "position_ids"), 3, True, True),
+        ),
+    )
+    def test_gpt_model_entry_prepares_only_stage_owned_mtp_fields(
+        self,
+        monkeypatch,
+        mtp_in_postprocess,
+        post_process,
+        labels_present,
+        loss_mask_present,
+        padding_present,
+        expected_keys,
+        expected_max_offset,
+        expect_mtp,
+        expect_loss,
+    ):
+        """GPT prepares one immutable field group matching its forward/loss ownership."""
+        input_ids = torch.arange(6, dtype=torch.long).view(1, 6)
+        position_ids = torch.arange(6, dtype=torch.long).view(1, 6)
+        labels = input_ids + 1 if labels_present else None
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float32) if loss_mask_present else None
+        padding_mask = torch.zeros_like(input_ids, dtype=torch.bool) if padding_present else None
+        hidden_states = torch.zeros(6, 1, 4)
+
+        preparation = {}
+        prepared_context = object()
+
+        class BareContext:
+            def prepare_fields(self, fields, *, max_offset):
+                preparation["keys"] = tuple(field.key for field in fields)
+                preparation["max_offset"] = max_offset
+                return prepared_context
+
+        monkeypatch.setattr(
+            gpt_model_module, "prepare_mtp_sequence_roll_context", lambda **_kwargs: BareContext()
+        )
+        seen_mtp_contexts = []
+        seen_mtp_sequence_roll_padding_masks = []
+        seen_loss_contexts = []
+
+        def mtp(**kwargs):
+            seen_mtp_contexts.append(kwargs["sequence_roll_context"])
+            seen_mtp_sequence_roll_padding_masks.append(kwargs["sequence_roll_padding_mask"])
+            return kwargs["hidden_states"]
+
+        def process_loss(**kwargs):
+            seen_loss_contexts.append(kwargs["sequence_roll_context"])
+            return kwargs["hidden_states"]
+
+        monkeypatch.setattr(gpt_model_module, "process_mtp_loss", process_loss)
+        model = types.SimpleNamespace(
+            config=types.SimpleNamespace(mtp_num_layers=2, use_mup=False),
+            post_process=post_process,
+            pg_collection=types.SimpleNamespace(cp=None),
+            embedding=types.SimpleNamespace(add_position_embedding=True),
+            share_embeddings_and_output_weights=False,
+            mtp=mtp,
+            output_layer=object(),
+            _scale_logits=lambda logits: logits,
+            training=True,
+            compute_language_model_loss=object(),
+            tp_group=None,
+        )
+
+        GPTModel._postprocess(
+            model,
+            hidden_states=hidden_states,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            labels=labels,
+            rotary_pos_emb=None,
+            rotary_pos_cos=None,
+            rotary_pos_sin=None,
+            mtp_in_postprocess=mtp_in_postprocess,
+            loss_mask=loss_mask,
+            attention_mask=None,
+            padding_mask=padding_mask,
+            mtp_padding_mask=padding_mask,
+            output_processor=lambda **kwargs: kwargs["hidden_states"],
+        )
+
+        assert preparation == {"keys": expected_keys, "max_offset": expected_max_offset}
+        assert seen_mtp_contexts == ([prepared_context] if expect_mtp else [])
+        assert seen_mtp_sequence_roll_padding_masks == ([padding_mask] if expect_mtp else [])
+        assert seen_loss_contexts == ([prepared_context] if expect_loss else [])
+
+    @pytest.mark.parametrize(
+        (
+            "mtp_process",
+            "post_process",
+            "labels_present",
+            "loss_mask_present",
+            "padding_present",
+            "expected_keys",
+            "expected_max_offset",
+            "expect_loss",
+        ),
+        (
+            (
+                True,
+                False,
+                True,
+                True,
+                True,
+                ("input_ids", "position_ids", "padding_mask"),
+                2,
+                False,
+            ),
+            (
+                True,
+                True,
+                True,
+                True,
+                True,
+                ("input_ids", "position_ids", "labels", "loss_mask", "padding_mask"),
+                2,
+                True,
+            ),
+            (True, True, True, False, False, ("input_ids", "position_ids", "labels"), 2, True),
+            (True, True, False, False, False, ("input_ids", "position_ids"), 3, True),
+            (False, True, True, True, True, None, None, False),
+        ),
+    )
+    def test_hybrid_model_entry_prepares_only_stage_owned_mtp_fields(
+        self,
+        monkeypatch,
+        mtp_process,
+        post_process,
+        labels_present,
+        loss_mask_present,
+        padding_present,
+        expected_keys,
+        expected_max_offset,
+        expect_loss,
+    ):
+        """Hybrid shares one prepared context between its local MTP forward and loss."""
+        input_ids = torch.arange(6, dtype=torch.long).view(1, 6)
+        position_ids = torch.arange(6, dtype=torch.long).view(1, 6)
+        labels = input_ids + 1 if labels_present else None
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float32) if loss_mask_present else None
+        padding_mask = torch.zeros_like(input_ids, dtype=torch.bool) if padding_present else None
+        hidden_states = torch.zeros(6, 1, 4)
+
+        preparation = {}
+        prepared_context = object()
+
+        class BareContext:
+            def prepare_fields(self, fields, *, max_offset):
+                preparation["keys"] = tuple(field.key for field in fields)
+                preparation["max_offset"] = max_offset
+                return prepared_context
+
+        prepare_calls = []
+
+        def prepare_context(**kwargs):
+            prepare_calls.append(kwargs)
+            return BareContext()
+
+        monkeypatch.setattr(
+            hybrid_model_module, "prepare_mtp_sequence_roll_context", prepare_context
+        )
+        seen_mtp_contexts = []
+        seen_mtp_sequence_roll_padding_masks = []
+        seen_loss_contexts = []
+
+        def mtp(**kwargs):
+            seen_mtp_contexts.append(kwargs["sequence_roll_context"])
+            seen_mtp_sequence_roll_padding_masks.append(kwargs["sequence_roll_padding_mask"])
+            return kwargs["hidden_states"]
+
+        def process_loss(**kwargs):
+            seen_loss_contexts.append(kwargs["sequence_roll_context"])
+            return kwargs["hidden_states"]
+
+        monkeypatch.setattr(hybrid_model_module, "process_mtp_loss", process_loss)
+
+        def output_layer(hidden, weight=None, runtime_gather_output=None):
+            del weight, runtime_gather_output
+            return hidden, None
+
+        model = types.SimpleNamespace(
+            config=types.SimpleNamespace(
+                fine_grained_activation_offloading=False,
+                moe_paged_stash=False,
+                sequence_parallel=False,
+                multi_latent_attention=False,
+                moe_n_hash_layers=0,
+                mtp_num_layers=2,
+                use_mup=False,
+            ),
+            pre_process=False,
+            post_process=post_process,
+            mtp_process=mtp_process,
+            position_embedding_type="none",
+            decoder=lambda **kwargs: kwargs["hidden_states"],
+            share_embeddings_and_output_weights=False,
+            pg_collection=types.SimpleNamespace(cp=None, tp=None),
+            embedding=types.SimpleNamespace(add_position_embedding=True),
+            mtp=mtp,
+            output_layer=output_layer,
+            _scale_logits=lambda logits: logits,
+            training=True,
+            compute_language_model_loss=lambda labels, logits: torch.zeros_like(
+                labels, dtype=logits.dtype
+            ),
+            tp_group=None,
+        )
+
+        HybridModel.forward(
+            model,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            decoder_input=hidden_states,
+            labels=labels,
+            loss_mask=loss_mask,
+            padding_mask=padding_mask,
+        )
+
+        if expected_keys is None:
+            assert prepare_calls == []
+            assert preparation == {}
+            assert seen_mtp_contexts == []
+            assert seen_mtp_sequence_roll_padding_masks == []
+            assert seen_loss_contexts == []
+        else:
+            assert len(prepare_calls) == 1
+            assert preparation == {"keys": expected_keys, "max_offset": expected_max_offset}
+            assert seen_mtp_contexts == [prepared_context]
+            assert seen_mtp_sequence_roll_padding_masks == [padding_mask]
+            assert seen_loss_contexts == ([prepared_context] if expect_loss else [])
+
     @pytest.mark.parametrize("cp", [1, 2])
     def test_roll_tensor_with_packed_sequences(self, cp):
         """Test roll_tensor function with packed sequences, with and without CP.
@@ -1470,7 +2069,7 @@ class TestMultiTokenPrediction:
 
     @pytest.mark.parametrize(("cp_size", "partition_mode"), [(1, "contiguous"), (2, "zigzag")])
     def test_prepare_mtp_sequence_roll_context_skips_other_layouts(self, cp_size, partition_mode):
-        """CP1 and zigzag keep their existing roll paths without prepared state."""
+        """CP1 gains local geometry while zigzag keeps the existing roll path."""
 
         class FakeCPGroup:
             def size(self):
@@ -1491,7 +2090,10 @@ class TestMultiTokenPrediction:
             tensor=tokens, cp_group=FakeCPGroup(), packed_seq_params=packed_seq_params
         )
 
-        assert sequence_roll_context is None
+        if cp_size == 1:
+            assert isinstance(sequence_roll_context, LocalRollContext)
+        else:
+            assert sequence_roll_context is None
 
     @pytest.mark.parametrize("cp", [1, 2])
     def test_roll_tensor_with_packed_sequences_odd_seqlen(self, cp):

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -1904,6 +1904,52 @@ class TestMTPLossLoggingHelper:
         assert MTPLossLoggingHelper.tracker["reduce_group"] is None
         assert MTPLossLoggingHelper.tracker["avg_group"] is None
 
+    def test_track_mtp_metrics_preserves_all_reduces_for_graph_replay(self, monkeypatch):
+        """Graph replay retains both loss and acceptance reduction metadata."""
+        fake_group = object()
+        all_reduce_calls = []
+
+        def record_all_reduce(tensor, group=None, op=None):
+            all_reduce_calls.append((tensor.shape, group, op))
+
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+        monkeypatch.setattr(torch.distributed, "all_reduce", record_all_reduce)
+        MTPLossLoggingHelper.save_loss_to_tracker(
+            loss_sum=torch.tensor(3.0),
+            num_tokens=torch.tensor(2.0),
+            correct=torch.tensor(1.0),
+            total=torch.tensor(2.0),
+            layer_number=0,
+            num_layers=1,
+            avg_group=fake_group,
+            calculate_per_token_loss=True,
+        )
+
+        def track_metrics(iteration):
+            MTPLossLoggingHelper.track_mtp_metrics(
+                loss_scale=1.0, iteration=iteration, writer=None, preserve_groups=True
+            )
+
+        track_metrics(iteration=1)
+        assert [(group, op) for _, group, op in all_reduce_calls] == [
+            (fake_group, None),
+            (fake_group, torch.distributed.ReduceOp.SUM),
+        ]
+        assert MTPLossLoggingHelper.tracker["avg_group"] is fake_group
+        assert MTPLossLoggingHelper.tracker["acceptance_avg_group"] is fake_group
+
+        # A full-iteration graph replay updates these captured buffers without
+        # rerunning save_loss_to_tracker(), so only the tensors change here.
+        MTPLossLoggingHelper.tracker["loss_sums"].fill_(4.0)
+        MTPLossLoggingHelper.tracker["num_tokens"].fill_(2.0)
+        MTPLossLoggingHelper.tracker["acceptance_counts"].copy_(torch.tensor([[1.0], [2.0]]))
+        track_metrics(iteration=2)
+
+        assert [(group, op) for _, group, op in all_reduce_calls[2:]] == [
+            (fake_group, None),
+            (fake_group, torch.distributed.ReduceOp.SUM),
+        ]
+
     def test_microbatch_means_are_not_globally_token_weighted(self):
         """MTP logging preserves the pre-#4226 microbatch-normalized semantics."""
         MTPLossLoggingHelper.save_loss_to_tracker(

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -1,8 +1,15 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from megatron.core.models.gpt.fine_grained_callables import build_layer_callables
+from megatron.core.models.common import model_chunk_schedule_plan
+from megatron.core.models.gpt import fine_grained_callables
+from megatron.core.models.gpt.fine_grained_callables import (
+    build_layer_callables,
+    build_mtp_layer_callables,
+)
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
@@ -19,6 +26,322 @@ from tests.unit_tests.a2a_overlap.utils import (
     reset_model,
 )
 from tests.unit_tests.test_utilities import Utils
+
+
+def test_repeated_mtp_te_graph_owns_backward_dw_wrapper_per_logical_depth():
+    """Each logical use of a repeated MTP layer updates its own wgrad wrapper."""
+
+    class FakeBackwardDWWrapper:
+        def __init__(self):
+            self.graphed_backward_dw_callable = None
+
+        def set_graphed_backward_dw_callable(self, callable_):
+            self.graphed_backward_dw_callable = callable_
+
+    class FakeGraphableLayer(fine_grained_callables.GraphableMegatronModule):
+        def __init__(self):
+            torch.nn.Module.__init__(self)
+            self.config = SimpleNamespace(
+                moe_token_dispatcher_type="alltoall",
+                moe_flex_dispatcher_backend=None,
+                cuda_graph_modules=[fine_grained_callables.CudaGraphModule.attn],
+            )
+            self.mlp = object()
+            self.cuda_graphs = [object()]
+            self.current_microbatch = 0
+            self.created_wrappers = []
+            self.graphed_dw_microbatches = []
+
+        def init_backward_dw_wrapper(self):
+            self.backward_dw_wrapper = FakeBackwardDWWrapper()
+            self.created_wrappers.append(self.backward_dw_wrapper)
+
+        def _te_cuda_graph_backward_dw_graph(self, microbatch):
+            self.graphed_dw_microbatches.append(microbatch)
+
+        @staticmethod
+        def _te_cuda_graph_replay(hidden_states, **_kwargs):
+            return hidden_states, None, None, None
+
+        @staticmethod
+        def _forward_mlp(hidden_states, **_kwargs):
+            return hidden_states
+
+    layer = FakeGraphableLayer()
+    logical_callables = []
+    owned_wrappers = []
+    for _ in range(3):
+        forward_callables, backward_dw = fine_grained_callables.build_transformer_layer_callables(
+            layer
+        )
+        logical_callables.append(forward_callables[0])
+        owned_wrappers.append(backward_dw["attn"])
+
+    assert len({id(wrapper) for wrapper in owned_wrappers}) == 3
+    assert layer.backward_dw_wrapper is owned_wrappers[-1]
+
+    chunk_state = SimpleNamespace(
+        padding_mask=None,
+        attention_mask=None,
+        rotary_pos_emb=None,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        packed_seq_params=None,
+        sequence_len_offset=None,
+    )
+    hidden_states = torch.ones(2, 1, 4)
+    for logical_depth, callable_ in enumerate(logical_callables):
+        layer.current_microbatch = logical_depth
+        node = SimpleNamespace(chunk_state=chunk_state, layer_state=SimpleNamespace())
+        assert callable_(node, hidden_states) is hidden_states
+
+    assert all(wrapper.graphed_backward_dw_callable is not None for wrapper in owned_wrappers)
+    for wrapper in owned_wrappers:
+        wrapper.graphed_backward_dw_callable()
+    assert layer.graphed_dw_microbatches == [0, 1, 2]
+
+
+def test_fine_grained_repeated_mtp_reuses_prepared_rows_by_absolute_depth(monkeypatch):
+    """One physical MTP layer consumes immutable rows for three logical depths."""
+
+    class FakeMoELayer:
+        pass
+
+    source_rows = {
+        "input_ids": tuple(torch.tensor([[depth, depth + 1, 0]]) for depth in (1, 2, 3)),
+        "position_ids": tuple(torch.tensor([[10 + depth, 11 + depth, 0]]) for depth in (1, 2, 3)),
+        "padding_mask": tuple(torch.tensor([[False, False, depth == 3]]) for depth in (1, 2, 3)),
+    }
+    materialize_calls = []
+
+    class FakeSequenceRollContext:
+        max_offset = 3
+        keys = tuple(source_rows)
+
+        @staticmethod
+        def is_prepared_for_fields(fields):
+            return {field.key for field in fields} == {
+                "input_ids",
+                "position_ids",
+                "labels",
+                "loss_mask",
+                "padding_mask",
+            }
+
+        def prepare_fields(self, fields, *, max_offset):
+            raise AssertionError("An already prepared context must be reused.")
+
+        @staticmethod
+        def materialize_all(key):
+            materialize_calls.append(key)
+            return source_rows[key]
+
+    sequence_roll_context = FakeSequenceRollContext()
+    prepare_calls = []
+
+    def fake_prepare(**kwargs):
+        prepare_calls.append(kwargs)
+        return sequence_roll_context
+
+    attn_calls = []
+
+    def fake_attn(node, hidden_states, padding_mask=None):
+        del node
+        attn_calls.append(padding_mask)
+        return hidden_states
+
+    def unused_callable(*args, **kwargs):
+        raise AssertionError("Only MTP attention/postprocess should run in this test.")
+
+    def fake_build_transformer_layer_callables(layer):
+        del layer
+        return [fake_attn, unused_callable, unused_callable, unused_callable, None, None], {
+            "attn": []
+        }
+
+    monkeypatch.setattr(fine_grained_callables, "MoELayer", FakeMoELayer)
+    monkeypatch.setattr(
+        fine_grained_callables,
+        "build_transformer_layer_callables",
+        fake_build_transformer_layer_callables,
+    )
+    monkeypatch.setattr(fine_grained_callables, "prepare_mtp_sequence_roll_context", fake_prepare)
+    monkeypatch.setattr(fine_grained_callables, "resolve_cp_group", lambda group, packed: group)
+
+    embedding_calls = []
+
+    def get_embeddings(**kwargs):
+        embedding_calls.append(kwargs)
+        return (
+            kwargs["input_ids"],
+            kwargs["position_ids"],
+            kwargs["padding_mask"],
+            torch.zeros_like(kwargs["hidden_states"]),
+            kwargs["hidden_states"],
+        )
+
+    config = SimpleNamespace(
+        enable_hyper_connections=False,
+        pipeline_model_parallel_layout=None,
+        pipeline_model_parallel_size=1,
+        sequence_parallel=False,
+        mtp_num_layers=3,
+    )
+    layer = SimpleNamespace(
+        config=config,
+        cp_group=object(),
+        tp_group=object(),
+        layer_number=1,
+        mtp_model_layer=SimpleNamespace(mlp=FakeMoELayer()),
+        eh_proj=object(),
+        _get_embeddings=get_embeddings,
+        _concat_embeddings=lambda hidden_states, decoder_input: hidden_states + decoder_input,
+        _postprocess=lambda hidden_states: hidden_states,
+    )
+    callables = build_mtp_layer_callables(layer)[0]
+    mtp_attn, mtp_postprocess = callables[0], callables[4]
+
+    input_ids = torch.tensor([[0, 1, 2]])
+    position_ids = torch.tensor([[10, 11, 12]])
+    padding_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+    packed_seq_params = SimpleNamespace(qkv_format="thd")
+    chunk_state = SimpleNamespace(
+        model=SimpleNamespace(
+            embedding=SimpleNamespace(add_position_embedding=True), post_process=True, vp_stage=None
+        ),
+        input_ids=input_ids,
+        position_ids=position_ids,
+        labels=input_ids + 1,
+        loss_mask=torch.ones_like(input_ids, dtype=torch.float32),
+        padding_mask=padding_mask,
+        mtp_padding_mask=padding_mask,
+        packed_seq_params=packed_seq_params,
+        context=None,
+        mhc_multistream=None,
+        mtp_hidden_states=None,
+        mtp_sequence_roll_context=None,
+        mtp_materialized_roll_rows=None,
+    )
+    hidden_states = torch.ones(3, 1, 4)
+    current = hidden_states
+    for depth in range(1, 4):
+        node = SimpleNamespace(
+            is_first_layer=depth == 1,
+            is_last_layer=depth == 3,
+            mtp_absolute_depth=depth,
+            chunk_state=chunk_state,
+        )
+        current = mtp_attn(node, current)
+        current = mtp_postprocess(node, current)
+
+    assert current.shape[0] == 4 * hidden_states.shape[0]
+    assert len(prepare_calls) == 1
+    assert prepare_calls[0] == {
+        "tensor": input_ids,
+        "cp_group": layer.cp_group,
+        "packed_seq_params": packed_seq_params,
+    }
+    assert materialize_calls == ["input_ids", "position_ids", "padding_mask"]
+    assert len(embedding_calls) == 3
+    for depth, call in enumerate(embedding_calls, 1):
+        assert call["input_ids"] is source_rows["input_ids"][depth - 1]
+        assert call["position_ids"] is source_rows["position_ids"][depth - 1]
+        assert call["padding_mask"] is source_rows["padding_mask"][depth - 1]
+        assert call["_inputs_pre_aligned"]
+        assert call["roll_depth"] == depth - 1
+        assert call["packed_seq_params"] is packed_seq_params
+    assert all(
+        actual is expected for actual, expected in zip(attn_calls, source_rows["padding_mask"])
+    )
+    assert chunk_state.input_ids is input_ids
+    assert chunk_state.position_ids is position_ids
+    assert chunk_state.padding_mask is padding_mask
+
+
+def test_repeated_mtp_schedule_expands_one_physical_layer_to_three_depths(monkeypatch):
+    """Fine-grained scheduling carries absolute depth without copying parameters."""
+    records = []
+
+    class RecordingLayerPlan:
+        def __init__(self, layer, event, chunk_state, comp_stream, comm_stream, extra_args):
+            del event, chunk_state, comp_stream, comm_stream
+            records.append((layer, dict(extra_args)))
+
+    monkeypatch.setattr(
+        model_chunk_schedule_plan, "TransformerLayerSchedulePlan", RecordingLayerPlan
+    )
+    config = SimpleNamespace(
+        mtp_num_layers=3,
+        enable_hyper_connections=False,
+        recompute_granularity=None,
+        recompute_modules=(),
+        mhc_recompute_layer_num=None,
+    )
+    physical_layer = SimpleNamespace(layer_number=1)
+    module = SimpleNamespace(
+        layers=[physical_layer],
+        config=config,
+        training=False,
+        mtp_use_repeated_layer=True,
+        mtp_num_depths=0,
+    )
+    owner = model_chunk_schedule_plan.TransformerModelChunkSchedulePlan.__new__(
+        model_chunk_schedule_plan.TransformerModelChunkSchedulePlan
+    )
+    owner._transformer_layers = []
+    owner._event = object()
+    owner._model_chunk_state = object()
+
+    owner._build_layer_schedule_plan(module, "compute", "communication", module_tag="mtp")
+
+    assert len(records) == 3
+    assert all(layer is physical_layer for layer, _ in records)
+    assert [extra["mtp_absolute_depth"] for _, extra in records] == [1, 2, 3]
+    assert [extra["is_first_layer"] for _, extra in records] == [True, False, False]
+    assert [extra["is_last_layer"] for _, extra in records] == [False, False, True]
+
+
+def test_fine_grained_postprocess_reuses_cached_sequence_context(monkeypatch):
+    """The loss side receives the exact context prepared before MTP forward."""
+    sequence_roll_context = object()
+    captured = {}
+
+    def postprocess(**kwargs):
+        captured.update(kwargs)
+        return kwargs["hidden_states"]
+
+    monkeypatch.setattr(fine_grained_callables, "float16_to_fp32", lambda tensor: tensor)
+    chunk_state = SimpleNamespace(
+        input_ids=object(),
+        position_ids=object(),
+        labels=object(),
+        decoder_input=object(),
+        rotary_pos_emb=None,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        loss_mask=object(),
+        attention_mask=None,
+        packed_seq_params=object(),
+        sequence_len_offset=None,
+        runtime_gather_output=None,
+        extra_block_kwargs=None,
+        output_processor=None,
+        output_processor_context=None,
+        mtp_sequence_roll_context=sequence_roll_context,
+    )
+    node = SimpleNamespace(
+        gpt_model=SimpleNamespace(
+            decoder=SimpleNamespace(layers=[object()]), _postprocess=postprocess
+        ),
+        chunk_state=chunk_state,
+    )
+    hidden_states = torch.ones(2, 1, 4)
+
+    output = fine_grained_callables.PostProcessNode.forward_impl(node, hidden_states)
+
+    assert output is hidden_states
+    assert captured["sequence_roll_context"] is sequence_roll_context
+    assert captured["mtp_in_postprocess"] is False
 
 
 def run_model_ref_with_capture(model, input_tensors, iterations):

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
 Unit tests for THD format with CUDA Graph support.
@@ -34,6 +34,7 @@ from megatron.core.datasets.data_schedule import _build_thd_padding_mask
 from megatron.core.packed_seq_params import (
     PackedSeqParams,
     _resolve_thd_padding_lengths,
+    _same_tensor_view,
     extend_thd_padding_before_cp_slice,
     get_thd_padding_kwargs,
     pad_sequence_for_thd,
@@ -77,6 +78,47 @@ def _make_psp(seqlens):
         max_seqlen_q=max(seqlens),
         max_seqlen_kv=max(seqlens),
     )
+
+
+def _make_same_view_cu_pair(boundaries):
+    storage = torch.tensor([-1, *boundaries, -1], dtype=torch.int32)
+    q = storage[1:-1]
+    kv = storage[1:-1]
+    assert q is not kv
+    assert q.data_ptr() == kv.data_ptr()
+    return q, kv
+
+
+def _make_same_view_psp(valid_boundaries, padded_boundaries):
+    cu_q, cu_kv = _make_same_view_cu_pair(valid_boundaries)
+    cu_q_padded, cu_kv_padded = _make_same_view_cu_pair(padded_boundaries)
+    max_seqlen = max(
+        right - left
+        for boundaries in (valid_boundaries, padded_boundaries)
+        for left, right in zip(boundaries, boundaries[1:])
+    )
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_q,
+        cu_seqlens_kv=cu_kv,
+        cu_seqlens_q_padded=cu_q_padded,
+        cu_seqlens_kv_padded=cu_kv_padded,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        pad_between_seqs=valid_boundaries != padded_boundaries,
+    )
+
+
+def _assert_qkv_views_are_shared(packed_seq_params):
+    for q, kv in (
+        (packed_seq_params.cu_seqlens_q, packed_seq_params.cu_seqlens_kv),
+        (packed_seq_params.cu_seqlens_q_padded, packed_seq_params.cu_seqlens_kv_padded),
+    ):
+        assert q is kv
+        assert q.data_ptr() == kv.data_ptr()
+        assert q.storage_offset() == kv.storage_offset()
+        assert q.shape == kv.shape
+        assert q.stride() == kv.stride()
 
 
 def _build_layer(H, nh, nkv, ffn, max_seqlen, max_num_seqs, tp=1, sp=False):
@@ -294,6 +336,250 @@ class TestResolveThdPaddingLengths:
             expected_global_target,
         )
         assert mask_device == psp.cu_seqlens_q.device
+
+
+class TestPadSequenceForThdAliasPreservation:
+
+    @pytest.mark.internal
+    def test_same_tensor_view_edge_cases_fail_closed(self):
+        base = torch.arange(6)
+        same_view = base[:4]
+        same_view_alias = base[:4]
+        assert _same_tensor_view(same_view, same_view)
+        assert _same_tensor_view(same_view, same_view_alias)
+        assert not _same_tensor_view(None, None)
+        assert not _same_tensor_view(same_view, None)
+
+        empty = torch.empty(0)
+        assert not _same_tensor_view(empty, empty)
+        assert not _same_tensor_view(empty, empty.view_as(empty))
+
+        meta = torch.empty(4, device="meta")
+        assert not _same_tensor_view(meta, meta)
+        assert not _same_tensor_view(meta, meta.view_as(meta))
+
+        assert not _same_tensor_view(same_view, base[1:5])
+        assert not _same_tensor_view(same_view, base[:3])
+
+    @pytest.mark.internal
+    def test_same_tensor_view_fake_tensor_fails_closed(self):
+        try:
+            from torch._subclasses.fake_tensor import FakeTensorMode
+        except ImportError:
+            pytest.skip("FakeTensorMode is not available in this PyTorch version.")
+
+        with FakeTensorMode():
+            fake = torch.empty(4, device="cuda")
+            fake_alias = fake.view_as(fake)
+
+        assert not _same_tensor_view(fake, fake)
+        assert not _same_tensor_view(fake, fake_alias)
+
+    @pytest.mark.internal
+    def test_append_dummy_sequence_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 5], [0, 3, 5])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5), None, None, None, psp, target_len=8, cp_size=1, cp_rank=0
+        )
+
+        expected = torch.tensor([0, 3, 5, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q, expected)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_extend_last_sequence_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 5], [0, 4, 7])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 7),
+            None,
+            None,
+            None,
+            psp,
+            target_len=10,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 5], dtype=torch.int32))
+        assert torch.equal(padded.cu_seqlens_q_padded, torch.tensor([0, 4, 10], dtype=torch.int32))
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_extend_last_missing_padded_metadata_inherits_valid_qkv_view(self):
+        cu_q, cu_kv = _make_same_view_cu_pair([0, 3, 5])
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 5], dtype=torch.int32))
+        assert torch.equal(padded.cu_seqlens_q_padded, torch.tensor([0, 3, 8], dtype=torch.int32))
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_extend_last_missing_padded_metadata_keeps_distinct_valid_qkv_views(self):
+        cu_q = torch.tensor([0, 3, 5], dtype=torch.int32)
+        cu_kv = cu_q.clone()
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        expected = torch.tensor([0, 3, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected)
+        assert padded.cu_seqlens_q_padded is not padded.cu_seqlens_kv_padded
+        assert padded.cu_seqlens_q_padded.data_ptr() != padded.cu_seqlens_kv_padded.data_ptr()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_extend_last_missing_padded_metadata_keeps_cp1_thd_scorer_eligible(self):
+        from megatron.core.transformer.experimental_attention_variant import dsa_cudnn_kernels
+
+        storage = torch.tensor([-1, 0, 3, 5, -1], dtype=torch.int32, device="cuda")
+        cu_q = storage[1:-1]
+        cu_kv = storage[1:-1]
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_kv_padded=None,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            pad_between_seqs=False,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            tail_padding_policy="extend_last",
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert dsa_cudnn_kernels._packed_thd_kernel_applicable(
+            b=1,
+            sq=8,
+            sk=8,
+            device=padded.cu_seqlens_q_padded.device,
+            packed_cu_seqlens_q=padded.cu_seqlens_q_padded,
+            packed_cu_seqlens_k=padded.cu_seqlens_kv_padded,
+            packed_max_seqlen_q=padded.max_seqlen_q,
+            packed_max_seqlen_k=padded.max_seqlen_kv,
+            cp_size=1,
+            cp_rank=0,
+            local_packed_cp_query_start=0,
+            local_packed_cp_query_len=None,
+        )
+
+    @pytest.mark.internal
+    def test_fixed_capacity_only_padding_preserves_qkv_views(self):
+        psp = _make_same_view_psp([0, 3, 8], [0, 4, 8])
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 8),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            max_num_seqs=5,
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        assert torch.equal(padded.cu_seqlens_q, torch.tensor([0, 3, 8, 8, 8, 8], dtype=torch.int32))
+        assert torch.equal(
+            padded.cu_seqlens_q_padded, torch.tensor([0, 4, 8, 8, 8, 8], dtype=torch.int32)
+        )
+        _assert_qkv_views_are_shared(padded)
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_q_padded.data_ptr()
+
+    @pytest.mark.internal
+    def test_distinct_equal_qkv_views_remain_distinct(self):
+        cu_q = torch.tensor([0, 3, 5], dtype=torch.int32)
+        cu_kv = cu_q.clone()
+        cu_q_padded = cu_q.clone()
+        cu_kv_padded = cu_q.clone()
+        psp = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=cu_q_padded,
+            cu_seqlens_kv_padded=cu_kv_padded,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+        )
+
+        _, _, _, _, padded, _ = pad_sequence_for_thd(
+            torch.ones(1, 5),
+            None,
+            None,
+            None,
+            psp,
+            target_len=8,
+            max_num_seqs=5,
+            cp_size=1,
+            cp_rank=0,
+        )
+
+        expected = torch.tensor([0, 3, 5, 8, 8, 8], dtype=torch.int32)
+        assert torch.equal(padded.cu_seqlens_q, expected)
+        assert torch.equal(padded.cu_seqlens_kv, expected)
+        assert torch.equal(padded.cu_seqlens_q_padded, expected)
+        assert torch.equal(padded.cu_seqlens_kv_padded, expected)
+        assert padded.cu_seqlens_q is not padded.cu_seqlens_kv
+        assert padded.cu_seqlens_q.data_ptr() != padded.cu_seqlens_kv.data_ptr()
+        assert padded.cu_seqlens_q_padded is not padded.cu_seqlens_kv_padded
+        assert padded.cu_seqlens_q_padded.data_ptr() != padded.cu_seqlens_kv_padded.data_ptr()
 
 
 class TestPadSequenceForThd:

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -1298,7 +1298,7 @@ def _get_available_port(preferred):
     raise RuntimeError("Could not find an available localhost port")
 
 
-def _run_pretrain(model_args, cuda_graph_args, master_port):
+def _run_pretrain(model_args, cuda_graph_args, master_port, extra_env=None, timeout=900):
     """Subprocess-launch `torchrun pretrain_gpt.py` once and capture stdout."""
     env = os.environ.copy()
     env["PYTHONPATH"] = str(_REPO_ROOT) + ":" + env.get("PYTHONPATH", "")
@@ -1325,6 +1325,8 @@ def _run_pretrain(model_args, cuda_graph_args, master_port):
     # least one of fused/flash attention to build the model.
     env.pop("NVTE_FLASH_ATTN", None)
     env.pop("NVTE_FUSED_ATTN", None)
+    if extra_env:
+        env.update(extra_env)
 
     cmd = (
         [
@@ -1344,7 +1346,7 @@ def _run_pretrain(model_args, cuda_graph_args, master_port):
     )
 
     result = subprocess.run(
-        cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True, timeout=900
+        cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True, timeout=timeout
     )
     return result
 

--- a/tests/unit_tests/transformer/test_thd_full_iteration_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_full_iteration_cuda_graph.py
@@ -31,6 +31,7 @@ from megatron.core.full_cuda_graph import (
     FullCudaGraphWrapper,
     StaticBufferLoader,
 )
+from megatron.core.packed_seq_params import PackedSeqParams, pad_sequence_for_thd
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.pipeline_parallel.schedules import get_tensor_shapes
 from megatron.core.process_groups_config import (
@@ -42,6 +43,12 @@ from megatron.core.tensor_parallel.random import (
     convert_cuda_rng_state,
     get_cuda_rng_tracker,
     initialize_rng_tracker,
+)
+from megatron.core.transformer.mtp_sequence_roll import (
+    MTPSequenceRollField,
+    ZigzagPackedCPRollContext,
+    prepare_mtp_sequence_roll_context,
+    prepare_mtp_sequence_roll_fields,
 )
 from megatron.core.utils import is_te_min_version
 from megatron.training.training import _resolve_thd_static_batch_pg_collection
@@ -73,6 +80,7 @@ def _make_thd_full_iter_config(**overrides):
         thd_tail_padding_policy=None,
         cp_partition_mode='zigzag',
         dynamic_context_parallel=False,
+        cuda_graph_static_dynamic_cp=False,
         pipeline_model_parallel_layout=None,
         mtp_num_layers=None,
         virtual_pipeline_model_parallel_size=None,
@@ -113,16 +121,71 @@ def _make_raw_packed_batch(sequence_lengths, seed, device='cuda', with_tokens=Tr
 class _FakeCPGroup:
     """Two-rank CP geometry for single-rank static-metadata lifecycle tests."""
 
-    @staticmethod
-    def size():
-        return 2
+    def __init__(self, size=2, rank=0, global_ranks=None):
+        self._size = size
+        self._rank = rank
+        self.global_ranks = tuple(range(size)) if global_ranks is None else tuple(global_ranks)
 
-    @staticmethod
-    def rank():
-        return 0
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
 
 
 _FAKE_CP_GROUP = _FakeCPGroup()
+
+
+def _pad_boundaries(boundaries):
+    """Pad one boundary list to the configured graph-static metadata width."""
+    return list(boundaries) + [boundaries[-1]] * (MAX_PACKED_SEQS + 1 - len(boundaries))
+
+
+def _make_dynamic_cp_batch_outputs(
+    group,
+    boundaries,
+    *,
+    seed,
+    cp_partition_mode='zigzag',
+    host_boundaries=None,
+    split_mismatch=False,
+    zigzag_cp_min_chunk_size=None,
+):
+    """Build already-sliced outputs for certificate-only dynamic-CP tests."""
+    generator = torch.Generator(device='cpu').manual_seed(seed)
+    tokens = torch.randint(0, VOCAB_SIZE - 2, (1, TOKEN_CAPACITY), generator=generator).cuda()
+    labels = (tokens + 1).clone()
+    loss_mask = torch.ones((1, TOKEN_CAPACITY), dtype=torch.float32, device='cuda')
+    position_ids = torch.arange(TOKEN_CAPACITY, dtype=torch.int64, device='cuda').unsqueeze(0)
+    padding_mask = torch.zeros((1, TOKEN_CAPACITY), dtype=torch.bool, device='cuda')
+    cu_seqlens = torch.tensor(_pad_boundaries(boundaries), dtype=torch.int32, device='cuda')
+    packed_seq_params = PackedSeqParams(
+        qkv_format='thd',
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        cu_seqlens_q_padded=cu_seqlens,
+        cu_seqlens_kv_padded=cu_seqlens,
+        max_seqlen_q=int(boundaries[-1]),
+        max_seqlen_kv=int(boundaries[-1]),
+        local_cp_size=group.size(),
+        cp_group=group,
+        cp_partition_mode=cp_partition_mode,
+        pad_between_seqs=True,
+        zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
+    )
+    if group.size() > 1:
+        packed_seq_params.cp_partition_route = build_thd_cp_partition_route(
+            cu_seqlens, cp_size=group.size(), cp_rank=group.rank(), device=cu_seqlens.device
+        )
+        if split_mismatch:
+            split_sizes = packed_seq_params.cp_partition_route.zigzag_split_sizes
+            assert len(split_sizes) >= 2 and split_sizes[1] > 0
+            split_sizes[0] += 1
+            split_sizes[1] -= 1
+    if host_boundaries is not None:
+        packed_seq_params.thd_cp_host_cu_seqlens_q = list(host_boundaries)
+        packed_seq_params.thd_cp_host_cu_seqlens_kv = list(host_boundaries)
+    return (tokens, labels, loss_mask, None, position_ids, packed_seq_params, padding_mask)
 
 
 def _finalize_with_fake_cp(packed_seq_params):
@@ -164,6 +227,169 @@ class TestThdStaticBatchPreparation:
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
+
+    def _prepare_dynamic_cp_batch(
+        self,
+        monkeypatch,
+        group,
+        boundaries,
+        *,
+        seed,
+        cp_partition_mode='zigzag',
+        host_boundaries=None,
+        split_mismatch=False,
+        local_cp_size=None,
+        zigzag_cp_min_chunk_size=None,
+        mtp_num_layers=None,
+    ):
+        outputs = _make_dynamic_cp_batch_outputs(
+            group,
+            boundaries,
+            seed=seed,
+            cp_partition_mode=cp_partition_mode,
+            host_boundaries=host_boundaries,
+            split_mismatch=split_mismatch,
+            zigzag_cp_min_chunk_size=zigzag_cp_min_chunk_size,
+        )
+        if local_cp_size is not None:
+            outputs[5].local_cp_size = local_cp_size
+
+        def _get_batch(*args, dynamic_cp=False, **kwargs):
+            assert dynamic_cp, "Static-certified preparation must preserve dynamic-CP batch mode."
+            return outputs
+
+        monkeypatch.setattr(
+            data_schedule, 'get_batch_on_this_rank_for_sequence_packing', _get_batch
+        )
+        monkeypatch.setattr(data_schedule, 'finalize_packed_seq_params', lambda params: params)
+        monkeypatch.setattr(
+            torch.distributed,
+            'get_process_group_ranks',
+            lambda process_group: list(process_group.global_ranks),
+        )
+        config = _make_thd_full_iter_config(
+            dynamic_context_parallel=True,
+            cuda_graph_static_dynamic_cp=True,
+            sequence_packing_scheduler='default_dynamic_cp',
+            cp_partition_mode=cp_partition_mode,
+            mtp_num_layers=mtp_num_layers,
+        )
+        return prepare_thd_static_batch_for_full_iteration_cuda_graph(iter([{}]), config=config)
+
+    def test_dynamic_cp_static_slot_preserves_graph_safe_zigzag_mtp_certificate(self, monkeypatch):
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        batch = self._prepare_dynamic_cp_batch(
+            monkeypatch,
+            group,
+            [0, 32, 64, 2 * TOKEN_CAPACITY],
+            seed=73,
+            zigzag_cp_min_chunk_size=8,
+            mtp_num_layers=7,
+        )
+        metadata = batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY]
+        assert metadata['thd_dynamic_cp']['validation_error'] is None
+        assert metadata['thd_cp_layout']['zigzag_cp_min_chunk_size'] == 8
+
+        static_batch = StaticBufferLoader()(batch, 'training', 0)
+        packed_seq_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=_make_thd_full_iter_config(mtp_num_layers=7)
+        )[5]
+        assert packed_seq_params.zigzag_cp_min_chunk_size == 8
+        context = prepare_mtp_sequence_roll_context(
+            static_batch['tokens'], group, packed_seq_params
+        )
+        assert isinstance(context, ZigzagPackedCPRollContext)
+        assert context.min_chunk_size == 8
+
+        monkeypatch.setattr(
+            torch.distributed,
+            'get_rank',
+            lambda group=None: group.rank() if isinstance(group, _FakeCPGroup) else 0,
+        )
+        monkeypatch.setattr(
+            'megatron.core.transformer.mtp_sequence_roll.'
+            '_exchange_zigzag_packed_cp_roll_field_halos',
+            lambda fields, transport, **kwargs: {
+                field.key: field.source.new_full(
+                    (2 * transport.front_prefix_rows.numel(), *field.source.shape[1:]),
+                    field.fill_value,
+                )
+                for field in fields
+            },
+        )
+        fields = [MTPSequenceRollField('input_ids', static_batch['tokens'], -1, 0, 0)]
+        prepared = prepare_mtp_sequence_roll_fields(context, fields, max_offset=8)
+        assert prepared is not None
+        assert prepared.max_offset == 8
+        assert prepared.materialize('input_ids', 8).shape == static_batch['tokens'].shape
+
+    @pytest.mark.parametrize('certificate', [None, 0, 7])
+    def test_dynamic_cp_defers_unsafe_zigzag_mtp_certificate_to_consensus(
+        self, monkeypatch, certificate
+    ):
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        batch = self._prepare_dynamic_cp_batch(
+            monkeypatch,
+            group,
+            [0, 32, 64, 2 * TOKEN_CAPACITY],
+            seed=74,
+            zigzag_cp_min_chunk_size=certificate,
+            mtp_num_layers=7,
+        )
+        metadata = batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY]
+        assert 'mtp_num_layers + 1 (8)' in metadata['thd_dynamic_cp']['validation_error']
+        assert 'thd_cp_layout' not in metadata
+
+        wrapper = FullCudaGraphWrapper(
+            lambda **kwargs: None, require_global_static_metadata_consensus=True
+        )
+        wrapper.static_loader.begin_batch('training', defer_static_metadata_mismatch=True)
+        wrapper.static_loader(batch, 'training', 0)
+        with pytest.raises(RuntimeError, match='legacy cumulative-roll fallback'):
+            wrapper._check_global_static_metadata_consensus('training')
+
+        assert StaticBufferLoader.static_buffers['training'] == []
+
+    def test_dynamic_cp_rejects_certificate_tightened_by_final_padding(self, monkeypatch):
+        """The full-iteration gate consumes the post-padding scheduler certificate."""
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        cu_seqlens = torch.tensor([0, 32], dtype=torch.int32, device='cuda')
+        packed_seq_params = PackedSeqParams(
+            qkv_format='thd',
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+            max_seqlen_q=32,
+            max_seqlen_kv=32,
+            local_cp_size=2,
+            cp_group=group,
+            cp_partition_mode='zigzag',
+            zigzag_cp_min_chunk_size=8,
+        )
+        tokens = torch.ones((1, 16), dtype=torch.int64, device='cuda')
+        _, _, _, _, padded_params, _ = pad_sequence_for_thd(
+            tokens,
+            None,
+            None,
+            None,
+            packed_seq_params,
+            target_len=30,
+            tail_padding_policy='append_dummy_seq',
+            cp_size=2,
+            cp_rank=0,
+        )
+        assert padded_params.zigzag_cp_min_chunk_size == 7
+
+        monkeypatch.setattr(
+            torch.distributed,
+            'get_process_group_ranks',
+            lambda process_group: list(process_group.global_ranks),
+        )
+        signature = data_schedule._build_thd_full_iteration_dynamic_cp_signature(
+            padded_params, config=_make_thd_full_iter_config(mtp_num_layers=7)
+        )
+        assert 'mtp_num_layers + 1 (8)' in signature['validation_error']
 
     @pytest.mark.parametrize(
         'sequence_lengths', [[10, 20, 5], [TOKEN_CAPACITY], [3, 3, 3, 3], [1, TOKEN_CAPACITY - 1]]
@@ -344,6 +570,207 @@ class TestThdStaticBatchPreparation:
         )
         with pytest.raises(RuntimeError, match='static input metadata changed'):
             loader(changed_geometry, 'training', 0)
+
+    def test_dynamic_cp1_restores_topology_while_valid_boundaries_change(self, monkeypatch):
+        """Effective CP1 keeps its certified group while token boundaries remain inputs."""
+        group = _FakeCPGroup(size=1, global_ranks=(7,))
+        loader = StaticBufferLoader()
+
+        first = self._prepare_dynamic_cp_batch(
+            monkeypatch, group, [0, 7, 16, TOKEN_CAPACITY], seed=31
+        )
+        static_batch = loader(first, 'training', 0)
+        first_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=_make_thd_full_iter_config()
+        )[5]
+        topology = first[FULL_CUDA_GRAPH_STATIC_METADATA_KEY]['thd_dynamic_cp']
+        assert topology['local_cp_size'] == 1
+        assert topology['cp_group_global_ranks'] == (7,)
+        assert first_params.local_cp_size == 1
+        assert first_params.cp_group is group
+
+        second = self._prepare_dynamic_cp_batch(
+            monkeypatch, group, [0, 8, 16, TOKEN_CAPACITY], seed=32
+        )
+        static_batch = loader(second, 'training', 0)
+        second_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=_make_thd_full_iter_config()
+        )[5]
+
+        assert second_params is not first_params
+        assert second_params.local_cp_size == 1
+        assert second_params.cp_group is group
+        assert second_params.cu_seqlens_q[:4].tolist() == [0, 8, 16, TOKEN_CAPACITY]
+
+    def test_dynamic_cp2_stable_certificate_reuses_route_and_metadata(self, monkeypatch):
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        loader = StaticBufferLoader()
+        boundaries = [0, 16, 32, 2 * TOKEN_CAPACITY]
+        host_boundaries = [0, 16, 32, 2 * TOKEN_CAPACITY]
+
+        first = self._prepare_dynamic_cp_batch(
+            monkeypatch, group, boundaries, seed=41, host_boundaries=host_boundaries
+        )
+        static_batch = loader(first, 'training', 0)
+        first_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=_make_thd_full_iter_config()
+        )[5]
+        first_route_ptr = first_params.cp_partition_route.contiguous_index.data_ptr()
+
+        second = self._prepare_dynamic_cp_batch(
+            monkeypatch, group, boundaries, seed=42, host_boundaries=host_boundaries
+        )
+        static_batch = loader(second, 'training', 0)
+        second_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=_make_thd_full_iter_config()
+        )[5]
+
+        assert second_params is first_params
+        assert second_params.local_cp_size == 2
+        assert second_params.cp_group is group
+        assert second_params.cp_partition_route.contiguous_index.data_ptr() == first_route_ptr
+
+    @pytest.mark.parametrize(
+        'mismatch', ['bucket', 'boundary', 'host_boundary', 'group', 'partition', 'split']
+    )
+    def test_dynamic_cp_certificate_rejects_realized_schedule_mismatch(self, monkeypatch, mismatch):
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        loader = StaticBufferLoader()
+        first = self._prepare_dynamic_cp_batch(
+            monkeypatch,
+            group,
+            [0, 16, 32, 2 * TOKEN_CAPACITY],
+            seed=51,
+            host_boundaries=[0, 16, 32, 2 * TOKEN_CAPACITY],
+        )
+        loader(first, 'training', 0)
+
+        next_group = group
+        next_boundaries = [0, 16, 32, 2 * TOKEN_CAPACITY]
+        next_host_boundaries = list(next_boundaries)
+        next_partition_mode = 'zigzag'
+        split_mismatch = False
+        if mismatch == 'bucket':
+            next_group = _FakeCPGroup(size=1, global_ranks=(4,))
+            next_boundaries = [0, 16, 32, TOKEN_CAPACITY]
+            next_host_boundaries = list(next_boundaries)
+        elif mismatch == 'boundary':
+            next_boundaries = [0, 8, 32, 2 * TOKEN_CAPACITY]
+            next_host_boundaries = list(next_boundaries)
+        elif mismatch == 'host_boundary':
+            next_host_boundaries = [0, 8, 32, 2 * TOKEN_CAPACITY]
+        elif mismatch == 'group':
+            # Same membership is still a mismatch: the captured collective is
+            # bound to the original ProcessGroup object.
+            next_group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        elif mismatch == 'partition':
+            next_partition_mode = 'contiguous'
+        elif mismatch == 'split':
+            split_mismatch = True
+
+        changed = self._prepare_dynamic_cp_batch(
+            monkeypatch,
+            next_group,
+            next_boundaries,
+            seed=52,
+            cp_partition_mode=next_partition_mode,
+            host_boundaries=next_host_boundaries,
+            split_mismatch=split_mismatch,
+        )
+        with pytest.raises(RuntimeError, match='static input metadata changed'):
+            loader(changed, 'training', 0)
+
+    def test_dynamic_cp_mismatch_consensus_fails_every_rank_before_replay(self):
+        wrapper = FullCudaGraphWrapper(
+            lambda **kwargs: None, require_global_static_metadata_consensus=True
+        )
+        wrapper.static_loader.begin_batch('training', defer_static_metadata_mismatch=True)
+        if torch.distributed.get_rank() == 0:
+            wrapper.static_loader.static_metadata_mismatch = 'rank-local layout mismatch.'
+
+        with pytest.raises(RuntimeError, match='before capture or replay'):
+            wrapper._check_global_static_metadata_consensus('training')
+
+    def test_invalid_dynamic_cp_topology_is_deferred_to_global_consensus(self, monkeypatch):
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        invalid = self._prepare_dynamic_cp_batch(
+            monkeypatch, group, [0, 16, 32, 2 * TOKEN_CAPACITY], seed=61, local_cp_size=1
+        )
+        wrapper = FullCudaGraphWrapper(
+            lambda **kwargs: None, require_global_static_metadata_consensus=True
+        )
+        wrapper.static_loader.begin_batch('training', defer_static_metadata_mismatch=True)
+        wrapper.static_loader(invalid, 'training', 0)
+
+        with pytest.raises(RuntimeError, match='inconsistent topology'):
+            wrapper._check_global_static_metadata_consensus('training')
+
+        assert StaticBufferLoader.static_buffers['training'] == []
+
+    def test_dynamic_cp_certificate_rejects_missing_raw_group_before_finalize(self, monkeypatch):
+        """The ordinary static-CP fallback must not manufacture a DCP certificate."""
+        group = _FakeCPGroup(size=2, global_ranks=(4, 9))
+        outputs = _make_dynamic_cp_batch_outputs(group, [0, 16, 32, 2 * TOKEN_CAPACITY], seed=62)
+        outputs[5].cp_group = None
+
+        def _get_batch(*args, dynamic_cp=False, **kwargs):
+            assert dynamic_cp
+            return outputs
+
+        monkeypatch.setattr(
+            data_schedule, 'get_batch_on_this_rank_for_sequence_packing', _get_batch
+        )
+        monkeypatch.setattr(
+            data_schedule,
+            'finalize_packed_seq_params',
+            lambda params: pytest.fail('invalid raw DCP metadata must not be finalized'),
+        )
+        config = _make_thd_full_iter_config(
+            dynamic_context_parallel=True,
+            cuda_graph_static_dynamic_cp=True,
+            sequence_packing_scheduler='default_dynamic_cp',
+        )
+
+        batch = prepare_thd_static_batch_for_full_iteration_cuda_graph(iter([{}]), config=config)
+        topology = batch[FULL_CUDA_GRAPH_STATIC_METADATA_KEY]['thd_dynamic_cp']
+        assert 'realized CP process group' in topology['validation_error']
+        assert topology['cp_group_identity'] is None
+        assert topology['cp_group_global_ranks'] == ()
+
+    @pytest.mark.parametrize('mismatch', ['current_signature', 'captured_signature'])
+    def test_signature_consensus_fails_before_data_read(self, monkeypatch, mismatch):
+        wrapper = FullCudaGraphWrapper(
+            lambda **kwargs: None, require_global_static_metadata_consensus=True
+        )
+        data_read_called = False
+
+        def _data_read(*args, **kwargs):
+            nonlocal data_read_called
+            data_read_called = True
+            raise AssertionError('signature consensus must run before data_read')
+
+        def _all_gather_into_tensor(output, local_state):
+            gathered = local_state.repeat(2, 1)
+            if mismatch == 'current_signature':
+                gathered[1, 0] += 1
+            else:
+                gathered[1, -1] = 1
+            output.copy_(gathered.flatten())
+
+        monkeypatch.setattr(wrapper, 'data_read', _data_read)
+        monkeypatch.setattr(torch.distributed, 'get_world_size', lambda: 2)
+        monkeypatch.setattr(torch.distributed, 'all_gather_into_tensor', _all_gather_into_tensor)
+
+        with pytest.raises(RuntimeError, match='before reading data, capture, or replay'):
+            wrapper(
+                model=torch.nn.Identity().cuda(),
+                data_iterator=None,
+                num_microbatches=2,
+                seq_length=TOKEN_CAPACITY,
+                forward_only=False,
+            )
+
+        assert not data_read_called
 
 
 def test_resolve_thd_static_batch_pg_collection():

--- a/tests/unit_tests/transformer/test_thd_full_iteration_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_full_iteration_cuda_graph.py
@@ -1,0 +1,1109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the THD full-iteration CUDA graph static-input contract.
+
+Covers the fixed-``num_microbatches`` contract from the THD full-iteration
+plan: batch canonicalization outside the captured region, the captured
+``get_batch`` fast path, capture-signature enforcement, static PP
+communication shapes, and eager-vs-graph loss equality on replay.
+"""
+
+import functools
+import itertools
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import ModelParallelConfig, parallel_state
+from megatron.core.context_parallel_layout import finalize_packed_seq_params
+from megatron.core.context_parallel_layout.routes import build_thd_cp_partition_route
+from megatron.core.datasets import data_schedule
+from megatron.core.datasets.data_schedule import (
+    THD_FULL_ITERATION_STATIC_BATCH_KEY,
+    get_batch_on_this_rank_for_sequence_packing,
+    prepare_thd_static_batch_for_full_iteration_cuda_graph,
+)
+from megatron.core.full_cuda_graph import (
+    FULL_CUDA_GRAPH_STATIC_METADATA_KEY,
+    FullCudaGraphWrapper,
+    StaticBufferLoader,
+)
+from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.pipeline_parallel.schedules import get_tensor_shapes
+from megatron.core.process_groups_config import (
+    MultiModuleProcessGroupCollection,
+    ProcessGroupCollection,
+)
+from megatron.core.tensor_parallel.random import (
+    HAVE_TE,
+    convert_cuda_rng_state,
+    get_cuda_rng_tracker,
+    initialize_rng_tracker,
+)
+from megatron.core.utils import is_te_min_version
+from megatron.training.training import _resolve_thd_static_batch_pg_collection
+from tests.unit_tests.test_utilities import Utils
+
+TOKEN_CAPACITY = 64
+MAX_PACKED_SEQS = 8
+VOCAB_SIZE = 1024
+HIDDEN_SIZE = 32
+
+GRAPH_SAFE_RNG_AVAILABLE = all(
+    (
+        hasattr(torch.cuda.CUDAGraph, 'register_generator_state'),
+        hasattr(torch.Generator, 'graphsafe_set_state'),
+        hasattr(torch.Generator, 'graphsafe_get_state'),
+        hasattr(torch.Generator, 'clone_state'),
+    )
+)
+
+
+def _make_thd_full_iter_config(**overrides):
+    """Minimal config namespace satisfying the THD full-iteration batch path."""
+    config = SimpleNamespace(
+        cuda_graph_impl='full_iteration',
+        sequence_packing_scheduler='dp_balanced',
+        pad_packed_seq_alignment='max',
+        max_seqlen_per_dp_cp_rank=TOKEN_CAPACITY,
+        thd_max_packed_sequences=MAX_PACKED_SEQS,
+        thd_tail_padding_policy=None,
+        cp_partition_mode='zigzag',
+        dynamic_context_parallel=False,
+        pipeline_model_parallel_layout=None,
+        mtp_num_layers=None,
+        virtual_pipeline_model_parallel_size=None,
+        # Derived field; TransformerConfig.__post_init__ sets it for
+        # full_iteration + sequence packing.
+        thd_static_pp_communication=True,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _make_raw_packed_batch(sequence_lengths, seed, device='cuda', with_tokens=True):
+    """Build one raw scheduler-style packed batch with the given seqlens."""
+    generator = torch.Generator(device='cpu').manual_seed(seed)
+    total = sum(sequence_lengths)
+    tokens = torch.randint(0, VOCAB_SIZE - 2, (total,), generator=generator, dtype=torch.int64).to(
+        device
+    )
+    position_ids = torch.cat(
+        [torch.arange(length, dtype=torch.int64) for length in sequence_lengths]
+    ).to(device)
+    cu_seqlens = torch.tensor(
+        [0] + list(itertools.accumulate(sequence_lengths)), dtype=torch.int32, device=device
+    )
+    batch = {
+        'tokens': tokens if with_tokens else None,
+        'position_ids': position_ids if with_tokens else None,
+        'labels': tokens + 1 if with_tokens else None,
+        'loss_mask': torch.ones(total, dtype=torch.float32, device=device) if with_tokens else None,
+        'cu_seqlens': cu_seqlens,
+        'cu_seqlens_padded': cu_seqlens.clone(),
+        'max_seqlen': torch.tensor([max(sequence_lengths)], dtype=torch.int32, device=device),
+    }
+    return batch
+
+
+class _FakeCPGroup:
+    """Two-rank CP geometry for single-rank static-metadata lifecycle tests."""
+
+    @staticmethod
+    def size():
+        return 2
+
+    @staticmethod
+    def rank():
+        return 0
+
+
+_FAKE_CP_GROUP = _FakeCPGroup()
+
+
+def _finalize_with_fake_cp(packed_seq_params):
+    """Attach representative CP>1 metadata without requiring a second process."""
+    packed_seq_params.cp_group = _FAKE_CP_GROUP
+    cu_seqlens = packed_seq_params.cu_seqlens_q_padded
+    packed_seq_params.cp_partition_route = build_thd_cp_partition_route(
+        cu_seqlens,
+        cp_size=_FAKE_CP_GROUP.size(),
+        cp_rank=_FAKE_CP_GROUP.rank(),
+        device=cu_seqlens.device,
+    )
+    host_cu = []
+    for value in cu_seqlens.cpu().tolist():
+        if not host_cu or value != host_cu[-1]:
+            host_cu.append(value)
+    packed_seq_params.thd_cp_host_cu_seqlens_q = host_cu
+    packed_seq_params.thd_cp_host_cu_seqlens_kv = host_cu
+    return packed_seq_params
+
+
+def _reset_full_cuda_graph_state():
+    FullCudaGraphWrapper.reset_cuda_graph()
+
+
+@pytest.fixture(autouse=True)
+def _clean_wrapper_state():
+    """Class-level graph/buffer state must not leak across tests."""
+    _reset_full_cuda_graph_state()
+    yield
+    _reset_full_cuda_graph_state()
+
+
+class TestThdStaticBatchPreparation:
+    """Canonicalization outside the graph produces one fixed static spec."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(
+        'sequence_lengths', [[10, 20, 5], [TOKEN_CAPACITY], [3, 3, 3, 3], [1, TOKEN_CAPACITY - 1]]
+    )
+    def test_different_seq_distributions_same_static_spec(self, sequence_lengths):
+        config = _make_thd_full_iter_config()
+        batch = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch(sequence_lengths, seed=17)]), config=config
+        )
+
+        assert batch[THD_FULL_ITERATION_STATIC_BATCH_KEY]
+        for key in ('tokens', 'labels', 'loss_mask', 'position_ids', 'padding_mask'):
+            assert batch[key].shape == (1, TOKEN_CAPACITY), key
+        assert batch['cu_seqlens'].numel() == MAX_PACKED_SEQS + 1
+        assert batch['cu_seqlens_padded'].numel() == MAX_PACKED_SEQS + 1
+        # Unused tail entries must repeat the final cumulative length.
+        num_real = len(sequence_lengths)
+        total = sum(sequence_lengths)
+        cu = batch['cu_seqlens'].cpu()
+        assert cu[num_real].item() == total
+        assert (cu[num_real + 1 :] == TOKEN_CAPACITY).all()
+        # max_seqlen must be the static config upper bound, not the batch max.
+        assert batch['max_seqlen'] == TOKEN_CAPACITY
+
+        # Real tokens keep their positions; the tail is masked as padding.
+        padding_mask = batch['padding_mask'][0].cpu()
+        assert not padding_mask[:total].any()
+        assert padding_mask[total:].all()
+
+    @pytest.mark.parametrize('tail_padding_policy', ['append_dummy_seq', 'extend_last'])
+    def test_fast_path_preserves_padding_contract(self, tail_padding_policy):
+        config = _make_thd_full_iter_config(thd_tail_padding_policy=tail_padding_policy)
+        batch = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([7, 9], seed=3)]), config=config
+        )
+
+        tokens, labels, loss_mask, attention_mask, position_ids, psp, padding_mask = (
+            get_batch_on_this_rank_for_sequence_packing(iter([batch]), config=config)
+        )
+
+        # The captured path must return the static buffer tensors themselves.
+        assert tokens is batch['tokens']
+        assert labels is batch['labels']
+        assert loss_mask is batch['loss_mask']
+        assert position_ids is batch['position_ids']
+        assert padding_mask is batch['padding_mask']
+        assert attention_mask is None
+        assert psp.qkv_format == 'thd'
+        assert psp.cu_seqlens_q is batch['cu_seqlens']
+        assert psp.cu_seqlens_kv is batch['cu_seqlens']
+        assert psp.cu_seqlens_q_padded is batch['cu_seqlens_padded']
+        assert psp.cu_seqlens_kv_padded is batch['cu_seqlens_padded']
+        assert psp.max_seqlen_q == TOKEN_CAPACITY
+        assert psp.max_seqlen_kv == TOKEN_CAPACITY
+        assert batch['pad_between_seqs'] is True
+        assert psp.pad_between_seqs is True
+        assert padding_mask[0, :16].logical_not().all()
+        assert padding_mask[0, 16:].all()
+
+        if tail_padding_policy == 'append_dummy_seq':
+            assert batch['cu_seqlens'][:4].tolist() == [0, 7, 16, TOKEN_CAPACITY]
+            assert batch['cu_seqlens_padded'][:4].tolist() == [0, 7, 16, TOKEN_CAPACITY]
+            assert (batch['cu_seqlens'][3:] == TOKEN_CAPACITY).all()
+            assert (batch['cu_seqlens_padded'][3:] == TOKEN_CAPACITY).all()
+        else:
+            assert batch['cu_seqlens'][:3].tolist() == [0, 7, 16]
+            assert batch['cu_seqlens_padded'][:3].tolist() == [0, 7, TOKEN_CAPACITY]
+            assert (batch['cu_seqlens'][2:] == 16).all()
+            assert (batch['cu_seqlens_padded'][2:] == TOKEN_CAPACITY).all()
+
+    def test_oversized_pack_is_rejected(self):
+        config = _make_thd_full_iter_config()
+        too_many_seqs = [4] * (MAX_PACKED_SEQS + 1)
+        with pytest.raises(AssertionError):
+            prepare_thd_static_batch_for_full_iteration_cuda_graph(
+                iter([_make_raw_packed_batch(too_many_seqs, seed=5)]), config=config
+            )
+
+    def test_prepare_is_repeatable_on_same_raw_batch(self):
+        """The PagedStashRunner overflow fallback replays the same raw batches,
+        so canonicalizing one raw batch twice must work and be deterministic."""
+        config = _make_thd_full_iter_config()
+        raw = _make_raw_packed_batch([7, 9], seed=3)
+        first = prepare_thd_static_batch_for_full_iteration_cuda_graph(iter([raw]), config=config)
+        second = prepare_thd_static_batch_for_full_iteration_cuda_graph(iter([raw]), config=config)
+        for key in (
+            'tokens',
+            'labels',
+            'loss_mask',
+            'position_ids',
+            'padding_mask',
+            'cu_seqlens',
+            'cu_seqlens_padded',
+        ):
+            assert torch.equal(first[key], second[key]), key
+        assert first['max_seqlen'] == second['max_seqlen']
+        assert first['pad_between_seqs'] is second['pad_between_seqs']
+
+    def test_cp1_static_slot_rebuilds_packed_params_when_boundaries_change(self):
+        """CP1 keeps dynamic packed boundaries and must not retain layout caches."""
+        config = _make_thd_full_iter_config()
+        loader = StaticBufferLoader()
+
+        first = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([7, 9], seed=3)]), config=config
+        )
+        static_batch = loader(first, 'training', 0)
+        first_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=config
+        )[5]
+
+        second = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([8, 8], seed=4)]), config=config
+        )
+        static_batch = loader(second, 'training', 0)
+        second_params = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=config
+        )[5]
+
+        assert second_params is not first_params
+        assert second_params.cu_seqlens_q is static_batch['cu_seqlens']
+        assert second_params.cu_seqlens_q_padded is static_batch['cu_seqlens_padded']
+        assert torch.equal(
+            second_params.cu_seqlens_q[:3],
+            torch.tensor([0, 8, 16], device='cuda', dtype=torch.int32),
+        )
+
+    def test_cp_metadata_uses_stable_slot_and_rejects_geometry_change(self, monkeypatch):
+        """CP>1 Python route metadata is fixed while tensor payloads remain updateable."""
+        monkeypatch.setattr(data_schedule, 'finalize_packed_seq_params', _finalize_with_fake_cp)
+        config = _make_thd_full_iter_config()
+        loader = StaticBufferLoader()
+
+        first = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([8, 8], seed=3)]), config=config
+        )
+        assert FULL_CUDA_GRAPH_STATIC_METADATA_KEY in first
+        static_batch = loader(first, 'training', 0)
+        first_tokens = static_batch['tokens'].clone()
+        first_outputs = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch]), config=config
+        )
+        first_params = first_outputs[5]
+        first_route = first_params.cp_partition_route
+        assert sum(first_route.zigzag_split_sizes) == TOKEN_CAPACITY // 2
+        assert sum(first_route.contiguous_split_sizes) == TOKEN_CAPACITY // 2
+        assert first_route.contiguous_index is not None
+        assert first_route.contiguous_index.numel() == TOKEN_CAPACITY // 2
+        first_route_ptr = first_route.contiguous_index.data_ptr()
+        assert first_params.thd_cp_host_cu_seqlens_q == [0, 8, 16, TOKEN_CAPACITY]
+        assert first_params.thd_cp_host_cu_seqlens_kv == [0, 8, 16, TOKEN_CAPACITY]
+
+        # The ordinary pretrain get_batch finalizer must recognize that the
+        # static fast path already finalized the metadata outside capture.
+        from megatron.core.context_parallel_layout import routes
+
+        monkeypatch.setattr(
+            routes,
+            'prebuild_thd_cp_partition_routes',
+            lambda *args, **kwargs: pytest.fail('CP route rebuilt on the captured path'),
+        )
+        assert finalize_packed_seq_params(first_params) is first_params
+
+        second = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([8, 8], seed=4)]), config=config
+        )
+        static_batch_again = loader(second, 'training', 0)
+        second_outputs = get_batch_on_this_rank_for_sequence_packing(
+            iter([static_batch_again]), config=config
+        )
+        second_params = second_outputs[5]
+        assert second_params is first_params
+        assert second_params.cp_partition_route.contiguous_index.data_ptr() == first_route_ptr
+        assert not torch.equal(static_batch_again['tokens'], first_tokens)
+
+        changed_geometry = prepare_thd_static_batch_for_full_iteration_cuda_graph(
+            iter([_make_raw_packed_batch([4, 12], seed=5)]), config=config
+        )
+        with pytest.raises(RuntimeError, match='static input metadata changed'):
+            loader(changed_geometry, 'training', 0)
+
+
+def test_resolve_thd_static_batch_pg_collection():
+    language_model_pgs = ProcessGroupCollection()
+    multimodule_pgs = MultiModuleProcessGroupCollection(
+        module_pgs={'language_model': language_model_pgs},
+        language_model_module_name='language_model',
+    )
+    assert _resolve_thd_static_batch_pg_collection(language_model_pgs) is language_model_pgs
+    assert _resolve_thd_static_batch_pg_collection(None) is None
+
+    with pytest.raises(ValueError, match='does not support MultiModuleProcessGroupCollection'):
+        _resolve_thd_static_batch_pg_collection(multimodule_pgs)
+
+    no_language_model_pgs = MultiModuleProcessGroupCollection(
+        module_pgs={'encoder': ProcessGroupCollection()}, language_model_module_name=None
+    )
+    with pytest.raises(ValueError, match='does not support MultiModuleProcessGroupCollection'):
+        _resolve_thd_static_batch_pg_collection(no_language_model_pgs)
+
+
+def test_stage_specific_reset_preserves_other_graph_state():
+    FullCudaGraphWrapper.result = {'training': object(), 'validation': object()}
+    FullCudaGraphWrapper.capture_signature = {
+        'training': {'num_microbatches': 2},
+        'validation': {'num_microbatches': 1},
+    }
+    StaticBufferLoader.static_buffers = {
+        'training': [{'tokens': object()}],
+        'validation': [{'tokens': object()}],
+    }
+
+    validation_result = FullCudaGraphWrapper.result['validation']
+    validation_signature = FullCudaGraphWrapper.capture_signature['validation']
+    validation_buffers = StaticBufferLoader.static_buffers['validation']
+    FullCudaGraphWrapper.reset_cuda_graph(stage='training')
+
+    assert FullCudaGraphWrapper.result['training'] is None
+    assert FullCudaGraphWrapper.capture_signature['training'] is None
+    assert StaticBufferLoader.static_buffers['training'] == []
+    assert FullCudaGraphWrapper.result['validation'] is validation_result
+    assert FullCudaGraphWrapper.capture_signature['validation'] is validation_signature
+    assert StaticBufferLoader.static_buffers['validation'] is validation_buffers
+
+
+class TestThdStaticPPCommunicationShapes:
+    """Full-iteration THD mode replaces the P2P shape handshake with static shapes."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_get_tensor_shapes_uses_static_thd_width(self):
+        config = _make_thd_full_iter_config(
+            variable_seq_lengths=True,
+            sequence_parallel=False,
+            hidden_size=HIDDEN_SIZE,
+            enable_hyper_connections=False,
+        )
+        shapes = get_tensor_shapes(
+            seq_length=8192,  # nominal value; must be ignored in THD static mode
+            micro_batch_size=4,
+            decoder_seq_length=None,
+            config=config,
+            tp_group=parallel_state.get_tensor_model_parallel_group(),
+            cp_group=parallel_state.get_context_parallel_group(),
+            pp_group=parallel_state.get_pipeline_model_parallel_group(),
+        )
+        assert shapes == [(TOKEN_CAPACITY, 1, HIDDEN_SIZE)]
+
+        # Without full-iteration graphs, variable-seq-length negotiation remains.
+        config.thd_static_pp_communication = False
+        shapes = get_tensor_shapes(
+            seq_length=8192,
+            micro_batch_size=4,
+            decoder_seq_length=None,
+            config=config,
+            tp_group=parallel_state.get_tensor_model_parallel_group(),
+            cp_group=parallel_state.get_context_parallel_group(),
+            pp_group=parallel_state.get_pipeline_model_parallel_group(),
+        )
+        assert shapes == [()]
+
+
+class _ThdToyModel(torch.nn.Module):
+    """Deterministic THD consumer: one-hot projection + head (no atomics)."""
+
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(VOCAB_SIZE, HIDDEN_SIZE, bias=False)
+        self.head = torch.nn.Linear(HIDDEN_SIZE, VOCAB_SIZE, bias=False)
+        self.model_type = 'unit-test'
+
+    def set_input_tensor(self, input_tensor):
+        pass
+
+    def forward(self, tokens):
+        one_hot = F.one_hot(tokens, VOCAB_SIZE).to(self.proj.weight.dtype)
+        return self.head(self.proj(one_hot))
+
+
+def _make_masked_loss_func(labels, loss_mask, padding_mask):
+    """Padding-aware cross-entropy loss over the static [1, T] batch tensors."""
+
+    def loss_func(output_tensor):
+        losses = F.cross_entropy(
+            output_tensor.view(-1, VOCAB_SIZE), labels.view(-1), reduction='none'
+        )
+        mask = loss_mask.view(-1) * (~padding_mask.view(-1)).to(loss_mask.dtype)
+        loss = (losses * mask).sum() / mask.sum().clamp(min=1.0)
+        return loss, {'loss': loss.detach().clone()}
+
+    return loss_func
+
+
+def _forward_backward_kwargs(forward_step, data_iterator, model, num_microbatches, seq_length):
+    return dict(
+        forward_step_func=forward_step,
+        data_iterator=data_iterator,
+        model=[model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=1,
+        forward_only=False,
+    )
+
+
+def _make_forward_step(config, call_counter):
+    def forward_step(data_iterator, model):
+        call_counter['calls'] += 1
+        tokens, labels, loss_mask, _, _, packed_seq_params, padding_mask = (
+            get_batch_on_this_rank_for_sequence_packing(data_iterator, config=config)
+        )
+        assert packed_seq_params.max_seqlen_q == TOKEN_CAPACITY
+        logits = model(tokens)
+        return logits, _make_masked_loss_func(labels, loss_mask, padding_mask)
+
+    return forward_step
+
+
+def _step_sequence_lengths(step, microbatch):
+    """A different real packing layout per (step, microbatch)."""
+    layouts = [
+        [10, 20, 5],
+        [TOKEN_CAPACITY],
+        [3, 3, 3, 3],
+        [1, 40],
+        [30, 30],
+        [8, 8, 8, 8, 8],
+        [50],
+        [2, 60, 2],
+    ]
+    return layouts[(2 * step + microbatch) % len(layouts)]
+
+
+def _raw_batches_for_step(step, num_microbatches, seed_base=1000):
+    return [
+        _make_raw_packed_batch(_step_sequence_lengths(step, mb), seed=seed_base + 10 * step + mb)
+        for mb in range(num_microbatches)
+    ]
+
+
+@pytest.mark.skipif(
+    not (HAVE_TE and is_te_min_version("1.5.0") and GRAPH_SAFE_RNG_AVAILABLE),
+    reason="full-iteration TE RNG capture requires TE >= 1.5 and graph-safe PyTorch RNG APIs",
+)
+class TestThdFullIterationWrapper:
+    """End-to-end capture/replay with a fixed num_microbatches."""
+
+    NUM_MICROBATCHES = 2
+    NUM_STEPS = 4
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel()
+        tracker = get_cuda_rng_tracker()
+        tracker.add('model-parallel-rng', 1234 + Utils.rank)
+        tracker.set_states(
+            {
+                name: convert_cuda_rng_state(state, to_graphable=False)
+                for name, state in tracker.get_states().items()
+            }
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_graphable_rng_states_are_accepted_and_consumed(self):
+        initialize_rng_tracker(use_cudagraphable_rng=True, force_reset=True)
+        tracker = get_cuda_rng_tracker()
+        tracker.add('model-parallel-rng', 1234)
+
+        states = FullCudaGraphWrapper._get_graphable_rng_states()
+
+        assert isinstance(states['model-parallel-rng'], torch.Generator)
+        assert tracker.get_states()['model-parallel-rng'] is states['model-parallel-rng']
+        with tracker.fork('model-parallel-rng'):
+            torch.rand(1, device='cuda')
+
+    def test_non_graphable_rng_tracker_fails_before_capture(self):
+        initialize_rng_tracker(use_cudagraphable_rng=False, force_reset=True)
+        tracker = get_cuda_rng_tracker()
+        tracker.add('model-parallel-rng', 1234)
+
+        with pytest.raises(RuntimeError, match='requires a graph-safe CUDA RNG tracker'):
+            FullCudaGraphWrapper._get_graphable_rng_states()
+
+    def test_te_tensor_rng_states_are_converted_and_consumed(self):
+        tracker = get_cuda_rng_tracker()
+        assert tracker.get_states()
+        assert all(isinstance(state, torch.Tensor) for state in tracker.get_states().values())
+
+        states = FullCudaGraphWrapper._get_graphable_rng_states()
+
+        assert all(isinstance(state, torch.Generator) for state in states.values())
+        for name, state in states.items():
+            assert tracker.get_states()[name] is state
+        with tracker.fork(next(iter(states))):
+            torch.rand(1, device='cuda')
+
+    def _make_models(self):
+        torch.manual_seed(1234 + Utils.rank)
+        model_graph = _ThdToyModel().cuda()
+        model_eager = _ThdToyModel().cuda()
+        model_eager.load_state_dict(model_graph.state_dict())
+        mp_config = ModelParallelConfig(pipeline_model_parallel_size=1)
+        model_graph.config = mp_config
+        model_eager.config = mp_config
+        return model_graph, model_eager
+
+    def _run_kwargs(self, forward_step, data_iterator, model, num_microbatches):
+        return _forward_backward_kwargs(
+            forward_step, data_iterator, model, num_microbatches, seq_length=None
+        )
+
+    def test_capture_replay_matches_eager(self):
+        thd_config = _make_thd_full_iter_config()
+        model_graph, model_eager = self._make_models()
+
+        graph_counter = {'calls': 0}
+        eager_counter = {'calls': 0}
+        forward_step_graph = _make_forward_step(thd_config, graph_counter)
+        forward_step_eager = _make_forward_step(thd_config, eager_counter)
+
+        prepare_fn = functools.partial(
+            prepare_thd_static_batch_for_full_iteration_cuda_graph, config=thd_config
+        )
+        wrapped = FullCudaGraphWrapper(
+            get_forward_backward_func(), cuda_graph_warmup_steps=1, batch_preparation_fn=prepare_fn
+        )
+        eager_fbf = get_forward_backward_func()
+
+        graph_losses, eager_losses = [], []
+        for step in range(self.NUM_STEPS):
+            raw = _raw_batches_for_step(step, self.NUM_MICROBATCHES)
+            losses = wrapped(
+                **self._run_kwargs(
+                    forward_step_graph, [iter(raw)], model_graph, self.NUM_MICROBATCHES
+                )
+            )
+            graph_losses.append([d['loss'].item() for d in losses])
+
+            raw = _raw_batches_for_step(step, self.NUM_MICROBATCHES)
+            static_batches = [prepare_fn(iter([b])) for b in raw]
+            losses = eager_fbf(
+                **self._run_kwargs(
+                    forward_step_eager, [iter(static_batches)], model_eager, self.NUM_MICROBATCHES
+                )
+            )
+            eager_losses.append([d['loss'].item() for d in losses])
+
+        # Graph must be captured after the warmup step and replayed afterwards:
+        # Python-side forward_step stops running once replay begins.
+        assert FullCudaGraphWrapper.cuda_graph['training'] is not None
+        assert graph_counter['calls'] == 2 * self.NUM_MICROBATCHES
+        assert eager_counter['calls'] == self.NUM_STEPS * self.NUM_MICROBATCHES
+
+        # Per-step, per-microbatch losses must match eager execution bitwise,
+        # including replay steps that saw packing layouts never captured.
+        assert graph_losses == eager_losses
+
+        # Gradients accumulate identically inside and outside the graph.
+        for p_graph, p_eager in zip(model_graph.parameters(), model_eager.parameters()):
+            assert torch.equal(p_graph.grad, p_eager.grad)
+
+    def test_cp_metadata_is_prebuilt_before_capture_and_reused(self, monkeypatch):
+        """A CP>1 static slot never rebuilds host-derived metadata in capture."""
+        monkeypatch.setattr(data_schedule, 'finalize_packed_seq_params', _finalize_with_fake_cp)
+        from megatron.core.context_parallel_layout import routes
+
+        monkeypatch.setattr(
+            routes,
+            'prebuild_thd_cp_partition_routes',
+            lambda *args, **kwargs: pytest.fail('CP route rebuilt in forward/capture'),
+        )
+
+        config = _make_thd_full_iter_config()
+        model, _ = self._make_models()
+        seen_params = []
+
+        def forward_step(data_iterator, model):
+            tokens, labels, loss_mask, _, _, packed_seq_params, padding_mask = (
+                get_batch_on_this_rank_for_sequence_packing(data_iterator, config=config)
+            )
+            finalize_packed_seq_params(packed_seq_params)
+            seen_params.append(packed_seq_params)
+            # Consume a route tensor so capture also pins the static tensor input,
+            # not only the Python metadata wrapper around it.
+            tokens = tokens + packed_seq_params.cp_partition_route.contiguous_index[0]
+            logits = model(tokens)
+            return logits, _make_masked_loss_func(labels, loss_mask, padding_mask)
+
+        prepare_fn = functools.partial(
+            prepare_thd_static_batch_for_full_iteration_cuda_graph, config=config
+        )
+        wrapped = FullCudaGraphWrapper(
+            get_forward_backward_func(), cuda_graph_warmup_steps=1, batch_preparation_fn=prepare_fn
+        )
+
+        for step in range(3):
+            raw = [_make_raw_packed_batch([8, 8], seed=800 + step)]
+            wrapped(**self._run_kwargs(forward_step, [iter(raw)], model, num_microbatches=1))
+
+        assert FullCudaGraphWrapper.cuda_graph['training'] is not None
+        assert len(seen_params) == 2  # eager warmup + capture; replay runs no Python
+        assert seen_params[0] is seen_params[1]
+
+    def test_num_microbatches_change_after_capture_raises(self):
+        thd_config = _make_thd_full_iter_config()
+        model_graph, _ = self._make_models()
+
+        prepare_fn = functools.partial(
+            prepare_thd_static_batch_for_full_iteration_cuda_graph, config=thd_config
+        )
+        wrapped = FullCudaGraphWrapper(
+            get_forward_backward_func(), cuda_graph_warmup_steps=1, batch_preparation_fn=prepare_fn
+        )
+        forward_step = _make_forward_step(thd_config, {'calls': 0})
+
+        for step in range(2):
+            raw = _raw_batches_for_step(step, self.NUM_MICROBATCHES)
+            wrapped(
+                **self._run_kwargs(forward_step, [iter(raw)], model_graph, self.NUM_MICROBATCHES)
+            )
+        assert FullCudaGraphWrapper.cuda_graph['training'] is not None
+
+        raw = _raw_batches_for_step(2, self.NUM_MICROBATCHES + 1)
+        with pytest.raises(RuntimeError, match='signature mismatch'):
+            wrapped(
+                **self._run_kwargs(
+                    forward_step, [iter(raw)], model_graph, self.NUM_MICROBATCHES + 1
+                )
+            )
+
+
+class _ThdToyFirstStage(torch.nn.Module):
+    """First PP stage: embeds tokens into the static [T, 1, H] PP shape."""
+
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(VOCAB_SIZE, HIDDEN_SIZE, bias=False)
+        self.model_type = 'unit-test'
+
+    def set_input_tensor(self, input_tensor):
+        pass
+
+    def forward(self, tokens):
+        one_hot = F.one_hot(tokens, VOCAB_SIZE).to(self.proj.weight.dtype)
+        return self.proj(one_hot).transpose(0, 1).contiguous()
+
+
+class _ThdToyLastStage(torch.nn.Module):
+    """Last PP stage: consumes the received [T, 1, H] activation."""
+
+    def __init__(self):
+        super().__init__()
+        self.head = torch.nn.Linear(HIDDEN_SIZE, VOCAB_SIZE, bias=False)
+        self.model_type = 'unit-test'
+        self.input_tensor = None
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            input_tensor = input_tensor[0]
+        self.input_tensor = input_tensor
+
+    def forward(self):
+        return self.head(self.input_tensor.transpose(0, 1))
+
+
+@pytest.mark.skipif(
+    not (HAVE_TE and is_te_min_version("1.5.0") and GRAPH_SAFE_RNG_AVAILABLE),
+    reason="full-iteration TE RNG capture requires TE >= 1.5 and graph-safe PyTorch RNG APIs",
+)
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="PP2 requires at least 2 GPUs")
+class TestThdFullIterationWrapperPP2:
+    """PP2 1F1B with graph-captured NCCL P2P and static THD shapes."""
+
+    NUM_MICROBATCHES = 4
+    NUM_STEPS = 4
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel(1, 2)
+        tracker = get_cuda_rng_tracker()
+        tracker.add('model-parallel-rng', 1234 + Utils.rank)
+        tracker.set_states(
+            {
+                name: convert_cuda_rng_state(state, to_graphable=False)
+                for name, state in tracker.get_states().items()
+            }
+        )
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _make_config(self):
+        config = ModelParallelConfig(
+            pipeline_model_parallel_size=2, pipeline_dtype=torch.float32, variable_seq_lengths=True
+        )
+        for key, value in vars(_make_thd_full_iter_config()).items():
+            setattr(config, key, value)
+        config.hidden_size = HIDDEN_SIZE
+        return config
+
+    def _make_stage_models(self, config):
+        torch.manual_seed(4321)  # identical init across the DP group per stage
+        if parallel_state.is_pipeline_first_stage():
+            model_graph, model_eager = _ThdToyFirstStage().cuda(), _ThdToyFirstStage().cuda()
+        else:
+            model_graph, model_eager = _ThdToyLastStage().cuda(), _ThdToyLastStage().cuda()
+        model_eager.load_state_dict(model_graph.state_dict())
+        model_graph.config = config
+        model_eager.config = config
+        return model_graph, model_eager
+
+    def _raw_batches(self, step):
+        # The two PP ranks of one pipeline must see identical raw batches.
+        dp_rank = parallel_state.get_data_parallel_rank()
+        return [
+            _make_raw_packed_batch(
+                _step_sequence_lengths(step, mb), seed=5000 + 100 * step + 10 * mb + dp_rank
+            )
+            for mb in range(self.NUM_MICROBATCHES)
+        ]
+
+    def _make_forward_step(self, config):
+        def forward_step(data_iterator, model):
+            tokens, labels, loss_mask, _, _, _, padding_mask = (
+                get_batch_on_this_rank_for_sequence_packing(data_iterator, config=config)
+            )
+            if parallel_state.is_pipeline_first_stage():
+                output = model(tokens)
+            else:
+                output = model()
+            return output, _make_masked_loss_func(labels, loss_mask, padding_mask)
+
+        return forward_step
+
+    def test_pp2_capture_replay_matches_eager(self):
+        config = self._make_config()
+        model_graph, model_eager = self._make_stage_models(config)
+        forward_step = self._make_forward_step(config)
+
+        prepare_fn = functools.partial(
+            prepare_thd_static_batch_for_full_iteration_cuda_graph, config=config
+        )
+        wrapped = FullCudaGraphWrapper(
+            get_forward_backward_func(), cuda_graph_warmup_steps=1, batch_preparation_fn=prepare_fn
+        )
+        eager_fbf = get_forward_backward_func()
+
+        def run_kwargs(data_iterator, model):
+            return _forward_backward_kwargs(
+                forward_step, data_iterator, model, self.NUM_MICROBATCHES, seq_length=TOKEN_CAPACITY
+            )
+
+        graph_losses, eager_losses = [], []
+        for step in range(self.NUM_STEPS):
+            losses = wrapped(**run_kwargs([iter(self._raw_batches(step))], model_graph))
+            graph_losses.append([d['loss'].item() for d in losses])
+
+            static_batches = [prepare_fn(iter([b])) for b in self._raw_batches(step)]
+            losses = eager_fbf(**run_kwargs([iter(static_batches)], model_eager))
+            eager_losses.append([d['loss'].item() for d in losses])
+
+        # The PP2 1F1B schedule, including its NCCL P2P, must have been captured.
+        assert FullCudaGraphWrapper.cuda_graph['training'] is not None
+        # Losses exist on the last stage only and must match eager bitwise.
+        if parallel_state.is_pipeline_last_stage():
+            assert all(len(step_losses) == self.NUM_MICROBATCHES for step_losses in graph_losses)
+            assert graph_losses == eager_losses
+        for p_graph, p_eager in zip(model_graph.parameters(), model_eager.parameters()):
+            assert torch.equal(p_graph.grad, p_eager.grad)
+
+
+# =============================================================================
+# E2E eager vs full-iteration bitwise loss/grad_norm match.
+#    Subprocess-launches `torchrun pretrain_gpt.py` twice (same recipe style as
+#    test_thd_cuda_graph.py::TestE2EBitwise) and asserts per-iteration metrics
+#    are byte-identical. Data uses fixed-length sequences so the packing
+#    scheduler emits a constant num_microbatches per step, as required by the
+#    full-iteration graph contract.
+# =============================================================================
+
+_E2E_TRAIN_ITERS = 8
+
+# Every sequence is exactly max_seqlen_per_dp_cp_rank tokens: one sequence per
+# pack, GBS 16 / dp 4 = 4 microbatches per rank per step, constant.
+_FIXED_LEN_VARLEN_JSON = (
+    '{"mode":"distribution","type":"lognormal",'
+    '"format":"thd","min_seq_len":4096,"max_seq_len":4096,'
+    '"mean_seq_len":4096,"lognormal_sigma":0.1}'
+)
+
+_E2E_COMMON_ARGS = [
+    "--seq-length",
+    "4096",
+    "--max-position-embeddings",
+    "8192",
+    "--micro-batch-size",
+    "1",
+    "--global-batch-size",
+    "16",
+    "--train-iters",
+    str(_E2E_TRAIN_ITERS),
+    "--lr",
+    "1e-5",
+    "--min-lr",
+    "1e-6",
+    "--lr-decay-style",
+    "cosine",
+    "--lr-warmup-iters",
+    "1",
+    "--weight-decay",
+    "0.01",
+    "--clip-grad",
+    "1.0",
+    "--seed",
+    "1234",
+    "--te-rng-tracker",
+    "--bf16",
+    "--tensor-model-parallel-size",
+    "1",
+    "--pipeline-model-parallel-size",
+    "2",
+    "--swiglu",
+    "--disable-bias-linear",
+    "--use-varlen-dataset",
+    "--mock-data",
+    "--tokenizer-type",
+    "NullTokenizer",
+    "--varlen-mock-dataset-config-json",
+    _FIXED_LEN_VARLEN_JSON,
+    "--sequence-packing-scheduler",
+    "dp_balanced",
+    "--max-seqlen-per-dp-cp-rank",
+    "4096",
+    "--pad-packed-seq-alignment",
+    "max",
+    "--thd-max-packed-sequences",
+    "8",
+    "--calculate-per-token-loss",
+    "--transformer-impl",
+    "transformer_engine",
+    "--attention-dropout",
+    "0",
+    "--hidden-dropout",
+    "0",
+    "--no-bias-swiglu-fusion",
+    "--no-gradient-accumulation-fusion",
+    "--no-save-optim",
+    "--no-save-rng",
+    "--save-interval",
+    "999999",
+    "--eval-interval",
+    "999999",
+    "--eval-iters",
+    "1",
+    "--log-interval",
+    "1",
+    "--no-check-for-nan-in-loss-and-grad",
+    "--deterministic-mode",
+]
+
+_DENSE_E2E_ARGS = _E2E_COMMON_ARGS + [
+    "--num-layers",
+    "8",
+    "--hidden-size",
+    "512",
+    "--ffn-hidden-size",
+    "1376",
+    "--num-attention-heads",
+    "8",
+    "--vocab-size",
+    "32000",
+]
+
+_DENSE_CP2_E2E_ARGS = _DENSE_E2E_ARGS + ["--context-parallel-size", "2"]
+
+# Moonlight-style MLA + MoE, downsized, with STATIC expert shapes: alltoall
+# dispatcher + capacity factor + pad-to-capacity (the v1 full-iteration MoE
+# contract). Router fusion exercises TE's fused_moe_aux_loss with a tensor
+# total_num_tokens inside the captured region. Native dropless HybridEP has
+# dynamic expert shapes and stays out of full-iteration scope.
+_MOONLIGHT_STATIC_E2E_ARGS = _E2E_COMMON_ARGS + [
+    "--num-layers",
+    "13",
+    "--hidden-size",
+    "1024",
+    "--ffn-hidden-size",
+    "5632",
+    "--num-attention-heads",
+    "16",
+    "--decoder-first-pipeline-num-layers",
+    "6",
+    "--decoder-last-pipeline-num-layers",
+    "7",
+    "--expert-model-parallel-size",
+    "4",
+    "--expert-tensor-parallel-size",
+    "1",
+    "--multi-latent-attention",
+    "--kv-lora-rank",
+    "512",
+    "--qk-head-dim",
+    "128",
+    "--qk-pos-emb-head-dim",
+    "64",
+    "--v-head-dim",
+    "128",
+    "--num-experts",
+    "64",
+    "--moe-ffn-hidden-size",
+    "704",
+    "--moe-router-topk",
+    "6",
+    "--moe-shared-expert-intermediate-size",
+    "1408",
+    "--moe-layer-freq",
+    "([0]+[1]*12)",
+    "--moe-token-dispatcher-type",
+    "alltoall",
+    "--moe-expert-capacity-factor",
+    "1.5",
+    "--moe-pad-expert-input-to-capacity",
+    "--moe-router-fusion",
+    "--moe-router-score-function",
+    "sigmoid",
+    "--moe-router-topk-scaling-factor",
+    "2.446",
+    "--moe-router-load-balancing-type",
+    "aux_loss",
+    "--moe-aux-loss-coeff",
+    "0.001",
+    "--normalization",
+    "RMSNorm",
+    "--norm-epsilon",
+    "1e-5",
+    "--rotary-base",
+    "50000",
+    "--vocab-size",
+    "32000",
+]
+
+_FULL_ITER_ARGS = ["--cuda-graph-impl", "full_iteration", "--cuda-graph-warmup-steps", "3"]
+
+# Subprocess timeout: two full pretrain runs of ~2 min each plus slack.
+_E2E_RUN_TIMEOUT = 1500
+
+
+def _wait_for_idle_gpus(timeout_s=90):
+    """Wait until no compute process holds a GPU.
+
+    Back-to-back parametrized cases each spawn 8-rank torchrun subprocesses;
+    the previous case's workers may still be tearing down when the next case
+    launches, which fails CUDA initialization.
+    """
+    import subprocess
+    import time
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return
+        time.sleep(2)
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(torch.cuda.device_count() < 8, reason="requires 8 GPUs")
+@pytest.mark.skipif(
+    os.environ.get("WORLD_SIZE", "1") != "1",
+    reason="spawns its own torchrun; run under plain pytest, not torch.distributed.run",
+)
+@pytest.mark.parametrize(
+    "model_name,model_args,base_port",
+    [
+        ("dense", _DENSE_E2E_ARGS, 29720),
+        ("dense_cp2", _DENSE_CP2_E2E_ARGS, 29722),
+        ("moonlight_static_capacity", _MOONLIGHT_STATIC_E2E_ARGS, 29724),
+    ],
+)
+class TestE2EFullIterationBitwise:
+    """End-to-end bitwise comparison: pretrain_gpt.py eager vs full_iteration.
+
+    Fixed num_microbatches per step (fixed-length packed data), THD sequence
+    packing, PP2. The full-iteration run enables the CUDA allocator's
+    graph_capture_record_stream_reuse option. Asserts per-iteration
+    `lm loss / grad norm` metrics are byte-identical and that the graph was
+    actually captured and replayed.
+
+    Slow (several minutes per model). Marked `internal` so CI can opt-in.
+    """
+
+    def test_eager_vs_full_iteration(self, model_name, model_args, base_port):
+        from tests.unit_tests.transformer.test_thd_cuda_graph import _extract_metrics, _run_pretrain
+
+        _wait_for_idle_gpus()
+        r1 = _run_pretrain(model_args, [], master_port=base_port, timeout=_E2E_RUN_TIMEOUT)
+        assert r1.returncode == 0, (
+            f"[{model_name}] eager pretrain failed (rc={r1.returncode})\n"
+            f"--- stdout (tail) ---\n{r1.stdout[-4000:]}\n"
+            f"--- stderr (tail) ---\n{r1.stderr[-2000:]}"
+        )
+        metrics_eager = _extract_metrics(r1.stdout)
+        assert len(metrics_eager) == _E2E_TRAIN_ITERS, (
+            f"[{model_name}] eager: expected {_E2E_TRAIN_ITERS} metric lines, "
+            f"got {len(metrics_eager)}\n--- stdout (tail) ---\n{r1.stdout[-2000:]}"
+        )
+
+        r2 = _run_pretrain(
+            model_args,
+            _FULL_ITER_ARGS,
+            master_port=base_port + 1,
+            extra_env={"PYTORCH_CUDA_ALLOC_CONF": "graph_capture_record_stream_reuse:True"},
+            timeout=_E2E_RUN_TIMEOUT,
+        )
+        assert r2.returncode == 0, (
+            f"[{model_name}] full_iteration pretrain failed (rc={r2.returncode})\n"
+            f"--- stdout (tail) ---\n{r2.stdout[-4000:]}\n"
+            f"--- stderr (tail) ---\n{r2.stderr[-2000:]}"
+        )
+        assert "Capture CUDA graph for training" in (
+            r2.stdout + r2.stderr
+        ), f"[{model_name}] full_iteration run never captured a CUDA graph"
+        metrics_graph = _extract_metrics(r2.stdout)
+        assert len(metrics_graph) == _E2E_TRAIN_ITERS, (
+            f"[{model_name}] full_iteration: expected {_E2E_TRAIN_ITERS} metric lines, "
+            f"got {len(metrics_graph)}\n--- stdout (tail) ---\n{r2.stdout[-2000:]}"
+        )
+
+        assert metrics_eager == metrics_graph, (
+            f"[{model_name}] eager vs full_iteration metrics diverge\n"
+            f"--- eager ---\n" + "\n".join(metrics_eager) + "\n"
+            f"--- full_iteration ---\n" + "\n".join(metrics_graph)
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1655,8 +1655,8 @@ wheels = [
 
 [[package]]
 name = "emerging-optimizers"
-version = "0.3.0"
-source = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=v0.3.0#b309e2f01cda75dc96a6dc1a2355a7b3b64b5e16" }
+version = "0.5.0a0"
+source = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=a44d1f83a4950b445f2a77ca71177c5f033d45d5#a44d1f83a4950b445f2a77ca71177c5f033d45d5" }
 dependencies = [
     { name = "absl-py", marker = "python_full_version >= '3.12'" },
     { name = "torch", marker = "python_full_version >= '3.12' and sys_platform == 'never'" },
@@ -3181,8 +3181,8 @@ requires-dist = [
     { name = "datasets", marker = "extra == 'lts'" },
     { name = "einops", marker = "extra == 'dev'", specifier = "~=0.8" },
     { name = "einops", marker = "extra == 'lts'", specifier = "~=0.8" },
-    { name = "emerging-optimizers", marker = "python_full_version >= '3.12' and extra == 'dev'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=v0.3.0" },
-    { name = "emerging-optimizers", marker = "python_full_version >= '3.12' and extra == 'lts'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=v0.3.0" },
+    { name = "emerging-optimizers", marker = "python_full_version >= '3.12' and extra == 'dev'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=a44d1f83a4950b445f2a77ca71177c5f033d45d5" },
+    { name = "emerging-optimizers", marker = "python_full_version >= '3.12' and extra == 'lts'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=a44d1f83a4950b445f2a77ca71177c5f033d45d5" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = "~=0.50" },
     { name = "fastapi", marker = "extra == 'lts'", specifier = "~=0.50" },
     { name = "flash-linear-attention", extras = ["tilelang"], marker = "extra == 'dev'", specifier = "==0.5.1" },
@@ -3261,7 +3261,7 @@ linting = [
     { name = "ruff", specifier = "~=0.9.0" },
 ]
 no-pypi-wheels = [
-    { name = "emerging-optimizers", marker = "python_full_version >= '3.12'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=v0.3.0" },
+    { name = "emerging-optimizers", marker = "python_full_version >= '3.12'", git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git?rev=a44d1f83a4950b445f2a77ca71177c5f033d45d5" },
     { name = "fast-hadamard-transform", git = "https://github.com/Dao-AILab/fast-hadamard-transform.git?rev=f134af63deb2df17e1171a9ec1ea4a7d8604d5ca" },
     { name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev" },
 ]


### PR DESCRIPTION
> [!CAUTION]
> This is a tracking-only integration PR. **Do not merge it.**
> Each feature not already upstream must be reviewed and merged through its source PR.

## Purpose

This draft tracks the runnable GLM-5.2 development stack, selected full-model benchmark configurations, current validation state, and the latest trustworthy performance results. Unmerged capabilities remain subject to review through their source PRs; the final stack-local commits record cross-PR compatibility and correctness fixes that still require their own upstream disposition.

- Validated source base snapshot: `NVIDIA/Megatron-LM:dev@5e12dce0057bcffdcad9cf7720e75df7e8153a7d`
- Current upstream dev at refresh: `68447eeaae0b8b5300dc5e3ae8d91d8a0753fae6`
- Current tracking head: `f68259e6f8c3fa504e5c2a0e8db4d00665efd2c1` (tree `a6bbb02b6e741497904b4c20590242e106a98dc5`)
- Exact full-model benchmark source: `9ddf32ed96263d7c37d56970296d7e60cc47c84c` (tree `6f7a4e294202f64d28bf8a803c46607dc8af6d3d`)
- Tracking branch: `buptzyb:codex/tracking/glm5-2-integration`
- Stack refresh: 2026-09-13; full-model benchmark snapshot: 2026-09-03

The tracking head now contains two unsubmitted follow-ups beyond the exact full-model benchmark source. The performance matrix below remains historical evidence for `9ddf32ed96`; it is not relabeled as validation of `f68259e6f8`. Upstream `dev` has also advanced beyond the validated base, and this tracking-only PR remains intentionally unsuitable for merge.

## Integrated PR stack

The validated base is the exact upstream `dev` snapshot ending at [PR #6397](https://github.com/NVIDIA/Megatron-LM/pull/6397). Capabilities already merged into that snapshot are baseline ancestry, not additional tracking-branch commits.

The table below follows the exact linear ancestry after the validated base snapshot. Aggregate commits may be dev ports or tested snapshots of their source PRs; the links identify provenance and do not claim that each aggregate commit equals the source PR's current head.

| Order | Source PR | Capability | Aggregate commit |
| ---: | --- | --- | --- |
| 1 | [PR #5807](https://github.com/NVIDIA/Megatron-LM/pull/5807) | THD full-iteration graphs with fixed accumulation | `a834c795f` |
| 2 | [PR #6783](https://github.com/NVIDIA/Megatron-LM/pull/6783) | Consistent fine-grained activation-offload handler advancement | `9bf95a482` |
| 3 | [PR #6206](https://github.com/NVIDIA/Megatron-LM/pull/6206) | Packed-THD DSA scoring plans and CP metadata | `b56246eb3` |
| 4 | [PR #6910](https://github.com/NVIDIA/Megatron-LM/pull/6910) | Static-shape DSA sparse backward and empty-row handling | `35f112f2a` |
| 5 | [PR #6980](https://github.com/NVIDIA/Megatron-LM/pull/6980) | DSA metrics under dynamic CP and CUDA Graph capture | `d193d0991` |
| 6 | [PR #6753](https://github.com/NVIDIA/Megatron-LM/pull/6753) | DSA and absorbed-MLA FLOP accounting; patch-equivalent code is already in current upstream `dev` | `c8f3422d7` |
| 7 | [PR #6326](https://github.com/NVIDIA/Megatron-LM/pull/6326) | Per-head Muon for attention projections | `6972049f5` |
| 8 | [PR #6472](https://github.com/NVIDIA/Megatron-LM/pull/6472) | Repeated-MTP DSA indexer/latent-KV sharing | `98e9eeab5` |
| 9 | [PR #6473](https://github.com/NVIDIA/Megatron-LM/pull/6473) | Fused end-to-end MTP TV objective | `8d7629d45` |
| 10 | [PR #6741](https://github.com/NVIDIA/Megatron-LM/pull/6741) | Absolute MTP sequence-roll addressing | `2e34ff87e` |
| 11 | [PR #6850](https://github.com/NVIDIA/Megatron-LM/pull/6850) | Parallel pipeline-stage prewarm | `bc1668da7` |
| 12 | — | Cross-stack CUDA Graph, paged-stash, DSA, and MTP compatibility | `9389a8e48` |
| 13 | — | Stack-local, unsubmitted fix: preserve experimental-attention specs on MTP-only stages | `9ddf32ed9` |
| 14 | — | Stack-local deterministic cuDNN DSA: deterministic top-k membership, indexer gradients, and sparse-attention backward | `9d7701993` |
| 15 | — | Stack-local LayerWise MXFP8 parameter-gather memory optimization | `f68259e6f` |

`9389a8e48` is integration-only compatibility glue. `9ddf32ed9`, `9d7701993`, and `f68259e6f` are stack-local follow-ups that still need independent upstream disposition. None should be merged through this tracking PR. The last two commits were not present in the 2026-09-03 full-model performance source.

## Full-model benchmark configurations

The latest formal measurements use the full 78-layer GLM-5.2 model (3 dense + 75 MoE layers), 256 experts, hidden size 6144, and the production attention, DSA, expert, and shared-expert dimensions. DSA uses the cuDNN backend with a 32-head × 128-dimension indexer, top-k 2048, frequency 4, full-model offset 3, and sparse loss coefficient `1e-2`. Runs use MXFP8, Muon with per-head QKV treatment, force-balanced routing, dynamic CP, MBS1, and 32 scheduled microbatches on 256×GB300. The resolved configuration exercises attention latent normalization from [PR #6204](https://github.com/NVIDIA/Megatron-LM/pull/6204), fused standard MLA RoPE from [PR #6343](https://github.com/NVIDIA/Megatron-LM/pull/6343), and paged stash from [PR #6022](https://github.com/NVIDIA/Megatron-LM/pull/6022), all inherited from the validated base.

| MTP mode | Shape | Selected PP layout | Recompute / offload | Purpose / status |
| --- | --- | --- | --- | --- |
| MTP off | 78L (3 dense + 75 MoE), 256E, `TP1/PP4/EP64/configured-CP64` | `Et*18\|t*20\|t*20\|t*20L` | none / none | Selected layout in the 4K/128K formal matrix |
| Repeated MTP7 | 78L (3 dense + 75 MoE), 256E, `TP1/PP4/EP64/configured-CP64` | `Et*18\|t*24\|t*24\|t*12m*7L` | selective `moe_act layernorm` / none | Selected layout in the 4K/128K formal matrix |

The MTP-on matrix does not use full-layer or whole-MTP recompute: only the configured `moe_act` and `layernorm` modules are recomputed. No same-layout recompute-on/off ablation has been run, so these results do not isolate the performance cost of recompute and do not establish that MTP intrinsically requires it.

The formal matrix below validates MXFP8 on GB300 only; it must not be interpreted as a GB200 or BF16 result. These runs enable per-head Muon treatment for attention projections. Remaining optimizer-parity questions concern the exact treatment of `W^QR` and packed MLA down projections.

## Latest formal performance

The latest formal matrix was run on 2026-09-03 directly from tracking head `9ddf32ed96263d7c37d56970296d7e60cc47c84c` (tree `6f7a4e294202f64d28bf8a803c46607dc8af6d3d`). The Emerging-Optimizers source was `a44d1f83a4950b445f2a77ca71177c5f033d45d5`; the container digest was `0c46ff6b56c1d683eaf8ab996718e7235662133328720cd7fb7fff17bda0af4b`.

Workload: 256×GB300 (64 hosts × 4 GPUs), with each PP stage placed on a distinct 16-node/64-GPU subset of an NVL72 domain. The model is GLM-5.2 78L (3 dense + 75 MoE), 256 experts, MXFP8, `TP1/PP4/EP64/configured-CP64`, dynamic CP, cuDNN DSA, force-balanced routing, MBS1, and 32 scheduled microbatches. The 4K cells use 3,968 valid tokens per sample, 64 samples per scheduled microbatch, effective CP1 × 64 groups, and GBS2048. The 128K cells use 126,976 valid tokens per sample, two samples per scheduled microbatch, effective CP32 × 2 groups, and GBS64. Both shapes carry 8,126,464 valid global tokens per optimizer step and 3,968 valid tokens per effective CP rank.

Each cell emitted 40 raw optimizer steps. After at least eight warmup steps, the analyzer selected the same accounting-safe consecutive ten-step ordinal window for the no-CG/full-CG pair. Performance runs had no profiler.

| Sequence | MTP | CUDA Graph | Median step (s) | p95 (s) | CV | Exact source TFLOPS/GPU | Audited logical TFLOPS/GPU | Tokens/s/GPU | Peak device-used (MiB) | HBM margin (MiB) |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4K | off | none | 21.4848 | 21.9012 | 1.555% | 430.29 | 440.50 | 1,477.51 | 225,229 | 58,979 |
| 4K | off | full iteration | 19.0641 | 19.2102 | 1.101% | 484.93 | 496.43 | 1,665.13 | 225,917 | 58,291 |
| 4K | on | none | 24.6523 | 25.0080 | 0.965% | 466.26 | 458.15 | 1,287.71 | 240,411 | 43,797 |
| 4K | on | full iteration | 21.9088 | 22.1613 | 1.002% | 524.63 | 515.50 | 1,448.92 | 240,653 | 43,555 |
| 128K | off | none | 19.6745 | 20.3836 | 1.577% | 548.02 | 529.13 | 1,613.46 | 236,351 | 47,857 |
| 128K | off | full iteration | 18.2130 | 18.4401 | 0.575% | 591.99 | 571.59 | 1,742.93 | 247,509 | 36,699 |
| 128K | on | none | 23.2958 | 23.7291 | 0.851% | 565.54 | 528.32 | 1,362.65 | 251,847 | 32,361 |
| 128K | on | full iteration | 21.0417 | 21.2208 | 0.476% | 626.13 | 584.92 | 1,508.62 | 261,991 | 22,217 |

The audited logical metric is the primary efficiency metric. It counts the defining GEMMs for the resolved repeated-MTP/cuDNN split-DSA graph, including split-path replays and sparse backward, and excludes elementwise work, communication, kernel padding, and activation recompute. The exact source metric is the pinned Megatron model-FLOP convention evaluated with exact real-token and `sum(L²)` scheduler statistics. Neither metric is a hardware-instruction counter.

| Sequence | MTP | Full-iteration-CG step-time improvement | Device-memory delta |
| --- | --- | ---: | ---: |
| 4K | off | 12.698% | +688 MiB |
| 4K | on | 12.522% | +242 MiB |
| 128K | off | 8.024% | +11,158 MiB |
| 128K | on | 10.713% | +10,144 MiB |

These are same-allocation paired comparisons, but every pair ran no-CG before full-CG rather than ABBA. The gains are large relative to the measured CVs, but a fresh-allocation ABBA is still required before treating the exact percentages as order-independent production estimates.

Across separate pair allocations and the selected mode-specific layouts, MTP increased median step time by 14.7% (4K/no-CG), 14.9% (4K/full-CG), 18.4% (128K/no-CG), and 15.5% (128K/full-CG), and increased peak device-used memory by 14.1–15.1 GiB. Those comparisons include MTP computation, different PP layouts, and different recompute policies; they are not a pure MTP feature toggle.

For the selected 128K/MTP7/full-iteration-CG workload, the calibrated memory model predicted a no-recompute peak of approximately 276,855 MiB on a 284,208 MiB GB300, leaving only 7,353 MiB and failing the 14,210 MiB post-smoke safety margin; this was not an observed no-recompute run. With selective `moe_act layernorm` recompute, the observed peak was 261,991 MiB with 22,217 MiB remaining. The selected long-context benchmark configuration therefore retains this selective recompute for memory safety. This is not evidence that MTP universally requires recompute: the 4K no-recompute variant was not measured, and there is no controlled same-layout recompute performance A/B.

## Deterministic eager versus full-iteration correctness follow-up

A separate 16-GPU correctness-only campaign compared eager and full-iteration execution for short/long THD inputs with repeated-MTP off/on. Each cell ran fresh-process `eager1/full1/full2/eager2` and compared raw-byte fingerprints for model inputs, packed metadata, LM/indexer losses, DSA top-k state, parameter gradients, parameters/master weights, optimizer state, scheduler state, and RNG state after every optimizer step.

This campaign was **not** a pristine run of tracking head `9ddf32ed96` and is not a performance benchmark. The four successful jobs used all of the following:

- Megatron validation commit `0b2cbc586c8a740a6c882634dc0a2dd805748346` (parent `9ddf32ed96`), plus controlled four-file patch `4a212b709a1f57a72198bff3bcbe9e40866c01d7e3a873fc3433951c60aae14c`;
- deterministic DSA changes for top-k cutoff ties, split-hook propagation, fixed-order indexer `dW/dK`, and deterministic sparse-attention backward workspace handling;
- cuDNN overlay `cudnn-fe-dswiglu-pinned-deterministic-20260910` (tree `89abb00c43114c36839e03c648588e19ed7e3f16992a989e7850f2072ac88498`) containing PR810-based SM100 deterministic DSA backward and a deterministic unified dSwiGLU implementation;
- deterministic experiment settings and intrusive fingerprint instrumentation. The instrumentation performs device-to-host hashing/synchronization, so these jobs cannot support timing claims.

The evidence chain matters: clean `0b2cbc586c` job 695622 first diverged in the DSA indexer-loss tracker; MCore-patched job 701181 then diverged in a MoE `[6144, 16384]` gradient; only after adding the deterministic dSwiGLU overlay did all four cells become raw-byte identical: long/MTP-off job 703243, long/MTP-on job 704696, short/MTP-off job 704861, and short/MTP-on job 705315.

The supported conclusion is therefore: **under the same patched MCore and deterministic cuDNN/dSwiGLU stack, eager and full-iteration CUDA Graph execution were raw-byte identical in these four fixed-shape cells.** This does not establish that the original remote aggregate was deterministic without modification. Commit `9d7701993` is the later cleaned integration of the DSA-side work, but it is not the exact source of those successful jobs and still requires a direct rerun. Commit `f68259e6f` was not used by this correctness campaign.

## Current validation snapshot

- Four exclusive 256×GB300 jobs produced the eight valid formal cells above: long/MTP-off job 648552, long/MTP-on job 648759, short/MTP-off job 648932, and short/MTP-on job 649068.
- Every valid cell completed 40 optimizer steps and passed scheduler-contract, required loss/gradient, fatal/fallback, CUDA Graph capture-and-replay, all-rank memory, strict GPU inventory, and topology gates.
- Every allocation contained exactly 64 hosts and 256 NVIDIA GB300 GPUs reporting 284,208 MiB each. Each PP stage occupied a different NVL72 domain subset.
- The predeclared CV≤2% gate rejected the first long/MTP-off attempt (2.011%) and the first long/MTP-on attempt (2.495% caused by one outlier); both were rerun on fresh allocations and passed.
- The tightest valid memory point was 128K/MTP-on/full-iteration-CG at 261,991 MiB peak device-used memory, leaving 22,217 MiB. All cells cleared the required 14,210.4 MiB (5% HBM) margin.
- All OCI-AGA jobs and GPU allocations were released after completion.

## Known limitations and update policy

- The v21 full-iteration-CG experiment configured dynamic CP but deliberately used fixed sample lengths, fixed effective CP per shape, fixed metadata per captured slot, and exactly 32 scheduled microbatches. It validates the fixed-microbatch full-iteration path, not a workload whose effective CP or microbatch count changes between iterations.
- The validated fixed-microbatch full-iteration path depends on [PR #6022](https://github.com/NVIDIA/Megatron-LM/pull/6022) in the base, [PR #5807](https://github.com/NVIDIA/Megatron-LM/pull/5807) in the tracking stack, `9389a8e48`, and the corresponding TransformerEngine support.
- The exact benchmark source contains `9ddf32ed9`, but the selected MTP layout includes ordinary transformer layers on every PP stage and therefore does not separately exercise that commit's MTP-only-stage fix.
- The [PR #6326](https://github.com/NVIDIA/Megatron-LM/pull/6326) aggregate commit is a dev-compatible port of a main-targeted PR; main-only generalized tensor-parallel code is not present on this dev base.
- The current tracking head is `f68259e6f`, while the full-model benchmark source remains `9ddf32ed9`; those performance results are explicitly historical and must not be attributed to the current head. The deterministic campaign used `0b2cbc586c` plus a controlled patch and dependency overlay, not either of those exact trees.
- The body tracks the current stack and latest verified measurements. Refresh comments should record source-head changes and superseded results.
- This PR must remain draft and must never become a merge candidate.

