### PR TITLE
[dev] fix: avoid duplicate offload of recomputed activations

### DIFF
--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional, Tuple
 import torch
 from torch.autograd.graph import saved_tensors_hooks
 
+from megatron.core.tensor_parallel.random import is_checkpoint_without_output_tensor
+
 # CPU offload implementation for pipeline parallelism
 DEBUG = False
 DEBUG_RANK = 0
@@ -987,6 +989,8 @@ class ChunkOffloadHandler:
         """Check if the tensor needs to be offloaded."""
         debug_rank("tensor_need_offloading_checker")
         if not self._can_manage_tensor_for_offload(tensor):
+            return False
+        if is_checkpoint_without_output_tensor(tensor):
             return False
         if _te_do_not_offload(tensor):
             return False

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -990,9 +990,9 @@ class ChunkOffloadHandler:
         debug_rank("tensor_need_offloading_checker")
         if not self._can_manage_tensor_for_offload(tensor):
             return False
-        if is_checkpoint_without_output_tensor(tensor):
-            return False
         if _te_do_not_offload(tensor):
+            return False
+        if is_checkpoint_without_output_tensor(tensor):
             return False
         if tensor.numel() < self.min_offloaded_tensor_size:
             return False

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -601,10 +601,8 @@ class PipelineOffloadManager:
         for chunk in self._cached_chunks_backward:
             for group in chunk.offload_groups:
                 if group.offload and keep_on_gpu_bytes > 0:
-                    debug_rank(
-                        f"group {group._name} offload {group.offload} \
-                        keep_on_gpu_bytes {keep_on_gpu_bytes}"
-                    )
+                    debug_rank(f"group {group._name} offload {group.offload} \
+                        keep_on_gpu_bytes {keep_on_gpu_bytes}")
                     keep_on_gpu_bytes -= group.total_offload_bytes
                     group.offload = False
         # Disable the later groups to meet the activation offload fraction.

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -66,15 +66,28 @@ _share_storage_ext = None
 _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR = "_mcore_checkpoint_without_output"
 
 
+def _get_checkpoint_without_output_storage(
+    tensor: torch.Tensor,
+) -> torch.UntypedStorage | None:
+    """Return a tensor's storage, or None for storage-less tensor subclasses."""
+    try:
+        return tensor.untyped_storage()
+    except (AttributeError, NotImplementedError, RuntimeError):
+        return None
+
+
 def _mark_checkpoint_without_output_tensor(tensor: torch.Tensor) -> None:
     """Mark a tensor's storage as owned by CheckpointWithoutOutput."""
-    setattr(tensor.untyped_storage(), _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, True)
+    storage = _get_checkpoint_without_output_storage(tensor)
+    if storage is not None:
+        setattr(storage, _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, True)
 
 
 def is_checkpoint_without_output_tensor(tensor: torch.Tensor) -> bool:
     """Return whether a tensor aliases a CheckpointWithoutOutput output storage."""
