### PR TITLE
[Dev] fix: Preserve offload events in Hybrid mHC CUDA graphs

### DIFF
--- a/docs/user-guide/features/fine_grained_activation_offloading.md
+++ b/docs/user-guide/features/fine_grained_activation_offloading.md
@@ -93,6 +93,8 @@ from all configured offload modules after those filters.
 
 Fine-grained offloading is compatible with CUDA graphs. When CUDA graph is enabled, the following constraints apply:
 
+> **Scope:** The event-boundary integration described in this section is specific to Transformer Engine's per-callable capture (`cuda_graph_impl=transformer_engine`). It does not change MCore's `local` or `full_iteration` CUDA graph runners.
+
 - `attn_norm` and `mlp_norm` **cannot** be offloaded (they cross CUDA graph boundaries).
 - Use an explicit scope containing each captured offloaded region: `attn` for attention-side offload, and add `moe_router` for the recommended partial-MoE delayed-expert setup.
 - Empty `cuda_graph_modules` (TE whole-layer capture) is not yet integrated with the offload event boundary and emits a warning; use explicit partial scopes.
@@ -200,6 +202,6 @@ A 'OffloadTensorPool` (on CPU with pinned memory) caches allocated tensors by `(
 When offloading interacts with CUDA graphs:
 
 - A dedicated `cuda_graph_stream` runs the captured computation, while `d2h_stream` overlaps D2H transfers for regions that are **inside** the graph capture.
-- The backward completion event is queued at the end of the autograd GraphTask, after all requested input and parameter gradients have been produced. TE can therefore synchronize the main stream without exposing partially written graph gradients; the subsequent `h2d_stream` join still prefetches the next offload group asynchronously.
+- During TE per-callable capture, the backward completion event is queued at the end of that callable's autograd GraphTask, after all requested input and parameter gradients have been produced. The CUDA event and stream wait become part of that callable's captured backward graph; replay does not run the Python callback again. TE can therefore synchronize the main stream without exposing partially written graph gradients, while the subsequent `h2d_stream` join still prefetches the next offload group asynchronously.
 - During CUDA graph **warmup**, offloading is disabled (`pre_warmup_hook` / `post_warmup_hook`).
 - The `delay_offload_until_cuda_graph` option defers D2H launches until graph replay, utilizing the CPU idle time during `cudaGraphLaunch` to issue offload commands with near-zero CPU overhead.

--- a/docs/user-guide/features/fine_grained_activation_offloading.md
+++ b/docs/user-guide/features/fine_grained_activation_offloading.md
@@ -94,7 +94,8 @@ from all configured offload modules after those filters.
 Fine-grained offloading is compatible with CUDA graphs. When CUDA graph is enabled, the following constraints apply:
 
 - `attn_norm` and `mlp_norm` **cannot** be offloaded (they cross CUDA graph boundaries).
-- `cuda_graph_scope` must include `attn` and `moe_router`.
+- Use an explicit scope containing each captured offloaded region: `attn` for attention-side offload, and add `moe_router` for the recommended partial-MoE delayed-expert setup.
+- Empty `cuda_graph_modules` (TE whole-layer capture) is not yet integrated with the offload event boundary and emits a warning; use explicit partial scopes.
 - `cuda_graph_impl` must be `transformer_engine`.
 - Requires `torch >= 2.9.0` and `transformer_engine >= 2.14.0`.
 
@@ -107,17 +108,19 @@ Fine-grained offloading is compatible with CUDA graphs. When CUDA graph is enabl
 
 **Inside vs outside `cuda_graph_scope`.** Offload boundaries that lie **inside** the captured `cuda_graph_scope` (for example `qkv_linear`, `core_attn`, and `attn_proj` when `attn` is in scope) are part of CUDA graph **capture and replay**. Their offload-related work is replayed with the graph rather than re-driven from Python each step, so they do **not** incur the same per-step CPU launch overhead as a purely eager path.
 
-Boundaries that run **outside** the captured region still execute as normal eager PyTorch each forward—for the recommended MoE setup, that includes expert compute after a graphed `moe_router` (e.g. offloading `expert_fc1` / `moe_act`). For those groups, each `group_offload` would otherwise submit D2H work from the host as soon as the forward hits the commit point.
+Boundaries that run **outside** the captured region still execute as normal eager PyTorch each forward—for the recommended MoE setup, that includes expert compute after a graphed `moe_router` (e.g. offloading `expert_fc1`, `moe_act`, or `fused_group_mlp`). For those groups, each `group_offload` would otherwise submit D2H work from the host as soon as the forward hits the commit point.
 
-**What this flag does.** It only affects offload commits that are explicitly wired with **delayed** group commit (currently the MoE expert path: `expert_fc1`, `moe_act`). Around each layer’s `TransformerEngine` CUDA graph replay, the offload manager enters **replay mode**; delayed commits **enqueue** `(callback, group name, forced tensors)` instead of launching D2H immediately, then **flush_delayed_groups** runs **after** that graph replay returns and issues the queued D2H copies in forward order, without changing the offload/reload semantics.
+**What this flag does.** It only affects offload commits that are explicitly wired with **delayed** group commit (currently the MoE expert path: `expert_fc1`, `moe_act`, and `fused_group_mlp`). Around each layer’s `TransformerEngine` CUDA graph replay, the offload manager enters **replay mode**; delayed commits **enqueue** `(callback, group name, forced tensors)` instead of launching D2H immediately, then **flush_delayed_groups** runs **after** that graph replay returns and issues the queued D2H copies in forward order, without changing the offload/reload semantics.
 
 **When this actually buys time (EP A2A after replay).** The benefit assumes a **real CPU/GPU synchronization gap right after graph replay**—in the usual MoE training layout, **expert parallel (EP) all-to-all** and related dispatch follows the graphed `moe_router` region. That A2A path typically needs the host to coordinate collectives and to **sync with the GPU** (e.g. wait for graph work to finish or for communication staging), so the CPU is not fully overlapped with useful launch work during that interval. Scheduling `flush_delayed_groups` **immediately after** `cudaGraphLaunch` returns uses that window to issue D2H copies from the host: the enqueue cost is largely **hidden** in slack that EP A2A would already incur. If there were no such post-replay sync (or expert work were fully captured inside the graph with no host-visible gap), deferring commits would not provide the same “free” host time.
 
 **Behavioral notes**
 
 - Does **not** replace or “delay” attention-side offloads inside the graphed `attn` region; those are not on the delayed path in the implementation.
+- HybridModel mHC wrappers currently leave their eager expert continuation outside this delayed replay lifecycle. They warn when delayed `expert_fc1`, `moe_act`, or `fused_group_mlp` offload is requested and commit those groups immediately until an explicit end-of-iteration drain is implemented.
 - Warmup and non-replay forwards still commit delayed-eligible groups immediately (no replay-mode deferral).
-- Must be used together with **fine-grained activation offloading** and **CUDA graph** under the same rules as this section (TE `cuda_graph_impl`, scope including `attn` and `moe_router`, etc.).
+- Must be used together with **fine-grained activation offloading** and **CUDA graph** under the same rules as this section (TE `cuda_graph_impl` and an explicit scope containing the relevant captured region—typically `moe_router`, plus `attn` when attention is also captured/offloaded).
+- The current lifecycle flushes delayed groups only at a later graph replay. The final eager expert group can therefore remain queued and be discarded by pipeline reset without a D2H copy, reducing the intended memory saving. A configuration warning is emitted until an explicit end-of-iteration drain is implemented.
 - Stream ordering between the graph compute path and `d2h_stream` still uses the existing events (`forward_record` / `backward_record`); this option only changes **when** eligible D2H work is submitted from the host.
 
 ### Combining with Fine-Grained Recomputation

--- a/docs/user-guide/features/fine_grained_activation_offloading.md
+++ b/docs/user-guide/features/fine_grained_activation_offloading.md
@@ -197,5 +197,6 @@ A 'OffloadTensorPool` (on CPU with pinned memory) caches allocated tensors by `(
 When offloading interacts with CUDA graphs:
 
 - A dedicated `cuda_graph_stream` runs the captured computation, while `d2h_stream` overlaps D2H transfers for regions that are **inside** the graph capture.
+- The backward completion event is queued at the end of the autograd GraphTask, after all requested input and parameter gradients have been produced. TE can therefore synchronize the main stream without exposing partially written graph gradients; the subsequent `h2d_stream` join still prefetches the next offload group asynchronously.
 - During CUDA graph **warmup**, offloading is disabled (`pre_warmup_hook` / `post_warmup_hook`).
 - The `delay_offload_until_cuda_graph` option defers D2H launches until graph replay, utilizing the CPU idle time during `cudaGraphLaunch` to issue offload commands with near-zero CPU overhead.

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -268,7 +268,11 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
 
     @property
     def offload_module_in_cuda_graph(self) -> bool:
-        """Whether TE must join the wrapper graph with offload streams."""
+        """Whether TE must join the wrapper graph with offload streams.
+
+        The graph-group tail setter is the only grouping mutation and invalidates
+        this replay-hot-path cache whenever it attaches a tail.
+        """
         cached = self._offload_module_in_cuda_graph_cached
         if cached is None:
             cached = self._compute_offload_module_in_cuda_graph()
@@ -365,18 +369,24 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         # The Hybrid wrapper, not its inner TransformerLayer(s), is the TE graph
         # callable. Place the offload events at this outer boundary so every D2H/H2D
         # stream dependency belongs to the graph being captured.
-        if self.offload_module_in_cuda_graph:
+        offload_in_graph = self.offload_module_in_cuda_graph
+        off_interface = self.off_interface
+        if offload_in_graph:
+            assert off_interface is not None, (
+                "offload_module_in_cuda_graph requires a TransformerLayer-backed "
+                "Hybrid wrapper with an offload interface."
+            )
             if args:
-                hidden_states = self.off_interface.backward_record(args[0])
+                hidden_states = off_interface.backward_record(args[0])
                 args = (hidden_states,) + args[1:]
             else:
-                hidden_states = self.off_interface.backward_record(kwargs.pop('hidden_states'))
+                hidden_states = off_interface.backward_record(kwargs.pop('hidden_states'))
                 kwargs['hidden_states'] = hidden_states
 
         cuda_graph_outputs = self._te_cuda_graph_capture_impl(*args, **kwargs)
 
-        if self.offload_module_in_cuda_graph:
-            self.off_interface.forward_record()
+        if offload_in_graph:
+            off_interface.forward_record()
         return cuda_graph_outputs
 
     def _te_cuda_graph_capture_impl(self, *args, **kwargs):

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -150,14 +150,13 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             )
         self.inner_layer = layer
         self.layer_number = layer.layer_number
+        self._offload_module_in_cuda_graph_cached: Optional[bool] = None
         self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
         # This wrapper is the TE graph callable, so it also owns the offload
-        # capture/replay boundary. Reuse the inner TransformerLayer interface when
-        # available; non-Transformer hybrid layers still need the interface to flush
-        # delayed groups left by a preceding partial-MoE wrapper.
-        self.off_interface = getattr(layer, 'off_interface', None)
-        if self.off_interface is None:
-            self.off_interface = _get_offloading_interface()
+        # capture/replay boundary. The interface methods operate on the process-global
+        # PipelineOffloadManager, so one wrapper interface intentionally covers a
+        # grouped attention head and partial-MoE tail.
+        self.off_interface = _get_offloading_interface()
         if config.params_dtype is not None:
             convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
         if hasattr(layer, 'tp_group'):
@@ -247,14 +246,13 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             and CudaGraphModule.moe_router in self.config.cuda_graph_modules
         )
 
-    def _inner_has_offload_module_in_cuda_graph(self) -> bool:
-        """Whether this wrapper's captured inner body contains an offload boundary.
+    def _compute_inner_offload_module_in_cuda_graph(self) -> bool:
+        """Whether the captured inner TransformerLayer contains an offload boundary.
 
         HybridStack can split attention and MoE into separate TransformerLayers while
-        sharing one global config. Consequently, the inner layer's cached flag is not
-        sufficient: a MoE-only layer with Identity attention may still report that
-        ``core_attn`` is offloaded. Inspect the concrete modules captured by this
-        wrapper instead.
+        sharing one global config. Start from TransformerLayer's explicit CUDA-graph
+        scope flag, then filter out scopes whose concrete module is Identity in this
+        split layer.
         """
         if not self.config.fine_grained_activation_offloading or not isinstance(
             self.inner_layer, TransformerLayer
@@ -262,43 +260,45 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             return False
 
         layer = self.inner_layer
-        has_attention = not (
+        if not layer.offload_module_in_cuda_graph or not self.config.cuda_graph_modules:
+            return False
+
+        attention_in_scope = CudaGraphModule.attn in self.config.cuda_graph_modules and not (
             isinstance(layer.self_attention, IdentityOp)
             and isinstance(layer.cross_attention, IdentityOp)
         )
-        captured_attention = has_attention and (
-            not self._inner_is_partial_moe_capture()
-            or not self.config.cuda_graph_modules
-            or CudaGraphModule.attn in self.config.cuda_graph_modules
-        )
-        if captured_attention and (
-            layer.offload_attn_norm
-            or layer.offload_qkv_linear
-            or layer.offload_core_attn
-            or layer.offload_attn_proj
+        if attention_in_scope and (
+            layer.offload_qkv_linear or layer.offload_core_attn or layer.offload_attn_proj
         ):
             return True
 
-        # Non-MoE wrappers capture their whole forward once selected as a TE
-        # callable. The pre-MLP norm is the only dense MLP offload boundary that
-        # contributes to the graph-level stream/event handshake.
+        # Mirror TransformerLayer's dense-MLP rule: only an explicit ``mlp``
+        # graph scope with ``mlp_norm`` offloading participates. The additional
+        # Identity check filters HybridStack's attention-only split layers.
         return bool(
-            not layer.is_moe_layer
+            CudaGraphModule.mlp in self.config.cuda_graph_modules
+            and not layer.is_moe_layer
             and not isinstance(layer.mlp, IdentityOp)
             and layer.offload_mlp_norm
         )
 
-    def _has_offload_module_in_cuda_graph(self) -> bool:
-        """Return the effective offload state for this complete TE callable."""
-        if self._inner_has_offload_module_in_cuda_graph():
+    def _compute_offload_module_in_cuda_graph(self) -> bool:
+        """Compute the effective offload state for this complete TE callable."""
+        if self._compute_inner_offload_module_in_cuda_graph():
             return True
         group_tail = self._get_te_cuda_graph_group_tail()
-        return bool(group_tail is not None and group_tail._inner_has_offload_module_in_cuda_graph())
+        return bool(
+            group_tail is not None and group_tail._compute_inner_offload_module_in_cuda_graph()
+        )
 
     @property
     def offload_module_in_cuda_graph(self) -> bool:
         """Whether TE must join the wrapper graph with offload streams."""
-        return self._has_offload_module_in_cuda_graph()
+        cached = getattr(self, '_offload_module_in_cuda_graph_cached', None)
+        if cached is None:
+            cached = self._compute_offload_module_in_cuda_graph()
+            object.__setattr__(self, '_offload_module_in_cuda_graph_cached', cached)
+        return cached
 
     def _can_group_te_cuda_graph_with(self, next_layer: MegatronModule) -> bool:
         """Whether this attention layer and the following MoE prefix can share one TE graph.
