### PR TITLE
fix: account for DSA top-k sparsity and indexer cost in FLOPs

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -119,7 +119,10 @@ from megatron.core.rerun_state_machine import (
 )
 from megatron.core.resharding.refit import swap_model_weights
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
-from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    DSAIndexerLossLoggingHelper,
+    is_dsa_skip_topk_layer,
+)
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.moe import upcycling_utils
 from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
@@ -818,6 +821,196 @@ def consume_seqlen_stats_in_iteration() -> Tuple[Optional[float], Optional[float
     return total_real_tokens / dedup, seqlen_squared_sum / dedup
 
 
+def _dsa_sparse_core_scale(total_real_tokens, seqlen_squared_sum, dsa_indexer_topk):
+    """Fraction of dense causal (query, key) pairs that DSA actually attends to.
+
+    A DSA layer scores every past position with the indexer but runs attention
+    only over the ``dsa_indexer_topk`` highest-scoring keys, so its core
+    attention cost is ``sum_i(min(i, topk))`` pairs per sequence instead of the
+    dense causal ``L^2 / 2``. Returns the ratio between the two, i.e. the
+    factor the dense core-attention coefficient must be scaled by.
+
+    The caller only has the batch aggregates ``sum_i(L_i)`` and
+    ``sum_i(L_i ** 2)``, not the individual sequence lengths, so the ratio is
+    evaluated at the length-weighted mean ``sum(L^2) / sum(L)``. That is exact
+    when every sequence in the batch has the same length (the usual packed-THD
+    benchmark case) and, for ragged batches, weights toward the long sequences
+    that dominate attention cost. Collapses to ``1.0`` when the sequences are
+    no longer than ``topk``, where top-k selects everything and attention is
+    dense.
+    """
+    if not dsa_indexer_topk or total_real_tokens <= 0 or seqlen_squared_sum <= 0:
+        return 1.0
+    mean_seqlen = seqlen_squared_sum / total_real_tokens
+    # Average attended KV entries per query: ``min(i, topk)`` averaged over the
+    # sequence, approximated as ``eff * (1 - eff / (2 * L))`` with
+    # ``eff = min(topk, floor(L))``. The exact discrete average has ``eff - 1``
+    # in the correction term; the O(1/L) difference is below the precision of
+    # this estimate.
+    eff = min(dsa_indexer_topk, math.floor(mean_seqlen))
+    attended = eff * (1 - eff / (2 * mean_seqlen))
+    # Dense causal attention averages ~``mean_seqlen / 2`` keys per query.
+    return attended / (mean_seqlen / 2)
+
+
+def _dsa_indexer_flops(
+    *, hidden_size, q_lora_rank, n_heads, head_dim, num_indexer_layers, indexer_loss_coeff
+):
+    """DSA lightning-indexer FLOPs coefficients, fwd/bwd expansion included.
+
+    Counts the indexer's projections (a Q projection off the shared ``q_lora``
+    residual, the ``linear_wk`` key path, and the per-head ``weights_proj``)
+    plus its dense scoring pass of every query against every past token under
+    a causal mask. Scoring is ``O(L^2)`` even though the attention consuming
+    it is sparse. The indexer KL loss (``dsa_indexer_loss_coeff``) and the
+    top-k selection itself are NOT counted: like everywhere else in this file
+    only the model's defining GEMMs enter the estimate, not auxiliary-loss or
+    sorting work.
+
+    Only ``num_indexer_layers`` layers pay: with cross-layer index sharing
+    (``dsa_indexer_topk_freq``) the layers in between reuse the most recent
+    top-k (see ``is_dsa_skip_topk_layer``).
+
+    The indexer does NOT get the global fwd+bwd factor of 3. It is trained
+    only by its own KL loss, so ``DSAttention.forward`` runs it under
+    ``torch.no_grad()`` unless ``dsa_indexer_loss_coeff > 0`` (which defaults
+    to None), and even then ``x`` / ``qr`` are detached so no gradient leaves
+    the indexer:
+
+      * loss off -> forward only, everything is 1x.
+      * loss on  -> the projections (wq_b / wk / weights_proj) read a detached
+        input, so autograd skips their dgrad and they pay fwd + wgrad = 2x.
+        The scoring GEMM has two activation operands that both need gradients
+        to reach those weights, so it pays fwd + dq + dk = 3x.
+
+    Whether the indexer is trained is part of the training procedure rather
+    than the kernel schedule, so it belongs in this model-FLOPs count. (With
+    ``dsa_indexer_use_sparse_loss`` the scoring backward only covers the top-k
+    entries, which the 3x does not model; it defaults to False.)
+
+    Returns ``(token_linear, core)`` INCLUDING the fwd/bwd and FMA factors.
+    Multiply ``token_linear`` by the real token count and ``core`` by
+    ``sum_i(L_i ** 2)``.
+    """
+    if num_indexer_layers <= 0:
+        return 0, 0
+    if q_lora_rank is None:
+        # Mirrors DSAIndexer's own fallback when the model has no q lora rank.
+        q_lora_rank = hidden_size
+    index_dim = n_heads * head_dim
+    token_linear = num_indexer_layers * (
+        q_lora_rank * index_dim  # wq_b
+        + hidden_size * head_dim  # wk
+        + hidden_size * n_heads  # weights_proj
+    )
+    # Scoring each query against every past token under a causal mask (/2).
+    core = num_indexer_layers * index_dim / 2
+    fma_expansion_factor = 2
+    loss_enabled = (indexer_loss_coeff or 0.0) > 0
+    return (
+        (2 if loss_enabled else 1) * fma_expansion_factor * token_linear,
+        (3 if loss_enabled else 1) * fma_expansion_factor * core,
+    )
+
+
+def _num_dsa_indexer_layers(num_layers, skip_topk_offset, topk_freq):
+    """Count layers that compute their own DSA index (the rest reuse one).
+
+    On the standard-model path every layer is a DSA attention layer (MTP
+    layers included -- ``DSAttention.__init__`` numbers them
+    ``layer_number + config.num_layers``, which is exactly how the caller
+    extends ``num_layers``), so the predicate runs over the whole
+    ``1..num_layers`` range.
+    """
+    return sum(
+        1
+        for layer_number in range(1, num_layers + 1)
+        if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset or 0, topk_freq or 1)
+    )
+
+
+def _num_dsa_indexer_layers_in_pattern(layer_types, dsa_symbol, skip_topk_offset, topk_freq):
+    """Count 'D' positions in a hybrid layer-type sequence that compute their
+    own DSA index.
+
+    ``layer_types`` is one hybrid block's layer sequence (main pattern with
+    pipes stripped, or one MTP depth's pattern). ``DSAttention`` receives the
+    block-local 1-indexed layer number (``HybridBlock`` numbers layers
+    ``i + 1 + pp_layer_offset`` across pipeline stages; hybrid MTP blocks
+    restart at 1 per depth with ``pp_layer_offset=0``), and the skip predicate
+    runs on that number -- non-DSA positions advance the numbering but never
+    compute an index.
+    """
+    return sum(
+        1
+        for layer_number, symbol in enumerate(layer_types, start=1)
+        if symbol == dsa_symbol
+        and not is_dsa_skip_topk_layer(layer_number, skip_topk_offset or 0, topk_freq or 1)
+    )
+
+
+def _dsa_layer_flops(args, total_real_tokens, seqlen_squared_sum):
+    """Per-DSA-layer FLOPs coefficients for the hybrid-model path.
+
+    Returns ``(token_linear, core)`` INCLUDING the fwd+bwd (x3) and FMA (x2)
+    expansion factors. Multiply ``token_linear`` by the real token count and
+    ``core`` by ``sum_i(L_i ** 2)``. The formulas mirror the standard-path
+    ``"dsa"`` branch in ``transformer_flops``:
+
+      * token-linear: the plain-MLA projection cost (q/kv lora, RoPE, output
+        projection). Absorption relocates the same ``W_UK``/``W_UV`` GEMMs, so
+        the absorbed form costs the same per token.
+      * core: the absorbed-MLA form (``QK^T`` over
+        ``kv_lora_rank + qk_pos_emb_head_dim`` per head, ``AV`` over
+        ``kv_lora_rank``), scaled down to the indexer's top-k pair count.
+
+    The indexer is NOT included here -- only ``dsa_indexer_topk_freq``-spaced
+    layers pay it; callers add ``_dsa_indexer_flops`` separately.
+    """
+    if args.q_lora_rank is None:
+        q_term = (
+            args.hidden_size
+            * args.num_attention_heads
+            * (args.qk_head_dim + args.qk_pos_emb_head_dim)
+        )
+    else:
+        q_term = args.q_lora_rank * (
+            args.hidden_size
+            + args.num_attention_heads * (args.qk_head_dim + args.qk_pos_emb_head_dim)
+            + 1
+        )
+    forward_backward_expansion_factor = 3
+    fma_expansion_factor = 2
+    token_linear = (
+        forward_backward_expansion_factor
+        * fma_expansion_factor
+        * (
+            ## q lora + rope + q norm
+            q_term
+            ## kv lora + rope + kv norm
+            + args.kv_lora_rank
+            * (
+                args.hidden_size
+                + args.num_attention_heads * (args.qk_head_dim + args.v_head_dim)
+                + 1
+            )
+            + args.hidden_size * args.qk_pos_emb_head_dim
+            ## o proj
+            + (args.num_attention_heads * args.v_head_dim) * args.hidden_size
+        )
+    )
+    core = (
+        forward_backward_expansion_factor
+        * fma_expansion_factor
+        * (
+            args.num_attention_heads * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2
+            + args.num_attention_heads * args.kv_lora_rank / 2
+        )
+        * _dsa_sparse_core_scale(total_real_tokens, seqlen_squared_sum, args.dsa_indexer_topk)
+    )
+    return token_linear, core
+
+
 def num_floating_point_operations(
     args,
     batch_size,
@@ -1188,6 +1381,8 @@ def num_floating_point_operations(
                 * 2  # QK^T and (QK^T)V
             )
 
+        dsa_extra_term = 0
+        dsa_extra_core_term = 0
         if is_linear_attention_variant(args.experimental_attention_variant):
             # Calculate number of dense and MoE Transformer MLPs.
             if isinstance(args.linear_attention_freq, int):
@@ -1255,6 +1450,51 @@ def num_floating_point_operations(
                     "Invalid experimental_attention_variant: "
                     f"{args.experimental_attention_variant}"
                 )
+        elif args.experimental_attention_variant == "dsa":
+            # DSA (e.g. GLM-5.2). The MLA projections are unchanged -- absorption
+            # relocates the same W_UK/W_UV GEMMs (per-token K/V up-projection
+            # becomes per-token q-side and output-side absorption of identical
+            # cost) -- so the standard token-linear term computed above still
+            # applies. Core attention differs from plain MLA in two ways:
+            #   * DSA always executes the absorbed-MLA path
+            #     (``AbsorbedMLASelfAttention``): ``QK^T`` is formed over the
+            #     compressed KV latent, spanning
+            #     ``kv_lora_rank + qk_pos_emb_head_dim`` per head, and ``AV``
+            #     spans ``kv_lora_rank`` -- not the up-projected
+            #     (``qk_head_dim``, ``v_head_dim``) counted for plain MLA
+            #     above. Each branch counts the form its variant executes.
+            #   * Attention runs over the indexer's top-k keys instead of the
+            #     full causal mask, so the dense causal coefficient is scaled
+            #     down to the top-k pair count.
+            # The indexer itself adds projections plus its own dense O(L^2)
+            # scoring pass; it carries its own (KL-loss-dependent) fwd/bwd
+            # expansion instead of the global factor of 3 -- see
+            # ``_dsa_indexer_flops``.
+            num_linear_attention_layers = 0
+            linear_self_attn_term = 0
+            num_standard_attention_layers = num_layers
+
+            standard_self_attn_core_term = (
+                forward_backward_expansion_factor
+                * fma_expansion_factor
+                * (
+                    args.num_attention_heads * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2
+                    + args.num_attention_heads * args.kv_lora_rank / 2
+                )
+                * _dsa_sparse_core_scale(
+                    total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
+                )
+            )
+            dsa_extra_term, dsa_extra_core_term = _dsa_indexer_flops(
+                hidden_size=args.hidden_size,
+                q_lora_rank=args.q_lora_rank,
+                n_heads=args.dsa_indexer_n_heads,
+                head_dim=args.dsa_indexer_head_dim,
+                num_indexer_layers=_num_dsa_indexer_layers(
+                    num_layers, args.dsa_indexer_skip_topk_offset, args.dsa_indexer_topk_freq
+                ),
+                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+            )
         else:
             num_linear_attention_layers = 0
             linear_self_attn_term = 0
@@ -1265,9 +1505,15 @@ def num_floating_point_operations(
         self_attn_term = (
             linear_self_attn_term * num_linear_attention_layers
             + standard_self_attn_term * num_standard_attention_layers
+            + dsa_extra_term
         )
-        # Core attention (L^2) FLOPs per standard-attention layer.
-        self_attn_core_term = standard_self_attn_core_term * num_standard_attention_layers
+        # Core attention (L^2) FLOPs per standard-attention layer. For DSA the
+        # standard coefficient is already the top-k-scaled absorbed form, and
+        # the extra term carries the indexer's dense scoring.
+        self_attn_core_term = (
+            standard_self_attn_core_term * num_standard_attention_layers
+            + dsa_extra_core_term
+        )
 
         # Token-linear FLOPs scale with the real (unpadded) token count.
         # For BSHD this falls back to ``batch_size * seq_length`` (no padding).
@@ -1355,52 +1601,109 @@ def num_floating_point_operations(
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
             Symbols,
             get_hybrid_layer_counts,
+            parse_hybrid_pattern,
         )
+        layer_counts = get_hybrid_layer_counts(args.hybrid_layer_pattern)
         num_mamba_layers, num_gdn_layers, num_attn_layers, num_mlp_layers, num_moe_layers = (
             itemgetter(Symbols.MAMBA, Symbols.GDN, Symbols.ATTENTION, Symbols.MLP, Symbols.MOE)(
-                get_hybrid_layer_counts(args.hybrid_layer_pattern)
+                layer_counts
             )
         )
+
+        # DSA ('D') layers: absorbed-MLA projections + top-k sparse core
+        # attention, plus the lightning indexer on the layers that compute
+        # their own top-k index. ``hybrid_flops`` below does not know about
+        # 'D' layers (its attention term models plain GQA/MHA '*' layers), so
+        # the DSA cost is added on top of its result. Key off the layer
+        # pattern itself, not ``args.experimental_attention_variant``: on the
+        # hybrid path a 'D' pattern sets the variant only in the config
+        # kwargs (``arguments.py``/``argument_utils.py`` write it into
+        # ``kw_args``, never back onto ``args``).
+        # The indexer keeps its own KL-loss-dependent fwd/bwd expansion (see
+        # ``_dsa_indexer_flops``), so it must NOT go through ``hybrid_flops``'s
+        # global x3 -- both DSA terms are therefore added after it.
+        num_dsa_layers = layer_counts[Symbols.DS_ATTENTION]
+        dsa_token_linear_term = 0
+        dsa_core_term = 0
+        if num_dsa_layers > 0:
+            per_layer_token_linear, per_layer_core = _dsa_layer_flops(
+                args, total_real_tokens_in_batch, seqlen_squared_sum_in_batch
+            )
+            # DSAttention's skip predicate runs on block-local layer numbers:
+            # the main pattern numbers layers sequentially across pipes, and
+            # each hybrid MTP depth restarts at 1 (``pp_layer_offset=0``).
+            parsed_pattern = parse_hybrid_pattern(args.hybrid_layer_pattern)
+            main_layer_types = (parsed_pattern.main_pattern or "").replace(Symbols.PIPE, "")
+            num_indexer_layers = _num_dsa_indexer_layers_in_pattern(
+                main_layer_types,
+                Symbols.DS_ATTENTION,
+                args.dsa_indexer_skip_topk_offset,
+                args.dsa_indexer_topk_freq,
+            )
+            if parsed_pattern.mtp_pattern:
+                num_indexer_layers += (
+                    parsed_pattern.mtp_num_depths
+                    * _num_dsa_indexer_layers_in_pattern(
+                        parsed_pattern.mtp_pattern,
+                        Symbols.DS_ATTENTION,
+                        args.dsa_indexer_skip_topk_offset,
+                        args.dsa_indexer_topk_freq,
+                    )
+                )
+            indexer_token_linear, indexer_core = _dsa_indexer_flops(
+                hidden_size=args.hidden_size,
+                q_lora_rank=args.q_lora_rank,
+                n_heads=args.dsa_indexer_n_heads,
+                head_dim=args.dsa_indexer_head_dim,
+                num_indexer_layers=num_indexer_layers,
+                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+            )
+            dsa_token_linear_term = num_dsa_layers * per_layer_token_linear + indexer_token_linear
+            dsa_core_term = num_dsa_layers * per_layer_core + indexer_core
 
         mtp_num_layers = args.mtp_num_layers
         if mtp_num_layers is None:
             mtp_num_layers = 0
         # Compute hybrid model FLOPs.
-        return hybrid_flops(
-            total_tokens=total_real_tokens_in_batch,
-            seqlen_squared_sum=seqlen_squared_sum_in_batch,
-            hidden_size=args.hidden_size,
-            num_attn_layers=num_attn_layers,
-            num_mamba_layers=num_mamba_layers,
-            num_mlp_layers=num_mlp_layers,
-            num_moe_layers=num_moe_layers,
-            num_gdn_layers=num_gdn_layers,
-            mamba_state_dim=args.mamba_state_dim,
-            mamba_head_dim=args.mamba_head_dim,
-            mamba_num_groups=args.mamba_num_groups,
-            mamba_num_heads=args.mamba_num_heads,
-            gdp_num_householder=args.gdp_num_householder,
-            num_attn_heads=args.num_attention_heads,
-            gqa=args.group_query_attention,
-            gqa_groups=args.num_query_groups,
-            kv_channels=args.kv_channels,
-            mlp_expansion=args.ffn_hidden_size / args.hidden_size,
-            swiglu=args.swiglu,
-            use_gated_delta_product=_uses_gated_delta_product_spec(args),
-            moe_latent_size=args.moe_latent_size,
-            moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
-                                 else args.ffn_hidden_size),
-            shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
-                                           else args.moe_shared_expert_intermediate_size),
-            num_experts_routed_to=args.moe_router_topk,
-            gdn_qk_head_dim=args.linear_key_head_dim or 128,
-            gdn_v_head_dim=args.linear_value_head_dim or 128,
-            gdn_num_qk_heads=args.linear_num_key_heads or 16,
-            gdn_num_v_heads=args.linear_num_value_heads or 32,
-            gdn_conv_kernel_dim=args.linear_conv_kernel_dim or 4,
-            gdn_use_gdn2=(args.experimental_attention_variant == "gdn2"),
-            vocab_size=args.padded_vocab_size,
-            mtp_num_layers=mtp_num_layers,
+        return (
+            total_real_tokens_in_batch * dsa_token_linear_term
+            + seqlen_squared_sum_in_batch * dsa_core_term
+            + hybrid_flops(
+                total_tokens=total_real_tokens_in_batch,
+                seqlen_squared_sum=seqlen_squared_sum_in_batch,
+                hidden_size=args.hidden_size,
+                num_attn_layers=num_attn_layers,
+                num_mamba_layers=num_mamba_layers,
+                num_mlp_layers=num_mlp_layers,
+                num_moe_layers=num_moe_layers,
+                num_gdn_layers=num_gdn_layers,
+                mamba_state_dim=args.mamba_state_dim,
+                mamba_head_dim=args.mamba_head_dim,
+                mamba_num_groups=args.mamba_num_groups,
+                mamba_num_heads=args.mamba_num_heads,
+                gdp_num_householder=args.gdp_num_householder,
+                num_attn_heads=args.num_attention_heads,
+                gqa=args.group_query_attention,
+                gqa_groups=args.num_query_groups,
+                kv_channels=args.kv_channels,
+                mlp_expansion=args.ffn_hidden_size / args.hidden_size,
+                swiglu=args.swiglu,
+                use_gated_delta_product=_uses_gated_delta_product_spec(args),
+                moe_latent_size=args.moe_latent_size,
+                moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
+                                     else args.ffn_hidden_size),
+                shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
+                                               else args.moe_shared_expert_intermediate_size),
+                num_experts_routed_to=args.moe_router_topk,
+                gdn_qk_head_dim=args.linear_key_head_dim or 128,
+                gdn_v_head_dim=args.linear_value_head_dim or 128,
+                gdn_num_qk_heads=args.linear_num_key_heads or 16,
+                gdn_num_v_heads=args.linear_num_value_heads or 32,
+                gdn_conv_kernel_dim=args.linear_conv_kernel_dim or 4,
+                gdn_use_gdn2=(args.experimental_attention_variant == "gdn2"),
+                vocab_size=args.padded_vocab_size,
+                mtp_num_layers=mtp_num_layers,
+            )
         )
     else:
         # Compute standard Transformer model FLOPs.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -854,7 +854,15 @@ def _dsa_sparse_core_scale(total_real_tokens, seqlen_squared_sum, dsa_indexer_to
 
 
 def _dsa_indexer_flops(
-    *, hidden_size, q_lora_rank, n_heads, head_dim, num_indexer_layers, indexer_loss_coeff
+    *,
+    hidden_size,
+    q_lora_rank,
+    n_heads,
+    head_dim,
+    num_indexer_layers,
+    dsa_indexer_loss_coeff,
+    dsa_indexer_use_sparse_loss=False,
+    sparse_core_scale=1.0,
 ):
     """DSA lightning-indexer FLOPs coefficients, fwd/bwd expansion included.
 
@@ -881,12 +889,27 @@ def _dsa_indexer_flops(
       * loss on  -> the projections (wq_b / wk / weights_proj) read a detached
         input, so autograd skips their dgrad and they pay fwd + wgrad = 2x.
         The scoring GEMM has two activation operands that both need gradients
-        to reach those weights, so it pays fwd + dq + dk = 3x.
+        to reach those weights, so it pays fwd + dq + dk. Forward scoring is
+        always dense (top-k selection needs every score). How much of the
+        backward is dense depends on the loss variant:
+
+          - dense KL (``dsa_indexer_use_sparse_loss=False``, the default):
+            every causal (query, key) pair carries a gradient, so
+            dq + dk are dense too and the scoring pays 3x.
+          - sparse KL (``dsa_indexer_use_sparse_loss=True``): the KL is
+            taken over the selected top-k keys only, so the score gradient is
+            zero outside them and dq + dk span just the top-k pairs. The
+            scoring pays ``1 + 2 * sparse_core_scale``, with
+            ``sparse_core_scale`` the same top-k / dense pair ratio that
+            ``_dsa_sparse_core_scale`` applies to core attention. The fused
+            cuDNN backend (``_compute_sparse_indexer_loss_and_grads``)
+            executes exactly this sparse backward; the reference PyTorch path
+            multiplies a dense zero-padded gradient instead, which is an
+            implementation detail and, like the dense-masked reference
+            attention, does not enter the model FLOPs count.
 
     Whether the indexer is trained is part of the training procedure rather
-    than the kernel schedule, so it belongs in this model-FLOPs count. (With
-    ``dsa_indexer_use_sparse_loss`` the scoring backward only covers the top-k
-    entries, which the 3x does not model; it defaults to False.)
+    than the kernel schedule, so it belongs in this model-FLOPs count.
 
     Returns ``(token_linear, core)`` INCLUDING the fwd/bwd and FMA factors.
     Multiply ``token_linear`` by the real token count and ``core`` by
@@ -906,10 +929,18 @@ def _dsa_indexer_flops(
     # Scoring each query against every past token under a causal mask (/2).
     core = num_indexer_layers * index_dim / 2
     fma_expansion_factor = 2
-    loss_enabled = (indexer_loss_coeff or 0.0) > 0
+    loss_enabled = (dsa_indexer_loss_coeff or 0.0) > 0
+    if not loss_enabled:
+        token_expansion, core_expansion = 1, 1
+    else:
+        # Projections: fwd + wgrad (input is detached, no dgrad).
+        token_expansion = 2
+        # Scoring: dense fwd + dq + dk, where dq/dk cover only the top-k pairs
+        # under the sparse KL loss (see docstring).
+        core_expansion = 1 + 2 * (sparse_core_scale if dsa_indexer_use_sparse_loss else 1.0)
     return (
-        (2 if loss_enabled else 1) * fma_expansion_factor * token_linear,
-        (3 if loss_enabled else 1) * fma_expansion_factor * core,
+        token_expansion * fma_expansion_factor * token_linear,
+        core_expansion * fma_expansion_factor * core,
     )
 
 
@@ -1474,6 +1505,9 @@ def num_floating_point_operations(
             linear_self_attn_term = 0
             num_standard_attention_layers = num_layers
 
+            dsa_sparse_core_scale = _dsa_sparse_core_scale(
+                total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
+            )
             standard_self_attn_core_term = (
                 forward_backward_expansion_factor
                 * fma_expansion_factor
@@ -1481,9 +1515,7 @@ def num_floating_point_operations(
                     args.num_attention_heads * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2
                     + args.num_attention_heads * args.kv_lora_rank / 2
                 )
-                * _dsa_sparse_core_scale(
-                    total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
-                )
+                * dsa_sparse_core_scale
             )
             dsa_extra_term, dsa_extra_core_term = _dsa_indexer_flops(
                 hidden_size=args.hidden_size,
@@ -1493,7 +1525,9 @@ def num_floating_point_operations(
                 num_indexer_layers=_num_dsa_indexer_layers(
                     num_layers, args.dsa_indexer_skip_topk_offset, args.dsa_indexer_topk_freq
                 ),
-                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_use_sparse_loss=getattr(args, "dsa_indexer_use_sparse_loss", False),
+                sparse_core_scale=dsa_sparse_core_scale,
             )
         else:
             num_linear_attention_layers = 0
@@ -1656,7 +1690,11 @@ def num_floating_point_operations(
                 n_heads=args.dsa_indexer_n_heads,
                 head_dim=args.dsa_indexer_head_dim,
                 num_indexer_layers=num_indexer_layers,
-                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_use_sparse_loss=getattr(args, "dsa_indexer_use_sparse_loss", False),
+                sparse_core_scale=_dsa_sparse_core_scale(
+                    total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
+                ),
             )
             dsa_token_linear_term = num_dsa_layers * per_layer_token_linear + indexer_token_linear
             dsa_core_term = num_dsa_layers * per_layer_core + indexer_core

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -675,3 +675,363 @@ class TestAccumulatorTopology:
             f"topology tp={tp} cp={cp} pp={pp} dp={dp_size}: "
             f"got seqlen_squared_sum={seqlen_squared_sum}, expected {expected_sum_sq}"
         )
+
+
+def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
+    """Minimal MLA + DSA args (GLM-5.2 style, small scale).
+
+    Uses ``dsa_indexer_topk_freq=1`` and ``dsa_indexer_skip_topk_offset=0``
+    so every layer computes its own top-k index -- the golden reference can
+    set ``num_indexer_layers = num_layers`` without importing the skip-layer
+    predicate from megatron.core.
+
+    ``dsa_indexer_loss_coeff`` drives the indexer's fwd/bwd expansion: the
+    indexer only has a backward pass when its KL loss is enabled. The default
+    here matches the in-tree functional test configs.
+    """
+    args = _make_gpt_args(
+        num_layers=4,
+        hidden_size=512,
+        num_attention_heads=8,
+        seq_length=256,
+        ffn_hidden_size=2048,
+        padded_vocab_size=1024,
+    )
+    args.multi_latent_attention = True
+    args.group_query_attention = False
+    args.q_lora_rank = 128
+    args.kv_lora_rank = 64
+    args.qk_head_dim = 48
+    args.qk_pos_emb_head_dim = 16
+    args.v_head_dim = 64
+    args.experimental_attention_variant = "dsa"
+    args.dsa_indexer_n_heads = 4
+    args.dsa_indexer_head_dim = 32
+    args.dsa_indexer_topk = 16
+    args.dsa_indexer_topk_freq = 1
+    args.dsa_indexer_skip_topk_offset = 0
+    args.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+    return args
+
+
+def _dsa_golden_layer_terms(
+    args, total_tokens, seqlen_squared_sum, num_dsa_layers, num_indexer_layers
+):
+    """Golden DSA attention terms: ``(token_linear, core)`` coefficients.
+
+    Independent reimplementation of the per-DSA-layer absorbed-MLA projections,
+    top-k-scaled sparse core attention, and the indexer (with its own
+    KL-loss-dependent expansion). Multiply ``token_linear`` by the real token
+    count and ``core`` by ``sum(L^2)``. Shared by the standard-path golden
+    (``_dsa_golden_flops``) and the hybrid-path tests.
+    """
+    fwd_bwd = 3
+    fma = 2
+    nh = args.num_attention_heads
+
+    # ---- MLA projections (token-linear, per layer) ----
+    q_term = args.q_lora_rank * (
+        args.hidden_size + nh * (args.qk_head_dim + args.qk_pos_emb_head_dim) + 1
+    )
+    kv_term = (
+        args.kv_lora_rank * (args.hidden_size + nh * (args.qk_head_dim + args.v_head_dim) + 1)
+        + args.hidden_size * args.qk_pos_emb_head_dim
+    )
+    o_term = nh * args.v_head_dim * args.hidden_size
+    mla_proj_per_layer = fwd_bwd * fma * (q_term + kv_term + o_term)
+
+    # ---- Core attention: absorbed-MLA cost scaled down to top-k sparse pairs.
+    # DSA executes ``AbsorbedMLASelfAttention``: QK^T over the compressed KV
+    # latent (kv_lora_rank + rope per head) and AV over kv_lora_rank.
+    raw_core = nh * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2 + nh * args.kv_lora_rank / 2
+    mean_seqlen = seqlen_squared_sum / total_tokens
+    topk = args.dsa_indexer_topk
+    if mean_seqlen <= topk:
+        sparse_scale = 1.0
+    else:
+        dense_pairs = mean_seqlen * mean_seqlen / 2
+        topk_pairs = topk * mean_seqlen - topk * topk / 2
+        sparse_scale = topk_pairs / dense_pairs
+    sparse_core_per_layer = fwd_bwd * fma * raw_core * sparse_scale
+
+    # ---- DSA indexer: only layers that compute their own top-k index ----
+    idx_dim = args.dsa_indexer_n_heads * args.dsa_indexer_head_dim
+    idx_token = num_indexer_layers * (
+        args.q_lora_rank * idx_dim  # wq_b
+        + args.hidden_size * args.dsa_indexer_head_dim  # wk
+        + args.hidden_size * args.dsa_indexer_n_heads  # weights_proj
+    )
+    idx_core = num_indexer_layers * idx_dim / 2
+    # The indexer only runs a backward pass when its KL loss is on, and its
+    # inputs are detached: projections pay fwd + wgrad, scoring pays fwd + dq + dk.
+    if (args.dsa_indexer_loss_coeff or 0.0) > 0:
+        idx_token_expansion, idx_core_expansion = 2, 3
+    else:
+        idx_token_expansion, idx_core_expansion = 1, 1
+    dsa_extra_token = idx_token_expansion * fma * idx_token
+    dsa_extra_core = idx_core_expansion * fma * idx_core
+
+    self_attn_term = mla_proj_per_layer * num_dsa_layers + dsa_extra_token
+    self_attn_core_term = sparse_core_per_layer * num_dsa_layers + dsa_extra_core
+    return self_attn_term, self_attn_core_term
+
+
+def _dsa_golden_flops(args, total_tokens, seqlen_squared_sum, num_indexer_layers=None):
+    """Independent golden calculator for standard-path DSA FLOPs.
+
+    Reimplements the formula from ``num_floating_point_operations`` so that
+    the test does not just call the same code twice. Assumes no MoE / MTP.
+    ``num_indexer_layers`` defaults to every layer, which is what
+    ``dsa_indexer_topk_freq=1`` / ``dsa_indexer_skip_topk_offset=0`` give;
+    cross-layer sharing cases pass the expected count explicitly.
+    """
+    fwd_bwd = 3
+    fma = 2
+    ffn_exp = 3 if args.swiglu else 2
+    num_layers = args.num_layers
+
+    if num_indexer_layers is None:
+        num_indexer_layers = num_layers
+    self_attn_term, self_attn_core_term = _dsa_golden_layer_terms(
+        args, total_tokens, seqlen_squared_sum, num_layers, num_indexer_layers
+    )
+
+    mlp = fwd_bwd * fma * args.hidden_size * (args.ffn_hidden_size * ffn_exp * num_layers)
+    logit = fwd_bwd * fma * args.hidden_size * args.padded_vocab_size
+
+    return total_tokens * (mlp + self_attn_term + logit) + seqlen_squared_sum * self_attn_core_term
+
+
+class TestDSA:
+    """DSA sparse-attention FLOPs against an independent golden calculator."""
+
+    def test_bshd(self):
+        """BSHD (uniform sequences) must match the golden calculator."""
+        args = _make_dsa_args()
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        flops = num_floating_point_operations(args, batch_size)
+        expected = _dsa_golden_flops(args, total_tokens, sum_sq)
+        assert flops == expected
+
+    def test_thd(self):
+        """THD (packed variable-length subsequences) must match the golden
+        calculator and be strictly less than BSHD due to the L^2 terms
+        (indexer scoring and sparse core attention)."""
+        args = _make_dsa_args()
+        batch_size = 2
+        packed_lengths = [64, 64, 128, 256]
+        total_tokens = sum(packed_lengths)
+        thd_sum_sq = sum(L**2 for L in packed_lengths)
+
+        flops = num_floating_point_operations(
+            args,
+            batch_size,
+            seqlen_squared_sum_in_batch=thd_sum_sq,
+            total_real_tokens_in_batch=total_tokens,
+        )
+        expected = _dsa_golden_flops(args, total_tokens, thd_sum_sq)
+        assert flops == expected
+        # THD must be strictly less than BSHD.
+        bshd_flops = num_floating_point_operations(args, batch_size)
+        assert flops < bshd_flops
+
+    @pytest.mark.parametrize("loss_coeff", [0.0, None])
+    def test_indexer_without_loss_is_forward_only(self, loss_coeff):
+        """With the indexer KL loss disabled the indexer has no backward pass.
+
+        ``DSAttention.forward`` runs it under ``torch.no_grad()`` in that case,
+        so its terms must drop from 2x/3x to 1x rather than keep the global
+        fwd+bwd factor. Everything outside the indexer is unchanged.
+        """
+        args = _make_dsa_args(dsa_indexer_loss_coeff=loss_coeff)
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        flops = num_floating_point_operations(args, batch_size)
+        assert flops == _dsa_golden_flops(args, total_tokens, sum_sq)
+        # A frozen indexer must cost strictly less than a trained one.
+        assert flops < num_floating_point_operations(_make_dsa_args(0.01), batch_size)
+
+    def test_cross_layer_index_sharing(self):
+        """Only layers that compute their own top-k index pay for the indexer.
+
+        ``dsa_indexer_topk_freq=1`` makes ``is_dsa_skip_topk_layer``
+        unconditionally False, so the layer-counting logic is only actually
+        exercised with sharing on. Here ``freq=4, offset=1`` leaves layers 1 and
+        5 computing out of 8, and ``_num_dsa_indexer_layers`` has to stay in
+        lockstep with the predicate in megatron.core.
+        """
+        args = _make_dsa_args()
+        args.num_layers = 8
+        args.dsa_indexer_topk_freq = 4
+        args.dsa_indexer_skip_topk_offset = 1
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        # Layers 1..8 compute when (max(L - 1, 0) % 4) == 0, i.e. layers 1 and 5.
+        expected = _dsa_golden_flops(args, total_tokens, sum_sq, num_indexer_layers=2)
+        assert num_floating_point_operations(args, batch_size) == expected
+
+        # Sharing must be cheaper than every layer running its own indexer.
+        no_sharing = _make_dsa_args()
+        no_sharing.num_layers = 8
+        assert num_floating_point_operations(args, batch_size) < num_floating_point_operations(
+            no_sharing, batch_size
+        )
+
+    def test_topk_caps_long_context_growth(self):
+        """Pin the bug: a long sequence must not be charged dense ``L^2 / 2``.
+
+        With ``seq_length`` well past ``dsa_indexer_topk`` the old behaviour
+        (plain dense MLA core, no top-k scaling) grows quadratically; the
+        corrected sparse core term is capped by top-k and only the indexer's
+        dense scoring keeps a (much smaller) quadratic component.
+        """
+        args = _make_dsa_args()
+        args.seq_length = 8192
+        batch_size = 1
+
+        corrected = num_floating_point_operations(args, batch_size)
+
+        # Same model reading as plain MLA (the branch DSA used to fall into).
+        dense = SimpleNamespace(**vars(args))
+        dense.experimental_attention_variant = None
+        assert corrected < num_floating_point_operations(dense, batch_size)
+
+
+class TestDSAHelperEdgeCases:
+    """Direct coverage of the helper guards and the hybrid rejection."""
+
+    def test_indexer_flops_zero_layers(self):
+        """No indexer layers contribute nothing."""
+        from megatron.training.training import _dsa_indexer_flops
+
+        assert _dsa_indexer_flops(
+            hidden_size=512,
+            q_lora_rank=128,
+            n_heads=4,
+            head_dim=32,
+            num_indexer_layers=0,
+            indexer_loss_coeff=0.01,
+        ) == (0, 0)
+
+    def test_sparse_core_scale_degenerate_inputs(self):
+        """Zero tokens or an unset top-k fall back to the dense scale of 1.0."""
+        from megatron.training.training import _dsa_sparse_core_scale
+
+        assert _dsa_sparse_core_scale(0, 0, 2048) == 1.0
+        assert _dsa_sparse_core_scale(512, 512 * 4096, None) == 1.0
+
+    def test_hybrid_dsa_variant_attribute_ignored(self):
+        """Hybrid DSA accounting keys off the 'D' symbols in the layer
+        pattern, not ``args.experimental_attention_variant``: on the hybrid
+        path a 'D' pattern sets the variant only in the config kwargs (never
+        back onto ``args``), so a real ``--hybrid-layer-pattern "D..."``
+        launch reaches this code with the attribute still ``None``."""
+        args = _make_hybrid_dsa_args()
+        args.hybrid_layer_pattern = "D-D-"
+        with_none = num_floating_point_operations(args, 2)
+        args.experimental_attention_variant = "dsa"
+        with_variant = num_floating_point_operations(args, 2)
+        assert with_none == pytest.approx(with_variant)
+
+
+def _make_hybrid_dsa_args(dsa_indexer_loss_coeff=0.01):
+    """DSA args extended with the fields the hybrid FLOPs path reads.
+
+    ``experimental_attention_variant`` is cleared because real hybrid
+    launches set the variant only in the config kwargs, never on ``args``.
+    """
+    args = _make_dsa_args(dsa_indexer_loss_coeff=dsa_indexer_loss_coeff)
+    args.experimental_attention_variant = None
+    args.mamba_state_dim = 128
+    args.mamba_head_dim = 64
+    args.mamba_num_groups = 8
+    args.mamba_num_heads = 128
+    args.gdp_num_householder = 1
+    return args
+
+
+class TestHybridDSA:
+    """Hybrid-path ('D' layers in --hybrid-layer-pattern) DSA accounting.
+
+    On this branch the hybrid path is the one that actually builds DSA
+    models (the standard GPT path rejects experimental attention variants),
+    so 'D' layers must be counted, not asserted away. 'D' layers previously
+    contributed nothing to ``hybrid_flops``, so deleting them from the
+    pattern leaves every other term unchanged -- the delta against the
+    D-less pattern isolates exactly the DSA terms.
+    """
+
+    def _delta(self, args, pattern_with_d, pattern_without_d, batch=2):
+        args.hybrid_layer_pattern = pattern_without_d
+        base = num_floating_point_operations(args, batch)
+        args.hybrid_layer_pattern = pattern_with_d
+        total = num_floating_point_operations(args, batch)
+        return total - base
+
+    def test_dsa_terms_golden(self):
+        """'D' layers add exactly the golden absorbed-MLA + sparse-core +
+        indexer cost on top of the same pattern with 'D' positions removed."""
+        args = _make_hybrid_dsa_args()
+        batch = 2
+        total_tokens = batch * args.seq_length
+        sum_sq = batch * args.seq_length**2
+
+        # freq=1 (from _make_dsa_args): both D layers compute their own index.
+        delta = self._delta(args, "D-D-", "--", batch=batch)
+        token_term, core_term = _dsa_golden_layer_terms(
+            args, total_tokens, sum_sq, num_dsa_layers=2, num_indexer_layers=2
+        )
+        assert delta == pytest.approx(total_tokens * token_term + sum_sq * core_term)
+
+    def test_cross_layer_index_sharing_uses_block_local_numbers(self):
+        """The skip predicate runs on the block's own 1-indexed layer numbers
+        (non-DSA positions advance the numbering but never pay the indexer).
+        Pattern 'DDDDD' with freq=4, offset=1 computes at layers 1 and 5."""
+        args = _make_hybrid_dsa_args()
+        args.dsa_indexer_topk_freq = 4
+        args.dsa_indexer_skip_topk_offset = 1
+        batch = 2
+        total_tokens = batch * args.seq_length
+        sum_sq = batch * args.seq_length**2
+
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            is_dsa_skip_topk_layer,
+        )
+
+        expected_indexer_layers = sum(1 for n in range(1, 6) if not is_dsa_skip_topk_layer(n, 1, 4))
+        assert expected_indexer_layers == 2
+
+        delta = self._delta(args, "DDDDD", "", batch=batch)
+        token_term, core_term = _dsa_golden_layer_terms(
+            args, total_tokens, sum_sq, num_dsa_layers=5, num_indexer_layers=expected_indexer_layers
+        )
+        assert delta == pytest.approx(total_tokens * token_term + sum_sq * core_term)
+
+    def test_mtp_depths_restart_numbering(self):
+        """Hybrid MTP blocks build their inner layers with block-local
+        numbers restarting at 1 per depth (``pp_layer_offset=0``), so each
+        depth's leading 'D' pays the indexer independently of the main
+        pattern. Main 'D-D-' (computes at 1) + 'D-' x 2 depths (each
+        computes at 1) with freq=4, offset=1 -> 3 indexer layers of 4 D
+        layers total."""
+        args = _make_hybrid_dsa_args()
+        args.dsa_indexer_topk_freq = 4
+        args.dsa_indexer_skip_topk_offset = 1
+        batch = 2
+        total_tokens = batch * args.seq_length
+        sum_sq = batch * args.seq_length**2
+
+        # Main: D at 1, 3; compute layers are 1, 5, ... -> only 1 pays.
+        # Each MTP depth: D at 1 -> pays. Total 1 + 2 = 3.
+        delta = self._delta(args, "D-D-/D-/D-", "--/-/-", batch=batch)
+        token_term, core_term = _dsa_golden_layer_terms(
+            args, total_tokens, sum_sq, num_dsa_layers=4, num_indexer_layers=3
+        )
+        assert delta == pytest.approx(total_tokens * token_term + sum_sq * core_term)

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -677,7 +677,7 @@ class TestAccumulatorTopology:
         )
 
 
-def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
+def _make_dsa_args(dsa_indexer_loss_coeff=0.01, dsa_indexer_use_sparse_loss=False):
     """Minimal MLA + DSA args (GLM-5.2 style, small scale).
 
     Uses ``dsa_indexer_topk_freq=1`` and ``dsa_indexer_skip_topk_offset=0``
