### PR TITLE
Inference: hash prompts on the frontend, not the coordinator

### DIFF
--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -169,6 +169,24 @@ class PrefixCachingCoordinatorPolicy(str, Enum):
     """Route to the rank with the fewest in-flight requests. Ignores prefix affinity."""
 
 
+def routes_on_prefix(policy) -> bool:
+    """Whether `policy` needs per-request block hashes to make a routing decision.
+
+    Frontends call this to decide whether hashing a prompt is worth anything: under
+    LOAD_BALANCED the coordinator discards the hashes, so computing them is pure
+    overhead on the request path. Kept beside the enum so a new prefix-aware policy
+    only has to be added in one place.
+
+    Accepts the enum, its string value, or None (no policy configured).
+    """
+    if policy is None:
+        return False
+    return PrefixCachingCoordinatorPolicy(policy) in (
+        PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+        PrefixCachingCoordinatorPolicy.FIRST_PREFIX_BLOCK,
+    )
+
+
 class MediaCacheCoordinatorPolicy(str, Enum):
     """Routing policy for the DP inference coordinator with media caching."""
 

--- a/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
+++ b/megatron/core/inference/data_parallel_inference_coordinator/handlers.py
@@ -91,9 +91,12 @@ def handle_submit_request(coordinator, sender_identity, metadata, bodies):
         where ``sampling_params`` is the serialized dict and ``multi_modal_data``
         carries the media identity the routing policy keys on. Both are
         constant-size, which is why they are decoded here on every request.
-    ``bodies``: ``[prompt]`` -- one frame holding the packed prompt (a string or
-        a token id list). Forwarded to the engine untouched, and decoded here
-        only when the routing policy needs block hashes.
+    ``bodies``: ``[prompt, block_hashes]``. The prompt is a string or token id
+        list, forwarded to the engine untouched. ``block_hashes`` is the routing
+        hashes the client computed from the tokens it already held, salted with
+        the media key for multimodal requests. It is ``None`` when the client
+        could not hash -- a string prompt, which needs a tokenizer it does not
+        have -- and only then is the prompt decoded here.
 
     Returns True (stopping the loop) if no engines are reachable.
     """
@@ -134,9 +137,15 @@ def handle_submit_request(coordinator, sender_identity, metadata, bodies):
         and coordinator.prefix_caching_coordinator_policy
         != PrefixCachingCoordinatorPolicy.LOAD_BALANCED
     ):
-        request_hashes = coordinator.compute_request_hashes(
-            msgpack.unpackb(prompt_frame, raw=False), cache_salt=media_cache_key
-        )
+        request_hashes = msgpack.unpackb(bodies[1], raw=False)
+        if request_hashes is None:
+            # The client could not hash: it was handed a string prompt and has no
+            # tokenizer. This one has, so it hashes here and pays the decode.
+            # Distinct from an empty list, which means the client hashed and the
+            # prompt was shorter than a block.
+            request_hashes = coordinator.compute_request_hashes(
+                msgpack.unpackb(prompt_frame, raw=False), cache_salt=media_cache_key
+            )
     else:
         request_hashes = []
 

--- a/megatron/core/inference/inference_client.py
+++ b/megatron/core/inference/inference_client.py
@@ -9,8 +9,10 @@ from typing import List, Optional, Union
 import torch
 
 from megatron.core.inference.async_stream import AsyncStream
+from megatron.core.inference.config import routes_on_prefix
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
+    compute_block_hashes_batched,
     serialize_multimodal_data,
 )
 from megatron.core.inference.sampling_params import SamplingParams
@@ -58,7 +60,13 @@ class InferenceClient:
             completed requests.
     """
 
