### PR TITLE
fix(checkpoint): initialize converter process groups

### DIFF
--- a/tests/unit_tests/tools/checkpoint/test_checkpoint_converter_process_groups.py
+++ b/tests/unit_tests/tools/checkpoint/test_checkpoint_converter_process_groups.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core import parallel_state
+from megatron.core.process_groups_config import ProcessGroupCollection
+from tools.checkpoint.utils import initialize_checkpoint_converter_fake_process_groups
+
+_FAKE_GROUP_GLOBALS = (
+    '_TENSOR_MODEL_PARALLEL_GROUP',
+    '_PIPELINE_MODEL_PARALLEL_GROUP',
+    '_EXPERT_MODEL_PARALLEL_GROUP',
+    '_DATA_PARALLEL_GROUP',
+    '_DATA_PARALLEL_GROUP_WITH_CP',
+    '_INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP',
+    '_DATA_PARALLEL_GROUP_WITH_GTP_REMAT',
+    '_DATA_PARALLEL_GROUP_WITH_CP_WITH_GTP_REMAT',
+    '_INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_WITH_GTP_REMAT',
+    '_EXPERT_DATA_PARALLEL_GROUP',
+    '_EXPERT_DATA_PARALLEL_GROUP_WITH_GTP_REMAT',
+    '_INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_WITH_GTP_REMAT',
+    '_EXPERT_TENSOR_PARALLEL_GROUP',
+    '_EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP',
+    '_EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP',
+    '_MODEL_PARALLEL_GROUP',
+)
+
+
+def test_fake_groups_support_default_process_group_collection():
+    original_groups = {name: getattr(parallel_state, name) for name in _FAKE_GROUP_GLOBALS}
+    try:
+        initialize_checkpoint_converter_fake_process_groups(
+            parallel_state, tensor_parallel_size=4, pipeline_parallel_size=2, expert_parallel_size=1
+        )
+
+        groups = ProcessGroupCollection.use_mpu_process_groups()
+
+        assert groups.tp.size() == 4
+        assert groups.pp.size() == 2
+        assert groups.ep.size() == 1
+        assert groups.dp.size() == 1
+        assert groups.dp_cp.size() == 1
+        assert groups.dp_cp_gtp_remat.size() == 1
+        assert groups.intra_dp_cp.size() == 1
+        assert groups.expt_dp.size() == 1
+        assert groups.expt_dp_gtp_remat.size() == 1
+    finally:
+        for name, group in original_groups.items():
+            setattr(parallel_state, name, group)

--- a/tools/checkpoint/loader_base.py
+++ b/tools/checkpoint/loader_base.py
@@ -5,7 +5,7 @@ import sys
 import types
 import torch
 
