### PR TITLE
[dev](feat): Support mHC recompute attention split capture range with THD format.

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1309,9 +1309,12 @@ class TransformerConfig(ModelParallelConfig):
 
     This buys the aggregate checkpoint's activation back -- one ``[s, b, C]`` per layer in the
     recompute group -- at the cost of a smaller captured region. The rest of the mHC recompute
-    group is outside the attention graph either way and is unaffected. The split additionally
-    constrains the configuration (see ``__post_init__``), which is why it is opt-in rather than
-    implied by ``recompute_modules=[mhc]``.
+    group is outside the attention graph either way and is unaffected. Static packed THD inputs,
+    including fixed context-parallel groups, are supported. Dynamic CP is not: its per-batch local
+    token count and process group cannot be represented by a graph with fixed tensor shapes and
+    collective topology. The split additionally constrains the configuration (see
+    ``__post_init__``), which is why it is opt-in rather than implied by
+    ``recompute_modules=[mhc]``.
     """
 
     ####################
@@ -3266,9 +3269,7 @@ class TransformerConfig(ModelParallelConfig):
                 "checkpoint is not recovered and the static graph input is "
                 "[s, b, n*C]. Set mhc_recompute_attn_cuda_graph_split=True for the "
                 "attention-only split, which keeps the producer eager and shrinks "
-                "the captured input to [s, b, C]. (The split's replay does not yet "
-                "forward THD captured kwargs; on packed sequences keep the switch "
-                "off.)",
+                "the captured input to [s, b, C].",
                 UserWarning,
                 stacklevel=2,
             )
@@ -3316,14 +3317,15 @@ class TransformerConfig(ModelParallelConfig):
                     "mhc_recompute_attn_cuda_graph_split to capture the whole attention "
                     "range instead."
                 )
-            if self.sequence_packing_scheduler is not None:
+            if (
+                self.dynamic_context_parallel
+                or self.sequence_packing_scheduler == "default_dynamic_cp"
+            ):
                 raise ValueError(
-                    "mhc_recompute_attn_cuda_graph_split does not support packed "
-                    "(THD) sequences: THD capture takes cu_seqlens_*/padding_mask "
-                    "as captured kwargs and the split's replay does not forward "
-                    "them, so the first replay fails at the Transformer Engine "
-                    "boundary. Keep the switch off on packed-sequence runs to "
-                    "capture the whole attention range instead."
+                    "mhc_recompute_attn_cuda_graph_split does not support Dynamic CP: "
+                    "local_cp_size and cp_group can vary between batches, while a "
+                    "Transformer Engine CUDA Graph captures fixed tensor shapes and "
+                    "collective topology. Static packed THD with fixed CP is supported."
                 )
             if self.fine_grained_activation_offloading:
                 # HyperConnectionTransformerLayer._te_cuda_graph_capture replaces

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -51,6 +51,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Tensor-only projection of ``PackedSeqParams`` used at the TE CUDA Graph boundary.
+# Keep capture/replay consumers on one field list so a newly supported THD path cannot
+# silently omit one of the captured keyword arguments.
+_THD_CUDA_GRAPH_TENSOR_KWARGS = (
+    "cu_seqlens_q",
+    "cu_seqlens_kv",
+    "cu_seqlens_q_padded",
+    "cu_seqlens_kv_padded",
+)
+
 
 @functools.lru_cache(maxsize=None)
 def _get_offloading_interface():
@@ -1294,10 +1304,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 cu_seqlens = torch.zeros(max_num_seqs + 1, dtype=torch.int32, device=device)
                 cu_seqlens[1:] = max_T
 
-                static_inputs["cu_seqlens_q"] = cu_seqlens
-                static_inputs["cu_seqlens_kv"] = cu_seqlens.clone()
-                static_inputs["cu_seqlens_q_padded"] = cu_seqlens.clone()
-                static_inputs["cu_seqlens_kv_padded"] = cu_seqlens.clone()
+                static_inputs[_THD_CUDA_GRAPH_TENSOR_KWARGS[0]] = cu_seqlens
+                for name in _THD_CUDA_GRAPH_TENSOR_KWARGS[1:]:
+                    static_inputs[name] = cu_seqlens.clone()
 
             slen_for_mask = self.config.max_seqlen_per_dp_cp_rank
             if self.config.sequence_parallel:
@@ -1388,10 +1397,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         packed_seq_params = kwargs.pop('packed_seq_params', None)
         if packed_seq_params is None:
             return
-        kwargs['cu_seqlens_q'] = packed_seq_params.cu_seqlens_q
-        kwargs['cu_seqlens_kv'] = packed_seq_params.cu_seqlens_kv
-        kwargs['cu_seqlens_q_padded'] = packed_seq_params.cu_seqlens_q_padded
-        kwargs['cu_seqlens_kv_padded'] = packed_seq_params.cu_seqlens_kv_padded
+        for name in _THD_CUDA_GRAPH_TENSOR_KWARGS:
+            kwargs[name] = getattr(packed_seq_params, name)
 
     def _reconstruct_packed_seq_params_from_kwargs(self, kwargs):
         """Reconstruct PackedSeqParams from individual tensor kwargs (CUDA graph path).
@@ -1406,13 +1413,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         if 'cu_seqlens_q' not in kwargs:
             return
         max_seqlen = self.config.max_seqlen_per_dp_cp_rank * self.config.context_parallel_size
