### PR TITLE
Fix full-iteration CUDA graph capture for PP and grouped hybrid models

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -233,7 +233,14 @@ class FullyShardedDataParallelV1(_BaseDataParallel):
         if config.overlap_moe_expert_parallel_comm and any_sharding_strategy_in(
             ddp_config, ["optim_grads_params"]
         ):
-            supported_fsdp_unit_modules = [TransformerLayer, MoETransformerLayer, MambaLayer]
+            from megatron.core.models.hybrid.hybrid_block import HybridStack
+
+            supported_fsdp_unit_modules = [
+                TransformerLayer,
+                MoETransformerLayer,
+                MambaLayer,
+                HybridStack,
+            ]
             assert self.fsdp_unit_modules and all(
                 module in supported_fsdp_unit_modules for module in self.fsdp_unit_modules
             ), (
@@ -242,6 +249,19 @@ class FullyShardedDataParallelV1(_BaseDataParallel):
                 f"{supported_fsdp_unit_modules}, "
                 f"got {self.fsdp_unit_modules}."
             )
+
+        # HybridStack-specific filter: when bracketed hybrid patterns are used,
+        # the model has a nested layout -- an outer HybridStack root
+        # (``is_layer_group_stack=False``) whose ``layers`` are inner
+        # bracket-group HybridStacks (``is_layer_group_stack=True``).
+        # ``named_modules()`` walks root-first, so with ``[HybridStack]`` the
+        # outer matches first, the inner ones get skipped as its submodules,
+        # and the whole decoder becomes a single FSDP unit. We exclude the
+        # outer so each bracket group is its own unit. Modules without the
+        # attribute (TransformerLayer, etc.) keep the default ``True``.
+        def _fsdp_unit_filter(m):
+            return getattr(m, "is_layer_group_stack", True)
+
         super().__init__(
             config=config,
             module=MegatronFSDP(
@@ -249,6 +269,7 @@ class FullyShardedDataParallelV1(_BaseDataParallel):
                 mixed_precision_policy=self.mp_policy,
                 module=module,
                 fsdp_unit_modules=self.fsdp_unit_modules,
+                fsdp_unit_filter=_fsdp_unit_filter,
                 disable_bucketing=disable_bucketing,
                 device=self.device,
                 dist_index=self.megatron_fsdp_dist_index,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from enum import Enum, auto
 from functools import partial
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type
 
 import torch
 import torch.nn as nn
@@ -217,6 +217,7 @@ class MegatronFSDP(torch.nn.Module):
         ddp_config: DistributedDataParallelConfig = None,
         mixed_precision_policy: MixedPrecisionPolicy = MixedPrecisionPolicy(),
         fsdp_unit_modules: Optional[List[torch.nn.Module] | List[str]] = None,
+        fsdp_unit_filter: Optional[Callable[[torch.nn.Module], bool]] = None,
         disable_bucketing: bool = False,
         device: Optional[torch.device] = None,
         calculate_per_token_loss: bool = False,
@@ -334,6 +335,11 @@ class MegatronFSDP(torch.nn.Module):
             if fsdp_unit_modules is not None
             else []
         )
+        # Optional caller-supplied filter run after the isinstance check; lets the
+        # adapter exclude specific class instances (e.g. an outer wrapper that
+        # shares its class with the actual FSDP-unit instances) without leaking
+        # model knowledge into this library.
+        self.fsdp_unit_filter = fsdp_unit_filter
 
         # Determine if we should delay the gradient reduction. Only if no parameter class
         # shards gradients, since a sharded class reduces on every backward pass.
@@ -453,7 +459,7 @@ class MegatronFSDP(torch.nn.Module):
                 total_param_elements = 0
                 total_fsdp_module = 0
                 for module in self.module.modules():
-                    if isinstance(module, tuple(self.fsdp_unit_modules)):
+                    if self._is_fsdp_unit_module(module):
                         total_fsdp_module += 1
                         total_param_elements += sum(p.numel() for p in module.parameters())
                 # The suggested size is twice the number of elements in the FSDP modules.
@@ -491,6 +497,21 @@ class MegatronFSDP(torch.nn.Module):
         module = importlib.import_module(module_path)
         cls = getattr(module, class_name)
         return cls
+
+    def _is_fsdp_unit_module(self, module: nn.Module) -> bool:
+        """Whether ``module`` should be treated as an FSDP unit.
+
+        Default: ``isinstance(module, tuple(fsdp_unit_modules))``. When the
+        caller provides ``fsdp_unit_filter``, the filter runs after the
+        isinstance check and can exclude specific instances -- useful when a
+        wrapping container shares its class with the actual unit instances
+        (so a pure class-based match would register the wrong layer).
+        """
+        if not isinstance(module, tuple(self.fsdp_unit_modules)):
+            return False
+        if self.fsdp_unit_filter is not None:
+            return self.fsdp_unit_filter(module)
+        return True
 
     def all_gather_and_wait_parameters_ready(
         self,
@@ -592,7 +613,6 @@ class MegatronFSDP(torch.nn.Module):
         `optim` and `optim_grads` do not require FSDP units because they do not
         shard model parameters.
         """
-        fsdp_unit_modules = self.fsdp_unit_modules
 
         def _param_list_for_submodule_unshard(
             module: nn.Module, pass_direction: Literal["forward", "backward"]
@@ -629,7 +649,7 @@ class MegatronFSDP(torch.nn.Module):
                     # recomputation on individual submodules.
                     return list(module.parameters(recurse=False))
             else:
-                if isinstance(module, tuple(fsdp_unit_modules)):
+                if self._is_fsdp_unit_module(module):
                     # FSDP unit modules should be unsharded and communicated together.
                     return list(module.parameters())
                 else:
@@ -735,7 +755,7 @@ class MegatronFSDP(torch.nn.Module):
             - Releases the module's parameters for the backward phase to free memory.
             - Marks the module as IDLE in the training state machine.
             """
-            assert isinstance(module, tuple(fsdp_unit_modules))
+            assert self._is_fsdp_unit_module(module)
             assert any_sharding_strategy_in(self.ddp_config, ["optim_grads_params"])
 
             # Release parameters for this module after backward.
@@ -1038,8 +1058,8 @@ class MegatronFSDP(torch.nn.Module):
                 lazy_release = False
                 module._training_state = TrainingState.IDLE
 
-            assert isinstance(
-                module, tuple(fsdp_unit_modules)
+            assert self._is_fsdp_unit_module(
+                module
             ), "_post_forward hook should only be registered on FSDP unit modules."
 
             # Release the module parameters after the forward pass to save memory.
@@ -1134,7 +1154,7 @@ class MegatronFSDP(torch.nn.Module):
             if not self.enable_fine_grained_param_gather_hook:
                 _register_pre_forward_param_unshard_hook(module)
 
-            if isinstance(module, tuple(fsdp_unit_modules)):
+            if self._is_fsdp_unit_module(module):
                 fsdp_modules.append(module)
 
                 if any_sharding_strategy_in(self.ddp_config, ["optim_grads_params"]):
@@ -1161,7 +1181,7 @@ class MegatronFSDP(torch.nn.Module):
 
             # Register the post-backward hook to deallocate model parameters
             # and reduce-scatter gradients after the backward pass.
-            if isinstance(module, tuple(fsdp_unit_modules)):
+            if self._is_fsdp_unit_module(module):
                 if any_sharding_strategy_in(self.ddp_config, ["optim_grads_params"]):
                     self.forward_pre_hooks[f"module {name} register post-backward hook"] = (
                         module.register_forward_pre_hook(

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -78,13 +78,20 @@ def clone_tensors_in_struct(tgt, src):
         raise Exception(f"Unsupported copy for tuple yet: {type(src)}")
     elif isinstance(src, list):
         for i in range(len(src)):
-            if isinstance(src[i], (tuple, list, dict, torch.Tensor)):
+            if tgt[i] is None:
+                tgt[i] = src[i]
+            elif isinstance(src[i], (tuple, list, dict, torch.Tensor)):
                 clone_tensors_in_struct(tgt[i], src[i])
             else:
                 tgt[i] = src[i]
     elif isinstance(src, dict):
         for k in src:
-            if isinstance(src[k], (tuple, list, dict, torch.Tensor)):
+            if tgt.get(k) is None:
+                # Static buffer slot was None at capture (field absent/None then), so the
+                # captured graph does not read it as a tensor input. Pass the value through
+                # rather than copying into a None buffer (avoids AttributeError on .copy_).
+                tgt[k] = src[k]
+            elif isinstance(src[k], (tuple, list, dict, torch.Tensor)):
                 clone_tensors_in_struct(tgt[k], src[k])
             else:
                 tgt[k] = src[k]

--- a/megatron/core/models/common/fine_grained_callables.py
+++ b/megatron/core/models/common/fine_grained_callables.py
@@ -151,9 +151,14 @@ def build_mtp_layer_callables(layer):
 
 def get_layer_moe_metadata(layer):
     """Return ``(is_moe, num_local_experts)`` for schedule-node construction."""
+    from megatron.core.models.hybrid.hybrid_block import HybridStack
 
     if isinstance(layer, MultiTokenPredictionLayer):
         return get_layer_moe_metadata(layer.mtp_model_layer)
+    if isinstance(layer, HybridStack):
+        from megatron.core.models.hybrid.fine_grained_callables import get_hybrid_stack_moe_metadata
+
+        return get_hybrid_stack_moe_metadata(layer)
     if isinstance(layer, TransformerLayer):
         is_moe = isinstance(layer.mlp, MoELayer)
         num_local_experts = layer.mlp.num_local_experts if is_moe else None
@@ -167,9 +172,15 @@ def build_layer_callables(layer):
 
     Returns ``(forward_funcs, backward_dw)``.
     """
+    from megatron.core.models.hybrid.hybrid_block import HybridStack
 
     if isinstance(layer, MultiTokenPredictionLayer):
         return build_mtp_layer_callables(layer)
+    if isinstance(layer, HybridStack):
+        from megatron.core.models.hybrid.fine_grained_callables import build_hybrid_stack_callables
+
+        forward_funcs, backward_dw, _, _ = build_hybrid_stack_callables(layer)
+        return forward_funcs, backward_dw
     if isinstance(layer, TransformerLayer):
         return build_transformer_layer_callables(layer)
 

--- a/megatron/core/models/common/fine_grained_callables.py
+++ b/megatron/core/models/common/fine_grained_callables.py
@@ -67,8 +67,27 @@ def build_mtp_layer_callables(layer):
             offset = get_mtp_layer_offset(
                 layer.config, model.vp_stage, pp_rank=model.pg_collection.pp.rank()
             )
-            node.chunk_state.mtp_hidden_states = list(torch.chunk(hidden_states, 1 + offset, dim=0))
-            hidden_states = node.chunk_state.mtp_hidden_states[offset]
+            chunks = list(torch.chunk(hidden_states, 1 + offset, dim=0))
+            # Store DETACHED chunks in chunk_state. mtp_hidden_states is a
+            # ``chunk_state``-level Python list that crosses slot boundaries
+            # (set here in MTP's pre_dispatch slot, later torch.cat'd in MTP's
+            # mtp_post_process slot before feeding the LM head). Without an
+            # explicit detach the chunks keep their grad_fn from torch.chunk →
+            # whatever upstream node produced ``hidden_states`` (e.g. the
+            # final_norm we apply above for the HybridModel empty-decoder case),
+            # which means mtp_post_process.backward and pre_dispatch.backward
+            # both traverse that same grad_fn — for a TENorm-backed final_norm
+            # (an OpFuser op) the second traversal hits ``ctx.tensor_objects is
+            # None`` and raises ``ctx must have .tensor_objects to restore
+            # saved tensors``. Using ``node.detach`` records the originals in
+            # before_detached so pre_dispatch's backward_impl still pulls the
+            # LM-head-side grad (accumulated on the detached leaves by the
+            # post_process / mtp_post_process backward chain) back into the
+            # outputs+before_detached run_backward — i.e. the gradient flow
+            # remains mathematically equivalent, just no longer shared across
+            # slots.
+            node.chunk_state.mtp_hidden_states = [node.detach(c) for c in chunks]
+            hidden_states = chunks[offset]
 
         input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states = (
             layer._get_embeddings(

--- a/megatron/core/models/hybrid/fine_grained_callables.py
+++ b/megatron/core/models/hybrid/fine_grained_callables.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from contextlib import nullcontext
+from functools import partial
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.fp4_utils import get_fp4_context
+from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.models.common.utils import TransformerLayerNode, should_free_input
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_allocation import LayerPatternItem
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as LayerSymbols
+from megatron.core.models.hybrid.hybrid_layer_allocation import is_layer_group
+from megatron.core.pipeline_parallel.utils import ScheduleNode
+from megatron.core.transformer.transformer_layer import make_viewless_tensor
+
+
+class _SharedExpertBackwardDWWrapper:
+    """Run MoE shared-experts wgrad as part of the ``pre_dispatch_computation`` slot.
+
+    Why: shared-experts forward is part of ``_run_moe_preprocess`` (which runs in the
+    pre_dispatch slot), and TE's delay-wgrad model only ``put``s to the wgrad queue
+    inside the autograd backward (dgrad). So shared-experts' ``backward_dw`` must
+    fire *after* the pre_dispatch slot's autograd backward — registering it in the
+    ``mlp`` slot would call it before that dgrad and trigger
+    ``RuntimeError: Pop empty queue`` from TE.
+    """
+
+    def __init__(self, layer):
+        self.layer = layer
+        self.shared_expert_dw_callable = None
+        if layer.mlp.use_shared_expert and not layer.mlp.shared_expert_overlap:
+            self.shared_expert_dw_callable = partial(
+                layer.mlp.backward_dw, routed_experts=False, shared_experts=True
+            )
+
+    def backward_dw(self):
+        """Run shared-expert backward wgrad after pre-dispatch autograd backward."""
+        if self.shared_expert_dw_callable is not None:
+            self.shared_expert_dw_callable()
+        self.layer = None
+        self.shared_expert_dw_callable = None
+
+    def parameters(self):
+        """Expose shared-expert params so post_wgrad_grad_acc_hook discovery works.
+
+        The schedule node's backward_dw iterates module.parameters() looking for
+        post_wgrad_grad_acc_hook on each param. _SharedExpertBackwardDWWrapper is
+        a plain class (not nn.Module), so we forward to layer.mlp.shared_experts.
+        Returns an empty iterator after backward_dw has cleared the layer ref.
+        """
+        if self.layer is None or self.layer.mlp.shared_experts is None:
+            return iter([])
+        return self.layer.mlp.shared_experts.parameters()
+
+
+class HybridStackNode(TransformerLayerNode):
+    """Schedule node for HybridStack-built fine-grained callables.
+
+    Subclassed from ``TransformerLayerNode`` so the runtime backbone (forward /
+    backward / backward_dw plumbing, detach bookkeeping, output-grad release)
+    is shared. The hybrid path keeps a separate node class so its free-input
+    policy can diverge from the GPT defaults — for example, the
+    ``pre_dispatch_computation`` slot here covers the whole pre-dispatch loop
+    (mamba + attention + …) rather than a single attention block, and
+    group-level decisions about whether the input is needed in backward may
+    differ from ``should_free_input`` in ``gpt/fine_grained_callables.py``.
+    Keep this override thin until a hybrid counter-example forces it to
+    diverge; the explicit subclass exists so the divergence can be made
+    surgically without touching the GPT class.
+    """
+
+    @staticmethod
+    def _resolve_free_input(name, is_moe, config, num_local_experts):
+        """Hybrid free-input policy.
+
+        Currently mirrors the GPT default: dense layers always retain their
+        input for backward; MoE-only "moe_dispatch", "mlp", and "moe_combine"
+        slots can free, subject to the dispatcher / cuda-graph constraints
+        encoded in ``should_free_input``. Hybrid groups have a
+        "pre_dispatch_computation" slot whose semantics differ (it covers a
+        loop over Mamba/attention/GDN sub-layers, not a single attention
+        block), but its policy resolves to ``False`` in
+        ``should_free_input``, which is correct: pre-layer outputs are needed
+        for backward through the loop. Override here when a hybrid-specific
+        rule is needed.
+        """
+        return should_free_input(name, is_moe, config, num_local_experts)
+
+
+def _get_inner_quant_context(layer):
+    config = layer.config
+    if config.fp8 and config.fp8_recipe != Fp8Recipe.delayed:
+        return get_fp8_context(config, layer.layer_number - 1)
+    if config.fp4:
+        return get_fp4_context(config, layer.layer_number - 1)
+    return nullcontext()
+
+
+def _as_hybrid_layers(layer, layer_type: Optional[LayerPatternItem]):
+    """Return ``(layer_type, layer)`` pairs for a hybrid logical layer."""
+    if isinstance(layer, HybridStack):
+        return list(zip(layer.layer_type_list, layer.layers))
+    assert layer_type is not None, "Hybrid layer scheduling requires the layer type symbol."
+    return [(layer_type, layer)]
+
+
+def _split_hybrid_layers_for_overlap(layer, layer_type: Optional[LayerPatternItem]):
+    layer_items = _as_hybrid_layers(layer, layer_type)
+    if any(is_layer_group(item_type) for item_type, _ in layer_items):
+        raise ValueError("Nested HybridStack groups are not supported in overlap scheduling.")
+
+    terminal_idx = None
+    for idx, (item_type, _) in enumerate(layer_items):
+        if item_type in (LayerSymbols.MLP, LayerSymbols.MOE):
+            terminal_idx = idx
+            break
+
+    if terminal_idx is not None and terminal_idx != len(layer_items) - 1:
+        raise ValueError("HybridStack overlap requires MLP/MoE to be the last layer in a group.")
+
+    terminal_type = layer_items[terminal_idx][0] if terminal_idx is not None else None
+    terminal_layer = layer_items[terminal_idx][1] if terminal_idx is not None else None
+    pre_layers = layer_items[:terminal_idx] if terminal_idx is not None else layer_items
+    is_moe = terminal_type == LayerSymbols.MOE
+    num_local_experts = terminal_layer.mlp.num_local_experts if is_moe else None
+    return pre_layers, terminal_type, terminal_layer, is_moe, num_local_experts
+
+
+def get_hybrid_stack_moe_metadata(layer, layer_type: Optional[LayerPatternItem] = None):
+    """Return ``(is_moe, num_local_experts)`` for one HybridStack schedule layer."""
+    _, _, _, is_moe, num_local_experts = _split_hybrid_layers_for_overlap(layer, layer_type)
+    return is_moe, num_local_experts
+
+
+def _maybe_apply_final_norm(node: ScheduleNode, hidden_states: Tensor):
+    final_norm = getattr(node.chunk_state.model.decoder, "final_norm", None)
+    final_norm = final_norm or getattr(node.chunk_state.model.decoder, "final_layernorm", None)
+    if not node.is_mtp and final_norm is not None and node.is_last_layer:
+        hidden_states = final_norm(hidden_states)
+        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+    return hidden_states
+
+
+def _get_moe_padding_mask(node: ScheduleNode):
+    padding_mask = node.chunk_state.padding_mask
+    if padding_mask is not None:
+        # MoELayer.forward receives [batch, seq] and transposes before routing.
+        padding_mask = padding_mask.transpose(0, 1).bool()
+    return padding_mask
+
+
+def _run_moe_preprocess(layer, node: ScheduleNode, hidden_states: Tensor):
+    pre_mlp_layernorm_output = layer._forward_pre_mlp_layernorm(hidden_states)
+    if isinstance(pre_mlp_layernorm_output, tuple):
+        if len(pre_mlp_layernorm_output) != 2:
+            raise ValueError(
+                f"When the output of pre_mlp_layernorm is a tuple, it is expected to have "
+                f"2 elements (output, residual), but got {len(pre_mlp_layernorm_output)}"
+            )
+        pre_mlp_layernorm_output, residual = pre_mlp_layernorm_output
+    else:
+        residual = hidden_states
+
+    if layer.config.fp32_residual_connection:
+        residual = residual.float()
+
+    shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)
+    probs, routing_map = layer.mlp.route(pre_mlp_layernorm_output, _get_moe_padding_mask(node))
+    local_tokens, probs = layer.mlp.preprocess(pre_mlp_layernorm_output, probs, routing_map)
+
+    node.layer_state.residual = node.detach(residual)
+    if layer.mlp.use_shared_expert and not layer.mlp.shared_expert_overlap:
+        node.layer_state.shared_expert_output = node.detach(shared_expert_output)
+
+    return local_tokens, probs
+
+
+def _run_moe_experts(layer, node: ScheduleNode, dispatched_tokens: Tensor):
+    dispatched_probs = node.layer_state.dispatched_probs
+    enable_hybridep = (
+        layer.config.moe_token_dispatcher_type == "flex"
+        and layer.config.moe_flex_dispatcher_backend == "hybridep"
+    )
+    enable_deepep = (
+        layer.config.moe_token_dispatcher_type == "flex"
+        and layer.config.moe_flex_dispatcher_backend == "deepep"
+    )
+    token_dispatcher = layer.mlp.token_dispatcher
+    if enable_deepep or enable_hybridep:
+        token_dispatcher._comm_manager.dispatched_probs = dispatched_probs
+
+    expert_output, _ = layer.mlp.routed_experts_compute(dispatched_tokens, dispatched_probs)
+
+    if enable_hybridep:
+        tokens_per_expert = token_dispatcher._comm_manager.get_number_of_tokens_per_expert()
+        node.layer_state.tokens_per_expert = tokens_per_expert
+
+    if layer.recompute_pre_mlp_layernorm:
+        layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(expert_output)
+
+    return expert_output
+
+
+def _run_moe_combine(layer, node: ScheduleNode, output: Tensor):
+    residual = node.layer_state.residual
+    shared_expert_output = getattr(node.layer_state, 'shared_expert_output', None)
+    output = layer.mlp.combine(output)
+    output = layer.mlp.postprocess(output, shared_expert_output)
+    output = layer._forward_post_mlp((output, None), residual)
+
+    node.layer_state.residual.record_stream(torch.cuda.current_stream())
+    if shared_expert_output is not None:
+        shared_expert_output.record_stream(torch.cuda.current_stream())
+
+    node.layer_state.residual = None
+    node.layer_state.shared_expert_output = None
+
+    return _maybe_apply_final_norm(node, output)
+
+
+def build_hybrid_stack_callables(layer, layer_type: Optional[LayerPatternItem] = None):
+    """Create fine-grained callables for one logical HybridStack layer.
+
+    A logical layer may be a bracketed nested ``HybridStack`` (for example ``[M*E]``)
+    or a single legacy hybrid layer symbol. The split is:
+    pre-dispatch compute -> dispatch -> MLP/experts -> combine.
+    """
+    pre_layers, terminal_type, terminal_layer, is_moe, num_local_experts = (
+        _split_hybrid_layers_for_overlap(layer, layer_type)
+    )
+
+    def pre_dispatch_computation(node: ScheduleNode, hidden_states: Tensor):
+        for item_type, item_layer in pre_layers:
+            with _get_inner_quant_context(item_layer):
+                if item_type == LayerSymbols.MAMBA:
+                    hidden_states = item_layer(
+                        hidden_states=hidden_states,
+                        attention_mask=node.chunk_state.attention_mask,
+                        inference_context=getattr(node.chunk_state, "inference_context", None),
+                        packed_seq_params=node.chunk_state.packed_seq_params,
+                    )
+                elif item_type in (
+                    LayerSymbols.ATTENTION,
+                    LayerSymbols.DS_ATTENTION,
+                    LayerSymbols.GDN,
+                ):
+                    # Use _forward_attention rather than __call__: an attention half-layer has
+                    # mlp=IdentityOp / mlp_bda=IdentityFuncOp by default, and TransformerLayer's
+                    # __call__ would route through _forward_mlp + mlp_bda, double-applying the
+                    # post-attention residual.
+                    hidden_states, _ = item_layer._forward_attention(
+                        hidden_states=hidden_states,
+                        attention_mask=node.chunk_state.attention_mask,
+                        rotary_pos_emb=node.chunk_state.rotary_pos_emb,
+                        rotary_pos_cos=node.chunk_state.rotary_pos_cos,
+                        rotary_pos_sin=node.chunk_state.rotary_pos_sin,
+                        packed_seq_params=node.chunk_state.packed_seq_params,
+                        sequence_len_offset=node.chunk_state.sequence_len_offset,
+                    )
+                    # _forward_attention returns the bias_dropout_add output which can be a
+                    # view tensor (the mlp_bda's add into the post-attention residual produces
+                    # a view from a fused/JIT kernel). Downstream cuBLAS matmuls — including
+                    # the terminal MLP/MoE's pre_mlp_layernorm and the next attention's QKV
+                    # projection in a multi-pre-layer group — pick algorithms based on input
+                    # strides; a view's non-canonical strides can lead to different algo
+                    # selection across processes and produce ~1e-5 bit drift on the forward
+                    # output. TransformerLayer's full forward() inserts this exact call at the
+                    # MLP exit (transformer_layer.py:895) for the same reason; the
+                    # _forward_attention shortcut here doesn't get that cleanup, so we add it
+                    # explicitly. Same idea as the make_viewless_tensor in _maybe_apply_final_norm.
+                    hidden_states = make_viewless_tensor(
+                        inp=hidden_states,
+                        requires_grad=hidden_states.requires_grad,
+                        keep_graph=True,
+                    )
+                else:
+                    raise ValueError(
+                        f"HybridStack overlap does not support layer type '{item_type}' before "
+                        "the terminal MLP/MoE layer."
+                    )
+
+            if isinstance(hidden_states, tuple):
+                hidden_states = hidden_states[0]
+
+        if terminal_type == LayerSymbols.MOE:
+            with _get_inner_quant_context(terminal_layer):
+                return _run_moe_preprocess(terminal_layer, node, hidden_states)
+
+        if terminal_type is None:
+            return _maybe_apply_final_norm(node, hidden_states)
+
+        return hidden_states
+
+    def dispatch(node: ScheduleNode, local_tokens: Tensor, probs: Tensor):
+        enable_hybridep = (
+            terminal_layer.config.moe_token_dispatcher_type == "flex"
+            and terminal_layer.config.moe_flex_dispatcher_backend == "hybridep"
+        )
+        enable_deepep = (
+            terminal_layer.config.moe_token_dispatcher_type == "flex"
+            and terminal_layer.config.moe_flex_dispatcher_backend == "deepep"
+        )
+        token_dispatcher = terminal_layer.mlp.token_dispatcher
+        if enable_deepep or enable_hybridep:
+            token_dispatcher._comm_manager.token_probs = probs
+        with _get_inner_quant_context(terminal_layer):
+            dispatched_tokens, dispatched_probs = terminal_layer.mlp.dispatch(local_tokens, probs)
+        node.layer_state.dispatched_probs = node.detach(dispatched_probs)
+        return dispatched_tokens
+
+    def mlp(node: ScheduleNode, hidden_states: Tensor):
+        if terminal_type == LayerSymbols.MLP:
+            with _get_inner_quant_context(terminal_layer):
+                hidden_states = terminal_layer._forward_mlp(
+                    hidden_states, padding_mask=node.chunk_state.padding_mask
+                )
+            return _maybe_apply_final_norm(node, hidden_states)
+        if terminal_type == LayerSymbols.MOE:
+            with _get_inner_quant_context(terminal_layer):
+                return _run_moe_experts(terminal_layer, node, hidden_states)
+        return hidden_states
+
+    def combine(node: ScheduleNode, output: Tensor):
+        with _get_inner_quant_context(terminal_layer):
+            return _run_moe_combine(terminal_layer, node, output)
+
+    def raise_not_implemented(*args):
+        raise NotImplementedError("This callable is not implemented for non-MoE hybrid layers.")
+
+    backward_dw = {}
+    pre_bwd_dw = []
+    for item_type, item_layer in pre_layers:
+        if item_type in (LayerSymbols.ATTENTION, LayerSymbols.DS_ATTENTION, LayerSymbols.GDN):
+            # TransformerLayer-backed pre-layers go through the standard
+            # _BackwardDWWrapper which coordinates attn / shared-expert wgrad
+            # with cuda-graph replay scopes.
+            item_layer.init_backward_dw_wrapper()
+            pre_bwd_dw.append(item_layer.backward_dw_wrapper)
+        elif item_type == LayerSymbols.MAMBA:
+            # MambaLayer is not a TransformerLayer, so init_backward_dw_wrapper
+            # would assert. MambaLayer.backward_dw delegates to its mixer, which
+            # in turn calls backward_dw on the in_proj / out_proj linears. The
+            # schedule node iterates this list and calls .backward_dw() on each;
+            # registering the layer directly is sufficient.
+            pre_bwd_dw.append(item_layer)
+    if is_moe:
+        # MoELayer.backward_dw default kwargs (routed_experts=True, shared_experts=False)
+        # handle the routed-experts wgrad in the mlp slot. The shared-experts wgrad goes
+        # into the pre_dispatch_computation slot so it runs after that slot's autograd
+        # backward (where TE's wgrad_store.put fires); the wrapper is a no-op when
+        # shared_expert_overlap is enabled.
+        shared_expert_dw = _SharedExpertBackwardDWWrapper(terminal_layer)
+        if shared_expert_dw.shared_expert_dw_callable is not None:
+            pre_bwd_dw.append(shared_expert_dw)
+        backward_dw["mlp"] = terminal_layer.mlp
+    elif terminal_type == LayerSymbols.MLP:
+        backward_dw["mlp"] = terminal_layer.mlp
+
+    if pre_bwd_dw:
+        backward_dw["pre_dispatch_computation"] = pre_bwd_dw
+
+    forward_funcs = [
+        pre_dispatch_computation,
+        dispatch if is_moe else raise_not_implemented,
+        mlp,
+        combine if is_moe else raise_not_implemented,
+        None,
+    ]
+    return forward_funcs, backward_dw, is_moe, num_local_experts

--- a/megatron/core/models/hybrid/fine_grained_callables.py
+++ b/megatron/core/models/hybrid/fine_grained_callables.py
@@ -15,6 +15,9 @@ from megatron.core.models.hybrid.hybrid_block import HybridStack
 from megatron.core.models.hybrid.hybrid_layer_allocation import LayerPatternItem
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as LayerSymbols
 from megatron.core.models.hybrid.hybrid_layer_allocation import is_layer_group
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+    FineGrainedActivationOffloadingInterface as off_interface,
+)
 from megatron.core.pipeline_parallel.utils import ScheduleNode
 from megatron.core.transformer.transformer_layer import make_viewless_tensor
 
@@ -211,7 +214,28 @@ def _run_moe_combine(layer, node: ScheduleNode, output: Tensor):
     shared_expert_output = getattr(node.layer_state, 'shared_expert_output', None)
     output = layer.mlp.combine(output)
     output = layer.mlp.postprocess(output, shared_expert_output)
-    output = layer._forward_post_mlp((output, None), residual)
+    # Inline bda instead of calling ``layer._forward_post_mlp`` so we can skip
+    # the redundant ``discard_output_and_register_recompute(mlp_output_with_bias[0])``
+    # that ``_forward_post_mlp`` would otherwise issue. The pre_mlp_layernorm recompute
+    # is already registered on ``expert_output`` inside ``_run_moe_experts``; the second
+    # hook on the combine-slot ``mlp_output_with_bias[0]`` is not only unnecessary but
+    # harmful in the bracketed-hybrid case (``[*E]``): it fires during combine_bwd's
+    # autograd backward and triggers the LN recompute ahead of attention's backward
+    # in the same pre_dispatch slot, corrupting attention gradients (grad_norm explodes
+    # from iter 2). GPT's ``submodule_combine_forward`` likewise inlines bda and does
+    # not call ``_forward_post_mlp`` for the same reason.
+    mlp_output_with_bias = (output, None)
+    with layer.bias_dropout_add_exec_handler():
+        output = layer.mlp_bda(layer.training, layer.config.bias_dropout_fusion)(
+            mlp_output_with_bias, residual, layer.hidden_dropout
+        )
+    if layer.offload_mlp_norm:
+        output = off_interface.group_commit(
+            output, name="mlp_norm", forced_released_tensors=[residual]
+        )
+    output = make_viewless_tensor(
+        inp=output, requires_grad=output.requires_grad, keep_graph=True
+    )
 
     node.layer_state.residual.record_stream(torch.cuda.current_stream())
     if shared_expert_output is not None:

--- a/megatron/core/models/hybrid/fine_grained_callables.py
+++ b/megatron/core/models/hybrid/fine_grained_callables.py
@@ -233,9 +233,7 @@ def _run_moe_combine(layer, node: ScheduleNode, output: Tensor):
         output = off_interface.group_commit(
             output, name="mlp_norm", forced_released_tensors=[residual]
         )
-    output = make_viewless_tensor(
-        inp=output, requires_grad=output.requires_grad, keep_graph=True
-    )
+    output = make_viewless_tensor(inp=output, requires_grad=output.requires_grad, keep_graph=True)
 
     node.layer_state.residual.record_stream(torch.cuda.current_stream())
     if shared_expert_output is not None:

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -24,7 +24,13 @@ from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.hybrid.hybrid_layer_allocation import (
+    LayerConfigItem,
+    LayerPatternItem,
+    flatten_layer_type_list,
     get_layer_type_list_from_layer_config_list,
+    get_layer_type_physical_count,
+    is_layer_group,
+    layer_type_list_to_str,
     validate_segment_layers,
 )
 from megatron.core.models.hybrid.layers import utils as layer_utils
@@ -69,6 +75,17 @@ class HybridStackSubmodules:
     mtp_block_spec: Optional[ModuleSpec] = None
 
 
+def _is_layer_type_entry(layer_type) -> bool:
+    """Return whether a ``layer_type_list`` entry is a layer symbol or a bracketed group."""
+    if isinstance(layer_type, str):
+        return len(layer_type) == 1
+    return (
+        isinstance(layer_type, tuple)
+        and len(layer_type) > 0
+        and all(isinstance(symbol, str) and len(symbol) == 1 for symbol in layer_type)
+    )
+
+
 class HybridStack(MegatronModule):
     """
     Constructor for the HybridStack class.
@@ -78,15 +95,23 @@ class HybridStack(MegatronModule):
         submodules (HybridStackSubmodules): the submodules for the stack
         pre_process (bool, optional): whether to include an embedding layer.
             Defaults to True.
-        layer_type_list (list[str], optional): This argument exists for backwards-compatibility
-            reasons, allowing callers to construct ``HybridStack`` directly with layer symbols.
+        layer_type_list (list[LayerPatternItem], optional): This argument exists for
+            backwards-compatibility reasons, allowing callers to construct ``HybridStack``
+            directly with layer symbols (bracketed groups as tuples of symbols).
             It is immediately converted to independent per-layer configs.
-        layer_config_list (Sequence[TransformerConfig], optional): per-layer configs for this
-            pipeline segment. When provided by HybridModel, pipeline stage selection has already
-            been done via '|' separators in the pattern. Exactly one of ``layer_type_list`` or
-            ``layer_config_list`` must be provided.
-        pp_layer_offset (int, optional): the global layer offset for this pipeline
+        layer_config_list (Sequence[LayerConfigItem], optional): per-layer configs for this
+            pipeline segment. A tuple of configs denotes a bracketed group (e.g. ``[M*E]``)
+            that is built as one nested ``HybridStack`` logical layer. When provided by
+            HybridModel, pipeline stage selection has already been done via '|' separators
+            in the pattern. Exactly one of ``layer_type_list`` or ``layer_config_list`` must
+            be provided.
+        pp_layer_offset (int, optional): the global physical layer offset for this pipeline
             segment. Defaults to 0.
+        logical_layer_offset (int, optional): the global logical layer offset for this
+            pipeline segment; bracketed groups count as one logical layer. Used for
+            checkpoint keys. Defaults to 0.
+        is_layer_group_stack (bool, optional): whether this stack is the nested stack built
+            for a bracketed group. Defaults to False.
         post_layer_norm (bool, optional): whether to include a final layer norm.
             Defaults to True.
         post_process (bool, optional): whether to include an output layer.
@@ -104,8 +129,10 @@ class HybridStack(MegatronModule):
         config: TransformerConfig,
         submodules: HybridStackSubmodules,
         pre_process: bool = True,
-        layer_type_list: list[str] | None = None,
+        layer_type_list: list[LayerPatternItem] | None = None,
         pp_layer_offset: int = 0,
+        logical_layer_offset: int = 0,
+        is_layer_group_stack: bool = False,
         post_layer_norm: bool = True,
         post_process: bool = True,
         device=None,
@@ -113,7 +140,7 @@ class HybridStack(MegatronModule):
         pg_collection: ProcessGroupCollection = None,
         is_mtp_layer: bool = False,
         name: str | None = None,
-        layer_config_list: Sequence[TransformerConfig] | None = None,
+        layer_config_list: Sequence[LayerConfigItem] | None = None,
         boundary_layout: CPLayout | None = None,
     ) -> None:
         """
@@ -123,12 +150,12 @@ class HybridStack(MegatronModule):
         if (layer_type_list is None) == (layer_config_list is None):
             raise ValueError("Exactly one of layer_type_list or layer_config_list must be provided")
         if layer_type_list is not None:
-            if any(
-                not isinstance(layer_symbol, str) or len(layer_symbol) != 1
-                for layer_symbol in layer_type_list
-            ):
-                raise ValueError("Each entry in layer_type_list must be a single layer symbol")
-            segment = ''.join(layer_type_list)
+            if any(not _is_layer_type_entry(layer_type) for layer_type in layer_type_list):
+                raise ValueError(
+                    "Each entry in layer_type_list must be a single layer symbol or a tuple of "
+                    "single layer symbols (a bracketed group)"
+                )
+            segment = layer_type_list_to_str(layer_type_list)
             warnings.warn(
                 "DEPRECATED(layer_type_list): please use `layer_config_list` instead",
                 DeprecationWarning,
@@ -136,7 +163,7 @@ class HybridStack(MegatronModule):
             )
             layer_config_list = validate_segment_layers(segment, config)
 
-        for layer_config in layer_config_list:
+        for layer_config in flatten_layer_type_list(layer_config_list):
             layer_utils.validate_tp_comm_overlap(
                 layer_config,
                 layer_utils.get_layer_symbol_from_config(layer_config),
@@ -148,6 +175,8 @@ class HybridStack(MegatronModule):
         self.post_layer_norm = post_layer_norm
         self.post_process = post_process
         self.is_mtp_layer = is_mtp_layer
+        self.logical_layer_offset = logical_layer_offset
+        self.is_layer_group_stack = is_layer_group_stack
         boundary_layout = (
             self.config.linear_cp_layout if boundary_layout is None else boundary_layout
         )
@@ -166,19 +195,20 @@ class HybridStack(MegatronModule):
         self._mhc_block_end_plan: Optional[List[bool]] = None
 
         self.layer_config_list = layer_config_list
+        has_layer_groups = any(is_layer_group(layer_config) for layer_config in layer_config_list)
+        if has_layer_groups and self.config.enable_mhc_connections:
+            raise NotImplementedError(
+                "Bracketed HybridStack layer groups are not supported with enable_mhc_connections."
+            )
         self._has_linear_layer_with_chunkwise_cp = self.cp_group.size() > 1 and any(
             type(layer_config) is layer_utils.MambaLayerConfig
             and layer_config.linear_cp_mode == "chunkwise"
-            for layer_config in self.layer_config_list
+            for layer_config in flatten_layer_type_list(self.layer_config_list)
         )
         self._cp_layout_manager = None
         if self.cp_group.size() > 1:
             layer_layouts = tuple(
-                (
-                    layer_config.attention_cp_layout
-                    if type(layer_config) in layer_utils.Symbols.ATTENTION_LAYER_CONFIGS
-                    else layer_config.linear_cp_layout
-                )
+                self._get_layer_cp_layout(layer_config, boundary_layout)
                 for layer_config in self.layer_config_list
             )
             self._cp_layout_manager = ContextParallelLayoutManager(
@@ -194,20 +224,49 @@ class HybridStack(MegatronModule):
 
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
+        # ``i`` is the logical layer index within this stack (module-list index and the
+        # ``name=...layers.{i}`` suffix). ``physical_layer_offset`` is the physical layer
+        # counter used for ``layer_number`` and the FP8/FP4 contexts; it advances by more
+        # than one for bracketed groups, which hold several physical layers.
+        physical_layer_offset = pp_layer_offset
         for i, layer_config in enumerate(self.layer_config_list):
-            layer_number = i + 1 + pp_layer_offset
-            if layer_config.fp8:
+            layer_number = physical_layer_offset + 1
+            if is_layer_group(layer_config):
+                # The nested stack applies its own per-layer quantization contexts.
+                quant_init_context = nullcontext()
+            elif layer_config.fp8:
                 quant_init_context = get_fp8_context(
-                    layer_config, i + pp_layer_offset, is_init=True
+                    layer_config, physical_layer_offset, is_init=True
                 )
             elif layer_config.fp4:
                 quant_init_context = get_fp4_context(
-                    layer_config, i + pp_layer_offset, is_init=True
+                    layer_config, physical_layer_offset, is_init=True
                 )
             else:
                 quant_init_context = nullcontext()
             with quant_init_context:
-                if type(layer_config) is layer_utils.MambaLayerConfig:
+                if is_layer_group(layer_config):
+                    # A bracketed group (e.g. ``[M*E]``) is one logical layer built as a
+                    # nested HybridStack over its physical layers. It restores the outer
+                    # stack's boundary CP layout on exit.
+                    layer = HybridStack(
+                        config=self.config,
+                        submodules=submodules,
+                        pre_process=True,
+                        layer_config_list=list(layer_config),
+                        pp_layer_offset=physical_layer_offset,
+                        logical_layer_offset=logical_layer_offset + len(self.layers),
+                        is_layer_group_stack=True,
+                        post_layer_norm=False,
+                        post_process=False,
+                        device=device,
+                        dtype=dtype,
+                        pg_collection=pg_collection,
+                        is_mtp_layer=is_mtp_layer,
+                        name=(name + f".layers.{i}") if name is not None else None,
+                        boundary_layout=boundary_layout,
+                    )
+                elif type(layer_config) is layer_utils.MambaLayerConfig:
                     layer = build_module(
                         submodules.mamba_layer,
                         config=layer_config,
@@ -294,6 +353,7 @@ class HybridStack(MegatronModule):
             if self.config.enable_mhc_connections:
                 layer = HyperConnectionHybridLayer(config=layer_config, layer=layer)
             self.layers.append(layer)
+            physical_layer_offset += get_layer_type_physical_count(layer_config)
 
         if self.config.cuda_graph_impl == "local":
             annotate_first_last_layer(self.layers)
@@ -331,6 +391,29 @@ class HybridStack(MegatronModule):
         """
         return get_layer_type_list_from_layer_config_list(self.layer_config_list)
 
+    @property
+    def final_layernorm(self):
+        """Alias for ``final_norm`` matching the attribute name on TransformerBlock.
+
+        Lets generic decoder consumers (e.g. ``GPTModel.PostProcessNode``) discover the
+        final norm via the same attribute name they use for non-hybrid decoders, while
+        keeping ``final_norm`` as the registered submodule so existing hybrid checkpoint
+        keys are unchanged.
+        """
+        return getattr(self, "final_norm", None)
+
+    @staticmethod
+    def _get_layer_cp_layout(layer_config: LayerConfigItem, boundary_layout: CPLayout) -> CPLayout:
+        """Return the CP layout the outer stack must provide for one logical layer."""
+        if is_layer_group(layer_config):
+            # A bracketed group runs as a nested HybridStack that manages the layout
+            # transitions of its own layers and restores ``boundary_layout`` on exit, so
+            # the outer stack hands the group its input in the boundary layout.
+            return boundary_layout
+        if type(layer_config) in layer_utils.Symbols.ATTENTION_LAYER_CONFIGS:
+            return layer_config.attention_cp_layout
+        return layer_config.linear_cp_layout
+
     def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
         # Avoid modifying the original object so users don't get surprised about their `submodules`
         # being modified underneath them.
@@ -367,6 +450,11 @@ class HybridStack(MegatronModule):
         if this block contains Mamba or GDN layers (this may not be the case with PP > 1).
         """
         for layer_config, layer in zip(self.layer_config_list, self.layers, strict=True):
+            if is_layer_group(layer_config):
+                state_shapes = layer.mamba_state_shapes_per_request()
+                if state_shapes is not None:
+                    return state_shapes
+                continue
             if type(layer_config) is layer_utils.MambaLayerConfig:
                 return layer.mamba_state_shapes_per_request()
             if type(layer_config) is layer_utils.GDNLayerConfig:
@@ -426,6 +514,10 @@ class HybridStack(MegatronModule):
         attention_mask: Tensor,
         inference_context: Optional[BaseInferenceContext] = None,
         rotary_pos_emb: Optional[Tensor] = None,
+        rotary_pos_cos: Optional[Tensor] = None,
+        rotary_pos_sin: Optional[Tensor] = None,
+        rotary_pos_cos_sin: Optional[Tensor] = None,
+        sequence_len_offset: Optional[Tensor] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
@@ -447,6 +539,11 @@ class HybridStack(MegatronModule):
             inference_context (BaseInferenceContext): the inference parameters.
             rotary_pos_emb (Tensor, optional): the rotary positional embeddings.
                 Defaults to None.
+            rotary_pos_cos / rotary_pos_sin / rotary_pos_cos_sin (Tensor, optional):
+                precomputed rotary embeddings forwarded to transformer layers (flash-decode /
+                fused-rope inference paths). Defaults to None.
+            sequence_len_offset (Tensor, optional): precomputed per-sample sequence offsets
+                for static-batching inference. Computed here when None.
         Returns:
             Tensor: the output tensor.
         """
@@ -496,7 +593,9 @@ class HybridStack(MegatronModule):
             inference_context.max_seqlen = inference_context.max_sequence_length
             inference_context.seqlen_offset = inference_context.sequence_len_offset
 
-        if (
+        if sequence_len_offset is not None:
+            pass
+        elif (
             (self.config.cuda_graph_impl == "local" or self.config.flash_decode)
             and inference_context
             and inference_context.is_static_batching()
@@ -569,10 +668,14 @@ class HybridStack(MegatronModule):
                         hidden_states, layer_packed_seq_params = cp_layout_state.prepare_layer(
                             layer_idx, hidden_states
                         )
-                    # Layers have 1-indexed layer numbers attribute.
-                    inner_quant_context = get_inner_quant_context(
-                        layer_config, layer.layer_number - 1
-                    )
+                    if is_layer_group(layer_config):
+                        # The nested stack applies its own per-layer quantization contexts.
+                        inner_quant_context = nullcontext()
+                    else:
+                        # Layers have 1-indexed layer numbers attribute.
+                        inner_quant_context = get_inner_quant_context(
+                            layer_config, layer.layer_number - 1
+                        )
                     mhc_manager = mhc_layer_managers[layer_idx]
                     if mhc_manager is not None:
                         mhc_manager.is_last_layer_in_recompute_block = mhc_block_ends[layer_idx]
@@ -584,7 +687,25 @@ class HybridStack(MegatronModule):
                     )
 
                     with inner_quant_context:
-                        if isinstance(layer, (TransformerLayer, HyperConnectionHybridLayer)):
+                        if isinstance(layer, HybridStack):
+                            # Bracketed group: the nested stack runs its physical layers
+                            # (with its own CP layout transitions) and returns hidden states
+                            # in this stack's layout.
+                            hidden_states = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                inference_context=inference_context,
+                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_cos=rotary_pos_cos,
+                                rotary_pos_sin=rotary_pos_sin,
+                                rotary_pos_cos_sin=rotary_pos_cos_sin,
+                                sequence_len_offset=sequence_len_offset,
+                                packed_seq_params=layer_packed_seq_params,
+                                padding_mask=padding_mask,
+                                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                                cp_layout_plan=cp_layout_plan,
+                            )
+                        elif isinstance(layer, (TransformerLayer, HyperConnectionHybridLayer)):
                             layer_kwargs = dict(
                                 hidden_states=hidden_states,
                                 attention_mask=attention_mask,
@@ -594,6 +715,14 @@ class HybridStack(MegatronModule):
                                 packed_seq_params=layer_packed_seq_params,
                                 padding_mask=padding_mask,
                             )
+                            # Only forward the precomputed rotary tensors when present so
+                            # layer wrappers without these parameters keep working.
+                            if rotary_pos_cos is not None:
+                                layer_kwargs["rotary_pos_cos"] = rotary_pos_cos
+                            if rotary_pos_sin is not None:
+                                layer_kwargs["rotary_pos_sin"] = rotary_pos_sin
+                            if rotary_pos_cos_sin is not None:
+                                layer_kwargs["rotary_pos_cos_sin"] = rotary_pos_cos_sin
                             if layer_cp_metadata is not None:
                                 layer_kwargs["packed_sequence_cp_metadata"] = layer_cp_metadata
                             if mhc_manager is not None and isinstance(
@@ -680,18 +809,55 @@ class HybridStack(MegatronModule):
             dict: The sharded state dictionary for the current object.
         """
 
+        return self._sharded_state_dict(
+            prefix=prefix,
+            sharded_offsets=sharded_offsets,
+            metadata=metadata,
+            sharded_layer_prefix=None,
+        )
+
+    def _sharded_state_dict(
+        self,
+        prefix: str = '',
+        sharded_offsets: Optional[tuple] = None,
+        metadata: Optional[dict] = None,
+        sharded_layer_prefix: Optional[str] = None,
+    ) -> ShardedStateDict:
+        """Build the sharded state dict using logical (bracketed-group aware) layer keys.
+
+        ``sharded_layer_prefix`` is the ``<prefix>layers.`` prefix of the outermost stack;
+        a nested group stack publishes all of its physical layers under the outer stack's
+        logical layer index so a ``[*-]`` group produces the same keys as one transformer
+        layer (``layers.N.self_attention.*`` and ``layers.N.mlp.*``).
+        """
         sharded_offsets = sharded_offsets or ()
         sharded_state_dict = {}
         layer_prefix = f'{prefix}layers.'
+        if sharded_layer_prefix is None:
+            sharded_layer_prefix = layer_prefix
 
-        for local_layer_idx, layer in enumerate(self.layers):
-
-            global_layer_offset = layer.layer_number - 1  # self.layer_number starts at 1
-            state_dict_prefix = (
-                f'{layer_prefix}{local_layer_idx}.'  # module list index in HybridStack
+        for local_layer_idx, (layer_config, layer) in enumerate(
+            zip(self.layer_config_list, self.layers, strict=True)
+        ):
+            state_dict_prefix = f'{layer_prefix}{local_layer_idx}.'  # module list index
+            logical_layer_idx = (
+                self.logical_layer_offset
+                if self.is_layer_group_stack
+                else self.logical_layer_offset + local_layer_idx
             )
 
-            sharded_prefix = f'{layer_prefix}{global_layer_offset}.'
+            if is_layer_group(layer_config):
+                sharded_state_dict.update(
+                    layer._sharded_state_dict(
+                        state_dict_prefix,
+                        sharded_offsets,
+                        metadata,
+                        sharded_layer_prefix=sharded_layer_prefix,
+                    )
+                )
+                continue
+
+            sharded_prefix = f'{sharded_layer_prefix}{logical_layer_idx}.'
             sharded_pp_offset = []
 
             layer_sharded_state_dict = layer.sharded_state_dict(
@@ -705,15 +871,10 @@ class HybridStack(MegatronModule):
         # Add modules other than self.layers
         for name, module in self.named_children():
             if not module is self.layers:
-                sharded_state_dict.update(
-                    sharded_state_dict_default(
-                        module,
-                        f'{prefix}{name}.',
-                        sharded_offsets,
-                        metadata,
-                        tp_group=self.tp_group,
-                    )
+                module_sharded_state_dict = sharded_state_dict_default(
+                    module, f'{prefix}{name}.', sharded_offsets, metadata, tp_group=self.tp_group
                 )
+                sharded_state_dict.update(module_sharded_state_dict)
 
         local_state_dict: dict = {}
         self._save_to_state_dict(local_state_dict, '', keep_vars=True)

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -397,8 +397,7 @@ class HybridStack(MegatronModule):
 
         Lets generic decoder consumers (e.g. ``GPTModel.PostProcessNode``) discover the
         final norm via the same attribute name they use for non-hybrid decoders, while
-        keeping ``final_norm`` as the registered submodule so existing hybrid checkpoint
-        keys are unchanged.
+        keeping ``final_norm`` as the registered submodule for local state-dict compatibility.
         """
         return getattr(self, "final_norm", None)
 
@@ -881,9 +880,14 @@ class HybridStack(MegatronModule):
         # Add modules other than self.layers
         for name, module in self.named_children():
             if not module is self.layers:
+                module_prefix = f'{prefix}{name}.'
                 module_sharded_state_dict = sharded_state_dict_default(
-                    module, f'{prefix}{name}.', sharded_offsets, metadata, tp_group=self.tp_group
+                    module, module_prefix, sharded_offsets, metadata, tp_group=self.tp_group
                 )
+                if name == 'final_norm':
+                    replace_prefix_for_sharding(
+                        module_sharded_state_dict, module_prefix, f'{prefix}final_layernorm.'
+                    )
                 sharded_state_dict.update(module_sharded_state_dict)
 
         local_state_dict: dict = {}

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -524,6 +524,7 @@ class HybridStack(MegatronModule):
         padding_mask=None,
         packed_seq_params_by_layout: dict[CPLayout, PackedSeqParams | None] | None = None,
         cp_layout_plan: THDCPLayoutPlan | None = None,
+        _checkpointed_forward_in_parent: bool = False,
     ):
         """
         Forward function of the HybridStack class.
@@ -544,6 +545,9 @@ class HybridStack(MegatronModule):
                 fused-rope inference paths). Defaults to None.
             sequence_len_offset (Tensor, optional): precomputed per-sample sequence offsets
                 for static-batching inference. Computed here when None.
+            _checkpointed_forward_in_parent (bool): set by ``checkpointed_forward`` when the
+                enclosing stack already checkpoints this nested group stack, so the group
+                must not checkpoint its layers a second time.
         Returns:
             Tensor: the output tensor.
         """
@@ -644,7 +648,11 @@ class HybridStack(MegatronModule):
         mhc_layer_managers, mhc_block_ends = self._build_mhc_recompute_layer_plan(use_mhc_recompute)
 
         with outer_fp8_context:
-            if self.config.recompute_granularity == 'full' and self.training:
+            if (
+                self.config.recompute_granularity == 'full'
+                and self.training
+                and not _checkpointed_forward_in_parent
+            ):
                 hidden_states = checkpointed_forward(
                     self,
                     hidden_states=hidden_states,
@@ -658,6 +666,8 @@ class HybridStack(MegatronModule):
                     use_inner_quantization_context=(use_inner_fp8_context or use_fp4_context),
                     cp_layout_state=cp_layout_state,
                     packed_sequence_cp_metadata=packed_sequence_cp_metadata,
+                    packed_seq_params_by_layout=packed_seq_params_by_layout,
+                    cp_layout_plan=cp_layout_plan,
                 )
             else:
                 for layer_idx, (layer_config, layer) in enumerate(

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -133,6 +133,7 @@ class HybridStack(MegatronModule):
         pp_layer_offset: int = 0,
         logical_layer_offset: int = 0,
         is_layer_group_stack: bool = False,
+        transformer_sharded_keys: bool = False,
         post_layer_norm: bool = True,
         post_process: bool = True,
         device=None,
@@ -145,6 +146,12 @@ class HybridStack(MegatronModule):
     ) -> None:
         """
         Args:
+            transformer_sharded_keys (bool): emit ``TransformerBlock``-style sharded
+                checkpoint keys (``final_layernorm`` instead of ``final_norm``) so the
+                checkpoint is interchangeable with a ``GPTModel`` one. Only set for
+                bracketed-group patterns, whose logical layers map one-to-one onto
+                transformer layers; leaving it off keeps the historical hybrid keys so
+                existing non-grouped hybrid checkpoints stay loadable.
             name (str | None): module instance name passed top-down from its paranet module
         """
         if (layer_type_list is None) == (layer_config_list is None):
@@ -180,6 +187,7 @@ class HybridStack(MegatronModule):
         boundary_layout = (
             self.config.linear_cp_layout if boundary_layout is None else boundary_layout
         )
+        self.transformer_sharded_keys = transformer_sharded_keys
 
         assert pg_collection is not None, "pg_collection must be provided for HybridStack"
 
@@ -257,6 +265,7 @@ class HybridStack(MegatronModule):
                         pp_layer_offset=physical_layer_offset,
                         logical_layer_offset=logical_layer_offset + len(self.layers),
                         is_layer_group_stack=True,
+                        transformer_sharded_keys=transformer_sharded_keys,
                         post_layer_norm=False,
                         post_process=False,
                         device=device,
@@ -884,7 +893,12 @@ class HybridStack(MegatronModule):
                 module_sharded_state_dict = sharded_state_dict_default(
                     module, module_prefix, sharded_offsets, metadata, tp_group=self.tp_group
                 )
-                if name == 'final_norm':
+                # The registered submodule stays ``final_norm`` (local state-dict keys
+                # are unchanged), but grouped stacks publish the sharded key under
+                # TransformerBlock's ``final_layernorm`` name so their checkpoints
+                # cross-load with GPTModel. Non-grouped stacks keep ``final_norm`` so
+                # hybrid checkpoints written before this feature still load.
+                if name == 'final_norm' and self.transformer_sharded_keys:
                     replace_prefix_for_sharding(
                         module_sharded_state_dict, module_prefix, f'{prefix}final_layernorm.'
                     )

--- a/megatron/core/models/hybrid/hybrid_layer_allocation.py
+++ b/megatron/core/models/hybrid/hybrid_layer_allocation.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 
@@ -13,6 +13,62 @@ from megatron.core.utils import log_on_each_pipeline_stage, log_single_rank
 Symbols = layer_utils.Symbols
 
 logger = logging.getLogger(__name__)
+
+
+# A parsed layer item is either a single layer symbol (e.g. ``'M'``) or a bracketed group of
+# symbols (e.g. ``('M', '*')`` for ``[M*]``) that HybridStack builds as one nested logical layer.
+LayerPatternItem = Union[str, Tuple[str, ...]]
+# The per-layer config projection of ``LayerPatternItem``: one independent config per physical
+# layer, with bracketed groups kept together as a tuple of configs.
+LayerConfigItem = Union[TransformerConfig, Tuple[TransformerConfig, ...]]
+
+
+def is_layer_group(layer_type) -> bool:
+    """Return whether a parsed layer item (symbol or config) is a bracketed group."""
+    return isinstance(layer_type, tuple)
+
+
+def flatten_layer_type_list(layer_type_list: Sequence) -> list:
+    """Flatten bracketed layer groups into their physical layer items (symbols or configs)."""
+    flattened = []
+    for layer_type in layer_type_list:
+        if is_layer_group(layer_type):
+            flattened.extend(layer_type)
+        else:
+            flattened.append(layer_type)
+    return flattened
+
+
+def get_layer_type_physical_count(layer_type) -> int:
+    """Return the number of physical layers represented by a parsed layer item."""
+    return len(layer_type) if is_layer_group(layer_type) else 1
+
+
+def get_layer_type_logical_count(layer_type) -> int:
+    """Return the number of logical layers represented by a parsed layer item."""
+    return 1
+
+
+def get_layer_type_list_physical_count(layer_type_list: Sequence) -> int:
+    """Return the number of physical layers represented by a parsed layer list."""
+    return sum(get_layer_type_physical_count(layer_type) for layer_type in layer_type_list)
+
+
+def get_layer_type_list_logical_count(layer_type_list: Sequence) -> int:
+    """Return the number of logical layers represented by a parsed layer list."""
+    return sum(get_layer_type_logical_count(layer_type) for layer_type in layer_type_list)
+
+
+def layer_type_item_to_str(layer_type: LayerPatternItem) -> str:
+    """Render one parsed layer item back to pattern syntax."""
+    if is_layer_group(layer_type):
+        return f"{Symbols.GROUP_START}{''.join(layer_type)}{Symbols.GROUP_END}"
+    return layer_type
+
+
+def layer_type_list_to_str(layer_type_list: Sequence[LayerPatternItem]) -> str:
+    """Render a parsed layer list back to pattern syntax."""
+    return ''.join(layer_type_item_to_str(layer_type) for layer_type in layer_type_list)
 
 
 @dataclass
@@ -106,7 +162,8 @@ def get_hybrid_total_layer_count(pattern: str) -> int:
     """Returns the total number of main decoder layers in a hybrid layer pattern.
 
     Extracts the main pattern (before the first MTP separator '/'), strips
-    pipeline stage separators '|', and returns the character count.
+    pipeline stage separators '|', and returns the physical layer count
+    (bracketed groups contribute one layer per symbol inside the brackets).
 
     Args:
         pattern: Full hybrid layer pattern, possibly including MTP and pipe separators.
@@ -116,7 +173,10 @@ def get_hybrid_total_layer_count(pattern: str) -> int:
     """
     main_pattern = pattern.split(Symbols.MTP_SEPARATOR)[0]
     _validate_pattern(main_pattern, allow_pipe=True)
-    return len(main_pattern.replace(Symbols.PIPE, ''))
+    return sum(
+        get_layer_type_list_physical_count(parse_segment_layers(segment))
+        for segment in main_pattern.split(Symbols.PIPE)
+    )
 
 
 def get_hybrid_total_pipeline_segment_count(pattern: str) -> int:
@@ -139,8 +199,9 @@ def get_hybrid_layer_counts(pattern: str) -> Dict[str, int]:
     """Count layers by type across the full hybrid pattern (main + MTP).
 
     Parses the pattern to extract main and MTP components, then counts
-    each layer type. Main pattern '|' separators are skipped. MTP layers
-    are counted once per MTP depth.
+    each layer type. Main pattern '|' separators are skipped and bracketed
+    groups are flattened to their physical layers. MTP layers are counted
+    once per MTP depth.
 
     Args:
         pattern: Full hybrid layer pattern string.
@@ -161,15 +222,14 @@ def get_hybrid_layer_counts(pattern: str) -> Dict[str, int]:
 
     # Count main decoder layers (skip '|' pipe separators)
     if parsed.main_pattern:
-        for char in parsed.main_pattern:
-            if char in counts:
+        for segment in parsed.main_pattern.split(Symbols.PIPE):
+            for char in flatten_layer_type_list(parse_segment_layers(segment)):
                 counts[char] += 1
 
     # Count MTP layers (pattern repeated mtp_num_depths times)
     if parsed.mtp_pattern and parsed.mtp_num_depths > 0:
-        for char in parsed.mtp_pattern:
-            if char in counts:
-                counts[char] += parsed.mtp_num_depths
+        for char in flatten_layer_type_list(parse_segment_layers(parsed.mtp_pattern)):
+            counts[char] += parsed.mtp_num_depths
 
     return counts
 
@@ -244,6 +304,16 @@ def parse_hybrid_pattern(pattern: Optional[str]) -> ParsedHybridPattern:
 
     _validate_pattern(mtp_pattern)
 
+    # MTP layers are themselves a fused unit (each MTP depth contains its own attention
+    # + MLP), so it does not make sense to wrap them in a HybridStack group. Reject
+    # bracketed groups inside MTP patterns to keep downstream construction simple.
+    if Symbols.GROUP_START in mtp_pattern or Symbols.GROUP_END in mtp_pattern:
+        raise ValueError(
+            f"In MTP pattern, layer groups '{Symbols.GROUP_START}...{Symbols.GROUP_END}' "
+            f"are not supported because each MTP depth is already a fused unit. "
+            f"Got MTP pattern: '{mtp_pattern}'."
+        )
+
     return ParsedHybridPattern(
         main_pattern=main_pattern if main_pattern else None,
         mtp_pattern=mtp_pattern,
@@ -251,54 +321,226 @@ def parse_hybrid_pattern(pattern: Optional[str]) -> ParsedHybridPattern:
     )
 
 
+def _invalid_symbol_message(char: str) -> str:
+    return (
+        f"'{char}' is not a valid layer symbol. "
+        f"Valid symbols are: {Symbols.LAYER_CONFIG_MAP.keys()}"
+    )
+
+
 def _validate_pattern(pattern: str, allow_pipe: bool = False) -> None:
-    """Validate that a pattern contains only valid layer symbols.
+    """Validate that a pattern contains only valid layer symbols and well-formed groups.
 
     Args:
         pattern: Layer pattern string to validate
         allow_pipe: Whether to allow the pipe '|' separator (for main patterns)
 
     Raises:
-        ValueError: If pattern contains invalid symbols
+        ValueError: If pattern contains invalid symbols or malformed bracketed groups
     """
-    for char in pattern:
-        if not layer_utils.is_valid_symbol(char, allow_pipe=allow_pipe):
-            raise ValueError(
-                f"'{char}' is not a valid layer symbol. "
-                f"Valid symbols are: {Symbols.LAYER_CONFIG_MAP.keys()}"
-            )
+    if not allow_pipe and Symbols.PIPE in pattern:
+        raise ValueError(_invalid_symbol_message(Symbols.PIPE))
+
+    flat_layers = []
+    for segment in pattern.split(Symbols.PIPE):
+        flat_layers.extend(flatten_layer_type_list(parse_segment_layers(segment)))
 
     # Disallow Attention + MLA/DSA hybridity.
-    if Symbols.ATTENTION in pattern and (Symbols.DS_ATTENTION in pattern or Symbols.MLA in pattern):
+    if Symbols.ATTENTION in flat_layers and (
+        Symbols.DS_ATTENTION in flat_layers or Symbols.MLA in flat_layers
+    ):
         raise ValueError("Not supported to have both Attention and MLA/DSA in one model")
 
 
-def validate_segment_layers(segment: str, config: TransformerConfig) -> List[TransformerConfig]:
+def parse_segment_layers(segment: str) -> List[LayerPatternItem]:
+    """Parse a pipe-free pattern segment into layer symbols and bracketed groups.
+
+    Bracketed groups such as ``[M*E]`` become tuples of symbols (``('M', '*', 'E')``); every
+    other valid symbol is returned as-is. Groups cannot be empty or nested, and an MoE
+    layer inside a group must be its last symbol so that EP-overlap scheduling can
+    split the group into pre-dispatch compute and the terminal MoE layer.
+
+    Args:
+        segment: A single pipeline segment pattern string (e.g., "M[M*]-").
+
+    Returns:
+        List of layer symbols and symbol tuples in pattern order.
+
+    Raises:
+        ValueError: If the segment contains invalid symbols or malformed groups.
+    """
+    layer_type_list: List[LayerPatternItem] = []
+    flat_layers = []
+    i = 0
+    while i < len(segment):
+        layer_char = segment[i]
+        if layer_char == Symbols.GROUP_START:
+            group_end = segment.find(Symbols.GROUP_END, i + 1)
+            if group_end == -1:
+                raise ValueError(
+                    f"'{Symbols.GROUP_START}' starts a layer group without a matching "
+                    f"'{Symbols.GROUP_END}'."
+                )
+            group = segment[i + 1 : group_end]
+            if group == "":
+                raise ValueError("Layer groups cannot be empty.")
+            if Symbols.GROUP_START in group or Symbols.GROUP_END in group:
+                raise ValueError("Nested layer groups are not supported.")
+            for group_char in group:
+                if not layer_utils.is_valid_symbol(group_char):
+                    raise ValueError(_invalid_symbol_message(group_char))
+            if Symbols.MOE in group[:-1]:
+                raise ValueError(
+                    f"MoE layer '{Symbols.MOE}' must be the last symbol inside a layer group."
+                )
+            group_tuple = tuple(group)
+            layer_type_list.append(group_tuple)
+            flat_layers.extend(group_tuple)
+            i = group_end + 1
+            continue
+        if layer_char == Symbols.GROUP_END:
+            raise ValueError(f"'{Symbols.GROUP_END}' closes a layer group that was not opened.")
+        if not layer_utils.is_valid_symbol(layer_char):
+            raise ValueError(_invalid_symbol_message(layer_char))
+        layer_type_list.append(layer_char)
+        flat_layers.append(layer_char)
+        i += 1
+
+    # Disallow Attention + MLA/DSA hybridity.
+    if Symbols.ATTENTION in flat_layers and (
+        Symbols.DS_ATTENTION in flat_layers or Symbols.MLA in flat_layers
+    ):
+        raise ValueError("Not supported to have both Attention and MLA/DSA in one model")
+
+    return layer_type_list
+
+
+def validate_segment_layers(segment: str, config: TransformerConfig) -> List[LayerConfigItem]:
     """Validate and convert a single pipeline segment pattern to layer configs.
 
     This is used after the main pattern has been split by '|' into segments.
-    Each segment should contain only valid layer symbols (no '|').
+    Each segment should contain only valid layer symbols (no '|'), optionally
+    grouped with brackets (e.g. ``M[M*]-``).
 
     Each layer config is copied from the source config without running ``__post_init__``
-    a second time.
+    a second time. Bracketed groups are returned as a tuple of per-layer configs so that
+    ``HybridStack`` can build them as one nested logical layer.
 
     Args:
-        segment: A single pipeline segment pattern string (e.g., "M-M*-")
+        segment: A single pipeline segment pattern string (e.g., "M-M*-" or "M[M*]-")
         config: Normalized stack-level config to copy for each layer.
 
     Returns:
-        List of independent per-layer configs.
+        List of independent per-layer configs, with groups kept as tuples of configs.
 
     Raises:
-        ValueError: If segment contains invalid layer symbols.
+        ValueError: If segment contains invalid layer symbols or malformed groups.
     """
-    _validate_pattern(segment)
+    layer_config_list: List[LayerConfigItem] = []
+    for layer_type in parse_segment_layers(segment):
+        if is_layer_group(layer_type):
+            layer_config_list.append(
+                tuple(layer_utils.create_layer_config(config, symbol) for symbol in layer_type)
+            )
+        else:
+            layer_config_list.append(layer_utils.create_layer_config(config, layer_type))
 
-    layer_configs: list[TransformerConfig] = []
-    for layer_symbol in segment:
-        layer_configs.append(layer_utils.create_layer_config(config, layer_symbol))
+    return layer_config_list
 
-    return layer_configs
+
+def _slice_layer_type_list_by_physical_range(
+    layer_type_list: List[LayerPatternItem], offset: int, count: int
+) -> List[LayerPatternItem]:
+    """Slice parsed layer items by physical layer range without splitting groups."""
+    selected = []
+    cursor = 0
+    end = offset + count
+    for layer_type in layer_type_list:
+        item_count = get_layer_type_physical_count(layer_type)
+        item_end = cursor + item_count
+        if item_end <= offset:
+            cursor = item_end
+            continue
+        if cursor >= end:
+            break
+        if cursor < offset or item_end > end:
+            raise ValueError(
+                "Pipeline splitting would split a bracketed hybrid layer group. "
+                "Add pipe ('|') separators around bracketed groups to define valid boundaries."
+            )
+        selected.append(layer_type)
+        cursor = item_end
+    return selected
+
+
+def _get_logical_offset_from_physical_offset(
+    layer_type_list: List[LayerPatternItem], offset: int
+) -> int:
+    """Return the logical item count before a physical-layer offset."""
+    logical_offset = 0
+    cursor = 0
+    for layer_type in layer_type_list:
+        item_count = get_layer_type_physical_count(layer_type)
+        item_end = cursor + item_count
+        if item_end <= offset:
+            logical_offset += get_layer_type_logical_count(layer_type)
+            cursor = item_end
+            continue
+        if cursor == offset:
+            return logical_offset
+        raise ValueError(
+            "Pipeline splitting would split a bracketed hybrid layer group. "
+            "Add pipe ('|') separators around bracketed groups to define valid boundaries."
+        )
+    if cursor == offset:
+        return logical_offset
+    raise ValueError(f"Physical layer offset {offset} is out of range for hybrid layer pattern.")
+
+
+def select_pipeline_segment_with_logical_offset(
+    main_pattern: str,
+    config: TransformerConfig,
+    pp_group: Optional[torch.distributed.ProcessGroup],
+    vp_stage: Optional[int],
+    first_stage_layers: Optional[int] = None,
+    last_stage_layers: Optional[int] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> Tuple[List[LayerConfigItem], int, int]:
+    """Select a pipeline segment and return physical and logical offsets.
+
+    The physical offset counts every layer symbol before this segment; the logical
+    offset counts pattern items, so a bracketed group before this segment adds one.
+    See :func:`select_pipeline_segment` for the argument semantics.
+    """
+    layer_config_list, layer_offset = select_pipeline_segment(
+        main_pattern,
+        config,
+        pp_group,
+        vp_stage,
+        first_stage_layers=first_stage_layers,
+        last_stage_layers=last_stage_layers,
+        tp_group=tp_group,
+        dp_cp_group=dp_cp_group,
+    )
+
+    segments = main_pattern.split(Symbols.PIPE) if main_pattern else ['']
+    if len(segments) == 1:
+        full_layer_type_list = parse_segment_layers(segments[0])
+        logical_layer_offset = _get_logical_offset_from_physical_offset(
+            full_layer_type_list, layer_offset
+        )
+    else:
+        pp_rank = torch.distributed.get_rank(pp_group) if pp_group is not None else 0
+        pp_size = torch.distributed.get_world_size(pp_group) if pp_group is not None else 1
+        vp_rel = vp_stage if vp_stage is not None else 0
+        segment_index = vp_rel * pp_size + pp_rank
+        logical_layer_offset = sum(
+            get_layer_type_list_logical_count(parse_segment_layers(segments[i]))
+            for i in range(segment_index)
+        )
+
+    return layer_config_list, layer_offset, logical_layer_offset
 
 
 def select_pipeline_segment(
@@ -310,7 +552,7 @@ def select_pipeline_segment(
     last_stage_layers: Optional[int] = None,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
-) -> Tuple[List[TransformerConfig], int]:
+) -> Tuple[List[LayerConfigItem], int]:
     """Select and validate the pipeline segment for the given PP rank and VP stage.
 
     When the main pattern contains '|' pipe separators, splits by '|' into
@@ -318,7 +560,8 @@ def select_pipeline_segment(
 
     When the pattern has no pipes but pp_size > 1, falls back to runtime layer
     slicing (for backwards compatibility), supporting both even and uneven PP splits
-    via first_stage_layers / last_stage_layers.
+    via first_stage_layers / last_stage_layers. Layer counts are physical layer
+    counts, and a split may not fall inside a bracketed group.
 
     Args:
         main_pattern: Main decoder pattern (may contain '|' separators).
@@ -335,8 +578,9 @@ def select_pipeline_segment(
 
     Returns:
         Tuple of (layer_config_list, layer_offset) where layer_config_list is
-        the list of independent configs for this segment, and layer_offset
-        is the sum of layer counts from all preceding segments.
+        the list of independent configs for this segment (bracketed groups as
+        tuples of configs), and layer_offset is the sum of physical layer counts
+        from all preceding segments.
 
     Raises:
         ValueError: If the segment contains invalid layer symbols, if
@@ -374,8 +618,8 @@ def select_pipeline_segment(
             "Example: 'M*M*M*M*' with pp_size=2 should become 'M*M*|M*M*'.",
         )
         full_pattern = segments[0]
-        _validate_pattern(full_pattern)
-        num_layers = len(full_pattern)
+        layer_type_list = parse_segment_layers(full_pattern)
+        num_layers = get_layer_type_list_physical_count(layer_type_list)
 
         if first_stage_layers is not None or last_stage_layers is not None:
             first = first_stage_layers or 0
@@ -418,14 +662,17 @@ def select_pipeline_segment(
             offset = pp_rank * layers_per_rank
             count = layers_per_rank
 
-        selected_pattern = full_pattern[offset : offset + count]
+        selected_pattern = layer_type_list_to_str(
+            _slice_layer_type_list_by_physical_range(layer_type_list, offset, count)
+        )
         layer_utils.validate_tp_comm_overlap(config, selected_pattern)
         selected = validate_segment_layers(selected_pattern, config)
         log_on_each_pipeline_stage(
             logger,
             logging.INFO,
             f"HybridModel: pp_rank={pp_rank}/{pp_size}, vp_stage={vp_stage}, "
-            f"layers='{selected_pattern}' ({len(selected)} layers), "
+            f"layers='{selected_pattern}' "
+            f"({get_layer_type_list_physical_count(selected)} layers), "
             f"layer_offset={offset} (auto-split)",
             tp_group=tp_group,
             dp_cp_group=dp_cp_group,
@@ -451,7 +698,10 @@ def select_pipeline_segment(
             f"the current PP/VPP configuration."
         )
 
-    layer_offset = sum(len(segments[i]) for i in range(segment_index))
+    layer_offset = sum(
+        get_layer_type_list_physical_count(parse_segment_layers(segments[i]))
+        for i in range(segment_index)
+    )
     my_segment = segments[segment_index]
 
     layer_utils.validate_tp_comm_overlap(config, my_segment)
@@ -462,7 +712,8 @@ def select_pipeline_segment(
         logging.INFO,
         f"HybridModel: pp_rank={pp_rank}/{pp_size}, vp_stage={vp_rel}, "
         f"segment_index={segment_index}/{len(segments)}, "
-        f"layers='{my_segment}' ({len(layer_config_list)} layers), "
+        f"layers='{my_segment}' "
+        f"({get_layer_type_list_physical_count(layer_config_list)} layers), "
         f"layer_offset={layer_offset}",
         tp_group=tp_group,
         dp_cp_group=dp_cp_group,
@@ -471,14 +722,17 @@ def select_pipeline_segment(
     return layer_config_list, layer_offset
 
 
-def get_layer_maps_from_layer_type_list(layer_type_list: list[str]) -> dict[str, dict[int, int]]:
+def get_layer_maps_from_layer_type_list(
+    layer_type_list: list[LayerPatternItem],
+) -> dict[str, dict[int, int]]:
     """
     Returns maps from global layer index to the corresponding layer index
     for each valid layer type (the keys of Symbols.LAYER_CONFIG_MAP) given a layer type list.
+    Bracketed groups are flattened to their physical layers first.
     """
     layer_types = [symbol for symbol in Symbols.name_sorted_valid_layer_symbols()]
     layer_maps = {layer_type: {} for layer_type in layer_types}
-    for global_layer_idx, layer_type in enumerate(layer_type_list):
+    for global_layer_idx, layer_type in enumerate(flatten_layer_type_list(layer_type_list)):
         layer_map = layer_maps[layer_type]
         local_layer_idx = len(layer_map)
         layer_map[global_layer_idx] = local_layer_idx
@@ -486,19 +740,26 @@ def get_layer_maps_from_layer_type_list(layer_type_list: list[str]) -> dict[str,
 
 
 def get_layer_type_list_from_layer_config_list(
-    layer_config_list: Sequence[TransformerConfig],
-) -> list[str]:
+    layer_config_list: Sequence[LayerConfigItem],
+) -> list[LayerPatternItem]:
     """Return the layer symbols corresponding to a sequence of layer configs.
 
     This compatibility projection keeps ``layer_config_list`` as the source of truth while
-    supporting callers that still read ``HybridStack.layer_type_list``.
+    supporting callers that still read ``HybridStack.layer_type_list``. Bracketed groups
+    (tuples of configs) map to tuples of symbols.
 
     Args:
         layer_config_list: Per-layer configs in layer order.
 
     Returns:
-        The canonical layer symbol for each config.
+        The canonical layer symbol (or symbol tuple) for each config item.
     """
-    return [
-        layer_utils.get_layer_symbol_from_config(layer_config) for layer_config in layer_config_list
-    ]
+    layer_type_list: list[LayerPatternItem] = []
+    for layer_config in layer_config_list:
+        if is_layer_group(layer_config):
+            layer_type_list.append(
+                tuple(layer_utils.get_layer_symbol_from_config(config) for config in layer_config)
+            )
+        else:
+            layer_type_list.append(layer_utils.get_layer_symbol_from_config(layer_config))
+    return layer_type_list

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -785,11 +785,14 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         padding_mask: Optional[Tensor] = None,
         *,
         mtp_input_mask: Optional[Tensor] = None,
+        output_processor: Optional[Callable[..., Any]] = None,
+        output_processor_context: Optional[Any] = None,
     ):
         """Build the HybridModel combined-1F1B schedule plan.
 
-        Mirrors ``GPTModel.build_schedule_plan``; ``mtp_input_mask`` is stored on the chunk
-        state so the schedule plan's MTP layer nodes and ``PostProcessNode`` apply it.
+        Mirrors ``GPTModel.build_schedule_plan``; ``mtp_input_mask``, ``output_processor``
+        and ``output_processor_context`` are stored on the chunk state so the schedule
+        plan's MTP layer nodes and ``PostProcessNode`` apply them.
         """
         if self.config.fine_grained_activation_offloading:
             self.preprocess_for_fine_grained_offloading()
@@ -811,6 +814,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             loss_mask,
             padding_mask,
             mtp_input_mask=mtp_input_mask,
+            output_processor=output_processor,
+            output_processor_context=output_processor_context,
         )
 
     def sharded_state_dict(

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -549,6 +549,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         extra_block_kwargs=None,
         inference_context=None,
         is_spec_decode=None,
+        output_processor=None,
+        output_processor_context=None,
         compute_mtp_loss=True,
         cp_batch=None,
         mhc_multistream=None,

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -200,6 +200,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
         # Parse unified pattern to extract main and MTP components.
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
+            Symbols,
             parse_hybrid_pattern,
             select_pipeline_segment_with_logical_offset,
         )
@@ -229,6 +230,13 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         # Validate TP communication overlap after determining whether this rank builds MTP,
         # before constructing the decoder or MTP modules.
         layer_utils.validate_tp_comm_overlap(self.config, '', has_mtp=self.mtp_process)
+
+        # Bracketed-group patterns give every logical layer the structure of a
+        # transformer layer, so their checkpoints are made key-compatible with
+        # GPTModel. Derived from the full pattern rather than this rank's segment so
+        # every PP stage agrees on the naming. Non-grouped patterns keep the
+        # historical hybrid keys, which existing hybrid checkpoints were saved with.
+        transformer_sharded_keys = Symbols.GROUP_START in (parsed.main_pattern or '')
 
         logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
 
@@ -299,6 +307,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             layer_config_list=layer_config_list,
             pp_layer_offset=layer_offset,
             logical_layer_offset=logical_layer_offset,
+            transformer_sharded_keys=transformer_sharded_keys,
             post_process=self.post_process,
             dtype=config.params_dtype,
             pg_collection=self.pg_collection,
@@ -565,6 +574,10 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         MTP forward runs here. ``compute_mtp_loss`` disables the MTP auxiliary
         objective (see ``forward``); ``cp_batch`` / ``mhc_multistream`` feed the MTP
         block's CP-layout preparation on the eager path.
+        ``output_processor`` replaces the default logits / loss computation with a
+        caller-supplied hook (used by RL and other custom output paths); it is
+        forwarded by ``PostProcessNode`` and handled here exactly as in
+        ``GPTModel._postprocess``.
         """
         in_inference_mode = InferenceMode.is_active()
         if in_inference_mode:
@@ -690,6 +703,27 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 )
 
         sequence_parallel_override = False
+
+        if output_processor is not None:
+            return output_processor(
+                hidden_states=hidden_states,
+                output_layer=self.output_layer,
+                output_weight=output_weight,
+                labels=labels,
+                loss_mask=loss_mask,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                decoder_input=decoder_input,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+                runtime_gather_output=runtime_gather_output,
+                context=output_processor_context,
+                compute_language_model_loss=self.compute_language_model_loss,
+                scale_logits=self._scale_logits,
+                config=self.config,
+            )
+
         if (
             in_inference_mode
             and inference_context is not None

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -759,6 +759,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         """
         if self.config.fine_grained_activation_offloading:
             self.preprocess_for_fine_grained_offloading()
+        if self.config.moe_paged_stash:
+            self.preprocess_for_paged_stash()
 
         from .model_chunk_schedule_plan import HybridStackModelChunkSchedulePlan
 

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -2,7 +2,7 @@
 
 import logging
 from contextlib import nullcontext
-from typing import Literal, Optional
+from typing import Any, Callable, Dict, Literal, Optional
 
 import torch
 from torch import Tensor
@@ -10,6 +10,7 @@ from torch import Tensor
 from megatron.core import tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
 from megatron.core.context_parallel import ContextParallelBatch
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.common.embeddings.language_model_embedding import LanguageModelEmbedding
@@ -200,7 +201,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         # Parse unified pattern to extract main and MTP components.
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
             parse_hybrid_pattern,
-            select_pipeline_segment,
+            select_pipeline_segment_with_logical_offset,
         )
 
         parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
@@ -231,14 +232,18 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
         logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
 
-        layer_config_list, layer_offset = select_pipeline_segment(
-            parsed.main_pattern or '',
-            self.config,
-            self.pg_collection.pp,
-            vp_stage,
-            first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
-            last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
-            **logging_pg_kwargs,
+        # Bracketed groups (e.g. ``[M*E]``) count as one logical layer for checkpoint
+        # keys but several physical layers for layer numbering, so track both offsets.
+        layer_config_list, layer_offset, logical_layer_offset = (
+            select_pipeline_segment_with_logical_offset(
+                parsed.main_pattern or '',
+                self.config,
+                self.pg_collection.pp,
+                vp_stage,
+                first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
+                last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
+                **logging_pg_kwargs,
+            )
         )
 
         # megatron core pipelining currently depends on model type
@@ -293,6 +298,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             pre_process=self.pre_process,
             layer_config_list=layer_config_list,
             pp_layer_offset=layer_offset,
+            logical_layer_offset=logical_layer_offset,
             post_process=self.post_process,
             dtype=config.params_dtype,
             pg_collection=self.pg_collection,
@@ -429,6 +435,362 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
             self.cudagraph_manager = CudaGraphManager(config)
 
+    def _preprocess(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        decoder_input: Tensor = None,
+        inference_context: BaseInferenceContext = None,
+        packed_seq_params: PackedSeqParams = None,
+        padding_mask: Optional[Tensor] = None,
+    ):
+        """Preprocess inputs for HybridStack or combined-1F1B scheduling.
+
+        Mirrors ``GPTModel._preprocess`` so the eager forward and the
+        EP-overlap ``PreProcessNode`` see the same embedding / rotary /
+        padding-mask code. Returns the canonical 6-tuple ``(decoder_input,
+        rotary_pos_emb, rotary_pos_cos, rotary_pos_sin, sequence_len_offset,
+        padding_mask)`` -- slots HybridModel does not compute (rotary cos/sin)
+        come back as ``None``.
+        """
+        in_inference_mode = InferenceMode.is_active()
+
+        # If decoder_input is provided, input_ids and position_ids are ignored;
+        # otherwise apply the embedding layer to get decoder_input.
+        if decoder_input is not None:
+            pass
+        elif self.pre_process:
+            # Decoder embedding.
+            decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
+
+            # Clear the outputs for padding tokens when using dynamic batching
+            # with quantization scales to avoid corrupting amax calculations.
+            if (
+                in_inference_mode
+                and inference_context is not None
+                and inference_context.is_dynamic_batching()
+                and is_using_quantization_scales(self.config)
+            ):
+                decoder_input[inference_context.padding_slice] = 0.0
+
+            if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
+                # The embedding skips SP scatter for models whose outer wrapper scatters instead
+                # (e.g. VLM LMs); scatter here so a standalone LM forward isn't double-gathered.
+                decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
+                    decoder_input, group=self.pg_collection.tp
+                )
+        else:
+            # Intermediate stage of pipeline parallelism -- the decoder will get
+            # hidden_states from encoder.input_tensor.
+            decoder_input = None
+
+        rotary_pos_emb = None
+        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
+            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+            )
+            rotary_pos_emb = self.rotary_pos_emb(
+                rotary_seq_len,
+                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
+            )
+        elif self.position_embedding_type == 'yarn':
+            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+            )
+            # YarnRotaryEmbedding.forward returns (emb, mscale); discard mscale here.
+            rotary_pos_emb, _ = self.rotary_pos_emb(
+                rotary_seq_len,
+                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
+            )
+
+        # ``sequence_len_offset`` is only needed for flash-decode / local-cudagraph
+        # static-batching inference; otherwise leave it as ``None``.
+        if (
+            in_inference_mode
+            and inference_context is not None
+            and (self.config.cuda_graph_impl == "local" or self.config.flash_decode)
+            and inference_context.is_static_batching()
+        ):
+            current_batch_size = input_ids.shape[0]
+            sequence_len_offset = torch.tensor(
+                [inference_context.sequence_len_offset] * current_batch_size,
+                dtype=torch.int32,
+                device='cuda',
+            )
+        else:
+            sequence_len_offset = None
+
+        # Wrap decoder_input so the decoder (HybridStack) can drop its caller's
+        # reference for early garbage collection during inference.
+        if in_inference_mode:
+            decoder_input = WrappedTensor(decoder_input)
+
+        return decoder_input, rotary_pos_emb, None, None, sequence_len_offset, padding_mask
+
+    def _postprocess(
+        self,
+        hidden_states,
+        input_ids,
+        position_ids,
+        labels,
+        rotary_pos_emb,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        mtp_in_postprocess=None,
+        loss_mask=None,
+        mtp_input_mask=None,
+        decoder_input=None,
+        attention_mask=None,
+        padding_mask=None,
+        inference_params=None,
+        packed_seq_params=None,
+        sequence_len_offset=None,
+        runtime_gather_output=None,
+        extra_block_kwargs=None,
+        inference_context=None,
+        is_spec_decode=None,
+        compute_mtp_loss=True,
+        cp_batch=None,
+        mhc_multistream=None,
+    ):
+        """Postprocess HybridStack hidden states into logits or language-model loss.
+
+        Mirrors ``GPTModel._postprocess`` so the eager forward and the EP-overlap
+        ``PostProcessNode`` produce the same logits / loss / MTP outputs.
+        ``mtp_in_postprocess`` lets the EP-overlap path skip the inline MTP block
+        (it schedules MTP as separate layer nodes and hands over the concatenated
+        main / MTP hidden states); the eager forward leaves it ``True`` so the regular
+        MTP forward runs here. ``compute_mtp_loss`` disables the MTP auxiliary
+        objective (see ``forward``); ``cp_batch`` / ``mhc_multistream`` feed the MTP
+        block's CP-layout preparation on the eager path.
+        """
+        in_inference_mode = InferenceMode.is_active()
+        if in_inference_mode:
+            assert runtime_gather_output, "Inference must always gather TP logits"
+
+        output_weight = None
+        if self.share_embeddings_and_output_weights:
+            output_weight = self.shared_embedding_or_output_weight()
+
+        # Speculative decoding: when active, MTP must run *after* verification so
+        # it conditions on verified tokens rather than stale speculative ones.
+        if is_spec_decode is None:
+            is_spec_decode = (
+                in_inference_mode
+                and inference_context is not None
+                and inference_context.is_dynamic_batching()
+                and inference_context.num_speculative_tokens > 0
+            )
+
+        # Whether the MTP auxiliary objective is computed in this call.
+        # ``self.mtp_process`` guards against models built without an MTP block.
+        mtp_loss_active = (
+            self.mtp_process and not (in_inference_mode or is_spec_decode) and compute_mtp_loss
+        )
+        # MTP forward inline (skipped when the EP-overlap plan schedules MTP separately).
+        mtp_forward_ran = bool(mtp_in_postprocess) and mtp_loss_active
+        mtp_hidden_states = hidden_states
+        mtp_inputs = None
+        if mtp_forward_ran:
+            packed_seq_params_by_layout = (
+                cp_batch.packed_seq_params_by_layout if cp_batch is not None else None
+            )
+            cp_layout_plan = cp_batch.thd_plan if cp_batch is not None else None
+            mtp_inputs = self.mtp.prepare_cp_layout(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                mhc_multistream=mhc_multistream,
+                labels=labels,
+                loss_mask=loss_mask,
+                mtp_input_mask=mtp_input_mask,
+                packed_seq_params=packed_seq_params,
+                cp_batch=cp_batch,
+            )
+            assert mtp_inputs.input_ids is not None and mtp_inputs.position_ids is not None
+            mtp_hidden_states = self.mtp(
+                input_ids=mtp_inputs.input_ids,
+                position_ids=mtp_inputs.position_ids,
+                hidden_states=mtp_inputs.hidden_states,
+                mhc_multistream=mtp_inputs.mhc_multistream,
+                attention_mask=attention_mask,
+                inference_params=inference_params,
+                rotary_pos_emb=rotary_pos_emb,
+                packed_seq_params=mtp_inputs.packed_seq_params,
+                embedding=self.embedding,
+                mtp_input_mask=mtp_inputs.mtp_input_mask,
+                packed_seq_params_by_layout=packed_seq_params_by_layout,
+                cp_layout_plan=cp_layout_plan,
+            )
+
+        if not self.post_process:
+            return mtp_hidden_states if mtp_forward_ran else hidden_states
+
+        if self.config.mtp_num_layers is not None and self.mtp_process:
+            assert self.config.mtp_num_layers > 0
+            if is_spec_decode:
+                # Cache decoder hidden states for serial MTP computation after
+                # speculative token verification.
+                assert inference_context is not None
+                if self.config.inference_cuda_graph_scope == InferenceCudaGraphScope.block:
+                    # Block-scope CUDA graph mode: copy_() into the pre-allocated buffer so
+                    # every graph replay writes to the same fixed GPU address regardless of
+                    # batch size.
+                    assert inference_context.mtp_decoder_hidden_states is not None
+                    inference_context.mtp_decoder_hidden_states[: hidden_states.shape[0]].copy_(
+                        hidden_states
+                    )
+                else:
+                    # Non-block scope: direct assignment; the controller will set
+                    # this back to None after reading to allow GC.
+                    inference_context.mtp_decoder_hidden_states = hidden_states
+            elif mtp_loss_active:
+                # In training/eval, fold the MTP loss into hidden_states. When the MTP block
+                # ran inline above, use its CP-layout-prepared inputs; on the EP-overlap path
+                # the MTP layer nodes already produced the concatenated hidden states and the
+                # raw inputs apply (mirrors ``GPTModel._postprocess``).
+                # For RL (labels is None), process_mtp_loss derives labels from
+                # input_ids to match the SFT label format.
+                if mtp_inputs is not None:
+                    mtp_loss_inputs = dict(
+                        hidden_states=mtp_hidden_states,
+                        labels=mtp_inputs.labels,
+                        loss_mask=mtp_inputs.loss_mask,
+                        packed_seq_params=mtp_inputs.packed_seq_params,
+                        input_ids=mtp_inputs.input_ids,
+                        mtp_input_mask=mtp_inputs.mtp_input_mask,
+                        main_hidden_states=hidden_states,
+                    )
+                else:
+                    mtp_loss_inputs = dict(
+                        hidden_states=hidden_states,
+                        labels=labels,
+                        loss_mask=loss_mask,
+                        packed_seq_params=packed_seq_params,
+                        input_ids=input_ids,
+                        mtp_input_mask=mtp_input_mask,
+                    )
+                hidden_states = process_mtp_loss(
+                    output_layer=self.output_layer,
+                    output_weight=output_weight,
+                    runtime_gather_output=runtime_gather_output,
+                    is_training=self.training,
+                    compute_language_model_loss=self.compute_language_model_loss,
+                    config=self.config,
+                    cp_group=self.pg_collection.cp,
+                    tp_group=self.tp_group,
+                    scale_logits_fn=self._scale_logits if self.config.use_mup else None,
+                    metric_avg_group=(
+                        getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
+                        or self.pg_collection.dp_cp
+                    ),
+                    **mtp_loss_inputs,
+                )
+
+        sequence_parallel_override = False
+        if (
+            in_inference_mode
+            and inference_context is not None
+            and inference_context.config.materialize_only_last_token_logits
+        ):
+            if inference_context.is_static_batching():
+                hidden_states = hidden_states[-1:, :, :]
+            else:
+                if self.output_layer.sequence_parallel:
+                    # Perform the sequence-parallel gather here instead of after
+                    # the output layer so we can slice the last-token logits from
+                    # the full view of the packed logits across all requests.
+                    hidden_states = gather_from_sequence_parallel_region(
+                        hidden_states, group=self.pg_collection.tp
+                    )
+                    self.output_layer.sequence_parallel = False
+                    sequence_parallel_override = True
+
+                # Reshape [S, B, H] (with B=1) to [1, S, H] for logit extraction,
+                # then back to [S', B, H] for the output layer.
+                reshaped = hidden_states.squeeze(1).unsqueeze(0)
+                hidden_states = inference_context.last_token_logits(reshaped).unsqueeze(1)
+
+        logits, _ = self.output_layer(
+            hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output
+        )
+        logits = self._scale_logits(logits)
+
+        # Restore sequence parallel execution to the output layer if necessary.
+        if sequence_parallel_override:
+            assert (
+                in_inference_mode
+                and inference_context.is_dynamic_batching()
+                and inference_context.config.materialize_only_last_token_logits
+            )
+            self.output_layer.sequence_parallel = True
+
+        if labels is None:
+            # [s b h] => [b s h]
+            return logits.transpose(0, 1).contiguous()
+
+        loss = self.compute_language_model_loss(labels, logits)
+
+        return loss
+
+    def build_schedule_plan(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        attention_mask: Tensor,
+        decoder_input: Tensor = None,
+        labels: Tensor = None,
+        inference_context: BaseInferenceContext = None,
+        packed_seq_params: PackedSeqParams = None,
+        extra_block_kwargs: dict = None,
+        runtime_gather_output: Optional[bool] = None,
+        inference_params: Optional[BaseInferenceContext] = None,
+        loss_mask: Optional[Tensor] = None,
+        padding_mask: Optional[Tensor] = None,
+        *,
+        mtp_input_mask: Optional[Tensor] = None,
+    ):
+        """Build the HybridModel combined-1F1B schedule plan.
+
+        Mirrors ``GPTModel.build_schedule_plan``; ``mtp_input_mask`` is stored on the chunk
+        state so the schedule plan's MTP layer nodes and ``PostProcessNode`` apply it.
+        """
+        if self.config.fine_grained_activation_offloading:
+            self.preprocess_for_fine_grained_offloading()
+
+        from .model_chunk_schedule_plan import HybridStackModelChunkSchedulePlan
+
+        return HybridStackModelChunkSchedulePlan(
+            self,
+            input_ids,
+            position_ids,
+            attention_mask,
+            decoder_input,
+            labels,
+            packed_seq_params,
+            extra_block_kwargs,
+            runtime_gather_output,
+            loss_mask,
+            padding_mask,
+            mtp_input_mask=mtp_input_mask,
+        )
+
+    def sharded_state_dict(
+        self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[Dict] = None
+    ) -> ShardedStateDict:
+        """Return a Transformer-compatible sharded state dict for HybridModel."""
+        sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        output_layer_extra_state_key = f'{prefix}output_layer._extra_state'
+
+        # Match GPTModel checkpoint compatibility: old GPT checkpoints do not include
+        # output layer extra state, and the TE extra state should be empty.
+        output_extra_state = sharded_state_dict.pop(output_layer_extra_state_key, None)
+        assert not (
+            output_extra_state and output_extra_state.data
+        ), f'Expected output layer extra state to be empty, got: {output_extra_state}'
+
+        return sharded_state_dict
+
     def forward(
         self,
         input_ids: Tensor,
@@ -461,9 +823,6 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 Defaults to True.
             cp_batch: Input tensors and packed metadata keyed by CP layout.
         """
-        # If decoder_input is provided (not None), then input_ids and position_ids are ignored.
-        # Otherwise, apply embedding layer on input_ids and position_ids to get decoder_input.
-
         if self.config.fine_grained_activation_offloading:
             self.preprocess_for_fine_grained_offloading()
 
@@ -473,61 +832,28 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         in_inference_mode = InferenceMode.is_active()
-
         if in_inference_mode:
             assert runtime_gather_output, "Inference must always gather TP logits"
 
-        # Decoder embedding.
-        if decoder_input is not None:
-            pass
-        elif self.pre_process:
-            decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
-
-            # Clear the outputs for padding tokens when using dynamic batching with
-            # quantization scales to avoid corrupting amax calculations
-            if (
-                in_inference_mode
-                and inference_context is not None
-                and inference_context.is_dynamic_batching()
-                and is_using_quantization_scales(self.config)
-            ):
-                decoder_input[inference_context.padding_slice] = 0.0
-
-            if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
-                # The embedding skips SP scatter for models whose outer wrapper scatters instead
-                # (e.g. VLM LMs); scatter here so a standalone LM forward isn't double-gathered.
-                decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
-                    decoder_input, group=self.pg_collection.tp
-                )
-        else:
-            # intermediate stage of pipeline
-            # decoder will get hidden_states from encoder.input_tensor
-            decoder_input = None
-
-        rotary_pos_emb = None
-        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            rotary_pos_emb = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
-        elif self.position_embedding_type == 'yarn':
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            # YarnRotaryEmbedding.forward returns (emb, mscale); discard mscale here
-            rotary_pos_emb, _ = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
-
-        # Wrap decoder_input to allow the decoder (HybridStack) to delete the
-        # reference held by this caller function, enabling early garbage collection
-        # for inference.
-        if in_inference_mode:
-            decoder_input = WrappedTensor(decoder_input)
+        # Mirror GPTModel.forward: delegate the embedding / rotary computation and
+        # the output-layer / MTP / loss computation to the same hooks the
+        # EP-overlap PreProcessNode / PostProcessNode call. Keeps the eager and
+        # combined-1F1B paths on the same code.
+        (
+            decoder_input,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            sequence_len_offset,
+            padding_mask,
+        ) = self._preprocess(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            decoder_input=decoder_input,
+            inference_context=inference_context,
+            packed_seq_params=packed_seq_params,
+            padding_mask=padding_mask,
+        )
 
         # The following assert will currently fail when running inference.
         # Commented out for now.
@@ -567,140 +893,26 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             hidden_states = decoder_output
             mhc_multistream = None
 
-        output_weight = None
-        if self.share_embeddings_and_output_weights:
-            output_weight = self.shared_embedding_or_output_weight()
-
-        # Check if speculative decoding is active. When it is, MTP must be
-        # computed *after* verification so that it is conditioned on verified
-        # tokens rather than stale speculative tokens from the previous step.
-        is_spec_decode = (
-            in_inference_mode
-            and inference_context is not None
-            and inference_context.is_dynamic_batching()
-            and inference_context.num_speculative_tokens > 0
+        return self._postprocess(
+            hidden_states=hidden_states,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            labels=labels,
+            rotary_pos_emb=rotary_pos_emb,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+            mtp_in_postprocess=True,
+            loss_mask=loss_mask,
+            mtp_input_mask=mtp_input_mask,
+            decoder_input=decoder_input,
+            attention_mask=attention_mask,
+            padding_mask=padding_mask,
+            inference_params=inference_params,
+            packed_seq_params=packed_seq_params,
+            sequence_len_offset=sequence_len_offset,
+            runtime_gather_output=runtime_gather_output,
+            inference_context=inference_context,
+            compute_mtp_loss=compute_mtp_loss,
+            cp_batch=cp_batch,
+            mhc_multistream=mhc_multistream,
         )
-
-        mtp_forward_ran = (
-            self.mtp_process and not (in_inference_mode or is_spec_decode) and compute_mtp_loss
-        )
-        mtp_hidden_states = hidden_states
-        mtp_inputs = None
-        if mtp_forward_ran:
-            mtp_inputs = self.mtp.prepare_cp_layout(
-                input_ids=input_ids,
-                position_ids=position_ids,
-                hidden_states=hidden_states,
-                mhc_multistream=mhc_multistream,
-                labels=labels,
-                loss_mask=loss_mask,
-                mtp_input_mask=mtp_input_mask,
-                packed_seq_params=packed_seq_params,
-                cp_batch=cp_batch,
-            )
-            assert mtp_inputs.input_ids is not None and mtp_inputs.position_ids is not None
-            mtp_hidden_states = self.mtp(
-                input_ids=mtp_inputs.input_ids,
-                position_ids=mtp_inputs.position_ids,
-                hidden_states=mtp_inputs.hidden_states,
-                mhc_multistream=mtp_inputs.mhc_multistream,
-                attention_mask=attention_mask,
-                inference_params=inference_params,
-                rotary_pos_emb=rotary_pos_emb,
-                packed_seq_params=mtp_inputs.packed_seq_params,
-                embedding=self.embedding,
-                mtp_input_mask=mtp_inputs.mtp_input_mask,
-                packed_seq_params_by_layout=packed_seq_params_by_layout,
-                cp_layout_plan=cp_layout_plan,
-            )
-
-        if not self.post_process:
-            return mtp_hidden_states if mtp_forward_ran else hidden_states
-
-        if self.config.mtp_num_layers is not None and self.mtp_process:
-            assert self.config.mtp_num_layers > 0
-            if is_spec_decode:
-                assert inference_context is not None
-                if self.config.inference_cuda_graph_scope == InferenceCudaGraphScope.block:
-                    # Block-scope CUDA graph mode: copy_() into the
-                    # pre-allocated buffer so every graph replay writes to
-                    # the same fixed GPU address regardless of batch size.
-                    assert inference_context.mtp_decoder_hidden_states is not None
-                    inference_context.mtp_decoder_hidden_states[: hidden_states.shape[0]].copy_(
-                        hidden_states
-                    )
-                else:
-                    # Non-block scope: direct assignment; the controller will set
-                    # this back to None after reading to allow GC.
-                    inference_context.mtp_decoder_hidden_states = hidden_states
-            elif mtp_forward_ran:
-                assert mtp_inputs is not None
-                # For RL (labels is None), process_mtp_loss derives labels from
-                # input_ids to match the SFT label format.
-                hidden_states = process_mtp_loss(
-                    hidden_states=mtp_hidden_states,
-                    labels=mtp_inputs.labels,
-                    loss_mask=mtp_inputs.loss_mask,
-                    output_layer=self.output_layer,
-                    output_weight=output_weight,
-                    runtime_gather_output=runtime_gather_output,
-                    is_training=self.training,
-                    compute_language_model_loss=self.compute_language_model_loss,
-                    config=self.config,
-                    cp_group=self.pg_collection.cp,
-                    tp_group=self.tp_group,
-                    packed_seq_params=mtp_inputs.packed_seq_params,
-                    scale_logits_fn=self._scale_logits if self.config.use_mup else None,
-                    input_ids=mtp_inputs.input_ids,
-                    mtp_input_mask=mtp_inputs.mtp_input_mask,
-                    metric_avg_group=(
-                        getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
-                        or self.pg_collection.dp_cp
-                    ),
-                    main_hidden_states=hidden_states,
-                )
-        sequence_parallel_override = False
-        if (
-            in_inference_mode
-            and inference_context is not None
-            and inference_context.config.materialize_only_last_token_logits
-        ):
-            if inference_context.is_static_batching():
-                hidden_states = hidden_states[-1:, :, :]
-            else:
-                if self.output_layer.sequence_parallel:
-                    # Perform the sequence parallel gather here instead of after the output layer
-                    # because we need to slice the last token logits from the full view of the
-                    # packed logits across all requests.
-                    hidden_states = gather_from_sequence_parallel_region(
-                        hidden_states, group=self.pg_collection.tp
-                    )
-                    self.output_layer.sequence_parallel = False
-                    sequence_parallel_override = True
-
-                # Reshape [S, B, H] (with B=1) to [1, S, H] for logit extraction,
-                # then back to [S', B, H] for the output layer.
-                reshaped = hidden_states.squeeze(1).unsqueeze(0)
-                hidden_states = inference_context.last_token_logits(reshaped).unsqueeze(1)
-
-        logits, _ = self.output_layer(
-            hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output
-        )
-        logits = self._scale_logits(logits)
-
-        # Restore sequence parallel execution to the output layer if necessary.
-        if sequence_parallel_override:
-            assert (
-                in_inference_mode
-                and inference_context.is_dynamic_batching()
-                and inference_context.config.materialize_only_last_token_logits
-            )
-            self.output_layer.sequence_parallel = True
-
-        if labels is None:
-            # [s b h] => [b s h]
-            return logits.transpose(0, 1).contiguous()
-
-        loss = self.compute_language_model_loss(labels, logits)
-
-        return loss

--- a/megatron/core/models/hybrid/layers/utils.py
+++ b/megatron/core/models/hybrid/layers/utils.py
@@ -22,6 +22,9 @@ class Symbols:
     MOE = 'E'
     PIPE = '|'
     MTP_SEPARATOR = "/"
+    # Bracketed groups (e.g. ``[M*E]``) build one nested HybridStack logical layer.
+    GROUP_START = "["
+    GROUP_END = "]"
     LAYER_CONFIG_MAP = {
         MAMBA: MambaLayerConfig,
         GDN: GDNLayerConfig,

--- a/megatron/core/models/hybrid/model_chunk_schedule_plan.py
+++ b/megatron/core/models/hybrid/model_chunk_schedule_plan.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Schedule-plan classes for HybridStack-based decoders.
+
+These extend the GPT-side ``TransformerLayerSchedulePlan`` /
+``TransformerModelChunkSchedulePlan`` with the per-layer ``layer_type`` symbol
+that HybridStack assigns to each entry of its ``layer_type_list`` (including
+bracketed groups like ``[*-]``). The base classes remain GPT-only; this module
+adds the hybrid-specific dispatch into ``build_hybrid_stack_callables`` and
+uses ``HybridStackNode`` so the schedule node's free-input policy can diverge
+from the GPT default. The pre/post-process nodes from
+``core.models.common.utils`` are reused as-is — they already call
+``model._preprocess`` / ``model._postprocess`` which work on a HybridModel.
+"""
+
+from contextlib import nullcontext
+
+from megatron.core.models.common.model_chunk_schedule_plan import (
+    TransformerLayerSchedulePlan,
+    TransformerModelChunkSchedulePlan,
+)
+
+
+class HybridStackSchedulePlan(TransformerLayerSchedulePlan):
+    """Per-layer schedule plan for HybridStack decoders.
+
+    Adds the ``layer_type`` extra-arg propagation; routes through
+    ``build_hybrid_stack_callables`` when ``layer_type`` is set (i.e. the layer
+    is a HybridStack entry, possibly a bracketed group); falls back to the GPT
+    path for plain TransformerLayer / MTP layers when ``layer_type`` is None.
+    """
+
+    def __init__(self, layer, event, chunk_state, comp_stream, comm_stream, extra_args=None):
+        if extra_args is None:
+            extra_args = {}
+        self.layer_type = extra_args.get("layer_type", None)
+        super().__init__(layer, event, chunk_state, comp_stream, comm_stream, extra_args)
+
+    def _build_callable_nodes(self, event, comp_stream, comm_stream, extra_args):
+        if self.layer_type is None:
+            return super()._build_callable_nodes(event, comp_stream, comm_stream, extra_args)
+
+        # Hybrid grouped path. Imports are local because hybrid pulls in TE / SSM
+        # extensions that we don't want to load when only the GPT path is used.
+        from megatron.core.models.hybrid.fine_grained_callables import (
+            HybridStackNode,
+            build_hybrid_stack_callables,
+        )
+        from megatron.core.pipeline_parallel.utils import NoopScheduleNode
+
+        fwd_callables, bwd_dw_callable_map, is_moe, num_local_experts = (
+            build_hybrid_stack_callables(self.layer, layer_type=self.layer_type)
+        )
+
+        extra_args["config"] = self.layer.config
+        extra_args["is_moe"] = is_moe
+        extra_args["num_local_experts"] = num_local_experts
+        extra_args["delay_wgrad_compute"] = self.layer.config.delay_wgrad_compute
+        extra_args["is_mtp"] = False
+
+        def create_node(stream, module, name):
+            bwd_dw_callables = bwd_dw_callable_map.get(name, None)
+            node_extra_args = dict(extra_args)
+            if bwd_dw_callables is None:
+                node_extra_args["delay_wgrad_compute"] = False
+            return HybridStackNode(
+                stream,
+                event,
+                self.layer_state,
+                self.chunk_state,
+                module,
+                name=name,
+                bwd_dw_callables=bwd_dw_callables,
+                extra_args=node_extra_args,
+            )
+
+        (
+            pre_dispatch_module,
+            moe_dispatch_module,
+            mlp_module,
+            moe_combine_module,
+            mtp_post_process_module,
+        ) = fwd_callables
+
+        self.pre_dispatch_computation = create_node(
+            comp_stream, pre_dispatch_module, "pre_dispatch_computation"
+        )
+        self.mlp = create_node(comp_stream, mlp_module, "mlp")
+        if is_moe:
+            self.moe_dispatch = create_node(comm_stream, moe_dispatch_module, "moe_dispatch")
+            self.moe_combine = create_node(comm_stream, moe_combine_module, "moe_combine")
+        else:
+            self.moe_dispatch = NoopScheduleNode()
+            self.moe_combine = NoopScheduleNode()
+
+        # HybridStack groups never carry an MTP terminal, so mtp_post_process is
+        # always a no-op here.
+        self.mtp_post_process = NoopScheduleNode()
+
+    def get_fp8_context(self):
+        """Return an FP8 context only for plain transformer layers."""
+        # Grouped hybrid layers (and inferred-layer-type entries that point at
+        # a HybridStack rather than a plain TransformerLayer) don't have a
+        # ``layer_number`` we can hand to ``get_fp8_context``; the inner layers
+        # manage their own per-layer fp8 context inside the hybrid callables.
+        if self.layer_type is not None or not hasattr(self.layer, "layer_number"):
+            return nullcontext()
+        return super().get_fp8_context()
+
+
+class HybridStackModelChunkSchedulePlan(TransformerModelChunkSchedulePlan):
+    """Model-chunk schedule plan that builds ``HybridStackSchedulePlan`` layer plans.
+
+    Threads HybridStack's ``layer_type_list[layer_idx]`` symbol into each
+    layer plan's ``extra_args`` so the per-layer plan can dispatch grouped
+    layers correctly. Ordinary GPT/MTP layers (no ``layer_type_list``)
+    default to ``layer_type=None`` and follow the GPT path. The pre/post
+    process nodes inherit from the GPT base class — they already dispatch
+    on ``model._preprocess`` / ``model._postprocess`` which a HybridModel
+    implements.
+    """
+
+    LAYER_SCHEDULE_PLAN_CLASS = HybridStackSchedulePlan
+
+    def __init__(self, model, *args, **kwargs):
+        """Initialize the hybrid chunk plan after validating cuda graph support."""
+        assert model.config.cuda_graph_impl == "none", (
+            "EP A2A overlap with grouped HybridStack patterns (e.g. '[*E]') does not "
+            "support cuda graphs yet. Set cuda_graph_impl='none' or use an ungrouped pattern."
+        )
+        # The schedule plan calls the layer callables directly and bypasses
+        # ``HybridStack.forward``, which is where per-layer context-parallel layout
+        # conversion happens; mixed linear/attention CP layouts are therefore unsupported.
+        cp_layout_manager = getattr(model.decoder, "_cp_layout_manager", None)
+        assert cp_layout_manager is None or not cp_layout_manager.requires_conversion, (
+            "EP A2A overlap with HybridStack does not support mixed context-parallel layouts "
+            "(linear_cp_layout != attention_cp_layout with context_parallel_size > 1)."
+        )
+        super().__init__(model, *args, **kwargs)
+
+    def _extra_args_for_layer(self, module, layer_idx, num_layers):
+        extra_args = super()._extra_args_for_layer(module, layer_idx, num_layers)
+        extra_args["layer_type"] = (
+            module.layer_type_list[layer_idx] if hasattr(module, "layer_type_list") else None
+        )
+        return extra_args

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -414,9 +414,14 @@ class P2PCommunicator:
                 req.wait()
             reqs = None
 
-        if config.batch_p2p_comm and config.batch_p2p_sync:
+        if (
+            config.batch_p2p_comm
+            and config.batch_p2p_sync
+            and not torch.cuda.is_current_stream_capturing()
+        ):
             # To protect against race condition when using batch_isend_irecv().
-            # User should assert that we have a modern enough PyTorch to not need this
+            # User should assert that we have a modern enough PyTorch to not need this.
+            # Skipped under CUDA graph capture (illegal during stream capture + unnecessary).
             torch.cuda.synchronize()
 
         return tensor_recv_prev, tensor_recv_next, reqs

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -35,6 +35,8 @@ def checkpointed_forward(
     layer_offset: int = 0,
     cp_layout_state: Optional[ContextParallelLayoutState] = None,
     packed_sequence_cp_metadata: object | None = None,
+    packed_seq_params_by_layout: Optional[dict] = None,
+    cp_layout_plan: object | None = None,
 ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
     """Forward method with activation checkpointing.
 
@@ -47,6 +49,11 @@ def checkpointed_forward(
             global indices when checking extract_layer_indices.
         cp_layout_state (ContextParallelLayoutState, optional): CP layout state for this forward.
         packed_sequence_cp_metadata (optional): Packed-sequence CP metadata for Mamba layers.
+        packed_seq_params_by_layout (dict, optional): Prebuilt packed metadata per CP layout,
+            forwarded to nested HybridStack group layers so they can build their own layout
+            state while being checkpointed by the enclosing stack.
+        cp_layout_plan (optional): Prebuilt packed contiguous/zigzag route, forwarded to nested
+            HybridStack group layers together with ``packed_seq_params_by_layout``.
 
     Returns:
         If extract_layer_indices is empty: hidden_states tensor
@@ -86,9 +93,10 @@ def checkpointed_forward(
                     hidden_states, layer_packed_seq_params = cp_layout_state.prepare_layer(
                         index, hidden_states
                     )
+                is_hybrid_group = getattr(layer, "is_layer_group_stack", False)
 
                 # Get appropriate inner quantization context
-                if use_inner_quantization_context:
+                if use_inner_quantization_context and not is_hybrid_group:
                     if self.config.fp8:
                         inner_quantization_context = get_fp8_context(
                             self.config, layer.layer_number - 1
@@ -120,6 +128,19 @@ def checkpointed_forward(
                 with inner_quantization_context:
                     if isinstance(layer, TransformerLayer):
                         hidden_states, context = layer(**layer_kwargs)
+                    elif is_hybrid_group:
+                        # Nested HybridStack group: run its physical layers inside this
+                        # checkpoint segment (it must not checkpoint them again) and let it
+                        # build its own CP layout state from the prebuilt per-layout metadata.
+                        for k in ("context", "context_mask", "attention_bias"):
+                            layer_kwargs.pop(k, None)
+                        if packed_seq_params_by_layout is not None or cp_layout_plan is not None:
+                            layer_kwargs["packed_seq_params_by_layout"] = (
+                                packed_seq_params_by_layout
+                            )
+                            layer_kwargs["cp_layout_plan"] = cp_layout_plan
+                        hidden_states = layer(**layer_kwargs, _checkpointed_forward_in_parent=True)
+                        context = None
                     else:  # MambaLayer (HybridStack `M` slot)
                         for k in ("context", "context_mask", "attention_bias", "padding_mask"):
                             layer_kwargs.pop(k, None)

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -192,6 +192,17 @@ class MambaLayer(GraphableMegatronModule):
 
             return hidden_states
 
+    def backward_dw(self):
+        """Compute weight gradients for the layer's linear projections.
+
+        Delegates to the mixer; lets the hybrid EP-overlap schedule plan
+        register a Mamba pre-layer's wgrad alongside attention/GDN pre-layers
+        so the schedule node iterates a uniform set of callables. No-op when
+        the linears in the spec do not support delayed wgrad.
+        """
+        if hasattr(self.mixer, "backward_dw"):
+            self.mixer.backward_dw()
+
     def sharded_state_dict(
         self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
     ) -> ShardedStateDict:

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -1289,6 +1289,21 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
         """
         return self.chunk_size
 
+    def backward_dw(self):
+        """Compute weight gradients for the linear layers wrapped by this mixer.
+
+        Mirrors ``GatedDeltaNet.backward_dw``. The selective-scan kernel is a
+        single autograd function whose wgrad runs in the regular backward pass,
+        so only the input/output projections need delayed wgrad here. Each
+        ``backward_dw`` call is a no-op unless the underlying linear is built
+        from a TE primitive that supports delayed wgrad; if the spec uses
+        non-TE linears, ``backward_dw`` simply does nothing.
+        """
+        if hasattr(self.in_proj, "backward_dw"):
+            self.in_proj.backward_dw()
+        if hasattr(self.out_proj, "backward_dw"):
+            self.out_proj.backward_dw()
+
     def _get_states_from_cache(self, inference_context, batch_size, *, inference_params=None):
         """Initializes or retrieves the SSM state tensors from the cache.
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2203,6 +2203,24 @@ def _layer_is_graphable(layer, config):
     return False
 
 
+def _graphable_leaves(module):
+    """Yield graphable leaf layers, descending into grouped HybridStack modules.
+
+    A HybridStack is a MegatronModule rather than a GraphableMegatronModule, so iterating
+    decoder.layers directly yields the stack instead of the inner Mamba/attention/MoE layers.
+    """
+    try:
+        from megatron.core.models.hybrid.hybrid_block import HybridStack
+    except ImportError:
+        # Hybrid models are optional; with no HybridStack there is nothing to descend into.
+        HybridStack = ()
+    if isinstance(module, HybridStack):
+        for inner in module.layers:
+            yield from _graphable_leaves(inner)
+    else:
+        yield module
+
+
 class TECudaGraphHelper:
     """
     Helper class to capture CUDA Graphs using TE make_graphed_callables().

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -1005,7 +1005,23 @@ class PagedStashRunner:
 
         # Local import avoids circular import: schedules -> paged_stash -> multi_token_prediction
         # -> megatron.core (still loading).
+        from megatron.core.transformer.cuda_graphs import _graphable_leaves
         from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+
+        def _moe_mlps_in(layer):
+            # Descend into grouped HybridStack layers: for bracketed hybrid patterns,
+            # decoder.layers[] holds the group whose own .mlp is None, so the flat lookup
+            # finds zero MoE layers and the paged stash silently skips the whole model.
+            if isinstance(layer, MultiTokenPredictionLayer):
+                layer = layer.mtp_model_layer
+            for leaf in _graphable_leaves(layer):
+                mlp = getattr(leaf, 'mlp', None)
+                if (
+                    mlp is not None
+                    and hasattr(mlp, 'token_dispatcher')
+                    and hasattr(mlp.token_dispatcher, 'check_over_budget')
+                ):
+                    yield mlp
 
         for model_chunk in self.model:
             model_with_decoder = get_attr_wrapped_model(
@@ -1023,16 +1039,7 @@ class PagedStashRunner:
                 _track_cfg(getattr(module, 'config', None))
 
             for layer in model_with_decoder.decoder.layers:
-                transformer_layer = (
-                    layer.mtp_model_layer if isinstance(layer, MultiTokenPredictionLayer) else layer
-                )
-                mlp = getattr(transformer_layer, "mlp", None)
-                if (
-                    mlp is not None
-                    and hasattr(mlp, 'token_dispatcher')
-                    and hasattr(mlp.token_dispatcher, 'check_over_budget')
-                ):
-                    self.moe_layers.append(mlp)
+                self.moe_layers.extend(_moe_mlps_in(layer))
             if model_with_decoder.mtp_process:
                 for layer in model_with_decoder.mtp.layers:
                     transformer_layer = (

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -587,16 +587,21 @@ class TopKRouter(Router):
         ):
             aux_loss = aux_loss / self.config.mtp_num_layers
 
-        # TODO (zijiey): fix the per_layer_logging for MTP, currently it will incorrectly
-        # add the aux loss logging value to other layer's since it is difficult to get the
-        # correct layer_number for MTP. It does not affect the correctness of the calculation
-        # results and the reduced load_balancing_loss logging value.
+        # The tracker has one slot per main decoder layer and one per MTP depth, so its
+        # size is (num_layers + mtp_num_layers). For MTP routers, the slot index must be
+        # in [num_layers + 1, num_layers + mtp_num_layers]. When the MTP block wraps a
+        # plain TransformerLayer, ``self.layer_number`` already equals the MTP depth
+        # (1..mtp_num_layers). When it wraps a HybridStack (e.g. ``*E`` for one depth),
+        # ``self.layer_number`` is the position within the inner HybridStack and can
+        # exceed mtp_num_layers, which would index past the tracker; collapse it to a
+        # valid MTP-depth slot via modulo so the aux loss lands at the right depth.
         num_layers = self.config.num_layers
         if self.config.mtp_num_layers is not None:
             num_layers += self.config.mtp_num_layers
 
         if self.is_mtp_layer:
-            layer_number = self.layer_number + self.config.num_layers
+            mtp_depth = ((self.layer_number - 1) % self.config.mtp_num_layers) + 1
+            layer_number = mtp_depth + self.config.num_layers
         else:
             layer_number = self.layer_number
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -704,7 +704,8 @@ class TopKRouter(Router):
                 num_layers += self.config.mtp_num_layers
 
             if self.is_mtp_layer:
-                layer_number = self.layer_number + self.config.num_layers
+                mtp_depth = ((self.layer_number - 1) % self.config.mtp_num_layers) + 1
+                layer_number = mtp_depth + self.config.num_layers
             else:
                 layer_number = self.layer_number
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2554,6 +2554,13 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             DP = torch_FSDP
         elif args.use_megatron_fsdp:
             DP = FullyShardedDataParallel
+            if args.overlap_moe_expert_parallel_comm and is_hybrid_model(args):
+                # Grouped HybridStack patterns (e.g. ``[M*E]``) make each bracket group the
+                # FSDP unit for the EP-overlap schedule plan; the adapter's unit filter
+                # excludes the outer decoder stack so only the groups become units.
+                from megatron.core.models.hybrid.hybrid_block import HybridStack
+
+                DP = functools.partial(FullyShardedDataParallel, fsdp_unit_modules=[HybridStack])
         else:
             DP = DDP
 

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -327,12 +327,13 @@ def loss_func(
     return loss, num_tokens, report
 
 
-def forward_step(data_iterator, model: HybridModel):
+def forward_step(data_iterator, model: HybridModel, return_schedule_plan: bool = False):
     """Forward training step.
 
     Args:
         data_iterator : Input data iterator
         model (HybridModel): The Hybrid Model
+        return_schedule_plan (bool): Whether to return the schedule plan instead of output tensor.
     """
     timers = get_timers()
 
@@ -357,16 +358,31 @@ def forward_step(data_iterator, model: HybridModel):
     timers('batch-generator').stop()
 
     with stimer:
-        output_tensor = model(
-            tokens,
-            position_ids,
-            attention_mask,
-            labels=labels,
-            packed_seq_params=packed_seq_params,
-            loss_mask=loss_mask,
-            padding_mask=padding_mask,
-            cp_batch=cp_batch,
-        )
+        if return_schedule_plan:
+            args = get_args()
+            assert (
+                args.overlap_moe_expert_parallel_comm
+            ), "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"
+            output_tensor = model.build_schedule_plan(
+                tokens,
+                position_ids,
+                attention_mask,
+                labels=labels,
+                packed_seq_params=packed_seq_params,
+                loss_mask=loss_mask,
+                padding_mask=padding_mask,
+            )
+        else:
+            output_tensor = model(
+                tokens,
+                position_ids,
+                attention_mask,
+                labels=labels,
+                packed_seq_params=packed_seq_params,
+                loss_mask=loss_mask,
+                padding_mask=padding_mask,
+                cp_batch=cp_batch,
+            )
 
     # [ModelOpt]: model is needed to access ModelOpt distillation losses
     return output_tensor, partial(loss_func, loss_mask, model=model)

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -335,6 +335,7 @@ def forward_step(data_iterator, model: HybridModel, return_schedule_plan: bool =
         model (HybridModel): The Hybrid Model
         return_schedule_plan (bool): Whether to return the schedule plan instead of output tensor.
     """
+    args = get_args()
     timers = get_timers()
 
     # Get the batch.
@@ -359,7 +360,6 @@ def forward_step(data_iterator, model: HybridModel, return_schedule_plan: bool =
 
     with stimer:
         if return_schedule_plan:
-            args = get_args()
             assert (
                 args.overlap_moe_expert_parallel_comm
             ), "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"

--- a/tests/unit_tests/a2a_overlap/test_fsdp_hybrid_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_hybrid_overlap.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""FSDP + EP overlap + Hybrid model integration test.
+
+End-to-end check that a HybridModel with a bracketed layer pattern (each
+bracket builds an inner ``HybridStack`` that becomes the FSDP unit) trains
+identically through two paths:
+
+- reference: standard FSDP forward/backward, no EP overlap
+- test: ``combined_1f1b_schedule_for_no_pipelining`` with
+  ``overlap_moe_expert_parallel_comm=True``
+
+Both paths use ``fsdp_unit_modules=[HybridStack]`` so meta-device
+materialization traversal is identical and the seed lands on the same
+parameter each draw -- a precondition for bit-exact comparison. The outer
+HybridStack root (``is_layer_group_stack=False``) is filtered out of the
+FSDP unit set by ``MegatronFSDP._is_fsdp_unit_module`` so each bracket
+group's inner HybridStack is its own unit; this test also asserts that
+property directly.
+"""
+
+import gc
+
+import pytest
+import torch
+
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+from megatron.core.distributed.fsdp.src.megatron_fsdp.fully_shard import fully_shard_optimizer
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.pipeline_parallel.utils import set_streams
+from megatron.core.ssm.mamba_mixer import HAVE_MAMBA_SSM
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.moe.moe_utils import MoEAuxLossAutoScaler
+
+try:
+    import causal_conv1d  # noqa: F401
+
+    HAVE_CAUSAL_CONV1D = True
+except ImportError:
+    HAVE_CAUSAL_CONV1D = False
+from megatron.core.utils import (
+    is_causal_conv1d_min_version,
+    is_te_min_version,
+    is_torch_min_version,
+)
+from tests.unit_tests.a2a_overlap.utils import (
+    assert_models_equal,
+    build_input_data,
+    deterministic_mode,
+    fsdp_train_step,
+    get_valid_flex_dispatcher_backend,
+    get_valid_token_dispatcher_types,
+    overlap_train_step,
+    reset_model,
+)
+from tests.unit_tests.test_utilities import Utils
+
+SEQ_LEN = 32
+VOCAB_SIZE = 128
+NUM_STEPS = 3
+LR = 0.01
+
+
+def _hybrid_config(hybrid_layer_pattern, num_moe_experts=8, extra_kwargs=None):
+    """Build a TransformerConfig usable by HybridModel + EP overlap."""
+    extra_kwargs = dict(extra_kwargs or {})
+    # HybridModel derives effective num_layers from the pattern; we still pass
+    # the flattened count so TransformerConfig.__post_init__ checks pass.
+    flat = hybrid_layer_pattern.replace("[", "").replace("]", "")
+    return TransformerConfig(
+        # ``deterministic_mode`` (utils.deterministic_mode) sets
+        # ``NVTE_FUSED_ATTN=0`` for reproducibility; the default attention
+        # backend ``auto`` asserts that env is unset, so pin it to ``unfused``
+        # like the GPT-side a2a_overlap tests do.
+        attention_backend="unfused",
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=4,
+        deterministic_mode=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        num_layers=len(flat),
+        hidden_size=512,
+        num_attention_heads=8,
+        num_query_groups=8,
+        ffn_hidden_size=512,
+        kv_channels=64,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        add_bias_linear=False,
+        num_moe_experts=num_moe_experts,
+        moe_grouped_gemm=True,
+        moe_router_dtype="fp32",
+        **extra_kwargs,
+    )
+
+
+def _hybrid_model(config, hybrid_layer_pattern):
+    return HybridModel(
+        config=config,
+        hybrid_stack_spec=hybrid_stack_spec,
+        vocab_size=VOCAB_SIZE,
+        max_sequence_length=SEQ_LEN,
+        hybrid_layer_pattern=hybrid_layer_pattern,
+        pre_process=True,
+        post_process=True,
+    ).cuda()
+
+
+def _make_ddp_config():
+    return DistributedDataParallelConfig(
+        use_megatron_fsdp=True,
+        data_parallel_sharding_strategy="optim_grads_params",
+        overlap_grad_reduce=True,
+        overlap_param_gather=True,
+        megatron_fsdp_main_params_dtype=None,
+    )
+
+
+def _count_fsdp_units(fsdp_wrapper):
+    """Count HybridStack instances actually registered as FSDP units."""
+    inner = fsdp_wrapper.module  # MegatronFSDP wrapper
+    return sum(
+        1
+        for m in inner.module.modules()
+        if isinstance(m, HybridStack) and inner._is_fsdp_unit_module(m)
+    )
+
+
+class TestFSDPHybridOverlap:
+    """FSDP + EP overlap + hybrid model: per-step loss and final weights
+    must match the no-overlap reference (both using HybridStack as the
+    FSDP unit)."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=4,
+        )
+        set_streams()
+        # MoEAuxLossAutoScaler keeps the aux-loss scale in a class attribute. A plain
+        # backward earlier in the same process leaves a 0-dim tensor there, and the
+        # schedule's set_loss_scale() then cannot copy_ its size-1 scale into it. Start
+        # clean, as test_schedules.py does for DSAIndexerLossAutoScaler.
+        MoEAuxLossAutoScaler.main_loss_backward_scale = None
+
+    def teardown_method(self, method):
+        MoEAuxLossAutoScaler.main_loss_backward_scale = None
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6.0"), reason="EP overlap hangs on torch < 2.6.0"
+    )
+    @pytest.mark.parametrize("dispatcher_type", get_valid_token_dispatcher_types())
+    @pytest.mark.parametrize("shared_expert_intermediate_size", [None, 512])
+    @pytest.mark.parametrize("hybrid_layer_pattern", ["[*E][*E]", "[M*E][M*E]"])
+    def test_fsdp_hybrid_overlap_training_step(
+        self, monkeypatch, dispatcher_type, shared_expert_intermediate_size, hybrid_layer_pattern
+    ):
+        if "M" in hybrid_layer_pattern and not (HAVE_MAMBA_SSM and HAVE_CAUSAL_CONV1D):
+            pytest.skip(
+                "Mamba pattern requires both mamba-ssm and causal-conv1d "
+                "(`pip install mamba-ssm causal-conv1d`)."
+            )
+        if "M" in hybrid_layer_pattern:
+            # deterministic_mode=True makes MambaMixer insist on the deterministic
+            # causal_conv1d backward (causal-conv1d >= 1.6.0, opted in through the env
+            # or torch.use_deterministic_algorithms); opt in the way the SSM tests do.
+            if not is_causal_conv1d_min_version("1.6.0"):
+                pytest.skip("deterministic Mamba needs causal-conv1d >= 1.6.0")
+            monkeypatch.setenv("CAUSAL_CONV1D_DETERMINISTIC", "1")
+        extra_kwargs = {"moe_token_dispatcher_type": dispatcher_type}
+        if dispatcher_type == "flex":
+            backend = get_valid_flex_dispatcher_backend()
+            if backend is None:
+                pytest.skip("No flex dispatcher backend available")
+            extra_kwargs["moe_flex_dispatcher_backend"] = backend
+        if shared_expert_intermediate_size is not None:
+            extra_kwargs["moe_shared_expert_intermediate_size"] = shared_expert_intermediate_size
+
+        with deterministic_mode():
+            data = build_input_data(seq_len=SEQ_LEN, vocab_size=VOCAB_SIZE)
+
+            # Reference: no EP overlap, but same FSDP unit class so init
+            # consumes the seeded RNG in the same order as the test path.
+            ref_config = _hybrid_config(hybrid_layer_pattern, extra_kwargs=extra_kwargs)
+            ref_model = _hybrid_model(ref_config, hybrid_layer_pattern)
+            init_params = reset_model(ref_model)
+
+            ref_fsdp = FullyShardedDataParallel(
+                config=ref_config,
+                ddp_config=_make_ddp_config(),
+                module=ref_model,
+                fsdp_unit_modules=[HybridStack],
+            )
+            ref_opt = torch.optim.SGD(ref_fsdp.parameters(), lr=LR)
+            ref_opt = fully_shard_optimizer(optimizer=ref_opt)
+
+            # Test: EP overlap on.
+            test_kwargs = {**extra_kwargs, "overlap_moe_expert_parallel_comm": True}
+            test_config = _hybrid_config(hybrid_layer_pattern, extra_kwargs=test_kwargs)
+            test_model = _hybrid_model(test_config, hybrid_layer_pattern)
+            reset_model(test_model, init_params)
+
+            test_fsdp = FullyShardedDataParallel(
+                config=test_config,
+                ddp_config=_make_ddp_config(),
+                module=test_model,
+                fsdp_unit_modules=[HybridStack],
+            )
+            test_opt = torch.optim.SGD(test_fsdp.parameters(), lr=LR)
+            test_opt = fully_shard_optimizer(optimizer=test_opt)
+
+            # Lock in the FSDP-unit selection: each bracket group's inner
+            # HybridStack is its own unit, and the outer root is excluded.
+            # Pattern `[*E][*E]` has 2 bracket groups.
+            expected_units = hybrid_layer_pattern.count("[")
+            assert _count_fsdp_units(ref_fsdp) == expected_units, (
+                f"reference: expected {expected_units} FSDP units, "
+                f"got {_count_fsdp_units(ref_fsdp)}"
+            )
+            assert _count_fsdp_units(test_fsdp) == expected_units, (
+                f"test: expected {expected_units} FSDP units, "
+                f"got {_count_fsdp_units(test_fsdp)}"
+            )
+
+            rank = torch.distributed.get_rank()
+            for step in range(NUM_STEPS):
+                if hasattr(ref_fsdp, "set_is_first_microbatch"):
+                    ref_fsdp.set_is_first_microbatch()
+                ref_loss = fsdp_train_step(ref_fsdp, ref_opt, data)
+                test_loss = overlap_train_step(test_fsdp, test_opt, test_config, data)
+
+                assert torch.equal(ref_loss, test_loss), (
+                    f"[rank {rank}] Loss mismatch at step {step}: "
+                    f"ref={ref_loss.item()}, test={test_loss.item()}"
+                )
+
+            assert_models_equal(ref_fsdp, test_fsdp)
+
+            del ref_fsdp, test_fsdp, ref_opt, test_opt
+            gc.collect()
+            torch.cuda.empty_cache()

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -30,7 +30,7 @@ from megatron.core.ssm.mlp_layer_config import MLPLayerConfig
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import MLATransformerConfig, TransformerConfig
 from megatron.core.transformer.attention_layer_config import AttentionLayerConfig
-from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.enums import AttnBackend, InferenceCudaGraphScope
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import divide, is_fa_min_version, is_torch_min_version
 from tests.unit_tests.test_utilities import Utils
@@ -97,6 +97,143 @@ def _assert_equal_with_partial_contents(left, right, path="root"):
         return
 
     assert left == right, f"{path}: values differ"
+
+
+def _make_postprocess_stub(config, training):
+    """Build the minimal model surface needed by ``HybridModel._postprocess``."""
+
+    def output_layer(hidden_states, weight=None, runtime_gather_output=None):
+        return hidden_states, None
+
+    output_layer.sequence_parallel = False
+    pg_collection = SimpleNamespace(cp=object(), tp=object(), dp_cp=object())
+    return SimpleNamespace(
+        config=config,
+        training=training,
+        post_process=True,
+        mtp_process=True,
+        share_embeddings_and_output_weights=False,
+        output_layer=output_layer,
+        pg_collection=pg_collection,
+        tp_group=pg_collection.tp,
+        _scale_logits=lambda logits: logits,
+        compute_language_model_loss=lambda labels, logits: logits,
+    )
+
+
+@pytest.mark.parametrize(
+    "cuda_graph_scope", [InferenceCudaGraphScope.none, InferenceCudaGraphScope.block]
+)
+def test_hybrid_postprocess_caches_spec_decode_hidden_states(cuda_graph_scope):
+    """Speculative decoding publishes decoder states through the inference context."""
+    hidden_states = torch.randn(3, 2, 8)
+    context_buffer = (
+        torch.full((5, 2, 8), -1.0) if cuda_graph_scope == InferenceCudaGraphScope.block else None
+    )
+    inference_context = SimpleNamespace(
+        config=SimpleNamespace(materialize_only_last_token_logits=False),
+        num_speculative_tokens=1,
+        mtp_decoder_hidden_states=context_buffer,
+        is_dynamic_batching=lambda: True,
+        is_static_batching=lambda: False,
+    )
+    model = _make_postprocess_stub(
+        SimpleNamespace(
+            mtp_num_layers=1, inference_cuda_graph_scope=cuda_graph_scope, use_mup=False
+        ),
+        training=False,
+    )
+
+    with InferenceMode.active():
+        output = HybridModel._postprocess(
+            model,
+            hidden_states=hidden_states,
+            input_ids=torch.zeros(2, 3, dtype=torch.long),
+            position_ids=torch.zeros(2, 3, dtype=torch.long),
+            labels=None,
+            rotary_pos_emb=None,
+            mtp_in_postprocess=False,
+            runtime_gather_output=True,
+            inference_context=inference_context,
+        )
+
+    torch.testing.assert_close(output, hidden_states.transpose(0, 1), rtol=0, atol=0)
+    if cuda_graph_scope == InferenceCudaGraphScope.block:
+        assert inference_context.mtp_decoder_hidden_states is context_buffer
+        torch.testing.assert_close(context_buffer[:3], hidden_states, rtol=0, atol=0)
+        assert torch.all(context_buffer[3:] == -1)
+    else:
+        assert inference_context.mtp_decoder_hidden_states is hidden_states
+    assert not hasattr(model, "_decoder_hidden_states_cache")
+
+
+def test_hybrid_postprocess_does_not_cache_regular_inference_hidden_states():
+    """Regular inference must not make the controller run serial MTP decoding."""
+    hidden_states = torch.randn(3, 2, 8)
+    inference_context = SimpleNamespace(
+        config=SimpleNamespace(materialize_only_last_token_logits=False),
+        num_speculative_tokens=0,
+        mtp_decoder_hidden_states=None,
+        is_dynamic_batching=lambda: True,
+        is_static_batching=lambda: False,
+    )
+    model = _make_postprocess_stub(
+        SimpleNamespace(
+            mtp_num_layers=1, inference_cuda_graph_scope=InferenceCudaGraphScope.none, use_mup=False
+        ),
+        training=False,
+    )
+
+    with InferenceMode.active():
+        HybridModel._postprocess(
+            model,
+            hidden_states=hidden_states,
+            input_ids=torch.zeros(2, 3, dtype=torch.long),
+            position_ids=torch.zeros(2, 3, dtype=torch.long),
+            labels=None,
+            rotary_pos_emb=None,
+            mtp_in_postprocess=False,
+            runtime_gather_output=True,
+            inference_context=inference_context,
+        )
+
+    assert inference_context.mtp_decoder_hidden_states is None
+    assert not hasattr(model, "_decoder_hidden_states_cache")
+
+
+def test_hybrid_postprocess_forwards_rl_mtp_inputs(monkeypatch):
+    """RL MTP loss receives token IDs and the TP group needed to derive labels."""
+    captured_kwargs = {}
+
+    def fake_process_mtp_loss(**kwargs):
+        captured_kwargs.update(kwargs)
+        return kwargs["hidden_states"][:2]
+
+    monkeypatch.setattr(
+        "megatron.core.models.hybrid.hybrid_model.process_mtp_loss", fake_process_mtp_loss
+    )
+    model = _make_postprocess_stub(
+        SimpleNamespace(
+            mtp_num_layers=1, inference_cuda_graph_scope=InferenceCudaGraphScope.none, use_mup=False
+        ),
+        training=True,
+    )
+    input_ids = torch.arange(4, dtype=torch.long).reshape(1, 4)
+
+    HybridModel._postprocess(
+        model,
+        hidden_states=torch.randn(4, 1, 8),
+        input_ids=input_ids,
+        position_ids=torch.arange(4, dtype=torch.long).reshape(1, 4),
+        labels=None,
+        rotary_pos_emb=None,
+        mtp_in_postprocess=False,
+        runtime_gather_output=False,
+        inference_context=None,
+    )
+
+    assert captured_kwargs["input_ids"] is input_ids
+    assert captured_kwargs["tp_group"] is model.tp_group
 
 
 def test_hybrid_logging_process_groups_are_paired():

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -530,6 +530,29 @@ class TestHybridModel:
 
         self.model.load_state_dict(torch.load(path))
 
+    def test_grouped_sharded_state_dict_uses_transformer_checkpoint_keys(self):
+        """Grouped HybridModel checkpoints should be load-compatible with GPTModel keys."""
+        model_config = TransformerConfig(
+            num_layers=2, hidden_size=256, num_attention_heads=4, use_cpu_initialization=True
+        )
+        model = HybridModel(
+            config=model_config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="[*-]",
+        )
+
+        sharded_state_dict = model.sharded_state_dict()
+        sharded_keys = {value.key for value in sharded_state_dict.values() if hasattr(value, "key")}
+
+        assert "decoder.layers.0.self_attention.linear_qkv.weight" in sharded_keys
+        assert "decoder.layers.0.mlp.linear_fc1.weight" in sharded_keys
+        assert "decoder.layers.1.mlp.linear_fc1.weight" not in sharded_keys
+        assert "decoder.final_layernorm.weight" in sharded_keys
+        assert "decoder.final_norm.weight" not in sharded_keys
+        assert "output_layer._extra_state" not in sharded_state_dict
+
     def test_layer_numbers(self):
         """
         The layer numbers should start at one (for the embedding # layer) and go up

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -236,6 +236,47 @@ def test_hybrid_postprocess_forwards_rl_mtp_inputs(monkeypatch):
     assert captured_kwargs["tp_group"] is model.tp_group
 
 
+def test_hybrid_postprocess_uses_output_processor_hook():
+    """A caller-supplied output processor replaces the default logits / loss path."""
+    captured_kwargs = {}
+    sentinel = torch.randn(2, 4, 8)
+
+    def output_processor(**kwargs):
+        captured_kwargs.update(kwargs)
+        return sentinel
+
+    model = _make_postprocess_stub(
+        SimpleNamespace(
+            mtp_num_layers=None, inference_cuda_graph_scope=InferenceCudaGraphScope.none
+        ),
+        training=True,
+    )
+    hidden_states = torch.randn(4, 2, 8)
+    labels = torch.zeros(2, 4, dtype=torch.long)
+    context = object()
+
+    output = HybridModel._postprocess(
+        model,
+        hidden_states=hidden_states,
+        input_ids=torch.zeros(2, 4, dtype=torch.long),
+        position_ids=torch.zeros(2, 4, dtype=torch.long),
+        labels=labels,
+        rotary_pos_emb=None,
+        mtp_in_postprocess=False,
+        runtime_gather_output=False,
+        inference_context=None,
+        output_processor=output_processor,
+        output_processor_context=context,
+    )
+
+    assert output is sentinel
+    assert captured_kwargs["hidden_states"] is hidden_states
+    assert captured_kwargs["labels"] is labels
+    assert captured_kwargs["context"] is context
+    assert captured_kwargs["output_layer"] is model.output_layer
+    assert captured_kwargs["compute_language_model_loss"] is model.compute_language_model_loss
+
+
 def test_hybrid_logging_process_groups_are_paired():
     tp_group = object()
     dp_cp_group = object()
@@ -689,6 +730,25 @@ class TestHybridModel:
         assert "decoder.final_layernorm.weight" in sharded_keys
         assert "decoder.final_norm.weight" not in sharded_keys
         assert "output_layer._extra_state" not in sharded_state_dict
+
+    def test_ungrouped_sharded_state_dict_keeps_hybrid_final_norm_key(self):
+        """Non-grouped patterns keep ``final_norm`` so older hybrid checkpoints load."""
+        model_config = TransformerConfig(
+            num_layers=2, hidden_size=256, num_attention_heads=4, use_cpu_initialization=True
+        )
+        model = HybridModel(
+            config=model_config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="*-",
+        )
+
+        sharded_state_dict = model.sharded_state_dict()
+        sharded_keys = {value.key for value in sharded_state_dict.values() if hasattr(value, "key")}
+
+        assert "decoder.final_norm.weight" in sharded_keys
+        assert "decoder.final_layernorm.weight" not in sharded_keys
 
     def test_layer_numbers(self):
         """

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -775,6 +775,9 @@ class TestHybridBlock:
             layer_config_list=layer_config_list,
             pp_layer_offset=0,
             logical_layer_offset=0,
+            # HybridModel sets this from the full layer pattern; a directly
+            # constructed stack has to opt in itself.
+            transformer_sharded_keys=True,
             pg_collection=self.get_pg_collection(),
         )
 
@@ -786,6 +789,31 @@ class TestHybridBlock:
         assert "decoder.layers.1.mlp.linear_fc1.weight" not in sharded_keys
         assert "decoder.final_layernorm.weight" in sharded_keys
         assert "decoder.final_norm.weight" not in sharded_keys
+
+    def test_sharded_state_dict_keeps_final_norm_key_without_transformer_keys(self):
+        """Default (non-grouped) stacks keep the historical ``final_norm`` sharded key."""
+        layer_pattern = "*-"
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=_num_physical_layers(layer_pattern),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+        )
+        layer_config_list = validate_segment_layers(layer_pattern, transformer_config)
+        block = HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_config_list=layer_config_list,
+            pp_layer_offset=0,
+            logical_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+
+        sharded_state_dict = block.sharded_state_dict(prefix="decoder.")
+        sharded_keys = {value.key for value in sharded_state_dict.values() if hasattr(value, "key")}
+
+        assert "decoder.final_norm.weight" in sharded_keys
+        assert "decoder.final_layernorm.weight" not in sharded_keys
 
     def test_group_forward_matches_equivalent_flat_layers(self):
         """A bracket group is only a scheduling/checkpoint boundary, not new math."""

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -629,6 +629,7 @@ class TestHybridBlock:
             Symbols.MLP * 5,
             Symbols.ATTENTION + Symbols.MLP + Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLP,
             Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLP,
+            "[*-]",
         ],
     )
     def test_recompute(self, recompute_kwargs: dict, layer_pattern: str):

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -8,6 +8,7 @@ import torch
 import megatron.core.models.hybrid.hybrid_block as hybrid_block_module
 import megatron.core.transformer.utils as transformer_utils
 from megatron.core.extensions.transformer_engine import TEDotProductAttention
+from megatron.core.models.hybrid.fine_grained_callables import build_hybrid_stack_callables
 from megatron.core.models.hybrid.hybrid_block import HybridStack
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import (
@@ -38,6 +39,11 @@ from tests.unit_tests.test_utilities import Utils
 
 def _make_pg_collection():
     return SimpleNamespace(pp=None, tp=None, cp=SimpleNamespace(size=lambda: 1), tp_cp=None)
+
+
+def _num_physical_layers(layer_pattern: str) -> int:
+    """Number of physical layers in a segment pattern (bracketed groups flattened)."""
+    return len(layer_pattern.replace(Symbols.GROUP_START, '').replace(Symbols.GROUP_END, ''))
 
 
 @pytest.mark.parametrize(
@@ -431,15 +437,17 @@ class TestHybridBlock:
         Utils.initialize_model_parallel(1, 1)
         model_parallel_cuda_manual_seed(123)
 
-    def get_pg_collection(self):
-        return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
+    def get_pg_collection(self, required_pgs=None):
+        if required_pgs is None:
+            required_pgs = ['tp', 'pp', 'cp']
+        return ProcessGroupCollection.use_mpu_process_groups(required_pgs=required_pgs)
 
     def get_hybrid_block(self, layer_pattern, **config_kwargs):
         transformer_config = TransformerConfig(
             hidden_size=256,  # The Mamba layer places several constraints on this
             # Need to specify num_attention_heads and num_layers or TransformerConfig
             # will generate errors.
-            num_layers=len(layer_pattern),
+            num_layers=_num_physical_layers(layer_pattern),
             num_attention_heads=4,
             use_cpu_initialization=True,
             **config_kwargs,
@@ -514,6 +522,60 @@ class TestHybridBlock:
             layer_config_list=layer_config_list,
             pp_layer_offset=0,
             pg_collection=self.get_pg_collection(),
+        )
+
+    def get_attention_mlp_block(self, layer_pattern):
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=_num_physical_layers(layer_pattern),
+            num_attention_heads=4,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            use_cpu_initialization=True,
+        )
+        layer_config_list = validate_segment_layers(layer_pattern, transformer_config)
+        return HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_config_list=layer_config_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+
+    def get_attention_moe_block(self, layer_pattern):
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=_num_physical_layers(layer_pattern),
+            num_attention_heads=4,
+            ffn_hidden_size=256,
+            num_moe_experts=8,
+            expert_model_parallel_size=1,
+            moe_router_topk=2,
+            moe_grouped_gemm=True,
+            moe_token_dispatcher_type="alltoall",
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            use_cpu_initialization=True,
+        )
+        layer_config_list = validate_segment_layers(layer_pattern, transformer_config)
+        return HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_config_list=layer_config_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(
+                required_pgs=[
+                    'tp',
+                    'pp',
+                    'cp',
+                    'tp_cp',
+                    'tp_dp_cp',
+                    'ep',
+                    'expt_tp',
+                    'tp_ep',
+                    'expt_dp',
+                ]
+            ),
         )
 
     def teardown_method(self, method):
@@ -647,6 +709,127 @@ class TestHybridBlock:
             layer.config is layer_config
             for layer, layer_config in zip(block.layers, block.layer_config_list)
         )
+
+    def test_group_layer_type_builds_nested_hybrid_stack(self):
+        """Bracketed groups build an inner HybridStack with physical layer numbering."""
+        layer_pattern = "M[M*]-"
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=_num_physical_layers(layer_pattern),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+        )
+        layer_config_list = validate_segment_layers(layer_pattern, transformer_config)
+        block = HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_config_list=layer_config_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+        assert block.layer_type_list == ['M', ('M', '*'), '-']
+        assert isinstance(block.layers[0], MambaLayer)
+        assert isinstance(block.layers[1], HybridStack)
+        assert block.layers[1].is_layer_group_stack
+        assert block.layers[1].layer_type_list == ['M', '*']
+        assert isinstance(block.layers[1].layers[0], MambaLayer)
+        assert isinstance(block.layers[1].layers[1], TransformerLayer)
+        assert isinstance(block.layers[2], TransformerLayer)
+        assert [layer.layer_number for layer in block.layers[1].layers] == [2, 3]
+        assert block.layers[2].layer_number == 4
+        # Each physical layer owns the independent per-layer config it was built from.
+        assert block.layers[1].layers[0].config is layer_config_list[1][0]
+        assert block.layers[1].layers[1].config is layer_config_list[1][1]
+
+    def test_group_layer_type_list_builds_nested_hybrid_stack(self):
+        """The deprecated ``layer_type_list`` path accepts symbol tuples for groups."""
+        transformer_config = TransformerConfig(
+            hidden_size=256, num_layers=3, num_attention_heads=4, use_cpu_initialization=True
+        )
+        with pytest.warns(DeprecationWarning, match=r"DEPRECATED\(layer_type_list\)"):
+            block = HybridStack(
+                transformer_config,
+                hybrid_stack_spec.submodules,
+                layer_type_list=[Symbols.MAMBA, (Symbols.ATTENTION, Symbols.MLP)],
+                pp_layer_offset=0,
+                pg_collection=self.get_pg_collection(),
+            )
+        assert block.layer_type_list == ['M', ('*', '-')]
+        assert isinstance(block.layers[1], HybridStack)
+        assert [layer.layer_number for layer in block.layers[1].layers] == [2, 3]
+
+    def test_group_sharded_state_dict_uses_logical_layer_keys(self):
+        """Grouped attention+MLP layers share one Transformer-compatible checkpoint key."""
+        layer_pattern = "[*-]"
+        transformer_config = TransformerConfig(
+            hidden_size=256,
+            num_layers=_num_physical_layers(layer_pattern),
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+        )
+        layer_config_list = validate_segment_layers(layer_pattern, transformer_config)
+        block = HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
+            layer_config_list=layer_config_list,
+            pp_layer_offset=0,
+            logical_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+
+        sharded_state_dict = block.sharded_state_dict(prefix="decoder.")
+        sharded_keys = {value.key for value in sharded_state_dict.values() if hasattr(value, "key")}
+
+        assert "decoder.layers.0.self_attention.linear_qkv.weight" in sharded_keys
+        assert "decoder.layers.0.mlp.linear_fc1.weight" in sharded_keys
+        assert "decoder.layers.1.mlp.linear_fc1.weight" not in sharded_keys
+        assert "decoder.final_layernorm.weight" in sharded_keys
+        assert "decoder.final_norm.weight" not in sharded_keys
+
+    def test_group_forward_matches_equivalent_flat_layers(self):
+        """A bracket group is only a scheduling/checkpoint boundary, not new math."""
+        flat_block = self.get_attention_mlp_block("*-")
+        group_block = self.get_attention_mlp_block("[*-]")
+
+        group_block.layers[0].layers[0].load_state_dict(flat_block.layers[0].state_dict())
+        group_block.layers[0].layers[1].load_state_dict(flat_block.layers[1].state_dict())
+        group_block.final_norm.load_state_dict(flat_block.final_norm.state_dict())
+
+        flat_block.cuda().eval()
+        group_block.cuda().eval()
+        sequence_length = 16
+        micro_batch_size = 2
+        hidden_states = torch.randn(
+            sequence_length, micro_batch_size, flat_block.config.hidden_size, device="cuda"
+        )
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool, device="cuda"
+        )
+
+        with torch.no_grad():
+            flat_output = flat_block(hidden_states.clone(), attention_mask=attention_mask)
+            group_output = group_block(hidden_states.clone(), attention_mask=attention_mask)
+
+        torch.testing.assert_close(group_output, flat_output, rtol=0, atol=0)
+
+    def test_group_overlap_callables_keep_ep_moe_split_visible(self):
+        """EP-overlap scheduling still sees dispatch/experts/combine inside a group."""
+        block = self.get_attention_moe_block("[*E]")
+
+        forward_callables, bwd_dw_callable_map, is_moe, num_local_experts = (
+            build_hybrid_stack_callables(block.layers[0], layer_type=block.layer_type_list[0])
+        )
+
+        pre_dispatch, dispatch, experts, combine, mtp_post_process = forward_callables
+        assert callable(pre_dispatch)
+        assert callable(dispatch)
+        assert callable(experts)
+        assert callable(combine)
+        assert mtp_post_process is None
+        assert is_moe
+        assert num_local_experts == 8
+        assert "pre_dispatch_computation" in bwd_dw_callable_map
+        assert "mlp" in bwd_dw_callable_map
 
     def test_invalid_layer_types_cause_failure(self):
         invalid_pattern_char = 'X'

--- a/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
+++ b/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
@@ -13,9 +13,12 @@ from megatron.core.models.hybrid.hybrid_layer_allocation import (
     get_hybrid_total_layer_count,
     get_hybrid_total_pipeline_segment_count,
     get_layer_maps_from_layer_type_list,
+    get_layer_type_list_from_layer_config_list,
     parse_hybrid_pattern,
+    parse_segment_layers,
     pattern_from_ratios,
     select_pipeline_segment,
+    select_pipeline_segment_with_logical_offset,
     validate_segment_layers,
 )
 from megatron.core.models.hybrid.layers import utils as layer_utils
@@ -114,6 +117,20 @@ class TestValidateSegmentLayers:
     def setup_method(self):
         self.config = _make_transformer_config()
 
+    def test_group_patterns(self):
+        """Bracketed groups parse to symbol tuples and build tuples of per-layer configs."""
+        assert parse_segment_layers("M[M*]-") == ['M', ('M', '*'), '-']
+        assert parse_segment_layers("[M*E]") == [('M', '*', 'E')]
+
+        result = validate_segment_layers("M[M*]-", self.config)
+        assert type(result[0]) is MambaLayerConfig
+        assert isinstance(result[1], tuple)
+        assert [type(config) for config in result[1]] == [MambaLayerConfig, AttentionLayerConfig]
+        assert type(result[2]) is MLPLayerConfig
+        assert get_layer_type_list_from_layer_config_list(result) == ['M', ('M', '*'), '-']
+        flat_configs = [result[0], *result[1], result[2]]
+        assert len({id(config) for config in flat_configs}) == len(flat_configs)
+
     def test_valid_patterns(self):
         """Test that valid segment patterns produce configs in the correct order."""
         for pattern in [
@@ -203,6 +220,10 @@ class TestValidateSegmentLayers:
         with pytest.raises(ValueError):
             validate_segment_layers("M/M", self.config)  # MTP separator not valid in a segment
         with pytest.raises(ValueError):
+            validate_segment_layers("M[[M]]", self.config)  # nested groups are not valid
+        with pytest.raises(ValueError):
+            validate_segment_layers("M[EM]", self.config)  # MoE must be last in a group
+        with pytest.raises(ValueError):
             # Not allowed to have both standard Attention and MLA/DSA
             validate_segment_layers("MDM*-", self.config)
         with pytest.raises(ValueError):
@@ -219,6 +240,8 @@ class TestGetHybridTotalLayerCount:
         assert get_hybrid_total_layer_count("M*M*") == 4
         assert get_hybrid_total_layer_count("MMMM") == 4
         assert get_hybrid_total_layer_count("M") == 1
+        assert get_hybrid_total_layer_count("[M*E]") == 3
+        assert get_hybrid_total_layer_count("M[M*]-") == 4
 
     def test_with_pipe_separators(self):
         assert get_hybrid_total_layer_count("M-M-|M-M*-") == 9
@@ -264,6 +287,8 @@ class TestParseHybridPattern:
         """Test patterns without MTP (no / separator)."""
         test_cases = [
             ("M*M*", "M*M*"),
+            ("[M*E]", "[M*E]"),
+            ("M[M*]-", "M[M*]-"),
             ("MMMM", "MMMM"),
             ("*M*M", "*M*M"),
             ("MM-*", "MM-*"),
@@ -342,10 +367,21 @@ class TestParseHybridPattern:
             "M*X*",  # X is not valid
             "MaMM",  # a is not valid
             "M*M*1",  # 1 is not valid
+            "M[M*]X",  # X is not valid after a group
         ]
         for pattern in invalid_patterns:
             with pytest.raises(ValueError, match="not a valid layer symbol"):
                 parse_hybrid_pattern(pattern)
+
+    def test_invalid_group_syntax(self):
+        with pytest.raises(ValueError, match="without a matching"):
+            parse_hybrid_pattern("M[M*")
+        with pytest.raises(ValueError, match="not supported"):
+            parse_hybrid_pattern("M[M[*]]")
+        with pytest.raises(ValueError, match="cannot be empty"):
+            parse_hybrid_pattern("M[]")
+        with pytest.raises(ValueError, match="must be the last"):
+            parse_hybrid_pattern("M[EM]")
 
     def test_invalid_symbols_in_mtp_pattern(self):
         """Test that invalid symbols in MTP pattern raise ValueError."""
@@ -515,6 +551,17 @@ class TestGetHybridLayerCounts:
             'E': 2,
         }
 
+    def test_group_pattern(self):
+        assert get_hybrid_layer_counts("M[M*]E") == {
+            '*': 1,
+            'D': 0,
+            'G': 0,
+            'M': 2,
+            '+': 0,
+            '-': 0,
+            'E': 1,
+        }
+
     def test_mtp_with_attention(self):
         # MTP pattern "*M" repeated 3 depths -> 3 attn + 3 mamba from MTP
         assert get_hybrid_layer_counts("MMMM/*M/*M/*M") == {
@@ -656,6 +703,25 @@ class TestSelectPipelineSegment:
             )
             _assert_layer_config_types(layer_configs, expected_pattern)
             assert offset == expected_offset, f"Failed for vp_stage={vp_stage}"
+
+    @patch('megatron.core.models.hybrid.hybrid_layer_allocation.log_on_each_pipeline_stage')
+    def test_group_segment_offsets(self, mock_log):
+        layer_configs, offset = select_pipeline_segment(
+            "[M*E]|M-", self.config, pp_group=None, vp_stage=1
+        )
+        _assert_layer_config_types(layer_configs, "M-")
+        assert offset == 3
+
+    @patch('megatron.core.models.hybrid.hybrid_layer_allocation.log_on_each_pipeline_stage')
+    def test_group_segment_logical_offsets(self, mock_log):
+        layer_configs, physical_offset, logical_offset = (
+            select_pipeline_segment_with_logical_offset(
+                "[*-][*-]|[*E][*E]", self.config, pp_group=None, vp_stage=1
+            )
+        )
+        assert get_layer_type_list_from_layer_config_list(layer_configs) == [('*', 'E'), ('*', 'E')]
+        assert physical_offset == 4
+        assert logical_offset == 2
 
     @patch('megatron.core.models.hybrid.hybrid_layer_allocation.log_on_each_pipeline_stage')
     def test_empty_segment(self, mock_log):
@@ -1012,3 +1078,12 @@ class TestGetLayerMapsFromLayerTypeList:
         assert mamba_map == {2: 0}
         assert mlp_map == {3: 0}
         assert moe_map == {}
+
+    def test_grouped_layers_are_flattened(self):
+        maps = get_layer_maps_from_layer_type_list([("M", "*", "E"), "M"])
+        attention_map, mamba_map, moe_map = operator.itemgetter(
+            Symbols.ATTENTION, Symbols.MAMBA, Symbols.MOE
+        )(maps)
+        assert attention_map == {1: 0}
+        assert mamba_map == {0: 0, 3: 1}
+        assert moe_map == {2: 0}

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -11,6 +11,7 @@ from megatron.core.tensor_parallel.random import (
     get_cuda_rng_tracker,
     model_parallel_cuda_manual_seed,
 )
+from megatron.core.transformer.moe.moe_logging import destroy_moe_metrics_tracker
 from megatron.core.transformer.moe.moe_utils import (
     clear_aux_losses_tracker,
     get_default_pg_collection,
@@ -157,7 +158,7 @@ def test_z_loss_wraps_hybrid_mtp_layer_number_to_tracker_slot():
         is_mtp_layer = True
         layer_number = 5
 
-    clear_aux_losses_tracker()
+    destroy_moe_metrics_tracker()
     try:
         logits = torch.randn(4, 3, requires_grad=True)
         TopKRouter.apply_z_loss(DummyRouter(), logits)
@@ -167,7 +168,7 @@ def test_z_loss_wraps_hybrid_mtp_layer_number_to_tracker_slot():
         assert values[8] > 0
         assert torch.count_nonzero(values) == 1
     finally:
-        clear_aux_losses_tracker()
+        destroy_moe_metrics_tracker()
 
 
 class TestSeqAuxLoss:

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -133,6 +133,43 @@ class TestAuxLoss:
         container.aux_loss_test(self.input, self.baseline_grad, "load_balancing_loss")
 
 
+@pytest.mark.internal
+def test_z_loss_wraps_hybrid_mtp_layer_number_to_tracker_slot():
+    """Hybrid MTP routers must record z-loss in one of the configured MTP slots."""
+
+    class DummyGroup:
+        @staticmethod
+        def size():
+            return 1
+
+    class DummyConfig:
+        moe_z_loss_coeff = 1.0
+        mtp_num_layers = 2
+        mtp_use_repeated_layer = False
+        num_layers = 8
+
+    class DummyRouter:
+        config = DummyConfig()
+        tp_cp_group = DummyGroup()
+        tp_dp_cp_group = DummyGroup()
+        training = True
+        calculate_per_token_loss = False
+        is_mtp_layer = True
+        layer_number = 5
+
+    clear_aux_losses_tracker()
+    try:
+        logits = torch.randn(4, 3, requires_grad=True)
+        TopKRouter.apply_z_loss(DummyRouter(), logits)
+
+        values = get_moe_layer_wise_logging_tracker()["z_loss"]["values"]
+        assert values.shape == (10,)
+        assert values[8] > 0
+        assert torch.count_nonzero(values) == 1
+    finally:
+        clear_aux_losses_tracker()
+
+
 class TestSeqAuxLoss:
     def setup_method(self, method):
         baseline_container = AuxlossTestContainer(

--- a/tests/unit_tests/transformer/test_full_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_full_cuda_graph.py
@@ -9,7 +9,11 @@ from pytest_mock import mocker
 
 import megatron.core.pipeline_parallel.schedules as schedule
 from megatron.core import ModelParallelConfig
-from megatron.core.full_cuda_graph import FullCudaGraphWrapper, get_shared_capture_stream
+from megatron.core.full_cuda_graph import (
+    FullCudaGraphWrapper,
+    clone_tensors_in_struct,
+    get_shared_capture_stream,
+)
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
     initialize_rng_tracker,
@@ -88,6 +92,27 @@ def test_ddp_grad_accumulators_share_full_cuda_graph_stream():
     ]
     assert not stream_mismatch_warnings
     assert all(param.grad is not None for param in wrapped_model.parameters())
+
+
+def test_clone_tensors_in_struct_passes_through_none_static_slots():
+    """A static-buffer slot that was None at capture must accept a later non-None value.
+
+    Full-iteration capture snapshots the first iteration's data dict into static buffers.
+    A field that is None then (e.g. an optional mask) but a Tensor on a later iteration has
+    no captured buffer to copy into; the value must pass through instead of crashing on
+    ``None.copy_``.
+    """
+    value = torch.arange(4, dtype=torch.float32)
+
+    tgt_dict = {"a": torch.zeros(4), "b": None}
+    clone_tensors_in_struct(tgt_dict, {"a": value, "b": value})
+    assert torch.equal(tgt_dict["a"], value)
+    assert torch.equal(tgt_dict["b"], value)
+
+    tgt_list = [torch.zeros(4), None]
+    clone_tensors_in_struct(tgt_list, [value, value])
+    assert torch.equal(tgt_list[0], value)
+    assert torch.equal(tgt_list[1], value)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# What does this PR do ?

**Stacked on #4944** (the #4941→#4944 split of #4798): the branch is `pr4798-4-training-wireup` plus one commit. Review only the top commit (`Fix full-iteration CUDA graph capture for PP and grouped hybrid models`); the base will be retargeted to `pull-request/4944` once copy-pr-bot creates that ref.

Fixes four independent blockers for `--cuda-graph-impl full_iteration` when combined with pipeline parallelism, the MoE paged stash, and grouped HybridStack patterns (`[M*E]`-style). The first two fixes are model-agnostic.

1. `clone_tensors_in_struct` crashed with `AttributeError: 'NoneType' object has no attribute 'copy_'` when a data-dict field was `None` at capture time but a tensor on a later iteration (optional fields, dataloader variation). Such slots have no captured static buffer, so the value now passes through instead.
2. `p2p_communication` runs `torch.cuda.synchronize()` as a `batch_isend_irecv` race workaround. That call is illegal during stream capture, so PP > 1 died at capture. Skip it while capturing — the graph records the comm ops and their stream dependencies.
3. New `_graphable_leaves()` in `cuda_graphs.py` descends grouped `HybridStack` modules to their inner Mamba/attention/MoE leaves. Iterating `decoder.layers` directly yields the stack objects, which breaks any per-leaf logic.
4. The paged stash discovered MoE layers via `decoder.layers[].mlp`, which is `None` for a HybridStack group — on grouped hybrid models it silently tracked zero MoE layers. It now discovers through `_graphable_leaves`.

## Validation

- New CPU unit test for the `None`-slot passthrough (`tests/unit_tests/transformer/test_full_cuda_graph.py`).
- System-level, 128 GPUs (GB300, 32 nodes): hybrid `[ME][ME][ME][M*E]` x6 (54 layers, 512 experts, EP64, seq 8192, GBS 1024) with full-iteration CUDA graphs + paged stash + EP A2A overlap trains to steady state; grouped-pattern loss drift vs CG-off is 6.8e-5, matching the ungrouped reference (6.9e-5) at 4 GPUs.
- Fix 2 also validated on a DSv3 GPTModel PP4/VPP4 run at 256 GPUs, which previously died at capture in `p2p_communication`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
