### PR TITLE
Fix MFSDP v2 precision-aware optimizer gradient clipping

### DIFF
--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -374,9 +374,9 @@ class MegatronOptimizer(ABC):
     def _uses_decoupled_grad(self, param_list) -> bool:
         """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
 
-        A wrong True here doesn't error: `clip_grad_by_total_norm_fp32`/`count_zeros_fp32`
-        silently skip any param whose `decoupled_grad` is unset, so it silently drops that
-        param from clipping/zero-counting instead.
+        Getting this wrong doesn't raise: `clip_grad_by_total_norm_fp32`/`count_zeros_fp32`
+        just skip params with no `decoupled_grad`, so a wrong True here quietly excludes
+        the param from clipping/zero-counting.
         """
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
             # MFSDP v2 always reduces directly into `.grad`.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -372,12 +372,7 @@ class MegatronOptimizer(ABC):
         return self.grad_norms_by_group
 
     def _uses_decoupled_grad(self, param_list) -> bool:
-        """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
-
-        Getting this wrong doesn't raise: `clip_grad_by_total_norm_fp32`/`count_zeros_fp32`
-        just skip params with no `decoupled_grad`, so a wrong True here quietly excludes
-        the param from clipping/zero-counting.
-        """
+        """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`."""
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
             # MFSDP v2 always reduces directly into `.grad`.
             return False

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -374,16 +374,9 @@ class MegatronOptimizer(ABC):
     def _uses_decoupled_grad(self, param_list) -> bool:
         """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
 
-        MFSDP v2 always reduces into `.grad`; `_mfsdp_parameter_group` (set in
-        `experimental/parameter_group.py`) marks v2-owned params, checked directly here the
-        same way `__fsdp_param__` below is duck-typed, without importing the experimental
-        module. Otherwise, `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is
-        `distrib_optimizer.py`'s precision-aware/non-FP8 flag, and `__fsdp_param__` marks a
-        v1 `MegatronFSDP` param.
-
-        `clip_grad_by_total_norm_fp32`/`count_zeros_fp32` silently skip any param with no
-        `decoupled_grad` rather than erroring, so a wrong True here silently drops that
-        param from clipping/zero-counting.
+        A wrong True here doesn't error: `clip_grad_by_total_norm_fp32`/`count_zeros_fp32`
+        silently skip any param whose `decoupled_grad` is unset, so it silently drops that
+        param from clipping/zero-counting instead.
         """
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
             # MFSDP v2 always reduces directly into `.grad`.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -374,26 +374,17 @@ class MegatronOptimizer(ABC):
     def _uses_decoupled_grad(self, param_list) -> bool:
         """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
 
-        Megatron-FSDP v2 (`megatron_fsdp/experimental/`) always reduces directly into
-        `.grad`, precision-aware optimizer or not -- see `FullyShardedOptimizer.get_grad_norm`.
-        `_mfsdp_parameter_group` is v2's own marker for "this param is in one of my
-        parameter groups" (set in `experimental/parameter_group.py`, read via
-        `get_containing_parameter_group`); checking it here directly, the same way
-        `__fsdp_param__` below is duck-typed rather than imported, answers "is this a v2
-        param" without a dependency on the experimental FSDP module, and leaves the
-        heuristic below untouched for everything else (v1 Megatron-FSDP, plain
-        DistributedOptimizer, no FSDP at all).
+        Megatron-FSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
+        `use_precision_aware_optimizer`. `_mfsdp_parameter_group` (set in
+        `experimental/parameter_group.py`) marks v2-owned params; checking it directly, like
+        `__fsdp_param__` below, avoids importing the experimental module.
 
-        `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is `distrib_optimizer.py`'s own
-        flag for whether *its* precision-aware path (no FP8 / no delayed-scaling FP8) uses
-        `param.grad` or `param.decoupled_grad`; it has no notion of Megatron-FSDP and is
-        `True` for any non-FP8 precision-aware run. The `__fsdp_param__` fallback is
-        v1-only: only v1's `MegatronFSDP` (`megatron_fsdp/fully_shard.py`) tags params
-        with it.
-
-        Left unchecked, `clip_grad_by_total_norm_fp32`/`count_zeros_fp32` silently skip
-        any param whose `decoupled_grad` is unset rather than raising, so wrongly
-        returning True here no-ops clipping/zero-counting instead of erroring.
+        The heuristic below predates v2 and misfires for it:
+        `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is a `distrib_optimizer.py` flag
+        with no FSDP awareness, and `__fsdp_param__` is v1-only (only v1's `MegatronFSDP`
+        sets it). Wrongly returning True here silently drops v2 params from
+        clipping/zero-counting instead of erroring (`clip_grad_by_total_norm_fp32`/
+        `count_zeros_fp32` skip params with no `decoupled_grad`).
         """
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
             # Megatron-FSDP v2 always reduces directly into `.grad`.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -374,17 +374,16 @@ class MegatronOptimizer(ABC):
     def _uses_decoupled_grad(self, param_list) -> bool:
         """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
 
-        MFSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
-        `use_precision_aware_optimizer`. `_mfsdp_parameter_group` (set in
-        `experimental/parameter_group.py`) marks v2-owned params; checking it directly, like
-        `__fsdp_param__` below, avoids importing the experimental module.
+        MFSDP v2 always reduces into `.grad`; `_mfsdp_parameter_group` (set in
+        `experimental/parameter_group.py`) marks v2-owned params, checked directly here the
+        same way `__fsdp_param__` below is duck-typed, without importing the experimental
+        module. Otherwise, `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is
+        `distrib_optimizer.py`'s precision-aware/non-FP8 flag, and `__fsdp_param__` marks a
+        v1 `MegatronFSDP` param.
 
-        The heuristic below predates v2 and misfires for it:
-        `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is a `distrib_optimizer.py` flag
-        with no FSDP awareness, and `__fsdp_param__` is v1-only (only v1's `MegatronFSDP`
-        sets it). Wrongly returning True here silently drops v2 params from
-        clipping/zero-counting instead of erroring (`clip_grad_by_total_norm_fp32`/
-        `count_zeros_fp32` skip params with no `decoupled_grad`).
+        `clip_grad_by_total_norm_fp32`/`count_zeros_fp32` silently skip any param with no
+        `decoupled_grad` rather than erroring, so a wrong True here silently drops that
+        param from clipping/zero-counting.
         """
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
             # MFSDP v2 always reduces directly into `.grad`.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -374,7 +374,7 @@ class MegatronOptimizer(ABC):
     def _uses_decoupled_grad(self, param_list) -> bool:
         """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
 
-        Megatron-FSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
+        MFSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
         `use_precision_aware_optimizer`. `_mfsdp_parameter_group` (set in
         `experimental/parameter_group.py`) marks v2-owned params; checking it directly, like
         `__fsdp_param__` below, avoids importing the experimental module.
@@ -387,14 +387,14 @@ class MegatronOptimizer(ABC):
         `count_zeros_fp32` skip params with no `decoupled_grad`).
         """
         if hasattr(param_list[0], "_mfsdp_parameter_group"):
