### PR TITLE
fix(datasets): correct S3 object existence checks

### DIFF
--- a/megatron/core/datasets/object_storage_utils.py
+++ b/megatron/core/datasets/object_storage_utils.py
@@ -141,17 +141,19 @@ def _s3_object_exists(client: S3Client, path: str) -> bool:
         path (str): The S3 path
 
     Raises:
-        botocore.exceptions.ClientError: The error code is 404
+        botocore.exceptions.ClientError: If the metadata request fails for a reason other than
+            the object not existing.
 
     Returns:
         bool: True if the object exists in S3, False otherwise
     """
     parsed_s3_path = parse_s3_path(path)
     try:
-        _ = client.head_object(bucket=parsed_s3_path[0], key=parsed_s3_path[1])
+        _ = client.head_object(Bucket=parsed_s3_path[0], Key=parsed_s3_path[1])
     except exceptions.ClientError as e:
-        if e.response["Error"]["Code"] != "404":
-            raise e
+        if e.response["Error"]["Code"] == "404":
+            return False
+        raise
     return True
 
 

--- a/tests/unit_tests/data/test_object_storage_utils.py
+++ b/tests/unit_tests/data/test_object_storage_utils.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from megatron.core.datasets import object_storage_utils
+
+
+class _ClientError(Exception):
+    """Minimal botocore ClientError replacement for unit tests."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture(autouse=True)
+def _patch_client_error(monkeypatch):
+    monkeypatch.setattr(
+        object_storage_utils,
+        "exceptions",
+        SimpleNamespace(ClientError=_ClientError),
+        raising=False,
+    )
+
+
+def test_s3_object_exists():
+    client = Mock()
+
+    assert object_storage_utils._s3_object_exists(client, "s3://bucket/path/to/data.bin")
+    client.head_object.assert_called_once_with(Bucket="bucket", Key="path/to/data.bin")
+
+
+def test_s3_object_does_not_exist():
+    client = Mock()
+    client.head_object.side_effect = _ClientError("404")
+
+    assert not object_storage_utils._s3_object_exists(client, "s3://bucket/missing.idx")
+    client.head_object.assert_called_once_with(Bucket="bucket", Key="missing.idx")
+
+
+def test_s3_object_exists_reraises_non_404_errors():
+    client = Mock()
+    error = _ClientError("403")
+    client.head_object.side_effect = error
+
+    with pytest.raises(_ClientError) as exc_info:
+        object_storage_utils._s3_object_exists(client, "s3://bucket/private.idx")
+
+    assert exc_info.value is error
+    client.head_object.assert_called_once_with(Bucket="bucket", Key="private.idx")


### PR DESCRIPTION
## Summary
- call S3 `HeadObject` with boto3's case-sensitive `Bucket` and `Key` parameters
- return `False` when S3 reports a missing object and preserve other `ClientError` failures
- cover existing, missing, and non-404 error paths with unit tests

## Problem
`IndexedDataset.exists()` delegates S3 checks to `_s3_object_exists()`. The current call uses lowercase keyword names, which boto3 rejects with `TypeError`. If a client accepts those keywords and reports a 404, the exception handler falls through and incorrectly returns `True`, so missing dataset shards can be reported as present.

## Testing
- isolated CPU regression checks against the exact production module: existing object, 404, and non-404 paths pass
- `python -m compileall` on the changed production and test files
- `git diff --check`

The repository's containerized pytest/format workflow was not available locally because this host has no Docker or `uv`; the PR is left as a draft for CI validation.