@@ -337,6 +337,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         # Bypass nn.Module.__setattr__: next_layer remains registered exactly once in
         # HybridStack.layers, so this capture-only reference cannot alter state_dict keys.
         object.__setattr__(self, '_te_cuda_graph_group_tail', next_layer)
+        object.__setattr__(self, '_offload_module_in_cuda_graph_cached', None)
 
     def _get_te_cuda_graph_group_tail(self) -> Optional['HyperConnectionHybridLayer']:
         """Return the capture-only MoE tail, if discovery grouped this layer."""
@@ -405,6 +406,10 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
 
     def _te_cuda_graph_capture_impl(self, *args, **kwargs):
         """Capture the wrapper body without adding offload boundary events."""
+        assert 'cu_seqlens_q' not in kwargs, (
+            "Hybrid CUDA graph capture body received raw THD sequence tensors. "
+            "The outer capture boundary must reconstruct PackedSeqParams first."
+        )
 
         group_tail = self._get_te_cuda_graph_group_tail()
         if group_tail is not None:
@@ -465,6 +470,9 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         group_tail = self._get_te_cuda_graph_group_tail()
         cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
         if self.config.delay_offload_until_cuda_graph:
+            # FineGrainedActivationOffloadingInterface is static over the
+            # process-global PipelineOffloadManager. The grouped head therefore
+            # intentionally flushes delayed work queued by either grouped layer.
             self.off_interface.flush_delayed_groups()
 
         if group_tail is not None:

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -43,7 +43,7 @@ from megatron.core.transformer.module import (
 )
 from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
-from megatron.core.transformer.transformer_layer import TransformerLayer, _get_offloading_interface
+from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import (
     ensure_metadata_has_dp_cp_group,
     make_sharded_tensors_for_checkpoint,
@@ -152,11 +152,11 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         self.layer_number = layer.layer_number
         self._offload_module_in_cuda_graph_cached: Optional[bool] = None
         self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
-        # This wrapper is the TE graph callable, so it also owns the offload
-        # capture/replay boundary. The interface methods operate on the process-global
-        # PipelineOffloadManager, so one wrapper interface intentionally covers a
-        # grouped attention head and partial-MoE tail.
-        self.off_interface = _get_offloading_interface()
+        # This wrapper is the TE graph callable, so it owns the captured offload event
+        # boundary. Reuse the inner Transformer's interface instead of reaching across
+        # modules for its private factory. Only TransformerLayer-backed wrappers can
+        # report an offload boundary in ``offload_module_in_cuda_graph``.
+        self.off_interface = layer.off_interface if isinstance(layer, TransformerLayer) else None
         if config.params_dtype is not None:
             convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
         if hasattr(layer, 'tp_group'):
@@ -250,37 +250,12 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         """Whether the captured inner TransformerLayer contains an offload boundary.
 
         HybridStack can split attention and MoE into separate TransformerLayers while
-        sharing one global config. Start from TransformerLayer's explicit CUDA-graph
-        scope flag, then filter out scopes whose concrete module is Identity in this
-        split layer.
+        sharing one global config, so require the configured scope to have a concrete
+        branch in this split layer.
         """
-        if not self.config.fine_grained_activation_offloading or not isinstance(
-            self.inner_layer, TransformerLayer
-        ):
+        if not isinstance(self.inner_layer, TransformerLayer):
             return False
-
-        layer = self.inner_layer
-        if not layer.offload_module_in_cuda_graph or not self.config.cuda_graph_modules:
-            return False
-
-        attention_in_scope = CudaGraphModule.attn in self.config.cuda_graph_modules and not (
-            isinstance(layer.self_attention, IdentityOp)
-            and isinstance(layer.cross_attention, IdentityOp)
-        )
-        if attention_in_scope and (
-            layer.offload_qkv_linear or layer.offload_core_attn or layer.offload_attn_proj
-        ):
-            return True
-
-        # Mirror TransformerLayer's dense-MLP rule: only an explicit ``mlp``
-        # graph scope with ``mlp_norm`` offloading participates. The additional
-        # Identity check filters HybridStack's attention-only split layers.
-        return bool(
-            CudaGraphModule.mlp in self.config.cuda_graph_modules
-            and not layer.is_moe_layer
-            and not isinstance(layer.mlp, IdentityOp)
-            and layer.offload_mlp_norm
-        )
+        return self.inner_layer.offload_scope_in_cuda_graph(require_concrete_modules=True)
 
     def _compute_offload_module_in_cuda_graph(self) -> bool:
         """Compute the effective offload state for this complete TE callable."""
@@ -452,28 +427,20 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         experts eagerly and apply the mHC n-stream BDA — reproducing exactly the eager
         wrapper tail (``layer_delta = layer_output - aggregated`` then
         ``fused_h_res_h_post_bda``), just with the deterministic prefix graphed.
+
+        Captured ``core_attn`` offload synchronization uses the wrapper-level events in
+        ``_te_cuda_graph_capture`` and does not use the delayed-offload queue. Delayed
+        expert offload is intentionally outside the Hybrid CUDA Graph support in this
+        change, so this wrapper must not enter or flush that queue around replay.
         """
         self._decompose_packed_seq_params_to_kwargs(kwargs)
-
-        if self.config.delay_offload_until_cuda_graph:
-            self.off_interface.enter_replay()
-
-        try:
-            return self._te_cuda_graph_replay_impl(args, kwargs)
-        finally:
-            if self.config.delay_offload_until_cuda_graph:
-                self.off_interface.exit_replay()
+        return self._te_cuda_graph_replay_impl(args, kwargs)
 
     def _te_cuda_graph_replay_impl(self, args, kwargs):
         """Replay the wrapper graph, then run any eager continuation."""
 
         group_tail = self._get_te_cuda_graph_group_tail()
         cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
-        if self.config.delay_offload_until_cuda_graph:
-            # FineGrainedActivationOffloadingInterface is static over the
-            # process-global PipelineOffloadManager. The grouped head therefore
-            # intentionally flushes delayed work queued by either grouped layer.
-            self.off_interface.flush_delayed_groups()
 
         if group_tail is not None:
             return group_tail._resume_partial_moe_cuda_graph(cuda_graph_output)

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -43,7 +43,7 @@ from megatron.core.transformer.module import (
 )
 from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
-from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.core.transformer.transformer_layer import TransformerLayer, _get_offloading_interface
 from megatron.core.transformer.utils import (
     ensure_metadata_has_dp_cp_group,
     make_sharded_tensors_for_checkpoint,
@@ -151,6 +151,13 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         self.inner_layer = layer
         self.layer_number = layer.layer_number
         self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
+        # This wrapper is the TE graph callable, so it also owns the offload
+        # capture/replay boundary. Reuse the inner TransformerLayer interface when
+        # available; non-Transformer hybrid layers still need the interface to flush
+        # delayed groups left by a preceding partial-MoE wrapper.
+        self.off_interface = getattr(layer, 'off_interface', None)
+        if self.off_interface is None:
+            self.off_interface = _get_offloading_interface()
         if config.params_dtype is not None:
             convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
         if hasattr(layer, 'tp_group'):
@@ -240,6 +247,59 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
             and CudaGraphModule.moe_router in self.config.cuda_graph_modules
         )
 
+    def _inner_has_offload_module_in_cuda_graph(self) -> bool:
+        """Whether this wrapper's captured inner body contains an offload boundary.
+
+        HybridStack can split attention and MoE into separate TransformerLayers while
+        sharing one global config. Consequently, the inner layer's cached flag is not
+        sufficient: a MoE-only layer with Identity attention may still report that
+        ``core_attn`` is offloaded. Inspect the concrete modules captured by this
+        wrapper instead.
+        """
+        if not self.config.fine_grained_activation_offloading or not isinstance(
+            self.inner_layer, TransformerLayer
+        ):
+            return False
+
+        layer = self.inner_layer
+        has_attention = not (
+            isinstance(layer.self_attention, IdentityOp)
+            and isinstance(layer.cross_attention, IdentityOp)
+        )
+        captured_attention = has_attention and (
+            not self._inner_is_partial_moe_capture()
+            or not self.config.cuda_graph_modules
+            or CudaGraphModule.attn in self.config.cuda_graph_modules
+        )
+        if captured_attention and (
+            layer.offload_attn_norm
+            or layer.offload_qkv_linear
+            or layer.offload_core_attn
+            or layer.offload_attn_proj
+        ):
+            return True
+
+        # Non-MoE wrappers capture their whole forward once selected as a TE
+        # callable. The pre-MLP norm is the only dense MLP offload boundary that
+        # contributes to the graph-level stream/event handshake.
+        return bool(
+            not layer.is_moe_layer
+            and not isinstance(layer.mlp, IdentityOp)
+            and layer.offload_mlp_norm
+        )
+
+    def _has_offload_module_in_cuda_graph(self) -> bool:
+        """Return the effective offload state for this complete TE callable."""
+        if self._inner_has_offload_module_in_cuda_graph():
+            return True
+        group_tail = self._get_te_cuda_graph_group_tail()
+        return bool(group_tail is not None and group_tail._inner_has_offload_module_in_cuda_graph())
+
+    @property
+    def offload_module_in_cuda_graph(self) -> bool:
+        """Whether TE must join the wrapper graph with offload streams."""
+        return self._has_offload_module_in_cuda_graph()
+
     def _can_group_te_cuda_graph_with(self, next_layer: MegatronModule) -> bool:
         """Whether this attention layer and the following MoE prefix can share one TE graph.
 
@@ -326,20 +386,42 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         """
         self._reconstruct_packed_seq_params_from_kwargs(kwargs)
 
+        # The Hybrid wrapper, not its inner TransformerLayer(s), is the TE graph
+        # callable. Place the offload events at this outer boundary so every D2H/H2D
+        # stream dependency belongs to the graph being captured.
+        if self.offload_module_in_cuda_graph:
+            if args:
+                hidden_states = self.off_interface.backward_record(args[0])
+                args = (hidden_states,) + args[1:]
+            else:
+                hidden_states = self.off_interface.backward_record(kwargs.pop('hidden_states'))
+                kwargs['hidden_states'] = hidden_states
+
+        cuda_graph_outputs = self._te_cuda_graph_capture_impl(*args, **kwargs)
+
+        if self.offload_module_in_cuda_graph:
+            self.off_interface.forward_record()
+        return cuda_graph_outputs
+
+    def _te_cuda_graph_capture_impl(self, *args, **kwargs):
+        """Capture the wrapper body without adding offload boundary events."""
+
         group_tail = self._get_te_cuda_graph_group_tail()
         if group_tail is not None:
             hidden_states, context = self.forward(*args, **kwargs)
             assert context is None, "Grouped hybrid CUDA graphs do not support cross-attention."
             tail_kwargs = dict(kwargs)
             tail_kwargs.pop("hidden_states", None)
-            return group_tail._te_cuda_graph_capture(hidden_states, **tail_kwargs)
+            return group_tail._te_cuda_graph_capture_impl(hidden_states, **tail_kwargs)
 
         if self._inner_is_partial_moe_capture():
             hidden_states = args[0] if args else kwargs["hidden_states"]
             aggregated, h_res, h_post, residual = self.hyper_connection(hidden_states)
             inner_kwargs = dict(kwargs)
             inner_kwargs.pop("hidden_states", None)
-            inner_out = list(self.inner_layer._te_cuda_graph_capture(aggregated, **inner_kwargs))
+            inner_out = list(
+                self.inner_layer._te_cuda_graph_capture_impl(aggregated, **inner_kwargs)
+            )
             # inner_out = router/preprocess intermediates ending in the inner residual;
             # append the mHC state AND the n-stream `residual` returned by the (graphed)
             # hyper_connection. Routing `residual` through the graph as an output keeps its
@@ -368,16 +450,29 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         """
         self._decompose_packed_seq_params_to_kwargs(kwargs)
 
+        if self.config.delay_offload_until_cuda_graph:
+            self.off_interface.enter_replay()
+
+        try:
+            return self._te_cuda_graph_replay_impl(args, kwargs)
+        finally:
+            if self.config.delay_offload_until_cuda_graph:
+                self.off_interface.exit_replay()
+
+    def _te_cuda_graph_replay_impl(self, args, kwargs):
+        """Replay the wrapper graph, then run any eager continuation."""
+
         group_tail = self._get_te_cuda_graph_group_tail()
+        cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
+        if self.config.delay_offload_until_cuda_graph:
+            self.off_interface.flush_delayed_groups()
+
         if group_tail is not None:
-            out = list(super()._te_cuda_graph_replay(*args, **kwargs))
-            return group_tail._resume_partial_moe_cuda_graph(out)
+            return group_tail._resume_partial_moe_cuda_graph(cuda_graph_output)
 
         if self._inner_is_partial_moe_capture():
-            out = list(super()._te_cuda_graph_replay(*args, **kwargs))
-            return self._resume_partial_moe_cuda_graph(out)
+            return self._resume_partial_moe_cuda_graph(cuda_graph_output)
 
-        cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
         return cuda_graph_output[0], None
 
     def _resume_partial_moe_cuda_graph(self, out: List[Tensor]) -> Tuple[Tensor, Optional[Tensor]]:

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -294,10 +294,10 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
     @property
     def offload_module_in_cuda_graph(self) -> bool:
         """Whether TE must join the wrapper graph with offload streams."""
-        cached = getattr(self, '_offload_module_in_cuda_graph_cached', None)
+        cached = self._offload_module_in_cuda_graph_cached
         if cached is None:
             cached = self._compute_offload_module_in_cuda_graph()
-            object.__setattr__(self, '_offload_module_in_cuda_graph_cached', cached)
+            self._offload_module_in_cuda_graph_cached = cached
         return cached
 
     def _can_group_te_cuda_graph_with(self, next_layer: MegatronModule) -> bool:
@@ -337,7 +337,7 @@ class HyperConnectionHybridLayer(GraphableMegatronModule):
         # Bypass nn.Module.__setattr__: next_layer remains registered exactly once in
         # HybridStack.layers, so this capture-only reference cannot alter state_dict keys.
         object.__setattr__(self, '_te_cuda_graph_group_tail', next_layer)
-        object.__setattr__(self, '_offload_module_in_cuda_graph_cached', None)
+        self._offload_module_in_cuda_graph_cached = None
 
     def _get_te_cuda_graph_group_tail(self) -> Optional['HyperConnectionHybridLayer']:
         """Return the capture-only MoE tail, if discovery grouped this layer."""

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -1339,13 +1339,21 @@ class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        """Record the backward event and wait for the h2d stream on cuda graph stream."""
+        """Queue the graph-tail event and H2D join after every backward node finishes."""
         debug_rank("FineGrainedOffloadingBackwardRecordFunction backward")
-        mgr = PipelineOffloadManager.get_instance()
-        # This event connects TE's graph stream with the reload stream so
-        # backward consumers do not race H2D reloads launched outside the graph.
-        torch.cuda.current_stream().record_event(mgr.cuda_graph_event)
-        torch.cuda.current_stream().wait_stream(mgr.h2d_stream)
+
+        def record_backward_completion():
+            mgr = PipelineOffloadManager.get_instance()
+            current_stream = torch.cuda.current_stream()
+            # TE uses this external event to synchronize the main stream after
+            # replay. Record it only after the entire GraphTask, including all
+            # requested parameter and input gradients, has completed. The following
+            # H2D join remains after the event so next-group reload can overlap
+            # main-stream work while still belonging to the captured graph.
+            current_stream.record_event(mgr.cuda_graph_event)
+            current_stream.wait_stream(mgr.h2d_stream)
+
+        torch.autograd.Variable._execution_engine.queue_callback(record_backward_completion)
         return (grad_output,)
 
 

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -1327,8 +1327,10 @@ def fine_grained_offloading_group_start(tensor, name=None):
 
 class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
     """
-    Identity operation that marks the end of a layer group for offload synchronization.
-    Triggers offload during forward and synchronizes reload during backward.
+    Identity operation that marks a Transformer Engine per-callable capture boundary.
+
+    This is inserted by ``_te_cuda_graph_capture``; MCore local and full-iteration
+    CUDA graph runners do not use this callback-based boundary.
     """
 
     @staticmethod
@@ -1339,7 +1341,7 @@ class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        """Queue the graph-tail event and H2D join after every backward node finishes."""
+        """Queue the event and H2D join at the current TE callable's GraphTask tail."""
         debug_rank("FineGrainedOffloadingBackwardRecordFunction backward")
 
         def record_backward_completion():
@@ -1353,9 +1355,12 @@ class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
             current_stream.record_event(mgr.cuda_graph_event)
             current_stream.wait_stream(mgr.h2d_stream)
 
-        # Keep backward_record's autograd node on the outermost TE CUDA Graph callable
-        # boundary. If this record point moves inside a reentrant checkpoint backward, the
-        # callback will run when that inner GraphTask ends and record the graph-tail event early.
+        # TE warms up and captures every callable with a separate autograd.backward(),
+        # so this callback runs before that callable's backward capture context closes.
+        # Its CUDA commands become the tail of that callable's backward graph; normal
+        # training replay calls bwd_graph.replay() and does not run this Python callback
+        # again. Keep backward_record's node on this outer per-callable boundary: moving
+        # it into a reentrant checkpoint would instead target the inner GraphTask tail.
         torch.autograd.Variable._execution_engine.queue_callback(record_backward_completion)
         return (grad_output,)
 

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -1353,6 +1353,9 @@ class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
             current_stream.record_event(mgr.cuda_graph_event)
             current_stream.wait_stream(mgr.h2d_stream)
 
+        # Keep backward_record's autograd node on the outermost TE CUDA Graph callable
+        # boundary. If this record point moves inside a reentrant checkpoint backward, the
+        # callback will run when that inner GraphTask ends and record the graph-tail event early.
         torch.autograd.Variable._execution_engine.queue_callback(record_backward_completion)
         return (grad_output,)
 

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2019,11 +2019,18 @@ class TECudaGraphHelper:
                 self.num_microbatches == len(order) // self.num_model_chunks // 2
             ), "num_microbatches must match the number of microbatches in order."
 
