### PR TITLE
Support FP4 tensors in the MoE paged activation stash

### DIFF
--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -23,6 +23,21 @@ logger = logging.getLogger(__name__)
 # receive budget to exceed) and disables paged stashing, so the retry cannot fail either way.
 _MAX_RERUN_ATTEMPTS = 2
 
+# Dtypes the paged-stash Triton copy kernels address natively. Anything else is
+# moved as uint8 bytes; see allocate_stash_buffers().
+_STASH_NATIVE_DTYPES = (
+    torch.float64,
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.int64,
+    torch.int32,
+    torch.int16,
+    torch.int8,
+    torch.uint8,
+    torch.bool,
+)
+
 SCALE_INV_BLOCK_SIZE = 32
 
 
@@ -611,12 +626,16 @@ class PagedStashManager:
                 if host_tokens_dict is not None and (dtype, hidden_size) in host_tokens_dict
                 else 0
             )
-            buf_dtype = (
-                torch.uint8
-                if dtype in [torch.float8_e4m3fn, torch.float8_e8m0fnu]
-                or dtype is getattr(torch, "float4_e2m1fn_x2", None)
-                else dtype
-            )
+            # Dtypes Triton can address natively are stashed as-is; all others (FP8, FP4, ...)
+            # are byte-copied as uint8, which only preserves shape for 1-byte dtypes.
+            if dtype in _STASH_NATIVE_DTYPES:
+                buf_dtype = dtype
+            else:
+                assert dtype.itemsize == 1, (
+                    f"Paged stash cannot byte-copy {dtype} (itemsize {dtype.itemsize}); "
+                    "add it to _STASH_NATIVE_DTYPES if Triton supports it."
+                )
+                buf_dtype = torch.uint8
             self.stash_buffers[dtype][hidden_size] = PagedStashBuffer(
                 num_tokens,
                 hidden_size,

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -612,7 +612,10 @@ class PagedStashManager:
                 else 0
             )
             buf_dtype = (
-                torch.uint8 if dtype in [torch.float8_e4m3fn, torch.float8_e8m0fnu] else dtype
+                torch.uint8
+                if dtype in [torch.float8_e4m3fn, torch.float8_e8m0fnu]
+                or dtype is getattr(torch, "float4_e2m1fn_x2", None)
+                else dtype
             )
             self.stash_buffers[dtype][hidden_size] = PagedStashBuffer(
                 num_tokens,

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _MAX_RERUN_ATTEMPTS = 2
 
 # Dtypes the paged-stash Triton copy kernels address natively. Anything else is
-# moved as uint8 bytes; see allocate_stash_buffers().
+# moved as uint8 bytes; see _stash_buffer_dtype().
 _STASH_NATIVE_DTYPES = (
     torch.float64,
     torch.float32,
@@ -39,6 +39,22 @@ _STASH_NATIVE_DTYPES = (
 )
 
 SCALE_INV_BLOCK_SIZE = 32
+
+
+def _stash_buffer_dtype(dtype: torch.dtype) -> torch.dtype:
+    """Dtype of the stash buffer that holds tensors of ``dtype``.
+
+    Dtypes the Triton copy kernels address natively are stashed as-is. Anything else (FP8,
+    FP4, ...) is byte-copied as uint8, which only preserves the shape for 1-byte dtypes.
+    """
+    if dtype in _STASH_NATIVE_DTYPES:
+        return dtype
+    if dtype.itemsize != 1:
+        raise ValueError(
+            f"Paged stash cannot byte-copy {dtype} (itemsize {dtype.itemsize}); "
+            "add it to _STASH_NATIVE_DTYPES if Triton supports it."
+        )
+    return torch.uint8
 
 
 class PagedStashBuffer:
@@ -626,16 +642,6 @@ class PagedStashManager:
                 if host_tokens_dict is not None and (dtype, hidden_size) in host_tokens_dict
                 else 0
             )
-            # Dtypes Triton can address natively are stashed as-is; all others (FP8, FP4, ...)
-            # are byte-copied as uint8, which only preserves shape for 1-byte dtypes.
-            if dtype in _STASH_NATIVE_DTYPES:
-                buf_dtype = dtype
-            else:
-                assert dtype.itemsize == 1, (
-                    f"Paged stash cannot byte-copy {dtype} (itemsize {dtype.itemsize}); "
-                    "add it to _STASH_NATIVE_DTYPES if Triton supports it."
-                )
-                buf_dtype = torch.uint8
             self.stash_buffers[dtype][hidden_size] = PagedStashBuffer(
                 num_tokens,
                 hidden_size,
@@ -643,7 +649,7 @@ class PagedStashManager:
                 self.device,
                 self.overflow,
                 self.host_spill,
-                buf_dtype,
+                _stash_buffer_dtype(dtype),
                 num_tokens_host=num_tokens_host,
             )
             sb = self.stash_buffers[dtype][hidden_size]

--- a/tests/unit_tests/transformer/moe/test_paged_stashing.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stashing.py
@@ -11,6 +11,7 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transfor
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.moe_utils import get_align_size_for_quantization
 from megatron.core.transformer.moe.paged_stash import (
+    _stash_buffer_dtype,
     check_paged_stash_overflow,
     paged_stash_init_chunk_handler,
     paged_stash_reset,
@@ -54,6 +55,23 @@ def _pad_token_counts_to_align_size(
     """Round each count up to a multiple of ``pad_multiple`` (``n + (-n % m)`` like budget)."""
     t = tokens_per_expert.to(torch.int64)
     return t + (-t % pad_multiple)
+
+
+class TestStashBufferDtype:
+    def test_native_dtypes_are_kept(self):
+        for dtype in (torch.bfloat16, torch.float32, torch.int64, torch.bool):
+            assert _stash_buffer_dtype(dtype) is dtype
+
+    def test_one_byte_dtypes_are_byte_copied(self):
+        dtypes = [torch.float8_e4m3fn, torch.float8_e8m0fnu]
+        if hasattr(torch, "float4_e2m1fn_x2"):
+            dtypes.append(torch.float4_e2m1fn_x2)
+        for dtype in dtypes:
+            assert _stash_buffer_dtype(dtype) is torch.uint8
+
+    def test_multi_byte_dtypes_are_rejected(self):
+        with pytest.raises(ValueError, match="complex64"):
+            _stash_buffer_dtype(torch.complex64)
 
 
 class MoEModelTestContainer:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

allocate_stash_buffers() remaps FP8 dtypes to torch.uint8 for the stash buffer so the Triton copy kernel receives a dtype Triton can canonicalize, but FP4 is missing from that list. When an FP4 tensor reaches the stash the buffer keeps dtype float4_e2m1fn_x2, and Triton's canonicalize_dtype() is a plain dict lookup, so it raises

    KeyError: 'float4_e2m1fn_x2'

from PagedTensor.offload_to_stash().

This is reachable today: with an NVFP4 quantization recipe that produces FP4 grouped-MLP outputs, moe_paged_stash aborts during warmup and no training step completes. Setting moe_paged_stash=False avoids the crash but gives up the offload and OOMs on configs sized to rely on it.

Include float4_e2m1fn_x2 in the remap. That dtype is one byte per element (two packed FP4 values), the same as uint8, so the existing tensor.view(paged_stash_buffer.cuda_buffer.dtype) in offload_to_stash keeps its shape, exactly as it already does for FP8. The copy is a pure byte move, so this is numerically neutral.

getattr() guards the lookup so the module still imports on PyTorch builds that predate float4_e2m1fn_x2.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
