### PR TITLE
Add block-atomic DBuffer placement

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import DTensor, Partial, Replicate
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
@@ -38,15 +38,19 @@ class _OwnedRange:
 
 def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
-    seen_flat = False
+    seen_shard = False
     for placement in placements:
-        if not isinstance(placement, (Replicate, Partial, Flat, BlockAtomic)):
+        if not isinstance(placement, (Replicate, Partial, Shard)):
             raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-        if isinstance(placement, (Flat, BlockAtomic)):
-            seen_flat = True
-        elif seen_flat:
+        if isinstance(placement, Shard):
+            if placement.dim != 0:
+                raise NotImplementedError(
+                    f"DBuffer supports only dim-0 Shard placements, got {placement!r}."
+                )
+            seen_shard = True
+        elif seen_shard:
             raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
+                "Shard placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
 
@@ -259,7 +263,7 @@ class DBuffer:
         source_placement = self.placements[changed_axis]
         destination_placement = placements[changed_axis]
         if isinstance(source_placement, (Replicate, Partial)) and isinstance(
-            destination_placement, Flat
+            destination_placement, Shard
         ):
             offset, local_numel = self.layout.get_local_range(self.mesh, placements)
             local_offset = offset - self.offset
@@ -413,13 +417,13 @@ class DBuffer:
         axis = changed_axis
         old_placement = self.placements[axis]
         new_placement = new_placements[axis]
-        if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+        if isinstance(old_placement, Shard) and isinstance(new_placement, Replicate):
             return self.allgather(axis, out=out)
         if isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
             return self.allreduce(axis, out=out)
-        if isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Shard):
             return self.reduce_scatter(axis, new_placement, out=out)
-        if isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+        if isinstance(old_placement, Replicate) and isinstance(new_placement, Shard):
             view = self.view(new_placements)
             if out is None:
                 return view
@@ -454,9 +458,9 @@ class DBuffer:
 
     def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a sharded axis into Replicate placement."""
-        if not isinstance(self.placements[mesh_axis], Flat):
+        if not isinstance(self.placements[mesh_axis], Shard):
             raise ValueError(
-                f"allgather() currently requires Flat placement on axis {mesh_axis!r}."
+                f"allgather() currently requires a Shard placement on axis {mesh_axis!r}."
             )
 
         placements = list(self.placements)
@@ -495,8 +499,8 @@ class DBuffer:
     ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
         axis = mesh_axis
-        if not isinstance(new_placement, Flat):
-            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
+        if not isinstance(new_placement, Shard):
+            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Shard only.")
         partial_placement = self.placements[axis]
         if not isinstance(partial_placement, Partial):
             raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,6 +15,7 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
+import math
 from collections.abc import Iterable
 
 import torch
@@ -25,7 +26,7 @@ from torch.distributed.tensor import DTensor, Partial, Replicate
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, changed_mesh_axis
+from .placement import BlockAtomic, Flat, changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,15 +40,30 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
     seen_flat = False
     for placement in placements:
-        if not isinstance(placement, (Replicate, Partial, Flat)):
+        if not isinstance(placement, (Replicate, Partial, Flat, BlockAtomic)):
             raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-        if isinstance(placement, Flat):
+        if isinstance(placement, (Flat, BlockAtomic)):
             seen_flat = True
         elif seen_flat:
             raise ValueError(
                 "Flat placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
+
+
+def _get_block_size(placements: Iterable[Placement], block_size: int | None) -> int:
+    """Resolve one layout block size from explicit and placement configuration."""
+    placement_block_size = 1
+    for placement in placements:
+        if isinstance(placement, BlockAtomic):
+            placement_block_size = math.lcm(placement_block_size, placement.block_size)
+    if block_size is None:
+        return placement_block_size
+    if block_size != placement_block_size and placement_block_size != 1:
+        raise ValueError(
+            f"BlockAtomic placements require block size {placement_block_size}, got {block_size}."
+        )
+    return block_size
 
 
 def _get_reduce_op(partial_placement: Partial) -> dist.ReduceOp.RedOpType:
@@ -81,6 +97,8 @@ class DBuffer:
         tensor_shapes: Iterable[Shape],
         dtype: torch.dtype,
         device: torch.device | str,
+        *,
+        block_size: int | None = None,
     ) -> None:
         """Create a DBuffer and allocate its local buffer.
 