-            # Megatron-FSDP v2 always reduces directly into `.grad`.
+            # MFSDP v2 always reduces directly into `.grad`.
             return False
         if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
             return True
         if self.config.use_precision_aware_optimizer and getattr(
             param_list[0], "__fsdp_param__", False
         ):
-            # Megatron-FSDP v1 always uses decoupled_grad with FusedAdam.
+            # MFSDP v1 always uses decoupled_grad with FusedAdam.
             return True
         return False
 

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -371,6 +371,42 @@ class MegatronOptimizer(ABC):
                 self.grad_norms_by_group[grad_norm_group] = group_grad_norm
         return self.grad_norms_by_group
 
+    def _uses_decoupled_grad(self, param_list) -> bool:
+        """Whether clip_grad_norm/count_zeros should read `.decoupled_grad` instead of `.grad`.
+
+        Megatron-FSDP v2 (`megatron_fsdp/experimental/`) always reduces directly into
+        `.grad`, precision-aware optimizer or not -- see `FullyShardedOptimizer.get_grad_norm`.
+        `_mfsdp_parameter_group` is v2's own marker for "this param is in one of my
+        parameter groups" (set in `experimental/parameter_group.py`, read via
+        `get_containing_parameter_group`); checking it here directly, the same way
+        `__fsdp_param__` below is duck-typed rather than imported, answers "is this a v2
+        param" without a dependency on the experimental FSDP module, and leaves the
+        heuristic below untouched for everything else (v1 Megatron-FSDP, plain
+        DistributedOptimizer, no FSDP at all).
+
+        `use_precision_aware_optimizer_no_fp8_or_ds_fp8` is `distrib_optimizer.py`'s own
+        flag for whether *its* precision-aware path (no FP8 / no delayed-scaling FP8) uses
+        `param.grad` or `param.decoupled_grad`; it has no notion of Megatron-FSDP and is
+        `True` for any non-FP8 precision-aware run. The `__fsdp_param__` fallback is
+        v1-only: only v1's `MegatronFSDP` (`megatron_fsdp/fully_shard.py`) tags params
+        with it.
+
+        Left unchecked, `clip_grad_by_total_norm_fp32`/`count_zeros_fp32` silently skip
+        any param whose `decoupled_grad` is unset rather than raising, so wrongly
+        returning True here no-ops clipping/zero-counting instead of erroring.
+        """
+        if hasattr(param_list[0], "_mfsdp_parameter_group"):
+            # Megatron-FSDP v2 always reduces directly into `.grad`.
+            return False
+        if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
+            return True
+        if self.config.use_precision_aware_optimizer and getattr(
+            param_list[0], "__fsdp_param__", False
+        ):
+            # Megatron-FSDP v1 always uses decoupled_grad with FusedAdam.
+            return True
+        return False
+
     def clip_grad_norm(self, clip_grad: float) -> float:
         """Compute and return grad norm, also clip grads.
 
@@ -385,13 +421,6 @@ class MegatronOptimizer(ABC):
             # Only reduce group grad norms when clipping can use them.
             self._compute_grad_norms_by_group()
 
-            def use_decoupled_grad(param_list):
-                return self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8 or (
-                    # Megatron-FSDP always uses decoupled_grad with FusedAdam.
-                    self.config.use_precision_aware_optimizer
-                    and getattr(param_list[0], "__fsdp_param__", False)
-                )
-
             main_params = []
             params_by_grad_norm_group = {}
             for p in params:
@@ -405,7 +434,7 @@ class MegatronOptimizer(ABC):
                     main_params,
                     clip_grad,
                     grad_norm,
-                    use_decoupled_grad=use_decoupled_grad(main_params),
+                    use_decoupled_grad=self._uses_decoupled_grad(main_params),
                 )
             for grad_norm_group, grouped_params in params_by_grad_norm_group.items():
                 group_grad_norm = self.grad_norms_by_group.get(grad_norm_group)
@@ -415,7 +444,7 @@ class MegatronOptimizer(ABC):
                     grouped_params,
                     clip_grad,
                     group_grad_norm,
-                    use_decoupled_grad=use_decoupled_grad(grouped_params),
+                    use_decoupled_grad=self._uses_decoupled_grad(grouped_params),
                 )
         return grad_norm
 
@@ -425,12 +454,7 @@ class MegatronOptimizer(ABC):
         return count_zeros_fp32(
             params,
             grad_stats_parallel_group=self.get_grad_stats_parallel_group(),
-            use_decoupled_grad=self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8
-            or (
-                # Megatron-FSDP always uses decoupled_grad with FusedAdam.
-                self.config.use_precision_aware_optimizer
-                and getattr(params[0], "__fsdp_param__", False)
-            ),
+            use_decoupled_grad=self._uses_decoupled_grad(params),
             tp_group=getattr(self, 'tp_group', None),
             expert_tp_group=getattr(self, 'expert_tp_group', None),
         )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -386,19 +386,16 @@ class TestMcoreAdapterDense:
         success, _, _ = optimizer.step()
         assert success
 
-    def test_gradient_clipping_reaches_global_norm(self):
-        """MFSDP v2 reports the true global gradient norm and clips the update to it.
+    @pytest.mark.parametrize("use_precision_aware_optimizer", [False, True])
+    def test_gradient_clipping_reaches_global_norm(self, use_precision_aware_optimizer):
+        """MFSDP v2 reports the true global gradient norm and clips the gradients to it.
 
-        Clipping is measured through the optimizer update rather than through
-        parameter.grad after the step. _copy_model_grads_to_main_grads installs a
-        dtype-cast copy of each gradient, clip_grad_norm scales that copy, and
-        step_with_ready_grads restores the original afterwards, so the post-step
-        gradient is unclipped by design. Plain SGD at lr=1.0 makes the weight delta
-        exactly the gradient the optimizer stepped with, which keeps this test on the
-        default FP32-main-weight / BF16-gradient configuration.
+        Main gradients are kept in the main-weight dtype so that clipping is measurable on
+        parameter.grad: _copy_model_grads_to_main_grads otherwise installs a dtype-cast copy
+        for non-precision-aware optimizers, clip_grad_norm scales that copy, and
+        step_with_ready_grads restores the original afterwards.
         """
         clip_grad = 1.0
