### PR TITLE
validate data-parallel sharding strategies

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -7,6 +7,10 @@ import torch
 
 from ..utils import is_torch_min_version
 
+# Sharding strategy names, ordered as the ZeRO ladder: each level shards one more
+# buffer than the last. Both data-parallel axes take a value from this set.
+_SHARDING_STRATEGIES = ("no_shard", "optim", "optim_grads", "optim_grads_params")
+
 
 @dataclass
 class DistributedDataParallelConfig:
@@ -281,6 +285,12 @@ class DistributedDataParallelConfig:
         import os
 
         """Check the validity of the config."""
+        for name in ("data_parallel_sharding_strategy", "outer_dp_sharding_strategy"):
+            value = getattr(self, name)
+            if value not in _SHARDING_STRATEGIES:
+                raise ValueError(
+                    f"{name} must be one of {list(_SHARDING_STRATEGIES)}, got {value!r}."
+                )
         if self.megatron_fsdp_version not in (1, 2):
             raise ValueError("megatron_fsdp_version must be either 1 or 2")
 


### PR DESCRIPTION
## Summary

- validate both data-parallel sharding strategy fields against the shared ZeRO ladder
- provide field-specific validation errors

Split from #6873 so the configuration change can be reviewed independently.

## Testing

- `isort --check megatron/core/distributed/distributed_data_parallel_config.py`
- `black --skip-magic-trailing-comma --skip-string-normalization --check megatron/core/distributed/distributed_data_parallel_config.py`
- `git diff --check`