-    return bool(
-        getattr(tensor.untyped_storage(), _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, False)
+    storage = _get_checkpoint_without_output_storage(tensor)
+    return storage is not None and bool(
+        getattr(storage, _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, False)
     )
 
 

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -61,6 +61,22 @@ void share_storage(at::Tensor dst, at::Tensor src) {
 
 _share_storage_ext = None
 
+# Set on the output StorageImpl wrapper used by CheckpointWithoutOutput.  The
+# storage-level marker is visible through aliases/views of the output tensor.
+_CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR = "_mcore_checkpoint_without_output"
+
+
+def _mark_checkpoint_without_output_tensor(tensor: torch.Tensor) -> None:
+    """Mark a tensor's storage as owned by CheckpointWithoutOutput."""
+    setattr(tensor.untyped_storage(), _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, True)
+
+
+def is_checkpoint_without_output_tensor(tensor: torch.Tensor) -> bool:
+    """Return whether a tensor aliases a CheckpointWithoutOutput output storage."""
+    return bool(
+        getattr(tensor.untyped_storage(), _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR, False)
+    )
+
 
 def _get_share_storage():
     """Lazily compile & cache the share_storage extension."""
@@ -1059,6 +1075,12 @@ class CheckpointWithoutOutput(object):
             if len(self.outputs) != 1:
                 raise ValueError("mHC arena slots currently support one checkpoint output")
             self.output_slot.validate_output(self.outputs[0])
+
+        # Offload group commits can run before discard_output_and_register_recompute().
+        # Mark the output storages now so activation offload does not copy or release
+        # memory that this checkpoint owns and regenerates itself.
+        for output in self.outputs:
+            _mark_checkpoint_without_output_tensor(output)
 
         # Auto-register to manager if provided
         if self.ckpt_manager is not None:

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -66,9 +66,7 @@ _share_storage_ext = None
 _CHECKPOINT_WITHOUT_OUTPUT_STORAGE_ATTR = "_mcore_checkpoint_without_output"
 
 
-def _get_checkpoint_without_output_storage(
-    tensor: torch.Tensor,
-) -> torch.UntypedStorage | None:
+def _get_checkpoint_without_output_storage(tensor: torch.Tensor) -> torch.UntypedStorage | None:
     """Return a tensor's storage, or None for storage-less tensor subclasses."""
     try:
         return tensor.untyped_storage()

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -16,6 +16,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
 )
 from megatron.core.tensor_parallel.random import (
     CheckpointWithoutOutput,
+    is_checkpoint_without_output_tensor,
     model_parallel_cuda_manual_seed,
 )
 from megatron.core.transformer.enums import AttnBackend
@@ -77,6 +78,47 @@ def test_chunk_offload_handler_respects_tensor_opt_out_flags():
 
     tensor._TE_do_not_offload = True
     assert not handler.tensor_need_offloading_checker(tensor)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")
+def test_chunk_offload_handler_handles_storage_less_tensor_wrapper():
+    """TE-style wrapper tensors must reach their opt-out without requiring storage."""
+
+    data_tensor = torch.empty(1, device="cuda")
+    data_tensor._TE_do_not_offload = True
+
+    class StorageLessTensor(torch.Tensor):
+        """Minimal TE-style tensor wrapper without backing storage."""
+
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_wrapper_subclass(
+                cls,
+                (1024,),
+                strides=(1,),
+                storage_offset=0,
+                dtype=torch.float32,
+                layout=torch.strided,
+                device="cuda",
+                requires_grad=False,
+            )
+
+        @classmethod
+        def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+            raise NotImplementedError
+
+        def get_data_tensors(self):
+            """Return the backing tensor inspected by TE's offload opt-out."""
+            return [data_tensor]
+
+        def untyped_storage(self):
+            raise RuntimeError("StorageLessTensor has no backing storage")
+
+    handler = _make_chunk_handler_for_offload_checker()
+    tensor = StorageLessTensor()
+
+    assert not handler.tensor_need_offloading_checker(tensor)
+    assert not is_checkpoint_without_output_tensor(tensor)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")

--- a/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
+++ b/tests/unit_tests/pipeline_parallel/test_fine_grained_activation_offloading.py
@@ -14,7 +14,10 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import Chun
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
-from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.tensor_parallel.random import (
+    CheckpointWithoutOutput,
+    model_parallel_cuda_manual_seed,
+)
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import MLATransformerConfig, TransformerConfig
 from megatron.core.utils import is_te_min_version
@@ -74,6 +77,23 @@ def test_chunk_offload_handler_respects_tensor_opt_out_flags():
 
     tensor._TE_do_not_offload = True
     assert not handler.tensor_need_offloading_checker(tensor)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for offload check.")
+def test_chunk_offload_handler_skips_checkpoint_without_output_storage():
+    """Checkpoint outputs and their views must not be copied or released by offload."""
+    handler = _make_chunk_handler_for_offload_checker()
+    Utils.initialize_model_parallel()
+    try:
+        input_tensor = torch.randn(8, device="cuda", requires_grad=True)
+        checkpoint = CheckpointWithoutOutput()
+        output = checkpoint.checkpoint(lambda tensor: tensor * 2, input_tensor)
+
+        assert not handler.tensor_need_offloading_checker(output)
+        assert not handler.tensor_need_offloading_checker(output.view(2, 4))
+        assert handler.tensor_need_offloading_checker(output.clone())
+    finally:
+        Utils.destroy_model_parallel()
 
 
 def _build_gpt_model(


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Prevents fine-grained activation offload from copying or releasing tensor storage already managed by `CheckpointWithoutOutput`.

`CheckpointWithoutOutput` outputs can be saved by a downstream module with activation offload enabled. Because the offload group may commit before `discard_output_and_register_recompute()` runs, both mechanisms can attempt to manage the same storage, causing redundant D2H traffic, host-memory usage, and competing storage release.

This PR:

- Marks output storage immediately when `CheckpointWithoutOutput.checkpoint()` returns.
- Makes the common offload eligibility checker skip marked storage, covering both D2H copies and forced storage release.
- Uses a storage-level marker so aliases and views are also skipped, while tensors with independent storage remain eligible for offload.
- Adds a regression test covering the original tensor, a shared-storage view, and an independent clone.


:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