-from utils import _ConverterFakeProcessGroup, print_memory_usage
+from utils import initialize_checkpoint_converter_fake_process_groups, print_memory_usage
 
 class MegatronCheckpointLoaderBase:
     """Orchestrates loading a Megatron checkpoint and sending
@@ -145,11 +145,12 @@ class MegatronCheckpointLoaderBase:
         mpu.set_virtual_pipeline_model_parallel_world_size(self.margs.virtual_pipeline_model_parallel_size)
         mpu.set_expert_model_parallel_world_size(self.margs.expert_model_parallel_size)
         
-        # For backward compatibility during local parallel states refactoring
-        fake_tp_group = _ConverterFakeProcessGroup(size=self.margs.tensor_model_parallel_size)
-        fake_ep_group = _ConverterFakeProcessGroup(size=self.margs.expert_model_parallel_size)
-        mpu._TENSOR_MODEL_PARALLEL_GROUP = fake_tp_group
-        mpu._EXPERT_MODEL_PARALLEL_GROUP = fake_ep_group
+        initialize_checkpoint_converter_fake_process_groups(
+            mpu,
+            self.margs.tensor_model_parallel_size,
+            self.margs.pipeline_model_parallel_size,
+            self.margs.expert_model_parallel_size,
+        )
 
     def compute_true_vocab_size(self):
         """Determine the 'true' (non-padded) vocab size."""
@@ -487,4 +488,3 @@ class MegatronCheckpointLoaderBase:
     def send_model_over_queue(self):
         """Creates model schema and sends the model over the queue"""
         raise NotImplementedError
-

--- a/tools/checkpoint/loader_mixtral_hf.py
+++ b/tools/checkpoint/loader_mixtral_hf.py
@@ -8,7 +8,7 @@ import transformers
 from tqdm import tqdm
 import types
 
-from tools.checkpoint.utils import _ConverterFakeProcessGroup
+from tools.checkpoint.utils import initialize_checkpoint_converter_fake_process_groups
 
 
 def add_arguments(parser):
@@ -240,11 +240,12 @@ def _load_checkpoint(queue, args):
     mpu.set_virtual_pipeline_model_parallel_world_size(margs.virtual_pipeline_model_parallel_size)
     mpu.set_expert_model_parallel_world_size(margs.expert_model_parallel_size)
     
-    # For backward compatibility during local parallel states refactoring
-    fake_tp_group = _ConverterFakeProcessGroup(size=margs.tensor_model_parallel_size)
-    fake_ep_group = _ConverterFakeProcessGroup(size=margs.expert_model_parallel_size)
-    mpu._TENSOR_MODEL_PARALLEL_GROUP = fake_tp_group
-    mpu._EXPERT_MODEL_PARALLEL_GROUP = fake_ep_group
+    initialize_checkpoint_converter_fake_process_groups(
+        mpu,
+        margs.tensor_model_parallel_size,
+        margs.pipeline_model_parallel_size,
+        margs.expert_model_parallel_size,
+    )
 
     # Metadata.
     md = types.SimpleNamespace()

--- a/tools/checkpoint/saver_base.py
+++ b/tools/checkpoint/saver_base.py
@@ -6,7 +6,11 @@ from packaging.version import Version as PkgVersion
 import sys
 import torch
 
-from utils import _ConverterFakeProcessGroup, chunk_bias, chunk_weight
+from utils import (
+    chunk_bias,
+    chunk_weight,
+    initialize_checkpoint_converter_fake_process_groups,
+)
 
 class MegatronCheckpointSaverBase:
     """Orchestrates saving a Megatron checkpoint using parameters received on a multiprocessing queue.
@@ -174,19 +178,12 @@ class MegatronCheckpointSaverBase:
         mpu.set_pipeline_model_parallel_rank(0)
         mpu.set_expert_model_parallel_rank(0)
         
-        # For backward compatibility during local parallel states refactoring
-        fake_tp_group = _ConverterFakeProcessGroup(size=self.args.target_tensor_parallel_size)
-        fake_pp_group = _ConverterFakeProcessGroup(size=self.args.target_pipeline_parallel_size)
-        fake_ep_group = _ConverterFakeProcessGroup(size=self.args.target_expert_parallel_size)
-        fake_dp_group = _ConverterFakeProcessGroup(size=1)
-        fake_dp_ep_group = _ConverterFakeProcessGroup(size=1)
-        mpu._TENSOR_MODEL_PARALLEL_GROUP = fake_tp_group
-        mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
-        mpu._EXPERT_MODEL_PARALLEL_GROUP = fake_ep_group
-        mpu._DATA_PARALLEL_GROUP = fake_dp_group
-        mpu._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
-        mpu._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
-        mpu._EXPERT_DATA_PARALLEL_GROUP = fake_dp_ep_group
+        initialize_checkpoint_converter_fake_process_groups(
+            mpu,
+            self.args.target_tensor_parallel_size,
+            self.args.target_pipeline_parallel_size,
+            self.args.target_expert_parallel_size,
+        )
         
         try:
             import torch_llm_debug_tools

--- a/tools/checkpoint/utils.py
+++ b/tools/checkpoint/utils.py
@@ -68,3 +68,53 @@ class _ConverterFakeProcessGroup:
 
     def set_size(self, size):
         self._size = size