+        # Import once per sample-building pass to avoid module-load cycles without
+        # repeating the imports for every layer and microbatch.
+        from megatron.core.models.hybrid.hybrid_block import HyperConnectionHybridLayer
+        from megatron.core.transformer.identity_op import IdentityOp
+        from megatron.core.transformer.transformer_layer import TransformerLayer
+
         # Generate sample arguments and keyword arguments for capturing.
         sample_args = [None] * (len(self.flattened_callables) * self.num_microbatches)
         sample_kwargs = [None] * (len(self.flattened_callables) * self.num_microbatches)
 
         rotary_pos_emb_cache = {}
+        # Avoid repeating the same message across layers within this capture setup.
         warned_rotary_sample_contracts = set()
 
         def _get_layer_static_inputs(layer, chunk_of_the_layer):
@@ -2063,10 +2070,6 @@ class TECudaGraphHelper:
                     1, local_slen, dtype=torch.bool, device=torch.cuda.current_device()
                 )
 
-            from megatron.core.models.hybrid.hybrid_block import HyperConnectionHybridLayer
-            from megatron.core.transformer.identity_op import IdentityOp
-            from megatron.core.transformer.transformer_layer import TransformerLayer
-
             # Hybrid mHC wraps the concrete TransformerLayer, but the wrapper is the
             # callable passed to TE. Inspect the inner layer when deciding whether
             # rotary embeddings belong to the graph's static keyword inputs.
@@ -2082,10 +2085,12 @@ class TECudaGraphHelper:
                 )
             )
 
-            position_embedding_type = getattr(chunk_of_the_layer, 'position_embedding_type', None)
             if contains_self_attn and not self.config.multi_latent_attention:
+                position_embedding_type = getattr(
+                    chunk_of_the_layer, 'position_embedding_type', None
+                )
                 is_thd = 'cu_seqlens_q' in static_inputs
-                context_parallel_size = getattr(self.config, 'context_parallel_size', 1)
+                context_parallel_size = self.config.context_parallel_size
                 unsupported_reasons = []
                 if position_embedding_type == 'yarn':
                     unsupported_reasons.append(
@@ -2101,12 +2106,7 @@ class TECudaGraphHelper:
                         'runtime packed sequences use the full table'
                     )
 
-                warning_key = (
-                    position_embedding_type,
-                    is_thd,
-                    context_parallel_size,
-                    tuple(unsupported_reasons),
-                )
+                warning_key = (position_embedding_type, is_thd, context_parallel_size)
                 if unsupported_reasons and warning_key not in warned_rotary_sample_contracts:
                     warned_rotary_sample_contracts.add(warning_key)
                     reasons = '; '.join(unsupported_reasons)

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2024,6 +2024,7 @@ class TECudaGraphHelper:
         sample_kwargs = [None] * (len(self.flattened_callables) * self.num_microbatches)
 
         rotary_pos_emb_cache = {}
+        warned_rotary_sample_contracts = set()
 
         def _get_layer_static_inputs(layer, chunk_of_the_layer):
             """
@@ -2034,6 +2035,11 @@ class TECudaGraphHelper:
             ), "Layer is not in the chunk"
 
             def get_rotary_pos_emb(transformer_module, transformer_input):
+                # The TE sample builder currently materializes only the regular RoPE
+                # contract. Yarn and mRoPE need different runtime inputs, while packed
+                # THD with CP>1 needs a full (not CP-sliced) RoPE table. Keep the legacy
+                # sample behavior unchanged here and warn below when one of those
+                # unsupported contracts is actually captured.
                 if (
                     transformer_module.position_embedding_type == 'rope'
                     and not self.config.multi_latent_attention
@@ -2075,6 +2081,55 @@ class TECudaGraphHelper:
                     or CudaGraphModule.attn in self.config.cuda_graph_modules
                 )
             )
+
+            position_embedding_type = getattr(chunk_of_the_layer, 'position_embedding_type', None)
+            if contains_self_attn and not self.config.multi_latent_attention:
+                is_thd = 'cu_seqlens_q' in static_inputs
+                context_parallel_size = getattr(self.config, 'context_parallel_size', 1)
+                unsupported_reasons = []
+                if position_embedding_type == 'yarn':
+                    unsupported_reasons.append(
+                        'Yarn rotary embeddings are not represented in the capture sample inputs'
+                    )
+                elif position_embedding_type == 'mrope':
+                    unsupported_reasons.append(
+                        'mRoPE rotary embeddings are not represented in the capture sample inputs'
+                    )
+                if position_embedding_type == 'rope' and is_thd and context_parallel_size > 1:
+                    unsupported_reasons.append(
+                        'THD with context parallelism captures a CP-sliced RoPE table, while '
+                        'runtime packed sequences use the full table'
+                    )
+
+                warning_key = (
+                    position_embedding_type,
+                    is_thd,
+                    context_parallel_size,
+                    tuple(unsupported_reasons),
+                )
+                if unsupported_reasons and warning_key not in warned_rotary_sample_contracts:
+                    warned_rotary_sample_contracts.add(warning_key)
+                    reasons = '; '.join(unsupported_reasons)
+                    if position_embedding_type == 'mrope':
+                        affected_models = 'GPTModel'
+                    else:
+                        affected_models = 'GPTModel and HybridModel'
+                    log_on_each_pipeline_stage(
+                        logger=logger,
+                        tp_group=self.tp_group,
+                        dp_cp_group=self.dp_cp_group,
+                        level=logging.WARNING,
+                        msg='TE CUDA Graph self-attention capture does not preserve the runtime '
+                        f'rotary embedding contract for position_embedding_type='
+                        f'{position_embedding_type!r}, input_format='
+                        f'{"THD" if is_thd else "SBHD"}, context_parallel_size='
+                        f'{context_parallel_size}: {reasons}. CUDA Graph replay may omit or '
+                        'mis-shape rotary_pos_emb, so numerical results are not reliable. '
+                        'This is a pre-existing limitation in the sample-input path affecting '
+                        f'{affected_models}. Disable TE attention capture, or use regular '
+                        'RoPE with SBHD (any supported CP) or THD with CP=1, until the shared '
+                        'sample-input path is fixed.',
+                    )
 
             _sample_kwargs = {}
             if is_te_min_version("1.10.0"):

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2057,12 +2057,19 @@ class TECudaGraphHelper:
                     1, local_slen, dtype=torch.bool, device=torch.cuda.current_device()
                 )
 
+            from megatron.core.models.hybrid.hybrid_block import HyperConnectionHybridLayer
             from megatron.core.transformer.identity_op import IdentityOp
             from megatron.core.transformer.transformer_layer import TransformerLayer
 
+            # Hybrid mHC wraps the concrete TransformerLayer, but the wrapper is the
+            # callable passed to TE. Inspect the inner layer when deciding whether
+            # rotary embeddings belong to the graph's static keyword inputs.
+            attention_layer = (
+                layer.inner_layer if isinstance(layer, HyperConnectionHybridLayer) else layer
+            )
             contains_self_attn = (
-                isinstance(layer, TransformerLayer)
-                and not isinstance(layer.self_attention, IdentityOp)
+                isinstance(attention_layer, TransformerLayer)
+                and not isinstance(attention_layer.self_attention, IdentityOp)
                 and (
                     not self.config.cuda_graph_modules
                     or CudaGraphModule.attn in self.config.cuda_graph_modules

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3459,7 +3459,59 @@ class TransformerConfig(ModelParallelConfig):
                     )
             elif self.cuda_graph_impl not in ("none", "full_iteration"):
                 raise ValueError(f"MOK does not support cuda_graph_impl={self.cuda_graph_impl!r}")
+        if (
+            self.fine_grained_activation_offloading
+            and self.offload_modules
+            and self.cuda_graph_impl == "transformer_engine"
+            and not self.cuda_graph_modules
+        ):
+            warnings.warn(
+                "Fine-grained activation offloading with Transformer Engine whole-layer "
+                "CUDA Graph capture (empty cuda_graph_modules) does not currently install "
+                "the per-module offload event boundary. This pre-existing limitation is "
+                "shared by GPTModel and HybridModel and may cause CUDA capture dependency "
+                "errors. Use explicit partial scopes containing the relevant region ('attn' "
+                "for attention-side offload or 'moe_router' for partial MoE expert offload) "
+                "until whole-layer offload integration is fixed.",
+                UserWarning,
+                stacklevel=2,
+            )
 
+        delayed_expert_modules = {"expert_fc1", "moe_act", "fused_group_mlp"} & set(
+            self.offload_modules or []
+        )
+        delayed_partial_expert_offload = (
+            self.fine_grained_activation_offloading
+            and self.delay_offload_until_cuda_graph
+            and self.cuda_graph_impl == "transformer_engine"
+            and CudaGraphModule.moe_router in self.cuda_graph_modules
+            and bool(delayed_expert_modules)
+        )
+        if (
+            delayed_partial_expert_offload
+            and self.is_hybrid_model
+            and self.enable_hyper_connections
+        ):
+            warnings.warn(
+                "HybridModel mHC wrappers do not currently support "
+                "delay_offload_until_cuda_graph for expert offloads "
+                f"{sorted(delayed_expert_modules)}. Their eager expert continuation "
+                "commits offloads immediately; captured attention offloads are unaffected. "
+                "Disable delay_offload_until_cuda_graph until the Hybrid delayed queue has "
+                "an explicit end-of-iteration drain.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif delayed_partial_expert_offload:
+            warnings.warn(
+                "Delayed expert offload currently flushes only at a later Transformer Engine "
+                "CUDA Graph replay. The final eager expert group can remain queued and be "
+                "discarded by the pipeline reset without a D2H copy, reducing the intended "
+                "memory saving. Disable delay_offload_until_cuda_graph to commit every expert "
+                "group immediately until an explicit end-of-iteration drain is implemented.",
+                UserWarning,
+                stacklevel=2,
+            )
         # mHC selective recompute composes with CUDA graphs on two paths: the
         # opt-in attention-only split, and whole-range capture for everything
         # else. This gate must stay below the cuda_graph_modules normalization

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3503,14 +3503,16 @@ class TransformerConfig(ModelParallelConfig):
                 stacklevel=2,
             )
         elif delayed_partial_expert_offload:
-            warnings.warn(
+            # TODO: replace this compatibility warning with a supported explicit
+            # end-of-iteration drain for the final delayed expert group.
+            log_single_rank(
+                logger,
+                logging.WARNING,
                 "Delayed expert offload currently flushes only at a later Transformer Engine "
                 "CUDA Graph replay. The final eager expert group can remain queued and be "
                 "discarded by the pipeline reset without a D2H copy, reducing the intended "
                 "memory saving. Disable delay_offload_until_cuda_graph to commit every expert "
                 "group immediately until an explicit end-of-iteration drain is implemented.",
-                UserWarning,
-                stacklevel=2,
             )
         # mHC selective recompute composes with CUDA graphs on two paths: the
         # opt-in attention-only split, and whole-range capture for everything

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1465,6 +1465,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         part of a larger callable, avoiding nested events in the middle of that graph.
         ``packed_seq_params`` must already be reconstructed by the boundary owner.
         """