@@ -688,6 +688,8 @@ def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
     ``dsa_indexer_loss_coeff`` drives the indexer's fwd/bwd expansion: the
     indexer only has a backward pass when its KL loss is enabled. The default
     here matches the in-tree functional test configs.
+    ``dsa_indexer_use_sparse_loss`` selects the sparse (top-k only) KL
+    variant, which shrinks the scoring backward to the selected pairs.
     """
     args = _make_gpt_args(
         num_layers=4,
@@ -711,6 +713,7 @@ def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
     args.dsa_indexer_topk_freq = 1
     args.dsa_indexer_skip_topk_offset = 0
     args.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+    args.dsa_indexer_use_sparse_loss = dsa_indexer_use_sparse_loss
     return args
 
 
@@ -764,8 +767,15 @@ def _dsa_golden_layer_terms(
     idx_core = num_indexer_layers * idx_dim / 2
     # The indexer only runs a backward pass when its KL loss is on, and its
     # inputs are detached: projections pay fwd + wgrad, scoring pays fwd + dq + dk.
+    # Forward scoring is always dense; with the sparse KL loss the score
+    # gradient is nonzero only on the top-k pairs, so dq + dk shrink by the
+    # same top-k / dense pair ratio as core attention.
     if (args.dsa_indexer_loss_coeff or 0.0) > 0:
-        idx_token_expansion, idx_core_expansion = 2, 3
+        idx_token_expansion = 2
+        if getattr(args, "dsa_indexer_use_sparse_loss", False):
+            idx_core_expansion = 1 + 2 * sparse_scale
+        else:
+            idx_core_expansion = 3
     else:
         idx_token_expansion, idx_core_expansion = 1, 1
     dsa_extra_token = idx_token_expansion * fma * idx_token
@@ -856,6 +866,47 @@ class TestDSA:
         # A frozen indexer must cost strictly less than a trained one.
         assert flops < num_floating_point_operations(_make_dsa_args(0.01), batch_size)
 
+    @pytest.mark.parametrize("seq_length", [256, 8192])
+    def test_sparse_indexer_loss_shrinks_scoring_backward(self, seq_length):
+        """``dsa_indexer_use_sparse_loss`` only back-propagates through the
+        top-k scores, so the indexer scoring backward must scale with the
+        top-k pair ratio instead of staying dense (3x).
+
+        With ``seq_length <= topk`` top-k selects everything and both loss
+        variants must agree exactly; past top-k the sparse variant must be
+        strictly cheaper and still match the golden calculator.
+        """
+        batch_size = 2
+        total_tokens = batch_size * seq_length
+        sum_sq = batch_size * seq_length**2
+
+        dense_args = _make_dsa_args(dsa_indexer_use_sparse_loss=False)
+        sparse_args = _make_dsa_args(dsa_indexer_use_sparse_loss=True)
+        dense_args.seq_length = sparse_args.seq_length = seq_length
+
+        dense = num_floating_point_operations(dense_args, batch_size)
+        sparse = num_floating_point_operations(sparse_args, batch_size)
+        assert sparse == _dsa_golden_flops(sparse_args, total_tokens, sum_sq)
+        if seq_length <= sparse_args.dsa_indexer_topk:
+            assert sparse == dense
+        else:
+            assert sparse < dense
+            # The sparse backward still costs more than a frozen indexer.
+            frozen = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True)
+            frozen.seq_length = seq_length
+            assert sparse > num_floating_point_operations(frozen, batch_size)
+
+    def test_sparse_loss_ignored_without_indexer_loss(self):
+        """Sparse vs dense KL is moot when the indexer loss is off: the
+        indexer is forward-only either way and the flag must not change the
+        count."""
+        batch_size = 2
+        off_dense = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=False)
+        off_sparse = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True)
+        assert num_floating_point_operations(off_dense, batch_size) == (
+            num_floating_point_operations(off_sparse, batch_size)
+        )
+
     def test_cross_layer_index_sharing(self):
         """Only layers that compute their own top-k index pay for the indexer.
 
