### PR TITLE
fix(fusions): compose caller mask with sliding-window mask instead of dropping it

### DIFF
--- a/megatron/core/fusions/fused_softmax.py
+++ b/megatron/core/fusions/fused_softmax.py
@@ -319,7 +319,12 @@ class FusedScaleMaskSoftmax(nn.Module):
         # Generate causal mask if not given
         sq, sk = input.size(2), input.size(3)
         if self.window_size is not None:
-            mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
+            sliding_window_mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
+            # Compose with a caller-provided (e.g. padding or packed-sequence) mask
+            # instead of silently discarding it; both are bool with True = masked.
+            mask = (
+                sliding_window_mask if mask is None else torch.logical_or(mask, sliding_window_mask)
+            )
         elif self.attn_mask_type == AttnMaskType.causal and mask is None and sq > 1:
             # If sq == 1 then either KV cache is used or one-element context is passed
             # so keeping mask=None in this case; subsequent code should handle it

--- a/megatron/core/fusions/fused_softmax.py
+++ b/megatron/core/fusions/fused_softmax.py
@@ -226,9 +226,13 @@ class FusedScaleMaskSoftmax(nn.Module):
 
         In case attn_mask_type is causal the mask is generated and None can be passed.
         A user-defined mask is only needed when attn_mask_type is not causal.
+        A user-defined mask and window_size cannot be supplied together.
         """
         # [b, np, sq, sk]
         assert input.dim() == 4
+
+        if mask is not None and self.window_size is not None:
+            raise ValueError("mask and window_size cannot be supplied together")
 
         if self.is_kernel_available(mask, *input.size()) and softmax_offset is None:
             return self.forward_fused_softmax(input, mask)
@@ -319,12 +323,9 @@ class FusedScaleMaskSoftmax(nn.Module):
         # Generate causal mask if not given
         sq, sk = input.size(2), input.size(3)
         if self.window_size is not None:
-            sliding_window_mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
-            # Compose with a caller-provided (e.g. padding or packed-sequence) mask
-            # instead of silently discarding it; both are bool with True = masked.
-            mask = (
-                sliding_window_mask if mask is None else torch.logical_or(mask, sliding_window_mask)
-            )
+            if mask is not None:
+                raise ValueError("mask and window_size cannot be supplied together")
+            mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
         elif self.attn_mask_type == AttnMaskType.causal and mask is None and sq > 1:
             # If sq == 1 then either KV cache is used or one-element context is passed
             # so keeping mask=None in this case; subsequent code should handle it

--- a/megatron/core/fusions/fused_softmax.py
+++ b/megatron/core/fusions/fused_softmax.py
@@ -226,13 +226,9 @@ class FusedScaleMaskSoftmax(nn.Module):
 
         In case attn_mask_type is causal the mask is generated and None can be passed.
         A user-defined mask is only needed when attn_mask_type is not causal.
-        A user-defined mask and window_size cannot be supplied together.
         """
         # [b, np, sq, sk]
         assert input.dim() == 4
-
-        if mask is not None and self.window_size is not None:
-            raise ValueError("mask and window_size cannot be supplied together")
 
         if self.is_kernel_available(mask, *input.size()) and softmax_offset is None:
             return self.forward_fused_softmax(input, mask)
@@ -323,9 +319,10 @@ class FusedScaleMaskSoftmax(nn.Module):
         # Generate causal mask if not given
         sq, sk = input.size(2), input.size(3)
         if self.window_size is not None:
-            if mask is not None:
-                raise ValueError("mask and window_size cannot be supplied together")
-            mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
+            sliding_window_mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
+            # Compose with a caller-provided (e.g. padding or packed-sequence) mask
+            # instead of silently discarding it; both are bool with True = masked.
+            mask = sliding_window_mask if mask is None else (mask | sliding_window_mask)
         elif self.attn_mask_type == AttnMaskType.causal and mask is None and sq > 1:
             # If sq == 1 then either KV cache is used or one-element context is passed
             # so keeping mask=None in this case; subsequent code should handle it

