### PR TITLE
fix(inference): preserve valid rows, cached KV, and greedy semantics

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -880,9 +880,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Bind the GPU real-token-count tensor onto the NVLS dispatcher class
         # so it can mask out CUDA-graph padding tokens during routing. The
         # tensor lives inside gpu_view._buf (fixed address) and is refreshed
-        # each step by transfer_bookkeeping_to_gpu(). NVLS-only — the NCCL
-        # dispatcher requires equal token counts across ranks already.
-        if self._nvls_dispatcher:
+        # each step by transfer_bookkeeping_to_gpu(). EP=1 still constructs the
+        # NVLS dispatcher even though it does not allocate communication
+        # buffers, and needs this tensor to distinguish real from graph-padded
+        # rows.
+        if model_config.inference_moe_token_dispatcher_type == 'nvls':
             NVLSAllGatherVDispatcher.set_real_token_count_tensor(self.gpu_view.real_token_count)
 
         # Print info.

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3476,10 +3476,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_block_idx[
             self.active_token_count : self.active_token_count + effective_prefill_chunk_length
         ] = self.request_to_kv_block_ids[current_id][token_offset_range // self.block_size_tokens]
-        if num_matched_blocks > 0:
-            # Some tokens we are about to compute may land inside a block we matched
-            # by hash. That block already holds the correct KV for exactly these
-            # tokens and is shared with whoever cached it, so send those writes to the
+        if num_matched_blocks > 0 or req.num_matched_prefix_blocks > 0:
+            # Some tokens we are about to compute may land inside a block this or an
+            # earlier chunk matched by hash. That block already holds the correct KV
+            # for exactly these tokens and is shared with whoever cached it, so send those writes to the
             # dummy block rather than perturb a concurrent reader's values.
             #
             # Only the write mapping moves. `request_to_kv_block_ids` still points at

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -754,10 +754,15 @@ class DynamicInferenceContext(BaseInferenceContext):
             and model_config.inference_moe_token_dispatcher_type == 'nccl'
         )
 
-        # are we using the inference_optimized nvls ep dispatcher for MoEs?
-        self._nvls_dispatcher = (
-            get_pg_size(self.expert_model_parallel_group) > 1
+        # Does the model construct the inference-optimized NVLS dispatcher? Unlike
+        # the communication-buffer predicate below, this remains true at EP=1.
+        self._uses_nvls_dispatcher = (
+            model_config.transformer_impl == "inference_optimized"
+            and model_config.num_moe_experts is not None
             and model_config.inference_moe_token_dispatcher_type == 'nvls'
+        )
+        self._nvls_dispatcher = (
+            get_pg_size(self.expert_model_parallel_group) > 1 and self._uses_nvls_dispatcher
         )
 
         # are we using the training a2a dispatcher for MoEs?
@@ -876,16 +881,6 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.is_tensor_state_allocated = False
         self._bookkeeping_no_real_work = False
         self.initialize_all_tensors()
-
-        # Bind the GPU real-token-count tensor onto the NVLS dispatcher class
-        # so it can mask out CUDA-graph padding tokens during routing. The
-        # tensor lives inside gpu_view._buf (fixed address) and is refreshed
-        # each step by transfer_bookkeeping_to_gpu(). EP=1 still constructs the
-        # NVLS dispatcher even though it does not allocate communication
-        # buffers, and needs this tensor to distinguish real from graph-padded
-        # rows.
-        if model_config.inference_moe_token_dispatcher_type == 'nvls':
-            NVLSAllGatherVDispatcher.set_real_token_count_tensor(self.gpu_view.real_token_count)
 
         # Print info.
         pool_size = self.kv_block_allocator.pool_size
@@ -1497,6 +1492,12 @@ class DynamicInferenceContext(BaseInferenceContext):
                 self._mamba_decode_indices_dtype if self.is_hybrid_model else torch.int64
             ),
         )
+        # Bind after every ContextGPUView allocation, including RECOMPUTE resume.
+        # The tensor lives inside gpu_view._buf (fixed address) and is refreshed
+        # each step by transfer_bookkeeping_to_gpu(). EP=1 still constructs the
+        # NVLS dispatcher even though it does not allocate communication buffers.
+        if self._uses_nvls_dispatcher:
+            NVLSAllGatherVDispatcher.set_real_token_count_tensor(self.gpu_view.real_token_count)
         self._bookkeeping_h2d_done_event = torch.cuda.Event()
 
         # Cache of (input_ids_view, pos_ids_view) keyed by num_tokens. Instead of slicing and

--- a/megatron/core/inference/sampling/flashinfer_sampling.py
+++ b/megatron/core/inference/sampling/flashinfer_sampling.py
@@ -18,6 +18,22 @@ from megatron.core.inference.sampling_params import (
 )
 
 
