### PR TITLE
Add CuTeDSL GDP chunkwise context parallelism

### DIFF
--- a/megatron/core/ssm/context_parallel/gdp.py
+++ b/megatron/core/ssm/context_parallel/gdp.py
@@ -44,9 +44,11 @@ from megatron.core.ssm.context_parallel.chunkwise import (
     CPForwardPackedSummary,
     CPForwardSummary,
     CPSavedContext,
-    LinearAttentionCPBackend,
-    chunkwise_cp_backward,
-    chunkwise_cp_forward,
+)
+from megatron.core.ssm.context_parallel.gdp_common import (
+    GDPChunkwiseContextParallel,
+    GDPInputGradients,
+    GDPInputs,
 )
 
 
@@ -55,29 +57,6 @@ def _expand_cu_seqlens(cu_seqlens: torch.Tensor, num_householder: int) -> torch.
     if num_householder == 1:
         return cu_seqlens
     return cu_seqlens * num_householder
-
-
-@dataclass(frozen=True)
-class GDPInputs:
-    """Local FLA GDP operands passed to the CP backend."""
-
-    q: torch.Tensor
-    k: torch.Tensor
-    v: torch.Tensor
-    g: torch.Tensor
-    beta: torch.Tensor
-    cu_seqlens: torch.Tensor | None
-    num_householder: int
-    scale: float
-
-
-GDPInputGradients = tuple[
-    torch.Tensor,  # dq
-    torch.Tensor,  # dk
-    torch.Tensor,  # dv
-    torch.Tensor,  # dg
-    torch.Tensor,  # dbeta
-]
 
 
 @dataclass(frozen=True)
@@ -136,8 +115,17 @@ class GDPBackwardContext:
     dv: torch.Tensor
 
 
+class FLAGDPChunkwiseContextParallel(GDPChunkwiseContextParallel):
+    """FLA-decorated form of the shared GDP autograd adapter."""
+
+    forward = staticmethod(input_guard(autocast_custom_fwd(GDPChunkwiseContextParallel.forward)))
+    backward = staticmethod(input_guard(autocast_custom_bwd(GDPChunkwiseContextParallel.backward)))
+
+
 class FLAGatedDeltaProductCPBackend:
     """FLA implementation of the linear-attention chunkwise-CP interface."""
+
+    autograd_function = FLAGDPChunkwiseContextParallel
 
     def cp_forward_prepare(self, inputs: GDPInputs) -> tuple[CPForwardSummary, GDPLocalContext]:
         """Compute the local state summary and reusable FLA forward workspace."""
@@ -676,114 +664,4 @@ def _apply_fla_backward(
         dv.to(inputs.v),
         dg.to(dtype=inputs.g_dtype),
         db.to(inputs.beta),
-    )
-
-
-class _GDPChunkwiseContextParallel(torch.autograd.Function):
-    @staticmethod
-    @input_guard
-    @autocast_custom_fwd
-    def forward(
-        ctx,
-        q,
-        k,
-        v,
-        g,
-        beta,
-        cu_seqlens,
-        num_householder,
-        scale,
-        cp_group,
-        backend,
-        preceding_rank_start,
-        following_rank_stop,
-    ):
-        """Run chunkwise-CP forward and save the backend context for backward."""
-        inputs = GDPInputs(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            cu_seqlens=cu_seqlens,
-            num_householder=num_householder,
-            scale=scale,
-        )
-        cp_rank = cp_group.rank()
-        result = chunkwise_cp_forward(
-            backend=backend,
-            inputs=inputs,
-            cp_group=cp_group,
-            preceding_slice=slice(preceding_rank_start, cp_rank),
-        )
-        ctx.save_for_backward(*result.saved_context.tensors)
-        ctx.saved_context_metadata = result.saved_context.metadata
-        ctx.cp_group = cp_group
-        ctx.cp_rank = cp_rank
-        ctx.following_rank_stop = following_rank_stop
-        ctx.backend = backend
-        return result.output
-
-    @staticmethod
-    @input_guard
-    @autocast_custom_bwd
-    def backward(ctx, output_grad):
-        """Run chunkwise-CP backward using the saved backend context."""
-        saved_context = CPSavedContext(
-            tensors=ctx.saved_tensors, metadata=ctx.saved_context_metadata
-        )
-        dq, dk, dv, dg, dbeta = chunkwise_cp_backward(
-            backend=ctx.backend,
-            output_grad=output_grad,
-            saved_context=saved_context,
-            cp_group=ctx.cp_group,
-            following_slice=slice(ctx.cp_rank + 1, ctx.following_rank_stop),
-        )
-        return dq, dk, dv, dg, dbeta, None, None, None, None, None, None, None
-
-
-@torch.compiler.disable
-def gdp_chunkwise_context_parallel(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    cu_seqlens: torch.Tensor | None,
-    num_householder: int,
-    scale: float,
-    cp_group: torch.distributed.ProcessGroup,
-    backend: LinearAttentionCPBackend[
-        GDPInputs, GDPLocalContext, GDPBackwardContext, GDPInputGradients
-    ],
-    preceding_rank_start: int = 0,
-    following_rank_stop: int | None = None,
-) -> torch.Tensor:
-    """Run FLA GDP with Megatron-owned chunkwise-CP communication."""
-    if following_rank_stop is None:
-        following_rank_stop = cp_group.size()
-    cp_rank = cp_group.rank()
-    if not 0 <= preceding_rank_start <= cp_rank:
-        raise ValueError(
-            "preceding_rank_start must be in [0, cp_rank], got "
-            f"{preceding_rank_start} for rank {cp_rank}"
-        )
-    if not cp_rank < following_rank_stop <= cp_group.size():
-        raise ValueError(
-            "following_rank_stop must be in (cp_rank, cp_size], got "
-            f"{following_rank_stop} for rank {cp_rank} and size {cp_group.size()}"
-        )
-    return _GDPChunkwiseContextParallel.apply(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        cu_seqlens,
-        num_householder,
-        scale,
-        cp_group,
-        backend,
-        preceding_rank_start,
-        following_rank_stop,
     )

