### PR TITLE
fix: cache a copy of the GPT dataset loss mask

### DIFF
--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -300,7 +300,10 @@ class GPTDataset(MegatronDataset):
             )
             if self.masks_and_position_ids_are_cacheable:
                 self.cached_attention_mask = attention_mask
-                self.cached_loss_mask = loss_mask
+                # Cache a copy: loss_mask is masked in place below, so caching the
+                # tensor itself would bake this sample's padding into every
+                # subsequent sample served by this dataset.
+                self.cached_loss_mask = loss_mask.clone()
                 self.cached_position_ids = position_ids
                 self.masks_and_position_ids_are_cached = True
         else:

--- a/tests/unit_tests/data/test_gpt_dataset.py
+++ b/tests/unit_tests/data/test_gpt_dataset.py
@@ -190,5 +190,62 @@ def test_inter_document_masking():
     assert "cu_seqlens" in sample
 
 
+def test_mask_cache_does_not_leak_padding():
+    """A sample's loss_mask must not depend on which sample was served first.
+
+    The mask cache is populated with the first sample's mask, which is then masked
+    in place for that sample's padding. Caching the tensor itself rather than a copy
+    bakes that padding into every subsequent sample, so a dataset instance whose
+    first served sample is padded returns wrong masks from then on.
+    """
+    if torch.distributed.is_available():
+        Utils.initialize_distributed()
+        if torch.distributed.get_rank() == 0:
+            compile_helpers()
+        torch.distributed.barrier()
+    else:
+        compile_helpers()
+
+    tokenizer = MegatronTokenizer.from_pretrained(
+        metadata_path={"library": "null-text"}, vocab_size=_MOCK_VOCAB_SIZE
+    )
+
+    def build_dataset():
+        config = GPTDatasetConfig(
+            random_seed=1234,
+            sequence_length=1024,
+            split="990,10,0",
+            # All three False is what makes the masks cacheable.
+            reset_position_ids=False,
+            reset_attention_mask=False,
+            eod_mask_loss=False,
+            create_attention_mask=False,
+            # Keeps the padded trailing sequence, which is what poisons the cache.
+            drop_last_partial_validation_sequence=False,
+            add_extra_token_to_sequence=False,
+            tokenizer=tokenizer,
+            mid_level_dataset_surplus=0.005,
+        )
+        return BlendedMegatronDatasetBuilder(
+            MockGPTDataset, [0, None, 0], lambda: True, config
+        ).build()[1]
+
+    # An instance served in index order, so the cache is filled by an unpadded sample.
+    expected = build_dataset()[0]["loss_mask"]
+
+    dataset = build_dataset()
+    assert dataset.masks_and_position_ids_are_cacheable, "config no longer uses the cache"
+
+    # Serve the padded trailing sequence first, filling the cache from it. Asserting
+    # that it really is padded keeps the comparison below from passing vacuously.
+    padded_index = int(dataset.shuffle_index.argmax())
+    padded_mask = dataset[padded_index]["loss_mask"]
+    assert int((padded_mask == 0).sum()) > 1, f"index {padded_index} is no longer padded"
+
+    assert torch.equal(
+        dataset[0]["loss_mask"], expected
+    ), "padding from the first served sample leaked into a later sample's loss_mask"
+
+
 if __name__ == "__main__":
     test_mock_gpt_dataset()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

## The bug

`GPTDataset.__getitem__` caches the loss mask, then masks in place:

```python
if not cacheable or not cached:                   # FILL — first sample only
    loss_mask = _get_ltor_masks_and_position_ids(...)
    if cacheable:
        self.cached_loss_mask = loss_mask         # 303: stores the tensor
else:                                             # HIT — every later sample
    loss_mask = self.cached_loss_mask.clone()     # 308: stores a copy

loss_mask[labels == self._pad_token_id] = 0.0     # 312: in-place
```

Line 303 stores the tensor itself rather than a copy, so line 312 writes *through* that reference
into the cache. Only the first sample served can do this — FILL runs once per dataset
(`masks_and_position_ids_are_cached` is set `True` there and never reset) and every later sample
masks a clone.

