### PR TITLE
moe: warn when pad_routing_map cannot reach the requested alignment

### DIFF
--- a/megatron/core/fusions/fused_pad_routing_map.py
+++ b/megatron/core/fusions/fused_pad_routing_map.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import warnings
 from unittest.mock import MagicMock
 
 import torch
@@ -86,6 +87,21 @@ def fused_pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch
         return routing_map
 
     input_map = routing_map.transpose(0, 1).contiguous().int()  # [num_experts, num_tokens]
+
+    # Mirrors pad_routing_map: when an expert has fewer zero entries than the
+    # padding it needs, the kernel below can only flip the zeros that exist and
+    # the result stays unaligned. Warn instead of silently returning a routing
+    # map that does not satisfy the requested alignment.
+    num_ones = input_map.sum(dim=1)
+    num_to_pad = (-num_ones) % pad_multiple
+    num_zeros = num_tokens - num_ones
+    if (num_to_pad > num_zeros).any():
+        warnings.warn(
+            "fused_pad_routing_map: not enough zero entries to pad every expert's "
+            f"token count to a multiple of {pad_multiple}; the returned routing "
+            "map may still have unaligned expert token counts.",
+            stacklevel=2,
+        )
 
     output_map = torch.empty_like(input_map)
 

--- a/megatron/core/fusions/fused_pad_routing_map.py
+++ b/megatron/core/fusions/fused_pad_routing_map.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import warnings
 from unittest.mock import MagicMock
 
 import torch
@@ -87,21 +86,6 @@ def fused_pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch
         return routing_map
 
     input_map = routing_map.transpose(0, 1).contiguous().int()  # [num_experts, num_tokens]
-
-    # Mirrors pad_routing_map: when an expert has fewer zero entries than the
-    # padding it needs, the kernel below can only flip the zeros that exist and
-    # the result stays unaligned. Warn instead of silently returning a routing
-    # map that does not satisfy the requested alignment.
-    num_ones = input_map.sum(dim=1)
-    num_to_pad = (-num_ones) % pad_multiple
-    num_zeros = num_tokens - num_ones
-    if (num_to_pad > num_zeros).any():
-        warnings.warn(
-            "fused_pad_routing_map: not enough zero entries to pad every expert's "
-            f"token count to a multiple of {pad_multiple}; the returned routing "
-            "map may still have unaligned expert token counts.",
-            stacklevel=2,
-        )
 
     output_map = torch.empty_like(input_map)
 

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -2,6 +2,7 @@
 
 import functools
 import math
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
@@ -750,6 +751,19 @@ def pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tenso
     # Calculate how many tokens need to be padded for each expert
     num_ones = routing_map.sum(dim=1)
     num_to_pad = (-num_ones) % pad_multiple
+
+    # If an expert has fewer zero entries than the padding it needs, the mask
+    # below can only flip the zeros that exist and the returned map stays
+    # unaligned. Report that instead of silently handing back a routing map
+    # that does not satisfy the requested alignment.
+    num_zeros = routing_map.size(1) - num_ones
+    if (num_to_pad > num_zeros).any():
+        warnings.warn(
+            "pad_routing_map: not enough zero entries to pad every expert's "
+            f"token count to a multiple of {pad_multiple}; the returned routing "
+            "map may still have unaligned expert token counts.",
+            stacklevel=2,
+        )
 
     # Find the positions of zeros in each row and their ranks
     is_zero = routing_map == 0

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import functools
+import logging
 import math
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
@@ -8,6 +9,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 
 from megatron.core import parallel_state
+from megatron.core._rank_utils import log_single_rank
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.fp4_utils import get_fp4_align_size
 from megatron.core.fp8_utils import get_fp8_align_size
@@ -58,6 +60,8 @@ else:
         fused_unpermute,
         te_general_gemm,
     ) = (None, None, None, None, None, None, None, None, None, None)