+def _greedy_batch_flags(context) -> tuple[bool, bool]:
+    """Return whether any/all active requests use greedy sampling.
+
+    Sampling parameters have a pinned CPU source of truth, so these checks add
+    no GPU synchronization to the sampling path.
+    """
+    active_count = context.total_request_count - context.paused_request_count
+    if active_count == 0:
+        return False, False
+    metadata = context.active_request_metadata
+    top_k = metadata["top_k"][:active_count]
+    top_p = metadata["top_p"][:active_count]
+    greedy = (top_k == 1) & is_no_op_top_p(top_p)
+    return bool(greedy.any()), bool(greedy.all())
+
+
 class FlashInferSampling(Sampling):
     """FlashInfer sampling with per-step unfiltered / top-p-only / top-k-only / joint dispatch.
 
@@ -102,6 +118,23 @@ class FlashInferSampling(Sampling):
             scaled = logits[gather_indices[:n], :] / temperature.unsqueeze(1)
         assert scaled.dtype == torch.float32, f"sampling math must be fp32, got {scaled.dtype}"
 
+        # SamplingParams defines top_k=1 as greedy, matching the torch backend's
+        # argmax fast path. FlashInfer's top-k kernels can retain multiple tokens
+        # when logits tie at the kth threshold and then sample among them. Besides
+        # violating greedy semantics, that makes output depend on unrelated RNG
+        # consumption (for example, a different prefix-cache graph shape).
+        # The common unconstrained path already tells us top-k is absent. Avoid
+        # adding either CPU metadata scans or GPU pointwise work to that path.
+        has_greedy_rows, all_greedy_rows = (
+            (False, False) if no_top_k else _greedy_batch_flags(context)
+        )
+        if all_greedy_rows:
+            sampled_tokens = torch.argmax(scaled, dim=-1)
+            if output is None:
+                return sampled_tokens
+            output.copy_(sampled_tokens)
+            return output
+
         # `no_top_k` / `no_top_p` are the caller-supplied batch-level dispatch flags:
         # a filter is absent only when NO active request uses it. Per-row sentinels
         # disable a filter for a row (top_k=vocab keeps all tokens, top_p=1.0 keeps
@@ -134,6 +167,12 @@ class FlashInferSampling(Sampling):
             sampled_tokens = flashinfer.sampling.top_k_top_p_sampling_from_logits(
                 scaled, top_k_safe, top_p_safe, deterministic=True, generator=self._rng
             ).long()
+
+        # Mixed batches still use FlashInfer for stochastic rows, then repair
+        # greedy rows with deterministic first-argmax tie breaking.
+        if has_greedy_rows:
+            greedy_mask = (top_k == 1) & is_no_op_top_p(top_p)
+            sampled_tokens = torch.where(greedy_mask, torch.argmax(scaled, dim=-1), sampled_tokens)
 
         if output is None:
             return sampled_tokens
@@ -169,10 +208,19 @@ class FlashInferSampling(Sampling):
         temperature = temperature.clamp(min=MIN_SAMPLING_TEMPERATURE)
         scaled = logits / temperature.unsqueeze(1)
 
-        # Batch-level no-op check.
+        # Batch-level no-op check. This is also the overwhelmingly common
+        # production path, so return before checking for greedy rows.
         no_top_k_batch, no_top_p_batch = context.active_sampling_filter_flags()
         if no_top_k_batch and no_top_p_batch:
             return torch.log_softmax(scaled, dim=-1)
+
+        has_greedy_rows, all_greedy_rows = (
+            (False, False) if no_top_k_batch else _greedy_batch_flags(context)
+        )
+        if all_greedy_rows:
+            greedy_log_probs = torch.full_like(scaled, float("-inf"))
+            greedy_log_probs.scatter_(1, torch.argmax(scaled, dim=-1, keepdim=True), 0.0)
+            return greedy_log_probs
 
         # Sentinel / no-op values disable filtering:
         # top_k=vocab_size keeps all tokens, top_p=1.0 keeps the full probability mass.
@@ -186,8 +234,14 @@ class FlashInferSampling(Sampling):
         renormed = flashinfer.sampling.top_k_renorm_probs(probs, top_k_safe)
         renormed = flashinfer.sampling.top_p_renorm_probs(renormed, top_p_safe)
         # Unfiltered rows of a mixed batch bypass the renorm rounding entirely.
-        return torch.where(
+        log_probs = torch.where(
             (no_top_k & no_top_p).unsqueeze(1),
             torch.log_softmax(scaled, dim=-1),
             torch.log(renormed),
         )
+        if has_greedy_rows:
+            greedy_mask = (top_k == 1) & is_no_op_top_p(top_p)
+            greedy_log_probs = torch.full_like(scaled, float("-inf"))
+            greedy_log_probs.scatter_(1, torch.argmax(scaled, dim=-1, keepdim=True), 0.0)
+            log_probs = torch.where(greedy_mask.unsqueeze(1), greedy_log_probs, log_probs)
+        return log_probs

--- a/megatron/core/inference/sampling/flashinfer_sampling.py
+++ b/megatron/core/inference/sampling/flashinfer_sampling.py
@@ -19,7 +19,7 @@ from megatron.core.inference.sampling_params import (
 
 
 def _greedy_batch_flags(context) -> tuple[bool, bool]:
-    """Return whether any/all active requests use greedy sampling.
+    """Return whether any/all active requests use ``top_k=1`` greedy sampling.
 
     Sampling parameters have a pinned CPU source of truth, so these checks add
     no GPU synchronization to the sampling path.
@@ -29,8 +29,9 @@ def _greedy_batch_flags(context) -> tuple[bool, bool]:
         return False, False
     metadata = context.active_request_metadata
     top_k = metadata["top_k"][:active_count]
-    top_p = metadata["top_p"][:active_count]
-    greedy = (top_k == 1) & is_no_op_top_p(top_p)
+    # Applying top-p after top-k cannot broaden top-k's one-token support, so
+    # top_k=1 remains greedy when the FlashInfer backend combines both filters.
+    greedy = top_k == 1
     return bool(greedy.any()), bool(greedy.all())
 
 
@@ -171,7 +172,7 @@ class FlashInferSampling(Sampling):
         # Mixed batches still use FlashInfer for stochastic rows, then repair
         # greedy rows with deterministic first-argmax tie breaking.
         if has_greedy_rows:
-            greedy_mask = (top_k == 1) & is_no_op_top_p(top_p)
+            greedy_mask = top_k == 1
             sampled_tokens = torch.where(greedy_mask, torch.argmax(scaled, dim=-1), sampled_tokens)
 
         if output is None:
@@ -240,7 +241,7 @@ class FlashInferSampling(Sampling):
             torch.log(renormed),
         )
         if has_greedy_rows:
-            greedy_mask = (top_k == 1) & is_no_op_top_p(top_p)
+            greedy_mask = top_k == 1
             greedy_log_probs = torch.full_like(scaled, float("-inf"))
             greedy_log_probs.scatter_(1, torch.argmax(scaled, dim=-1, keepdim=True), 0.0)
             log_probs = torch.where(greedy_mask.unsqueeze(1), greedy_log_probs, log_probs)

--- a/megatron/core/inference/sampling/torch_sampling.py
+++ b/megatron/core/inference/sampling/torch_sampling.py
@@ -158,6 +158,14 @@ class TorchSampling(Sampling):
         log_probs = torch.empty_like(logits)
         for (t, k, p), rows in buckets.items():
             idx = torch.tensor(rows, device=logits.device, dtype=torch.long)
+            if int(k) == 1:
+                # Sampling treats top_k=1 as deterministic first-argmax. Preserve
+                # that exact distribution when maximum logits tie instead of
+                # retaining every value equal to the top-k cutoff.
+                bucket_log_probs = torch.full_like(logits[idx], float("-inf"))
+                bucket_log_probs.scatter_(1, torch.argmax(logits[idx], dim=-1, keepdim=True), 0.0)
+                log_probs[idx] = bucket_log_probs
+                continue
             filtered = TorchSampling.filter_logits(
                 logits[idx], float(t), int(k), float(p), vocab_size=self._vocab_size
             )

--- a/megatron/core/inference/text_generation_controllers/mtp_inference_mixin.py
+++ b/megatron/core/inference/text_generation_controllers/mtp_inference_mixin.py
@@ -195,7 +195,7 @@ class MTPInferenceMixin:
         # active_request_count real rows followed by padding up to padded_count.
         # The NVLS routing mask defaults to the main step's token count, so point
         # it at the MTP row count instead, else padding rows route to experts.
-        if context._nvls_dispatcher:
+        if context._uses_nvls_dispatcher:
             NVLSAllGatherVDispatcher.modify_real_token_count_for_mtp(active_request_count)
 
         for depth in range(self.num_mtp_depths):

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -505,6 +505,7 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # Rank inside pg_collection.tp — the *standard* TP group that SP shards
         # the routing map along. Base class self.tp_rank is the expt_tp rank,
         # which is not what we want for the SP padding offset.
+        self.sp_size = get_pg_size(pg_collection.tp)
         self.sp_rank = get_pg_rank(pg_collection.tp)
         # Set in dispatch_preprocess; consumed by token_dispatch and token_combine.
         self._local_tokens: int = 0
@@ -557,7 +558,16 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             Also updates self.routing_map to [global_max, topk] int64.
         """
         if self.ep_size == 1:
-            if self._runs_metadata_sync:
+            real_token_count = self.__class__._real_token_count_tensor
+            if real_token_count is not None:
+                if self._runs_metadata_sync:
+                    valid_tokens = InferenceAllGatherDispatcherBase._valid_tokens_tensor
+                    valid_tokens.copy_(real_token_count)
+                    if self.sp_size > 1:
+                        valid_tokens.sub_(self.sp_rank * hidden_states.shape[0])
+                        valid_tokens.clamp_(min=0, max=hidden_states.shape[0])
+                mask_routing_padding(self.routing_map, real_token_count, self.sp_rank)
+            elif self._runs_metadata_sync:
                 InferenceAllGatherDispatcherBase._valid_tokens_tensor.fill_(hidden_states.shape[0])
             return hidden_states, probs
 

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -320,7 +320,7 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
     # [1] int32 view onto context.gpu_view.real_token_count. Fixed GPU address;
     # written each step by the context's transfer_bookkeeping_to_gpu(). Holds the
     # real (unpadded) local token count so the dispatcher can mask routing for
-    # CUDA-graph padding tokens. Wired once by the context after gpu_view init.
+    # CUDA-graph padding tokens. Rebound by the context after each gpu_view init.
     _real_token_count_tensor: Optional[torch.Tensor] = None
 
     # ── Class-level symmetric buffer handles (allocated once at model init) ───────
@@ -340,7 +340,7 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
     def set_real_token_count_tensor(cls, tensor: torch.Tensor) -> None:
         """Bind the context's GPU real-token-count tensor on the dispatcher class.
 
-        Called once by DynamicInferenceContext after gpu_view is initialised.
+        Called by DynamicInferenceContext whenever gpu_view is initialised.
         The tensor is a fixed-address int32[1] view whose value is refreshed
         each step by transfer_bookkeeping_to_gpu().
         """

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1329,12 +1329,14 @@ class TransformerConfig(ModelParallelConfig):
     """
 
     inference_moe_token_dispatcher_type: Literal['nccl', 'nvls'] = 'nvls'
-    """Token dispatcher to use for MoE expert parallelism during inference.
+    """Token dispatcher to use for inference-optimized MoE layers.
     - 'nccl': AllGather/ReduceScatter via NCCL. Fixed token counts per rank; requires
       decode-only CUDA graphs (forced automatically).
     - 'nvls': Variable-count AllGather-V/ReduceScatter-V via NVLS multimem kernels.
-      Requires Hopper+ GPUs with NVLink and symmetric memory. Default.
-    Only applies when transformer_impl='inference_optimized' and EP > 1."""
+      With EP > 1, requires Hopper+ GPUs with NVLink and symmetric memory. Default.
+    With EP = 1, the selected dispatcher still handles local routing and valid-token
+    metadata, but does not allocate communication buffers. Only applies when
+    transformer_impl='inference_optimized'."""
 
     mrope_section: Optional[List[int]] = None
     """ Multimodal rope section is for channel dimension of temporal, height and width

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -4230,6 +4230,7 @@ class TestDynamicContext:
     [
         ([0, 0, 0], [0.0, 1.0, 1.0], [None, None, None]),  # all no-op: fast path
         ([4, 0], [0.0, 1.0], [4, None]),  # mixed batch: per-row repair
+        ([1], [1.0], [1]),  # greedy: exactly one finite argmax, even on a tie
     ],
 )
 def test_flashinfer_no_op_filter_rows_get_exact_log_softmax(top_k, top_p, finite_counts):