+
+
+def initialize_checkpoint_converter_fake_process_groups(
+    parallel_state, tensor_parallel_size, pipeline_parallel_size, expert_parallel_size
+):
+    """Initialize the process-group globals used by checkpoint converters.
+
+    Checkpoint conversion runs in one process and does not call
+    ``initialize_model_parallel``. Model construction still resolves the full
+    ``ProcessGroupCollection``, so populate its parallel-state dependencies with
+    lightweight groups that report the requested target sizes.
+
+    GTP rematerialization is not active during conversion. Its data-parallel
+    groups therefore alias the corresponding non-GTP groups, matching
+    ``initialize_model_parallel`` when the GTP axes have size one.
+    """
+    fake_tp_group = _ConverterFakeProcessGroup(size=tensor_parallel_size)
+    fake_pp_group = _ConverterFakeProcessGroup(size=pipeline_parallel_size)
+    fake_ep_group = _ConverterFakeProcessGroup(size=expert_parallel_size)
+    fake_dp_group = _ConverterFakeProcessGroup(size=1)
+    fake_expert_dp_group = _ConverterFakeProcessGroup(size=1)
+    fake_expert_tp_group = _ConverterFakeProcessGroup(size=tensor_parallel_size)
+    fake_expert_tp_ep_group = _ConverterFakeProcessGroup(
+        size=tensor_parallel_size * expert_parallel_size
+    )
+    fake_expert_tp_ep_pp_group = _ConverterFakeProcessGroup(
+        size=tensor_parallel_size * expert_parallel_size * pipeline_parallel_size
+    )
+    fake_model_parallel_group = _ConverterFakeProcessGroup(
+        size=tensor_parallel_size * pipeline_parallel_size
+    )
+
+    parallel_state._TENSOR_MODEL_PARALLEL_GROUP = fake_tp_group
+    parallel_state._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
+    parallel_state._EXPERT_MODEL_PARALLEL_GROUP = fake_ep_group
+    parallel_state._DATA_PARALLEL_GROUP = fake_dp_group
+    parallel_state._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
+    parallel_state._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
+    parallel_state._DATA_PARALLEL_GROUP_WITH_GTP_REMAT = fake_dp_group
+    parallel_state._DATA_PARALLEL_GROUP_WITH_CP_WITH_GTP_REMAT = fake_dp_group
+    parallel_state._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_WITH_GTP_REMAT = fake_dp_group
+    parallel_state._EXPERT_DATA_PARALLEL_GROUP = fake_expert_dp_group
+    parallel_state._EXPERT_DATA_PARALLEL_GROUP_WITH_GTP_REMAT = fake_expert_dp_group
+    parallel_state._INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_WITH_GTP_REMAT = (
+        fake_expert_dp_group
+    )
+    parallel_state._EXPERT_TENSOR_PARALLEL_GROUP = fake_expert_tp_group
+    parallel_state._EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = fake_expert_tp_ep_group
+    parallel_state._EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP = fake_expert_tp_ep_pp_group
+    parallel_state._MODEL_PARALLEL_GROUP = fake_model_parallel_group


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Centralizes the checkpoint converter's fake process-group initialization and covers the GTP-remat groups required by the current `ProcessGroupCollection` defaults.

## Background

The checkpoint converter runs in a single process and does not call
`initialize_model_parallel`. It nevertheless constructs Megatron models, whose
`LanguageModule` initializes a default `ProcessGroupCollection` by calling:

```python
ProcessGroupCollection.use_mpu_process_groups()
```

With no explicit `required_pgs`, this resolves every entry in `pg_to_func`.
Several entries call hard-asserting data-parallel getters:

- `dp`
- `dp_cp`
- `dp_cp_gtp_remat`
- `intra_dp_cp`

The converter currently works around the lack of distributed initialization by
assigning `_ConverterFakeProcessGroup` objects directly to selected
`parallel_state` globals. These assignments are duplicated between loader and
saver paths and do not include the GTP-remat data-parallel groups introduced in
`core_v0.19.0`.

As a result, model construction aborts with:

```text
AssertionError: data parallel group with CP (with GTP_remat) is not initialized
```

This occurs before any model weights are converted.

## Changes

This PR:

- adds `initialize_checkpoint_converter_fake_process_groups` as the common
  initialization path for checkpoint converters;
- initializes the fake TP, PP, EP, DP, expert-DP, model-parallel, and combined
  expert process groups with the requested converter parallelism;
