### PR TITLE
fix(fsdp): reuse persistent model-weight storage

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -237,13 +237,7 @@ class DBuffer:
 
         changed_axis = changed_mesh_axis(self.placements, placements)
         if changed_axis is None:
-            return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                placements,
-                self.layout.tensor_shapes,
-                allocation_stream=self.allocation_stream,
-            )
+            return self
         if isinstance(self.placements[changed_axis], Replicate) and isinstance(
             placements[changed_axis], Flat
         ):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -223,6 +223,46 @@ class DBuffer:
         buffer.allocation_stream = allocation_stream
         return buffer
 
+    def view(self, placements: Iterable[Placement]) -> "DBuffer":
+        """Return a storage-sharing buffer with supported ``placements``.
+
+        Views preserve placements or locally slice one Replicate axis to Flat.
+        Other placement changes require communication and are not views.
+        """
+        placements = tuple(placements)
+        if len(placements) != self.mesh.ndim:
+            raise ValueError(
+                f"Expected {self.mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+
+        changed_axis = changed_mesh_axis(self.placements, placements)
+        if changed_axis is None:
+            return DBuffer.from_local(
+                self.local_buffer,
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                allocation_stream=self.allocation_stream,
+            )
+        if isinstance(self.placements[changed_axis], Replicate) and isinstance(
+            placements[changed_axis], Flat
+        ):
+            offset, local_numel = self.layout.get_local_range(self.mesh, placements)
+            local_offset = offset - self.offset
+            if local_offset < 0 or local_offset + local_numel > self.local_buffer.numel():
+                raise RuntimeError("DBuffer view is not contained in its source local buffer.")
+            return DBuffer.from_local(
+                self.local_buffer.narrow(0, local_offset, local_numel),
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                allocation_stream=self.allocation_stream,
+            )
+        raise ValueError(
+            "DBuffer.view() supports identical placements or a Replicate-to-Flat slice, "
+            f"got {self.placements!r} -> {placements!r}."
+        )
+
     @classmethod
     def distribute_tensors(
         cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
@@ -350,7 +390,12 @@ class DBuffer:
         if isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
             return self.reduce_scatter(axis, new_placement, out=out)
         if isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
-            return self.scatter(axis, new_placement, out=out)
+            view = self.view(new_placements)
+            if out is None:
+                return view
+            out = self._create_or_validate_out(out, placements=new_placements)
+            out.local_buffer.copy_(view.local_buffer)
+            return out
         if isinstance(old_placement, Replicate) and isinstance(new_placement, Partial):
             # Replicate and Partial share the same local layout, so relabel the
             # buffer without communication. Value-preserving for AVG only -- the
@@ -448,48 +493,6 @@ class DBuffer:
         )
         if self.is_symmetric_memory and partial_placement.reduce_op == "avg":
             out.local_buffer.div_(self.mesh.size(axis))
-        return out
-
-    def scatter(
-        self, mesh_axis: int, new_placement: Placement, *, out: "DBuffer | None" = None
-    ) -> "DBuffer":
-        """Locally chunk a Replicate axis into ``new_placement``."""
-        axis = mesh_axis
-        if not isinstance(new_placement, Flat):
-            raise NotImplementedError("DBuffer currently supports scatter() to Flat only.")
-        if not isinstance(self.placements[axis], Replicate):
-            raise ValueError(f"scatter() requires Replicate placement on axis {mesh_axis!r}.")
-
-        placements = list(self.placements)
-        placements[axis] = new_placement
-        _validate_placements(placements)
-
-        if out is None:
-            destination_offset, destination_numel = self.layout.get_local_range(
-                self.mesh, placements
-            )
-        else:
-            out = self._create_or_validate_out(out, placements=placements)
-            destination_offset = out.offset
-            destination_numel = out.local_buffer.numel()
-
-        local_buffer_offset = destination_offset - self.offset
-        if (
-            local_buffer_offset < 0
-            or local_buffer_offset + destination_numel > self.local_buffer.numel()
-        ):
-            raise RuntimeError("scatter() destination is not contained in the source local buffer.")
-        local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
-        if out is None:
-            return DBuffer.from_local(
-                local_slice,
-                self.mesh,
-                placements,
-                self.layout.tensor_shapes,
-                allocation_stream=self.allocation_stream,
-            )
-
-        out.local_buffer.copy_(local_slice)
         return out
 
     def get_local_tensor(self, index: int) -> torch.Tensor:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -40,9 +40,8 @@ class FsdpContext:
 
     allgather_stream: torch.cuda.Stream
     reduce_scatter_stream: torch.cuda.Stream
-    # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
-    # unnecessary because it can be detected when ``model_weight``, after syncing
-    # from ``main_weight``, has placements different from ``Placements.optimizer``.
+    # HFSDP/HSDP need explicit last-microbatch state. Parameter groups track whether
+    # a post-step model-weight sync needs its first all-gather independently.
     is_last_microbatch: bool
     use_symmetric_memory: bool
     unify_communication_stream: bool
@@ -204,7 +203,6 @@ class FsdpModule:
                         main_weight_placements, group_dtype
                     ),
                     mixed_precision_policy=mixed_precision_policy,