@@ -917,8 +968,42 @@ class TestDSAHelperEdgeCases:
             n_heads=4,
             head_dim=32,
             num_indexer_layers=0,
-            indexer_loss_coeff=0.01,
+            dsa_indexer_loss_coeff=0.01,
         ) == (0, 0)
+
+    def test_indexer_flops_sparse_loss_expansion(self):
+        """Direct check of the fwd/bwd expansion factors on the scoring term:
+        dense KL pays 3x, sparse KL pays ``1 + 2 * sparse_core_scale``, and a
+        frozen indexer pays 1x regardless of the loss variant."""
+        from megatron.training.training import _dsa_indexer_flops
+
+        common = dict(
+            hidden_size=512, q_lora_rank=128, n_heads=4, head_dim=32, num_indexer_layers=1
+        )
+        fma = 2
+        core = 4 * 32 / 2
+        _, off = _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.0)
+        _, dense = _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.01)
+        _, sparse = _dsa_indexer_flops(
+            **common,
+            dsa_indexer_loss_coeff=0.01,
+            dsa_indexer_use_sparse_loss=True,
+            sparse_core_scale=0.25,
+        )
+        _, sparse_dense_scale = _dsa_indexer_flops(
+            **common,
+            dsa_indexer_loss_coeff=0.01,
+            dsa_indexer_use_sparse_loss=True,
+            sparse_core_scale=1.0,
+        )
+        assert off == 1 * fma * core
+        assert dense == 3 * fma * core
+        assert sparse == (1 + 2 * 0.25) * fma * core
+        assert sparse_dense_scale == dense
+        # The flag is a no-op without the loss.
+        assert _dsa_indexer_flops(
+            **common, dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True
+        ) == _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.0)
 
     def test_sparse_core_scale_degenerate_inputs(self):
         """Zero tokens or an unset top-k fall back to the dense scale of 1.0."""