```
·  loss counted    ×  masked

Case B — the masked sample is served anywhere but first       NO EFFECT
──────────────────────────────────────────────────────────────────────
              self.cached_loss_mask       per-call tensor        returned

 1st  s0      ┌───────────────┐
      FILL    │ A ··········· │ ← the only write that ever happens     A
              └───────────────┘

 2nd  s_k     ┌───────────────┐
      HIT     │ A ··········· │ ─clone→ B ···········                  B
              └───────────────┘  read    312 masks B: ······×××××
                A not touched            the zeros land in B only

 3rd  s_j     ┌───────────────┐
      HIT     │ A ··········· │ ─clone→ C ···········                  C
              └───────────────┘         clones A — NOT B


Case A — the masked sample is served FIRST                        BUG
──────────────────────────────────────────────────────────────────────
 1st  s_k     ┌───────────────┐
      FILL    │ A ··········· │ ←── 303 stored the tensor itself, so the
              └───────────────┘     slot and the tensor masked at 312
                     ↑              are THE SAME OBJECT
                     └── 312 writes here: A ······×××××            A

 2nd  s0      ┌───────────────┐
      HIT     │ A ······××××× │ ─clone→ B ······×××××                  B  WRONG
              └───────────────┘         a dirty base

 3rd  s_j     ┌───────────────┐
      HIT     │ A ······××××× │ ─clone→ C ······×××××                  C  WRONG
              └───────────────┘                ^^^^^
                                        s_k's zeros, on every sample
```

Step 3 does not reuse "the cache from step 2" — step 2 never wrote one. Line 308
always clones the slot, which has held `A` since step 1.

## Impact

**The cached mask is masked in place, so the first sample's padding poisons every batch after
it.** Line 303 stores the tensor itself, then line 312 writes into that same object — so whatever
the first sample masks (real padding, or the pad id among its tokens) is written straight into the
cache and silently inherited by every following batch. Later samples are harmless by comparison:
they clone the cache first, so their own padding lands on a throwaway copy.

Two ways a sample gets masked positions:

- **Real padding**, when a sample is shorter than `sequence_length`. Training never hits this
  (`drop_last_partial_sequence` is hardcoded `True` at line 248), but validation can, with
  `drop_last_partial_validation_sequence=False`.
- **The pad id as ordinary data.** `_pad_token_id` is `tokenizer.pad` verbatim
  (`megatron_dataset.py:75`), so any occurrence in the token stream is masked, on any sample.
  `MockGPTLowLevelDataset` generates `(arange(length - 1) + 1) % vocab_size` — a ramp over the whole
  vocabulary — so under `--mock-data` this fires on essentially every sample.

**It breaks bitwise checkpoint resume, silently.** Which sample runs FILL is a property of the
*process*: a fresh run fills from its first training sample, a resumed run from whatever sample its
step maps to. The two then serve different masks for the same sample, so gradients diverge from the
first step after the resume even with checkpoint state, `tokens`, `labels` and `position_ids` all
bitwise identical. Nothing errors — the loss stays plausible because it is normalised by the mask sum.

`MockGPTDataset` and `GPTFIMDataset` inherit this `__getitem__`. `SFTDataset` defines its own and is
unaffected.

## The fix

Cache a clone at 303, mirroring the clone already made at 308. One line — the first
sample's in-place write then lands on a throwaway and the slot stays clean.

## Test

`test_mask_cache_does_not_leak_padding` builds two dataset instances, serves the
masked sample first in one, and asserts both return the same `loss_mask` for
index 0. It first asserts that sample really is masked, so it fails loudly rather
than passing vacuously if the fixture stops producing one. It reproduces the defect
via trigger 1, which is the one constructible from an in-tree tokenizer; both
triggers exercise the same aliasing.

Fails before the change (`AssertionError: padding from the first served sample
leaked into a later sample's loss_mask`), passes after.

`cached_attention_mask` and `cached_position_ids` are stored by reference too.
Neither is mutated today so neither is buggy; left unchanged to keep the diff
minimal.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.




