### PR TITLE
[Dev] Fix fine-grained offload throttling across CUDA graphs

### DIFF
--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -1,13 +1,15 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Full iteration CUDA graph for training."""
 
 import gc
 import logging
+from contextlib import nullcontext
 
 import torch
 
 from megatron.core.tensor_parallel.random import get_all_rng_states
+from megatron.core.utils import get_model_config
 
 logger = logging.getLogger(__name__)
 
@@ -240,15 +242,26 @@ class FullCudaGraphWrapper:
                 FullCudaGraphWrapper.cuda_graph[training_str].register_generator_state(state)
             torch.cuda.synchronize()
             capture_stream = get_shared_capture_stream()
-            with torch.cuda.graph(
-                FullCudaGraphWrapper.cuda_graph[training_str],
-                stream=capture_stream,
-                pool=get_graph_pool(self.use_single_mempool),
-                capture_error_mode="thread_local",
-            ):
-                FullCudaGraphWrapper.result[training_str] = self.forward_backward_func(
-                    *args, **kwargs
+            capture_scope = nullcontext()
+            config = get_model_config(model[0] if isinstance(model, list) else model)
+            if getattr(config, 'fine_grained_activation_offloading', False):
+                from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                    FineGrainedActivationOffloadingInterface as off_interface,
                 )
+
+                # Forward and backward are captured into one graph, so every
+                # max-inflight dependency inside this body is capture-local.
+                capture_scope = off_interface.cuda_graph_capture_scope(may_cross_graphs=False)
+            with capture_scope:
+                with torch.cuda.graph(
+                    FullCudaGraphWrapper.cuda_graph[training_str],
+                    stream=capture_stream,
+                    pool=get_graph_pool(self.use_single_mempool),
+                    capture_error_mode="thread_local",
+                ):
+                    FullCudaGraphWrapper.result[training_str] = self.forward_backward_func(
+                        *args, **kwargs
+                    )
             torch.cuda.synchronize()
             torch.distributed.barrier()
             logger.info(f'CUDA graph capture done for {training_str}!!!')

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -243,7 +243,12 @@ class FullCudaGraphWrapper:
             torch.cuda.synchronize()
             capture_stream = get_shared_capture_stream()
             capture_scope = nullcontext()
-            config = get_model_config(model[0] if isinstance(model, list) else model)
+            try:
+                config = get_model_config(model[0] if isinstance(model, list) else model)
+            except RuntimeError:
+                # FullCudaGraphWrapper historically accepted model wrappers with
+                # no reachable config; only offload integration needs this flag.
+                config = None
             if getattr(config, 'fine_grained_activation_offloading', False):
                 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
                     FineGrainedActivationOffloadingInterface as off_interface,

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -377,9 +377,8 @@ class OffloadTensorGroup:
         # also the correct max-inflight edge within one capture. Separately captured
         # module graphs cannot share that internal edge, so cap > 0 groups may also
         # carry an external event whose explicit record/wait nodes bridge graphs.
-        self._offload_throttle_event: Optional[torch.cuda.Event] = (
-            torch.cuda.Event(external=True) if enable_offload_throttle else None
-        )
+        self._offload_throttle_enabled = enable_offload_throttle
+        self._offload_throttle_event: Optional[torch.cuda.Event] = None
         self.offload = True
         self.total_offload_bytes = 0
         self.total_tensor_count = 0
@@ -409,8 +408,13 @@ class OffloadTensorGroup:
 
     def record_offload_throttle_event(self, stream):
         """Record the external event used only for max-inflight throttling."""
-        if self._offload_throttle_event is None:
+        if not self._offload_throttle_enabled:
             raise RuntimeError("Offload throttle event was not enabled for this group")
+        # Full-iteration capture never crosses graph boundaries, so avoid even
+        # creating the external-event wrapper unless a sibling-graph producer
+        # actually needs to publish an event node.
+        if self._offload_throttle_event is None:
+            self._offload_throttle_event = torch.cuda.Event(external=True)
         self._offload_throttle_event.record(stream)
 
     def wait_offload_throttle_event(self, stream):
@@ -480,6 +484,10 @@ class PipelineOffloadManager:
         # modules inherit it so max-inflight dependencies can distinguish a
         # same-graph edge from a dependency between separately captured graphs.
         self._cuda_graph_capture_owner: Optional[_OffloadCudaGraphCaptureOwner] = None
+        # The outermost capture session owns every handler that enqueues a
+        # capture-time throttle entry. Tracking touched handlers, rather than
+        # only cached forward/backward lists, makes exception cleanup complete.
+        self._cuda_graph_capture_session_handlers: Optional[set] = None
         # Cache OffloadChunkHandler objects for each virtual pipeline stage and each forward pass.
         self._cached_chunks_forward = []
         # Cache OffloadChunkHandler objects for each virtual pipeline stage and each backward pass.
@@ -554,21 +562,33 @@ class PipelineOffloadManager:
         finally:
             self._cuda_graph_capture_owner = previous_owner
 
+    def register_cuda_graph_capture_handler(self, handler) -> None:
+        """Register a handler for cleanup at the outer capture-session boundary."""
+        if self._cuda_graph_capture_session_handlers is not None:
+            self._cuda_graph_capture_session_handlers.add(handler)
+
     @contextmanager
     def cuda_graph_capture_session(self):
         """Keep throttle FIFOs across sibling captures, then discard capture-only state.
 