+        assert 'cu_seqlens_q' not in kwargs, (
+            "TransformerLayer CUDA graph capture body received raw THD sequence tensors. "
+            "The outer capture boundary must reconstruct PackedSeqParams first."
+        )
+
         context = None
         if (
             not self.config.cuda_graph_modules
@@ -2153,7 +2158,13 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         return attention_output, output_bias
 
     def _te_cuda_graph_capture(self, *args, **kwargs):
-        """Capture only the attention consumer for the split mHC path."""
+        """Capture only the attention consumer for the split mHC path.
+
+        This GPT layer is itself the top-level TE graph callable. HybridStack instead wraps
+        plain ``TransformerLayer`` instances in ``HyperConnectionHybridLayer``, so no outer
+        wrapper calls this subclass's ``_te_cuda_graph_capture_impl``. If that topology changes,
+        this subclass must override the implementation entry point as well.
+        """
         if not self._uses_mhc_recompute_attn_cuda_graph_split():
             return super()._te_cuda_graph_capture(*args, **kwargs)
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1447,6 +1447,24 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 hidden_states = kwargs.pop("hidden_states")
                 hidden_states = self.off_interface.backward_record(hidden_states)
                 kwargs["hidden_states"] = hidden_states
+
+        cuda_graph_outputs = self._te_cuda_graph_capture_impl(*args, **kwargs)
+
+        # Record the forward event on cuda graph stream for cuda graph capture.
+        # This is to ensure the main stream waits for computing on cuda graph stream to complete,
+        # and overlaps with the D2H transfer on offloading stream.
+        if self.offload_module_in_cuda_graph:
+            self.off_interface.forward_record()
+        return cuda_graph_outputs
+
+    def _te_cuda_graph_capture_impl(self, *args, **kwargs):
+        """Capture this layer's graph-safe body without offload boundary events.
+
+        The public capture entry owns the graph boundary. Outer graphable wrappers
+        may call this implementation when they capture the TransformerLayer body as
+        part of a larger callable, avoiding nested events in the middle of that graph.
+        ``packed_seq_params`` must already be reconstructed by the boundary owner.
+        """
         context = None
         if (
             not self.config.cuda_graph_modules
@@ -1482,11 +1500,6 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             cuda_graph_outputs = list(hidden_states)
         if context is not None:
             cuda_graph_outputs.append(context)
-        # Record the forward event on cuda graph stream for cuda graph capture.
-        # This is to ensure the main stream waits for computing on cuda graph stream to complete,
-        # and overlaps with the D2H transfer on offloading stream.
-        if self.offload_module_in_cuda_graph:
-            self.off_interface.forward_record()
         return tuple(cuda_graph_outputs)
 
     def _te_cuda_graph_replay(self, *args, **kwargs):

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1839,6 +1839,48 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         return super().__call__(*args, **kwargs)
 
+    def offload_scope_in_cuda_graph(self, *, require_concrete_modules: bool = False) -> bool:
+        """Return whether this layer's CUDA Graph scope contains an offload boundary.
+
+        Args:
+            require_concrete_modules: When ``True``, ignore configured scopes whose branch is an
+                ``IdentityOp``. HybridStack uses this mode because it represents attention and
+                MLP/MoE branches as separate ``TransformerLayer`` instances that share one config.
+                The default preserves the regular GPT ``TransformerLayer`` scope semantics.
+
+        An empty ``cuda_graph_modules`` list means whole-layer capture, but the legacy
+        fine-grained-offload integration does not install a per-module event boundary for that
+        scope. ``TransformerConfig`` warns about that shared GPT/Hybrid limitation; keep returning
+        ``False`` here until whole-layer attention, norm, and expert boundaries are handled
+        together.
+        """
+        if not self.config.fine_grained_activation_offloading:
+            return False
+
+        cuda_graph_modules = self.config.cuda_graph_modules
+        if not cuda_graph_modules:
+            return False
+
+        if CudaGraphModule.attn in cuda_graph_modules and (
+            self.offload_core_attn or self.offload_attn_proj or self.offload_qkv_linear
+        ):
+            has_attention = not (
+                isinstance(self.self_attention, IdentityOp)
+                and isinstance(self.cross_attention, IdentityOp)
+            )
+            if not require_concrete_modules or has_attention:
+                return True
+
+        if (
+            not self.is_moe_layer
+            and CudaGraphModule.mlp in cuda_graph_modules
+            and self.offload_mlp_norm
+        ):
+            if not require_concrete_modules or not isinstance(self.mlp, IdentityOp):
+                return True
+
+        return False
+
     def _set_offload_modules(self):
         """Set the offload modules for the transformer layer."""
         if self.config.fine_grained_activation_offloading:
@@ -1898,13 +1940,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     "Disabling mlp_norm offloading.",
                 )
         # Set the offload module in cuda graph flag.
-        self.offload_module_in_cuda_graph = False
-        if CudaGraphModule.attn in self.config.cuda_graph_modules:
-            if self.offload_core_attn or self.offload_attn_proj or self.offload_qkv_linear:
-                self.offload_module_in_cuda_graph = True
-        if not self.is_moe_layer and CudaGraphModule.mlp in self.config.cuda_graph_modules:
-            if self.offload_mlp_norm:
-                self.offload_module_in_cuda_graph = True
+        self.offload_module_in_cuda_graph = self.offload_scope_in_cuda_graph()
         if self.offload_module_in_cuda_graph:
             assert is_torch_min_version(
                 "2.9.0a0"

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1940,7 +1940,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     "Disabling mlp_norm offloading.",
                 )
         # Set the offload module in cuda graph flag.
-        self.offload_module_in_cuda_graph = self.offload_scope_in_cuda_graph()
+        # A shared Hybrid config can request an attention graph for a split layer
+        # whose attention branches are both IdentityOp. Require a real branch here
+        # as well as at the outer wrapper so this inner layer never advertises a
+        # graph/offload boundary that it cannot execute.
+        self.offload_module_in_cuda_graph = self.offload_scope_in_cuda_graph(
+            require_concrete_modules=True
+        )
         if self.offload_module_in_cuda_graph:
             assert is_torch_min_version(
                 "2.9.0a0"

--- a/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
@@ -1,0 +1,68 @@
+{
+    "lm loss": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 10.46823,
+            "2": 10.14756,
+            "3": 9.83748,
+            "4": 9.65865
+        }
+    },
+    "grad-norm": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 1.92781,
+            "2": 1.86541,
+            "3": 2.51769,
+            "4": 2.38709
+        }
+    },
+    "num-zeros": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 14668050.0,
+            "2": 14430299.0,
+            "3": 14826777.0,
+            "4": 14671972.0
+        }
+    },
+    "mem-allocated-bytes": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 307129856.0,
+            "2": 307129856.0,
+            "3": 307129856.0,
+            "4": 314737152.0
+        }
+    },
+    "mem-max-allocated-bytes": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 488871424.0,
+            "2": 537406976.0,
+            "3": 537406976.0,
+            "4": 537406976.0
+        }
+    },
+    "iteration-time": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": "nan",
+            "2": 0.09215,
+            "3": 0.04742,
+            "4": 1.79973
+        }
+    }
+}

--- a/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
@@ -10,17 +10,6 @@
             "4": 9.65865
         }
     },
-    "grad-norm": {
-        "start_step": 1,
-        "end_step": 4,
-        "step_interval": 1,
-        "values": {
-            "1": 1.92781,
-            "2": 1.86541,
-            "3": 2.51769,
-            "4": 2.38709
-        }
-    },
     "num-zeros": {
         "start_step": 1,
         "end_step": 4,

--- a/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -6,11 +6,9 @@ ENV_VARS:
   PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True,graph_capture_record_stream_reuse:True"
   NCCL_GRAPH_REGISTER: "0"
 MODEL_ARGS:
-  # Put one adjacent attention/MoE pair on each PP rank. Hybrid graph discovery
-  # groups each pair into one callable: attention + router are captured, while
-  # expert dispatch/compute and the mHC BDA tail stay eager.
-  --hybrid-layer-pattern: "*E|*E"
-  --spec: "[megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec]"
+  # Exercise the ordinary GPTModel/TransformerLayer capture boundary directly.
+  # Two layers per PP rank run through the non-interleaved 1F1B schedule.
+  --num-layers: 4
   --hidden-size: 512
   --ffn-hidden-size: 2048
   --num-attention-heads: 8
@@ -20,38 +18,17 @@ MODEL_ARGS:
   --disable-bias-linear: true
   --untie-embeddings-and-output-weights: true
 
-  # mHC makes HyperConnectionHybridLayer the top-level TE graph callable.
-  --enable-hyper-connections: true
-  --num-residual-streams: 4
-  --mhc-sinkhorn-iterations: 20
-  --mhc-init-gating-factor: 0.01
-
-  # Minimal MoE settings for the eager continuation after partial router capture.
-  --num-experts: 4
-  --moe-ffn-hidden-size: 1024
-  --moe-router-topk: 2
-  --moe-router-load-balancing-type: aux_loss
-  --moe-aux-loss-coeff: 1.0e-3
-  --moe-token-dispatcher-type: alltoall
-  --moe-grouped-gemm: true
-  --moe-router-dtype: fp32
-  --expert-model-parallel-size: 1
-  --expert-tensor-parallel-size: 1
-
-  # Exercise core-attention D2H/H2D event handling across the grouped attention ->
-  # partial-MoE graph boundary. core_attn is captured and does not use the delayed
-  # expert-offload queue; delayed expert offload is outside this regression's scope.
-  # fine-grained-offloading-max-inflight-offloads is intentionally omitted (None).
+  # core_attn is inside the captured attention range. Its D2H/H2D dependencies
+  # must be enclosed by TransformerLayer's top-level TE graph event boundary.
+  # Delayed expert offload is intentionally absent from this regression.
   --fine-grained-activation-offloading: true
   --offload-modules: "[core_attn]"
   --min-offloaded-tensor-size: 1024
   --activation-offload-fraction: 1.0
 
-  # This numerical smoke runs exactly four iterations. After three eager warmups,
-  # the graph is created before iteration four, so the golden trajectory includes
-  # one graph replay plus the eager MoE experts.
+  # Three eager warmups are followed by one real graph replay in iteration four.
   --cuda-graph-impl: transformer_engine
-  --cuda-graph-modules: "[attn moe_router]"
+  --cuda-graph-modules: "[attn]"
   --cuda-graph-warmup-steps: 3
   --te-rng-tracker: true
 

--- a/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -78,5 +78,4 @@ MODEL_ARGS:
 TEST_TYPE: regular
 METRICS:
   - "lm loss"
-  - "grad-norm"
   - "num-zeros"

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
@@ -1,0 +1,68 @@
+{
+    "lm loss": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 10.48293,
+            "2": 10.2397,
+            "3": 9.99191,
+            "4": 9.88682
+        }
+    },
+    "grad-norm": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 1.23828,
+            "2": 1.1464,
+            "3": 1.33764,
+            "4": 1.31791
+        }
+    },
+    "num-zeros": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 14668159.0,
+            "2": 14430083.0,
+            "3": 14826618.0,
+            "4": 14671716.0
+        }
+    },
+    "mem-allocated-bytes": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 439328256.0,
+            "2": 439328768.0,
+            "3": 439328768.0,
+            "4": 588933120.0
+        }
+    },
+    "mem-max-allocated-bytes": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": 651911168.0,
+            "2": 698570240.0,
+            "3": 698570240.0,
+            "4": 817107968.0
+        }
+    },
+    "iteration-time": {
+        "start_step": 1,
+        "end_step": 4,
+        "step_interval": 1,
+        "values": {
+            "1": "nan",
+            "2": 0.14202,
+            "3": 0.10639,
+            "4": 1.50123
+        }
+    }
+}

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/golden_values_dev_dgx_h100.json
@@ -10,17 +10,6 @@
             "4": 9.88682
         }
     },
