### PR TITLE
Remove obsolete FusedAdam empty parameter workaround

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -1124,18 +1124,6 @@ def get_megatron_optimizer(
                 param_groups = _get_param_groups(
                     model_chunk, config, config_overrides, param_group_process_group
                 )
-                # TE FusedAdam can skip pending updates when a group ends in an empty tensor:
-                # https://github.com/NVIDIA/TransformerEngine/issues/3207.
-                # Empty local shards have no optimizer state or data to update, so omit them.
-                for param_group in param_groups:
-                    param_group['params'] = [
-                        parameter
-                        for parameter in param_group['params']
-                        if parameter.to_local().numel() > 0
-                    ]
-                param_groups = [
-                    param_group for param_group in param_groups if param_group['params']
-                ]
                 # MFSDP v2 owns its sharded parameter and gradient storage, so
                 # FullyShardedOptimizer does not need DDP param-and-grad buffers.
                 buffers = None


### PR DESCRIPTION
## What

Remove MFSDP v2 parameter-group filtering for empty local tensors.

## Why

Transformer Engine #3212 fixed #3207, and Megatron-LM’s pinned Transformer Engine revision contains that fix. FusedAdam now treats empty local parameters as no-op updates without skipping earlier parameters in the group.

## Testing

- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`