-        Local CUDA graphs are captured one at a time but may consume external
-        events produced by an earlier sibling graph. The FIFOs must therefore
-        survive individual capture scopes and be cleared only after the complete
-        local capture session has finished.
+        CUDA graphs are captured one at a time but may consume external events
+        produced by an earlier sibling graph. The FIFOs must therefore survive
+        individual capture scopes and be cleared only after the complete outer
+        capture session has finished.
         """
+        outermost = self._cuda_graph_capture_session_handlers is None
+        if outermost:
+            self._cuda_graph_capture_session_handlers = set()
         try:
             yield
         finally:
-            cached_chunks = set(self._cached_chunks_forward) | set(self._cached_chunks_backward)
-            for chunk in cached_chunks:
-                chunk.clear_offload_pending()
+            if outermost:
+                touched_chunks = self._cuda_graph_capture_session_handlers
+                assert touched_chunks is not None
+                self._cuda_graph_capture_session_handlers = None
+                cached_chunks = set(self._cached_chunks_forward) | set(self._cached_chunks_backward)
+                for chunk in cached_chunks | touched_chunks:
+                    chunk.clear_offload_pending()
 
     def push_offload_groups(self, group_hook, name, forced_released_tensors):
         """Push the offload groups to the delayed queue."""
@@ -1092,7 +1112,8 @@ class ChunkOffloadHandler:
         debug_rank("------bulk_offload_group")
         nvtx_msg = "activation offloading " + group_to_offload._name
         nvtx_range_push(nvtx_msg)
-        capture_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
+        offload_manager = PipelineOffloadManager.get_instance()
+        capture_owner = offload_manager.cuda_graph_capture_owner
         external_recorded = bool(
             self._max_inflight_offloads is not None
             and self._max_inflight_offloads > 0
@@ -1114,6 +1135,8 @@ class ChunkOffloadHandler:
                 group_to_offload.record_offload_throttle_event(self.d2h_stream)
         nvtx_range_pop(nvtx_msg)
         if self._max_inflight_offloads is not None:
+            if capture_owner is not None:
+                offload_manager.register_cuda_graph_capture_handler(self)
             gname = group_to_offload._name
             self._offload_pending_by_name[gname].append(
                 _PendingOffload(group_to_offload, capture_owner, external_recorded)
@@ -1220,7 +1243,10 @@ class ChunkOffloadHandler:
             if (pending.producer_owner is None) != (consumer_owner is None):
                 raise RuntimeError(
                     "Max-inflight offload dependency crossed between eager execution "
-                    f"and CUDA graph capture for group {group_name!r}"
+                    f"and CUDA graph capture for group {group_name!r}. This indicates "
+                    "that the throttle FIFO was not cleared at a capture-session boundary; "
+                    "unset fine_grained_offloading_max_inflight_offloads to disable "
+                    "throttling while reporting this capture-boundary bug."
                 )
             if pending.producer_owner is consumer_owner:
                 pending.group.wait_offload_event(cur)
@@ -1510,7 +1536,7 @@ class FineGrainedActivationOffloadingInterface:
 
     @staticmethod
     def cuda_graph_capture_session():
-        """Return a scope covering all sibling captures in one local capture session."""
+        """Return a scope covering all sibling captures in one capture session."""
         return PipelineOffloadManager.get_instance().cuda_graph_capture_session()
 
     @staticmethod

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -357,10 +357,11 @@ class OffloadTensorGroup:
         self._offload_event = torch.cuda.Event()
         self._reload_event = torch.cuda.Event()
         # Keep throttling separate from the internal offload/reload handshake.
-        # External events capture record/wait as explicit graph nodes, allowing
-        # separate module graphs to synchronize through the same event.
-        # A stream wait binds to the event state at the wait call, so recording
-        # this cached event in a later iteration does not retarget earlier waits.
+        # External events make record/wait explicit graph nodes, so separate
+        # module graphs can synchronize through the same event object. A captured
+        # wait node resolves against the event's live state at each replay, which
+        # lets a later graph wait on an earlier graph's re-recorded event; reuse the
+        # event across iterations rather than reallocating it per offload.
         self._offload_throttle_event: Optional[torch.cuda.Event] = (
             torch.cuda.Event(external=True) if enable_offload_throttle else None
         )

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -359,6 +359,8 @@ class OffloadTensorGroup:
         # Keep throttling separate from the internal offload/reload handshake.
         # External events capture record/wait as explicit graph nodes, allowing
         # separate module graphs to synchronize through the same event.
+        # A stream wait binds to the event state at the wait call, so recording
+        # this cached event in a later iteration does not retarget earlier waits.
         self._offload_throttle_event: Optional[torch.cuda.Event] = (
             torch.cuda.Event(external=True) if enable_offload_throttle else None
         )
@@ -391,8 +393,13 @@ class OffloadTensorGroup:
 
     def record_offload_throttle_event(self, stream):
         """Record the external event used only for max-inflight throttling."""
+        self.offload_throttle_event.record(stream)
+
+    @property
+    def offload_throttle_event(self) -> torch.cuda.Event:
+        """Return the external event used only for max-inflight throttling."""
         assert self._offload_throttle_event is not None
-        self._offload_throttle_event.record(stream)
+        return self._offload_throttle_event
 
     def record_reload_event(self, stream):
         """Record the reload event."""
@@ -610,8 +617,10 @@ class PipelineOffloadManager:
         for chunk in self._cached_chunks_backward:
             for group in chunk.offload_groups:
                 if group.offload and keep_on_gpu_bytes > 0:
-                    debug_rank(f"group {group._name} offload {group.offload} \
-                        keep_on_gpu_bytes {keep_on_gpu_bytes}")
+                    debug_rank(
+                        f"group {group._name} offload {group.offload} "
+                        f"keep_on_gpu_bytes {keep_on_gpu_bytes}"
+                    )
                     keep_on_gpu_bytes -= group.total_offload_bytes
                     group.offload = False
         # Disable the later groups to meet the activation offload fraction.
@@ -1033,9 +1042,7 @@ class ChunkOffloadHandler:
         # reload dependency, whose capture-local semantics must remain unchanged.
         if self._max_inflight_offloads is not None:
             gname = group_to_offload._name
-            throttle_event = group_to_offload._offload_throttle_event
-            assert throttle_event is not None
-            self._offload_pending_by_name[gname].append(throttle_event)
+            self._offload_pending_by_name[gname].append(group_to_offload.offload_throttle_event)
             self._drain_offload_pending(gname)
 
     def get_max_deduplicated_groups(self):

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -566,7 +566,8 @@ class PipelineOffloadManager:
         try:
             yield
         finally:
-            for chunk in self._cached_chunks_forward:
+            cached_chunks = set(self._cached_chunks_forward) | set(self._cached_chunks_backward)
+            for chunk in cached_chunks:
                 chunk.clear_offload_pending()
 
     def push_offload_groups(self, group_hook, name, forced_released_tensors):
@@ -1091,6 +1092,13 @@ class ChunkOffloadHandler:
         debug_rank("------bulk_offload_group")
         nvtx_msg = "activation offloading " + group_to_offload._name
         nvtx_range_push(nvtx_msg)
+        capture_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
+        external_recorded = bool(
+            self._max_inflight_offloads is not None
+            and self._max_inflight_offloads > 0
+            and capture_owner is not None
+            and capture_owner.may_cross_graphs
+        )
         with torch.cuda.stream(self.d2h_stream):
             for tensor_tag, tensor_on_device in group_to_offload._tensors.items():
                 if self.tensor_need_offloading_checker(tensor_on_device):
@@ -1102,13 +1110,6 @@ class ChunkOffloadHandler:
                     tensor_on_device.record_stream(self.d2h_stream)
                     group_to_offload.push_tensor(tensor_tag, state)
             group_to_offload.record_offload_event(self.d2h_stream)
-            capture_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
-            external_recorded = bool(
-                self._max_inflight_offloads is not None
-                and self._max_inflight_offloads > 0
-                and capture_owner is not None
-                and capture_owner.may_cross_graphs
-            )
             if external_recorded:
                 group_to_offload.record_offload_throttle_event(self.d2h_stream)
         nvtx_range_pop(nvtx_msg)
@@ -1212,10 +1213,10 @@ class ChunkOffloadHandler:
         if self._max_inflight_offloads is None:
             return
         cur = torch.cuda.current_stream()
+        consumer_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
         q = self._offload_pending_by_name[group_name]
         while len(q) > self._max_inflight_offloads:
             pending = q.popleft()
-            consumer_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
             if (pending.producer_owner is None) != (consumer_owner is None):
                 raise RuntimeError(
                     "Max-inflight offload dependency crossed between eager execution "

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -357,6 +357,8 @@ class OffloadTensorGroup:
         self._offload_event = torch.cuda.Event()
         self._reload_event = torch.cuda.Event()
         # Keep throttling separate from the internal offload/reload handshake.
+        # ``_offload_event`` must remain capture-local because ``bulk_reload_group``
+        # uses it for the reload dependency; sharing it would change that graph edge.
         # External events make record/wait explicit graph nodes, so separate
         # module graphs can synchronize through the same event object. A captured
         # wait node resolves against the event's live state at each replay, which
@@ -920,7 +922,9 @@ class ChunkOffloadHandler:
         self._tensor_count_current_group = 0
         self._reloading_group = []
         # Clear the pending-event FIFO at iter boundary so we never wait on
-        # an event recorded in a previous (non-captured) iteration.
+        # an event recorded in a previous (non-captured) iteration. Groups and
+        # their event objects persist, but a reused event is only waited on in
+        # the iteration that re-recorded it.
         self._offload_pending_by_name.clear()
 
     def find_group_with_name(

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -351,11 +351,17 @@ class OffloadTensorGroup:
     A group of tensors to be offloaded together.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, enable_offload_throttle: bool = False):
         self._name = name
         self._tensors = {}
         self._offload_event = torch.cuda.Event()
         self._reload_event = torch.cuda.Event()
+        # Keep throttling separate from the internal offload/reload handshake.
+        # External events capture record/wait as explicit graph nodes, allowing
+        # separate module graphs to synchronize through the same event.
+        self._offload_throttle_event: Optional[torch.cuda.Event] = (
+            torch.cuda.Event(external=True) if enable_offload_throttle else None
+        )
         self.offload = True
         self.total_offload_bytes = 0
         self.total_tensor_count = 0
@@ -382,6 +388,11 @@ class OffloadTensorGroup:
     def wait_offload_event(self, stream):
         """Wait for the offload event."""
         stream.wait_event(self._offload_event)
+
+    def record_offload_throttle_event(self, stream):
+        """Record the external event used only for max-inflight throttling."""
+        assert self._offload_throttle_event is not None
+        self._offload_throttle_event.record(stream)
 
     def record_reload_event(self, stream):
         """Record the reload event."""
@@ -599,10 +610,8 @@ class PipelineOffloadManager:
         for chunk in self._cached_chunks_backward:
             for group in chunk.offload_groups:
                 if group.offload and keep_on_gpu_bytes > 0:
-                    debug_rank(
-                        f"group {group._name} offload {group.offload} \
-                        keep_on_gpu_bytes {keep_on_gpu_bytes}"
-                    )
+                    debug_rank(f"group {group._name} offload {group.offload} \
+                        keep_on_gpu_bytes {keep_on_gpu_bytes}")
                     keep_on_gpu_bytes -= group.total_offload_bytes
                     group.offload = False
         # Disable the later groups to meet the activation offload fraction.
@@ -1017,14 +1026,16 @@ class ChunkOffloadHandler:
                     tensor_on_device.record_stream(self.d2h_stream)
                     group_to_offload.push_tensor(tensor_tag, state)
             group_to_offload.record_offload_event(self.d2h_stream)
+            if self._max_inflight_offloads is not None:
+                group_to_offload.record_offload_throttle_event(self.d2h_stream)
         nvtx_range_pop(nvtx_msg)
-        # Under full-iteration CG capture, the main stream may not wait on d2h
-        # events; optional max-inflight enqueues each group's offload event and
-        # has main wait on older events for this group name when its pending
-        # count exceeds the cap (each name is tracked separately).
+        # Max-inflight uses its dedicated external event rather than the internal
+        # reload dependency, whose capture-local semantics must remain unchanged.
         if self._max_inflight_offloads is not None:
             gname = group_to_offload._name
-            self._offload_pending_by_name[gname].append(group_to_offload._offload_event)
+            throttle_event = group_to_offload._offload_throttle_event
+            assert throttle_event is not None
+            self._offload_pending_by_name[gname].append(throttle_event)
             self._drain_offload_pending(gname)
 
     def get_max_deduplicated_groups(self):
@@ -1179,7 +1190,11 @@ class ChunkOffloadHandler:
         debug_rank(f"--on_group_start_forward {name}")
         self._offloaded_group_index = self._offloaded_group_index + 1
         if self.is_warmup:
-            self.offload_groups.append(OffloadTensorGroup(name))
+            self.offload_groups.append(
+                OffloadTensorGroup(
+                    name, enable_offload_throttle=self._max_inflight_offloads is not None
+                )
+            )
             self._max_group_size = max(self._max_group_size, self._offloaded_group_index)
             debug_rank(f"max group size {self._max_group_size}")
         else:

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from collections import defaultdict, deque
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -39,6 +40,22 @@ def _te_do_not_offload(tensor):
         data_tensor is not None and getattr(data_tensor, "_TE_do_not_offload", False)
         for data_tensor in data_tensors
     )
+
+
+@dataclass(frozen=True, eq=False)
+class _OffloadCudaGraphCaptureOwner:
+    """Identity token for one outermost CUDA graph capture scope."""
+
+    may_cross_graphs: bool
+
+
+@dataclass(frozen=True)
+class _PendingOffload:
+    """One max-inflight FIFO entry and the capture that recorded it."""
+
+    group: "OffloadTensorGroup"
+    producer_owner: Optional[_OffloadCudaGraphCaptureOwner]
+    external_recorded: bool
 
 
 def print_offload_summary_table(total_offload_bytes: Dict[str, int]):
@@ -356,14 +373,10 @@ class OffloadTensorGroup:
         self._tensors = {}
         self._offload_event = torch.cuda.Event()
         self._reload_event = torch.cuda.Event()
-        # Keep throttling separate from the internal offload/reload handshake.
-        # ``_offload_event`` must remain capture-local because ``bulk_reload_group``
-        # uses it for the reload dependency; sharing it would change that graph edge.
-        # External events make record/wait explicit graph nodes, so separate
-        # module graphs can synchronize through the same event object. A captured
-        # wait node resolves against the event's live state at each replay, which
-        # lets a later graph wait on an earlier graph's re-recorded event; reuse the
-        # event across iterations rather than reallocating it per offload.
+        # ``_offload_event`` remains the internal offload/reload handshake and is
+        # also the correct max-inflight edge within one capture. Separately captured
+        # module graphs cannot share that internal edge, so cap > 0 groups may also
+        # carry an external event whose explicit record/wait nodes bridge graphs.
         self._offload_throttle_event: Optional[torch.cuda.Event] = (
             torch.cuda.Event(external=True) if enable_offload_throttle else None
         )
@@ -396,13 +409,15 @@ class OffloadTensorGroup:
 
     def record_offload_throttle_event(self, stream):
         """Record the external event used only for max-inflight throttling."""
-        self.offload_throttle_event.record(stream)
+        if self._offload_throttle_event is None:
+            raise RuntimeError("Offload throttle event was not enabled for this group")
+        self._offload_throttle_event.record(stream)
 
-    @property
-    def offload_throttle_event(self) -> torch.cuda.Event:
-        """Return the external event used only for max-inflight throttling."""
-        assert self._offload_throttle_event is not None
-        return self._offload_throttle_event
+    def wait_offload_throttle_event(self, stream):
+        """Wait for the external event used only for cross-graph throttling."""
+        if self._offload_throttle_event is None:
+            raise RuntimeError("Offload throttle event was not enabled for this group")
+        stream.wait_event(self._offload_throttle_event)
 
     def record_reload_event(self, stream):
         """Record the reload event."""
@@ -461,6 +476,10 @@ class PipelineOffloadManager:
         self._is_warmup = True
         # Whether the manager is in CUDA graph replay phase.
         self._in_replay = False
+        # Outermost capture scopes create an identity token. Nested graphable
+        # modules inherit it so max-inflight dependencies can distinguish a
+        # same-graph edge from a dependency between separately captured graphs.
+        self._cuda_graph_capture_owner: Optional[_OffloadCudaGraphCaptureOwner] = None
         # Cache OffloadChunkHandler objects for each virtual pipeline stage and each forward pass.
         self._cached_chunks_forward = []
         # Cache OffloadChunkHandler objects for each virtual pipeline stage and each backward pass.
@@ -509,6 +528,29 @@ class PipelineOffloadManager:
     def cpu_tensor_pool(self):
         """Get the shared CPU tensor pool."""
         return self._cpu_tensor_pool
+
+    @property
+    def cuda_graph_capture_owner(self) -> Optional[_OffloadCudaGraphCaptureOwner]:
+        """Return the identity token for the active outermost capture, if any."""
+        return self._cuda_graph_capture_owner
+
+    @contextmanager
+    def cuda_graph_capture_scope(self, may_cross_graphs: bool):
+        """Associate offload work with one (possibly nested) CUDA graph capture.
+
+        The outermost scope creates the owner token. Nested graphable modules
+        reuse that exact object, including its cross-graph policy.
+        """
+        if not isinstance(may_cross_graphs, bool):
+            raise TypeError("may_cross_graphs must be a bool")
+
+        previous_owner = self._cuda_graph_capture_owner
+        if previous_owner is None:
+            self._cuda_graph_capture_owner = _OffloadCudaGraphCaptureOwner(may_cross_graphs)
+        try:
+            yield self._cuda_graph_capture_owner
+        finally:
+            self._cuda_graph_capture_owner = previous_owner
 
     def push_offload_groups(self, group_hook, name, forced_released_tensors):
         """Push the offload groups to the delayed queue."""
@@ -911,8 +953,8 @@ class ChunkOffloadHandler:
         self.is_warmup = True
         # Max per-group-name inflight offloads not yet joined on the main stream (None = off).
         self._max_inflight_offloads = max_inflight_offloads
-        # group_name -> FIFO of offload events for that name (same cap for every name).
-        self._offload_pending_by_name: Dict[str, deque] = defaultdict(deque)
+        # group_name -> FIFO of pending offloads for that name (same cap for every name).
+        self._offload_pending_by_name: Dict[str, deque[_PendingOffload]] = defaultdict(deque)
 
     def reset(self):
         """Reset the chunk offload handler."""
@@ -921,10 +963,9 @@ class ChunkOffloadHandler:
         self._groups_to_reload = []
         self._tensor_count_current_group = 0
         self._reloading_group = []
-        # Clear the pending-event FIFO at iter boundary so we never wait on
-        # an event recorded in a previous (non-captured) iteration. Groups and
-        # their event objects persist, but a reused event is only waited on in
-        # the iteration that re-recorded it.
+        # Clear eager/warmup Python bookkeeping at the iteration boundary. CUDA
+        # graph replay follows the already captured event nodes and does not
+        # execute or mutate this FIFO.
         self._offload_pending_by_name.clear()
 
     def find_group_with_name(
@@ -1040,14 +1081,21 @@ class ChunkOffloadHandler:
                     tensor_on_device.record_stream(self.d2h_stream)
                     group_to_offload.push_tensor(tensor_tag, state)
             group_to_offload.record_offload_event(self.d2h_stream)
-            if self._max_inflight_offloads is not None:
+            capture_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
+            external_recorded = bool(
+                self._max_inflight_offloads is not None
+                and self._max_inflight_offloads > 0
+                and capture_owner is not None
+                and capture_owner.may_cross_graphs
+            )
+            if external_recorded:
                 group_to_offload.record_offload_throttle_event(self.d2h_stream)
         nvtx_range_pop(nvtx_msg)
-        # Max-inflight uses its dedicated external event rather than the internal
-        # reload dependency, whose capture-local semantics must remain unchanged.
         if self._max_inflight_offloads is not None:
             gname = group_to_offload._name
-            self._offload_pending_by_name[gname].append(group_to_offload.offload_throttle_event)
+            self._offload_pending_by_name[gname].append(
+                _PendingOffload(group_to_offload, capture_owner, external_recorded)
+            )
             self._drain_offload_pending(gname)
 
     def get_max_deduplicated_groups(self):
@@ -1135,14 +1183,31 @@ class ChunkOffloadHandler:
     def _drain_offload_pending(self, group_name: str) -> None:
         """For ``group_name``, have the main stream wait on older D2H events
         when that name's pending count exceeds ``_max_inflight_offloads``
-        (same cap for every name; 0 = wait on each commit for that name)."""
+        (same cap for every name; 0 = wait on each commit for that name).
+
+        Same-capture (including eager/eager) waits use the internal event edge;
+        only dependencies between two distinct captures use an external event.
+        """
         if self._max_inflight_offloads is None:
             return
         cur = torch.cuda.current_stream()
         q = self._offload_pending_by_name[group_name]
         while len(q) > self._max_inflight_offloads:
-            old_evt = q.popleft()
-            cur.wait_event(old_evt)
+            pending = q.popleft()
+            consumer_owner = PipelineOffloadManager.get_instance().cuda_graph_capture_owner
+            if (pending.producer_owner is None) != (consumer_owner is None):
+                raise RuntimeError(
+                    "Max-inflight offload dependency crossed between eager execution "
+                    "and CUDA graph capture"
+                )
+            if pending.producer_owner is consumer_owner:
+                pending.group.wait_offload_event(cur)
+            else:
+                if not pending.external_recorded:
+                    raise RuntimeError(
+                        "Cross-graph max-inflight dependency has no recorded external event"
+                    )
+                pending.group.wait_offload_throttle_event(cur)
 
     def on_group_commit_forward(self, name, forced_released_tensors):
         """Called at the end of a layer group's forward pass to trigger offloading."""
@@ -1204,7 +1269,10 @@ class ChunkOffloadHandler:
         if self.is_warmup:
             self.offload_groups.append(
                 OffloadTensorGroup(
-                    name, enable_offload_throttle=self._max_inflight_offloads is not None
+                    name,
+                    enable_offload_throttle=(
+                        self._max_inflight_offloads is not None and self._max_inflight_offloads > 0
+                    ),
                 )
             )
             self._max_group_size = max(self._max_group_size, self._offloaded_group_index)
@@ -1411,6 +1479,11 @@ class FineGrainedActivationOffloadingInterface:
     def cuda_graph_event():
         """Get the CUDA graph event."""
         return PipelineOffloadManager.get_instance().cuda_graph_event
+
+    @staticmethod
+    def cuda_graph_capture_scope(may_cross_graphs: bool):
+        """Return a nested scope identifying one CUDA graph capture owner."""
+        return PipelineOffloadManager.get_instance().cuda_graph_capture_scope(may_cross_graphs)
 
     @staticmethod
     def init_chunk_handler(

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -539,7 +539,9 @@ class PipelineOffloadManager:
         """Associate offload work with one (possibly nested) CUDA graph capture.
 
         The outermost scope creates the owner token. Nested graphable modules
-        reuse that exact object, including its cross-graph policy.
+        reuse that exact object, including its cross-graph policy. Capture
+        implementations are selected exclusively by ``cuda_graph_impl``, so a
+        nested entry belongs to the same physical graph as its outer scope.
         """
         if not isinstance(may_cross_graphs, bool):
             raise TypeError("may_cross_graphs must be a bool")
@@ -551,6 +553,21 @@ class PipelineOffloadManager:
             yield self._cuda_graph_capture_owner
         finally:
             self._cuda_graph_capture_owner = previous_owner
+
+    @contextmanager
+    def cuda_graph_capture_session(self):
+        """Keep throttle FIFOs across sibling captures, then discard capture-only state.
+
+        Local CUDA graphs are captured one at a time but may consume external
+        events produced by an earlier sibling graph. The FIFOs must therefore
+        survive individual capture scopes and be cleared only after the complete
+        local capture session has finished.
+        """
+        try:
+            yield
+        finally:
+            for chunk in self._cached_chunks_forward:
+                chunk.clear_offload_pending()
 
     def push_offload_groups(self, group_hook, name, forced_released_tensors):
         """Push the offload groups to the delayed queue."""
@@ -956,6 +973,10 @@ class ChunkOffloadHandler:
         # group_name -> FIFO of pending offloads for that name (same cap for every name).
         self._offload_pending_by_name: Dict[str, deque[_PendingOffload]] = defaultdict(deque)
 
+    def clear_offload_pending(self):
+        """Clear Python bookkeeping that is not executed during graph replay."""
+        self._offload_pending_by_name.clear()
+
     def reset(self):
         """Reset the chunk offload handler."""
         self._offloaded_group_index = 0
@@ -966,7 +987,7 @@ class ChunkOffloadHandler:
         # Clear eager/warmup Python bookkeeping at the iteration boundary. CUDA
         # graph replay follows the already captured event nodes and does not
         # execute or mutate this FIFO.
-        self._offload_pending_by_name.clear()
+        self.clear_offload_pending()
 
     def find_group_with_name(
         self, groups: list[OffloadTensorGroup], name: str, start_index: int = 0
@@ -1198,14 +1219,15 @@ class ChunkOffloadHandler:
             if (pending.producer_owner is None) != (consumer_owner is None):
                 raise RuntimeError(
                     "Max-inflight offload dependency crossed between eager execution "
-                    "and CUDA graph capture"
+                    f"and CUDA graph capture for group {group_name!r}"
                 )
             if pending.producer_owner is consumer_owner:
                 pending.group.wait_offload_event(cur)
             else:
                 if not pending.external_recorded:
                     raise RuntimeError(
-                        "Cross-graph max-inflight dependency has no recorded external event"
+                        "Cross-graph max-inflight dependency has no recorded external event "
+                        f"for group {group_name!r}"
                     )
                 pending.group.wait_offload_throttle_event(cur)
 
@@ -1484,6 +1506,11 @@ class FineGrainedActivationOffloadingInterface:
     def cuda_graph_capture_scope(may_cross_graphs: bool):
         """Return a nested scope identifying one CUDA graph capture owner."""
         return PipelineOffloadManager.get_instance().cuda_graph_capture_scope(may_cross_graphs)
+
+    @staticmethod
+    def cuda_graph_capture_session():
+        """Return a scope covering all sibling captures in one local capture session."""
+        return PipelineOffloadManager.get_instance().cuda_graph_capture_session()
 
     @staticmethod
     def init_chunk_handler(

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2764,7 +2764,18 @@ class TECudaGraphHelper:
                 rng_context = nullcontext()
             from megatron.core.transformer.moe.paged_stash import paged_stash_te_graph_capture
 
+            capture_session = nullcontext()
+            if self.config.fine_grained_activation_offloading:
+                from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                    FineGrainedActivationOffloadingInterface as off_interface,
+                )
+
+                # TE captures the callables as sibling graphs. Preserve throttle
+                # FIFOs across those captures, then clear them even if TE raises.
+                capture_session = off_interface.cuda_graph_capture_session()
+
             with (
+                capture_session,
                 rng_context,
                 paged_stash_te_graph_capture(
                     self._should_enable_paged_stash_capture(),

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -432,7 +432,7 @@ class _CudagraphGlobalRecord:
 
         capture_session = nullcontext()
         if any(
-            record[0].base_module.config.fine_grained_activation_offloading
+            getattr(record[0], "fine_grained_activation_offloading", False)
             for record in cls.cudagraph_record
         ):
             from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
@@ -725,6 +725,7 @@ class _CudaGraphRunner(torch.nn.Module):
         self.status = _GraphStatus.FWD_READY
 
         self.backward_retain_grad = False
+        self.fine_grained_activation_offloading = False
         self.fp8_enabled = False
         self.fp4_enabled = False
         self.fp8_runtime_enabled = None
@@ -747,6 +748,9 @@ class _CudaGraphRunner(torch.nn.Module):
             self.base_module.config, TransformerConfig
         ):
             self.backward_retain_grad = self.base_module.config.cuda_graph_retain_backward_graph
+            self.fine_grained_activation_offloading = (
+                self.base_module.config.fine_grained_activation_offloading
+            )
             self.deallocate_pipeline_outputs = self.base_module.config.deallocate_pipeline_outputs
             self.num_warmup_steps = self.base_module.config.cuda_graph_warmup_steps
             self.fp8_enabled = self.base_module.config.fp8 is not None
@@ -977,7 +981,7 @@ class _CudaGraphRunner(torch.nn.Module):
                     gc.freeze()
 
                 capture_scope = nullcontext()
-                if self.base_module.config.fine_grained_activation_offloading:
+                if self.fine_grained_activation_offloading:
                     from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
                         FineGrainedActivationOffloadingInterface as off_interface,
                     )
@@ -1106,7 +1110,7 @@ class _CudaGraphRunner(torch.nn.Module):
             gc.freeze()
 
         capture_scope = nullcontext()
-        if self.base_module.config.fine_grained_activation_offloading:
+        if self.fine_grained_activation_offloading:
             from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
                 FineGrainedActivationOffloadingInterface as off_interface,
             )

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -964,12 +964,20 @@ class _CudaGraphRunner(torch.nn.Module):
                 if FREEZE_GC:
                     gc.freeze()
 
-                with torch.cuda.graph(
-                    self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
-                ):
-                    fwd_graph_outputs = self.func(
-                        *self.fwd_graph_input_args, **self.fwd_graph_input_kwargs
+                capture_scope = nullcontext()
+                if self.base_module.config.fine_grained_activation_offloading:
+                    from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                        FineGrainedActivationOffloadingInterface as off_interface,
                     )
+
+                    capture_scope = off_interface.cuda_graph_capture_scope(may_cross_graphs=True)
+                with capture_scope:
+                    with torch.cuda.graph(
+                        self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
+                    ):
+                        fwd_graph_outputs = self.func(
+                            *self.fwd_graph_input_args, **self.fwd_graph_input_kwargs
+                        )
 
                 # Unfreeze GC.
                 if FREEZE_GC:

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -430,25 +430,37 @@ class _CudagraphGlobalRecord:
                     return f"{sign}{n / 1024**p:.1f} {s}"
             return f"{sign}{n} bytes"
 
-        for g_idx, g in progress_bar:
-            if torch.distributed.get_rank() == 0:
-                mem_stats = torch.cuda.memory_stats()
-                progress_str = "create cuda graphs | mem: alloc %s, res %s" % (
-                    format_mem_bytes(mem_stats["allocated_bytes.all.current"]),
-                    format_mem_bytes(mem_stats["reserved_bytes.all.current"]),
-                )
-                if HAVE_TQDM:
-                    progress_bar.set_description(progress_str)
-                elif g_idx % 100 == 0 or g_idx == len(cls.cudagraph_record) - 1:
-                    logger.info(f"{g_idx}/{len(cls.cudagraph_record)}. {progress_str}")
+        capture_session = nullcontext()
+        if any(
+            record[0].base_module.config.fine_grained_activation_offloading
+            for record in cls.cudagraph_record
+        ):
+            from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                FineGrainedActivationOffloadingInterface as off_interface,
+            )
 
-            runner, graph_type = g[0:2]
-            if graph_type == 'fwd':
-                args, kwargs, out = g[2:]
-                runner.create_fwd_graph(args, kwargs, out, clone_inputs=True)
-            else:
-                assert fwd_buffer_reuse_ref_count == 0
-                runner.create_bwd_graph()
+            capture_session = off_interface.cuda_graph_capture_session()
+
+        with capture_session:
+            for g_idx, g in progress_bar:
+                if torch.distributed.get_rank() == 0:
+                    mem_stats = torch.cuda.memory_stats()
+                    progress_str = "create cuda graphs | mem: alloc %s, res %s" % (
+                        format_mem_bytes(mem_stats["allocated_bytes.all.current"]),
+                        format_mem_bytes(mem_stats["reserved_bytes.all.current"]),
+                    )
+                    if HAVE_TQDM:
+                        progress_bar.set_description(progress_str)
+                    elif g_idx % 100 == 0 or g_idx == len(cls.cudagraph_record) - 1:
+                        logger.info(f"{g_idx}/{len(cls.cudagraph_record)}. {progress_str}")
+
+                runner, graph_type = g[0:2]
+                if graph_type == 'fwd':
+                    args, kwargs, out = g[2:]
+                    runner.create_fwd_graph(args, kwargs, out, clone_inputs=True)
+                else:
+                    assert fwd_buffer_reuse_ref_count == 0
+                    runner.create_bwd_graph()
 
         # Memory usage.
         time_end = time.time()
@@ -1093,22 +1105,30 @@ class _CudaGraphRunner(torch.nn.Module):
         if FREEZE_GC:
             gc.freeze()
 
-        with torch.cuda.graph(self.bwd_graph, pool=self.mempool):
-            grad_inputs = torch.autograd.grad(
-                outputs=tuple(o for o in self.fwd_graph_output_surface if o.requires_grad),
-                inputs=tuple(i for i in self.fwd_graph_input_surface if i.requires_grad),
-                grad_outputs=tuple(o for o in self.static_grad_outputs if o is not None),
-                retain_graph=self.backward_retain_grad,
-                only_inputs=True,
-                allow_unused=True,
+        capture_scope = nullcontext()
+        if self.base_module.config.fine_grained_activation_offloading:
+            from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                FineGrainedActivationOffloadingInterface as off_interface,
             )
