### PR TITLE
fix(checkpoint): preserve target weight shard args

### DIFF
--- a/tests/unit_tests/tools/checkpoint/test_checkpoint_saver_target_args.py
+++ b/tests/unit_tests/tools/checkpoint/test_checkpoint_saver_target_args.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import os
+import sys
+from types import SimpleNamespace
+
+_REPO_ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..')
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'tools', 'checkpoint'))
+
+from saver_base import MegatronCheckpointSaverBase
+
+
+def test_target_derived_weight_shard_args_are_not_loaded_from_source_checkpoint():
+    source_args = SimpleNamespace(
+        tensor_parallel_num_weight_shards=1,
+        gtp_weight_remat_size=1,
+        expert_tensor_parallel_num_weight_shards=1,
+        expert_gtp_weight_remat_size=1,
+        num_layers=24,
+    )
+    target_args = SimpleNamespace(
+        tensor_parallel_num_weight_shards=4,
+        gtp_weight_remat_size=2,
+        expert_tensor_parallel_num_weight_shards=8,
+        expert_gtp_weight_remat_size=2,
+        num_layers=12,
+    )
+    saver = MegatronCheckpointSaverBase(args=None, queue=None)
+    saver.md = SimpleNamespace(checkpoint_args=source_args)
+
+    result = saver._load_checkpoint_args(target_args)
+
+    assert result.tensor_parallel_num_weight_shards == 4
+    assert result.gtp_weight_remat_size == 2
+    assert result.expert_tensor_parallel_num_weight_shards == 8
+    assert result.expert_gtp_weight_remat_size == 2
+    assert result.num_layers == 24

--- a/tools/checkpoint/saver_base.py
+++ b/tools/checkpoint/saver_base.py
@@ -60,6 +60,8 @@ class MegatronCheckpointSaverBase:
             # These are arguments that we are either changing, or cause problems for validation if they are set
             # Note that some of these deal with T5 so will need to be changed if we support T5.
             args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size', 'world_size', 'params_dtype',
+                            'tensor_parallel_num_weight_shards', 'gtp_weight_remat_size',
+                            'expert_tensor_parallel_num_weight_shards', 'expert_gtp_weight_remat_size',
                             'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                             'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
                             'sequence_parallel',


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Prevents source checkpoint metadata from overwriting weight-shard and GTP-remat arguments derived from the converter's target parallelism.

## Background

`MegatronCheckpointSaverBase._load_checkpoint_args` copies arguments recorded in
the source checkpoint onto the target saver arguments unless their names appear
in `args_to_keep`.

This is appropriate for model properties such as layer counts, but not for
arguments derived from the requested target parallelism. The converter already
preserves values such as:

- `tensor_model_parallel_size`;
- `pipeline_model_parallel_size`;
- `expert_model_parallel_size`.

`core_v0.19.0` added four related arguments that `validate_args` derives through
`resolve_tensor_parallel_weight_shards`:

- `tensor_parallel_num_weight_shards`;
- `gtp_weight_remat_size`;
- `expert_tensor_parallel_num_weight_shards`;
- `expert_gtp_weight_remat_size`.

These arguments were not added to `args_to_keep`.

For an HF source model represented with TP=1 and a requested conversion target
of TP=4, the saver therefore performs the following sequence:

1. argument parsing establishes the TP=4 target;
2. target validation derives a compatible weight-shard count;
3. `_load_checkpoint_args` replaces it with the source checkpoint's value of 1;
4. the saver runs `validate_args`;
5. validation rejects the source shard count against the target TP size.

The forked saver then aborts with:

```text
ValueError: tensor_parallel_num_weight_shards (1) must be >=
tensor_model_parallel_size (4).
```

## Changes

This PR adds the four target-derived arguments to `args_to_keep`:

```text
tensor_parallel_num_weight_shards
gtp_weight_remat_size
expert_tensor_parallel_num_weight_shards
expert_gtp_weight_remat_size
```

The target values are consequently retained until `validate_args` derives their
final values from the requested target parallelism.

Other source checkpoint arguments continue to be inherited as before.

A focused unit test verifies both sides of this behavior:

- the four target-derived arguments retain their target values;
- an ordinary checkpoint argument (`num_layers`) is still inherited from the
  source metadata.