@@ -941,13 +1026,16 @@ class TestDSAHelperEdgeCases:
         assert with_none == pytest.approx(with_variant)
 
 
-def _make_hybrid_dsa_args(dsa_indexer_loss_coeff=0.01):
+def _make_hybrid_dsa_args(dsa_indexer_loss_coeff=0.01, dsa_indexer_use_sparse_loss=False):
     """DSA args extended with the fields the hybrid FLOPs path reads.
 
     ``experimental_attention_variant`` is cleared because real hybrid
     launches set the variant only in the config kwargs, never on ``args``.
     """
-    args = _make_dsa_args(dsa_indexer_loss_coeff=dsa_indexer_loss_coeff)
+    args = _make_dsa_args(
+        dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+        dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+    )
     args.experimental_attention_variant = None
     args.mamba_state_dim = 128
     args.mamba_head_dim = 64
@@ -989,6 +1077,28 @@ class TestHybridDSA:
             args, total_tokens, sum_sq, num_dsa_layers=2, num_indexer_layers=2
         )
         assert delta == pytest.approx(total_tokens * token_term + sum_sq * core_term)
+
+    def test_sparse_indexer_loss_shrinks_scoring_backward(self):
+        """The hybrid call site must apply the same sparse-KL rule as the
+        standard path: past top-k the indexer scoring backward covers only
+        the selected pairs, so the 'D' delta is strictly smaller than with
+        the dense KL and still matches the golden terms."""
+        batch = 1
+        seq_length = 8192
+        total_tokens = batch * seq_length
+        sum_sq = batch * seq_length**2
+
+        sparse_args = _make_hybrid_dsa_args(dsa_indexer_use_sparse_loss=True)
+        dense_args = _make_hybrid_dsa_args(dsa_indexer_use_sparse_loss=False)
+        sparse_args.seq_length = dense_args.seq_length = seq_length
+
+        sparse_delta = self._delta(sparse_args, "D-D-", "--", batch=batch)
+        dense_delta = self._delta(dense_args, "D-D-", "--", batch=batch)
+        token_term, core_term = _dsa_golden_layer_terms(
+            sparse_args, total_tokens, sum_sq, num_dsa_layers=2, num_indexer_layers=2
+        )
+        assert sparse_delta == pytest.approx(total_tokens * token_term + sum_sq * core_term)
+        assert sparse_delta < dense_delta
 
     def test_cross_layer_index_sharing_uses_block_local_numbers(self):
         """The skip predicate runs on the block's own 1-indexed layer numbers


### PR DESCRIPTION
Port of #6753 (merged to `dev`) onto `main`, extended with **hybrid-path DSA accounting** — which on `main` is the part that actually matters.

## Problem

On `main`, DSA models (GLM-5.2) are only buildable through the hybrid path (`--hybrid-layer-pattern` with `D` layers; the standard GPT path rejects experimental attention variants). `hybrid_flops` counts only `M`/`G`/`*`/`-`/`E` layers, so every `D` layer — the absorbed-MLA attention *and* its indexer — is silently missing from `num_floating_point_operations`. For a small DSA proxy (16 hybrid layers, seq 4096) the reported throughput is 2.26x too low; the gap grows with the attention share of the model.

The dev PR instead guarded the hybrid path with a fail-loud assert. That is not portable to `main`: with hybrid as the only DSA path and `num_floating_point_operations` running unconditionally every iteration, the assert would abort every DSA training run.

## Changes

`megatron/training/training.py`:

- **Hybrid path (new here, not in the dev PR):** count `D` layers on top of `hybrid_flops` — per-layer absorbed-MLA projections and top-k-scaled sparse core attention (`_dsa_layer_flops`), plus the lightning indexer on the `D` positions that compute their own top-k index (`_num_dsa_indexer_layers_in_pattern`). The indexer count uses the block-local layer numbers `DSAttention` actually receives: the main pattern numbers layers sequentially across `|` pipes, and each hybrid MTP depth restarts at 1 (`pp_layer_offset=0`). The indexer keeps its own KL-loss-dependent fwd/bwd expansion (1x off; 2x projections when on; scoring 3x with the dense KL or `1 + 2 * sparse_scale` with the sparse KL, see below), so it is added after `hybrid_flops`'s global x3.
- **Standard path (ported verbatim from #6753):** the `"dsa"` branch in `transformer_flops` — absorbed-MLA core form, top-k sparsity scale, indexer. Unreachable on `main` today (the experimental-variant spec helper has no callers yet), but it keeps this PR line-for-line with the dev-reviewed change and becomes live as soon as standard-path DSA support lands. See #6753 for the derivation and full-scale GLM-5.2 measurements.

`tests/unit_tests/test_num_floating_point_operations.py`: the dev PR's `TestDSA`/`TestDSAHelperEdgeCases` (BSHD/THD goldens, loss on/off expansions, cross-layer sharing, top-k caps long-context growth), plus `TestHybridDSA`: since `D` layers contributed nothing before, deleting them from the pattern isolates exactly the DSA terms — the delta is pinned against an independent golden; cross-layer sharing is pinned on block-local numbering, and an MTP case pins that depths restart at 1.

## Test plan

- Unit tests on a lyris GB200 node under the CI harness (`Dockerfile.ci.dev`, `torch.distributed.run --nproc_per_node 4`): results in a comment below.
- **Numerical equivalence**: one fixed 16-layer DSA arg set (`ffn_hidden_size=0`, no MoE/MTP, so the comparable surface is exactly this PR's terms) fed to `dev`@85902ef standard path, this PR's standard path, and this PR's hybrid path (`"D"*16`) returns **bit-identical** FLOPs (`146585086328832.0`) — the port is faithful and the hybrid accounting reproduces the dev-reviewed formulas exactly.
- **End-to-end smoke at this head**: a hybrid DSA proxy (`--hybrid-layer-pattern D-D-DEDEDEDEDEDE`, DSv3-proxy MLA dims, MoE 32E, indexer loss on) trained 10 iterations on 4 GB200 GPUs via `pretrain_hybrid.py`; stable TFLOP/s/GPU from the new accounting (20.5 vs 9.1 before this PR).
- `tools/autoformat.sh` (black 26.3.0) and `tools/check_copyright.py` pass on the changed files.

## Update: honour `--dsa-indexer-use-sparse-loss` (second commit)

Counterpart of #7157 on `dev`; the change is identical except that here both the standard-path and the hybrid-path call sites are updated.

#6753 charged the indexer scoring pass a flat `fwd + dq + dk = 3x` whenever `dsa_indexer_loss_coeff > 0`, and its docstring noted that the sparse KL variant was not modelled. With `--dsa-indexer-use-sparse-loss` the KL is taken over the selected top-k keys only, so the score gradient is zero outside them and dq/dk of the scoring GEMM span `sum_i(min(i, topk))` pairs instead of the dense causal `L^2 / 2`. The fused cuDNN backend (`_compute_sparse_indexer_loss_and_grads` -> `_run_sparse_indexer_backward`) executes exactly this sparse backward; the reference PyTorch path multiplies a dense zero-padded gradient, which is an implementation detail and, like dense-masked reference attention, not part of the model FLOPs count. Since the indexer's dense O(L^2) scoring dominates the quadratic term at long context (core attention is already top-k scaled), the overcount on that term was close to 3x.

- `_dsa_indexer_flops` takes `dsa_indexer_use_sparse_loss` and `sparse_core_scale` (the same top-k / dense pair ratio `_dsa_sparse_core_scale` applies to core attention). Scoring expansion: indexer loss off 1x (unchanged); dense KL 3x (unchanged); sparse KL `1 + 2 * sparse_core_scale`.
- Parameters renamed to match the corresponding `args` (`dsa_indexer_loss_coeff`, `dsa_indexer_use_sparse_loss`). Both the standard-path and the hybrid-path (`D` layers) call sites pass the flag and the shared scale.
- Default configs (`dsa_indexer_use_sparse_loss=False`) produce identical numbers to before.
- Tests: golden calculator follows the same rule; `TestDSA::test_sparse_indexer_loss_shrinks_scoring_backward[256|8192]` (sparse == dense at `L <= topk`, strictly smaller past topk and still above a frozen indexer), `TestHybridDSA::test_sparse_indexer_loss_shrinks_scoring_backward` (same on the hybrid call site), `test_sparse_loss_ignored_without_indexer_loss`, and `test_indexer_flops_sparse_loss_expansion` (direct 1x / 3x / `1 + 2 * scale` check).
- Unit tests rerun on a lyris GB200 node under the CI harness: `42 passed, 8 skipped` (skips are the 8-rank topology cases on a 4-GPU node). `black` 26.3.0 clean.

Not covered, consistent with the rule of excluding auxiliary-loss work: the teacher-side attention score recompute inside the indexer KL loss (dense over all keys, or top-k only under the sparse variant).
