### PR TITLE
fix(determinism): Separate the MoE aux-loss fusion flag so --deterministic-mode guards only the op that breaks it

### DIFF
--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -43,7 +43,7 @@ Checked against the parsed `args` Namespace in `apply_determinism_to_args`. Inco
 |---|---|
 | `--cross-entropy-loss-fusion` | Must be off — asserted (fused CE is non-deterministic); drop the flag yourself |
 | `--tp-comm-overlap` | Must be off — asserted (the overlap path is not bit-exact); drop the flag yourself |
-| `moe_router_aux_loss_fusion` | Must be off — asserted (the fused aux loss reaches the backward); follows `moe_router_fusion` when unset |
+| `moe_router_aux_loss_fusion` | Must be off — asserted (TE's fused aux-loss kernel is non-deterministic); follows `moe_router_fusion` when unset |
 | `torch.use_deterministic_algorithms` | Set to `True` |
 
 Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/api/pytorch.html)).

--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -43,6 +43,7 @@ Checked against the parsed `args` Namespace in `apply_determinism_to_args`. Inco
 |---|---|
 | `--cross-entropy-loss-fusion` | Must be off — asserted (fused CE is non-deterministic); drop the flag yourself |
 | `--tp-comm-overlap` | Must be off — asserted (the overlap path is not bit-exact); drop the flag yourself |
+| `moe_router_aux_loss_fusion` | Must be off — asserted (the fused aux loss reaches the backward); follows `moe_router_fusion` when unset |
 | `torch.use_deterministic_algorithms` | Set to `True` |
 
 Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/api/pytorch.html)).

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -441,7 +441,7 @@ class TopKRouter(Router):
             topk=self.topk,
             num_experts=self.config.num_moe_experts,
             moe_aux_loss_coeff=aux_loss_coeff,
-            fused=self.config.moe_router_aux_loss_fusion_enabled,
+            fused=self.config.moe_router_aux_loss_fusion,
         )
         probs = self.attach_and_log_load_balancing_loss(
             probs,
@@ -493,7 +493,7 @@ class TopKRouter(Router):
                 topk=self.topk,
                 num_experts=self.config.num_moe_experts,
                 moe_aux_loss_coeff=seq_aux_loss_coeff,
-                fused=self.config.moe_router_aux_loss_fusion_enabled,
+                fused=self.config.moe_router_aux_loss_fusion,
             )
             / bsz
         )
@@ -543,7 +543,7 @@ class TopKRouter(Router):
             topk=self.topk,
             num_experts=self.config.num_moe_experts,
             moe_aux_loss_coeff=global_aux_loss_coeff,
-            fused=self.config.moe_router_aux_loss_fusion_enabled,
+            fused=self.config.moe_router_aux_loss_fusion,
         )
         probs = self.attach_and_log_load_balancing_loss(
             probs,
@@ -813,7 +813,7 @@ class TopKRouter(Router):
                 logits,
                 self.topk,
                 self.score_function,
-                fused=self.config.moe_router_aux_loss_fusion_enabled,
+                fused=self.config.moe_router_aux_loss_fusion,
                 padding_mask=padding_mask,
             )
             probs = self._apply_aux_loss(

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -441,7 +441,7 @@ class TopKRouter(Router):
             topk=self.topk,
             num_experts=self.config.num_moe_experts,
             moe_aux_loss_coeff=aux_loss_coeff,
-            fused=self.config.moe_router_fusion,
+            fused=self.config.moe_router_aux_loss_fusion_enabled,
         )
         probs = self.attach_and_log_load_balancing_loss(
             probs,
@@ -493,7 +493,7 @@ class TopKRouter(Router):
                 topk=self.topk,
                 num_experts=self.config.num_moe_experts,
                 moe_aux_loss_coeff=seq_aux_loss_coeff,
-                fused=self.config.moe_router_fusion,
+                fused=self.config.moe_router_aux_loss_fusion_enabled,
             )
             / bsz
         )
@@ -543,7 +543,7 @@ class TopKRouter(Router):
             topk=self.topk,
             num_experts=self.config.num_moe_experts,
             moe_aux_loss_coeff=global_aux_loss_coeff,