## Reproduction

Reproduced with `core_v0.19.0` and confirmed to remain present on `main`.

Use a source checkpoint whose recorded tensor parallelism is 1 and request a
target tensor parallel size greater than 1:

```bash
python tools/checkpoint/convert.py \
  --model-type GPT \
  --loader mixtral_hf \
  --saver mcore \
  --target-tensor-parallel-size 4 \
  --target-pipeline-parallel-size 2 \
  --target-expert-parallel-size 1 \
  --load-dir <local copy of mistralai/Mixtral-8x7B-v0.1 safetensors> \
  --save-dir <output directory> \
  --tokenizer-model <tokenizer.model>
```

The converter runs the loader in its main process and forks a separate saver
process. Once the independent process-group initialization failure from #6989
is fixed, the saver reaches:

```text
MegatronCheckpointSaverBase.parse_megatron_args
  -> MegatronCheckpointSaverBase._load_checkpoint_args
  -> validate_args
  -> resolve_tensor_parallel_weight_shards

ValueError: tensor_parallel_num_weight_shards (1) must be >=
tensor_model_parallel_size (4).
```

The significant values are:

```text
source tensor_model_parallel_size:         1
source tensor_parallel_num_weight_shards:  1
target tensor_model_parallel_size:         4
incorrect inherited shard count:           1
expected target-derived shard count:        4
```

The converter is explicitly re-sharding to
`--target-tensor-parallel-size 4`. It exposes no separate target GTP-remat flag,
so the source checkpoint's derived value must not override the value derived
from the target configuration.

The preceding loader failure is addressed by the companion PR:

```text
Companion PR: <add link after creation>
```

## Validation

### Focused regression coverage

Added:

```bash
python -m pytest \
  tests/unit_tests/tools/checkpoint/test_checkpoint_saver_target_args.py
```

The test constructs source and target argument namespaces with deliberately
different values:

```text
                                      source   target
tensor_parallel_num_weight_shards       1       4
gtp_weight_remat_size                    1       2
expert_tensor_parallel_num_weight_shards 1       8
expert_gtp_weight_remat_size             1       2
num_layers                              24      12
```

After `_load_checkpoint_args`:

```text
tensor_parallel_num_weight_shards         4  (target preserved)
gtp_weight_remat_size                      2  (target preserved)
expert_tensor_parallel_num_weight_shards   8  (target preserved)
expert_gtp_weight_remat_size               2  (target preserved)
num_layers                                24  (source inherited)
```

Local preparation checks completed successfully:

```text
target-argument regression test passed
python -m py_compile <all changed Python files>
git diff --check passed
```

The complete pytest suite was not run in the local preparation environment
because that Python environment does not contain PyTorch. CI should execute the
new unit test in the normal project test environment.

### End-to-end conversion

The end-to-end validation included the companion process-group fix because the
loader otherwise aborts before the saver reaches this code.

With both changes applied, the original TP=4/PP=2/EP=1 conversion completes:

```text
successfully saved checkpoint from iteration 1 to <output directory>
[ t 1/4 ... 4/4, gtp_remat 1/0, p 2/2 ]
Done!
```

The saver argument output shows the intended separation:

```text
source / loader:
  tensor_model_parallel_size = 1
  tensor_parallel_num_weight_shards = 1

target / saver:
  tensor_model_parallel_size = 4
  tensor_parallel_num_weight_shards = 4
```

There is no longer an `Overwriting default` message for any of the four
target-derived arguments.

The generated checkpoint subsequently loads at TP=4/PP=2 and evaluation
completes successfully:

```text
successfully loaded checkpoint ... [ t 1/4, gtp_remat 1/1, p 1/2 ]

bf16:       lm loss value 1.952644
fp8-hybrid: lm loss value 1.979680
```

No source model revision, target parallelism, or converter parameters were
changed to obtain the successful result.

## Scope

This PR intentionally does not:

- change how `resolve_tensor_parallel_weight_shards` derives its values;
- introduce new converter command-line options;
- change checkpoint metadata;
- change model or training behavior;
- address process-group initialization in the loader or saver.

## Issue tracking

Related to #6989.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests — manual end-to-end validation is documented above
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate review.