-                    allgather_stream=context.allgather_stream,
                     reduce_scatter_stream=context.reduce_scatter_stream,
                     grad_divisor=grad_divisor,
                     use_symmetric_memory=use_symmetric_memory,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -40,8 +40,9 @@ class FsdpContext:
 
     allgather_stream: torch.cuda.Stream
     reduce_scatter_stream: torch.cuda.Stream
-    # HFSDP/HSDP need explicit last-microbatch state. Parameter groups track whether
-    # a post-step model-weight sync needs its first all-gather independently.
+    # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
+    # unnecessary because each parameter group tracks whether model_weight is stale
+    # after syncing from main_weight.
     is_last_microbatch: bool
     use_symmetric_memory: bool
     unify_communication_stream: bool

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -82,7 +82,10 @@ class FsdpParameterGroup:
     requires_grad: bool
     main_weight: DBuffer
     model_weight: DBuffer
+    # Optimizer-layout view into model_weight storage, avoiding a second allocation.
     post_optimizer_model_weight: DBuffer
+    # sync_model_weight_from_main_weight() updates only this rank's optimizer-layout
+    # view; the remaining model_weight slices must be all-gathered before compute.
     _model_weight_is_stale: bool
     main_grad: DBuffer | None
     _unsharded_model_weight: DBuffer

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -281,13 +281,9 @@ class FsdpParameterGroup:
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
         if self._model_weight_is_stale:
-            # This persistent owner may also back parameter views saved by autograd.
-            # Preserve its version counter while the optimizer-layout alias all-gathers
-            # directly into it.
-            with torch.autograd._unsafe_preserve_version_counter(self.model_weight.local_buffer):
-                self.post_optimizer_model_weight.redistribute(
-                    self.model_weight.placements, out=self.model_weight
-                )
+            self.post_optimizer_model_weight.redistribute(
+                self.model_weight.placements, out=self.model_weight
+            )
             self._model_weight_is_stale = False
         if self.model_weight.placements == self._unsharded_model_weight.placements:
             unsharded_model_weight = self.model_weight

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,7 +28,7 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import changed_mesh_axis
+from .placement import Flat, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -82,6 +82,8 @@ class FsdpParameterGroup:
     requires_grad: bool
     main_weight: DBuffer
     model_weight: DBuffer
+    post_optimizer_model_weight: DBuffer
+    _model_weight_is_stale: bool
     main_grad: DBuffer | None
     _unsharded_model_weight: DBuffer
     _symm_mem_pool: torch.cuda.MemPool | None
@@ -96,7 +98,6 @@ class FsdpParameterGroup:
         main_grad_placements: tuple[Placement, ...],
         main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
-        allgather_stream: torch.cuda.Stream,
         reduce_scatter_stream: torch.cuda.Stream,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
@@ -111,7 +112,6 @@ class FsdpParameterGroup:
             main_grad_placements: Main-gradient buffer placements.
             main_weight_placements: Main-weight buffer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
-            allgather_stream: Stream used to allocate model weights when a dtype cast is required.
             reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
             use_symmetric_memory: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
@@ -127,7 +127,6 @@ class FsdpParameterGroup:
         for fqn, parameter in parameters.items():
             parameter_to_fqns.setdefault(parameter, []).append(fqn)
 
-        self._model_weight_placements = model_weight_placements
         # main_grad rests here (DP-outer-Partial for HSDP) between microbatches and
         # is finalized to main_weight's placements after the last microbatch.
         self._main_grad_placements = main_grad_placements
@@ -166,22 +165,40 @@ class FsdpParameterGroup:
             self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)
         else:
             self._symm_mem_pool = None
-        if main_weight_dtype == self.dtype:
+        if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
         else:
-            # Record the all-gather stream as model_weight's allocation stream to allow
-            # its uses to be joined back to it before the buffer is deleted.
-            with torch.cuda.stream(allgather_stream):
+            # Keep the configured compute-weight layout alive for the lifetime of this
+            # parameter group. The optimizer-layout sync buffer below is only a view
+            # into its local storage, so the first ZeRO-1 unshard can all-gather
+            # directly into this allocation.
+            with self._symmetric_memory_context():
                 self.model_weight = DBuffer(
                     mesh=self.mesh,
-                    placements=main_weight_placements,
+                    placements=model_weight_placements,
                     tensor_shapes=tensor_shapes,
                     dtype=self.dtype,
                     device=self.main_weight.device,
                 )
