### PR TITLE
Don't assert an address across DBuffer storage release and reallocate

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -135,6 +135,9 @@ class DBuffer:
 
     def reallocate_storage(self) -> None:
         """Restore the local buffer's backing storage to its logical size."""
+        # The allocator may hand back a different address than release_storage() freed.
+        # Tensors sharing this Storage read its pointer on each access, so views into the
+        # buffer -- including ones autograd saved -- follow it to the new allocation.
         self._resize_storage(self.local_buffer.numel())
 
     def release_storage(self) -> None:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -209,8 +209,6 @@ def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup
         device=distributed_setup.device,
     )
     tensor_view = buffer.get_local_tensor(0)
-    buffer_data_ptr = buffer.local_buffer.data_ptr()
-    tensor_view_data_ptr = tensor_view.data_ptr()
 
     buffer.release_storage()
     assert buffer.local_buffer.untyped_storage().nbytes() == 0
@@ -220,8 +218,6 @@ def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup
         buffer.local_buffer.untyped_storage().nbytes()
         == buffer.local_buffer.numel() * buffer.local_buffer.element_size()
     )
-    assert buffer.local_buffer.data_ptr() == buffer_data_ptr
-    assert tensor_view.data_ptr() == tensor_view_data_ptr
     buffer.local_buffer.fill_(7.0)
     torch.testing.assert_close(tensor_view, torch.full_like(tensor_view, 7.0))
 


### PR DESCRIPTION
`test_release_and_reallocate_storage_preserves_buffer_views` asserts that `release_storage()` + `reallocate_storage()` hand back the same address, which CUDACachingAllocator doesn't guarantee. 

A different address is expected, and fine. `release_storage()` resizes the existing Storage rather than replacing it, so tensors sharing it — including views autograd saved — read the new pointer from it on next access. See #4810, which notes the allocator "may return a different address ... and that's fine".

Drop the two address assertions; the storage-size checks and the write-through-and-read-back already cover what the test claims. Add a comment on `reallocate_storage()` so they don't come back.

## Verification

H100, 4 ranks, whole `mfsdp_v2` bucket in one process:

| | result |
|---|---|
| main | 1 failed, 112 passed, 1 skipped |
| this PR | **113 passed**, 1 skipped |