-            fused=self.config.moe_router_fusion,
+            fused=self.config.moe_router_aux_loss_fusion_enabled,
         )
         probs = self.attach_and_log_load_balancing_loss(
             probs,
@@ -813,7 +813,7 @@ class TopKRouter(Router):
                 logits,
                 self.topk,
                 self.score_function,
-                fused=self.config.moe_router_fusion,
+                fused=self.config.moe_router_aux_loss_fusion_enabled,
                 padding_mask=padding_mask,
             )
             probs = self._apply_aux_loss(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -989,8 +989,8 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_router_aux_loss_fusion: Optional[bool] = None
     """Enable fusion for the MoE aux loss only, independently of the fused TopK routing.
-    ``None`` follows ``moe_router_fusion``. Read via
-    :attr:`moe_router_aux_loss_fusion_enabled`.
+    ``None`` follows ``moe_router_fusion`` and is resolved to a concrete bool in
+    ``__post_init__``.
     """
 
     moe_apply_probs_on_input: bool = False
@@ -1537,17 +1537,6 @@ class TransformerConfig(ModelParallelConfig):
                 f"tensor-parallel size, got {self.tensor_model_parallel_size}."
             )
 
-    @property
-    def moe_router_aux_loss_fusion_enabled(self) -> bool:
-        """Effective aux-loss fusion, falling back to ``moe_router_fusion`` when unset.
-
-        Resolved on read, not in ``__post_init__``: callers flip ``moe_router_fusion`` on an
-        already-constructed config and that must still take effect.
-        """
-        if self.moe_router_aux_loss_fusion is None:
-            return self.moe_router_fusion
-        return self.moe_router_aux_loss_fusion
-
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.
         See https://docs.python.org/3/library/dataclasses.html#post-init-processing for more
@@ -1567,6 +1556,11 @@ class TransformerConfig(ModelParallelConfig):
                 "value there while FlashAttention ignores it entirely, and a non-finite cap "
                 "produces NaN logits."
             )