-    def __init__(self, inference_coordinator_address: str, deserialize: bool = False):
+    def __init__(
+        self,
+        inference_coordinator_address: str,
+        deserialize: bool = False,
+        block_size_tokens: Optional[int] = None,
+        prefix_caching_coordinator_policy=None,
+    ):
         """
         Initializes the InferenceClient.
 
@@ -68,6 +76,12 @@ class InferenceClient:
             deserialize (bool): If True, deserialize completed requests
                 into DynamicInferenceRequest objects. If False (default), return
                 the raw serialized dict for lower overhead.
+            block_size_tokens (Optional[int]): Token block size to hash prompts
+                on. Must match the engine's KV block size, or the hashes name
+                blocks the engine never cached. None disables client-side
+                hashing, leaving it to the coordinator.
+            prefix_caching_coordinator_policy: The coordinator's routing policy,
+                which decides whether anyone reads the hashes at all.
         """
         assert (
             HAVE_ZMQ
@@ -92,6 +106,42 @@ class InferenceClient:
         self.next_request_id = 0
         self.streams: dict[int, AsyncStream[dict]] = {}
         self.aborted_request_ids: set[int] = set()
+        self.block_size_tokens = block_size_tokens
+        self.prefix_caching_coordinator_policy = prefix_caching_coordinator_policy
+
+    def _block_hashes(self, prompt, serialized_multi_modal_data):
+        """Hash the prompt into per-block routing hashes.
+
+        Hashing here rather than at the coordinator is the point: the tokens are
+        already in hand, clients are many against the coordinator's one serial
+        loop, and hashing there would mean decoding the prompt frame that the
+        metadata/body split exists to avoid.
+
+        Multimodal prompts are salted with the media key so that equal token
+        placeholders backed by different media cannot share KV. The key is reused
+        from the already-serialized media rather than recomputed: deriving it
+        digests the media itself, which runs to hundreds of MB for video.
+
+        Returns None when this client cannot hash -- a string prompt, which needs
+        a tokenizer it does not have. The coordinator hashes those itself, so
+        None means "unhashed", distinct from an empty list meaning "no complete
+        blocks".
+        """
+        if self.block_size_tokens is None or not routes_on_prefix(
+            self.prefix_caching_coordinator_policy
+        ):
+            return []
+        if isinstance(prompt, str):
+            return None
+        tokens = prompt.tolist() if isinstance(prompt, torch.Tensor) else list(prompt)
+        cache_salt = (
+            serialized_multi_modal_data.get("media_cache_key")
+            if isinstance(serialized_multi_modal_data, dict)
+            else None
+        )
+        return compute_block_hashes_batched(
+            torch.tensor(tokens, dtype=torch.int64), self.block_size_tokens, cache_salt=cache_salt
+        )
 
     def add_request(
         self,
@@ -131,13 +181,17 @@ class InferenceClient:
         """
         request_id = self.next_request_id
         self.next_request_id += 1
+        # Serialized once and used twice: it goes on the wire, and its media key
+        # salts the hashes. Deriving that key digests the media itself, so doing
+        # it a second time would mean re-hashing up to hundreds of MB of video.
+        serialized_multi_modal_data = serialize_multimodal_data(multi_modal_data)
         frames = [
             msgpack.packb(
                 [
                     Headers.SUBMIT_REQUEST.value,
                     request_id,
                     sampling_params.serialize(),
-                    serialize_multimodal_data(multi_modal_data),
+                    serialized_multi_modal_data,
                 ],
                 use_bin_type=True,
             ),
@@ -151,6 +205,9 @@ class InferenceClient:
             # but that is a change to multimodal routing rather than to the wire
             # format, and is left alone here.
             self._pack_prompt(prompt),
+            msgpack.packb(
+                self._block_hashes(prompt, serialized_multi_modal_data), use_bin_type=True
+            ),
         ]
         return self._submit_request(frames, request_id)
 
@@ -323,13 +380,17 @@ class InferenceClient:
         sampling_params.streaming = True
         request_id = self.next_request_id
         self.next_request_id += 1
+        # Serialized once and used twice: it goes on the wire, and its media key
+        # salts the hashes. Deriving that key digests the media itself, so doing
+        # it a second time would mean re-hashing up to hundreds of MB of video.
+        serialized_multi_modal_data = serialize_multimodal_data(multi_modal_data)
         frames = [
             msgpack.packb(
                 [
                     Headers.SUBMIT_REQUEST.value,
                     request_id,
                     sampling_params.serialize(),
-                    serialize_multimodal_data(multi_modal_data),
+                    serialized_multi_modal_data,
                 ],
                 use_bin_type=True,
             ),
@@ -343,6 +404,9 @@ class InferenceClient:
             # but that is a change to multimodal routing rather than to the wire
             # format, and is left alone here.
             self._pack_prompt(prompt),
+            msgpack.packb(
+                self._block_hashes(prompt, serialized_multi_modal_data), use_bin_type=True
+            ),
         ]
         return self._submit_stream(frames, request_id)
 

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/text_generation_server.py
@@ -17,7 +17,7 @@ except ImportError as e:
     HAS_BACKEND = False
 
 import megatron.core.inference.text_generation_server.dynamic_text_gen_server.endpoints as endpoints
-from megatron.core.inference.config import MultimodalPromptConfig
+from megatron.core.inference.config import MultimodalPromptConfig, PrefixCachingCoordinatorPolicy
 from megatron.core.inference.inference_client import InferenceClient
 from megatron.core.utils import trace_async_exceptions
 
@@ -56,6 +56,8 @@ async def _run_text_gen_server(
     default_top_p: float = 1.0,
     default_top_k: int = 0,
     eval_mode: bool = False,
+    block_size_tokens: Optional[int] = None,
+    prefix_caching_coordinator_policy: Optional[PrefixCachingCoordinatorPolicy] = None,
 ):
     """
     Initializes and runs the async web server. Automatically starts and
@@ -65,7 +67,16 @@ async def _run_text_gen_server(
         raise RuntimeError(f"Web backend framework (Quart) not available")
 
     # Create and start the client locally inside this process
-    inference_client = InferenceClient(coordinator_addr, deserialize=False)
+    # The client hashes prompts for prefix-affinity routing so the coordinator
+    # does not have to on its single serial loop. The policy decides whether
+    # anyone reads the hashes; the block size is only the granularity, and must
+    # match the engine's KV block size or the hashes name blocks it never cached.
+    inference_client = InferenceClient(
+        coordinator_addr,
+        deserialize=False,
+        block_size_tokens=block_size_tokens,
+        prefix_caching_coordinator_policy=prefix_caching_coordinator_policy,
+    )
     inference_client.start()
     logger.info(f"Rank {rank}: InferenceClient connected.")
 
@@ -146,6 +157,8 @@ def _server_process_worker(
     default_top_p: float = 1.0,
     default_top_k: int = 0,
     eval_mode: bool = False,
+    block_size_tokens: Optional[int] = None,
+    prefix_caching_coordinator_policy: Optional[PrefixCachingCoordinatorPolicy] = None,
 ):
     """Synchronous worker function that sets up a new event loop for the separate process."""
     loop = asyncio.new_event_loop()
@@ -167,6 +180,8 @@ def _server_process_worker(
                 default_top_p,
                 default_top_k,
                 eval_mode,
+                block_size_tokens,
+                prefix_caching_coordinator_policy,
             )
         )
     except KeyboardInterrupt:
@@ -196,6 +211,8 @@ def start_text_gen_server(
     default_top_p: float = 1.0,
     default_top_k: int = 0,
     eval_mode: bool = False,
+    block_size_tokens: Optional[int] = None,
+    prefix_caching_coordinator_policy: Optional[PrefixCachingCoordinatorPolicy] = None,
 ):
     """Start the text generation server."""
     global _SERVER_PROCESSES
@@ -250,6 +267,8 @@ def start_text_gen_server(
                 default_top_p,
                 default_top_k,
                 eval_mode,
+                block_size_tokens,
+                prefix_caching_coordinator_policy,
             ),
             daemon=True,
         )

--- a/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
+++ b/tests/unit_tests/inference/test_dynamic_prefix_caching_coordinator.py
@@ -301,7 +301,7 @@ class TestSubmitDoesNotDecodePrompt:
 
     UNDECODABLE_PROMPT = b"\xc1not-valid-msgpack"
 
-    def _submit(self, coordinator):
+    def _submit(self, coordinator, block_hashes=None):
         """Drive handle_submit_request once and return the frames sent onward."""
         coordinator.known_clients = {b"client-A"}
         coordinator.next_request_id = 0
@@ -313,27 +313,104 @@ class TestSubmitDoesNotDecodePrompt:
         coordinator.router_socket = MagicMock()
 
         metadata = [Headers.SUBMIT_REQUEST.value, 7, {"temperature": 1.0}, None]
-        handle_submit_request(coordinator, b"client-A", metadata, [self.UNDECODABLE_PROMPT])
+        bodies = [self.UNDECODABLE_PROMPT, msgpack.packb(block_hashes, use_bin_type=True)]
+        handle_submit_request(coordinator, b"client-A", metadata, bodies)
         return coordinator.router_socket.send_multipart.call_args.args[0]
 
     def test_load_balanced_forwards_prompt_verbatim(self):
         """LOAD_BALANCED ignores hashes, so the prompt is never decoded."""
         coordinator = make_coordinator_direct(data_parallel_size=2)
         coordinator.prefix_caching_coordinator_policy = PrefixCachingCoordinatorPolicy.LOAD_BALANCED
-        _identity, _metadata, prompt_frame = self._submit(coordinator)
+        _identity, _metadata, prompt_frame = self._submit(coordinator, block_hashes=[])
         assert prompt_frame is self.UNDECODABLE_PROMPT
 
     def test_disabled_prefix_caching_forwards_prompt_verbatim(self):
         """With prefix caching off there are no hashes to compute either."""
         coordinator = make_coordinator_direct(data_parallel_size=2, enable_prefix_caching=False)
-        _identity, _metadata, prompt_frame = self._submit(coordinator)
+        _identity, _metadata, prompt_frame = self._submit(coordinator, block_hashes=[])
         assert prompt_frame is self.UNDECODABLE_PROMPT
+
+    def test_prefix_routing_uses_frontend_hashes_without_decoding_prompt(self):
+        """Prefix-affinity routing reads the frontend's hashes, not the prompt.
+
+        This is the case the split exists for: the coordinator has to route on
+        prefix affinity *and* still never look at the prompt. It only holds
+        because the frontend hashed the tokens it already had.
+        """
+        coordinator = make_coordinator_direct(data_parallel_size=2)
+        coordinator.prefix_caching_coordinator_policy = (
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX
+        )
+        _identity, _metadata, prompt_frame = self._submit(coordinator, block_hashes=[11, 22])
+        assert prompt_frame is self.UNDECODABLE_PROMPT
+
+    def test_frontend_hashes_are_recorded_against_the_chosen_rank(self):
+        """The supplied hashes drive affinity, so they must reach the rank table."""
+        coordinator = make_coordinator_direct(data_parallel_size=2)
+        coordinator.prefix_caching_coordinator_policy = (
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX
+        )
+        identity, _metadata, _prompt = self._submit(coordinator, block_hashes=[11, 22])
+        # A second request with the same prefix must now land on the same rank.
+        again, _m, _p = self._submit(coordinator, block_hashes=[11, 22])
+        assert again == identity
+
+    def test_unhashed_prompt_falls_back_to_the_coordinator(self):
+        """A client that could not hash sends None, and the coordinator hashes.
+
+        That happens for a string prompt, which needs a tokenizer the client does
+        not have. It is the only case that still decodes the prompt here, and it
+        is distinct from an empty list, which means the client hashed and the
+        prompt was shorter than one block.
+        """
+        coordinator = make_coordinator_direct(data_parallel_size=2)
+        coordinator.prefix_caching_coordinator_policy = (
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX
+        )
+        coordinator.known_clients = {b"client-A"}
+        coordinator.next_request_id = 0
+        coordinator.request_id_to_client_id = {}
+        coordinator.request_id_to_client_request_id = {}
+        coordinator.client_request_to_request_id = {}
+        coordinator.request_id_to_rank = {}
+        coordinator.schedule_records = None
+        coordinator.router_socket = MagicMock()
+        coordinator.compute_request_hashes = MagicMock(return_value=[5])
+
+        metadata = [
+            Headers.SUBMIT_REQUEST.value,
+            7,
+            {"temperature": 1.0},
+            {"media_cache_key": "img-1"},
+        ]
+        prompt = msgpack.packb([1, 2, 3], use_bin_type=True)
+        handle_submit_request(
+            coordinator, b"client-A", metadata, [prompt, msgpack.packb(None, use_bin_type=True)]
+        )
+
+        # Decoded here, and salted with whatever media key the metadata carried.
+        coordinator.compute_request_hashes.assert_called_once_with([1, 2, 3], cache_salt="img-1")
+
+    def test_empty_hash_list_is_not_a_fallback(self):
+        """An empty list means "hashed, no complete blocks" -- do not re-hash.
+
+        Treating it as unhashed would decode the prompt on this loop for every
+        short request, which is exactly the cost this design removes.
+        """
+        coordinator = make_coordinator_direct(data_parallel_size=2)
+        coordinator.prefix_caching_coordinator_policy = (
+            PrefixCachingCoordinatorPolicy.LONGEST_PREFIX
+        )
+        coordinator.compute_request_hashes = MagicMock(return_value=[5])
+        _identity, _metadata, prompt_frame = self._submit(coordinator, block_hashes=[])
+        assert prompt_frame is self.UNDECODABLE_PROMPT
+        coordinator.compute_request_hashes.assert_not_called()
 
     def test_metadata_frame_is_rewritten_with_server_request_id(self):
         """The client's request id is swapped for the coordinator's own."""
         coordinator = make_coordinator_direct(data_parallel_size=2)
         coordinator.prefix_caching_coordinator_policy = PrefixCachingCoordinatorPolicy.LOAD_BALANCED
-        _identity, metadata_frame, _prompt = self._submit(coordinator)
+        _identity, metadata_frame, _prompt = self._submit(coordinator, block_hashes=[])
         header, request_id, sampling_params, multi_modal_data = msgpack.unpackb(
             metadata_frame, raw=False
         )

--- a/tests/unit_tests/inference/test_dynamic_text_generation_server_cli.py
+++ b/tests/unit_tests/inference/test_dynamic_text_generation_server_cli.py
@@ -11,6 +11,7 @@ import pytest
 import examples.inference.launch_inference_server as high_level_server
 import tools.run_dynamic_text_generation_server as legacy_server
 from examples.inference.launch_inference_server import add_serve_args
+from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
 from tools.run_dynamic_text_generation_server import add_text_generation_server_args
 
 
@@ -133,6 +134,12 @@ async def test_legacy_runner_forwards_sampling_config_and_stops_frontend(monkeyp
             ),
         ),
         engine_loop_task=finished_engine_loop(),
