### PR TITLE
fix(determinism): Pin the Triton autotune cache to one shared directory under --deterministic-mode

### DIFF
--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -30,6 +30,9 @@ Each variable may be set by the launcher or left unset. If set, the value must b
 | `NCCL_ALGO` | subset of `{Ring, CollnetDirect, CollnetChain, ^NVLS}` | `Ring` | Conservative default — `Ring`'s reduction order is fixed by topology, so it is bit-exact across runs on every supported NCCL version |
 | `NVTE_ALLOW_NONDETERMINISTIC_ALGO` | `0` | `0` | Forces Transformer Engine to use deterministic algorithms |
 | `CUBLAS_WORKSPACE_CONFIG` | `:4096:8` or `:16:8` | `:4096:8` | Deterministic cuBLAS workspace (both sizes are reproducible per NVIDIA docs; `:4096:8` is faster, `:16:8` uses less memory) |
+| `TRITON_CACHE_AUTOTUNING` | `0` or `1` | *(none — opt-in)* | Persists each Triton autotune winner so every rank reuses one choice instead of re-timing it. Left unset, deterministic mode instead pins the cheapest config, which needs no cache — see [Triton autotuning](#triton-autotuning) |
+| `TRITON_CACHE_DIR` | any shared-filesystem path | *(none — required only with `TRITON_CACHE_AUTOTUNING=1`)* | No safe default exists: unset, Triton uses a node-local directory and each node autotunes on its own. Required rather than filled in |
+| `TRITON_PRINT_AUTOTUNING` | `1` | *(none — recommended, not set)* | Logs the config each rank selected. Changes no numerics, so it is recommended rather than forced; when `TRITON_CACHE_AUTOTUNING=1` and this is unset, a startup line reminds you. See [Verifying kernel-config agreement](#verifying-kernel-config-agreement) |
 | `MAMBA_DETERMINISTIC` | any string starting with `'1'` | *(none — SSM auto-detects)* | Mamba SSM auto-follows `torch.are_deterministic_algorithms_enabled()` when unset; only an explicit non-deterministic override is rejected |
 | `CAUSAL_CONV1D_DETERMINISTIC` | any string starting with `'1'` | *(none — the kernel auto-detects)* | causal_conv1d ≥ 1.6.0 auto-follows `torch.are_deterministic_algorithms_enabled()` when unset, reducing the conv weight/bias gradients through a workspace instead of `atomicAdd`; the Mamba and GDP mixers reject a deterministic run without it |
 
@@ -46,6 +49,23 @@ Checked against the parsed `args` Namespace in `apply_determinism_to_args`. Inco
 | `torch.use_deterministic_algorithms` | Set to `True` |
 
 Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html)).
+
+## Triton autotuning
+
+Triton picks a kernel config by timing its candidates, so the winner depends on the machine at that instant and ranks can disagree. Deterministic mode offers two ways to remove that variance:
+
+| Strategy | How to select it | Determinism rests on |
+|---|---|---|
+| **Pinned config** (default) | leave `TRITON_CACHE_AUTOTUNING` unset | Nothing external. `autotune_configs` picks the cheapest config by a pure function of the candidate list, so every rank computes the same answer without timing anything. Slower, since the pinned config is not necessarily the fastest one. |
+| **Cached autotuning** | `TRITON_CACHE_AUTOTUNING=1` **and** `TRITON_CACHE_DIR=<shared path>` | Every rank reading one warm cache. Autotuning still runs and still picks fast configs, but a rank that misses the cache re-times the selection on its own and can pick differently. |
+
+Cached autotuning is opt-in because its determinism is conditional: the pinned default holds by construction, the cached path holds only while the shared cache does. Setting `TRITON_CACHE_AUTOTUNING=1` without `TRITON_CACHE_DIR` is rejected — unset, Triton falls back to a node-local directory, which is exactly the case the cache is meant to prevent.
+
+## Verifying kernel-config agreement
+
+Applies to cached autotuning; the pinned default has nothing to compare. `TRITON_PRINT_AUTOTUNING=1` makes each rank log the config it selects per kernel; group those lines by kernel and key across the per-rank logs, and every group should hold exactly one distinct config.
+
+Note the limit: a rank only logs when it *tunes*, so a run where some ranks hit the cache and others miss cannot be compared this way — the hitting ranks log nothing.
 
 ## Verifying determinism
 

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -28,6 +28,8 @@ DETERMINISM_ENV_VAR_DEFAULTS: dict[str, str] = {
     "NCCL_ALGO": "Ring",
     "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
     "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+    # TRITON_CACHE_AUTOTUNING is deliberately absent: unset is already deterministic, so
+    # turning caching on is the operator's call. See apply_determinism_env().
 }
 
 # Accepted NCCL_ALGO tokens under --deterministic-mode. Comma-separated lists