-        learning_rate = 1.0
         config = TransformerConfig(
             num_layers=2,
             hidden_size=16,
@@ -416,19 +413,21 @@ class TestMcoreAdapterDense:
                 megatron_fsdp_version=2,
                 use_distributed_optimizer=False,
                 data_parallel_sharding_strategy="optim_grads_params",
+                megatron_fsdp_main_grads_dtype=torch.float32,
             ),
             module=_build_block(config),
             pg_collection=self.pg_collection,
         )
         optimizer = get_megatron_optimizer(
             OptimizerConfig(
-                optimizer="sgd",
-                lr=learning_rate,
+                optimizer="adam",
+                lr=1.0e-3,
                 weight_decay=0.0,
                 bf16=True,
                 params_dtype=torch.bfloat16,
                 use_distributed_optimizer=False,
                 clip_grad=clip_grad,
+                use_precision_aware_optimizer=use_precision_aware_optimizer,
             ),
             [model],
         )
@@ -457,97 +456,14 @@ class TestMcoreAdapterDense:
         ]
         assert all(isinstance(parameter.grad, DTensor) for parameter in parameters)
         expected_pre_clip_norm = global_norm([p.grad.to_local() for p in parameters])
-        weights_before = [p.data.to_local().float().clone() for p in parameters]
-
-        success, pre_clip_norm, _ = optimizer.step()
-        updates = [
-            before - parameter.data.to_local().float()
-            for parameter, before in zip(parameters, weights_before)
-        ]
-
-        assert success
-        torch.testing.assert_close(pre_clip_norm.item(), expected_pre_clip_norm)
         assert (
             expected_pre_clip_norm > clip_grad
         ), "Test gradients must exceed the clipping threshold to exercise clipping."
