### PR TITLE
Fix DSA index sharing during activation recompute

### DIFF
--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -56,6 +56,21 @@ def checkpointed_forward(
         extract_layer_indices = set()
     intermediate_hidden_states: List[Tensor] = []
 
+    dsa_index_share_carrier = None
+    dsa_index_share_carrier_scope = None
+    if (
+        packed_seq_params is None
+        and getattr(self.config, "experimental_attention_variant", None) == "dsa"
+        and (getattr(self.config, "dsa_indexer_topk_freq", 1) or 1) > 1
+    ):
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            _dsa_index_share_carrier_scope,
+            _DSAIndexShareCarrier,
+        )
+
+        dsa_index_share_carrier = _DSAIndexShareCarrier()
+        dsa_index_share_carrier_scope = _dsa_index_share_carrier_scope
+
     # Wrap non-dual RoPE to tuple to unify custom_forward interface.
     is_dual_rope = isinstance(rotary_pos_emb, (tuple, list))
     assert not is_dual_rope or len(rotary_pos_emb) == 2, "Dual RoPE input length is not equal to 2"
@@ -141,7 +156,14 @@ def checkpointed_forward(
                     hidden_states = cp_layout_state.finalize_layer(index, hidden_states)
             return hidden_states, context
 
-        return custom_forward
+        if dsa_index_share_carrier_scope is None:
+            return custom_forward
+
+        def carrier_scoped_forward(*args):
+            with dsa_index_share_carrier_scope(dsa_index_share_carrier):
+                return custom_forward(*args)
+
+        return carrier_scoped_forward
 
     def chunk_runner(start: int, end: int, use_checkpoint: bool):
         nonlocal hidden_states, context

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -2,8 +2,10 @@
 
 import copy
 import math
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Iterator, Optional, Tuple, Union
 
 import torch
 
@@ -32,6 +34,25 @@ try:
     from fast_hadamard_transform import hadamard_transform
 except ImportError:
     hadamard_transform = None
+
+
+class _DSAIndexShareCarrier:
+    """Per-forward DSA index-share carrier for non-packed activation recompute."""
+
+
+_CURRENT_DSA_INDEX_SHARE_CARRIER: ContextVar[Optional[object]] = ContextVar(
+    "current_dsa_index_share_carrier", default=None
+)
+
+
+@contextmanager
+def _dsa_index_share_carrier_scope(carrier: object) -> Iterator[None]:
+    """Expose one non-packed forward's index-share carrier to its checkpoint closures."""
+    token = _CURRENT_DSA_INDEX_SHARE_CARRIER.set(carrier)
+    try:
+        yield
+    finally:
+        _CURRENT_DSA_INDEX_SHARE_CARRIER.reset(token)
 
 
 def is_dsa_skip_topk_layer(layer_number: int, skip_topk_offset: int, topk_freq: int) -> bool:
@@ -1695,6 +1716,9 @@ class DSAttention(MegatronModule):
         """Return the object that carries DSA top-k sharing state for this forward."""
         if packed_seq_params is not None:
             return packed_seq_params
+        carrier = _CURRENT_DSA_INDEX_SHARE_CARRIER.get()
+        if carrier is not None:
+            return carrier
         return attention_mask if attention_mask is not None else self.config
 
     def _get_index_share_topk_holder(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -15,6 +15,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 )
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.recompute import checkpointed_forward
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_kernels
@@ -197,6 +198,86 @@ class TestDSAIndexShareHelpers:
         assert length_holder is getattr(packed_seq_params, DSAttention._LENGTH_HOLDER_ATTR)
         assert not hasattr(attention_mask, DSAttention._HOLDER_ATTR)
         assert not hasattr(attention_mask, DSAttention._LENGTH_HOLDER_ATTR)
+
+    def test_nonpacked_checkpointed_forwards_keep_index_share_holders_isolated(self, monkeypatch):
+        config = SimpleNamespace(
+            dsa_indexer_topk=8,
+            dsa_indexer_topk_freq=4,
+            dsa_indexer_skip_topk_offset=1,
+            kv_channels=16,
+        )
+        attention = DSAttention(
+            config=config,
+            submodules=DSAttentionSubmodules(indexer=object()),
+            layer_number=2,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            softmax_scale=1.0,
+            pg_collection=SimpleNamespace(),
+        )
+        recomputed_supports = []
+
+        class HolderLayer:
+            layer_number = 2
+
+            def __call__(self, hidden_states, attention_mask, packed_seq_params, **_kwargs):
+                topk_holder = attention._get_index_share_topk_holder(
+                    packed_seq_params, attention_mask
+                )
+                length_holder = attention._get_index_share_topk_length_holder(
+                    packed_seq_params, attention_mask
+                )
+                if torch.is_grad_enabled():
+                    recomputed_supports.append((topk_holder[1].clone(), length_holder[1].clone()))
+                else:
+                    topk_holder[1] = hidden_states.detach().to(torch.int64)
+                    length_holder[1] = hidden_states.detach().to(torch.int32)
+                return hidden_states
+
+        block = SimpleNamespace(
+            config=SimpleNamespace(
+                experimental_attention_variant="dsa",
+                dsa_indexer_topk_freq=4,
+                fp8=False,
+                fp4=False,
+                distribute_saved_activations=False,
+                recompute_method="block",
+                recompute_num_layers=1,
+            ),
+            layers=[HolderLayer()],
+            num_layers_per_pipeline_rank=1,
+            pg_collection=SimpleNamespace(tp=None),
+        )
+        checkpoint_calls = []
+
+        def fake_checkpoint(function, _distribute_saved_activations, *args):
+            checkpoint_calls.append((function, args))
+            with torch.no_grad():
+                return function(*args)
+
+        monkeypatch.setattr("megatron.core.recompute.tensor_parallel.checkpoint", fake_checkpoint)
+        shared_attention_mask = torch.empty(1)
+        for value in (1.0, 2.0):
+            checkpointed_forward(
+                block,
+                hidden_states=torch.tensor([value]),
+                attention_mask=shared_attention_mask,
+                context=None,
+                context_mask=None,
+                rotary_pos_emb=torch.empty(1),
+                attention_bias=None,
+                packed_seq_params=None,
+                use_inner_quantization_context=False,
+            )
+
+        for function, args in checkpoint_calls:
+            with torch.enable_grad():
+                function(*args)
+
+        assert [support.item() for support, _length in recomputed_supports] == [1, 2]
+        assert [length.item() for _support, length in recomputed_supports] == [1, 2]
+        assert not hasattr(shared_attention_mask, DSAttention._HOLDER_ATTR)
+        assert not hasattr(shared_attention_mask, DSAttention._LENGTH_HOLDER_ATTR)
 
 
 def _build_packed_causal_mask_for_test(


### PR DESCRIPTION
## Summary

- Keep DSA index-sharing state isolated per non-packed checkpointed forward.
- Re-enter the same carrier during activation recomputation so skip layers can recover the source layer's shared top-k indices.
- Add a regression that interleaves two checkpoint closures over a shared attention mask and verifies that each recomputation sees its own state.

## Problem

DSA stores shared top-k indices on the packed-sequence or attention-mask carrier. Non-packed activation checkpointing can recreate or reuse those inputs between the original forward and recomputation. A skip layer can then miss its source layer's top-k indices or read another microbatch's values.

The fix creates one carrier per checkpointed forward and exposes it only while that forward or its recomputation closure executes. Packed-sequence behavior is unchanged.

## Validation

- Repository formatter, isort, pylint, and Ruff pass on all three changed files.
- The focused regression was previously exercised in the qualified GLM stack; this PR reapplies that exact behavior to current `main`.
- GLM 5.2 standalone replay `glm52-m1a-native-dsa-recompute-20260829k` completed two forward/backward and optimizer steps with nonzero gradients and durable checkpoints.
- TCLI XIDs `1048304` and `1048311` completed reward-bearing `4x4x1` and `8x8x1` training respectively; the pre-fix standalone run `glm52-m1a-dsa2043-20260827a` failed deterministically at skip layer 78 because source layer 75's shared indices were absent during recomputation.

The full Megatron unit test requires the repository GPU test runner and is left to upstream CI.