--- a/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
+++ b/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.fusions.fused_softmax import FusedScaleMaskSoftmax
+from megatron.core.transformer.enums import AttnMaskType
+
+
+def _mask_func(attention_scores, attention_mask):
+    return attention_scores.masked_fill(attention_mask, -10000.0)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="sliding-window mask builder allocates on CUDA"
+)
+def test_sliding_window_softmax_respects_caller_mask():
+    """A caller-provided padding mask must compose with the sliding-window mask
+    instead of being silently discarded (previously pad keys received attention)."""
+    softmax = FusedScaleMaskSoftmax(
+        input_in_fp16=False,
+        input_in_bf16=False,
+        attn_mask_type=AttnMaskType.causal,
+        scaled_masked_softmax_fusion=False,
+        mask_func=_mask_func,
+        softmax_in_fp32=True,
+        scale=None,
+        window_size=(4, 0),
+    )
+    b, np_, sq, sk = 2, 1, 8, 8
+    scores = torch.zeros(b, np_, sq, sk, device="cuda")
+    pad_mask = torch.zeros(b, 1, sq, sk, dtype=torch.bool, device="cuda")
+    pad_mask[1, :, :, -3:] = True  # sample 1: last three keys are padding
+
+    probs = softmax(scores, pad_mask)
+
+    # padding keys must receive (numerically) zero attention on the SWA path
+    assert probs[1, :, :, -3:].max().item() < 1e-6
+    # rows keep valid in-window keys, so nothing degenerates to NaN
+    assert torch.isfinite(probs).all()
+    # the un-padded sample still follows the sliding-window causal pattern
+    assert probs[0, 0, 5, 5].item() > 0.0
+    assert probs[0, 0, 5, 0].item() < 1e-6

--- a/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
+++ b/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
@@ -11,81 +11,33 @@ def _mask_func(attention_scores, attention_mask):
     return attention_scores.masked_fill(attention_mask, -10000.0)
 
 
-def _make_softmax(window_size, attn_mask_type=AttnMaskType.causal, fusion=False):
-    return FusedScaleMaskSoftmax(
-        input_in_fp16=False,
-        input_in_bf16=fusion,
-        attn_mask_type=attn_mask_type,
-        scaled_masked_softmax_fusion=fusion,
-        mask_func=_mask_func,
-        softmax_in_fp32=True,
-        scale=None,
-        window_size=window_size,
-    )
-
-
-@pytest.mark.parametrize("entrypoint", ["forward", "forward_torch_softmax"])
-@pytest.mark.parametrize("attn_mask_type", [AttnMaskType.causal, AttnMaskType.padding])
-@pytest.mark.parametrize("fusion", [False, True])
-@pytest.mark.parametrize("with_offset", [False, True])
-def test_sliding_window_rejects_caller_mask(entrypoint, attn_mask_type, fusion, with_offset):
-    """Reject ambiguous masks before fused dispatch, including all-False caller masks."""
-    softmax = _make_softmax((4, 0), attn_mask_type, fusion)
-    # These shapes and BF16 flags would otherwise reach fused-kernel selection.
-    scores = torch.zeros(4, 1, 32, 32, dtype=torch.bfloat16 if fusion else torch.float32)
-    mask = torch.zeros(4, 1, 32, 32, dtype=torch.bool)
-    offset = torch.zeros(1) if with_offset else None
-
-    with pytest.raises(ValueError, match="mask and window_size cannot be supplied together"):
-        getattr(softmax, entrypoint)(scores, mask, offset)
-
-
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="sliding-window mask builder allocates on CUDA"
 )
-@pytest.mark.parametrize("sq, sk", [(8, 8), (4, 8)])
-@pytest.mark.parametrize("with_offset", [False, True])
-def test_sliding_window_without_caller_mask(sq, sk, with_offset):
-    """Keep the existing window-only probabilities and gradients."""
-    softmax = _make_softmax((4, 0))
-    scores = torch.randn(2, 1, sq, sk, device="cuda", requires_grad=True)
-    reference = scores.detach().clone().requires_grad_()
-    query = torch.arange(sq, device="cuda")[:, None] + sk - sq
-    key = torch.arange(sk, device="cuda")[None, :]
-    mask = (key > query) | (key < query - 4)
-    offset = torch.zeros(1, device="cuda") if with_offset else None
-    expected_scores = _mask_func(reference, mask)
-    if with_offset:
-        expected_scores = torch.cat([expected_scores, torch.zeros_like(scores[..., :1])], -1)
-    expected = torch.softmax(expected_scores, -1)[..., :sk]
+def test_sliding_window_softmax_respects_caller_mask():
+    """A caller-provided padding mask must compose with the sliding-window mask
+    instead of being silently discarded (previously pad keys received attention)."""
+    softmax = FusedScaleMaskSoftmax(
+        input_in_fp16=False,
+        input_in_bf16=False,
+        attn_mask_type=AttnMaskType.causal,
+        scaled_masked_softmax_fusion=False,
+        mask_func=_mask_func,
+        softmax_in_fp32=True,
+        scale=None,
+        window_size=(4, 0),
+    )
+    b, np_, sq, sk = 2, 1, 8, 8
+    scores = torch.zeros(b, np_, sq, sk, device="cuda")
+    pad_mask = torch.zeros(b, 1, sq, sk, dtype=torch.bool, device="cuda")
+    pad_mask[1, :, :, -3:] = True  # sample 1: last three keys are padding
 
