### PR TITLE
Reuse persistent main-grad storage

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -73,10 +73,6 @@ class DBuffer:
     layout: GlobalLayout
     offset: int
     local_buffer: torch.Tensor
-    # Record the allocation stream so DBuffer users can check that uses are joined back to it
-    # before deleting the buffer. See https://github.com/NVIDIA/Megatron-LM/pull/6187 and
-    # https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.record_stream.html.
-    allocation_stream: torch.cuda.Stream | None
 
     def __init__(
         self,
@@ -110,11 +106,6 @@ class DBuffer:
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
-        self.allocation_stream = (
-            torch.cuda.current_stream(self.local_buffer.device)
-            if self.local_buffer.is_cuda
-            else None
-        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -180,8 +171,6 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         tensor_shapes: Iterable[Shape],
-        *,
-        allocation_stream: torch.cuda.Stream | None,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -192,7 +181,6 @@ class DBuffer:
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
-            allocation_stream: CUDA stream that allocated ``local_buffer``, or ``None`` for CPU.
 
         Returns:
             A DBuffer that reuses ``local_buffer`` without allocating storage.
@@ -223,7 +211,6 @@ class DBuffer:
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_buffer = local_buffer
-        buffer.allocation_stream = allocation_stream
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -257,15 +244,10 @@ class DBuffer:
                 self.mesh,
                 placements,
                 self.layout.tensor_shapes,
-                allocation_stream=self.allocation_stream,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
             return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                placements,
-                self.layout.tensor_shapes,
-                allocation_stream=self.allocation_stream,
+                self.local_buffer, self.mesh, placements, self.layout.tensor_shapes
             )
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
@@ -421,11 +403,7 @@ class DBuffer:
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
             return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                new_placements,
-                self.layout.tensor_shapes,
-                allocation_stream=self.allocation_stream,
+                self.local_buffer, self.mesh, new_placements, self.layout.tensor_shapes
             )
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -229,8 +229,10 @@ class DBuffer:
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
         """Return a storage-sharing buffer with supported ``placements``.
 
-        Views preserve placements or locally slice one Replicate axis to Flat.
-        Other placement changes require communication and are not views.
+        Views preserve placements, relabel a full local buffer, or locally slice
+        one full local buffer to Flat. A view that changes a Partial placement is
+        only a storage destination: callers must populate it with a reduction
+        before reading it.
         """
         placements = tuple(placements)
         if len(placements) != self.mesh.ndim:
@@ -241,8 +243,10 @@ class DBuffer:
         changed_axis = changed_mesh_axis(self.placements, placements)
         if changed_axis is None:
             return self
-        if isinstance(self.placements[changed_axis], Replicate) and isinstance(
-            placements[changed_axis], Flat
+        source_placement = self.placements[changed_axis]
+        destination_placement = placements[changed_axis]
+        if isinstance(source_placement, (Replicate, Partial)) and isinstance(
+            destination_placement, Flat
         ):
             offset, local_numel = self.layout.get_local_range(self.mesh, placements)
             local_offset = offset - self.offset
@@ -255,8 +259,17 @@ class DBuffer:
                 self.layout.tensor_shapes,
                 allocation_stream=self.allocation_stream,
             )
+        if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
+            return DBuffer.from_local(
+                self.local_buffer,
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                allocation_stream=self.allocation_stream,
+            )
         raise ValueError(
-            "DBuffer.view() supports identical placements or a Replicate-to-Flat slice, "
+            "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
+            "or a Replicate/Partial-to-Flat slice, "
             f"got {self.placements!r} -> {placements!r}."
         )
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -204,7 +204,6 @@ class FsdpModule:
                         main_weight_placements, group_dtype
                     ),
                     mixed_precision_policy=mixed_precision_policy,
-                    reduce_scatter_stream=context.reduce_scatter_stream,
                     grad_divisor=grad_divisor,
                     use_symmetric_memory=use_symmetric_memory,
                 )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -89,9 +89,10 @@ class FsdpParameterGroup:
     main_grad: DBuffer | None
     # Optimizer-layout view into main_grad storage, avoiding a second allocation.
     pre_optimizer_main_grad: DBuffer | None
