### PR TITLE
fix(moe): preserve fused expert weight storage through DDP

### DIFF
--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -1002,8 +1002,9 @@ def _compute_default_per_buffer_param_layout(
 ) -> 'PerBufferParamLayout':
     """Compute parameter layout for the non-distributed-optimizer case.
 
-    No padding is applied. Parameters are iterated in reverse order (backprop order)
-    and grouped into buckets of approximately `bucket_size` elements.
+    No padding is applied. Parameters are iterated in reverse order (backprop order), except
+    gapless shared-storage groups retain their storage order, and are grouped into buckets of
+    approximately `bucket_size` elements.
 
     Args:
         params: List of parameters to lay out.
@@ -1012,7 +1013,11 @@ def _compute_default_per_buffer_param_layout(
     Returns:
         PerBufferParamLayout with the computed mapping.
     """
-    from ..optimizer.param_layout import PerBufferParamLayout
+    from ..optimizer.param_layout import (
+        PerBufferParamLayout,
+        order_params_for_layout,
+        params_share_gapless_storage,
+    )
 
     param_index_map = {}
     bucket_indices = []
@@ -1023,13 +1028,21 @@ def _compute_default_per_buffer_param_layout(
     bucket_params = set()
     bucket_id = 0
 
-    for param in params[::-1]:
+    ordered_params = order_params_for_layout(params)
+    for position, param in enumerate(ordered_params):
+        grouped_with_next = position + 1 < len(ordered_params) and params_share_gapless_storage(
+            param, ordered_params[position + 1]
+        )
         this_numel = param.data.nelement()
         param_end_index = param_start_index + this_numel
         param_index_map[param] = (param_start_index, param_end_index, bucket_id)
         bucket_params.add(param)
 
-        if bucket_size is not None and (param_end_index - bucket_start_index) >= bucket_size:
+        if (
+            not grouped_with_next
+            and bucket_size is not None
+            and (param_end_index - bucket_start_index) >= bucket_size
+        ):
             per_bucket_numel_unpadded.append(param_end_index - bucket_start_index)
             bucket_indices.append((bucket_start_index, param_end_index))
             bucket_start_index = param_end_index

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -70,7 +70,14 @@ from .optimizer import (
     param_group_identifier_keys,
 )
 from .optimizer_config import OptimizerConfig
-from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end, pad_param_start
+from .param_layout import (
+    FullParamLayout,
+    PerBufferParamLayout,
+    order_params_for_layout,
+    pad_bucket_end,
+    pad_param_start,
+    params_share_gapless_storage,
+)
 
 logger = getLogger(__name__)
 
@@ -521,9 +528,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
     ) -> 'PerBufferParamLayout':
         """Compute how parameters should be laid out in the contiguous buffer.
 
-        Iterates params in reverse order (backprop order), applies 64-byte param
-        alignment, bucket-end padding for DP divisibility, and shared-embedding
-        bucket splitting.
+        Iterates params in reverse order (backprop order), except gapless shared-storage groups
+        retain their storage order. Applies 64-element parameter alignment, bucket-end padding
+        for DP divisibility, and shared-embedding bucket splitting.
 
         Args:
             params: List of parameters to lay out.
@@ -558,8 +565,20 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             bucket_indices.append((bucket_start_index, bucket_end_index))
             return bucket_end_index, bucket_id + 1
 
-        for param in params[::-1]:
-            param_start_index = pad_param_start(param_start_index)
+        ordered_params = order_params_for_layout(params)
+        for position, param in enumerate(ordered_params):
+            grouped_with_previous = (
+                position > 0
+                and params_share_gapless_storage(ordered_params[position - 1], param)
+                and ordered_params[position - 1].numel() % 64 == 0
+            )
+            grouped_with_next = (
+                position + 1 < len(ordered_params)
+                and params_share_gapless_storage(param, ordered_params[position + 1])
+                and param.numel() % 64 == 0
+            )
+            if not grouped_with_previous:
+                param_start_index = pad_param_start(param_start_index)
 
             # Split shared embedding params into separate bucket.
             if _does_param_require_new_bucket(param) and len(bucket_params) > 0:
@@ -574,9 +593,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             param_index_map[param] = (param_start_index, param_end_index, bucket_id)
             bucket_params.add(param)
 
-            if (
-                bucket_size is not None and (param_end_index - bucket_start_index) >= bucket_size
-            ) or _does_param_require_new_bucket(param):
+            if not grouped_with_next and (
+                (bucket_size is not None and (param_end_index - bucket_start_index) >= bucket_size)
+                or _does_param_require_new_bucket(param)
+            ):
                 bucket_start_index, bucket_id = _finalize_bucket(
                     param_end_index, bucket_start_index, bucket_id
                 )

--- a/megatron/core/optimizer/param_layout.py
+++ b/megatron/core/optimizer/param_layout.py
@@ -42,6 +42,75 @@ def pad_bucket_end(
     )
 
 
+def shared_storage_group_key(
+    param: torch.nn.Parameter,
+) -> Optional[Tuple[torch.device, torch.dtype, int]]:
+    """Identify a plain parameter that is a view into a larger shared storage.
+
+    Some modules expose several independently named parameters to training and checkpointing,
+    while deliberately allocating their data as adjacent views of one tensor. The parameter
+    buffer must preserve that structural relationship so consumers can recover a fused view
+    after DDP remaps the parameters.
+
+    This intentionally uses storage identity rather than an attribute set out-of-band by the
+    module. Standalone parameters and non-strided or meta tensors are not grouped.
+    """
+    data = param.data
+    if data.device.type == "meta" or data.layout != torch.strided or not data.is_contiguous():
+        return None
+    storage = data.untyped_storage()
+    if storage.nbytes() <= data.numel() * data.element_size():
+        return None
+    return (data.device, data.dtype, storage.data_ptr())
+
+
+def params_share_gapless_storage(first: torch.nn.Parameter, second: torch.nn.Parameter) -> bool:
+    """Return whether two parameters are consecutive views of one storage."""
+    first_key = shared_storage_group_key(first)
+    return (
+        first_key is not None
+        and first_key == shared_storage_group_key(second)
+        and first.data.storage_offset() + first.numel() == second.data.storage_offset()
+    )
+
+
+def order_params_for_layout(params: List[torch.nn.Parameter]) -> List[torch.nn.Parameter]:
+    """Return reverse-registration order while preserving adjacent shared-storage groups.
+
+    DDP normally packs parameters in reverse registration order. Reversing each member of a
+    shared allocation would destroy its layout, so a gapless run of views into one storage is
+    kept in ascending storage-offset order. The groups themselves remain in normal reverse
+    registration order.
+    """
+    reversed_params = list(params)[::-1]
+    ordered: List[torch.nn.Parameter] = []
+    index = 0
+    while index < len(reversed_params):
+        group_key = shared_storage_group_key(reversed_params[index])
+        if group_key is None:
+            ordered.append(reversed_params[index])
+            index += 1
+            continue
+
+        run_end = index + 1
+        while (
+            run_end < len(reversed_params)
+            and shared_storage_group_key(reversed_params[run_end]) == group_key
+        ):
+            run_end += 1
+
+        run = reversed_params[index:run_end]
+        ascending = sorted(run, key=lambda param: param.data.storage_offset())
+        is_gapless_group = len(ascending) > 1 and all(
+            params_share_gapless_storage(first, second)
+            for first, second in zip(ascending, ascending[1:])
+        )
+
+        ordered.extend(ascending if is_gapless_group else run)
+        index = run_end
+    return ordered
+
+
 @dataclass(frozen=True)
 class BufferKey:
     """Identifies a distinct parameter buffer.

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -1160,6 +1160,12 @@ class InferenceGroupedMLP(TEGroupedMLP):
             name=name,
         )
 