+        packed_seq_tensor_kwargs = {
+            name: kwargs.pop(name) for name in _THD_CUDA_GRAPH_TENSOR_KWARGS
+        }
         packed_seq_params = PackedSeqParams(
             qkv_format='thd',
             cp_partition_mode=self.config.cp_partition_mode,
-            cu_seqlens_q=kwargs.pop('cu_seqlens_q'),
-            cu_seqlens_kv=kwargs.pop('cu_seqlens_kv'),
-            cu_seqlens_q_padded=kwargs.pop('cu_seqlens_q_padded'),
-            cu_seqlens_kv_padded=kwargs.pop('cu_seqlens_kv_padded'),
+            **packed_seq_tensor_kwargs,
             max_seqlen_q=max_seqlen,
             max_seqlen_kv=max_seqlen,
             # CUDA graph inputs do not carry this Python bool. Sequence-packing
@@ -2145,15 +2152,18 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             return super()._te_cuda_graph_capture(*args, **kwargs)
 
         self._reconstruct_packed_seq_params_from_kwargs(kwargs)
-        # Backstop for packed inputs the config gate cannot see (the gate keys
-        # on sequence_packing_scheduler): fail with a clear message instead of
-        # the TE TypeError a replay with missing captured kwargs would raise.
-        if kwargs.get("packed_seq_params") is not None:
+        # Dynamic CP may replace both the local token count and process group per
+        # batch. A per-layer TE graph has tensor-only inputs and captures fixed
+        # collective topology, so it cannot represent those runtime changes.
+        if (
+            self.config.dynamic_context_parallel
+            or self.config.sequence_packing_scheduler == "default_dynamic_cp"
+        ):
             raise NotImplementedError(
-                "mhc_recompute_attn_cuda_graph_split does not support packed "
-                "(THD) sequences: the split's replay does not forward the THD "
-                "captured kwargs (cu_seqlens_*, padding_mask). Disable the "
-                "switch to capture the whole attention range instead."
+                "mhc_recompute_attn_cuda_graph_split does not support Dynamic CP: "
+                "local_cp_size and cp_group can vary between batches, while a "
+                "Transformer Engine CUDA Graph captures fixed tensor shapes and "
+                "collective topology."
             )
         return self._forward_mhc_attention_cuda_graph_consumer(*args, **kwargs)
 
@@ -2561,6 +2571,19 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             value = kwargs.get(name)
             if value is not None:
                 graph_kwargs[name] = value
+
+        # The public TransformerLayer replay entry point has already decomposed
+        # PackedSeqParams by the time it dispatches here. Preserve the exact THD
+        # keyword set captured by TE, including padding_mask (and input_ids on
+        # hash-routed MoE layers), even though the attention consumer itself does
+        # not inspect every tensor.
+        captured_exact_kwargs = (*_THD_CUDA_GRAPH_TENSOR_KWARGS, "padding_mask", "input_ids")
+        for name in captured_exact_kwargs:
+            if name in kwargs:
+                graph_kwargs[name] = kwargs[name]
+
+        # Retain compatibility with direct callers that enter the split replay
+        # with an object rather than through TransformerLayer._te_cuda_graph_replay.
         if kwargs.get("packed_seq_params") is not None:
             graph_kwargs["packed_seq_params"] = kwargs["packed_seq_params"]
             self._decompose_packed_seq_params_to_kwargs(graph_kwargs)

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -2176,6 +2176,19 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             )
         return self._forward_mhc_attention_cuda_graph_consumer(*args, **kwargs)
 
+    def _te_cuda_graph_replay(self, *args, **kwargs):
+        """Reject runtime Dynamic-CP metadata before the split replay decomposes it."""
+        if self._uses_mhc_recompute_attn_cuda_graph_split():
+            packed_seq_params = kwargs.get("packed_seq_params")
+            if packed_seq_params is not None and packed_seq_params.local_cp_size is not None:
+                raise NotImplementedError(
+                    "mhc_recompute_attn_cuda_graph_split does not support Dynamic CP: "
+                    "PackedSeqParams.local_cp_size selects per-batch CP geometry, which "
+                    "cannot be replayed by a Transformer Engine CUDA Graph with fixed "
+                    "tensor shapes and collective topology."
+                )
+        return super()._te_cuda_graph_replay(*args, **kwargs)
+
     def _forward_mhc_attention_post_cuda_graph(
         self,
         attention_output_with_bias,

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1505,6 +1505,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         For THD format, PackedSeqParams is decomposed into individual tensor kwargs.
         """
         context = None
+        # Keep the Python metadata object for any eager continuation after a
+        # partial graph. The graph boundary still receives only its decomposed
+        # tensor fields; in particular, tokens_per_sample is needed to restore
+        # the batch dimension before an eager MoE tail.
+        packed_seq_params = kwargs.get("packed_seq_params")
         padding_mask = kwargs.get("padding_mask", None)
         if (
             self.config.cuda_graph_modules
@@ -1533,7 +1538,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             self.off_interface.enter_replay()
 
         try:
-            return self._te_cuda_graph_replay_impl(args, kwargs, context)
+            return self._te_cuda_graph_replay_impl(
+                args, kwargs, context, packed_seq_params=packed_seq_params
+            )
         finally:
             if self.config.delay_offload_until_cuda_graph:
                 self.off_interface.exit_replay()
@@ -1590,7 +1597,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         nvtx_range_pop(suffix="mlp")
         return mlp_output_with_bias
 
-    def _te_cuda_graph_replay_impl(self, args, kwargs, context):
+    def _te_cuda_graph_replay_impl(
+        self, args, kwargs, context, packed_seq_params: Optional[PackedSeqParams] = None
+    ):
         """Implementation of _te_cuda_graph_replay, separated for replay mode cleanup."""
         cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
 
@@ -1704,7 +1713,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 hidden_states,
                 padding_mask=kwargs.get("padding_mask", None),
                 input_ids=kwargs.get("input_ids", None),
-                packed_seq_params=kwargs.get("packed_seq_params", None),
+                packed_seq_params=packed_seq_params,
             )
         return output, context
 
@@ -2627,17 +2636,23 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         )
         return hidden_states, context, mhc_recompute_manager, kwargs
 
-    def _te_cuda_graph_replay_mhc_attention_split(self, args, kwargs, context):
+    def _te_cuda_graph_replay_mhc_attention_split(
+        self, args, kwargs, context, packed_seq_params: Optional[PackedSeqParams] = None
+    ):
         """Replay captured attention between eager mHC pre/post operations."""
         hidden_states, context, mhc_recompute_manager, kwargs = self._replay_mhc_attention_consumer(
             args, kwargs, context
         )
+        if packed_seq_params is None:
+            # Preserve compatibility with tests or integrations that call the
+            # split implementation directly instead of the public replay entry.
+            packed_seq_params = kwargs.get("packed_seq_params")
         output = self._forward_mlp(
             hidden_states,
             inference_context=kwargs.get("inference_context"),
             padding_mask=kwargs.get("padding_mask"),
             input_ids=kwargs.get("input_ids"),
-            packed_seq_params=kwargs.get("packed_seq_params"),
+            packed_seq_params=packed_seq_params,
             mhc_recompute_manager=mhc_recompute_manager,
         )
         return output, context
@@ -2706,7 +2721,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         local_tokens, probs = self.mlp.preprocess(pre_mlp_layernorm_output, probs, routing_map)
         return (residual, local_tokens, probs, shared_expert_output, mlp_h_res, mlp_hc_h_post)
 
-    def _te_cuda_graph_replay_impl(self, args, kwargs, context):
+    def _te_cuda_graph_replay_impl(
+        self, args, kwargs, context, packed_seq_params: Optional[PackedSeqParams] = None
+    ):
         """Implementation of _te_cuda_graph_replay with hyper connection support.
 
         Overrides the parent's _te_cuda_graph_replay_impl so that the
@@ -2720,7 +2737,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         if self._uses_mhc_recompute_attn_cuda_graph_split():
             if self.config.overlap_moe_expert_parallel_comm:
                 return self._te_cuda_graph_replay_mhc_attention_split_overlap(args, kwargs, context)
-            return self._te_cuda_graph_replay_mhc_attention_split(args, kwargs, context)
+            return self._te_cuda_graph_replay_mhc_attention_split(
+                args, kwargs, context, packed_seq_params=packed_seq_params
+            )
 
         # Read, do not pop: on THD, padding_mask IS a capture-time kwarg
         # (get_layer_static_inputs adds it whenever _is_thd_cuda_graph()), and
@@ -2882,7 +2901,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 *cuda_graph_output,
                 padding_mask=padding_mask,
                 input_ids=kwargs.get("input_ids", None),
-                packed_seq_params=kwargs.get("packed_seq_params", None),
+                packed_seq_params=packed_seq_params,
                 mhc_recompute_manager=getattr(self, '_mhc_recompute_manager', None),
             )
         return output, context

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_cp.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_attention_cp.py
@@ -64,7 +64,7 @@ _DSV4_CP_TEST_VARIANT = "flash"
 # Keep every segment at least as long as the smallest compression ratio (4).
 # The cuDNN dense-indexer backward kernel does not yet support a THD segment
 # with Q rows but no compressed K rows. Padded total remains 4096, divisible
