### PR TITLE
Recompute RoPE during bwd pass for DSv4

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -179,11 +179,12 @@ def _mla_rope_fwd_inplace_kernel(
         triton.Config({"BLOCK_H": 128}),
     ],
     key=["emb_dim", "head_num"],
-    restore_value=["DO"],
+    restore_value=["DO_OUT"],
 )
 @triton.jit
-def _mla_rope_bwd_inplace_kernel(
-    DO,
+def _mla_rope_bwd_kernel(
+    DO_IN,
+    DO_OUT,
     COS,
     SIN,
     nope_dim,
@@ -202,19 +203,30 @@ def _mla_rope_bwd_inplace_kernel(
     INVERSE: tl.constexpr,
     REMOVE_INTERLEAVING: tl.constexpr,
     ROPE_FIRST: tl.constexpr,
+    COPY_NOPE: tl.constexpr,
+    BLOCK_NOPE: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
-    Backward pass: inverse RoPE inplace on the leading emb_dim elements when ROPE_FIRST is true,
+    Backward pass: inverse RoPE on the leading emb_dim elements when ROPE_FIRST is true,
     otherwise on the trailing emb_dim elements.
     Reads from interleaved layout, writes to interleaved layout.
 
+    ``DO_IN`` and ``DO_OUT`` may alias, which gives the in-place form. When they
+    are distinct buffers, ``COPY_NOPE`` must be set so the leading ``nope_dim``
+    elements, which the rotation never touches, are copied across and ``DO_OUT``
+    is left fully populated. ``BLOCK_NOPE`` is then the next power of two at or
+    above ``nope_dim``.
+
     Input:
-        DO: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+        DO_IN: [seq_len, batch_size, head_num, nope_dim + emb_dim]
             or [total_seq_len, head_num, nope_dim + emb_dim]
         COS/SIN: [max_seq_len, emb_dim]
 
         batch_size, seq_num, and cu_seqlens_q are the same as in the forward pass
+
+    Output:
+        DO_OUT: same shape and strides as DO_IN
     """
     pid_m = tl.program_id(axis=0)
     pid_head = tl.program_id(axis=1)
@@ -242,29 +254,201 @@ def _mla_rope_bwd_inplace_kernel(
     cos_right = cos_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     sin_right = sin_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
 
-    DO = DO + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
+    row_off = pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
+    DO_IN = DO_IN + row_off
+    DO_OUT = DO_OUT + row_off
 
+    head_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads
     rope_offset = 0 if ROPE_FIRST else nope_dim
-    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + rope_offset
+    x_off = head_off + rope_offset
     mask = x_off < head_num * stride_x_nheads
     if REMOVE_INTERLEAVING:
         x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
         x_2_off = x_1_off + 1
-        x_left = tl.load(DO + x_1_off, mask=mask)
-        x_right = tl.load(DO + x_2_off, mask=mask)
+        x_left = tl.load(DO_IN + x_1_off, mask=mask)
+        x_right = tl.load(DO_IN + x_2_off, mask=mask)
     else:
         x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
         x_right_off = x_left_off + emb_dim // 2
-        x_left = tl.load(DO + x_left_off, mask=mask)
-        x_right = tl.load(DO + x_right_off, mask=mask)
+        x_left = tl.load(DO_IN + x_left_off, mask=mask)
+        x_right = tl.load(DO_IN + x_right_off, mask=mask)
         x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
         x_2_off = x_1_off + 1
 
     x_1 = x_left * cos_left + x_right * sin_right
     x_2 = -x_left * sin_left + x_right * cos_right
 
-    tl.store(DO + x_1_off, x_1, mask=mask)
-    tl.store(DO + x_2_off, x_2, mask=mask)
+    tl.store(DO_OUT + x_1_off, x_1, mask=mask)
+    tl.store(DO_OUT + x_2_off, x_2, mask=mask)
+
+    if COPY_NOPE:
+        nope_idx = tl.arange(0, BLOCK_NOPE)[None, :]
+        nope_off = head_off + (emb_dim if ROPE_FIRST else 0) + nope_idx
+        nope_mask = mask & (nope_idx < nope_dim)
+        tl.store(
+            DO_OUT + nope_off,
+            tl.load(DO_IN + nope_off, mask=nope_mask),
+            mask=nope_mask,
+        )
+
+
+def _flatten_rope_input(x, cu_seqlens_q, position_ids):
+    """Normalize an sbhd or thd RoPE input to a ``(rows, head_num, head_dim)`` view.
+
+    Returns ``(x_flat, batch_size, seq_num)``.  ``batch_size`` is only meaningful
+    for sbhd and ``seq_num`` only for thd; the unused one is None, matching what
+    the kernels expect.
+    """
+    if cu_seqlens_q is None:
+        # sbhd
+        assert position_ids is None
+        _max_seqlen, batch_size, nheads, headdim = x.shape
+        return x.view(-1, nheads, headdim), batch_size, None
+    # thd
+    total_seqlen = x.shape[0]
+    if position_ids is not None:
+        assert position_ids.shape == (total_seqlen,)
+    return x, None, len(cu_seqlens_q) - 1
+
+
+def _check_rope_layout(x, cos, sin, nope_dim, emb_dim):
+    """Validate the contiguity and head-dim invariants both RoPE kernels rely on."""
+    assert x.stride(-1) == 1
+    assert cos.stride(-1) == 1
+    assert sin.stride(-1) == 1
+    assert x.shape[-1] == nope_dim + emb_dim
+    assert emb_dim % 4 == 0
+
+
+def mla_rope_apply_raw_(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    nope_dim: int,
+    emb_dim: int,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+    position_ids: Optional[torch.Tensor] = None,
+    rope_first: bool = False,
+) -> torch.Tensor:
+    """Apply the MLA RoPE rotation to ``t`` in place, bypassing autograd.
+
+    Same kernel and semantics as :func:`fused_mla_rope_inplace`, but without the
+    autograd node.  Intended for callers that already run inside a custom
+    ``torch.autograd.Function`` and take care of the backward themselves.
+
+    Args:
+        t: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+            or [total_seq_len, head_num, nope_dim + emb_dim]
+        cos/sin: [max_seq_len, 1, 1, emb_dim]
+        cu_seqlens_q: [seq_num + 1] accumulated sequence lengths for thd format
+        inverse: if True, apply the inverse rotation
+        remove_interleaving: if True, output RoPE dims in non-interleaved layout
+        position_ids: optional thd row positions overriding the CP row mapping
+        rope_first: if True, rotate the leading emb_dim elements instead of the trailing ones
+
+    Returns:
+        t: the same tensor, modified in place
+    """
+    x, batch_size, seq_num = _flatten_rope_input(t, cu_seqlens_q, position_ids)
+    _check_rope_layout(x, cos, sin, nope_dim, emb_dim)
+    total_seqlen, nheads, _ = x.shape
+
+    grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+    _mla_rope_fwd_inplace_kernel[grid](
+        x,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        nheads,
+        batch_size,
+        seq_num,
+        cu_seqlens_q,
+        position_ids,
+        x.stride(0),
+        x.stride(1),
+        cos.stride(0),
+        sin.stride(0),
+        cp_rank,
+        cp_size,
+        INVERSE=inverse,
+        REMOVE_INTERLEAVING=remove_interleaving,
+        ROPE_FIRST=rope_first,
+    )
+    return t
+
+
+def mla_rope_unapply_raw(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    nope_dim: int,
+    emb_dim: int,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+    position_ids: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    rope_first: bool = False,
+) -> torch.Tensor:
+    """Undo :func:`mla_rope_apply_raw_`, bypassing autograd.
+
+    This is the exact transpose of the forward rotation, so for a unit-magnitude
+    rotation (``mscale == 1.0``) it is also its exact inverse.  Pass the same
+    ``inverse`` and ``remove_interleaving`` flags that were used to apply it.
+
+    With ``out=None`` the un-rotation happens in place.  Pass ``out`` when ``t``
+    is aliased by a tensor another autograd node still expects to hold the
+    rotated values; the leading ``nope_dim`` elements are copied across so
+    ``out`` is fully populated in a single pass.
+
+    Returns:
+        ``t`` when ``out`` is None, otherwise ``out``.
+    """
+    x, batch_size, seq_num = _flatten_rope_input(t, cu_seqlens_q, position_ids)
+    _check_rope_layout(x, cos, sin, nope_dim, emb_dim)
+    total_seqlen, nheads, _ = x.shape
+
+    if out is None:
+        y = x
+    else:
+        assert out.shape == t.shape
+        assert out.stride() == t.stride()
+        assert out.dtype == t.dtype
+        y, _, _ = _flatten_rope_input(out, cu_seqlens_q, position_ids)
+
+    grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+    _mla_rope_bwd_kernel[grid](
+        x,
+        y,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        nheads,
+        batch_size,
+        seq_num,
+        cu_seqlens_q,
+        position_ids,
+        x.stride(0),
+        x.stride(1),
+        cos.stride(0),
+        sin.stride(0),
+        cp_rank,
+        cp_size,
+        INVERSE=inverse,
+        REMOVE_INTERLEAVING=remove_interleaving,
+        ROPE_FIRST=rope_first,
+        COPY_NOPE=out is not None,
+        BLOCK_NOPE=triton.next_power_of_2(nope_dim) if out is not None else 1,
+    )
+    return t if out is None else out
 
 
 class _FusedMLARoPEInplace(torch.autograd.Function):
@@ -302,48 +486,19 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             rope_first: if True, rotate the leading emb_dim elements instead of the trailing ones
         """
         assert not rotary_interleaved
-        max_seqlen = None
-        batch_size = None
-        seq_num = None
-        if cu_seqlens_q is None:
-            # sbhd
-            assert position_ids is None
-            max_seqlen, batch_size, nheads, headdim = q.shape
-            q = q.view(-1, nheads, headdim)
-            total_seqlen = q.shape[0]
-        else:
-            # thd
-            total_seqlen, nheads, headdim = q.shape
-            seq_num = len(cu_seqlens_q) - 1
-            if position_ids is not None:
-                assert position_ids.shape == (total_seqlen,)
-        assert q.stride(-1) == 1
-        assert cos.stride(-1) == 1
-        assert sin.stride(-1) == 1
-        assert headdim == nope_dim + emb_dim
-        assert emb_dim % 4 == 0
-
-        grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        _mla_rope_fwd_inplace_kernel[grid](
+        mla_rope_apply_raw_(
             q,
             cos,
             sin,
             nope_dim,
             emb_dim,
-            nheads,
-            batch_size,
-            seq_num,
-            cu_seqlens_q,
-            position_ids,
-            q.stride(0),
-            q.stride(1),
-            cos.stride(0),
-            sin.stride(0),
-            cp_rank,
-            cp_size,
-            INVERSE=inverse,
-            REMOVE_INTERLEAVING=remove_interleaving,
-            ROPE_FIRST=rope_first,
+            cu_seqlens_q=cu_seqlens_q,
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            inverse=inverse,
+            remove_interleaving=remove_interleaving,
+            position_ids=position_ids,
+            rope_first=rope_first,
         )
         ctx.save_for_backward(cos, sin, *(() if position_ids is None else (position_ids,)))
         ctx.has_position_ids = position_ids is not None
@@ -356,8 +511,6 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
         ctx.rope_first = rope_first
         ctx.cp_rank = cp_rank
         ctx.cp_size = cp_size
-        if cu_seqlens_q is None:
-            q = q.view(max_seqlen, batch_size, nheads, headdim)
         return q
 
     @staticmethod
@@ -374,44 +527,23 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
         else:
             cos, sin = ctx.saved_tensors
             position_ids = None
-        max_seqlen = None
-        batch_size = None
-        seq_num = None
-        if ctx.cu_seqlens_q is None:
-            max_seqlen, batch_size, nheads, headdim = grad.shape
-            grad = grad.contiguous().view(-1, nheads, headdim)
-            total_seqlen = grad.shape[0]
-        else:
-            seq_num = len(ctx.cu_seqlens_q) - 1
-            if ctx.has_position_ids:
-                grad = grad.contiguous()
-            total_seqlen, nheads, headdim = grad.shape
-        assert grad.stride(-1) == 1
+        if ctx.cu_seqlens_q is None or ctx.has_position_ids:
+            grad = grad.contiguous()
 
-        grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        _mla_rope_bwd_inplace_kernel[grid](
+        mla_rope_unapply_raw(
             grad,
             cos,
             sin,
             ctx.nope_dim,
             ctx.emb_dim,
-            nheads,
-            batch_size,
-            seq_num,
-            ctx.cu_seqlens_q,
-            position_ids,
-            grad.stride(0),
-            grad.stride(1),
-            cos.stride(0),
-            sin.stride(0),
-            ctx.cp_rank,
-            ctx.cp_size,
-            INVERSE=ctx.inverse,
-            REMOVE_INTERLEAVING=ctx.remove_interleaving,
-            ROPE_FIRST=ctx.rope_first,
+            cu_seqlens_q=ctx.cu_seqlens_q,
+            cp_rank=ctx.cp_rank,
+            cp_size=ctx.cp_size,
+            inverse=ctx.inverse,
+            remove_interleaving=ctx.remove_interleaving,
+            position_ids=position_ids,
+            rope_first=ctx.rope_first,
         )
-        if ctx.cu_seqlens_q is None:
-            grad = grad.view(max_seqlen, batch_size, nheads, headdim)
         return grad, None, None, None, None, None, None, None, None, None, None, None, None
 
 
@@ -486,6 +618,7 @@ def fused_mla_rope_out_of_place(
     rotary_interleaved: bool = False,
     inverse: bool = False,
     remove_interleaving: bool = False,
+    position_ids: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Apply the fused RoPE kernel without modifying the input tensor.
 
@@ -505,6 +638,7 @@ def fused_mla_rope_out_of_place(
         rotary_interleaved=rotary_interleaved,
         inverse=inverse,
         remove_interleaving=remove_interleaving,
+        position_ids=position_ids,
     )
 
 

--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -285,11 +285,7 @@ def _mla_rope_bwd_kernel(
         nope_idx = tl.arange(0, BLOCK_NOPE)[None, :]
         nope_off = head_off + (emb_dim if ROPE_FIRST else 0) + nope_idx
         nope_mask = mask & (nope_idx < nope_dim)
-        tl.store(
-            DO_OUT + nope_off,
-            tl.load(DO_IN + nope_off, mask=nope_mask),
-            mask=nope_mask,
-        )
+        tl.store(DO_OUT + nope_off, tl.load(DO_IN + nope_off, mask=nope_mask), mask=nope_mask)
 
 
 def _flatten_rope_input(x, cu_seqlens_q, position_ids):

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -834,8 +834,8 @@ def _unfused_indexer_sparse_attn_from_topk(
     _max_seqlen_q: int,
     indexer_layout: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
     q_padding_mask: Optional[torch.Tensor] = None,
-    out_rope: Optional[OutputRopeParams] = None,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    out_rope: Optional[OutputRopeParams] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """PyTorch sparse attention plus caller-supplied indexer loss for THD CP.
 
@@ -3071,7 +3071,6 @@ class CompressedSparseAttention(MegatronModule):
                 max_seqlen_q,
                 indexer_layout,
                 q_padding_mask,
-                fused_out_rope,
             )
             if overlap_cp_backward:
                 output, indexer_loss = FusedCSAIndexerSparseAttnFromTopkFunc.apply(
@@ -3083,10 +3082,13 @@ class CompressedSparseAttention(MegatronModule):
                     seq_to_rank_row if not sparse_indexer_loss else None,
                     indexer_k_rs_state,
                     compressed_kv_rs_state,
+                    fused_out_rope,
                 )
             else:
                 output, indexer_loss = _unfused_indexer_sparse_attn_from_topk(
-                    *indexer_loss_args, tp_group=indexer.pg_collection.tp
+                    *indexer_loss_args,
+                    out_rope=fused_out_rope,
+                    tp_group=indexer.pg_collection.tp,
                 )
             if fused_out_rope is None:
                 flat_shape = output.shape

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -9,7 +9,10 @@ import torch
 import torch.nn as nn
 
 from megatron.core.fp8_utils import get_fp8_disabled_context
-from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_inplace
+from megatron.core.fusions.fused_mla_yarn_rope_apply import (
+    fused_mla_rope_inplace,
+    fused_mla_rope_out_of_place,
+)
 from megatron.core.models.common.embeddings import RotaryEmbedding, apply_rotary_pos_emb
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -27,6 +30,7 @@ from megatron.core.transformer.experimental_attention_variant.csa_utils.fused_co
 )
 from megatron.core.transformer.experimental_attention_variant.csa_utils.fused_sparse_attention import (  # pylint: disable=line-too-long
     FusedCSAIndexerSparseAttnFromTopkFunc,
+    OutputRopeParams,
     batch_of_row,
     build_flat_topk_idxs,
     csa_sparse_attn,
@@ -49,7 +53,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa_kernels import
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import nvtx_range_pop, nvtx_range_push
+from megatron.core.utils import get_pg_rank, get_pg_size, nvtx_range_pop, nvtx_range_push
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -830,6 +834,7 @@ def _unfused_indexer_sparse_attn_from_topk(
     _max_seqlen_q: int,
     indexer_layout: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
     q_padding_mask: Optional[torch.Tensor] = None,
+    out_rope: Optional[OutputRopeParams] = None,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """PyTorch sparse attention plus caller-supplied indexer loss for THD CP.
@@ -839,7 +844,15 @@ def _unfused_indexer_sparse_attn_from_topk(
     ``indexer_topk_indices`` indexes compressed K for sparse indexer loss.
     ``_max_seqlen_q`` is unused here; it is retained to match the fused
     callable's signature, with the leading underscore marking it as unused.
+
+    ``out_rope`` is likewise only there for signature parity. There is no output
+    buffer to fuse the rotation into on this path, so the caller applies it.
     """
+    if out_rope is not None:
+        raise ValueError(
+            "The unfused THD CP path cannot fuse the output inverse RoPE; "
+            "the caller must apply it to the returned output."
+        )
     output = unfused_compressed_sparse_attn(query, kv_full, attn_sink, topk_indices, softmax_scale)
 
     total_q, np_, hn = query.shape
@@ -1692,6 +1705,137 @@ class CSAIndexer(MegatronModule):
 # ---------------------------------------------------------------------------
 
 
+class _OutputInverseRope:
+    """Undoes the query-side RoPE on the DSv4 attention output.
+
+    Built once per :meth:`CompressedSparseAttention.forward` from the layout
+    metadata, then used one of two ways:
+
+    * :attr:`fused_params` is handed to the sparse-attention ``Function``, which
+      rotates in place on the output it already saves for backward.  Only
+      available when ``config.apply_rope_fusion`` is set.
+    * :meth:`apply` rotates out of place, for every path whose output is still
+      owned by autograd and therefore cannot be mutated.
+
+    ``mscale`` is pinned to 1.0 throughout.  DSv4's reference (DS-Inf) RoPE is a
+    pure rotation and the model relies on Q/KV RMS-norm rather than yarn's
+    concentration factor.  That unit magnitude is also what makes the rotation
+    orthogonal, which is what lets the fused backward invert it.
+    """
+
+    def __init__(
+        self,
+        attn: "CompressedSparseAttention",
+        dtype: torch.dtype,
+        rope_seqlen: int,
+        packed_seq: bool,
+        cu_seqlens_q: Optional[torch.Tensor] = None,
+        sbhd_batch_size: Optional[int] = None,
+        thd_cp_global_start: Optional[int] = None,
+        thd_cp_rows: Optional[int] = None,
+    ):
+        if attn.rotary_pos_emb is None:
+            raise ValueError(
+                "CompressedSparseAttention needs rotary_pos_emb to undo the "
+                "query-side RoPE on its output."
+            )
+        self.config = attn.config
+        self.cp_group = attn.pg_collection.cp
+        self.pos_dim = attn.qk_pos_emb_head_dim
+        self.nope_dim = attn.v_head_dim - self.pos_dim
+        self.cu_seqlens_q = cu_seqlens_q
+        self.max_seqlen = rope_seqlen if packed_seq else None
+        self.thd_cp_global_start = thd_cp_global_start
+
+        position_ids = None
+        if thd_cp_global_start is not None:
+            position_ids = cp_utils.thd_cp_position_ids(
+                cu_seqlens_q, thd_cp_global_start, thd_cp_rows
+            )
+
+        self.freqs = None
+        self.fused_params = None
+        if self.config.apply_rope_fusion:
+            cos, sin = attn.rotary_pos_emb.get_cached_cos_sin(
+                rope_seqlen, dtype=dtype, packed_seq=packed_seq, mscale=1.0
+            )
+            # position_ids supersedes the kernel's built-in CP row mapping.
+            self.fused_params = OutputRopeParams(
+                cos=cos,
+                sin=sin,
+                nope_dim=self.nope_dim,
+                pos_dim=self.pos_dim,
+                cu_seqlens_q=cu_seqlens_q,
+                cp_rank=0 if position_ids is not None else get_pg_rank(self.cp_group),
+                cp_size=1 if position_ids is not None else get_pg_size(self.cp_group),
+                position_ids=position_ids,
+                sbhd_batch_size=sbhd_batch_size,
+            )
+        else:
+            rope_result = attn.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
+            self.freqs = rope_result[0] if isinstance(rope_result, tuple) else rope_result
+
+    def apply(self, x: torch.Tensor) -> torch.Tensor:
+        """Inverse-RoPE ``x`` out of place.
+
+        Args:
+            x: ``(sq, b, np, head_dim)`` for sbhd, ``(rows, np, head_dim)`` for thd.
+        """
+        if self.thd_cp_global_start is not None:
+            if self.fused_params is not None:
+                return cp_utils.apply_thd_cp_local_rope_fused(
+                    x,
+                    self.fused_params.cos,
+                    self.fused_params.sin,
+                    self.nope_dim,
+                    self.pos_dim,
+                    self.cu_seqlens_q,
+                    self.thd_cp_global_start,
+                    inverse=True,
+                )
+            return cp_utils.apply_thd_cp_local_rope_unfused(
+                x,
+                self.freqs,
+                self.nope_dim,
+                self.pos_dim,
+                self.cu_seqlens_q,
+                self.thd_cp_global_start,
+                self.config,
+                inverse=True,
+            )
+
+        if self.fused_params is not None:
+            return fused_mla_rope_out_of_place(
+                x,
+                self.fused_params.cos,
+                self.fused_params.sin,
+                self.nope_dim,
+                self.pos_dim,
+                cu_seqlens_q=self.cu_seqlens_q,
+                cp_rank=self.fused_params.cp_rank,
+                cp_size=self.fused_params.cp_size,
+                inverse=True,
+                remove_interleaving=True,
+            )
+
+        content_part, rot_part = torch.split(
+            x, [x.size(-1) - self.pos_dim, self.pos_dim], dim=-1
+        )
+        rot_part = apply_rotary_pos_emb(
+            rot_part,
+            self.freqs,
+            self.config,
+            cu_seqlens=self.cu_seqlens_q,
+            mscale=1.0,
+            cp_group=self.cp_group,
+            mla_rotary_interleaved=True,
+            inverse=True,
+            mla_output_remove_interleaving=True,
+            max_seqlen=self.max_seqlen,
+        )
+        return torch.cat([content_part, rot_part], dim=-1)
+
+
 @dataclass
 class CompressedSparseAttentionSubmodules:
     """Submodule specs for CompressedSparseAttention."""
@@ -1746,6 +1890,11 @@ class CompressedSparseAttention(MegatronModule):
         self.compress_ratio = compress_ratio
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
+        # Owned here rather than by the parent attention module: the inverse RoPE
+        # on the attention output is applied by this module (fused into the
+        # sparse-attention Function where possible), so it needs the cos/sin.
+        self.rotary_pos_emb = rotary_pos_emb
+        self.qk_pos_emb_head_dim = config.qk_pos_emb_head_dim
 
         self.n_local_heads = config.num_attention_heads
 
@@ -1940,6 +2089,7 @@ class CompressedSparseAttention(MegatronModule):
         n_compressed: int,
         offset: int,
         window_idxs: torch.Tensor,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> torch.Tensor:
         """Path A: fused sparse attn with window or deterministic compressed indices."""
         sq, b, np, hn = query.size()
@@ -1956,7 +2106,12 @@ class CompressedSparseAttention(MegatronModule):
 
         nvtx_range_push("sparse_attn_kernel")
         output = csa_sparse_attn(
-            query, kv_full, self.attn_sink.float(), flat_idxs, self.softmax_scale
+            query,
+            kv_full,
+            self.attn_sink.float(),
+            flat_idxs,
+            self.softmax_scale,
+            out_rope=out_rope,
         )
         nvtx_range_pop("sparse_attn_kernel")
         return output
@@ -1971,6 +2126,7 @@ class CompressedSparseAttention(MegatronModule):
         offset: int,
         window_idxs: torch.Tensor,
         packed_seq_params: Optional[PackedSeqParams],
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> torch.Tensor:
         """Path C: separate indexer forward (no loss) + fused sparse attn (compact)."""
         b = query.size(1)
@@ -2003,6 +2159,7 @@ class CompressedSparseAttention(MegatronModule):
             flat_idxs,
             self.softmax_scale,
             topk_length=flat_tlen,
+            out_rope=out_rope,
         )
         nvtx_range_pop("sparse_attn_kernel")
         return output
@@ -2017,8 +2174,12 @@ class CompressedSparseAttention(MegatronModule):
         offset: int,
         window_idxs: torch.Tensor,
         packed_seq_params: Optional[PackedSeqParams],
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Path B: fused indexer (with loss) + fused sparse attn.
+
+        ``out_rope`` is applied to the attention output inside the Function, so
+        the returned output is already inverse-RoPE'd.
 
         Returns ``(output, indexer_loss)``.
         """
@@ -2049,6 +2210,7 @@ class CompressedSparseAttention(MegatronModule):
             sparse_loss=getattr(self.config, "dsa_indexer_use_sparse_loss", True),
             kv_offset=offset,
             calculate_per_token_loss=self.config.calculate_per_token_loss,
+            out_rope=out_rope,
         )
         nvtx_range_pop("sparse_attn_kernel")
 
@@ -2089,7 +2251,8 @@ class CompressedSparseAttention(MegatronModule):
             qr:     [sq, b, q_lora_rank]  compressed query representation.
 
         Returns:
-            output: [sq, b, np * v_head_dim]
+            output: [sq, b, np * v_head_dim], with DSv4's inverse RoPE already
+                applied to the trailing ``qk_pos_emb_head_dim`` of each head.
         """
         nvtx_range_push("compressed_sparse_attn")
 
@@ -2131,6 +2294,14 @@ class CompressedSparseAttention(MegatronModule):
         )
 
         indexer_loss = None
+        out_rope = _OutputInverseRope(
+            self, x.dtype, rope_seqlen=sq, packed_seq=False, sbhd_batch_size=b
+        )
+        # Every fused path rotates in place inside its Function, which owns the
+        # output buffer and un-rotates what it needs in its own backward. Only
+        # the unfused reference path leaves its output owned by autograd, so
+        # that one rotates out of place below.
+        fused_out_rope = out_rope.fused_params if self.use_fused_kernels else None
 
         if not self.use_fused_kernels:
             output, indexer_loss = self._forward_unfused_csa(
@@ -2146,16 +2317,36 @@ class CompressedSparseAttention(MegatronModule):
             )
         elif has_indexer_compressed and self.training and torch.is_grad_enabled():
             output, indexer_loss = self._forward_fused_indexer_training(
-                query, x, qr, kv_full, n_compressed, offset, window_idxs, packed_seq_params
+                query,
+                x,
+                qr,
+                kv_full,
+                n_compressed,
+                offset,
+                window_idxs,
+                packed_seq_params,
+                out_rope=fused_out_rope,
             )
         elif has_indexer_compressed:
             output = self._forward_fused_indexer_inference(
-                query, x, qr, kv_full, n_compressed, offset, window_idxs, packed_seq_params
+                query,
+                x,
+                qr,
+                kv_full,
+                n_compressed,
+                offset,
+                window_idxs,
+                packed_seq_params,
+                out_rope=fused_out_rope,
             )
         else:
             output = self._forward_fused_no_indexer(
-                query, kv_full, n_compressed, offset, window_idxs
+                query, kv_full, n_compressed, offset, window_idxs, out_rope=fused_out_rope
             )
+
+        if fused_out_rope is None:
+            flat_shape = output.shape
+            output = out_rope.apply(output.reshape(sq, b, np, -1)).reshape(flat_shape)
 
         if indexer_loss is not None:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
@@ -2333,6 +2524,7 @@ class CompressedSparseAttention(MegatronModule):
         n_compressed_total: int,
         window_idxs: torch.Tensor,
         max_seqlen_compressed_idx: int = 0,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> torch.Tensor:
         """Path A (THD): fused sparse attn with window or deterministic
         compressed indices.
@@ -2364,7 +2556,13 @@ class CompressedSparseAttention(MegatronModule):
             )
 
         output = csa_sparse_attn(
-            query, kv_full_thd, self.attn_sink.float(), flat_idxs, self.softmax_scale, is_thd=True
+            query,
+            kv_full_thd,
+            self.attn_sink.float(),
+            flat_idxs,
+            self.softmax_scale,
+            is_thd=True,
+            out_rope=out_rope,
         )
         return output.unsqueeze(1)
 
@@ -2383,6 +2581,7 @@ class CompressedSparseAttention(MegatronModule):
         max_seqlen_q: int,
         max_seqlen_compressed_idx: int,
         max_seqlen_kv: int,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> torch.Tensor:
         """Path C (THD): separate indexer forward (no loss) + fused sparse attn (compact).
 
@@ -2442,6 +2641,7 @@ class CompressedSparseAttention(MegatronModule):
             self.softmax_scale,
             topk_length=flat_tlen,
             is_thd=True,
+            out_rope=out_rope,
         )
         return output.unsqueeze(1)
 
@@ -2461,8 +2661,12 @@ class CompressedSparseAttention(MegatronModule):
         compressed_kv: torch.Tensor,
         kv_full_thd: torch.Tensor,
         window_idxs: torch.Tensor,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> torch.Tensor:
         """Path B (THD): fused indexer (with loss) + fused sparse attn.
+
+        ``out_rope`` is applied to the attention output inside the Function, so
+        the returned output is already inverse-RoPE'd.
 
         Returns ``(output, indexer_loss)`` where *output* is
         ``(total_q, 1, np * hn)``.
@@ -2523,6 +2727,7 @@ class CompressedSparseAttention(MegatronModule):
             compressed_kv=compressed_kv,
             calculate_per_token_loss=self.config.calculate_per_token_loss,
             cu_seqlens_q_unpadded=cu_seqlens_q_unpadded,
+            out_rope=out_rope,
         )
 
         if indexer_loss_coeff > 0:
@@ -2554,7 +2759,7 @@ class CompressedSparseAttention(MegatronModule):
         cp_size = cp_group.size()
         cp_rank = cp_group.rank()
 
-        l_local = query.shape[0]
+        l_local, np_local = query.shape[0], query.shape[1]
         if l_local != key.shape[0]:
             raise RuntimeError("DSv4 THD CP path currently supports self-attention only.")
         cu_seqlens = (
@@ -2566,6 +2771,17 @@ class CompressedSparseAttention(MegatronModule):
 
         # ---- Step 2: local CP rows, local KV, and boundary tensors ------------
         global_start = cp_rank * l_local
+        # Self-attention only on this path, so the q cu_seqlens double as the kv
+        # ones and keep the CP row-to-position mapping self-consistent.
+        out_rope = _OutputInverseRope(
+            self,
+            x.dtype,
+            rope_seqlen=max_seqlen_q,
+            packed_seq=True,
+            cu_seqlens_q=cu_seqlens,
+            thd_cp_global_start=global_start,
+            thd_cp_rows=l_local,
+        )
         kv_local = key.squeeze(-2).squeeze(1)
         if boundary_hidden is None or boundary_kv is None:
             raise RuntimeError(
@@ -2790,6 +3006,9 @@ class CompressedSparseAttention(MegatronModule):
                 for_indexer_loss=use_indexer_loss,
             )
         )
+        # Only the fused Functions can rotate in place; see :meth:`forward`.
+        fused_out_rope = out_rope.fused_params if self.use_fused_kernels else None
+
         if use_indexer_loss:
             # ---- Step 7a: indexer-loss path ----------------------------------
             k_indexer_for_loss = k_indexer_rank_major
@@ -2852,6 +3071,7 @@ class CompressedSparseAttention(MegatronModule):
                 max_seqlen_q,
                 indexer_layout,
                 q_padding_mask,
+                fused_out_rope,
             )
             if overlap_cp_backward:
                 output, indexer_loss = FusedCSAIndexerSparseAttnFromTopkFunc.apply(
@@ -2868,6 +3088,9 @@ class CompressedSparseAttention(MegatronModule):
                 output, indexer_loss = _unfused_indexer_sparse_attn_from_topk(
                     *indexer_loss_args, tp_group=indexer.pg_collection.tp
                 )
+            if fused_out_rope is None:
+                flat_shape = output.shape
+                output = out_rope.apply(output.reshape(l_local, np_local, -1)).reshape(flat_shape)
             if indexer_loss_coeff > 0:
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
@@ -2888,11 +3111,15 @@ class CompressedSparseAttention(MegatronModule):
                 self.softmax_scale,
                 topk_length=topk_length,
                 is_thd=True,
+                out_rope=fused_out_rope,
             )
         else:
             output = unfused_compressed_sparse_attn(
                 query, kv_full_thd, self.attn_sink.float(), topk_idxs, self.softmax_scale
             )
+        if fused_out_rope is None:
+            flat_shape = output.shape
+            output = out_rope.apply(output.reshape(l_local, np_local, -1)).reshape(flat_shape)
         return output.unsqueeze(1)
 
     def _forward_thd(
@@ -2983,6 +3210,16 @@ class CompressedSparseAttention(MegatronModule):
         )
 
         indexer_loss = None
+        out_rope = _OutputInverseRope(
+            self,
+            x.dtype,
+            rope_seqlen=max_seqlen_kv,
+            packed_seq=True,
+            cu_seqlens_q=cu_seqlens_kv,
+        )
+        # See :meth:`forward`: every fused path rotates in place inside its
+        # Function, only the unfused reference path rotates out of place.
+        fused_out_rope = out_rope.fused_params if self.use_fused_kernels else None
 
         if not self.use_fused_kernels:
             output, indexer_loss = self._forward_unfused_csa_thd(
@@ -3019,6 +3256,7 @@ class CompressedSparseAttention(MegatronModule):
                 compressed_kv,
                 kv_full_thd,
                 window_idxs,
+                out_rope=fused_out_rope,
             )
         elif has_indexer:
             output = self._forward_fused_indexer_inference_thd(
@@ -3035,6 +3273,7 @@ class CompressedSparseAttention(MegatronModule):
                 max_seqlen_q,
                 max_seqlen_compressed_idx,
                 max_seqlen_kv,
+                out_rope=fused_out_rope,
             )
         else:
             output = self._forward_fused_no_indexer_thd(
@@ -3048,7 +3287,12 @@ class CompressedSparseAttention(MegatronModule):
                 n_compressed_total,
                 window_idxs,
                 max_seqlen_compressed_idx=max_seqlen_compressed_idx,
+                out_rope=fused_out_rope,
             )
+
+        if fused_out_rope is None:
+            flat_shape = output.shape
+            output = out_rope.apply(output.reshape(total_q, _np, -1)).reshape(flat_shape)
 
         if indexer_loss is not None:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1818,9 +1818,7 @@ class _OutputInverseRope:
                 remove_interleaving=True,
             )
 
-        content_part, rot_part = torch.split(
-            x, [x.size(-1) - self.pos_dim, self.pos_dim], dim=-1
-        )
+        content_part, rot_part = torch.split(x, [x.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
         rot_part = apply_rotary_pos_emb(
             rot_part,
             self.freqs,
@@ -2106,12 +2104,7 @@ class CompressedSparseAttention(MegatronModule):
 
         nvtx_range_push("sparse_attn_kernel")
         output = csa_sparse_attn(
-            query,
-            kv_full,
-            self.attn_sink.float(),
-            flat_idxs,
-            self.softmax_scale,
-            out_rope=out_rope,
+            query, kv_full, self.attn_sink.float(), flat_idxs, self.softmax_scale, out_rope=out_rope
         )
         nvtx_range_pop("sparse_attn_kernel")
         return output
@@ -3086,9 +3079,7 @@ class CompressedSparseAttention(MegatronModule):
                 )
             else:
                 output, indexer_loss = _unfused_indexer_sparse_attn_from_topk(
-                    *indexer_loss_args,
-                    out_rope=fused_out_rope,
-                    tp_group=indexer.pg_collection.tp,
+                    *indexer_loss_args, out_rope=fused_out_rope, tp_group=indexer.pg_collection.tp
                 )
             if fused_out_rope is None:
                 flat_shape = output.shape
@@ -3213,11 +3204,7 @@ class CompressedSparseAttention(MegatronModule):
 
         indexer_loss = None
         out_rope = _OutputInverseRope(
-            self,
-            x.dtype,
-            rope_seqlen=max_seqlen_kv,
-            packed_seq=True,
-            cu_seqlens_q=cu_seqlens_kv,
+            self, x.dtype, rope_seqlen=max_seqlen_kv, packed_seq=True, cu_seqlens_q=cu_seqlens_kv
         )
         # See :meth:`forward`: every fused path rotates in place inside its
         # Function, only the unfused reference path rotates out of place.

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/cp_utils.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/cp_utils.py
@@ -23,7 +23,7 @@ from .fused_sparse_attention import indexer_topk
 # =============================================================================
 
 
-def _thd_cp_position_ids(
+def thd_cp_position_ids(
     cu_seqlens_padded: torch.Tensor, global_start: int, local_rows: int
 ) -> torch.Tensor:
     """Map a consecutive CP row interval to positions within packed sequences."""
@@ -42,6 +42,10 @@ def _thd_cp_position_ids(
     return torch.where(valid_rows, global_rows - sequence_starts, 0)
 
 
+# Retained for callers outside megatron.core that already use the private name.
+_thd_cp_position_ids = thd_cp_position_ids
+
+
 def apply_thd_cp_local_rope_fused(
     x: torch.Tensor,
     cos: torch.Tensor,
@@ -53,7 +57,7 @@ def apply_thd_cp_local_rope_fused(
     inverse: bool = False,
 ) -> torch.Tensor:
     """Apply fused non-interleaved RoPE to local THD CP rows."""
-    position_ids = _thd_cp_position_ids(cu_seqlens_padded, global_start, x.shape[0])
+    position_ids = thd_cp_position_ids(cu_seqlens_padded, global_start, x.shape[0])
 
     squeezed_batch = x.ndim == 4 and x.shape[1] == 1
     squeezed_head = x.ndim == 2
@@ -91,7 +95,7 @@ def apply_thd_cp_local_rope_unfused(
     inverse: bool = False,
 ) -> torch.Tensor:
     """Apply unfused RoPE to a consecutive interval of packed CP rows."""
-    position_ids = _thd_cp_position_ids(cu_seqlens_padded, global_start, x.shape[0])
+    position_ids = thd_cp_position_ids(cu_seqlens_padded, global_start, x.shape[0])
     freqs = torch.index_select(rotary_pos_emb, 0, position_ids.long())
 
     squeezed_batch = x.ndim == 4 and x.shape[1] == 1

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -22,16 +22,112 @@ Public API (same shape as the old ``dsa_kernels`` package):
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
 
+from megatron.core.fusions.fused_mla_yarn_rope_apply import (
+    mla_rope_apply_raw_,
+    mla_rope_unapply_raw,
+)
 from megatron.core.tensor_parallel.mappings import async_reduce_scatter_along_first_dim
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
 from .csa_teacher_lse import can_use_fused_csa_teacher_lse, fused_csa_teacher_lse
+
+# ---------------------------------------------------------------------------
+# Output inverse-RoPE fused into the sparse-attention Functions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OutputRopeParams:
+    """Inverse-RoPE applied to the attention output inside the fused Functions.
+
+    DSv4 undoes the query-side RoPE on the attention output.  Folding that into
+    the sparse-attention ``Function`` lets the rotation happen in place on the
+    tensor the Function already saves for backward, instead of on a private
+    clone, which removes one full ``(rows, heads, v_head_dim)`` buffer per layer
+    from the forward-to-backward live set.
+
+    The rotation is orthogonal only when the cos/sin were built with
+    ``mscale=1.0`` (DSv4's "pure rotation" contract).  That is what makes
+    :meth:`undo` an exact inverse rather than just a transpose, so the backward
+    can recover the pre-RoPE output and gradient.
+
+    ``sbhd_batch_size`` is required for the sbhd layout, where the flat
+    ``(sq * b, ...)`` rows are sq-major and the kernel derives the token index
+    as ``row // batch_size``.  For thd it must be None and ``cu_seqlens_q``
+    supplies the segment boundaries instead.
+    """
+
+    cos: Tensor
+    sin: Tensor
+    nope_dim: int
+    pos_dim: int
+    cu_seqlens_q: Optional[Tensor] = None
+    cp_rank: int = 0
+    cp_size: int = 1
+    position_ids: Optional[Tensor] = None
+    sbhd_batch_size: Optional[int] = None
+
+    def _kernel_view(self, out_flat: Tensor) -> Tensor:
+        """View a flat ``(rows, heads, head_dim)`` output the way the kernel wants it."""
+        if out_flat.shape[-1] != self.nope_dim + self.pos_dim:
+            raise ValueError(
+                "Output inverse-RoPE expects head_dim == nope_dim + pos_dim, got "
+                f"{out_flat.shape[-1]} != {self.nope_dim} + {self.pos_dim}."
+            )
+        if self.cu_seqlens_q is not None:
+            return out_flat
+        if self.sbhd_batch_size is None:
+            raise ValueError("sbhd_batch_size is required when cu_seqlens_q is None.")
+        rows, nheads, head_dim = out_flat.shape
+        return out_flat.view(rows // self.sbhd_batch_size, self.sbhd_batch_size, nheads, head_dim)
+
+    def _kernel_kwargs(self) -> dict:
+        return dict(
+            cu_seqlens_q=self.cu_seqlens_q,
+            cp_rank=self.cp_rank,
+            cp_size=self.cp_size,
+            inverse=True,
+            remove_interleaving=True,
+            position_ids=self.position_ids,
+        )
+
+    def apply_(self, out_flat: Tensor) -> Tensor:
+        """Inverse-RoPE a ``(rows, heads, head_dim)`` attention output in place."""
+        mla_rope_apply_raw_(
+            self._kernel_view(out_flat),
+            self.cos,
+            self.sin,
+            self.nope_dim,
+            self.pos_dim,
+            **self._kernel_kwargs(),
+        )
+        return out_flat
+
+    def undo(self, t: Tensor, out: Optional[Tensor] = None) -> Tensor:
+        """Recover the pre-RoPE values of ``t``, in place or into ``out``.
+
+        Pass ``out`` whenever ``t`` is aliased by a tensor that another autograd
+        node still expects to hold the rotated values, which is the case for the
+        saved attention output.
+        """
+        mla_rope_unapply_raw(
+            self._kernel_view(t),
+            self.cos,
+            self.sin,
+            self.nope_dim,
+            self.pos_dim,
+            out=None if out is None else self._kernel_view(out),
+            **self._kernel_kwargs(),
+        )
+        return t if out is None else out
+
 
 # ---------------------------------------------------------------------------
 # Lazy kernel imports
@@ -177,6 +273,33 @@ def _csa_fwd_flash_mla(
             return out, lse, lse.clone()
         return out, lse, lse_indexer
     return out, lse, None
+
+
+def _undo_output_rope_for_backward(
+    out_rope: Optional[OutputRopeParams], out_flat: Tensor, dO_flat: Tensor
+) -> Tuple[Tensor, Tensor]:
+    """Recover the pre-RoPE ``(O, dO)`` pair that the cuDNN backward expects.
+
+    ``dO`` is un-rotated in place; the gradient buffer is exclusively ours.
+    ``O`` is un-rotated into a fresh buffer because the saved output aliases the
+    tensor the downstream output projection saved for its own backward, and a
+    triton in-place write would corrupt it without tripping autograd's version
+    counter.
+
+    #TODO:
+    Two follow-ups can remove work here. The only thing ``O`` feeds is cuDNN's
+    internal ``delta = rowsum(dO * O)``, which the rotation leaves unchanged, so
+    a ``sparse_attention_backward_wrapper`` that accepts a precomputed delta
+    would let the ``O`` un-rotation be dropped entirely. Short of that, one
+    triton kernel could un-rotate ``O`` and ``dO`` in a single launch.
+    """
+    if out_rope is None:
+        return out_flat, dO_flat
+    o_unrot = torch.empty_like(out_flat)
+    out_rope.undo(out_flat, out=o_unrot)
+    dO_flat = dO_flat.contiguous()
+    out_rope.undo(dO_flat)
+    return o_unrot, dO_flat
 
 
 def _ensure_dsa_namespace():
@@ -716,6 +839,7 @@ class CSASparseAttnFunc(torch.autograd.Function):
         topk_length: Optional[Tensor],  # (total_sq,) int32 or None
         softmax_scale: float,
         indexer_topk: int,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
         """Run FlashMLA sparse-attention forward and save tensors for backward."""
         out, lse, lse_indexer = _csa_fwd_flash_mla(
@@ -728,9 +852,16 @@ class CSASparseAttnFunc(torch.autograd.Function):
             indexer_topk=indexer_topk,
         )
 
+        # Inverse-RoPE in place before the save, so the saved tensor, the
+        # returned tensor and what the downstream projection saves are all one
+        # buffer. Mutating after the save would trip the version counter.
+        if out_rope is not None:
+            out_rope.apply_(out)
+
         ctx.save_for_backward(q, kv, attn_sink, topk_idxs, out, lse)
         ctx.softmax_scale = softmax_scale
         ctx.topk_length = topk_length
+        ctx.out_rope = out_rope
         return out, lse, lse_indexer
 
     @staticmethod
@@ -739,6 +870,8 @@ class CSASparseAttnFunc(torch.autograd.Function):
         _ensure_dsa_namespace()
 
         q, kv, attn_sink, topk_idxs, out, lse = ctx.saved_tensors
+
+        out, dO = _undo_output_rope_for_backward(ctx.out_rope, out, dO)
 
         result = _DSA.sparse_attention_backward_wrapper(
             q,
@@ -752,7 +885,7 @@ class CSASparseAttnFunc(torch.autograd.Function):
             topk_length=ctx.topk_length,
         )
         dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
-        return dq, dkv, d_sink, None, None, None, None
+        return dq, dkv, d_sink, None, None, None, None, None
 
 
 def csa_sparse_attn(
@@ -764,6 +897,7 @@ def csa_sparse_attn(
     topk_length: Optional[Tensor] = None,
     indexer_topk: int = 0,
     is_thd: bool = False,
+    out_rope: Optional[OutputRopeParams] = None,
 ) -> Tensor:
     """Sparse attention (Path A / Path C step 2).
 
@@ -791,9 +925,14 @@ def csa_sparse_attn(
         indexer_topk: int; ``0`` for Paths A/C, positive for Path B.
         is_thd: when True, treat ``query`` and ``kv`` as already-packed
             THD tensors and skip the SBHD reshape steps.
+        out_rope: when given, the DSv4 output inverse-RoPE is applied inside
+            the Function, in place on the tensor it saves for backward, and
+            undone there before the cuDNN backward. Saves one full O buffer
+            per layer against rotating the returned tensor out of place.
 
     Returns:
-        SBHD ``(sq, b, np * d_v)`` or THD ``(total_sq, np * d_v)`` bf16.
+        SBHD ``(sq, b, np * d_v)`` or THD ``(total_sq, np * d_v)`` bf16,
+        inverse-RoPE'd when ``out_rope`` is given.
     """
     # Layout-specific input pre-reshape — the kernel always consumes a
     # flat ``(rows, np, d)`` query and ``(n_kv, d)`` KV; only the rows
@@ -818,7 +957,7 @@ def csa_sparse_attn(
         kv_flat = kv.reshape(skv * b, d)
 
     out_flat, _lse, _lse_indexer = CSASparseAttnFunc.apply(
-        q_flat, kv_flat, attn_sink, topk_idxs, topk_length, softmax_scale, indexer_topk
+        q_flat, kv_flat, attn_sink, topk_idxs, topk_length, softmax_scale, indexer_topk, out_rope
     )  # (rows, np, d_v)
 
     # Layout-specific output reshape: collapse (np, d_v) → (np * d_v),
@@ -1417,6 +1556,7 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
         max_seqlen_compressed_idx: Optional[int],  # indexer K max
         compressed_kv: Optional[Tensor] = None,  # THD only — pre-packed compressed KV
         cu_seqlens_q_unpadded: Optional[Tensor] = None,  # THD only — unpadded Q cu_seqlens
+        out_rope: Optional[OutputRopeParams] = None,  # inverse-RoPE fused onto the output
     ) -> Tuple[Tensor, Tensor]:
         """Fused forward: indexer scoring, sparse attention, KL loss, and indexer backward."""
         _ensure_dsa_namespace()
@@ -1787,7 +1927,15 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             precomputed_grad_q_indexer[padding_row_mask] = 0
             precomputed_grad_weights[padding_row_mask] = 0
 
-        # ---- 7. Save context (only sparse-attn bwd tensors + indexer grads). -
+        # ---- 7. Inverse-RoPE the output, in place, before it is saved. -------
+        # Saving the rotated output means it is the same storage the caller
+        # returns and the downstream projection saves, so only one copy of O is
+        # live from here to backward. Must happen before save_for_backward:
+        # mutating a saved tensor afterwards trips the version counter.
+        if out_rope is not None:
+            out_rope.apply_(out_flat)
+
+        # ---- 8. Save context (only sparse-attn bwd tensors + indexer grads). -
         ctx.save_for_backward(
             q_flat,
             kv_flat,
@@ -1805,6 +1953,7 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
         ctx.padding_row_mask = padding_row_mask
         ctx.np_ = np_
         ctx.d = d
+        ctx.out_rope = out_rope
         if is_thd:
             ctx.total_q = total_q
         else:
@@ -1851,6 +2000,8 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             dO_flat = dO_flat.masked_fill(ctx.padding_row_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.padding_row_mask[:, None], 0)
 
+        out_flat, dO_flat = _undo_output_rope_for_backward(ctx.out_rope, out_flat, dO_flat)
+
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
             q_flat,
             kv_flat,
@@ -1881,7 +2032,7 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
         #   cu_seqlens_q, cu_seqlens_kv, cu_seqlens_kv_full,
         #   cu_seqlens_compressed_idx,
         #   max_seqlen_q, max_seqlen_compressed_idx,
-        #   compressed_kv, cu_seqlens_q_unpadded
+        #   compressed_kv, cu_seqlens_q_unpadded, out_rope
         return (
             grad_query,
             grad_kv_full,
@@ -1890,6 +2041,7 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             grad_q_indexer,
             grad_k_indexer,
             grad_weights,
+            None,
             None,
             None,
             None,
@@ -1937,6 +2089,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         max_seqlen_q: int,
         indexer_layout: Tuple[Tensor, Tensor, Tensor],
         q_padding_mask: Optional[Tensor] = None,
+        out_rope: Optional[OutputRopeParams] = None,
         local_k_indexer: Optional[Tensor] = None,
         local_compressed_kv: Optional[Tensor] = None,
         cp_group=None,
@@ -2134,6 +2287,12 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         ctx.compressed_kv_reduce_scatter_state = compressed_kv_reduce_scatter_state
         ctx.indexer_grad_is_sequence_major = cp_group is not None and not sparse_loss
         ctx.num_forward_inputs = len(ctx.needs_input_grad)
+
+        # Inverse-RoPE in place before saving, so the saved output and the
+        # returned one are a single buffer. See FusedCSAIndexerSparseAttnFunc.
+        if out_rope is not None:
+            out_rope.apply_(out_flat)
+
         ctx.save_for_backward(
             query,
             kv_full,
@@ -2149,6 +2308,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         )
         ctx.softmax_scale = softmax_scale
         ctx.q_padding_mask = q_padding_mask
+        ctx.out_rope = out_rope
 
         return out_flat.reshape(total_q, np_ * out_flat.shape[-1]), indexer_loss
 
@@ -2192,6 +2352,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         if ctx.q_padding_mask is not None:
             dO_flat = dO_flat.masked_fill(ctx.q_padding_mask[:, None, None], 0)
             lse = lse.masked_fill(ctx.q_padding_mask[:, None], 0)
+
+        out_flat, dO_flat = _undo_output_rope_for_backward(ctx.out_rope, out_flat, dO_flat)
+
         nvtx_range_push("dsv4_cp_sparse_attention_backward")
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
             query,
@@ -2279,6 +2442,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
             None,
             None,
             None,
+            None,
             grad_local_k_indexer,
             grad_local_compressed_kv,
             None,
@@ -2317,6 +2481,7 @@ def fused_csa_indexer_sparse_attn(
     max_seqlen_compressed_idx: Optional[int] = None,
     compressed_kv: Optional[Tensor] = None,
     cu_seqlens_q_unpadded: Optional[Tensor] = None,
+    out_rope: Optional[OutputRopeParams] = None,
 ) -> Tuple[Tensor, Tensor]:
     """Path B (training): fused indexer (+KL loss) + sparse attention.
 
@@ -2395,6 +2560,9 @@ def fused_csa_indexer_sparse_attn(
             so padding rows are excluded from the indexer KL loss and
             backward gradients.  Ignored when ``None`` or when it equals
             ``cu_seqlens_q``.
+        out_rope: when supplied, DSv4's inverse RoPE is applied to the attention
+            output in place before it is saved, so the returned output is
+            already rotated and only one copy of it is live until backward.
     """
     if cu_seqlens_q is not None:
         missing = [
@@ -2437,10 +2605,12 @@ def fused_csa_indexer_sparse_attn(
         max_seqlen_compressed_idx,
         compressed_kv,
         cu_seqlens_q_unpadded,
+        out_rope,
     )
 
 
 __all__ = [
+    "OutputRopeParams",
     "batch_of_row",
     "build_flat_topk_idxs",
     "local_to_global_flat",

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -2089,7 +2089,6 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         max_seqlen_q: int,
         indexer_layout: Tuple[Tensor, Tensor, Tensor],
         q_padding_mask: Optional[Tensor] = None,
-        out_rope: Optional[OutputRopeParams] = None,
         local_k_indexer: Optional[Tensor] = None,
         local_compressed_kv: Optional[Tensor] = None,
         cp_group=None,
@@ -2097,6 +2096,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
         indexer_rank_map: Optional[Tensor] = None,
         indexer_k_reduce_scatter_state: Optional[_DeferredReduceScatterState] = None,
         compressed_kv_reduce_scatter_state: Optional[_DeferredReduceScatterState] = None,
+        out_rope: Optional[OutputRopeParams] = None,
     ) -> Tuple[Tensor, Tensor]:
         """Run fused sparse attention using caller-supplied top-k indices."""
         _ensure_dsa_namespace()
@@ -2442,9 +2442,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
             None,
             None,
             None,
-            None,
             grad_local_k_indexer,
             grad_local_compressed_kv,
+            None,
             None,
             None,
             None,

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -8,10 +8,7 @@ import torch
 
 from megatron.core import tensor_parallel
 from megatron.core.extensions.transformer_engine import HAVE_TE
-from megatron.core.fusions.fused_mla_yarn_rope_apply import (
-    fused_mla_rope_inplace,
-    fused_mla_rope_out_of_place,
-)
+from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_inplace
 from megatron.core.models.common.embeddings import (
     RotaryEmbedding,
     YarnRotaryEmbedding,
@@ -342,121 +339,9 @@ class DSv4HybridAttention(Attention):
             self.qkv_up_checkpoint.discard_output_and_register_recompute(core_attn_out)
             self.qkv_up_checkpoint = None
 
-        # inverse RoPE on last qk_pos_emb_head_dim of each head
-        seq_len = core_attn_out.size(0)
-        n_heads = self.num_attention_heads_per_partition
-        pos_dim = self.config.qk_pos_emb_head_dim
-        nope_dim = self.config.v_head_dim - pos_dim
-        core_attn_out = core_attn_out.view(seq_len, core_attn_out.size(1), n_heads, -1)
-        packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
-        if packed_seq:
-            cu_seqlens_kv = (
-                packed_seq_params.cu_seqlens_kv_padded
-                if packed_seq_params.cu_seqlens_kv_padded is not None
-                else packed_seq_params.cu_seqlens_kv
-            )
-            rope_seqlen = packed_seq_params.max_seqlen_kv
-            rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
-        else:
-            cu_seqlens_kv = None
-            rope_seqlen = seq_len
-            rope_max_seqlen_kv = None
-        # DSv4 reference (DS-Inf) RoPE is pure rotation (norm-preserving). Yarn's
-        # concentration factor (mscale) is NOT part of the DSv4 model contract --
-        # the model relies on Q/KV RMS-norm + unit-magnitude rotation. Force 1.0.
-        mscale = 1.0
-        rotary_pos_cos = None
-        rotary_pos_sin = None
-        if self.config.apply_rope_fusion:
-            # ``mscale=1.0`` strips yarn's concentration factor from the
-            # cached cos/sin so the fused kernel matches the unfused
-            # path's forced ``mscale=1.0`` (DSv4 "pure rotation").
-            rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
-                rope_seqlen, dtype=hidden_states.dtype, packed_seq=packed_seq, mscale=mscale
-            )
-            rotary_pos_emb = None
-            assert inference_context is None, "Inference with MLA RoPE fusion is not supported"
-            assert (
-                fused_mla_rope_inplace is not None
-            ), "Fused MLA RoPE apply is not imported successfully"
-        elif self._dsv4_uses_yarn_rope:
-            rotary_pos_emb, _ = self.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
-        else:
-            rotary_pos_emb = self.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
-        if self.config.apply_rope_fusion:
-            if use_thd_cp:
-                global_start = self.pg_collection.cp.rank() * core_attn_out.shape[0]
-                core_attn_out = cp_utils.apply_thd_cp_local_rope_fused(
-                    core_attn_out,
-                    rotary_pos_cos,
-                    rotary_pos_sin,
-                    nope_dim,
-                    pos_dim,
-                    cu_seqlens_kv,
-                    global_start,
-                    inverse=True,
-                )
-            else:
-                if packed_seq:
-                    core_attn_out = core_attn_out.squeeze(1)
-                # Fused DSA backward retains the raw attention output O. Applying
-                # inverse RoPE to its view in-place corrupts the retained O used by
-                # the softmax backward, so this call needs private storage.
-                core_attn_out = fused_mla_rope_out_of_place(
-                    core_attn_out,
-                    rotary_pos_cos,
-                    rotary_pos_sin,
-                    nope_dim,
-                    pos_dim,
-                    cu_seqlens_kv,
-                    self.pg_collection.cp.rank(),
-                    self.pg_collection.cp.size(),
-                    inverse=True,
-                    remove_interleaving=True,
-                )
-                if packed_seq:
-                    core_attn_out = core_attn_out.unsqueeze(1)
-        elif use_thd_cp:
-            global_start = self.pg_collection.cp.rank() * core_attn_out.shape[0]
-            core_attn_out = cp_utils.apply_thd_cp_local_rope_unfused(
-                core_attn_out,
-                rotary_pos_emb,
-                nope_dim,
-                pos_dim,
-                cu_seqlens_kv,
-                global_start,
-                self.config,
-                inverse=True,
-            )
-        else:
-            content_part, rot_part = torch.split(
-                core_attn_out, [core_attn_out.size(-1) - pos_dim, pos_dim], dim=-1
-            )
-            # ``_apply_rotary_pos_emb_thd`` documents 3-D ``(total, h, d)`` input
-            # and adds its own batch dim internally; drop the dummy ``b=1`` axis
-            # for THD before the rope and add it back after.
-            if packed_seq:
-                rot_part_in = rot_part.squeeze(1)
-            else:
-                rot_part_in = rot_part
-            rot_part_out = apply_rotary_pos_emb(
-                rot_part_in,
-                rotary_pos_emb,
-                self.config,
-                cu_seqlens=cu_seqlens_kv,
-                mscale=mscale,
-                cp_group=self.pg_collection.cp,
-                mla_rotary_interleaved=True,
-                inverse=True,
-                mla_output_remove_interleaving=True,
-                max_seqlen=rope_max_seqlen_kv,
-            )
-            if packed_seq:
-                rot_part = rot_part_out.unsqueeze(1)
-            else:
-                rot_part = rot_part_out
-            core_attn_out = torch.cat([content_part, rot_part], dim=-1)
-        core_attn_out = core_attn_out.view(seq_len, core_attn_out.size(1), -1)
+        # ``core_attention`` already applied the inverse RoPE to the last
+        # qk_pos_emb_head_dim of each head, fusing it into the sparse-attention
+        # Function where that path allows it.
 
         # Grouped output
         core_attn_out = core_attn_out.view(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
@@ -1091,6 +1091,7 @@ class TestCPCommunicationOverlap:
             local_compressed_kv_rows = 2
             softmax_scale = 0.5
             q_padding_mask = None
+            out_rope = None
             num_forward_inputs = 25
 
         gradients = FusedCSAIndexerSparseAttnFromTopkFunc.backward(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
@@ -4161,6 +4161,422 @@ class TestRealKernelDenseIndexerBackward:
 
 
 # ---------------------------------------------------------------------------
+# Output inverse RoPE fused into the sparse-attention Functions
+# ---------------------------------------------------------------------------
+
+
+def _make_rotation_cos_sin(max_seqlen, pos_dim, device, dtype=torch.bfloat16):
+    """Build cos/sin tables laid out the way ``RotaryEmbedding`` emits them.
+
+    Both halves of the ``pos_dim`` axis carry the same angle, which is what
+    makes the kernel's forward and backward an exact rotation / inverse pair
+    and therefore what lets the fused backward recover the pre-RoPE output.
+    """
+    torch.manual_seed(11)
+    theta = torch.rand(max_seqlen, pos_dim // 2, device=device) * (2 * math.pi)
+    cos = torch.cat([theta.cos(), theta.cos()], dim=-1).to(dtype)
+    sin = torch.cat([theta.sin(), theta.sin()], dim=-1).to(dtype)
+    return cos.view(max_seqlen, 1, 1, pos_dim), sin.view(max_seqlen, 1, 1, pos_dim)
+
+
+def _make_small_flash_mla_stub():
+    """FlashMLA stand-in whose output is O(1), so a bf16 rotate/un-rotate
+    round trip stays well inside a meaningful tolerance.
+    """
+
+    def _impl(q, kv, indices, softmax_scale, d_v, attn_sink, topk_length, indexer_topk):
+        total_s_q, h, _ = q.shape
+        gen = torch.Generator(device=q.device).manual_seed(23)
+        out = (
+            torch.randn(total_s_q, h, d_v, generator=gen, device=q.device, dtype=torch.float32)
+            .mul_(0.5)
+            .to(q.dtype)
+        )
+        max_logits = torch.zeros(total_s_q, h, dtype=torch.float32, device=q.device)
+        lse = torch.zeros(total_s_q, h, dtype=torch.float32, device=q.device)
+        if indexer_topk > 0:
+            return out, max_logits, lse, lse + 1.0
+        return out, max_logits, lse
+
+    stub = MagicMock(name='small_flash_mla_stub')
+    stub.side_effect = _impl
+    return stub
+
+
+class TestFusedOutputInverseRope:
+    """DSv4's output inverse RoPE, fused into the Path B Function, must be
+    indistinguishable from running the Function and rotating afterwards.
+
+    The cuDNN / FlashMLA kernels are mocked but the RoPE triton kernels are
+    real. The mocked sparse-attention backward records the ``(O, dO)`` pair it
+    is handed and derives its gradients from it, so an incorrect un-rotation
+    shows up both in the recorded tensors and in every returned gradient.
+    """
+
+    SHAPES = dict(sq=4, b=2, np_=2, d=512, skv=8, n_comp=4, idx_nh=4, idx_hd=64)
+    POS_DIM = 64
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("layout", ["sbhd", "thd"])
+    def test_apply_matches_helper_and_undo_inverts(self, layout):
+        """``OutputRopeParams.apply_`` reproduces the shipped out-of-place
+        helper, and ``undo`` inverts it both in place and into a buffer.
+        """
+        from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_out_of_place
+
+        dev = 'cuda'
+        pos_dim = nope_dim = 64
+        head_dim = nope_dim + pos_dim
+        nheads = 4
+        sq = b = None
+        if layout == 'sbhd':
+            sq, b = 5, 3
+            rows, cu_seqlens, batch_size, max_seqlen = sq * b, None, b, sq
+        else:
+            seg_lens = [4, 6, 5]
+            rows = sum(seg_lens)
+            cu_seqlens = _make_cu_seqlens(seg_lens, device=dev)
+            batch_size, max_seqlen = None, max(seg_lens)
+
+        cos, sin = _make_rotation_cos_sin(max_seqlen, pos_dim, dev, dtype=torch.float32)
+        params = dk.OutputRopeParams(
+            cos=cos,
+            sin=sin,
+            nope_dim=nope_dim,
+            pos_dim=pos_dim,
+            cu_seqlens_q=cu_seqlens,
+            sbhd_batch_size=batch_size,
+        )
+
+        torch.manual_seed(5)
+        out_flat = torch.randn(rows, nheads, head_dim, dtype=torch.float32, device=dev)
+        original = out_flat.clone()
+
+        helper_input = original.view(sq, b, nheads, head_dim) if layout == 'sbhd' else original
+        expected = fused_mla_rope_out_of_place(
+            helper_input,
+            cos,
+            sin,
+            nope_dim,
+            pos_dim,
+            cu_seqlens_q=cu_seqlens,
+            inverse=True,
+            remove_interleaving=True,
+        ).reshape(rows, nheads, head_dim)
+
+        params.apply_(out_flat)
+        assert torch.equal(out_flat, expected), "fused in-place rope diverged from the helper"
+
+        recovered = torch.empty_like(out_flat)
+        params.undo(out_flat, out=recovered)
+        torch.testing.assert_close(recovered, original, rtol=1e-5, atol=1e-5)
+        # An out-of-place undo must leave the rotated buffer alone: in the real
+        # backward that buffer is still the module output another node saved.
+        assert torch.equal(out_flat, expected), "out-of-place undo mutated its input"
+
+        params.undo(out_flat)
+        torch.testing.assert_close(out_flat, original, rtol=1e-5, atol=1e-5)
+
+    def _make_inputs(self):
+        """Six differentiable leaves plus the non-differentiable window idxs."""
+        s = self.SHAPES
+        win_topk = _get_topk_alignment() - 2
+        torch.manual_seed(0)
+
+        def leaf(*shape, dtype=torch.bfloat16):
+            return torch.randn(*shape, dtype=dtype, device='cuda').requires_grad_(True)
+
+        return dict(
+            query=leaf(s['sq'], s['b'], s['np_'], s['d']),
+            kv_full=leaf(s['skv'], s['b'], s['d']),
+            attn_sink=torch.zeros(s['np_'], dtype=torch.float32, device='cuda').requires_grad_(
+                True
+            ),
+            window_idxs=torch.zeros(
+                s['b'], s['sq'], win_topk, dtype=torch.int32, device='cuda'
+            ),
+            q_indexer=leaf(s['sq'], s['b'], s['idx_nh'], s['idx_hd']),
+            k_indexer=leaf(s['n_comp'], s['b'], s['idx_hd']),
+            weights=leaf(s['sq'], s['b'], s['idx_nh']),
+        )
+
+    def _install_recording_mock(self, captured):
+        """Full DSA mock whose sparse-attn backward records ``(O, dO)`` and
+        derives every gradient from them.
+        """
+        s = self.SHAPES
+        fake_dsa, _ = _install_full_dsa_mock(
+            b=s['b'],
+            sq=s['sq'],
+            np_=s['np_'],
+            d=s['d'],
+            n_comp=s['n_comp'],
+            idx_nh=s['idx_nh'],
+        )
+
+        def recording_backward(q, kv, out, dout, lse, attn_sink, topk_idxs, **kwargs):
+            captured['out'] = out.detach().clone()
+            captured['dout'] = dout.detach().clone()
+            scale = out.float().abs().mean() + dout.float().abs().mean()
+            return {
+                'dq': torch.full_like(q, 1.0) * scale.to(q.dtype),
+                'dkv': torch.full_like(kv, 1.0) * scale.to(kv.dtype),
+                'd_sink': torch.full_like(attn_sink, 1.0) * scale,
+            }
+
+        fake_dsa.sparse_attention_backward_wrapper.side_effect = recording_backward
+        dk._flash_mla_sparse_fwd = _make_small_flash_mla_stub()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fused_rope_matches_external_rope(self, reset_lazy_kernel_state):
+        """Running Path B with ``out_rope`` equals running it without and
+        rotating the output afterwards, for the output, every gradient, and
+        the ``(O, dO)`` pair the sparse-attn backward is handed.
+        """
+        from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_out_of_place
+
+        s = self.SHAPES
+        dev = 'cuda'
+        pos_dim = self.POS_DIM
+        nope_dim = s['d'] - pos_dim
+        cos, sin = _make_rotation_cos_sin(s['sq'], pos_dim, dev)
+        params = dk.OutputRopeParams(
+            cos=cos, sin=sin, nope_dim=nope_dim, pos_dim=pos_dim, sbhd_batch_size=s['b']
+        )
+
+        torch.manual_seed(7)
+        grad_out = torch.randn(
+            s['sq'], s['b'], s['np_'] * s['d'], dtype=torch.bfloat16, device=dev
+        )
+        grad_loss = torch.tensor(1.0, device=dev)
+
+        runs = {}
+        for name, rope in (('fused', params), ('external', None)):
+            inputs = self._make_inputs()
+            captured = {}
+            self._install_recording_mock(captured)
+
+            output, indexer_loss = fused_csa_indexer_sparse_attn(
+                **inputs,
+                indexer_topk=2,
+                ratio=4,
+                softmax_scale=0.5,
+                loss_coeff=0.7,
+                sparse_loss=True,
+                kv_offset=s['skv'] - s['n_comp'],
+                out_rope=rope,
+            )
+            if rope is None:
+                output = fused_mla_rope_out_of_place(
+                    output.view(s['sq'], s['b'], s['np_'], s['d']),
+                    cos,
+                    sin,
+                    nope_dim,
+                    pos_dim,
+                    inverse=True,
+                    remove_interleaving=True,
+                ).reshape(s['sq'], s['b'], s['np_'] * s['d'])
+
+            leaves = [
+                inputs['query'],
+                inputs['kv_full'],
+                inputs['attn_sink'],
+                inputs['q_indexer'],
+                inputs['k_indexer'],
+                inputs['weights'],
+            ]
+            frozen_output = output.detach().clone()
+            # Fresh grad copies: the backward un-rotates dO in place, matching
+            # what _FusedMLARoPEInplace already does to its incoming gradient.
+            grads = torch.autograd.grad(
+                [output, indexer_loss],
+                leaves,
+                [grad_out.clone(), grad_loss.clone()],
+                retain_graph=True,
+            )
+            grads_again = torch.autograd.grad(
+                [output, indexer_loss],
+                leaves,
+                [grad_out.clone(), grad_loss.clone()],
+                retain_graph=True,
+            )
+
+            assert torch.equal(output, frozen_output), f"{name}: backward corrupted the output"
+            for i, (first, second) in enumerate(zip(grads, grads_again)):
+                assert torch.equal(first, second), f"{name}: leaf {i} differs on second backward"
+
+            runs[name] = dict(output=frozen_output, grads=grads, captured=captured)
+
+        assert torch.equal(
+            runs['fused']['output'], runs['external']['output']
+        ), "fused rope output differs from the externally rotated output"
+
+        # The un-rotated O survives a bf16 rotate/un-rotate round trip, so
+        # compare against the baseline's untouched O with a bf16 tolerance.
+        torch.testing.assert_close(
+            runs['fused']['captured']['out'],
+            runs['external']['captured']['out'],
+            rtol=2e-2,
+            atol=2e-2,
+        )
+        torch.testing.assert_close(
+            runs['fused']['captured']['dout'],
+            runs['external']['captured']['dout'],
+            rtol=2e-2,
+            atol=2e-2,
+        )
+        for i, (fused_grad, external_grad) in enumerate(
+            zip(runs['fused']['grads'], runs['external']['grads'])
+        ):
+            torch.testing.assert_close(
+                fused_grad, external_grad, rtol=2e-2, atol=2e-2, msg=f"leaf {i} gradient differs"
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("layout", ["sbhd", "thd"])
+    def test_sparse_attn_fused_rope_matches_external_rope(self, reset_lazy_kernel_state, layout):
+        """Path A carries the same guarantee as Path B: ``csa_sparse_attn`` with
+        ``out_rope`` equals the same call without it followed by an
+        out-of-place rotation, for the output, the leaf gradients and the
+        ``(O, dO)`` pair handed to the sparse-attn backward.
+
+        Path A covers the window-only and ratio-128 layers, which have no
+        indexer and so never reach Path B.
+        """
+        from megatron.core.fusions.fused_mla_yarn_rope_apply import fused_mla_rope_out_of_place
+
+        s = self.SHAPES
+        dev = 'cuda'
+        pos_dim = self.POS_DIM
+        nope_dim = s['d'] - pos_dim
+        topk = _get_topk_alignment()
+
+        if layout == 'sbhd':
+            rows, cu_seqlens, batch_size, max_seqlen = s['sq'] * s['b'], None, s['b'], s['sq']
+        else:
+            seg_lens = [s['sq'], s['sq']]
+            rows = sum(seg_lens)
+            cu_seqlens = _make_cu_seqlens(seg_lens, device=dev)
+            batch_size, max_seqlen = None, max(seg_lens)
+
+        cos, sin = _make_rotation_cos_sin(max_seqlen, pos_dim, dev)
+        params = dk.OutputRopeParams(
+            cos=cos,
+            sin=sin,
+            nope_dim=nope_dim,
+            pos_dim=pos_dim,
+            cu_seqlens_q=cu_seqlens,
+            sbhd_batch_size=batch_size,
+        )
+
+        torch.manual_seed(11)
+        grad_out = torch.randn(rows, s['np_'] * s['d'], dtype=torch.bfloat16, device=dev)
+        if layout == 'sbhd':
+            grad_out = grad_out.reshape(s['sq'], s['b'], s['np_'] * s['d'])
+
+        runs = {}
+        for name, rope in (('fused', params), ('external', None)):
+            torch.manual_seed(3)
+            if layout == 'sbhd':
+                query = torch.randn(
+                    s['sq'], s['b'], s['np_'], s['d'], dtype=torch.bfloat16, device=dev
+                )
+                kv = torch.randn(s['skv'], s['b'], s['d'], dtype=torch.bfloat16, device=dev)
+            else:
+                query = torch.randn(rows, s['np_'], s['d'], dtype=torch.bfloat16, device=dev)
+                kv = torch.randn(s['skv'] * 2, s['d'], dtype=torch.bfloat16, device=dev)
+            query.requires_grad_(True)
+            kv.requires_grad_(True)
+            attn_sink = torch.zeros(s['np_'], dtype=torch.float32, device=dev).requires_grad_(True)
+            topk_idxs = torch.zeros(rows, topk, dtype=torch.int32, device=dev)
+
+            captured = {}
+            self._install_recording_mock(captured)
+
+            output = csa_sparse_attn(
+                query,
+                kv,
+                attn_sink,
+                topk_idxs,
+                softmax_scale=0.5,
+                is_thd=layout == 'thd',
+                out_rope=rope,
+            )
+            if rope is None:
+                rope_in = output.reshape(rows, s['np_'], s['d'])
+                if layout == 'sbhd':
+                    rope_in = rope_in.view(s['sq'], s['b'], s['np_'], s['d'])
+                output = fused_mla_rope_out_of_place(
+                    rope_in,
+                    cos,
+                    sin,
+                    nope_dim,
+                    pos_dim,
+                    cu_seqlens_q=cu_seqlens,
+                    inverse=True,
+                    remove_interleaving=True,
+                ).reshape(output.shape)
+
+            leaves = [query, kv, attn_sink]
+            frozen_output = output.detach().clone()
+            grads = torch.autograd.grad(output, leaves, grad_out.clone(), retain_graph=True)
+            grads_again = torch.autograd.grad(output, leaves, grad_out.clone(), retain_graph=True)
+
+            assert torch.equal(output, frozen_output), f"{name}: backward corrupted the output"
+            for i, (first, second) in enumerate(zip(grads, grads_again)):
+                assert torch.equal(first, second), f"{name}: leaf {i} differs on second backward"
+
+            runs[name] = dict(output=frozen_output, grads=grads, captured=captured)
+
+        assert torch.equal(
+            runs['fused']['output'], runs['external']['output']
+        ), "fused rope output differs from the externally rotated output"
+
+        for key in ('out', 'dout'):
+            torch.testing.assert_close(
+                runs['fused']['captured'][key],
+                runs['external']['captured'][key],
+                rtol=2e-2,
+                atol=2e-2,
+                msg=f"{key} handed to the sparse-attn backward differs",
+            )
+        for i, (fused_grad, external_grad) in enumerate(
+            zip(runs['fused']['grads'], runs['external']['grads'])
+        ):
+            torch.testing.assert_close(
+                fused_grad, external_grad, rtol=2e-2, atol=2e-2, msg=f"leaf {i} gradient differs"
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_head_dim_mismatch_raises(self, reset_lazy_kernel_state):
+        """A rope whose ``nope_dim + pos_dim`` misses the head dim is rejected
+        rather than silently rotating the wrong slice.
+        """
+        s = self.SHAPES
+        cos, sin = _make_rotation_cos_sin(s['sq'], self.POS_DIM, 'cuda')
+        params = dk.OutputRopeParams(
+            cos=cos,
+            sin=sin,
+            nope_dim=s['d'] - self.POS_DIM - 8,
+            pos_dim=self.POS_DIM,
+            sbhd_batch_size=s['b'],
+        )
+        inputs = self._make_inputs()
+        self._install_recording_mock({})
+        with pytest.raises(ValueError, match="nope_dim \\+ pos_dim"):
+            fused_csa_indexer_sparse_attn(
+                **inputs,
+                indexer_topk=2,
+                ratio=4,
+                softmax_scale=0.5,
+                loss_coeff=0.0,
+                sparse_loss=True,
+                kv_offset=s['skv'] - s['n_comp'],
+                out_rope=params,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Public surface
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
@@ -4293,9 +4293,7 @@ class TestFusedOutputInverseRope:
             attn_sink=torch.zeros(s['np_'], dtype=torch.float32, device='cuda').requires_grad_(
                 True
             ),
-            window_idxs=torch.zeros(
-                s['b'], s['sq'], win_topk, dtype=torch.int32, device='cuda'
-            ),
+            window_idxs=torch.zeros(s['b'], s['sq'], win_topk, dtype=torch.int32, device='cuda'),
             q_indexer=leaf(s['sq'], s['b'], s['idx_nh'], s['idx_hd']),
             k_indexer=leaf(s['n_comp'], s['b'], s['idx_hd']),
             weights=leaf(s['sq'], s['b'], s['idx_nh']),
@@ -4307,12 +4305,7 @@ class TestFusedOutputInverseRope:
         """
         s = self.SHAPES
         fake_dsa, _ = _install_full_dsa_mock(
-            b=s['b'],
-            sq=s['sq'],
-            np_=s['np_'],
-            d=s['d'],
-            n_comp=s['n_comp'],
-            idx_nh=s['idx_nh'],
+            b=s['b'], sq=s['sq'], np_=s['np_'], d=s['d'], n_comp=s['n_comp'], idx_nh=s['idx_nh']
         )
 
         def recording_backward(q, kv, out, dout, lse, attn_sink, topk_idxs, **kwargs):
@@ -4346,9 +4339,7 @@ class TestFusedOutputInverseRope:
         )
 
         torch.manual_seed(7)
-        grad_out = torch.randn(
-            s['sq'], s['b'], s['np_'] * s['d'], dtype=torch.bfloat16, device=dev
-        )
+        grad_out = torch.randn(s['sq'], s['b'], s['np_'] * s['d'], dtype=torch.bfloat16, device=dev)
         grad_loss = torch.tensor(1.0, device=dev)
 
         runs = {}


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Apply the query-side inverse RoPE on CSA's attention output inside the sparse-attention autograd Functions (in place on the Function-owned output) so a separate rotated activation is not retained for backward. Extend the MLA RoPE bwd kernel to accept distinct DO_IN/DO_OUT (with optional NOPE copy) so un-rotation can write out of place when the rotated tensor is still aliased.
Per-file:

fused_mla_yarn_rope_apply.py: generalize _mla_rope_bwd_* to DO_IN/DO_OUT with COPY_NOPE; add mla_rope_apply_raw_ / mla_rope_unapply_raw (no autograd) and route the inplace Function through them; plumb position_ids through fused_mla_rope_out_of_place.

csa.py: own rotary_pos_emb; add _OutputInverseRope; pass OutputRopeParams into fused SBHD/THD paths and apply out of place only on unfused paths.

csa_kernels.py: add OutputRopeParams; fuse inverse RoPE into CSASparseAttn / FusedCSAIndexer* Functions (fwd rotate, bwd un-rotate via mla_rope_unapply_raw).

csa_cp_utils.py: export thd_cp_position_ids (keep _thd_cp_* alias); use the public name from the THD CP RoPE helpers.

deepseek_v4_hybrid_attention.py: drop the post-attn inverse-RoPE block; CSA now returns already-corrected output.

test_mla_yarn_rope_apply.py: call the renamed inplace test helper.

test_csa_kernels.py: add TestFusedOutputInverseRope covering fused vs unfused, alias-safe bwd, and sparse Function paths.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