@@ -4255,6 +4256,8 @@ def test_flashinfer_no_op_filter_rows_get_exact_log_softmax(top_k, top_p, finite
     )
 
     backend = FlashInferSampling(64, torch.Generator(device="cuda"))
+    if top_k.tolist() == [1]:
+        logits[0, 0] = logits[0, 1] = logits.max()
     log_probs = backend.log_probs_kernel(logits, context)
     expected = torch.log_softmax(logits, dim=-1)
     for row, finite_count in enumerate(finite_counts):
@@ -4262,6 +4265,8 @@ def test_flashinfer_no_op_filter_rows_get_exact_log_softmax(top_k, top_p, finite
             assert torch.equal(log_probs[row], expected[row])
         else:
             assert int(torch.isfinite(log_probs[row]).sum()) == finite_count
+    if top_k.tolist() == [1]:
+        assert log_probs[0, 0].item() == 0.0
 
 
 @pytest.mark.parametrize(
@@ -4300,7 +4305,13 @@ def test_flashinfer_sample_kernel_dispatch(
             temperature=torch.ones(n),
             top_k=torch.tensor(top_k, dtype=torch.int32),
             top_p=torch.tensor(top_p),
-        )
+        ),
+        active_request_metadata={
+            "top_k": torch.tensor(top_k, dtype=torch.int32),
+            "top_p": torch.tensor(top_p),
+        },
+        total_request_count=n,
+        paused_request_count=0,
     )
     rng = torch.Generator()
     backend = FlashInferSampling(vocab_size, rng)
@@ -4332,3 +4343,52 @@ def test_flashinfer_sample_kernel_dispatch(
     }
     for safe_arg, expected in zip(args[1:], expected_safe.get(expected_kernel, [])):
         assert torch.equal(safe_arg, expected)
+
+
+def test_flashinfer_top_k_one_ties_use_deterministic_argmax(monkeypatch):
+    """top_k=1 is greedy even when several logits tie for the maximum."""
+    fake = mock.MagicMock()
+    fake.sampling.top_k_sampling_from_probs.return_value = torch.tensor([3, 1])
+    monkeypatch.setattr("megatron.core.inference.sampling.flashinfer_sampling.flashinfer", fake)
+
+    logits = torch.tensor([[0.0, 3.0, 1.0, 3.0], [2.0, 2.0, 1.0, 0.0]])
+    n, vocab_size = logits.shape
+    top_k = torch.ones(n, dtype=torch.int32)
+    top_p = torch.ones(n)
+    context = SimpleNamespace(
+        gpu_view=SimpleNamespace(temperature=torch.ones(n), top_k=top_k, top_p=top_p),
+        active_request_metadata={"top_k": top_k, "top_p": top_p},
+        total_request_count=n,
+        paused_request_count=0,
+    )
+
+    backend = FlashInferSampling(vocab_size, torch.Generator())
+    sampled = backend.sample_kernel(logits, n, context, no_top_k=False, no_top_p=True)
+
+    assert torch.equal(sampled, torch.tensor([1, 0]))
+    fake.sampling.top_k_sampling_from_probs.assert_not_called()
+
+
+def test_flashinfer_mixed_batch_repairs_greedy_ties(monkeypatch):
+    """Greedy rows remain deterministic alongside stochastic top-k rows."""
+    fake = mock.MagicMock()
+    fake.sampling.top_k_sampling_from_probs.return_value = torch.tensor(
+        [3, 2], dtype=torch.int32
+    )
+    monkeypatch.setattr("megatron.core.inference.sampling.flashinfer_sampling.flashinfer", fake)
+
+    logits = torch.tensor([[0.0, 3.0, 1.0, 3.0], [2.0, 2.0, 1.0, 0.0]])
+    top_k = torch.tensor([1, 2], dtype=torch.int32)
+    top_p = torch.ones(2)
+    context = SimpleNamespace(
+        gpu_view=SimpleNamespace(temperature=torch.ones(2), top_k=top_k, top_p=top_p),
+        active_request_metadata={"top_k": top_k, "top_p": top_p},
+        total_request_count=2,
+        paused_request_count=0,
+    )
+
+    backend = FlashInferSampling(logits.size(1), torch.Generator())
+    sampled = backend.sample_kernel(logits, 2, context, no_top_k=False, no_top_p=True)
+
+    assert torch.equal(sampled, torch.tensor([1, 2]))
+    fake.sampling.top_k_sampling_from_probs.assert_called_once()

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -9,7 +9,11 @@ import pytest
 import torch
 
 from megatron.core import parallel_state
-from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
+from megatron.core.inference.config import (
+    InferenceConfig,
+    KVCacheManagementMode,
+    MambaInferenceStateConfig,
+)
 from megatron.core.inference.contexts.dynamic_context import (
     DynamicInferenceContext,
     RequestOverflowError,
@@ -21,6 +25,7 @@ from megatron.core.inference.sampling.torch_sampling import TorchSampling
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe.token_dispatcher_inference import NVLSAllGatherVDispatcher
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
@@ -78,6 +83,52 @@ class TestDynamicContext:
             tensor_model_parallel_size=1, pipeline_model_parallel_size=1
         )
         model_parallel_cuda_manual_seed(123)
