### PR TITLE
feat: coalesce partial CUDA graph captures for HybridStack

### DIFF
--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -237,6 +237,7 @@ The table below covers every GTP-related CLI flag and Python knob. "Required" me
 | `--gtp-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the dense gtp_remat wgrad reduce-scatter path. Takes precedence over fp32-accum on its group; incompatible with `--disable-symmetric-registration`. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
 | `--gtp-expert-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the routed-expert egtp_remat wgrad reduce-scatter path. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
 | `--gtp-remat-opt-in-modules` | **Optional** | MoE models with large `--moe-latent-size` | `[]` | Space-separated list of module tokens to opt in to GTP_remat sharding. Currently supported: `moe_latent_proj` (shards `fc1_latent_proj` / `fc2_latent_proj`; only beneficial when the latent size is large enough to amortize the all-gather). [§1.5](#15-opt-in-minimally-invasive-integration) |
+| `--cuda-graph-coalesce-partial-captures` | **Optional** | HybridStack local CG | off | Coalesces eligible partial captures into maximal spans. Unsupported span configurations fall back automatically. [§3.6](#36-cuda-graph-integration) |
 | `--fp8-param-gather` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Gathers native MXFP8 shard directly; without it the grad-buffer reuse path is unavailable and `arguments.py` asserts. Always paired with `--reuse-grad-buf-for-mxfp8-param-ag`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
 | `--reuse-grad-buf-for-mxfp8-param-ag` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Reuses the grad buffer for the MXFP8 all-gather (MXFP8 cannot map into the contiguous param buffer). Must accompany `--fp8-param-gather`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
 | `--fp4-param-gather` | **Required** | GTP + `--fp4-format` | off | Gathers native NVFP4 shard directly; without it NVFP4 weights fall back to a BF16 gather that fails the backward GEMM. [§1.3 → GTP + NVFP4](#gtp--nvfp4-native-nvfp4-param) |
@@ -788,6 +789,19 @@ The two modes differ only in release timing and the storage required to make ear
 
 The feature applies only to **local/partial CUDA graphs** and is enabled automatically. Full-iteration CUDA graphs do not use this feature because their backward execution has no local graph boundary.
 
+#### Coalesced partial-capture spans
+
+`--cuda-graph-coalesce-partial-captures` combines adjacent static HybridStack operations into maximal graph spans when the selected scopes are limited to `mamba`, `attn`, and `moe_router`. A span ends at an eager layer or at the dynamic expert-compute island of a MoE layer, so the execution plan alternates captured spans with eager work:
+
+```text
+forward:  [M ... router] -> eager expert -> [postprocess ... router] -> eager expert -> [postprocess]
+backward: [postprocess]  -> eager expert -> [router ... postprocess] -> eager expert -> [router ... M]
+```
+
+The span path does not replace the cross-graph RS overlap described above. Span runners retain the same two-stage drain: Stage 1 releases the following eager island while Stage 2 drains the current span's RS tail. Every span uses one shared replay stream, so the next span cannot reuse graph-pool wgrad scratch before the previous span finishes Stage 2. Span runners therefore do not need the separate wgrad ring used by per-module runners.
+
+The span path is opt-in. Without the flag, or for unsupported configurations such as context parallelism, mHC, full-layer recomputation, whole-layer local scopes, and non-HybridStack modules, local CUDA graphs continue to use per-module runners.
+
 ### 3.7 Per-parameter alignment padding
 
 Low-precision tiling formats need each rank's local shard aligned to their tile size (MXFP8: 32, NVFP4: 16) — plain equal-sized AG/RS shards only need `dim0` divisible by `gtp_remat_size`, which padding is not required for (`_gtp_slice_one_param` skips it and just asserts that divisibility when `pad_for_alignment == 0`). BF16 has no tile-size requirement, so `training.py` sets `pad_for_alignment=1` for it — `dim0` still isn't guaranteed divisible by `gtp_remat_size` on its own, so padding stays on, just bounded to `gtp_remat_size - 1` rows instead of a 16/32-row tile margin. A weight's real `dim0` is rarely already a multiple of `pad_for_alignment × gtp_remat_size`, so `_gtp_slice_one_param` pads the *logical* tensor up to the next multiple before slicing it evenly across `gtp_remat_group` (§1.3) — the padding lands as a contiguous suffix of that padded buffer. It is real, allocated storage, but the wgrad GEMM only ever writes the logical prefix (§3.6), so it stays exact `0.0` for the life of the run: a permanent structural zero, not a value that merely happens to be zero.
@@ -865,7 +879,7 @@ torchrun --nproc-per-node 4 -m pytest tests/unit_tests/generalized_tensor_parall
 | `test_gtp_loss_correctness.py` | End-to-end: GTP_remat per-step loss trajectory matches a no-GTP_remat baseline. |
 | `test_gtp_grad_correctness.py` | Gradient + dist-opt + grad-norm numeric parity vs a DP baseline at replicate (DP) > 1. Also the fp32-accumulation reduce-scatter (§2.6): gtp_remat-axis and DDP-axis parity, plus the size-2 bypass. |
 | `test_gtp_cudagraph_grad.py` | Capture-step grad-norm guard (§1.2): `_backup_grads_before_capture`/`_restore_grads_after_capture` keep a graph capture from clobbering finalized `main_grad` (own params + cross-graph `next_w`, incl. routed-expert `weight_list`). |
-| `test_gtp_partial_cg.py` | Four-layer partial-CG loss and eager-vs-replay grad-norm parity with two-slot ring reuse across independently replayed graphs (§3.5). |
+| `test_gtp_partial_cg.py` | Partial-CG loss and eager-vs-replay grad-norm parity for per-module and coalesced-span modes (§3.6). |
 | `test_gtp_dcp.py` | DCP sharding metadata (§3.3): TP×GTP_remat offsets, pad reshard, `replica_id`, native-FP8 save/load. Also the SSM `in_proj` gather+split: the gated-delta-product mixer's factory build/merge at MXFP8 alignment, and a full DCP save→load roundtrip of that mixer. |
 | `test_gtp_muon_dcp.py` | Muon optimizer-state DCP roundtrip (§1.6): `replica_id` fold + native-FP8 backfill matching. |
 | `test_gtp_recompute_chain.py` | Recompute-chain buffers (§3.1): adjacent nodes never share a gather buffer, dense and grouped, plus dgrad/wgrad parity vs no-recompute. |

--- a/docs/user-guide/features/cuda_graph.md
+++ b/docs/user-guide/features/cuda_graph.md
@@ -53,6 +53,12 @@ Operationally, this path is tightly integrated into MCore training and inference
 - users select the mode through config flags only; there is no separate helper API to
   wire into a custom training loop or a separate need to handle static input buffers
 
+A graph captured during training can also be replayed by standard evaluation. CUDA graph replay
+preserves capture-time side effects, so the graph manager clears temporary model accumulators when
+the model returns to training; for example, validation token counts cannot affect the next
+expert-bias update. The captured computation must otherwise have compatible training and
+evaluation semantics.
+
 ### Usage
 
 ```bash

--- a/megatron/core/models/hybrid/cuda_graph_spans.py
+++ b/megatron/core/models/hybrid/cuda_graph_spans.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""CUDA-graph spans for hybrid stacks.
+
+The local CUDA-graph implementation normally creates one runner for every selected module. A
+hybrid stack has a stronger execution structure: Mamba and attention layers are static, while a
+MoE layer has one dynamic expert-compute island between a static router and static postprocess.
+This module coalesces adjacent static operations into maximal spans, so CUDA graphs meet only
+eager execution at their boundaries.
+"""
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Iterator, Sequence, TypeAlias
+
+import torch
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.fp4_utils import get_fp4_context
+from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.models.hybrid.layers import utils as layer_utils
+from megatron.core.ssm.mamba_layer import MambaLayer
+from megatron.core.transformer.enums import CudaGraphModule
+from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
+from megatron.core.transformer.transformer_layer import MoETransformerLayer
+
+
+class HybridCudaGraphOperation(Enum):
+    """One statically graphable operation in a hybrid stack."""
+
+    LAYER = auto()
+    MOE_ROUTER = auto()
+    MOE_POSTPROCESS = auto()
+
+
+@dataclass(frozen=True)
+class HybridCudaGraphOperationSpec:
+    """A graph operation and the HybridStack layer that owns it."""
+
+    operation: HybridCudaGraphOperation
+    layer_index: int
+
+
+@dataclass(frozen=True)
+class HybridCudaGraphSpanSpec:
+    """A maximal sequence of adjacent graphable operations."""
+
+    operations: tuple[HybridCudaGraphOperationSpec, ...]
+
+
+@dataclass(frozen=True)
+class HybridCudaGraphEagerExpertSpec:
+    """The dynamic expert-compute island of one MoE layer."""
+
+    layer_index: int
+
+
+@dataclass(frozen=True)
+class HybridCudaGraphEagerLayerSpec:
+    """A complete layer that is outside the selected CUDA-graph modules."""
+
+    layer_index: int
+
+
+HybridCudaGraphPlanEntry: TypeAlias = (
+    HybridCudaGraphSpanSpec | HybridCudaGraphEagerExpertSpec | HybridCudaGraphEagerLayerSpec
+)
+
+_SUPPORTED_HYBRID_CUDA_GRAPH_MODULES = frozenset(
+    {
+        CudaGraphModule.mamba,
+        CudaGraphModule.attn,
+        CudaGraphModule.moe_router,
+        CudaGraphModule.moe_preprocess,
+    }
+)
+
+
+def should_use_hybrid_cuda_graph_spans(config, *, cp_size: int = 1) -> bool:
+    """Select spans for eligible HybridStack local partial-CG configurations."""
+
+    if not config.cuda_graph_coalesce_partial_captures or config.cuda_graph_impl != "local":
+        return False
+    if cp_size != 1 or config.enable_mhc_connections:
+        return False
+    if config.recompute_granularity == "full":
+        return False
+
+    modules = set(config.cuda_graph_modules)
+    unsupported = modules - _SUPPORTED_HYBRID_CUDA_GRAPH_MODULES
+    if not modules or unsupported:
+        return False
+
+    return True
+
+
+def build_hybrid_cuda_graph_span_plan(
+    layer_config_list: Sequence, cuda_graph_modules: Sequence[CudaGraphModule]
+) -> tuple[HybridCudaGraphPlanEntry, ...]:
+    """Build maximal graph spans separated by eager layers or MoE expert compute."""
+
+    scopes = set(cuda_graph_modules)
+    plan: list[HybridCudaGraphPlanEntry] = []
+    pending: list[HybridCudaGraphOperationSpec] = []
+
+    def flush_span() -> None:
+        if pending:
+            plan.append(HybridCudaGraphSpanSpec(tuple(pending)))
+            pending.clear()
+
+    for layer_index, layer_config in enumerate(layer_config_list):
+        config_type = type(layer_config)
+        if config_type is layer_utils.MambaLayerConfig and CudaGraphModule.mamba in scopes:
+            pending.append(
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.LAYER, layer_index)
+            )
+        elif config_type is layer_utils.AttentionLayerConfig and CudaGraphModule.attn in scopes:
+            pending.append(
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.LAYER, layer_index)
+            )
+        elif config_type is layer_utils.MoELayerConfig and CudaGraphModule.moe_router in scopes:
+            pending.append(
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.MOE_ROUTER, layer_index)
+            )
+            flush_span()
+            plan.append(HybridCudaGraphEagerExpertSpec(layer_index))
+            pending.append(
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.MOE_POSTPROCESS, layer_index)
+            )
+        else:
+            flush_span()
+            plan.append(HybridCudaGraphEagerLayerSpec(layer_index))
+
+    flush_span()
+    return tuple(plan)
+
+
+def _call_module_without_local_cudagraph(module, **kwargs):
+    """Run a graphable module through normal PyTorch hooks, bypassing its local graph manager."""
+
+    return super(MegatronModule, module).__call__(**kwargs)
+
+
+def _inner_quantization_context(layer):
+    config = layer.config
+    if config.fp8 and config.fp8_recipe != Fp8Recipe.delayed:
+        return get_fp8_context(config, layer.layer_number - 1)
+    if config.fp4:
+        return get_fp4_context(config, layer.layer_number - 1)
+    return nullcontext()
+
+
+class HybridCudaGraphSpan(GraphableMegatronModule):
+    """One local CUDA graph spanning adjacent operations from several HybridStack layers.
+
+    Referenced layers stay registered only under ``HybridStack.layers``. The span exposes their
+    modules, parameters, and buffers to ``CudaGraphManager`` without registering duplicate module
+    paths in the model state dict.
+    """
+
+    def __init__(self, config, spec: HybridCudaGraphSpanSpec, layers: Sequence[torch.nn.Module]):
+        from megatron.core.transformer.cuda_graphs import set_cuda_graph_stream_pool_size
+
+        # One shared replay stream serializes graph-pool scratch reuse through the Stage-2 RS tail.
+        set_cuda_graph_stream_pool_size(1)
+        super().__init__(config)
+        self.spec = spec
+        self.is_hybrid_cuda_graph_span = True
+        self._span_layers = tuple(layers[op.layer_index] for op in spec.operations)
+
+    def _unique_layers(self) -> Iterator[torch.nn.Module]:
+        seen = set()
+        for layer in self._span_layers:
+            if id(layer) not in seen:
+                seen.add(id(layer))
+                yield layer
+
+    def modules(self) -> Iterator[torch.nn.Module]:
+        """Expose referenced layer modules to CUDA-graph DDP and FP8 handling."""
+
+        yield self
+        seen = {id(self)}
+        for layer in self._unique_layers():
+            for module in layer.modules():
+                if id(module) not in seen:
+                    seen.add(id(module))
+                    yield module
+
+    def parameters(self, recurse: bool = True) -> Iterator[torch.nn.Parameter]:
+        """Expose referenced parameters without registering duplicate module ownership."""
+
+        if not recurse:
+            return
+        seen = set()
+        for layer in self._unique_layers():
+            for param in layer.parameters():
+                if id(param) not in seen:
+                    seen.add(id(param))
+                    yield param
+
+    def buffers(self, recurse: bool = True) -> Iterator[torch.Tensor]:
+        """Expose referenced buffers for capture-time backup and restore."""
+
+        if not recurse:
+            return
+        seen = set()
+        for layer in self._unique_layers():
+            for buffer in layer.buffers():
+                if id(buffer) not in seen:
+                    seen.add(id(buffer))
+                    yield buffer
+
+    def forward(
+        self,
+        *state,
+        attention_mask=None,
+        inference_context=None,
+        rotary_pos_emb=None,
+        packed_seq_params=None,
+        sequence_len_offset=None,
+        padding_mask=None,
+    ):
+        """Execute every operation in this span as one graphable callable."""
+
+        if inference_context is not None:
+            raise ValueError("Hybrid CUDA-graph spans currently support training only")
+
+        for op, layer in zip(self.spec.operations, self._span_layers, strict=True):
+            with _inner_quantization_context(layer):
+                if op.operation is HybridCudaGraphOperation.LAYER:
+                    if len(state) != 1:
+                        raise RuntimeError(
+                            "A complete hybrid layer expects one hidden-state tensor"
+                        )
+                    if isinstance(layer, MambaLayer):
+                        output = _call_module_without_local_cudagraph(
+                            layer,
+                            hidden_states=state[0],
+                            attention_mask=attention_mask,
+                            inference_context=inference_context,
+                            rotary_pos_emb=rotary_pos_emb,
+                            packed_seq_params=packed_seq_params,
+                        )
+                    else:
+                        output = _call_module_without_local_cudagraph(
+                            layer,
+                            hidden_states=state[0],
+                            attention_mask=attention_mask,
+                            inference_context=inference_context,
+                            rotary_pos_emb=rotary_pos_emb,
+                            packed_seq_params=packed_seq_params,
+                            sequence_len_offset=sequence_len_offset,
+                            padding_mask=padding_mask,
+                        )
+                    state = (output[0] if isinstance(output, tuple) else output,)
+                elif op.operation is HybridCudaGraphOperation.MOE_ROUTER:
+                    if len(state) != 1 or not isinstance(layer, MoETransformerLayer):
+                        raise RuntimeError("A MoE router span expects one hidden-state tensor")
+                    hidden_states, context = layer._forward_attention(
+                        hidden_states=state[0],
+                        attention_mask=attention_mask,
+                        inference_context=inference_context,
+                        rotary_pos_emb=rotary_pos_emb,
+                        packed_seq_params=packed_seq_params,
+                        sequence_len_offset=sequence_len_offset,
+                        padding_mask=padding_mask,
+                    )
+                    if context is not None:
+                        raise NotImplementedError("Cross attention is unsupported in hybrid spans")
+                    state = tuple(
+                        layer._forward_mlp_router(hidden_states, padding_mask=padding_mask)
+                    )
+                elif op.operation is HybridCudaGraphOperation.MOE_POSTPROCESS:
+                    if len(state) != 4 or not isinstance(layer, MoETransformerLayer):
+                        raise RuntimeError(
+                            "A MoE postprocess span expects residual, expert output, shared "
+                            "expert output, and MLP bias"
+                        )
+                    state = (layer._forward_mlp_postprocess(*state),)
+                else:
+                    raise AssertionError(f"Unknown hybrid CUDA-graph operation: {op.operation}")
+
+        return state[0] if len(state) == 1 else tuple(state)
+
+
+def run_hybrid_eager_expert(layer: MoETransformerLayer, router_outputs):
+    """Run the dynamic expert-compute island between two CUDA-graph spans."""
+
+    residual, hidden_states, probs, shared_expert_output, *token_dispatcher_attr_outputs = (
+        router_outputs
+    )
+    layer._synchronize_router_host_outputs(token_dispatcher_attr_outputs)
+    with _inner_quantization_context(layer):
+        expert_output, mlp_bias = layer._forward_mlp_expert_compute(
+            hidden_states, probs, token_dispatcher_attr_outputs
+        )
+    return residual, expert_output, shared_expert_output, mlp_bias
+
+
+def run_hybrid_eager_layer(
+    layer,
+    hidden_states,
+    *,
+    attention_mask,
+    inference_context,
+    rotary_pos_emb,
+    packed_seq_params,
+    sequence_len_offset,
+    padding_mask,
+):
+    """Run a complete non-span layer while bypassing any per-layer graph manager."""
+
+    with _inner_quantization_context(layer):
+        if isinstance(layer, MambaLayer):
+            output = _call_module_without_local_cudagraph(
+                layer,
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                packed_seq_params=packed_seq_params,
+            )
+        else:
+            output = _call_module_without_local_cudagraph(
+                layer,
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                padding_mask=padding_mask,
+            )
+    return output[0] if isinstance(output, tuple) else output

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -23,6 +23,16 @@ from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
+from megatron.core.models.hybrid.cuda_graph_spans import (
+    HybridCudaGraphEagerExpertSpec,
+    HybridCudaGraphEagerLayerSpec,
+    HybridCudaGraphSpan,
+    HybridCudaGraphSpanSpec,
+    build_hybrid_cuda_graph_span_plan,
+    run_hybrid_eager_expert,
+    run_hybrid_eager_layer,
+    should_use_hybrid_cuda_graph_spans,
+)
 from megatron.core.models.hybrid.hybrid_layer_allocation import (
     get_layer_type_list_from_layer_config_list,
     validate_segment_layers,
@@ -36,6 +46,7 @@ from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_c
 from megatron.core.tensor_parallel.random import CheckpointWithoutOutputManager
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.cuda_graphs import annotate_first_last_layer
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.hyper_connection import (
     HyperConnectionModule,
     learned_output_contract,
@@ -44,7 +55,7 @@ from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
-from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.core.transformer.transformer_layer import MoETransformerLayer, TransformerLayer
 from megatron.core.transformer.utils import (
     ensure_metadata_has_dp_cp_group,
     make_sharded_tensors_for_checkpoint,
@@ -157,6 +168,9 @@ class HybridStack(MegatronModule):
         # Required for pipeline parallel schedules
         self.input_tensor = None
         self.pg_collection = pg_collection
+        use_cuda_graph_spans = should_use_hybrid_cuda_graph_spans(
+            self.config, cp_size=self.cp_group.size()
+        )
 
         self._mhc_block_end_plan: Optional[List[bool]] = None
 
@@ -210,6 +224,7 @@ class HybridStack(MegatronModule):
                         pp_layer_offset=pp_layer_offset,
                         pg_collection=pg_collection,
                         name=(name + f".layers.{i}") if name is not None else None,
+                        create_cudagraph_manager=not use_cuda_graph_spans,
                     )
                 elif type(layer_config) is layer_utils.AttentionLayerConfig:
                     layer = build_module(
@@ -221,6 +236,7 @@ class HybridStack(MegatronModule):
                         add_layer_offset=False,
                         pp_layer_offset=pp_layer_offset,
                         name=(name + f".layers.{i}") if name is not None else None,
+                        create_cudagraph_manager=not use_cuda_graph_spans,
                     )
                 elif type(layer_config) is layer_utils.DSALayerConfig:
                     layer = build_module(
@@ -261,6 +277,7 @@ class HybridStack(MegatronModule):
                         is_mtp_layer=is_mtp_layer,
                         add_layer_offset=False,
                         name=(name + f".layers.{i}") if name is not None else None,
+                        create_cudagraph_manager=not use_cuda_graph_spans,
                     )
                 elif type(layer_config) is layer_utils.GDNLayerConfig:
                     gdn_layer_spec = submodules.gdn_layer
@@ -288,10 +305,36 @@ class HybridStack(MegatronModule):
 
             if self.config.enable_mhc_connections:
                 layer = HyperConnectionHybridLayer(config=layer_config, layer=layer)
+            elif (
+                use_cuda_graph_spans
+                and isinstance(layer, MoETransformerLayer)
+                and CudaGraphModule.moe_router in self.config.cuda_graph_modules
+            ):
+                layer.transition_cudagraph_scope('partial', create_managers=False)
             self.layers.append(layer)
 
         if self.config.cuda_graph_impl == "local":
             annotate_first_last_layer(self.layers)
+
+        self._cuda_graph_span_plan = None
+        if use_cuda_graph_spans:
+            self._cuda_graph_span_plan = build_hybrid_cuda_graph_span_plan(
+                self.layer_config_list, self.config.cuda_graph_modules
+            )
+            self._cuda_graph_spans = nn.ModuleList(
+                HybridCudaGraphSpan(self.config, entry, self.layers)
+                for entry in self._cuda_graph_span_plan
+                if isinstance(entry, HybridCudaGraphSpanSpec)
+            )
+
+            span_index = 0
+            for plan_index, entry in enumerate(self._cuda_graph_span_plan):
+                if not isinstance(entry, HybridCudaGraphSpanSpec):
+                    continue
+                span = self._cuda_graph_spans[span_index]
+                span.is_first_layer = plan_index == 0
+                span.is_last_layer = plan_index == len(self._cuda_graph_span_plan) - 1
+                span_index += 1
 
         # Required for activation recomputation
         self.num_layers_per_pipeline_rank = len(self.layers)
@@ -414,6 +457,65 @@ class HybridStack(MegatronModule):
         """Finalize the current mHC recompute block when its last layer finishes."""
         if manager is not None and is_block_end:
             manager.discard_all_outputs_and_register_unified_recompute(hidden_states)
+
+    def _forward_cuda_graph_spans(
+        self,
+        hidden_states,
+        *,
+        attention_mask,
+        inference_context,
+        rotary_pos_emb,
+        packed_seq_params,
+        sequence_len_offset,
+        padding_mask,
+    ):
+        """Execute the precomputed alternating span/eager plan."""
+
+        if inference_context is not None:
+            raise ValueError("Hybrid CUDA-graph spans currently support training only")
+        if packed_seq_params is not None:
+            raise NotImplementedError("Hybrid CUDA-graph spans do not yet support packed sequences")
+
+        state = (hidden_states,)
+        span_index = 0
+        for entry in self._cuda_graph_span_plan:
+            if isinstance(entry, HybridCudaGraphSpanSpec):
+                output = self._cuda_graph_spans[span_index](
+                    *state,
+                    attention_mask=attention_mask,
+                    inference_context=inference_context,
+                    rotary_pos_emb=rotary_pos_emb,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                    padding_mask=padding_mask,
+                )
+                state = output if isinstance(output, tuple) else (output,)
+                span_index += 1
+            elif isinstance(entry, HybridCudaGraphEagerExpertSpec):
+                layer = self.layers[entry.layer_index]
+                state = run_hybrid_eager_expert(layer, state)
+            elif isinstance(entry, HybridCudaGraphEagerLayerSpec):
+                if len(state) != 1:
+                    raise RuntimeError("A complete eager layer expects one hidden-state tensor")
+                layer = self.layers[entry.layer_index]
+                state = (
+                    run_hybrid_eager_layer(
+                        layer,
+                        state[0],
+                        attention_mask=attention_mask,
+                        inference_context=inference_context,
+                        rotary_pos_emb=rotary_pos_emb,
+                        packed_seq_params=packed_seq_params,
+                        sequence_len_offset=sequence_len_offset,
+                        padding_mask=padding_mask,
+                    ),
+                )
+            else:
+                raise AssertionError(f"Unknown hybrid CUDA-graph plan entry: {entry}")
+
+        if len(state) != 1:
+            raise RuntimeError(f"Hybrid CUDA-graph span plan ended with {len(state)} tensors")
+        return state[0]
 
     def forward(
         self,
@@ -548,6 +650,16 @@ class HybridStack(MegatronModule):
                     use_inner_quantization_context=(use_inner_fp8_context or use_fp4_context),
                     cp_layout_state=cp_layout_state,
                     packed_sequence_cp_metadata=packed_sequence_cp_metadata,
+                )
+            elif self._cuda_graph_span_plan is not None:
+                hidden_states = self._forward_cuda_graph_spans(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    inference_context=inference_context,
+                    rotary_pos_emb=rotary_pos_emb,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                    padding_mask=padding_mask,
                 )
             else:
                 for layer_idx, (layer_config, layer) in enumerate(

--- a/megatron/core/ssm/mamba_layer.py
+++ b/megatron/core/ssm/mamba_layer.py
@@ -73,13 +73,14 @@ class MambaLayer(GraphableMegatronModule):
         pg_collection: ProcessGroupCollection = None,
         pp_layer_offset: int = 0,
         name: str | None = None,
+        create_cudagraph_manager: bool = True,
     ):
         """Initialize Mamba Layer.
 
         Args:
             name (str | None): module instance name passed top-down from its paranet module
         """
-        super().__init__(config)
+        super().__init__(config, create_cudagraph_manager=create_cudagraph_manager)
         assert pg_collection is not None, "pg_collection must be provided for MambaLayer"
         self.tp_group = pg_collection.tp
 

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -390,7 +390,7 @@ def get_rs_stream(chain_id: str = GTPChain.GRAPHED.value, group=None) -> torch.c
 
 
 def initialize_graph_wgrad_rings() -> None:
-    """Allocate persistent wgrad inputs before local CUDA-graph capture."""
+    """Allocate persistent wgrad inputs for per-module local CUDA-graph runners."""
     allocate_graph_wgrad_rings(
         _GTP_PARAMS,
         full_iteration=_FULL_ITERATION,
@@ -448,7 +448,7 @@ class GTPRematConfig:
     # wire, but accumulation no longer loses precision as the axis grows. Bypassed at axis size
     # <= 2. Independent of the DDP-axis --ddp-reduce-scatter-with-fp32-accumulation.
     reduce_scatter_with_fp32_accumulation: bool = False
-    # Persistent wgrad slots per scheduling/shape domain for partial-CG asynchronous reduce-scatter.
+    # Persistent wgrad slots per scheduling/shape domain for non-span local-CG async RS.
     # Two slots cover the usual case of one same-key writer per graph. A graph containing multiple
     # same-key writers may need more slots to keep all in-flight RS inputs distinct.
     # TODO: Infer each domain's ring size automatically.

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -336,17 +336,21 @@ def _wgrad_pool_get(
     pool = _wgrad_buf_pool.get(key)
     if pool:
         buf = pool.pop()
+        reuse_event = getattr(buf, "_gtp_wgrad_reuse_event", None)
+        if reuse_event is not None:
+            torch.cuda.current_stream(device=device).wait_event(reuse_event)
     else:
         buf = torch.empty(shape, dtype=dtype, device=device, requires_grad=False)
     buf._from_gtp_wgrad_pool = True
     return buf
 
 
-def _wgrad_pool_put(buf: torch.Tensor):
+def _wgrad_pool_put(buf: torch.Tensor, ready_event=None):
     """Return a pool-owned buffer for reuse (no-op for untagged buffers; see
-    _wgrad_pool_get)."""
+    _wgrad_pool_get). The caller supplies a recorded event when reuse needs a stream fence."""
     if not getattr(buf, "_from_gtp_wgrad_pool", False):
         return
+    buf._gtp_wgrad_reuse_event = ready_event
     key = (tuple(buf.shape), buf.dtype)
     if key not in _wgrad_buf_pool:
         _wgrad_buf_pool[key] = []
@@ -1913,15 +1917,18 @@ class GTPShardedParam(torch.nn.Parameter):
                     for w in self._weights:
                         self._handle_megatron_grad_accum(w)
                     self._already_finalized = True
-        self._release_wgrad_scratch()
+        self._release_wgrad_scratch(stream=rs_stream, ready_event=self.rs_event)
         return waited
 
-    def _release_wgrad_scratch(self, attrs=("_wgrad_input_bufs", "_rs_a2a_bufs")):
+    def _release_wgrad_scratch(
+        self, attrs=("_wgrad_input_bufs", "_rs_a2a_bufs"), stream=None, ready_event=None
+    ):
         """Release the buffers a finished RS was reading.
 
         Its wgrad inputs, and the fp32-accum all-to-all scratch (input to the deferred FP32 sum,
-        so only free once the handle has been waited on). UNGRAPHED buffers go back to the pool;
-        GRAPHED just drops Python refs (addresses must stay stable for CG).
+        so only release once the handle has been waited on). Plain UNGRAPHED buffers return to the
+        manual pool, graph-pool buffers drop their Python references, and symmetric buffers return
+        to their registered pool. Reusable buffers carry the RS completion event to their next use.
         """
         for attr in attrs:
             bufs = getattr(self, attr, None)
@@ -1929,12 +1936,15 @@ class GTPShardedParam(torch.nn.Parameter):
                 continue
             if not _chain_is_graphed(self.chain_id):
                 for buf in bufs:
-                    _wgrad_pool_put(buf)
+                    _wgrad_pool_put(buf, ready_event=ready_event)
+            elif stream is not None and not torch.cuda.is_current_stream_capturing():
+                # The FP32 handle enqueues its local sum before returning. Keep eager-recording
+                # scratch alive until that sum has consumed it on the RS stream.
+                for buf in bufs:
+                    buf.record_stream(stream)
             for buf in bufs:
-                # Return symm pool buffers (tag-gated no-op for plain and ring buffers).
-                # Unconditional on chain kind: free() is captured, so replayed reuse keeps
-                # the eager wait edges, and replays serialize on the launch stream.
-                symmetric_wgrad_pool.free(buf)
+                # Return symmetric-pool buffers; this is a tag-gated no-op for other storage.
+                symmetric_wgrad_pool.free(buf, ready_event=ready_event)
             setattr(self, attr, None)
 
     def _record_graph_wgrad_ring_slots_ready(self) -> None:
@@ -2081,7 +2091,8 @@ class GTPShardedParam(torch.nn.Parameter):
                 # Only the a2a scratch is ours to release — the wgrad inputs belong to the
                 # caller on this path (recycled in wgrad_reduce_scatter).
                 handle.wait()
-                self._release_wgrad_scratch(("_rs_a2a_bufs",))
+                self.rs_event.record()
+                self._release_wgrad_scratch(("_rs_a2a_bufs",), ready_event=self.rs_event)
                 return outputs, None, release_bufs
 
             if len(wgrads) == 1:
@@ -2134,7 +2145,9 @@ class GTPShardedParam(torch.nn.Parameter):
                     if wgrad.data_ptr() != symm_slot.data_ptr():
                         symm_slot[: weight._unsharded_shape[0]].copy_(wgrad)
                         if not _chain_is_graphed(self.chain_id):
-                            _wgrad_pool_put(wgrad)
+                            copy_complete_event = torch.cuda.Event()
+                            copy_complete_event.record()
+                            _wgrad_pool_put(wgrad, ready_event=copy_complete_event)
 
                     send_bufs.append(symm_slot)
                     release_bufs.append(symm_slot)
@@ -2206,7 +2219,8 @@ class GTPShardedParam(torch.nn.Parameter):
             result = [self._handle_megatron_grad_accum(p) for p in weights]
             # The sync RS is complete: hand the inputs to the shared release path.
             self._wgrad_input_bufs = release_bufs
-            self._release_wgrad_scratch()
+            self.rs_event.record()
+            self._release_wgrad_scratch(ready_event=self.rs_event)
             ret = result if batched else result[0]
 
         # Wait for last reduce scatter if it was async

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -323,9 +323,15 @@ def _alloc_symmetric_wgrad_buffer(weight, dtype, device) -> torch.Tensor:
     return buf
 
 
-def _wgrad_pool_get(shape: tuple, dtype: torch.dtype, device) -> torch.Tensor:
+def _wgrad_pool_get(
+    shape: tuple, dtype: torch.dtype, device, *, graph_capture_safe: bool = False
+) -> torch.Tensor:
     """Get a pool buffer or allocate fresh, tagged so _wgrad_pool_put accepts only
     pool-owned buffers (other callers fall through to the caching allocator on release)."""
+    if graph_capture_safe and torch.cuda.is_current_stream_capturing():
+        # An eager-pool tensor may be recycled after capture while the graph retains its address.
+        # Allocate transient capture storage from the graph's private pool instead.
+        return torch.empty(shape, dtype=dtype, device=device, requires_grad=False)
     key = (shape, dtype)
     pool = _wgrad_buf_pool.get(key)
     if pool:
@@ -1818,7 +1824,12 @@ class GTPShardedParam(torch.nn.Parameter):
             buf = _alloc_symmetric_wgrad_buffer(self, self.main_grad.dtype, self.device)
             self._wgrad_symm_slot = buf
             return buf[: self._unsharded_shape[0]]
-        return _wgrad_pool_get(self._unsharded_shape, self.main_grad.dtype, self.device)
+        return _wgrad_pool_get(
+            self._unsharded_shape,
+            self.main_grad.dtype,
+            self.device,
+            graph_capture_safe=_chain_is_graphed(self.chain_id),
+        )
 
     def register_grad_accum_hook(
         self, grad_accum_node: torch.autograd.graph.Node | None, hook: Callable[..., None] | None
@@ -1969,7 +1980,12 @@ class GTPShardedParam(torch.nn.Parameter):
             out_shape = [tensor.shape[0] // self.group.size(), *tensor.shape[1:]]
             out_buffer = torch.empty(out_shape, dtype=tensor.dtype, device=tensor.device)
 
-        a2a_buf = _wgrad_pool_get(tuple(tensor.shape), tensor.dtype, tensor.device)
+        a2a_buf = _wgrad_pool_get(
+            tuple(tensor.shape),
+            tensor.dtype,
+            tensor.device,
+            graph_capture_safe=_chain_is_graphed(self.chain_id),
+        )
         handle = reduce_scatter_with_fp32_accumulation(
             out_buffer,
             tensor,

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -130,11 +130,10 @@ class RegisteredLIFOPool:
     untagged tensors, which lets callers pass mixed buffer lists to both this pool and
     the plain scratch pool and have each take only its own.
 
-    Why LIFO: ordering cannot affect correctness (buffers enter the free list only
-    after their reduce-scatter has been waited on), but LIFO keeps the same buffer
-    reused for the same operation at steady state even if a key ever over-allocates,
-    whereas FIFO would rotate the assignment every iteration -- LIFO keeps memory
-    behavior deterministic and repeatable across iterations.
+    Why LIFO: callers attach an event whenever prior use may outlive release, and allocation
+    waits on that event. LIFO keeps the same buffer reused for the same operation at steady state
+    even if a key ever over-allocates, whereas FIFO would rotate the assignment every iteration --
+    LIFO keeps memory behavior deterministic and repeatable across iterations.
     """
 
     def __init__(self) -> None:
@@ -155,8 +154,12 @@ class RegisteredLIFOPool:
         """
         numel = int(math.prod(shape))
         bucket = self._free[(numel, dtype, group.group_name)]
+        reuse_event = None
         if bucket:
             flat = bucket.pop()
+            reuse_event = getattr(flat, "_gtp_wgrad_reuse_event", None)
+            if reuse_event is not None:
+                torch.cuda.current_stream(device=device).wait_event(reuse_event)
         else:
             if torch.cuda.is_current_stream_capturing():
                 mine = sum(len(v) for k, v in self._free.items() if k[2] == group.group_name)
@@ -191,14 +194,18 @@ class RegisteredLIFOPool:
                 flat = torch.empty(numel, dtype=dtype, device=device)
         out = flat.view(shape)
         out._gtp_symm_group = group  # marks the buffer as pool-owned; free() keys on this
+        if reuse_event is not None:
+            out._gtp_wgrad_reuse_event = reuse_event
         return out
 
-    def free(self, buf: torch.Tensor) -> None:
-        """Return ``buf`` to its group's free list; no-op for untagged (foreign) buffers."""
+    def free(self, buf: torch.Tensor, ready_event=None) -> None:
+        """Return ``buf`` with an optional, already-recorded prior-use completion event."""
         group = getattr(buf, "_gtp_symm_group", None)
         if group is None:
             return
-        self._free[(buf.numel(), buf.dtype, group.group_name)].append(buf.view(-1))
+        flat = buf.view(-1)
+        flat._gtp_wgrad_reuse_event = ready_event
+        self._free[(buf.numel(), buf.dtype, group.group_name)].append(flat)
 
     def clear(self) -> None:
         """Drop every cached buffer. Called at teardown, before the pools they alias go away."""

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1907,8 +1907,10 @@ class CudaGraphManager(torch.nn.Module):
                 Setting this argument to True always forces the inline capture path to be taken.
             num_warmup_steps: If set, overrides the per-runner warmup step count.
         """
+        self.config = config
         self._inline_capture = inline_capture
         self._num_warmup_steps = num_warmup_steps
+        self._replayed_training_graph_in_eval = False
         if pg_collection is None:
             pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         self.pg_collection = pg_collection
@@ -1968,6 +1970,29 @@ class CudaGraphManager(torch.nn.Module):
         # idempotent, and graph creation removes the hook before capture begins.
         if need_backward:
             _CudagraphGlobalRecord._enable_saved_tensors_observer()
+
+    def train(self, mode: bool = True):
+        """Set training mode and discard temporary state replayed during evaluation."""
+        was_training = self.training
+        super().train(mode)
+
+        if mode and not was_training and self._replayed_training_graph_in_eval:
+            # A training-captured graph preserves capture-time buffer updates even when replayed
+            # under no_grad. Reset each distinct graph owner before its next training forward so
+            # validation state cannot reach the next finalize_model_grads call.
+            from megatron.core.distributed.finalize_model_grads import reset_model_temporary_tensors
+
+            graph_owners = []
+            seen_owner_ids = set()
+            for runner in self.cudagraph_runners:
+                owner = runner.base_module
+                if isinstance(owner, torch.nn.Module) and id(owner) not in seen_owner_ids:
+                    graph_owners.append(owner)
+                    seen_owner_ids.add(id(owner))
+            reset_model_temporary_tensors(self.config, graph_owners)
+            self._replayed_training_graph_in_eval = False
+
+        return self
 
     def call_ddp_preforward_hook(self, module):
         """Call any DDP pre-forward hooks which are used to launch async data parallel
@@ -2087,6 +2112,12 @@ class CudaGraphManager(torch.nn.Module):
                 megatron_module, args, kwargs, self.reuse_cudagraphs, cache_key=cache_key
             )
             out = runner.replay_graph_capture(self.is_first_microbatch, args, kwargs)
+            if (
+                not is_inference_mode
+                and not self._inline_capture
+                and not getattr(megatron_module, "training", self.training)
+            ):
+                self._replayed_training_graph_in_eval = True
         else:
             if is_inference_mode or self._inline_capture:
                 # Inference generation mode creates graphs immediately

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -993,7 +993,10 @@ class _CudagraphReplayNode(torch.autograd.Function):
         else:
             runner.bwd_graph.replay()
 
-        runner.bwd_graph_replay_complete_event.record(torch.cuda.current_stream())
+        # The early bwd_completion_event releases outer-stream work before GTP phase 2. DDP must
+        # instead wait for the graph tail, so record its readiness event on the replay stream.
+        replay_complete_stream = runner.stream if runner.use_stream else torch.cuda.current_stream()
+        runner.bwd_graph_replay_complete_event.record(replay_complete_stream)
         for param in runner.params_to_backprop:
             param._cudagraph_wgrad_ready_event = runner.bwd_graph_replay_complete_event
             if hasattr(param, 'grad_added_to_main_grad'):

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -801,7 +801,9 @@ class _CudagraphGlobalRecord:
         if has_te_modules:
             te_set_capture_end()
 
-        torch.cuda.set_stream(torch.cuda.default_stream())
+        default_stream = torch.cuda.default_stream()
+        default_stream.wait_stream(torch.cuda.current_stream())
+        torch.cuda.set_stream(default_stream)
 
         # Return capture time and memory usage.
         return capture_stats

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 import torch
 from torch.utils._pytree import tree_map as tree_map_pyt
 
+from megatron.core.enums import Fp8Recipe
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
@@ -105,6 +106,30 @@ _CUDA_GRAPH_STREAM_NEXT_SLOT = 0
 logger = logging.getLogger(__name__)
 
 
+def set_cuda_graph_stream_pool_size(pool_size: int) -> None:
+    """Set the local CUDA-graph stream-pool size before the pool is initialized."""
+
+    global _CUDA_GRAPH_STREAM_POOL_SIZE, _CUDA_GRAPH_STREAM_POOLS, _CUDA_GRAPH_STREAM_NEXT_SLOT
+
+    if pool_size < 1:
+        raise ValueError(f"CUDA graph stream pool size must be positive, got {pool_size}")
+    if _CUDA_GRAPH_STREAM_POOLS is not None:
+        if len(_CUDA_GRAPH_STREAM_POOLS) != pool_size:
+            effective_pool_size = min(pool_size, len(_CUDA_GRAPH_STREAM_POOLS))
+            logger.warning(
+                "CUDA graph stream pool already contains %d streams; using the first %d for "
+                "future assignments instead of the requested %d",
+                len(_CUDA_GRAPH_STREAM_POOLS),
+                effective_pool_size,
+                pool_size,
+            )
+            _CUDA_GRAPH_STREAM_POOLS = _CUDA_GRAPH_STREAM_POOLS[:effective_pool_size]
+            _CUDA_GRAPH_STREAM_POOL_SIZE = effective_pool_size
+            _CUDA_GRAPH_STREAM_NEXT_SLOT %= effective_pool_size
+        return
+    _CUDA_GRAPH_STREAM_POOL_SIZE = pool_size
+
+
 def _get_cuda_graph_stream() -> torch.cuda.Stream:
     """Assign local CUDA-graph runners across a bounded set of distinct streams.
 
@@ -152,6 +177,28 @@ def _get_cuda_graph_stream() -> torch.cuda.Stream:
     return pool[slot]
 
 
+def _gtp_backward_requires_wgrad_rings(runners) -> bool:
+    """Return whether the recorded GTP backward runners use per-module graph boundaries."""
+
+    has_coalesced_runner = False
+    has_per_module_runner = False
+    for runner in runners:
+        if not runner.gtp_remat or not runner.grad_enabled:
+            continue
+        if runner.is_hybrid_cuda_graph_span:
+            has_coalesced_runner = True
+        else:
+            has_per_module_runner = True
+
+    if has_coalesced_runner and has_per_module_runner:
+        raise RuntimeError(
+            "GTP backward capture cannot mix coalesced and per-module local CUDA-graph runners. "
+            "Remove --cuda-graph-coalesce-partial-captures to use per-module graphs for the "
+            "complete model."
+        )
+    return has_per_module_runner
+
+
 def _get_tensor_alias_chain(tensor):
     """Return a tensor followed by each underlying base tensor."""
     aliases = []
@@ -171,13 +218,10 @@ def _apply_cudagraph_buffer_metadata(tensor, *, is_output=False):
         (alias.cg_buffer_metadata for alias in aliases if hasattr(alias, "cg_buffer_metadata")),
         None,
     )
-    if is_output:
-        metadata = CudagraphBufferMetadata(
-            is_cudagraph_output=True,
-            is_saved_for_backward=bool(metadata and metadata.is_saved_for_backward),
-        )
-    elif metadata is None:
+    if metadata is None:
         metadata = CudagraphBufferMetadata()
+    if is_output:
+        metadata.is_cudagraph_output = True
     for alias in aliases:
         alias.cg_buffer_metadata = metadata
     return metadata
@@ -674,11 +718,13 @@ class _CudagraphGlobalRecord:
                     "https://github.com/NVIDIA/TransformerEngine/blob/v2.10/transformer_engine/pytorch/utils.py#L759"  # pylint: disable=line-too-long
                 )
 
-        gtp_active = any(r[0].gtp_remat for r in cls.cudagraph_record)
+        runners = [record[0] for record in cls.cudagraph_record]
+        gtp_active = any(runner.gtp_remat for runner in runners)
         if gtp_active:
             # GTP buffer reuse during capture trips the param-state debug asserts; disable them.
             GTP_CONFIG.check_param_states = False
-            initialize_graph_wgrad_rings()
+            if _gtp_backward_requires_wgrad_rings(runners):
+                initialize_graph_wgrad_rings()
 
         _set_capture_start()
         if has_te_modules:
@@ -816,11 +862,10 @@ class _GraphStatus(Enum):
 
 
 class _CudagraphRecordNode(torch.autograd.Function):
-    """Inserts a noop node into the autograd graph, used to record when a bwd graph needs
-    to be created."""
+    """Record a runner's backward after all differentiable graph outputs are ready."""
 
     @staticmethod
-    def forward(ctx, runner, inputs):
+    def forward(ctx, runner, *inputs):
         """Forward pass, does nothing but registers an autograd node."""
 
         assert (
@@ -828,10 +873,10 @@ class _CudagraphRecordNode(torch.autograd.Function):
         ), "Tried calling the fwd cudagraph when the bwd cudagraph was expected to be called next!"
 
         ctx.runner = runner
-        return inputs
+        return inputs[0] if len(inputs) == 1 else inputs
 
     @staticmethod
-    def backward(ctx, grads):
+    def backward(ctx, *grads):
         """If this is the first bwd pass of this runner, record that a
         bwd graph needs to be created."""
 
@@ -844,7 +889,7 @@ class _CudagraphRecordNode(torch.autograd.Function):
             _CudagraphGlobalRecord.record_bwd_graph(runner)
             runner.bwd_graph_recorded = True
 
-        return None, grads
+        return (None,) + grads
 
 
 class _CudagraphReplayNode(torch.autograd.Function):
@@ -1021,6 +1066,7 @@ class _CudaGraphRunner(torch.nn.Module):
         self.needs_recompute_param_discovery = False
         self.use_stream = False
         self.gtp_remat = False
+        self.is_hybrid_cuda_graph_span = False
         # Populated by create_bwd_graph: one entry per captured GTP wgrad-finalization occurrence.
         # Repeated parameters intentionally appear more than once so replay matches eager DDP
         # grad-ready accounting.
@@ -1028,7 +1074,7 @@ class _CudaGraphRunner(torch.nn.Module):
         # (rs_stream, params) DDP grad-ready hook plan; built in create_bwd_graph.
         self._gtp_finalize_hook_plan = []
         # Persistent wgrad slots written by this graph. Replay waits for each slot's previous RS
-        # reader before launching the graph.
+        # reader before launching the graph. Span runners leave this empty.
         self._gtp_wgrad_ring_slots = []
         # GTP weights read by this forward graph before their owning module pre-hooks execute.
         self._gtp_fwd_params_to_ensure_ready = ()
@@ -1058,6 +1104,9 @@ class _CudaGraphRunner(torch.nn.Module):
             self.fp8_runtime_enabled = None
             self.fp4_runtime_enabled = None
             self.gtp_remat = self.base_module.config.gtp_weight_remat_size > 1
+            self.is_hybrid_cuda_graph_span = bool(
+                getattr(self.base_module, "is_hybrid_cuda_graph_span", False)
+            )
 
             if self.gtp_remat:
                 # Ensure internal warmup (inside create_fwd_graph) has >= 2 steps
@@ -1119,6 +1168,16 @@ class _CudaGraphRunner(torch.nn.Module):
 
     def get_quantization_context(self):
         """Return appropriate quantization context (FP8 or FP4) in cudagraph mode."""
+        if self.is_hybrid_cuda_graph_span:
+            # Deferred graph warmup/capture invokes the span after HybridStack's outer delayed-FP8
+            # context has exited, so restore that context around this span. Normal execution and
+            # replay still use HybridStack's outer context. MXFP8 and FP4 remain per-operation
+            # contexts inside HybridCudaGraphSpan.forward(), where each layer number is available.
+            if self.fp8_runtime_enabled and self.base_module.config.fp8_recipe == Fp8Recipe.delayed:
+                from megatron.core.fp8_utils import get_fp8_context  # to avoid circular import
+
+                return get_fp8_context(self.base_module.config)
+            return nullcontext()
         if self.fp8_runtime_enabled:
             from megatron.core.fp8_utils import get_fp8_context  # to avoid circular import
 
@@ -1175,18 +1234,17 @@ class _CudaGraphRunner(torch.nn.Module):
                 torch.is_tensor(tensor) and metadata is not None and metadata.is_saved_for_backward
             )
 
-        def is_differentiable_cudagraph_output_escape(tensor) -> bool:
-            """Return whether a differentiable graph output escapes to eager code.
+        def is_cudagraph_output_escape(tensor) -> bool:
+            """Return whether a graph output escapes to eager code.
 
             Outputs that are also inputs to another CUDA graph are protected by graph-to-graph
             reuse accounting. However, an output that is not another graph's input has no
-            such owner. Preserving it's ownership guards against premature graph-pool storage
+            such owner. Preserving its ownership guards against premature graph-pool storage
             reuse across that graph boundary.
             """
             metadata = getattr(tensor, "cg_buffer_metadata", None)
             return bool(
                 torch.is_tensor(tensor)
-                and tensor.requires_grad
                 and metadata is not None
                 and metadata.is_cudagraph_output
                 and not metadata.is_cudagraph_input
@@ -1194,6 +1252,8 @@ class _CudaGraphRunner(torch.nn.Module):
 
         def weakref_input(tensor):
             if preserve_forward_to_backward_lifetimes:
+                # This observer sees Python FunctionCtx.save_for_backward calls only; PyTorch-native
+                # C++ autograd nodes save through SavedVariable without setting this metadata tag.
                 if is_saved_for_backward(tensor):
                     return tensor
             return make_weakref(tensor)
@@ -1202,7 +1262,7 @@ class _CudaGraphRunner(torch.nn.Module):
             if preserve_forward_to_backward_lifetimes:
                 if is_saved_for_backward(tensor):
                     return tensor
-                if is_differentiable_cudagraph_output_escape(tensor):
+                if is_cudagraph_output_escape(tensor):
                     return tensor
             return make_weakref(tensor)
 
@@ -1253,7 +1313,12 @@ class _CudaGraphRunner(torch.nn.Module):
         # cache the moe aux loss if needed, which is accumulated inside the forward pass
         from megatron.core.transformer.transformer_layer import MoETransformerLayer
 
-        is_moe = isinstance(self.base_module, MoETransformerLayer)
+        is_moe = isinstance(self.base_module, MoETransformerLayer) or (
+            isinstance(self.base_module, torch.nn.Module)
+            and any(
+                isinstance(module, MoETransformerLayer) for module in self.base_module.modules()
+            )
+        )
         if is_moe:
             from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 
@@ -1569,14 +1634,13 @@ class _CudaGraphRunner(torch.nn.Module):
                     param.main_grad.add_(param.grad)
                 param.grad_added_to_main_grad = True
 
-            # GTP cross-graph RS overlap, two phases:
-            #   Phase 1 — drain AG, fence runner_stream past ag_stream's tail,
-            #             then record bwd_completion_event so main_stream can
-            #             release the next runner while RS is still in flight.
-            #   Phase 2 — drain RS wait on rs_stream. For cross-graph chain
-            #             tails the wait is captured here, the add in the
-            #             consumer's cascade; for within-graph tails both
-            #             happen here (see wait_async_comms).
+            # GTP cross-graph or graph-eager RS overlap, two phases:
+            #   Phase 1 — drain AG, fence runner_stream past ag_stream's tail, then record
+            #             bwd_completion_event so main_stream can release the next runner
+            #             or eager work while RS is still in flight.
+            #   Phase 2 — drain RS wait on rs_stream. For cross-graph chain tails the wait
+            #             is captured here, the add in the consumer's cascade; for within-graph
+            #             tails both happen here (see wait_async_comms).
             if self.gtp_remat:
                 captured_params, captured_ag_streams, captured_rs_streams = (
                     capture_comms.get_comms_for_chain(GTPChain.GRAPHED.value)
@@ -1585,7 +1649,7 @@ class _CudaGraphRunner(torch.nn.Module):
                 wait_async_comms(GTPChain.GRAPHED.value, skip_rs=True, params=captured_params)
                 self._wait_side_streams(captured_ag_streams)
 
-                # Release the next runner after AG drain but before RS drain.
+                # Release the next runner or eager work after AG drain but before RS drain.
                 self.bwd_completion_event.record()
 
                 # Phase 2: in-graph RS drain + finalize.
@@ -1634,8 +1698,9 @@ class _CudaGraphRunner(torch.nn.Module):
         self.static_grad_inputs = tuple(self.static_grad_inputs)
         self.static_grad_outputs = tuple(self.static_grad_outputs)
 
-        # It is safe to weakref static_grad_inputs as any inuse input grads have a strong ref
-        # stored in 'bwd_cudagraph_buffer'
+        # Graph-to-graph dgrads retain ownership through bwd_cudagraph_buffer. Graph-to-eager
+        # dgrads are consumed before the next graph replay, which either uses the same stream or
+        # waits on the current stream, so their storage can be reused by that graph.
         self.static_grad_inputs = tree_map(make_weakref, self.static_grad_inputs)
         self.static_grad_outputs = tree_map(make_weakref, self.static_grad_outputs)
         # Backward capture is the final recorded use of forward buffers retained for autograd.
@@ -1688,17 +1753,21 @@ class _CudaGraphRunner(torch.nn.Module):
         if type(out) != tuple:
             out = (out,)
 
-        # Register a noop autograd node that toggles `self.graph_status` in the bwd pass, which
-        # tracks when the runner completes its bwd pass.
-        # If it's the first bwd encountered by this runner, record it to _CudagraphGlobalRecord
-        # We record the noop autograd node to the first output tensor. This is sufficient for
-        # TransformerLayer and MambaLayer as their output is just the hidden_states.
-        out = tuple(
-            [
-                _CudagraphRecordNode.apply(self, o) if torch.is_tensor(o) and i == 0 else o
-                for i, o in enumerate(out)
-            ]
-        )
+        # Match replay's single autograd node: record backward only after every differentiable
+        # output is ready, including multi-output partial-MoE graph boundaries.
+        differentiable_indices = [
+            i for i, output in enumerate(out) if torch.is_tensor(output) and output.requires_grad
+        ]
+        if differentiable_indices:
+            recorded = _CudagraphRecordNode.apply(
+                self, *(out[index] for index in differentiable_indices)
+            )
+            if len(differentiable_indices) == 1:
+                recorded = (recorded,)
+            out = list(out)
+            for index, output in zip(differentiable_indices, recorded):
+                out[index] = output
+            out = tuple(out)
         # Custom autograd Function outputs are views. Pipeline schedules may pseudo-deallocate
         # this first-pass output before create_cudagraphs() switches the runner to replay mode.
         out = self._make_pipeline_output_viewless(out)

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -173,13 +173,18 @@ class GraphableMegatronModule(MegatronModule):
         config (TransformerConfig): Transformer config
     """
 
-    def __init__(self, config: TransformerConfig, vp_stage: Optional[int] = None):
+    def __init__(
+        self,
+        config: TransformerConfig,
+        vp_stage: Optional[int] = None,
+        create_cudagraph_manager: bool = True,
+    ):
         super().__init__(config)
 
         assert isinstance(config, TransformerConfig), "config must be a TransformerConfig"
 
         # Enable cuda graphs.
-        if config.cuda_graph_impl == "local":
+        if config.cuda_graph_impl == "local" and create_cudagraph_manager:
             if hasattr(self, "create_mcore_cudagraph_manager"):
                 self.create_mcore_cudagraph_manager(config)
             else:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1125,6 +1125,10 @@ class TransformerConfig(ModelParallelConfig):
     cuda_graph_modules has no effect when cuda_graph_impl="none" and must be empty when
     cuda_graph_impl="full_iteration"."""
 
+    cuda_graph_coalesce_partial_captures: bool = False
+    """Coalesce eligible HybridStack operations into maximal local partial CUDA graphs. Enable
+    with ``--cuda-graph-coalesce-partial-captures``; otherwise use the per-module graph."""
+
     cuda_graph_modules: Union[str, CudaGraphModule, List[str], List[CudaGraphModule]] = "full"
     """Selects training capture coverage within per-layer CUDA graphs (local and
     transformer_engine implementations).
@@ -2940,6 +2944,9 @@ class TransformerConfig(ModelParallelConfig):
             "local",
             "full_iteration",
         ], f"Invalid cuda graph implementation: {self.cuda_graph_impl}"
+        assert (
+            not self.cuda_graph_coalesce_partial_captures or self.cuda_graph_impl == "local"
+        ), "cuda_graph_coalesce_partial_captures requires cuda_graph_impl='local'."
 
         self.inference_cuda_graph_scope = normalize_inference_cuda_graph_scope(
             self.inference_cuda_graph_scope, self.cuda_graph_impl

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -334,6 +334,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         add_layer_offset: bool = True,
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
+        create_cudagraph_manager: bool = True,
     ):
         """
         Args:
@@ -344,7 +345,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # Dense layers need a default before that hook runs, while MoETransformerLayer sets this
         # to True before entering this constructor.
         self.is_moe_layer = getattr(self, "is_moe_layer", False)
-        super().__init__(config=config, vp_stage=vp_stage)
+        super().__init__(
+            config=config, vp_stage=vp_stage, create_cudagraph_manager=create_cudagraph_manager
+        )
 
         if pg_collection is None:
             pg_collection = ProcessGroupCollection.use_mpu_process_groups()
@@ -2096,12 +2099,14 @@ class MoETransformerLayer(TransformerLayer):
             return False
         return super()._should_call_local_cudagraph(*args, **kwargs)
 
-    def transition_cudagraph_scope(self, mode):
+    def transition_cudagraph_scope(self, mode, *, create_managers=True):
         """Transition between full-layer and partial CUDA graph capture.
 
         Args:
             mode: 'full' for inference (full-layer capture) or 'partial' for training
-            (router + postprocess captured, expert dispatch runs eagerly).
+                (router + postprocess captured, expert dispatch runs eagerly).
+            create_managers: Whether partial mode should install separate router and postprocess
+                CUDA-graph managers. Coalesced spans own those operations directly.
         """
         from megatron.core.transformer.cuda_graphs import CudaGraphManager
 
@@ -2112,11 +2117,11 @@ class MoETransformerLayer(TransformerLayer):
                 and "moe" in self.config.recompute_modules
                 and self.config.cuda_graph_impl == "local"
             )
-            if not hasattr(self, 'cudagraph_manager_router'):
+            if create_managers and not hasattr(self, 'cudagraph_manager_router'):
                 self.cudagraph_manager_router = CudaGraphManager(
                     self.config, self, function_name="_forward_mlp_router"
                 )
-            if not hasattr(self, 'cudagraph_manager_postprocess'):
+            if create_managers and not hasattr(self, 'cudagraph_manager_postprocess'):
                 self.cudagraph_manager_postprocess = CudaGraphManager(
                     self.config, self, function_name="_forward_mlp_postprocess"
                 )

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -654,6 +654,9 @@ def validate_args(args, defaults={}):
     _normalize_cuda_graph_modules_args(args)
     _normalize_inference_cuda_graph_scope_arg(args)
     assert (
+        not args.cuda_graph_coalesce_partial_captures or args.cuda_graph_impl == "local"
+    ), "--cuda-graph-coalesce-partial-captures requires --cuda-graph-impl=local."
+    assert (
         args.inference_cuda_graph_scope
         in ALLOWED_INFERENCE_SCOPES[args.cuda_graph_impl]
     ), (

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1555,6 +1555,21 @@ class TestGTPGraphWgradRing:
         assert torch.count_nonzero(rs_input[4:]) == 0
 
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA allocator test")
+    def test_capture_does_not_borrow_eager_wgrad_pool(self, monkeypatch):
+        monkeypatch.setattr(gtp_module, "_wgrad_buf_pool", {})
+        eager_buffer = gtp_module._wgrad_pool_get((8,), torch.bfloat16, "cuda")
+        gtp_module._wgrad_pool_put(eager_buffer)
+
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        capture_buffer = gtp_module._wgrad_pool_get(
+            (8,), torch.bfloat16, "cuda", graph_capture_safe=True
+        )
+
+        assert capture_buffer.data_ptr() != eager_buffer.data_ptr()
+        assert gtp_module._wgrad_buf_pool[((8,), torch.bfloat16)] == [eager_buffer]
+
+
 class TestActivationRecomputePhaseFlag:
     """GTP's forward-only readiness gate rests on TE's recompute flag being dtype-agnostic."""
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1554,7 +1554,6 @@ class TestGTPGraphWgradRing:
         torch.testing.assert_close(rs_input[:4], wgrad)
         assert torch.count_nonzero(rs_input[4:]) == 0
 
-
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA allocator test")
     def test_capture_does_not_borrow_eager_wgrad_pool(self, monkeypatch):
         monkeypatch.setattr(gtp_module, "_wgrad_buf_pool", {})
@@ -1568,6 +1567,71 @@ class TestGTPGraphWgradRing:
 
         assert capture_buffer.data_ptr() != eager_buffer.data_ptr()
         assert gtp_module._wgrad_buf_pool[((8,), torch.bfloat16)] == [eager_buffer]
+
+    def test_ungraphed_wgrad_pool_fences_cross_stream_reuse(self, monkeypatch):
+        class FakeBuffer:
+            shape = (8,)
+            dtype = torch.bfloat16
+            _from_gtp_wgrad_pool = True
+
+        class FakeEvent:
+            def __init__(self):
+                self.recorded_stream = None
+
+            def record(self, stream=None):
+                self.recorded_stream = stream
+
+        class FakeStream:
+            def __init__(self):
+                self.waited_events = []
+
+            def wait_event(self, event):
+                self.waited_events.append(event)
+
+        producer_stream = object()
+        consumer_stream = FakeStream()
+        event = FakeEvent()
+        buffer = FakeBuffer()
+        monkeypatch.setattr(gtp_module, "_wgrad_buf_pool", {})
+        monkeypatch.setattr(torch.cuda, "current_stream", lambda device=None: consumer_stream)
+
+        event.record(producer_stream)
+        gtp_module._wgrad_pool_put(buffer, ready_event=event)
+        reused = gtp_module._wgrad_pool_get(buffer.shape, buffer.dtype, "cuda")
+
+        assert reused is buffer
+        assert event.recorded_stream is producer_stream
+        assert consumer_stream.waited_events == [event]
+
+        gtp_module._wgrad_pool_put(reused)
+        assert gtp_module._wgrad_pool_get(buffer.shape, buffer.dtype, "cuda") is buffer
+        assert consumer_stream.waited_events == [event]
+
+    def test_eager_recording_releases_scratch_on_rs_stream(self, monkeypatch):
+        class Scratch:
+            def __init__(self):
+                self.recorded_streams = []
+
+            def record_stream(self, stream):
+                self.recorded_streams.append(stream)
+
+        scratch = Scratch()
+        param = type(
+            "FakeGTPParam",
+            (),
+            {
+                "chain_id": GTPChain.GRAPHED.value,
+                "_wgrad_input_bufs": [scratch],
+                "_rs_a2a_bufs": None,
+            },
+        )()
+        stream = object()
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+        GTPShardedParam._release_wgrad_scratch(param, stream=stream)
+
+        assert scratch.recorded_streams == [stream]
+        assert param._wgrad_input_bufs is None
 
 
 class TestActivationRecomputePhaseFlag:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_partial_cg.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_partial_cg.py
@@ -3,9 +3,9 @@
 """Integration test for GTP correctness with local partial CUDA graphs.
 
 This is the local-CUDA-graph counterpart of ``test_gtp_loss_correctness.py``. It compares eager
-execution with attention-only local CUDA graphs under the same GTP2 x DP2 topology, with and
-without cross-graph RS overlap. It verifies the complete loss trajectory and global gradient norm,
-including repeated replays of one backward.
+execution with per-module and coalesced local CUDA graphs under the same GTP2 x DP2 topology. It
+verifies outputs, gradients, the complete loss trajectory, and global gradient norm, including
+repeated replays of one backward.
 """
 
 import copy
@@ -18,6 +18,8 @@ from megatron.core.tensor_parallel.gtp_api import (
     HAVE_GTP,
     GTPChain,
     classify_gtp_remat_chains,
+    deregister_and_clear_gtp_symm_pools,
+    register_gtp_symm_pool,
     wait_for_gtp_grad_reduction_on_current_stream,
 )
 
@@ -36,13 +38,25 @@ from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (  # noq
 )
 
 
-def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_modules, opt_in_modules):
+def _worker_gtp_partial_cg_correctness(
+    rank,
+    world_size,
+    port,
+    partial_cg_modules,
+    opt_in_modules,
+    coalesce_partial_captures,
+    use_symmetric_memory,
+    repeated_span_uses,
+):
     """Compare eager and local CUDA graphs with GTP2 x DP2."""
     del port
     gtp_module._GTP_PARAMS.clear()
 
     from megatron.core import parallel_state as ps
     from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+    from megatron.core.models.hybrid.hybrid_block import HybridStack
+    from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
+    from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
     from megatron.core.optimizer.clip_grads import get_grad_norm_fp32
     from megatron.core.process_groups_config import ProcessGroupCollection
     from megatron.core.tensor_parallel import param_is_not_gtp_duplicate
@@ -56,15 +70,21 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
         delete_cuda_graphs,
     )
     from megatron.core.transformer.identity_op import IdentityFuncOp, IdentityOp
+    from megatron.core.transformer.spec_utils import ModuleSpec
     from megatron.core.transformer.transformer_config import TransformerConfig
     from megatron.core.transformer.transformer_layer import MoETransformerLayer
 
     latent_projection_case = "moe_latent_proj" in opt_in_modules
+    span_layer_pattern = "MEM*E"
     hidden = 256 if latent_projection_case else 4096
     num_heads = 8 if latent_projection_case else 32
     ffn_hidden = 512 if latent_projection_case else 16384
     # Use multiple layers to exercise repeated local CUDA-graph execution with GTP parameters.
-    num_layers = 1 if latent_projection_case else 4
+    num_layers = (
+        len(span_layer_pattern)
+        if coalesce_partial_captures
+        else (1 if latent_projection_case else 4)
+    )
     sequence_length = 16 if latent_projection_case else 32
     batch_size = 1
     learning_rate = 0.01
@@ -97,13 +117,16 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
             hidden_dropout=0.0,
             attention_dropout=0.0,
             bias_dropout_fusion=False,
-            gradient_accumulation_fusion=latent_projection_case,
+            # Repeated use changes expert-GEMM launch ordering. Disable TE's fused accumulation
+            # there so this strict comparison measures CUDA-graph correctness, not eager jitter.
+            gradient_accumulation_fusion=latent_projection_case and repeated_span_uses == 1,
             tensor_model_parallel_size=1,
             pipeline_model_parallel_size=1,
             gtp_weight_remat_size=gtp_degree,
             gtp_remat_opt_in_modules=opt_in_modules,
             cuda_graph_impl="local" if partial_cg else "none",
             cuda_graph_modules=partial_cg_modules if partial_cg else [],
+            cuda_graph_coalesce_partial_captures=(partial_cg and coalesce_partial_captures),
             cuda_graph_warmup_steps=2,
             **moe_options,
         )
@@ -119,6 +142,19 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
             spec.submodules.input_layernorm = IdentityOp
             spec.submodules.self_attention = IdentityOp
             spec.submodules.self_attn_bda = IdentityFuncOp
+            if coalesce_partial_captures:
+                span_submodules = copy.deepcopy(hybrid_stack_spec.submodules)
+                span_submodules.moe_layer = ModuleSpec(
+                    module=MoETransformerLayer, submodules=spec.submodules
+                )
+                return HybridStack(
+                    config,
+                    span_submodules,
+                    layer_config_list=validate_segment_layers(span_layer_pattern, config),
+                    pp_layer_offset=0,
+                    post_layer_norm=False,
+                    pg_collection=pg_collection,
+                )
             return torch.nn.ModuleList(
                 [
                     MoETransformerLayer(
@@ -144,6 +180,8 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
         )
 
     def get_cudagraph_managers(layers):
+        if coalesce_partial_captures:
+            return [span.cudagraph_manager for span in layers._cuda_graph_spans]
         if latent_projection_case:
             return [
                 manager
@@ -165,10 +203,18 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
         return ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp", "cp", "gtp_remat"])
 
     def run_step(layers, x):
+        span_use_outputs = []
         with fp8_autocast(enabled=False):
-            for layer in layers:
-                x, _ = layer(x, attention_mask=None)
-        return x.mean()
+            if coalesce_partial_captures:
+                for _ in range(repeated_span_uses):
+                    x = layers(x, attention_mask=None)
+                    span_use_outputs.append(x.detach().float().cpu().clone())
+            else:
+                for layer in layers:
+                    x, _ = layer(x, attention_mask=None)
+        output = x.detach().float().cpu().clone() if coalesce_partial_captures else None
+        loss = x.float().mean()
+        return output, loss, span_use_outputs
 
     def reset_grad_state(layers):
         for param in layers.parameters():
@@ -191,19 +237,42 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
         torch.manual_seed(seed + replica_rank)
         return torch.randn(sequence_length, batch_size, hidden, dtype=dtype, device="cuda")
 
+    def get_param_grad(param):
+        if isinstance(param, GTPShardedParam) or getattr(param, "grad_added_to_main_grad", False):
+            return param.main_grad
+        return param.grad if param.grad is not None else param.main_grad
+
     def global_grad_norm(layers, grad_stats_group):
         """Mirror Megatron's GTP duplicate filtering and global L2-norm reduction."""
         grads = []
         for param in layers.parameters():
             if not param_is_not_gtp_duplicate(param):
                 continue
-            if isinstance(param, GTPShardedParam):
-                grad = param.main_grad
-            else:
-                grad = param.grad if param.grad is not None else param.main_grad
+            grad = get_param_grad(param)
             assert grad is not None
-            grads.append(grad)
+            # Hybrid stacks mix FP32 Mamba state grads with BF16 model grads. Apex's single
+            # multi-tensor L2 invocation expects one dtype, so normalize this test input to FP32.
+            grads.append(grad.detach().float())
         return float(get_grad_norm_fp32(grads, grad_stats_parallel_group=grad_stats_group))
+
+    def snapshot_param_grads(layers):
+        grads = {}
+        for name, param in layers.named_parameters():
+            grad = get_param_grad(param)
+            assert grad is not None, f"Missing gradient for {name}"
+            grads[name] = grad.detach().float().cpu().clone()
+        return grads
+
+    def assert_param_grads_close(actual, expected):
+        assert actual.keys() == expected.keys()
+        for name in expected:
+            torch.testing.assert_close(
+                actual[name],
+                expected[name],
+                atol=1e-6,
+                rtol=5e-3,
+                msg=lambda message: f"Gradient mismatch for {name}: {message}",
+            )
 
     def apply_sgd_step(layers, gtp_size):
         with torch.no_grad():
@@ -211,7 +280,7 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
                 if isinstance(param, GTPShardedParam):
                     param.data.sub_((learning_rate / gtp_size) * param.main_grad)
                 else:
-                    grad = param.grad if param.grad is not None else param.main_grad
+                    grad = get_param_grad(param)
                     param.data.sub_(learning_rate * grad)
                     param.grad = None
 
@@ -222,6 +291,8 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
     )
     model_parallel_cuda_manual_seed(42)
     pg_collection = make_pg_collection()
+    if use_symmetric_memory:
+        register_gtp_symm_pool(ps.get_gtp_weight_remat_group())
     eager_config = make_config()
     eager = make_layer_stack(eager_config, pg_collection).cuda()
     eager_gtp_group = ps.get_gtp_weight_remat_group()
@@ -232,26 +303,38 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
     assert any(isinstance(param, GTPShardedParam) for param in eager.parameters())
     if latent_projection_case:
         eager_latent_params = get_latent_params(eager)
-        assert len(eager_latent_params) == 2
+        expected_latent_params = 2 * span_layer_pattern.count(Symbols.MOE)
+        if not coalesce_partial_captures:
+            expected_latent_params = 2
+        assert len(eager_latent_params) == expected_latent_params
         assert all(isinstance(param, GTPShardedParam) for param in eager_latent_params)
     initialize_main_grads(eager)
     saved_local_weights = {name: param.data.clone() for name, param in eager.named_parameters()}
 
     eager_losses = []
     eager_grad_norms = []
+    eager_outputs = []
+    eager_input_grads = []
+    eager_param_grads = []
     for step in range(steps):
         reset_grad_state(eager)
         x = make_replica_input(step * world_size, eager_dp_rank)
         x.requires_grad_()
-        loss = run_step(eager, x)
+        output, loss, _ = run_step(eager, x)
         eager_losses.append(loss.item())
         loss.backward()
         wait_for_gtp_grad_reduction_on_current_stream()
         eager_grad_norms.append(global_grad_norm(eager, eager_gtp_group))
+        if coalesce_partial_captures:
+            eager_outputs.append(output)
+            eager_input_grads.append(x.grad.detach().float().cpu().clone())
+            eager_param_grads.append(snapshot_param_grads(eager))
         apply_sgd_step(eager, eager_gtp_group.size())
 
-    del eager, loss, x
+    del eager, loss, output, x
     torch.cuda.synchronize()
+    if use_symmetric_memory:
+        deregister_and_clear_gtp_symm_pools()
     ps.destroy_model_parallel()
     gtp_module.reset_gtp_state()
     gtp_module._GTP_PARAMS.clear()
@@ -263,8 +346,16 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
     initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
     model_parallel_cuda_manual_seed(42)
     pg_collection = make_pg_collection()
+    if use_symmetric_memory:
+        register_gtp_symm_pool(ps.get_gtp_weight_remat_group())
     partial_cg_config = make_config(partial_cg=True)
     partial_cg = make_layer_stack(partial_cg_config, pg_collection).cuda()
+    if coalesce_partial_captures:
+        assert all(not hasattr(layer, "cudagraph_manager") for layer in partial_cg.layers)
+        for layer in partial_cg.layers:
+            if isinstance(layer, MoETransformerLayer):
+                assert not hasattr(layer, "cudagraph_manager_router")
+                assert not hasattr(layer, "cudagraph_manager_postprocess")
     classify_gtp_remat_chains(
         partial_cg,
         cuda_graph_modules=partial_cg_config.cuda_graph_modules,
@@ -281,8 +372,15 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
     assert dp_rank == eager_dp_rank
     gtp_params = [param for param in partial_cg.parameters() if isinstance(param, GTPShardedParam)]
     assert gtp_params, "GTP not active: no GTPShardedParam found"
-    params_in_scope = get_latent_params(partial_cg) if latent_projection_case else gtp_params
-    assert all(param.chain_id == GTPChain.GRAPHED.value for param in params_in_scope)
+    if latent_projection_case:
+        latent_params = get_latent_params(partial_cg)
+        expected_chain = (
+            GTPChain.GRAPHED.value
+            if "moe_router" in partial_cg_modules
+            else GTPChain.UNGRAPHED.value
+        )
+        assert all(param.chain_id == expected_chain for param in latent_params)
+    assert any(param.chain_id == GTPChain.GRAPHED.value for param in gtp_params)
     for name, param in partial_cg.named_parameters():
         param.data.copy_(saved_local_weights[name])
     # Production captures after DDP maps every parameter into a main-grad buffer and initializes
@@ -292,37 +390,84 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
 
     partial_cg_losses = []
     partial_cg_grad_norms = []
+    partial_cg_outputs = []
+    partial_cg_input_grads = []
+    partial_cg_param_grads = []
     try:
         # Record one eager backward, then replay the same input and weights. This isolates the
         # graph execution path: model state, GTP topology, and reduction order are unchanged.
         reset_grad_state(partial_cg)
         eager_probe_x = make_replica_input(1234, dp_rank)
         eager_probe_x.requires_grad_()
-        eager_probe_loss = run_step(partial_cg, eager_probe_x)
+        eager_probe_output, eager_probe_loss, eager_probe_span_outputs = run_step(
+            partial_cg, eager_probe_x
+        )
         eager_probe_loss.backward()
         wait_for_gtp_grad_reduction_on_current_stream()
         eager_grad_norm = global_grad_norm(partial_cg, gtp_group)
         eager_probe_loss_value = eager_probe_loss.item()
-        del eager_probe_loss, eager_probe_x
-        reset_grad_state(partial_cg)
+        if coalesce_partial_captures:
+            eager_probe_output_value = eager_probe_output
+            eager_probe_input_grad = eager_probe_x.grad.detach().float().cpu().clone()
+            eager_probe_param_grads = snapshot_param_grads(partial_cg)
+        pre_capture_param_grads = snapshot_param_grads(partial_cg)
+        del eager_probe_loss, eager_probe_output, eager_probe_x
 
         create_cudagraphs()
         assert _CudagraphGlobalRecord.cudagraph_created
+        post_capture_param_grads = snapshot_param_grads(partial_cg)
+        assert post_capture_param_grads.keys() == pre_capture_param_grads.keys()
+        for name in pre_capture_param_grads:
+            torch.testing.assert_close(
+                post_capture_param_grads[name],
+                pre_capture_param_grads[name],
+                atol=0,
+                rtol=0,
+                msg=lambda message: f"Capture changed finalized gradient for {name}: {message}",
+            )
         managers = get_cudagraph_managers(partial_cg)
-        assert all(len(manager.cudagraph_runners) == 1 for manager in managers)
+        assert all(len(manager.cudagraph_runners) == repeated_span_uses for manager in managers)
         runners = [manager.cudagraph_runners[0] for manager in managers]
         assert any(runner.gtp_remat for runner in runners)
+        if coalesce_partial_captures:
+            assert partial_cg._cuda_graph_span_plan is not None
+            expected_span_count = 3 if "moe_router" in partial_cg_modules else 2
+            assert len(partial_cg._cuda_graph_spans) == expected_span_count
+            assert all(runner.is_hybrid_cuda_graph_span for runner in runners)
 
         replay_grad_norms = []
         replay_losses = []
         for _ in range(3):
             reset_grad_state(partial_cg)
             replay_x = make_replica_input(1234, dp_rank).requires_grad_()
-            replay_loss = run_step(partial_cg, replay_x)
+            replay_output, replay_loss, replay_span_outputs = run_step(partial_cg, replay_x)
             replay_loss.backward()
             wait_for_gtp_grad_reduction_on_current_stream()
             replay_losses.append(replay_loss.item())
             replay_grad_norms.append(global_grad_norm(partial_cg, gtp_group))
+            if coalesce_partial_captures:
+                for span_use, (actual, expected) in enumerate(
+                    zip(replay_span_outputs, eager_probe_span_outputs, strict=True)
+                ):
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        atol=1e-6,
+                        rtol=5e-3,
+                        msg=lambda message, span_use=span_use: (
+                            f"Span-stack use {span_use} output mismatch: {message}"
+                        ),
+                    )
+                torch.testing.assert_close(
+                    replay_output, eager_probe_output_value, atol=1e-6, rtol=5e-3
+                )
+                torch.testing.assert_close(
+                    replay_x.grad.detach().float().cpu(),
+                    eager_probe_input_grad,
+                    atol=1e-6,
+                    rtol=5e-3,
+                )
+                assert_param_grads_close(snapshot_param_grads(partial_cg), eager_probe_param_grads)
 
         replay_grad_norms_tensor = torch.tensor(replay_grad_norms)
         assert torch.isfinite(replay_grad_norms_tensor).all()
@@ -345,19 +490,23 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
                 flush=True,
             )
 
-        del replay_loss, replay_x
+        del replay_loss, replay_output, replay_x
 
         for step in range(steps):
             reset_grad_state(partial_cg)
             x = make_replica_input(step * world_size, dp_rank)
             x.requires_grad_()
-            loss = run_step(partial_cg, x)
+            output, loss, _ = run_step(partial_cg, x)
             partial_cg_losses.append(loss.item())
             loss.backward()
             wait_for_gtp_grad_reduction_on_current_stream()
             partial_cg_grad_norms.append(global_grad_norm(partial_cg, gtp_group))
+            if coalesce_partial_captures:
+                partial_cg_outputs.append(output)
+                partial_cg_input_grads.append(x.grad.detach().float().cpu().clone())
+                partial_cg_param_grads.append(snapshot_param_grads(partial_cg))
             apply_sgd_step(partial_cg, gtp_size)
-        del loss, x
+        del loss, output, x
     finally:
         torch.cuda.synchronize()
         managers = get_cudagraph_managers(partial_cg)
@@ -370,10 +519,12 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
         delete_cuda_graphs()
         for manager in managers:
             manager.cudagraph_runners.clear()
+        if use_symmetric_memory:
+            deregister_and_clear_gtp_symm_pools()
+        gtp_module.reset_gtp_state()
         gc.collect()
         ps.destroy_model_parallel()
         ps.initialize_model_parallel()
-        gtp_module.reset_gtp_state()
         gtp_module._GTP_PARAMS.clear()
 
     if rank == 0:
@@ -388,20 +539,91 @@ def _worker_gtp_partial_cg_correctness(rank, world_size, port, partial_cg_module
     torch.testing.assert_close(
         torch.tensor(partial_cg_grad_norms), torch.tensor(eager_grad_norms), atol=1e-6, rtol=5e-3
     )
+    if coalesce_partial_captures:
+        for actual, expected in zip(partial_cg_outputs, eager_outputs, strict=True):
+            torch.testing.assert_close(actual, expected, atol=1e-6, rtol=5e-3)
+        for actual, expected in zip(partial_cg_input_grads, eager_input_grads, strict=True):
+            torch.testing.assert_close(actual, expected, atol=1e-6, rtol=5e-3)
+        for actual, expected in zip(partial_cg_param_grads, eager_param_grads, strict=True):
+            assert_param_grads_close(actual, expected)
 
 
 class TestGTPPartialCGCorrectness:
     @pytest.mark.parametrize(
-        "partial_cg_modules,opt_in_modules",
+        "partial_cg_modules,opt_in_modules,coalesce_partial_captures,use_symmetric_memory,"
+        "repeated_span_uses",
         [
-            pytest.param(["attn"], [], id="attention"),
-            pytest.param(["moe_router"], ["moe_latent_proj"], id="moe-router-latent-projections"),
+            pytest.param(["attn"], [], False, False, 1, id="attention"),
+            pytest.param(
+                ["moe_router"],
+                ["moe_latent_proj"],
+                False,
+                False,
+                1,
+                id="moe-router-latent-projections",
+            ),
+            pytest.param(
+                ["mamba", "attn", "moe_router"],
+                ["moe_latent_proj"],
+                True,
+                False,
+                1,
+                id="mamba-attn-moe-router-coalesced",
+            ),
+            pytest.param(
+                ["mamba", "attn"], ["moe_latent_proj"], True, False, 1, id="mamba-attn-coalesced"
+            ),
+            pytest.param(
+                ["mamba", "attn"],
+                ["moe_latent_proj"],
+                True,
+                False,
+                2,
+                id="mamba-attn-coalesced-repeated-use",
+            ),
+            pytest.param(
+                ["moe_router"],
+                ["moe_latent_proj"],
+                False,
+                True,
+                1,
+                id="moe-router-latent-projections-symmetric-memory",
+            ),
+            pytest.param(
+                ["mamba", "attn", "moe_router"],
+                ["moe_latent_proj"],
+                True,
+                True,
+                1,
+                id="mamba-attn-moe-router-coalesced-symmetric-memory",
+            ),
+            pytest.param(
+                ["mamba", "attn"],
+                ["moe_latent_proj"],
+                True,
+                True,
+                2,
+                id="mamba-attn-coalesced-repeated-use-symmetric-memory",
+            ),
         ],
     )
     def test_gtp_partial_cg_loss_and_grad_norm_match_eager(
-        self, partial_cg_modules, opt_in_modules
+        self,
+        partial_cg_modules,
+        opt_in_modules,
+        coalesce_partial_captures,
+        use_symmetric_memory,
+        repeated_span_uses,
     ):
-        """Local-CG loss trajectory and global grad norm must match eager execution."""
+        """Local-CG outputs, gradients, and optimization trajectory must match eager."""
         if torch.cuda.device_count() < 4:
             pytest.skip("Requires at least 4 CUDA devices")
-        _run_distributed(_worker_gtp_partial_cg_correctness, 4, partial_cg_modules, opt_in_modules)
+        _run_distributed(
+            _worker_gtp_partial_cg_correctness,
+            4,
+            partial_cg_modules,
+            opt_in_modules,
+            coalesce_partial_captures,
+            use_symmetric_memory,
+            repeated_span_uses,
+        )

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -165,6 +165,44 @@ class TestRegisteredLIFOPool:
         pool.free(torch.empty(8, device="cuda"))
         assert not pool._free  # nothing entered the free lists
 
+    def test_reuse_waits_for_release_stream(self, monkeypatch):
+        class FakeEvent:
+            def __init__(self, *, external=False):
+                self.external = external
+                self.recorded_stream = None
+
+            def record(self, stream=None):
+                self.recorded_stream = stream
+
+        class FakeStream:
+            def __init__(self):
+                self.waited_events = []
+
+            def wait_event(self, event):
+                self.waited_events.append(event)
+
+        pool = RegisteredLIFOPool()
+        group = _StubGroup()
+        producer_stream = object()
+        consumer_stream = FakeStream()
+        event = FakeEvent(external=True)
+        buffer = pool.alloc((8,), torch.bfloat16, "cuda", group)
+
+        monkeypatch.setattr(torch.cuda, "current_stream", lambda device=None: consumer_stream)
+
+        event.record(producer_stream)
+        pool.free(buffer, ready_event=event)
+        reused = pool.alloc(buffer.shape, buffer.dtype, "cuda", group)
+
+        assert reused.data_ptr() == buffer.data_ptr()
+        assert event.external
+        assert event.recorded_stream is producer_stream
+        assert consumer_stream.waited_events == [event]
+
+        pool.free(reused)
+        assert pool.alloc(buffer.shape, buffer.dtype, "cuda", group).data_ptr() == buffer.data_ptr()
+        assert consumer_stream.waited_events == [event]
+
     def test_capture_guard_raises_on_empty_bucket(self, monkeypatch):
         pool = RegisteredLIFOPool()
         group = _StubGroup()

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -8,6 +8,15 @@ import torch
 import megatron.core.models.hybrid.hybrid_block as hybrid_block_module
 import megatron.core.transformer.utils as transformer_utils
 from megatron.core.extensions.transformer_engine import TEDotProductAttention
+from megatron.core.models.hybrid.cuda_graph_spans import (
+    HybridCudaGraphEagerExpertSpec,
+    HybridCudaGraphOperation,
+    HybridCudaGraphOperationSpec,
+    HybridCudaGraphSpan,
+    HybridCudaGraphSpanSpec,
+    build_hybrid_cuda_graph_span_plan,
+    should_use_hybrid_cuda_graph_spans,
+)
 from megatron.core.models.hybrid.hybrid_block import HybridStack
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import (
@@ -24,6 +33,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.attention_layer_config import AttentionLayerConfig
+from megatron.core.transformer.enums import CudaGraphModule
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
     AbsorbedMLASelfAttention,
 )
@@ -38,6 +48,144 @@ from tests.unit_tests.test_utilities import Utils
 
 def _make_pg_collection():
     return SimpleNamespace(pp=None, tp=None, cp=SimpleNamespace(size=lambda: 1), tp_cp=None)
+
+
+def test_hybrid_cuda_graph_plan_coalesces_adjacent_modules_around_eager_experts():
+    config = TransformerConfig(
+        num_layers=5,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_moe_experts=8,
+        cuda_graph_impl="local",
+        cuda_graph_modules=[
+            CudaGraphModule.mamba,
+            CudaGraphModule.attn,
+            CudaGraphModule.moe_router,
+        ],
+        cuda_graph_coalesce_partial_captures=True,
+    )
+    layer_configs = validate_segment_layers("MEM*E", config)
+
+    assert should_use_hybrid_cuda_graph_spans(config)
+    plan = build_hybrid_cuda_graph_span_plan(layer_configs, config.cuda_graph_modules)
+
+    assert len(plan) == 5
+    assert isinstance(plan[0], HybridCudaGraphSpanSpec)
+    assert [(op.operation, op.layer_index) for op in plan[0].operations] == [
+        (HybridCudaGraphOperation.LAYER, 0),
+        (HybridCudaGraphOperation.MOE_ROUTER, 1),
+    ]
+    assert plan[1] == HybridCudaGraphEagerExpertSpec(1)
+    assert isinstance(plan[2], HybridCudaGraphSpanSpec)
+    assert [(op.operation, op.layer_index) for op in plan[2].operations] == [
+        (HybridCudaGraphOperation.MOE_POSTPROCESS, 1),
+        (HybridCudaGraphOperation.LAYER, 2),
+        (HybridCudaGraphOperation.LAYER, 3),
+        (HybridCudaGraphOperation.MOE_ROUTER, 4),
+    ]
+    assert plan[3] == HybridCudaGraphEagerExpertSpec(4)
+    assert isinstance(plan[4], HybridCudaGraphSpanSpec)
+    assert [(op.operation, op.layer_index) for op in plan[4].operations] == [
+        (HybridCudaGraphOperation.MOE_POSTPROCESS, 4)
+    ]
+    assert all(
+        not isinstance(left, HybridCudaGraphSpanSpec)
+        or not isinstance(right, HybridCudaGraphSpanSpec)
+        for left, right in zip(plan, plan[1:])
+    )
+
+
+def test_hybrid_cuda_graph_span_exposes_layers_without_duplicate_state_dict_paths(monkeypatch):
+    class FakeCudaGraphManager(torch.nn.Module):
+
+        def __init__(self, config):
+            super().__init__()
+
+    class FakeLayer(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.projection = torch.nn.Linear(4, 4, bias=False)
+            self.register_buffer("running_value", torch.ones(1))
+
+    import megatron.core.transformer.cuda_graphs as cuda_graphs
+
+    monkeypatch.setattr(cuda_graphs, "CudaGraphManager", FakeCudaGraphManager)
+    monkeypatch.setattr(cuda_graphs, "_CUDA_GRAPH_STREAM_POOL_SIZE", 3)
+    monkeypatch.setattr(cuda_graphs, "_CUDA_GRAPH_STREAM_POOLS", None)
+    config = TransformerConfig(
+        num_layers=2,
+        hidden_size=4,
+        num_attention_heads=1,
+        cuda_graph_impl="local",
+        cuda_graph_modules=[CudaGraphModule.mamba],
+    )
+    layers = torch.nn.ModuleList([FakeLayer(), FakeLayer()])
+    span = HybridCudaGraphSpan(
+        config,
+        HybridCudaGraphSpanSpec(
+            (
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.LAYER, 0),
+                HybridCudaGraphOperationSpec(HybridCudaGraphOperation.LAYER, 1),
+            )
+        ),
+        layers,
+    )
+
+    model = torch.nn.Module()
+    model.layers = layers
+    model.cuda_graph_spans = torch.nn.ModuleList([span])
+
+    assert {id(param) for param in span.parameters()} == {
+        id(param) for layer in layers for param in layer.parameters()
+    }
+    assert {id(buffer) for buffer in span.buffers()} == {
+        id(buffer) for layer in layers for buffer in layer.buffers()
+    }
+    assert list(span.parameters(recurse=False)) == []
+    assert list(span.buffers(recurse=False)) == []
+    assert not any(key.startswith("cuda_graph_spans.") for key in model.state_dict())
+    assert cuda_graphs._CUDA_GRAPH_STREAM_POOL_SIZE == 1
+
+
+def test_gtp_local_cuda_graph_falls_back_for_non_span_scope():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=4,
+        num_attention_heads=1,
+        gtp_weight_remat_size=2,
+        cuda_graph_impl="local",
+        cuda_graph_modules=[CudaGraphModule.mlp],
+        cuda_graph_coalesce_partial_captures=True,
+    )
+
+    assert not should_use_hybrid_cuda_graph_spans(config)
+
+
+def test_hybrid_cuda_graph_spans_require_opt_in():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=4,
+        num_attention_heads=1,
+        cuda_graph_impl="local",
+        cuda_graph_modules=[CudaGraphModule.mamba],
+    )
+
+    assert not should_use_hybrid_cuda_graph_spans(config)
+
+
+@pytest.mark.parametrize("cp_size", [2, 4])
+def test_hybrid_cuda_graph_spans_fall_back_for_context_parallelism(cp_size):
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=4,
+        num_attention_heads=1,
+        cuda_graph_impl="local",
+        cuda_graph_modules=[CudaGraphModule.mamba],
+        cuda_graph_coalesce_partial_captures=True,
+    )
+
+    assert not should_use_hybrid_cuda_graph_spans(config, cp_size=cp_size)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -3,6 +3,7 @@
 import gc
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -10,7 +11,7 @@ from transformer_engine.pytorch.fp8 import check_fp8_support
 
 import megatron.core.transformer.cuda_graphs as cuda_graphs_module
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
-from megatron.core.enums import ModelType
+from megatron.core.enums import Fp8Recipe, ModelType
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_decoder_block_spec,
     get_gpt_layer_with_transformer_engine_spec,
@@ -37,9 +38,13 @@ from megatron.core.tensor_parallel.random import (
 from megatron.core.transformer.cuda_graphs import (
     CudaGraphManager,
     TECudaGraphHelper,
+    _apply_cudagraph_buffer_metadata,
     _CudagraphGlobalRecord,
+    _CudagraphRecordNode,
     _CudagraphReplayNode,
     _CudaGraphRunner,
+    _GraphStatus,
+    _gtp_backward_requires_wgrad_rings,
     create_cudagraphs,
     delete_cuda_graphs,
 )
@@ -71,6 +76,88 @@ from tests.unit_tests.test_utilities import Utils
 fp8_available, _ = check_fp8_support()
 
 
+class TestCudaGraphBoundaryInvariants:
+    @staticmethod
+    def _gtp_runner(*, span, grad_enabled=True):
+        return SimpleNamespace(
+            gtp_remat=True, grad_enabled=grad_enabled, is_hybrid_cuda_graph_span=span
+        )
+
+    def test_coalesced_gtp_backward_does_not_require_wgrad_rings(self):
+        runners = [self._gtp_runner(span=True), self._gtp_runner(span=False, grad_enabled=False)]
+
+        assert not _gtp_backward_requires_wgrad_rings(runners)
+
+    def test_per_module_gtp_backward_requires_wgrad_rings(self):
+        assert _gtp_backward_requires_wgrad_rings([self._gtp_runner(span=False)])
+
+    def test_mixed_gtp_backward_capture_is_rejected(self):
+        runners = [self._gtp_runner(span=True), self._gtp_runner(span=False)]
+
+        with pytest.raises(RuntimeError, match="cannot mix coalesced and per-module"):
+            _gtp_backward_requires_wgrad_rings(runners)
+
+    def test_coalesced_span_uses_per_operation_mxfp8_contexts(self):
+        runner = SimpleNamespace(
+            is_hybrid_cuda_graph_span=True,
+            fp8_runtime_enabled=True,
+            fp4_runtime_enabled=False,
+            base_module=SimpleNamespace(config=SimpleNamespace(fp8_recipe=Fp8Recipe.mxfp8)),
+        )
+
+        with _CudaGraphRunner.get_quantization_context(runner):
+            pass
+
+    def test_output_alias_preserves_input_metadata(self):
+        base = torch.empty(8)
+        view = base[2:]
+        metadata = _apply_cudagraph_buffer_metadata(base)
+        metadata.is_cudagraph_input = True
+        metadata.is_saved_for_backward = True
+        metadata.input_use_count = 3
+        metadata.cudagraph_reuse_ref_count = 2
+        metadata.capture_reuse_count = 1
+
+        output_metadata = _apply_cudagraph_buffer_metadata(view, is_output=True)
+
+        assert output_metadata is metadata
+        assert view.cg_buffer_metadata is metadata
+        assert base.cg_buffer_metadata is metadata
+        assert metadata.is_cudagraph_input
+        assert metadata.is_cudagraph_output
+        assert metadata.is_saved_for_backward
+        assert metadata.input_use_count == 3
+        assert metadata.cudagraph_reuse_ref_count == 2
+        assert metadata.capture_reuse_count == 1
+
+    def test_record_node_waits_for_all_differentiable_outputs(self, monkeypatch):
+        class FakeRunner:
+            status = _GraphStatus.FWD_READY
+            bwd_graph_recorded = False
+
+        runner = FakeRunner()
+        x = torch.ones(4, requires_grad=True)
+        y = torch.ones(4, requires_grad=True)
+        x_out, y_out = _CudagraphRecordNode.apply(runner, x, y)
+
+        ready_outputs = set()
+        x_out.register_hook(lambda grad: ready_outputs.add("x"))
+        y_out.register_hook(lambda grad: ready_outputs.add("y"))
+        record_snapshots = []
+        monkeypatch.setattr(
+            _CudagraphGlobalRecord,
+            "record_bwd_graph",
+            classmethod(lambda cls, recorded_runner: record_snapshots.append(set(ready_outputs))),
+        )
+
+        runner.status = _GraphStatus.BWD_READY
+        (x_out.sum() + 2 * y_out.sum()).backward()
+
+        assert record_snapshots == [{"x", "y"}]
+        assert torch.equal(x.grad, torch.ones_like(x))
+        assert torch.equal(y.grad, torch.full_like(y, 2))
+
+
 def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
     created_streams = []
 
@@ -81,6 +168,7 @@ def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
 
     monkeypatch.setattr(torch.cuda, "Stream", FakeStream)
     monkeypatch.setenv("CUDA_DEVICE_MAX_CONNECTIONS", "32")
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOL_SIZE", 3)
     monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", None)
     monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", 0)
 
@@ -90,6 +178,52 @@ def test_cuda_graph_runner_stream_pool_is_bounded(monkeypatch):
     assert len(created_streams) == pool_size
     assert len({stream.cuda_stream for stream in created_streams}) == pool_size
     assert assigned[:pool_size] == assigned[pool_size:]
+
+
+def test_hybrid_cuda_graph_spans_use_one_stream_pool(monkeypatch):
+    created_streams = []
+
+    class FakeStream:
+        def __init__(self):
+            self.cuda_stream = len(created_streams) + 1
+            created_streams.append(self)
+
+    monkeypatch.setattr(torch.cuda, "Stream", FakeStream)
+    monkeypatch.setenv("CUDA_DEVICE_MAX_CONNECTIONS", "32")
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOL_SIZE", 3)
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", None)
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", 0)
+
+    cuda_graphs_module.set_cuda_graph_stream_pool_size(1)
+    span_streams = [cuda_graphs_module._get_cuda_graph_stream() for _ in range(3)]
+
+    assert span_streams[0] is span_streams[1] is span_streams[2]
+    assert cuda_graphs_module._CUDA_GRAPH_STREAM_POOL_SIZE == 1
+    assert len(created_streams) == 1
+
+
+def test_hybrid_cuda_graph_stream_pool_warns_and_narrows_late_resize(monkeypatch, caplog):
+    class FakeStream:
+        _next_id = 0
+
+        def __init__(self):
+            type(self)._next_id += 1
+            self.cuda_stream = type(self)._next_id
+
+    monkeypatch.setattr(torch.cuda, "Stream", FakeStream)
+    monkeypatch.setenv("CUDA_DEVICE_MAX_CONNECTIONS", "32")
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOL_SIZE", 3)
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_POOLS", None)
+    monkeypatch.setattr(cuda_graphs_module, "_CUDA_GRAPH_STREAM_NEXT_SLOT", 0)
+
+    first_stream = cuda_graphs_module._get_cuda_graph_stream()
+
+    with caplog.at_level("WARNING"):
+        cuda_graphs_module.set_cuda_graph_stream_pool_size(1)
+
+    assigned = [cuda_graphs_module._get_cuda_graph_stream() for _ in range(3)]
+    assert "using the first 1 for future assignments" in caplog.text
+    assert assigned == [first_stream] * 3
 
 
 def _base_cuda_graph_config(**kwargs) -> TransformerConfig:
@@ -128,6 +262,36 @@ def _validated_cuda_graph_cli_args(monkeypatch, cli_args=None, **overrides):
 
 
 class TestCudaGraphConfigAndArguments:
+    def test_partial_cuda_graph_capture_coalescing_default_off(self, monkeypatch):
+        args, _, _ = _validated_cuda_graph_cli_args(monkeypatch)
+
+        assert not args.cuda_graph_coalesce_partial_captures
+
+    def test_partial_cuda_graph_capture_coalescing_can_be_enabled_with_local_impl(
+        self, monkeypatch
+    ):
+        args, _, _ = _validated_cuda_graph_cli_args(
+            monkeypatch, ["--cuda-graph-impl", "local", "--cuda-graph-coalesce-partial-captures"]
+        )
+
+        assert args.cuda_graph_coalesce_partial_captures
+
+    def test_partial_cuda_graph_capture_coalescing_rejects_nonlocal_impl(self, monkeypatch):
+        with pytest.raises(
+            AssertionError,
+            match="--cuda-graph-coalesce-partial-captures requires --cuda-graph-impl=local",
+        ):
+            _validated_cuda_graph_cli_args(monkeypatch, ["--cuda-graph-coalesce-partial-captures"])
+
+    def test_partial_cuda_graph_capture_coalescing_rejects_nonlocal_config(self):
+        with pytest.raises(
+            AssertionError,
+            match="cuda_graph_coalesce_partial_captures requires cuda_graph_impl='local'",
+        ):
+            _base_cuda_graph_config(
+                cuda_graph_impl="transformer_engine", cuda_graph_coalesce_partial_captures=True
+            )
+
     def test_local_impl_defaults_to_layer_scope(self):
         cfg = _base_cuda_graph_config(cuda_graph_impl='local')
         assert cfg.inference_cuda_graph_scope == InferenceCudaGraphScope.layer
@@ -1771,17 +1935,17 @@ class _CheckpointDependencyModule(MegatronModule):
 
 
 class _RepeatedParameterModule(MegatronModule):
-    """Invoke one graphed operation twice so two runners share its parameter."""
+    """Invoke one graphed projection twice so two runners share its parameters."""
 
     def __init__(self, config):
         super().__init__(config)
-        self.weight = torch.nn.Parameter(torch.randn(config.hidden_size))
+        self.projection = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
 
     def forward(self, x):
         return self.project(x) + self.project(0.5 * x)
 
     def project(self, x):
-        return x + self.weight
+        return self.projection(x)
 
 
 class _TemporaryBufferModule(MegatronModule):
@@ -2067,7 +2231,7 @@ class TestRepeatedParameterCapture:
         reference_output = reference(test_input.detach().clone().requires_grad_(True))
         reference_output_value = reference_output.detach().clone()
         reference_output.sum().backward()
-        reference_local_wgrad = reference.weight.grad.detach().clone()
+        reference_local_wgrad = reference.projection.weight.grad.detach().clone()
         reference_wgrad = reference_local_wgrad.clone()
         torch.distributed.all_reduce(reference_wgrad, group=ddp_model.dp_group)
         reference_wgrad.div_(ddp_model.dp_group.size())
@@ -2076,13 +2240,13 @@ class TestRepeatedParameterCapture:
         record_output = ddp_model(test_input.detach().clone().requires_grad_(True))
         record_output.sum().backward()
         ddp_model.finish_grad_sync()
-        record_wgrad = module.weight.main_grad.detach().clone()
+        record_wgrad = module.projection.weight.main_grad.detach().clone()
         torch.testing.assert_close(record_wgrad, reference_wgrad)
 
         create_cudagraphs()
 
         assert len(manager.cudagraph_runners) == 2
-        torch.testing.assert_close(module.weight.main_grad, record_wgrad)
+        torch.testing.assert_close(module.projection.weight.main_grad, record_wgrad)
 
         ddp_model.zero_grad_buffer()
         with ddp_model.no_sync():
@@ -2091,7 +2255,7 @@ class TestRepeatedParameterCapture:
         torch.cuda.synchronize()
 
         torch.testing.assert_close(replay_output, reference_output_value)
-        torch.testing.assert_close(module.weight.main_grad, reference_local_wgrad)
+        torch.testing.assert_close(module.projection.weight.main_grad, reference_local_wgrad)
 
         for _ in range(2):
             ddp_model.zero_grad_buffer()
@@ -2101,7 +2265,7 @@ class TestRepeatedParameterCapture:
             torch.cuda.synchronize()
 
             torch.testing.assert_close(replay_output, reference_output_value)
-            torch.testing.assert_close(module.weight.main_grad, reference_wgrad)
+            torch.testing.assert_close(module.projection.weight.main_grad, reference_wgrad)
 
 
 class TestInlineCaptureManager:

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -50,7 +50,7 @@ from megatron.core.transformer.enums import (
     InferenceCudaGraphScope,
 )
 from megatron.core.transformer.mlp import MLPSubmodules
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.module import GraphableMegatronModule, MegatronModule
 from megatron.core.transformer.moe.fused_a2a import reset_hybrid_ep_buffer
 from megatron.core.transformer.spec_utils import ModuleSpec, get_submodules
 from megatron.core.transformer.transformer_block import TransformerBlock
@@ -1784,6 +1784,39 @@ class _RepeatedParameterModule(MegatronModule):
         return x + self.weight
 
 
+class _TemporaryBufferModule(MegatronModule):
+    """Mimic the expert-bias token accumulator updated by a captured training graph."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.projection = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.register_buffer("expert_bias", torch.zeros(1))
+        self.register_buffer("local_tokens_per_expert", torch.zeros(1))
+
+    def forward(self, x):
+        return self.project(x)
+
+    def project(self, x):
+        if torch.is_grad_enabled():
+            self.local_tokens_per_expert.add_(1)
+        return self.projection(x)
+
+
+class _WholeGraphTemporaryBufferModule(GraphableMegatronModule):
+    """Whole-module variant of the temporary-buffer test module."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.projection = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.register_buffer("expert_bias", torch.zeros(1))
+        self.register_buffer("local_tokens_per_expert", torch.zeros(1))
+
+    def forward(self, x):
+        if torch.is_grad_enabled():
+            self.local_tokens_per_expert.add_(1)
+        return self.projection(x)
+
+
 class _SimpleNonModule:
     """non-nn.Module base_module for testing the function_name= form of `CudaGraphManager`."""
 
@@ -1800,6 +1833,97 @@ def _make_simple_module(config):
 
 def _make_simple_non_module(config):
     return _SimpleNonModule(config)
+
+
+class TestLocalCudaGraphEvaluation:
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel()
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        if _CudagraphGlobalRecord.cudagraph_created:
+            delete_cuda_graphs()
+        else:
+            _CudagraphGlobalRecord.cudagraph_record = []
+            _CudagraphGlobalRecord.cudagraph_inference_record = []
+            CudaGraphManager.global_mempool = None
+        torch.cuda.set_stream(torch.cuda.default_stream())
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    @pytest.mark.parametrize("whole_module", [False, True], ids=["wrapped_method", "whole_module"])
+    def test_training_graph_temporary_state_is_reset_when_training_resumes(self, whole_module):
+        def first_output(output):
+            return output[0] if isinstance(output, tuple) else output
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_warmup_steps=0,
+            moe_router_enable_expert_bias=True,
+            moe_router_score_function="sigmoid",
+        )
+        if whole_module:
+            module = _WholeGraphTemporaryBufferModule(config).cuda()
+            manager = module.cudagraph_manager
+        else:
+            module = _TemporaryBufferModule(config).cuda()
+            manager = CudaGraphManager(
+                config, base_module=module, function_name="project", need_backward=True
+            )
+            module.cudagraph_manager = manager
+        ddp_model = DistributedDataParallel(
+            config,
+            DistributedDataParallelConfig(overlap_grad_reduce=True, bucket_size=1_000_000),
+            module,
+        )
+        test_input = torch.randn(4, config.hidden_size, device="cuda", requires_grad=True)
+
+        ddp_model.zero_grad_buffer()
+        first_output(ddp_model(test_input)).sum().backward()
+        ddp_model.finish_grad_sync()
+        assert module.local_tokens_per_expert.item() == 1
+
+        create_cudagraphs()
+        assert module.local_tokens_per_expert.item() == 1
+        runner = manager.cudagraph_runners[0]
+        runner_status = runner.status
+
+        # Match the end-of-training-step reset before validation begins.
+        module.local_tokens_per_expert.zero_()
+        module.expert_bias.fill_(2)
+
+        ddp_model.eval()
+        with torch.no_grad():
+            eval_output = ddp_model(test_input.detach())
+            if whole_module:
+                reference_output = module.forward(test_input.detach())
+            else:
+                reference_output = module.project(test_input.detach(), eager=True)
+
+        torch.testing.assert_close(first_output(eval_output), first_output(reference_output))
+        # no_grad does not change the operations already captured in the training graph.
+        assert module.local_tokens_per_expert.item() == 1
+        assert manager.cudagraph_runners == [runner]
+        assert runner.status is runner_status
+
+        ddp_model.train()
+        assert module.local_tokens_per_expert.item() == 0
+        assert module.expert_bias.item() == 2
+
+        ddp_model.zero_grad_buffer()
+        replay_input = test_input.detach().clone().requires_grad_()
+        first_output(ddp_model(replay_input)).sum().backward()
+        ddp_model.finish_grad_sync()
+
+        assert module.local_tokens_per_expert.item() == 1
 
 
 class TestCheckpointParameterDiscovery:

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -580,6 +580,58 @@ class TestCudaGraphConfigAndArguments:
 
 
 class TestCudaGraphReplay:
+    def test_backward_ready_event_records_on_runner_stream(self, monkeypatch):
+        calls = []
+
+        class FakeStream:
+            def __init__(self, name):
+                self.name = name
+
+            def wait_stream(self, stream):
+                calls.append((self.name, "wait_stream", stream.name))
+
+            def wait_event(self, event):
+                calls.append((self.name, "wait_event", event))
+
+        class FakeStreamContext:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        class FakeEvent:
+            def record(self, stream):
+                calls.append(("ready_event", "record", stream.name))
+
+        outer_stream = FakeStream("outer")
+        runner_stream = FakeStream("runner")
+        early_completion_event = object()
+        runner = SimpleNamespace(
+            bwd_graph=SimpleNamespace(replay=lambda: calls.append(("graph", "replay"))),
+            status=_GraphStatus.BWD_READY,
+            static_grad_outputs=(),
+            use_stream=True,
+            stream=runner_stream,
+            gtp_remat=True,
+            _gtp_wgrad_ring_slots=(),
+            _gtp_finalize_hook_plan=(),
+            bwd_completion_event=early_completion_event,
+            bwd_graph_replay_complete_event=FakeEvent(),
+            params_to_backprop=(),
+            fp8_enabled=False,
+            static_grad_inputs=(),
+        )
+        ctx = SimpleNamespace(runner=runner)
+        monkeypatch.setattr(torch.cuda, "current_stream", lambda: outer_stream)
+        monkeypatch.setattr(torch.cuda, "stream", lambda stream: FakeStreamContext())
+
+        _CudagraphReplayNode.backward(ctx)
+
+        assert ("outer", "wait_event", early_completion_event) in calls
+        assert ("ready_event", "record", "runner") in calls
+        assert ("ready_event", "record", "outer") not in calls
+
     def test_gtp_forward_ensures_captured_params_ready_before_replay(self, monkeypatch):
         calls = []
         first = object()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds an opt-in local CUDA-graph mode that coalesces adjacent graphable HybridStack operations into maximal partial-capture spans.

With `--cuda-graph-coalesce-partial-captures`, Mamba, attention, and MoE router/postprocess operations are grouped into spans separated by eager MoE expert-compute islands. This reduces graph boundaries while preserving eager execution for dynamic expert work.

The implementation:

- builds an explicit alternating span/eager execution plan for HybridStack;
- bypasses per-layer graph managers when span mode is selected;
- preserves per-operation FP8/FP4 contexts within a multi-layer span;
- records backward only after all differentiable span outputs are ready;
- preserves non-gradient outputs that escape a graph, including router metadata;
- keeps the existing two-stage GTP backward RS drain;
- uses one shared span replay stream, allowing span runners to avoid the per-module wgrad ring;
- retains the existing per-module CUDA-graph path when the option is disabled or unsupported;
- rejects the option unless `--cuda-graph-impl=local`.

_Coalescing partial captures provides much higher throughput and lower memory consumption compared to non-coalescing one._

## Issue tracking

Linked issue:

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR


