### PR TITLE
[dev] Add DeepSeek-V4-Flash-Vision support to multimodal_dev

### DIFF
--- a/examples/multimodal_dev/README.md
+++ b/examples/multimodal_dev/README.md
@@ -14,7 +14,8 @@ multimodal_dev/
 │   └── mock.py              # Mock dataset for end-to-end testing
 ├── models/
 │   ├── __init__.py          # MODEL_REGISTRY — central model registry
-│   ├── base.py              # MultimodalModel base class (vision encoder + GPTModel)
+│   ├── base.py              # Shared vision + language assembly
+│   ├── deepseek_v4/         # DeepSeek-V4-Flash-Vision + HybridModel
 │   └── qwen35_vl/           # Qwen3.5-VL architecture
 │       ├── factory.py       # Factory functions for pretrain entry point
 │       ├── model.py         # Qwen35VLModel (MRoPE, vision encoder wiring)
@@ -33,6 +34,41 @@ torchrun --nproc_per_node=8 multimodal_dev/pretrain_multimodal.py \
     --dataset-provider mock \
     ... # other Megatron args (--num-layers, --hidden-size, etc.)
 ```
+
+## DeepSeek-V4-Flash-Vision
+
+The native `deepseek_v4_vision` path implements the public
+`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` architecture:
+
+- 32-layer, 1024-wide ViT with full per-image attention and 2D RoPE;
+- the 3x3 pad-and-unfold aligner and official N-layout permutation;
+- four decoder-side image boundary/padding embeddings;
+- the existing DSv4 `hybrid_dsv4_stack_spec` decoder with the 43-block
+  `W/W/C/(H/C)x20` attention layout;
+- bidirectional visibility inside each image span while preserving sparse
+  causal attention outside it; and
+- VL-aware routing for synthetic image IDs, including the first three
+  hash-routed MoE layers.
+
+MTP is intentionally out of scope for this first phase: the model rejects a
+`--hybrid-layer-pattern` containing `/` MTP segments. The model forward accepts
+precomputed `vision_embeddings` and optional `vision_token_indices`;
+constructing with `build_vision_encoder=False` (or passing
+`--use-external-vision-embeddings`) leaves the same decoder-side contract for a
+future MDP vision stage.
+
+This first phase implements the architecture and training path only; conversion
+from the published Hugging Face checkpoint is not included yet.
+
+Start with a dry run of the proxy recipe:
+
+```bash
+bash examples/multimodal_dev/scripts/run_deepseek_v4_vision.sh
+```
+
+Set `DRY_RUN=0` to execute it. `MODEL_VARIANT=flash` selects the full 43-layer
+decoder / 32-layer vision tower. The current image-span visibility path supports
+CP=1; context-parallel image spans require a later CSA/MDP transport extension.
 
 ## Checkpoint Conversion (HF → Megatron-FSDP DTensor)
 

--- a/examples/multimodal_dev/arguments.py
+++ b/examples/multimodal_dev/arguments.py
@@ -5,15 +5,13 @@
 
 def add_multimodal_args(parser):
     """Add multimodal-specific arguments to the Megatron argument parser."""
-    group = parser.add_argument_group(
-        "Multimodal", "Multimodal model arguments",
-    )
+    group = parser.add_argument_group("Multimodal", "Multimodal model arguments")
 
     group.add_argument(
         "--model-arch",
         type=str,
         default="qwen35_vl",
-        help="Model architecture. Available: qwen35_vl",
+        help="Model architecture. Available: qwen35_vl, deepseek_v4_vision",
     )
     group.add_argument(
         "--model-variant",
@@ -22,51 +20,32 @@ def add_multimodal_args(parser):
         help="Model variant (size). E.g. proxy, 9b, 397b_a17b",
     )
     group.add_argument(
-        "--dataset-provider",
-        type=str,
-        default="mock",
-        help="Dataset provider: mock",
+        "--dataset-provider", type=str, default="mock", help="Dataset provider: mock"
     )
     group.add_argument(
-        "--image-token-id",
-        type=int,
-        default=248056,
-        help="Token ID for image placeholder tokens",
+        "--image-token-id", type=int, default=248056, help="Token ID for image placeholder tokens"
     )
     group.add_argument(
-        "--image-size",
-        type=int,
-        default=224,
-        help="Image size (height and width) for mock data",
+        "--image-size", type=int, default=224, help="Image size (height and width) for mock data"
     )
     group.add_argument(
-        "--total-seq-length",
-        type=int,
-        default=1024,
-        help="Total sequence length for mock data",
+        "--total-seq-length", type=int, default=1024, help="Total sequence length for mock data"
     )
     group.add_argument(
-        "--image-seq-length",
-        type=int,
-        default=256,
-        help="Number of image tokens in mock data",
+        "--image-seq-length", type=int, default=256, help="Number of image tokens in mock data"
     )
     group.add_argument(
         "--vision-num-layers",
         type=int,
         default=None,
-        help=(
-            "Override for vision backbone depth. "
-            "Useful for proxy perf runs."
-        ),
+        help=("Override for vision backbone depth. " "Useful for proxy perf runs."),
     )
     group.add_argument(
         "--hf-processor-path",
         type=str,
         default=None,
         help=(
-            "HuggingFace processor path for real VLM datasets "
-            "(e.g. Qwen/Qwen2.5-VL-7B-Instruct)"
+            "HuggingFace processor path for real VLM datasets " "(e.g. Qwen/Qwen2.5-VL-7B-Instruct)"
         ),
     )
     group.add_argument(
@@ -80,21 +59,25 @@ def add_multimodal_args(parser):
         ),
     )
     group.add_argument(
-        "--use-packed-sequence",
+        "--use-external-vision-embeddings",
         action="store_true",
         default=False,
         help=(
-            "Pack variable-length sequences into THD format to eliminate "
-            "padding waste."
+            "Do not construct the local vision encoder. The caller must inject "
+            "vision_embeddings (and optionally vision_token_indices); intended for MDP."
         ),
+    )
+    group.add_argument(
+        "--use-packed-sequence",
+        action="store_true",
+        default=False,
+        help=("Pack variable-length sequences into THD format to eliminate " "padding waste."),
     )
     group.add_argument(
         "--use-vanilla-collate-fn",
         action="store_true",
         default=False,
-        help=(
-            "Use vanilla collate function to collate the data."
-        ),
+        help=("Use vanilla collate function to collate the data."),
     )
 
     return parser

--- a/examples/multimodal_dev/data/deepseek_v4_mock.py
+++ b/examples/multimodal_dev/data/deepseek_v4_mock.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Synthetic DeepSeek-V4-Flash-Vision samples for launch and smoke tests."""
+
+import math
+
+import torch
+from torch.utils.data import Dataset
+
+from examples.multimodal_dev.models.deepseek_v4.configuration import (
+    DEEPSEEK_V4_VOCAB_SIZE,
+    VISION_DOWNSAMPLE_RATIO,
+    VISION_PATCH_SIZE,
+    build_image_block,
+)
+
+
+class MockDeepSeekV4VisionDataset(Dataset):
+    """Generate one-image samples using the official synthetic-token N-layout."""
+
+    def __init__(
+        self,
+        num_samples: int = 1000,
+        seq_length: int = 1024,
+        image_size: int = 224,
+        vocab_size: int = DEEPSEEK_V4_VOCAB_SIZE,
+    ) -> None:
+        if image_size % VISION_PATCH_SIZE:
+            raise ValueError(
+                f"image_size={image_size} must be divisible by patch size {VISION_PATCH_SIZE}."
+            )
+        self.num_samples = num_samples
+        self.seq_length = seq_length
+        self.image_size = image_size
+        self.vocab_size = vocab_size
+        self.n_vit_h = image_size // VISION_PATCH_SIZE
+        self.n_vit_w = image_size // VISION_PATCH_SIZE
+        self.n_llm_h = math.ceil(self.n_vit_h / VISION_DOWNSAMPLE_RATIO)
+        self.n_llm_w = math.ceil(self.n_vit_w / VISION_DOWNSAMPLE_RATIO)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        del index
+        # The compression-prefix length depends on the image block start modulo four.
+        tentative_start = max(1, self.seq_length // 3)
+        image_types, _ = build_image_block(self.n_llm_h, self.n_llm_w, tentative_start)
+        if image_types.numel() >= self.seq_length:
+            raise ValueError(
+                f"seq_length={self.seq_length} is too short for a {image_types.numel()}-token "
+                "image block."
+            )
+        prefix_length = min(tentative_start, self.seq_length - image_types.numel() - 1)
+        # Rebuild because changing start position may change compression padding.
+        image_types, _ = build_image_block(self.n_llm_h, self.n_llm_w, prefix_length)
+        suffix_length = self.seq_length - prefix_length - image_types.numel()
+        if suffix_length < 0:
+            raise ValueError("seq_length became too short after image-block alignment padding.")
+
+        text = torch.randint(1, self.vocab_size, (prefix_length + suffix_length,), dtype=torch.long)
+        input_ids = torch.cat(
+            (text[:prefix_length], image_types + self.vocab_size, text[prefix_length:])
+        )
+        labels = torch.empty_like(input_ids)
+        labels[:-1] = input_ids[1:]
+        labels[-1] = 0
+        loss_mask = (labels < self.vocab_size).float()
+        loss_mask[-1] = 0
+        # Synthetic image IDs live immediately above the decoder vocabulary and
+        # therefore cannot be gathered from the language-model output logits.
+        labels[loss_mask == 0] = -100
+
+        patch_dim = 3 * VISION_PATCH_SIZE**2
+        pixel_values = torch.randn(self.n_vit_h * self.n_vit_w, patch_dim, dtype=torch.float32)
+        image_grid_thw = torch.tensor([[1, self.n_vit_h, self.n_vit_w]], dtype=torch.long)
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }
+
+
+def train_valid_test_datasets_provider(train_val_test_num_samples):
+    """Return synthetic train, validation, and test datasets."""
+    from megatron.training import get_args
+
+    args = get_args()
+    kwargs = {
+        "seq_length": getattr(args, "total_seq_length", args.seq_length),
+        "image_size": getattr(args, "image_size", 224),
+        "vocab_size": DEEPSEEK_V4_VOCAB_SIZE,
+    }
+    return tuple(
+        MockDeepSeekV4VisionDataset(num_samples=num_samples, **kwargs)
+        for num_samples in train_val_test_num_samples
+    )

--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -418,6 +418,8 @@ def forward_step(data_iterator, model):
         padding_mask=batch.get("padding_mask", None),
         pixel_values=pixel_values,
         image_grid_thw=batch.get("image_grid_thw", None),
+        vision_embeddings=batch.get("vision_embeddings", None),
+        vision_token_indices=batch.get("vision_token_indices", None),
         packed_seq_params=batch.get("packed_seq_params", None),
     )
 

--- a/examples/multimodal_dev/models/__init__.py
+++ b/examples/multimodal_dev/models/__init__.py
@@ -33,6 +33,16 @@ Registry entry fields
     ``(train_val_test_num_samples) -> (train_ds, val_ds, test_ds)``.
 """
 
+from examples.multimodal_dev.models.deepseek_v4.configuration import get_deepseek_v4_vision_config
+from examples.multimodal_dev.models.deepseek_v4.factory import (
+    build_model as _build_deepseek_v4_model,
+)
+from examples.multimodal_dev.models.deepseek_v4.factory import (
+    post_language_config as _deepseek_v4_post_language_config,
+)
+from examples.multimodal_dev.models.deepseek_v4.factory import (
+    set_vision_flops_metadata as _deepseek_v4_vision_flops,
+)
 from examples.multimodal_dev.models.qwen35_vl.configuration import get_qwen35_vl_vision_config
 from examples.multimodal_dev.models.qwen35_vl.factory import build_model as _build_qwen35_vl_model
 from examples.multimodal_dev.models.qwen35_vl.factory import (
@@ -43,19 +53,27 @@ from examples.multimodal_dev.models.qwen35_vl.factory import (
 )
 
 MODEL_REGISTRY = {
+    "deepseek_v4_vision": {
+        "model_factory_fn": _build_deepseek_v4_model,
+        "vision_config_fn": get_deepseek_v4_vision_config,
+        "post_language_config_fn": _deepseek_v4_post_language_config,
+        "vision_flops_fn": _deepseek_v4_vision_flops,
+        "dataset_providers": {
+            "mock": (
+                "examples.multimodal_dev.data.deepseek_v4_mock"
+                ".train_valid_test_datasets_provider"
+            )
+        },
+    },
     "qwen35_vl": {
         "model_factory_fn": _build_qwen35_vl_model,
         "vision_config_fn": get_qwen35_vl_vision_config,
         "post_language_config_fn": _qwen35_vl_post_language_config,
         "vision_flops_fn": _qwen35_vl_vision_flops,
         "dataset_providers": {
-            "mock": (
-                "examples.multimodal_dev.data.mock"
-                ".train_valid_test_datasets_provider"
-            ),
+            "mock": ("examples.multimodal_dev.data.mock" ".train_valid_test_datasets_provider"),
             "cord_v2": (
-                "examples.multimodal_dev.data.cord_v2"
-                ".train_valid_test_datasets_provider"
+                "examples.multimodal_dev.data.cord_v2" ".train_valid_test_datasets_provider"
             ),
         },
     },

--- a/examples/multimodal_dev/models/base.py
+++ b/examples/multimodal_dev/models/base.py
@@ -2,7 +2,7 @@
 
 """Base multimodal model for FSDP + EP training.
 
-Composes a vision encoder and a ``GPTModel`` language decoder.  Designed
+Composes a vision encoder and either a ``GPTModel`` or ``HybridModel`` language decoder. Designed
 for FSDP + EP: always builds the **full** model on every rank (no PP
 flags).  PP support is only available through the MIMO ``MimoModel``
 assembly path.
@@ -19,6 +19,7 @@ from torch import Tensor
 
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.models.gpt import GPTModel
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -82,7 +83,7 @@ def _thd_cp_partition_index(cu_seqlens_padded, total_tokens, cp_size, cp_rank):
 class MultimodalModel(MegatronModule):
     """Base class for multimodal vision-language models.
 
-    Composes a pre-constructed vision encoder and a ``GPTModel`` language
+    Composes a pre-constructed vision encoder and a language decoder.
     decoder.  Designed for FSDP + EP; always builds the full model on
     every rank.
 
@@ -100,6 +101,9 @@ class MultimodalModel(MegatronModule):
         mtp_block_spec: Optional MTP block spec.
         parallel_output: Keep outputs split across TP ranks.
         share_embeddings_and_output_weights: Tie input/output embeddings.
+        hybrid_stack_spec: Optional HybridModel stack spec. When supplied,
+            ``language_spec`` must be ``None``.
+        hybrid_layer_pattern: Unified HybridModel layer pattern.
     """
 
     def __init__(
@@ -117,26 +121,57 @@ class MultimodalModel(MegatronModule):
         mtp_block_spec: Optional[ModuleSpec] = None,
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
+        hybrid_stack_spec: Optional[ModuleSpec] = None,
+        hybrid_layer_pattern: Optional[str] = None,
     ):
         super().__init__(config=language_config)
 
         self.image_token_id = image_token_id
 
         self.vision_model = vision_encoder
-        self.language_model = GPTModel(
-            config=language_config,
-            transformer_layer_spec=language_spec,
-            vocab_size=vocab_size,
-            max_sequence_length=max_sequence_length,
-            pre_process=True,
-            post_process=True,
-            parallel_output=parallel_output,
-            share_embeddings_and_output_weights=(share_embeddings_and_output_weights),
-            position_embedding_type=position_embedding_type,
-            rotary_percent=rotary_percent,
-            rotary_base=rotary_base,
-            mtp_block_spec=mtp_block_spec,
-        )
+        if hybrid_stack_spec is not None or hybrid_layer_pattern is not None:
+            if hybrid_stack_spec is None or hybrid_layer_pattern is None:
+                raise ValueError(
+                    "Hybrid multimodal decoders require both hybrid_stack_spec and "
+                    "hybrid_layer_pattern."
+                )
+            if language_spec is not None:
+                raise ValueError("language_spec and hybrid_stack_spec are mutually exclusive.")
+            if mtp_block_spec is not None:
+                raise ValueError(
+                    "HybridModel expresses MTP in hybrid_layer_pattern; mtp_block_spec is invalid."
+                )
+            self.language_model = HybridModel(
+                config=language_config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                vocab_size=vocab_size,
+                max_sequence_length=max_sequence_length,
+                hybrid_layer_pattern=hybrid_layer_pattern,
+                pre_process=True,
+                post_process=True,
+                parallel_output=parallel_output,
+                share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+                position_embedding_type=position_embedding_type,
+                rotary_percent=rotary_percent,
+                rotary_base=rotary_base,
+            )
+        else:
+            if language_spec is None:
+                raise ValueError("GPTModel multimodal decoders require language_spec.")
+            self.language_model = GPTModel(
+                config=language_config,
+                transformer_layer_spec=language_spec,
+                vocab_size=vocab_size,
+                max_sequence_length=max_sequence_length,
+                pre_process=True,
+                post_process=True,
+                parallel_output=parallel_output,
+                share_embeddings_and_output_weights=(share_embeddings_and_output_weights),
+                position_embedding_type=position_embedding_type,
+                rotary_percent=rotary_percent,
+                rotary_base=rotary_base,
+                mtp_block_spec=mtp_block_spec,
+            )
 
     def set_input_tensor(self, input_tensor):
         """Route input tensors (simplified, no PP routing)."""
@@ -146,7 +181,11 @@ class MultimodalModel(MegatronModule):
         self.language_model.set_input_tensor(input_tensor[0])
 
     def _scatter_vision_embeddings(
-        self, input_ids: Tensor, text_embeddings: Tensor, vision_embeddings: Tensor
+        self,
+        input_ids: Tensor,
+        text_embeddings: Tensor,
+        vision_embeddings: Tensor,
+        vision_token_indices: Tensor = None,
     ) -> Tensor:
         """Replace image-token positions with vision embeddings.
 
@@ -171,15 +210,55 @@ class MultimodalModel(MegatronModule):
             )
 
         combined = text_embeddings.transpose(0, 1).contiguous()
-        image_mask = input_ids == self.image_token_id
-        mask_expanded = image_mask.unsqueeze(-1).expand_as(combined)
-        combined = combined.masked_scatter(mask_expanded, vision_embeddings)
+        if vision_token_indices is None:
+            image_mask = input_ids == self.image_token_id
+            num_slots = int(image_mask.sum())
+            if vision_embeddings.ndim != 2 or vision_embeddings.shape[0] != num_slots:
+                raise ValueError(
+                    f"Found {num_slots} image-token positions but received vision embeddings "
+                    f"with shape {tuple(vision_embeddings.shape)}."
+                )
+            mask_expanded = image_mask.unsqueeze(-1).expand_as(combined)
+            combined = combined.masked_scatter(
+                mask_expanded, vision_embeddings.to(device=combined.device, dtype=combined.dtype)
+            )
+        else:
+            if vision_token_indices.ndim == 2 and vision_token_indices.shape[1] == 2:
+                vision_token_indices = (
+                    vision_token_indices[:, 0] * input_ids.shape[1] + vision_token_indices[:, 1]
+                )
+            if vision_token_indices.ndim != 1:
+                raise ValueError(
+                    "vision_token_indices must be flattened [N] or (batch, sequence) pairs [N, 2]."
+                )
+            if vision_embeddings.ndim != 2 or vision_embeddings.shape[0] != len(
+                vision_token_indices
+            ):
+                raise ValueError(
+                    f"Received {len(vision_token_indices)} vision token positions but vision "
+                    f"embeddings have shape {tuple(vision_embeddings.shape)}."
+                )
+            flat = combined.view(-1, combined.shape[-1])
+            flat = flat.index_copy(
+                0,
+                vision_token_indices.to(device=flat.device, dtype=torch.long),
+                vision_embeddings.to(device=flat.device, dtype=flat.dtype),
+            )
+            combined = flat.view_as(combined)
         combined = combined.transpose(0, 1).contiguous()
 
         if sp:
             combined = tensor_parallel.scatter_to_sequence_parallel_region(combined)
 
         return combined
+
+    def _embed_input_ids(self, input_ids: Tensor) -> Tensor:
+        """Embed decoder token IDs. Subclasses may sanitize synthetic IDs."""
+        return self.language_model.embedding(input_ids=input_ids, position_ids=None)
+
+    def prepare_attention_mask(self, input_ids: Tensor, attention_mask, packed_seq_params=None):
+        """Build model-specific attention metadata before CP partitioning."""
+        return attention_mask
 
     def compute_position_ids(
         self, input_ids: Tensor, image_grid_thw: Optional[Tensor] = None, packed_seq_params=None
@@ -217,8 +296,13 @@ class MultimodalModel(MegatronModule):
         cp_size = parallel_state.get_context_parallel_world_size()
         if cp_size <= 1:
             return (
-                decoder_input, input_ids, labels, loss_mask,
-                attention_mask, position_ids, padding_mask,
+                decoder_input,
+                input_ids,
+                labels,
+                loss_mask,
+                attention_mask,
+                position_ids,
+                padding_mask,
             )
         cp_rank = parallel_state.get_context_parallel_rank()
 
@@ -245,7 +329,11 @@ class MultimodalModel(MegatronModule):
                 return (
                     None
                     if t is None
-                    else _cp_split_tensor(t, seq_dim=seq_dim, cp_size=cp_size, cp_rank=cp_rank)
+                    else (
+                        _cp_split_tensor(t, seq_dim=seq_dim, cp_size=cp_size, cp_rank=cp_rank)
+                        if isinstance(t, Tensor)
+                        else t
+                    )
                 )
 
             decoder_input = _split(decoder_input, 0)
@@ -256,8 +344,13 @@ class MultimodalModel(MegatronModule):
             padding_mask = _split(padding_mask, 1)
 
         return (
-            decoder_input, input_ids, labels, loss_mask,
-            attention_mask, position_ids, padding_mask,
+            decoder_input,
+            input_ids,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            padding_mask,
         )
 
     @staticmethod
@@ -315,6 +408,8 @@ class MultimodalModel(MegatronModule):
         pixel_values: Tensor = None,
         image_grid_thw: Tensor = None,
         decoder_input: Tensor = None,
+        vision_embeddings: Tensor = None,
+        vision_token_indices: Tensor = None,
         packed_seq_params=None,
         **kwargs,
     ):
@@ -335,6 +430,10 @@ class MultimodalModel(MegatronModule):
             pixel_values: Preprocessed image pixels.
             image_grid_thw: ``[num_images, 3]`` grid dimensions.
             decoder_input: Pre-computed decoder input (skip embed).
+            vision_embeddings: Pre-computed visual embeddings. This bypasses
+                ``vision_model`` and is the stable injection point for MDP.
+            vision_token_indices: Optional flattened ``[B*S]`` decoder positions
+                for externally supplied visual rows.
             packed_seq_params: ``PackedSeqParams`` for THD attention.
 
         Returns:
@@ -347,23 +446,36 @@ class MultimodalModel(MegatronModule):
                 packed_seq_params=packed_seq_params,
             )
 
-        vision_embeddings = None
-        if self.vision_model is not None and pixel_values is not None:
+        if vision_embeddings is not None and pixel_values is not None:
+            raise ValueError("Pass either pixel_values or vision_embeddings, not both.")
+        if vision_embeddings is None and self.vision_model is not None and pixel_values is not None:
             vision_embeddings = self.vision_model(pixel_values, image_grid_thw)
 
         if decoder_input is None and self.language_model is not None:
-            text_embeddings = self.language_model.embedding(input_ids=input_ids, position_ids=None)
+            text_embeddings = self._embed_input_ids(input_ids)
 
             if vision_embeddings is not None:
                 decoder_input = self._scatter_vision_embeddings(
-                    input_ids, text_embeddings, vision_embeddings
+                    input_ids,
+                    text_embeddings,
+                    vision_embeddings,
+                    vision_token_indices=vision_token_indices,
                 )
             else:
                 decoder_input = text_embeddings
 
+        attention_mask = self.prepare_attention_mask(
+            input_ids, attention_mask, packed_seq_params=packed_seq_params
+        )
+
         (
-            decoder_input, input_ids, labels, loss_mask,
-            attention_mask, position_ids, padding_mask,
+            decoder_input,
+            input_ids,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            padding_mask,
         ) = self._cp_split_for_forward(
             decoder_input=decoder_input,
             input_ids=input_ids,

--- a/examples/multimodal_dev/models/deepseek_v4/__init__.py
+++ b/examples/multimodal_dev/models/deepseek_v4/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""DeepSeek-V4-Flash-Vision model package."""
+
+from examples.multimodal_dev.models.deepseek_v4.configuration import (
+    DEEPSEEK_V4_FLASH_VISION_COMPRESS_RATIOS,
+    DEEPSEEK_V4_FLASH_VISION_HYBRID_PATTERN,
+    DEEPSEEK_V4_VOCAB_SIZE,
+    build_image_block,
+    build_image_token_visibility,
+    get_deepseek_v4_vision_config,
+)
+from examples.multimodal_dev.models.deepseek_v4.factory import (
+    build_model,
+    post_language_config,
+    set_vision_flops_metadata,
+)
+from examples.multimodal_dev.models.deepseek_v4.model import DeepSeekV4VisionModel
+from examples.multimodal_dev.models.deepseek_v4.vision_encoder import DeepSeekV4VisionEncoder
+
+__all__ = [
+    "DEEPSEEK_V4_FLASH_VISION_COMPRESS_RATIOS",
+    "DEEPSEEK_V4_FLASH_VISION_HYBRID_PATTERN",
+    "DEEPSEEK_V4_VOCAB_SIZE",
+    "DeepSeekV4VisionEncoder",
+    "DeepSeekV4VisionModel",
+    "build_image_block",
+    "build_image_token_visibility",
+    "build_model",
+    "get_deepseek_v4_vision_config",
+    "post_language_config",
+    "set_vision_flops_metadata",
+]

--- a/examples/multimodal_dev/models/deepseek_v4/configuration.py
+++ b/examples/multimodal_dev/models/deepseek_v4/configuration.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""DeepSeek-V4-Flash-Vision configuration and image-layout helpers."""
+
+import math
+from typing import Optional
+
+import torch
+
+from megatron.core.transformer.experimental_attention_variant.csa import SparseAttentionVisibility
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+DEEPSEEK_V4_VOCAB_SIZE = 129_280
+
+IMAGE_START = 0
+IMAGE_PAD = 1
+IMAGE = 2
+IMAGE_NEW_LINE = 3
+IMAGE_END = 4
+NUM_IMAGE_TOKEN_TYPES = 5
+
+VISION_PATCH_SIZE = 14
+VISION_DOWNSAMPLE_RATIO = 3
+VISION_MAX_IMAGE_TOKENS = 384
+VISION_MIN_PIXELS = 147_456
+VISION_MAX_WH_RATIO = 8
+VISION_ROPE_THETA = 10_000.0
+COMPRESS_PAD_TO = 4
+
+# Forty-three decoder blocks. Each HybridModel block is one attention symbol and one MoE symbol.
+DEEPSEEK_V4_FLASH_VISION_HYBRID_PATTERN = "WEWECE" + "HECE" * 20
+DEEPSEEK_V4_FLASH_VISION_COMPRESS_RATIOS = [0, 0, 4] + [128, 4] * 20
+
+
+def get_deepseek_v4_vision_config(
+    num_layers_override: Optional[int] = None, variant: Optional[str] = None
+) -> TransformerConfig:
+    """Return the official DeepSeek-V4-Flash-Vision ViT configuration.
+
+    ``variant`` is accepted for the common multimodal registry contract. ``proxy`` keeps the
+    official widths and can reduce depth through ``num_layers_override`` so the aligner remains
+    compatible with the 4096-wide language decoder.
+    """
+    if variant not in (None, "flash", "proxy"):
+        raise ValueError(f"Unknown DeepSeek-V4-Vision variant '{variant}'.")
+
+    config = TransformerConfig(
+        num_layers=32 if num_layers_override is None else num_layers_override,
+        hidden_size=1024,
+        num_attention_heads=16,
+        num_query_groups=16,
+        kv_channels=64,
+        ffn_hidden_size=2816,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        gated_linear_unit=True,
+        activation_func=torch.nn.functional.silu,
+        add_bias_linear=False,
+        bias_activation_fusion=False,
+        apply_rope_fusion=False,
+        bf16=False,
+    )
+    # These fields describe the non-Transformer parts of the official vision tower.
+    config.vision_patch_size = VISION_PATCH_SIZE
+    config.vision_downsample_ratio = VISION_DOWNSAMPLE_RATIO
+    config.vision_rope_theta = VISION_ROPE_THETA
+    config.vision_out_hidden_size = 4096
+    config.vision_max_image_tokens = VISION_MAX_IMAGE_TOKENS
+    return config
+
+
+def image_token_id(image_type: int, vocab_size: int = DEEPSEEK_V4_VOCAB_SIZE) -> int:
+    """Return the synthetic token ID for one DeepSeek image token type."""
+    if not 0 <= image_type < NUM_IMAGE_TOKEN_TYPES:
+        raise ValueError(f"Invalid image token type {image_type}.")
+    return vocab_size + image_type
+
+
+def build_image_block(
+    n_llm_h: int, n_llm_w: int, start_pos: int, *, device: Optional[torch.device] = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build official N-layout token types and the aligner-output permutation."""
+    if n_llm_h <= 0 or n_llm_w <= 0:
+        raise ValueError(f"Image grid must be positive, got {n_llm_h}x{n_llm_w}.")
+
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = (rows // 2 * row_len) % 2 * 2
+
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h + [IMAGE_PAD] * (row_len * pad_h),
+        dtype=torch.long,
+        device=device,
+    )
+    order = (
+        torch.arange(rows * row_len, device=device)
+        .view(rows // 2, 2, row_len)
+        .transpose(1, 2)
+        .reshape(-1)
+    )
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.long, device=device)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w, device=device
+    ).view(n_llm_h, n_llm_w)
+    permutation = image_idx[order]
+    permutation = permutation[permutation >= 0]
+
+    types = torch.cat(
+        (
+            torch.full((compress_pad,), IMAGE_PAD, dtype=torch.long, device=device),
+            torch.tensor([IMAGE_START], dtype=torch.long, device=device),
+            types[order],
+            torch.full((pad_last,), IMAGE_PAD, dtype=torch.long, device=device),
+            torch.tensor([IMAGE_END], dtype=torch.long, device=device),
+        )
+    )
+    return types, permutation
+
+
+def build_aligner_permutation(
+    n_vit_h: int,
+    n_vit_w: int,
+    downsample_ratio: int = VISION_DOWNSAMPLE_RATIO,
+    *,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """Return the N-layout permutation for one aligned ViT grid."""
+    n_llm_h = math.ceil(n_vit_h / downsample_ratio)
+    n_llm_w = math.ceil(n_vit_w / downsample_ratio)
+    _, permutation = build_image_block(n_llm_h, n_llm_w, 0, device=device)
+    return permutation
+
+
+def build_image_token_visibility(
+    input_ids: torch.Tensor,
+    vocab_size: int = DEEPSEEK_V4_VOCAB_SIZE,
+    max_image_tokens: int = VISION_MAX_IMAGE_TOKENS,
+) -> SparseAttentionVisibility:
+    """Compute compact bidirectional visibility inside every image token span."""
+    if input_ids.ndim != 2:
+        raise ValueError(f"input_ids must be [batch, sequence], got {tuple(input_ids.shape)}.")
+    seqlen = input_ids.shape[1]
+    positions = torch.arange(seqlen, dtype=torch.int32, device=input_ids.device).unsqueeze(0)
+    is_start = input_ids == image_token_id(IMAGE_START, vocab_size)
+    is_end = input_ids == image_token_id(IMAGE_END, vocab_size)
+    valid = (is_start.cumsum(1) > is_end.cumsum(1)) | is_end
+    starts = torch.where(is_start, positions, 0).cummax(1)[0]
+    left = (positions - starts) * valid
+    ends = torch.where(is_end, positions, seqlen).flip(1).cummin(1)[0].flip(1)
+    right = (ends - positions) * valid
+    return SparseAttentionVisibility(
+        left=left.clamp(max=max_image_tokens - 1),
+        right=right.clamp(max=max_image_tokens),
+        max_span=max_image_tokens,
+    )

--- a/examples/multimodal_dev/models/deepseek_v4/factory.py
+++ b/examples/multimodal_dev/models/deepseek_v4/factory.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Factory functions for DeepSeek-V4-Flash-Vision construction."""
+
+from examples.multimodal_dev.models.deepseek_v4.configuration import (
+    DEEPSEEK_V4_VOCAB_SIZE,
+    VISION_DOWNSAMPLE_RATIO,
+    VISION_PATCH_SIZE,
+)
+from megatron.core.models.hybrid.hybrid_layer_allocation import parse_hybrid_pattern
+
+
+def post_language_config(language_config, args) -> None:
+    """Apply decoder fields that are specific to DSv4's multimodal checkpoint."""
+    if not language_config.moe_router_enable_expert_bias:
+        raise ValueError(
+            "DeepSeek-V4-Vision requires --moe-router-enable-expert-bias for separate "
+            "text and vision-language routing biases."
+        )
+    language_config.actual_vocab_size = DEEPSEEK_V4_VOCAB_SIZE
+    language_config.moe_router_enable_vl_bias = True
+    if language_config.experimental_attention_variant != "dsv4_hybrid":
+        raise ValueError(
+            "DeepSeek-V4-Vision requires experimental_attention_variant='dsv4_hybrid'."
+        )
+    if not language_config.multi_latent_attention:
+        raise ValueError("DeepSeek-V4-Vision requires --multi-latent-attention.")
+
+
+def set_vision_flops_metadata(args, language_config, vision_config) -> None:
+    """Expose the native DSv4 vision dimensions to throughput accounting."""
+    args.count_vision_model_flops = True
+    args.vision_flops_variant = "deepseek_v4"
+    args.vision_num_layers = vision_config.num_layers
+    args.vision_hidden_size = vision_config.hidden_size
+    args.vision_ffn_hidden_size = vision_config.ffn_hidden_size
+    args.vision_num_attention_heads = vision_config.num_attention_heads
+    args.vision_kv_channels = vision_config.kv_channels
+    args.vision_in_channels = 3
+    args.vision_patch_size = VISION_PATCH_SIZE
+    args.vision_temporal_patch_size = 1
+    args.vision_spatial_merge_size = VISION_DOWNSAMPLE_RATIO
+    args.vision_out_hidden_size = language_config.hidden_size
+
+
+def build_model(args, language_config, vision_config, **kwargs):
+    """Build DeepSeek-V4-Flash-Vision on the PR-6315-style HybridModel path."""
+    from examples.multimodal_dev.models.deepseek_v4.model import DeepSeekV4VisionModel
+    from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_dsv4_stack_spec
+
+    pattern = getattr(args, "hybrid_layer_pattern", None)
+    if not pattern:
+        raise ValueError("DeepSeek-V4-Vision requires --hybrid-layer-pattern.")
+    parsed = parse_hybrid_pattern(pattern)
+    if parsed.mtp_num_depths or getattr(args, "mtp_num_layers", 0):
+        raise ValueError("DeepSeek-V4-Vision phase one does not support MTP.")
+    if getattr(args, "position_embedding_type", "rope") != "rope":
+        raise ValueError("DeepSeek-V4-Vision requires --position-embedding-type rope.")
+
+    return DeepSeekV4VisionModel(
+        language_config=language_config,
+        hybrid_stack_spec=hybrid_dsv4_stack_spec(language_config),
+        hybrid_layer_pattern=pattern,
+        vision_config=vision_config,
+        vocab_size=args.padded_vocab_size,
+        actual_vocab_size=DEEPSEEK_V4_VOCAB_SIZE,
+        max_sequence_length=args.max_position_embeddings,
+        build_vision_encoder=not getattr(args, "use_external_vision_embeddings", False),
+        parallel_output=True,
+        share_embeddings_and_output_weights=not getattr(
+            args, "untie_embeddings_and_output_weights", False
+        ),
+    )

--- a/examples/multimodal_dev/models/deepseek_v4/model.py
+++ b/examples/multimodal_dev/models/deepseek_v4/model.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""DeepSeek-V4-Flash-Vision model with a native HybridModel decoder."""
+
+from typing import Optional
+
+import torch
+from torch import Tensor, nn
+
+from examples.multimodal_dev.models.base import MultimodalModel
+from examples.multimodal_dev.models.deepseek_v4.configuration import (
+    DEEPSEEK_V4_VOCAB_SIZE,
+    IMAGE,
+    NUM_IMAGE_TOKEN_TYPES,
+    VISION_MAX_IMAGE_TOKENS,
+    build_image_token_visibility,
+    image_token_id,
+)
+from examples.multimodal_dev.models.deepseek_v4.vision_encoder import DeepSeekV4VisionEncoder
+from megatron.core import parallel_state, tensor_parallel
+from megatron.core.models.hybrid.hybrid_layer_allocation import parse_hybrid_pattern
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class DeepSeekV4VisionModel(MultimodalModel):
+    """Compose the DSv4 vision tower, decoder-side image embeddings, and HybridModel.
+
+    ``vision_embeddings`` plus ``vision_token_indices`` in :meth:`forward` form the stable
+    boundary for a future MDP vision stage. The native and external paths share all decoder-side
+    image-token semantics.
+    """
+
+    def __init__(
+        self,
+        language_config: TransformerConfig,
+        hybrid_stack_spec: ModuleSpec,
+        hybrid_layer_pattern: str,
+        vision_config: TransformerConfig,
+        vocab_size: int = DEEPSEEK_V4_VOCAB_SIZE,
+        actual_vocab_size: int = DEEPSEEK_V4_VOCAB_SIZE,
+        max_sequence_length: int = 4096,
+        build_vision_encoder: bool = True,
+        parallel_output: bool = True,
+        share_embeddings_and_output_weights: bool = False,
+    ) -> None:
+        parsed_pattern = parse_hybrid_pattern(hybrid_layer_pattern)
+        if parsed_pattern.mtp_num_depths:
+            raise ValueError("DeepSeek-V4-Vision phase one does not support MTP.")
+        if actual_vocab_size > vocab_size:
+            raise ValueError(
+                f"actual_vocab_size={actual_vocab_size} exceeds vocab_size={vocab_size}."
+            )
+
+        self.actual_vocab_size = actual_vocab_size
+        self.max_image_tokens = vision_config.vision_max_image_tokens
+        vision_config.params_dtype = language_config.params_dtype
+        vision_config.vision_out_hidden_size = language_config.hidden_size
+        vision_encoder = DeepSeekV4VisionEncoder(vision_config) if build_vision_encoder else None
+
+        super().__init__(
+            language_config=language_config,
+            language_spec=None,
+            vision_encoder=vision_encoder,
+            vocab_size=vocab_size,
+            max_sequence_length=max_sequence_length,
+            image_token_id=image_token_id(IMAGE, actual_vocab_size),
+            position_embedding_type="rope",
+            rotary_percent=language_config.rotary_percent,
+            rotary_base=int(language_config.rotary_base),
+            parallel_output=parallel_output,
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            hybrid_stack_spec=hybrid_stack_spec,
+            hybrid_layer_pattern=hybrid_layer_pattern,
+        )
+
+        dtype = language_config.params_dtype
+        self.image_start = nn.Parameter(torch.empty(language_config.hidden_size, dtype=dtype))
+        self.image_end = nn.Parameter(torch.empty(language_config.hidden_size, dtype=dtype))
+        self.image_newline = nn.Parameter(torch.empty(language_config.hidden_size, dtype=dtype))
+        self.image_pad = nn.Parameter(torch.empty(language_config.hidden_size, dtype=dtype))
+        if language_config.perform_initialization:
+            for parameter in (self.image_start, self.image_end, self.image_newline, self.image_pad):
+                language_config.init_method(parameter)
+
+    def _embed_input_ids(self, input_ids: Tensor) -> Tensor:
+        """Embed text IDs while replacing synthetic image IDs with a safe lookup row."""
+        safe_input_ids = torch.where(
+            (input_ids >= 0) & (input_ids < self.actual_vocab_size),
+            input_ids,
+            torch.zeros_like(input_ids),
+        )
+        return self.language_model.embedding(input_ids=safe_input_ids, position_ids=None)
+
+    def _special_embedding_table(self) -> Tensor:
+        # IMAGE uses image_pad as a temporary value and is overwritten by encoded rows below.
+        return torch.stack(
+            (self.image_start, self.image_pad, self.image_pad, self.image_newline, self.image_end)
+        )
+
+    @staticmethod
+    def _flatten_vision_token_indices(indices: Tensor, batch_size: int, seqlen: int) -> Tensor:
+        if indices.ndim == 1:
+            return indices.long()
+        if indices.ndim == 2 and indices.shape[1] == 2:
+            return (indices[:, 0].long() * seqlen + indices[:, 1].long()).long()
+        raise ValueError(
+            "vision_token_indices must be flattened positions [N] or (batch, sequence) pairs [N, 2]."
+        )
+
+    def _scatter_vision_embeddings(
+        self,
+        input_ids: Tensor,
+        text_embeddings: Tensor,
+        vision_embeddings: Tensor,
+        vision_token_indices: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Install special image embeddings and encoded IMAGE rows into decoder input."""
+        sequence_parallel = (
+            self.config.sequence_parallel
+            and parallel_state.get_tensor_model_parallel_world_size() > 1
+        )
+        if sequence_parallel:
+            text_embeddings = tensor_parallel.gather_from_sequence_parallel_region(
+                text_embeddings, tensor_parallel_output_grad=False
+            )
+
+        batch_size, seqlen = input_ids.shape
+        combined = text_embeddings.transpose(0, 1).contiguous()
+        flat_embeddings = combined.view(-1, combined.shape[-1])
+        flat_ids = input_ids.reshape(-1)
+        image_types = flat_ids - self.actual_vocab_size
+        visual_mask = (image_types >= 0) & (image_types < NUM_IMAGE_TOKEN_TYPES)
+        invalid_visual = (flat_ids >= self.actual_vocab_size) & (~visual_mask)
+        if invalid_visual.any():
+            invalid_id = int(flat_ids[invalid_visual][0].item())
+            raise ValueError(f"Unknown synthetic DeepSeek image token ID {invalid_id}.")
+
+        visual_positions = torch.nonzero(visual_mask, as_tuple=False).flatten()
+        visual_types = image_types.index_select(0, visual_positions)
+        special_rows = self._special_embedding_table().index_select(0, visual_types)
+        flat_embeddings = flat_embeddings.index_copy(
+            0,
+            visual_positions,
+            special_rows.to(device=flat_embeddings.device, dtype=flat_embeddings.dtype),
+        )
+
+        if vision_embeddings.ndim == 3 and vision_embeddings.shape[1] == 1:
+            vision_embeddings = vision_embeddings.squeeze(1)
+        if vision_embeddings.ndim != 2:
+            raise ValueError(
+                f"vision_embeddings must be [num_rows, hidden], got {tuple(vision_embeddings.shape)}."
+            )
+        if vision_token_indices is None:
+            decoder_positions = torch.nonzero(image_types == IMAGE, as_tuple=False).flatten()
+        else:
+            decoder_positions = self._flatten_vision_token_indices(
+                vision_token_indices, batch_size, seqlen
+            ).to(device=input_ids.device)
+            if (decoder_positions < 0).any() or (decoder_positions >= flat_ids.numel()).any():
+                raise ValueError("vision_token_indices contains an out-of-range decoder position.")
+            if not torch.all(image_types.index_select(0, decoder_positions) == IMAGE):
+                raise ValueError("Every vision_token_indices entry must point to an IMAGE token.")
+        if decoder_positions.numel() != vision_embeddings.shape[0]:
+            raise ValueError(
+                f"Found {decoder_positions.numel()} IMAGE positions but received "
+                f"{vision_embeddings.shape[0]} vision embedding rows."
+            )
+        flat_embeddings = flat_embeddings.index_copy(
+            0,
+            decoder_positions,
+            vision_embeddings.to(device=flat_embeddings.device, dtype=flat_embeddings.dtype),
+        )
+        combined = flat_embeddings.view(batch_size, seqlen, -1).transpose(0, 1).contiguous()
+
+        if sequence_parallel:
+            combined = tensor_parallel.scatter_to_sequence_parallel_region(combined)
+        return combined
+
+    def prepare_attention_mask(self, input_ids: Tensor, attention_mask, packed_seq_params=None):
+        """Expand each image span bidirectionally inside DSv4's sparse window."""
+        has_image_tokens = torch.any(input_ids >= self.actual_vocab_size)
+        if not has_image_tokens:
+            return attention_mask
+        if attention_mask is not None:
+            raise ValueError(
+                "DeepSeek-V4 image-span visibility cannot be combined with another attention mask."
+            )
+        return build_image_token_visibility(
+            input_ids, vocab_size=self.actual_vocab_size, max_image_tokens=self.max_image_tokens
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Optional[Tensor],
+        *,
+        pixel_values: Optional[Tensor] = None,
+        vision_embeddings: Optional[Tensor] = None,
+        decoder_input: Optional[Tensor] = None,
+        **kwargs,
+    ):
+        """Run native vision encoding or consume externally supplied visual rows."""
+        has_image_tokens = torch.any(input_ids >= self.actual_vocab_size)
+        if has_image_tokens and all(
+            value is None for value in (pixel_values, vision_embeddings, decoder_input)
+        ):
+            raise ValueError(
+                "Image tokens require pixel_values, vision_embeddings, or a complete decoder_input."
+            )
+        if self.vision_model is None and pixel_values is not None and vision_embeddings is None:
+            raise ValueError(
+                "This model was built without a local vision encoder; pass vision_embeddings "
+                "from the external/MDP vision stage instead of pixel_values."
+            )
+        return super().forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            pixel_values=pixel_values,
+            vision_embeddings=vision_embeddings,
+            decoder_input=decoder_input,
+            **kwargs,
+        )

--- a/examples/multimodal_dev/models/deepseek_v4/vision_encoder.py
+++ b/examples/multimodal_dev/models/deepseek_v4/vision_encoder.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Megatron-native DeepSeek-V4-Flash-Vision encoder and aligner."""
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.utils.checkpoint import checkpoint
+
+from examples.multimodal_dev.models.deepseek_v4.configuration import build_aligner_permutation
+from megatron.core.models.common.vision_module.vision_module import VisionModule
+from megatron.core.transformer.module import mark_keep_in_fp32
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class DeepSeekV4VisionRMSNorm(nn.Module):
+    """RMSNorm matching the official vision reference implementation."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+        self.weight = mark_keep_in_fp32(nn.Parameter(torch.ones(hidden_size, dtype=torch.float32)))
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        """Normalize the final dimension in float32 and restore input dtype."""
+        dtype = hidden_states.dtype
+        states = hidden_states.float()
+        states = states * torch.rsqrt(states.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * states).to(dtype)
+
+
+def get_vision_cos_sin(
+    n_h: int, n_w: int, dim: int, theta: float, device: torch.device
+) -> tuple[Tensor, Tensor]:
+    """Build DeepSeek's row/column 2D rotary tables for one image."""
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim))
+    hpos = torch.arange(n_h, device=device).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w, device=device).unsqueeze(0).expand(n_h, n_w)
+    freqs = (torch.stack((hpos, wpos), dim=-1).reshape(-1, 2, 1).float() * inv_freq).flatten(1)
+    return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+
+
+def apply_vision_rotary(hidden_states: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    """Apply DeepSeek's half-split rotary transform in float32."""
+    dtype = hidden_states.dtype
+    first, second = hidden_states.float().chunk(2, dim=-1)
+    return torch.cat((first * cos - second * sin, second * cos + first * sin), dim=-1).to(dtype)
+
+
+class DeepSeekV4VisionPatchEmbed(nn.Module):
+    """Biasful linear projection over flattened RGB patches."""
+
+    def __init__(self, patch_size: int, hidden_size: int, params_dtype: torch.dtype) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.proj = nn.Linear(3 * patch_size**2, hidden_size, bias=True, dtype=params_dtype)
+
+    def forward(self, patches: Tensor) -> Tensor:
+        """Project ``[num_patches, 3, patch, patch]`` or flattened patches."""
+        patches = patches.flatten(1)
+        return self.proj(patches.to(dtype=self.proj.weight.dtype))
+
+
+class DeepSeekV4VisionAttention(nn.Module):
+    """Full bidirectional vision attention with 2D RoPE."""
+
+    def __init__(self, hidden_size: int, num_heads: int, params_dtype: torch.dtype) -> None:
+        super().__init__()
+        if hidden_size % num_heads != 0:
+            raise ValueError(
+                f"hidden_size={hidden_size} must be divisible by num_heads={num_heads}."
+            )
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.wqkv = nn.Linear(hidden_size, 3 * hidden_size, bias=True, dtype=params_dtype)
+        self.wo = nn.Linear(hidden_size, hidden_size, bias=True, dtype=params_dtype)
+
+    def forward(self, hidden_states: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+        """Apply full self-attention to one image's patch sequence."""
+        num_tokens = hidden_states.shape[0]
+        query, key, value = (
+            projection.view(num_tokens, self.num_heads, self.head_dim)
+            for projection in self.wqkv(hidden_states).chunk(3, dim=-1)
+        )
+        query = apply_vision_rotary(query, cos, sin)
+        key = apply_vision_rotary(key, cos, sin)
+        output = F.scaled_dot_product_attention(
+            query.transpose(0, 1), key.transpose(0, 1), value.transpose(0, 1)
+        )
+        return self.wo(output.transpose(0, 1).reshape(num_tokens, -1))
+
+
+class DeepSeekV4VisionMLP(nn.Module):
+    """Bias-free SwiGLU MLP used by the vision tower."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int, params_dtype: torch.dtype) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(hidden_size, 2 * intermediate_size, bias=False, dtype=params_dtype)
+        self.w2 = nn.Linear(intermediate_size, hidden_size, bias=False, dtype=params_dtype)
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        """Apply the SwiGLU feed-forward network."""
+        gate, up = self.w1(hidden_states).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class DeepSeekV4VisionBlock(nn.Module):
+    """Pre-norm attention and MLP residual block."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        intermediate_size: int,
+        eps: float,
+        params_dtype: torch.dtype,
+    ) -> None:
+        super().__init__()
+        self.norm1 = DeepSeekV4VisionRMSNorm(hidden_size, eps)
+        self.attn = DeepSeekV4VisionAttention(hidden_size, num_heads, params_dtype)
+        self.norm2 = DeepSeekV4VisionRMSNorm(hidden_size, eps)
+        self.mlp = DeepSeekV4VisionMLP(hidden_size, intermediate_size, params_dtype)
+
+    def forward(self, hidden_states: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+        """Run one vision block."""
+        hidden_states = hidden_states + self.attn(self.norm1(hidden_states), cos, sin)
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+class DeepSeekV4VisionAligner(nn.Module):
+    """Pad-and-unfold 3x3 aligner that projects ViT rows to decoder width."""
+
+    def __init__(
+        self,
+        vision_hidden_size: int,
+        language_hidden_size: int,
+        downsample_ratio: int,
+        params_dtype: torch.dtype,
+    ) -> None:
+        super().__init__()
+        self.downsample_ratio = downsample_ratio
+        in_features = vision_hidden_size * downsample_ratio**2
+        self.w1 = nn.Linear(in_features, language_hidden_size, bias=True, dtype=params_dtype)
+        self.w2 = nn.Linear(
+            language_hidden_size, language_hidden_size, bias=True, dtype=params_dtype
+        )
+
+    def forward(self, hidden_states: Tensor, n_h: int, n_w: int) -> Tensor:
+        """Downsample one ``n_h x n_w`` patch grid and project it."""
+        ratio = self.downsample_ratio
+        grid = hidden_states.view(n_h, n_w, -1).permute(2, 0, 1)
+        grid = F.pad(grid, (0, -n_w % ratio, 0, -n_h % ratio))
+        rows = F.unfold(grid.unsqueeze(0), ratio, stride=ratio).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(rows)))
+
+
+class DeepSeekV4VisionEncoder(VisionModule):
+    """DeepSeek-V4 ViT plus aligner, with one full-attention segment per image."""
+
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__(config=config)
+        self.patch_size = config.vision_patch_size
+        self.downsample_ratio = config.vision_downsample_ratio
+        self.rope_theta = config.vision_rope_theta
+        self.rope_dim = config.kv_channels // 2
+
+        self.patch_embed = DeepSeekV4VisionPatchEmbed(
+            self.patch_size, config.hidden_size, config.params_dtype
+        )
+        self.blocks = nn.ModuleList(
+            [
+                DeepSeekV4VisionBlock(
+                    hidden_size=config.hidden_size,
+                    num_heads=config.num_attention_heads,
+                    intermediate_size=config.ffn_hidden_size,
+                    eps=config.layernorm_epsilon,
+                    params_dtype=config.params_dtype,
+                )
+                for _ in range(config.num_layers)
+            ]
+        )
+        self.norm = DeepSeekV4VisionRMSNorm(config.hidden_size, config.layernorm_epsilon)
+        self.aligner = DeepSeekV4VisionAligner(
+            vision_hidden_size=config.hidden_size,
+            language_hidden_size=config.vision_out_hidden_size,
+            downsample_ratio=self.downsample_ratio,
+            params_dtype=config.params_dtype,
+        )
+
+    def _encode_one_image(self, patches: Tensor, n_h: int, n_w: int) -> Tensor:
+        hidden_states = self.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(
+            n_h, n_w, self.rope_dim, self.rope_theta, hidden_states.device
+        )
+        for block in self.blocks:
+            if self.training and self.config.recompute_granularity == "full":
+                hidden_states = checkpoint(block, hidden_states, cos, sin, use_reentrant=False)
+            else:
+                hidden_states = block(hidden_states, cos, sin)
+        hidden_states = self.norm(hidden_states)
+        aligned = self.aligner(hidden_states, n_h, n_w)
+        permutation = build_aligner_permutation(
+            n_h, n_w, self.downsample_ratio, device=aligned.device
+        )
+        return aligned.index_select(0, permutation)
+
+    def forward(self, pixel_values: Tensor, image_grid_thw: Tensor) -> Tensor:
+        """Encode concatenated image patches in batch/image encounter order.
+
+        Args:
+            pixel_values: Concatenated flattened patches ``[total_patches, 3*p*p]``.
+            image_grid_thw: ``[num_images, 3]`` rows containing ``(1, H, W)``.
+
+        Returns:
+            Decoder-width image embeddings in official N-layout IMAGE-token order.
+        """
+        if image_grid_thw is None or image_grid_thw.ndim != 2:
+            raise ValueError("image_grid_thw must be a [num_images, 3] tensor.")
+        if image_grid_thw.shape[1] == 2:
+            image_grid_hw = image_grid_thw
+        elif image_grid_thw.shape[1] == 3:
+            if not torch.all(image_grid_thw[:, 0] == 1):
+                raise ValueError("DeepSeek-V4-Vision currently supports images, not video grids.")
+            image_grid_hw = image_grid_thw[:, 1:]
+        else:
+            raise ValueError(
+                f"image_grid_thw must have 2 or 3 columns, got {image_grid_thw.shape[1]}."
+            )
+
+        outputs = []
+        offset = 0
+        for grid in image_grid_hw:
+            n_h, n_w = int(grid[0].item()), int(grid[1].item())
+            num_patches = n_h * n_w
+            image_patches = pixel_values[offset : offset + num_patches]
+            if image_patches.shape[0] != num_patches:
+                raise ValueError("pixel_values has fewer rows than image_grid_thw describes.")
+            outputs.append(self._encode_one_image(image_patches, n_h, n_w))
+            offset += num_patches
+        if offset != pixel_values.shape[0]:
+            raise ValueError(
+                f"pixel_values has {pixel_values.shape[0]} rows, but grids consume {offset}."
+            )
+        if not outputs:
+            return pixel_values.new_empty((0, self.config.vision_out_hidden_size))
+        return torch.cat(outputs, dim=0)

--- a/examples/multimodal_dev/scripts/run_deepseek_v4_vision.sh
+++ b/examples/multimodal_dev/scripts/run_deepseek_v4_vision.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+# Launch DeepSeek-V4-Flash-Vision through multimodal_dev + HybridModel.
+# Phase one intentionally omits MTP. DRY_RUN=1 is the default.
+#
+# Full architecture:
+#   MODEL_VARIANT=flash NNODES=8 GPUS_PER_NODE=8 NUM_LAYERS=43 \
+#     VISION_NUM_LAYERS=32 EP=64 DRY_RUN=0 \
+#     bash examples/multimodal_dev/scripts/run_deepseek_v4_vision.sh
+# Small construction/smoke proxy:
+#   MODEL_VARIANT=proxy DRY_RUN=0 \
+#     bash examples/multimodal_dev/scripts/run_deepseek_v4_vision.sh
+
+set -euo pipefail
+
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-8}
+export NVTE_FUSED_ATTN=${NVTE_FUSED_ATTN:-1}
+
+DRY_RUN=${DRY_RUN:-1}
+MODEL_VARIANT=${MODEL_VARIANT:-proxy}
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+NNODES=${NNODES:-1}
+MASTER_ADDR=${MASTER_ADDR:-localhost}
+MASTER_PORT=${MASTER_PORT:-6000}
+TP=${TP:-1}
+PP=${PP:-1}
+CP=${CP:-1}
+MBS=${MBS:-1}
+GBS=${GBS:-8}
+SEQ_LEN=${SEQ_LEN:-1024}
+IMAGE_SIZE=${IMAGE_SIZE:-224}
+TRAIN_ITERS=${TRAIN_ITERS:-10}
+USE_FSDP=${USE_FSDP:-1}
+USE_PACKED_SEQUENCE=${USE_PACKED_SEQUENCE:-0}
+USE_EXTERNAL_VISION_EMBEDDINGS=${USE_EXTERNAL_VISION_EMBEDDINGS:-0}
+
+case "$MODEL_VARIANT" in
+    flash)
+        NUM_LAYERS=${NUM_LAYERS:-43}
+        VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-32}
+        NUM_EXPERTS=${NUM_EXPERTS:-256}
+        ROUTER_TOPK=${ROUTER_TOPK:-6}
+        HASH_LAYERS=${HASH_LAYERS:-3}
+        EP=${EP:-64}
+        DSA_KERNEL_BACKEND=${DSA_KERNEL_BACKEND:-cudnn}
+        ;;
+    proxy)
+        NUM_LAYERS=${NUM_LAYERS:-3}
+        VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-2}
+        NUM_EXPERTS=${NUM_EXPERTS:-8}
+        ROUTER_TOPK=${ROUTER_TOPK:-2}
+        HASH_LAYERS=${HASH_LAYERS:-3}
+        EP=${EP:-1}
+        DSA_KERNEL_BACKEND=${DSA_KERNEL_BACKEND:-none}
+        ;;
+    *)
+        echo "Unsupported MODEL_VARIANT=$MODEL_VARIANT (expected flash or proxy)" >&2
+        exit 1
+        ;;
+esac
+
+if [ "$TP" -ne 1 ]; then
+    echo "DeepSeek-V4 hybrid attention currently requires TP=1." >&2
+    exit 1
+fi
+if [ "$PP" -ne 1 ]; then
+    echo "multimodal_dev currently requires PP=1." >&2
+    exit 1
+fi
+if [ "$HASH_LAYERS" -gt "$NUM_LAYERS" ]; then
+    echo "HASH_LAYERS=$HASH_LAYERS exceeds NUM_LAYERS=$NUM_LAYERS." >&2
+    exit 1
+fi
+
+# Official main-decoder cadence: W, W, C, then H/C alternating. Each decoder
+# block is represented as one HybridModel attention layer followed by one MoE layer.
+HYBRID_LAYER_PATTERN=""
+COMPRESS_RATIOS="["
+for ((layer = 0; layer < NUM_LAYERS; layer++)); do
+    if [ "$layer" -lt 2 ]; then
+        symbol="W"
+        ratio=0
+    elif [ "$layer" -eq 2 ]; then
+        symbol="C"
+        ratio=4
+    elif [ $(((layer - 3) % 2)) -eq 0 ]; then
+        symbol="H"
+        ratio=128
+    else
+        symbol="C"
+        ratio=4
+    fi
+    HYBRID_LAYER_PATTERN+="${symbol}E"
+    if [ "$layer" -gt 0 ]; then
+        COMPRESS_RATIOS+=","
+    fi
+    COMPRESS_RATIOS+="$ratio"
+done
+COMPRESS_RATIOS+="]"
+
+MEGATRON_LM_PATH=${MEGATRON_LM_PATH:-$(cd "$(dirname "$0")/../../.." && pwd)}
+OUTPUT_DIR=${OUTPUT_DIR:-${MEGATRON_LM_PATH}/local/dsv4_vision_${MODEL_VARIANT}}
+TOKENIZER_MODEL=${TOKENIZER_MODEL:-deepseek-ai/DeepSeek-V4-Flash-Vision-Exp}
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node "$GPUS_PER_NODE"
+    --nnodes "$NNODES"
+    --master_addr "$MASTER_ADDR"
+    --master_port "$MASTER_PORT"
+)
+
+MODEL_ARGS=(
+    --model-arch deepseek_v4_vision
+    --model-variant "$MODEL_VARIANT"
+    --hybrid-layer-pattern "$HYBRID_LAYER_PATTERN"
+    --hidden-size 4096
+    --ffn-hidden-size 2048
+    --num-attention-heads 64
+    --kv-channels 512
+    --max-position-embeddings "$SEQ_LEN"
+    --seq-length "$SEQ_LEN"
+    --normalization RMSNorm
+    --norm-epsilon 1e-20
+    --swiglu
+    --disable-bias-linear
+    --untie-embeddings-and-output-weights
+    --position-embedding-type rope
+    --rotary-base 10000
+    --rotary-scaling-factor 16
+    --original-max-position-embeddings 65536
+    --mscale 1.0
+    --mscale-all-dim 1.0
+    --multi-latent-attention
+    --q-lora-rank 1024
+    --qk-pos-emb-head-dim 64
+    --v-head-dim 512
+    --qk-layernorm
+    --o-groups 8
+    --o-lora-rank 1024
+    --experimental-attention-variant dsv4_hybrid
+    --csa-window-size 128
+    --csa-compress-ratios "$COMPRESS_RATIOS"
+    --csa-compress-rotary-base 160000
+    --dsa-indexer-n-heads 64
+    --dsa-indexer-head-dim 128
+    --dsa-indexer-topk 512
+    --dsa-indexer-loss-coeff 1e-2
+    --dsa-indexer-use-sparse-loss
+    --dsa-kernel-backend "$DSA_KERNEL_BACKEND"
+    --num-experts "$NUM_EXPERTS"
+    --moe-n-hash-layers "$HASH_LAYERS"
+    --moe-ffn-hidden-size 2048
+    --moe-shared-expert-intermediate-size 2048
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-topk "$ROUTER_TOPK"
+    --moe-aux-loss-coeff 1e-4
+    --moe-router-topk-scaling-factor 1.5
+    --moe-router-score-function sqrtsoftplus
+    --moe-router-dtype fp32
+    --moe-router-enable-expert-bias
+    --moe-router-bias-update-rate 1e-3
+    --activation-func-clamp-value 10.0
+    --enable-hyper-connections
+    --num-residual-streams 4
+    --mhc-sinkhorn-iterations 20
+    --use-fused-mhc
+    --vision-num-layers "$VISION_NUM_LAYERS"
+    --make-vocab-size-divisible-by 3232
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+)
+
+DATA_ARGS=(
+    --dataset-provider mock
+    --use-vanilla-collate-fn
+    --image-size "$IMAGE_SIZE"
+    --total-seq-length "$SEQ_LEN"
+    --dataloader-type cyclic
+    --num-workers 0
+    --tokenizer-type HuggingFaceTokenizer
+    --tokenizer-model "$TOKENIZER_MODEL"
+)
+
+PARALLEL_ARGS=(
+    --tensor-model-parallel-size "$TP"
+    --pipeline-model-parallel-size "$PP"
+    --expert-model-parallel-size "$EP"
+    --context-parallel-size "$CP"
+    --expert-tensor-parallel-size 1
+    --sequence-parallel
+    --use-distributed-optimizer
+)
+
+TRAINING_ARGS=(
+    --micro-batch-size "$MBS"
+    --global-batch-size "$GBS"
+    --train-iters "$TRAIN_ITERS"
+    --lr 3.9e-6
+    --min-lr 3.9e-7
+    --lr-decay-style cosine
+    --lr-warmup-iters 1
+    --weight-decay 0.1
+    --clip-grad 1.0
+    --adam-beta1 0.9
+    --adam-beta2 0.95
+    --bf16
+    --use-mcore-models
+    --transformer-impl transformer_engine
+    --cross-entropy-loss-fusion
+    --cross-entropy-fusion-impl native
+    --calculate-per-token-loss
+    --enable-experimental
+    --log-interval 1
+    --eval-interval 1000
+    --eval-iters 0
+    --save-interval 1000
+    --save "$OUTPUT_DIR"
+)
+
+EXTRA_ARGS=()
+if [ "$USE_PACKED_SEQUENCE" -eq 1 ]; then
+    EXTRA_ARGS+=(--use-packed-sequence)
+fi
+if [ "$USE_EXTERNAL_VISION_EMBEDDINGS" -eq 1 ]; then
+    EXTRA_ARGS+=(--use-external-vision-embeddings)
+fi
+if [ "$USE_FSDP" -eq 1 ]; then
+    EXTRA_ARGS+=(
+        --use-megatron-fsdp
+        --data-parallel-sharding-strategy optim_grads_params
+        --init-model-with-meta-device
+        --ckpt-format fsdp_dtensor
+    )
+fi
+
+cmd=(
+    torchrun "${DISTRIBUTED_ARGS[@]}"
+    "$MEGATRON_LM_PATH/examples/multimodal_dev/pretrain_multimodal.py"
+    "${MODEL_ARGS[@]}"
+    "${DATA_ARGS[@]}"
+    "${PARALLEL_ARGS[@]}"
+    "${TRAINING_ARGS[@]}"
+    "${EXTRA_ARGS[@]}"
+)
+
+echo "DeepSeek-V4-Flash-Vision (MTP disabled)"
+echo "  hybrid pattern: $HYBRID_LAYER_PATTERN"
+echo "  compress ratios: $COMPRESS_RATIOS"
+echo "${cmd[@]}"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    mkdir -p "$OUTPUT_DIR"
+    "${cmd[@]}"
+fi

--- a/examples/multimodal_dev/tests/test_deepseek_v4_vision.py
+++ b/examples/multimodal_dev/tests/test_deepseek_v4_vision.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Focused architecture tests for native DeepSeek-V4-Flash-Vision support."""
+
+import inspect
+import math
+from types import SimpleNamespace
+
+import torch
+
+from examples.multimodal_dev.data.deepseek_v4_mock import MockDeepSeekV4VisionDataset
+from examples.multimodal_dev.models.deepseek_v4.configuration import (
+    DEEPSEEK_V4_FLASH_VISION_COMPRESS_RATIOS,
+    DEEPSEEK_V4_FLASH_VISION_HYBRID_PATTERN,
+    DEEPSEEK_V4_VOCAB_SIZE,
+    IMAGE,
+    IMAGE_END,
+    IMAGE_START,
+    build_image_block,
+    build_image_token_visibility,
+    get_deepseek_v4_vision_config,
+)
+from examples.multimodal_dev.models.deepseek_v4.model import DeepSeekV4VisionModel
+from examples.multimodal_dev.models.deepseek_v4.vision_encoder import DeepSeekV4VisionEncoder
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def test_official_vision_config_and_hybrid_pattern():
+    config = get_deepseek_v4_vision_config()
+    layers = validate_segment_layers(DEEPSEEK_V4_FLASH_VISION_HYBRID_PATTERN)
+
+    assert config.num_layers == 32
+    assert config.hidden_size == 1024
+    assert config.num_attention_heads == 16
+    assert config.ffn_hidden_size == 2816
+    assert config.vision_patch_size == 14
+    assert config.vision_downsample_ratio == 3
+    assert len(layers) == 86
+    assert layers[1::2] == [Symbols.MOE] * 43
+    assert DEEPSEEK_V4_FLASH_VISION_COMPRESS_RATIOS == [0, 0, 4] + [128, 4] * 20
+
+
+def test_image_block_has_official_n_layout_and_permutation():
+    n_llm_h, n_llm_w = 3, 2
+    types, permutation = build_image_block(n_llm_h, n_llm_w, start_pos=5)
+
+    assert (types == IMAGE_START).sum().item() == 1
+    assert types[2].item() == IMAGE_START
+    assert types[-1].item() == IMAGE_END
+    assert (types == IMAGE).sum().item() == n_llm_h * n_llm_w
+    assert torch.equal(permutation.sort().values, torch.arange(n_llm_h * n_llm_w))
+
+
+def test_image_visibility_matches_bidirectional_span_contract():
+    start = DEEPSEEK_V4_VOCAB_SIZE + IMAGE_START
+    end = DEEPSEEK_V4_VOCAB_SIZE + IMAGE_END
+    input_ids = torch.tensor([[11, start, DEEPSEEK_V4_VOCAB_SIZE + IMAGE, end, 12]])
+
+    visibility = build_image_token_visibility(input_ids, max_image_tokens=16)
+
+    assert torch.equal(visibility.left, torch.tensor([[0, 0, 1, 2, 0]], dtype=torch.int32))
+    assert torch.equal(visibility.right, torch.tensor([[0, 2, 1, 0, 0]], dtype=torch.int32))
+
+
+def _tiny_vision_config() -> TransformerConfig:
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_query_groups=4,
+        kv_channels=4,
+        ffn_hidden_size=12,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        use_cpu_initialization=True,
+    )
+    config.vision_patch_size = 2
+    config.vision_downsample_ratio = 2
+    config.vision_rope_theta = 10_000.0
+    config.vision_out_hidden_size = 8
+    config.vision_max_image_tokens = 16
+    return config
+
+
+def test_tiny_vision_encoder_shape_and_backward():
+    config = _tiny_vision_config()
+    encoder = DeepSeekV4VisionEncoder(config)
+    n_h, n_w = 3, 5
+    patches = torch.randn(n_h * n_w, 3 * config.vision_patch_size**2, requires_grad=True)
+    grid = torch.tensor([[1, n_h, n_w]])
+
+    output = encoder(patches, grid)
+
+    assert output.shape == (
+        math.ceil(n_h / config.vision_downsample_ratio)
+        * math.ceil(n_w / config.vision_downsample_ratio),
+        config.vision_out_hidden_size,
+    )
+    output.sum().backward()
+    assert patches.grad is not None
+
+
+def test_vision_parameter_precision_contract():
+    config = _tiny_vision_config()
+    config.num_layers = 0
+    config.params_dtype = torch.bfloat16
+
+    encoder = DeepSeekV4VisionEncoder(config)
+
+    assert encoder.patch_embed.proj.weight.dtype == torch.bfloat16
+    assert encoder.aligner.w1.weight.dtype == torch.bfloat16
+    assert encoder.norm.weight.dtype == torch.float32
+    assert encoder.norm.weight.keep_in_fp32
+
+
+def test_forward_exposes_future_mdp_embedding_injection_seam():
+    parameters = inspect.signature(DeepSeekV4VisionModel.forward).parameters
+
+    assert "vision_embeddings" in parameters
+    assert "decoder_input" in parameters
+
+
+def test_external_vision_rows_share_native_special_embedding_merge():
+    model = DeepSeekV4VisionModel.__new__(DeepSeekV4VisionModel)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(sequence_parallel=False)
+    model.actual_vocab_size = 10
+    model.image_start = torch.nn.Parameter(torch.full((3,), 1.0))
+    model.image_pad = torch.nn.Parameter(torch.full((3,), 2.0))
+    model.image_newline = torch.nn.Parameter(torch.full((3,), 4.0))
+    model.image_end = torch.nn.Parameter(torch.full((3,), 5.0))
+    input_ids = torch.tensor(
+        [[1, 10 + IMAGE_START, 10 + IMAGE, 10 + IMAGE_END, 2]], dtype=torch.long
+    )
+    text_embeddings = torch.zeros(5, 1, 3)
+    vision_embeddings = torch.full((1, 3), 3.0, requires_grad=True)
+
+    merged = model._scatter_vision_embeddings(
+        input_ids, text_embeddings, vision_embeddings, vision_token_indices=torch.tensor([[0, 2]])
+    )
+
+    assert torch.equal(merged[:, 0, 0], torch.tensor([0.0, 1.0, 3.0, 5.0, 0.0]))
+    merged.sum().backward()
+    assert torch.equal(vision_embeddings.grad, torch.ones_like(vision_embeddings))
+
+
+def test_sparse_visibility_metadata_is_safe_for_full_recompute(monkeypatch):
+    from megatron.core import recompute
+
+    visibility = build_image_token_visibility(
+        torch.tensor(
+            [[1, DEEPSEEK_V4_VOCAB_SIZE + IMAGE_START, DEEPSEEK_V4_VOCAB_SIZE + IMAGE_END]]
+        )
+    )
+    seen = {}
+
+    class Layer:
+        layer_number = 1
+
+        def __call__(self, hidden_states, attention_mask, **kwargs):
+            seen["attention_mask"] = attention_mask
+            return hidden_states + 1
+
+    stack = SimpleNamespace(
+        config=SimpleNamespace(
+            recompute_method="uniform",
+            recompute_num_layers=1,
+            distribute_saved_activations=False,
+            fp8=False,
+            fp4=None,
+        ),
+        layers=[Layer()],
+        num_layers_per_pipeline_rank=1,
+        pg_collection=SimpleNamespace(tp=None),
+    )
+
+    def checkpoint_without_autograd(function, distribute_saved_activations, *args):
+        del distribute_saved_activations
+        assert all(argument is None or isinstance(argument, torch.Tensor) for argument in args)
+        return function(*args)
+
+    monkeypatch.setattr(recompute.tensor_parallel, "checkpoint", checkpoint_without_autograd)
+    hidden_states = torch.zeros(3, 1, 2)
+
+    output = recompute.checkpointed_forward(
+        stack,
+        hidden_states=hidden_states,
+        attention_mask=visibility,
+        context=None,
+        context_mask=None,
+        rotary_pos_emb=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        use_inner_quantization_context=False,
+        padding_mask=None,
+    )
+
+    assert seen["attention_mask"] is visibility
+    assert torch.equal(output, hidden_states + 1)
+
+
+def test_mock_dataset_never_uses_synthetic_ids_as_lm_targets():
+    sample = MockDeepSeekV4VisionDataset(num_samples=1, seq_length=128, image_size=42)[0]
+
+    assert torch.all(sample["labels"][sample["loss_mask"] == 0] == -100)
+    assert torch.all(sample["labels"][sample["loss_mask"] == 1] < DEEPSEEK_V4_VOCAB_SIZE)

--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -326,6 +326,12 @@ def reset_model_temporary_tensors(config: TransformerConfig, model: List[torch.n
             ):
                 module.local_tokens_per_expert.zero_()
             if (
+                config.moe_router_enable_vl_bias
+                and hasattr(module, 'expert_bias_vl')
+                and module.expert_bias_vl is not None
+            ):
+                module.local_tokens_per_expert_vl.zero_()
+            if (
                 config.moe_router_load_balancing_type == "global_aux_loss"
                 or "global_aux_loss" in config.moe_router_load_balancing_type
             ) and hasattr(module, 'reset_global_aux_loss_tracker'):
@@ -349,14 +355,15 @@ def _update_router_expert_bias(
             # cases where only the student is in training mode but the teacher is in eval mode
             # when using online knoweldge-distillation with Model-Optimizer. In this case, we want
             # to avoid updating teacher's expert_bias.
-            if (
-                hasattr(module, 'expert_bias')
-                and module.training
-                and module.expert_bias is not None
-                and not getattr(module, 'frozen_expert_bias', False)
-            ):
-                tokens_per_expert_list.append(module.local_tokens_per_expert)
-                expert_bias_list.append(module.expert_bias)
+            if module.training and not getattr(module, 'frozen_expert_bias', False):
+                for bias_name, counts_name in (
+                    ('expert_bias', 'local_tokens_per_expert'),
+                    ('expert_bias_vl', 'local_tokens_per_expert_vl'),
+                ):
+                    expert_bias = getattr(module, bias_name, None)
+                    if expert_bias is not None:
+                        tokens_per_expert_list.append(getattr(module, counts_name))
+                        expert_bias_list.append(expert_bias)
     # For hybrid models with both MoE and Dense layers, this list can be empty.
     if len(expert_bias_list) == 0:
         return

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -577,7 +577,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
         # Pass input_ids to decoder for hash-based MoE routing.
         decoder_extra_block_kwargs = {}
-        if self.config.moe_n_hash_layers > 0 and input_ids is not None:
+        if (
+            self.config.moe_n_hash_layers > 0 or self.config.moe_router_enable_vl_bias
+        ) and input_ids is not None:
             decoder_extra_block_kwargs['input_ids'] = input_ids
 
         # Run decoder.

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -51,10 +51,24 @@ def checkpointed_forward(
         extract_layer_indices = set()
     intermediate_hidden_states: List[Tensor] = []
 
+    # ``CheckpointFunction`` can save only tensors (and ``None``). Some sparse-attention
+    # variants carry compact, read-only metadata objects as ``attention_mask`` instead of a
+    # dense tensor. Keep that metadata in this invocation's closure and pass a ``None``
+    # placeholder through the checkpoint autograd function. The metadata is derived from token
+    # IDs, never requires gradients, and the same object must be reused during recomputation.
+    attention_mask_metadata = (
+        attention_mask
+        if attention_mask is not None and not isinstance(attention_mask, Tensor)
+        else None
+    )
+    checkpoint_attention_mask = None if attention_mask_metadata is not None else attention_mask
+
     def custom(start: int, end: int):
         def custom_forward(
             hidden_states, attention_mask, context, context_mask, rotary_pos_emb, padding_mask=None
         ):
+            if attention_mask_metadata is not None:
+                attention_mask = attention_mask_metadata
             for index in range(start, end):
                 # Use self.layers[index] (not self._get_layer) so this
                 # function works for both TransformerBlock and HybridStack.
@@ -124,7 +138,14 @@ def checkpointed_forward(
     def chunk_runner(start: int, end: int, use_checkpoint: bool):
         nonlocal hidden_states, context
         cf = custom(start, end)
-        args = (hidden_states, attention_mask, context, context_mask, rotary_pos_emb, padding_mask)
+        args = (
+            hidden_states,
+            checkpoint_attention_mask,
+            context,
+            context_mask,
+            rotary_pos_emb,
+            padding_mask,
+        )
         if use_checkpoint:
             # Precision-aware activation checkpoint: TE under FP8/FP4,
             # tensor_parallel under BF16/FP16/FP32.

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -56,6 +56,20 @@ from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class SparseAttentionVisibility:
+    """Compact per-token extension of a causal sliding-attention window.
+
+    ``left`` and ``right`` contain the additional visible-token counts around each query.
+    A zero pair preserves ordinary causal sliding-window attention. This representation avoids
+    materializing an ``[B, S, S]`` mask and is used by DeepSeek-V4-Vision image spans.
+    """
+
+    left: torch.Tensor
+    right: torch.Tensor
+    max_span: int
+
+
 @lru_cache(maxsize=8)
 def _get_window_topk_idxs_cached(window_size: int, seqlen: int, device_str: str) -> torch.Tensor:
     """Compute sliding-window indices for a single sequence (cached).
@@ -76,6 +90,28 @@ def get_window_topk_idxs(
     """Sliding-window indices [batch, seqlen, window_size]."""
     matrix = _get_window_topk_idxs_cached(window_size, seqlen, str(device))
     return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def get_window_topk_idxs_visible(
+    window_size: int, seqlen: int, visibility: SparseAttentionVisibility, device: torch.device
+) -> torch.Tensor:
+    """Sliding-window indices extended by compact left/right visibility counts."""
+    left = visibility.left.to(device=device)
+    right = visibility.right.to(device=device)
+    if left.shape != right.shape or left.ndim != 2 or left.shape[1] != seqlen:
+        raise ValueError(
+            "Sparse attention visibility must provide matching [batch, sequence] tensors; "
+            f"got left={tuple(left.shape)}, right={tuple(right.shape)}, seqlen={seqlen}."
+        )
+
+    width = min(seqlen, window_size + visibility.max_span)
+    positions = torch.arange(seqlen, device=device, dtype=left.dtype).unsqueeze(0)
+    left_add = (left - (window_size - 1)).clamp(min=0)
+    starts = (positions - (window_size - 1) - left_add).clamp(min=0)
+    matrix = starts.unsqueeze(-1) + torch.arange(width, device=device, dtype=left.dtype)
+    max_visible = (positions + right).clamp(max=seqlen - 1)
+    matrix = torch.where(matrix > max_visible.unsqueeze(-1), -1, matrix)
+    return matrix.int().contiguous()
 
 
 @lru_cache(maxsize=8)
@@ -257,6 +293,48 @@ def get_window_topk_idxs_thd(
     matrix = torch.where(matrix > pos_in_seq.unsqueeze(1), torch.full_like(matrix, -1), matrix)
     matrix = torch.where(valid.unsqueeze(1), matrix, torch.full_like(matrix, -1))
     return matrix.int()
+
+
+def get_window_topk_idxs_visible_thd(
+    window_size: int,
+    cu_seqlens_q: torch.Tensor,
+    visibility: SparseAttentionVisibility,
+    total_q: Optional[int] = None,
+) -> torch.Tensor:
+    """Packed-THD counterpart of :func:`get_window_topk_idxs_visible`.
+
+    Returned indices remain local to each packed segment, matching
+    :func:`get_window_topk_idxs_thd` and the CSA full-KV layout.
+    """
+    if total_q is None:
+        total_q = int(cu_seqlens_q[-1].item())
+    device = cu_seqlens_q.device
+    left = visibility.left.reshape(-1).to(device=device, dtype=cu_seqlens_q.dtype)
+    right = visibility.right.reshape(-1).to(device=device, dtype=cu_seqlens_q.dtype)
+    if left.numel() != total_q or right.numel() != total_q:
+        raise ValueError(
+            "Packed sparse attention visibility must have one entry per query token; "
+            f"got left={left.numel()}, right={right.numel()}, total_q={total_q}."
+        )
+
+    batch_of_token = batch_of_row(cu_seqlens_q, total_q=total_q)
+    token_idx = torch.arange(total_q, device=device, dtype=cu_seqlens_q.dtype)
+    valid = token_idx < cu_seqlens_q[-1]
+    segment_starts = cu_seqlens_q[batch_of_token]
+    segment_lengths = cu_seqlens_q[batch_of_token + 1] - segment_starts
+    positions = token_idx - segment_starts
+    positions = torch.where(valid, positions, torch.zeros_like(positions))
+
+    width = min(total_q, window_size + visibility.max_span)
+    left_add = (left - (window_size - 1)).clamp(min=0)
+    starts = (positions - (window_size - 1) - left_add).clamp(min=0)
+    matrix = starts.unsqueeze(1) + torch.arange(
+        width, device=device, dtype=cu_seqlens_q.dtype
+    ).unsqueeze(0)
+    max_visible = torch.minimum(positions + right, segment_lengths - 1)
+    matrix = torch.where(matrix > max_visible.unsqueeze(1), -1, matrix)
+    matrix = torch.where(valid.unsqueeze(1), matrix, torch.full_like(matrix, -1))
+    return matrix.int().contiguous()
 
 
 def get_compress_topk_idxs_thd(
@@ -2100,6 +2178,13 @@ class CompressedSparseAttention(MegatronModule):
 
         cp_size = self.pg_collection.cp.size() if self.pg_collection.cp is not None else 1
         qkv_format = packed_seq_params.qkv_format if packed_seq_params is not None else None
+        sparse_visibility = (
+            attention_mask if isinstance(attention_mask, SparseAttentionVisibility) else None
+        )
+        if sparse_visibility is not None and cp_size > 1:
+            raise ValueError(
+                "Sparse image-span visibility is not yet supported with context parallelism."
+            )
         if cp_size > 1 and qkv_format != 'thd':
             raise ValueError("CompressedSparseAttention with CP requires qkv_format='thd'.")
         if cp_size > 1 and packed_seq_params.cp_partition_mode != "contiguous":
@@ -2114,7 +2199,9 @@ class CompressedSparseAttention(MegatronModule):
                     query, key, x, qr, boundary_hidden, boundary_kv, packed_seq_params
                 )
             else:
-                output = self._forward_thd(query, key, x, qr, packed_seq_params)
+                output = self._forward_thd(
+                    query, key, x, qr, packed_seq_params, sparse_visibility=sparse_visibility
+                )
             self.pg_collection.cp = _orig_cp_group
             nvtx_range_pop("compressed_sparse_attn")
             return output
@@ -2124,7 +2211,12 @@ class CompressedSparseAttention(MegatronModule):
         kv = key.squeeze(-2)  # [sq, b, 1, v_head_dim] -> [sq, b, v_head_dim]
         kv_full, compressed_kv, n_compressed = self._build_kv_full(kv, x)
         offset = sq  # compressed indices start after original positions
-        window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
+        if sparse_visibility is None:
+            window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
+        else:
+            window_idxs = get_window_topk_idxs_visible(
+                self.window_size, sq, sparse_visibility, query.device
+            )
 
         has_indexer_compressed = (
             self.compress_ratio > 1 and n_compressed > 0 and self.indexer is not None
@@ -2902,6 +2994,7 @@ class CompressedSparseAttention(MegatronModule):
         x: torch.Tensor,  # (total_q, 1, hidden_size)
         qr: torch.Tensor,  # (total_q, 1, q_lora_rank)
         packed_seq_params: PackedSeqParams,
+        sparse_visibility: Optional[SparseAttentionVisibility] = None,
     ) -> torch.Tensor:
         """THD-packed branch of :meth:`forward`. See class docstring for layout.
 
@@ -2965,9 +3058,14 @@ class CompressedSparseAttention(MegatronModule):
         )
 
         # ---- Step 3: window indices (per-segment local) ---------------------
-        window_idxs = get_window_topk_idxs_thd(
-            self.window_size, cu_seqlens_q, total_q=total_q
-        )  # (total_q, win_topk) local-to-segment
+        if sparse_visibility is None:
+            window_idxs = get_window_topk_idxs_thd(
+                self.window_size, cu_seqlens_q, total_q=total_q
+            )  # (total_q, win_topk) local-to-segment
+        else:
+            window_idxs = get_window_topk_idxs_visible_thd(
+                self.window_size, cu_seqlens_q, sparse_visibility, total_q=total_q
+            )
 
         # Upper bound on the max compressed-KV length per segment.  Not exact
         # when segment lengths aren't divisible by compress_ratio, but

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -255,6 +255,29 @@ class TopKRouter(Router):
             self.local_tokens_per_expert = None
             self.expert_bias = None
 
+        self.enable_vl_expert_bias = self.config.moe_router_enable_vl_bias
+        if self.enable_vl_expert_bias:
+            self.register_buffer(
+                'local_tokens_per_expert_vl',
+                torch.zeros(
+                    self.config.num_moe_experts,
+                    dtype=torch.float32,
+                    device=torch.cuda.current_device(),
+                ),
+                persistent=False,
+            )
+            self.register_buffer(
+                'expert_bias_vl',
+                torch.zeros(
+                    self.config.num_moe_experts,
+                    dtype=torch.float32,
+                    device=torch.cuda.current_device(),
+                ),
+            )
+        else:
+            self.local_tokens_per_expert_vl = None
+            self.expert_bias_vl = None
+
         # Initialize global tokens per expert for global aux loss
         if self.get_aux_loss_coeff("global_aux_loss") > 0:
             self.register_buffer(
@@ -289,6 +312,9 @@ class TopKRouter(Router):
         if hasattr(self, 'expert_bias') and self.expert_bias is not None:
             if self.expert_bias.dtype != torch.float32:
                 self.expert_bias.data = self.expert_bias.data.to(torch.float32)
+        if hasattr(self, 'expert_bias_vl') and self.expert_bias_vl is not None:
+            if self.expert_bias_vl.dtype != torch.float32:
+                self.expert_bias_vl.data = self.expert_bias_vl.data.to(torch.float32)
 
     def sinkhorn_load_balancing(self, logits: torch.Tensor):
         """Apply sinkhorn routing to the logits tensor.
@@ -716,13 +742,16 @@ class TopKRouter(Router):
 
     @jit_fuser
     def _apply_expert_bias(
-        self, routing_map: torch.Tensor, padding_mask: Optional[torch.Tensor] = None
+        self,
+        routing_map: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        input_ids: Optional[torch.Tensor] = None,
     ):
         """
         Update expert bias and tokens_per_expert
         Prevent extra local tokens accumulation on evaluation or activation recomputation
         """
-        if self.enable_expert_bias and torch.is_grad_enabled():
+        if (self.enable_expert_bias or self.enable_vl_expert_bias) and torch.is_grad_enabled():
             with torch.no_grad():
                 if padding_mask is not None:
                     flat_mask = padding_mask.reshape(-1)
@@ -730,7 +759,24 @@ class TopKRouter(Router):
                         flat_mask.shape[0] == routing_map.shape[0]
                     ), f"padding_mask flat {flat_mask.shape} vs routing_map {routing_map.shape}"
                     routing_map = routing_map & (~flat_mask).unsqueeze(-1)
-                self.local_tokens_per_expert += routing_map.sum(dim=0)
+                if self.enable_vl_expert_bias:
+                    assert (
+                        input_ids is not None
+                    ), "input_ids are required when moe_router_enable_vl_bias=True."
+                    flat_ids = input_ids.T.reshape(-1)
+                    assert (
+                        flat_ids.shape[0] == routing_map.shape[0]
+                    ), f"input_ids flat {flat_ids.shape} vs routing_map {routing_map.shape}"
+                    image_mask = flat_ids >= self.config.actual_vocab_size
+                    self.local_tokens_per_expert_vl += (routing_map & image_mask.unsqueeze(-1)).sum(
+                        dim=0
+                    )
+                    if self.enable_expert_bias:
+                        self.local_tokens_per_expert += (
+                            routing_map & (~image_mask).unsqueeze(-1)
+                        ).sum(dim=0)
+                elif self.enable_expert_bias:
+                    self.local_tokens_per_expert += routing_map.sum(dim=0)
 
     def _hash_routing(self, logits: torch.Tensor, input_ids: torch.Tensor):
         """Hash-based routing: expert indices come from the tid2eid lookup table.
@@ -759,7 +805,19 @@ class TopKRouter(Router):
         # input_ids is [b, s] from the model, but hidden_states are [s, b, h]
         # and get flattened to [s*b, h]. Transpose to match.
         flat_ids = input_ids.T.reshape(-1)
-        top_indices = self.tid2eid[flat_ids].long()  # [num_tokens, topk]
+        image_mask = flat_ids >= self.config.actual_vocab_size
+        if image_mask.any() and not self.enable_vl_expert_bias:
+            raise ValueError(
+                "Hash routing received synthetic vision token IDs, but "
+                "moe_router_enable_vl_bias is disabled."
+            )
+        lookup_ids = torch.where(image_mask, torch.zeros_like(flat_ids), flat_ids)
+        top_indices = self.tid2eid[lookup_ids].long()  # [num_tokens, topk]
+        if self.enable_vl_expert_bias:
+            _, vl_indices = torch.topk(
+                scores + self.expert_bias_vl.to(dtype=scores.dtype), k=self.topk, dim=1
+            )
+            top_indices = torch.where(image_mask.unsqueeze(-1), vl_indices, top_indices)
         if (
             self.config.moe_router_force_load_balancing
             or self.config.moe_router_force_biased is not None
@@ -822,6 +880,18 @@ class TopKRouter(Router):
         elif self.routing_type == "sinkhorn":
             probs, routing_map = self.sinkhorn_load_balancing(logits)
         else:
+            expert_bias = self.expert_bias
+            if self.enable_vl_expert_bias:
+                assert (
+                    input_ids is not None
+                ), "input_ids are required when moe_router_enable_vl_bias=True."
+                flat_ids = input_ids.T.reshape(-1)
+                image_mask = flat_ids >= self.config.actual_vocab_size
+                expert_bias = torch.where(
+                    image_mask.unsqueeze(-1),
+                    self.expert_bias_vl.unsqueeze(0),
+                    self.expert_bias.unsqueeze(0),
+                )
             probs, routing_map = topk_routing_with_score_function(
                 logits,
                 self.topk,
@@ -830,8 +900,10 @@ class TopKRouter(Router):
                 group_topk=self.config.moe_router_group_topk,
                 scaling_factor=self.config.moe_router_topk_scaling_factor,
                 score_function=self.score_function,
-                expert_bias=self.expert_bias,
-                fused=self.config.moe_router_fusion,
+                expert_bias=expert_bias,
+                # Transformer Engine's fused router currently accepts a single
+                # per-expert bias, not the per-token text/VL bias matrix.
+                fused=self.config.moe_router_fusion and not self.enable_vl_expert_bias,
                 router_replay=self.router_replay,
             )
 
@@ -894,7 +966,7 @@ class TopKRouter(Router):
             )
 
         # Optionally apply expert bias
-        self._apply_expert_bias(routing_map, padding_mask=padding_mask)
+        self._apply_expert_bias(routing_map, padding_mask=padding_mask, input_ids=input_ids)
 
         return probs, routing_map
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -887,6 +887,14 @@ class TransformerConfig(ModelParallelConfig):
     The routing decision is based on the sum of the routing scores and the expert bias.
     See https://arxiv.org/abs/2408.15664 for details."""
 
+    moe_router_enable_vl_bias: bool = False
+    """Use a second dynamic expert-selection bias for vision-language tokens.
+
+    Tokens whose IDs are greater than or equal to ``actual_vocab_size`` use the VL bias.
+    This matches DeepSeek-V4-Vision, where synthetic image token IDs use learned routing in
+    hash-routed layers and a distinct expert bias in the remaining MoE layers.
+    """
+
     moe_router_bias_update_rate: float = 1e-3
     """The expert bias is updated based on the number of assigned tokens to each expert
     in a global batch, where the bias is increased for the experts with less assigned tokens
@@ -2986,6 +2994,16 @@ class TransformerConfig(ModelParallelConfig):
                 "score functions. Please set --moe-router-score-function to 'sigmoid' or "
                 "'sqrtsoftplus', or unset --moe-router-enable-expert-bias."
             )
+
+        if self.moe_router_enable_vl_bias:
+            if not self.moe_router_enable_expert_bias:
+                raise ValueError(
+                    "Vision-language expert bias requires moe_router_enable_expert_bias=True."
+                )
+            if self.actual_vocab_size is None:
+                raise ValueError(
+                    "actual_vocab_size must be set when moe_router_enable_vl_bias=True."
+                )
 
         if self.moe_n_hash_layers > 0:
             assert (

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_csa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_csa.py
@@ -16,6 +16,7 @@ from megatron.core.transformer.experimental_attention_variant.csa import (
     CompressorSubmodules,
     CSAIndexer,
     CSAIndexerSubmodules,
+    SparseAttentionVisibility,
     _apply_rope,
     _compute_unfused_csa_non_compressed_lse,
     build_cu_seqlens_kv_full,
@@ -24,6 +25,8 @@ from megatron.core.transformer.experimental_attention_variant.csa import (
     get_compress_topk_idxs_thd,
     get_window_topk_idxs,
     get_window_topk_idxs_thd,
+    get_window_topk_idxs_visible,
+    get_window_topk_idxs_visible_thd,
     unfused_compressed_sparse_attn,
 )
 from megatron.core.transformer.experimental_attention_variant.dsa import (
@@ -80,6 +83,37 @@ class _SingleRankTP:
 
 class _SingleRankPG:
     tp = _SingleRankTP()
+
+
+def test_visible_window_extends_bidirectionally_inside_image_span():
+    visibility = SparseAttentionVisibility(
+        left=torch.tensor([[0, 0, 0, 1, 2, 3, 0, 0]], dtype=torch.int32),
+        right=torch.tensor([[0, 0, 3, 2, 1, 0, 0, 0]], dtype=torch.int32),
+        max_span=4,
+    )
+
+    indices = get_window_topk_idxs_visible(3, 8, visibility, torch.device("cpu"))
+
+    assert indices.shape == (1, 8, 7)
+    assert torch.equal(indices[0, 2, :6], torch.arange(6, dtype=torch.int32))
+    assert torch.equal(indices[0, 5, :5], torch.arange(1, 6, dtype=torch.int32))
+    assert torch.equal(indices[0, 6, :3], torch.arange(4, 7, dtype=torch.int32))
+    assert torch.all(indices[0, 6, 3:] == -1)
+
+
+def test_visible_window_thd_keeps_indices_local_to_each_segment():
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    visibility = SparseAttentionVisibility(
+        left=torch.tensor([[0, 0, 0, 0, 0, 1, 2, 0]], dtype=torch.int32),
+        right=torch.tensor([[0, 0, 0, 0, 2, 1, 0, 0]], dtype=torch.int32),
+        max_span=3,
+    )
+
+    indices = get_window_topk_idxs_visible_thd(2, cu_seqlens, visibility, total_q=8)
+
+    # Global row 4 is local position 0 of segment 2 and sees its full local image span.
+    assert torch.equal(indices[4, :3], torch.tensor([0, 1, 2], dtype=torch.int32))
+    assert indices[4].max() < 4
 
 
 @pytest.mark.parametrize("layout", ["sbhd", "thd"])

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -761,6 +761,61 @@ class TestHashRouting:
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_hash_routing_uses_learned_selection_for_synthetic_vl_ids(self):
+        """Synthetic image IDs bypass tid2eid and select experts with the VL bias."""
+        config = _hash_routing_config(
+            moe_router_enable_expert_bias=True,
+            moe_router_enable_vl_bias=True,
+            moe_router_score_function="sqrtsoftplus",
+        )
+        router = TopKRouter(
+            config=config, pg_collection=get_default_pg_collection(), layer_number=1
+        )
+        router.expert_bias_vl.copy_(torch.tensor([0.0, 0.0, 9.0, 10.0], device="cuda"))
+        logits = torch.zeros(4, 4, device="cuda")
+        input_ids = torch.tensor([[1, 128], [2, 129]], device="cuda")
+
+        _, routing_map = router._hash_routing(logits, input_ids)
+
+        flat_ids = input_ids.T.reshape(-1)
+        for row, token_id in enumerate(flat_ids.tolist()):
+            selected = routing_map[row].nonzero(as_tuple=True)[0].sort().values
+            if token_id >= config.actual_vocab_size:
+                assert torch.equal(selected, torch.tensor([2, 3], device="cuda"))
+            else:
+                expected = router.tid2eid[token_id].long().sort().values
+                assert torch.equal(selected, expected)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_non_hash_routing_separates_text_and_vl_bias_counts(self):
+        """Normal MoE layers select and balance text and synthetic IDs independently."""
+        config = _hash_routing_config(
+            moe_router_enable_expert_bias=True,
+            moe_router_enable_vl_bias=True,
+            moe_router_score_function="sqrtsoftplus",
+        )
+        router = TopKRouter(
+            config=config, pg_collection=get_default_pg_collection(), layer_number=2
+        )
+        router.expert_bias.copy_(torch.tensor([10.0, 9.0, 0.0, 0.0], device="cuda"))
+        router.expert_bias_vl.copy_(torch.tensor([0.0, 0.0, 9.0, 10.0], device="cuda"))
+        logits = torch.zeros(2, 2, 4, device="cuda")
+        input_ids = torch.tensor([[1, 128], [2, 129]], device="cuda")
+
+        _, routing_map = router.routing(logits, input_ids=input_ids)
+
+        assert torch.equal(
+            routing_map[0].nonzero(as_tuple=True)[0], torch.tensor([0, 1], device="cuda")
+        )
+        assert torch.equal(
+            routing_map[2].nonzero(as_tuple=True)[0], torch.tensor([2, 3], device="cuda")
+        )
+        assert router.local_tokens_per_expert.sum() == 4
+        assert router.local_tokens_per_expert_vl.sum() == 4
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_moe_layer_hash_routing_integration(self):
         """End-to-end MoELayer forward/backward with hash routing; raises without input_ids."""
         config = _hash_routing_config(moe_n_hash_layers=1)


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
## Overview

This PR adds first-phase, architecture-level training support for `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` to `examples/multimodal_dev`.

## Changes

- Add the native vision tower with:
  - full per-image attention and 2D RoPE;
  - the 3x3 pad-and-unfold aligner;
  - the official N-layout permutation; and
  - decoder-side image boundary and padding embeddings.
- Construct the DeepSeek V4 decoder using the 43-block `W/W/C/(H/C)x20` hybrid attention layout.
- Add bidirectional attention within image spans while preserving sparse causal attention outside those spans.
- Add VL-aware expert-bias updates and image-token handling for the first three hash-routed MoE layers.
- Add model registration, mock multimodal data, configuration helpers, unit coverage, documentation, and proxy/full launch recipes.
- Support precomputed `vision_embeddings` and optional `vision_token_indices`, providing a stable decoder interface for future MDP integration without introducing an MDP dependency in this PR.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