-            # Accumulate wgrads directly into main_grad inside the graph
-            n_act_grads = sum(
-                1 for i in self.fwd_graph_input_surface[: self.num_dgrads] if i.requires_grad
-            )
-            for param, wgrad in zip(self.params_to_backprop, grad_inputs[n_act_grads:]):
-                if wgrad is not None and not getattr(param, 'grad_added_to_main_grad', False):
-                    param.main_grad.add_(wgrad)
+
+            capture_scope = off_interface.cuda_graph_capture_scope(may_cross_graphs=True)
+        with capture_scope:
+            with torch.cuda.graph(self.bwd_graph, pool=self.mempool):
+                grad_inputs = torch.autograd.grad(
+                    outputs=tuple(o for o in self.fwd_graph_output_surface if o.requires_grad),
+                    inputs=tuple(i for i in self.fwd_graph_input_surface if i.requires_grad),
+                    grad_outputs=tuple(o for o in self.static_grad_outputs if o is not None),
+                    retain_graph=self.backward_retain_grad,
+                    only_inputs=True,
+                    allow_unused=True,
+                )
+                # Accumulate wgrads directly into main_grad inside the graph
+                n_act_grads = sum(
+                    1 for i in self.fwd_graph_input_surface[: self.num_dgrads] if i.requires_grad
+                )
+                for param, wgrad in zip(self.params_to_backprop, grad_inputs[n_act_grads:]):
+                    if wgrad is not None and not getattr(param, 'grad_added_to_main_grad', False):
+                        param.main_grad.add_(wgrad)
 
         # Unfreeze GC.
         if FREEZE_GC:

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -434,6 +434,7 @@ class GraphableMegatronModule(MegatronModule):
         if self._should_call_local_cudagraph(*args, **kwargs):
             return self.cudagraph_manager(self, args, kwargs)
         elif self._should_call_te_cudagraph(*args, **kwargs):
+            capture_scope = nullcontext()
             if not self.cuda_graphs:
                 # Do CUDA Graphs capture.
                 cuda_graph_func = self._te_cuda_graph_capture
@@ -445,12 +446,12 @@ class GraphableMegatronModule(MegatronModule):
                     # Each top-level TE callable is captured independently. Nested
                     # graphable modules reuse this owner rather than pretending to
                     # be a separate graph.
-                    with off_interface.cuda_graph_capture_scope(may_cross_graphs=True):
-                        return cuda_graph_func(*args, **kwargs)
+                    capture_scope = off_interface.cuda_graph_capture_scope(may_cross_graphs=True)
             else:
                 # Do CUDA Graphs replay.
                 cuda_graph_func = self._te_cuda_graph_replay
-            return cuda_graph_func(*args, **kwargs)
+            with capture_scope:
+                return cuda_graph_func(*args, **kwargs)
         return super().__call__(*args, **kwargs)
 
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -2,6 +2,7 @@
 
 """Megatron Module."""
 
+from contextlib import nullcontext
 from functools import partial
 from typing import Optional, Tuple
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -435,10 +435,9 @@ class GraphableMegatronModule(MegatronModule):
         if self._should_call_local_cudagraph(*args, **kwargs):
             return self.cudagraph_manager(self, args, kwargs)
         elif self._should_call_te_cudagraph(*args, **kwargs):
-            capture_scope = nullcontext()
             if not self.cuda_graphs:
                 # Do CUDA Graphs capture.
-                cuda_graph_func = self._te_cuda_graph_capture
+                capture_scope = nullcontext()
                 if self.config.fine_grained_activation_offloading:
                     from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
                         FineGrainedActivationOffloadingInterface as off_interface,
@@ -448,11 +447,10 @@ class GraphableMegatronModule(MegatronModule):
                     # graphable modules reuse this owner rather than pretending to
                     # be a separate graph.
                     capture_scope = off_interface.cuda_graph_capture_scope(may_cross_graphs=True)
-            else:
-                # Do CUDA Graphs replay.
-                cuda_graph_func = self._te_cuda_graph_replay
-            with capture_scope:
-                return cuda_graph_func(*args, **kwargs)
+                with capture_scope:
+                    return self._te_cuda_graph_capture(*args, **kwargs)
+            # Do CUDA Graphs replay without entering a context manager on the hot path.
+            return self._te_cuda_graph_replay(*args, **kwargs)
         return super().__call__(*args, **kwargs)
 
 

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -437,6 +437,16 @@ class GraphableMegatronModule(MegatronModule):
             if not self.cuda_graphs:
                 # Do CUDA Graphs capture.
                 cuda_graph_func = self._te_cuda_graph_capture
+                if self.config.fine_grained_activation_offloading:
+                    from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                        FineGrainedActivationOffloadingInterface as off_interface,
+                    )
+
+                    # Each top-level TE callable is captured independently. Nested
+                    # graphable modules reuse this owner rather than pretending to
+                    # be a separate graph.
+                    with off_interface.cuda_graph_capture_scope(may_cross_graphs=True):
+                        return cuda_graph_func(*args, **kwargs)
             else:
                 # Do CUDA Graphs replay.
                 cuda_graph_func = self._te_cuda_graph_replay

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -13,7 +13,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     PipelineOffloadManager,
 )
 from megatron.core.transformer import cuda_graphs
-from megatron.core.transformer.cuda_graphs import _CudaGraphRunner
+from megatron.core.transformer.cuda_graphs import _CudagraphGlobalRecord, _CudaGraphRunner
 
 
 @pytest.fixture
@@ -157,13 +157,16 @@ def test_local_capture_session_clears_pending_before_returning_to_eager(
     main_stream = Mock()
     monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
     handler = _new_handler(manager, max_inflight_offloads=1)
+    backward_only_handler = _new_handler(manager, max_inflight_offloads=1)
     manager._cached_chunks_forward.append(handler)
+    manager._cached_chunks_backward.extend((handler, backward_only_handler))
 
     with manager.cuda_graph_capture_session():
         with manager.cuda_graph_capture_scope(may_cross_graphs=True):
             first_captured = _bulk_empty_group(handler, "core_attn")
         with manager.cuda_graph_capture_scope(may_cross_graphs=True):
             second_captured = _bulk_empty_group(handler, "core_attn")
+            _bulk_empty_group(backward_only_handler, "mlp")
 
         main_stream.wait_event.assert_called_once_with(first_captured._offload_throttle_event)
         assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
@@ -171,6 +174,7 @@ def test_local_capture_session_clears_pending_before_returning_to_eager(
         ]
 
     assert not handler._offload_pending_by_name["core_attn"]
+    assert not backward_only_handler._offload_pending_by_name["mlp"]
 
     first_eager = _bulk_empty_group(handler, "core_attn")
     _bulk_empty_group(handler, "core_attn")
@@ -194,6 +198,7 @@ def test_local_backward_capture_uses_offload_capture_owner(mocked_offload_manage
 
     runner = SimpleNamespace(
         grad_enabled=True,
+        fine_grained_activation_offloading=True,
         base_module=SimpleNamespace(
             config=SimpleNamespace(fine_grained_activation_offloading=True)
         ),
@@ -215,6 +220,43 @@ def test_local_backward_capture_uses_offload_capture_owner(mocked_offload_manage
     assert observed_owners[0] is not None
     assert observed_owners[0].may_cross_graphs
     assert manager.cuda_graph_capture_owner is None
+
+
+def test_local_capture_session_selection_accepts_configless_graphable(
+    mocked_offload_manager, monkeypatch
+):
+    base_module = torch.nn.Module()
+    runner = _CudaGraphRunner(
+        base_module=base_module,
+        mempool=None,
+        fwd_graph_input_args=[],
+        fwd_graph_input_kwargs={},
+        func=Mock(),
+        need_backward=False,
+    )
+    assert not runner.fine_grained_activation_offloading
+
+    runner.create_fwd_graph = Mock()
+    monkeypatch.setattr(_CudagraphGlobalRecord, "cudagraph_created", False)
+    monkeypatch.setattr(_CudagraphGlobalRecord, "cudagraph_record", [(runner, "fwd", (), {}, None)])
+    monkeypatch.setattr(cuda_graphs, "HAVE_TE_GRAPHS", False)
+    monkeypatch.setattr(cuda_graphs, "HAVE_TQDM", False)
+    monkeypatch.setattr(cuda_graphs, "_set_capture_start", Mock())
+    monkeypatch.setattr(cuda_graphs, "_set_capture_end", Mock())
+    monkeypatch.setattr(cuda_graphs, "log_single_rank", Mock())
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "memory_stats",
+        lambda: {"allocated_bytes.all.current": 0, "reserved_bytes.all.current": 0},
+    )
+    monkeypatch.setattr(torch.cuda, "default_stream", Mock(return_value=Mock()))
+    monkeypatch.setattr(torch.cuda, "set_stream", Mock())
+
+    _CudagraphGlobalRecord.create_cudagraphs()
+
+    runner.create_fwd_graph.assert_called_once_with((), {}, None, clone_inputs=True)
+    assert runner.cudagraph_created
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 from unittest.mock import Mock, call
 
 import pytest
@@ -11,6 +12,8 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     ChunkOffloadHandler,
     PipelineOffloadManager,
 )
+from megatron.core.transformer import cuda_graphs
+from megatron.core.transformer.cuda_graphs import _CudaGraphRunner
 
 
 @pytest.fixture
@@ -145,6 +148,73 @@ def test_different_capture_owner_waits_on_external_event(mocked_offload_manager,
     assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
         second_group
     ]
+
+
+def test_local_capture_session_clears_pending_before_returning_to_eager(
+    mocked_offload_manager, monkeypatch
+):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=1)
+    manager._cached_chunks_forward.append(handler)
+
+    with manager.cuda_graph_capture_session():
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            first_captured = _bulk_empty_group(handler, "core_attn")
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            second_captured = _bulk_empty_group(handler, "core_attn")
+
+        main_stream.wait_event.assert_called_once_with(first_captured._offload_throttle_event)
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+            second_captured
+        ]
+
+    assert not handler._offload_pending_by_name["core_attn"]
+
+    first_eager = _bulk_empty_group(handler, "core_attn")
+    _bulk_empty_group(handler, "core_attn")
+    assert main_stream.wait_event.call_args_list[-1] == call(first_eager._offload_event)
+
+
+def test_local_backward_capture_uses_offload_capture_owner(mocked_offload_manager, monkeypatch):
+    manager, _, _ = mocked_offload_manager
+    observed_owners = []
+
+    @contextmanager
+    def fake_cuda_graph(*args, **kwargs):
+        observed_owners.append(manager.cuda_graph_capture_owner)
+        yield
+
+    monkeypatch.setattr(torch.cuda, "CUDAGraph", lambda: Mock())
+    monkeypatch.setattr(torch.cuda, "graph", fake_cuda_graph)
+    monkeypatch.setattr(torch.autograd, "grad", Mock(return_value=()))
+    monkeypatch.setattr(cuda_graphs, "get_all_rng_states", lambda: {})
+    monkeypatch.setattr(cuda_graphs, "FREEZE_GC", False)
+
+    runner = SimpleNamespace(
+        grad_enabled=True,
+        base_module=SimpleNamespace(
+            config=SimpleNamespace(fine_grained_activation_offloading=True)
+        ),
+        mempool=None,
+        outputs=(),
+        args=(),
+        kwargs={},
+        fwd_graph_output_surface=(),
+        fwd_graph_input_surface=(),
+        backward_retain_grad=False,
+        num_dgrads=0,
+        params_to_backprop=(),
+        get_arg_metas=lambda *args: (),
+    )
+
+    _CudaGraphRunner.create_bwd_graph(runner)
+
+    assert len(observed_owners) == 1
+    assert observed_owners[0] is not None
+    assert observed_owners[0].may_cross_graphs
+    assert manager.cuda_graph_capture_owner is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -13,7 +13,11 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     PipelineOffloadManager,
 )
 from megatron.core.transformer import cuda_graphs
-from megatron.core.transformer.cuda_graphs import _CudagraphGlobalRecord, _CudaGraphRunner
+from megatron.core.transformer.cuda_graphs import (
+    TECudaGraphHelper,
+    _CudagraphGlobalRecord,
+    _CudaGraphRunner,
+)
 
 
 @pytest.fixture
@@ -42,8 +46,12 @@ def mocked_offload_manager(monkeypatch):
     old_manager = PipelineOffloadManager.OFFLOAD_MGR
     manager = PipelineOffloadManager()
     PipelineOffloadManager.OFFLOAD_MGR = manager
-    yield manager, events, streams
-    PipelineOffloadManager.OFFLOAD_MGR = old_manager
+    try:
+        yield manager, events, streams
+    finally:
+        assert manager.cuda_graph_capture_owner is None, "test leaked a capture scope"
+        assert manager._cuda_graph_capture_session_handlers is None, "test leaked a capture session"
+        PipelineOffloadManager.OFFLOAD_MGR = old_manager
 
 
 def _new_handler(manager, max_inflight_offloads):
@@ -66,17 +74,40 @@ def _bulk_empty_group(handler, name):
 
 
 @pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
-def test_handler_allocates_external_event_only_for_positive_throttling_cap(
+def test_handler_lazily_allocates_external_event_only_when_cross_graph_recorded(
     mocked_offload_manager, max_inflight_offloads
 ):
     manager, _, _ = mocked_offload_manager
     handler = _new_handler(manager, max_inflight_offloads=max_inflight_offloads)
 
     group = _empty_group(handler, "core_attn")
+    assert group._offload_throttle_event is None
+
+    with manager.cuda_graph_capture_session():
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            handler.bulk_offload_group(group)
 
     assert (group._offload_throttle_event is not None) == (
         max_inflight_offloads is not None and max_inflight_offloads > 0
     )
+
+
+def test_capture_local_throttle_never_allocates_external_event(mocked_offload_manager, monkeypatch):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=1)
+    first_group = _empty_group(handler, "core_attn")
+    second_group = _empty_group(handler, "core_attn")
+
+    with manager.cuda_graph_capture_scope(may_cross_graphs=False):
+        handler.bulk_offload_group(first_group)
+        handler.bulk_offload_group(second_group)
+
+    main_stream.wait_event.assert_called_once_with(first_group._offload_event)
+    assert first_group._offload_throttle_event is None
+    assert second_group._offload_throttle_event is None
+    handler.clear_offload_pending()
 
 
 def test_capture_scope_nests_but_sibling_scopes_get_distinct_owners(mocked_offload_manager):
@@ -137,17 +168,122 @@ def test_different_capture_owner_waits_on_external_event(mocked_offload_manager,
     monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
     handler = _new_handler(manager, max_inflight_offloads=1)
 
-    with manager.cuda_graph_capture_scope(may_cross_graphs=True):
-        group = _bulk_empty_group(handler, "core_attn")
+    with manager.cuda_graph_capture_session():
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            group = _bulk_empty_group(handler, "core_attn")
 
-    with manager.cuda_graph_capture_scope(may_cross_graphs=True):
-        second_group = _bulk_empty_group(handler, "core_attn")
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            second_group = _bulk_empty_group(handler, "core_attn")
 
-    assert group._offload_throttle_event is not None
-    main_stream.wait_event.assert_called_once_with(group._offload_throttle_event)
-    assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
-        second_group
+        assert group._offload_throttle_event is not None
+        main_stream.wait_event.assert_called_once_with(group._offload_throttle_event)
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+            second_group
+        ]
+
+    assert not handler._offload_pending_by_name["core_attn"]
+
+
+def test_nested_capture_session_clears_only_at_outer_boundary(mocked_offload_manager, monkeypatch):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=1)
+
+    with manager.cuda_graph_capture_session():
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            first_group = _bulk_empty_group(handler, "core_attn")
+        with manager.cuda_graph_capture_session():
+            with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+                second_group = _bulk_empty_group(handler, "core_attn")
+            assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+                second_group
+            ]
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+            second_group
+        ]
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            third_group = _bulk_empty_group(handler, "core_attn")
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+            third_group
+        ]
+
+    assert main_stream.wait_event.call_args_list == [
+        call(first_group._offload_throttle_event),
+        call(second_group._offload_throttle_event),
     ]
+    assert not handler._offload_pending_by_name["core_attn"]
+
+
+def test_capture_session_tracks_handler_outside_cached_chunk_lists(
+    mocked_offload_manager, monkeypatch
+):
+    manager, _, _ = mocked_offload_manager
+    monkeypatch.setattr(torch.cuda, "current_stream", Mock())
+
+    with manager.cuda_graph_capture_session():
+        handler = _new_handler(manager, max_inflight_offloads=1)
+        assert handler not in manager._cached_chunks_forward
+        assert handler not in manager._cached_chunks_backward
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            group = _bulk_empty_group(handler, "core_attn")
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [group]
+
+    assert not handler._offload_pending_by_name["core_attn"]
+
+
+@pytest.mark.parametrize("raise_during_capture", [False, True], ids=["success", "exception"])
+def test_te_capture_session_preserves_sibling_fifo_and_always_clears(
+    mocked_offload_manager, monkeypatch, raise_during_capture
+):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=1)
+
+    helper = object.__new__(TECudaGraphHelper)
+    helper.config = SimpleNamespace(
+        fine_grained_activation_offloading=True, sequence_parallel=False
+    )
+    helper.flattened_callables = [Mock()]
+    helper.callables_per_chunk = []
+    helper._start_capturing = lambda: 0.0
+    helper._finish_capturing = Mock()
+    helper._get_cuda_graph_input_data = lambda: ([()], {"_order": [1, -1]})
+    helper._validate_mhc_static_hidden_inputs = Mock()
+    helper._uses_mhc_direct_write_arena = lambda: False
+    helper._should_enable_paged_stash_capture = lambda: False
+
+    monkeypatch.setattr(cuda_graphs, "validate_moe_cuda_graph_support", Mock())
+    monkeypatch.setattr(
+        "megatron.core.transformer.moe.paged_stash.paged_stash_te_graph_capture",
+        lambda *args, **kwargs: nullcontext(),
+    )
+
+    def fake_make_graphed_callables(*args, **kwargs):
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            first_group = _bulk_empty_group(handler, "core_attn")
+        if raise_during_capture:
+            raise ValueError("original TE capture failure")
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            second_group = _bulk_empty_group(handler, "core_attn")
+        main_stream.wait_event.assert_called_once_with(first_group._offload_throttle_event)
+        assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+            second_group
+        ]
+        return ()
+
+    monkeypatch.setattr(cuda_graphs, "make_graphed_callables", fake_make_graphed_callables)
+
+    if raise_during_capture:
+        with pytest.raises(ValueError, match="original TE capture failure"):
+            helper.create_cudagraphs()
+        helper._finish_capturing.assert_not_called()
+    else:
+        helper.create_cudagraphs()
+        helper._finish_capturing.assert_called_once_with(0.0)
+
+    assert not handler._offload_pending_by_name["core_attn"]
 
 
 def test_local_capture_session_clears_pending_before_returning_to_eager(

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -40,6 +40,7 @@ def mocked_offload_manager(monkeypatch):
     monkeypatch.setattr(torch.cuda, "Event", make_event)
     monkeypatch.setattr(torch.cuda, "Stream", make_stream)
     monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
+    monkeypatch.setattr(torch.cuda, "current_stream", Mock(name="current_stream"))
     monkeypatch.setattr(offload, "nvtx_range_push", Mock())
     monkeypatch.setattr(offload, "nvtx_range_pop", Mock())
 

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import os
 from contextlib import nullcontext
 from unittest.mock import Mock, call
 
@@ -10,7 +9,6 @@ import torch
 from megatron.core.pipeline_parallel import fine_grained_activation_offload as offload
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     ChunkOffloadHandler,
-    FineGrainedActivationOffloadingInterface,
     PipelineOffloadManager,
 )
 
@@ -202,152 +200,3 @@ def test_max_inflight_fifo_is_per_group_name(
             entry.group for entry in handler._offload_pending_by_name["core_attn"]
         ] == core_groups[1:]
         assert [entry.group for entry in handler._offload_pending_by_name["mlp"]] == [mlp_group]