--- a/megatron/core/ssm/context_parallel/gdp_common.py
+++ b/megatron/core/ssm/context_parallel/gdp_common.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Shared execution path for Gated Delta Product context parallelism."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+from megatron.core.ssm.context_parallel.chunkwise import (
+    BackwardContextT,
+    CPSavedContext,
+    LinearAttentionCPBackend,
+    LocalContextT,
+    chunkwise_cp_backward,
+    chunkwise_cp_forward,
+)
+
+
+@dataclass(frozen=True)
+class GDPInputs:
+    """Rank-local GDP operands passed to a chunkwise-CP backend."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    g: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    num_householder: int
+    scale: float
+
+
+GDPInputGradients = tuple[
+    torch.Tensor,  # dq
+    torch.Tensor,  # dk
+    torch.Tensor,  # dv
+    torch.Tensor,  # dg
+    torch.Tensor,  # dbeta
+]
+
+
+class GDPChunkwiseContextParallel(torch.autograd.Function):
+    """Connect a GDP backend's saved context to PyTorch autograd."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        num_householder,
+        scale,
+        cp_group,
+        backend,
+        preceding_rank_start,
+        following_rank_stop,
+    ):
+        """Run chunkwise-CP forward and save the backend context for backward."""
+        inputs = GDPInputs(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+            num_householder=num_householder,
+            scale=scale,
+        )
+        cp_rank = cp_group.rank()
+        result = chunkwise_cp_forward(
+            backend=backend,
+            inputs=inputs,
+            cp_group=cp_group,
+            preceding_slice=slice(preceding_rank_start, cp_rank),
+        )
+        ctx.save_for_backward(*result.saved_context.tensors)
+        ctx.saved_context_metadata = result.saved_context.metadata
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.following_rank_stop = following_rank_stop
+        ctx.backend = backend
+        return result.output
+
+    @staticmethod
+    def backward(ctx, output_grad):
+        """Run chunkwise-CP backward using the saved backend context."""
+        saved_context = CPSavedContext(
+            tensors=ctx.saved_tensors, metadata=ctx.saved_context_metadata
+        )
+        dq, dk, dv, dg, dbeta = chunkwise_cp_backward(
+            backend=ctx.backend,
+            output_grad=output_grad,
+            saved_context=saved_context,
+            cp_group=ctx.cp_group,
+            following_slice=slice(ctx.cp_rank + 1, ctx.following_rank_stop),
+        )
+        return dq, dk, dv, dg, dbeta, None, None, None, None, None, None, None
+
+
+class GDPChunkwiseCPBackend(
+    LinearAttentionCPBackend[GDPInputs, LocalContextT, BackwardContextT, GDPInputGradients],
+    Protocol[LocalContextT, BackwardContextT],
+):
+    """GDP local-kernel and autograd-adapter contract."""
+
+    autograd_function: type[GDPChunkwiseContextParallel]
+
+
+@torch.compiler.disable
+def gdp_chunkwise_context_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    num_householder: int,
+    scale: float,
+    cp_group: torch.distributed.ProcessGroup,
+    backend: GDPChunkwiseCPBackend[LocalContextT, BackwardContextT],
+    preceding_rank_start: int = 0,
+    following_rank_stop: int | None = None,
+) -> torch.Tensor:
+    """Run GDP chunkwise CP through the selected local-kernel backend."""
+    if following_rank_stop is None:
+        following_rank_stop = cp_group.size()
+    cp_rank = cp_group.rank()
+    if not 0 <= preceding_rank_start <= cp_rank:
+        raise ValueError(
+            "preceding_rank_start must be in [0, cp_rank], got "
+            f"{preceding_rank_start} for rank {cp_rank}"
+        )
+    if not cp_rank < following_rank_stop <= cp_group.size():
+        raise ValueError(
+            "following_rank_stop must be in (cp_rank, cp_size], got "
+            f"{following_rank_stop} for rank {cp_rank} and size {cp_group.size()}"
+        )
+    return backend.autograd_function.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        num_householder,
+        scale,
+        cp_group,
+        backend,
+        preceding_rank_start,
+        following_rank_stop,
+    )