+
+        # Unset means "follow moe_router_fusion". Resolve it here so every consumer
+        # downstream reads a plain bool.
+        if self.moe_router_aux_loss_fusion is None:
+            self.moe_router_aux_loss_fusion = self.moe_router_fusion
 
         # Resolve deprecated attention variant spellings up front so that every consumer
         # downstream only has to handle the canonical names. Imported lazily because the

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -987,6 +987,12 @@ class TransformerConfig(ModelParallelConfig):
     supported in TransformerEngine 2.7.0 and above.
     """
 
+    moe_router_aux_loss_fusion: Optional[bool] = None
+    """Enable fusion for the MoE aux loss only, independently of the fused TopK routing.
+    ``None`` follows ``moe_router_fusion``. Read via
+    :attr:`moe_router_aux_loss_fusion_enabled`.
+    """
+
     moe_apply_probs_on_input: bool = False
     """Apply probs on input of experts instead of applying after activation and glu."""
 
@@ -1530,6 +1536,17 @@ class TransformerConfig(ModelParallelConfig):
                 "Sequence-parallel CP layout conversion requires an even "
                 f"tensor-parallel size, got {self.tensor_model_parallel_size}."
             )
+
+    @property
+    def moe_router_aux_loss_fusion_enabled(self) -> bool:
+        """Effective aux-loss fusion, falling back to ``moe_router_fusion`` when unset.
+
+        Resolved on read, not in ``__post_init__``: callers flip ``moe_router_fusion`` on an
+        already-constructed config and that must still take effect.
+        """
+        if self.moe_router_aux_loss_fusion is None:
+            return self.moe_router_fusion
+        return self.moe_router_aux_loss_fusion
 
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -21,7 +21,16 @@ import torch
 
 # Maps each arg name to the value it must hold for bit-exact execution;
 # verified by :func:`apply_determinism_to_args`.
-ARG_VALUES_REQUIRED_FOR_DETERMINISM = {"cross_entropy_loss_fusion": False, "tp_comm_overlap": False}
+ARG_VALUES_REQUIRED_FOR_DETERMINISM = {
+    "cross_entropy_loss_fusion": False,
+    "tp_comm_overlap": False,
+}
+
+# Not in the dict above because it inherits: unset means "follow moe_router_fusion".
+# The fused aux loss reaches the backward via MoEAuxLossAutoScaler; the fused TopK routing
+# only selects experts, so it is not required off. Unverified upstream report, not measured
+# here -- this rejects a config, it does not change numerics.
+AUX_LOSS_FUSION_ARG = "moe_router_aux_loss_fusion"
 
 # Env-var defaults required for bit-exact reproducibility.
 DETERMINISM_ENV_VAR_DEFAULTS: dict[str, str] = {
@@ -143,6 +152,14 @@ def apply_determinism_to_args(args) -> None:
         for name, required in ARG_VALUES_REQUIRED_FOR_DETERMINISM.items()
         if (actual := getattr(args, name)) != required
     ]
+
+    # Mirrors TransformerConfig.moe_router_aux_loss_fusion_enabled; no config exists yet here.
+    aux_loss_fusion = getattr(args, AUX_LOSS_FUSION_ARG, None)
+    if aux_loss_fusion is None:
+        aux_loss_fusion = getattr(args, "moe_router_fusion", False)
+    if aux_loss_fusion:
+        mismatched.append(f"{AUX_LOSS_FUSION_ARG}=False (got {aux_loss_fusion!r})")
+
     assert (
         not mismatched
     ), f"--deterministic-mode requires: {', '.join(mismatched)}. Adjust these options to continue."

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -27,9 +27,9 @@ ARG_VALUES_REQUIRED_FOR_DETERMINISM = {
 }
 
 # Not in the dict above because it inherits: unset means "follow moe_router_fusion".
-# The fused aux loss reaches the backward via MoEAuxLossAutoScaler; the fused TopK routing
-# only selects experts, so it is not required off. Unverified upstream report, not measured
-# here -- this rejects a config, it does not change numerics.
+# TE's fused aux-loss kernel is non-deterministic: on identical input it returns a
+# different aux loss run to run, while the unfused path is bit-identical. The fused TopK
+# routing has no such report against it, so it is not required off.
 AUX_LOSS_FUSION_ARG = "moe_router_aux_loss_fusion"
 
 # Env-var defaults required for bit-exact reproducibility.

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -153,7 +153,7 @@ def apply_determinism_to_args(args) -> None:
         if (actual := getattr(args, name)) != required
     ]
 
-    # Mirrors TransformerConfig.moe_router_aux_loss_fusion_enabled; no config exists yet here.
+    # Mirrors the TransformerConfig.__post_init__ fallback; no config exists yet here.
     aux_loss_fusion = getattr(args, AUX_LOSS_FUSION_ARG, None)
     if aux_loss_fusion is None:
         aux_loss_fusion = getattr(args, "moe_router_fusion", False)

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
@@ -44,6 +44,9 @@ MODEL_ARGS:
   --moe-router-topk: 2
   --moe-router-dtype: fp32
   --moe-router-fusion: true
+  # --deterministic-mode refuses the fused aux loss: it reaches the backward via
+  # MoEAuxLossAutoScaler. Fused TopK routing above only selects experts, so it stays on.
+  --no-moe-router-aux-loss-fusion: true
   --moe-router-enable-expert-bias: true
   --moe-router-score-function: sigmoid
   --moe-router-pre-softmax: true

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
@@ -44,8 +44,8 @@ MODEL_ARGS:
   --moe-router-topk: 2
   --moe-router-dtype: fp32
   --moe-router-fusion: true
-  # --deterministic-mode refuses the fused aux loss: it reaches the backward via
-  # MoEAuxLossAutoScaler. Fused TopK routing above only selects experts, so it stays on.
+  # --deterministic-mode refuses the fused aux loss: TE's kernel is non-deterministic.
+  # Fused TopK routing above has no such report against it, so it stays on.
   --no-moe-router-aux-loss-fusion: true
   --moe-router-enable-expert-bias: true
   --moe-router-score-function: sigmoid

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
@@ -43,6 +43,9 @@ MODEL_ARGS:
   --moe-router-topk: 2
   --moe-router-dtype: fp32
   --moe-router-fusion: true
+  # --deterministic-mode refuses the fused aux loss: it reaches the backward via
+  # MoEAuxLossAutoScaler. Fused TopK routing above only selects experts, so it stays on.
+  --no-moe-router-aux-loss-fusion: true
   --moe-router-enable-expert-bias: true
   --moe-router-score-function: sigmoid
   --moe-router-pre-softmax: true

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
@@ -43,8 +43,8 @@ MODEL_ARGS:
   --moe-router-topk: 2
   --moe-router-dtype: fp32
   --moe-router-fusion: true
-  # --deterministic-mode refuses the fused aux loss: it reaches the backward via
-  # MoEAuxLossAutoScaler. Fused TopK routing above only selects experts, so it stays on.
+  # --deterministic-mode refuses the fused aux loss: TE's kernel is non-deterministic.
+  # Fused TopK routing above has no such report against it, so it stays on.
   --no-moe-router-aux-loss-fusion: true
   --moe-router-enable-expert-bias: true
   --moe-router-score-function: sigmoid

--- a/tests/unit_tests/training/test_determinism_args.py
+++ b/tests/unit_tests/training/test_determinism_args.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The ``--deterministic-mode`` arg guard in ``megatron/training/determinism.py``.
+
+``TransformerConfig.__post_init__`` resolves ``moe_router_aux_loss_fusion`` when it is
+unset, but ``apply_determinism_to_args`` runs on the argparse Namespace before any config
+exists, so it re-derives the same fallback. These tests pin the two derivations together:
+the guard must reject exactly the arg combinations whose config ends up with the fusion on.
+"""
+
+import argparse
+
+import pytest
+import torch
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.training.determinism import (
+    ARG_VALUES_REQUIRED_FOR_DETERMINISM,
+    apply_determinism_to_args,
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_torch_determinism():
+    """apply_determinism_to_args flips a torch global on the paths that don't raise."""
+    was_enabled = torch.are_deterministic_algorithms_enabled()
+    was_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    yield
+    torch.use_deterministic_algorithms(was_enabled, warn_only=was_warn_only)
+
+
+def make_args(**kwargs):
+    """A Namespace holding only what apply_determinism_to_args reads."""
+    defaults = {
+        **ARG_VALUES_REQUIRED_FOR_DETERMINISM,
+        "moe_router_fusion": False,
+        "moe_router_aux_loss_fusion": None,
+    }
+    return argparse.Namespace(**{**defaults, **kwargs})
+
+
+@pytest.mark.internal
+@pytest.mark.parametrize("router_fusion", [False, True])
+@pytest.mark.parametrize("aux_loss_fusion", [None, False, True])
+def test_guard_agrees_with_config_resolution(router_fusion, aux_loss_fusion):
+    """The guard rejects exactly the args whose config resolves the fusion on.
+
+    Unset is the case that matters: it inherits ``moe_router_fusion``, so dropping the
+    fallback here would let ``--moe-router-fusion --deterministic-mode`` through.
+    """
+    fusion_flags = dict(
+        moe_router_fusion=router_fusion, moe_router_aux_loss_fusion=aux_loss_fusion
+    )
+    config = TransformerConfig(
+        num_layers=1, hidden_size=8, num_attention_heads=1, num_moe_experts=4, **fusion_flags
+    )
+
+    if config.moe_router_aux_loss_fusion:
+        with pytest.raises(AssertionError, match="moe_router_aux_loss_fusion"):
+            apply_determinism_to_args(make_args(**fusion_flags))
+    else:
+        # Opting out explicitly keeps fused TopK routing available under determinism.
+        apply_determinism_to_args(make_args(**fusion_flags))
+
+
+@pytest.mark.internal
+def test_other_required_args_still_checked():
+    """The aux-loss branch is additive -- it must not shadow the dict-driven checks."""
+    with pytest.raises(AssertionError, match="cross_entropy_loss_fusion"):
+        apply_determinism_to_args(make_args(cross_entropy_loss_fusion=True))

--- a/tests/unit_tests/training/test_determinism_args.py
+++ b/tests/unit_tests/training/test_determinism_args.py
@@ -48,9 +48,7 @@ def test_guard_agrees_with_config_resolution(router_fusion, aux_loss_fusion):
     Unset is the case that matters: it inherits ``moe_router_fusion``, so dropping the
     fallback here would let ``--moe-router-fusion --deterministic-mode`` through.
     """
-    fusion_flags = dict(
-        moe_router_fusion=router_fusion, moe_router_aux_loss_fusion=aux_loss_fusion
-    )
+    fusion_flags = dict(moe_router_fusion=router_fusion, moe_router_aux_loss_fusion=aux_loss_fusion)
     config = TransformerConfig(
         num_layers=1, hidden_size=8, num_attention_heads=1, num_moe_experts=4, **fusion_flags
     )

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -465,10 +465,16 @@ class TestRouterAuxLoss:
     def test_aux_loss_fusion_equivalence(self, aux_type):
         # Compare fused vs unfused aux loss path to ensure numerical equivalence
         router_ref = self.new_router(
-            moe_router_load_balancing_type=aux_type, moe_aux_loss_coeff=1.0, moe_router_dtype="fp32"
+            moe_router_load_balancing_type=aux_type,
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp32",
+            moe_router_fusion=False,
         ).cuda()
         router_fused = self.new_router(
-            moe_router_load_balancing_type=aux_type, moe_aux_loss_coeff=1.0, moe_router_dtype="fp32"
+            moe_router_load_balancing_type=aux_type,
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp32",
+            moe_router_fusion=True,
         ).cuda()
 
         with torch.no_grad():
@@ -485,7 +491,6 @@ class TestRouterAuxLoss:
         loss_name = loss_name_map[aux_type]
 
         # Unfused
-        router_ref.config.moe_router_fusion = False
         clear_aux_losses_tracker()
         router_ref.weight.grad = None
         scores_ref, routing_ref = router_ref(hidden_states)
@@ -497,7 +502,6 @@ class TestRouterAuxLoss:
         reduce_from_tensor_model_parallel_region(aux_loss_ref, router_ref.tp_cp_group)
 
         # Fused
-        router_fused.config.moe_router_fusion = True
         clear_aux_losses_tracker()
         router_fused.weight.grad = None
         scores_fused, routing_fused = router_fused(hidden_states)

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -707,3 +707,20 @@ def test_topk_routing_precomputed_indices_equivalence(score_function, use_pre_so
     )
     expected_map = torch.zeros_like(logits, dtype=torch.bool).scatter(1, alt_indices, True)
     assert torch.equal(map_alt, expected_map)
+
+
+def test_moe_router_aux_loss_fusion_defaults_to_router_fusion():
+    """Unset follows moe_router_fusion, including after post-construction mutation."""
+    kwargs = dict(num_layers=1, hidden_size=8, num_attention_heads=1, num_moe_experts=4)
+
+    config = TransformerConfig(**kwargs)
+    assert config.moe_router_aux_loss_fusion is None
+    assert config.moe_router_aux_loss_fusion_enabled is False
+    config.moe_router_fusion = True
+    assert config.moe_router_aux_loss_fusion_enabled is True
+
+    for routing, aux in ((True, False), (False, True)):
+        config = TransformerConfig(
+            moe_router_fusion=routing, moe_router_aux_loss_fusion=aux, **kwargs
+        )
+        assert config.moe_router_aux_loss_fusion_enabled is aux

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -722,3 +722,9 @@ def test_moe_router_aux_loss_fusion_defaults_to_router_fusion():
             moe_router_fusion=routing, moe_router_aux_loss_fusion=aux, **kwargs
         )
         assert config.moe_router_aux_loss_fusion is aux
+
+    # Resolving at construction means the value is concrete afterwards, so a child built
+    # by dataclasses.replace inherits it rather than re-deriving from its own flag.
+    parent = TransformerConfig(moe_router_fusion=False, **kwargs)
+    child = dataclasses.replace(parent, moe_router_fusion=True)
+    assert child.moe_router_aux_loss_fusion is False

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -710,17 +710,15 @@ def test_topk_routing_precomputed_indices_equivalence(score_function, use_pre_so
 
 
 def test_moe_router_aux_loss_fusion_defaults_to_router_fusion():
-    """Unset follows moe_router_fusion, including after post-construction mutation."""
+    """Unset resolves to moe_router_fusion; an explicit value is left alone."""
     kwargs = dict(num_layers=1, hidden_size=8, num_attention_heads=1, num_moe_experts=4)
 
-    config = TransformerConfig(**kwargs)
-    assert config.moe_router_aux_loss_fusion is None
-    assert config.moe_router_aux_loss_fusion_enabled is False
-    config.moe_router_fusion = True
-    assert config.moe_router_aux_loss_fusion_enabled is True
+    for routing in (False, True):
+        config = TransformerConfig(moe_router_fusion=routing, **kwargs)
+        assert config.moe_router_aux_loss_fusion is routing
 
     for routing, aux in ((True, False), (False, True)):
         config = TransformerConfig(
             moe_router_fusion=routing, moe_router_aux_loss_fusion=aux, **kwargs
         )
-        assert config.moe_router_aux_loss_fusion_enabled is aux
+        assert config.moe_router_aux_loss_fusion is aux


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Separates the MoE aux-loss fusion from the TopK routing fusion, so `--deterministic-mode` guards only the op that actually breaks determinism.

Determinism breaks with Transformer Engine's fused MoE aux-loss kernel, so `--deterministic-mode` has to reject it. `moe_router_fusion` is too coarse to express that — one flag gates two things:

- `switch_load_balancing_loss_func` and `compute_routing_scores_for_aux_loss` — the **aux loss**, which reaches the backward through `MoEAuxLossAutoScaler.apply`, so a nonzero `--moe-aux-loss-coeff` puts any wobble in it straight into the gradients
- `topk_routing_with_score_function` — **TopK routing**, which only selects experts

Only the first is implicated. Requiring the whole flag off would also disable the fused routing path, costing throughput for something that is not the problem.

So: add `moe_router_aux_loss_fusion`, point the four aux-loss call sites at it, leave the three routing sites on `moe_router_fusion`, and have `--deterministic-mode` require only the new flag off.

**Compatibility.** The new flag defaults to `None`, meaning "follow `moe_router_fusion`", so existing configs are unaffected — `moe_router_fusion=True` still enables both fusions and still trips the assert. Keeping fused routing under `--deterministic-mode` means setting `moe_router_aux_loss_fusion=False` explicitly.

Resolution happens on read, via `moe_router_aux_loss_fusion_enabled`, not in `__post_init__`: callers flip `moe_router_fusion` on an already-constructed config (`tests/unit_tests/transformer/moe/test_aux_loss.py` does this to exercise its fused leg), and resolving at construction would freeze the inherited value. `apply_determinism_to_args` applies the same rule to `args`, which has no config yet.

**Evidence.** Measured locally. Running the router on identical input in one process, 8 repeats per aux-loss type, comparing the aux loss bitwise (1 GPU, `moe_aux_loss_coeff=1.0`, `moe_router_dtype=fp32`):

| aux-loss type | unfused | fused |
|---|---|---|
| `aux_loss` | 0/7 mismatches | **7/7 mismatches** |
| `seq_aux_loss` | 0/7 mismatches | **5/7 mismatches** |
| `global_aux_loss` | 0/7 mismatches | **5/7 mismatches** |

The unfused path is bit-identical on every repeat; the fused path is not, for all three types.

Two limits. The mismatch was in the aux-loss **value** — the router-weight gradient stayed bit-identical in every fused repeat — so this does not by itself show the wobble reaching the weights; the path for that is `MoEAuxLossAutoScaler.apply` putting the aux loss in the backward, amplified by `--moe-router-enable-expert-bias`. And a 2-node, 5-step training A/A at the production `moe_aux_loss_coeff=1e-4` came back identical, which is consistent with a coefficient four orders of magnitude smaller.

The fused **routing** path is unmeasured in either direction. This change stops requiring it off on the grounds that nothing has been reported against it.

## Issue tracking

Linked issue: <!-- none; small bug fix -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