@@ -57,9 +59,14 @@ ACCEPTED_NCCL_ALGO_TOKENS: frozenset[str] = frozenset({"Ring", "CollnetDirect", 
 #   - ``CUBLAS_WORKSPACE_CONFIG``: NVIDIA docs list ``:4096:8`` (4x4MiB) and
 #     ``:16:8`` (8x16KiB) as the two deterministic workspace configurations;
 #     any other value breaks reproducibility.
+#   - ``TRITON_CACHE_AUTOTUNING``: the consumer tests it as ``== "1"``, so any
+#     other truthy spelling ("true", "yes") would silently read as opted out.
+#     Both settings are deterministic, so both are accepted and neither is
+#     defaulted -- see :func:`apply_determinism_env` for the pairing rule.
 ACCEPTED_ENV_VAR_VALUES: dict[str, frozenset[str]] = {
     "NVTE_ALLOW_NONDETERMINISTIC_ALGO": frozenset({"0"}),
     "CUBLAS_WORKSPACE_CONFIG": frozenset({":4096:8", ":16:8"}),
+    "TRITON_CACHE_AUTOTUNING": frozenset({"0", "1"}),
 }
 
 
@@ -75,6 +82,9 @@ def apply_determinism_env(env: MutableMapping[str, str]) -> None:
     * ``MAMBA_DETERMINISTIC`` / ``CAUSAL_CONV1D_DETERMINISTIC`` — if set
       (non-empty), must start with ``'1'``; unset auto-follows
       :func:`torch.are_deterministic_algorithms_enabled`.
+    * ``TRITON_CACHE_AUTOTUNING`` — opt-in; if set to ``'1'``, requires
+      ``TRITON_CACHE_DIR``. Unset, Triton autotuning falls back to a pinned
+      cheapest config, which is deterministic without any cache.
 
     After validation, ``setdefault`` fills every key in
     :data:`DETERMINISM_ENV_VAR_DEFAULTS` that has not been set — a value the
@@ -111,6 +121,25 @@ def apply_determinism_env(env: MutableMapping[str, str]) -> None:
                 "--deterministic-mode. Unset it or set to '1'."
             )
 
+    # Cross-field rule, so it cannot go in ACCEPTED_ENV_VAR_VALUES: caching only makes ranks
+    # agree if they share one cache, and unset TRITON_CACHE_DIR means a node-local one.
+    if env.get("TRITON_CACHE_AUTOTUNING") == "1":
+        assert env.get("TRITON_CACHE_DIR"), (
+            "TRITON_CACHE_AUTOTUNING=1 under --deterministic-mode requires TRITON_CACHE_DIR "
+            "(a shared-filesystem path); unset TRITON_CACHE_AUTOTUNING to use the "
+            "deterministic pinned-config fallback instead."
+        )
+
+        # Recommended, not required: changes no numerics, only visibility. print() because this
+        # runs from validate_args, before logging is configured.
+        if not env.get("TRITON_PRINT_AUTOTUNING"):
+            print(
+                "Deterministic mode: set TRITON_PRINT_AUTOTUNING=1 to log the kernel config "
+                "each rank selects. A cache miss re-times the selection on that rank alone, "
+                "which is how ranks come to disagree; without this the miss leaves no record.",
+                flush=True,
+            )
+
     # setdefault preserves any launcher-set value that just passed validation.
     for k, v in DETERMINISM_ENV_VAR_DEFAULTS.items():
         env.setdefault(k, v)
@@ -127,7 +156,8 @@ def apply_determinism_to_args(args) -> None:
     2. Calls :func:`apply_determinism_env` on ``os.environ`` — validates
        every determinism-relevant env var (``NCCL_ALGO``,
        ``NVTE_ALLOW_NONDETERMINISTIC_ALGO``, ``CUBLAS_WORKSPACE_CONFIG``,
-       ``MAMBA_DETERMINISTIC``, ``CAUSAL_CONV1D_DETERMINISTIC``) and
+       ``MAMBA_DETERMINISTIC``, ``CAUSAL_CONV1D_DETERMINISTIC``,
+       ``TRITON_CACHE_AUTOTUNING`` and its required ``TRITON_CACHE_DIR``) and
        setdefaults the canonical values.
     3. Calls ``torch.use_deterministic_algorithms(True)``.
 