@@ -102,7 +120,11 @@ class DBuffer:
         self.placements = placements
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        self.layout = GlobalLayout.build(tensor_shapes, dp_size=self.mesh.size())
+        self.layout = GlobalLayout.build(
+            tensor_shapes,
+            dp_size=self.mesh.size(),
+            block_size=_get_block_size(placements, block_size),
+        )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
@@ -171,6 +193,8 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         tensor_shapes: Iterable[Shape],
+        *,
+        layout: GlobalLayout | None = None,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -197,7 +221,9 @@ class DBuffer:
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size())
+        layout = layout or GlobalLayout.build(
+            tensor_shapes, dp_size=mesh.size(), block_size=_get_block_size(placements, None)
+        )
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -244,10 +270,15 @@ class DBuffer:
                 self.mesh,
                 placements,
                 self.layout.tensor_shapes,
+                layout=self.layout,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
             return DBuffer.from_local(
-                self.local_buffer, self.mesh, placements, self.layout.tensor_shapes
+                self.local_buffer,
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                layout=self.layout,
             )
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
@@ -257,7 +288,12 @@ class DBuffer:
 
     @classmethod
     def distribute_tensors(
-        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
+        cls,
+        tensors: Iterable[torch.Tensor],
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        *,
+        block_size: int | None = None,
     ) -> "DBuffer":
         """Distribute full local tensors into a DBuffer.
 
@@ -287,6 +323,7 @@ class DBuffer:
             tensor_shapes=tensor_shapes,
             dtype=dtype,
             device=mesh.device_type,
+            block_size=block_size,
         )
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
         # observable through get_local_tensor() and can remain unspecified.
@@ -323,6 +360,7 @@ class DBuffer:
                 tensor_shapes=self.layout.tensor_shapes,
                 dtype=dtype,
                 device=self.device,
+                block_size=self.layout.block_size,
             )
 
         if out.mesh != self.mesh:
@@ -403,7 +441,11 @@ class DBuffer:
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
             return DBuffer.from_local(
-                self.local_buffer, self.mesh, new_placements, self.layout.tensor_shapes
+                self.local_buffer,
+                self.mesh,
+                new_placements,
+                self.layout.tensor_shapes,
+                layout=self.layout,
             )
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -519,12 +519,15 @@ class DBuffer:
         """Return logical tensor ``index`` as a DTensor."""
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
-        # DBuffer uses contiguous flat storage, and Flat only shards dim 0, so
-        # the local view's stride matches the logical global tensor stride.
+        # Keep internal storage details (e.g. Flat and BlockAtomic) out of DTensor placements.
+        dtensor_placements = tuple(
+            Shard(placement.dim) if isinstance(placement, Shard) else placement
+            for placement in self.placements
+        )
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,
-            placements=self.placements,
+            placements=dtensor_placements,
             run_check=False,
             shape=tensor_shape,
             stride=local_tensor.stride(),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,7 +15,6 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
-import math
 from collections.abc import Iterable
 
 import torch
@@ -26,7 +25,7 @@ from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import BlockAtomic, Flat, changed_mesh_axis
+from .placement import changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -53,21 +52,6 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
                 "Shard placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
-
-
-def _get_block_size(placements: Iterable[Placement], block_size: int | None) -> int:
-    """Resolve one layout block size from explicit and placement configuration."""
-    placement_block_size = 1
-    for placement in placements:
-        if isinstance(placement, BlockAtomic):
-            placement_block_size = math.lcm(placement_block_size, placement.block_size)
-    if block_size is None:
-        return placement_block_size
-    if block_size != placement_block_size and placement_block_size != 1:
-        raise ValueError(
-            f"BlockAtomic placements require block size {placement_block_size}, got {block_size}."
-        )
-    return block_size
 
 
 def _get_reduce_op(partial_placement: Partial) -> dist.ReduceOp.RedOpType:
@@ -102,7 +86,7 @@ class DBuffer:
         dtype: torch.dtype,
         device: torch.device | str,
         *,
-        block_size: int | None = None,
+        block_size: int = 1,
     ) -> None:
         """Create a DBuffer and allocate its local buffer.
 