-# by CP2/CP4, and only the final segment has tail padding.
+# by CP2/CP4/CP8, and only the final segment has tail padding.
 _DSV4_CP_RAGGED_SEG_LENS = (5, 127, 1000, 23, 129, 900, 55, 257, 800, 95, 509, 148)
 _DSV4_CP_RAGGED_PADDED_SEG_LENS = (5, 127, 1000, 23, 129, 900, 55, 257, 800, 95, 509, 196)
 # Same shape, padded total, and max padded sequence length as
@@ -457,6 +457,102 @@ def _clear_cuda_test_state():
     gc.collect()
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
+
+
+def _run_thd_cp_cuda_graph_metadata_replay_case(
+    *, cp_size, cp_rank, pg, layer_number, fused_kernels_available
+):
+    """Check CUDA graph replay after changing same-shape THD metadata tensors."""
+    if not fused_kernels_available:
+        pytest.skip(_DSV4_CP_FUSED_KERNELS_UNAVAILABLE_REASON)
+
+    capture_packed = _make_thd_packed_seq_params(
+        _DSV4_CP_RAGGED_SEG_LENS, _DSV4_CP_RAGGED_PADDED_SEG_LENS
+    )
+    replay_packed = _make_thd_packed_seq_params(
+        _DSV4_CP_RAGGED_SEG_LENS, _DSV4_CP_REPLAY_PADDED_SEG_LENS
+    )
+    padded_tokens = sum(_DSV4_CP_RAGGED_PADDED_SEG_LENS)
+    assert padded_tokens == sum(_DSV4_CP_REPLAY_PADDED_SEG_LENS)
+    assert capture_packed.cu_seqlens_q.shape == replay_packed.cu_seqlens_q.shape
+    assert capture_packed.cu_seqlens_q_padded.shape == replay_packed.cu_seqlens_q_padded.shape
+    assert capture_packed.max_seqlen_q == replay_packed.max_seqlen_q
+    assert capture_packed.max_seqlen_kv == replay_packed.max_seqlen_kv
+    assert not torch.equal(capture_packed.cu_seqlens_q_padded, replay_packed.cu_seqlens_q_padded)
+    local_rows = padded_tokens // cp_size
+    local_idx = torch.arange(cp_rank * local_rows, (cp_rank + 1) * local_rows, device='cuda')
+
+    torch.manual_seed(_SEED + 1100 + layer_number)
+    model_parallel_cuda_manual_seed(_SEED + 1100 + layer_number)
+    config = _make_dsv4_cp_config(
+        context_parallel_size=cp_size,
+        dsa_indexer_loss_coeff=1.0,
+        dsa_indexer_use_sparse_loss=True,
+        use_fused_kernels=True,
+        apply_rope_fusion=True,
+    )
+    graph_attn = _build_attention(config, layer_number=layer_number, pg_collection=pg).cuda()
+    eager_attn = _build_attention(config, layer_number=layer_number, pg_collection=pg).cuda()
+    graph_attn.train()
+    eager_attn.train()
+    _copy_module_parameters(graph_attn, eager_attn)
+
+    capture_full_hidden = torch.randn(
+        padded_tokens, 1, config.hidden_size, dtype=torch.bfloat16, device='cuda'
+    )
+    replay_full_hidden = torch.randn_like(capture_full_hidden)
+    capture_hidden = capture_full_hidden.index_select(0, local_idx).detach().clone()
+    replay_hidden = replay_full_hidden.index_select(0, local_idx).detach().clone()
+    capture_grad = torch.randn_like(capture_hidden)
+    replay_grad = torch.randn_like(replay_hidden)
+    static_hidden = capture_hidden.detach().clone().requires_grad_(True)
+    static_grad = capture_grad.detach().clone()
+
+    graph, graph_output = _capture_dsv4_attention_forward_backward(
+        graph_attn, static_hidden, static_grad, capture_packed
+    )
+    with torch.no_grad():
+        capture_packed.cu_seqlens_q.copy_(replay_packed.cu_seqlens_q)
+        capture_packed.cu_seqlens_kv.copy_(replay_packed.cu_seqlens_kv)
+        capture_packed.cu_seqlens_q_padded.copy_(replay_packed.cu_seqlens_q_padded)
+        capture_packed.cu_seqlens_kv_padded.copy_(replay_packed.cu_seqlens_kv_padded)
+        static_hidden.copy_(replay_hidden)
+        static_grad.copy_(replay_grad)
+        if static_hidden.grad is not None:
+            static_hidden.grad.zero_()
+        for param in graph_attn.parameters():
+            if param.grad is not None:
+                param.grad.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+    graph_out = graph_output.detach().clone()
+    graph_hidden_grad = static_hidden.grad.detach().clone()
+    graph_param_grads = {
+        name: param.grad.detach().clone()
+        for name, param in graph_attn.named_parameters()
+        if param.grad is not None
+    }
+
+    eager_hidden = replay_hidden.detach().clone().requires_grad_(True)
+    eager_out, eager_hidden_grad, eager_param_grads = _run_dsv4_attention_forward_backward(
+        eager_attn, eager_hidden, replay_grad, replay_packed
+    )
+    torch.cuda.synchronize()
+    assert graph_param_grads.keys() == eager_param_grads.keys()
+    label_prefix = f"cp{cp_size}:layer={layer_number}:metadata_replay"
+    _assert_cp_graph_bitwise_match(graph_out, eager_out, f"{label_prefix}:output")
+    _assert_cp_graph_fused_grad_match(
+        graph_hidden_grad, eager_hidden_grad, f"{label_prefix}:hidden_grad"
+    )
+    for name, graph_grad in graph_param_grads.items():
+        _assert_cp_graph_fused_grad_match(
+            graph_grad, eager_param_grads[name], f"{label_prefix}:param_grad:{name}"
+        )
+
+    del graph, graph_output, graph_attn, eager_attn, capture_full_hidden, replay_full_hidden
+    del capture_hidden, replay_hidden, capture_grad, replay_grad, static_hidden, static_grad
+    del graph_out, graph_hidden_grad, eager_hidden
+    _clear_cuda_test_state()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -1064,109 +1160,13 @@ class TestDSv4HybridAttentionTHDCP:
         failure means the CP path baked capture-time padded boundaries or a
         host-derived dynamic shape into the graph.
         """
-        if not self.fused_kernels_available:
-            pytest.skip(_DSV4_CP_FUSED_KERNELS_UNAVAILABLE_REASON)
-
-        capture_packed = _make_thd_packed_seq_params(
-            _DSV4_CP_RAGGED_SEG_LENS, _DSV4_CP_RAGGED_PADDED_SEG_LENS
+        _run_thd_cp_cuda_graph_metadata_replay_case(
+            cp_size=self.cp_size,
+            cp_rank=self.cp_rank,
+            pg=self.pg,
+            layer_number=layer_number,
+            fused_kernels_available=self.fused_kernels_available,
         )
-        replay_packed = _make_thd_packed_seq_params(
-            _DSV4_CP_RAGGED_SEG_LENS, _DSV4_CP_REPLAY_PADDED_SEG_LENS
-        )
-        padded_tokens = sum(_DSV4_CP_RAGGED_PADDED_SEG_LENS)
-        assert padded_tokens == sum(_DSV4_CP_REPLAY_PADDED_SEG_LENS)
-        assert capture_packed.cu_seqlens_q.shape == replay_packed.cu_seqlens_q.shape
-        assert capture_packed.cu_seqlens_q_padded.shape == replay_packed.cu_seqlens_q_padded.shape
-        assert capture_packed.max_seqlen_q == replay_packed.max_seqlen_q
-        assert capture_packed.max_seqlen_kv == replay_packed.max_seqlen_kv
-        assert not torch.equal(
-            capture_packed.cu_seqlens_q_padded, replay_packed.cu_seqlens_q_padded
-        )
-        local_rows = padded_tokens // self.cp_size
-        local_idx = torch.arange(
-            self.cp_rank * local_rows, (self.cp_rank + 1) * local_rows, device='cuda'
-        )
-
-        torch.manual_seed(_SEED + 1100 + layer_number)
-        model_parallel_cuda_manual_seed(_SEED + 1100 + layer_number)
-        config = _make_dsv4_cp_config(
-            context_parallel_size=self.cp_size,
-            dsa_indexer_loss_coeff=1.0,
-            dsa_indexer_use_sparse_loss=True,
-            use_fused_kernels=True,
-            apply_rope_fusion=True,
-        )
-        graph_attn = _build_attention(
-            config, layer_number=layer_number, pg_collection=self.pg
-        ).cuda()
-        eager_attn = _build_attention(
-            config, layer_number=layer_number, pg_collection=self.pg
-        ).cuda()
-        graph_attn.train()
-        eager_attn.train()
-        _copy_module_parameters(graph_attn, eager_attn)
-
-        capture_full_hidden = torch.randn(
-            padded_tokens, 1, config.hidden_size, dtype=torch.bfloat16, device='cuda'
-        )
-        replay_full_hidden = torch.randn_like(capture_full_hidden)
-        capture_hidden = capture_full_hidden.index_select(0, local_idx).detach().clone()
-        replay_hidden = replay_full_hidden.index_select(0, local_idx).detach().clone()
-        capture_grad = torch.randn_like(capture_hidden)
-        replay_grad = torch.randn_like(replay_hidden)
-        static_hidden = capture_hidden.detach().clone().requires_grad_(True)
-        static_grad = capture_grad.detach().clone()
-
-        graph, graph_output = _capture_dsv4_attention_forward_backward(
-            graph_attn, static_hidden, static_grad, capture_packed
-        )
-        with torch.no_grad():
-            capture_packed.cu_seqlens_q.copy_(replay_packed.cu_seqlens_q)
-            capture_packed.cu_seqlens_kv.copy_(replay_packed.cu_seqlens_kv)
-            capture_packed.cu_seqlens_q_padded.copy_(replay_packed.cu_seqlens_q_padded)
-            capture_packed.cu_seqlens_kv_padded.copy_(replay_packed.cu_seqlens_kv_padded)
-            static_hidden.copy_(replay_hidden)
-            static_grad.copy_(replay_grad)
-            if static_hidden.grad is not None:
-                static_hidden.grad.zero_()
-            for param in graph_attn.parameters():
-                if param.grad is not None:
-                    param.grad.zero_()
-        graph.replay()
-        torch.cuda.synchronize()
-        graph_out = graph_output.detach().clone()
-        graph_hidden_grad = static_hidden.grad.detach().clone()
-        graph_param_grads = {
-            name: param.grad.detach().clone()
-            for name, param in graph_attn.named_parameters()
-            if param.grad is not None
-        }
-
-        eager_hidden = replay_hidden.detach().clone().requires_grad_(True)
-        eager_out, eager_hidden_grad, eager_param_grads = _run_dsv4_attention_forward_backward(
-            eager_attn, eager_hidden, replay_grad, replay_packed
-        )
-        torch.cuda.synchronize()
-        assert graph_param_grads.keys() == eager_param_grads.keys()
-        _assert_cp_graph_bitwise_match(
-            graph_out, eager_out, f"layer={layer_number}:metadata_replay:output"
-        )
-        _assert_cp_graph_fused_grad_match(
-            graph_hidden_grad,
-            eager_hidden_grad,
-            f"layer={layer_number}:metadata_replay:hidden_grad",
-        )
-        for name, graph_grad in graph_param_grads.items():
-            _assert_cp_graph_fused_grad_match(
-                graph_grad,
-                eager_param_grads[name],
-                f"layer={layer_number}:metadata_replay:param_grad:{name}",
-            )
-
-        del graph, graph_output, graph_attn, eager_attn, capture_full_hidden, replay_full_hidden
-        del capture_hidden, replay_hidden, capture_grad, replay_grad, static_hidden, static_grad
-        del graph_out, graph_hidden_grad, eager_hidden
-        _clear_cuda_test_state()
 
     @pytest.mark.parametrize(
         "layer_number",
@@ -1275,3 +1275,50 @@ class TestDSv4HybridAttentionTHDCP:
 
         del cp_attn, local_hidden, local_grad
         _clear_cuda_test_state()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not HAVE_TE, reason="transformer_engine not available")
+class TestDSv4HybridAttentionTHDCP8CudaGraph:
+    """Focused CP8 CUDA graph metadata replay coverage."""
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_cp8_model_parallel(self, request):
+        """Initialize only the focused CP8 test's model-parallel groups."""
+        cp_size = 8
+        if Utils.world_size < cp_size:
+            pytest.skip(f"THD CP8 path test requires at least {cp_size} distributed ranks")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=cp_size,
+        )
+        torch.manual_seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+        cls = request.cls
+        cls.cp_size = cp_size
+        cls.cp_rank = parallel_state.get_context_parallel_rank()
+        cls.pg = ProcessGroupCollection.use_mpu_process_groups()
+        cls.fused_kernels_available = _dsv4_cp_fused_kernels_available()
+
+        yield
+        _clear_cuda_test_state()
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture(autouse=True)
+    def clear_cuda_test_case(self):
+        """Clear CUDA state around the focused CP8 replay case."""
+        _clear_cuda_test_state()
+        yield
+        _clear_cuda_test_state()
+
+    def test_thd_cp8_ratio4_cuda_graph_replay_accepts_changed_padded_boundaries(self):
+        """CP8 ratio-4 replay honors updated same-shape THD metadata."""
+        _run_thd_cp_cuda_graph_metadata_replay_case(
+            cp_size=self.cp_size,
+            cp_rank=self.cp_rank,
+            pg=self.pg,
+            layer_number=2,
+            fused_kernels_available=self.fused_kernels_available,
+        )

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -14,6 +14,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
     get_gpt_layer_with_transformer_engine_submodules,
 )
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
     MHCCheckpointManager,