+        # The serving kernels consume one [expert, out, in] tensor, while TE and checkpointing
+        # expose one named parameter per expert. Give those parameters shared, gapless storage
+        # before checkpoint loading or DDP construction. DDP recognizes that structural layout
+        # and preserves it when remapping the parameters into its own buffer.
+        self._fuse_expert_weight_storage()
+
         # Concatenated weights are built lazily on first forward to ensure
         # checkpoint loading has already populated the per-expert parameters.
         self._concatenated_weights_built = False
@@ -1171,6 +1177,33 @@ class InferenceGroupedMLP(TEGroupedMLP):
         self.inference_grouped_gemm_backend = config.inference_grouped_gemm_backend
         self._nvls_dispatcher = config.inference_moe_token_dispatcher_type == 'nvls'
         self._flashinfer_mxfp8_token_capacity = config.inference_flashinfer_mxfp8_token_capacity
+
+    @torch.no_grad()
+    def _fuse_expert_weight_storage(self) -> None:
+        """Make each linear's per-expert parameters views of one allocation.
+
+        Parameter objects and names remain unchanged, so TE bookkeeping and the legacy
+        ``weight0..weightN`` checkpoint schema are preserved. Only their initial storage is
+        replaced, before any distributed wrapper can own it.
+        """
+        for linear in (self.linear_fc1, self.linear_fc2):
+            params = [
+                getattr(linear, f'weight{expert_idx}', None)
+                for expert_idx in range(self.num_local_experts)
+            ]
+            if not all(isinstance(param, torch.nn.Parameter) for param in params):
+                raise RuntimeError("InferenceGroupedMLP requires one Parameter per local expert.")
+
+            first = params[0]
+            if any(param.shape != first.shape or param.dtype != first.dtype for param in params):
+                raise RuntimeError("Grouped expert weights must have matching shapes and dtypes.")
+
+            fused = torch.empty(
+                (self.num_local_experts, *first.shape), device=first.device, dtype=first.dtype
+            )
+            for expert_idx, param in enumerate(params):
+                fused[expert_idx].copy_(param.data)
+                param.data = fused[expert_idx]
 
     def _resolve_flashinfer_activation_type(self):
         """Map megatron activation config to FlashInfer ActivationType."""
