### PR TITLE
perf: remove 104 host synchronizations per training iteration

### DIFF
--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -226,7 +226,7 @@ def count_zeros_fp32(
     use_decoupled_grad: bool = False,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     expert_tp_group: Optional[torch.distributed.ProcessGroup] = None,
-) -> float:
+) -> torch.Tensor:
     """Counts the number of zero values in the gradients of the given parameters.
 
     The count is performed in FP32. This method filters parameters to ensure
@@ -245,7 +245,9 @@ def count_zeros_fp32(
             Defaults to False.
 
     Returns:
-        float: The total number of zeros in the gradients across the process group.
+        torch.Tensor: Device-resident count of zeros in the gradients across the
+            process group. Left on device so the host read can be deferred to the
+            log point; only logging consumes it.
     """
 
     if isinstance(parameters, torch.Tensor):
@@ -300,7 +302,5 @@ def count_zeros_fp32(
     torch.distributed.all_reduce(
         total_num_zeros, op=torch.distributed.ReduceOp.SUM, group=grad_stats_parallel_group
     )
-
-    total_num_zeros = total_num_zeros.item()
 
     return total_num_zeros

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -419,8 +419,8 @@ class MegatronOptimizer(ABC):
                 )
         return grad_norm
 
-    def count_zeros(self) -> float:
-        """Count number of zeros in model's gradients."""
+    def count_zeros(self) -> torch.Tensor:
+        """Count number of zeros in model's gradients, left on device for logging."""
         params = self.get_parameters()
         return count_zeros_fp32(
             params,

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1533,7 +1533,7 @@ class ChainedOptimizer(MegatronOptimizer):
         if self.chained_optimizers:
             return self.chained_optimizers[0].get_loss_scale()
         else:
-            return torch.tensor([1.0], dtype=torch.float32, device=torch.cuda.current_device())
+            return torch.ones(1, dtype=torch.float32, device=torch.cuda.current_device())
 
     def _split_state_dict(self, state_dict):
         """Split the state dict into sub-state dicts according to the chunks of each sub-optimizer

--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -238,7 +238,91 @@ class RerunStateMachine:
 
         self.saved_results: dict[Call, Any] = {}
         self.stats: dict[Caller, QuickStats] = defaultdict(lambda: QuickStats())
+
+        # Bank validate_result() verdicts on device; merge them into the all-reduce
+        # should_run_forward_backward() already performs at the loop exit.
+        self._defer_capacity: int = 0
+        self._deferred_flags: Optional[torch.Tensor] = None
+        self._deferred_calls: List[Tuple[Call, Any, str]] = []
+        self._deferred_streams: Set[Any] = set()
+        self._defer_overflow_warned: bool = False
+
         log_single_rank(logger, logging.WARNING, f"RerunStateMachine initialized in mode {mode}")
+
+    def _record_initial_rejection(self, validation_call: Call, result: Any, message: str) -> None:
+        """Record the rejection that drives the rerun."""
+        self.failed_validation_call = validation_call
+        self.initial_result = result
+        self.rerun_requested = True
+        self._log_validation_error_to_file(
+            status=RerunValidationStatus.INITIAL_RUN, result=result, message=message
+        )
+        logger.error(
+            f"Unexpected result {result} "
+            f"on rank {safe_get_rank()} "
+            f"at iteration #{self.current_iteration + 1} "
+            f"invocation #{validation_call.sequence} "
+            f"(message='{message}')"
+        )
+
+    def _reset_deferred_validations(self) -> None:
+        """Drop the previous iteration's verdicts and size the flag vector.
+
+        Call only where nothing is in flight, so the realloc cannot race a pending write.
+        """
+        needed: int = max(4096, 2 * len(self._deferred_calls))
+        if self._deferred_flags is None or self._defer_capacity < needed:
+            self._defer_capacity = needed
+            self._deferred_flags = torch.zeros(
+                (needed,), dtype=torch.int8, device=torch.cuda.current_device()
+            )
+        self._deferred_calls = []
+        self._deferred_streams = set()
+
+    def _defer_validation(
+        self, validation_call: Call, result: Any, message: str, rejected: torch.Tensor
+    ) -> bool:
+        """Bank one verdict on device. Return False if it must be validated synchronously."""
+        index: int = len(self._deferred_calls)
+        if self._deferred_flags is None or index >= self._defer_capacity:
+            # Fall back rather than realloc mid-iteration; resize at the next reset.
+            if not self._defer_overflow_warned:
+                self._defer_overflow_warned = True
+                log_single_rank(
+                    logger,
+                    logging.WARNING,
+                    f"deferred validation buffer ({self._defer_capacity}) exceeded; "
+                    "validating synchronously for the remainder",
+                )
+            return False
+        self._deferred_calls.append((validation_call, result, message))
+        self._deferred_flags[index] = rejected.reshape(()).to(torch.int8)
+        self._deferred_streams.add(torch.cuda.current_stream())
+        return True
+
+    def _deferred_rejection_flag(self) -> Optional[torch.Tensor]:
+        """Return the device-side OR of this iteration's verdicts, or None if empty."""
+        if not self._deferred_calls:
+            return None
+        collector = torch.cuda.current_stream()
+        for stream in self._deferred_streams:
+            if stream != collector:
+                # Order the read after the producing stream's writes. check_grads()
+                # runs on autograd's backward streams, not this one.
+                collector.wait_stream(stream)
+        return self._deferred_flags[: len(self._deferred_calls)].any()
+
+    def _identify_deferred_rejection(self) -> None:
+        """Attribute a rejection to its call. Reached only when the reduction came back set."""
+        if not self._deferred_calls:
+            return
+        flags = self._deferred_flags[: len(self._deferred_calls)].tolist()
+        for index, flag in enumerate(flags):
+            if flag:
+                # Act on the first rejection only, matching the synchronous path's
+                # `and not self.rerun_requested` short-circuit.
+                self._record_initial_rejection(*self._deferred_calls[index])
+                break
 
     def set_mode(self, mode: RerunMode) -> None:
         """Method to set the operating mode"""
@@ -264,6 +348,14 @@ class RerunStateMachine:
             val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device='cuda')
             torch.distributed.all_reduce(val_tensor)
             return tuple([x > 0 for x in val_tensor.tolist()])
