### PR TITLE
fix(resharding): initialize NCCL on idle ranks

### DIFF
--- a/megatron/core/resharding/copy_services/nccl_copy_service.py
+++ b/megatron/core/resharding/copy_services/nccl_copy_service.py
@@ -27,8 +27,20 @@ class NCCLCopyService(CopyService):
         # Dedicated stream for local (same-rank) copies to avoid unnecessary
         # serialization with work on the default stream.
         self._copy_stream = torch.cuda.Stream()
+        self._nccl_connected = False
         if self.rank == 0:
             logger.info(f"NCCLCopyService initialized with {self.world_size} ranks")
+
+    def _ensure_nccl_connected(self) -> None:
+        """Collectively initialize the NCCL communicator on the current device."""
+        if self._nccl_connected:
+            return
+        group = self.group if self.group is not None else dist.group.WORLD
+        if group is None:
+            raise RuntimeError("NCCLCopyService requires an initialized process group")
+        device = torch.device("cuda", torch.cuda.current_device())
+        group._get_backend(device).eager_connect_single_device(device)
+        self._nccl_connected = True
 
     def submit_send(self, src_tensor: torch.Tensor, dest_rank: int, task_id: Optional[int] = None):
         self.send_ops.append(SendOp(task_id=task_id, tensor=src_tensor, dest_rank=dest_rank))
@@ -37,6 +49,11 @@ class NCCLCopyService(CopyService):
         self.recv_ops.append(RecvOp(task_id=task_id, tensor=dest_tensor, src_rank=src_rank))
 
     def run(self):
+        # The first NCCL P2P operation lazily initializes a group-wide
+        # communicator. Connect before inspecting local queues because valid
+        # reshard plans may leave some ranks with no operations.
+        self._ensure_nccl_connected()
+
         total_ops = len(self.send_ops) + len(self.recv_ops)
         if self.rank == 0:
             logger.info(

--- a/tests/unit_tests/resharding/test_copy_services.py
+++ b/tests/unit_tests/resharding/test_copy_services.py
@@ -6,6 +6,7 @@ Covers:
 - ``match_local_ops_by_task_id``: pairing semantics and every error branch.
 - ``CopyService.close()`` default no-op contract.
 - Explicit opt-in for multiple runs per plan.
+- NCCL communicator initialization on ranks with no local operations.
 """
 
 import pytest
@@ -183,3 +184,48 @@ def test_multiple_runs_per_plan_require_explicit_backend_support():
     assert NCCLCopyService.supports_multiple_runs_per_plan is True
     assert NVSHMEMCopyService.supports_multiple_runs_per_plan is True
     assert NixlCopyService.supports_multiple_runs_per_plan is False
+
+
+def test_nccl_service_eagerly_connects_before_first_run(monkeypatch):
+    """Idle ranks must join NCCL setup before active ranks issue their first P2P."""
+    device = torch.device("cuda", 1)
+
+    class Backend:
+        def __init__(self):
+            self.connected_devices = []
+
+        def eager_connect_single_device(self, connected_device):
+            self.connected_devices.append(connected_device)
+
+    class Group:
+        def __init__(self, backend):
+            self.backend = backend
+            self.requested_devices = []
+
+        def rank(self):
+            return 1
+
+        def size(self):
+            return 4
+
+        def _get_backend(self, requested_device):
+            self.requested_devices.append(requested_device)
+            return self.backend
+
+    class Stream:
+        def wait_stream(self, _stream):
+            pass
+
+    backend = Backend()
+    group = Group(backend)
+    stream = Stream()
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: device.index)
+    monkeypatch.setattr(torch.cuda, "Stream", lambda: stream)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: stream)
+
+    service = NCCLCopyService(group=group)
+    service.run()
+    service.run()
+
+    assert group.requested_devices == [device]
+    assert backend.connected_devices == [device]


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

We have a corner case in refit where depending on the topology some ranks nccl was not initialized yet which caused a hang


  The failure sequence was:

  1. NeMo-RL creates a four-rank hybrid process group: Gloo for CPU operations and NCCL for CUDA tensors.
  2. With TP=1 and DP=2, the planner may choose only one training replica as the source. The other training rank receives no send or receive operations.
  3. batch_isend_irecv() lazily initializes NCCL, and that initialization requires every rank in the process group.
  4. The idle rank skipped batch_isend_irecv() and entered the Gloo barrier.
  5. The active ranks waited forever for that idle rank during NCCL initialization.

  The fix adds this one-time setup to NCCLCopyService:

  def _ensure_nccl_connected(self) -> None:
      if self._nccl_connected:
          return

      group = self.group if self.group is not None else dist.group.WORLD
      device = torch.device("cuda", torch.cuda.current_device())
      group._get_backend(device).eager_connect_single_device(device)
      self._nccl_connected = True

  run() calls it before checking whether the rank has any queued operations. Since every rank already calls run(), even idle ranks now participate in the initial NCCL communicator
  creation.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