-        torch.testing.assert_close(global_norm(updates), clip_grad, rtol=1e-3, atol=0)
 
-    def test_gradient_clipping_reaches_global_norm_with_precision_aware_optimizer(self):
-        """clip_grad_norm still clips MFSDP v2 gradients under a precision-aware optimizer.
+        success, pre_clip_norm, _ = optimizer.step()
 
-        MFSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
-        `use_precision_aware_optimizer`. `_uses_decoupled_grad` has to know that: getting it
-        wrong makes `clip_grad_by_total_norm_fp32` skip every v2 parameter (it treats a
-        param with no `decoupled_grad` as nothing to clip rather than raising), so clipping
-        silently becomes a no-op instead of erroring.
-        """
-        clip_grad = 1.0
-        config = TransformerConfig(
-            num_layers=2,
-            hidden_size=16,
-            num_attention_heads=4,
-            ffn_hidden_size=32,
-            bf16=True,
-            params_dtype=torch.bfloat16,
-            attention_dropout=0.0,
-            hidden_dropout=0.0,
-        )
-        model = FullyShardedDataParallel(
-            config=config,
-            ddp_config=DistributedDataParallelConfig(
-                use_megatron_fsdp=True,
-                megatron_fsdp_version=2,
-                use_distributed_optimizer=False,
-                data_parallel_sharding_strategy="optim_grads_params",
-            ),
-            module=_build_block(config),
-            pg_collection=self.pg_collection,
-        )
-        optimizer = get_megatron_optimizer(
-            OptimizerConfig(
-                optimizer="adam",
-                lr=1.0e-3,
-                weight_decay=0.0,
-                bf16=True,
-                params_dtype=torch.bfloat16,
-                use_distributed_optimizer=False,
-                clip_grad=clip_grad,
-                use_precision_aware_optimizer=True,
-            ),
-            [model],
-        )
-
-        def global_norm(local_tensors) -> float:
-            squared_norm = torch.zeros(1, dtype=torch.float32, device="cuda")
-            for local_tensor in local_tensors:
-                squared_norm += local_tensor.float().square().sum()
-            torch.distributed.all_reduce(squared_norm)
-            return squared_norm.sqrt().item()
-
-        optimizer.zero_grad(set_to_none=True)
-        output = model(
-            hidden_states=(
-                torch.arange(1, config.hidden_size + 1, device="cuda", dtype=torch.bfloat16)
-                .view(1, 1, -1)
-                .expand(8, 2, -1)
-                * (torch.distributed.get_rank() + 1)
-            ),
-            attention_mask=None,
-        )
-        output.float().square().sum().backward()
-
-        parameters = [
-            parameter for parameter in optimizer.get_parameters() if parameter.grad is not None
-        ]
-        pre_clip_norm = global_norm([p.grad.to_local() for p in parameters])
-        assert (
-            pre_clip_norm > clip_grad
-        ), "Test gradients must exceed the clipping threshold to exercise clipping."
-
-        optimizer.prepare_grads()
-        clip_grad_norm = optimizer.clip_grad_norm(clip_grad)
-
-        torch.testing.assert_close(clip_grad_norm.item(), pre_clip_norm)
+        assert success
+        torch.testing.assert_close(pre_clip_norm.item(), expected_pre_clip_norm)
         torch.testing.assert_close(
             global_norm([p.grad.to_local() for p in parameters]), clip_grad, rtol=1e-3, atol=0
         )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -472,6 +472,86 @@ class TestMcoreAdapterDense:
         ), "Test gradients must exceed the clipping threshold to exercise clipping."
         torch.testing.assert_close(global_norm(updates), clip_grad, rtol=1e-3, atol=0)
 