-    # HFSDP finalization writes a smaller optimizer view, leaving the rest of
-    # main_grad untouched until the next accumulation begins.
-    _main_grad_has_smaller_optimizer_view: bool
+    # HFSDP finalization writes only a smaller optimizer view. After
+    # zero_grad(set_to_none=False) clears that view, the remaining main_grad
+    # storage is stale and must be cleared before the next accumulation begins.
+    _main_grad_is_stale: bool
     _unsharded_model_weight: DBuffer
     _symm_mem_pool: torch.cuda.MemPool | None
     grad_divisor: int
@@ -200,7 +201,7 @@ class FsdpParameterGroup:
 
         self.main_grad = None
         self.pre_optimizer_main_grad = None
-        self._main_grad_has_smaller_optimizer_view = False
+        self._main_grad_is_stale = False
         if self.requires_grad:
             grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
             # Keep main_grad persistent for the initial implementation. For micro-batch
@@ -385,13 +386,13 @@ class FsdpParameterGroup:
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
         has_sharded_grads = self._has_sharded_grads()
-        if self._main_grad_has_smaller_optimizer_view:
+        if self._main_grad_is_stale:
             # In HFSDP, zero_grad(set_to_none=False) only zeros the smaller optimizer
             # view. Clear the persistent full accumulation buffer before this new step;
             # set_to_none=True needs no clear because out= below overwrites it.
             if has_sharded_grads:
                 self.main_grad.local_buffer.zero_()