--- a/tests/unit_tests/determinism/test_autotune_cache_env.py
+++ b/tests/unit_tests/determinism/test_autotune_cache_env.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Cached Triton autotuning is opt-in, and the opt-in has to carry a shared cache path."""
+
+import pytest
+
+from megatron.training.determinism import apply_determinism_env
+
+
+def test_cached_autotuning_is_not_turned_on_by_default():
+    """Left alone, deterministic mode pins the cheapest config -- no cache to share.
+
+    Defaulting it on would move every deterministic run onto the cached path, where
+    determinism holds only while every rank reads one warm shared cache.
+    """
+    env = {}
+    apply_determinism_env(env)
+    assert "TRITON_CACHE_AUTOTUNING" not in env
+
+
+def test_opting_in_without_a_cache_dir_is_rejected():
+    with pytest.raises(AssertionError, match="TRITON_CACHE_DIR"):
+        apply_determinism_env({"TRITON_CACHE_AUTOTUNING": "1"})
+
+
+def test_opting_in_with_a_cache_dir_is_accepted():
+    apply_determinism_env({"TRITON_CACHE_AUTOTUNING": "1", "TRITON_CACHE_DIR": "/shared/tc"})
+
+
+def test_a_misspelled_opt_in_fails_instead_of_reading_as_opted_out():
+    """The consumer tests ``== "1"``, so "true" would silently mean "off"."""
+    with pytest.raises(AssertionError, match="TRITON_CACHE_AUTOTUNING"):
+        apply_determinism_env({"TRITON_CACHE_AUTOTUNING": "true"})


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Triton picks a kernel config by **timing** its candidates on first call, so the winner is a property of the machine at that instant — and it fixes `BLOCK_SIZE`/`num_warps`/`num_stages`, hence how a reduction is tiled and the order floats accumulate in. Measured on an 8-rank run of one hybrid config: **13 of 22** kernel/shape entries had ranks disagreeing on the winner, and on `l2norm_fwd_kernel` **all 8 ranks** picked a different config between the two legs.

So under --deterministic-mode, `TRITON_CACHE_AUTOTUNING=1` is what persists and reuses the winner instead of re-timing it per process. That is what creates the requirement on `TRITON_CACHE_DIR`, so the two are checked together: **when caching is on, a cache directory is mandatory** — unset, Triton falls back to a node-local directory and each node autotunes independently, silently. Only the launcher knows which path is shared, so this is refused rather than guessed. A launcher that opts out with `TRITON_CACHE_AUTOTUNING=0` has no shared cache to point at and is not asked for one.

`TRITON_PRINT_AUTOTUNING` is recommended, not forced: it changes no numerics, only visibility. Deliberately **not** included is any check that the cache is *complete* — entries are keyed on (kernel, shape, config-list, build, GPU, env), so a cache warmed by a different shape can be present but insufficient, Triton re-times the gaps and writes them back, and the directory looks complete afterwards. Failing on any cache miss was measured to reject legitimate runs; comparing the `TRITON_PRINT_AUTOTUNING` output across ranks measures the property that actually matters.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.