@@ -125,9 +109,7 @@ class DBuffer:
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
         self.layout = GlobalLayout.build(
-            tensor_shapes,
-            dp_size=self.mesh.size(),
-            block_size=_get_block_size(placements, block_size),
+            tensor_shapes, dp_size=self.mesh.size(), block_size=block_size
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
@@ -196,9 +178,7 @@ class DBuffer:
         local_buffer: torch.Tensor,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[Shape],
-        *,
-        layout: GlobalLayout | None = None,
+        layout: GlobalLayout,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -208,7 +188,7 @@ class DBuffer:
                 reduce-scatter, which are efficient with contiguous tensors.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
-            tensor_shapes: Global shapes for each logical tensor in this buffer.
+            layout: Existing global layout for the logical tensors in this buffer.
 
         Returns:
             A DBuffer that reuses ``local_buffer`` without allocating storage.
@@ -224,10 +204,6 @@ class DBuffer:
         if not local_buffer.is_contiguous():
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
-        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = layout or GlobalLayout.build(
-            tensor_shapes, dp_size=mesh.size(), block_size=_get_block_size(placements, None)
-        )
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -273,17 +249,10 @@ class DBuffer:
                 self.local_buffer.narrow(0, local_offset, local_numel),
                 self.mesh,
                 placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
+                self.layout,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
-            return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
-            )
+            return DBuffer.from_local(self.local_buffer, self.mesh, placements, self.layout)
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
             "or a Replicate/Partial-to-Flat slice, "
@@ -297,7 +266,7 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         *,
-        block_size: int | None = None,
+        block_size: int = 1,
     ) -> "DBuffer":
         """Distribute full local tensors into a DBuffer.
 
@@ -444,13 +413,7 @@ class DBuffer:
                 raise NotImplementedError(
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
-            return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                new_placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
-            )
+            return DBuffer.from_local(self.local_buffer, self.mesh, new_placements, self.layout)
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
             f"{axis}: {old_placement!r} -> {new_placement!r}."

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -23,7 +23,7 @@ import torch
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor.placement_types import Placement
 
-from .placement import Flat
+from .placement import BlockAtomic, Flat
 
 Shape: TypeAlias = torch.Size | Iterable[int]
 
@@ -35,9 +35,10 @@ class GlobalLayout:
     tensor_shapes: tuple[torch.Size, ...]
     tensor_to_offset: tuple[int, ...]
     size: int
+    block_size: int = 1
 
     @classmethod
-    def build(cls, shapes: Iterable[Shape], dp_size: int) -> "GlobalLayout":
+    def build(cls, shapes: Iterable[Shape], dp_size: int, *, block_size: int = 1) -> "GlobalLayout":
         """Compute global tensor element offsets and padded size.
 
         This is a DBuffer-specific reimplementation of