- aliases the GTP-remat data-parallel groups to their non-GTP counterparts,
  matching `initialize_model_parallel` when the GTP-remat axes have size one;
- uses the common helper from:
  - `MegatronCheckpointLoaderBase`;
  - the Mixtral Hugging Face loader;
  - `MegatronCheckpointSaverBase`;
- adds a unit test that initializes the default `ProcessGroupCollection` at
  TP=4, PP=2, EP=1 and verifies the legacy and GTP-remat groups resolve with the
  expected sizes.

The helper remains under `tools/checkpoint`; training initialization paths are
unchanged.

## Reproduction

Reproduced with `core_v0.19.0` and confirmed to remain present on `main`.

The converter is single-process and does not require `torchrun` or distributed
initialization:

```bash
python tools/checkpoint/convert.py \
  --model-type GPT \
  --loader mixtral_hf \
  --saver mcore \
  --target-tensor-parallel-size 4 \
  --target-pipeline-parallel-size 2 \
  --target-expert-parallel-size 1 \
  --load-dir <local copy of mistralai/Mixtral-8x7B-v0.1 safetensors> \
  --save-dir <output directory> \
  --tokenizer-model <tokenizer.model>
```

The failure occurs while the loader builds `GPTModel`:

```text
tools/checkpoint/convert.py
  -> loader_mixtral_hf.load_checkpoint
  -> model_provider
  -> GPTModel
  -> LanguageModule.__init__
  -> ProcessGroupCollection.use_mpu_process_groups
  -> parallel_state.get_data_parallel_group

AssertionError: data parallel group with CP (with GTP_remat) is not initialized
```

The same conversion completed with the preceding `core_v0.18.2` setup. The
regression appeared after moving to `core_v0.19.0`, which added the GTP-remat
process-group globals and made the GTP-aware data-parallel group the default.

## Validation

### Focused regression coverage

Added:

```bash
python -m pytest \
  tests/unit_tests/tools/checkpoint/test_checkpoint_converter_process_groups.py
```

The test verifies that the converter helper supports the complete default
`ProcessGroupCollection`, including:

```text
tp=4
pp=2
ep=1
dp=1
dp_cp=1
dp_cp_gtp_remat=1
intra_dp_cp=1
expt_dp=1
expt_dp_gtp_remat=1
```

Local preparation checks completed successfully:

```text
python -m py_compile <all changed Python files>
fake process-group helper smoke test passed
git diff --check passed
```

The complete pytest suite was not run in the local preparation environment
because that Python environment does not contain PyTorch. CI should execute the
new unit test in the normal project test environment.

### Converter reproduction

With this process-group change applied:

- the GTP-remat assertion is eliminated;
- model construction completes;
- the converter advances into the forked saver process.

That exposes the second, independent regression described in #6989:

```text
ValueError: tensor_parallel_num_weight_shards (1) must be >=
tensor_model_parallel_size (4).
```

That target-argument inheritance issue is addressed by the companion PR:

```text
Companion PR: <add link after creation>
```

With both changes applied, the original command completes and prints:

```text
successfully saved checkpoint from iteration 1 to <output directory>
[ t 1/4 ... 4/4, gtp_remat 1/0, p 2/2 ]
Done!
```

The generated checkpoint was then loaded successfully by `pretrain_gpt.py` at
the unchanged target parallelism:

```text
--tensor-model-parallel-size 4
--pipeline-model-parallel-size 2
--expert-model-parallel-size 1
```

The load reported:

```text
successfully loaded checkpoint ... [ t 1/4, gtp_remat 1/1, p 1/2 ]
```

Subsequent evaluation completed 500/500 iterations and reported:

```text
bf16:       lm loss value 1.952644
fp8-hybrid: lm loss value 1.979680
```

No model revision, target parallelism, or converter workload parameters were
weakened to obtain the successful result.

## Scope

This PR intentionally does not:

- initialize real distributed process groups during conversion;
- enable GTP rematerialization in the converter;
- change training process-group initialization;
- change source or target checkpoint formats;
- address the independent target-derived argument inheritance failure.

## Issue tracking

Related to #6989.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests — manual end-to-end validation is documented above
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate review.