--- a/megatron/core/ssm/context_parallel/gdp_cutedsl.py
+++ b/megatron/core/ssm/context_parallel/gdp_cutedsl.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CuTeDSL backend for Gated Delta Product chunkwise context parallelism.
+
+This backend is deterministic, but not batch invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+try:
+    from gdp_attn import cp_backward_apply as cutedsl_cp_backward_apply
+    from gdp_attn import cp_backward_prepare as cutedsl_cp_backward_prepare
+    from gdp_attn import cp_forward_apply as cutedsl_cp_forward_apply
+    from gdp_attn import cp_forward_prepare as cutedsl_cp_forward_prepare
+    from gdp_attn.chunk_gated_delta_product import (
+        GdpCpBackwardContext,
+        GdpCpForwardLocalContext,
+        GdpCpSavedContext,
+    )
+except ImportError as exc:
+    # The caller guards this optional backend; this marker handles direct imports in CI.
+    raise ImportError("UnavailableError: CuTeDSL GDP chunkwise CP backend is unavailable") from exc
+
+from megatron.core.ssm.context_parallel.chunkwise import (
+    CPBackwardPackedSummary,
+    CPBackwardSummary,
+    CPForwardPackedSummary,
+    CPForwardSummary,
+    CPSavedContext,
+)
+from megatron.core.ssm.context_parallel.gdp_common import (
+    GDPChunkwiseContextParallel,
+    GDPInputGradients,
+    GDPInputs,
+)
+
+
+@dataclass(frozen=True)
+class CuTeDSLGDPSavedMetadata:
+    """Non-tensor fields needed to reconstruct the CuTeDSL backend's saved CP context."""
+
+    scale: float
+    num_householder: int
+    use_qk_l2norm_in_kernel: bool
+    recompute_chunk_num: int
+    has_initial_states: bool
+
+
+class CuTeDSLGatedDeltaProductCPBackend:
+    """Adapt ``gdp_attn``'s four-function CP protocol to Megatron collectives."""
+
+    autograd_function = GDPChunkwiseContextParallel
+
+    def __init__(self, recompute_chunk_num: int = 0) -> None:
+        self.recompute_chunk_num = recompute_chunk_num
+
+    def cp_forward_prepare(
+        self, inputs: GDPInputs
+    ) -> tuple[CPForwardSummary, GdpCpForwardLocalContext]:
+        """Compute the trailing-boundary ``[E | M]`` summary for this rank."""
+        if inputs.cu_seqlens is None:
+            raise ValueError("The CuTeDSL GDP backend requires cu_seqlens")
+        packed_summary, local_context = cutedsl_cp_forward_prepare(
+            inputs.q,
+            inputs.k,
+            inputs.v,
+            inputs.g,
+            inputs.beta,
+            inputs.cu_seqlens,
+            inputs.scale,
+            inputs.num_householder,
+            use_qk_l2norm_in_kernel=True,
+            recompute_chunk_num=self.recompute_chunk_num,
+        )
+        return CPForwardPackedSummary(packed=packed_summary), local_context
+
+    def cp_forward_apply(
+        self, local_context: GdpCpForwardLocalContext, preceding_summaries: CPForwardSummary
+    ) -> tuple[torch.Tensor, CPSavedContext]:
+        """Apply the causal prefix and retain the CuTeDSL backward checkpoint state."""
+        packed_prefix = _forward_packed_tensor(preceding_summaries)
+        output, saved_context = cutedsl_cp_forward_apply(
+            local_context, packed_prefix, output_final_state=False
+        )
+        saved_tensors = [
+            saved_context.q,
+            saved_context.k,
+            saved_context.v,
+            saved_context.g,
+            saved_context.beta,
+            saved_context.cu_seqlens,
+            saved_context.state,
+        ]
+        has_initial_states = saved_context.initial_states is not None
+        if has_initial_states:
+            saved_tensors.append(saved_context.initial_states)
+        return output, CPSavedContext(
+            tensors=tuple(saved_tensors),
+            metadata=CuTeDSLGDPSavedMetadata(
+                scale=saved_context.scale,
+                num_householder=saved_context.num_householder,
+                use_qk_l2norm_in_kernel=saved_context.use_qk_l2norm_in_kernel,
+                recompute_chunk_num=saved_context.recompute_chunk_num,
+                has_initial_states=has_initial_states,
+            ),
+        )
+
+    def cp_backward_prepare(
+        self, output_grad: torch.Tensor, saved_context: CPSavedContext
+    ) -> tuple[CPBackwardSummary, GdpCpBackwardContext]:
+        """Compute the leading-boundary ``[gamma | M^T]`` summary for this rank."""
+        backend_saved_context = _restore_saved_context(saved_context)
+        # boundary_len only tightens the launch grid; the backend's conservative None mode
+        # preserves correctness without extracting a host scalar here.
+        packed_summary, backward_context = cutedsl_cp_backward_prepare(
+            output_grad, backend_saved_context, boundary_len=None
+        )
+        return CPBackwardPackedSummary(packed=packed_summary), backward_context
+
+    def cp_backward_apply(
+        self, backward_context: GdpCpBackwardContext, following_summaries: CPBackwardSummary
+    ) -> GDPInputGradients:
+        """Apply the reverse-causal suffix and compute all local input gradients."""
+        return cutedsl_cp_backward_apply(
+            backward_context, _backward_packed_tensor(following_summaries), dht=None
+        )
+
+
+def _forward_packed_tensor(summary: CPForwardSummary) -> torch.Tensor:
+    if not isinstance(summary, CPForwardPackedSummary):
+        raise TypeError("The CuTeDSL GDP backend requires packed forward summaries")
+    return summary.packed
+
+
+def _backward_packed_tensor(summary: CPBackwardSummary) -> torch.Tensor:
+    if not isinstance(summary, CPBackwardPackedSummary):
+        raise TypeError("The CuTeDSL GDP backend requires packed backward summaries")
+    return summary.packed
+
+
+def _restore_saved_context(saved_context: CPSavedContext) -> GdpCpSavedContext:
+    metadata = saved_context.metadata
+    if not isinstance(metadata, CuTeDSLGDPSavedMetadata):
+        raise TypeError("CuTeDSLGatedDeltaProductCPBackend received incompatible metadata")
+    expected_count = 8 if metadata.has_initial_states else 7
+    if len(saved_context.tensors) != expected_count:
+        raise ValueError("CuTeDSLGatedDeltaProductCPBackend received an incompatible tensor bundle")
+
+    q, k, v, g, beta, cu_seqlens, state = saved_context.tensors[:7]
+    initial_states = saved_context.tensors[7] if metadata.has_initial_states else None
+    return GdpCpSavedContext(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        state=state,
+        initial_states=initial_states,
+        scale=metadata.scale,
+        num_householder=metadata.num_householder,
+        use_qk_l2norm_in_kernel=metadata.use_qk_l2norm_in_kernel,
+        recompute_chunk_num=metadata.recompute_chunk_num,
+    )

--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -29,6 +29,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.causal_conv1d import assert_causal_conv1d_deterministic, causal_conv1d_cp
 from megatron.core.ssm.context_parallel.chunkwise import PackedSequenceCPMetadata
+from megatron.core.ssm.context_parallel.gdp_common import gdp_chunkwise_context_parallel
 from megatron.core.ssm.gdp_context_parallel import GDPContextParallel
 from megatron.core.ssm.packed_seq_helpers import check_fla_sequence_packing_support, get_cu_seqlens
 from megatron.core.ssm.ssm_inference import SSMDynamicInferenceMixin
@@ -80,15 +81,11 @@ except ImportError:
     HAVE_FLA = False
 
 try:
-    from megatron.core.ssm.context_parallel.gdp import (
-        FLAGatedDeltaProductCPBackend,
-        gdp_chunkwise_context_parallel,
-    )
+    from megatron.core.ssm.context_parallel.gdp import FLAGatedDeltaProductCPBackend
 
     HAVE_FLA_GDP_CP = True
 except ImportError:
     FLAGatedDeltaProductCPBackend = None
-    gdp_chunkwise_context_parallel = None
     HAVE_FLA_GDP_CP = False
 
 try:
@@ -97,6 +94,14 @@ try:
     HAVE_CUTEDSL_GDP = True
 except ImportError:
     HAVE_CUTEDSL_GDP = False
+
+try:
+    from megatron.core.ssm.context_parallel.gdp_cutedsl import CuTeDSLGatedDeltaProductCPBackend
+
+    HAVE_CUTEDSL_GDP_CP = True
+except ImportError:
+    CuTeDSLGatedDeltaProductCPBackend = None
+    HAVE_CUTEDSL_GDP_CP = False
 
 # Dynamic-batching inference runs the in-tree fork of these kernels rather than
 # the pip `flash-linear-attention` / `causal_conv1d` ones. The fork is
@@ -156,13 +161,10 @@ class ExtendedRMSNorm(RMSNormGated):
 
 @dataclass
 class GatedDeltaProductMixerSubmodules:
-    """
-    Contains the module specs for the projections and chunkwise-CP backend.
-    """
+    """Contains the module specs for the input and output projections."""
 
     in_proj: Union[ModuleSpec, type] = None
     out_proj: Union[ModuleSpec, type] = None
-    chunkwise_cp_backend: Union[ModuleSpec, type] = FLAGatedDeltaProductCPBackend
 
 
 class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
@@ -175,9 +177,9 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
 
     GDP projects each token into an output gate and the ``V``, ``K``, ``Q``, beta, and decay
     terms used by a sequence of Householder updates. A depthwise causal convolution mixes
-    local context in ``V/K/Q``; the FLA GDP recurrence then updates a matrix-valued state,
-    and gated RMS normalization plus the output projection map the result back to the
-    model hidden size.
+    local context in ``V/K/Q``; the selected GDP kernel then updates a matrix-valued state,
+    and gated RMS normalization plus the output projection map the result back to the model
+    hidden size.
 
     The module shards projections and recurrent parameters across tensor-parallel ranks,
     redistributes sequence and head dimensions for context parallelism, handles packed
