### PR TITLE
fix: Do not pass is_first_microbatch to TE when it is not maintained

### DIFF
--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -45,7 +45,7 @@ Checked against the parsed `args` Namespace in `apply_determinism_to_args`. Inco
 | `--tp-comm-overlap` | Must be off — asserted (the overlap path is not bit-exact); drop the flag yourself |
 | `torch.use_deterministic_algorithms` | Set to `True` |
 
-Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html)).
+Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/api/pytorch.html)).
 
 ## Verifying determinism
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -49,6 +49,7 @@ from megatron.core.tensor_parallel.random import (
 from megatron.core.tensor_parallel.utils import divide
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.module import is_first_microbatch_tracked
 from megatron.core.transformer.torch_norm import LayerNormInterface
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import (
@@ -1375,7 +1376,10 @@ class TELinear(te.pytorch.Linear):
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Forward."""
         _is_first_microbatch = (
-            None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+            None
+            if self.disable_parameter_transpose_cache
+            or not is_first_microbatch_tracked(self.config)
+            else self.is_first_microbatch
         )
         quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
@@ -1624,7 +1628,10 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
     def forward(self, x):
         """Forward."""
         _is_first_microbatch = (
-            None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+            None
+            if self.disable_parameter_transpose_cache
+            or not is_first_microbatch_tracked(self.config)
+            else self.is_first_microbatch
         )
         quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
@@ -2776,7 +2783,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
         def forward(self, x, m_splits):
             """Forward."""
             _is_first_microbatch = (
-                None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+                None
+                if self.disable_parameter_transpose_cache
+                or not is_first_microbatch_tracked(self.config)
+                else self.is_first_microbatch
             )
             quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -402,18 +402,10 @@ def _get_should_context_be_quantized_params(
 
 
 def _resolve_is_first_microbatch(module) -> Optional[bool]:
-    """The value of ``is_first_microbatch`` to hand TE, or ``None`` when the flag is meaningless.
+    """The value to pass TE, or ``None`` meaning "no opinion, just accumulate".
 
-    TE reads the flag twice: it refreshes the quantized parameter cache on ``True``, and it
-    derives the weight-gradient accumulation mode from it in backward --
-    ``accumulate = fuse_wgrad_accumulation and not is_first_microbatch`` -- so a wrong ``True``
-    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it. ``None`` opts out
-    of both: always accumulate, never cache.
-
-    That is the right answer whenever nobody keeps the flag honest: the transpose cache is off,
-    the config is not quantized so :meth:`MegatronModule.set_is_first_microbatch` never re-arms
-    it, or the module belongs to a repeated layer, run once per MTP depth, which pairs its first
-    forward with its last backward and so inverts what the flag means.
+    A ``True`` tells TE the gradient is fresh, so backward writes over ``main_grad`` instead of
+    adding into it. Pass the flag on only when it can be trusted.
     """
     if (
         module.disable_parameter_transpose_cache

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -401,6 +401,29 @@ def _get_should_context_be_quantized_params(
         )
 
 
+def _resolve_is_first_microbatch(module) -> Optional[bool]:
+    """The value of ``is_first_microbatch`` to hand TE, or ``None`` when the flag is meaningless.
+
+    TE reads the flag twice: it refreshes the quantized parameter cache on ``True``, and it
+    derives the weight-gradient accumulation mode from it in backward --
+    ``accumulate = fuse_wgrad_accumulation and not is_first_microbatch`` -- so a wrong ``True``
+    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it. Passing ``None``
+    opts out of both: always accumulate, never cache.
+
+    That is the right answer whenever nobody keeps the flag honest -- the transpose cache is off,
+    the config is not quantized so :meth:`MegatronModule.set_is_first_microbatch` never re-arms
+    it, or the module is invoked more than once per forward pass so first-forward and
+    first-backward are not the same call.
+    """
+    if module.disable_parameter_transpose_cache:
+        return None
+    if not is_first_microbatch_tracked(module.config):
+        return None
+    if getattr(module, 'is_first_microbatch_unsafe', False):
+        return None
+    return module.is_first_microbatch
+
+
 def _get_extra_te_kwargs(config: TransformerConfig):
     extra_transformer_engine_kwargs = {"params_dtype": config.params_dtype}
 
@@ -586,6 +609,8 @@ def split_te_layernorm_column_parallel_linear(
     linear_layer.sequence_parallel = fused_layer.sequence_parallel
     linear_layer.is_first_microbatch = fused_layer.is_first_microbatch
     linear_layer.disable_parameter_transpose_cache = fused_layer.disable_parameter_transpose_cache
+    if getattr(fused_layer, 'is_first_microbatch_unsafe', False):
+        linear_layer.is_first_microbatch_unsafe = True
 
     return norm_layer, linear_layer
 
@@ -1375,12 +1400,7 @@ class TELinear(te.pytorch.Linear):
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Forward."""
-        _is_first_microbatch = (
-            None
-            if self.disable_parameter_transpose_cache
-            or not is_first_microbatch_tracked(self.config)
-            else self.is_first_microbatch
-        )
+        _is_first_microbatch = _resolve_is_first_microbatch(self)
         quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
         with quant_context:
@@ -1627,12 +1647,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
 
     def forward(self, x):
         """Forward."""
-        _is_first_microbatch = (
-            None
-            if self.disable_parameter_transpose_cache
-            or not is_first_microbatch_tracked(self.config)
-            else self.is_first_microbatch
-        )
+        _is_first_microbatch = _resolve_is_first_microbatch(self)
         quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
         # FP32 residual connections pass the FP32 residual stream into this fused module, but
@@ -2782,12 +2797,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
 
         def forward(self, x, m_splits):
             """Forward."""
-            _is_first_microbatch = (
-                None
-                if self.disable_parameter_transpose_cache
-                or not is_first_microbatch_tracked(self.config)
-                else self.is_first_microbatch
-            )
+            _is_first_microbatch = _resolve_is_first_microbatch(self)
             quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
             with quant_context:

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -412,13 +412,13 @@ def _resolve_is_first_microbatch(module) -> Optional[bool]:
 
     That is the right answer whenever nobody keeps the flag honest: the transpose cache is off,
     the config is not quantized so :meth:`MegatronModule.set_is_first_microbatch` never re-arms
-    it, or the module is reused within a microbatch (a repeated MTP layer, run once per depth),
-    which pairs its first forward with its last backward and inverts what the flag means.
+    it, or the module belongs to a repeated layer, run once per MTP depth, which pairs its first
+    forward with its last backward and so inverts what the flag means.
     """
     if (
         module.disable_parameter_transpose_cache
         or not is_first_microbatch_tracked(module.config)
-        or getattr(module, 'is_reused_within_microbatch', False)
+        or getattr(module, 'is_repeated_layer', False)
     ):
         return None
     return module.is_first_microbatch

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -407,19 +407,19 @@ def _resolve_is_first_microbatch(module) -> Optional[bool]:
     TE reads the flag twice: it refreshes the quantized parameter cache on ``True``, and it
     derives the weight-gradient accumulation mode from it in backward --
     ``accumulate = fuse_wgrad_accumulation and not is_first_microbatch`` -- so a wrong ``True``
-    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it. Passing ``None``
-    opts out of both: always accumulate, never cache.
+    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it. ``None`` opts out
+    of both: always accumulate, never cache.
 
-    That is the right answer whenever nobody keeps the flag honest -- the transpose cache is off,
+    That is the right answer whenever nobody keeps the flag honest: the transpose cache is off,
     the config is not quantized so :meth:`MegatronModule.set_is_first_microbatch` never re-arms
-    it, or the module is invoked more than once per forward pass so first-forward and
-    first-backward are not the same call.
+    it, or the module is invoked more than once per forward pass (``is_first_microbatch_unsafe``,
+    set by a repeated MTP block) so its first forward is paired with its last backward.
     """
-    if module.disable_parameter_transpose_cache:
-        return None
-    if not is_first_microbatch_tracked(module.config):
-        return None
-    if getattr(module, 'is_first_microbatch_unsafe', False):
+    if (
+        module.disable_parameter_transpose_cache
+        or not is_first_microbatch_tracked(module.config)
+        or getattr(module, 'is_first_microbatch_unsafe', False)
+    ):
         return None
     return module.is_first_microbatch
 
@@ -609,8 +609,6 @@ def split_te_layernorm_column_parallel_linear(
     linear_layer.sequence_parallel = fused_layer.sequence_parallel
     linear_layer.is_first_microbatch = fused_layer.is_first_microbatch
     linear_layer.disable_parameter_transpose_cache = fused_layer.disable_parameter_transpose_cache
-    if getattr(fused_layer, 'is_first_microbatch_unsafe', False):
-        linear_layer.is_first_microbatch_unsafe = True
 
     return norm_layer, linear_layer
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -412,13 +412,13 @@ def _resolve_is_first_microbatch(module) -> Optional[bool]:
 
     That is the right answer whenever nobody keeps the flag honest: the transpose cache is off,
     the config is not quantized so :meth:`MegatronModule.set_is_first_microbatch` never re-arms
-    it, or the module is invoked more than once per forward pass (``is_first_microbatch_unsafe``,
-    set by a repeated MTP block) so its first forward is paired with its last backward.
+    it, or the module is reused within a microbatch (a repeated MTP layer, run once per depth),
+    which pairs its first forward with its last backward and inverts what the flag means.
     """
     if (
         module.disable_parameter_transpose_cache
         or not is_first_microbatch_tracked(module.config)
-        or getattr(module, 'is_first_microbatch_unsafe', False)
+        or getattr(module, 'is_reused_within_microbatch', False)
     ):
         return None
     return module.is_first_microbatch

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -27,6 +27,31 @@ def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
     return not hasattr(param, 'shared') or not param.shared
 
 
+def is_first_microbatch_tracked(config) -> bool:
+    """Whether ``is_first_microbatch`` is maintained across iterations for this config.
+
+    :meth:`MegatronModule.set_is_first_microbatch` re-arms the flag only for quantized configs,
+    because its purpose is refreshing TE's quantized parameter cache. Outside those configs the
+    flag is set once at module construction and cleared after the first forward, so it is stale
+    for the rest of the process and carries no meaning.
+
+    This predicate is the definition, not a heuristic: ``set_is_first_microbatch`` consults it to
+    re-arm the flag and TE call sites consult it before reading, so the two cannot drift. Its body
+    is quantization-shaped only because re-arming exists to refresh TE's quantized parameter cache.
+
+    Callers must consult this before passing the flag to TE. It is not merely an optimization
+    hint: TE derives the weight-gradient accumulation mode from it --
+    ``accumulate = fuse_wgrad_accumulation and not is_first_microbatch`` -- so a stale ``True``
+    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it.
+    """
+    return (
+        config.fp8 is not None
+        or config.fp4 is not None
+        or getattr(config, 'use_kitchen', False)
+        or getattr(config, 'quant_recipe', None) is not None
+    )
+
+
 class MegatronModule(torch.nn.Module):
     """Base Megatron module inhertied by all Models.
 
@@ -117,12 +142,7 @@ class MegatronModule(torch.nn.Module):
         If kitchen is being used, kitchen controls quantization level.
         A quant_recipe (e.g. from --te-precision-config-file) also enables the flag.
         """
-        if (
-            self.config.fp8 is not None
-            or self.config.fp4 is not None
-            or getattr(self.config, 'use_kitchen', False)
-            or getattr(self.config, 'quant_recipe', None) is not None
-        ):
+        if is_first_microbatch_tracked(self.config):
             if not hasattr(self, "modules_with_is_first_microbatch"):
                 self.modules_with_is_first_microbatch = []
                 for m in self.modules():

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -52,6 +52,25 @@ def is_first_microbatch_tracked(config) -> bool:
     )
 
 
+def mark_is_first_microbatch_unsafe(module: torch.nn.Module) -> None:
+    """Mark a subtree as one whose ``is_first_microbatch`` flag must never be acted on.
+
+    The flag is armed before a module's *first* forward of an iteration and cleared by that
+    forward, which only means "this backward may overwrite ``main_grad``" when the module runs
+    exactly once per forward pass. A module invoked several times per pass -- an MTP block
+    sharing one layer across depths under ``--mtp-use-repeated-layer`` -- has its first forward
+    paired with its *last* backward, so the ``True`` invocation lands last and its wgrad GEMM
+    overwrites the gradients the other depths already accumulated.
+
+    Marked modules pass ``None`` to TE rather than ``False``. Both accumulate, but ``False`` also
+    tells TE to reuse its cached quantized weights, which would go stale across optimizer steps
+    now that nothing ever re-arms the flag; ``None`` re-quantizes on every call instead.
+    """
+    for m in module.modules():
+        if hasattr(m, "is_first_microbatch"):
+            m.is_first_microbatch_unsafe = True
+
+
 class MegatronModule(torch.nn.Module):
     """Base Megatron module inhertied by all Models.
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -52,25 +52,6 @@ def is_first_microbatch_tracked(config) -> bool:
     )
 
 
-def mark_is_first_microbatch_unsafe(module: torch.nn.Module) -> None:
-    """Mark a subtree as one whose ``is_first_microbatch`` flag must never be acted on.
-
-    The flag is armed before a module's *first* forward of an iteration and cleared by that
-    forward, which only means "this backward may overwrite ``main_grad``" when the module runs
-    exactly once per forward pass. A module invoked several times per pass -- an MTP block
-    sharing one layer across depths under ``--mtp-use-repeated-layer`` -- has its first forward
-    paired with its *last* backward, so the ``True`` invocation lands last and its wgrad GEMM
-    overwrites the gradients the other depths already accumulated.
-
-    Marked modules pass ``None`` to TE rather than ``False``. Both accumulate, but ``False`` also
-    tells TE to reuse its cached quantized weights, which would go stale across optimizer steps
-    now that nothing ever re-arms the flag; ``None`` re-quantizes on every call instead.
-    """
-    for m in module.modules():
-        if hasattr(m, "is_first_microbatch"):
-            m.is_first_microbatch_unsafe = True
-
-
 class MegatronModule(torch.nn.Module):
     """Base Megatron module inhertied by all Models.
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -39,10 +39,9 @@ def is_first_microbatch_tracked(config) -> bool:
     re-arm the flag and TE call sites consult it before reading, so the two cannot drift. Its body
     is quantization-shaped only because re-arming exists to refresh TE's quantized parameter cache.
 
-    Callers must consult this before passing the flag to TE. It is not merely an optimization
-    hint: TE derives the weight-gradient accumulation mode from it --
-    ``accumulate = fuse_wgrad_accumulation and not is_first_microbatch`` -- so a stale ``True``
-    makes a wgrad GEMM OVERWRITE ``main_grad`` instead of accumulating into it.
+    Callers must consult this before passing the flag to TE. Passing a stale flag corrupts
+    gradients rather than merely missing an optimization -- see
+    ``megatron.core.extensions.transformer_engine._resolve_is_first_microbatch``.
     """
     return (
         config.fp8 is not None

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -28,20 +28,14 @@ def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
 
 
 def is_first_microbatch_tracked(config) -> bool:
-    """Whether ``is_first_microbatch`` is maintained across iterations for this config.
+    """True if ``is_first_microbatch`` is still being kept up to date.
 
-    :meth:`MegatronModule.set_is_first_microbatch` re-arms the flag only for quantized configs,
-    because its purpose is refreshing TE's quantized parameter cache. Outside those configs the
-    flag is set once at module construction and cleared after the first forward, so it is stale
-    for the rest of the process and carries no meaning.
+    A training step runs N microbatches. The flag marks microbatch 1 -- the one that
+    re-quantizes the weights and starts a fresh main_grad, while 2..N reuse and accumulate::
 
-    This predicate is the definition, not a heuristic: ``set_is_first_microbatch`` consults it to
-    re-arm the flag and TE call sites consult it before reading, so the two cannot drift. Its body
-    is quantization-shaped only because re-arming exists to refresh TE's quantized parameter cache.
-
-    Callers must consult this before passing the flag to TE. Passing a stale flag corrupts
-    gradients rather than merely missing an optimization -- see
-    ``megatron.core.extensions.transformer_engine._resolve_is_first_microbatch``.
+        layer is built      ->  flag = True
+        every forward       ->  flag = False   (microbatch 1 is over)
+        start of each step  ->  flag = True    (only quantized configs)
     """
     return (
         config.fp8 is not None

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2189,7 +2189,7 @@ class MultiTokenPredictionBlock(MegatronModule):
             # first depth's wgrad GEMM overwrite the gradients the later depths accumulated.
             for m in self.layers.modules():
                 if hasattr(m, 'is_first_microbatch'):
-                    m.is_first_microbatch_unsafe = True
+                    m.is_reused_within_microbatch = True
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
         self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -31,11 +31,7 @@ from megatron.core.tensor_parallel.inference_layers import (
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.hyper_connection import learned_output_contract
-from megatron.core.transformer.module import (
-    MegatronModule,
-    mark_is_first_microbatch_unsafe,
-    mark_keep_in_fp32,
-)
+from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
@@ -2187,12 +2183,13 @@ class MultiTokenPredictionBlock(MegatronModule):
         self._build_layers(pg_collection)
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
 
-        if self.mtp_use_repeated_layer and self.config.mtp_num_layers > 1:
+        if self.mtp_use_repeated_layer:
             # forward() drives the single shared layer once per depth, so its first forward is
             # paired with its last backward. Acting on is_first_microbatch there would let the
             # first depth's wgrad GEMM overwrite the gradients the later depths accumulated.
-            for layer in self.layers:
-                mark_is_first_microbatch_unsafe(layer)
+            for m in self.layers.modules():
+                if hasattr(m, 'is_first_microbatch'):
+                    m.is_first_microbatch_unsafe = True
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
         self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2189,7 +2189,7 @@ class MultiTokenPredictionBlock(MegatronModule):
             # first depth's wgrad GEMM overwrite the gradients the later depths accumulated.
             for m in self.layers.modules():
                 if hasattr(m, 'is_first_microbatch'):
-                    m.is_reused_within_microbatch = True
+                    m.is_repeated_layer = True
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
         self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2184,9 +2184,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
 
         if self.mtp_use_repeated_layer:
-            # forward() drives the single shared layer once per depth, so its first forward is
-            # paired with its last backward. Acting on is_first_microbatch there would let the
-            # first depth's wgrad GEMM overwrite the gradients the later depths accumulated.
+            # One layer object, called once per MTP depth, every call adding into the same
+            # main_grad. A True would make one of those calls overwrite instead of add.
             for m in self.layers.modules():
                 if hasattr(m, 'is_first_microbatch'):
                     m.is_repeated_layer = True

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -31,7 +31,11 @@ from megatron.core.tensor_parallel.inference_layers import (
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.hyper_connection import learned_output_contract
-from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
+from megatron.core.transformer.module import (
+    MegatronModule,
+    mark_is_first_microbatch_unsafe,
+    mark_keep_in_fp32,
+)
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
@@ -2182,6 +2186,13 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         self._build_layers(pg_collection)
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
+
+        if self.mtp_use_repeated_layer and self.config.mtp_num_layers > 1:
+            # forward() drives the single shared layer once per depth, so its first forward is
+            # paired with its last backward. Acting on is_first_microbatch there would let the
+            # first depth's wgrad GEMM overwrite the gradients the later depths accumulated.
+            for layer in self.layers:
+                mark_is_first_microbatch_unsafe(layer)
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp
         self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)

--- a/tests/unit_tests/transformer/test_module.py
+++ b/tests/unit_tests/transformer/test_module.py
@@ -4,7 +4,12 @@ import pytest
 import torch
 
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.module import Float16Module, MegatronModule, mark_keep_in_fp32
+from megatron.core.transformer.module import (
+    Float16Module,
+    MegatronModule,
+    mark_is_first_microbatch_unsafe,
+    mark_keep_in_fp32,
+)
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -114,6 +119,25 @@ class TestSetIsFirstMicrobatch:
 
         module.set_is_first_microbatch()
         assert module.child.is_first_microbatch is False
+
+    def test_mark_unsafe_tags_only_flag_carrying_submodules(self):
+        # The marker rides on the modules TE actually reads the flag from, not the whole tree.
+        module = self._build_module(quant_recipe=object())
+        assert getattr(module.child, 'is_first_microbatch_unsafe', False) is False
+
+        mark_is_first_microbatch_unsafe(module)
+        assert module.child.is_first_microbatch_unsafe is True
+        assert not hasattr(module, 'is_first_microbatch_unsafe')
+
+    def test_mark_unsafe_does_not_stop_the_flag_being_re_armed(self):
+        # Marking changes what TE is handed, not the bookkeeping; the two stay independent so a
+        # marked module still reports the same state as its unmarked siblings.
+        module = self._build_module(quant_recipe=object())
+        mark_is_first_microbatch_unsafe(module)
+
+        module.set_is_first_microbatch()
+        assert module.child.is_first_microbatch is True
+        assert module.child.is_first_microbatch_unsafe is True
 
 
 class TestFloat16Module:

--- a/tests/unit_tests/transformer/test_module.py
+++ b/tests/unit_tests/transformer/test_module.py
@@ -4,12 +4,7 @@ import pytest
 import torch
 
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.module import (
-    Float16Module,
-    MegatronModule,
-    mark_is_first_microbatch_unsafe,
-    mark_keep_in_fp32,
-)
+from megatron.core.transformer.module import Float16Module, MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -119,25 +114,6 @@ class TestSetIsFirstMicrobatch:
 
         module.set_is_first_microbatch()
         assert module.child.is_first_microbatch is False
-
-    def test_mark_unsafe_tags_only_flag_carrying_submodules(self):
-        # The marker rides on the modules TE actually reads the flag from, not the whole tree.
-        module = self._build_module(quant_recipe=object())
-        assert getattr(module.child, 'is_first_microbatch_unsafe', False) is False
-
-        mark_is_first_microbatch_unsafe(module)
-        assert module.child.is_first_microbatch_unsafe is True
-        assert not hasattr(module, 'is_first_microbatch_unsafe')
-
-    def test_mark_unsafe_does_not_stop_the_flag_being_re_armed(self):
-        # Marking changes what TE is handed, not the bookkeeping; the two stay independent so a
-        # marked module still reports the same state as its unmarked siblings.
-        module = self._build_module(quant_recipe=object())
-        mark_is_first_microbatch_unsafe(module)
-
-        module.set_is_first_microbatch()
-        assert module.child.is_first_microbatch is True
-        assert module.child.is_first_microbatch_unsafe is True
 
 
 class TestFloat16Module:

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -626,6 +626,46 @@ class TestMultiTokenPredictionLayer:
         elif tp == 4:
             assert num_weights == 15216 * config.mtp_num_layers
 
+    @pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
+    @pytest.mark.parametrize('repeated', [False, True])
+    def test_repeated_layer_opts_out_of_is_first_microbatch(self, repeated):
+        """A shared MTP layer must hand TE None, because its first forward is its last backward."""
+        from megatron.core.extensions.transformer_engine import _resolve_is_first_microbatch
+
+        torch.manual_seed(_SEED)
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+        config = TransformerConfig(
+            mtp_num_layers=2,
+            num_layers=4,
+            hidden_size=64,
+            num_attention_heads=8,
+            use_cpu_initialization=True,
+            mtp_use_repeated_layer=repeated,
+        )
+        mtp_block_spec = get_gpt_mtp_block_spec(
+            config=config,
+            spec=get_gpt_layer_with_transformer_engine_spec(),
+            use_transformer_engine=True,
+        )
+        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+
+        # Quantization is what would otherwise make TE act on the flag, so ask under it.
+        config.fp8 = "hybrid"
+        mtp.set_is_first_microbatch()
+        te_modules = [
+            m
+            for m in mtp.modules()
+            if hasattr(m, 'is_first_microbatch') and hasattr(m, 'disable_parameter_transpose_cache')
+        ]
+        assert te_modules, "expected the TE spec to produce modules carrying is_first_microbatch"
+
+        if repeated:
+            assert len(mtp.layers) == 1
+            assert all(_resolve_is_first_microbatch(m) is None for m in te_modules)
+        else:
+            assert len(mtp.layers) == config.mtp_num_layers
+            assert all(_resolve_is_first_microbatch(m) is True for m in te_modules)
+
     def test_get_embeddings_rolls_padding_mask(self):
         """Test that _get_embeddings rolls padding_mask alongside input ids."""
         torch.manual_seed(_SEED)

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -10,7 +10,7 @@ import torch
 
 from megatron.core.context_parallel import ContextParallelBatch
 from megatron.core.enums import ModelType
-from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.extensions.transformer_engine import HAVE_TE, _resolve_is_first_microbatch
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
@@ -103,7 +103,7 @@ class TestMultiTokenPredictionLayer:
         destroy_global_vars()
         destroy_num_microbatches_calculator()
 
-    def _create_config_and_mtp_block_spec(self, tp, cp, use_te=False):
+    def _create_config_and_mtp_block_spec(self, tp, cp, use_te=False, use_repeated_layer=False):
         Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
         config = TransformerConfig(
             mtp_num_layers=2,
@@ -114,6 +114,7 @@ class TestMultiTokenPredictionLayer:
             tensor_model_parallel_size=tp,
             sequence_parallel=True if tp > 1 else False,
             context_parallel_size=cp,  # Enable CP for MTP testing
+            mtp_use_repeated_layer=use_repeated_layer,
         )
         if use_te:
             transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec()
@@ -630,33 +631,16 @@ class TestMultiTokenPredictionLayer:
     @pytest.mark.parametrize('repeated', [False, True])
     def test_repeated_layer_opts_out_of_is_first_microbatch(self, repeated):
         """A shared MTP layer must hand TE None, because its first forward is its last backward."""
-        from megatron.core.extensions.transformer_engine import _resolve_is_first_microbatch
-
         torch.manual_seed(_SEED)
-        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
-        config = TransformerConfig(
-            mtp_num_layers=2,
-            num_layers=4,
-            hidden_size=64,
-            num_attention_heads=8,
-            use_cpu_initialization=True,
-            mtp_use_repeated_layer=repeated,
-        )
-        mtp_block_spec = get_gpt_mtp_block_spec(
-            config=config,
-            spec=get_gpt_layer_with_transformer_engine_spec(),
-            use_transformer_engine=True,
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(
+            tp=1, cp=1, use_te=True, use_repeated_layer=repeated
         )
         mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
 
         # Quantization is what would otherwise make TE act on the flag, so ask under it.
         config.fp8 = "hybrid"
         mtp.set_is_first_microbatch()
-        te_modules = [
-            m
-            for m in mtp.modules()
-            if hasattr(m, 'is_first_microbatch') and hasattr(m, 'disable_parameter_transpose_cache')
-        ]
+        te_modules = [m for m in mtp.modules() if hasattr(m, 'is_first_microbatch')]
         assert te_modules, "expected the TE spec to produce modules carrying is_first_microbatch"
 
         if repeated:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

TEGroupedLinear.is_first_microbatch resets to True after checkpoint resume, causing the first shared-layer call to overwrite main_grad instead of accumulating into it. When an MTP layer is reused across depths, this discards one depth’s gradient and makes resumed training differ from uninterrupted training.

* Before fix
```
Uninterrupted training retains:
is_first_microbatch = False

forward:   depth 1 [False] → depth 2 [False]
backward:  depth 2 accumulates → depth 1 accumulates

main_grad = grad(depth 2) + grad(depth 1)  ✓
```
* What is not expected after ckpt resume:
```
After checkpoint resume, the process-local flag resets:
is_first_microbatch = True

forward:   depth 1 [True] → depth 2 [False]
backward:  depth 2 accumulates → depth 1 overwrites (beta=0)

main_grad = grad(depth 1)  ✗
                         └─ grad(depth 2) is discarded
```
This only becomes destructive when the same layer is invoked multiple times, such as MTP repeated-layer sharing.

* Fixed
Restore or initialize the state deterministically so resume matches uninterrupted training:
```
is_first_microbatch = False

forward:   depth 1 [False] → depth 2 [False]
backward:  depth 2 accumulates → depth 1 accumulates

main_grad = grad(depth 2) + grad(depth 1)  ✓
```
## Why no existing test catches it

A run-to-run A/A check cannot detect this. Both fresh processes make the same mistake and agree. It only appears between a process that has trained N steps and one that has just loaded a checkpoint, so it takes three separate processes to observe.

## Fix

Two independent reasons the flag must not reach TE, both resolved to `None`:

1. **Nobody maintains it.** `is_first_microbatch_tracked(config)`, added next to `set_is_first_microbatch`, returns whether the flag is actually re-armed for this config. Outside fp8/fp4/kitchen/`quant_recipe` it is set once at construction and cleared by the first forward, so it is stale for the rest of the process.
2. **It is maintained, but it means the wrong thing.** A repeated MTP layer is invoked once per depth, so its first forward is paired with its *last* backward. The `True` lands on the last wgrad GEMM and overwrites `main_grad` with beta=0, discarding what the later depths accumulated. `mark_is_first_microbatch_unsafe` tags the shared layer's TE submodules at construction (only when `mtp_num_layers > 1`).

| Configuration | Before | After |
|---|---|---|
| BF16 / non-quantized | stale `True`/`False` | `None` — always accumulate |
| FP8 / FP4 / Kitchen, ordinary layer | maintained `True`/`False` | unchanged; the cache optimization is kept |
| FP8 / FP4 / Kitchen, **repeated MTP layer** | maintained `True`/`False` | `None` — always accumulate |
| Transpose cache disabled | `None` | `None` |

`None` rather than `False`: both accumulate, but `False` also tells TE to reuse its cached quantized weights, which would go stale across optimizer steps now that nothing re-arms the flag. The cost is re-quantizing one MTP layer per forward, and `--fp8-param-gather` removes even that by quantizing in the optimizer instead.

The three copies of the gate are now one `_resolve_is_first_microbatch` helper so they cannot drift apart.

Thanks @zhongbozhu for catching that the first version stopped at reason 1.

## Verification

Three-leg check — train-through to step 10 / save at 5 / resume from 5 — all legs in one allocation, comparing checkpoint shards byte for byte:

| | result |
|---|---|
| 2 nodes | A/A identical; **RESUME identical**, all 7 state shards byte-identical at `iter_10` |
| 64 nodes | 255/256 shards byte-identical (the 256th is rank 0's args blob, which differs by construction) |
| without this fix | diverges in grad-norm one step **after** the resume, loss still matching |

Confirming arm: disabling gradient-accumulation fusion also makes the divergence vanish, which is what the mechanism predicts — with fusion off the `and` short-circuits and `is_first_microbatch` can no longer select overwrite.

The BF16 leg above is what the cluster runs; the quantized repeated-MTP leg is covered by unit test rather than a resume run. `test_repeated_layer_opts_out_of_is_first_microbatch` builds a TE-spec MTP block both ways under `fp8`, and asserts the resolver answers `None` for every flag-carrying submodule when the layer is shared and `True` when it is not.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.