-            self._main_grad_has_smaller_optimizer_view = False
+            self._main_grad_is_stale = False
 
         if can_reduce_into_main_grad := (
             not has_sharded_grads and partial_grad.dtype == self.main_grad.dtype
@@ -421,7 +422,7 @@ class FsdpParameterGroup:
             optimizer_main_grad = self.main_grad.redistribute(
                 self.main_weight.placements, out=self.pre_optimizer_main_grad
             )
-            self._main_grad_has_smaller_optimizer_view = (
+            self._main_grad_is_stale = (
                 optimizer_main_grad.local_buffer.numel() < self.main_grad.local_buffer.numel()
             )
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -88,6 +88,7 @@ class FsdpParameterGroup:
     _model_weight_is_stale: bool
     main_grad: DBuffer | None
     # Optimizer-layout view into main_grad storage, avoiding a second allocation.
+    # This is None exactly when main_grad is None.
     pre_optimizer_main_grad: DBuffer | None
     # zero_grad(set_to_none=False) clears only the current optimizer view. If final
     # reduction created a smaller view (e.g. ZeRO-1 or HFSDP), the remaining main_grad
@@ -209,17 +210,13 @@ class FsdpParameterGroup:
             # eagerly deallocated right after optimizer.step(), avoiding main_grad
             # storage during forward. That requires a separate lifetime contract with
             # the optimizer, so this version keeps the simpler persistent buffer.
-            # This persistent buffer is allocated on the default stream rather than the
-            # reduce-scatter stream. The latter is reserved for transient communication
-            # buffers and CUDA graph replay can otherwise observe a stream-local allocation.
-            with torch.cuda.stream(torch.cuda.default_stream(self.main_weight.device)):
-                self.main_grad = DBuffer(
-                    mesh=self.mesh,
-                    placements=main_grad_placements,
-                    tensor_shapes=self.main_weight.layout.tensor_shapes,
-                    dtype=grad_dtype,
-                    device=self.main_weight.device,
-                )
+            self.main_grad = DBuffer(
+                mesh=self.mesh,
+                placements=main_grad_placements,
+                tensor_shapes=self.main_weight.layout.tensor_shapes,
+                dtype=grad_dtype,
+                device=self.main_weight.device,
+            )
             self.pre_optimizer_main_grad = self.main_grad.view(main_weight_placements)
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "
@@ -387,9 +384,9 @@ class FsdpParameterGroup:
         # leaves sharded grads installed, so this backward accumulates into main_grad.
         has_sharded_grads = self._has_sharded_grads()
         if self._main_grad_is_stale:
-            # In HFSDP, zero_grad(set_to_none=False) only zeros the smaller optimizer
-            # view. Clear the persistent full accumulation buffer before this new step;
-            # set_to_none=True needs no clear because out= below overwrites it.
+            # In ZeRO-1 and HFSDP, zero_grad(set_to_none=False) only zeros the smaller
+            # optimizer view. Clear the persistent full accumulation buffer before this
+            # new step; set_to_none=True needs no clear because out= below overwrites it.
             if has_sharded_grads:
                 self.main_grad.local_buffer.zero_()
             self._main_grad_is_stale = False
@@ -422,9 +419,7 @@ class FsdpParameterGroup:
             optimizer_main_grad = self.main_grad.redistribute(
                 self.main_weight.placements, out=self.pre_optimizer_main_grad
             )
-            self._main_grad_is_stale = (
-                optimizer_main_grad.local_buffer.numel() < self.main_grad.local_buffer.numel()
-            )
+            self._main_grad_is_stale = True
 
         # Make each sharded parameter's .grad consistent with the final main_grad.
         for index, fsdp_parameter in enumerate(self.fsdp_parameters):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -378,6 +378,11 @@ class FsdpParameterGroup:
         rests finalized.
         """
         assert self.main_grad is not None
+        assert self.pre_optimizer_main_grad is not None
+
+        def install_sharded_grads(grad: DBuffer) -> None:
+            for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+                fsdp_parameter.sharded.grad = grad.get_dtensor(index)
 
         # zero_grad(set_to_none=True) clears sharded parameter grads, so this
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
@@ -410,20 +415,20 @@ class FsdpParameterGroup:
             else:
                 self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
 
-        optimizer_main_grad = self.main_grad
         if is_last_microbatch and self.pre_optimizer_main_grad is not self.main_grad:
             # Finalize the deferred DP-outer reduction (all-reduce for HSDP,
             # reduce-scatter for HFSDP) into the persistent buffer's optimizer-layout
             # view before binding the sharded parameter grads.
-            assert self.pre_optimizer_main_grad is not None
-            optimizer_main_grad = self.main_grad.redistribute(
+            self.main_grad.redistribute(
                 self.main_weight.placements, out=self.pre_optimizer_main_grad
             )
             self._main_grad_is_stale = True
-
-        # Make each sharded parameter's .grad consistent with the final main_grad.
-        for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            fsdp_parameter.sharded.grad = optimizer_main_grad.get_dtensor(index)
+            install_sharded_grads(self.pre_optimizer_main_grad)
+        else:
+            # We could install pre_optimizer_main_grad unconditionally, but before
+            # finalization it lacks the deferred DP-outer reduction and is not a valid
+            # optimizer gradient.
+            install_sharded_grads(self.main_grad)
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -380,10 +380,6 @@ class FsdpParameterGroup:
         assert self.main_grad is not None
         assert self.pre_optimizer_main_grad is not None
 
-        def install_sharded_grads(grad: DBuffer) -> None:
-            for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-                fsdp_parameter.sharded.grad = grad.get_dtensor(index)
-
         # zero_grad(set_to_none=True) clears sharded parameter grads, so this
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
@@ -414,6 +410,10 @@ class FsdpParameterGroup:
                 self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
             else:
                 self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+
+        def install_sharded_grads(main_grad: DBuffer) -> None:
+            for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+                fsdp_parameter.sharded.grad = main_grad.get_dtensor(index)
 
         if is_last_microbatch and self.pre_optimizer_main_grad is not self.main_grad:
             # Finalize the deferred DP-outer reduction (all-reduce for HSDP,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -425,9 +425,9 @@ class FsdpParameterGroup:
             self._main_grad_is_stale = True
             install_sharded_grads(self.pre_optimizer_main_grad)
         else:
-            # We could install pre_optimizer_main_grad unconditionally, but before
-            # finalization it lacks the deferred DP-outer reduction and is not a valid
-            # optimizer gradient.
+            # We could install pre_optimizer_main_grad unconditionally because
+            # sharded.grad is only read by the optimizer. However, for consistency and
+            # debugging, keep sharded.grad valid even between microbatches.
             install_sharded_grads(self.main_grad)
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -89,8 +89,8 @@ class FsdpParameterGroup:
     main_grad: DBuffer | None
     # Optimizer-layout view into main_grad storage, avoiding a second allocation.
     pre_optimizer_main_grad: DBuffer | None
-    # HFSDP finalization writes only a smaller optimizer view. After
-    # zero_grad(set_to_none=False) clears that view, the remaining main_grad
+    # zero_grad(set_to_none=False) clears only the current optimizer view. If final
+    # reduction created a smaller view (e.g. ZeRO-1 or HFSDP), the remaining main_grad
     # storage is stale and must be cleared before the next accumulation begins.
     _main_grad_is_stale: bool
     _unsharded_model_weight: DBuffer

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,7 +28,6 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -88,6 +87,11 @@ class FsdpParameterGroup:
     # view; the remaining model_weight slices must be all-gathered before compute.
     _model_weight_is_stale: bool
     main_grad: DBuffer | None
+    # Optimizer-layout view into main_grad storage, avoiding a second allocation.
+    pre_optimizer_main_grad: DBuffer | None
+    # HFSDP finalization writes a smaller optimizer view, leaving the rest of
+    # main_grad untouched until the next accumulation begins.
+    _main_grad_has_smaller_optimizer_view: bool
     _unsharded_model_weight: DBuffer
     _symm_mem_pool: torch.cuda.MemPool | None
     grad_divisor: int
@@ -101,7 +105,6 @@ class FsdpParameterGroup:
         main_grad_placements: tuple[Placement, ...],
         main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
-        reduce_scatter_stream: torch.cuda.Stream,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
     ) -> None:
@@ -115,7 +118,6 @@ class FsdpParameterGroup:
             main_grad_placements: Main-gradient buffer placements.
             main_weight_placements: Main-weight buffer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
-            reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
             use_symmetric_memory: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
             grad_divisor: Additional divisor applied on top of the mesh-size
@@ -129,10 +131,6 @@ class FsdpParameterGroup:
         parameter_to_fqns: dict[nn.Parameter, list[str]] = {}
         for fqn, parameter in parameters.items():
             parameter_to_fqns.setdefault(parameter, []).append(fqn)
-
-        # main_grad rests here (DP-outer-Partial for HSDP) between microbatches and
-        # is finalized to main_weight's placements after the last microbatch.
-        self._main_grad_placements = main_grad_placements
 
         # Python dicts preserve insertion order, so parameter_to_fqns and
         # fsdp_parameters define the same stable DBuffer tensor order.
@@ -201,6 +199,8 @@ class FsdpParameterGroup:
             )
 
         self.main_grad = None
+        self.pre_optimizer_main_grad = None
+        self._main_grad_has_smaller_optimizer_view = False
         if self.requires_grad:
             grad_dtype = mixed_precision_policy.main_grads_dtype or self.dtype
             # Keep main_grad persistent for the initial implementation. For micro-batch
@@ -208,7 +208,10 @@ class FsdpParameterGroup:
             # eagerly deallocated right after optimizer.step(), avoiding main_grad
             # storage during forward. That requires a separate lifetime contract with
             # the optimizer, so this version keeps the simpler persistent buffer.
-            with torch.cuda.stream(reduce_scatter_stream):
+            # This persistent buffer is allocated on the default stream rather than the
+            # reduce-scatter stream. The latter is reserved for transient communication
+            # buffers and CUDA graph replay can otherwise observe a stream-local allocation.
+            with torch.cuda.stream(torch.cuda.default_stream(self.main_weight.device)):
                 self.main_grad = DBuffer(
                     mesh=self.mesh,
                     placements=main_grad_placements,
@@ -216,6 +219,7 @@ class FsdpParameterGroup:
                     dtype=grad_dtype,
                     device=self.main_weight.device,
                 )
+            self.pre_optimizer_main_grad = self.main_grad.view(main_weight_placements)
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "
                 "and DBuffer layouts are deterministic from those shapes and mesh size."
@@ -381,38 +385,13 @@ class FsdpParameterGroup:
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
         has_sharded_grads = self._has_sharded_grads()
-
-        # A non-accumulation main_grad means the previous step finalized it; this
-        # only happens on the first microbatch. Restore it to the DP-outer-Partial
-        # accumulation placement. HSDP's finalize keeps the buffer size (Replicate
-        # on DP-outer), so relabel it in place; HFSDP's finalize reduce-scattered
-        # DP-outer to a smaller optimizer-sharded buffer, so allocate a fresh one
-        # (zeroed only when we accumulate into it, i.e. sharded grads are still set).
-        if self.main_grad.placements != self._main_grad_placements:
-            assert self.main_grad.allocation_stream == (
-                torch.cuda.current_stream(self.main_grad.device)
-            )
-            reset_axis = changed_mesh_axis(self.main_grad.placements, self._main_grad_placements)
-            assert reset_axis is not None  # the placements differ, so an axis changed
-            if isinstance(self.main_grad.placements[reset_axis], Replicate):
-                # HSDP: Replicate -> Partial changes only metadata and reuses the tensor.
-                self.main_grad = self.main_grad.redistribute(self._main_grad_placements)
-            else:
-                # HFSDP: main_grad was reduce-scattered to the optimizer shard, too small
-                # to hold the accumulation, so re-allocate. This runs inside the
-                # reduce_scatter stream context (see FsdpModule._reduce_gradient_groups),
-                # so the buffer is allocated on that stream and stays race-safe. Zero it
-                # only when we accumulate (set_to_none=False); with set_to_none=True the
-                # reduction below overwrites it via out=.
-                self.main_grad = DBuffer(
-                    mesh=self.mesh,
-                    placements=self._main_grad_placements,
-                    tensor_shapes=self.main_weight.layout.tensor_shapes,
-                    dtype=self.main_grad.dtype,
-                    device=self.main_weight.device,
-                )
-                if has_sharded_grads:
-                    self.main_grad.local_buffer.zero_()
+        if self._main_grad_has_smaller_optimizer_view:
+            # In HFSDP, zero_grad(set_to_none=False) only zeros the smaller optimizer
+            # view. Clear the persistent full accumulation buffer before this new step;
+            # set_to_none=True needs no clear because out= below overwrites it.
+            if has_sharded_grads:
+                self.main_grad.local_buffer.zero_()
+            self._main_grad_has_smaller_optimizer_view = False
 
         if can_reduce_into_main_grad := (
             not has_sharded_grads and partial_grad.dtype == self.main_grad.dtype
@@ -433,17 +412,22 @@ class FsdpParameterGroup:
             else:
                 self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
 
-        if is_last_microbatch:
+        optimizer_main_grad = self.main_grad
+        if is_last_microbatch and self.pre_optimizer_main_grad is not self.main_grad:
             # Finalize the deferred DP-outer reduction (all-reduce for HSDP,
-            # reduce-scatter for HFSDP) before binding the sharded parameter grads.
-            assert self.main_grad.allocation_stream == (
-                torch.cuda.current_stream(self.main_grad.device)
+            # reduce-scatter for HFSDP) into the persistent buffer's optimizer-layout
+            # view before binding the sharded parameter grads.
+            assert self.pre_optimizer_main_grad is not None
+            optimizer_main_grad = self.main_grad.redistribute(
+                self.main_weight.placements, out=self.pre_optimizer_main_grad
             )
-            self.main_grad = self.main_grad.redistribute(self.main_weight.placements)
+            self._main_grad_has_smaller_optimizer_view = (
+                optimizer_main_grad.local_buffer.numel() < self.main_grad.local_buffer.numel()
+            )
 
         # Make each sharded parameter's .grad consistent with the final main_grad.
         for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            fsdp_parameter.sharded.grad = self.main_grad.get_dtensor(index)
+            fsdp_parameter.sharded.grad = optimizer_main_grad.get_dtensor(index)
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -232,11 +232,7 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(
-        local_buffer,
-        mesh,
-        iter([Flat()]),
-        replicated_buffer.layout.tensor_shapes,
-        allocation_stream=replicated_buffer.allocation_stream,
+        local_buffer, mesh, [Flat()], replicated_buffer.layout.tensor_shapes
     )
 
     assert sharded_buffer.placements == (Flat(),)
@@ -392,10 +388,7 @@ def test_partial_allreduce(distributed_setup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
-    assert (
-        replicated_buffer.local_buffer.untyped_storage().data_ptr()
-        == partial_buffer.local_buffer.untyped_storage().data_ptr()
-    )
+    assert replicated_buffer.local_buffer.data_ptr() == partial_buffer.local_buffer.data_ptr()
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
@@ -446,8 +439,8 @@ def test_partial_reduce_scatter_to_flat(distributed_setup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert (
-        sharded_buffer.local_buffer.untyped_storage().data_ptr()
-        == partial_buffer.local_buffer.untyped_storage().data_ptr()
+        sharded_buffer.local_buffer.untyped_storage()
+        is partial_buffer.local_buffer.untyped_storage()
     )
     assert replicated_buffer.layout == layout
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -393,8 +393,8 @@ def test_partial_allreduce(distributed_setup):
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
     assert (
-        replicated_buffer.local_buffer.untyped_storage()
-        is partial_buffer.local_buffer.untyped_storage()
+        replicated_buffer.local_buffer.untyped_storage().data_ptr()
+        == partial_buffer.local_buffer.untyped_storage().data_ptr()
     )
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
@@ -446,8 +446,8 @@ def test_partial_reduce_scatter_to_flat(distributed_setup):
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
     assert (
-        sharded_buffer.local_buffer.untyped_storage()
-        is partial_buffer.local_buffer.untyped_storage()
+        sharded_buffer.local_buffer.untyped_storage().data_ptr()
+        == partial_buffer.local_buffer.untyped_storage().data_ptr()
     )
     assert replicated_buffer.layout == layout
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -256,7 +256,7 @@ def test_view_rejects_non_aliasing_placement_change(distributed_setup):
         _same_tensors_on_all_ranks(distributed_setup.device), mesh, [Flat()]
     )
 
-    with pytest.raises(ValueError, match="Replicate-to-Flat slice"):
+    with pytest.raises(ValueError, match="DBuffer.view"):
         buffer.view([Replicate()])
 
 
@@ -384,13 +384,18 @@ def test_partial_allreduce(distributed_setup):
     ]
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
 
-    replicated_buffer = partial_buffer.allreduce(0)
+    replicated_buffer = partial_buffer.view([Replicate()])
+    partial_buffer.allreduce(0, out=replicated_buffer)
 
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected = [
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
+    assert (
+        replicated_buffer.local_buffer.untyped_storage()
+        is partial_buffer.local_buffer.untyped_storage()
+    )
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
@@ -433,19 +438,17 @@ def test_partial_reduce_scatter_to_flat(distributed_setup):
     partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial()])
     layout = partial_buffer.layout
 
-    destination = DBuffer(
-        mesh=mesh,
-        placements=[Flat()],
-        tensor_shapes=partial_buffer.layout.tensor_shapes,
-        dtype=partial_buffer.dtype,
-        device=partial_buffer.local_buffer.device,
-    )
+    destination = partial_buffer.view([Flat()])
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat(), out=destination)
     replicated_buffer = sharded_buffer.allgather(0)
 
     assert sharded_buffer is destination
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
+    assert (
+        sharded_buffer.local_buffer.untyped_storage()
+        is partial_buffer.local_buffer.untyped_storage()
+    )
     assert replicated_buffer.layout == layout
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected_tensors = [

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -249,7 +249,7 @@ def test_fully_shard_sgd_losses_match_baseline(
     )
 
 
-def test_zero1_main_grad_reuses_default_stream_storage(distributed_setup):
+def test_zero1_main_grad_reuses_storage(distributed_setup):
     """ZeRO-1 keeps its main-gradient allocation and optimizer view across backwards."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -258,18 +258,15 @@ def test_zero1_main_grad_reuses_default_stream_storage(distributed_setup):
 
     mesh = init_device_mesh(device.type, (world_size,))
     model = TinyModel().to(device)
-    construction_stream = torch.cuda.Stream(device)
-    with torch.cuda.stream(construction_stream):
-        with fully_shard_context(device=device):
-            fully_shard(model.fc1, mesh=mesh, placements=_zero1_placements())
-            fully_shard(model.fc2, mesh=mesh, placements=_zero1_placements())
+    with fully_shard_context(device=device):
+        fully_shard(model.fc1, mesh=mesh, placements=_zero1_placements())
+        fully_shard(model.fc2, mesh=mesh, placements=_zero1_placements())
 
     (parameter_group,) = model.fc1.parameter_groups
     main_grad = parameter_group.main_grad
     pre_optimizer_main_grad = parameter_group.pre_optimizer_main_grad
     assert main_grad is not None
     assert pre_optimizer_main_grad is not None
-    assert main_grad.allocation_stream == torch.cuda.default_stream(device)
     assert pre_optimizer_main_grad.placements == (Flat(),)
     assert (
         pre_optimizer_main_grad.local_buffer.untyped_storage()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -21,6 +21,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     microbatch,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import Flat
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_event_groups
 
@@ -248,6 +249,40 @@ def test_fully_shard_sgd_losses_match_baseline(
     )
 
 
+def test_zero1_main_grad_reuses_default_stream_storage(distributed_setup):
+    """ZeRO-1 keeps its main-gradient allocation and optimizer view across backwards."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = TinyModel().to(device)
+    construction_stream = torch.cuda.Stream(device)
+    with torch.cuda.stream(construction_stream):
+        with fully_shard_context(device=device):
+            fully_shard(model.fc1, mesh=mesh, placements=_zero1_placements())
+            fully_shard(model.fc2, mesh=mesh, placements=_zero1_placements())
+
+    (parameter_group,) = model.fc1.parameter_groups
+    main_grad = parameter_group.main_grad
+    pre_optimizer_main_grad = parameter_group.pre_optimizer_main_grad
+    assert main_grad is not None
+    assert pre_optimizer_main_grad is not None
+    assert main_grad.allocation_stream == torch.cuda.default_stream(device)
+    assert pre_optimizer_main_grad.placements == (Flat(),)
+    assert (
+        pre_optimizer_main_grad.local_buffer.untyped_storage()
+        is main_grad.local_buffer.untyped_storage()
+    )
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    for _ in range(2):
+        optimizer.zero_grad(set_to_none=True)
+        model(torch.randn(2, 8, device=device)).sum().backward()
+        assert parameter_group.main_grad is main_grad
+
+
 @pytest.mark.parametrize("use_reentrant", [False, True], ids=["non_reentrant", "reentrant"])
 def test_fully_shard_activation_recompute_reshards_parameters(distributed_setup, use_reentrant):
     """Activation recomputation should leave every FSDP module resharded.
@@ -372,10 +407,11 @@ def test_hfsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to
     Like HSDP, gradients reduce-scatter within DP-inner every backward and
     accumulate into main_grad. Unlike HSDP, the last-microbatch DP-outer reduction
     is a reduce-scatter (not an all-reduce) that finalizes main_grad to the
-    optimizer's [Shard(0), Shard(0)] placement, shrinking the buffer; the next step's reset
-    therefore allocates a fresh [Partial, Shard(0)] accumulation buffer. Every rank
-    sees identical data, so the averaged gradient equals the single-rank gradient
-    and losses must match. Both ``zero_grad`` modes are covered.
+    optimizer's [Shard(0), Shard(0)] placement. The optimizer layout is a view into
+    persistent [Partial, Shard(0)] accumulation storage, which is cleared before the
+    next ``zero_grad(set_to_none=False)`` accumulation. Every rank sees identical data,
+    so the averaged gradient equals the single-rank gradient and losses must match.
+    Both ``zero_grad`` modes are covered.
     """
     rank = distributed_setup.rank
     world_size = distributed_setup.world_size
@@ -729,7 +765,7 @@ def test_rejects_optimizer_placements_larger_than_model_weight_placements(distri
     placements = Placements(
         dp_axes=[0], parameter=[Shard(0)], gradient=[Shard(0)], optimizer=[Replicate()]
     )
-    with pytest.raises(ValueError, match="Replicate-to-Flat slice"):
+    with pytest.raises(ValueError, match="DBuffer.view"):
         with fully_shard_context(device=device):
             fully_shard(
                 model,

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -21,7 +21,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     microbatch,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import Flat
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import collect_linked_event_groups
 
@@ -249,37 +248,6 @@ def test_fully_shard_sgd_losses_match_baseline(
     )
 
 
-def test_zero1_main_grad_reuses_storage(distributed_setup):
-    """ZeRO-1 keeps its main-gradient allocation and optimizer view across backwards."""
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    model = TinyModel().to(device)
-    with fully_shard_context(device=device):
-        fully_shard(model.fc1, mesh=mesh, placements=_zero1_placements())
-        fully_shard(model.fc2, mesh=mesh, placements=_zero1_placements())
-
-    (parameter_group,) = model.fc1.parameter_groups
-    main_grad = parameter_group.main_grad
-    pre_optimizer_main_grad = parameter_group.pre_optimizer_main_grad
-    assert main_grad is not None
-    assert pre_optimizer_main_grad is not None
-    assert pre_optimizer_main_grad.placements == (Flat(),)
-    assert (
-        pre_optimizer_main_grad.local_buffer.untyped_storage()
-        is main_grad.local_buffer.untyped_storage()
-    )
-
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
-    for _ in range(2):
-        optimizer.zero_grad(set_to_none=True)
-        model(torch.randn(2, 8, device=device)).sum().backward()
-        assert parameter_group.main_grad is main_grad
-
-
 @pytest.mark.parametrize("use_reentrant", [False, True], ids=["non_reentrant", "reentrant"])
 def test_fully_shard_activation_recompute_reshards_parameters(distributed_setup, use_reentrant):
     """Activation recomputation should leave every FSDP module resharded.
@@ -399,17 +367,7 @@ def test_hsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to_
 @pytest.mark.parametrize("set_to_none", [True, False])
 @pytest.mark.parametrize("num_microbatches", [1, 3])
 def test_hfsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to_none):
-    """HFSDP (optimizer sharded across DP-outer too) training should match single-rank SGD.
-
-    Like HSDP, gradients reduce-scatter within DP-inner every backward and
-    accumulate into main_grad. Unlike HSDP, the last-microbatch DP-outer reduction
-    is a reduce-scatter (not an all-reduce) that finalizes main_grad to the
-    optimizer's [Shard(0), Shard(0)] placement. The optimizer layout is a view into
-    persistent [Partial, Shard(0)] accumulation storage, which is cleared before the
-    next ``zero_grad(set_to_none=False)`` accumulation. Every rank sees identical data,
-    so the averaged gradient equals the single-rank gradient and losses must match.
-    Both ``zero_grad`` modes are covered.
-    """
+    """HFSDP (optimizer sharded across DP-outer too) training should match single-rank SGD."""
     rank = distributed_setup.rank
     world_size = distributed_setup.world_size
     device = distributed_setup.device


### PR DESCRIPTION
## Summary
- allocate persistent `main_grad` storage on the default stream
- expose `pre_optimizer_main_grad` as its optimizer-layout view
- preserve correct accumulation when the optimizer view is smaller

Depends on #6962.
Related to #6152.

## Validation
- `isort --check`, Black, and Ruff on changed files
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py` (50 passed, 12 skipped)