+        elif torch.is_tensor(value):
+            # Skip the blocking pageable copy torch.tensor([...], device='cuda') would do.
+            # Keep int32: the all-reduce below sums across ranks and is tested > 0, so a
+            # narrower dtype would wrap past 127 ranks. copy=True so the in-place
+            # all-reduce never lands in the caller's buffer.
+            val_tensor = value.reshape(1).to(torch.int32, copy=True)
+            torch.distributed.all_reduce(val_tensor)
+            return val_tensor.item() > 0
         else:
             val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device='cuda')
             torch.distributed.all_reduce(val_tensor)
@@ -318,6 +410,7 @@ class RerunStateMachine:
             self.restart_again_requested = False
             self.continue_requested = False
             self.injected_result = None
+            self._reset_deferred_validations()
             self.current_iteration += 1
             self.state = RerunState.INITIAL_RUN
             return True
@@ -326,7 +419,22 @@ class RerunStateMachine:
             if self.mode == RerunMode.DISABLED:
                 self.state = RerunState.NOT_RUNNING_YET
                 return False
-            will_rerun = self._reduce_any(self.rerun_requested)
+            # Merge this iteration's banked verdicts into the all-reduce already here.
+            # Still before optimizer.step(), so a NaN is caught before the step consumes it.
+            # Reduce a scalar, never the flag vector: ranks bank different numbers of
+            # verdicts, and a rank that banked none takes the bool branch below. Both
+            # paths must reduce (1,) int32 over the world group for the collective to
+            # match across ranks.
+            deferred_any = self._deferred_rejection_flag()
+            if deferred_any is not None:
+                if self.rerun_requested:
+                    deferred_any.fill_(1)
+                will_rerun = self._reduce_any(deferred_any)
+            else:
+                will_rerun = self._reduce_any(self.rerun_requested)
+            if will_rerun:
+                self._identify_deferred_rejection()
+            self._reset_deferred_validations()
             if not will_rerun:
                 self.state = RerunState.NOT_RUNNING_YET
                 return False
@@ -594,21 +702,19 @@ class RerunStateMachine:
             if not self.first_iteration_complete:
                 return
 