+
+    @pytest.mark.internal
+    def test_recompute_rebinds_nvls_real_token_count_tensor(self):
+        """A RECOMPUTE resume binds NVLS to the newly allocated GPU view."""
+        model_config = TransformerConfig(
+            params_dtype=torch.float32,
+            num_layers=4,
+            hidden_size=16,
+            ffn_hidden_size=16,
+            kv_channels=8,
+            num_attention_heads=2,
+            num_moe_experts=2,
+            moe_ffn_hidden_size=16,
+            moe_router_topk=2,
+            moe_router_dtype="fp32",
+            moe_grouped_gemm=True,
+            transformer_impl="inference_optimized",
+            inference_grouped_gemm_backend="torch",
+            normalization="RMSNorm",
+            add_bias_linear=False,
+            add_qkv_bias=False,
+            use_cpu_initialization=True,
+        )
+        context = DynamicInferenceContext(
+            model_config=model_config,
+            inference_config=InferenceConfig(
+                max_sequence_length=512,
+                buffer_size_gb=0.03,
+                paused_buffer_size_gb=0.006,
+                block_size_tokens=128,
+                kv_cache_management_mode=KVCacheManagementMode.RECOMPUTE,
+                use_flashinfer_fused_rope=False,
+                unified_memory_level=0,
+            ),
+        )
+
+        old_real_token_count = context.gpu_view.real_token_count
+        assert NVLSAllGatherVDispatcher._real_token_count_tensor is old_real_token_count
+
+        context.deallocate_inference_state_buffers()
+        context.reinitialize_inference_state_buffers()
+
+        assert context.gpu_view.real_token_count is not old_real_token_count
+        assert (
+            NVLSAllGatherVDispatcher._real_token_count_tensor is context.gpu_view.real_token_count
+        )
 
     def _get_dynamic_context(
         self,

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -4231,6 +4231,7 @@ class TestDynamicContext:
         ([0, 0, 0], [0.0, 1.0, 1.0], [None, None, None]),  # all no-op: fast path
         ([4, 0], [0.0, 1.0], [4, None]),  # mixed batch: per-row repair
         ([1], [1.0], [1]),  # greedy: exactly one finite argmax, even on a tie
+        ([1], [0.9], [1]),  # top-k=1 remains greedy when combined with top-p
     ],
 )
 def test_flashinfer_no_op_filter_rows_get_exact_log_softmax(top_k, top_p, finite_counts):