-    "grad-norm": {
-        "start_step": 1,
-        "end_step": 4,
-        "step_interval": 1,
-        "values": {
-            "1": 1.23828,
-            "2": 1.1464,
-            "3": 1.33764,
-            "4": 1.31791
-        }
-    },
     "num-zeros": {
         "start_step": 1,
         "end_step": 4,

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -4,6 +4,7 @@ ENV_VARS:
   NVTE_CPU_OFFLOAD_V1: 1
   NVTE_FUSED_ATTN: 1
   PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True,graph_capture_record_stream_reuse:True"
+  NCCL_GRAPH_REGISTER: "0"
   ENABLE_LIGHTWEIGHT_MODE: true
 MODEL_ARGS:
   # Put one adjacent attention/MoE pair on each PP rank. Hybrid graph discovery
@@ -38,8 +39,9 @@ MODEL_ARGS:
   --expert-model-parallel-size: 1
   --expert-tensor-parallel-size: 1
 
-  # Exercise delayed core-attention D2H/H2D event handling across the grouped
-  # attention -> partial-MoE graph boundary.
+  # Exercise core-attention D2H/H2D event handling across the grouped attention ->
+  # partial-MoE graph boundary. Keep the delayed replay lifecycle enabled on GPU;
+  # core-attention commits immediately, while delayed-queue flush ordering is unit-tested.
   # fine-grained-offloading-max-inflight-offloads is intentionally omitted (None).
   --fine-grained-activation-offloading: true
   --offload-modules: "[core_attn]"

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -1,0 +1,87 @@
+ENV_VARS:
+  CUDA_DEVICE_MAX_CONNECTIONS: 1
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: 1
+  NVTE_CPU_OFFLOAD_V1: 1
+  NVTE_FUSED_ATTN: 1
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True,graph_capture_record_stream_reuse:True"
+  ENABLE_LIGHTWEIGHT_MODE: true
+MODEL_ARGS:
+  # Keep both PP ranks dependency-free while placing attention on each rank.
+  --hybrid-layer-pattern: "*-*-|*-*-"
+  --spec: "[megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec]"
+  --hidden-size: 512
+  --ffn-hidden-size: 2048
+  --num-attention-heads: 8
+  --position-embedding-type: rope
+  --max-position-embeddings: 1024
+  --normalization: RMSNorm
+  --disable-bias-linear: true
+  --untie-embeddings-and-output-weights: true
+
+  # mHC makes HyperConnectionHybridLayer the top-level TE graph callable.
+  --enable-hyper-connections: true
+  --num-residual-streams: 4
+  --mhc-sinkhorn-iterations: 20
+  --mhc-init-gating-factor: 0.01
+
+  # Exercise core-attention D2H/H2D event boundaries inside the attention graph.
+  # fine-grained-offloading-max-inflight-offloads is intentionally omitted (None).
+  --fine-grained-activation-offloading: true
+  --offload-modules: "[core_attn]"
+  --min-offloaded-tensor-size: 1024
+  --activation-offload-fraction: 1.0
+  --delay-offload-until-cuda-graph: false
+
+  # Lightweight mode runs four iterations: three warmups followed by capture/replay.
+  --cuda-graph-impl: transformer_engine
+  --cuda-graph-modules: "[attn]"
+  --cuda-graph-warmup-steps: 3
+  --te-rng-tracker: true
+
+  --transformer-impl: transformer_engine
+  --attention-backend: fused
+  --tensor-model-parallel-size: 1
+  --pipeline-model-parallel-size: 2
+  --context-parallel-size: 1
+  --use-distributed-optimizer: true
+  --use-mcore-models: true
+  --micro-batch-size: 1
+  --global-batch-size: 8
+  --seq-length: 1024
+  --train-iters: 8
+  --exit-interval: 8
+  --tokenizer-type: NullTokenizer
+  --vocab-size: 32000
+  --mock-data: true
+  --split: 949,50,1
+  --distributed-backend: nccl
+  --data-cache-path: ${DATA_CACHE_PATH}
+
+  --lr: 0.0001
+  --min-lr: 1.0e-5
+  --lr-decay-style: cosine
+  --lr-decay-iters: 8
+  --lr-warmup-iters: 0
+  --weight-decay: 0.1
+  --clip-grad: 1.0
+  --adam-beta1: 0.9
+  --adam-beta2: 0.95
+  --bf16: true
+  --init-method-std: 0.02
+  --attention-dropout: 0.0
+  --hidden-dropout: 0.0
+  --no-gradient-accumulation-fusion: true
+  --attention-softmax-in-fp32: true
+  --eval-interval: 1000
+  --eval-iters: 1
+
+  --log-interval: 1
+  --log-memory-to-tensorboard: true
+  --log-num-zeros-in-grad: true
+  --log-timers-to-tensorboard: true
+  --log-params-norm: true
+  --tensorboard-dir: ${TENSORBOARD_PATH}
+TEST_TYPE: regular
+METRICS:
+  - "lm loss"
+  - "num-zeros"

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -6,8 +6,10 @@ ENV_VARS:
   PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True,graph_capture_record_stream_reuse:True"
   ENABLE_LIGHTWEIGHT_MODE: true
 MODEL_ARGS:
-  # Keep both PP ranks dependency-free while placing attention on each rank.
-  --hybrid-layer-pattern: "*-*-|*-*-"
+  # Put one adjacent attention/MoE pair on each PP rank. Hybrid graph discovery
+  # groups each pair into one callable: attention + router are captured, while
+  # expert dispatch/compute and the mHC BDA tail stay eager.
+  --hybrid-layer-pattern: "*E|*E"
   --spec: "[megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec]"
   --hidden-size: 512
   --ffn-hidden-size: 2048
@@ -24,17 +26,32 @@ MODEL_ARGS:
   --mhc-sinkhorn-iterations: 20
   --mhc-init-gating-factor: 0.01
 
-  # Exercise core-attention D2H/H2D event boundaries inside the attention graph.
+  # Minimal MoE settings for the eager continuation after partial router capture.
+  --num-experts: 4
+  --moe-ffn-hidden-size: 1024
+  --moe-router-topk: 2
+  --moe-router-load-balancing-type: aux_loss
+  --moe-aux-loss-coeff: 1.0e-3
+  --moe-token-dispatcher-type: alltoall
+  --moe-grouped-gemm: true
+  --moe-router-dtype: fp32
+  --expert-model-parallel-size: 1
+  --expert-tensor-parallel-size: 1
+
+  # Exercise delayed core-attention D2H/H2D event handling across the grouped
+  # attention -> partial-MoE graph boundary.
   # fine-grained-offloading-max-inflight-offloads is intentionally omitted (None).
   --fine-grained-activation-offloading: true
   --offload-modules: "[core_attn]"
   --min-offloaded-tensor-size: 1024
   --activation-offload-fraction: 1.0
-  --delay-offload-until-cuda-graph: false
+  --delay-offload-until-cuda-graph: true
 
-  # Lightweight mode runs four iterations: three warmups followed by capture/replay.
+  # This crash-only smoke runs exactly four iterations. After three eager warmups,
+  # the graph is created before iteration four, which exercises graph replay plus
+  # the eager MoE experts. Lightweight CI also pins exit-interval to four.
   --cuda-graph-impl: transformer_engine
-  --cuda-graph-modules: "[attn]"
+  --cuda-graph-modules: "[attn moe_router]"
   --cuda-graph-warmup-steps: 3
   --te-rng-tracker: true
 
@@ -48,8 +65,8 @@ MODEL_ARGS:
   --micro-batch-size: 1
   --global-batch-size: 8
   --seq-length: 1024
-  --train-iters: 8
-  --exit-interval: 8
+  --train-iters: 4
+  --exit-interval: 4
   --tokenizer-type: NullTokenizer
   --vocab-size: 32000
   --mock-data: true
@@ -60,7 +77,7 @@ MODEL_ARGS:
   --lr: 0.0001
   --min-lr: 1.0e-5
   --lr-decay-style: cosine
-  --lr-decay-iters: 8
+  --lr-decay-iters: 4
   --lr-warmup-iters: 0
   --weight-decay: 0.1
   --clip-grad: 1.0
@@ -82,6 +99,3 @@ MODEL_ARGS:
   --log-params-norm: true
   --tensorboard-dir: ${TENSORBOARD_PATH}
 TEST_TYPE: regular
-METRICS:
-  - "lm loss"
-  - "num-zeros"

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -5,7 +5,6 @@ ENV_VARS:
   NVTE_FUSED_ATTN: 1
   PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True,graph_capture_record_stream_reuse:True"
   NCCL_GRAPH_REGISTER: "0"
-  ENABLE_LIGHTWEIGHT_MODE: true
 MODEL_ARGS:
   # Put one adjacent attention/MoE pair on each PP rank. Hybrid graph discovery
   # groups each pair into one callable: attention + router are captured, while
@@ -49,9 +48,9 @@ MODEL_ARGS:
   --activation-offload-fraction: 1.0
   --delay-offload-until-cuda-graph: true
 
-  # This crash-only smoke runs exactly four iterations. After three eager warmups,
-  # the graph is created before iteration four, which exercises graph replay plus
-  # the eager MoE experts. Lightweight CI also pins exit-interval to four.
+  # This numerical smoke runs exactly four iterations. After three eager warmups,
+  # the graph is created before iteration four, so the golden trajectory includes
+  # one graph replay plus the eager MoE experts.
   --cuda-graph-impl: transformer_engine
   --cuda-graph-modules: "[attn moe_router]"
   --cuda-graph-warmup-steps: 3
@@ -101,3 +100,7 @@ MODEL_ARGS:
   --log-params-norm: true
   --tensorboard-dir: ${TENSORBOARD_PATH}
 TEST_TYPE: regular
+METRICS:
+  - "lm loss"
+  - "grad-norm"
+  - "num-zeros"

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph/model_config.yaml
@@ -101,5 +101,4 @@ MODEL_ARGS:
 TEST_TYPE: regular
 METRICS:
   - "lm loss"
-  - "grad-norm"
   - "num-zeros"

--- a/tests/test_utils/recipes/h100/gpt.yaml
+++ b/tests/test_utils/recipes/h100/gpt.yaml
@@ -140,6 +140,11 @@ products:
       - environment: [dev]
         scope: [mr, mr-github, mr-github-slim]
         platforms: [dgx_h100]
+  - test_case: [gpt3_mr_mcore_te_tp1_pp2_core_attn_offload_attn_cudagraph]
+    products:
+      - environment: [dev]
+        scope: [mr, mr-github, mr-github-slim]
+        platforms: [dgx_h100]
   # - test_case: [gpt3_mcore_te_tp1_pp2_resume_torch_dist_cp4_a2a_p2p_nondeterministic]
   #   products:
   #     - environment: [dev]

--- a/tests/test_utils/recipes/h100/mamba.yaml
+++ b/tests/test_utils/recipes/h100/mamba.yaml
@@ -81,6 +81,12 @@ products:
       # - environment: [lts] # disabled until triton is bumped
       #   scope: [nightly]
 
+  - test_case: [hybrid_mr_mcore_te_tp1_pp2_mhc_core_attn_offload_attn_cudagraph]
+    products:
+      - environment: [dev]
+        scope: [mr, mr-github, mr-github-slim]
+        platforms: [dgx_h100]
+
   - test_case: [hybrid_mr_mcore_te_tp2_pp1_cp1_dgx_a100_1N8G]
     products:
       - environment: [dev]

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -14,6 +14,10 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import Chun
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+    FineGrainedOffloadingBackwardRecordFunction,
+    PipelineOffloadManager,
+)
 from megatron.core.tensor_parallel.random import (
     CheckpointWithoutOutput,
     is_checkpoint_without_output_tensor,
@@ -67,6 +71,47 @@ def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
     assert not handler.tensor_need_offloading_checker(fake_tensor)
     assert handler.tensor_push(fake_tensor) is fake_tensor
     assert handler.tensor_pop(fake_tensor) is fake_tensor
+
+
+def test_cuda_graph_backward_completion_event_follows_accumulate_grad(monkeypatch):
+    """The TE sync-back event must be the true GraphTask tail, not just input dgrad-ready."""
+    calls = []
+
+    class RecordingStream:
+        def record_event(self, event):
+            calls.append(("record_event", event))
+
+        def wait_stream(self, stream):
+            calls.append(("wait_stream", stream))
+
+    graph_event = object()
+    h2d_stream = object()
+    recording_stream = RecordingStream()
+
+    def current_stream():
+        calls.append(("callback_boundary", recording_stream))
+        return recording_stream
+
+    monkeypatch.setattr(
+        PipelineOffloadManager,
+        "OFFLOAD_MGR",
+        type("Manager", (), {"cuda_graph_event": graph_event, "h2d_stream": h2d_stream})(),
+    )
+    monkeypatch.setattr(torch.cuda, "current_stream", current_stream)
+
+    hidden_states = torch.tensor(2.0, requires_grad=True)
+    weight = torch.nn.Parameter(torch.tensor(3.0))
+    weight.register_post_accumulate_grad_hook(lambda _param: calls.append(("param_grad", weight)))
+
+    recorded_input = FineGrainedOffloadingBackwardRecordFunction.apply(hidden_states)
+    (recorded_input * weight).backward()
+
+    assert calls == [
+        ("param_grad", weight),
+        ("callback_boundary", recording_stream),
+        ("record_event", graph_event),
+        ("wait_stream", h2d_stream),
+    ]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -73,45 +73,59 @@ def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
     assert handler.tensor_pop(fake_tensor) is fake_tensor
 
 
-def test_cuda_graph_backward_completion_event_follows_accumulate_grad(monkeypatch):
-    """The TE sync-back event must be the true GraphTask tail, not just input dgrad-ready."""
+def test_cuda_graph_backward_completion_callback_is_per_graph_task(monkeypatch):
+    """Each TE-style GraphTask queues its own sync-back event after AccumulateGrad."""
     calls = []
+    active_task = None
 
     class RecordingStream:
         def record_event(self, event):
-            calls.append(("record_event", event))
+            calls.append((active_task, "record_event", event))
 
         def wait_stream(self, stream):
-            calls.append(("wait_stream", stream))
+            calls.append((active_task, "wait_stream", stream))
 
-    graph_event = object()
-    h2d_stream = object()
     recording_stream = RecordingStream()
 
     def current_stream():
-        calls.append(("callback_boundary", recording_stream))
+        calls.append((active_task, "callback_boundary", recording_stream))
         return recording_stream
 
-    monkeypatch.setattr(
-        PipelineOffloadManager,
-        "OFFLOAD_MGR",
-        type("Manager", (), {"cuda_graph_event": graph_event, "h2d_stream": h2d_stream})(),
-    )
     monkeypatch.setattr(torch.cuda, "current_stream", current_stream)
 
-    hidden_states = torch.tensor(2.0, requires_grad=True)
-    weight = torch.nn.Parameter(torch.tensor(3.0))
-    weight.register_post_accumulate_grad_hook(lambda _param: calls.append(("param_grad", weight)))
+    for task_name in ("first", "second"):
+        active_task = task_name
+        graph_event = object()
+        h2d_stream = object()
+        monkeypatch.setattr(
+            PipelineOffloadManager,
+            "OFFLOAD_MGR",
+            type("Manager", (), {"cuda_graph_event": graph_event, "h2d_stream": h2d_stream})(),
+        )
 
-    recorded_input = FineGrainedOffloadingBackwardRecordFunction.apply(hidden_states)
-    (recorded_input * weight).backward()
+        hidden_states = torch.tensor(2.0, requires_grad=True)
+        weight = torch.nn.Parameter(torch.tensor(3.0))
+        hidden_states.register_post_accumulate_grad_hook(
+            lambda _tensor, name=task_name, tensor=hidden_states: calls.append(
+                (name, "input_grad", tensor)
+            )
+        )
+        weight.register_post_accumulate_grad_hook(
+            lambda _param, name=task_name, param=weight: calls.append((name, "param_grad", param))
+        )
 
-    assert calls == [
-        ("param_grad", weight),
-        ("callback_boundary", recording_stream),
-        ("record_event", graph_event),
-        ("wait_stream", h2d_stream),
-    ]
+        task_start = len(calls)
+        recorded_input = FineGrainedOffloadingBackwardRecordFunction.apply(hidden_states)
+        (recorded_input * weight).backward()
+        task_calls = calls[task_start:]
+
+        assert [call[0] for call in task_calls] == [task_name] * 5
+        assert {call[1] for call in task_calls[:2]} == {"input_grad", "param_grad"}
+        assert task_calls[2:] == [
+            (task_name, "callback_boundary", recording_stream),
+            (task_name, "record_event", graph_event),
+            (task_name, "wait_stream", h2d_stream),
+        ]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1145,8 +1145,7 @@ class TestHybridTECudaGraphDiscovery:
         )
         helper = object.__new__(TECudaGraphHelper)
         helper.config = SimpleNamespace(
-            multi_latent_attention=multi_latent_attention,
-            cuda_graph_modules=[CudaGraphModule.attn],
+            multi_latent_attention=multi_latent_attention, cuda_graph_modules=[CudaGraphModule.attn]
         )
         helper.seq_length = 8
         helper.micro_batch_size = 1

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1274,6 +1274,15 @@ class TestHybridTECudaGraphDiscovery:
                 torch.ones(2, 1, 4), cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32)
             )
 
+    def test_transformer_capture_impl_rejects_raw_packed_sequence_kwargs(self):
+        layer = TransformerLayer.__new__(TransformerLayer)
+        torch.nn.Module.__init__(layer)
+
+        with pytest.raises(AssertionError):
+            layer._te_cuda_graph_capture_impl(
+                torch.ones(2, 1, 4), cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32)
+            )
+
     def test_grouped_hybrid_capture_has_one_outer_offload_boundary(self):
         calls = []
         head = self._bare_hybrid_wrapper(offload_in_graph=True)

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -4,6 +4,7 @@ import gc
 import os
 import sys
 from contextlib import nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -1029,6 +1030,61 @@ class TestParallelHybridBlockCudagraphs:
 
 
 class TestHybridTECudaGraphDiscovery:
+    @staticmethod
+    def _bare_hybrid_wrapper(*, offload_in_graph=False, delay_offload=False):
+        wrapper = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
+        torch.nn.Module.__init__(wrapper)
+        wrapper.config = SimpleNamespace(
+            cuda_graph_modules=[CudaGraphModule.attn],
+            delay_offload_until_cuda_graph=delay_offload,
+            fine_grained_activation_offloading=True,
+        )
+        object.__setattr__(wrapper, '_has_offload_module_in_cuda_graph', lambda: offload_in_graph)
+        return wrapper
+
+    @staticmethod
+    def _bare_transformer_inner(*, has_attention, offload_core_attn, is_moe=False):
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        inner = TransformerLayer.__new__(TransformerLayer)
+        torch.nn.Module.__init__(inner)
+        inner.self_attention = torch.nn.Linear(2, 2) if has_attention else IdentityOp()
+        inner.cross_attention = IdentityOp()
+        inner.mlp = IdentityOp()
+        inner.offload_attn_norm = False
+        inner.offload_qkv_linear = False
+        inner.offload_core_attn = offload_core_attn
+        inner.offload_attn_proj = False
+        inner.offload_mlp_norm = False
+        inner.is_moe_layer = is_moe
+        return inner
+
+    @staticmethod
+    def _recording_offload_interface(calls):
+        class RecordingOffloadInterface:
+            @staticmethod
+            def backward_record(hidden_states):
+                calls.append('backward_record')
+                return hidden_states + 1
+
+            @staticmethod
+            def forward_record():
+                calls.append('forward_record')
+
+            @staticmethod
+            def enter_replay():
+                calls.append('enter_replay')
+
+            @staticmethod
+            def flush_delayed_groups():
+                calls.append('flush_delayed_groups')
+
+            @staticmethod
+            def exit_replay():
+                calls.append('exit_replay')
+
+        return RecordingOffloadInterface
+
     def test_hybrid_mtp_layers_are_flattened_and_adjacent_layers_are_grouped(self, monkeypatch):
         from megatron.core.transformer import cuda_graphs
 
@@ -1155,6 +1211,163 @@ class TestHybridTECudaGraphDiscovery:
         inner.is_mtp_layer = True
         head.layer_number, tail.layer_number = 1, 2
         assert head._can_group_te_cuda_graph_with(tail)