-
-
-def _set_local_cuda_device():
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    if local_rank >= torch.cuda.device_count():
-        pytest.fail(
-            f"LOCAL_RANK={local_rank} is outside visible CUDA device count "
-            f"{torch.cuda.device_count()}"
-        )
-    torch.cuda.set_device(local_rank)
-
-
-@pytest.fixture
-def cuda_offload_manager():
-    _set_local_cuda_device()
-    torch.cuda.synchronize()
-    FineGrainedActivationOffloadingInterface.reset_instance()
-    manager = PipelineOffloadManager.get_instance()
-    try:
-        yield manager
-    finally:
-        torch.cuda.synchronize()
-        FineGrainedActivationOffloadingInterface.reset_instance()
-        torch.cuda.empty_cache()
-
-
-def _prewarm_cpu_pool(handler, count, shape, dtype):
-    backups = [handler.cpu_tensor_pool.allocate(shape, dtype=dtype) for _ in range(count)]
-    for backup in backups:
-        handler.cpu_tensor_pool.free(backup)
-
-
-def _capture_real_d2h_group(handler, group, source, tag):
-    handler.d2h_stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(handler.d2h_stream):
-        torch.cuda._sleep(50_000_000)
-    group.push_tensor(tag, source)
-    handler.bulk_offload_group(group)
-
-
-def _assert_cpu_backup(group, tag, expected):
-    _, backup, _ = group._tensors[tag]
-    torch.testing.assert_close(backup, torch.full_like(backup, expected))
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
-@pytest.mark.launch_on_gb200
-@pytest.mark.parametrize(
-    ("max_inflight_offloads", "may_cross_graphs"),
-    [
-        pytest.param(0, False, id="full-iteration-cap0"),
-        pytest.param(2, False, id="full-iteration-cap2"),
-        pytest.param(0, True, id="te-like-same-owner-cap0"),
-        pytest.param(2, True, id="te-like-same-owner-cap2"),
-    ],
-)
-def test_same_graph_throttle_orders_real_d2h_before_source_reuse(
-    cuda_offload_manager, max_inflight_offloads, may_cross_graphs
-):
-    manager = cuda_offload_manager
-    handler = _new_handler(manager, max_inflight_offloads)
-    group_count = max_inflight_offloads + 1
-    shape = (4096,)
-    dtype = torch.float32
-    _prewarm_cpu_pool(handler, group_count, shape, dtype)
-    sources = [torch.empty(shape, dtype=dtype, device="cuda") for _ in range(group_count)]
-    tags = [(index + 1, 0) for index in range(group_count)]
-    groups = []
-    graph = torch.cuda.CUDAGraph()
-
-    capture_scope = (
-        FineGrainedActivationOffloadingInterface.cuda_graph_capture_scope
-        if may_cross_graphs
-        else manager.cuda_graph_capture_scope
-    )
-    with capture_scope(may_cross_graphs=may_cross_graphs):
-        for _ in range(group_count):
-            groups.append(_empty_group(handler, "core_attn"))
-        with torch.cuda.graph(graph):
-            for group, source, tag in zip(groups, sources, tags):
-                _capture_real_d2h_group(handler, group, source, tag)
-            # The oldest copy is the one drained by cap=0/cap=2. Reusing its
-            # source immediately after the drain exposes a missing graph edge.
-            sources[0].add_(1000)
-            torch.cuda.current_stream().wait_stream(handler.d2h_stream)
-
-    try:
-        for replay, value in enumerate((11.0, 22.0)):
-            for source in sources:
-                source.fill_(value)
-            torch.cuda.synchronize()
-            graph.replay()
-            torch.cuda.synchronize()
-            _assert_cpu_backup(groups[0], tags[0], value)
-            assert sources[0][0].item() == value + 1000
-    finally:
-        torch.cuda.synchronize()
-        graph = None
-        groups.clear()
-        sources.clear()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
-@pytest.mark.launch_on_gb200
-def test_cross_graph_throttle_captures_real_d2h_with_external_event(cuda_offload_manager):
-    manager = cuda_offload_manager
-    handler = _new_handler(manager, max_inflight_offloads=2)
-    shape = (4096,)
-    dtype = torch.float32
-    _prewarm_cpu_pool(handler, 3, shape, dtype)
-    sources = [torch.empty(shape, dtype=dtype, device="cuda") for _ in range(3)]
-    tags = [(index + 1, 0) for index in range(3)]
-    groups = []
-    graphs = []
-
-    for index in range(3):
-        graph = torch.cuda.CUDAGraph()
-        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
-            group = _empty_group(handler, "core_attn")
-            groups.append(group)
-            with torch.cuda.graph(graph):
-                _capture_real_d2h_group(handler, group, sources[index], tags[index])
-                if index == 2:
-                    # Graph three drains graph one's pending entry. Capture must
-                    # encode an external wait; an internal event is invalid here.
-                    sources[0].add_(1000)
-                # CUDA capture requires every forked stream to rejoin its own
-                # graph. Because this local join may also order payload completion,
-                # capture/replay success is the cross-graph event regression signal;
-                # payload checks below only prove that each graph performed real D2H.
-                torch.cuda.current_stream().wait_stream(handler.d2h_stream)
-        graphs.append(graph)
-
-    try:
-        for value in (31.0, 42.0):
-            for source in sources:
-                source.fill_(value)
-            torch.cuda.synchronize()
-            for graph in graphs:
-                graph.replay()
-            torch.cuda.synchronize()
-            for group, tag in zip(groups, tags):
-                _assert_cpu_backup(group, tag, value)
-            assert sources[0][0].item() == value + 1000
-    finally:
-        torch.cuda.synchronize()
-        graphs.clear()
-        groups.clear()
-        sources.clear()

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offload_cuda_graph_events.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import os
+from contextlib import nullcontext
+from unittest.mock import Mock, call
+
+import pytest
+import torch
+
+from megatron.core.pipeline_parallel import fine_grained_activation_offload as offload
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+    ChunkOffloadHandler,
+    FineGrainedActivationOffloadingInterface,
+    PipelineOffloadManager,
+)
+
+
+@pytest.fixture
+def mocked_offload_manager(monkeypatch):
+    """Build the singleton without requiring a CUDA device."""
+    events = []
+    streams = []
+
+    def make_event(**kwargs):
+        event = Mock(name=f"event_{len(events)}")
+        event.external = kwargs.get("external", False)
+        events.append(event)
+        return event
+
+    def make_stream():
+        stream = Mock(name=f"stream_{len(streams)}")
+        streams.append(stream)
+        return stream
+
+    monkeypatch.setattr(torch.cuda, "Event", make_event)
+    monkeypatch.setattr(torch.cuda, "Stream", make_stream)
+    monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
+    monkeypatch.setattr(offload, "nvtx_range_push", Mock())
+    monkeypatch.setattr(offload, "nvtx_range_pop", Mock())
+
+    old_manager = PipelineOffloadManager.OFFLOAD_MGR
+    manager = PipelineOffloadManager()
+    PipelineOffloadManager.OFFLOAD_MGR = manager
+    yield manager, events, streams
+    PipelineOffloadManager.OFFLOAD_MGR = old_manager
+
+
+def _new_handler(manager, max_inflight_offloads):
+    return ChunkOffloadHandler(
+        min_offloaded_tensor_size=1,
+        cpu_tensor_pool=manager.cpu_tensor_pool,
+        max_inflight_offloads=max_inflight_offloads,
+    )
+
+
+def _empty_group(handler, name):
+    handler.on_group_start_forward(name)
+    return handler.offload_groups[-1]
+
+
+def _bulk_empty_group(handler, name):
+    group = _empty_group(handler, name)
+    handler.bulk_offload_group(group)
+    return group
+
+
+@pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
+def test_handler_allocates_external_event_only_for_positive_throttling_cap(
+    mocked_offload_manager, max_inflight_offloads
+):
+    manager, _, _ = mocked_offload_manager
+    handler = _new_handler(manager, max_inflight_offloads=max_inflight_offloads)
+
+    group = _empty_group(handler, "core_attn")
+
+    assert (group._offload_throttle_event is not None) == (
+        max_inflight_offloads is not None and max_inflight_offloads > 0
+    )
+
+
+def test_capture_scope_nests_but_sibling_scopes_get_distinct_owners(mocked_offload_manager):
+    manager, _, _ = mocked_offload_manager
+
+    assert manager.cuda_graph_capture_owner is None
+    with manager.cuda_graph_capture_scope(may_cross_graphs=False):
+        first_owner = manager.cuda_graph_capture_owner
+        assert first_owner is not None
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            assert manager.cuda_graph_capture_owner is first_owner
+            assert not manager.cuda_graph_capture_owner.may_cross_graphs
+        assert manager.cuda_graph_capture_owner is first_owner
+
+    assert manager.cuda_graph_capture_owner is None
+    with manager.cuda_graph_capture_scope(may_cross_graphs=False):
+        sibling_owner = manager.cuda_graph_capture_owner
+
+    assert sibling_owner is not first_owner
+    assert manager.cuda_graph_capture_owner is None
+
+
+def test_capture_scope_restores_owner_after_exception(mocked_offload_manager):
+    manager, _, _ = mocked_offload_manager
+
+    with pytest.raises(RuntimeError, match="capture failed"):
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            assert manager.cuda_graph_capture_owner is not None
+            raise RuntimeError("capture failed")
+
+    assert manager.cuda_graph_capture_owner is None
+
+
+@pytest.mark.parametrize("use_capture_scope", [False, True], ids=["eager", "same-owner"])
+def test_same_owner_and_eager_throttle_wait_on_internal_event(
+    mocked_offload_manager, monkeypatch, use_capture_scope
+):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=0)
+
+    scope = (
+        manager.cuda_graph_capture_scope(may_cross_graphs=True)
+        if use_capture_scope
+        else nullcontext()
+    )
+    with scope:
+        group = _bulk_empty_group(handler, "core_attn")
+
+    main_stream.wait_event.assert_called_once_with(group._offload_event)
+    assert not handler._offload_pending_by_name["core_attn"]
+
+
+def test_different_capture_owner_waits_on_external_event(mocked_offload_manager, monkeypatch):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=1)
+
+    with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+        group = _bulk_empty_group(handler, "core_attn")
+
+    with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+        second_group = _bulk_empty_group(handler, "core_attn")
+
+    assert group._offload_throttle_event is not None
+    main_stream.wait_event.assert_called_once_with(group._offload_throttle_event)
+    assert [entry.group for entry in handler._offload_pending_by_name["core_attn"]] == [
+        second_group
+    ]
+
+
+@pytest.mark.parametrize(
+    "producer_is_captured", [False, True], ids=["eager-to-graph", "graph-to-eager"]
+)
+def test_mixed_eager_and_capture_owner_fails_fast(
+    mocked_offload_manager, monkeypatch, producer_is_captured
+):
+    manager, _, _ = mocked_offload_manager
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: Mock())
+    handler = _new_handler(manager, max_inflight_offloads=1)
+
+    producer_scope = (
+        manager.cuda_graph_capture_scope(may_cross_graphs=True)
+        if producer_is_captured
+        else nullcontext()
+    )
+    with producer_scope:
+        _bulk_empty_group(handler, "core_attn")
+
+    consumer_scope = (
+        nullcontext()
+        if producer_is_captured
+        else manager.cuda_graph_capture_scope(may_cross_graphs=True)
+    )
+    with consumer_scope, pytest.raises(RuntimeError, match="eager execution.*CUDA graph capture"):
+        _bulk_empty_group(handler, "core_attn")
+
+
+@pytest.mark.parametrize("max_inflight_offloads", [0, 2])
+def test_max_inflight_fifo_is_per_group_name(
+    mocked_offload_manager, monkeypatch, max_inflight_offloads
+):
+    manager, _, _ = mocked_offload_manager
+    main_stream = Mock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+    handler = _new_handler(manager, max_inflight_offloads=max_inflight_offloads)
+
+    core_groups = [_bulk_empty_group(handler, "core_attn") for _ in range(3)]
+    mlp_group = _bulk_empty_group(handler, "mlp")
+
+    if max_inflight_offloads == 0:
+        expected_waits = [
+            *[call(group._offload_event) for group in core_groups],
+            call(mlp_group._offload_event),
+        ]
+        assert main_stream.wait_event.call_args_list == expected_waits
+        assert not handler._offload_pending_by_name["core_attn"]
+        assert not handler._offload_pending_by_name["mlp"]
+    else:
+        main_stream.wait_event.assert_called_once_with(core_groups[0]._offload_event)
+        assert [
+            entry.group for entry in handler._offload_pending_by_name["core_attn"]
+        ] == core_groups[1:]
+        assert [entry.group for entry in handler._offload_pending_by_name["mlp"]] == [mlp_group]
+
+
+def _set_local_cuda_device():
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if local_rank >= torch.cuda.device_count():
+        pytest.fail(
+            f"LOCAL_RANK={local_rank} is outside visible CUDA device count "
+            f"{torch.cuda.device_count()}"
+        )
+    torch.cuda.set_device(local_rank)
+
+
+@pytest.fixture
+def cuda_offload_manager():
+    _set_local_cuda_device()
+    torch.cuda.synchronize()
+    FineGrainedActivationOffloadingInterface.reset_instance()
+    manager = PipelineOffloadManager.get_instance()
+    try:
+        yield manager
+    finally:
+        torch.cuda.synchronize()
+        FineGrainedActivationOffloadingInterface.reset_instance()
+        torch.cuda.empty_cache()
+
+
+def _prewarm_cpu_pool(handler, count, shape, dtype):
+    backups = [handler.cpu_tensor_pool.allocate(shape, dtype=dtype) for _ in range(count)]
+    for backup in backups:
+        handler.cpu_tensor_pool.free(backup)
+
+
+def _capture_real_d2h_group(handler, group, source, tag):
+    handler.d2h_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(handler.d2h_stream):
+        torch.cuda._sleep(50_000_000)
+    group.push_tensor(tag, source)
+    handler.bulk_offload_group(group)
+
+
+def _assert_cpu_backup(group, tag, expected):
+    _, backup, _ = group._tensors[tag]
+    torch.testing.assert_close(backup, torch.full_like(backup, expected))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
+@pytest.mark.launch_on_gb200
+@pytest.mark.parametrize(
+    ("max_inflight_offloads", "may_cross_graphs"),
+    [
+        pytest.param(0, False, id="full-iteration-cap0"),
+        pytest.param(2, False, id="full-iteration-cap2"),
+        pytest.param(0, True, id="te-like-same-owner-cap0"),
+        pytest.param(2, True, id="te-like-same-owner-cap2"),
+    ],
+)
+def test_same_graph_throttle_orders_real_d2h_before_source_reuse(
+    cuda_offload_manager, max_inflight_offloads, may_cross_graphs
+):
+    manager = cuda_offload_manager
+    handler = _new_handler(manager, max_inflight_offloads)
+    group_count = max_inflight_offloads + 1
+    shape = (4096,)
+    dtype = torch.float32
+    _prewarm_cpu_pool(handler, group_count, shape, dtype)
+    sources = [torch.empty(shape, dtype=dtype, device="cuda") for _ in range(group_count)]
+    tags = [(index + 1, 0) for index in range(group_count)]
+    groups = []
+    graph = torch.cuda.CUDAGraph()
+
+    capture_scope = (
+        FineGrainedActivationOffloadingInterface.cuda_graph_capture_scope
+        if may_cross_graphs
+        else manager.cuda_graph_capture_scope
+    )
+    with capture_scope(may_cross_graphs=may_cross_graphs):
+        for _ in range(group_count):
+            groups.append(_empty_group(handler, "core_attn"))
+        with torch.cuda.graph(graph):
+            for group, source, tag in zip(groups, sources, tags):
+                _capture_real_d2h_group(handler, group, source, tag)
+            # The oldest copy is the one drained by cap=0/cap=2. Reusing its
+            # source immediately after the drain exposes a missing graph edge.
+            sources[0].add_(1000)
+            torch.cuda.current_stream().wait_stream(handler.d2h_stream)
+
+    try:
+        for replay, value in enumerate((11.0, 22.0)):
+            for source in sources:
+                source.fill_(value)
+            torch.cuda.synchronize()
+            graph.replay()
+            torch.cuda.synchronize()
+            _assert_cpu_backup(groups[0], tags[0], value)
+            assert sources[0][0].item() == value + 1000
+    finally:
+        torch.cuda.synchronize()
+        graph = None
+        groups.clear()
+        sources.clear()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
+@pytest.mark.launch_on_gb200
+def test_cross_graph_throttle_captures_real_d2h_with_external_event(cuda_offload_manager):
+    manager = cuda_offload_manager
+    handler = _new_handler(manager, max_inflight_offloads=2)
+    shape = (4096,)
+    dtype = torch.float32
+    _prewarm_cpu_pool(handler, 3, shape, dtype)
+    sources = [torch.empty(shape, dtype=dtype, device="cuda") for _ in range(3)]
+    tags = [(index + 1, 0) for index in range(3)]
+    groups = []
+    graphs = []
+
+    for index in range(3):
+        graph = torch.cuda.CUDAGraph()
+        with manager.cuda_graph_capture_scope(may_cross_graphs=True):
+            group = _empty_group(handler, "core_attn")
+            groups.append(group)
+            with torch.cuda.graph(graph):
+                _capture_real_d2h_group(handler, group, sources[index], tags[index])
+                if index == 2:
+                    # Graph three drains graph one's pending entry. Capture must
+                    # encode an external wait; an internal event is invalid here.
+                    sources[0].add_(1000)
+                # CUDA capture requires every forked stream to rejoin its own
+                # graph. Because this local join may also order payload completion,
+                # capture/replay success is the cross-graph event regression signal;
+                # payload checks below only prove that each graph performed real D2H.
+                torch.cuda.current_stream().wait_stream(handler.d2h_stream)
+        graphs.append(graph)
+
+    try:
+        for value in (31.0, 42.0):
+            for source in sources:
+                source.fill_(value)
+            torch.cuda.synchronize()
+            for graph in graphs:
+                graph.replay()
+            torch.cuda.synchronize()
+            for group, tag in zip(groups, tags):
+                _assert_cpu_backup(group, tag, value)
+            assert sources[0][0].item() == value + 1000
+    finally:
+        torch.cuda.synchronize()
+        graphs.clear()
+        groups.clear()
+        sources.clear()

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -2,10 +2,7 @@
 
 import gc
 import os
-from collections import deque
-from contextlib import nullcontext
 from typing import Dict, List, Optional, Tuple
-from unittest.mock import Mock
 
 import pytest
 import torch
@@ -15,10 +12,6 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import ChunkOffloadHandler
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
-)
-from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
-    OffloadTensorGroup,
-    PipelineOffloadManager,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
@@ -69,137 +62,6 @@ def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
     assert not handler.tensor_need_offloading_checker(fake_tensor)
     assert handler.tensor_push(fake_tensor) is fake_tensor
     assert handler.tensor_pop(fake_tensor) is fake_tensor
