### PR TITLE
Use TE quantization_backward_scope in combined 1F1B

### DIFF
--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -683,7 +683,7 @@ else:
 
 
 def get_fp8_backward_quantization_update_context() -> AbstractContextManager:
-    """Run the TE delayed-scaling update once for a logical backward made of several autograd calls."""
+    """Run the TE delayed-scaling update once for a backward made of several autograd calls."""
     if not HAVE_TE:
         return nullcontext()
     scope = getattr(transformer_engine.pytorch, "quantization_backward_scope", None)

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -4,7 +4,7 @@
 
 import importlib
 import weakref
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from functools import wraps
 from typing import List, Optional, Union
 
@@ -680,6 +680,14 @@ else:
     def get_fp8_context(config: TransformerConfig, layer_no: int = -1, is_init: bool = False):
         """Returns dummy fp8 context manager since TE is not available."""
         return nullcontext()
+
+
+def get_fp8_backward_quantization_update_context() -> AbstractContextManager:
+    """Group TE quantization updates for one logical backward."""
+    if not HAVE_TE:
+        return nullcontext()
+    scope = getattr(transformer_engine.pytorch, "backward_quantization_update_scope", None)
+    return scope() if scope is not None else nullcontext()
 
 
 if HAVE_TE:

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -683,10 +683,10 @@ else:
 
 
 def get_fp8_backward_quantization_update_context() -> AbstractContextManager:
-    """Group TE quantization updates for one logical backward."""
+    """Run the TE delayed-scaling update once for a logical backward made of several autograd calls."""
     if not HAVE_TE:
         return nullcontext()
-    scope = getattr(transformer_engine.pytorch, "backward_quantization_update_scope", None)
+    scope = getattr(transformer_engine.pytorch, "quantization_backward_scope", None)
     return scope() if scope is not None else nullcontext()
 
 

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -8,7 +8,7 @@ import torch
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import find_megatron_fsdp
 from megatron.core.enums import Fp8Recipe
-from megatron.core.fp8_utils import get_fp8_context
+from megatron.core.fp8_utils import get_fp8_backward_quantization_update_context, get_fp8_context
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     ScheduleNode,
@@ -413,62 +413,68 @@ def combined_forward_backward_step(
                     forward_fsdp_wrapper.post_backward_release_module,
                 )
 
-    # backward preprocess, the same as the backward_step()
-    unwrap_input_tensor_grad = False
-    b_schedule_plan = None
-    loss_node_inputs_to_release = None
-    if b_model is not None:
-        # Retain the grad on the input_tensor.
-        if not isinstance(b_input_tensor, list):
-            b_input_tensor = [b_input_tensor]
-            unwrap_input_tensor_grad = True
-        for x in b_input_tensor:
-            if x is not None:
-                x.retain_grad()
-
-        if not isinstance(b_output_tensor, list):
-            b_output_tensor = [b_output_tensor]
-        if not isinstance(b_output_tensor_grad, list):
-            b_output_tensor_grad = [b_output_tensor_grad]
-
-        # Get the schedule plan from the output tensor
-        b_schedule_plan = b_output_tensor[0].schedule_plan
-        b_output_tensor[0].schedule_plan = None
-        # Get the loss function from the output tensor
-        loss_node = b_output_tensor[0].loss_func
-        b_output_tensor[0].loss_func = None
-
-        if b_output_tensor_grad[0] is None:
-            if config.grad_scale_func is not None:
-                b_output_tensor[0] = config.grad_scale_func(b_output_tensor[0])
-            # Backward pass for loss function
-            torch.autograd.backward(b_output_tensor[0], grad_tensors=b_output_tensor_grad[0])
-            b_output_tensor_grad[0] = loss_node.get_grad()
-            loss_node_inputs_to_release = loss_node.inputs
-            loss_node._release_state()
-
-    # If fp8_recipe is delayed, wrap the entire pass with get_fp8_context(),
-    # otherwise do nothing extra at the outer level
-    # if we are using other fp8 recipes, then the context manager enter&exit are free
-    # we can wrap fp8_context within the for loop over layers, so that we can fine-grained
-    # control which layer will be fp8 or bf16
     use_outer_fp8_context = config.fp8 and config.fp8_recipe == Fp8Recipe.delayed
-    outer_fp8_context = get_fp8_context(config) if use_outer_fp8_context else nullcontext()
+    backward_update_context = (
+        get_fp8_backward_quantization_update_context()
+        if b_model is not None and config.fp8
+        else nullcontext()
+    )
+    with backward_update_context:
+        # backward preprocess, the same as the backward_step()
+        unwrap_input_tensor_grad = False
+        b_schedule_plan = None
+        loss_node_inputs_to_release = None
+        if b_model is not None:
+            # Retain the grad on the input_tensor.
+            if not isinstance(b_input_tensor, list):
+                b_input_tensor = [b_input_tensor]
+                unwrap_input_tensor_grad = True
+            for x in b_input_tensor:
+                if x is not None:
+                    x.retain_grad()
 