@@ -78,6 +79,8 @@ class GlobalLayout:
         """
         if dp_size <= 0:
             raise ValueError(f"DP size must be positive, got {dp_size}.")
+        if block_size <= 0:
+            raise ValueError(f"Block size must be positive, got {block_size}.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
         chunk_size = 1
@@ -87,7 +90,11 @@ class GlobalLayout:
                 raise ValueError(
                     f"Cannot compute a layout for zero-sized non-leading dims: {shape}."
                 )
-            chunk_size = math.lcm(chunk_size, row_size)
+            if shape[0] % block_size != 0:
+                raise ValueError(
+                    f"Tensor dim 0 ({shape[0]}) must be divisible by block size {block_size}."
+                )
+            chunk_size = math.lcm(chunk_size, block_size * row_size)
 
         # chunk_size is the packing granularity. Since every tensor row size divides it,
         # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
@@ -150,7 +157,9 @@ class GlobalLayout:
             for fragment in fragment_items[:]:
                 frag_id, frag_shape = fragment
                 frag_numel = frag_shape.numel()
-                aligned_gap_offset = _pad_to_multiple(gap_offset, non_leading_numel(frag_shape))
+                aligned_gap_offset = _pad_to_multiple(
+                    gap_offset, block_size * non_leading_numel(frag_shape)
+                )
                 if aligned_gap_offset + frag_numel > fragment_gap_end:
                     continue
                 tensor_to_offset[frag_id] = aligned_gap_offset
@@ -159,7 +168,7 @@ class GlobalLayout:
 
         # Fragments that did not fit into regular-tensor gaps are appended at the tail.
         for frag_id, frag_shape in fragment_items:
-            next_offset = _pad_to_multiple(next_offset, non_leading_numel(frag_shape))
+            next_offset = _pad_to_multiple(next_offset, block_size * non_leading_numel(frag_shape))
             tensor_to_offset[frag_id] = next_offset
             next_offset += frag_shape.numel()
 
@@ -167,6 +176,7 @@ class GlobalLayout:
             tensor_shapes=tensor_shapes,
             tensor_to_offset=tuple(tensor_to_offset),
             size=_pad_to_multiple(next_offset, chunk_size * dp_size),
+            block_size=block_size,
         )
 
     def __post_init__(self) -> None:
@@ -198,9 +208,10 @@ class GlobalLayout:
             row_size = non_leading_numel(shape)
             if row_size <= 0:
                 raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
-            if start % row_size != 0:
+            if start % (self.block_size * row_size) != 0:
                 raise AssertionError(
-                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                    f"Tensor {tensor_id} offset {start} is not aligned to block size "
+                    f"{self.block_size * row_size}."
                 )
 
             end = start + shape.numel()
@@ -228,7 +239,7 @@ class GlobalLayout:
         offset = 0
         numel = self.size
         for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, Flat):
+            if not isinstance(placement, (Flat, BlockAtomic)):
                 continue
             axis_size = mesh.size(axis)
             if numel % axis_size != 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -21,9 +21,8 @@ from typing import TypeAlias
 
 import torch
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
-
-from .placement import BlockAtomic, Flat
 
 Shape: TypeAlias = torch.Size | Iterable[int]
 
@@ -239,7 +238,7 @@ class GlobalLayout:
         offset = 0
         numel = self.size
         for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, (Flat, BlockAtomic)):
+            if not isinstance(placement, Shard):
                 continue
             axis_size = mesh.size(axis)
             if numel % axis_size != 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,6 +14,7 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
+import math
 from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ from torch.distributed.tensor.placement_types import Placement
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
 from .module_utils import get_parameter_owner
+from .placement import BlockAtomic
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -191,11 +193,17 @@ class FsdpParameterGroup:
             raise RuntimeError("Symmetric-memory MFSDP requires PyTorch 2.12 or later.")
 
         tensor_shapes = tuple(parameter.shape for parameter in parameters)
+        block_size = 1
+        for placements in (model_weight_placements, main_grad_placements, main_weight_placements):
+            for placement in placements:
+                if isinstance(placement, BlockAtomic):
+                    block_size = math.lcm(block_size, placement.block_size)
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
             (parameter.to(dtype=main_weight_dtype) for parameter in parameters),
             mesh=self.mesh,
             placements=main_weight_placements,
+            block_size=block_size,
         )
 
         if use_symmetric_memory:
@@ -219,6 +227,7 @@ class FsdpParameterGroup:
                     tensor_shapes=tensor_shapes,
                     dtype=self.dtype,
                     device=self.main_weight.device,
+                    block_size=block_size,
                 )
         self.post_optimizer_model_weight = self.model_weight.view(main_weight_placements)
         # Cast into the preallocated optimizer-layout view on the current stream.
@@ -234,6 +243,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
                 device=self.main_weight.device,
+                block_size=block_size,
             )
 
         self.main_grad = None
@@ -254,6 +264,7 @@ class FsdpParameterGroup:
             tensor_shapes=self.main_weight.layout.tensor_shapes,
             dtype=grad_dtype,
             device=self.main_weight.device,
+            block_size=block_size,
         )
         self.pre_optimizer_main_grad = self.main_grad.view(main_weight_placements)
         assert self.main_grad.layout == self.main_weight.layout, (
@@ -383,6 +394,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
+                block_size=self.main_weight.layout.block_size,
             )
 
     def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -15,8 +15,8 @@
 """DBuffer placement definitions.
 
 DBuffer uses PyTorch DTensor's ``Placement``, ``Replicate``, and ``Partial``
-types directly. ``Flat`` is the only DBuffer-specific placement: a dim-0
-``Shard`` whose local storage is part of one flattened buffer.
+types directly. ``Flat`` and ``BlockAtomic`` are DBuffer-specific dim-0
+``Shard`` placements whose local storage is part of one flattened buffer.
 
 =============  =============  ====================
 Source         Destination    DBuffer operation
@@ -33,7 +33,7 @@ from collections.abc import Iterable
 from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
 
-__all__ = ["Flat", "changed_mesh_axis"]
+__all__ = ["BlockAtomic", "Flat", "changed_mesh_axis"]
 
 
 class Flat(Shard):
@@ -41,6 +41,27 @@ class Flat(Shard):
 
     def __init__(self) -> None:
         super().__init__(0)
