### PR TITLE
Avoid duplicate host allocation during parameter offload

### DIFF
--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -1680,7 +1680,10 @@ class _ParamAndGradBuffer:
             if self.param_data_cpu is not None:
                 self.param_data_cpu.copy_(self.param_data, non_blocking=True)
             else:
-                self.param_data_cpu = self.param_data.cpu().pin_memory()
+                self.param_data_cpu = torch.empty_like(
+                    self.param_data, device="cpu", pin_memory=True
+                )
+                self.param_data_cpu.copy_(self.param_data, non_blocking=True)
             self.param_data.storage().resize_(0)
 
     def reload_from_cpu(self, move_params: bool = True, move_grads: bool = True):

--- a/tests/unit_tests/distributed/test_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/test_param_and_grad_buffer.py
@@ -105,6 +105,36 @@ def get_model_and_buffers(
     return model, param_and_grad_buffer, bucket_groups
 
 
+def test_param_offload_allocates_pinned_destination_directly():
+    Utils.initialize_model_parallel()
+    try:
+        _, param_and_grad_buffer, _ = get_model_and_buffers(
+            input_dim=4,
+            output_dim=4,
+            num_layers=1,
+            bias=False,
+            shared_embedding=False,
+            bucket_size=None,
+            use_distributed_optimizer=True,
+            overlap_grad_reduce=False,
+            average_in_collective=False,
+        )
+        expected = param_and_grad_buffer.param_data.cpu()
+
+        original_empty_like = torch.empty_like
+        with mock.patch.object(torch, "empty_like", wraps=original_empty_like) as empty_like:
+            param_and_grad_buffer.offload_to_cpu(move_params=True, move_grads=False)
+
+        empty_like.assert_called_once_with(
+            param_and_grad_buffer.param_data, device="cpu", pin_memory=True
+        )
+        assert param_and_grad_buffer.param_data_cpu.is_pinned()
+        torch.testing.assert_close(param_and_grad_buffer.param_data_cpu, expected)
+        assert param_and_grad_buffer.param_data.storage().size() == 0
+    finally:
+        Utils.destroy_model_parallel()
+
+
 @pytest.mark.parametrize("bucket_size", [None, 9000, 9025, 9050, 18000, 18050, 20000])
 @pytest.mark.parametrize("use_distributed_optimizer", [False, True])
 @pytest.mark.parametrize("bias", [False, True])


### PR DESCRIPTION
## Summary

Allocate the pinned CPU parameter buffer directly, then copy CUDA parameters into it.

The previous `.cpu().pin_memory()` sequence first allocated a pageable CPU tensor and then allocated a second pinned tensor. For large parameter buffers, both host allocations overlapped during the first offload.

## Testing

- Added a unit test that verifies the pinned destination is allocated directly, receives the parameter values, and permits releasing the CUDA storage.
- Black 26.1.0 check passes on both changed files.
- The equivalent downstream patch has been exercised in repeated large-model GPU offload/backload cycles.

The repository unit test requires the normal distributed GPU runner and is left for CI/maintainer execution.