-    b_grad = b_output_tensor_grad[0] if b_model else None
-    # combined forward and backward model chunk execution of two micro-batches
-    with context_manager and outer_fp8_context:  # autocast context and delayed fp8 context
-        # For GPT models, it calls common::TransformerModelChunkSchedulePlan.run(),
-        output_tensor = type(f_schedule_plan or b_schedule_plan).run(
-            f_schedule_plan,
-            b_schedule_plan,
-            b_grad=b_grad,
-            pre_forward=pre_forward,
-            pre_backward=pre_backward,
-            post_forward=post_forward,
-            post_backward=post_backward,
-        )
-    _release_tensor_storage(loss_node_inputs_to_release)
+            if not isinstance(b_output_tensor, list):
+                b_output_tensor = [b_output_tensor]
+            if not isinstance(b_output_tensor_grad, list):
+                b_output_tensor_grad = [b_output_tensor_grad]
+
+            # Get the schedule plan from the output tensor
+            b_schedule_plan = b_output_tensor[0].schedule_plan
+            b_output_tensor[0].schedule_plan = None
+            # Get the loss function from the output tensor
+            loss_node = b_output_tensor[0].loss_func
+            b_output_tensor[0].loss_func = None
+
+            if b_output_tensor_grad[0] is None:
+                if config.grad_scale_func is not None:
+                    b_output_tensor[0] = config.grad_scale_func(b_output_tensor[0])
+                # Backward pass for loss function
+                torch.autograd.backward(b_output_tensor[0], grad_tensors=b_output_tensor_grad[0])
+                b_output_tensor_grad[0] = loss_node.get_grad()
+                loss_node_inputs_to_release = loss_node.inputs
+                loss_node._release_state()
+
+        # If fp8_recipe is delayed, wrap the entire pass with get_fp8_context(),
+        # otherwise do nothing extra at the outer level
+        # if we are using other fp8 recipes, then the context manager enter&exit are free
+        # we can wrap fp8_context within the for loop over layers, so that we can fine-grained
+        # control which layer will be fp8 or bf16
+        outer_fp8_context = get_fp8_context(config) if use_outer_fp8_context else nullcontext()
+
+        b_grad = b_output_tensor_grad[0] if b_model else None
+        # combined forward and backward model chunk execution of two micro-batches
+        with context_manager and outer_fp8_context:  # autocast context and delayed fp8 context
+            # For GPT models, it calls common::TransformerModelChunkSchedulePlan.run(),
+            output_tensor = type(f_schedule_plan or b_schedule_plan).run(
+                f_schedule_plan,
+                b_schedule_plan,
+                b_grad=b_grad,
+                pre_forward=pre_forward,
+                pre_backward=pre_backward,
+                post_forward=post_forward,
+                post_backward=post_backward,
+            )
+        _release_tensor_storage(loss_node_inputs_to_release)
 
     # forward post process
     num_tokens = None

--- a/tests/unit_tests/a2a_overlap/test_combined_1f1b_scope.py
+++ b/tests/unit_tests/a2a_overlap/test_combined_1f1b_scope.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.pipeline_parallel import combined_1f1b
+
+
+@pytest.mark.parametrize("fp8_recipe", [Fp8Recipe.delayed, Fp8Recipe.custom])
+def test_fp8_backward_scope_covers_schedule_and_wgrad(monkeypatch, fp8_recipe):
+    events = []
+
+    @contextmanager
+    def backward_update_context():
+        events.append("scope_enter")
+        try:
+            yield
+        finally:
+            events.append("scope_exit")
+
+    class LossNode:
+        inputs = ()
+
+        def get_grad(self):
+            return object()
+
+        def _release_state(self):
+            pass
+
+    class SchedulePlan:
+        @staticmethod
+        def run(_forward_plan, _backward_plan, **_kwargs):
+            events.append("schedule_backward")
+            events.append("backward_dw")
+            events.append("final_wait")
+            return object()
+
+    class Output:
+        schedule_plan = SchedulePlan()
+        loss_func = LossNode()
+
+    monkeypatch.setattr(
+        combined_1f1b,
+        "get_fp8_backward_quantization_update_context",
+        backward_update_context,
+    )
+    monkeypatch.setattr(combined_1f1b, "get_fp8_context", lambda _config: nullcontext())
+    monkeypatch.setattr(torch.autograd, "backward", lambda *_args, **_kwargs: events.append("loss_backward"))
+
+    config = SimpleNamespace(
+        enable_autocast=False,
+        fp8="hybrid",
+        fp8_recipe=fp8_recipe,
+        grad_scale_func=None,
+        timers=None,
+    )
+    combined_1f1b.combined_forward_backward_step(
+        forward_step_func=None,
+        data_iterator=None,
+        f_model=None,
+        num_microbatches=1,
+        input_tensor=None,
+        forward_data_store=[],
+        b_model=object(),
+        b_input_tensor=None,
+        b_output_tensor=Output(),
+        b_output_tensor_grad=None,
+        config=config,
+    )
+
+    assert events == [
+        "scope_enter",
+        "loss_backward",
+        "schedule_backward",
+        "backward_dw",
+        "final_wait",
+        "scope_exit",
+    ]

