### PR TITLE
Refactor FSDP gradient readiness countdown

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/countdown.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/countdown.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A self-resetting countdown."""
+
+
+class Countdown:
+    """Countdown that automatically re-arms after reaching zero."""
+
+    def __init__(self, initial_value: int) -> None:
+        """Create a countdown starting at ``initial_value``."""
+        if initial_value < 0:
+            raise ValueError(f"Countdown initial_value must be non-negative, got {initial_value}.")
+        self._initial_value = initial_value
+        self._value = initial_value
+
+    @property
+    def initial_value(self) -> int:
+        """Return the number of decrements in one countdown cycle."""
+        return self._initial_value
+
+    def decrement(self) -> bool:
+        """Decrement and return whether the countdown completed this call."""
+        self._value -= 1
+        completed = self._value == 0
+        if completed:
+            self._value = self._initial_value
+        return completed

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -25,6 +25,7 @@ from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
+from .countdown import Countdown
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Flat
@@ -155,9 +156,8 @@ class FsdpModule:
     _name: str | None
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
-    _num_ready_grad_parameters: int
+    _trainable_parameter_countdown: Countdown
     _is_root: bool
-    _num_trainable_parameters: int
     # Event recorded after this FsdpModule's full parameters are materialized.
     # ``None`` lets pre_forward enqueue an all-gather unless an earlier FsdpModule
     # already prefetched this module.
@@ -211,9 +211,12 @@ class FsdpModule:
                 )
             )
         self._parameter_groups = tuple(parameter_groups)
-        self._num_ready_grad_parameters = 0
-        self._num_trainable_parameters = sum(
-            len(group.fsdp_parameters) for group in self._parameter_groups if group.requires_grad
+        self._trainable_parameter_countdown = Countdown(
+            sum(
+                len(group.fsdp_parameters)
+                for group in self._parameter_groups
+                if group.requires_grad
+            )
         )
         self._register_hooks()
         context.register_module(self)
@@ -267,7 +270,7 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
-        if self._num_trainable_parameters == 0:
+        if self._trainable_parameter_countdown.initial_value == 0:
             module.register_full_backward_hook(
                 lambda hooked_module, _grad_input, _grad_output: cast(
                     FsdpModule, hooked_module
@@ -285,8 +288,7 @@ class FsdpModule:
             module = module_ref()
             if module is None:
                 return
-            module._num_ready_grad_parameters += 1
-            if module._num_ready_grad_parameters == module._num_trainable_parameters:
+            if module._trainable_parameter_countdown.decrement():
                 module.post_backward()
 
         for group in self._parameter_groups:
@@ -331,7 +333,6 @@ class FsdpModule:
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
-        self._num_ready_grad_parameters = 0
         allgather_stream = context.allgather_stream
         current_stream = context.current_stream()
 


### PR DESCRIPTION
## Summary
- extract a self-resetting Countdown for experimental Megatron-FSDP
- use it to track gradient readiness before post-backward reduction

## Validation
- `python -m py_compile megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/countdown.py`
- exercised countdown completion and automatic re-arming behavior