-            # Cast into the preallocated model_weight on the current stream without
-            # replacing its storage or its all-gather allocation stream.
-            self.main_weight.cast(self.model_weight.dtype, out=self.model_weight)
+        sync_axis = changed_mesh_axis(model_weight_placements, main_weight_placements)
+        if sync_axis is None:
+            self.post_optimizer_model_weight = self.model_weight
+        elif isinstance(model_weight_placements[sync_axis], Replicate) and isinstance(
+            main_weight_placements[sync_axis], Flat
+        ):
+            self.post_optimizer_model_weight = self.model_weight.scatter(
+                sync_axis, main_weight_placements[sync_axis]
+            )
+        else:
+            raise ValueError(
+                "Optimizer/main-weight placements must match the parameter/model-weight "
+                "placements or be a Replicate-to-Flat slice."
+            )
+        # Cast into the preallocated optimizer-layout view on the current stream.
+        self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
+        self._model_weight_is_stale = (
+            self.post_optimizer_model_weight.placements != self.model_weight.placements
+        )
 
         with self._symmetric_memory_context():
             self._unsharded_model_weight = DBuffer(
@@ -268,26 +285,22 @@ class FsdpParameterGroup:
 
     def sync_model_weight_from_main_weight(self) -> None:
         """Refresh compute weights from optimizer weights."""
-        allgather_stream = self.model_weight.allocation_stream
-        assert allgather_stream is not None
-        current_stream = torch.cuda.current_stream(self.model_weight.device)
-        allgather_stream.wait_stream(current_stream)
-        with torch.cuda.stream(allgather_stream):
-            self.model_weight = self.main_weight.cast(self.model_weight.dtype)
-        # CUDA graph capture requires every forked stream to rejoin the capture
-        # stream before capture ends.
-        current_stream.wait_stream(allgather_stream)
+        self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
+        self._model_weight_is_stale = (
+            self.post_optimizer_model_weight.placements != self.model_weight.placements
+        )
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        # In ZeRO-1, the post-step cast leaves model_weight sharded. Only the first
-        # microbatch sees placements different from the configured model placements
-        # and restores the replicated model weight.
-        if self.model_weight.placements != self._model_weight_placements:
-            with self._symmetric_memory_context():
-                # Allocate the restored destination in symmetric memory when enabled so the
-                # redistribution can use the faster symmetric-memory all-gather path.
-                self.model_weight = self.model_weight.redistribute(self._model_weight_placements)
+        if self._model_weight_is_stale:
+            # This persistent owner may also back parameter views saved by autograd.
+            # Preserve its version counter while the optimizer-layout alias all-gathers
+            # directly into it.
+            with torch.autograd._unsafe_preserve_version_counter(self.model_weight.local_buffer):
+                self.post_optimizer_model_weight.redistribute(
+                    self.model_weight.placements, out=self.model_weight
+                )
+            self._model_weight_is_stale = False
         if self.model_weight.placements == self._unsharded_model_weight.placements:
             unsharded_model_weight = self.model_weight
         else:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,7 +28,7 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Flat, changed_mesh_axis
+from .placement import changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -165,6 +165,7 @@ class FsdpParameterGroup:
             self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)
         else:
             self._symm_mem_pool = None
+
         if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
         else:
@@ -180,20 +181,7 @@ class FsdpParameterGroup:
                     dtype=self.dtype,
                     device=self.main_weight.device,
                 )