-
-
-def test_offload_tensor_group_allocates_external_throttle_event_only_when_enabled(monkeypatch):
-    event_calls = []
-
-    def _make_event(**kwargs):
-        event = Mock()
-        event_calls.append((kwargs, event))
-        return event
-
-    monkeypatch.setattr(torch.cuda, "Event", _make_event)
-
-    unthrottled_group = OffloadTensorGroup("core_attn")
-    assert len(event_calls) == 2
-    assert not any(kwargs.get("external", False) for kwargs, _ in event_calls)
-    assert unthrottled_group._offload_throttle_event is None
-
-    event_calls.clear()
-    throttled_group = OffloadTensorGroup("core_attn", enable_offload_throttle=True)
-    assert len(event_calls) == 3
-    external_events = [event for kwargs, event in event_calls if kwargs.get("external", False)]
-    assert external_events == [throttled_group.offload_throttle_event]
-
-
-@pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
-def test_chunk_offload_handler_wires_throttle_event_to_max_inflight(
-    monkeypatch, max_inflight_offloads: Optional[int]
-):
-    monkeypatch.setattr(torch.cuda, "Event", lambda **_: Mock())
-
-    handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
-    handler.do_offload = True
-    handler.is_warmup = True
-    handler.offload_groups = []
-    handler._offloaded_group_index = 0
-    handler._max_group_size = 0
-    handler._groups_to_offload = []
-    handler._max_inflight_offloads = max_inflight_offloads
-
-    handler.on_group_start_forward("core_attn")
-
-    group = handler.offload_groups[0]
-    assert (group._offload_throttle_event is not None) == (max_inflight_offloads is not None)
-    assert handler._groups_to_offload == [group]
-
-
-@pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
-def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
-    monkeypatch, max_inflight_offloads: Optional[int]
-):
-    from megatron.core.pipeline_parallel import fine_grained_activation_offload as off
-
-    monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
-    monkeypatch.setattr(off, "nvtx_range_push", Mock())
-    monkeypatch.setattr(off, "nvtx_range_pop", Mock())
-
-    handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
-    handler.d2h_stream = Mock()
-    handler.is_warmup = False
-    handler._max_inflight_offloads = max_inflight_offloads
-    handler._offload_pending_by_name = {"core_attn": deque()}
-    handler._drain_offload_pending = Mock()
-
-    group = Mock()
-    group._name = "core_attn"
-    group._tensors = {}
-    group.offload_throttle_event = Mock() if max_inflight_offloads is not None else None
-
-    handler.bulk_offload_group(group)
-
-    group.record_offload_event.assert_called_once_with(handler.d2h_stream)
-    if max_inflight_offloads is None:
-        group.record_offload_throttle_event.assert_not_called()
-        handler._drain_offload_pending.assert_not_called()
-        assert not handler._offload_pending_by_name["core_attn"]
-    else:
-        group.record_offload_throttle_event.assert_called_once_with(handler.d2h_stream)
-        handler._drain_offload_pending.assert_called_once_with("core_attn")
-        assert list(handler._offload_pending_by_name["core_attn"]) == [group.offload_throttle_event]
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
-@pytest.mark.launch_on_gb200
-@pytest.mark.parametrize(
-    "max_inflight_offloads",
-    [pytest.param(0, id="same-graph-smoke"), pytest.param(2, id="cross-graph-regression")],
-)
-def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_offloads: int):
-    """Exercise the exact throttle-event record/wait regression across graphs.
-
-    The GB200 marker also selects this file into the GB200 unit-test bucket.
-    """
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    torch.cuda.set_device(local_rank % torch.cuda.device_count())
-    off_interface.reset_instance()
-    graphs = []
-    try:
-        manager = PipelineOffloadManager.get_instance()
-        handler = ChunkOffloadHandler(
-            min_offloaded_tensor_size=1,
-            cpu_tensor_pool=manager.cpu_tensor_pool,
-            max_inflight_offloads=max_inflight_offloads,
-        )
-        groups = [OffloadTensorGroup("core_attn", enable_offload_throttle=True) for _ in range(3)]
-
-        torch.cuda.synchronize()
-        for group in groups:
-            graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph):
-                # Match the fork/join boundaries used by a TE per-module graph.
-                handler.d2h_stream.wait_stream(torch.cuda.current_stream())
-                handler.bulk_offload_group(group)
-                torch.cuda.current_stream().wait_stream(handler.d2h_stream)
-            graphs.append(graph)
-
-        for _ in range(2):
-            for graph in graphs:
-                graph.replay()
-        torch.cuda.synchronize()
-
-        # Cap 0 is a same-graph record/wait smoke case. Cap 2 is the regression:
-        # graph three waits on graph one's event, leaving the last two events pending.
-        expected_events = (
-            [group.offload_throttle_event for group in groups[-max_inflight_offloads:]]
-            if max_inflight_offloads > 0
-            else []
-        )
-        assert list(handler._offload_pending_by_name["core_attn"]) == expected_events
-    finally:
-        graphs.clear()
-        off_interface.reset_instance()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -82,13 +82,15 @@ def test_offload_tensor_group_allocates_external_throttle_event_only_when_enable
     monkeypatch.setattr(torch.cuda, "Event", _make_event)
 
     unthrottled_group = OffloadTensorGroup("core_attn")
-    assert [kwargs for kwargs, _ in event_calls] == [{}, {}]
+    assert len(event_calls) == 2
+    assert not any(kwargs.get("external", False) for kwargs, _ in event_calls)
     assert unthrottled_group._offload_throttle_event is None
 
     event_calls.clear()
     throttled_group = OffloadTensorGroup("core_attn", enable_offload_throttle=True)
-    assert [kwargs for kwargs, _ in event_calls] == [{}, {}, {"external": True}]
-    assert throttled_group._offload_throttle_event is event_calls[-1][1]
+    assert len(event_calls) == 3
+    external_events = [event for kwargs, event in event_calls if kwargs.get("external", False)]
+    assert external_events == [throttled_group.offload_throttle_event]
 
 
 @pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
@@ -111,7 +113,7 @@ def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
     group = Mock()
     group._name = "core_attn"
     group._tensors = {}
-    group._offload_throttle_event = Mock() if max_inflight_offloads is not None else None
+    group.offload_throttle_event = Mock() if max_inflight_offloads is not None else None
 
     handler.bulk_offload_group(group)
 
@@ -123,16 +125,17 @@ def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
     else:
         group.record_offload_throttle_event.assert_called_once_with(handler.d2h_stream)
         handler._drain_offload_pending.assert_called_once_with("core_attn")
-        assert list(handler._offload_pending_by_name["core_attn"]) == [
-            group._offload_throttle_event
-        ]
+        assert list(handler._offload_pending_by_name["core_attn"]) == [group.offload_throttle_event]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
 @pytest.mark.launch_on_gb200
-@pytest.mark.parametrize("max_inflight_offloads", [0, 2])
+@pytest.mark.parametrize(
+    "max_inflight_offloads",
+    [pytest.param(0, id="same-graph-smoke"), pytest.param(2, id="cross-graph-regression")],
+)
 def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_offloads: int):
-    """Throttle waits remain valid when same-name groups are captured separately."""
+    """Exercise throttle event capture and the cap-2 cross-graph wait regression."""
     off_interface.reset_instance()
     graphs = []
     try:
@@ -159,7 +162,14 @@ def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_o
                 graph.replay()
         torch.cuda.synchronize()
 
-        assert len(handler._offload_pending_by_name["core_attn"]) == max_inflight_offloads
+        # Cap 0 is a same-graph record/wait smoke case. Cap 2 is the regression:
+        # graph three waits on graph one's event, leaving the last two events pending.
+        expected_events = (
+            [group.offload_throttle_event for group in groups[-max_inflight_offloads:]]
+            if max_inflight_offloads > 0
+            else []
+        )
+        assert list(handler._offload_pending_by_name["core_attn"]) == expected_events
     finally:
         graphs.clear()
         off_interface.reset_instance()
@@ -767,7 +777,6 @@ def _build_gpt_model_with_cuda_graph(
     cuda_graph_warmup_steps: int,
     delay_offload_until_cuda_graph: bool = False,
     activation_offload_fraction: float = 1.0,
-    max_inflight_offloads: Optional[int] = None,
     enable_hyper_connections: bool = False,
     num_residual_streams: int = 4,
 ) -> GPTModel:
@@ -796,7 +805,6 @@ def _build_gpt_model_with_cuda_graph(
         min_offloaded_tensor_size=min_offloaded_tensor_size,
         delay_offload_until_cuda_graph=delay_offload_until_cuda_graph,
         activation_offload_fraction=activation_offload_fraction,
-        fine_grained_offloading_max_inflight_offloads=max_inflight_offloads,
         # CUDA Graph settings
         cuda_graph_impl=cuda_graph_impl,
         cuda_graph_modules=cuda_graph_modules,
@@ -935,29 +943,18 @@ def _run_iters_with_cuda_graph(
 )
 @pytest.mark.flaky_in_dev
 @pytest.mark.parametrize(
-    (
-        "is_mla, offload_modules, cuda_graph_modules, activation_offload_fraction, "
-        "delay_offload, max_inflight_offloads"
-    ),
+    "is_mla, offload_modules, cuda_graph_modules, activation_offload_fraction, delay_offload",
     [
         # MoE model with attention CUDA graph + attn offloading
-        (False, ["core_attn", "attn_proj"], ["attn", "moe_router"], 1.0, True, None),
-        (
-            False,
-            ["expert_fc1", "moe_act"],
-            ["attn", "moe_router", "moe_preprocess"],
-            1.0,
-            True,
-            None,
-        ),
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, True, None),
+        (False, ["core_attn", "attn_proj"], ["attn", "moe_router"], 1.0, True),
+        (False, ["expert_fc1", "moe_act"], ["attn", "moe_router", "moe_preprocess"], 1.0, True),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, True),
         (
             False,
             ["core_attn", "attn_proj", "expert_fc1", "moe_act"],
             ["attn", "moe_router"],
             1.0,
             True,
-            None,
         ),
         (
             False,
@@ -965,7 +962,6 @@ def _run_iters_with_cuda_graph(
             ["attn", "moe_router", "moe_preprocess"],
             1.0,
             True,
-            None,
         ),
         (
             True,
@@ -973,18 +969,12 @@ def _run_iters_with_cuda_graph(
             ["attn", "moe_router", "moe_preprocess"],
             1.0,
             True,
-            None,
         ),
         # Test activation_offload_fraction parameter
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.0, True, None),
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.5, True, None),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.0, True),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.5, True),
         # Test delay_offload_until_cuda_graph parameter
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, False, None),
-        # Three active core_attn groups exercise max-inflight waits during TE
-        # per-module capture: cap 0 waits on every group and cap 2 waits on the
-        # oldest group when the third same-name offload is committed.
-        pytest.param(False, ["core_attn"], ["attn"], 1.0, False, 0, id="max-inflight-0"),
-        pytest.param(False, ["core_attn"], ["attn"], 1.0, False, 2, id="max-inflight-2"),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, False),
     ],
 )
 def test_fine_grained_activation_offloading_with_cuda_graph(
@@ -993,7 +983,6 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
     cuda_graph_modules: List[str],
     activation_offload_fraction: float,
     delay_offload: bool,
-    max_inflight_offloads: Optional[int],
 ):
     """
     Test fine-grained activation offloading combined with CUDA graph capture.
@@ -1004,7 +993,6 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
     - Memory savings from offloading are preserved with CUDA graphs
     - Different activation_offload_fraction values work correctly
     - Both delay_offload_until_cuda_graph=True/False produce correct results
-    - max_inflight_offloads=0/2 remain valid across TE per-module capture
     """
     from megatron.core.tensor_parallel.random import initialize_rng_tracker
 
@@ -1085,7 +1073,6 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
             cuda_graph_warmup_steps=cuda_graph_warmup_steps,
             delay_offload_until_cuda_graph=delay_offload,
             activation_offload_fraction=activation_offload_fraction,
-            max_inflight_offloads=max_inflight_offloads,
         ).cuda()
         off_model.train()
 
@@ -1098,19 +1085,6 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
             num_measure_iters=2,
             enable_offload_reset=True,
         )
-
-        if max_inflight_offloads is not None:
-            manager = PipelineOffloadManager.get_instance()
-            active_core_attn_groups = [
-                group
-                for chunk in manager._cached_chunks_forward
-                for group in chunk.offload_groups
-                if group._name == "core_attn" and group.offload
-            ]
-            assert len(active_core_attn_groups) >= 3, (
-                "max-inflight CUDA graph coverage requires at least three active "
-                f"same-name core_attn groups, found {len(active_core_attn_groups)}"
-            )
         del off_model
         _reset_cuda_memory()
 

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -94,6 +94,28 @@ def test_offload_tensor_group_allocates_external_throttle_event_only_when_enable
 
 
 @pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
+def test_chunk_offload_handler_wires_throttle_event_to_max_inflight(
+    monkeypatch, max_inflight_offloads: Optional[int]
+):
+    monkeypatch.setattr(torch.cuda, "Event", lambda **_: Mock())
+
+    handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
+    handler.do_offload = True
+    handler.is_warmup = True
+    handler.offload_groups = []
+    handler._offloaded_group_index = 0
+    handler._max_group_size = 0
+    handler._groups_to_offload = []
+    handler._max_inflight_offloads = max_inflight_offloads
+
+    handler.on_group_start_forward("core_attn")
+
+    group = handler.offload_groups[0]
+    assert (group._offload_throttle_event is not None) == (max_inflight_offloads is not None)
+    assert handler._groups_to_offload == [group]
+
+
+@pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
 def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
     monkeypatch, max_inflight_offloads: Optional[int]
 ):
@@ -135,7 +157,10 @@ def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
     [pytest.param(0, id="same-graph-smoke"), pytest.param(2, id="cross-graph-regression")],
 )
 def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_offloads: int):
-    """Exercise throttle event capture and the cap-2 cross-graph wait regression."""
+    """Exercise the exact throttle-event record/wait regression across graphs.
+
+    The GB200 marker also selects this file into the GB200 unit-test bucket.
+    """
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     torch.cuda.set_device(local_rank % torch.cuda.device_count())
     off_interface.reset_instance()

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -136,6 +136,8 @@ def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
 )
 def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_offloads: int):
     """Exercise throttle event capture and the cap-2 cross-graph wait regression."""
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank % torch.cuda.device_count())
     off_interface.reset_instance()
     graphs = []
     try:

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -2,8 +2,10 @@
 
 import gc
 import os
