### PR TITLE
test: update SSM test to set manual seed to handle flaky failures

### DIFF
--- a/tests/unit_tests/ssm/gated_delta_net_test_utils.py
+++ b/tests/unit_tests/ssm/gated_delta_net_test_utils.py
@@ -48,6 +48,7 @@ class GatedDeltaNetTestBase:
             pipeline_model_parallel_size=1,
             context_parallel_size=cp_size,
         )
+        torch.manual_seed(123)
         model_parallel_cuda_manual_seed(123)
         self.tp_size = tp_size
         self.cp_size = cp_size

--- a/tests/unit_tests/ssm/test_gated_delta_net_padding.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net_padding.py
@@ -17,8 +17,6 @@ from tests.unit_tests.transformer.test_multi_latent_attention import (
     [(1, False, 1), (2, False, 1), (2, True, 1), (1, False, 2), (2, False, 2), (2, True, 2)],
 )
 @pytest.mark.skipif(not HAVE_FLA, reason="FLA is not installed.")
-@pytest.mark.flaky
-@pytest.mark.flaky_in_dev
 @pytest.mark.internal
 class TestGatedDeltaNet(GatedDeltaNetTestBase):
     def test_gpu_forward_thd_padding_correctness(self):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
 Splitting the Gated Delta Net padding test into a standalone CI job exposed a hidden test-order dependency.

  GatedDeltaNetTestBase uses use_cpu_initialization=True, but its setup seeded only the CUDA RNG. As a result, CPU-initialized model weights depended on prior tests and could vary across standalone ranks, intermittently triggering BF16 padding comparison failures.
  Regrouping the test would only restore the incidental RNG state and mask the issue. This change explicitly seeds the CPU RNG before model construction, making initialization deterministic regardless of test order.
  It also removes the temporary flaky markers added in #6954, restoring the standalone test in both dev and LTS CI.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