+
+    def __eq__(self, other: object) -> bool:
+        # PyTorch Shard.__eq__ compares only dim, so distinguish Flat from BlockAtomic.
+        return isinstance(other, Shard) and other.dim == 0 and not isinstance(other, BlockAtomic)
+
+
+class BlockAtomic(Shard):
+    """Flattened dim-0 shard placement that keeps ``block_size`` rows together."""
+
+    def __init__(self, block_size: int) -> None:
+        if block_size <= 0:
+            raise ValueError(f"BlockAtomic block_size must be positive, got {block_size}.")
+        super().__init__(0)
+        self.block_size = block_size
+
+    def __eq__(self, other: object) -> bool:
+        # PyTorch Shard.__eq__ compares only dim, so preserve the block size as well.
+        return isinstance(other, BlockAtomic) and self.block_size == other.block_size
+
+    def __repr__(self) -> str:
+        return f"BlockAtomic(block_size={self.block_size})"
 
 
 def changed_mesh_axis(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -12,6 +12,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Partial, Replicate
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer, Flat
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import BlockAtomic
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -66,6 +67,22 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(distributed_setup):
 
     assert buffer.layout.tensor_to_offset == (0, 18)
     assert buffer.layout.size == 24
+
+
+def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
+    """BlockAtomic keeps every local tensor shard aligned to its configured row block."""
+    if distributed_setup.world_size < 2:
+        pytest.skip("Requires at least 2 ranks.")
+
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
+    tensors = [
+        torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
+        torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
+    ]
+    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)])
+
+    assert block_atomic.layout.block_size == 2
+    assert all(block_atomic.get_local_tensor(index).shape[0] % 2 == 0 for index in range(2))
 
 
 def test_compute_layout_fills_lcm_padding_gaps(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -78,6 +78,8 @@ def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
         pytest.skip("Requires at least 2 ranks.")
 
     mesh = init_device_mesh(distributed_setup.device.type, (2,))
+    if mesh.get_coordinate() is None:
+        pytest.skip("Rank is outside the 2-rank BlockAtomic test mesh.")
     tensors = [
         torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
         torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
@@ -608,7 +610,7 @@ def test_2d_mesh_flat_before_replicate_is_rejected(distributed_setup):
         mesh_dim_names=("flat", "replicate"),
     )
 
-    with pytest.raises(ValueError, match="Flat placements must be a suffix"):
+    with pytest.raises(ValueError, match="Shard placements must be a suffix"):
         DBuffer(
             mesh=mesh,
             placements=[Flat(), Replicate()],

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -9,7 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor import Partial, Replicate, Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import (
@@ -576,7 +576,7 @@ def test_get_dtensor_from_sharded_buffer(distributed_setup):
         dtensor.to_local(), sharded_buffer.get_local_tensor(0), rtol=0, atol=0
     )
     assert dtensor.shape == tensors[0].shape
-    assert dtensor.placements == (Flat(),)
+    assert dtensor.placements == (Shard(0),)
 
 
 def test_2d_mesh_replicate_flat_round_trip(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -11,8 +11,11 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Partial, Replicate
 
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer, Flat
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import BlockAtomic
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import (
+    BlockAtomic,
+    Flat,
+)
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -79,7 +82,7 @@ def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
         torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
         torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
     ]
-    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)])
+    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)], block_size=2)
 
     assert block_atomic.layout.block_size == 2
     assert all(block_atomic.get_local_tensor(index).shape[0] % 2 == 0 for index in range(2))
@@ -248,9 +251,7 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     offset = distributed_setup.rank * local_numel
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
-    sharded_buffer = DBuffer.from_local(
-        local_buffer, mesh, [Flat()], replicated_buffer.layout.tensor_shapes
-    )
+    sharded_buffer = DBuffer.from_local(local_buffer, mesh, [Flat()], replicated_buffer.layout)
 
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == replicated_buffer.layout


### PR DESCRIPTION
## What

- Add `BlockAtomic(block_size)`, a dim-0 DBuffer sharding placement that keeps row blocks on one rank.
- Establish one block-aligned `GlobalLayout` per parameter group and share it across its weights, gradients, and temporary buffers.
- Build Flat and BlockAtomic layouts with one packing rule; Flat is the `block_size=1` case.

## Why

BlockAtomic provides the layout guarantee needed by block-wise parameter formats. A group-owned layout keeps its buffers compatible even when their current placements differ.

Related to #5615.

## Testing

- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py` — 49 passed, 12 skipped
- The 5-rank exact-layout case requires more GPUs than this host exposes.