-            result_rejected = self.error_injector.maybe_inject() or rejection_func(result)
-            if result_rejected:
-                self.failed_validation_call = validation_call
-                self.initial_result = result
-                self.rerun_requested = True
-                self._log_validation_error_to_file(
-                    status=RerunValidationStatus.INITIAL_RUN, result=result, message=message
-                )
-                logger.error(
-                    f"Unexpected result {result} "
-                    f"on rank {safe_get_rank()} "
-                    f"at iteration #{self.current_iteration + 1} "
-                    f"invocation #{validation_call.sequence} "
-                    f"(message='{message}')"
-                )
+            injected = self.error_injector.maybe_inject()
+            rejected = rejection_func(result)
+            # Bank a device verdict instead of reading it; nothing consumes it until
+            # the loop exit merges it into the all-reduce there.
+            if (
+                not injected
+                and torch.is_tensor(rejected)
+                and rejected.is_cuda
+                and self._defer_validation(validation_call, result, message, rejected)
+            ):
+                return
+            if bool(injected) or bool(rejected):
+                self._record_initial_rejection(validation_call, result, message)
         # If this the first rerun (same GPU) or second 2nd rerun (different GPU), and have we
         # reached the validation call that failed during the initial run?
         elif (

--- a/megatron/core/timers.py
+++ b/megatron/core/timers.py
@@ -3,9 +3,9 @@
 """Megatron timers."""
 
 import logging
-import time
 from abc import ABC, abstractmethod
-from typing import List
+from collections import deque
+from typing import Deque, List
 
 import torch
 
@@ -110,6 +110,17 @@ class Timer(TimerBase):
     """
     Timer class with ability to start/stop.
 
+    Timing is taken from CUDA events, not the host clock, so start() and stop()
+    do not synchronize. An interval is resolved only once its events have
+    completed, which means a measurement is reported a few calls after the
+    interval it describes. Reporting is lagged but lossless: every interval is
+    reported exactly once, in order, so an aggregate over many iterations is
+    exact.
+
+    The alternative -- host clock plus torch.cuda.synchronize() -- fences the
+    whole training loop on every call, which both costs the sync and hides any
+    other host stall behind it.
+
     Comment on using `barrier`: If this flag is passed, then all
     the caller processes will wait till all reach the timing routine.
     It is up to the user to make sure all the ranks in `barrier_group`
@@ -118,6 +129,11 @@ class Timer(TimerBase):
     in torch distributed land, it will result in the global communicator.
     """
 
+    # Cap on unresolved windows. The CUDA launch queue bounds how far the host
+    # can run ahead in practice; this only stops events accumulating without
+    # limit if the device stalls, and costs one wait when hit.
+    _MAX_PENDING = 1024
+
     def __init__(self, name):
         """Initialize Timer.
 
@@ -125,12 +141,21 @@ class Timer(TimerBase):
             name (str): Name of the timer.
         """
         super().__init__(name)
-        self._elapsed = 0.0
         self._active_time = 0.0
         self._started = False
         # Note that None will default to the global process group
         self._barrier_group = None
-        self._start_time = time.time()
+        self._start_event = None
+        # Current window: intervals whose events have not completed yet, the
+        # seconds already resolved out of it, and how many intervals it holds.
+        self._open_window: Deque = deque()
+        self._open_resolved = 0.0
+        self._open_count = 0
+        # Windows closed by elapsed(), as (pending, resolved_seconds, count).
+        self._closed_windows: Deque = deque()
+        # Resolved window durations in seconds, oldest first, not yet reported.
+        self._ready: Deque = deque()
+        self._last_reported = 0.0
 
     def set_barrier_group(self, barrier_group):
         """Sets barrier group.
@@ -149,8 +174,8 @@ class Timer(TimerBase):
         assert not self._started, 'timer has already been started'
         if barrier:
             torch.distributed.barrier(group=self._barrier_group)
-        torch.cuda.synchronize()
-        self._start_time = time.time()
+        self._start_event = torch.cuda.Event(enable_timing=True)
+        self._start_event.record()
         self._started = True
 
     def stop(self, barrier=False):
@@ -162,16 +187,60 @@ class Timer(TimerBase):
         assert self._started, 'timer is not started'
         if barrier:
             torch.distributed.barrier(group=self._barrier_group)
-        torch.cuda.synchronize()
-        elapsed = time.time() - self._start_time
-        self._elapsed += elapsed
-        self._active_time += elapsed
+        stop_event = torch.cuda.Event(enable_timing=True)
+        stop_event.record()
+        self._open_window.append((self._start_event, stop_event))
+        self._open_count += 1
+        self._start_event = None
         self._started = False
+        # Fold away whatever has completed, so a window spanning many intervals
+        # holds only the events still in flight.
+        self._drain_open()
+
+    def _drain_open(self):
+        """Resolve completed intervals of the current window into a partial sum."""
+        while self._open_window and self._open_window[0][1].query():
+            start_event, stop_event = self._open_window.popleft()
+            # elapsed_time is milliseconds; this class reports seconds.
+            self._open_resolved += start_event.elapsed_time(stop_event) / 1000.0
+
+    def _resolve(self, block=False):
+        """Move every completed window from the pending queue to the ready queue.
+
+        Events complete in stream order, so the last event of a window standing
+        in for the whole window is sufficient.
+
+        Args:
+            block (bool): Wait for the first window rather than returning empty.
+                Used only for the very first report, which has no earlier value
+                to stand in for it.
+        """
+        while self._closed_windows:
+            pending, resolved, count = self._closed_windows[0]
+            if pending and not pending[-1][1].query():
+                if not block and len(self._closed_windows) <= self._MAX_PENDING:
+                    break
+                # Either the first report, or backlogged and holding too many
+                # events. Wait rather than report nothing / accumulate forever.
+                pending[-1][1].synchronize()
+            self._closed_windows.popleft()
+            if count == 0:
+                # Nothing was timed in this window. Reporting 0.0 for it would
+                # blow up the throughput the caller divides out of it.
+                continue
+            total = resolved + sum(s.elapsed_time(e) for s, e in pending) / 1000.0
+            self._ready.append(total)
+            self._active_time += total
+            block = False  # got one; go back to never waiting
 
     def reset(self):
-        """Reset timer."""
+        """Reset timer, discarding intervals not yet reported."""
         # Don't reset _active_time
-        self._elapsed = 0.0
+        self._open_window.clear()
+        self._open_resolved = 0.0
+        self._open_count = 0
+        self._closed_windows.clear()
+        self._ready.clear()
         self._started = False
 
     def set_elapsed(self, value):
@@ -183,31 +252,48 @@ class Timer(TimerBase):
         Args:
             value (float): The elapsed time value in seconds.
         """
-        self._elapsed = value
+        self._ready.append(value)
+        self._last_reported = value
 
     def elapsed(self, reset=True, barrier=False):
         """Calculates the elapsed time and restarts timer.
 
+        Reports the oldest interval whose events have completed, so the value
+        describes a slightly earlier window than the one just closed. Until the
+        first window resolves, reports the last value seen -- never 0.0, which
+        callers divide by to get throughput.
+
         Args:
-            reset (bool, optional): Resets timer before restarting. Defaults to True.
+            reset (bool, optional): Consume the reported value, so the next call
+                returns the following interval. When False, peek without
+                consuming. Defaults to True.
             barrier (bool, optional): Synchronizes ranks before stopping. Defaults to False.
 
         Returns:
-            float: Elapsed time.
+            float: Elapsed time in seconds.
         """
         _started = self._started
         # If the timing in progress, end it first.
         if self._started:
             self.stop(barrier=barrier)
-        # Get the elapsed time.
-        _elapsed = self._elapsed
-        # Reset the elapsed time
-        if reset:
-            self.reset()
-        # If timing was in progress, set it back.
+        # Everything recorded since the last call belongs to the window we close
+        # here. Restart immediately so the caller's remaining work lands in the
+        # next window rather than in a gap between windows.
+        self._drain_open()
+        self._closed_windows.append(
+            (self._open_window, self._open_resolved, self._open_count)
+        )
+        self._open_window = deque()
+        self._open_resolved = 0.0
+        self._open_count = 0
         if _started:
             self.start(barrier=barrier)
-        return _elapsed
+        # The first report has nothing to fall back on and the caller divides by
+        # it, so pay one wait for it. Once per run.
+        self._resolve(block=self._last_reported == 0.0)
+        if self._ready:
+            self._last_reported = self._ready.popleft() if reset else self._ready[0]
+        return self._last_reported
 
     def active_time(self):
         """Calculates the cumulative duration for which the timer has been active"""

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3295,10 +3295,13 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     update_successful = logical_and_across_model_parallel_group(update_successful, group=mp_group)
     # grad_norm and num_zeros_in_grad will be None on ranks without trainable params,
     # so we must gather across mp ranks
-    grad_norm = reduce_max_stat_across_model_parallel_group(grad_norm, group=mp_group)
+    # Logging-only: leave them on device, training_log reads the whole bundle once.
+    grad_norm = reduce_max_stat_across_model_parallel_group(
+        grad_norm, group=mp_group, return_tensor=True
+    )
     if args.log_num_zeros_in_grad:
         num_zeros_in_grad = reduce_max_stat_across_model_parallel_group(
-            num_zeros_in_grad, group=mp_group
+            num_zeros_in_grad, group=mp_group, return_tensor=True
         )
 
     # Vision momentum.
@@ -3494,22 +3497,25 @@ def training_log(
 
     # learning rate will be None on ranks without trainable params, so we must gather across mp ranks
     _lr_mp_group = pg_collection.mp if pg_collection is not None else None
-    learning_rate: float | None = reduce_max_stat_across_model_parallel_group(
-        learning_rate, group=_lr_mp_group
+    learning_rate = reduce_max_stat_across_model_parallel_group(
+        learning_rate, group=_lr_mp_group, return_tensor=True
     )
-    if learning_rate is None and args.freeze_all_layers:
-        learning_rate = 0.0
     # Tensorboard values.
     if writer and (iteration % args.tensorboard_log_interval == 0):
         # Runs before the log block below, so it pays for the read; still one copy.
         # Only reached when a writer is configured.
-        loss_scale, params_norm, grad_norm, num_zeros_in_grad = _read_logging_stats(
-            [loss_scale, params_norm, grad_norm, num_zeros_in_grad]
+        loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate = (
+            _read_logging_stats(
+                [loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate]
+            )
         )
         # calc_params_l2_norm returned the SQUARED norm; root it here.
         params_norm = None if params_norm is None else params_norm**0.5
         grad_norm = _none_if_absent(grad_norm)
         num_zeros_in_grad = _none_if_absent(num_zeros_in_grad)
+        learning_rate = _none_if_absent(learning_rate)
+        if learning_rate is None and args.freeze_all_layers:
+            learning_rate = 0.0
         if wandb_writer:
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
@@ -3692,9 +3698,9 @@ def training_log(
             for key in total_loss_dict
             if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]
         ]
-        loss_scale, params_norm, grad_norm, num_zeros_in_grad, *loss_totals = (
+        loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate, *loss_totals = (
             _read_logging_stats(
-                [loss_scale, params_norm, grad_norm, num_zeros_in_grad]
+                [loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate]
                 + [total_loss_dict[key] for key in loss_keys]
             )
         )
@@ -3703,6 +3709,9 @@ def training_log(
         params_norm = None if params_norm is None else params_norm**0.5
         grad_norm = _none_if_absent(grad_norm)
         num_zeros_in_grad = _none_if_absent(num_zeros_in_grad)
+        learning_rate = _none_if_absent(learning_rate)
+        if learning_rate is None and args.freeze_all_layers:
+            learning_rate = 0.0
 
         throughput = num_floating_point_operations(
             args,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3357,6 +3357,36 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
 
 
+def _read_logging_stats(stats):
+    """Read every deferred logging stat to the host in one device-to-host copy.
+
+    Each stat is a device tensor or an already-host value; host values pass
+    through untouched, so this is idempotent. Batching matters: one `.item()` per
+    stat is one cudaStreamSynchronize per stat, and the whole point of deferring
+    them is to pay for the log line once.
+
+    Args:
+        stats: Sequence of 1-element device tensors and/or host values.
+
+    Returns:
+        list: The same sequence with every tensor replaced by a Python float.
+    """
+    out = list(stats)
+    slots = [i for i, stat in enumerate(out) if torch.is_tensor(stat)]
+    if not slots:
+        return out
+    # fp64 so a float32 stat reads back the exact value .item() would have given.
+    packed = torch.cat([out[i].detach().reshape(1).double() for i in slots]).tolist()
+    for slot, value in zip(slots, packed):
+        out[slot] = value
+    return out
+
+
+def _none_if_absent(stat):
+    """Decode reduce_max_stat's -1.0 'no rank had this stat' sentinel back to None."""
+    return None if stat == -1.0 else stat
+
+
 def training_log(
     loss_dict,
     total_loss_dict,
@@ -3402,7 +3432,7 @@ def training_log(
     for key in loss_dict:
         if not skipped_iter:
             total_loss_dict[key] = (
-                total_loss_dict.get(key, torch.tensor([0.0], dtype=torch.float, device='cuda'))
+                total_loss_dict.get(key, torch.zeros(1, dtype=torch.float, device='cuda'))
                 + loss_dict[key]
             )
         else:
@@ -3471,6 +3501,15 @@ def training_log(
         learning_rate = 0.0
     # Tensorboard values.
     if writer and (iteration % args.tensorboard_log_interval == 0):
+        # Runs before the log block below, so it pays for the read; still one copy.
+        # Only reached when a writer is configured.
+        loss_scale, params_norm, grad_norm, num_zeros_in_grad = _read_logging_stats(
+            [loss_scale, params_norm, grad_norm, num_zeros_in_grad]
+        )
+        # calc_params_l2_norm returned the SQUARED norm; root it here.
+        params_norm = None if params_norm is None else params_norm**0.5
+        grad_norm = _none_if_absent(grad_norm)
+        num_zeros_in_grad = _none_if_absent(num_zeros_in_grad)
         if wandb_writer:
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
@@ -3645,6 +3684,26 @@ def training_log(
         elapsed_time_per_iteration = elapsed_time / total_iterations
         llm_world_size = getattr(args, 'mimo_llm_world_size', args.world_size)
 
+        # The one host read of the iteration: every logged stat, including the loss
+        # averages below, in a single copy. Idempotent -- the tensorboard block
+        # above may have already resolved them.
+        loss_keys = [
+            key
+            for key in total_loss_dict
+            if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]
+        ]
+        loss_scale, params_norm, grad_norm, num_zeros_in_grad, *loss_totals = (
+            _read_logging_stats(
+                [loss_scale, params_norm, grad_norm, num_zeros_in_grad]
+                + [total_loss_dict[key] for key in loss_keys]
+            )
+        )
+        loss_totals = dict(zip(loss_keys, loss_totals))
+        # calc_params_l2_norm returned the SQUARED norm; root it here.
+        params_norm = None if params_norm is None else params_norm**0.5
+        grad_norm = _none_if_absent(grad_norm)
+        num_zeros_in_grad = _none_if_absent(num_zeros_in_grad)
+
         throughput = num_floating_point_operations(
             args,
             batch_size,
@@ -3701,29 +3760,24 @@ def training_log(
         # point sees 0.0 loss and 0 skipped iterations on EVERY export, which is exactly
         # what the metrics emission (further below, where the other emission inputs like
         # `throughput` are in scope) used to do. Take the values here and emit them there.
-        # The .item() is a device sync, so it stays inside the telemetry guard and is not
-        # paid at all when telemetry is off -- the same guard the emission itself uses.
+        # Reads loss_totals, already resolved by the batched host read above, so the
+        # telemetry path no longer costs a device sync of its own.
         _otel_telemetry_log = get_telemetry()
         _otel_loss_snapshot = None
         _otel_skipped_iters_snapshot = 0
         if _otel_telemetry_log is not None and _otel_telemetry_log.is_exporting:
-            _meta_keys = (advanced_iters_key, skipped_iters_key, nan_iters_key)
-            _loss_keys = [k for k in total_loss_dict if k not in _meta_keys]
-            if _loss_keys:
-                _otel_loss_snapshot = total_loss_dict[_loss_keys[0]].item() / float(
+            if loss_keys:
+                _otel_loss_snapshot = loss_totals[loss_keys[0]] / float(
                     max(1, total_loss_dict.get(advanced_iters_key, 1))
                 )
             _otel_skipped_iters_snapshot = int(total_loss_dict.get(skipped_iters_key, 0))
 
-        for key in total_loss_dict:
-            if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]:
-                avg = total_loss_dict[key].item() / float(
-                    max(1, total_loss_dict[advanced_iters_key])
-                )
-                if avg >= 0.0:
-                    log_string += ' {}: {:.6E} |'.format(key, avg)
-                if should_reset:
-                    total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device='cuda')
+        for key in loss_keys:
+            avg = loss_totals[key] / float(max(1, total_loss_dict[advanced_iters_key]))
+            if avg >= 0.0:
+                log_string += ' {}: {:.6E} |'.format(key, avg)
+            if should_reset:
+                total_loss_dict[key] = torch.zeros(1, dtype=torch.float, device='cuda')
         if args.num_experts is not None and moe_log_string:
             log_string += moe_log_string
         log_string += f' loss scale: {loss_scale:.1f} |'
@@ -4966,9 +5020,8 @@ def train(
 
             # Logging.
             if optimizer is not None and not optimizer.is_stub_optimizer:
-                # First .item() after the train_step: a device sync draining the
-                # iteration's pending GPU queue (captured under iteration_report).
-                loss_scale = optimizer.get_loss_scale().item()
+                # A device tensor by contract; training_log reads it past its fence.
+                loss_scale = optimizer.get_loss_scale()
             else:
                 loss_scale = 1.0
             params_norm = None
@@ -4979,7 +5032,12 @@ def train(
                 # (~1.5s cold on the first iteration, ~10ms steady). Kept as a real
                 # cost span (it stalls the critical path), unlike passive monitors.
                 with _otel_managed_span('step', 'megatron.train.params_norm', is_goodput_span=True):
-                    params_norm = calc_params_l2_norm(model, pg_collection=pg_collection)
+                    # return_squared_tensor keeps it on device; training_log takes the
+                    # square root on the host after the batched read, which is exactly
+                    # what norm_2.item() ** 0.5 did.
+                    params_norm = calc_params_l2_norm(
+                        model, pg_collection=pg_collection, return_squared_tensor=True
+                    )
             if optimizer is not None:
                 learning_rate = get_canonical_lr_for_logging(optimizer.param_groups)
             else:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3686,7 +3686,10 @@ def training_log(
             snapshot_filename = f"{base}_{rank}{ext}"
             torch.cuda.memory._dump_snapshot(snapshot_filename)
 
-        elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)
+        # No barrier: the timer measures on device now, and each rank's own
+        # timeline already includes waiting inside the collectives. A barrier
+        # here would fence the whole loop every iteration for nothing.
+        elapsed_time = timers('interval-time').elapsed(barrier=False, reset=should_reset)
         elapsed_time_per_iteration = elapsed_time / total_iterations
         llm_world_size = getattr(args, 'mimo_llm_world_size', args.world_size)
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3390,6 +3390,37 @@ def _none_if_absent(stat):
     return None if stat == -1.0 else stat
 
 
+def start_exit_duration_vote(args, iteration, is_first_iteration):
+    """Reduce every rank's --exit-duration-in-mins verdict, without reading it.
+
+    Each rank reads its own host clock, so the ranks must agree before any of
+    them exits or the survivors hang in the next collective. Issue the collective
+    here and leave the result on device; training_log() reads it along with the
+    logging stats, which costs nothing extra, and hands it to
+    checkpoint_and_decide_exit().
+
+    Gated on exactly the condition training_log() gates that batched read on, and
+    gated here rather than at the call site so the two cannot drift: casting more
+    often adds a collective nobody reads, casting less leaves the verdict unread
+    and the run past its limit.
+
+    Returns:
+        A device tensor holding the reduced verdict, or None when no duration
+        limit is set or this iteration will not read it.
+    """
+    if not args.exit_duration_in_mins:
+        return None
+    if iteration % args.log_interval != 0 and not is_first_iteration:
+        return None
+    train_time = (time.time() - _TRAIN_START_TIME) / 60.0
+    # full(), not tensor([...]): the latter is a pageable host-to-device copy.
+    done = torch.full(
+        (1,), int(train_time > args.exit_duration_in_mins), dtype=torch.int, device='cuda'
+    )
+    torch.distributed.all_reduce(done, op=torch.distributed.ReduceOp.MAX)
+    return done
+
+
 def training_log(
     loss_dict,
     total_loss_dict,
@@ -3406,8 +3437,17 @@ def training_log(
     is_first_iteration=False,
     seqlen_squared_sum_in_batch: float | None = None,
     total_real_tokens_in_batch: float | None = None,
+    exit_duration_vote=None,
 ):
-    """Log training information such as losses, timing, ...."""
+    """Log training information such as losses, timing, ....
+
+    Args:
+        exit_duration_vote: Device tensor from start_exit_duration_vote(), read
+            here with the logging stats so it costs no synchronization of its own.
+
+    Returns:
+        tuple: (report_memory_flag, exit_duration_done)
+    """
     args = get_args()
     timers = get_timers()
     writer = get_tensorboard_writer()
@@ -3417,6 +3457,8 @@ def training_log(
 
     # On first iteration, log stats but don't reset accumulators so normal interval stats remain accurate.
     should_reset = not is_first_iteration
+    # False unless this iteration performs the batched read that resolves the vote.
+    exit_duration_done = False
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'
@@ -3701,13 +3743,16 @@ def training_log(
             for key in total_loss_dict
             if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]
         ]
-        loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate, *loss_totals = (
-            _read_logging_stats(
-                [loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate]
-                + [total_loss_dict[key] for key in loss_keys]
-            )
-        )
-        loss_totals = dict(zip(loss_keys, loss_totals))
+        stats = [loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate]
+        n_fixed = len(stats)
+        stats += [total_loss_dict[key] for key in loss_keys]
+        if exit_duration_vote is not None:
+            stats.append(exit_duration_vote)
+        resolved = _read_logging_stats(stats)
+        loss_scale, params_norm, grad_norm, num_zeros_in_grad, learning_rate = resolved[:n_fixed]
+        loss_totals = dict(zip(loss_keys, resolved[n_fixed : n_fixed + len(loss_keys)]))
+        if exit_duration_vote is not None:
+            exit_duration_done = bool(resolved[-1])
         # calc_params_l2_norm returned the SQUARED norm; root it here.
         params_norm = None if params_norm is None else params_norm**0.5
         grad_norm = _none_if_absent(grad_norm)
@@ -3880,7 +3925,7 @@ def training_log(
         # Log timers to stdout
         timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
 
-    return report_memory_flag
+    return report_memory_flag, exit_duration_done
 
 
 def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point_operations_so_far):
@@ -4209,10 +4254,18 @@ def checkpoint_and_decide_exit(
     num_floating_point_operations_so_far,
     checkpointing_context,
     train_data_iterator,
+    exit_duration_done=False,
 ):
     """Save checkpoint and decide whether to exit based on arguments (e.g., if
     --exit-duration-in-mins is set). Actual exit happens in main training loop
-    based on the return value of this function."""
+    based on the return value of this function.
+
+    Args:
+        exit_duration_done (bool): Already-reduced verdict for
+            --exit-duration-in-mins, cast by start_exit_duration_vote() and read
+            by training_log() in its batched host read. Reading it here instead
+            would cost a synchronization per iteration.
+    """
     args = get_args()
     timers = get_timers()
 
@@ -4265,19 +4318,11 @@ def checkpoint_and_decide_exit(
         )
         saved_checkpoint = True
 
-    # Exit based on duration.
+    # Exit based on duration. The vote was cast before training_log and read
+    # there as part of the batched host read, so nothing synchronizes here.
     if args.exit_duration_in_mins:
         train_time = (time.time() - _TRAIN_START_TIME) / 60.0
-        done_cuda = torch.tensor(
-            [train_time > args.exit_duration_in_mins], dtype=torch.int, device='cuda'
-        )
-        # MAX all-reduce so every rank makes the SAME exit decision despite each
-        # reading its own wall-clock (a determinism guarantee, not a sync point).
-        # ~0.1ms and left unspanned: the GPU is already drained by here, and the
-        # real post-checkpoint wait is the cross-rank save skew at timers.log.
-        torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
-        done = done_cuda.item()
-        if done:
+        if exit_duration_done:
             if args.save and not saved_checkpoint:
                 save_checkpoint_and_time(
                     iteration,
@@ -5054,10 +5099,15 @@ def train(
                 learning_rate = get_canonical_lr_for_logging(optimizer.param_groups)
             else:
                 learning_rate = None
+            # Cast the exit-duration vote before the log, so its host read rides
+            # along with the logging batch instead of paying for a sync of its own.
+            exit_duration_vote = start_exit_duration_vote(
+                args, iteration, is_first_iteration
+            )
             # Per-iteration logging (throughput calc, tensorboard/wandb writes) --
             # uninstrumented per-iteration overhead outside the train_step span.
             with _otel_managed_span('step', 'megatron.train.log', is_goodput_span=True):
-                report_memory_flag = training_log(
+                report_memory_flag, exit_duration_done = training_log(
                     loss_dict,
                     total_loss_dict,
                     learning_rate,
@@ -5073,6 +5123,7 @@ def train(
                     is_first_iteration=is_first_iteration,
                     seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
                     total_real_tokens_in_batch=total_real_tokens_in_batch,
+                    exit_duration_vote=exit_duration_vote,
                 )
             # OTel: close the iteration-report super-span (parents params_norm + log;
             # its own uninstrumented time is the loss_scale sync + FLOPs bookkeeping).
@@ -5171,6 +5222,7 @@ def train(
             num_floating_point_operations_so_far,
             checkpointing_context,
             train_data_iterator,
+            exit_duration_done=exit_duration_done,
         )
         if should_exit:
             break

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -56,7 +56,7 @@ from megatron.training import get_adlr_autoresume, get_args, get_timers
 def _compute_norm_2(params_list):
     """Compute squared L2 norm of a list of tensors. Returns a CUDA scalar."""
     if len(params_list) > 0:
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
+        dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device='cuda')
         norm, _ = multi_tensor_applier(
             multi_tensor_l2norm, dummy_overflow_buf, [params_list], False,
         )
@@ -347,6 +347,7 @@ def average_losses_across_data_parallel_group(
 def reduce_max_stat_across_model_parallel_group(
     stat: Union[float, torch.Tensor, None],
     group: Optional[torch.distributed.ProcessGroup] = None,
+    return_tensor: bool = False,
 ) -> Union[float, torch.Tensor, None]:
     """
     Ranks without an optimizer will have no grad_norm or num_zeros_in_grad stats.
@@ -355,31 +356,35 @@ def reduce_max_stat_across_model_parallel_group(
 
     We use an all_reduce max since the values have already been summed across optimizer ranks where possible
 
-    The return follows the input's kind. A device tensor in gives a device tensor
-    out, with the -1.0 "no rank had this stat" sentinel still encoded, so the host
-    read defers to the log point; decode it there with `_to_host_or_none`. A float
-    or None in behaves as before and resolves here.
+    Args:
+        stat: The value to reduce, as a device tensor, a host float, or None.
+        group: Model-parallel process group; defaults to mpu.get_model_parallel_group().
+        return_tensor (bool): Leave the result on device, with the -1.0 "no rank
+            had this stat" sentinel still encoded, so a logging-only caller can
+            defer the host read. Decode it at the log point with `_none_if_absent`.
 
-    group: model-parallel process group; defaults to mpu.get_model_parallel_group().
+    Returns:
+        float or None, or a device tensor when ``return_tensor`` is set.
     """
     if group is None:
         group = mpu.get_model_parallel_group()
-    if torch.is_tensor(stat):
-        # Match the float branch's (1,) float32 signature exactly: ranks without
-        # trainable params take that branch in the same collective. copy=True so
-        # the in-place all-reduce never lands in the caller's buffer.
-        stat = stat.reshape(1).to(torch.float32, copy=True)
-        torch.distributed.all_reduce(stat, op=torch.distributed.ReduceOp.MAX, group=group)
-        return stat
     if stat is None:
         stat = -1.0
-    stat = torch.tensor([stat], dtype=torch.float32, device=torch.cuda.current_device())
-    torch.distributed.all_reduce(stat, op=torch.distributed.ReduceOp.MAX, group=group)
-    if stat.item() == -1.0:
-        # No rank has a valid stat, so return None to indicate that it is None across all ranks.
-        return None
+    if torch.is_tensor(stat):
+        # copy=True so the in-place all-reduce never lands in the caller's buffer.
+        stat = stat.reshape(1).to(torch.float32, copy=True)
     else:
-        return stat.item()
+        # full(), not tensor([stat]): the latter is a pageable host-to-device copy
+        # and blocks. full() passes the value in the kernel argument buffer.
+        stat = torch.full((1,), stat, dtype=torch.float32, device=torch.cuda.current_device())
+    # Every rank reduces the same (1,) float32 buffer regardless of which branch it
+    # took above; ranks with and without trainable params meet in this collective.
+    torch.distributed.all_reduce(stat, op=torch.distributed.ReduceOp.MAX, group=group)
+    if return_tensor:
+        return stat
+    stat = stat.item()
+    # No rank has a valid stat, so return None to indicate that it is None across all ranks.
+    return None if stat == -1.0 else stat
 
 
 def logical_and_across_model_parallel_group(
@@ -396,7 +401,8 @@ def logical_and_across_model_parallel_group(
         input = 1
     else:
         input = 0
-    input = torch.tensor([input], dtype=torch.int, device=torch.cuda.current_device())
+    # full(), not tensor([input]) -- see reduce_max_stat above.
+    input = torch.full((1,), input, dtype=torch.int, device=torch.cuda.current_device())
     torch.distributed.all_reduce(input, op=torch.distributed.ReduceOp.MIN, group=group)
     return bool(input.item())
 

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -8,7 +8,7 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 
@@ -345,8 +345,9 @@ def average_losses_across_data_parallel_group(
 
 
 def reduce_max_stat_across_model_parallel_group(
-    stat: float, group: Optional[torch.distributed.ProcessGroup] = None
-) -> float | None:
+    stat: Union[float, torch.Tensor, None],
+    group: Optional[torch.distributed.ProcessGroup] = None,
+) -> Union[float, torch.Tensor, None]:
     """
     Ranks without an optimizer will have no grad_norm or num_zeros_in_grad stats.
     We need to ensure the logging and writer rank has those values.
@@ -354,10 +355,22 @@ def reduce_max_stat_across_model_parallel_group(
 
     We use an all_reduce max since the values have already been summed across optimizer ranks where possible
 
+    The return follows the input's kind. A device tensor in gives a device tensor
+    out, with the -1.0 "no rank had this stat" sentinel still encoded, so the host
+    read defers to the log point; decode it there with `_to_host_or_none`. A float
+    or None in behaves as before and resolves here.
+
     group: model-parallel process group; defaults to mpu.get_model_parallel_group().
     """
     if group is None:
         group = mpu.get_model_parallel_group()
+    if torch.is_tensor(stat):
+        # Match the float branch's (1,) float32 signature exactly: ranks without
+        # trainable params take that branch in the same collective. copy=True so
+        # the in-place all-reduce never lands in the caller's buffer.
+        stat = stat.reshape(1).to(torch.float32, copy=True)
+        torch.distributed.all_reduce(stat, op=torch.distributed.ReduceOp.MAX, group=group)
+        return stat
     if stat is None:
         stat = -1.0
     stat = torch.tensor([stat], dtype=torch.float32, device=torch.cuda.current_device())

--- a/tasks/finetune_utils.py
+++ b/tasks/finetune_utils.py
@@ -194,7 +194,7 @@ def _train(model, optimizer, opt_param_scheduler, forward_step,
             params_norm = None
             if args.log_params_norm:
                 params_norm = calc_params_l2_norm(model)
-            report_memory_flag = training_log(losses_dict, losses_dict_sum,
+            report_memory_flag, _ = training_log(losses_dict, losses_dict_sum,
                                               optimizer.param_groups[0]['lr'],
                                               iteration,
                                               optimizer.get_loss_scale().item(),


### PR DESCRIPTION
# perf: remove 104 host synchronizations per training iteration

Every training iteration blocked the host far more often than it needed to. Nearly all of
those blocks were diagnostic — values produced on device, pulled to the host immediately,
and then not consumed until the next log line. This removes 104 host synchronizations per
iteration without changing any kernel, any collective, any numerics, or any optimizer math.

7 files · +433 / −100 · 5 commits

---

## The problem

Measured on rank 0 with a CUPTI-based tool counting driver-domain `cu*Synchronize` calls
over a 6-iteration region of interest:

| | before | after |
|---|---|---|
| host syncs / iteration | 142 | 38 |
| distinct sync sites | 18 | 4 |
| dynamic-shape sites (out of scope, see below) | 35 | 35 |
| **everything else** | **107** | **3** |

The 35 dynamic-shape syncs come from an MoE dispatcher outside this tree; they are counted
here only so the totals reconcile. **The removable population is 107, and 104 of them go.**

Where they came from, per iteration:

| count | site | what it was |
|---:|---|---|
| 74 | `rerun_state_machine.py` `validate_result` | NaN/inf check reading a **device** predicate into Python control flow — one `.item()` per gradient bucket, on the autograd thread inside the grad-ready hook |
| 8 | `common_utils.py` `logical_and_across_model_parallel_group` | `update_successful` — pageable H2D construction plus a host read |
| 7 | `common_utils.py` `reduce_max_stat_across_model_parallel_group` | grad norm, num zeros, learning rate |
| 5 | `training.py` | `torch.tensor([0.0], device='cuda')` seeding the loss accumulator |
| 4 | `common_utils.py` `calc_params_l2_norm` | reading its result |
| 4 | `timers.py` + `barrier()` | the interval timer: host clock behind `torch.cuda.synchronize()` **and** a world barrier, in **both** `start()` and `stop()` |
| 2 | `rerun_state_machine.py` `_reduce_any` | the rerun decision's own construction and read |
| 2 | `training.py` `checkpoint_and_decide_exit` | `--exit-duration-in-mins`, tested every iteration |
| 1 | `clip_grads.py` `count_zeros_fp32` | `.item()` on the zero count |
| 1 | `training.py` | `get_loss_scale().item()` |

Three recurring root causes:

1. **A device value pulled into Python control flow** where nothing consumed it until much
   later (the NaN checks, `update_successful`).
2. **`torch.tensor([x], device='cuda')` for a host scalar** — a pageable host-to-device
   copy, which blocks. Measured 20/20 blocking over 20 repetitions behind pending device
   work; `torch.full` / `zeros` / `fill_` are 0/20, because the value rides in the kernel
   argument buffer with no copy at all.
3. **Diagnostics on the critical path** — timing, logging and the exit check reading values
   every iteration that are only ever printed.

---

## How they were removed

| commit | change | syncs/iter |
|---|---|---:|
| 1 | Bank `validate_result` verdicts on device; merge them into the all-reduce `should_run_forward_backward` already performs at the loop exit. Detection timing is unchanged — still before `optimizer.step()`. | 74 |
| 2 | Keep the logged stats on device and read the whole bundle — grad norm, num zeros, params norm, loss scale **and the per-key loss averages** — in **one** device-to-host copy at the log point. | 17 |
| 3 | Build device scalars with `torch.full` / `zeros` / `ones` instead of `torch.tensor([x], device='cuda')`; defer the learning rate into the same batched read. | 7 |
| 4 | Time with **CUDA events** instead of host clock plus `torch.cuda.synchronize()`, and drop the per-iteration `barrier()`. Reporting becomes lagged but lossless — every interval reported exactly once, in order. | 4 |
| 5 | Fold the `--exit-duration-in-mins` vote into the same batched read. | 2 |
| | **total** | **104** |

Three design points worth a reviewer's attention:

- **Batching, not just deferring.** Deferring each read individually removed the six target
  sites but netted only 10 of 17 syncs: PyTorch elides the sync when the stream is already
  idle, so the old early reads had been *hiding* the later ones. One batched
  `torch.cat(...).tolist()` is what actually collapsed them.
- **The timer's first report blocks once, deliberately.** It has no earlier value to stand
  in for it and the caller divides by it for throughput; without that the run dies with
  `ZeroDivisionError` on the first log line.
- **`non_blocking` is gated on `is_pinned()`, not forced.** A pageable source ignores the
  flag and stalls anyway *while emitting no synchronize call* — forcing it would move the
  stall and hide it from the trace.

**The 3 remaining removable syncs are load-bearing:** the rerun decision (`_reduce_any`),
`update_successful` (`logical_and`), and the single batched logging read.

---

## Results

Measured on an internal large-scale MoE pretraining workload; the configuration is not
disclosed here, so treat the percentage as indicative rather than reproducible. Both arms
ran in a **single allocation** as adjacent phases, because rack placement moves step time by
more than the effect being measured — an early attempt across separate allocations inverted
the sign.

At 256 GPUs, over iterations 40→160:

| | ms/iteration |
|---|---|
| baseline | 2646.96 |
| this branch | 2595.99 |
| | **−1.93%** |

Measured as wall-clock between log-line timestamps with identical machinery in both arms —
the arms' *internal* timers differ by construction after commit 4 and are not comparable
across arms. Per-20-iteration windows: five of six branch windows sit below every baseline
window (Mann-Whitney 6v6, one inversion, p ≈ 0.004). This was measured at `--log-interval
20`, where the baseline pays its logging syncs only one iteration in twenty — the setting
that gives this change the least to remove.

Nsight attribution on a smaller comm-bound configuration shows the gain landing entirely in
launch starvation: launch-starved time −108.3 ms/iteration against a step-time delta of
−105.8 ms, while blocking (98% communication) and dependency-stalled time are unchanged
(−8.0 ms and +0.1 ms). The two deltas agree to within 3 ms.

Expect the benefit to scale with how much exposed host time a configuration has. A
comm-bound run with a long log interval recovers the least; a run with `--log-interval 1`,
or one whose device work does not already cover the host, recovers more.

---

## Correctness

- **Iteration-1 `lm loss` identical between arms** at 256 GPUs, with every resolved argument
  identical across the two arms.
- **Iterations 1–2: `lm loss` and `params norm` bit-identical across all six runs of both
  arms** at a smaller scale — spread exactly 0 within each arm *and* between arms. This is
  the sharp test that the computation is unchanged.
- `grad norm` and `num zeros` vary in the last digits — **but they vary that much within
  each arm too**, and the between-arm mean difference is smaller than the within-arm spread
  at every field. Under 64-way data parallelism NCCL reduction order varies run to run; this
  is a property of the reference, not of the change.
- **Learning-rate sequence bit-identical over 200 iterations, all six runs.**
- **Zero NaN, zero skipped iterations** in every run of both arms at both scales — relevant
  because commit 1 changed *when* NaN verdicts are read.
- Unit tests: 66 checks for the logging/exit changes, 21 for the CUDA-event timer.
  Multi-GPU model-parallel smoke: PP=2, and TP=2 with `--sequence-parallel`.

**Limits of the convergence evidence, stated plainly.** Beyond iteration 2 the loss
trajectories cannot be compared: the reference workload disagrees with *itself* by ~13% mean
and ~37% max relative loss deviation over iterations 50–200, and a held-out reference run
falls outside the envelope of two other reference runs 39–87% of the time. A distributional
test at n=3 has no power there. A bit-exact deterministic convergence test was also
unavailable — `--deterministic-mode` aborts on this hardware with `SM100 backward with
head_dim=256 does not support deterministic mode`. The evidence is therefore the
bit-identical early iterations and the paired-run analysis above.

---

## Reviewer notes — API changes

- **`count_zeros_fp32` now returns a device tensor** rather than a Python float; its return
  annotation changed with it, and `MegatronOptimizer.count_zeros()` follows.
  `LayerWiseOptimizer.count_zeros()` forwards the tensor unchanged;
  `MimoOptimizer.count_zeros()` already reduces to a Python int and is unaffected — the
  batched read accepts host values transparently.
- **`reduce_max_stat_across_model_parallel_group` gained `return_tensor`**, replacing an
  earlier kind-follows-input rule that could not express "a host float that defers".
  Defaults unchanged, so existing callers and `tests/unit_tests/test_utils.py` are untouched.
- **`training_log()` now returns a tuple** `(report_memory_flag, exit_duration_done)`;
  `tasks/finetune_utils.py` updated.
- **Timer reporting is lagged.** `Timer.elapsed()` returns intervals resolved from completed
  CUDA events, so a log line reports slightly older windows than it used to. Every interval
  is still reported exactly once and in order; open windows are drained on `stop()` and
  bounded at 1024 pending events. Aggregates over many iterations remain exact.
- **Exit granularity is now `--log-interval`** rather than every iteration, since the
  `--exit-duration-in-mins` verdict rides the batched read. For a limit measured in minutes
  this is not a behavioral regression, and it reuses a knob that already exists rather than
  inventing one.
