### PR TITLE
perf(refit): reduce MXFP8 conversion overhead

### DIFF
--- a/megatron/core/inference/quantization/mxfp8_quantize.py
+++ b/megatron/core/inference/quantization/mxfp8_quantize.py
@@ -161,6 +161,52 @@ def _mxfp8_quant_swizzle_kernel(
     tl.store(scale_ptr + swizzled_offs, scale_exp, mask=col_mask)
 
 
+def mxfp8_quantize_into(x: torch.Tensor, out_data: torch.Tensor, out_scale: torch.Tensor) -> None:
+    """Quantize a 2D tensor into existing MXFP8 data and scale storage.
+
+    Args:
+        x: [M, K] tensor in bf16/fp16/fp32. K must be divisible by 32.
+        out_data: [M, K] contiguous float8_e4m3fn output tensor.
+        out_scale: Contiguous 1D scale storage in cuBLAS blocked layout. The
+            dtype may be uint8 or float8_e8m0fnu.
+    """
+    assert x.is_cuda and x.dim() == 2
+    assert x.dtype in (torch.bfloat16, torch.float16, torch.float32)
+    M, K = x.shape
+    assert K % MXFP8_BLOCK_SIZE == 0, f"K ({K}) must be divisible by {MXFP8_BLOCK_SIZE}"
+    assert out_data.is_cuda and out_data.device == x.device
+    assert out_data.shape == x.shape and out_data.dtype == torch.float8_e4m3fn
+    assert out_data.is_contiguous()
+    assert out_scale.is_cuda and out_scale.device == x.device
+    assert out_scale.dim() == 1 and out_scale.is_contiguous()
+    assert out_scale.dtype in (torch.uint8, torch.float8_e8m0fnu)
+
+    scale_cols = K // MXFP8_BLOCK_SIZE
+    n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
+    n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
+    total_scale_bytes = n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
+    assert out_scale.numel() == total_scale_bytes
+
+    # The quantization kernel only writes logical scale entries. Clear the
+    # padded rows and columns so reused storage matches freshly quantized output.
+    out_scale_bytes = out_scale.view(torch.uint8)
+    out_scale_bytes.zero_()
+
+    BLOCK_K = triton.next_power_of_2(K)
+    BLOCK_GROUPS = BLOCK_K // MXFP8_BLOCK_SIZE
+
+    _mxfp8_quant_swizzle_kernel[(M,)](
+        out_data,
+        out_scale_bytes,
+        x,
+        K,
+        n_col_blocks,
+        REAL_GROUPS=scale_cols,
+        BLOCK_K=BLOCK_K,
+        BLOCK_GROUPS=BLOCK_GROUPS,
+    )
+
+
 def mxfp8_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize a 2D tensor to MXFP8 with fused scale swizzle.
 
@@ -176,27 +222,13 @@ def mxfp8_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.dtype in (torch.bfloat16, torch.float16, torch.float32)
     M, K = x.shape
     assert K % MXFP8_BLOCK_SIZE == 0, f"K ({K}) must be divisible by {MXFP8_BLOCK_SIZE}"
-
     scale_cols = K // MXFP8_BLOCK_SIZE
     n_row_blocks = _ceil_div(M, MXFP8_SCALE_ROW_BLOCK)
     n_col_blocks = _ceil_div(scale_cols, MXFP8_SCALE_COL_BLOCK)
     total_scale_bytes = n_row_blocks * n_col_blocks * MXFP8_SCALE_ROW_BLOCK * MXFP8_SCALE_COL_BLOCK
 
     out_data = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x.device)
