### PR TITLE
Draft: Expose FsdpModule in M-FSDP v2 1F1B Direct

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -507,8 +507,9 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             module: Root model module to shard.
             fsdp_unit_modules: Module types to shard as child FSDP units. If
                 unspecified, transformer, MoE transformer, and Mamba layers are used.
-            disable_bucketing: Compatibility argument that must remain ``False`` for
-                MFSDP v2.
+            disable_bucketing: Compatibility argument accepted for callers that
+                configure DDP or MFSDP v1 bucketing. MFSDP v2 ignores it because
+                FSDP units, rather than DDP buckets, define collective granularity.
             device: Device whose type is used to construct the data-parallel mesh.
                 Defaults to CUDA.
             pg_collection: Explicit process groups. The ``dp_cp`` group defines the
@@ -523,9 +524,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise IMPORT_MEGATRON_FSDP_ERROR
         if pg_collection is None:
             raise ValueError("MFSDP v2 requires an explicit ProcessGroupCollection.")
-        FullyShardedDataParallelV2._validate_config(
-            config, ddp_config, module, pg_collection, disable_bucketing
-        )
+        FullyShardedDataParallelV2._validate_config(config, ddp_config, module, pg_collection)
 
         if has_config_logger_enabled(config):
             log_config_to_disk(config, locals(), prefix=type(self).__name__)
@@ -603,7 +602,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         ddp_config: DistributedDataParallelConfig,
         module: torch.nn.Module,
         pg_collection: ProcessGroupCollection,
-        disable_bucketing: bool,
     ) -> None:
         """Validate that the model and configuration are supported by MFSDP v2.
 
@@ -613,14 +611,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             module: Model whose parameters are checked for expert parallelism.
             pg_collection: Materialized process groups whose topology must match the
                 supported MFSDP v2 topology.
-            disable_bucketing: Whether parameter bucketing is disabled.
-
         Raises:
             ValueError: If a required process group is missing or the model,
                 topology, or data-parallel configuration uses an unsupported feature.
         """
-        if disable_bucketing:
-            raise ValueError("MFSDP v2 does not support disabling bucketing.")
         if not hasattr(pg_collection, 'dp_cp'):
             raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
 
@@ -635,7 +629,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
         unsupported_parallelisms = [
             "tensor_model_parallel_size",
-            "pipeline_model_parallel_size",
             "context_parallel_size",
         ]
         if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
@@ -649,7 +642,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
         # The config validates the requested topology, while these checks validate the
         # materialized topology supplied by the caller's process-group collection.
-        for group_name in ("tp", "pp", "cp"):
+        # Pipeline stages own independent model chunks and FSDP contexts. PP
+        # communication does not participate in the data-parallel sharding
+        # mesh, so a nontrivial PP group is valid for MFSDP v2.
+        for group_name in ("tp", "cp"):
             group = getattr(pg_collection, group_name, None)
             if group is not None and group.size() != 1:
                 raise ValueError(
@@ -670,8 +666,9 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 )
             if pg_collection.expt_dp is None:
                 raise ValueError("MFSDP v2 with EP requires an explicit expert-DP process group.")
