### PR TITLE
Document signing rewritten commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ skill keyword — infer it from the artifact you read.
 
 - All PRs must be created as **drafts**. Use `gh pr create --draft` or the GitHub UI draft option.
 - Never push branches directly to `https://github.com/NVIDIA/Megatron-LM`. You must push your branch to a personal fork (e.g. `https://github.com/<your-username>/Megatron-LM`), then open a PR from the fork's branch against `NVIDIA/Megatron-LM`.
-- Commit PR changes with both `-s` and `-S`: `-s` adds the required
+- When rebasing, cherrypicking or commiting, sign the commits with both `-s` and `-S`: `-s` adds the required
   `Signed-off-by` trailer, and `-S` signs the commit so copy-pr-bot and `/ok to
 test` can verify the pushed commit without manually specifying the SHA.
 Megatron Core engineers at NVIDIA should sign using their NVIDIA emails so they


### PR DESCRIPTION
## Summary

Require `-s` and `-S` when rebasing, cherrypicking, or committing so rewritten history retains both DCO trailers and GPG signatures. Otherwise, agents often miss this. 

## Testing

Not applicable: documentation-only change.