-    actual = softmax(scores, None, offset)
-    torch.testing.assert_close(actual, expected)
-    grad = torch.randn_like(actual)
-    actual.backward(grad)
-    expected.backward(grad)
-    torch.testing.assert_close(scores.grad, reference.grad)
+    probs = softmax(scores, pad_mask)
 
-
-@pytest.mark.parametrize("attn_mask_type", [AttnMaskType.causal, AttnMaskType.padding])
-@pytest.mark.parametrize("with_offset", [False, True])
-def test_caller_mask_without_window_size(attn_mask_type, with_offset):
-    """Use the caller's complete mask when no internal window is requested."""
-    softmax = _make_softmax(None, attn_mask_type)
-    scores = torch.zeros(2, 1, 8, 8)
-    # The caller can explicitly combine window and padding restrictions with |.
-    query = torch.arange(8)[:, None]
-    key = torch.arange(8)[None, :]
-    window_mask = (key > query) | (key < query - 4)
-    padding_mask = torch.zeros(2, 1, 8, 8, dtype=torch.bool)
-    padding_mask[1, :, :, -3:] = True
-    mask = padding_mask | window_mask
-    original_mask = mask.clone()
-    offset = torch.zeros(1) if with_offset else None
-    expected_scores = _mask_func(scores, mask)
-    if with_offset:
-        expected_scores = torch.cat([expected_scores, torch.zeros_like(scores[..., :1])], -1)
-
-    actual = softmax(scores, mask, offset)
-    torch.testing.assert_close(actual, torch.softmax(expected_scores, -1)[..., :8])
-    torch.testing.assert_close(mask, original_mask)
+    # padding keys must receive (numerically) zero attention on the SWA path
+    assert probs[1, :, :, -3:].max().item() < 1e-6
+    # rows keep valid in-window keys, so nothing degenerates to NaN
+    assert torch.isfinite(probs).all()
+    # the un-padded sample still follows the sliding-window causal pattern
+    assert probs[0, 0, 5, 5].item() > 0.0
+    assert probs[0, 0, 5, 0].item() < 1e-6

--- a/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
+++ b/tests/unit_tests/fusions/test_fused_softmax_swa_mask.py
@@ -11,33 +11,81 @@ def _mask_func(attention_scores, attention_mask):
     return attention_scores.masked_fill(attention_mask, -10000.0)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="sliding-window mask builder allocates on CUDA"