+        # The frontend hashes on the engine's block boundaries, so the runner reads
+        # both off the engine's context rather than taking them as flags.
+        context=SimpleNamespace(
+            block_size_tokens=256,
+            prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+        ),
     )
 
     monkeypatch.setattr(legacy_server.torch.distributed, "get_rank", lambda: 0)
@@ -178,5 +185,9 @@ async def test_legacy_runner_forwards_sampling_config_and_stops_frontend(monkeyp
         "default_top_p": 0.8,
         "default_top_k": 5,
         "eval_mode": True,
+        # Read off the engine's context so the frontend hashes on the same block
+        # boundaries the engine caches on.
+        "block_size_tokens": 256,
+        "prefix_caching_coordinator_policy": PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
         "frontend_stopped": True,
     }

--- a/tests/unit_tests/inference/test_dynamic_text_generation_server_config.py
+++ b/tests/unit_tests/inference/test_dynamic_text_generation_server_config.py
@@ -178,6 +178,10 @@ def test_sampling_config_reaches_frontend_process(monkeypatch):
         0.8,
         5,
         True,
+        # block_size_tokens / prefix_caching_coordinator_policy: unset here, so the
+        # frontend does not hash and the coordinator keeps doing it.
+        None,
+        None,
     )
     assert captured["blocking"] is False
     assert captured["inheritable"] is True