-    out_scale = torch.zeros(total_scale_bytes, dtype=torch.uint8, device=x.device)
-
-    BLOCK_K = triton.next_power_of_2(K)
-    BLOCK_GROUPS = BLOCK_K // MXFP8_BLOCK_SIZE
-
-    _mxfp8_quant_swizzle_kernel[(M,)](
-        out_data,
-        out_scale,
-        x,
-        K,
-        n_col_blocks,
-        REAL_GROUPS=scale_cols,
-        BLOCK_K=BLOCK_K,
-        BLOCK_GROUPS=BLOCK_GROUPS,
-    )
+    out_scale = torch.empty(total_scale_bytes, dtype=torch.uint8, device=x.device)
+    mxfp8_quantize_into(x, out_data, out_scale)
 
     return out_data, out_scale.view(torch.float8_e8m0fnu)

--- a/megatron/core/inference/quantization/mxfp8_tensor.py
+++ b/megatron/core/inference/quantization/mxfp8_tensor.py
@@ -20,6 +20,9 @@ from megatron.core.inference.quantization.mxfp8_quantize import (
 from megatron.core.inference.quantization.mxfp8_quantize import (
     mxfp8_quantize as mcore_mxfp8_quantize,
 )
+from megatron.core.inference.quantization.mxfp8_quantize import (
+    mxfp8_quantize_into as mcore_mxfp8_quantize_into,
+)
 
 
 def _ceil_div(a, b):
@@ -183,9 +186,19 @@ class MXFP8Tensor:
         if self.backend == "flashinfer" and value.dtype == torch.float32:
             value = value.to(dtype=torch.bfloat16)
         value = value.contiguous()
-        quantized = MXFP8Tensor.from_bf16(value, backend=self.backend)
-        self.data.copy_(quantized.data)
-        self.scale.view(torch.uint8).copy_(quantized.scale.view(torch.uint8))
+        if (
+            self.backend == "triton"
+            and self.data.dtype == torch.float8_e4m3fn
+            and self.data.is_contiguous()
+            and self.scale.ndim == 1
+            and self.scale.dtype in (torch.uint8, torch.float8_e8m0fnu)
+            and self.scale.is_contiguous()
+        ):
+            mcore_mxfp8_quantize_into(value, self.data, self.scale)
+        else:
+            quantized = MXFP8Tensor.from_bf16(value, backend=self.backend)
+            self.data.copy_(quantized.data)
+            self.scale.view(torch.uint8).copy_(quantized.scale.view(torch.uint8))
         if self.dtype is None:
             self.dtype = value.dtype
         return self

--- a/megatron/core/resharding/transforms.py
+++ b/megatron/core/resharding/transforms.py
@@ -240,8 +240,19 @@ class MXFP8ReshardTransform(ReshardTransform):
             # allocation.  This halves the BF16 overhead for 1D-scale params.
             if buf.scale.ndim == 1:
                 if buf_key not in self._pending_1d:
+                    is_full_slice = len(dst_slice) == buf.data.ndim and all(
+                        isinstance(dim, slice)
+                        and dim.start is None
+                        and dim.stop is None
+                        and dim.step is None
+                        for dim in dst_slice
+                    )
+                    # A complete receive overwrites every element, so avoid a
+                    # redundant full-weight zero fill. Partial accumulation
+                    # remains zero-initialized for deterministic missing slices.
+                    allocate = torch.empty if is_full_slice else torch.zeros
                     self._pending_1d[buf_key] = [
-                        torch.zeros(buf.data.shape, dtype=torch.bfloat16, device=buf.data.device),
+                        allocate(buf.data.shape, dtype=torch.bfloat16, device=buf.data.device),
                         0,
                     ]
                 accum_view = self._pending_1d[buf_key][0][dst_slice]

--- a/tests/unit_tests/inference/test_mxfp8_utils.py
+++ b/tests/unit_tests/inference/test_mxfp8_utils.py
@@ -11,6 +11,7 @@ Tests cover:
 import pytest
 import torch
 
+from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize, mxfp8_quantize_into
 from megatron.core.inference.quantization.mxfp8_tensor import HAVE_FLASHINFER, MXFP8Tensor
 
 pytestmark = [
@@ -149,8 +150,6 @@ class TestMxfp8Quantize:
     )
     def test_data_matches_reference(self, M, K):
         """Quantized FP8 data matches PyTorch reference."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         torch.manual_seed(42)
         x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
@@ -180,8 +179,6 @@ class TestMxfp8Quantize:
     )
     def test_scales_match_reference(self, M, K):
         """Swizzled scales match ref_to_mxfp scales passed through ref_swizzle."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         torch.manual_seed(42)
         x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
@@ -199,8 +196,6 @@ class TestMxfp8Quantize:
     @pytest.mark.parametrize("M,K", [(1, 32), (16, 128), (128, 2688)])
     def test_all_zeros_input(self, M, K):
         """All-zero input produces all-zero FP8 data and zero scales."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         x = torch.zeros(M, K, device="cuda", dtype=torch.bfloat16)
         data, scales = mxfp8_quantize(x)
         assert (data.float() == 0).all()
@@ -209,8 +204,6 @@ class TestMxfp8Quantize:
     @pytest.mark.parametrize("M,K", [(1, 32), (16, 128), (128, 256)])
     def test_constant_input(self, M, K):
         """Constant input: all elements in a group have the same value."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         x = torch.full((M, K), 1.0, device="cuda", dtype=torch.bfloat16)
         data, _ = mxfp8_quantize(x)
         _, ref_data = ref_to_mxfp(x)
@@ -221,8 +214,6 @@ class TestMxfp8Quantize:
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_input_dtypes(self, dtype):
         """Kernel accepts bf16, fp16, and fp32 inputs."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         x = torch.randn(16, 128, device="cuda", dtype=dtype)
         data, _ = mxfp8_quantize(x)
         assert data.dtype == torch.float8_e4m3fn
@@ -231,8 +222,6 @@ class TestMxfp8Quantize:
     @pytest.mark.parametrize("M", [1, 127, 128, 129, 255, 256, 257, 512])
     def test_various_row_counts(self, M):
         """Test row counts that are not multiples of 128 (macro tile boundary)."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         K = 128
         torch.manual_seed(42)
         x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
@@ -245,14 +234,31 @@ class TestMxfp8Quantize:
     @pytest.mark.parametrize("seed", [0, 7, 42, 123, 999])
     def test_reproducible(self, seed):
         """Same input always produces same output."""
-        from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
-
         torch.manual_seed(seed)
         x = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
         d1, s1 = mxfp8_quantize(x)
         d2, s2 = mxfp8_quantize(x)
         torch.testing.assert_close(d1.view(torch.uint8), d2.view(torch.uint8), atol=0, rtol=0)
         torch.testing.assert_close(s1.view(torch.uint8), s2.view(torch.uint8), atol=0, rtol=0)
+
+    def test_quantize_into_reuses_storage_and_clears_padding(self):
+        """Existing output buffers match allocating quantization byte-for-byte."""
+        torch.manual_seed(42)
+        x = torch.randn(129, 160, device="cuda", dtype=torch.bfloat16)
+        expected_data, expected_scale = mxfp8_quantize(x)
+        out_data = torch.empty_like(expected_data)
+        out_scale = torch.full_like(expected_scale.view(torch.uint8), 0xFF).view(
+            torch.float8_e8m0fnu
+        )
+        data_ptr = out_data.data_ptr()
+        scale_ptr = out_scale.data_ptr()
+
+        mxfp8_quantize_into(x, out_data, out_scale)
+
+        assert out_data.data_ptr() == data_ptr
+        assert out_scale.data_ptr() == scale_ptr
+        assert torch.equal(out_data, expected_data)
+        assert torch.equal(out_scale.view(torch.uint8), expected_scale.view(torch.uint8))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -300,6 +306,22 @@ class TestMXFP8Tensor:
         )
         with pytest.raises(ValueError, match="shape mismatch"):
             tensor.copy_(torch.randn(32, 128, device="cuda", dtype=torch.bfloat16))
+
+    def test_triton_copy_does_not_allocate_quantized_outputs(self, monkeypatch):
+        source = torch.randn(129, 160, device="cuda", dtype=torch.bfloat16)
+        tensor = MXFP8Tensor.from_bf16(source, backend="triton")
+        updated = torch.randn_like(source)
+        expected = MXFP8Tensor.from_bf16(updated, backend="triton")
+
+        def fail_from_bf16(*args, **kwargs):
+            raise AssertionError("Triton copy_ allocated temporary quantized outputs")
+
+        monkeypatch.setattr(MXFP8Tensor, "from_bf16", fail_from_bf16)
+
+        tensor.copy_(updated)
+
+        assert torch.equal(tensor.data, expected.data)
+        assert torch.equal(tensor.scale.view(torch.uint8), expected.scale.view(torch.uint8))
 
     def test_copy_requires_backend(self):
         source = torch.randn(16, 128, device="cuda", dtype=torch.bfloat16)

--- a/tests/unit_tests/resharding/test_mxfp8_refit.py
+++ b/tests/unit_tests/resharding/test_mxfp8_refit.py
@@ -3,8 +3,10 @@
 import pytest
 import torch
 
+from megatron.core.inference.quantization.mxfp8_tensor import MXFP8Tensor
 from megatron.core.resharding.copy_services.base import CopyService
 from megatron.core.resharding.execution import execute_reshard_plan