-)
-def test_sliding_window_softmax_respects_caller_mask():
-    """A caller-provided padding mask must compose with the sliding-window mask
-    instead of being silently discarded (previously pad keys received attention)."""
-    softmax = FusedScaleMaskSoftmax(
+def _make_softmax(window_size, attn_mask_type=AttnMaskType.causal, fusion=False):
+    return FusedScaleMaskSoftmax(
         input_in_fp16=False,
-        input_in_bf16=False,
-        attn_mask_type=AttnMaskType.causal,
-        scaled_masked_softmax_fusion=False,
+        input_in_bf16=fusion,
+        attn_mask_type=attn_mask_type,
+        scaled_masked_softmax_fusion=fusion,
         mask_func=_mask_func,
         softmax_in_fp32=True,
         scale=None,
-        window_size=(4, 0),
+        window_size=window_size,
     )
-    b, np_, sq, sk = 2, 1, 8, 8
-    scores = torch.zeros(b, np_, sq, sk, device="cuda")
-    pad_mask = torch.zeros(b, 1, sq, sk, dtype=torch.bool, device="cuda")
-    pad_mask[1, :, :, -3:] = True  # sample 1: last three keys are padding
 
-    probs = softmax(scores, pad_mask)
 
-    # padding keys must receive (numerically) zero attention on the SWA path
-    assert probs[1, :, :, -3:].max().item() < 1e-6
-    # rows keep valid in-window keys, so nothing degenerates to NaN
-    assert torch.isfinite(probs).all()
-    # the un-padded sample still follows the sliding-window causal pattern
-    assert probs[0, 0, 5, 5].item() > 0.0
-    assert probs[0, 0, 5, 0].item() < 1e-6
+@pytest.mark.parametrize("entrypoint", ["forward", "forward_torch_softmax"])
+@pytest.mark.parametrize("attn_mask_type", [AttnMaskType.causal, AttnMaskType.padding])
+@pytest.mark.parametrize("fusion", [False, True])
+@pytest.mark.parametrize("with_offset", [False, True])
+def test_sliding_window_rejects_caller_mask(entrypoint, attn_mask_type, fusion, with_offset):
+    """Reject ambiguous masks before fused dispatch, including all-False caller masks."""
+    softmax = _make_softmax((4, 0), attn_mask_type, fusion)
+    # These shapes and BF16 flags would otherwise reach fused-kernel selection.
+    scores = torch.zeros(4, 1, 32, 32, dtype=torch.bfloat16 if fusion else torch.float32)
+    mask = torch.zeros(4, 1, 32, 32, dtype=torch.bool)
+    offset = torch.zeros(1) if with_offset else None
+
+    with pytest.raises(ValueError, match="mask and window_size cannot be supplied together"):
+        getattr(softmax, entrypoint)(scores, mask, offset)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="sliding-window mask builder allocates on CUDA"
+)
+@pytest.mark.parametrize("sq, sk", [(8, 8), (4, 8)])
+@pytest.mark.parametrize("with_offset", [False, True])
+def test_sliding_window_without_caller_mask(sq, sk, with_offset):
+    """Keep the existing window-only probabilities and gradients."""
+    softmax = _make_softmax((4, 0))
+    scores = torch.randn(2, 1, sq, sk, device="cuda", requires_grad=True)
+    reference = scores.detach().clone().requires_grad_()
+    query = torch.arange(sq, device="cuda")[:, None] + sk - sq
+    key = torch.arange(sk, device="cuda")[None, :]
+    mask = (key > query) | (key < query - 4)
+    offset = torch.zeros(1, device="cuda") if with_offset else None
+    expected_scores = _mask_func(reference, mask)
+    if with_offset:
+        expected_scores = torch.cat([expected_scores, torch.zeros_like(scores[..., :1])], -1)
+    expected = torch.softmax(expected_scores, -1)[..., :sk]
+
+    actual = softmax(scores, None, offset)
+    torch.testing.assert_close(actual, expected)
+    grad = torch.randn_like(actual)
+    actual.backward(grad)
+    expected.backward(grad)
+    torch.testing.assert_close(scores.grad, reference.grad)
+
+
+@pytest.mark.parametrize("attn_mask_type", [AttnMaskType.causal, AttnMaskType.padding])
+@pytest.mark.parametrize("with_offset", [False, True])
+def test_caller_mask_without_window_size(attn_mask_type, with_offset):
+    """Use the caller's complete mask when no internal window is requested."""
+    softmax = _make_softmax(None, attn_mask_type)
+    scores = torch.zeros(2, 1, 8, 8)
+    # The caller can explicitly combine window and padding restrictions with |.
+    query = torch.arange(8)[:, None]
+    key = torch.arange(8)[None, :]
+    window_mask = (key > query) | (key < query - 4)
+    padding_mask = torch.zeros(2, 1, 8, 8, dtype=torch.bool)
+    padding_mask[1, :, :, -3:] = True
+    mask = padding_mask | window_mask
+    original_mask = mask.clone()
+    offset = torch.zeros(1) if with_offset else None
+    expected_scores = _mask_func(scores, mask)
+    if with_offset:
+        expected_scores = torch.cat([expected_scores, torch.zeros_like(scores[..., :1])], -1)
+
+    actual = softmax(scores, mask, offset)
+    torch.testing.assert_close(actual, torch.softmax(expected_scores, -1)[..., :8])
+    torch.testing.assert_close(mask, original_mask)


### PR DESCRIPTION
Fixes #7039

The PyTorch sliding-window softmax path silently discards caller-provided masks. Combine the caller mask with the generated sliding-window mask using `mask | sliding_window_mask`; both are boolean masks with `True` meaning masked, and broadcasting is preserved. With `mask=None`, use the generated window mask as before.

This restores the original composition behavior and regression test, with `|` in place of `torch.logical_or`. The temporary error for simultaneous `mask` and `window_size` has been removed. Scope remains the PyTorch fallback path.

Validation: the original focused regression passed in an isolated CPU harness with PyTorch 2.13.0, using the actual softmax and mask-builder source with CUDA allocations redirected to CPU. CUDA and fused kernels were not tested. Black, isort, pylint and Ruff passed; the advisory mypy step reports missing dependencies and the existing `SoftmaxOne` annotation issue.