--- a/tests/unit_tests/a2a_overlap/test_combined_1f1b_scope.py
+++ b/tests/unit_tests/a2a_overlap/test_combined_1f1b_scope.py
@@ -49,7 +49,9 @@ def test_fp8_backward_scope_covers_schedule_and_wgrad(monkeypatch, fp8_recipe):
         backward_update_context,
     )
     monkeypatch.setattr(combined_1f1b, "get_fp8_context", lambda _config: nullcontext())
-    monkeypatch.setattr(torch.autograd, "backward", lambda *_args, **_kwargs: events.append("loss_backward"))
+    monkeypatch.setattr(
+        torch.autograd, "backward", lambda *_args, **_kwargs: events.append("loss_backward")
+    )
 
     config = SimpleNamespace(
         enable_autocast=False,

--- a/tests/unit_tests/test_fp8_utils.py
+++ b/tests/unit_tests/test_fp8_utils.py
@@ -25,7 +25,7 @@ def test_get_fp8_backward_quantization_update_context():
     context = Mock()
     scope = Mock(return_value=context)
     transformer_engine = Mock()
-    transformer_engine.pytorch.backward_quantization_update_scope = scope
+    transformer_engine.pytorch.quantization_backward_scope = scope
 
     with (
         patch.object(fp8_utils, 'HAVE_TE', True),
@@ -44,7 +44,7 @@ def test_get_fp8_backward_quantization_update_context_without_te():
 
 def test_get_fp8_backward_quantization_update_context_without_scope_api():
     transformer_engine = Mock()
-    transformer_engine.pytorch.backward_quantization_update_scope = None
+    transformer_engine.pytorch.quantization_backward_scope = None
 
     with (
         patch.object(fp8_utils, 'HAVE_TE', True),

--- a/tests/unit_tests/test_fp8_utils.py
+++ b/tests/unit_tests/test_fp8_utils.py
@@ -21,6 +21,39 @@ class MockTELinear(nn.Module):
         return x @ self.weight.t()
 
 
+def test_get_fp8_backward_quantization_update_context():
+    context = Mock()
+    scope = Mock(return_value=context)
+    transformer_engine = Mock()
+    transformer_engine.pytorch.backward_quantization_update_scope = scope
+
+    with (
+        patch.object(fp8_utils, 'HAVE_TE', True),
+        patch.object(fp8_utils, 'transformer_engine', transformer_engine, create=True),
+    ):
+        assert fp8_utils.get_fp8_backward_quantization_update_context() is context
+
+    scope.assert_called_once_with()
+
+
+def test_get_fp8_backward_quantization_update_context_without_te():
+    with patch.object(fp8_utils, 'HAVE_TE', False):
+        with fp8_utils.get_fp8_backward_quantization_update_context():
+            pass
+
+
+def test_get_fp8_backward_quantization_update_context_without_scope_api():
+    transformer_engine = Mock()
+    transformer_engine.pytorch.backward_quantization_update_scope = None
+
+    with (
+        patch.object(fp8_utils, 'HAVE_TE', True),
+        patch.object(fp8_utils, 'transformer_engine', transformer_engine, create=True),
+    ):
+        with fp8_utils.get_fp8_backward_quantization_update_context():
+            pass
+
+
 class TestFP8Padding:
 
     def setup_method(self, method):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Wrap the backward part of `combined_forward_backward_step` (combined 1F1B) in Transformer Engine's `quantization_backward_scope()`.

Combined 1F1B does not run one `backward()` per microbatch. Every `ScheduleNode` (attention, MLP, MoE dispatch/combine, post-process, ...) runs its own `Variable._execution_engine.run_backward`, so one microbatch backward consists of many independent autograd tasks.

Transformer Engine (NVIDIA/TransformerEngine#3456) moves the delayed-scaling update (gradient amax reduction and scale recomputation) to the end of the autograd task in which a quantized module ran backward. Without this change, combined 1F1B would therefore run that update after every node instead of once per microbatch: several amax all-reduces per layer and an amax history that advances by two slots per layer per microbatch. Inside `quantization_backward_scope()` the modules only mark the update as pending and it runs once, when the scope exits after `SchedulePlan.run()`.

The scope is entered only when a backward microbatch is present and FP8 is enabled. It is a no-op for recipes without delayed-scaling state. The TE API is feature-detected; older TE versions fall back to `nullcontext()` and keep their current behavior. The standard schedules in `schedules.py` are unaffected because they run a single backward per microbatch.

## Issue tracking

Companion TE change: NVIDIA/TransformerEngine#3456

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the full autoformatter on my PR (`git diff --check` clean)