@@ -255,21 +257,24 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.num_householder = config.gdp_num_householder
 
         # Select the chunked gated delta product kernel once. The CuTeDSL and FLA
-        # implementations share the same keyword API but are imported under distinct
-        # names so neither shadows the other when both packages are installed.
+        # implementations share the main call surface but are imported under distinct
+        # names; checkpoint-keyword differences are normalized below.
         self.gdp_kernel = (
             cutedsl_chunk_gated_delta_product
             if config.gdp_cutedsl_kernel
             else chunk_gated_delta_product
         )
 
-        # Newer CuTeDSL kernel builds accept num_chunk_states_to_recompute; probe the
-        # signature once so older builds that predate the argument still work.
+        # CuTeDSL releases have used two names for checkpoint coarsening. Probe once and
+        # prefer the current API spelling while retaining compatibility with older releases.
         self.gdp_kernel_extra_kwargs = {}
-        if _kernel_accepts_kwarg(self.gdp_kernel, "num_chunk_states_to_recompute"):
-            self.gdp_kernel_extra_kwargs["num_chunk_states_to_recompute"] = (
-                config.gdp_num_chunk_states_to_recompute
-            )
+        if config.gdp_cutedsl_kernel:
+            for recompute_kwarg in ("recompute_chunk_num", "num_chunk_states_to_recompute"):
+                if _kernel_accepts_kwarg(self.gdp_kernel, recompute_kwarg):
+                    self.gdp_kernel_extra_kwargs[recompute_kwarg] = (
+                        config.gdp_num_chunk_states_to_recompute
+                    )
+                    break
 
         self.config = config
         self.d_model = d_model
@@ -283,18 +288,25 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.chunkwise_context_parallel = (
             self.config.linear_cp_mode == "chunkwise" and self.pg_collection.cp.size() > 1
         )
-        if self.chunkwise_context_parallel and self.config.gdp_cutedsl_kernel:
-            raise NotImplementedError(
-                "GDP chunkwise context parallelism supports only the FLA kernel."
-            )
         self.chunkwise_cp_backend = None
         if self.chunkwise_context_parallel:
-            if not HAVE_FLA_GDP_CP:
-                raise ImportError(
-                    "GDP chunkwise CP requires Triton and an FLA build with "
-                    "fla.ops.cp.chunk_delta_h"
+            if self.config.gdp_cutedsl_kernel:
+                if not HAVE_CUTEDSL_GDP_CP:
+                    raise ImportError(
+                        "CuTeDSL GDP chunkwise CP requires a gdp_attn build exposing "
+                        "cp_forward_prepare/apply and cp_backward_prepare/apply"
+                    )
+                self.chunkwise_cp_backend = build_module(
+                    CuTeDSLGatedDeltaProductCPBackend,
+                    recompute_chunk_num=config.gdp_num_chunk_states_to_recompute,
                 )
-            self.chunkwise_cp_backend = build_module(submodules.chunkwise_cp_backend)
+            else:
+                if not HAVE_FLA_GDP_CP:
+                    raise ImportError(
+                        "GDP chunkwise CP requires Triton and an FLA build with "
+                        "fla.ops.cp.chunk_delta_h"
+                    )
+                self.chunkwise_cp_backend = build_module(FLAGatedDeltaProductCPBackend)
 
         self.d_state = self.config.mamba_state_dim
         self.headdim = self.config.mamba_head_dim
@@ -570,11 +582,34 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
 
         return out, out_bias
 
-    def _packed_metadata(self, packed_seq_params):
+    def _packed_metadata(
+        self, packed_seq_params: PackedSeqParams | None
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         """Return sequence indices and cumulative lengths for packed input."""
         if packed_seq_params is None:
             return None, None
         return packed_seq_params.seq_idx, get_cu_seqlens(packed_seq_params)
+
+    def _make_uniform_cutedsl_cu_seqlens(self, VKQ: torch.Tensor) -> torch.Tensor:
+        """Build uniform sequence boundaries for an unpacked CuTeDSL input.
+
+        Under chunkwise CP, ``sequence_length`` is the rank-local shard length, so these
+        boundaries describe only this rank. The CP metadata determines which boundary
+        sequence continues on adjacent ranks.
+        """
+        batch_size, sequence_length = VKQ.shape[:2]
+        if self.chunkwise_context_parallel and batch_size != 1:
+            raise ValueError(
+                "CuTeDSL GDP chunkwise CP requires a single flattened token stream; "
+                f"got batch size {batch_size}"
+            )
+        return torch.arange(
+            0,
+            (batch_size + 1) * sequence_length,
+            sequence_length,
+            device=VKQ.device,
+            dtype=torch.int32,
+        )
 
     def _gdp_chunk_forward(
         self,
@@ -615,16 +650,19 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 hidden_states, packed_seq_params=packed_seq_params
             )
 
+        conv_seq_idx, kernel_cu_seqlens = self._packed_metadata(packed_seq_params)
         preceding_rank_start = 0
         following_rank_stop = self.pg_collection.cp.size()
         if self.chunkwise_context_parallel:
-            seq_idx_packed, cu_seqlens_packed, preceding_rank_start, following_rank_stop = (
-                self._chunkwise_packed_metadata(
-                    packed_seq_params, VKQ.shape[1], packed_sequence_cp_metadata
-                )
+            chunkwise_packed_metadata = self._chunkwise_packed_metadata(
+                packed_seq_params, VKQ.shape[1], packed_sequence_cp_metadata
             )
-        else:
-            seq_idx_packed, cu_seqlens_packed = self._packed_metadata(packed_seq_params)
+            if chunkwise_packed_metadata is not None:
+                kernel_cu_seqlens = chunkwise_packed_metadata.local_cu_seqlens
+                preceding_rank_start = chunkwise_packed_metadata.preceding_rank_start
+                following_rank_stop = chunkwise_packed_metadata.following_rank_stop
+        if self.config.gdp_cutedsl_kernel and kernel_cu_seqlens is None:
+            kernel_cu_seqlens = self._make_uniform_cutedsl_cu_seqlens(VKQ)
 
         # The offload group captures the tensors saved for backward inside the causal
         # conv and QKV preparation: the checkpoint's saved input VKQ when QKV recompute
@@ -640,7 +678,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                     partial(
                         self._prepare_qkv,
                         conv_state=conv_state,
-                        seq_idx=seq_idx_packed,
+                        seq_idx=conv_seq_idx,
                         l2_norm_in_kernel=self.config.gdp_cutedsl_kernel,
                     ),
                     VKQ,
@@ -650,7 +688,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 query, key, value = self._prepare_qkv(
                     VKQ,
                     conv_state=conv_state,
-                    seq_idx=seq_idx_packed,
+                    seq_idx=conv_seq_idx,
                     l2_norm_in_kernel=self.config.gdp_cutedsl_kernel,
                 )
 
@@ -664,7 +702,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             beta,
             VKQ,
             output_final_state=(ssm_state is not None),
-            cu_seqlens=cu_seqlens_packed,
+            cu_seqlens=kernel_cu_seqlens,
             preceding_rank_start=preceding_rank_start,
             following_rank_stop=following_rank_stop,
         )
@@ -707,12 +745,10 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         """Run the selected chunked gated delta product kernel and return
         (core_attn_out, final_state).
 
-        For the CuTeDSL path the kernel expects packed varlen sequences described by
-        cu_seqlens and applies the query/key L2 norm itself, and its output is collapsed
-        to (b l) h p and restored here; the FLA path uses the batched layout and has
-        already applied the L2 norm in _prepare_qkv. ``cu_seqlens`` is the packed-sequence
-        layout when THD packing is active; otherwise the CuTeDSL path synthesizes the
-        uniform-length equivalent and the FLA path leaves it unset."""
+        The CuTeDSL kernel uses a flattened token axis described by ``cu_seqlens`` and
+        applies the query/key L2 norm itself. Its output is restored to ``(b, l, h, p)``
+        here. The FLA kernel uses the batched layout and receives query/key tensors already
+        normalized by ``_prepare_qkv``. Unpacked FLA leaves ``cu_seqlens`` unset."""
         if self.chunkwise_context_parallel:
             assert self.chunkwise_cp_backend is not None
             core_attn_out = gdp_chunkwise_context_parallel(
@@ -723,33 +759,27 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 beta=beta,
                 cu_seqlens=cu_seqlens,
                 num_householder=self.num_householder,
-                scale=query.shape[-1] ** -0.5,
+                scale=self.d_state**-0.5,
                 cp_group=self.pg_collection.cp,
                 backend=self.chunkwise_cp_backend,
                 preceding_rank_start=preceding_rank_start,
                 following_rank_stop=following_rank_stop,
             )
-            return core_attn_out, None
-
-        if self.config.gdp_cutedsl_kernel and cu_seqlens is None:
-            # query/key/value are already collapsed to (b l) ..., so read the batch and
-            # sequence dimensions from VKQ, which is still in (b, l, d) layout.
-            b, l = VKQ.shape[0], VKQ.shape[1]
-            cu_seqlens = torch.arange(0, (b + 1) * l, l, device=VKQ.device, dtype=torch.int32)
-
-        core_attn_out, final_state = self.gdp_kernel(
-            q=query,
-            k=key,
-            v=value,
-            g=g,
-            beta=beta,
-            num_householder=self.num_householder,
-            initial_state=None,
-            output_final_state=output_final_state,
-            use_qk_l2norm_in_kernel=self.config.gdp_cutedsl_kernel,
-            cu_seqlens=cu_seqlens,
-            **self.gdp_kernel_extra_kwargs,
-        )
+            final_state = None
+        else:
+            core_attn_out, final_state = self.gdp_kernel(
+                q=query,
+                k=key,
+                v=value,
+                g=g,
+                beta=beta,
+                num_householder=self.num_householder,
+                initial_state=None,
+                output_final_state=output_final_state,
+                use_qk_l2norm_in_kernel=self.config.gdp_cutedsl_kernel,
+                cu_seqlens=cu_seqlens,
+                **self.gdp_kernel_extra_kwargs,
+            )
         if self.config.gdp_cutedsl_kernel:
             core_attn_out = rearrange(
                 core_attn_out, "(b l) (h p) -> b l h p", b=VKQ.shape[0], p=self.headdim
@@ -761,15 +791,12 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         packed_seq_params: PackedSeqParams | None,
         local_sequence_length: int,
         metadata: PackedSequenceCPMetadata | None,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None, int, int]:
-        """Return cached local FLA metadata and cross-rank summary bounds for packed GDP."""
-        cp_rank = self.pg_collection.cp.rank()
-        cp_size = self.pg_collection.cp.size()
+    ) -> PackedSequenceCPMetadata | None:
+        """Validate and return cached rank-local packed-sequence metadata."""
         if packed_seq_params is None:
-            return None, None, 0, cp_size
+            return None
 
-        global_seq_idx = packed_seq_params.seq_idx
-        if global_seq_idx is None:
+        if packed_seq_params.seq_idx is None:
             raise ValueError("Packed GDP chunkwise CP requires packed_seq_params.seq_idx")
         if metadata is None:
             raise ValueError(
@@ -783,12 +810,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 f"{tuple(metadata.local_seq_idx.shape)}, expected {expected_shape}"
             )
 
-        return (
-            global_seq_idx,
-            metadata.local_cu_seqlens,
-            metadata.preceding_rank_start,
-            metadata.following_rank_stop,
-        )
+        return metadata
 
     def _in_proj_preprocess(self, hidden_states, packed_seq_params=None):
         """Run the input projection, gather its output across CP ranks, switch to
@@ -938,6 +960,10 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             value = rearrange(
                 value, "b l (m h p) -> (b l) (m h p)", m=self.num_householder, p=self.headdim
             )
+            if self.chunkwise_context_parallel:
+                # The CuTeDSL CP backward suffix merge requires a uniform token-row pitch.
+                # Keep this copy inside _prepare_qkv so selective QKV recompute owns it.
+                value = value.contiguous()
             key = rearrange(key, "b l (m g n) -> b l m g n", m=self.num_householder, n=self.d_state)
             query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state)
         else:

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -227,7 +227,7 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.pg_collection = pg_collection
         if self.config.linear_cp_mode == "chunkwise" and self.pg_collection.cp.size() > 1:
             raise NotImplementedError(
-                "This branch supports linear_cp_mode='chunkwise' only for FLA GDP mixers."
+                "linear_cp_mode='chunkwise' is supported only by GatedDeltaProductMixer."
             )
         self.use_mem_eff_path = self.config.use_mamba_mem_eff_path
         self.mamba_training_ssm_states_dtype = (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1378,7 +1378,8 @@ class TransformerConfig(ModelParallelConfig):
     stores one checkpoint per group of N+1 chunks (1/(N+1) the checkpoint memory) and the
     backward recomputes each group's N missing chunk states, trading recompute time for
     activation memory monotonically in N (sweet spot N=2..3). Only honored by kernel
-    builds that expose the num_chunk_states_to_recompute argument."""
+    builds that expose ``recompute_chunk_num`` or the legacy
+    ``num_chunk_states_to_recompute`` argument."""
 
     mlp_chunks_for_prefill: int = 1
     """The number of chunks along the sequence dimension to use for MLP computation

--- a/tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py
+++ b/tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py
@@ -6,13 +6,32 @@ import pytest
 import torch
 
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_cp_metadata
-from megatron.core.ssm.gated_delta_product import HAVE_FLA_GDP_CP, GatedDeltaProductMixer
+from megatron.core.ssm.context_parallel import gdp_common
+from megatron.core.ssm.context_parallel.chunkwise import (
+    CPBackwardPackedSummary,
+    CPForwardPackedSummary,
+    CPForwardResult,
+    CPSavedContext,
+    build_packed_sequence_cp_metadata,
+)
+from megatron.core.ssm.context_parallel.gdp_common import GDPInputs
+from megatron.core.ssm.gated_delta_product import (
+    HAVE_CUTEDSL_GDP_CP,
+    HAVE_FLA_GDP_CP,
+    GatedDeltaProductMixer,
+)
+
+pytestmark = pytest.mark.launch_on_gb200
 
 if HAVE_FLA_GDP_CP:
     import megatron.core.ssm.context_parallel.gdp as gdp_cp_module
 else:
     gdp_cp_module = None
+
+if HAVE_CUTEDSL_GDP_CP:
+    import megatron.core.ssm.context_parallel.gdp_cutedsl as gdp_cutedsl_cp_module
+else:
+    gdp_cutedsl_cp_module = None
 
 
 class _FakeGroup:
@@ -25,6 +44,50 @@ class _FakeGroup:
 
     def size(self) -> int:
         return self._size
+
+
+def test_shared_autograd_adapter(monkeypatch):
+    """Verify the common adapter's backend-independent autograd contract."""
+    calls = {}
+    group = _FakeGroup(rank=1, size=3)
+    backend = SimpleNamespace(autograd_function=gdp_common.GDPChunkwiseContextParallel)
+
+    def fake_forward(*, backend, inputs, cp_group, preceding_slice):
+        calls["forward"] = (backend, inputs, cp_group, preceding_slice)
+        return CPForwardResult(
+            output=inputs.q + inputs.k + inputs.v + inputs.g + inputs.beta,
+            saved_context=CPSavedContext(tensors=(inputs.q,), metadata="saved"),
+        )
+
+    def fake_backward(*, backend, output_grad, saved_context, cp_group, following_slice):
+        calls["backward"] = (backend, output_grad, saved_context, cp_group, following_slice)
+        return tuple(output_grad * multiplier for multiplier in range(1, 6))
+
+    monkeypatch.setattr(gdp_common, "chunkwise_cp_forward", fake_forward)
+    monkeypatch.setattr(gdp_common, "chunkwise_cp_backward", fake_backward)
+
+    inputs = [torch.randn(2, 3, requires_grad=True) for _ in range(5)]
+    output = gdp_common.gdp_chunkwise_context_parallel(
+        *inputs,
+        cu_seqlens=None,
+        num_householder=1,
+        scale=0.125,
+        cp_group=group,
+        backend=backend,
+        preceding_rank_start=0,
+        following_rank_stop=3,
+    )
+    output.sum().backward()
+
+    assert calls["forward"][0] is backend
+    assert calls["forward"][2] is group
+    assert calls["forward"][3] == slice(0, 1)
+    assert calls["backward"][0] is backend
+    assert calls["backward"][2].metadata == "saved"
+    assert calls["backward"][3] is group
+    assert calls["backward"][4] == slice(2, 3)
+    for multiplier, tensor in enumerate(inputs, start=1):
+        torch.testing.assert_close(tensor.grad, torch.full_like(tensor, multiplier))
 
 
 @pytest.mark.skipif(not HAVE_FLA_GDP_CP, reason="FLA GDP CP kernels are not installed")
@@ -46,17 +109,100 @@ def test_reuse_rank_local_metadata():
     global_seq_idx = torch.tensor([[0, 0, 0, 0, 0, 1, 1, 1]], dtype=torch.int32)
     metadata = build_packed_sequence_cp_metadata(global_seq_idx, cp_rank=1, cp_size=2)
     mixer = GatedDeltaProductMixer.__new__(GatedDeltaProductMixer)
-    mixer.pg_collection = SimpleNamespace(cp=_FakeGroup(rank=1, size=2))
     packed_seq_params = PackedSeqParams(qkv_format="thd", seq_idx=global_seq_idx)
 
-    returned_seq_idx, local_cu_seqlens, preceding_start, following_stop = (
-        mixer._chunkwise_packed_metadata(
-            packed_seq_params, local_sequence_length=4, metadata=metadata
-        )
+    returned_metadata = mixer._chunkwise_packed_metadata(
+        packed_seq_params, local_sequence_length=4, metadata=metadata
     )
 
-    assert returned_seq_idx is global_seq_idx
-    assert local_cu_seqlens is metadata.local_cu_seqlens
-    torch.testing.assert_close(local_cu_seqlens, torch.tensor([0, 1, 4], dtype=torch.int32))
-    assert preceding_start == 0
-    assert following_stop == 2
+    assert returned_metadata is metadata
+    torch.testing.assert_close(
+        returned_metadata.local_cu_seqlens, torch.tensor([0, 1, 4], dtype=torch.int32)
+    )
+    assert returned_metadata.preceding_rank_start == 0
+    assert returned_metadata.following_rank_stop == 2
+
+
+@pytest.mark.skipif(not HAVE_CUTEDSL_GDP_CP, reason="CuTeDSL GDP CP backend is unavailable")
+def test_cutedsl_backend_adapts_four_function_protocol(monkeypatch):
+    """Verify summaries and the recompute policy reach the CuTeDSL API."""
+    assert gdp_cutedsl_cp_module is not None
+    calls = {}
+    tensor = torch.randn(2, 3)
+    cu_seqlens = torch.tensor([0, 2], dtype=torch.int32)
+    forward_summary = torch.randn(2, 4, 7)
+    backward_summary = torch.randn(2, 4, 7)
+    backend_local_context = object()
+    backend_backward_context = object()
+
+    def fake_forward_prepare(*args, **kwargs):
+        calls["forward_prepare"] = (args, kwargs)
+        return forward_summary, backend_local_context
+
+    def fake_forward_apply(local_context, preceding_summaries, *, output_final_state):
+        calls["forward_apply"] = (local_context, preceding_summaries, output_final_state)
+        return tensor, SimpleNamespace(
+            q=tensor,
+            k=tensor,
+            v=tensor,
+            g=tensor,
+            beta=tensor,
+            cu_seqlens=cu_seqlens,
+            state=tensor,
+            initial_states=tensor,
+            scale=0.125,
+            num_householder=3,
+            use_qk_l2norm_in_kernel=True,
+            recompute_chunk_num=2,
+        )
+
+    def fake_backward_prepare(output_grad, saved_context, *, boundary_len=None):
+        calls["backward_prepare"] = (output_grad, saved_context, boundary_len)
+        return backward_summary, backend_backward_context
+
+    gradients = tuple(torch.randn_like(tensor) for _ in range(5))
+
+    def fake_backward_apply(backward_context, following_summaries, *, dht):
+        calls["backward_apply"] = (backward_context, following_summaries, dht)
+        return gradients
+
+    monkeypatch.setattr(gdp_cutedsl_cp_module, "cutedsl_cp_forward_prepare", fake_forward_prepare)
+    monkeypatch.setattr(gdp_cutedsl_cp_module, "cutedsl_cp_forward_apply", fake_forward_apply)
+    monkeypatch.setattr(gdp_cutedsl_cp_module, "cutedsl_cp_backward_prepare", fake_backward_prepare)
+    monkeypatch.setattr(gdp_cutedsl_cp_module, "cutedsl_cp_backward_apply", fake_backward_apply)
+
+    backend = gdp_cutedsl_cp_module.CuTeDSLGatedDeltaProductCPBackend(recompute_chunk_num=2)
+    inputs = GDPInputs(
+        q=tensor,
+        k=tensor,
+        v=tensor,
+        g=tensor,
+        beta=tensor,
+        cu_seqlens=cu_seqlens,
+        num_householder=3,
+        scale=0.125,
+    )
+
+    local_summary, local_context = backend.cp_forward_prepare(inputs)
+    assert isinstance(local_summary, CPForwardPackedSummary)
+    assert local_summary.packed is forward_summary
+    assert calls["forward_prepare"][1]["recompute_chunk_num"] == 2
+
+    prefix = CPForwardPackedSummary(packed=forward_summary.unsqueeze(0))
+    output, saved_context = backend.cp_forward_apply(local_context, prefix)
+    assert output is tensor
+    assert calls["forward_apply"][0] is backend_local_context
+    assert calls["forward_apply"][1] is prefix.packed
+    assert calls["forward_apply"][2] is False
+
+    local_backward_summary, backward_context = backend.cp_backward_prepare(tensor, saved_context)
+    assert isinstance(local_backward_summary, CPBackwardPackedSummary)
+    assert local_backward_summary.packed is backward_summary
+    assert calls["backward_prepare"][1].initial_states is tensor
+    assert calls["backward_prepare"][2] is None
+
+    suffix = CPBackwardPackedSummary(packed=backward_summary.unsqueeze(0))
+    assert backend.cp_backward_apply(backward_context, suffix) is gradients
+    assert calls["backward_apply"][0] is backend_backward_context
+    assert calls["backward_apply"][1] is suffix.packed
+    assert calls["backward_apply"][2] is None

--- a/tests/unit_tests/ssm/test_gdp_packed_seq.py
+++ b/tests/unit_tests/ssm/test_gdp_packed_seq.py
@@ -33,6 +33,7 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.context_parallel.chunkwise import build_packed_sequence_cp_metadata
 from megatron.core.ssm.gated_delta_product import (
+    HAVE_CUTEDSL_GDP_CP,
     GatedDeltaProductMixer,
     GatedDeltaProductMixerSubmodules,
 )
@@ -66,6 +67,7 @@ except ImportError:
 _WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
 pytestmark = [
     pytest.mark.internal,
+    pytest.mark.launch_on_gb200,
     pytest.mark.skipif(
         _WORLD_SIZE < 2,
         reason=(
@@ -110,31 +112,35 @@ def _make_packed_seq_params(seq_lens: List[int]) -> PackedSeqParams:
     )
 
 
-def _make_config(cp_size: int, linear_cp_mode: str = "headwise") -> TransformerConfig:
+def _make_config(
+    cp_size: int, linear_cp_mode: str = "headwise", **config_overrides
+) -> TransformerConfig:
     """Small-but-shape-valid TransformerConfig for the v4 GDP mixer."""
-    return TransformerConfig(
-        num_layers=1,
-        hidden_size=64,
-        num_attention_heads=4,
-        num_query_groups=4,
-        ffn_hidden_size=128,
-        normalization="RMSNorm",
-        bf16=True,
-        mamba_num_heads=4,
-        mamba_head_dim=16,
-        mamba_num_groups=4,
-        mamba_state_dim=16,
-        tensor_model_parallel_size=1,
-        sequence_parallel=False,
-        context_parallel_size=cp_size,
-        linear_cp_mode=linear_cp_mode,
-        linear_cp_layout="contiguous" if linear_cp_mode == "chunkwise" else "zigzag",
-    )
+    config_kwargs = {
+        "num_layers": 1,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_query_groups": 4,
+        "ffn_hidden_size": 128,
+        "normalization": "RMSNorm",
+        "bf16": True,
+        "mamba_num_heads": 4,
+        "mamba_head_dim": 16,
+        "mamba_num_groups": 4,
+        "mamba_state_dim": 16,
+        "tensor_model_parallel_size": 1,
+        "sequence_parallel": False,
+        "context_parallel_size": cp_size,
+        "linear_cp_mode": linear_cp_mode,
+        "linear_cp_layout": "contiguous" if linear_cp_mode == "chunkwise" else "zigzag",
+    }
+    config_kwargs.update(config_overrides)
+    return TransformerConfig(**config_kwargs)
 
 
-def _build_mixer(cp_group, linear_cp_mode: str = "headwise"):
+def _build_mixer(cp_group, linear_cp_mode: str = "headwise", **config_overrides):
     """Construct a v4 GDP mixer wired to the given CP group."""
-    config = _make_config(cp_group.size(), linear_cp_mode=linear_cp_mode)
+    config = _make_config(cp_group.size(), linear_cp_mode=linear_cp_mode, **config_overrides)
     pg = ProcessGroupCollection(tp=parallel_state.get_tensor_model_parallel_group(), cp=cp_group)
     submodules = GatedDeltaProductMixerSubmodules(
         in_proj=TELayerNormColumnParallelLinear, out_proj=TERowParallelLinear
@@ -156,7 +162,7 @@ def _sync_weights_from_rank0(mixer):
         torch.distributed.broadcast(p.data, src=0)
 
 
-def _build_cp_pair(linear_cp_mode: str = "headwise"):
+def _build_cp_pair(linear_cp_mode: str = "headwise", **config_overrides):
     """Build a CP mixer and per-rank CP=1 reference mixers with identical weights.
 
     Returns ``(mixer_cp, mixer_cp1, config, cp_group, cp_rank)``. The cp=1
@@ -171,8 +177,8 @@ def _build_cp_pair(linear_cp_mode: str = "headwise"):
     cp1_groups = [torch.distributed.new_group(ranks=[r]) for r in range(world_size)]
     cp1_group = cp1_groups[global_rank]
 
-    mixer_cp, _ = _build_mixer(cp_group, linear_cp_mode=linear_cp_mode)
-    mixer_cp1, config = _build_mixer(cp1_group, linear_cp_mode=linear_cp_mode)
+    mixer_cp, _ = _build_mixer(cp_group, linear_cp_mode=linear_cp_mode, **config_overrides)
+    mixer_cp1, config = _build_mixer(cp1_group, linear_cp_mode=linear_cp_mode, **config_overrides)
     _sync_weights_from_rank0(mixer_cp)
     mixer_cp1.load_state_dict(mixer_cp.state_dict())
     return mixer_cp, mixer_cp1, config, cp_group, cp_rank
@@ -240,9 +246,9 @@ def _assert_chunkwise_equivalence(
         torch.distributed.all_reduce(reduced_grad, group=cp_group)
         reduced_gradients.append((name, local_grad, reference_grad, reduced_grad))
 
-    torch.testing.assert_close(local_output, reference_output[local_slice], atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(local_output, reference_output[local_slice], atol=1e-2, rtol=1e-2)
     torch.testing.assert_close(
-        local_input.grad, reference_input.grad[local_slice], atol=8e-2, rtol=8e-2
+        local_input.grad, reference_input.grad[local_slice], atol=3e-2, rtol=3e-2
     )
     assert set(reference_parameters) == set(local_parameters)
     for name, local_grad, reference_grad, reduced_grad in reduced_gradients:
@@ -250,7 +256,7 @@ def _assert_chunkwise_equivalence(
             continue
         assert local_grad is not None, f"chunkwise CP has no gradient for {name}"
         assert reference_grad is not None, f"reference has no gradient for {name}"
-        torch.testing.assert_close(reduced_grad, reference_grad, atol=8e-2, rtol=8e-2)
+        torch.testing.assert_close(reduced_grad, reference_grad, atol=3e-2, rtol=3e-2)
 
 
 @pytest.mark.internal
@@ -385,13 +391,21 @@ class TestGDPPackedSequence:
         )
         assert n_compared > 0, "no parameters received a gradient — test setup is wrong"
 
-    @pytest.mark.parametrize("packed", [False, True], ids=["blh", "thd"])
-    def test_chunkwise_forward_and_backward_equivalence(self, packed):
-        """Contiguous GDP CP matches a full-sequence FLA run for BLH and THD."""
+    @pytest.mark.parametrize(
+        "packed,recompute_modules",
+        (
+            pytest.param(False, [], id="blh"),
+            pytest.param(True, ["gdp_in_proj", "gdp_qkv"], id="thd-selective-recompute"),
+        ),
+    )
+    def test_chunkwise_forward_and_backward_equivalence(self, packed, recompute_modules):
+        """Contiguous GDP CP matches FLA with BLH, THD, and selective recompute."""
         if packed and not is_causal_conv1d_min_version("1.7.0"):
             pytest.skip("THD CP causal convolution requires causal-conv1d >= 1.7.0")
         mixer_cp, mixer_reference, config, cp_group, cp_rank = _build_cp_pair(
-            linear_cp_mode="chunkwise"
+            linear_cp_mode="chunkwise",
+            recompute_granularity="selective" if recompute_modules else None,
+            recompute_modules=recompute_modules,
         )
         if packed:
             hidden_full, packed_seq_params = _make_hidden_packed([20, 28], config.hidden_size)
@@ -406,6 +420,69 @@ class TestGDPPackedSequence:
         _assert_chunkwise_equivalence(
             mixer_cp, mixer_reference, cp_group, cp_rank, hidden_full, packed_seq_params
         )
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA + NCCL")
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2 if torch.cuda.is_available() else True,
+    reason="CP=2 test requires at least 2 GPUs",
+)
+@pytest.mark.skipif(not HAVE_MAMBA_DEPS, reason="GDP mixer requires mamba_ssm + einops")
+@pytest.mark.skipif(not HAVE_CUTEDSL_GDP_CP, reason="CuTeDSL GDP CP backend is unavailable")
+@pytest.mark.skipif(
+    not is_causal_conv1d_min_version("1.7.0"),
+    reason="GDP CP causal convolution requires causal-conv1d >= 1.7.0",
+)
+@pytest.mark.parametrize(
+    "seq_lens,recompute_modules",
+    (
+        pytest.param(None, [], id="blh-single-stream"),
+        pytest.param(
+            [256], ["gdp_in_proj", "gdp_qkv"], id="thd-single-sequence-selective-recompute"
+        ),
+        pytest.param([64, 192], [], id="thd-varlen"),
+    ),
+)
+def test_cutedsl_chunkwise_forward_and_backward_equivalence(seq_lens, recompute_modules):
+    """CuTeDSL CP=2 matches CP=1 for BLH, packed THD, and selective recompute."""
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("CuTeDSL GDP requires an SM100 GPU")
+
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, context_parallel_size=2
+    )
+    try:
+        model_parallel_cuda_manual_seed(123)
+        mixer_cp, mixer_reference, config, cp_group, cp_rank = _build_cp_pair(
+            linear_cp_mode="chunkwise",
+            hidden_size=128,
+            num_attention_heads=2,
+            num_query_groups=2,
+            ffn_hidden_size=256,
+            mamba_num_heads=2,
+            mamba_head_dim=64,
+            mamba_num_groups=2,
+            mamba_state_dim=128,
+            gdp_cutedsl_kernel=True,
+            gdp_num_chunk_states_to_recompute=2,
+            recompute_granularity="selective" if recompute_modules else None,
+            recompute_modules=recompute_modules,
+        )
+        if seq_lens is None:
+            packed_seq_params = None
+            torch.manual_seed(0)
+            hidden_full = torch.randn(
+                256, 1, config.hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+            torch.distributed.broadcast(hidden_full, src=0)
+        else:
+            hidden_full, packed_seq_params = _make_hidden_packed(seq_lens, config.hidden_size)
+        _assert_chunkwise_equivalence(
+            mixer_cp, mixer_reference, cp_group, cp_rank, hidden_full, packed_seq_params
+        )
+    finally:
+        Utils.destroy_model_parallel()
 
 
 @pytest.mark.internal


### PR DESCRIPTION
## Summary
- Add CuTeDSL GDP support for chunkwise context parallelism.
- Share the GDP CP/autograd path between the FLA and CuTeDSL backends.

## Test
```
uv run python -m torch.distributed.run --nproc-per-node 2 -m pytest -q \
  tests/unit_tests/ssm/test_gdp_chunkwise_context_parallel.py \
  tests/unit_tests/ssm/test_gdp_packed_seq.py
```