+
+    @pytest.mark.parametrize('offload_in_graph', [False, True])
+    def test_hybrid_offload_graph_replay_args_include_te_stream_and_event(
+        self, monkeypatch, offload_in_graph
+    ):
+        from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+            FineGrainedActivationOffloadingInterface,
+        )
+
+        wrapper = self._bare_hybrid_wrapper(offload_in_graph=offload_in_graph)
+        graph_stream = object()
+        graph_event = object()
+        monkeypatch.setattr(
+            FineGrainedActivationOffloadingInterface, 'cuda_graph_stream', lambda: graph_stream
+        )
+        monkeypatch.setattr(
+            FineGrainedActivationOffloadingInterface, 'cuda_graph_event', lambda: graph_event
+        )
+
+        cudagraph_args, cudagraph_kwargs = wrapper._get_te_cuda_graph_replay_args(
+            torch.ones(2, 1, 4)
+        )
+
+        assert len(cudagraph_args) == 1
+        if offload_in_graph:
+            assert cudagraph_kwargs['cuda_graph_stream'] is graph_stream
+            assert cudagraph_kwargs['cuda_graph_event'] is graph_event
+        else:
+            assert 'cuda_graph_stream' not in cudagraph_kwargs
+            assert 'cuda_graph_event' not in cudagraph_kwargs
+
+    def test_hybrid_capture_records_offload_boundary_exactly_once(self):
+        calls = []
+        wrapper = self._bare_hybrid_wrapper(offload_in_graph=True)
+        object.__setattr__(wrapper, 'off_interface', self._recording_offload_interface(calls))
+        object.__setattr__(wrapper, '_get_te_cuda_graph_group_tail', lambda: None)
+        object.__setattr__(wrapper, '_inner_is_partial_moe_capture', lambda: False)
+
+        def forward(hidden_states, **_kwargs):
+            calls.append('body')
+            assert torch.equal(hidden_states, torch.full_like(hidden_states, 2))
+            return hidden_states * 2, None
+
+        object.__setattr__(wrapper, 'forward', forward)
+        output = wrapper._te_cuda_graph_capture(torch.ones(2, 1, 4))
+
+        assert calls == ['backward_record', 'body', 'forward_record']
+        assert torch.equal(output[0], torch.full((2, 1, 4), 4.0))
+
+    def test_grouped_hybrid_capture_has_one_outer_offload_boundary(self):
+        calls = []
+        head = self._bare_hybrid_wrapper(offload_in_graph=True)
+        tail = self._bare_hybrid_wrapper(offload_in_graph=True)
+        off_interface = self._recording_offload_interface(calls)
+        object.__setattr__(head, 'off_interface', off_interface)
+        object.__setattr__(tail, 'off_interface', off_interface)
+        object.__setattr__(head, '_get_te_cuda_graph_group_tail', lambda: tail)
+
+        def head_forward(hidden_states, **_kwargs):
+            calls.append('attention_body')
+            return hidden_states + 1, None
+
+        def tail_capture_impl(hidden_states, **_kwargs):
+            calls.append('moe_prefix_body')
+            return (hidden_states + 1,)
+
+        object.__setattr__(head, 'forward', head_forward)
+        object.__setattr__(tail, '_te_cuda_graph_capture_impl', tail_capture_impl)
+
+        output = head._te_cuda_graph_capture(torch.ones(2, 1, 4))
+
+        assert calls == ['backward_record', 'attention_body', 'moe_prefix_body', 'forward_record']
+        assert torch.equal(output[0], torch.full((2, 1, 4), 4.0))
+
+    def test_moe_only_tail_does_not_claim_attention_offload(self):
+        # Reproduce the stale inner-layer flag: cuda_graph_modules contains ``attn``
+        # globally even though this split Hybrid layer has no attention body.
+        inner = self._bare_transformer_inner(
+            has_attention=False, offload_core_attn=True, is_moe=True
+        )
+
+        tail = self._bare_hybrid_wrapper()
+        tail.inner_layer = inner
+        # Exercise the real predicate instead of the test helper override.
+        object.__delattr__(tail, '_has_offload_module_in_cuda_graph')
+
+        assert not tail._has_offload_module_in_cuda_graph()
+        assert not tail.offload_module_in_cuda_graph
+
+    def test_hybrid_offload_predicate_reads_real_inner_flags_and_group_tail(self):
+        attention_inner = self._bare_transformer_inner(has_attention=True, offload_core_attn=True)
+
+        attention_wrapper = self._bare_hybrid_wrapper()
+        attention_wrapper.inner_layer = attention_inner
+        object.__delattr__(attention_wrapper, '_has_offload_module_in_cuda_graph')
+        assert attention_wrapper.offload_module_in_cuda_graph
+
+        no_attention_inner = self._bare_transformer_inner(
+            has_attention=False, offload_core_attn=True, is_moe=True
+        )
+
+        group_head = self._bare_hybrid_wrapper()
+        group_head.inner_layer = no_attention_inner
+        object.__delattr__(group_head, '_has_offload_module_in_cuda_graph')
+        object.__setattr__(group_head, '_get_te_cuda_graph_group_tail', lambda: attention_wrapper)
+        assert group_head.offload_module_in_cuda_graph
+
+    @pytest.mark.parametrize(
+        ('delay_offload', 'tail_raises'), [(False, False), (True, False), (True, True)]
+    )
+    @pytest.mark.parametrize('grouped', [False, True])
+    def test_hybrid_partial_replay_preserves_delayed_offload_lifecycle(
+        self, monkeypatch, delay_offload, tail_raises, grouped
+    ):
+        calls = []
+        head = self._bare_hybrid_wrapper(delay_offload=delay_offload)
+
+        class Tail:
+            @staticmethod
+            def _resume_partial_moe_cuda_graph(_outputs):
+                calls.append('eager_tail')
+                if tail_raises:
+                    raise RuntimeError('eager tail failed')
+                return torch.full((2, 1, 4), 3.0), None
+
+        object.__setattr__(head, 'off_interface', self._recording_offload_interface(calls))
+        object.__setattr__(
+            head, '_get_te_cuda_graph_group_tail', lambda: Tail() if grouped else None
+        )
+        object.__setattr__(head, '_inner_is_partial_moe_capture', lambda: not grouped)
+        object.__setattr__(
+            head, '_resume_partial_moe_cuda_graph', Tail._resume_partial_moe_cuda_graph
+        )
+
+        def graph_replay(_self, *_args, **_kwargs):
+            calls.append('graph_replay')
+            return (torch.ones(2, 1, 4),)
+
+        monkeypatch.setattr(GraphableMegatronModule, '_te_cuda_graph_replay', graph_replay)
+
+        if tail_raises:
+            with pytest.raises(RuntimeError, match='eager tail failed'):
+                head._te_cuda_graph_replay(torch.ones(2, 1, 4))
+        else:
+            output = head._te_cuda_graph_replay(torch.ones(2, 1, 4))
+            assert torch.equal(output[0], torch.full((2, 1, 4), 3.0))
+
+        expected_calls = ['graph_replay', 'eager_tail']
+        if delay_offload:
+            expected_calls = [
+                'enter_replay',
+                'graph_replay',
+                'flush_delayed_groups',
+                'eager_tail',
+                'exit_replay',
+            ]
+        assert calls == expected_calls
 
 
 # Global storage for comparing unique buffer counts across different num_microbatches,

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1091,6 +1091,82 @@ class TestHybridTECudaGraphDiscovery:
 
         return RecordingOffloadInterface
 
+    @pytest.mark.parametrize(
+        ('has_attention', 'position_embedding_type', 'multi_latent_attention', 'expects_rotary'),
+        [
+            (True, 'rope', False, True),
+            (False, 'rope', False, False),
+            (True, 'learned_absolute', False, False),
+            (True, 'rope', True, False),
+        ],
+    )
+    def test_hybrid_wrapper_sample_inputs_include_rotary_embeddings(
+        self,
+        monkeypatch,
+        has_attention,
+        position_embedding_type,
+        multi_latent_attention,
+        expects_rotary,
+    ):
+        """The TE sample signature must match the wrapped attention replay signature."""
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        inner = TransformerLayer.__new__(TransformerLayer)
+        torch.nn.Module.__init__(inner)
+        inner.self_attention = torch.nn.Linear(2, 2) if has_attention else IdentityOp()
+        inner.cross_attention = IdentityOp()
+
+        wrapper = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
+        torch.nn.Module.__init__(wrapper)
+        wrapper.inner_layer = inner
+        object.__setattr__(
+            wrapper,
+            'get_layer_static_inputs',
+            lambda _seq_length, _micro_batch_size: {
+                'hidden_states': torch.ones(8, 1, 8, requires_grad=True)
+            },
+        )
+
+        rotary_pos_emb = torch.ones(8, 1, 1, 2)
+
+        class RotaryEmbedding:
+            @staticmethod
+            def get_rotary_seq_len(*_args):
+                return 8
+
+            @staticmethod
+            def __call__(_seq_length):
+                return rotary_pos_emb
+
+        chunk = SimpleNamespace(
+            decoder=SimpleNamespace(layers=[wrapper]),
+            position_embedding_type=position_embedding_type,
+            rotary_pos_emb=RotaryEmbedding(),
+        )
+        helper = object.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            multi_latent_attention=multi_latent_attention,
+            cuda_graph_modules=[CudaGraphModule.attn],
+        )
+        helper.seq_length = 8
+        helper.micro_batch_size = 1
+        helper.num_model_chunks = 1
+        helper.num_microbatches = 1
+        helper.flattened_callables = [wrapper]
+        helper.num_layers_per_chunk = [1]
+        helper.callables_per_chunk = [[wrapper]]
+        helper.chunks_with_decoder = [chunk]
+        helper._needs_full_local_padding_mask = lambda *_args: False
+        helper._uses_mhc_direct_write_arena = lambda: False
+        monkeypatch.setattr(cuda_graphs_module, 'is_te_min_version', lambda _version: True)
+
+        _sample_args, sample_kwargs = helper._get_sample_arguments([1, -1])
+
+        if expects_rotary:
+            assert sample_kwargs[0]['rotary_pos_emb'] is rotary_pos_emb
+        else:
+            assert 'rotary_pos_emb' not in sample_kwargs[0]
+
     def test_hybrid_mtp_layers_are_flattened_and_adjacent_layers_are_grouped(self, monkeypatch):
         from megatron.core.transformer import cuda_graphs
 

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import gc
+import logging
 import os
 import sys
 from contextlib import nullcontext
@@ -159,6 +160,56 @@ class TestCudaGraphConfigAndArguments:
                 fine_grained_activation_offloading=True,
                 offload_modules=['expert_fc1'],
             )
+
+    def test_te_whole_layer_graph_with_activation_offload_warns(self):
+        with pytest.warns(UserWarning, match="does not currently install.*offload event boundary"):
+            cfg = _base_cuda_graph_config(
+                cuda_graph_impl='transformer_engine',
+                cuda_graph_modules=[],
+                fine_grained_activation_offloading=True,
+                offload_modules=['core_attn'],
+            )
+
+        assert cfg.cuda_graph_modules == []
+
+    @pytest.mark.parametrize(
+        ('expert_module', 'use_transformer_engine_op_fuser'),
+        [('expert_fc1', False), ('moe_act', False), ('fused_group_mlp', True)],
+    )
+    def test_hybrid_mhc_delayed_expert_offload_warns(
+        self, expert_module, use_transformer_engine_op_fuser
+    ):
+        with pytest.warns(
+            UserWarning, match="HybridModel mHC wrappers do not currently support"
+        ) as warning_records:
+            cfg = _base_cuda_graph_config(
+                cuda_graph_impl='transformer_engine',
+                cuda_graph_modules=[CudaGraphModule.attn, CudaGraphModule.moe_router],
+                fine_grained_activation_offloading=True,
+                offload_modules=[expert_module],
+                delay_offload_until_cuda_graph=True,
+                is_hybrid_model=True,
+                enable_hyper_connections=True,
+                num_residual_streams=2,
+                num_moe_experts=4,
+                use_transformer_engine_op_fuser=use_transformer_engine_op_fuser,
+            )
+
+        assert cfg.delay_offload_until_cuda_graph
+        assert any(expert_module in str(record.message) for record in warning_records)
+
+    def test_delayed_expert_offload_warns_about_final_queue_drain(self):
+        with pytest.warns(UserWarning, match="final eager expert group can remain queued"):
+            cfg = _base_cuda_graph_config(
+                cuda_graph_impl='transformer_engine',
+                cuda_graph_modules=[CudaGraphModule.moe_router],
+                fine_grained_activation_offloading=True,
+                offload_modules=['expert_fc1'],
+                delay_offload_until_cuda_graph=True,
+                num_moe_experts=4,
+            )
+
+        assert cfg.delay_offload_until_cuda_graph
 
     def test_local_impl_rejects_moe_router_graph_with_mlp_norm_offload(self):
         with pytest.raises(
@@ -1031,14 +1082,12 @@ class TestParallelHybridBlockCudagraphs:
 
 class TestHybridTECudaGraphDiscovery:
     @staticmethod
-    def _bare_hybrid_wrapper(*, offload_in_graph=None, delay_offload=False):
+    def _bare_hybrid_wrapper(*, offload_in_graph=None):
         wrapper = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
         torch.nn.Module.__init__(wrapper)
         # Intentionally minimal: individual CPU mocks provide only the state they exercise.
         wrapper.config = SimpleNamespace(
-            cuda_graph_modules=[CudaGraphModule.attn],
-            delay_offload_until_cuda_graph=delay_offload,
-            fine_grained_activation_offloading=True,
+            cuda_graph_modules=[CudaGraphModule.attn], fine_grained_activation_offloading=True
         )
         object.__setattr__(wrapper, '_offload_module_in_cuda_graph_cached', None)
         if offload_in_graph is not None:
@@ -1063,6 +1112,9 @@ class TestHybridTECudaGraphDiscovery:
         inner.offload_mlp_norm = False
         inner.is_moe_layer = is_moe
         inner.offload_module_in_cuda_graph = offload_core_attn
+        inner.config = SimpleNamespace(
+            cuda_graph_modules=[CudaGraphModule.attn], fine_grained_activation_offloading=True
+        )
         return inner
 
     @staticmethod
@@ -1077,19 +1129,87 @@ class TestHybridTECudaGraphDiscovery:
             def forward_record():
                 calls.append('forward_record')
 
-            @staticmethod
-            def enter_replay():
-                calls.append('enter_replay')
-
-            @staticmethod
-            def flush_delayed_groups():
-                calls.append('flush_delayed_groups')
-
-            @staticmethod
-            def exit_replay():
-                calls.append('exit_replay')
-
         return RecordingOffloadInterface
+
+    @staticmethod
+    def _rotary_sample_helper(
+        monkeypatch,
+        *,
+        layer_kind,
+        position_embedding_type,
+        has_attention=True,
+        multi_latent_attention=False,
+        is_thd=False,
+        context_parallel_size=1,
+        cuda_graph_modules=None,
+        num_layers=1,
+    ):
+        """Build a CPU-only TE sample-input helper for rotary contract tests."""
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        if cuda_graph_modules is None:
+            cuda_graph_modules = [CudaGraphModule.attn]
+
+        layers = []
+        for _ in range(num_layers):
+            inner = TransformerLayer.__new__(TransformerLayer)
+            torch.nn.Module.__init__(inner)
+            inner.self_attention = torch.nn.Linear(2, 2) if has_attention else IdentityOp()
+            inner.cross_attention = IdentityOp()
+
+            if layer_kind == 'hybrid':
+                layer = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
+                torch.nn.Module.__init__(layer)
+                layer.inner_layer = inner
+            else:
+                assert layer_kind == 'transformer'
+                layer = inner
+
+            def get_layer_static_inputs(_seq_length, _micro_batch_size):
+                static_inputs = {'hidden_states': torch.ones(8, 1, 8, requires_grad=True)}
+                if is_thd:
+                    static_inputs['cu_seqlens_q'] = torch.tensor([0, 8], dtype=torch.int32)
+                return static_inputs
+
+            object.__setattr__(layer, 'get_layer_static_inputs', get_layer_static_inputs)
+            layers.append(layer)
+
+        rotary_pos_emb = torch.ones(8, 1, 1, 2)
+
+        class RotaryEmbedding:
+            @staticmethod
+            def get_rotary_seq_len(*_args):
+                return 8
+
+            @staticmethod
+            def __call__(_seq_length):
+                return rotary_pos_emb
+
+        chunk = SimpleNamespace(
+            decoder=SimpleNamespace(layers=layers),
+            position_embedding_type=position_embedding_type,
+            rotary_pos_emb=RotaryEmbedding(),
+        )
+        helper = object.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            multi_latent_attention=multi_latent_attention,
+            cuda_graph_modules=cuda_graph_modules,
+            context_parallel_size=context_parallel_size,
+        )
+        helper.seq_length = 8
+        helper.micro_batch_size = 1
+        helper.num_model_chunks = 1
+        helper.num_microbatches = 1
+        helper.flattened_callables = layers
+        helper.num_layers_per_chunk = [len(layers)]
+        helper.callables_per_chunk = [layers]
+        helper.chunks_with_decoder = [chunk]
+        helper.tp_group = None
+        helper.dp_cp_group = None
+        helper._needs_full_local_padding_mask = lambda *_args: False
+        helper._uses_mhc_direct_write_arena = lambda: False
+        monkeypatch.setattr(cuda_graphs_module, 'is_te_min_version', lambda _version: True)
+        return helper, rotary_pos_emb
 
     @pytest.mark.parametrize(
         ('has_attention', 'position_embedding_type', 'multi_latent_attention', 'expects_rotary'),
@@ -1109,55 +1229,13 @@ class TestHybridTECudaGraphDiscovery:
         expects_rotary,
     ):
         """The TE sample signature must match the wrapped attention replay signature."""