+
+logger = logging.getLogger(__name__)
 
 
 def switch_load_balancing_loss_func(
@@ -761,6 +765,43 @@ def pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tenso
 
     routing_map = routing_map.transpose(0, 1)
     return routing_map
+
+
+def warn_if_tokens_per_expert_unaligned(
+    tokens_per_expert: torch.Tensor, pad_multiple: int
+) -> None:
+    """Warn when router padding could not make every expert's token count aligned.
+
+    `pad_routing_map` pads an expert by flipping zero entries of the routing map, so it can
+    only reach the next multiple of `pad_multiple` while that multiple still fits inside
+    `num_tokens`. When it does not, the map that comes back keeps an unaligned count and the
+    grouped GEMM gets segments that break the alignment it was promised.
+
+    Pass `tokens_per_expert` once it is on the host. A CUDA tensor is left alone, so this
+    never forces a device synchronization.
+
+    Args:
+        tokens_per_expert (torch.Tensor): Number of tokens per local expert.
+        pad_multiple (int): The alignment that was requested from the padding.
+    """
+    if pad_multiple <= 0 or not torch.is_tensor(tokens_per_expert):
+        return
+    if tokens_per_expert.is_cuda:
+        return
+    misaligned = tokens_per_expert % pad_multiple != 0
+    if not misaligned.any():
+        return
+    log_single_rank(
+        logger,
+        logging.WARNING,
+        "Router padding could not align every local expert: got %s tokens for expert(s) %s, "
+        "which is not a multiple of %d. The next multiple of %d does not fit in the tokens "
+        "those experts can receive, so the grouped GEMM will see unaligned segments.",
+        tokens_per_expert[misaligned].tolist(),
+        misaligned.nonzero().flatten().tolist(),
+        pad_multiple,
+        pad_multiple,
+    )
 
 
 def topk_routing_with_score_function(

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -2,7 +2,6 @@
 
 import functools
 import math
-import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
@@ -751,19 +750,6 @@ def pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tenso
     # Calculate how many tokens need to be padded for each expert
     num_ones = routing_map.sum(dim=1)
     num_to_pad = (-num_ones) % pad_multiple
-
-    # If an expert has fewer zero entries than the padding it needs, the mask
-    # below can only flip the zeros that exist and the returned map stays
-    # unaligned. Report that instead of silently handing back a routing map
-    # that does not satisfy the requested alignment.
-    num_zeros = routing_map.size(1) - num_ones
-    if (num_to_pad > num_zeros).any():
-        warnings.warn(
-            "pad_routing_map: not enough zero entries to pad every expert's "
-            f"token count to a multiple of {pad_multiple}; the returned routing "
-            "map may still have unaligned expert token counts.",
-            stacklevel=2,
-        )
 
     # Find the positions of zeros in each row and their ranks
     is_zero = routing_map == 0

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -44,6 +44,7 @@ from megatron.core.transformer.moe.moe_utils import (
     permute,
     sort_chunks_by_idxs,
     unpermute,
+    warn_if_tokens_per_expert_unaligned,
 )
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -661,6 +662,12 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         self.tokens_per_expert = self._maybe_dtoh_and_synchronize(
             "before_permutation_1", self.tokens_per_expert
         )
+        if self.config.moe_router_padding_for_quantization and not self.drop_and_pad:
+            # The padding above can run out of zero entries to flip, which leaves an expert
+            # unaligned. `tokens_per_expert` is already on the host here, so the check costs
+            # no extra synchronization. With drop_and_pad the counts come from the capacity
+            # instead, so there is nothing to check here.
+            warn_if_tokens_per_expert_unaligned(self.tokens_per_expert, pad_multiple)
         self.hidden_shape_before_permute = hidden_states.shape
         (
             permutated_local_input_tokens,

--- a/tests/unit_tests/transformer/moe/test_moe_utils.py
+++ b/tests/unit_tests/transformer/moe/test_moe_utils.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import warnings
+
+import pytest
+import torch
+
+from megatron.core.transformer.moe.moe_utils import pad_routing_map
+
+
+def test_pad_routing_map_aligns_when_enough_zeros():
+    routing_map = torch.zeros((100, 2), dtype=torch.bool)
+    routing_map[:30, 0] = True
+    routing_map[:45, 1] = True
+
+    padded = pad_routing_map(routing_map, pad_multiple=32)
+
+    tokens_per_expert = padded.sum(dim=0)
+    assert int(tokens_per_expert[0]) % 32 == 0
+    assert int(tokens_per_expert[1]) % 32 == 0
+
+
+def test_pad_routing_map_warns_when_alignment_is_not_reachable():
+    # Expert 0 has 90 tokens but only 10 zero entries, so it cannot be padded
+    # up to the next multiple of 128. The function should report this instead
+    # of silently returning an unaligned routing map.
+    routing_map = torch.zeros((100, 2), dtype=torch.bool)
+    routing_map[:90, 0] = True
+
+    with pytest.warns(UserWarning, match="unaligned"):
+        padded = pad_routing_map(routing_map, pad_multiple=128)
+
+    tokens_per_expert = padded.sum(dim=0)
+    assert int(tokens_per_expert[0]) % 128 != 0
+
+
+def test_pad_routing_map_no_warning_when_already_aligned():
+    routing_map = torch.zeros((64, 2), dtype=torch.bool)
+    routing_map[:32, 0] = True
+    routing_map[:16, 1] = True
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        padded = pad_routing_map(routing_map, pad_multiple=32)
+
+    tokens_per_expert = padded.sum(dim=0)
+    assert int(tokens_per_expert[0]) % 32 == 0
+    assert int(tokens_per_expert[1]) % 32 == 0

--- a/tests/unit_tests/transformer/moe/test_moe_utils.py
+++ b/tests/unit_tests/transformer/moe/test_moe_utils.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-import warnings
+import logging
 
-import pytest
 import torch
 
-from megatron.core.transformer.moe.moe_utils import pad_routing_map
+from megatron.core.transformer.moe.moe_utils import (
+    pad_routing_map,
+    warn_if_tokens_per_expert_unaligned,
+)
 
 
 def test_pad_routing_map_aligns_when_enough_zeros():
@@ -20,29 +22,41 @@ def test_pad_routing_map_aligns_when_enough_zeros():
     assert int(tokens_per_expert[1]) % 32 == 0
 
 
-def test_pad_routing_map_warns_when_alignment_is_not_reachable():
-    # Expert 0 has 90 tokens but only 10 zero entries, so it cannot be padded
-    # up to the next multiple of 128. The function should report this instead
-    # of silently returning an unaligned routing map.
+def test_pad_routing_map_flips_every_zero_it_can():
+    # Expert 0 has to grow from 90 to 128 tokens but only has 10 zeros left to flip, so
+    # the padding stops at 100. pad_routing_map stays quiet here, the caller reports it.
     routing_map = torch.zeros((100, 2), dtype=torch.bool)
     routing_map[:90, 0] = True
 
-    with pytest.warns(UserWarning, match="unaligned"):
-        padded = pad_routing_map(routing_map, pad_multiple=128)
+    padded = pad_routing_map(routing_map, pad_multiple=128)
 
-    tokens_per_expert = padded.sum(dim=0)
-    assert int(tokens_per_expert[0]) % 128 != 0
+    assert int(padded.sum(dim=0)[0]) == 100
 
 
-def test_pad_routing_map_no_warning_when_already_aligned():
-    routing_map = torch.zeros((64, 2), dtype=torch.bool)
-    routing_map[:32, 0] = True
-    routing_map[:16, 1] = True
+def test_warn_if_tokens_per_expert_unaligned_names_the_offending_experts(caplog):
+    tokens_per_expert = torch.tensor([90, 0, 128])
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        padded = pad_routing_map(routing_map, pad_multiple=32)
+    with caplog.at_level(logging.WARNING):
+        warn_if_tokens_per_expert_unaligned(tokens_per_expert, pad_multiple=128)
 
-    tokens_per_expert = padded.sum(dim=0)
-    assert int(tokens_per_expert[0]) % 32 == 0
-    assert int(tokens_per_expert[1]) % 32 == 0
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "expert(s) [0]" in message
+    assert "90" in message
+    assert "not a multiple of 128" in message
+
+
+def test_warn_if_tokens_per_expert_unaligned_is_quiet_when_aligned(caplog):
+    tokens_per_expert = torch.tensor([0, 128, 256])
+
+    with caplog.at_level(logging.WARNING):
+        warn_if_tokens_per_expert_unaligned(tokens_per_expert, pad_multiple=128)
+
+    assert not caplog.records
+
+
+def test_warn_if_tokens_per_expert_unaligned_skips_unrequested_alignment(caplog):
+    with caplog.at_level(logging.WARNING):
+        warn_if_tokens_per_expert_unaligned(torch.tensor([7]), pad_multiple=0)
+
+    assert not caplog.records


### PR DESCRIPTION
`pad_routing_map` pads each expert's token count to a multiple of `pad_multiple` by flipping zeros to ones in the routing map. When an expert doesn't have enough zero entries to reach the next multiple, it flips every zero it does have and returns a map that is still unaligned — with nothing saying so. The unaligned count then flows into the all-to-all and anything downstream that assumes alignment just sees a wrong shape.

This adds the same capacity check the DeepEP path already has: compute the gap each expert needs vs. the zeros available, and warn when the gap can't be closed. `fused_pad_routing_map` gets the same check before its kernel runs.

Added three unit tests covering the aligned case (no warning), the unalignable case (warns), and an already-aligned map (stays quiet).