@@ -900,29 +901,57 @@ class TestMHCWithCudaGraph:
         assert layer.self_attention in graph_submodules
         assert layer.self_attention_hyper_connection not in graph_submodules
 
-    def test_mhc_split_config_rejects_packed_sequence(self):
-        """The split validator rejects packed (THD) sequences at config time.
+    @pytest.mark.parametrize("context_parallel_size", [1, 2, 8, 16])
+    def test_mhc_split_config_accepts_static_packed_sequence(self, context_parallel_size):
+        """Static dp-balanced THD has no split-specific CP-size ceiling."""
+        config = _make_mhc_config(
+            bf16=True,
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            recompute_granularity="selective",
+            recompute_modules=["mhc"],
+            mhc_recompute_attn_cuda_graph_split=True,
+            context_parallel_size=context_parallel_size,
+            sequence_packing_scheduler="dp_balanced",
+            max_seqlen_per_dp_cp_rank=32,
+            thd_max_packed_sequences=2,
+            pad_packed_seq_alignment="max",
+        )
 
-        The split replay's kwargs assembly does not forward the THD captured
-        kwargs (cu_seqlens_*, padding_mask) to the graphed callable, and
-        Transformer Engine raises TypeError for a kwarg present at capture but
-        missing at replay -- so without this gate a THD split run is accepted
-        and then dies on the first replay. The gate keys on
-        sequence_packing_scheduler, the same signal _is_thd_cuda_graph() uses
-        to shape the THD static inputs.
-        """
-        with pytest.raises(ValueError, match="does not support packed"):
-            self._create_mhc_layer(
+        assert config.context_parallel_size == context_parallel_size
+        assert config.sequence_packing_scheduler == "dp_balanced"
+
+    @pytest.mark.parametrize(
+        "dynamic_config",
+        [
+            pytest.param(
+                {
+                    "dynamic_context_parallel": True,
+                    "context_parallel_size": 8,
+                    "min_dynamic_context_parallel_size": 1,
+                    "sequence_packing_scheduler": "default_dynamic_cp",
+                },
+                id="dynamic-context-parallel",
+            ),
+            pytest.param(
+                {"sequence_packing_scheduler": "default_dynamic_cp"}, id="dynamic-scheduler"
+            ),
+        ],
+    )
+    def test_mhc_split_config_rejects_dynamic_packed_sequence(self, dynamic_config):
+        """Dynamic CP needs per-batch graph topology and remains unsupported."""
+        with pytest.raises(ValueError, match="Dynamic CP"):
+            _make_mhc_config(
                 bf16=True,
                 cuda_graph_impl="transformer_engine",
                 cuda_graph_modules=[CudaGraphModule.attn],
                 recompute_granularity="selective",
                 recompute_modules=["mhc"],
                 mhc_recompute_attn_cuda_graph_split=True,
-                sequence_packing_scheduler="dp_balanced",
                 max_seqlen_per_dp_cp_rank=32,
                 thd_max_packed_sequences=2,
                 pad_packed_seq_alignment="max",
+                **dynamic_config,
             )
 
     @pytest.mark.parametrize(
@@ -1077,7 +1106,16 @@ class TestMHCWithCudaGraph:
                 (hidden,), {"hidden_states": hidden}, None
             )
 
-    def _run_split_replay(self, layer, config, fake_graph_output, monkeypatch, manager=None):
+    def _run_split_replay(
+        self,
+        layer,
+        config,
+        fake_graph_output,
+        monkeypatch,
+        manager=None,
+        replay_kwargs=None,
+        public_entry=False,
+    ):
         """Drive the split replay with a stubbed captured graph and eager tails."""
         from megatron.core.transformer.module import GraphableMegatronModule
 
@@ -1085,6 +1123,7 @@ class TestMHCWithCudaGraph:
 
         def fake_replay(layer_self, *args, **kwargs):
             recorded["graph_input"] = args[0]
+            recorded["graph_kwargs"] = kwargs.copy()
             out = fake_graph_output(args[0])
             return out
 
@@ -1095,6 +1134,7 @@ class TestMHCWithCudaGraph:
 
         def fake_mlp(hidden_states, **kwargs):
             recorded["mlp_manager"] = kwargs.get("mhc_recompute_manager")
+            recorded["mlp_kwargs"] = kwargs.copy()
             return hidden_states
 
         monkeypatch.setattr(GraphableMegatronModule, "_te_cuda_graph_replay", fake_replay)
@@ -1103,10 +1143,112 @@ class TestMHCWithCudaGraph:
         layer._mhc_recompute_manager = manager
 
         hidden = torch.randn(8, 2, config.num_residual_streams * config.hidden_size, device="cuda")
-        output, context = layer._te_cuda_graph_replay_mhc_attention_split(
-            (hidden,), {"attention_mask": None}, None
-        )
+        replay_kwargs = {"attention_mask": None} if replay_kwargs is None else replay_kwargs
+        if public_entry:
+            output, context = layer._te_cuda_graph_replay(hidden, **replay_kwargs)
+        else:
+            output, context = layer._te_cuda_graph_replay_mhc_attention_split(
+                (hidden,), replay_kwargs, None
+            )
         return output, recorded
+
+    def test_split_public_replay_projects_all_thd_tensor_kwargs(self, monkeypatch):
+        """Public replay expands PackedSeqParams before the split selects graph kwargs."""
+        layer, config = self._create_split_layer()
+        cu_seqlens_q = torch.tensor([0, 3, 8], dtype=torch.int32, device="cuda")
+        cu_seqlens_kv = cu_seqlens_q.clone()
+        cu_seqlens_q_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
+        cu_seqlens_kv_padded = cu_seqlens_q_padded.clone()
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
+            cu_seqlens_q_padded=cu_seqlens_q_padded,
+            cu_seqlens_kv_padded=cu_seqlens_kv_padded,
+            max_seqlen_q=4,
+            max_seqlen_kv=4,
+        )
+        padding_mask = torch.zeros((1, 8), dtype=torch.bool, device="cuda")
+        input_ids = torch.arange(8, device="cuda").unsqueeze(0)
+
+        _, recorded = self._run_split_replay(
+            layer,
+            config,
+            lambda aggregated: aggregated,
+            monkeypatch,
+            replay_kwargs={
+                "attention_mask": None,
+                "packed_seq_params": packed_seq_params,
+                "padding_mask": padding_mask,
+                "input_ids": input_ids,
+            },
+            public_entry=True,
+        )
+
+        graph_kwargs = recorded["graph_kwargs"]
+        expected_cu_tensors = {
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_kv": cu_seqlens_kv,
+            "cu_seqlens_q_padded": cu_seqlens_q_padded,
+            "cu_seqlens_kv_padded": cu_seqlens_kv_padded,
+        }
+        assert "packed_seq_params" not in graph_kwargs
+        for name, tensor in expected_cu_tensors.items():
+            assert graph_kwargs[name] is tensor
+        assert graph_kwargs["padding_mask"] is padding_mask
+        assert graph_kwargs["input_ids"] is input_ids
+        assert recorded["mlp_kwargs"]["padding_mask"] is padding_mask
+        assert recorded["mlp_kwargs"]["input_ids"] is input_ids
+
+    def test_split_capture_reconstructs_static_cp_packed_sequence(self, monkeypatch):
+        """Capture rebuilds graph-static PackedSeqParams from flat THD tensors."""
+        layer, config = self._create_mhc_layer(
+            bf16=True,
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            recompute_granularity="selective",
+            recompute_modules=["mhc"],
+            mhc_recompute_attn_cuda_graph_split=True,
+            sequence_packing_scheduler="dp_balanced",
+            max_seqlen_per_dp_cp_rank=32,
+            thd_max_packed_sequences=2,
+            pad_packed_seq_alignment="max",
+        )
+        # Isolate the reconstruction contract from distributed CP initialization.
+        config.context_parallel_size = 8
+        config.cp_partition_mode = "contiguous"
+        cu_tensors = {
+            "cu_seqlens_q": torch.tensor([0, 64, 256], dtype=torch.int32, device="cuda"),
+            "cu_seqlens_kv": torch.tensor([0, 64, 256], dtype=torch.int32, device="cuda"),
+            "cu_seqlens_q_padded": torch.tensor([0, 128, 256], dtype=torch.int32, device="cuda"),
+            "cu_seqlens_kv_padded": torch.tensor([0, 128, 256], dtype=torch.int32, device="cuda"),
+        }
+        padding_mask = torch.zeros((1, 32), dtype=torch.bool, device="cuda")
+        captured = {}
+
+        def fake_consumer(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs.copy()
+            hidden_states = args[0] if args else kwargs["hidden_states"]
+            return (hidden_states,)
+
+        monkeypatch.setattr(layer, "_forward_mhc_attention_cuda_graph_consumer", fake_consumer)
+        hidden_states = torch.randn(32, 1, config.hidden_size, device="cuda")
+        layer._te_cuda_graph_capture(
+            hidden_states=hidden_states, padding_mask=padding_mask, **cu_tensors
+        )
+
+        capture_kwargs = captured["kwargs"]
+        reconstructed = capture_kwargs["packed_seq_params"]
+        assert reconstructed.qkv_format == "thd"
+        assert reconstructed.cp_partition_mode == "contiguous"
+        assert reconstructed.max_seqlen_q == 256
+        assert reconstructed.max_seqlen_kv == 256
+        assert reconstructed.pad_between_seqs is True
+        for name, tensor in cu_tensors.items():
+            assert getattr(reconstructed, name) is tensor
+            assert name not in capture_kwargs
+        assert capture_kwargs["padding_mask"] is padding_mask
 
     def test_split_replay_maps_output_arity_and_bias(self, monkeypatch):
         """Captured output arity: 1 tensor -> (out, None); 2 -> (out, bias); else error."""

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -1168,6 +1168,7 @@ class TestMHCWithCudaGraph:
         cu_seqlens_kv = cu_seqlens_q.clone()
         cu_seqlens_q_padded = torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda")
         cu_seqlens_kv_padded = cu_seqlens_q_padded.clone()
+        static_cp_group = object()
         packed_seq_params = PackedSeqParams(
             qkv_format="thd",
             cu_seqlens_q=cu_seqlens_q,
@@ -1177,6 +1178,7 @@ class TestMHCWithCudaGraph:
             max_seqlen_q=4,
             max_seqlen_kv=4,
             tokens_per_sample=8,
+            cp_group=static_cp_group,
         )
         padding_mask = torch.zeros((1, 8), dtype=torch.bool, device="cuda")
         input_ids = torch.arange(8, device="cuda").unsqueeze(0)
@@ -1210,6 +1212,32 @@ class TestMHCWithCudaGraph:
         assert recorded["mlp_kwargs"]["padding_mask"] is padding_mask
         assert recorded["mlp_kwargs"]["input_ids"] is input_ids
         assert recorded["mlp_kwargs"]["packed_seq_params"] is packed_seq_params
+        assert recorded["mlp_kwargs"]["packed_seq_params"].cp_group is static_cp_group
+
+    @pytest.mark.parametrize(
+        ("local_cp_size", "cp_group"),
+        [
+            pytest.param(1, None, id="cp1-without-group"),
+            pytest.param(2, object(), id="cp2-with-group"),
+        ],
+    )
+    def test_split_public_replay_rejects_runtime_dynamic_cp_metadata_before_decomposition(
+        self, local_cp_size, cp_group, monkeypatch
+    ):
+        """Runtime Dynamic-CP metadata must not replay against captured fixed groups."""
+        layer, config = self._create_split_layer()
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd", local_cp_size=local_cp_size, cp_group=cp_group
+        )
+        hidden = torch.randn(8, 2, config.num_residual_streams * config.hidden_size, device="cuda")
+        monkeypatch.setattr(
+            layer,
+            "_decompose_packed_seq_params_to_kwargs",
+            lambda _kwargs: pytest.fail("Dynamic-CP metadata was decomposed before validation"),
+        )
+
+        with pytest.raises(NotImplementedError, match="does not support Dynamic CP"):
+            layer._te_cuda_graph_replay(hidden, packed_seq_params=packed_seq_params)
 
     def test_split_capture_reconstructs_static_cp_packed_sequence(self, monkeypatch):
         """Capture rebuilds graph-static PackedSeqParams from flat THD tensors."""