-        from megatron.core.transformer.identity_op import IdentityOp
-
-        inner = TransformerLayer.__new__(TransformerLayer)
-        torch.nn.Module.__init__(inner)
-        inner.self_attention = torch.nn.Linear(2, 2) if has_attention else IdentityOp()
-        inner.cross_attention = IdentityOp()
-
-        wrapper = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
-        torch.nn.Module.__init__(wrapper)
-        wrapper.inner_layer = inner
-        object.__setattr__(
-            wrapper,
-            'get_layer_static_inputs',
-            lambda _seq_length, _micro_batch_size: {
-                'hidden_states': torch.ones(8, 1, 8, requires_grad=True)
-            },
-        )
-
-        rotary_pos_emb = torch.ones(8, 1, 1, 2)
-
-        class RotaryEmbedding:
-            @staticmethod
-            def get_rotary_seq_len(*_args):
-                return 8
-
-            @staticmethod
-            def __call__(_seq_length):
-                return rotary_pos_emb
-
-        chunk = SimpleNamespace(
-            decoder=SimpleNamespace(layers=[wrapper]),
+        helper, rotary_pos_emb = self._rotary_sample_helper(
+            monkeypatch,
+            layer_kind='hybrid',
             position_embedding_type=position_embedding_type,
-            rotary_pos_emb=RotaryEmbedding(),
+            has_attention=has_attention,
+            multi_latent_attention=multi_latent_attention,
         )
-        helper = object.__new__(TECudaGraphHelper)
-        helper.config = SimpleNamespace(
-            multi_latent_attention=multi_latent_attention, cuda_graph_modules=[CudaGraphModule.attn]
-        )
-        helper.seq_length = 8
-        helper.micro_batch_size = 1
-        helper.num_model_chunks = 1
-        helper.num_microbatches = 1
-        helper.flattened_callables = [wrapper]
-        helper.num_layers_per_chunk = [1]
-        helper.callables_per_chunk = [[wrapper]]
-        helper.chunks_with_decoder = [chunk]
-        helper._needs_full_local_padding_mask = lambda *_args: False
-        helper._uses_mhc_direct_write_arena = lambda: False
-        monkeypatch.setattr(cuda_graphs_module, 'is_te_min_version', lambda _version: True)
 
         _sample_args, sample_kwargs = helper._get_sample_arguments([1, -1])
 
@@ -1165,6 +1243,101 @@ class TestHybridTECudaGraphDiscovery:
             assert sample_kwargs[0]['rotary_pos_emb'] is rotary_pos_emb
         else:
             assert 'rotary_pos_emb' not in sample_kwargs[0]
+
+    @pytest.mark.parametrize(
+        (
+            'layer_kind',
+            'position_embedding_type',
+            'has_attention',
+            'multi_latent_attention',
+            'is_thd',
+            'context_parallel_size',
+            'cuda_graph_modules',
+            'expected_fragment',
+        ),
+        [
+            ('transformer', 'yarn', True, False, False, 1, [CudaGraphModule.attn], 'Yarn'),
+            ('hybrid', 'yarn', True, False, False, 1, [CudaGraphModule.attn], 'Yarn'),
+            ('transformer', 'mrope', True, False, False, 1, [CudaGraphModule.attn], 'mRoPE'),
+            ('transformer', 'rope', True, False, True, 2, [CudaGraphModule.attn], 'THD'),
+            ('hybrid', 'rope', True, False, True, 2, [CudaGraphModule.attn], 'THD'),
+            ('transformer', 'yarn', True, False, False, 1, [], 'Yarn'),
+            ('hybrid', 'rope', True, False, True, 1, [CudaGraphModule.attn], None),
+            ('transformer', 'rope', True, False, False, 2, [CudaGraphModule.attn], None),
+            ('transformer', 'yarn', True, True, True, 2, [CudaGraphModule.attn], None),
+            ('hybrid', 'rope', True, True, True, 2, [CudaGraphModule.attn], None),
+            ('hybrid', 'yarn', False, False, True, 2, [CudaGraphModule.attn], None),
+            ('transformer', 'yarn', True, False, True, 2, [CudaGraphModule.mlp], None),
+        ],
+    )
+    def test_rotary_sample_contract_warning_matrix(
+        self,
+        monkeypatch,
+        layer_kind,
+        position_embedding_type,
+        has_attention,
+        multi_latent_attention,
+        is_thd,
+        context_parallel_size,
+        cuda_graph_modules,
+        expected_fragment,
+    ):
+        records = []
+        monkeypatch.setattr(
+            cuda_graphs_module,
+            'log_on_each_pipeline_stage',
+            lambda **kwargs: records.append((kwargs['level'], kwargs['msg'])),
+        )
+        helper, _rotary_pos_emb = self._rotary_sample_helper(
+            monkeypatch,
+            layer_kind=layer_kind,
+            position_embedding_type=position_embedding_type,
+            has_attention=has_attention,
+            multi_latent_attention=multi_latent_attention,
+            is_thd=is_thd,
+            context_parallel_size=context_parallel_size,
+            cuda_graph_modules=cuda_graph_modules,
+        )
+
+        helper._get_sample_arguments([1, -1])
+
+        if expected_fragment is None:
+            assert records == []
+        else:
+            assert len(records) == 1
+            assert records[0][0] == logging.WARNING
+            assert expected_fragment in records[0][1]
+            assert f"position_embedding_type={position_embedding_type!r}" in records[0][1]
+            assert f'input_format={"THD" if is_thd else "SBHD"}' in records[0][1]
+            assert f'context_parallel_size={context_parallel_size}' in records[0][1]
+            assert 'numerical results are not reliable' in records[0][1]
+            if position_embedding_type == 'mrope':
+                assert 'affecting GPTModel.' in records[0][1]
+                assert 'GPTModel and HybridModel' not in records[0][1]
+
+    def test_rotary_sample_contract_warning_is_deduplicated_for_yarn_thd_cp2(self, monkeypatch):
+        records = []
+        monkeypatch.setattr(
+            cuda_graphs_module,
+            'log_on_each_pipeline_stage',
+            lambda **kwargs: records.append((kwargs['level'], kwargs['msg'])),
+        )
+        helper, _rotary_pos_emb = self._rotary_sample_helper(
+            monkeypatch,
+            layer_kind='hybrid',
+            position_embedding_type='yarn',
+            is_thd=True,
+            context_parallel_size=2,
+            num_layers=2,
+        )
+
+        helper._get_sample_arguments([1, -1])
+
+        assert len(records) == 1
+        assert records[0][0] == logging.WARNING
+        assert "position_embedding_type='yarn'" in records[0][1]
+        assert 'input_format=THD' in records[0][1]
+        assert 'context_parallel_size=2' in records[0][1]
 
     def test_hybrid_mtp_layers_are_flattened_and_adjacent_layers_are_grouped(self, monkeypatch):
         from megatron.core.transformer import cuda_graphs
@@ -1396,26 +1569,6 @@ class TestHybridTECudaGraphDiscovery:
         assert not tail._compute_offload_module_in_cuda_graph()
         assert not tail.offload_module_in_cuda_graph
 
-    def test_hybrid_empty_cuda_graph_scope_does_not_claim_inner_offload(self):
-        calls = []
-        wrapper = self._bare_hybrid_wrapper()
-        wrapper.config.cuda_graph_modules = []
-        wrapper.inner_layer = self._bare_transformer_inner(
-            has_attention=True, offload_core_attn=True
-        )
-        object.__setattr__(wrapper, 'off_interface', self._recording_offload_interface(calls))
-        object.__setattr__(wrapper, '_get_te_cuda_graph_group_tail', lambda: None)
-        object.__setattr__(wrapper, '_inner_is_partial_moe_capture', lambda: False)
-        object.__setattr__(
-            wrapper,
-            'forward',
-            lambda hidden_states, **_kwargs: (calls.append('body') or hidden_states, None),
-        )
-
-        assert not wrapper.offload_module_in_cuda_graph
-        wrapper._te_cuda_graph_capture(torch.ones(2, 1, 4))
-        assert calls == ['body']
-
     def test_hybrid_explicit_attn_scope_claims_inner_offload(self):
         attention_inner = self._bare_transformer_inner(has_attention=True, offload_core_attn=True)
 
@@ -1450,15 +1603,13 @@ class TestHybridTECudaGraphDiscovery:
         assert calls == ['head', 'head', 'tail']
         assert head._offload_module_in_cuda_graph_cached is True
 
-    @pytest.mark.parametrize(
-        ('delay_offload', 'tail_raises'), [(False, False), (True, False), (True, True)]
-    )
+    @pytest.mark.parametrize('tail_raises', [False, True])
     @pytest.mark.parametrize('grouped', [False, True])
-    def test_hybrid_partial_replay_preserves_delayed_offload_lifecycle(
-        self, monkeypatch, delay_offload, tail_raises, grouped
+    def test_hybrid_partial_replay_runs_eager_tail_and_propagates_errors(
+        self, monkeypatch, tail_raises, grouped
     ):
         calls = []
-        head = self._bare_hybrid_wrapper(delay_offload=delay_offload)
+        head = self._bare_hybrid_wrapper()
 
         class Tail:
             @staticmethod
@@ -1468,7 +1619,6 @@ class TestHybridTECudaGraphDiscovery:
                     raise RuntimeError('eager tail failed')
                 return torch.full((2, 1, 4), 3.0), None
 
-        object.__setattr__(head, 'off_interface', self._recording_offload_interface(calls))
         object.__setattr__(
             head, '_get_te_cuda_graph_group_tail', lambda: Tail() if grouped else None
         )
@@ -1490,16 +1640,7 @@ class TestHybridTECudaGraphDiscovery:
             output = head._te_cuda_graph_replay(torch.ones(2, 1, 4))
             assert torch.equal(output[0], torch.full((2, 1, 4), 3.0))
 
-        expected_calls = ['graph_replay', 'eager_tail']
-        if delay_offload:
-            expected_calls = [
-                'enter_replay',
-                'graph_replay',
-                'flush_delayed_groups',
-                'eager_tail',
-                'exit_replay',
-            ]
-        assert calls == expected_calls
+        assert calls == ['graph_replay', 'eager_tail']
 
 
 # Global storage for comparing unique buffer counts across different num_microbatches,

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1031,15 +1031,20 @@ class TestParallelHybridBlockCudagraphs:
 
 class TestHybridTECudaGraphDiscovery:
     @staticmethod
-    def _bare_hybrid_wrapper(*, offload_in_graph=False, delay_offload=False):
+    def _bare_hybrid_wrapper(*, offload_in_graph=None, delay_offload=False):
         wrapper = HyperConnectionHybridLayer.__new__(HyperConnectionHybridLayer)
         torch.nn.Module.__init__(wrapper)
+        # Intentionally minimal: individual CPU mocks provide only the state they exercise.
         wrapper.config = SimpleNamespace(
             cuda_graph_modules=[CudaGraphModule.attn],
             delay_offload_until_cuda_graph=delay_offload,
             fine_grained_activation_offloading=True,
         )
-        object.__setattr__(wrapper, '_has_offload_module_in_cuda_graph', lambda: offload_in_graph)
+        object.__setattr__(wrapper, '_offload_module_in_cuda_graph_cached', None)
+        if offload_in_graph is not None:
+            object.__setattr__(
+                wrapper, '_compute_offload_module_in_cuda_graph', lambda: offload_in_graph
+            )
         return wrapper
 
     @staticmethod
@@ -1057,6 +1062,7 @@ class TestHybridTECudaGraphDiscovery:
         inner.offload_attn_proj = False
         inner.offload_mlp_norm = False
         inner.is_moe_layer = is_moe
+        inner.offload_module_in_cuda_graph = offload_core_attn
         return inner
 
     @staticmethod
@@ -1260,6 +1266,14 @@ class TestHybridTECudaGraphDiscovery:
         assert calls == ['backward_record', 'body', 'forward_record']
         assert torch.equal(output[0], torch.full((2, 1, 4), 4.0))
 
+    def test_hybrid_capture_impl_rejects_raw_packed_sequence_kwargs(self):
+        wrapper = self._bare_hybrid_wrapper(offload_in_graph=False)
+
+        with pytest.raises(AssertionError):
+            wrapper._te_cuda_graph_capture_impl(
+                torch.ones(2, 1, 4), cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32)
+            )
+
     def test_grouped_hybrid_capture_has_one_outer_offload_boundary(self):
         calls = []
         head = self._bare_hybrid_wrapper(offload_in_graph=True)
@@ -1294,29 +1308,63 @@ class TestHybridTECudaGraphDiscovery:
 
         tail = self._bare_hybrid_wrapper()
         tail.inner_layer = inner
-        # Exercise the real predicate instead of the test helper override.
-        object.__delattr__(tail, '_has_offload_module_in_cuda_graph')
 
-        assert not tail._has_offload_module_in_cuda_graph()
+        assert not tail._compute_offload_module_in_cuda_graph()
         assert not tail.offload_module_in_cuda_graph
 
-    def test_hybrid_offload_predicate_reads_real_inner_flags_and_group_tail(self):
+    def test_hybrid_empty_cuda_graph_scope_does_not_claim_inner_offload(self):
+        calls = []
+        wrapper = self._bare_hybrid_wrapper()
+        wrapper.config.cuda_graph_modules = []
+        wrapper.inner_layer = self._bare_transformer_inner(
+            has_attention=True, offload_core_attn=True
+        )
+        object.__setattr__(wrapper, 'off_interface', self._recording_offload_interface(calls))
+        object.__setattr__(wrapper, '_get_te_cuda_graph_group_tail', lambda: None)
+        object.__setattr__(wrapper, '_inner_is_partial_moe_capture', lambda: False)
+        object.__setattr__(
+            wrapper,
+            'forward',
+            lambda hidden_states, **_kwargs: (calls.append('body') or hidden_states, None),
+        )
+
+        assert not wrapper.offload_module_in_cuda_graph
+        wrapper._te_cuda_graph_capture(torch.ones(2, 1, 4))
+        assert calls == ['body']
+
+    def test_hybrid_explicit_attn_scope_claims_inner_offload(self):
         attention_inner = self._bare_transformer_inner(has_attention=True, offload_core_attn=True)
 
         attention_wrapper = self._bare_hybrid_wrapper()
         attention_wrapper.inner_layer = attention_inner
-        object.__delattr__(attention_wrapper, '_has_offload_module_in_cuda_graph')
         assert attention_wrapper.offload_module_in_cuda_graph
 
-        no_attention_inner = self._bare_transformer_inner(
-            has_attention=False, offload_core_attn=True, is_moe=True
+    def test_hybrid_offload_property_caches_and_grouping_invalidates(self):
+        calls = []
+        head = self._bare_hybrid_wrapper()
+        tail = self._bare_hybrid_wrapper()
+        object.__setattr__(
+            head,
+            '_compute_inner_offload_module_in_cuda_graph',
+            lambda: calls.append('head') or False,
         )
+        object.__setattr__(
+            tail,
+            '_compute_inner_offload_module_in_cuda_graph',
+            lambda: calls.append('tail') or True,
+        )
+        object.__setattr__(head, '_can_group_te_cuda_graph_with', lambda _tail: True)
 
-        group_head = self._bare_hybrid_wrapper()
-        group_head.inner_layer = no_attention_inner
-        object.__delattr__(group_head, '_has_offload_module_in_cuda_graph')
-        object.__setattr__(group_head, '_get_te_cuda_graph_group_tail', lambda: attention_wrapper)
-        assert group_head.offload_module_in_cuda_graph
+        assert not head.offload_module_in_cuda_graph
+        assert not head.offload_module_in_cuda_graph
+        assert calls == ['head']
+
+        head._set_te_cuda_graph_group_tail(tail)
+        assert head._offload_module_in_cuda_graph_cached is None
+        assert head.offload_module_in_cuda_graph
+        assert head.offload_module_in_cuda_graph
+        assert calls == ['head', 'head', 'tail']
+        assert head._offload_module_in_cuda_graph_cached is True
 
     @pytest.mark.parametrize(
         ('delay_offload', 'tail_raises'), [(False, False), (True, False), (True, True)]

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -198,18 +198,28 @@ class TestCudaGraphConfigAndArguments:
         assert cfg.delay_offload_until_cuda_graph
         assert any(expert_module in str(record.message) for record in warning_records)
 
-    def test_delayed_expert_offload_warns_about_final_queue_drain(self):
-        with pytest.warns(UserWarning, match="final eager expert group can remain queued"):
-            cfg = _base_cuda_graph_config(
-                cuda_graph_impl='transformer_engine',
-                cuda_graph_modules=[CudaGraphModule.moe_router],
-                fine_grained_activation_offloading=True,
-                offload_modules=['expert_fc1'],
-                delay_offload_until_cuda_graph=True,
-                num_moe_experts=4,
-            )
+    def test_delayed_expert_offload_logs_about_final_queue_drain(self, monkeypatch):
+        log_records = []
+        monkeypatch.setattr(
+            transformer_config_module,
+            'log_single_rank',
+            lambda logger, level, message: log_records.append((logger, level, message)),
+        )
+
+        cfg = _base_cuda_graph_config(
+            cuda_graph_impl='transformer_engine',
+            cuda_graph_modules=[CudaGraphModule.moe_router],
+            fine_grained_activation_offloading=True,
+            offload_modules=['expert_fc1'],
+            delay_offload_until_cuda_graph=True,
+            num_moe_experts=4,
+        )
 
         assert cfg.delay_offload_until_cuda_graph
+        assert len(log_records) == 1
+        assert log_records[0][0] is transformer_config_module.logger
+        assert log_records[0][1] == logging.WARNING
+        assert "final eager expert group can remain queued" in log_records[0][2]
 
     def test_local_impl_rejects_moe_router_graph_with_mlp_norm_offload(self):
         with pytest.raises(
@@ -1513,6 +1523,13 @@ class TestHybridTECudaGraphDiscovery:
 
         assert calls == ['backward_record', 'body', 'forward_record']
         assert torch.equal(output[0], torch.full((2, 1, 4), 4.0))
+
+    def test_hybrid_capture_requires_offload_interface_for_enabled_boundary(self):
+        wrapper = self._bare_hybrid_wrapper(offload_in_graph=True)
+        object.__setattr__(wrapper, 'off_interface', None)
+
+        with pytest.raises(AssertionError, match='offload[ _]interface'):
+            wrapper._te_cuda_graph_capture(torch.ones(2, 1, 4))
 
     def test_hybrid_capture_impl_rejects_raw_packed_sequence_kwargs(self):
         wrapper = self._bare_hybrid_wrapper(offload_in_graph=False)

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -159,6 +159,31 @@ class TestParallelTransformerLayer:
         layer.mlp = torch.nn.Linear(2, 2)
         assert layer.offload_scope_in_cuda_graph(require_concrete_modules=True)
 
+    def test_set_offload_modules_requires_concrete_attention_branch(self, monkeypatch):
+        """The stored capture flag must not survive on an attention-free split layer."""
+        import megatron.core.transformer.transformer_layer as transformer_layer_module
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        layer = self.parallel_transformer_layer
+        layer.config.fine_grained_activation_offloading = True
+        layer.config.offload_modules = ['core_attn']
+        layer.config.cuda_graph_modules = [CudaGraphModule.attn]
+        layer.config.cuda_graph_warmup_steps = 1
+        layer.is_moe_layer = False
+        monkeypatch.setattr(transformer_layer_module, 'is_torch_min_version', lambda _version: True)
+        monkeypatch.setattr(transformer_layer_module, 'is_te_min_version', lambda _version: True)
+
+        # A normal GPT attention layer owns the configured core-attention boundary.
+        assert not isinstance(layer.self_attention, IdentityOp)
+        layer._set_offload_modules()
+        assert layer.offload_module_in_cuda_graph
+
+        # A split Hybrid MoE tail shares the config but has no attention body.
+        layer.self_attention = IdentityOp()
+        layer.cross_attention = IdentityOp()
+        layer._set_offload_modules()
+        assert not layer.offload_module_in_cuda_graph
+
     def test_split_branch_norms_join_mhc_recompute_manager(self, monkeypatch):
         """Explicit norms in split hybrid branches use the unified mHC manager."""
         from contextlib import nullcontext

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -109,6 +109,56 @@ class TestParallelTransformerLayer:
         num_weights = sum([p.numel() for p in parallel_transformer_layer.parameters()])
         assert num_weights == 1884
 
+    def test_offload_scope_in_cuda_graph_preserves_gpt_rules(self):
+        """The shared helper keeps the existing GPT attention/dense-MLP scope rules."""
+        layer = self.parallel_transformer_layer
+        layer.config.fine_grained_activation_offloading = True
+        layer.offload_qkv_linear = False
+        layer.offload_core_attn = True
+        layer.offload_attn_proj = False
+        layer.offload_mlp_norm = False
+        layer.is_moe_layer = False
+
+        layer.config.cuda_graph_modules = [CudaGraphModule.attn]
+        assert layer.offload_scope_in_cuda_graph()
+
+        layer.offload_core_attn = False
+        assert not layer.offload_scope_in_cuda_graph()
+
+        layer.config.cuda_graph_modules = [CudaGraphModule.mlp]
+        layer.offload_mlp_norm = True
+        assert layer.offload_scope_in_cuda_graph()
+
+        layer.is_moe_layer = True
+        assert not layer.offload_scope_in_cuda_graph()
+
+    def test_offload_scope_in_cuda_graph_can_require_concrete_branches(self):
+        """Hybrid split layers ignore configured scopes backed only by IdentityOp."""
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        layer = self.parallel_transformer_layer
+        layer.config.fine_grained_activation_offloading = True
+        layer.config.cuda_graph_modules = [CudaGraphModule.attn, CudaGraphModule.mlp]
+        layer.offload_qkv_linear = False
+        layer.offload_core_attn = True
+        layer.offload_attn_proj = False
+        layer.offload_mlp_norm = True
+        layer.is_moe_layer = False
+        layer.self_attention = IdentityOp()
+        layer.cross_attention = IdentityOp()
+        layer.mlp = IdentityOp()
+
+        # The default intentionally preserves GPT's config-based rule.
+        assert layer.offload_scope_in_cuda_graph()
+        assert not layer.offload_scope_in_cuda_graph(require_concrete_modules=True)
+
+        layer.self_attention = torch.nn.Linear(2, 2)
+        assert layer.offload_scope_in_cuda_graph(require_concrete_modules=True)
+
+        layer.offload_core_attn = False
+        layer.mlp = torch.nn.Linear(2, 2)
+        assert layer.offload_scope_in_cuda_graph(require_concrete_modules=True)
+
     def test_split_branch_norms_join_mhc_recompute_manager(self, monkeypatch):
         """Explicit norms in split hybrid branches use the unified mHC manager."""
         from contextlib import nullcontext


### PR DESCRIPTION
## Summary

- Make `HyperConnectionHybridLayer` own the fine-grained activation-offload event boundary when Transformer Engine captures the outer mHC wrapper, while the inner `TransformerLayer` contributes an event-free capture body.
- Centralize the `TransformerLayer` offload-in-graph scope query and let Hybrid require concrete (non-`IdentityOp`) split modules, so MoE-only split layers do not claim a nonexistent `core_attn` boundary.
- During TE capture, queue backward completion at the tail of each callable's own autograd `GraphTask` before joining H2D work. The recorded CUDA operations become part of that callable's backward graph and the Python callback is not run again during replay.
- Teach `TECudaGraphHelper` to inspect the wrapped Transformer layer for self-attention, so Hybrid mHC capture/replay preserves regular RoPE arguments.
- Keep delayed expert offload out of the Hybrid wrapper path instead of exposing a lifecycle that cannot drain the final eager MoE tail correctly.

## Root cause

TE captures the outer `HyperConnectionHybridLayer`, while fine-grained activation-offload state lives on its inner `TransformerLayer`. Calling the inner forward body during capture bypassed the inner layer's normal `forward_record()` / `backward_record()` boundary. Its D2H stream could therefore escape the graph-owned event pair and produce `capturing stream has unjoined work` or dependencies on uncaptured work.

The outer callable was also not recognized as containing self-attention while TE built its static sample arguments. `rotary_pos_emb` could be omitted from the capture signature, and replay cannot add a keyword that was absent during capture.

## CUDA Graph scope

This PR is intentionally scoped to Transformer Engine's per-callable CUDA Graph path (`cuda_graph_impl=transformer_engine`). It does not modify MCore's `local` or `full_iteration` capture/replay runners. In particular, `FineGrainedOffloadingBackwardRecordFunction` is inserted only by `_te_cuda_graph_capture`; full-iteration capture never registers this Python callback.

TE's `make_graphed_callables` drives warmup and capture with a separate `torch.autograd.backward()` for each callable. The queued callback therefore closes that callable's GraphTask inside its backward capture context; it does not collect callbacks from every layer at the end of the normal training microbatch. Normal training invokes TE's captured `bwd_graph.replay()` and does not execute the Python callback again.

## Guardrails for shared legacy paths

- Warn when fine-grained offload is combined with an empty TE CUDA Graph module list (whole-layer capture). That shared GPT/Hybrid boundary still needs a broader audit across attention, norms, dense MLP, and MoE.
- Warn for the known captured-attention rotary sample contracts that this PR does not repair: non-MLA YaRN, GPT mRoPE, and regular RoPE with actual THD inputs plus CP > 1.
- Warn that delayed expert offload (`expert_fc1`, `moe_act`, or `fused_group_mlp`) can leave the final eager expert group queued on direct TE partial-graph paths, and that Hybrid mHC intentionally commits those expert tensors immediately.

These are explicit warnings rather than silent behavior changes; the underlying shared fixes are follow-up work.

## Coverage

- Unit coverage for direct `TransformerLayer` and wrapped Hybrid sample construction, warning/deduplication matrices, concrete split-module filtering at the stored call site, explicit offload-interface invariants, replay ordering, and two independent callback GraphTasks.
- Existing H100 Hybrid regression: mHC + HybridModel + `core_attn` offload + TE `[attn]` partial CUDA Graphs.
- New H100 plain GPT regression: GPTModel + `core_attn` offload + TE `[attn]` partial CUDA Graphs, with three warmups and a fourth iteration that executes replay. Its golden is bootstrapped from GitHub CI rather than generated locally.

## Validation

- Current head: `8fd493122` (Draft, base `dev`, rebased onto `3c5a39967`).
- Changed-file Black, isort, Ruff, Pylint, copyright, Python AST, YAML, recipe-parser, and `git diff --check` validation pass locally.
- Independent context-free reviews were used to audit the TE GraphTask call path, split-layer state, warning behavior, tests, and H100 registration.
- Final-head 4-GPU GB200 smokes at `8fd493122` exercised Hybrid mHC + PP2 + `core_attn` offload + TE `[attn, moe_router]` partial CUDA Graphs with `fine_grained_offloading_max_inflight_offloads` set to `None`, `0`, and `2`. All three completed 8/8 iterations (three eager warmups, capture on iteration 4, replay on iterations 5-8) with identical finite loss/gradient trajectories and no invalid-event, unjoined-work, uncaptured-work, or NaN failure.
- Previous Hybrid H100 regression at head `6da26342a`: [job 100287107309](https://github.com/NVIDIA/Megatron-LM/actions/runs/33633590666/job/100287107309), 5/5 repeats passed with stable finite metrics.
- GPT golden bootstrap at head `5aa086adc`: [job 100542062469](https://github.com/NVIDIA/Megatron-LM/actions/runs/33717372074/job/100542062469) completed all 4 iterations, including the first TE graph replay, with finite loss/gradient metrics. It then failed only because the checked-in golden did not yet exist; artifact `9880599540` supplied the committed golden.
- Fresh final-head [strict review](https://github.com/NVIDIA/Megatron-LM/actions/runs/33725833769) completed successfully with no new findings.
- Final-head H100 golden validation passed for both the [plain GPT boundary](https://github.com/NVIDIA/Megatron-LM/actions/runs/33725817069/job/100572567374) and the [Hybrid mHC wrapper boundary](https://github.com/NVIDIA/Megatron-LM/actions/runs/33725817069/job/100572570312).
- The complete final-head [`/ok to test` CI run](https://github.com/NVIDIA/Megatron-LM/actions/runs/33725817069) finished successfully with no failing jobs.

## Scope

The cross-capture `max_inflight_offloads > 0` event-lifetime fix remains separate in #7020. This PR does not silently broaden TE whole-layer offload support or implement the shared rotary/delayed-expert-tail fixes described above.