-        sync_axis = changed_mesh_axis(model_weight_placements, main_weight_placements)
-        if sync_axis is None:
-            self.post_optimizer_model_weight = self.model_weight
-        elif isinstance(model_weight_placements[sync_axis], Replicate) and isinstance(
-            main_weight_placements[sync_axis], Flat
-        ):
-            self.post_optimizer_model_weight = self.model_weight.scatter(
-                sync_axis, main_weight_placements[sync_axis]
-            )
-        else:
-            raise ValueError(
-                "Optimizer/main-weight placements must match the parameter/model-weight "
-                "placements or be a Replicate-to-Flat slice."
-            )
+        self.post_optimizer_model_weight = self.model_weight.view(main_weight_placements)
         # Cast into the preallocated optimizer-layout view on the current stream.
         self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
         self._model_weight_is_stale = (

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -24,7 +24,7 @@ Source         Destination    DBuffer operation
 sharded        ``Replicate``  ``allgather()``
 ``Partial``    sharded        ``reduce_scatter()``
 ``Partial``    ``Replicate``  ``allreduce()``
-``Replicate``  sharded        ``scatter()`` (local)
+``Replicate``  sharded        ``view()`` (local)
 =============  =============  ====================
 """
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -250,43 +250,6 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
-def test_view_aliases_owner_and_allgathers_into_it(distributed_setup):
-    """A placement view aliases its owner and can materialize it in place."""
-    if distributed_setup.world_size < 2:
-        pytest.skip("DBuffer view test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
-    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
-    owner = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    same_layout_view = owner.view([Replicate()])
-    sharded_buffer = owner.view([Flat()])
-    owner_data_ptr = owner.local_buffer.data_ptr()
-
-    assert same_layout_view is owner
-    assert (
-        sharded_buffer.local_buffer.untyped_storage().data_ptr()
-        == owner.local_buffer.untyped_storage().data_ptr()
-    )
-    assert sharded_buffer.offset >= owner.offset
-    sharded_buffer.local_buffer.copy_(
-        torch.arange(
-            sharded_buffer.local_buffer.numel(),
-            device=sharded_buffer.device,
-            dtype=sharded_buffer.dtype,
-        )
-        + sharded_buffer.offset
-    )
-
-    result = sharded_buffer.allgather(0, out=owner)
-
-    assert result is owner
-    assert owner.local_buffer.data_ptr() == owner_data_ptr
-    torch.testing.assert_close(
-        owner.local_buffer,
-        torch.arange(owner.local_buffer.numel(), device=owner.device, dtype=owner.dtype),
-    )
-
-
 def test_view_rejects_non_aliasing_placement_change(distributed_setup):
     """A view rejects placement changes that need communication."""
     if distributed_setup.world_size < 2:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -250,6 +250,41 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
+def test_scatter_aliases_owner_and_allgathers_into_it(distributed_setup):
+    """Scatter returns an alias that can materialize its owner in place."""
+    if distributed_setup.world_size < 2:
+        pytest.skip("DBuffer scatter-alias test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    tensors = _same_tensors_on_all_ranks(distributed_setup.device)
+    owner = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
+    sharded_buffer = owner.scatter(0, Flat())
+    owner_data_ptr = owner.local_buffer.data_ptr()
+
+    assert (
+        sharded_buffer.local_buffer.untyped_storage().data_ptr()
+        == owner.local_buffer.untyped_storage().data_ptr()
+    )
+    assert sharded_buffer.offset >= owner.offset
+    sharded_buffer.local_buffer.copy_(
+        torch.arange(
+            sharded_buffer.local_buffer.numel(),
+            device=sharded_buffer.device,
+            dtype=sharded_buffer.dtype,
+        )
+        + sharded_buffer.offset
+    )
+
+    result = sharded_buffer.allgather(0, out=owner)
+
+    assert result is owner
+    assert owner.local_buffer.data_ptr() == owner_data_ptr
+    torch.testing.assert_close(
+        owner.local_buffer,
+        torch.arange(owner.local_buffer.numel(), device=owner.device, dtype=owner.dtype),
+    )
+
+
 def test_replicate_get_local_tensor_and_dtensor(distributed_setup):
     """Replicated DBuffer returns full local tensors and replicated DTensors."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -250,17 +250,20 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
-def test_scatter_aliases_owner_and_allgathers_into_it(distributed_setup):
-    """Scatter returns an alias that can materialize its owner in place."""
+def test_view_aliases_owner_and_allgathers_into_it(distributed_setup):
+    """A placement view aliases its owner and can materialize it in place."""
     if distributed_setup.world_size < 2:
-        pytest.skip("DBuffer scatter-alias test requires at least 2 ranks.")
+        pytest.skip("DBuffer view test requires at least 2 ranks.")
 
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensors = _same_tensors_on_all_ranks(distributed_setup.device)
     owner = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    sharded_buffer = owner.scatter(0, Flat())
+    same_layout_view = owner.view([Replicate()])
+    sharded_buffer = owner.view([Flat()])
     owner_data_ptr = owner.local_buffer.data_ptr()
 
+    assert same_layout_view is not owner
+    assert same_layout_view.local_buffer.data_ptr() == owner_data_ptr
     assert (
         sharded_buffer.local_buffer.untyped_storage().data_ptr()
         == owner.local_buffer.untyped_storage().data_ptr()
@@ -283,6 +286,20 @@ def test_scatter_aliases_owner_and_allgathers_into_it(distributed_setup):
         owner.local_buffer,
         torch.arange(owner.local_buffer.numel(), device=owner.device, dtype=owner.dtype),
     )
+
+
+def test_view_rejects_non_aliasing_placement_change(distributed_setup):
+    """A view rejects placement changes that need communication."""
+    if distributed_setup.world_size < 2:
+        pytest.skip("DBuffer view test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    buffer = DBuffer.distribute_tensors(
+        _same_tensors_on_all_ranks(distributed_setup.device), mesh, [Flat()]
+    )
+
+    with pytest.raises(ValueError, match="Replicate-to-Flat slice"):
+        buffer.view([Replicate()])
 
 
 def test_replicate_get_local_tensor_and_dtensor(distributed_setup):
@@ -366,13 +383,13 @@ def test_sharded_allgather_into_existing_buffer(distributed_setup):
     _assert_dbuffer_local_tensors_close(destination, tensors)
 
 
-def test_replicate_scatter_round_trip(distributed_setup):
-    """Replicated buffers locally chunk into sharded buffers and all-gather back."""
+def test_replicate_view_round_trip(distributed_setup):
+    """Replicated buffers view sharded local storage and all-gather back."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensors = _same_tensors_on_all_ranks(distributed_setup.device)
 
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
-    sharded_buffer = replicated_buffer.scatter(0, Flat())
+    sharded_buffer = replicated_buffer.view([Flat()])
     redistribute_destination = DBuffer(
         mesh=mesh,
         placements=[Flat()],
@@ -700,8 +717,8 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(distributed_setup):
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
-def test_2d_mesh_replicate_flat_scatter_to_flat_flat(distributed_setup):
-    """Replicate+Flat scatter chunks the existing Flat local shard."""
+def test_2d_mesh_replicate_flat_view_to_flat_flat(distributed_setup):
+    """A Replicate+Flat view chunks the existing Flat local shard."""
     if distributed_setup.world_size < 4 or distributed_setup.world_size % 2 != 0:
         pytest.skip("2D DBuffer test requires an even world size of at least 4.")
 
@@ -713,7 +730,7 @@ def test_2d_mesh_replicate_flat_scatter_to_flat_flat(distributed_setup):
     )
 
     replicated_sharded_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate(), Flat()])
-    fully_sharded_buffer = replicated_sharded_buffer.scatter(0, Flat())
+    fully_sharded_buffer = replicated_sharded_buffer.view([Flat(), Flat()])
     replicated_buffer = fully_sharded_buffer.allgather(0).allgather(1)
 
     assert fully_sharded_buffer.placements == (Flat(), Flat())

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -262,8 +262,7 @@ def test_view_aliases_owner_and_allgathers_into_it(distributed_setup):
     sharded_buffer = owner.view([Flat()])
     owner_data_ptr = owner.local_buffer.data_ptr()
 
-    assert same_layout_view is not owner
-    assert same_layout_view.local_buffer.data_ptr() == owner_data_ptr
+    assert same_layout_view is owner
     assert (
         sharded_buffer.local_buffer.untyped_storage().data_ptr()
         == owner.local_buffer.untyped_storage().data_ptr()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -719,52 +719,6 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
         torch.testing.assert_close(second_loss, first_loss)
 
 
-def test_zero1_mixed_precision_sync_aliases_persistent_model_weight(distributed_setup):
-    """ZeRO-1 sync should cast into a stable model-weight allocation's local view."""
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(device)
-    with fully_shard_context(device=device):
-        fully_shard(
-            model,
-            mesh=mesh,
-            placements=_zero1_placements(),
-            mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
-        )
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
-    fully_shard_optimizer(optimizer)
-    (group,) = model.parameter_groups
-    post_optimizer_model_weight = group.post_optimizer_model_weight
-    model_weight_data_ptr = group.model_weight.local_buffer.data_ptr()
-    assert (
-        post_optimizer_model_weight.local_buffer.untyped_storage().data_ptr()
-        == group.model_weight.local_buffer.untyped_storage().data_ptr()
-    )
-
-    x = torch.ones(1, 4, device=device, dtype=torch.bfloat16)
-    for _ in range(2):
-        optimizer.zero_grad(set_to_none=True)
-        model(x).sum().backward()
-        optimizer.step()
-
-        assert group._model_weight_is_stale
-        assert group.model_weight.local_buffer.data_ptr() == model_weight_data_ptr
-        assert (
-            post_optimizer_model_weight.local_buffer.untyped_storage().data_ptr()
-            == group.model_weight.local_buffer.untyped_storage().data_ptr()
-        )
-
-        # The next forward performs the first-microbatch all-gather directly into
-        # the persistent owner without replacing its storage.
-        model(x)
-        assert not group._model_weight_is_stale
-        assert group.model_weight.local_buffer.data_ptr() == model_weight_data_ptr
-
-
 def test_mixed_precision_rejects_optimizer_range_larger_than_model_range(distributed_setup):
     """Mixed precision requires the optimizer-layout slice to fit the model-weight owner."""
     world_size = distributed_setup.world_size

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -723,8 +723,6 @@ def test_rejects_optimizer_placements_larger_than_model_weight_placements(distri
     """Optimizer placements must fit within the model-weight placements."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
     model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(device)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -719,6 +719,74 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
         torch.testing.assert_close(second_loss, first_loss)
 
 
+def test_zero1_mixed_precision_sync_aliases_persistent_model_weight(distributed_setup):
+    """ZeRO-1 sync should cast into a stable model-weight allocation's local view."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(device)
+    with fully_shard_context(device=device):
+        fully_shard(
+            model,
+            mesh=mesh,
+            placements=_zero1_placements(),
+            mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+        )
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
+    fully_shard_optimizer(optimizer)
+    (group,) = model.parameter_groups
+    post_optimizer_model_weight = group.post_optimizer_model_weight
+    model_weight_data_ptr = group.model_weight.local_buffer.data_ptr()
+    assert (
+        post_optimizer_model_weight.local_buffer.untyped_storage().data_ptr()
+        == group.model_weight.local_buffer.untyped_storage().data_ptr()
+    )
+
+    x = torch.ones(1, 4, device=device, dtype=torch.bfloat16)
+    for _ in range(2):
+        optimizer.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+        optimizer.step()
+
+        assert group._model_weight_is_stale
+        assert group.model_weight.local_buffer.data_ptr() == model_weight_data_ptr
+        assert (
+            post_optimizer_model_weight.local_buffer.untyped_storage().data_ptr()
+            == group.model_weight.local_buffer.untyped_storage().data_ptr()
+        )
+
+        # The next forward performs the first-microbatch all-gather directly into
+        # the persistent owner without replacing its storage.
+        model(x)
+        assert not group._model_weight_is_stale
+        assert group.model_weight.local_buffer.data_ptr() == model_weight_data_ptr
+
+
+def test_mixed_precision_rejects_optimizer_range_larger_than_model_range(distributed_setup):
+    """Mixed precision requires the optimizer-layout slice to fit the model-weight owner."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Linear(4, 4, bias=False, dtype=torch.bfloat16).to(device)
+    placements = Placements(
+        dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Replicate()]
+    )
+    with pytest.raises(ValueError, match="Replicate-to-Flat slice"):
+        with fully_shard_context(device=device):
+            fully_shard(
+                model,
+                mesh=mesh,
+                placements=placements,
+                mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+            )
+
+
 def test_optimizer_post_step_syncs_once_per_parameter_group(distributed_setup, monkeypatch):
     """Optimizer synchronization should run once per group, not once per microbatch."""
     world_size = distributed_setup.world_size

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -719,8 +719,8 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
         torch.testing.assert_close(second_loss, first_loss)
 
 
-def test_mixed_precision_rejects_optimizer_range_larger_than_model_range(distributed_setup):
-    """Mixed precision requires the optimizer-layout slice to fit the model-weight owner."""
+def test_rejects_optimizer_placements_larger_than_model_weight_placements(distributed_setup):
+    """Optimizer placements must fit within the model-weight placements."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
     if world_size < 2:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -104,8 +104,8 @@ def test_persistent_sharded_storage(distributed_setup, main_params_dtype):
                     "model and main weights."
                 )
                 assert group.post_optimizer_model_weight is group.model_weight, (
-                    f"Layer {layer_index}, parameter group {group_index} should alias "
-                    "post-optimizer and model weights."
+                    f"ZeRO-3 layer {layer_index}, parameter group {group_index} should use "
+                    "model_weight itself as its post-optimizer model weight."
                 )
         expected_per_child_nbytes = 2 * child_weight_nbytes
     else:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -228,9 +228,7 @@ def test_zero1_memory_uses_sharded_optimizer_and_replicated_weight(distributed_s
     # Resting memory holds one replicated BF16 model weight, one sharded BF16
     # main gradient, and three sharded FP32 buffers: main weight and two Adam states.
     expected_resting_nbytes = (
-        full_bf16_weight_nbytes
-        + sharded_bf16_weight_nbytes
-        + 3 * sharded_fp32_weight_nbytes
+        full_bf16_weight_nbytes + sharded_bf16_weight_nbytes + 3 * sharded_fp32_weight_nbytes
     )
     # Peak memory additionally holds the casted gradient and the sqrt and division
     # intermediates in ``denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)``.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -181,8 +181,8 @@ def test_training_step_peak_memory_bounds_full_size_buffers(
     )
 
 
-def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distributed_setup):
-    """First-step peak memory should match the expected ZeRO-1 training allocations."""
+def test_zero1_memory_uses_sharded_optimizer_and_replicated_weight(distributed_setup):
+    """ZeRO-1 keeps optimizer state sharded while model weights are replicated."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
     if world_size < 2:
@@ -192,6 +192,7 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     num_tokens = 256
     dtype = torch.bfloat16
     x = torch.ones(num_tokens, dim, device=device, dtype=dtype)
+    allocated_before_setup = torch.cuda.memory_allocated(device)
     model = ElementwiseModel(dim).to(device=device, dtype=dtype)
     mesh = init_device_mesh(device.type, (world_size,))
     placements = _zero1_placements()
@@ -201,69 +202,42 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     fully_shard_optimizer(optimizer)
     (parameter_group,) = model.parameter_groups
 
-    allocated_before_training = torch.cuda.memory_allocated(device)
+    full_bf16_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+    sharded_bf16_weight_nbytes = full_bf16_weight_nbytes // world_size
+    sharded_fp32_weight_nbytes = (
+        dim * dim // world_size * torch.empty((), dtype=torch.float32).element_size()
+    )
+    torch._C._cuda_clearCublasWorkspaces()
     torch.cuda.reset_peak_memory_stats(device)
 
-    loss = model(x).sum()
-    loss.backward()
-    optimizer.step()
+    def train_step() -> None:
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+    train_step()
+    peak_nbytes = torch.cuda.max_memory_allocated(device) - allocated_before_setup
+    resting_nbytes = torch.cuda.memory_allocated(device) - allocated_before_setup
     assert parameter_group.model_weight.placements == (Replicate(),)
     assert parameter_group.post_optimizer_model_weight.placements == (Flat(),)
 
-    actual_optimizer_size = sum(
+    optimizer_state_nbytes = sum(
         state["exp_avg"].to_local().nbytes + state["exp_avg_sq"].to_local().nbytes
         for state in optimizer.state.values()
     )
-    actual_training_growth = torch.cuda.max_memory_allocated(device) - allocated_before_training
-
-    # Theoretical sharded Adam size.
-    shard_numel = dim * dim // world_size
-    fp32_size = torch.empty((), dtype=torch.float32).element_size()
-    bf16_size = torch.empty((), dtype=dtype).element_size()
-    theoretical_optimizer_size = 2 * shard_numel * fp32_size
-
-    # ElementwiseModel itself is the only layer in this test model.
-    num_layers = 1
-    full_bf16_weight_size = dim * dim * bf16_size
-    sharded_bf16_weight_size = full_bf16_weight_size // world_size
-    sharded_fp32_weight_size = shard_numel * fp32_size
-    activation_size = num_tokens * dim * bf16_size
-    # Backward peak growth. The persistent replicated model weight was allocated
-    # before the measurement, so it adds no step-local allocation here.
-    backward_model_weight_size = 0
-    # - Full parameter gradient: dim * dim * bf16_size.
-    backward_parameter_gradient_size = full_bf16_weight_size
-    # - Unreduced partial-gradient buffer: dim * dim * bf16_size.
-    backward_partial_gradient_size = full_bf16_weight_size
-    # - Earlier-layer activations: (num_layers - 1) * num_tokens * dim * bf16_size.
-    #   This one-layer model has no stacked activation at its backward peak.
-    backward_stacked_activation_size = (num_layers - 1) * activation_size
-    theoretical_backward_growth = (
-        backward_model_weight_size
-        + backward_parameter_gradient_size
-        + backward_partial_gradient_size
-        + backward_stacked_activation_size
+    # Resting memory holds one replicated BF16 model weight, one sharded BF16
+    # main gradient, and three sharded FP32 buffers: main weight and two Adam states.
+    expected_resting_nbytes = (
+        full_bf16_weight_nbytes
+        + sharded_bf16_weight_nbytes
+        + 3 * sharded_fp32_weight_nbytes
     )
-
-    # - BF16 main gradient shrinks from full to sharded: -(full - sharded BF16 weight).
-    optimizer_main_gradient_reduction = full_bf16_weight_size - sharded_bf16_weight_size
-    # - Casted gradient: shard_numel * fp32_size.
-    optimizer_casted_gradient_size = sharded_fp32_weight_size
-    # - Optimizer states exp_avg and exp_avg_sq: 2 * shard_numel * fp32_size.
-    optimizer_state_size = 2 * sharded_fp32_weight_size
-    # - Two FP32 buffers that briefly coexist while Adam computes the
-    #   bias-corrected denominator: 2 * shard_numel * fp32_size.
-    optimizer_temporary_size = 2 * sharded_fp32_weight_size
-    theoretical_optimizer_growth = (
-        -optimizer_main_gradient_reduction
-        + optimizer_casted_gradient_size
-        + optimizer_state_size
-        + optimizer_temporary_size
-    )
-    theoretical_training_growth = max(theoretical_backward_growth, theoretical_optimizer_growth)
-
-    assert actual_optimizer_size == theoretical_optimizer_size
-    assert abs(actual_training_growth - theoretical_training_growth) < 1024**2
+    # Peak memory additionally holds the casted gradient and the sqrt and division
+    # intermediates in ``denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)``.
+    expected_peak_nbytes = expected_resting_nbytes + 3 * sharded_fp32_weight_nbytes
+    assert optimizer_state_nbytes == 2 * sharded_fp32_weight_nbytes
+    assert resting_nbytes < expected_resting_nbytes + 1024**2
+    assert peak_nbytes < expected_peak_nbytes + 1024**2
 
 
 def test_deleted_model_releases_fsdp_storage(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -202,7 +202,7 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     loss = model(x).sum()
     loss.backward()
     optimizer.step()
-    assert parameter_group.model_weight.placements == (Flat(),)
+    assert parameter_group.model_weight.placements == (Replicate(),)
 
     actual_optimizer_size = sum(
         state["exp_avg"].to_local().nbytes + state["exp_avg_sq"].to_local().nbytes
@@ -222,9 +222,9 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     sharded_bf16_weight_size = full_bf16_weight_size // world_size
     sharded_fp32_weight_size = shard_numel * fp32_size
     activation_size = num_tokens * dim * bf16_size
-    # Backward peak growth:
-    # - Unsharded model weight: dim * dim * bf16_size.
-    backward_model_weight_size = full_bf16_weight_size
+    # Backward peak growth. The persistent replicated model weight was allocated
+    # before the measurement, so it adds no step-local allocation here.
+    backward_model_weight_size = 0
     # - Full parameter gradient: dim * dim * bf16_size.
     backward_parameter_gradient_size = full_bf16_weight_size
     # - Unreduced partial-gradient buffer: dim * dim * bf16_size.
@@ -232,19 +232,13 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     # - Earlier-layer activations: (num_layers - 1) * num_tokens * dim * bf16_size.
     #   This one-layer model has no stacked activation at its backward peak.
     backward_stacked_activation_size = (num_layers - 1) * activation_size
-    # - Released baseline model-weight shard: -(dim * dim * bf16_size / world_size).
-    released_sharded_model_weight_size = sharded_bf16_weight_size
     theoretical_backward_growth = (
         backward_model_weight_size
         + backward_parameter_gradient_size
         + backward_partial_gradient_size
         + backward_stacked_activation_size
-        - released_sharded_model_weight_size
     )
 
-    # First-Adam-step peak growth:
-    # - Model weight grows from sharded to full BF16: full - sharded BF16 weight.
-    optimizer_model_weight_growth = full_bf16_weight_size - sharded_bf16_weight_size
     # - BF16 main gradient shrinks from full to sharded: -(full - sharded BF16 weight).
     optimizer_main_gradient_reduction = full_bf16_weight_size - sharded_bf16_weight_size
     # - Casted gradient: shard_numel * fp32_size.
@@ -255,8 +249,7 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     #   bias-corrected denominator: 2 * shard_numel * fp32_size.
     optimizer_temporary_size = 2 * sharded_fp32_weight_size
     theoretical_optimizer_growth = (
-        optimizer_model_weight_growth
-        - optimizer_main_gradient_reduction
+        -optimizer_main_gradient_reduction
         + optimizer_casted_gradient_size
         + optimizer_state_size
         + optimizer_temporary_size

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -97,12 +97,16 @@ def test_persistent_sharded_storage(distributed_setup, main_params_dtype):
     if main_params_dtype == dtype:
         # Model and main weights alias, leaving only one BF16 weight buffer and one
         # BF16 main-gradient buffer per child.
-        assert all(
-            group.model_weight is group.main_weight
-            and group.post_optimizer_model_weight is group.model_weight
-            for layer in model.layers
-            for group in layer.parameter_groups
-        )
+        for layer_index, layer in enumerate(model.layers):
+            for group_index, group in enumerate(layer.parameter_groups):
+                assert group.model_weight is group.main_weight, (
+                    f"Layer {layer_index}, parameter group {group_index} should alias "
+                    "model and main weights."
+                )
+                assert group.post_optimizer_model_weight is group.model_weight, (
+                    f"Layer {layer_index}, parameter group {group_index} should alias "
+                    "post-optimizer and model weights."
+                )
         expected_per_child_nbytes = 2 * child_weight_nbytes
     else:
         # FP32 main weights require a distinct buffer in addition to the BF16 model
@@ -204,6 +208,7 @@ def test_zero1_memory_matches_sharded_optimizer_and_replicated_weight(distribute
     loss.backward()
     optimizer.step()
     assert parameter_group.model_weight.placements == (Replicate(),)
+    assert parameter_group.post_optimizer_model_weight.placements == (Flat(),)
 
     actual_optimizer_size = sum(
         state["exp_avg"].to_local().nbytes + state["exp_avg_sq"].to_local().nbytes

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -99,7 +99,7 @@ def test_persistent_sharded_storage(distributed_setup, main_params_dtype):
         # BF16 main-gradient buffer per child.
         assert all(
             group.model_weight is group.main_weight
-            and group.post_optimizer_model_weight is not group.model_weight
+            and group.post_optimizer_model_weight is group.model_weight
             for layer in model.layers
             for group in layer.parameter_groups
         )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -99,6 +99,7 @@ def test_persistent_sharded_storage(distributed_setup, main_params_dtype):
         # BF16 main-gradient buffer per child.
         assert all(
             group.model_weight is group.main_weight
+            and group.post_optimizer_model_weight is not group.model_weight
             for layer in model.layers
             for group in layer.parameter_groups
         )


### PR DESCRIPTION
## What
- Keep the configured parameter-layout `model_weight` allocation persistent across optimizer steps.
- Represent the optimizer-layout post-step weight as a storage-sharing `DBuffer.view()` and all-gather it directly into that persistent owner.
- Reject unsupported optimizer/model-weight placement pairs and simplify the associated placement and ZeRO-1 memory coverage.

## Why
- Avoid resetting `self.model_weight` after synchronization, so it can be allocated once on the default stream for simplicity. 
- Make optimizer post-step synchronization CUDA-graph-safe by writing into preallocated model-weight storage instead of reallocating it. See #6152 
- A follow-up can apply the same persistent-owner/view simplification to `main_grad`.

## Testing
- `python -m torch.distributed.run --nproc-per-node 1 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_rejects_optimizer_placements_larger_than_model_weight_placements`
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_memory.py::test_zero1_memory_uses_sharded_optimizer_and_replicated_weight`
- Focused 2-GPU DBuffer, mixed-precision optimizer-update, and persistent-memory tests.