### PR TITLE
Add deterministic training to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ models/index
 :hidden:
 :caption: Advanced Features
 
+user-guide/deterministic-training
 user-guide/features/moe
 user-guide/features/megatron_fsdp
 user-guide/features/dist_optimizer

--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -11,10 +11,10 @@
 
 Deterministic training guarantees that two runs with identical inputs produce identical outputs at every step. Useful for debugging regressions and for reproducibility studies.
 
-Pass `--deterministic-mode` to any Megatron training entry point (e.g. `pretrain_gpt.py`):
+Pass `--deterministic-mode` to any Megatron training entry point (e.g. `pretrain_hybrid.py`):
 
 ```bash
-python pretrain_gpt.py \
+python pretrain_hybrid.py \
   --deterministic-mode \
   <other args ...>
 ```
@@ -51,4 +51,4 @@ Flash attention is permitted: Transformer Engine's flash-attention backend is de
 
 The bit-exact correctness suite lives at `tests/unit_tests/determinism/correctness/`. It parametrizes over model presets (GPT-like, Llama-like, Hybrid/Mamba) × parallelism cells (TP, PP, VPP, EP, FSDP, and composites) and asserts that two runs of the same configuration produce bit-identical outputs and gradients. FP8 / FP4 recipes (`tensorwise`, `delayed`, `mxfp8`, `nvfp4`) are covered by `tests/unit_tests/determinism/correctness/test_fp8_determinism.py`; the Blackwell-only recipes are capability-skipped on Hopper.
 
-The cost of `--deterministic-mode` is measured outside pytest by an nsys-driven per-NVTX-range breakdown: `tests/performance_tests/shell_test_utils/determinism/run_nsys_breakdown.sh` wraps any training entry point (e.g. `pretrain_gpt.py --profile`) under nsys for a det-vs-nondet comparison, and `tests/performance_tests/shell_test_utils/determinism/print_nsys_leaderboard.py` joins the two CSVs into a side-by-side table. The CI invocation lives at `tests/test_utils/recipes/h100/determinism-perf.yaml`.
+The cost of `--deterministic-mode` is measured outside pytest by an nsys-driven per-NVTX-range breakdown: `tests/performance_tests/shell_test_utils/determinism/run_nsys_breakdown.sh` wraps any training entry point (e.g. `pretrain_hybrid.py --profile`) under nsys for a det-vs-nondet comparison, and `tests/performance_tests/shell_test_utils/determinism/print_nsys_leaderboard.py` joins the two CSVs into a side-by-side table. The CI invocation lives at `tests/test_utils/recipes/h100/determinism-perf.yaml`.


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adding determinism docs to "Advanced Features" section. Also, updating examples to use `pretrain_hybrid.py`.