@@ -1412,13 +1440,56 @@ class TestMHCWithCudaGraph:
             for packed_seq_params in packed_inputs:
                 layer.zero_grad(set_to_none=True)
                 hidden_states = base_hidden_states.clone().requires_grad_(True)
+                manager = MHCCheckpointManager()
+                manager.is_last_layer_in_recompute_block = True
                 output, context = layer(
-                    hidden_states, packed_seq_params=packed_seq_params, padding_mask=padding_mask
+                    hidden_states,
+                    packed_seq_params=packed_seq_params,
+                    padding_mask=padding_mask,
+                    mhc_recompute_manager=manager,
                 )
+
+                assert manager.checkpoints
+                arena_checkpoints = [
+                    checkpoint
+                    for checkpoint in manager.checkpoints
+                    if checkpoint.output_slot is not None
+                ]
+                assert len(arena_checkpoints) == 1
+                non_arena_outputs = [
+                    checkpoint_output
+                    for checkpoint in manager.checkpoints
+                    if checkpoint.output_slot is None
+                    for checkpoint_output in checkpoint.outputs
+                ]
+                assert non_arena_outputs
+                static_graph_input = layer.get_te_cuda_graph_static_hidden_input()
+                arena_checkpoint = arena_checkpoints[0]
+                assert len(manager.mhc_arena.slots) == 1
+                assert manager.mhc_arena.slots[0].consumer is static_graph_input
+                assert arena_checkpoint.outputs[0].data_ptr() == static_graph_input.data_ptr()
+
+                # Mirror TransformerBlock's group-finalization lifecycle. The
+                # static graph input keeps its address while eager checkpoint
+                # outputs are discarded, then the output hook replays the whole
+                # group before captured attention backward consumes that input.
+                manager.discard_all_outputs_and_register_unified_recompute(output)
+                assert manager._outputs_discarded
+                assert all(
+                    checkpoint_output.untyped_storage().nbytes() == 0
+                    for checkpoint_output in non_arena_outputs
+                )
+                assert arena_checkpoint.outputs[0].data_ptr() == static_graph_input.data_ptr()
+
                 loss = output.float().square().mean()
                 loss.backward()
 
                 assert context is None