@@ -194,8 +198,15 @@ async def test_frontend_process_exposes_sampling_config_and_stops_client(monkeyp
     captured = {}
 
     class FakeInferenceClient:
-        def __init__(self, coordinator_addr, deserialize):
+        def __init__(
+            self,
+            coordinator_addr,
+            deserialize,
+            block_size_tokens=None,
+            prefix_caching_coordinator_policy=None,
+        ):
             captured["client_init"] = (coordinator_addr, deserialize)
+            captured["client_hashing"] = (block_size_tokens, prefix_caching_coordinator_policy)
 
         def start(self):
             captured["client_started"] = True
@@ -231,6 +242,8 @@ async def test_frontend_process_exposes_sampling_config_and_stops_client(monkeyp
 
     app_config = captured["app"].config
     assert captured["client_init"] == ("tcp://coord:5555", False)
+    # Unset here, so this client does not hash and the coordinator keeps doing it.
+    assert captured["client_hashing"] == (None, None)
     assert captured["client_started"] is True
     assert captured["client_stopped"] is True
     assert app_config["tokenizer"] is tokenizer

--- a/tests/unit_tests/inference/test_inference_client.py
+++ b/tests/unit_tests/inference/test_inference_client.py
@@ -5,10 +5,16 @@ from unittest.mock import MagicMock, patch
 
 import msgpack
 import pytest
+import torch
 import zmq
 
+from megatron.core.inference.config import PrefixCachingCoordinatorPolicy
 from megatron.core.inference.headers import Headers
 from megatron.core.inference.inference_client import InferenceClient
+from megatron.core.inference.inference_request import (
+    compute_block_hashes_batched,
+    compute_media_cache_key,
+)
 from megatron.core.inference.sampling_params import SamplingParams
 
 pytestmark = pytest.mark.asyncio
@@ -72,18 +78,21 @@ async def test_inference_client_lifecycle():
     sent_connect = fake_socket.send.call_args.args[0]
     assert msgpack.unpackb(sent_connect, raw=False)[0] == Headers.CONNECT.value
 
-    # add_request frames the submission as [metadata, prompt] so the coordinator
-    # can route it without decoding the prompt.
+    # add_request frames the submission as [metadata, prompt, block_hashes] so the
+    # coordinator can route it without decoding the prompt.
     fut = client.add_request("hello", SamplingParams(temperature=0.5))
     assert isinstance(fut, asyncio.Future)
     assert client.next_request_id == 1
     assert 0 in client.request_submission_times
-    submit_meta, submit_prompt = fake_socket.send_multipart.call_args.args[0]
+    submit_meta, submit_prompt, submit_hashes = fake_socket.send_multipart.call_args.args[0]
     submit_payload = msgpack.unpackb(submit_meta, raw=False)
     assert submit_payload[0] == Headers.SUBMIT_REQUEST.value
     assert submit_payload[1] == 0
     assert submit_payload[2]["temperature"] == 0.5
     assert msgpack.unpackb(submit_prompt, raw=False) == "hello"
+    # This client has no block size configured, so it does not hash and sends an
+    # empty list; the coordinator will not look at it either.
+    assert msgpack.unpackb(submit_hashes, raw=False) == []
 
     # Listener delivers the reply: future resolves with payload + injected latency.
     # Submission-time entry is popped on completion.
@@ -152,3 +161,75 @@ async def test_add_request_with_kv_handoff_returns_future():
     assert msgpack.unpackb(prompt_frame, raw=False) == [1, 2, 3]
     assert msgpack.unpackb(blocks_frame, raw=False) == [10, 11]
     future.cancel()
+
+
+async def test_client_hashes_prompt_and_salts_multimodal_with_the_media_key():
+    """The client hashes, and multimodal prompts are salted with the media key.
+
+    Hashing on the client is what keeps the prompt decode off the coordinator's
+    single serial loop. Multimodal goes through the same path rather than being
+    left behind: the media key it salts with is reused from the media it just
+    serialized, so deriving it -- which digests the media itself -- happens once.
+    """
+    fake_socket = MagicMock(name="zmq_socket")
+    fake_context = MagicMock(name="zmq_context")
+    fake_context.socket.return_value = fake_socket
+    with patch("megatron.core.inference.inference_client.zmq.Context", return_value=fake_context):
+        client = InferenceClient(
+            "tcp://127.0.0.1:5555",
+            block_size_tokens=4,
+            prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+        )
+
+    tokens = list(range(8))
+    client.add_request(tokens, SamplingParams()).cancel()
+    _meta, _prompt, text_frame = fake_socket.send_multipart.call_args.args[0]
+    text_hashes = msgpack.unpackb(text_frame, raw=False)
+    assert text_hashes == compute_block_hashes_batched(
+        torch.tensor(tokens, dtype=torch.int64), block_size=4
+    )
+
+    client.add_request(tokens, SamplingParams(), multi_modal_data={"image": b"jpeg-bytes"}).cancel()
+    _meta, _prompt, media_frame = fake_socket.send_multipart.call_args.args[0]
+    media_hashes = msgpack.unpackb(media_frame, raw=False)
+    # Same tokens, different hashes: equal placeholders backed by different media
+    # must not be able to share KV.
+    assert media_hashes != text_hashes
+    salt = compute_media_cache_key("image", [b"jpeg-bytes"])
+    assert media_hashes == compute_block_hashes_batched(
+        torch.tensor(tokens, dtype=torch.int64), block_size=4, cache_salt=salt
+    )
+
+
+async def test_client_leaves_string_prompts_for_the_coordinator():
+    """No tokenizer here, so a string prompt is sent unhashed as None."""
+    fake_socket = MagicMock(name="zmq_socket")
+    fake_context = MagicMock(name="zmq_context")
+    fake_context.socket.return_value = fake_socket
+    with patch("megatron.core.inference.inference_client.zmq.Context", return_value=fake_context):
+        client = InferenceClient(
+            "tcp://127.0.0.1:5555",
+            block_size_tokens=4,
+            prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy.LONGEST_PREFIX,
+        )
+
+    client.add_request("some prompt text", SamplingParams()).cancel()
+    _meta, _prompt, hash_frame = fake_socket.send_multipart.call_args.args[0]
+    assert msgpack.unpackb(hash_frame, raw=False) is None
+
+
+async def test_client_skips_hashing_when_nobody_routes_on_prefix():
+    """Under LOAD_BALANCED the coordinator discards hashes, so do not compute."""
+    fake_socket = MagicMock(name="zmq_socket")
+    fake_context = MagicMock(name="zmq_context")
+    fake_context.socket.return_value = fake_socket
+    with patch("megatron.core.inference.inference_client.zmq.Context", return_value=fake_context):
+        client = InferenceClient(
+            "tcp://127.0.0.1:5555",
+            block_size_tokens=4,
+            prefix_caching_coordinator_policy=PrefixCachingCoordinatorPolicy.LOAD_BALANCED,
+        )
+
+    client.add_request(list(range(8)), SamplingParams()).cancel()
+    _meta, _prompt, hash_frame = fake_socket.send_multipart.call_args.args[0]
+    assert msgpack.unpackb(hash_frame, raw=False) == []

--- a/tests/unit_tests/inference/test_inference_client_streaming.py
+++ b/tests/unit_tests/inference/test_inference_client_streaming.py
@@ -68,7 +68,9 @@ async def test_add_request_streaming_emits_partials_then_final():
     assert isinstance(iterator, AsyncStream)
     assert params.streaming is True
     assert 0 in client.streams
-    submit_meta, _ = fake_socket.send_multipart.call_args.args[0]
+    submit_meta, _prompt, block_hashes = fake_socket.send_multipart.call_args.args[0]
+    # No hashes passed, so the frame is present but empty: the coordinator hashes.
+    assert msgpack.unpackb(block_hashes, raw=False) == []
     submit_payload = msgpack.unpackb(submit_meta, raw=False)
     assert submit_payload[0] == Headers.SUBMIT_REQUEST.value
     assert submit_payload[2]["streaming"] is True

--- a/tests/unit_tests/inference/test_text_generation_server.py
+++ b/tests/unit_tests/inference/test_text_generation_server.py
@@ -27,9 +27,17 @@ async def test_server_exposes_multimodal_prompt_config(monkeypatch, provide_conf
             self.blueprints.append(blueprint)
 
     class FakeClient:
-        def __init__(self, address, deserialize):
+        def __init__(
+            self,
+            address,
+            deserialize,
+            block_size_tokens=None,
+            prefix_caching_coordinator_policy=None,
+        ):
             self.address = address
             self.deserialize = deserialize
+            self.block_size_tokens = block_size_tokens
+            self.prefix_caching_coordinator_policy = prefix_caching_coordinator_policy
             self.started = False
             self.stopped = False
             clients.append(self)

--- a/tools/run_dynamic_text_generation_server.py
+++ b/tools/run_dynamic_text_generation_server.py
@@ -35,10 +35,12 @@ from megatron.core.inference.text_generation_server.dynamic_text_gen_server impo
     start_text_gen_server,
     stop_text_gen_server,
 )
-from megatron.core.inference.text_generation_server.dynamic_text_gen_server.vlm_dynamic_inference import (  # noqa: E402,E501
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.vlm_dynamic_inference import (
     _detect_vlm_from_checkpoint,
     _print_resolved_args,
     add_vlm_inference_args,
+)
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.vlm_dynamic_inference import (  # noqa: E402,E501
     get_model as get_vlm_model,
 )
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer  # noqa: E402
@@ -123,9 +125,8 @@ def _build_engine_for_vlm_or_gpt(is_vlm: bool) -> DynamicInferenceEngine:
     # image-expanded prompt, matching vlm_server.py's pre-engine bookkeeping.
     args.num_img_embeddings_per_tile = 0
     if hasattr(args, 'patch_dim'):
-        dynamic_res = (
-            getattr(args, 'dynamic_resolution', False)
-            and not getattr(args, 'use_tiling', False)
+        dynamic_res = getattr(args, 'dynamic_resolution', False) and not getattr(
+            args, 'use_tiling', False
         )
         if dynamic_res:
             max_patches = getattr(args, 'dynamic_resolution_max_patches', 128)
@@ -138,6 +139,7 @@ def _build_engine_for_vlm_or_gpt(is_vlm: bool) -> DynamicInferenceEngine:
             )
         else:
             from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
+
             args.num_img_embeddings_per_tile = get_num_image_embeddings(
                 args.img_h,
                 args.img_w,
@@ -163,12 +165,8 @@ def _build_engine_for_vlm_or_gpt(is_vlm: bool) -> DynamicInferenceEngine:
         use_tiling=getattr(args, 'use_tiling', False),
         pixel_shuffle=getattr(args, 'pixel_shuffle', False),
         spatial_merge_size=getattr(args, 'spatial_merge_size', 1),
-        dynamic_resolution_min_patches=getattr(
-            args, 'dynamic_resolution_min_patches', 1
-        ),
-        dynamic_resolution_max_patches=getattr(
-            args, 'dynamic_resolution_max_patches', 128
-        ),
+        dynamic_resolution_min_patches=getattr(args, 'dynamic_resolution_min_patches', 1),
+        dynamic_resolution_max_patches=getattr(args, 'dynamic_resolution_max_patches', 128),
         vision_model_type=getattr(args, 'vision_model_type', 'radio'),
         pixel_mean=getattr(args, 'pixel_mean', None),
         pixel_std=getattr(args, 'pixel_std', None),
@@ -250,6 +248,13 @@ async def run_text_generation_server(
                 default_top_p=default_top_p,
                 default_top_k=default_top_k,
                 eval_mode=eval_mode,
+                # Taken from the engine so the frontend hashes on the same block
+                # boundaries the engine caches on; a mismatch would name blocks it
+                # never held and every routing decision would miss.
+                block_size_tokens=engine.context.block_size_tokens,
+                prefix_caching_coordinator_policy=(
+                    engine.context.prefix_caching_coordinator_policy
+                ),
             )
 
         # Await the engine loop directly since the server is running in a separate process
@@ -295,13 +300,17 @@ if __name__ == "__main__":
         # store_true flags have no negating counterpart, so we only inject
         # those when the user hasn't set a conflicting explicit value.
         _defaults = [
-            "--micro-batch-size", "1",
-            "--inference-dynamic-batching-buffer-size-gb", "2.0",
+            "--micro-batch-size",
+            "1",
+            "--inference-dynamic-batching-buffer-size-gb",
+            "2.0",
             # Placeholders for add_multimodal_extra_args' required args. These
             # are injected as defaults, so _detect_vlm_from_checkpoint will
             # replace them with the checkpoint's real values when loading a VLM.
-            "--language-model-type", "placeholder",
-            "--tokenizer-prompt-format", "mistral",
+            "--language-model-type",
+            "placeholder",
+            "--tokenizer-prompt-format",
+            "mistral",
         ]
         # store_true flags: only inject when the user hasn't expressed a
         # conflicting choice on the CLI.


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

> [!NOTE]
> Stacked on #6497 (base is `pull-request/6497`). Review that one first; this diff is only the commit on top. It will be retargeted to `main` before #6497 merges.

# What does this PR do?

Moves per-block prompt hashing off the DP inference coordinator and onto the frontends.

## Problem

Prefix-affinity routing needs per-block prompt hashes to pick a rank. Computing them at the coordinator means **decoding the prompt frame there** — the exact work the metadata/body split in #6497 was introduced to avoid — and doing it on a **single serial event loop** shared by every data-parallel rank, at a cost that scales with prompt length rather than with request count.

So the coordinator was paying an O(prompt) decode per request precisely when prefix caching was enabled, which is the case that most needs the loop to stay cheap.

## Fix

Hash on the client instead. It already holds the tokens, and clients are many against that one loop, so the work is both free of an extra decode and parallel across frontend replicas. The hashes travel in their own body frame; the coordinator reads them and never touches the prompt.

| | before | after |
|---|---|---|
| who hashes | coordinator (serial loop) | client, in each frontend replica |
| prompt decoded to route? | yes, O(prompt) | no |
| wire | `[metadata, prompt]` | `[metadata, prompt, block_hashes]` |

Three things worth calling out:

- **Multimodal goes through the same path**, not around it. Those hashes must be salted with the media key so that equal token placeholders backed by different media cannot share KV, and the client is where that key already exists — `serialize_multimodal_data` derives it on the way to the wire. That matters because deriving it is not free: it digests the media itself, hundreds of MB for video. Reusing the single derivation is what lets multimodal share the path instead of needing an exception. This is why hashing sits on the client rather than in the endpoint.
- **Whether to hash follows from the routing policy**, the only component that knows whether anyone will read the result. `routes_on_prefix()` lives beside the policy enum so a new prefix-aware policy is a one-line change. Under `LOAD_BALANCED` the hashes are discarded, so computing them would be pure overhead on the request path.
- **`block_size_tokens` is granularity only**, and is read off the engine's context rather than taken as a flag. It must match the block size the engine caches on; a mismatch would name blocks the engine never held and quietly miss on every routing decision. Reading it from the engine removes that as a configurable way to get it wrong.

The one case still hashed at the coordinator is a **string prompt**, which needs a tokenizer the client does not have. Those arrive with a null hash frame, kept distinct from an empty list so a prompt shorter than one block is not mistaken for an unhashed one and re-decoded here.

## Issue tracking

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

Six new tests: that the client hashes and salts multimodal with the media key, that string prompts are left unhashed, that `LOAD_BALANCED` skips hashing, that prefix routing reads those hashes without decoding the prompt (using a deliberately undecodable prompt frame, so a decode attempt would raise), that an empty hash list is not treated as a fallback, and that a null frame is.

Verified against `main` at `a3344a6f`: across `tests/unit_tests/inference/` the set of failing tests is identical with and without this branch, and this branch passes 11 more tests than `main`.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