@@ -1304,19 +1337,35 @@ class InferenceGroupedMLP(TEGroupedMLP):
 
     @torch.inference_mode(False)  # needed for non-colocated inference.
     def _build_concatenated_weights(self):
-        """Create big contiguous weight tensors that share storage with TE's per-expert parameters.
+        """Expose fused serving views over the expert parameters' shared storage.
 
-        Creates _fc1_weight and _fc2_weight as contiguous tensors of shape
-        [num_experts, out_features, in_features]. Instead of replacing TE's parameters
-        (which breaks TE's internal bookkeeping), we redirect each parameter's .data
-        to be a view into the contiguous buffer. The nn.Parameter objects themselves
-        remain untouched in TE's module, preserving FP8 scaling state, etc.
-
-        This allows:
-        - TE's forward to work correctly (same Parameter objects, same internal state)
-        - Training updates to flow through (param.data is a view into the big tensor)
-        - torch.nn.functional.grouped_mm / FlashInfer to use the big tensor directly
+        The normal path is zero-copy both before and after DDP construction. A copied fallback
+        remains for dedicated, non-DDP inference models with nonstandard parameter storage.
+        Falling back after DDP would detach serving from optimizer-owned storage, so it fails
+        closed instead.
         """
+        fc1_view = self._stacked_view_over_group(self.linear_fc1)
+        fc2_view = self._stacked_view_over_group(self.linear_fc2)
+        if (fc1_view is None) != (fc2_view is None):
+            raise RuntimeError(
+                "InferenceGroupedMLP requires FC1 and FC2 to use the same storage layout."
+            )
+        if fc1_view is not None:
+            self.register_buffer('_fc1_weight', fc1_view, persistent=False)
+            self.register_buffer('_fc2_weight', fc2_view, persistent=False)
+            return
+
+        discrete_params = [
+            getattr(linear, f'weight{i}')
+            for linear in (self.linear_fc1, self.linear_fc2)
+            for i in range(self.num_local_experts)
+        ]
+        if any(getattr(param, 'main_grad', None) is not None for param in discrete_params):
+            raise RuntimeError(
+                "InferenceGroupedMLP expert weights lost their shared layout during DDP "
+                "construction; refusing to create detached serving storage."
+            )
+
         # Get device/dtype from existing TE weights
         device = self.linear_fc1.weight0.device
         dtype = self.linear_fc1.weight0.dtype
@@ -1345,6 +1394,32 @@ class InferenceGroupedMLP(TEGroupedMLP):
         # Register big tensors as non-persistent buffers (for .to() device movement, not saved)
         self.register_buffer('_fc1_weight', _fc1_weight, persistent=False)
         self.register_buffer('_fc2_weight', _fc2_weight, persistent=False)
+
+    def _stacked_view_over_group(self, linear: torch.nn.Module) -> Optional[torch.Tensor]:
+        """Return a contiguous expert-axis view when all named weights share storage."""
+        params = [getattr(linear, f'weight{i}', None) for i in range(self.num_local_experts)]
+        if not all(isinstance(param, torch.nn.Parameter) for param in params):
+            return None
+
+        first = params[0].data
+        storage = first.untyped_storage()
+        member_numel = first.numel()
+        base_offset = first.storage_offset()
+        for expert_idx, param in enumerate(params):
+            data = param.data
+            if (
+                data.dtype != first.dtype
+                or data.device != first.device
+                or data.shape != first.shape
+                or not data.is_contiguous()
+                or data.untyped_storage().data_ptr() != storage.data_ptr()
+                or data.storage_offset() != base_offset + expert_idx * member_numel
+            ):
+                return None
+
+        return torch.empty(0, dtype=first.dtype, device=first.device).set_(
+            storage, base_offset, (self.num_local_experts, *first.shape)
+        )
 
     def _flashinfer_forward(self, hidden_states, routing_map, probs):
         """FlashInfer fused MoE kernel for CUDA-graphed inference iterations."""

--- a/tests/unit_tests/distributed/test_param_layout.py
+++ b/tests/unit_tests/distributed/test_param_layout.py
@@ -25,9 +25,12 @@ from megatron.core.distributed.param_and_grad_buffer import (
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.optimizer.param_layout import (
     BufferKey,
+    order_params_for_layout,
     pad_bucket_end,
     pad_param_start,
     pad_to_divisor,
+    params_share_gapless_storage,
+    shared_storage_group_key,
 )
 
 # ---------------------------------------------------------------------------
@@ -48,9 +51,37 @@ def _make_param_with_attrs(shape, dtype=torch.bfloat16, **attrs):
     return param
 
 
+def _make_shared_params(count, numel, dtype=torch.bfloat16):
+    storage = torch.randn(count, numel, dtype=dtype)
+    return [torch.nn.Parameter(storage[index]) for index in range(count)]
+
+
 # ---------------------------------------------------------------------------
 # Tests for shared padding utilities
 # ---------------------------------------------------------------------------
+
+
+def test_order_params_preserves_gapless_shared_storage_group():
+    dense_before, dense_after = _make_params((5,), (6,))
+    experts = _make_shared_params(3, 7)
+
+    ordered = order_params_for_layout([dense_before, *experts, dense_after])
+
+    assert ordered == [dense_after, *experts, dense_before]
+    assert shared_storage_group_key(experts[0]) is not None
+    assert shared_storage_group_key(_make_params((7,))[0]) is None
+    assert params_share_gapless_storage(experts[0], experts[1])
+
+
+def test_order_params_does_not_group_shared_storage_views_with_gaps():
+    storage = torch.randn(21, dtype=torch.bfloat16)
+    first = torch.nn.Parameter(storage[:7])
+    second = torch.nn.Parameter(storage[14:])
+
+    ordered = order_params_for_layout([first, second])
+
+    assert ordered == [second, first]
+    assert not params_share_gapless_storage(first, second)
 
 
 class TestPaddingUtilities:
@@ -169,6 +200,29 @@ class TestGroupParamsForBuffers:
 
 class TestDefaultParamLayout:
 
+    def test_shared_storage_group_is_gapless_and_not_split(self):
+        experts = _make_shared_params(3, 7)
+
+        layout = _compute_default_per_buffer_param_layout(experts, bucket_size=10)
+
+        assert [layout.param_index_map[param] for param in experts] == [
+            (0, 7, 0),
+            (7, 14, 0),
+            (14, 21, 0),
+        ]
+        assert layout.bucket_indices == [(0, 21)]
+
+    def test_shared_storage_views_with_gaps_are_not_grouped(self):
+        storage = torch.randn(21, dtype=torch.bfloat16)
+        first = torch.nn.Parameter(storage[:7])
+        second = torch.nn.Parameter(storage[14:])
+
+        layout = _compute_default_per_buffer_param_layout([first, second], bucket_size=7)
+
+        assert layout.param_index_map[second] == (0, 7, 0)
+        assert layout.param_index_map[first] == (7, 14, 1)
+        assert layout.bucket_indices == [(0, 7), (7, 14)]
+
     def test_single_bucket_no_padding(self):
         """With bucket_size=None, all params go in one bucket with no padding."""
         params = _make_params((100, 100), (50, 50))
@@ -242,6 +296,36 @@ class TestDistOptParamLayout:
             start, end, _ = layout.param_index_map[param]
             assert start % 64 == 0, f"Start {start} should be 64-aligned"
             assert end - start == param.numel()
+
+    def test_shared_storage_group_is_gapless_and_keeps_param_indices_aligned(self):
+        dense_before, dense_after = _make_params((5,), (6,))
+        experts = _make_shared_params(3, 64)
+        params = [dense_before, *experts, dense_after]
+        ddp_config = self._make_ddp_config()
+
+        layout = DistributedOptimizer._compute_per_buffer_param_layout(
+            params,
+            bucket_size=10,
+            data_parallel_world_size=2,
+            ddp_config=ddp_config,
+            param_indices=list(range(len(params))),
+        )
+
+        starts = [layout.param_index_map[param][0] for param in experts]
+        assert starts == [64, 128, 192]
+        assert len({layout.param_index_map[param][2] for param in experts}) == 1
+        assert layout.param_indices == list(range(len(params)))
+
+    def test_shared_storage_group_does_not_override_param_alignment(self):
+        experts = _make_shared_params(3, 7)
+        ddp_config = self._make_ddp_config()
+
+        layout = DistributedOptimizer._compute_per_buffer_param_layout(
+            experts, bucket_size=None, data_parallel_world_size=2, ddp_config=ddp_config
+        )
+
+        starts = [layout.param_index_map[param][0] for param in experts]
+        assert starts == [0, 64, 128]
 
     def test_bucket_end_dp_divisible(self):
         """Each bucket end should be divisible by lcm(dp_size, 128)."""

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -16,7 +16,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.transformer.module import Float16Module
-from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.experts import InferenceGroupedMLP, TEGroupedMLP
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -42,6 +42,58 @@ def test_op_fuser_transformer_config_args_are_exposed():
     assert args.use_transformer_engine_op_fuser is True
     assert args.moe_mlp_glu_interleave_size == 16
     assert args.moe_use_grouped_tensor is True
+
+
+def _make_inference_grouped_mlp_stub(num_local_experts=3):
+    module = InferenceGroupedMLP.__new__(InferenceGroupedMLP)
+    torch.nn.Module.__init__(module)
+    module.num_local_experts = num_local_experts
+    for linear_name in ("linear_fc1", "linear_fc2"):
+        linear = torch.nn.Module()
+        for expert_idx in range(num_local_experts):
+            linear.register_parameter(
+                f"weight{expert_idx}", torch.nn.Parameter(torch.full((2, 4), float(expert_idx + 1)))
+            )
+        setattr(module, linear_name, linear)
+    return module
+
+
+def test_inference_grouped_mlp_fuses_storage_without_changing_parameter_schema():
+    module = _make_inference_grouped_mlp_stub()
+
+    module._fuse_expert_weight_storage()
+
+    for linear in (module.linear_fc1, module.linear_fc2):
+        params = [getattr(linear, f"weight{i}") for i in range(module.num_local_experts)]
+        assert list(linear.state_dict()) == [f"weight{i}" for i in range(module.num_local_experts)]
+        assert len({param.untyped_storage().data_ptr() for param in params}) == 1
+        for expert_idx, param in enumerate(params):
+            assert param.storage_offset() == expert_idx * param.numel()
+            torch.testing.assert_close(param, torch.full_like(param, float(expert_idx + 1)))
+
+
+def test_inference_grouped_mlp_serving_view_aliases_fused_parameters():
+    module = _make_inference_grouped_mlp_stub()
+    module._fuse_expert_weight_storage()
+
+    module._build_concatenated_weights()
+
+    assert module._fc1_weight.shape == (module.num_local_experts, 2, 4)
+    assert module._fc1_weight.data_ptr() == module.linear_fc1.weight0.data_ptr()
+    with torch.no_grad():
+        module.linear_fc1.weight1.add_(5)
+    torch.testing.assert_close(module._fc1_weight[1], module.linear_fc1.weight1)
+
+
+def test_inference_grouped_mlp_rejects_layout_lost_after_ddp():
+    module = _make_inference_grouped_mlp_stub()
+    for linear in (module.linear_fc1, module.linear_fc2):
+        for expert_idx in range(module.num_local_experts):
+            param = getattr(linear, f"weight{expert_idx}")
+            param.main_grad = torch.empty_like(param)
+
+    with pytest.raises(RuntimeError, match="lost their shared layout during DDP"):
+        module._build_concatenated_weights()
 
 
 def test_op_fuser_enables_grouped_tensor():


### PR DESCRIPTION
The distributed optimizer updates its parameter buffer, but serving previously captured a separately fused expert tensor. Its values therefore froze at capture time, causing colocated RL generation to use stale expert weights.

Allocate per-expert weights as adjacent views before DDP construction and preserve their gapless layout in parameter buffers. Serving can then recover a zero-copy fused view without changing checkpoint parameter names.

- [x] I, the PR author, have personally reviewed every line of this PR.

### Result
<img width="2528" height="1328" alt="W B Chart 8_31_2026, 9_03_16 AM" src="https://github.com/user-attachments/assets/4ab47c41-d36f-4579-af5a-f0a9a1bcb6fb" />

### Notes

- this replaces https://github.com/NVIDIA/Megatron-LM/pull/6931 
