### PR TITLE
Add output processor support to HybridModel

### DIFF
--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
-from typing import Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import torch
 from torch import Tensor
@@ -443,7 +443,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         padding_mask: Optional[Tensor] = None,
         compute_mtp_loss: bool = True,
-    ) -> Tensor:
+        output_processor: Optional[Callable[..., Any]] = None,
+        output_processor_context: Optional[Any] = None,
+    ) -> Any:
         """Forward function of the Hybrid model. This function passes the input tensors
         through the embedding layer, and then the decoder and finally into the post
         processing layer (optional).
@@ -456,6 +458,10 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 loaded. This does not control speculative decoding. On post-process stages,
                 ``labels`` still determine whether the model returns loss or logits.
                 Defaults to True.
+            output_processor (Callable, optional): Custom postprocess hook that receives
+                decoder hidden states and output-layer helpers, then returns the model output.
+            output_processor_context (Any, optional): User-defined context object forwarded to
+                `output_processor`.
         """
         # If decoder_input is provided (not None), then input_ids and position_ids are ignored.
         # Otherwise, apply embedding layer on input_ids and position_ids to get decoder_input.
@@ -625,6 +631,26 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     ),
                 )
         sequence_parallel_override = False
+
+        if output_processor is not None:
+            return output_processor(
+                hidden_states=hidden_states,
+                output_layer=self.output_layer,
+                output_weight=output_weight,
+                labels=labels,
+                loss_mask=loss_mask,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                decoder_input=decoder_input,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+                runtime_gather_output=runtime_gather_output,
+                context=output_processor_context,
+                compute_language_model_loss=self.compute_language_model_loss,
+                scale_logits=self._scale_logits,
+                config=self.config,
+            )
         if (
             in_inference_mode
             and inference_context is not None

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -390,6 +390,43 @@ class TestHybridModel:
         assert logits.shape[1] == sequence_length
         assert logits.shape[2] == self.model.vocab_size
 
+    def test_output_processor_forward(self):
+        sequence_length = self.model.max_sequence_length
+        micro_batch_size = 2
+        self.model.cuda()
+
+        input_ids = torch.arange(sequence_length, device="cuda").repeat(micro_batch_size, 1)
+        position_ids = input_ids.clone()
+        labels = (input_ids + 1) % self.model.vocab_size
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, sequence_length, sequence_length), dtype=torch.bool, device="cuda"
+        )
+        context = {"selected_token_positions": torch.tensor([0, 2], device="cuda")}
+        result = {"payload": torch.ones(1, device="cuda")}
+        seen = {}
+
+        def output_processor(**kwargs):
+            seen.update(kwargs)
+            return result
+
+        output = self.model.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            output_processor=output_processor,
+            output_processor_context=context,
+        )
+
+        assert output is result
+        assert seen["context"] is context
+        assert seen["output_layer"] is self.model.output_layer
+        assert seen["output_weight"] is None
+        assert seen["labels"] is labels
+        assert seen["runtime_gather_output"] is None
+        assert seen["config"] is self.model.config
+        assert seen["compute_language_model_loss"].__self__ is self.model
+
     def test_forward_packed_sequence(self):
         os.environ.pop('NVTE_FUSED_ATTN', None)
         os.environ.pop('NVTE_FLASH_ATTN', None)


### PR DESCRIPTION
## Summary

- Add the same optional output-processor callback contract already exposed by `GPTModel.forward` to `HybridModel.forward`.
- Pass hidden states, output-layer helpers, labels, masks, inference context, and caller context before the default logits/loss path.
- Add focused HybridModel coverage for callback dispatch and identity.

## Why

RL trainers use the output processor to compute selected-token log probabilities without materializing a full vocabulary-logit tensor. Standard GPT models support that path, but hybrid Nemotron models do not, so downstream runtimes currently patch `HybridModel` at startup.

## Validation

- Black 26.1 check passes for both changed files.
- Python compilation passes.
- The focused test mirrors the established `GPTModel` callback contract. It requires the GPU unit-test environment and is left to CI in this draft.
- The equivalent downstream patch completed real Nemotron forward/backward and ten-step training.

This is intentionally separate from the optional FlashAttention 4 import guard in #6964.