-            if not any(isinstance(submodule, MoELayer) for submodule in module.modules()):
-                raise ValueError("MFSDP v2 with EP requires MoE transformer layers.")
+            # With PP/VPP, a model chunk can contain only dense layers even when
+            # other chunks in the globally configured model contain MoE layers.
+            # Such a chunk simply has no expert parameters to shard over expt_dp.
         if ddp_config.data_parallel_sharding_strategy != "optim_grads_params":
             raise ValueError(
                 "MFSDP v2 requires data_parallel_sharding_strategy='optim_grads_params'."
@@ -696,8 +693,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             raise ValueError("MFSDP v2 requires symmetric registration when nccl_ub is enabled.")
         if ddp_config.fsdp_manual_registration:
             raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
-        if ddp_config.delay_wgrad_compute:
-            raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
         if ddp_config.suggested_communication_unit_size is not None:
             raise ValueError("MFSDP v2 does not support suggested_communication_unit_size.")
         if ddp_config.num_buckets is not None:

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -14,6 +14,7 @@
 
 import logging
 import random
+from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Type
 
 __all__ = ["FullyShardedDataParallel"]
@@ -54,6 +55,7 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -565,7 +567,15 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         # without symmetric memory: it uses ncclCommRegister rather than the more performant
         # ncclCommWindowRegister:
         # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#window-registration
-        with fully_shard_context(device=device, use_symmetric_memory=ddp_config.nccl_ub):
+        with fully_shard_context(
+            device=device,
+            use_symmetric_memory=ddp_config.nccl_ub,
+            custom_forward_backward_hooks=config.overlap_moe_expert_parallel_comm,
+        ):
+            # The 1F1B EP-overlap schedule drives the FsdpModule lifecycle explicitly
+            # (pre_forward/pre_backward/post_forward) and calls submodules directly, so
+            # the context's custom_forward_backward_hooks flag suppresses the module's
+            # own forward/backward hooks to avoid double-driving.
             if expert_dp_mesh is not None:
                 # Expert parameters are replicated over expert-DP, not the full DP group.
                 # Their gradients need the EP divisor because the same expert receives
@@ -594,6 +604,18 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             fully_shard(
                 module, mesh=dp_mesh, placements=placements, mixed_precision_policy=self.mp_policy
             )
+
+        if config.overlap_moe_expert_parallel_comm:
+            # The 1F1B EP-overlap schedule interleaves forward and backward work in
+            # the same step, so the autograd-GraphTask recompute detection in
+            # FsdpModule.pre_forward/post_forward can misfire and wrongly suppress
+            # forward prefetch or parameter resharding. Activation recomputation is
+            # forbidden with the overlap schedule (see TransformerConfig validation),
+            # so disable the detection on every unit while the schedule switch is on.
+            for submodule in module.modules():
+                if isinstance(submodule, FsdpModule):
+                    submodule._disable_recompute_detection = True
+
         super().__init__(config=config, module=module)
 
     @staticmethod
@@ -627,10 +649,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             # silently inflated norm.
             raise ValueError("MFSDP v2 does not currently support mtp_detach_heads.")
 
-        unsupported_parallelisms = [
-            "tensor_model_parallel_size",
-            "context_parallel_size",
-        ]
+        unsupported_parallelisms = ["tensor_model_parallel_size", "context_parallel_size"]
         if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
             raise ValueError(
                 "MFSDP v2 does not currently support: "
@@ -714,6 +733,24 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
     def finish_grad_sync(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 gradient reduction is complete when backward returns."""
+
+    @contextmanager
+    def no_sync(self):
+        """Suppress gradient finalization for non-final microbatches.
+
+        Toggles ``is_last_microbatch`` on this model's ``FsdpContext`` so gradient
+        reduce-scatters accumulate between microbatches rather than finalizing on
+        every backward. Called by the training loop via ``config.no_sync_func``
+        and the 1F1B overlap schedule.
+        """
+        self.module.context.ensure_finalized()
+        context = self.module.context
+        previous_state = context.is_last_microbatch
+        context.is_last_microbatch = False
+        try:
+            yield
+        finally:
+            context.is_last_microbatch = previous_state
 
     def synchronize_param_gather(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 parameter gathers complete inside module hooks."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -64,6 +64,7 @@ def fully_shard_context(
     *,
     use_symmetric_memory: bool = False,
     unify_communication_stream: bool = False,
+    custom_forward_backward_hooks: bool = False,
 ) -> Iterator[FsdpContext]:
     """Construct FSDP modules that share runtime streams and prefetch orders.
 
@@ -78,6 +79,9 @@ def fully_shard_context(
         unify_communication_stream: Whether all-gathers and reduce-scatters share one
             communication stream to reduce peak transient memory. See
             https://github.com/NVIDIA/Megatron-LM/issues/6471.
+        custom_forward_backward_hooks: Whether a custom schedule (e.g. the 1F1B
+            EP-overlap) drives the module lifecycle with its own forward-backward
+            hooks. When True, the strict phase-transition check is relaxed.
     """
     if _FSDP_CONTEXT.get() is not None:
         raise RuntimeError("fully_shard_context does not support nesting.")
@@ -90,6 +94,7 @@ def fully_shard_context(
         device=device,
         use_symmetric_memory=use_symmetric_memory,
         unify_communication_stream=unify_communication_stream,
+        custom_forward_backward_hooks=custom_forward_backward_hooks,
     )
     token = _FSDP_CONTEXT.set(context)
     try:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -156,6 +156,7 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _num_ready_grad_parameters: int
+    _manual_backward_finalize: bool
     _is_root: bool
     _num_trainable_parameters: int
     # Event recorded after this FsdpModule's full parameters are materialized.
@@ -212,6 +213,7 @@ class FsdpModule:
             )
         self._parameter_groups = tuple(parameter_groups)
         self._num_ready_grad_parameters = 0
+        self._manual_backward_finalize = False
         self._num_trainable_parameters = sum(
             len(group.fsdp_parameters) for group in self._parameter_groups if group.requires_grad
         )
@@ -286,14 +288,28 @@ class FsdpModule:
             if module is None:
                 return
             module._num_ready_grad_parameters += 1
-            if module._num_ready_grad_parameters == module._num_trainable_parameters:
+            if (
+                module._num_ready_grad_parameters == module._num_trainable_parameters
+                and not module._manual_backward_finalize
+            ):
                 module.post_backward()
 
         for group in self._parameter_groups:
             if not group.requires_grad:
                 continue
             for fsdp_parameter in group.fsdp_parameters:
-                fsdp_parameter.unsharded.register_post_accumulate_grad_hook(grad_hook)
+                parameter = fsdp_parameter.unsharded
+                # ``skip_backward_post_hook`` is TE's delayed-wgrad contract: these
+                # gradients are materialized by ``backward_dw()``, not autograd.
+                if not getattr(parameter, "skip_backward_post_hook", False):
+                    parameter.register_post_accumulate_grad_hook(grad_hook)
+                    continue
+
+                module_fqn, _, _ = fsdp_parameter.fqns[0].rpartition(".")
+                parameter_module = module.get_submodule(module_fqn) if module_fqn else module
+                parameter_module.register_wgrad_accumulation_and_reduce_hooks(
+                    lambda parameter=parameter: grad_hook(parameter)
+                )
 
     @staticmethod
     def _pre_load_state_dict(
@@ -399,14 +415,31 @@ class FsdpModule:
                 group.release_unsharded_storage()
             self._unshard_event = None
 
-    def pre_backward(self) -> None:
-        """Prepare full parameters and prefetch the next FsdpModule in backward order."""
+    def pre_backward(self, manual_finalize: bool = False) -> None:
+        """Prepare full parameters and prefetch the next FsdpModule in backward order.
+
+        Args:
+            manual_finalize: Whether a segmented backward schedule will explicitly call
+                :meth:`finalize_backward`. This suppresses both the autograd final callback
+                and parameter-readiness finalization for this module.
+        """
+        # A segmented schedule may start an FSDP unit explicitly before launching
+        # the unit's autograd GraphTask. The regular full-backward pre-hook then
+        # observes the same unit a second time. Its parameters are already ready;
+        # preserve the stronger finalization request and avoid a duplicate phase
+        # transition/all-gather.
+        if self.phase is FsdpModule.Phase.BACKWARD:
+            self._manual_backward_finalize |= manual_finalize
+            return
+
+        self._manual_backward_finalize = manual_finalize
         self.phase = FsdpModule.Phase.BACKWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         context = self.context
         current_stream = context.current_stream()
         if self.is_root():
-            context.register_post_backward_final_callback()
+            if not manual_finalize:
+                context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
             # part of any active CUDA-graph capture. A stream only joins the
@@ -428,8 +461,29 @@ class FsdpModule:
         """Reduce gradients and return parameters to their sharded resting state."""
         self._reshard_parameter_groups()
         self._reduce_gradient_groups()
+        self._manual_backward_finalize = False
         self.phase = FsdpModule.Phase.RESTING
         torch.cuda.nvtx.range_pop()
+
+    def finalize_backward(self) -> None:
+        """Finalize a root after a manually segmented backward schedule.
+
+        Schedule nodes execute separate autograd GraphTasks, so the root cannot use an
+        autograd final callback as its completion boundary. Finalize all units that remain
+        in backward, then order the current stream after their reduce-scatters.
+        """
+        if not self.is_root():
+            raise RuntimeError("Only a root FsdpModule can finalize a segmented backward.")
+
+        for fsdp_module in reversed(list(cast(nn.Module, self).modules())):
+            if not isinstance(fsdp_module, FsdpModule):
+                continue
+            if fsdp_module.phase is not FsdpModule.Phase.BACKWARD:
+                continue
+            fsdp_module.post_backward()
+            fsdp_module._num_ready_grad_parameters = 0
+
+        self.context.current_stream().wait_stream(self.context.reduce_scatter_stream)
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -46,6 +46,11 @@ class FsdpContext:
     is_last_microbatch: bool
     use_symmetric_memory: bool
     unify_communication_stream: bool
+    # The 1F1B EP-overlap schedule drives the FsdpModule forward/backward lifecycle
+    # explicitly (custom forward-backward hooks), so the standard RESTING/FORWARD/
+    # BACKWARD phase-transition invariants do not hold. When set, the phase check in
+    # FsdpModule.set_phase() is relaxed (this is the 1F1B EP-overlap path).
+    custom_forward_backward_hooks: bool
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
@@ -57,6 +62,7 @@ class FsdpContext:
         device: torch.device,
         use_symmetric_memory: bool = False,
         unify_communication_stream: bool = False,
+        custom_forward_backward_hooks: bool = False,
     ) -> None:
         """Create rank-local runtime state for FSDP modules on ``device``.
 
@@ -66,10 +72,14 @@ class FsdpContext:
                 communication staging buffers from PyTorch's NCCL symmetric-memory pool.
             unify_communication_stream: Whether all-gathers and reduce-scatters share one
                 communication stream to reduce peak transient memory.
+            custom_forward_backward_hooks: Whether a custom schedule (e.g. the 1F1B
+                EP-overlap) drives the module lifecycle with its own forward-backward
+                hooks. When True, the strict phase-transition check is relaxed.
         """
         self.is_last_microbatch = True
         self.use_symmetric_memory = use_symmetric_memory
         self.unify_communication_stream = unify_communication_stream
+        self.custom_forward_backward_hooks = custom_forward_backward_hooks
         self.forward_order = IndexedOrder()
         self.backward_order = IndexedOrder()
         # Construction-only; empty after finalization.
@@ -156,7 +166,6 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _num_ready_grad_parameters: int
-    _manual_backward_finalize: bool
     _is_root: bool
     _num_trainable_parameters: int
     # Event recorded after this FsdpModule's full parameters are materialized.
@@ -213,7 +222,6 @@ class FsdpModule:
             )
         self._parameter_groups = tuple(parameter_groups)
         self._num_ready_grad_parameters = 0
-        self._manual_backward_finalize = False
         self._num_trainable_parameters = sum(
             len(group.fsdp_parameters) for group in self._parameter_groups if group.requires_grad
         )
@@ -232,15 +240,25 @@ class FsdpModule:
 
     @phase.setter
     def phase(self, phase: Phase) -> None:
-        """Transition this module between its valid lifecycle phases."""
+        """Transition this module between its valid lifecycle phases.
+
+        The 1F1B EP-overlap schedule drives the lifecycle explicitly with custom
+        forward-backward hooks, so its RESTING/FORWARD/BACKWARD transitions do not
+        follow the strict pairwise invariants defined here. When the context has
+        ``custom_forward_backward_hooks`` set (the 1F1B EP-overlap path), the
+        transition check is relaxed.
+        """
         allowed_transitions = {
             (FsdpModule.Phase.RESTING, FsdpModule.Phase.FORWARD),
             (FsdpModule.Phase.FORWARD, FsdpModule.Phase.RESTING),
             (FsdpModule.Phase.RESTING, FsdpModule.Phase.BACKWARD),
             (FsdpModule.Phase.BACKWARD, FsdpModule.Phase.RESTING),
         }
-        if (self._phase, phase) not in allowed_transitions:
-            raise RuntimeError(f"Invalid FSDP module phase transition: {self._phase} -> {phase}.")
+        if not self.context.custom_forward_backward_hooks:
+            if (self._phase, phase) not in allowed_transitions:
+                raise RuntimeError(
+                    f"Invalid FSDP module phase transition: {self._phase} -> {phase}."
+                )
         self._phase = phase
 
     @property
@@ -258,24 +276,25 @@ class FsdpModule:
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
         module.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
-        # Use PyTorch's callback module argument instead of capturing self so
-        # these hooks do not retain a deleted FSDP module.
-        module.register_forward_pre_hook(
-            lambda hooked_module, _args: cast(FsdpModule, hooked_module).pre_forward()
-        )
-        module.register_forward_hook(
-            lambda hooked_module, _args, _output: cast(FsdpModule, hooked_module).post_forward()
-        )
-        module.register_full_backward_pre_hook(
-            lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
-        )
-        if self._num_trainable_parameters == 0:
-            module.register_full_backward_hook(
-                lambda hooked_module, _grad_input, _grad_output: cast(
-                    FsdpModule, hooked_module
-                ).post_backward()
+        if not self.context.custom_forward_backward_hooks:
+            # Use PyTorch's callback module argument instead of capturing self so
+            # these hooks do not retain a deleted FSDP module.
+            module.register_forward_pre_hook(
+                lambda hooked_module, _args: cast(FsdpModule, hooked_module).pre_forward()
             )
-            return
+            module.register_forward_hook(
+                lambda hooked_module, _args, _output: cast(FsdpModule, hooked_module).post_forward()
+            )
+            module.register_full_backward_pre_hook(
+                lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
+            )
+            if self._num_trainable_parameters == 0:
+                module.register_full_backward_hook(
+                    lambda hooked_module, _grad_input, _grad_output: cast(
+                        FsdpModule, hooked_module
+                    ).post_backward()
+                )
+                return
 
         # Gradient reduction for trainable parameters is parameter-completion
         # based: once every owned Parameter has accumulated its grad, this
@@ -288,10 +307,7 @@ class FsdpModule:
             if module is None:
                 return
             module._num_ready_grad_parameters += 1
-            if (
-                module._num_ready_grad_parameters == module._num_trainable_parameters
-                and not module._manual_backward_finalize
-            ):
+            if module._num_ready_grad_parameters == module._num_trainable_parameters:
                 module.post_backward()
 
         for group in self._parameter_groups:
@@ -300,11 +316,15 @@ class FsdpModule:
             for fsdp_parameter in group.fsdp_parameters:
                 parameter = fsdp_parameter.unsharded
                 # ``skip_backward_post_hook`` is TE's delayed-wgrad contract: these
-                # gradients are materialized by ``backward_dw()``, not autograd.
+                # gradients are materialized by ``backward_dw()``, not autograd, so
+                # the readiness counter must be driven by the delayed-wgrad hook
+                # (register_wgrad_accumulation_and_reduce_hooks), which fires inside
+                # backward_dw() -- i.e. AFTER the gradient actually exists. Using the
+                # normal post_accumulate_grad_hook here would complete the counter
+                # before backward_dw() populates the grad (stale/None at reduce time).
                 if not getattr(parameter, "skip_backward_post_hook", False):
                     parameter.register_post_accumulate_grad_hook(grad_hook)
                     continue
-
                 module_fqn, _, _ = fsdp_parameter.fqns[0].rpartition(".")
                 parameter_module = module.get_submodule(module_fqn) if module_fqn else module
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
@@ -343,11 +363,15 @@ class FsdpModule:
         context.ensure_finalized()
         # A reentrant checkpoint recomputes before the child module's backward-pre
         # hook runs. The active autograd GraphTask identifies that recomputation.
-        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
+        # Integrations whose schedules interleave forwards and backwards (such as
+        # the MCore 1F1B EP-overlap adapter) set ``_disable_recompute_detection``
+        # on the unit so every call is treated as a genuine forward.
+        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or (
+            not getattr(self, "_disable_recompute_detection", False) and _is_in_backward()
+        )
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
-        self._num_ready_grad_parameters = 0
         allgather_stream = context.allgather_stream
         current_stream = context.current_stream()
 
@@ -390,7 +414,9 @@ class FsdpModule:
         # Recomputed parameters are consumed immediately by this module's
         # backward. Keep them materialized to avoid an unnecessary all-gather;
         # post_backward() will reshard them after gradient reduction.
-        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
+        is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or (
+            not getattr(self, "_disable_recompute_detection", False) and _is_in_backward()
+        )
         if not is_recomputing:
             self._reshard_parameter_groups()
         if self.phase is FsdpModule.Phase.FORWARD:
@@ -415,30 +441,19 @@ class FsdpModule:
                 group.release_unsharded_storage()
             self._unshard_event = None
 
-    def pre_backward(self, manual_finalize: bool = False) -> None:
-        """Prepare full parameters and prefetch the next FsdpModule in backward order.
-
-        Args:
-            manual_finalize: Whether a segmented backward schedule will explicitly call
-                :meth:`finalize_backward`. This suppresses both the autograd final callback
-                and parameter-readiness finalization for this module.
-        """
-        # A segmented schedule may start an FSDP unit explicitly before launching
-        # the unit's autograd GraphTask. The regular full-backward pre-hook then
-        # observes the same unit a second time. Its parameters are already ready;
-        # preserve the stronger finalization request and avoid a duplicate phase
-        # transition/all-gather.
-        if self.phase is FsdpModule.Phase.BACKWARD:
-            self._manual_backward_finalize |= manual_finalize
-            return
-
-        self._manual_backward_finalize = manual_finalize
+    def pre_backward(self) -> None:
+        """Prepare full parameters and prefetch the next FsdpModule in backward order."""
         self.phase = FsdpModule.Phase.BACKWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         context = self.context
         current_stream = context.current_stream()
         if self.is_root():
-            if not manual_finalize:
+            # The autograd final callback can only be installed during a backward
+            # GraphTask. A schedule driving pre_backward explicitly is not inside a
+            # backward (it launches its own GraphTasks), so suppress it there; the
+            # caller coordinates the reducer stream instead. Skip the callback also
+            # when hooks are skipped (the 1F1B overlap path).
+            if not self.context.custom_forward_backward_hooks:
                 context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
@@ -458,32 +473,24 @@ class FsdpModule:
             next_module._unshard_parameter_groups()
 
     def post_backward(self) -> None:
-        """Reduce gradients and return parameters to their sharded resting state."""
+        """Reduce gradients and return parameters to their sharded resting state.
+
+        ``post_backward`` is invoked when this unit's backward pass has completed (the
+        parameter-readiness counter in ``grad_hook`` once every owned parameter's grad has
+        accumulated). It reduces the gradients and reshard/releases the parameters, then
+        re-arms the grad-readiness counter for the next backward. Callers only invoke it
+        while the unit is in its BACKWARD pass; ``set_phase`` enforces phase transitions
+        (relaxed only by ``custom_forward_backward_hooks`` for the 1F1B EP-overlap path).
+        """
         self._reshard_parameter_groups()
         self._reduce_gradient_groups()
-        self._manual_backward_finalize = False
         self.phase = FsdpModule.Phase.RESTING
+        # 1F1B cooldown can run consecutive backward passes without an intervening
+        # pre_forward(), so reset the grad-readiness counter as soon as this pass
+        # is finalized (re-arms every sub-unit, incl. the MoE experts, for the next
+        # backward -- otherwise the expert units never re-complete it and freeze).
+        self._num_ready_grad_parameters = 0
         torch.cuda.nvtx.range_pop()
-
-    def finalize_backward(self) -> None:
-        """Finalize a root after a manually segmented backward schedule.
-
-        Schedule nodes execute separate autograd GraphTasks, so the root cannot use an
-        autograd final callback as its completion boundary. Finalize all units that remain
-        in backward, then order the current stream after their reduce-scatters.
-        """
-        if not self.is_root():
-            raise RuntimeError("Only a root FsdpModule can finalize a segmented backward.")
-
-        for fsdp_module in reversed(list(cast(nn.Module, self).modules())):
-            if not isinstance(fsdp_module, FsdpModule):
-                continue
-            if fsdp_module.phase is not FsdpModule.Phase.BACKWARD:
-                continue
-            fsdp_module.post_backward()
-            fsdp_module._num_ready_grad_parameters = 0
-
-        self.context.current_stream().wait_stream(self.context.reduce_scatter_stream)
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -219,12 +219,14 @@ class FsdpParameterGroup:
             if parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
-                # This may be problematic if attributes from the original Parameter need
-                # to be copied to the unsharded Parameter.
+                # swap_tensors also swaps __dict__, so preserve module-specific parameter
+                # metadata such as TE's delayed-wgrad ``skip_backward_post_hook`` marker.
+                parameter_attributes = parameter.__dict__.copy()
                 materialized_parameter = nn.Parameter(
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
                 torch.utils.swap_tensors(parameter, materialized_parameter)
+                parameter.__dict__.update(parameter_attributes)
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -230,13 +230,25 @@ class FsdpParameterGroup:
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
+            # TE's delayed-wgrad (skip_backward_post_hook) path computes the
+            # weight gradient in FP32 (fused grouped-GEMM backward_dw) and assigns it directly
+            # to the FP32 main-weight view, which PyTorch's grad_dtype check (BF16, from
+            # main_grads_dtype) would otherwise reject (RuntimeError: float grad to BF16
+            # grad_dtype).
+            if getattr(parameter, "skip_backward_post_hook", False):
+                parameter.grad_dtype = None
             # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
-            if main_grad_dtype:
+            # Same as above -- for delayed-wgrad params the fused grouped-GEMM
+            # backward_dw assigns an FP32 wgrad to this FP32 view, so we relax grad_dtype to
+            # None to avoid the BF16 grad_dtype rejection.
+            if getattr(parameter, "skip_backward_post_hook", False):
+                sharded_parameter.grad_dtype = None
+            elif main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
             fsdp_parameters.append(
@@ -353,9 +365,15 @@ class FsdpParameterGroup:
             fsdp_parameter.unsharded.grad = None
 
     def _has_sharded_grads(self) -> bool:
+        # Delayed-wgrad parameters (TE's ``skip_backward_post_hook``) materialize
+        # their gradient in ``backward_dw()`` on a separate stream and are consumed
+        # from ``unsharded.grad``; their ``sharded.grad`` is legitimately ``None``
+        # at reduce time, so exclude them from the all-set-or-all-None invariant.
         has_any_grad = False
         has_any_missing_grad = False
         for fsdp_parameter in self.fsdp_parameters:
+            if getattr(fsdp_parameter.unsharded, "skip_backward_post_hook", False):
+                continue
             if fsdp_parameter.sharded.grad is None:
                 has_any_missing_grad = True
             else:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 import torch
 from torch import Tensor
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.enums import Fp8Recipe
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.pipeline_parallel.utils import (
@@ -258,9 +259,22 @@ class TransformerLayerSchedulePlan:
             Functions or values for next iteration's computation
         """
 
+        if b_layer and isinstance(b_layer.layer, FsdpModule):
+            # The fine-grained schedule invokes layer submodules directly and
+            # splits their backward into separate GraphTasks. Start every nested
+            # FSDP unit explicitly so delayed weight-gradient computation still
+            # sees its full compute parameters. In particular, MoE experts are a
+            # child FSDP unit distinct from the TransformerLayer that owns them.
+            for fsdp_module in b_layer.layer.modules():
+                if isinstance(fsdp_module, FsdpModule):
+                    fsdp_module.pre_backward()
+
         if b_layer is not None:
             b_grad = b_layer.mtp_post_process.backward(b_grad)
             b_grad = b_layer.moe_combine.backward(b_grad)
+
+        if f_layer and isinstance(f_layer.layer, FsdpModule):
+            f_layer.layer.pre_forward()
 
         if f_layer is not None:
             with f_layer.get_fp8_context():
@@ -294,6 +308,9 @@ class TransformerLayerSchedulePlan:
         if f_layer is not None:
             with f_layer.get_fp8_context():
                 f_input = f_layer.mtp_post_process.forward(f_input)
+
+        if f_layer and isinstance(f_layer.layer, FsdpModule):
+            f_layer.layer.post_forward()
 
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad
         # of the first layer) for overlapping with the p2p comm.
@@ -623,6 +640,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         # post process forward
         if f_schedule_plan is not None and f_schedule_plan.post_process is not None:
             f_input = f_schedule_plan.post_process.forward(f_input)
+
         # pre process backward
         if b_schedule_plan is not None:
             b_schedule_plan.pre_process.backward(b_grad)

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -18,6 +18,29 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
 
+def _resolve_fsdp_root(model: Any) -> Optional[FsdpModule]:
+    """Return the outermost ``FsdpModule`` (root unit) for a schedule model.
+
+    An M-FSDP v2 model chunk wraps the root model as ``adapter ->
+    Float16Module(FsdpModule) -> GPTModel``. The schedule plan is built on the
+    inner ``GPTModel``, so walking ``.module`` downward never reaches the FSDP
+    root unit (which owns the embedding, final norm, and lm head). Every
+    ``FsdpModule`` descendant shares one ``FsdpContext`` whose forward order
+    always begins with the root unit, so we resolve it from there.
+    """
+    if isinstance(model, FsdpModule):
+        return model
+    if model is None:
+        return None
+    for submodule in model.modules():
+        if isinstance(submodule, FsdpModule):
+            for candidate in submodule.context.forward_order:
+                if candidate.is_root():
+                    return candidate
+            return None
+    return None
+
+
 class ModelChunkState:
     """State shared across a model chunk.
 
@@ -309,13 +332,15 @@ class TransformerLayerSchedulePlan:
             with f_layer.get_fp8_context():
                 f_input = f_layer.mtp_post_process.forward(f_input)
 
-        if f_layer and isinstance(f_layer.layer, FsdpModule):
-            f_layer.layer.post_forward()
-
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad
         # of the first layer) for overlapping with the p2p comm.
         if b_layer is not None and not is_last_layer_in_bwd:
             b_layer.pre_dispatch_computation.backward_dw()
+
+        # Delay releasing forward-layer parameters. The forward and backward layers may
+        # be the same, and backward pre-dispatch still needs to read those parameters.
+        if f_layer and isinstance(f_layer.layer, FsdpModule):
+            f_layer.layer.post_forward()
 
         return f_input, b_grad
 
@@ -557,6 +582,17 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         Returns:
             The output of the forward pass.
         """
+        f_model = f_schedule_plan.state.model if f_schedule_plan else None
+        b_model = b_schedule_plan.state.model if b_schedule_plan else None
+
+        # The schedule model may be an adapter; resolve its root FSDP module.
+        root_fsdp = _resolve_fsdp_root(f_model) or _resolve_fsdp_root(b_model)
+
+        # The root owns shared parameters used by both interleaved passes. Initialize
+        # its lifecycle once so it remains unsharded until all root gradients are ready.
+        if root_fsdp is not None:
+            root_fsdp.pre_backward()
+
         f_input = None
         if f_schedule_plan:
             # pp output send/receive sync
@@ -644,6 +680,11 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         # pre process backward
         if b_schedule_plan is not None:
             b_schedule_plan.pre_process.backward(b_grad)
+
+        # Order gradient consumers (optimizer) after the root unit's finalize
+        # reduce-scatter, which the parameter-readiness counter launched.
+        if root_fsdp is not None:
+            root_fsdp.context.current_stream().wait_stream(root_fsdp.context.reduce_scatter_stream)
 
         if f_schedule_plan:
             f_schedule_plan.wait_current_stream()

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -87,8 +87,8 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
     @staticmethod
     def _validate_config(config: OptimizerConfig, model_chunks: List[MegatronModule]) -> None:
         """Validate the MFSDP v2 optimizer support contract."""
-        if len(model_chunks) != 1:
-            raise ValueError("MFSDP v2 currently supports exactly one model chunk.")
+        if not model_chunks:
+            raise ValueError("MFSDP v2 requires at least one model chunk.")
         if config.use_distributed_optimizer:
             raise ValueError("MFSDP v2 currently requires use_distributed_optimizer=False.")
         if config.loss_scale is not None:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4364,11 +4364,17 @@ def train(
     config.timers = timers
     if isinstance(
         model[0], (FullyShardedDataParallelV1, FullyShardedDataParallelV2, DDP)
-    ) and args.overlap_grad_reduce:
-        assert config.no_sync_func is None, (
-            'When overlap_grad_reduce is True, config.no_sync_func must be None; '
-            'a custom no_sync_func is not supported when overlapping grad-reduce'
-        )
+    ) and (
+        args.overlap_grad_reduce or args.overlap_moe_expert_parallel_comm
+    ):
+        # For MFSDP v2 the 1F1B EP-overlap schedule needs no_sync to toggle
+        # is_last_microbatch so gradient reduce-scatters accumulate across
+        # non-final microbatches instead of finalizing on every backward.
+        if config.no_sync_func is not None and args.overlap_grad_reduce:
+            raise ValueError(
+                'When overlap_grad_reduce is True, config.no_sync_func must be None; '
+                'a custom no_sync_func is not supported when overlapping grad-reduce'
+            )
         config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
         if len(model) == 1:
             config.no_sync_func = config.no_sync_func[0]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_lifecycle_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_lifecycle_overlap.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the M-FSDP v2 1F1B EP-overlap lifecycle controls.
+
+Covers PR #6949 ("Expose FsdpModule in M-FSDP v2 1F1B Direct"):
+- ``FsdpContext.custom_forward_backward_hooks`` relaxes ``set_phase`` so the
+  1F1B EP-overlap schedule can drive the lifecycle outside the strict
+  RESTING/FORWARD/BACKWARD ordering.
+- ``FsdpModule.post_backward`` re-arms the grad-readiness counter so every
+  nested FSDP unit re-completes the counter on each backward (the frozen-experts
+  fix).
+- Delayed-wgrad (``skip_backward_post_hook``) params get an unconstrained
+  ``grad_dtype`` so TE's FP32 fused grouped-GEMM wgrad assignment is accepted.
+
+These are distributed tests: run under ``torchrun`` (see the suite's conftest).
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Placements,
+    fully_shard,
+    fully_shard_context,
+)
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
+
+
+class SingleLinear(nn.Module):
+    """Tiny model with a root bias and one linear child, convenient for lifecycle tests."""
+
+    def __init__(self, dim: int = 4) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.ones(dim))
+        self.fc = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the model."""
+        return self.fc(x) + self.bias
+
+
+@pytest.fixture(scope="function")
+def dp_mesh(distributed_setup):
+    """A single-dimension DP device mesh over the default process group."""
+    if distributed_setup.world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    return init_device_mesh(
+        distributed_setup.device.type, (distributed_setup.world_size,), mesh_dim_names=("dp",)
+    )
+
+
+@pytest.fixture(scope="function")
+def placements():
+    """All-Shard(0) placements (plain DP / optim-grads-params)."""
+    return Placements(dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Shard(0)])
+
+
+def _wrap(model, mesh, placements, device, custom_forward_backward_hooks=False):
+    """fully_shard a single model under a context with the given flag."""
+    policy = MixedPrecisionPolicy(main_params_dtype=torch.bfloat16, main_grads_dtype=torch.bfloat16)
+    model = model.to(device=device)
+    ctx = fully_shard_context(
+        device=device, custom_forward_backward_hooks=custom_forward_backward_hooks
+    )
+    context = ctx.__enter__()
+    try:
+        fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+    except BaseException:
+        ctx.__exit__(None, None, None)
+        raise
+    assert isinstance(model, FsdpModule), "fully_shard should attach the FsdpModule mixin."
+    return context
+
+
+def test_custom_forward_backward_hooks_relaxes_phase_check(dp_mesh, placements, distributed_setup):
+    """With the flag, ``set_phase`` allows transitions outside the strict table."""
+    device = distributed_setup.device
+    model = SingleLinear(dim=8)
+    context = _wrap(model, dp_mesh, placements, device, custom_forward_backward_hooks=True)
+
+    assert context.custom_forward_backward_hooks is True
+    # FORWARD -> BACKWARD is rejected by the strict table, but the overlap path
+    # may drive it; with the flag set the check must be relaxed (no raise).
+    model.phase = FsdpModule.Phase.FORWARD
+    model.phase = FsdpModule.Phase.BACKWARD  # no raise
+    model.phase = FsdpModule.Phase.RESTING
+
+
+def test_custom_forward_backward_hooks_default_enforces_phase_check(
+    dp_mesh, placements, distributed_setup
+):
+    """Without the flag, an out-of-order transition raises RuntimeError."""
+    device = distributed_setup.device
+    model = SingleLinear(dim=8)
+    context = _wrap(model, dp_mesh, placements, device, custom_forward_backward_hooks=False)
+
+    assert context.custom_forward_backward_hooks is False
+    model.phase = FsdpModule.Phase.FORWARD
+    with pytest.raises(RuntimeError):
+        model.phase = FsdpModule.Phase.BACKWARD  # FORWARD -> BACKWARD is invalid
+    # Leave the module in a valid state for the rest of the test.
+    model.phase = FsdpModule.Phase.RESTING
+
+
+def test_post_backward_rearms_readiness_counter(dp_mesh, placements, distributed_setup):
+    """``post_backward`` resets ``_num_ready_grad_parameters`` so the counter can
+    re-complete on the next backward (the frozen-experts fix)."""
+    device = distributed_setup.device
+    model = SingleLinear(dim=8)
+    _wrap(model, dp_mesh, placements, device, custom_forward_backward_hooks=False)
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, foreach=False)
+    x = torch.randn(4, 8, device=device, dtype=torch.bfloat16, requires_grad=True)
+
+    # One full forward+backward through the module's own hooks: the readiness
+    # counter reaches total and post_backward fires.
+    optimizer.zero_grad(set_to_none=True)
+    model(x).sum().backward()
+
+    # post_backward re-armed the counter to 0 (not a stale value that would
+    # prevent the next backward from re-completing).
+    assert model._num_ready_grad_parameters == 0
+    assert model._num_ready_grad_parameters < model._num_trainable_parameters
+
+
+def test_grad_dtype_stopgap_only_for_delayed_wgrad(dp_mesh, placements, distributed_setup):
+    """``skip_backward_post_hook`` params get ``grad_dtype=None``; normal params keep
+    the configured main-grad dtype (the PR #6949 stopgap)."""
+    device = distributed_setup.device
+    model = SingleLinear(dim=8)
+    # Simulate a TE delayed-wgrad flag on the linear weight only.
+    model.fc.weight.skip_backward_post_hook = True  # type: ignore[attr-defined]
+    _wrap(model, dp_mesh, placements, device, custom_forward_backward_hooks=False)
+
+    grad_dtype_by_fqn = {}
+    for group in model._parameter_groups:
+        for p in group.fsdp_parameters:
+            grad_dtype_by_fqn[p.fqns[0]] = p.sharded.grad_dtype
+
+    assert "fc.weight" in grad_dtype_by_fqn
+    assert "bias" in grad_dtype_by_fqn
+    # Delayed-wgrad param: unconstrained so the FP32 wgrad assignment is accepted.
+    assert grad_dtype_by_fqn["fc.weight"] is None
+    # Normal param: keeps the configured main-grad dtype.
+    assert grad_dtype_by_fqn["bias"] is not None


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Expose `FsdpModule` in the M-FSDP v2 1F1B **direct** overlap schedule.

The M-FSDP v2 1F1B EP-overlap schedule drives the `FsdpModule` lifecycle explicitly (`pre_forward` / `pre_backward` / `post_forward`) and calls the layer submodules directly. This PR:
- Wires the `FsdpModule` units into the 1F1B schedule (root + per-layer + MoE-expert units) so they unshard, reduce gradients, and reshard at the right boundaries.
- Adds a context-level `custom_forward_backward_hooks` flag (set for `overlap_moe_expert_parallel_comm`) that relaxes the `set_phase` transition check for the overlap path and drives hook registration.

## Summary of changes
- `megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py`
  - `FsdpContext.custom_forward_backward_hooks`: context flag that (a) relaxes the `set_phase` phase-transition check and (b) gates registration of the module's own forward/backward hooks (single flag instead of the previous per-module `skip_forward_backward_hooks`).
  - `post_backward`: re-arm `_num_ready_grad_parameters = 0` so experts re-complete the counter every microbatch; reshard-before-reduce.
- `megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py`
  - `grad_dtype=None` **stopgap** for `skip_backward_post_hook` params (TE's fused grouped-GEMM `backward_dw` assigns an FP32 wgrad directly to the FP32 main-weight view; a BF16 `grad_dtype` would reject it). Documented as a stopgap — the clean fix belongs in the fused-wgrad path (cast/accumulate into the BF16 buffer).
- `megatron/core/distributed/fsdp/mcore_fsdp_adapter.py`, `fully_shard.py`: consolidate on the context `custom_forward_backward_hooks` flag; remove the per-module `skip_forward_backward_hooks`.
- `megatron/core/models/common/model_chunk_schedule_plan.py`, `megatron/training/training.py`: 1F1B schedule life cycle + `no_sync`/`is_last_microbatch` for gradient accumulation.

## Validation / convergence
- **30-iter smoke** (16-GPU, real SlimPajama): trains cleanly — no phase-transition / missing-gradient / dtype errors; expert gradient nonzero.
- **End-to-end 1000-iter convergence run** (16-GPU, real SlimPajama, `global_batch_size=512`, cosine LR `1e-4 → 1e-5`): results below.
  - Final lm loss: **_PENDING_ (run in progress; the equivalent run before the guard-removal reached 3.936)**.
  - Reference: v1 baseline ≈ 4.04, reference v2 ≈ 3.81.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
