### PR TITLE
Fix: add missing import in examples/multimodal/train.py

### DIFF
--- a/examples/multimodal/train.py
+++ b/examples/multimodal/train.py
@@ -29,6 +29,7 @@ from megatron.core.parallel_state import (
     is_pipeline_last_stage,
 )
 from megatron.training import get_args, get_timers, get_tokenizer, pretrain
+from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.core.utils import get_batch_on_this_cp_rank
 from megatron.training.utils import is_last_rank
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes a missing import in `examples/multimodal/train.py` that causes `NameError` when running the multimodal training example.

## Issue tracking

Linked issue: Fixes #XXXX (replace with actual issue number if you create one first)

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests (N/A - simple import fix, no new logic to test)
- [ ] I have added relevant functional tests (N/A - simple import fix, existing tests will verify)
- [ ] I have added proper typing to my code (N/A - no new code added, only import statement)
- [ ] I have added relevant documentation (N/A - simple import fix, no API changes)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Description

### Problem
After commit [223e244f5](https://github.com/NVIDIA/Megatron-LM/commit/223e244f5) (PR #5516 - training migration), `examples/multimodal/train.py` fails with:

```
NameError: name 'pretrain_cfg_container_from_args' is not defined
```

### Root Cause
The commit refactored the API to use `pretrain_cfg_container_from_args(args)` but forgot to add the required import statement. Other example files updated in the same refactoring already have this import:
- `examples/bert/pretrain_bert.py:11`
- `examples/t5/pretrain_t5.py:12`  
- `examples/mimo/pretrain_mimo.py:11`

### Solution
Add the missing import:
```python
from megatron.training.argument_utils import pretrain_cfg_container_from_args
```

### Testing
Verified that the multimodal training example now runs without import errors.