+                assert manager._recomputed
+                assert all(
+                    checkpoint.ctx is None and checkpoint.outputs is None
+                    for checkpoint in manager.checkpoints
+                )
                 assert torch.isfinite(output).all()
                 assert hidden_states.grad is not None
                 assert torch.isfinite(hidden_states.grad).all()

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -14,14 +14,23 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
     get_gpt_layer_with_transformer_engine_submodules,
 )
+from megatron.core.num_microbatches_calculator import (
+    destroy_num_microbatches_calculator,
+    init_num_microbatches_calculator,
+)
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
     MHCCheckpointManager,
     initialize_rng_tracker,
     model_parallel_cuda_manual_seed,
 )
-from megatron.core.transformer.cuda_graphs import CudaGraphManager, _CudagraphGlobalRecord
+from megatron.core.transformer.cuda_graphs import (
+    CudaGraphManager,
+    TECudaGraphHelper,
+    _CudagraphGlobalRecord,
+)
 from megatron.core.transformer.enums import AttnMaskType, CudaGraphModule, InferenceCudaGraphScope
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import (
@@ -1088,7 +1097,7 @@ class TestMHCWithCudaGraph:
         monkeypatch.setattr(
             HyperConnectionTransformerLayer,
             "_te_cuda_graph_replay_mhc_attention_split",
-            lambda self, args, kwargs, context: sentinel,
+            lambda self, args, kwargs, context, packed_seq_params=None: sentinel,
         )
         hidden = torch.randn(8, 2, config.num_residual_streams * config.hidden_size, device="cuda")
         assert layer._te_cuda_graph_replay_impl((hidden,), {}, None) is sentinel
@@ -1167,6 +1176,7 @@ class TestMHCWithCudaGraph:
             cu_seqlens_kv_padded=cu_seqlens_kv_padded,
             max_seqlen_q=4,
             max_seqlen_kv=4,
+            tokens_per_sample=8,
         )
         padding_mask = torch.zeros((1, 8), dtype=torch.bool, device="cuda")
         input_ids = torch.arange(8, device="cuda").unsqueeze(0)