@@ -4345,16 +4346,18 @@ def test_flashinfer_sample_kernel_dispatch(
         assert torch.equal(safe_arg, expected)
 
 
-def test_flashinfer_top_k_one_ties_use_deterministic_argmax(monkeypatch):
-    """top_k=1 is greedy even when several logits tie for the maximum."""
+@pytest.mark.parametrize("top_p_value", [1.0, 0.9])
+def test_flashinfer_top_k_one_ties_use_deterministic_argmax(monkeypatch, top_p_value):
+    """top_k=1 is greedy on ties, including when combined with top-p."""
     fake = mock.MagicMock()
     fake.sampling.top_k_sampling_from_probs.return_value = torch.tensor([3, 1])
+    fake.sampling.top_k_top_p_sampling_from_logits.return_value = torch.tensor([3, 1])
     monkeypatch.setattr("megatron.core.inference.sampling.flashinfer_sampling.flashinfer", fake)
 
     logits = torch.tensor([[0.0, 3.0, 1.0, 3.0], [2.0, 2.0, 1.0, 0.0]])
     n, vocab_size = logits.shape
     top_k = torch.ones(n, dtype=torch.int32)
-    top_p = torch.ones(n)
+    top_p = torch.full((n,), top_p_value)
     context = SimpleNamespace(
         gpu_view=SimpleNamespace(temperature=torch.ones(n), top_k=top_k, top_p=top_p),
         active_request_metadata={"top_k": top_k, "top_p": top_p},
@@ -4363,23 +4366,24 @@ def test_flashinfer_top_k_one_ties_use_deterministic_argmax(monkeypatch):
     )
 
     backend = FlashInferSampling(vocab_size, torch.Generator())
-    sampled = backend.sample_kernel(logits, n, context, no_top_k=False, no_top_p=True)
+    sampled = backend.sample_kernel(logits, n, context, no_top_k=False, no_top_p=top_p_value >= 1.0)
 
     assert torch.equal(sampled, torch.tensor([1, 0]))
     fake.sampling.top_k_sampling_from_probs.assert_not_called()
+    fake.sampling.top_k_top_p_sampling_from_logits.assert_not_called()
 
 
 def test_flashinfer_mixed_batch_repairs_greedy_ties(monkeypatch):
     """Greedy rows remain deterministic alongside stochastic top-k rows."""
     fake = mock.MagicMock()
-    fake.sampling.top_k_sampling_from_probs.return_value = torch.tensor(
+    fake.sampling.top_k_top_p_sampling_from_logits.return_value = torch.tensor(
         [3, 2], dtype=torch.int32
     )
     monkeypatch.setattr("megatron.core.inference.sampling.flashinfer_sampling.flashinfer", fake)
 
     logits = torch.tensor([[0.0, 3.0, 1.0, 3.0], [2.0, 2.0, 1.0, 0.0]])
     top_k = torch.tensor([1, 2], dtype=torch.int32)
-    top_p = torch.ones(2)
+    top_p = torch.full((2,), 0.9)
     context = SimpleNamespace(
         gpu_view=SimpleNamespace(temperature=torch.ones(2), top_k=top_k, top_p=top_p),
         active_request_metadata={"top_k": top_k, "top_p": top_p},
@@ -4388,7 +4392,7 @@ def test_flashinfer_mixed_batch_repairs_greedy_ties(monkeypatch):
     )
 
     backend = FlashInferSampling(logits.size(1), torch.Generator())
-    sampled = backend.sample_kernel(logits, 2, context, no_top_k=False, no_top_p=True)
+    sampled = backend.sample_kernel(logits, 2, context, no_top_k=False, no_top_p=False)
 
     assert torch.equal(sampled, torch.tensor([1, 2]))
-    fake.sampling.top_k_sampling_from_probs.assert_called_once()
+    fake.sampling.top_k_top_p_sampling_from_logits.assert_called_once()

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -87,48 +87,53 @@ class TestDynamicContext:
     @pytest.mark.internal
     def test_recompute_rebinds_nvls_real_token_count_tensor(self):
         """A RECOMPUTE resume binds NVLS to the newly allocated GPU view."""
-        model_config = TransformerConfig(
-            params_dtype=torch.float32,
-            num_layers=4,
-            hidden_size=16,
-            ffn_hidden_size=16,
-            kv_channels=8,
-            num_attention_heads=2,
-            num_moe_experts=2,
-            moe_ffn_hidden_size=16,
-            moe_router_topk=2,
-            moe_router_dtype="fp32",
-            moe_grouped_gemm=True,
-            transformer_impl="inference_optimized",
-            inference_grouped_gemm_backend="torch",
-            normalization="RMSNorm",
-            add_bias_linear=False,
-            add_qkv_bias=False,
-            use_cpu_initialization=True,
-        )
-        context = DynamicInferenceContext(
-            model_config=model_config,
-            inference_config=InferenceConfig(
-                max_sequence_length=512,
-                buffer_size_gb=0.03,
-                paused_buffer_size_gb=0.006,
-                block_size_tokens=128,
-                kv_cache_management_mode=KVCacheManagementMode.RECOMPUTE,
-                use_flashinfer_fused_rope=False,
-                unified_memory_level=0,
-            ),
-        )
+        previous_real_token_count = NVLSAllGatherVDispatcher._real_token_count_tensor
+        try:
+            model_config = TransformerConfig(
+                params_dtype=torch.float32,
+                num_layers=4,
+                hidden_size=16,
+                ffn_hidden_size=16,
+                kv_channels=8,
+                num_attention_heads=2,
+                num_moe_experts=2,
+                moe_ffn_hidden_size=16,
+                moe_router_topk=2,
+                moe_router_dtype="fp32",
+                moe_grouped_gemm=True,
+                transformer_impl="inference_optimized",
+                inference_grouped_gemm_backend="torch",
+                normalization="RMSNorm",
+                add_bias_linear=False,
+                add_qkv_bias=False,
+                use_cpu_initialization=True,
+            )
+            context = DynamicInferenceContext(
+                model_config=model_config,
+                inference_config=InferenceConfig(
+                    max_sequence_length=512,
+                    buffer_size_gb=0.03,
+                    paused_buffer_size_gb=0.006,
+                    block_size_tokens=128,
+                    kv_cache_management_mode=KVCacheManagementMode.RECOMPUTE,
+                    use_flashinfer_fused_rope=False,
+                    unified_memory_level=0,
+                ),
+            )
 
-        old_real_token_count = context.gpu_view.real_token_count
-        assert NVLSAllGatherVDispatcher._real_token_count_tensor is old_real_token_count
+            old_real_token_count = context.gpu_view.real_token_count
+            assert NVLSAllGatherVDispatcher._real_token_count_tensor is old_real_token_count
 
-        context.deallocate_inference_state_buffers()
-        context.reinitialize_inference_state_buffers()
+            context.deallocate_inference_state_buffers()
+            context.reinitialize_inference_state_buffers()
 
-        assert context.gpu_view.real_token_count is not old_real_token_count
-        assert (
-            NVLSAllGatherVDispatcher._real_token_count_tensor is context.gpu_view.real_token_count
-        )
+            assert context.gpu_view.real_token_count is not old_real_token_count
+            assert (
+                NVLSAllGatherVDispatcher._real_token_count_tensor
+                is context.gpu_view.real_token_count
+            )
+        finally:
+            NVLSAllGatherVDispatcher._real_token_count_tensor = previous_real_token_count
 
     def _get_dynamic_context(
         self,

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -4447,3 +4447,26 @@ def test_flashinfer_mixed_batch_repairs_greedy_ties(monkeypatch):
 
     assert torch.equal(sampled, torch.tensor([1, 2]))
     fake.sampling.top_k_top_p_sampling_from_logits.assert_called_once()
+
+
+def test_torch_processed_log_probs_match_top_k_one_greedy_tie_breaking():
+    """Torch processed log-probs match deterministic top_k=1 sampling on ties."""
+    logits = torch.tensor([[0.0, 3.0, 1.0, 3.0], [2.0, 2.0, 1.0, 0.0]])
+    top_k = torch.ones(2, dtype=torch.int32)
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        active_request_metadata={
+            "temperature": torch.ones(2),
+            "top_k": top_k,
+            "top_p": torch.zeros(2),
+        },
+    )
+
+    backend = TorchSampling(torch.Generator(), vocab_size=logits.size(1))
+    log_probs = backend.log_probs_kernel(logits, context)
+
+    expected = torch.full_like(logits, float("-inf"))
+    expected[0, 1] = 0.0
+    expected[1, 0] = 0.0
+    assert torch.equal(log_probs, expected)

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -1715,6 +1715,27 @@ class TestMatchedBlockWriteRedirect(PrefixCachingTestBase):
         for block_id in self._block_ids(ctx, 1, 4):
             assert ctx.kv_block_allocator.block_ref_counts[block_id].item() == 2
 
+    @pytest.mark.internal
+    def test_unaligned_continuation_without_new_matches_protects_inherited_block(self):
+        """An inherited partial match remains shared even when this chunk finds no new blocks."""
+        ctx = self._ctx()
+        block_size = ctx.block_size_tokens
+        dummy = ctx.kv_block_allocator.dummy_block_idx
+        prompt = self._prompt(block_size * 4)
+
+        ctx.add_request(self._req(ctx, prompt.clone()))
+        req = self._req(ctx, prompt.clone(), request_id=2)
+
+        first_chunk_length = block_size + 8
+        self._add_chunk(ctx, req, first_chunk_length)
+        assert req.num_matched_prefix_blocks == 2
+
+        # This chunk remains inside the second inherited block, so its matching
+        # range is empty: already_allocated_blocks == overall_required_blocks.
+        start, end = self._add_chunk(ctx, req, chunk_length=8)
+        assert req.num_matched_prefix_blocks == 2
+        assert ctx.token_to_block_idx[start:end].tolist() == [dummy] * (end - start)
+
 
 def _make_cpu_mamba_slot_allocator(
     monkeypatch, *, total_blocks: int, max_slots: int

--- a/tests/unit_tests/inference/test_moe_dispatching_and_routing.py
+++ b/tests/unit_tests/inference/test_moe_dispatching_and_routing.py
@@ -944,3 +944,89 @@ class TestMaskRoutingPadding:
         mask_routing_padding(routing_map, self._real_token_count(8), tp_rank=1)
 
         assert torch.all(routing_map == -1)
+
+    @pytest.mark.parametrize(
+        "sp_size,sp_rank,n_rows,real_count,expected_local_count",
+        [(1, 0, 16, 9, 9), (2, 0, 8, 11, 8), (2, 1, 8, 11, 3)],
+    )
+    def test_ep1_nvls_dispatch_uses_real_token_count(
+        self, sp_size, sp_rank, n_rows, real_count, expected_local_count
+    ):
+        """EP=1 reports and routes only real rows, including SP-sharded inputs."""
+        from megatron.core.transformer.moe.token_dispatcher_inference import (
+            InferenceAllGatherDispatcherBase,
+            NVLSAllGatherVDispatcher,
+        )
+
+        dispatcher = object.__new__(NVLSAllGatherVDispatcher)
+        dispatcher.ep_size = 1
+        dispatcher.sp_size = sp_size
+        dispatcher.sp_rank = sp_rank
+        dispatcher._runs_metadata_sync = True
+        dispatcher.routing_map = self._routing_map(n_rows)
+        original = dispatcher.routing_map.clone()
+        real_token_count_tensor = self._real_token_count(real_count)
+
+        previous_real_count = NVLSAllGatherVDispatcher._real_token_count_tensor
+        previous_valid_tokens = InferenceAllGatherDispatcherBase._valid_tokens_tensor
+        try:
+            InferenceAllGatherDispatcherBase.allocate_valid_tokens_tensor()
+            NVLSAllGatherVDispatcher.set_real_token_count_tensor(real_token_count_tensor)
+            hidden_states = torch.zeros((n_rows, 8), dtype=torch.bfloat16, device="cuda")
+            probs = torch.zeros((n_rows, self.TOPK), dtype=torch.float32, device="cuda")
+
+            dispatched_hidden, dispatched_probs = dispatcher.token_dispatch(hidden_states, probs)
+            torch.cuda.synchronize()
+
+            assert dispatched_hidden is hidden_states
+            assert dispatched_probs is probs
+            assert (
+                InferenceAllGatherDispatcherBase._valid_tokens_tensor.item() == expected_local_count
+            )
+            torch.testing.assert_close(
+                dispatcher.routing_map[:expected_local_count], original[:expected_local_count]
+            )
+            assert torch.all(dispatcher.routing_map[expected_local_count:] == -1)
+        finally:
+            NVLSAllGatherVDispatcher._real_token_count_tensor = previous_real_count
+            InferenceAllGatherDispatcherBase._valid_tokens_tensor = previous_valid_tokens
+
+    def test_ep1_nvls_dispatch_replays_with_new_real_token_count(self):
+        """CUDA graph replay reads the current real-token count from its stable GPU address."""
+        from megatron.core.transformer.moe.token_dispatcher_inference import (
+            InferenceAllGatherDispatcherBase,
+            NVLSAllGatherVDispatcher,
+        )
+
+        n_rows = 16
+        dispatcher = object.__new__(NVLSAllGatherVDispatcher)
+        dispatcher.ep_size = 1
+        dispatcher.sp_size = 1
+        dispatcher.sp_rank = 0
+        dispatcher._runs_metadata_sync = True
+        dispatcher.routing_map = self._routing_map(n_rows)
+        real_token_count_tensor = self._real_token_count(n_rows)
+        hidden_states = torch.zeros((n_rows, 8), dtype=torch.bfloat16, device="cuda")
+        probs = torch.zeros((n_rows, self.TOPK), dtype=torch.float32, device="cuda")
+
+        previous_real_count = NVLSAllGatherVDispatcher._real_token_count_tensor
+        previous_valid_tokens = InferenceAllGatherDispatcherBase._valid_tokens_tensor
+        try:
+            InferenceAllGatherDispatcherBase.allocate_valid_tokens_tensor()
+            NVLSAllGatherVDispatcher.set_real_token_count_tensor(real_token_count_tensor)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                dispatcher.token_dispatch(hidden_states, probs)
+
+            for real_count in (9, 13):
+                real_token_count_tensor.fill_(real_count)
+                dispatcher.routing_map.fill_(3)
+                graph.replay()
+                torch.cuda.synchronize()
+
+                assert InferenceAllGatherDispatcherBase._valid_tokens_tensor.item() == real_count
+                assert torch.all(dispatcher.routing_map[:real_count] == 3)
+                assert torch.all(dispatcher.routing_map[real_count:] == -1)
+        finally:
+            NVLSAllGatherVDispatcher._real_token_count_tensor = previous_real_count
+            InferenceAllGatherDispatcherBase._valid_tokens_tensor = previous_valid_tokens

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -1788,6 +1788,43 @@ def test_async_generate_output_tokens_dynamic_batch_assertions(mode, expected_me
         asyncio.run(controller.async_generate_output_tokens_dynamic_batch(skip_bookkeeping=True))
 
 
+def test_ep1_nvls_mtp_overrides_main_forward_real_token_count(monkeypatch):
+    """MTP refreshes NVLS routing metadata when EP=1 has no communication buffers."""
+    controller = object.__new__(TextGenerationController)
+    context = SimpleNamespace(
+        total_request_count=2,
+        paused_request_count=0,
+        mtp_decoder_hidden_states=None,
+        _uses_nvls_dispatcher=True,
+        _nvls_dispatcher=False,
+        inference_cuda_graph_scope=InferenceCudaGraphScope.none,
+    )
+    controller.inference_wrapped_model = SimpleNamespace(inference_context=context)
+    controller._unwrapped_model = SimpleNamespace()
+    controller._is_last_pp_stage = False
+    controller._sp_enabled = False
+    controller._mtp_resolved_padded_count = None
+    controller._sampled_tokens_cuda = torch.tensor([10, 11])
+    controller._sampled_mtp_tokens_cuda = torch.empty((1, 2), dtype=torch.int64)
+    controller._mtp_token_ids_buf = torch.empty((1, 2), dtype=torch.int64)
+    controller._mtp_position_ids_buf = torch.empty((1, 2), dtype=torch.int64)
+    controller.num_mtp_depths = 1
+    controller.model_is_pipeline_parallel = False
+    controller._sample_from_logits_2d = mock.Mock(return_value=torch.tensor([12, 13]))
+
+    mtp_mixin_module = "megatron.core.inference.text_generation_controllers.mtp_inference_mixin"
+    modify_count = mock.Mock()
+    monkeypatch.setattr(f"{mtp_mixin_module}.nvtx_range_push", lambda *_: None)
+    monkeypatch.setattr(f"{mtp_mixin_module}.nvtx_range_pop", lambda *_: None)
+    monkeypatch.setattr(
+        f"{mtp_mixin_module}.NVLSAllGatherVDispatcher.modify_real_token_count_for_mtp", modify_count
+    )
+
+    controller._compute_serial_mtp_and_sample(base_position=torch.tensor([5, 7]))
+
+    modify_count.assert_called_once_with(2)
+
+
 class TestTextGenerationController(TextGenerationControllerTestBase):
 
     @classmethod


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes six independently reproduced dynamic-inference correctness edge cases that remain on current `main`:

1. **NVLS with EP=1 treats CUDA-graph padding rows as valid tokens.**
   `DynamicInferenceContext._nvls_dispatcher` is false at EP=1, although the model still constructs `NVLSAllGatherVDispatcher`. Consequently, its GPU real-token-count tensor was never bound, and `token_dispatch()` reported the graph-padded local tensor height as valid. This change binds the scalar whenever NVLS is selected, masks routing padding, and converts the global count to an SP-local valid-row count.
2. **A continuation can rewrite an inherited shared KV block when it finds no new complete-block matches.**
   The write-redirection guard checked only `num_matched_blocks` from the current chunk. A short, unaligned continuation within a partial block inherited from an earlier prefix match has zero newly matched blocks, so its recomputed KV was written into the shared cached block. This change also checks `req.num_matched_prefix_blocks` before redirecting those writes to the dummy block.
3. **FlashInfer `top_k=1` is not reliably greedy when maximum logits tie.**
   FlashInfer's threshold-based top-k kernel retains equal logits at the cutoff and can sample among them, whereas `SamplingParams` and the Torch backend define `top_k=1` as first-`argmax`. This change uses `argmax` for all-greedy batches, repairs greedy rows in mixed batches, and returns the corresponding one-hot processed log-probability distribution. The common unfiltered path still returns before the greedy checks.
4. **RECOMPUTE resume leaves NVLS bound to a stale real-token-count tensor.**
   Reinitializing inference state creates a new `ContextGPUView`, but the class-level NVLS binding still referenced the tensor in the deallocated view. Subsequent bookkeeping updated the new tensor while routing read the stale count. This change binds NVLS after every GPU-view allocation and limits the binding to inference-optimized MoE models that actually construct the dispatcher.
5. **Torch processed log-probabilities disagree with `top_k=1` sampling on tied maxima.**
   Sampling uses deterministic first-`argmax`, but the generic top-k filter retained every value equal to the cutoff and reported `-log(tie_count)` for each tied maximum. This change emits the same one-hot log-probability distribution that the backend actually samples.
6. **EP=1 NVLS does not refresh the routing mask count for MTP forwards.**
   The MTP override was gated on the EP>1 communication-buffer predicate. At EP=1, MTP therefore reused the main forward's token count and could route request-shape padding rows as real tokens. This change gates the override on whether the model constructs an NVLS dispatcher, including EP=1.

Each issue has focused regression coverage. The original reproducers failed on untouched `main` at `06a1d8e6f`; the new RECOMPUTE lifecycle case awaits GPU CI.

## Upstream audit

Related candidates were excluded because current `main` already contains their fixes:

- no-op sampling-filter dispatch, CDF fallback, and finite processed log-probabilities: #6993 (`f76d34522`)
- Mamba no-intermediate-state aliasing: #6598 (`6e5a8c11f`)
- matched-KV write protection across continuation chunks: #6895 (`d0612089d`)
- attention block-table tail sanitation: #6481 (`487bb3948`)

## Validation

- Untouched `06a1d8e6f`: 6 failed and 1 passed across the new focused reproducers.
- Original branch head: all 7 focused regression cases passed.
- Follow-up `c1725d9d6` adds joint top-k/top-p greedy coverage; 7 CPU-safe sampling dispatch/greedy cases passed locally.
- Follow-up `2965d99ef` rebinds NVLS metadata after RECOMPUTE resume and adds lifecycle coverage. The lifecycle regression is GPU-only and awaits CI.
- Follow-up `fdd7419ac` makes Torch `top_k=1` processed log-probabilities match deterministic sampling.
- Follow-up `d0abc6502` refreshes the NVLS real-token count for EP=1 MTP forwards and prevents the lifecycle test from leaking class-level state.
- Latest focused CPU-safe set: 9 passed; 4 CUDA-only cases skipped locally.
- Broader affected test groups: 28 passed.
- Direct FlashInfer tie reproducer on GPU: 4,096 tied rows returned IDs `{1: 2087, 3: 2009}`; Torch first-`argmax` returned ID `1`.
- Official autoformatter: Black, isort, pylint (10/10), and Ruff passed; mypy was unavailable in the supplied locked lint environment.
- Rebasing onto current `main` (`5762bacc3`) required porting the MTP fix to the new `MTPInferenceMixin`; focused tests remained green.
- `git diff --check`: passed.

This remains a draft pending full GPU CI and reviewer validation.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge this PR.