+    def test_gradient_clipping_reaches_global_norm_with_precision_aware_optimizer(self):
+        """clip_grad_norm still clips MFSDP v2 gradients under a precision-aware optimizer.
+
+        MFSDP v2 always reduces into `.grad`, never `.decoupled_grad`, regardless of
+        `use_precision_aware_optimizer`. `_uses_decoupled_grad` has to know that: getting it
+        wrong makes `clip_grad_by_total_norm_fp32` skip every v2 parameter (it treats a
+        param with no `decoupled_grad` as nothing to clip rather than raising), so clipping
+        silently becomes a no-op instead of erroring.
+        """
+        clip_grad = 1.0
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+            ),
+            module=_build_block(config),
+            pg_collection=self.pg_collection,
+        )
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(
+                optimizer="adam",
+                lr=1.0e-3,
+                weight_decay=0.0,
+                bf16=True,
+                params_dtype=torch.bfloat16,
+                use_distributed_optimizer=False,
+                clip_grad=clip_grad,
+                use_precision_aware_optimizer=True,
+            ),
+            [model],
+        )
+
+        def global_norm(local_tensors) -> float:
+            squared_norm = torch.zeros(1, dtype=torch.float32, device="cuda")
+            for local_tensor in local_tensors:
+                squared_norm += local_tensor.float().square().sum()
+            torch.distributed.all_reduce(squared_norm)
+            return squared_norm.sqrt().item()
+
+        optimizer.zero_grad(set_to_none=True)
+        output = model(
+            hidden_states=(
+                torch.arange(1, config.hidden_size + 1, device="cuda", dtype=torch.bfloat16)
+                .view(1, 1, -1)
+                .expand(8, 2, -1)
+                * (torch.distributed.get_rank() + 1)
+            ),
+            attention_mask=None,
+        )
+        output.float().square().sum().backward()
+
+        parameters = [
+            parameter for parameter in optimizer.get_parameters() if parameter.grad is not None
+        ]
+        pre_clip_norm = global_norm([p.grad.to_local() for p in parameters])
+        assert (
+            pre_clip_norm > clip_grad
+        ), "Test gradients must exceed the clipping threshold to exercise clipping."
+
+        optimizer.prepare_grads()
+        clip_grad_norm = optimizer.clip_grad_norm(clip_grad)
+
+        torch.testing.assert_close(clip_grad_norm.item(), pre_clip_norm)
+        torch.testing.assert_close(
+            global_norm([p.grad.to_local() for p in parameters]), clip_grad, rtol=1e-3, atol=0
+        )
+
 
 class TestMcoreAdapterExpertParallel:
     """Exercise the MFSDP v2 adapter over an MoE model with EP=2."""

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -695,6 +695,7 @@ def test_mtp_grad_clipping_uses_separate_norms():
         get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
         has_grad_norm_group = MegatronOptimizer.has_grad_norm_group
         _compute_grad_norms_by_group = MegatronOptimizer._compute_grad_norms_by_group
+        _uses_decoupled_grad = MegatronOptimizer._uses_decoupled_grad
         clip_grad_norm = MegatronOptimizer.clip_grad_norm
 
         def __init__(self, params):


### PR DESCRIPTION
## Problem

MFSDP v2 never reads or writes `decoupled_grad`; it always reduces into `.grad`. But
`clip_grad_norm`/`count_zeros` decide otherwise: their `use_decoupled_grad` calculation
returns True for any precision-aware optimizer, with no notion of which Megatron-FSDP
version (if any) owns the parameter.

## Fix

Return False for parameters MFSDP v2 owns, detected via the `_mfsdp_parameter_group`
attribute it sets on them.

## Test plan

- [x] `test_gradient_clipping_reaches_global_norm` is now parameterized over
      `use_precision_aware_optimizer`. The precision-aware case fails without this fix,
      leaving gradients at their unclipped norm (213.6 against a `clip_grad` of 1.0).
- [x] Verified on 8xH100 with a DeepSeek-V3 MLA/MoE proxy at EP=2: before the fix,
      `use_precision_aware_optimizer=True` with `clip_grad=1.0` gave a loss curve
      bit-identical to `clip_grad=0.0`; after, it matches the `clip_grad=1.0` baseline.
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)