@@ -1199,6 +1209,7 @@ class TestMHCWithCudaGraph:
         assert graph_kwargs["input_ids"] is input_ids
         assert recorded["mlp_kwargs"]["padding_mask"] is padding_mask
         assert recorded["mlp_kwargs"]["input_ids"] is input_ids
+        assert recorded["mlp_kwargs"]["packed_seq_params"] is packed_seq_params
 
     def test_split_capture_reconstructs_static_cp_packed_sequence(self, monkeypatch):
         """Capture rebuilds graph-static PackedSeqParams from flat THD tensors."""
@@ -1249,6 +1260,206 @@ class TestMHCWithCudaGraph:
             assert getattr(reconstructed, name) is tensor
             assert name not in capture_kwargs
         assert capture_kwargs["padding_mask"] is padding_mask
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("2.10.0")),
+        reason="Partial CUDA graph UT support requires TransformerEngine >= 2.10",
+    )
+    @pytest.mark.parametrize("context_parallel_size", [2, 8])
+    def test_real_te_thd_attention_split_with_static_cp(self, context_parallel_size, monkeypatch):
+        """Real TE capture/replay keeps static CP and runtime THD metadata intact.
+
+        CP2 is the mandatory distributed regression; CP8 runs when the launcher has
+        enough ranks.  The production ``TECudaGraphHelper`` drives
+        ``make_graphed_callables`` without replacing either side of the graph boundary.
+        Two public replays then use different, same-shape cu-seqlens tensors and run
+        backward through the captured attention plus the eager mHC/MLP tails.
+        """
+        if Utils.world_size < context_parallel_size:
+            pytest.skip(f"CP{context_parallel_size} requires at least that many ranks")
+        if Utils.world_size % context_parallel_size != 0:
+            pytest.skip(
+                f"world size {Utils.world_size} is not divisible by CP{context_parallel_size}"
+            )
+
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, context_parallel_size=context_parallel_size
+        )
+        model_parallel_cuda_manual_seed(123, te_rng_tracker=True, force_reset_rng=True)
+
+        local_tokens = 16
+        global_tokens = local_tokens * context_parallel_size
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        config = _make_mhc_config(
+            hidden_size=32,
+            num_streams=2,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.bfloat16,
+            use_te_rng_tracker=True,
+            tensor_model_parallel_size=1,
+            context_parallel_size=context_parallel_size,
+            cp_comm_type="p2p",
+            cp_partition_mode="zigzag",
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            cuda_graph_warmup_steps=3,
+            recompute_granularity="selective",
+            recompute_modules=["mhc"],
+            mhc_recompute_attn_cuda_graph_split=True,
+            sequence_packing_scheduler="dp_balanced",
+            max_seqlen_per_dp_cp_rank=local_tokens,
+            thd_max_packed_sequences=2,
+            pad_packed_seq_alignment="max",
+            create_attention_mask_in_dataloader=False,
+        )
+        layer_spec = get_gpt_layer_with_transformer_engine_spec(enable_hyper_connection=True)
+        layer = HyperConnectionTransformerLayer(
+            config, layer_spec.submodules, pg_collection=pg_collection
+        ).cuda()
+        layer.train()
+
+        fixed_cp_group = pg_collection.cp
+        assert fixed_cp_group is not None
+        assert fixed_cp_group.size() == context_parallel_size
+        assert layer.pg_collection is pg_collection
+        assert layer.self_attention.pg_collection.cp is fixed_cp_group
+
+        class _SingleLayerModel(torch.nn.Module):
+            """Smallest model surface discoverable by ``TECudaGraphHelper``."""
+
+            def __init__(self, graph_layer, graph_config):
+                super().__init__()
+                self.config = graph_config
+                self.position_embedding_type = "none"
+                self.decoder = torch.nn.Module()
+                self.decoder.layers = torch.nn.ModuleList([graph_layer])
+
+            def zero_grad_buffer(self):
+                self.zero_grad(set_to_none=True)
+
+        model = _SingleLayerModel(layer, config)
+        helper = None
+        destroy_num_microbatches_calculator()
+        init_num_microbatches_calculator(
+            rank=torch.distributed.get_rank(),
+            rampup_batch_size=None,
+            global_batch_size=pg_collection.dp.size(),
+            micro_batch_size=1,
+            data_parallel_size=pg_collection.dp.size(),
+            decrease_batch_size_if_needed=False,
+        )
+
+        def make_packed_seq_params(first_boundary):
+            cu_seqlens = torch.tensor(
+                [0, first_boundary, global_tokens], dtype=torch.int32, device="cuda"
+            )
+            return PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens.clone(),
+                cu_seqlens_q_padded=cu_seqlens.clone(),
+                cu_seqlens_kv_padded=cu_seqlens.clone(),
+                max_seqlen_q=global_tokens,
+                max_seqlen_kv=global_tokens,
+                tokens_per_sample=global_tokens,
+                cp_partition_mode=config.cp_partition_mode,
+            )
+
+        packed_inputs = (
+            make_packed_seq_params(global_tokens // 2),
+            make_packed_seq_params(global_tokens // 4),
+        )
+        assert packed_inputs[0].cu_seqlens_q.shape == packed_inputs[1].cu_seqlens_q.shape
+        assert not torch.equal(packed_inputs[0].cu_seqlens_q, packed_inputs[1].cu_seqlens_q)
+        assert all(packed.cp_group is None for packed in packed_inputs)
+
+        observed_mlp_packed_inputs = []
+        eager_mlp_tail = layer._forward_mlp
+
+        def recording_mlp_tail(hidden_states, *args, **kwargs):
+            observed_mlp_packed_inputs.append(kwargs.get("packed_seq_params"))
+            return eager_mlp_tail(hidden_states, *args, **kwargs)
+
+        try:
+            helper = TECudaGraphHelper(
+                model=[model],
+                config=config,
+                seq_length=global_tokens,
+                micro_batch_size=1,
+                optimizers=[],
+                pg_collection=pg_collection,
+                thd_sequence_length_upper_bound=global_tokens,
+            )
+            helper.create_cudagraphs()
+            assert helper.graphs_created()
+            assert len(layer.cuda_graphs) == 1
+
+            # The spy is intentionally installed only on the eager continuation;
+            # capture and replay still cross the production TE graph unchanged.
+            monkeypatch.setattr(layer, "_forward_mlp", recording_mlp_tail)
+            padding_mask = torch.zeros((1, local_tokens), dtype=torch.bool, device="cuda")
+            base_hidden_states = torch.randn(
+                local_tokens,
+                1,
+                config.num_residual_streams * config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            replay_outputs = []
+            for packed_seq_params in packed_inputs:
+                layer.zero_grad(set_to_none=True)
+                hidden_states = base_hidden_states.clone().requires_grad_(True)
+                output, context = layer(
+                    hidden_states, packed_seq_params=packed_seq_params, padding_mask=padding_mask
+                )
+                loss = output.float().square().mean()
+                loss.backward()
+
+                assert context is None
+                assert torch.isfinite(output).all()
+                assert hidden_states.grad is not None
+                assert torch.isfinite(hidden_states.grad).all()
+                parameter_grads = [
+                    parameter.grad for parameter in layer.parameters() if parameter.grad is not None
+                ]
+                assert parameter_grads
+                assert all(torch.isfinite(grad).all() for grad in parameter_grads)
+                for attention_parameter in (
+                    layer.self_attention.linear_qkv.weight,
+                    layer.self_attention.linear_proj.weight,
+                ):
+                    assert attention_parameter.grad is not None
+                    assert torch.isfinite(attention_parameter.grad).all()
+                replay_outputs.append(output.detach().clone())
+
+            assert len(observed_mlp_packed_inputs) == len(packed_inputs)
+            assert all(
+                observed is expected
+                for observed, expected in zip(observed_mlp_packed_inputs, packed_inputs)
+            )
+            assert not torch.allclose(replay_outputs[0], replay_outputs[1])
+            assert layer.self_attention.pg_collection.cp is fixed_cp_group
+        finally:
+            try:
+                if helper is not None and helper.graphs_created():
+                    helper.delete_cuda_graphs()
+                elif layer.cuda_graphs:
+                    # Capture can fail after graphs are attached but before the
+                    # helper marks the lifecycle complete.  Do not leave those
+                    # graph pools live for the next distributed test.
+                    for graph in layer.cuda_graphs:
+                        graph.reset()
+                    layer.cuda_graphs = []
+                    layer.cuda_graph_manual_hooks = []
+                    layer.clear_te_cuda_graph_static_hidden_inputs()
+            finally:
+                destroy_num_microbatches_calculator()
+                torch.cuda.synchronize()
+                Utils.destroy_model_parallel()
+                initialize_rng_tracker(use_cudagraphable_rng=True, force_reset=True)
 
     def test_split_replay_maps_output_arity_and_bias(self, monkeypatch):
         """Captured output arity: 1 tensor -> (out, None); 2 -> (out, bias); else error."""


### PR DESCRIPTION
## Summary

- Enable the mHC recompute attention-only Transformer Engine partial CUDA Graph split for graph-static packed THD inputs with fixed context parallelism.
- Preserve the exact THD capture/replay signature (`cu_seqlens_*`, `padding_mask`, and optional `input_ids`) and reconstruct `PackedSeqParams` at the graph boundary.
- Keep the original Python `PackedSeqParams` for the eager MLP/MoE continuation, while continuing to reject Dynamic CP because graph shapes and collective topology may change per batch.
- Shrink the captured attention input from `[s, b, n*C]` to `[s, b, C]`, allowing the attention activation to be reclaimed by mHC recompute.

## Test plan

- `tests/unit_tests/transformer/test_transformer_layer.py::TestMHCWithCudaGraph`: 34 passed, 1 skipped.
- THD CUDA Graph suite: 39 passed, 2 skipped.
- Real Transformer Engine capture/replay integration with static CP2: passed.
- Lyris GB200 end-to-end packed THD partial-CG runs with CP8 and CP16: completed 14/14 iterations, including capture and replay, without errors.