+from collections import deque
 from contextlib import nullcontext
 from typing import Dict, List, Optional, Tuple
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -13,6 +15,10 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import ChunkOffloadHandler
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
+)
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+    OffloadTensorGroup,
+    PipelineOffloadManager,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
@@ -63,6 +69,100 @@ def test_chunk_offload_handler_skips_non_offloadable_tensor_types():
     assert not handler.tensor_need_offloading_checker(fake_tensor)
     assert handler.tensor_push(fake_tensor) is fake_tensor
     assert handler.tensor_pop(fake_tensor) is fake_tensor
+
+
+def test_offload_tensor_group_allocates_external_throttle_event_only_when_enabled(monkeypatch):
+    event_calls = []
+
+    def _make_event(**kwargs):
+        event = Mock()
+        event_calls.append((kwargs, event))
+        return event
+
+    monkeypatch.setattr(torch.cuda, "Event", _make_event)
+
+    unthrottled_group = OffloadTensorGroup("core_attn")
+    assert [kwargs for kwargs, _ in event_calls] == [{}, {}]
+    assert unthrottled_group._offload_throttle_event is None
+
+    event_calls.clear()
+    throttled_group = OffloadTensorGroup("core_attn", enable_offload_throttle=True)
+    assert [kwargs for kwargs, _ in event_calls] == [{}, {}, {"external": True}]
+    assert throttled_group._offload_throttle_event is event_calls[-1][1]
+
+
+@pytest.mark.parametrize("max_inflight_offloads", [None, 0, 2])
+def test_chunk_offload_handler_uses_throttle_event_only_when_configured(
+    monkeypatch, max_inflight_offloads: Optional[int]
+):
+    from megatron.core.pipeline_parallel import fine_grained_activation_offload as off
+
+    monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
+    monkeypatch.setattr(off, "nvtx_range_push", Mock())
+    monkeypatch.setattr(off, "nvtx_range_pop", Mock())
+
+    handler = ChunkOffloadHandler.__new__(ChunkOffloadHandler)
+    handler.d2h_stream = Mock()
+    handler.is_warmup = False
+    handler._max_inflight_offloads = max_inflight_offloads
+    handler._offload_pending_by_name = {"core_attn": deque()}
+    handler._drain_offload_pending = Mock()
+
+    group = Mock()
+    group._name = "core_attn"
+    group._tensors = {}
+    group._offload_throttle_event = Mock() if max_inflight_offloads is not None else None
+
+    handler.bulk_offload_group(group)
+
+    group.record_offload_event.assert_called_once_with(handler.d2h_stream)
+    if max_inflight_offloads is None:
+        group.record_offload_throttle_event.assert_not_called()
+        handler._drain_offload_pending.assert_not_called()
+        assert not handler._offload_pending_by_name["core_attn"]
+    else:
+        group.record_offload_throttle_event.assert_called_once_with(handler.d2h_stream)
+        handler._drain_offload_pending.assert_called_once_with("core_attn")
+        assert list(handler._offload_pending_by_name["core_attn"]) == [
+            group._offload_throttle_event
+        ]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for graph capture.")
+@pytest.mark.launch_on_gb200
+@pytest.mark.parametrize("max_inflight_offloads", [0, 2])
+def test_max_inflight_throttle_events_cross_cuda_graph_boundaries(max_inflight_offloads: int):
+    """Throttle waits remain valid when same-name groups are captured separately."""
+    off_interface.reset_instance()
+    graphs = []
+    try:
+        manager = PipelineOffloadManager.get_instance()
+        handler = ChunkOffloadHandler(
+            min_offloaded_tensor_size=1,
+            cpu_tensor_pool=manager.cpu_tensor_pool,
+            max_inflight_offloads=max_inflight_offloads,
+        )
+        groups = [OffloadTensorGroup("core_attn", enable_offload_throttle=True) for _ in range(3)]
+
+        torch.cuda.synchronize()
+        for group in groups:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                # Match the fork/join boundaries used by a TE per-module graph.
+                handler.d2h_stream.wait_stream(torch.cuda.current_stream())
+                handler.bulk_offload_group(group)
+                torch.cuda.current_stream().wait_stream(handler.d2h_stream)
+            graphs.append(graph)
+
+        for _ in range(2):
+            for graph in graphs:
+                graph.replay()
+        torch.cuda.synchronize()
+
+        assert len(handler._offload_pending_by_name["core_attn"]) == max_inflight_offloads
+    finally:
+        graphs.clear()
+        off_interface.reset_instance()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")
@@ -667,6 +767,7 @@ def _build_gpt_model_with_cuda_graph(
     cuda_graph_warmup_steps: int,
     delay_offload_until_cuda_graph: bool = False,
     activation_offload_fraction: float = 1.0,
+    max_inflight_offloads: Optional[int] = None,
     enable_hyper_connections: bool = False,
     num_residual_streams: int = 4,
 ) -> GPTModel:
@@ -695,6 +796,7 @@ def _build_gpt_model_with_cuda_graph(
         min_offloaded_tensor_size=min_offloaded_tensor_size,
         delay_offload_until_cuda_graph=delay_offload_until_cuda_graph,
         activation_offload_fraction=activation_offload_fraction,
+        fine_grained_offloading_max_inflight_offloads=max_inflight_offloads,
         # CUDA Graph settings
         cuda_graph_impl=cuda_graph_impl,
         cuda_graph_modules=cuda_graph_modules,
@@ -833,18 +935,29 @@ def _run_iters_with_cuda_graph(
 )
 @pytest.mark.flaky_in_dev
 @pytest.mark.parametrize(
-    "is_mla, offload_modules, cuda_graph_modules, activation_offload_fraction, delay_offload",
+    (
+        "is_mla, offload_modules, cuda_graph_modules, activation_offload_fraction, "
+        "delay_offload, max_inflight_offloads"
+    ),
     [
         # MoE model with attention CUDA graph + attn offloading
-        (False, ["core_attn", "attn_proj"], ["attn", "moe_router"], 1.0, True),
-        (False, ["expert_fc1", "moe_act"], ["attn", "moe_router", "moe_preprocess"], 1.0, True),
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, True),
+        (False, ["core_attn", "attn_proj"], ["attn", "moe_router"], 1.0, True, None),
+        (
+            False,
+            ["expert_fc1", "moe_act"],
+            ["attn", "moe_router", "moe_preprocess"],
+            1.0,
+            True,
+            None,
+        ),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, True, None),
         (
             False,
             ["core_attn", "attn_proj", "expert_fc1", "moe_act"],
             ["attn", "moe_router"],
             1.0,
             True,
+            None,
         ),
         (
             False,
@@ -852,6 +965,7 @@ def _run_iters_with_cuda_graph(
             ["attn", "moe_router", "moe_preprocess"],
             1.0,
             True,
+            None,
         ),
         (
             True,
@@ -859,12 +973,18 @@ def _run_iters_with_cuda_graph(
             ["attn", "moe_router", "moe_preprocess"],
             1.0,
             True,
+            None,
         ),
         # Test activation_offload_fraction parameter
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.0, True),
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.5, True),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.0, True, None),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 0.5, True, None),
         # Test delay_offload_until_cuda_graph parameter
-        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, False),
+        (False, ["core_attn", "attn_proj", "expert_fc1"], ["attn", "moe_router"], 1.0, False, None),
+        # Three active core_attn groups exercise max-inflight waits during TE
+        # per-module capture: cap 0 waits on every group and cap 2 waits on the
+        # oldest group when the third same-name offload is committed.
+        pytest.param(False, ["core_attn"], ["attn"], 1.0, False, 0, id="max-inflight-0"),
+        pytest.param(False, ["core_attn"], ["attn"], 1.0, False, 2, id="max-inflight-2"),
     ],
 )
 def test_fine_grained_activation_offloading_with_cuda_graph(
@@ -873,6 +993,7 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
     cuda_graph_modules: List[str],
     activation_offload_fraction: float,
     delay_offload: bool,
+    max_inflight_offloads: Optional[int],
 ):
     """
     Test fine-grained activation offloading combined with CUDA graph capture.
@@ -883,6 +1004,7 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
     - Memory savings from offloading are preserved with CUDA graphs
     - Different activation_offload_fraction values work correctly
     - Both delay_offload_until_cuda_graph=True/False produce correct results
+    - max_inflight_offloads=0/2 remain valid across TE per-module capture
     """
     from megatron.core.tensor_parallel.random import initialize_rng_tracker
 
@@ -963,6 +1085,7 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
             cuda_graph_warmup_steps=cuda_graph_warmup_steps,
             delay_offload_until_cuda_graph=delay_offload,
             activation_offload_fraction=activation_offload_fraction,
+            max_inflight_offloads=max_inflight_offloads,
         ).cuda()
         off_model.train()
 
@@ -975,6 +1098,19 @@ def test_fine_grained_activation_offloading_with_cuda_graph(
             num_measure_iters=2,
             enable_offload_reset=True,
         )
+
+        if max_inflight_offloads is not None:
+            manager = PipelineOffloadManager.get_instance()
+            active_core_attn_groups = [
+                group
+                for chunk in manager._cached_chunks_forward
+                for group in chunk.offload_groups
+                if group._name == "core_attn" and group.offload
+            ]
+            assert len(active_core_attn_groups) >= 3, (
+                "max-inflight CUDA graph coverage requires at least three active "
+                f"same-name core_attn groups, found {len(active_core_attn_groups)}"
+            )
         del off_model
         _reset_cuda_memory()
 


### PR DESCRIPTION
## Summary

- Keep the capture-local offload/reload handshake event separate from max-inflight throttling.
- Record a group-owned external CUDA event only when a dependency may be consumed by a different module graph; full-iteration capture keeps using the internal event only.
- Give both local and Transformer Engine sibling-graph capture an explicit, nested-safe session boundary that preserves FIFO entries between siblings and clears them on success or exception.
- Track every handler that enqueues capture-time FIFO state, including handlers outside the forward/backward caches, while retaining fail-closed eager/capture owner checks.
- Keep TE replay off the context-manager hot path and preserve full-iteration compatibility with config-less model wrappers.
- Add focused CPU lifecycle/owner/TE-exception tests and multi-graph CUDA coverage without adding a GB-only functional test.

## Root cause

TE captures graphable modules into separate CUDA graphs. The max-inflight FIFO could retain an internal event recorded by one module capture and later call `wait_event(old_evt)` from a sibling capture. CUDA rejects that cross-capture internal event with `cudaErrorInvalidValue`, invalidating capture. Changing the cap to 0 only changes where the bad dependency is consumed; it does not repair event ownership.

The FIFO now records a group-owned external event for cross-owner waits while preserving the internal event for same-owner and eager dependencies. The outer capture session preserves those entries until all sibling graphs are captured, then clears Python-only bookkeeping without destroying the group-owned events needed by replay. TE capture exceptions now clear that FIFO before propagating the original exception, so a later owner-mismatch error cannot mask it.

## Validation

- Current head: `db9614a979f0ec2cad6bd1faa87ce9ced9afce2c` (Draft, base `dev`, DCO passing).
- Previous production head `e8719d551`: full GitHub CICD [run 33621945382](https://github.com/NVIDIA/Megatron-LM/actions/runs/33621945382), **60 success / 0 failure**, including unit and functional tests. Copyright, build/docs/wheels, and installation workflows also passed.
- Focused GB200 CI-style test on the production event path: **15 passed on each of 4 ranks**; existing fine-grained-offload regression: **9 passed on each of 4 ranks**.
- Review follow-up production commit `2c26b4e52`: py_compile, Black, isort, Ruff, Pylint (10/10), copyright-compatible headers, and diff checks pass. Its first CICD [run 33653195770](https://github.com/NVIDIA/Megatron-LM/actions/runs/33653195770) exposed only a CPU-test fixture bug: the mocked `torch.cuda.Stream` could not service `torch.cuda.current_stream()` for the cap-0 immediate-drain case. Test-only head `db9614a97` adds the missing current-stream mock; py_compile, Black, isort, Ruff, Pylint, and diff checks pass. Fresh CICD [run 33658675658](https://github.com/NVIDIA/Megatron-LM/actions/runs/33658675658) and strict re-review are in progress.
- Fresh stack with #7014 production code at `93edfe092`: 4x GB200, TP1/PP2/CP1/EP1, mHC, HybridModel, `[attn, moe_router]` partial CG, `core_attn` offload, and `max_inflight_offloads=2` completed **30/30** with zero NaN/capture/event errors. The `*E*E*E*E|*E*E*E*E` layout gives four attention offload groups per PP rank, so the third queued group makes `len=3 > cap=2` and exercises the real cross-graph external-event drain path. [W&B](https://wandb.ai/megatron-core-moe-dev/jingqiny-mcore-pr7014-7020-final/runs/f3b8a6acf4f944a9bbf461d785162514)
- Exact current-head stack `aaf7230c0` is frozen for the same 30-iteration W&B/Nsys hard gate. Submission is pending Lyris login connectivity; no GPU job has been submitted on this head yet.

## Scope

The Hybrid/mHC wrapper capture-boundary and RoPE sample-surface fixes are intentionally handled by #7014. This PR fixes the public max-inflight event-lifetime path independently.