+from megatron.core.resharding.transforms import MXFP8ReshardTransform
 from megatron.core.resharding.utils import ReshardPlan, TransferOp
 
 _IS_BLACKWELL = torch.cuda.is_available() and (torch.cuda.get_device_properties(0).major >= 10)
@@ -154,6 +156,26 @@ class TestMXFP8ReshardTransform:
             assert buf.scale.data_ptr() == scale_ptr
             assert buf.backend == "triton"
             assert buf.scale.dtype == torch.float8_e8m0fnu
+
+    def test_full_prepare_recv_skips_staging_zero_fill(self, monkeypatch):
+        """A complete receive need not initialize storage that the transport overwrites."""
+        buf = MXFP8Tensor.from_bf16(
+            torch.randn(64, 128, dtype=torch.bfloat16, device="cuda"), backend="triton"
+        )
+        transform = MXFP8ReshardTransform(
+            convertible_params={"decoder.weight"},
+            persistent_buffers={"weight": buf},
+            buffer_key_prefix="decoder.",
+        )
+
+        def fail_zeros(*args, **kwargs):
+            raise AssertionError("full receive unexpectedly zero-initialized staging storage")
+
+        monkeypatch.setattr(torch, "zeros", fail_zeros)
+        recv_buffers = transform.prepare_recv("decoder.weight", (slice(None), slice(None)))
+
+        assert recv_buffers[0].shape == buf.shape
+        assert recv_buffers[0].dtype == torch.bfloat16
 
     def test_sender_side_conversion_supports_explicit_triton_backend(self):
         """A sender without persistent buffers can select the Triton wire format."""


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

Follow-up to #6878 that reduces the local BF16-to-MXFP8 conversion overhead during refit without changing communication, numerical formats, or refit semantics.

  ## Performance improvements

  Previously, updating a persistent MXFP8 weight required:

  1. Allocating temporary MXFP8 data and scale tensors.
  2. Quantizing the BF16 staging tensor into those temporaries.
  3. Copying both temporary tensors into the persistent destination storage.

  This change adds `mxfp8_quantize_into()` so the Triton kernel writes directly into the persistent MXFP8 data and scale buffers. This removes two temporary allocations and
  two device-to-device copies for every converted weight, reducing conversion latency, allocator pressure, HBM traffic, and peak transient memory.

  For full-tensor receives, the BF16 staging allocation now uses `torch.empty()` because the transport overwrites every element. This avoids an unnecessary full-tensor zero fill. Partial receives remain zero-initialized because they may accumulate multiple slices.

  These improvements primarily benefit models with many large MXFP8 weights, particularly MoE expert weights, where repeated allocation, copying, and initialization made local conversion a significant part of refit time.

  Unsupported backends and storage layouts retain the existing allocation-and-copy fallback.