### PR TITLE
fix(optimizer) Split gated linear_fc1 gradients for Muon NS

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -788,7 +788,7 @@ def _get_megatron_emerging_optimizer(
 
     log_single_rank(logger, logging.INFO, f'Setting up emerging optimizer with config {config}')
 
-    # Tag parameters with optimizer-specific attributes (expert_tp, is_qkv).
+    # Tag parameters with optimizer-specific attributes (expert_tp, is_qkv, is_gated_fc1).
     for model_chunk in model_chunks:
         qkv_split_shapes = None
         for name, param in model_chunk.named_parameters():
@@ -810,6 +810,16 @@ def _get_megatron_emerging_optimizer(
                         f"Emerging optimizer QKV split skipped for {name}: "
                         f"shape={tuple(param.shape)}, split_shapes={qkv_split_shapes}",
                     )
+
+            # Standard fused gated linear_fc1 uses output-dimension
+            # partition_stride=2, so no module-tree lookup is required.
+            if (
+                model_chunk.config.gated_linear_unit
+                and len(param.shape) == 2
+                and 'linear_fc1.weight' in name
+                and getattr(param, 'partition_stride', 1) == 2
+            ):
+                param.is_gated_fc1 = True
 
     # Apply optimizer-specific default param overrides (e.g. muon: non-linear -> adam).
     # For Muon-family optimizers, the scalar optimizer that handles non-linear/embedding

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -355,6 +355,66 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         """Re-append ``pad_length`` zero rows to dim 0 (no-op if ``pad_length == 0``)."""
         return torch.nn.functional.pad(t, (0, 0, 0, pad_length)) if pad_length else t
 
+    def _get_gtp_remat_group(self, p):
+        """Return the GTP-remat group associated with a parameter."""
+        if self.pg_collection is None:
+            return None
+        group_name = 'expt_gtp_remat' if getattr(p, 'expert_tp', False) else 'gtp_remat'
+        return getattr(self.pg_collection, group_name, None)
+
+    def _gather_gated_fc1_grad(self, p, grad):
+        """Gather a GTP-sharded fused FC1 gradient before splitting gate and up."""
+        if not getattr(p, 'is_gtp_weight_remat', False):
+            return grad, None
+
+        gtp_group = self._get_gtp_remat_group(p)
+        group_size = get_pg_size(gtp_group) if gtp_group is not None else 1
+        rank = get_pg_rank(gtp_group) if gtp_group is not None else 0
+        if group_size > 1:
+            grad = self._all_gather_tensor(grad, gtp_group, dim=0)
+
+        pad_length = p.pad_length
+        logical_grad = self._strip_pad(grad, pad_length)
+        return logical_grad, (rank, group_size, grad.size(0) // group_size, pad_length)
+
+    @staticmethod
+    def _restore_gated_fc1_grad(grad, restore_info):
+        """Restore GTP padding and return the original local fused-FC1 shard."""
+        if restore_info is None:
+            return grad
+        rank, group_size, shard_size, pad_length = restore_info
+        if pad_length:
+            grad = torch.nn.functional.pad(grad, (0, 0, 0, pad_length))
+        return grad[rank * shard_size : (rank + 1) * shard_size].contiguous()
+
+    def _orthogonalize_split_gated_fc1(self, p, grad, tp_group, partition_dim):
+        """Apply NS independently to the two logical matrices of fused FC1."""
+        logical_grad, restore_info = self._gather_gated_fc1_grad(p, grad)
+        gate_grad, up_grad = torch.chunk(logical_grad, 2, dim=0)
+        if restore_info is None:
+            gate_grad = self.scaled_orthogonalize_fn_with_gtp_remat(
+                p, gate_grad, tp_group, partition_dim
+            )
+            up_grad = self.scaled_orthogonalize_fn_with_gtp_remat(
+                p, up_grad, tp_group, partition_dim
+            )
+        else:
+            # GTP has already been gathered and padding removed, so invoke the base
+            # NS function directly; gathering each half again would be incorrect.
+            mode = self.tp_mode
+            if mode == 'auto' and not getattr(p, 'expert_tp', False):
+                gtp_size = restore_info[1]
+                mode = self._resolve_tp_mode(
+                    gate_grad.size(0) * gtp_size, gate_grad.size(1), gtp_size
+                )
+            gate_grad = self.scaled_orthogonalize_fn(
+                gate_grad, tp_group, partition_dim, tp_mode_this_group=mode
+            )
+            up_grad = self.scaled_orthogonalize_fn(
+                up_grad, tp_group, partition_dim, tp_mode_this_group=mode
+            )
+        return self._restore_gated_fc1_grad(torch.cat((gate_grad, up_grad), dim=0), restore_info)
+
     def _resolve_tp_mode(self, m: int, n: int, group_size: int) -> str:
         """Cached per-shape mode for tp_mode="auto", dense (GTP) weights only.
 
@@ -402,11 +462,7 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         """
         # TODO: Clean up code that determines if parameter is a MoE layer and which TP group to use
         is_expert = getattr(p, 'expert_tp', False)
-        gtp_remat_group = (
-            (self.pg_collection.expt_gtp_remat if is_expert else self.pg_collection.gtp_remat)
-            if self.pg_collection
-            else None
-        )
+        gtp_remat_group = self._get_gtp_remat_group(p)
 
         # Parameters with is_gtp_weight_remat=False are not sharded along the
         # GTP process group, and do not require all-gathering prior to
@@ -417,12 +473,11 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             and getattr(p, 'is_gtp_weight_remat', False)
         )
         gtp_remat_size = get_pg_size(gtp_remat_group) if gtp_active else 1
-
         mode = self.tp_mode
         if mode == "auto":
-            # Scoped to dense (GTP) weights for now; expert weights keep today's default.
+            # Use the current gradient shape. Gated FC1 handles its logical halves separately.
             mode = (
-                self._resolve_tp_mode(p.shape[0] * gtp_remat_size, p.shape[1], gtp_remat_size)
+                self._resolve_tp_mode(grad.size(0) * gtp_remat_size, grad.size(1), gtp_remat_size)
                 if gtp_active and not is_expert
                 else "duplicated"
             )
@@ -434,7 +489,6 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
 
         gtp_rank = get_pg_rank(gtp_remat_group)
         pad_length = getattr(p, 'pad_length', 0)
-
         if mode == "blockwise":
             # Local block NS on this rank's GTP row-shard (shape [M/gtp_remat_size, K]):
             # partition_dim=None makes scaled_orthogonalize_fn run a plain Newton-Schulz on
@@ -532,7 +586,9 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
         if partition_dim == -1:
             partition_dim = None
 
-        if self.split_qkv and self.is_qkv_fn(p):  # type: ignore[misc]
+        if getattr(p, "is_gated_fc1", False):
+            grad = self._orthogonalize_split_gated_fc1(p, grad, tp_group, partition_dim)
+        elif self.split_qkv and self.is_qkv_fn(p):  # type: ignore[misc]
             grad_shape = grad.shape
             qkv_split_shapes = getattr(p, "qkv_split_shapes", None)
             if qkv_split_shapes is None:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -182,6 +182,8 @@ def copy_optimizer_param_metadata(destination: torch.Tensor, source: torch.Tenso
         destination.shared = source.shared
     if hasattr(source, GRAD_NORM_GROUP_ATTR):
         setattr(destination, GRAD_NORM_GROUP_ATTR, getattr(source, GRAD_NORM_GROUP_ATTR))
+    if hasattr(source, 'is_gated_fc1'):
+        destination.is_gated_fc1 = source.is_gated_fc1
 
 
 class MegatronOptimizer(ABC):

--- a/tests/unit_tests/optimizer/test_gated_fc1_muon_split.py
+++ b/tests/unit_tests/optimizer/test_gated_fc1_muon_split.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch
+
+from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon
+
+
+def _make_gated_fc1_param():
+    param = torch.nn.Parameter(torch.empty(8, 3))
+    param.is_gated_fc1 = True
+    param.partition_dim = 0
+    param.partition_stride = 2
+    param.pad_length = 0
+    return param
+
+
+def test_gated_fc1_orthogonalizes_gate_and_up_independently():
+    param = _make_gated_fc1_param()
+    grad = torch.arange(24, dtype=torch.float32).view(8, 3)
+    optimizer = TensorParallelMuon.__new__(TensorParallelMuon)
+    optimizer.pg_collection = None
+    optimizer.tp_mode = "duplicated"
+    optimizer.is_qkv_fn = lambda _: False
+
+    calls = []
+
+    def fake_orthogonalize(p, local_grad, tp_group, partition_dim):
+        del p, tp_group, partition_dim
+        calls.append(local_grad.clone())
+        return local_grad + 1.0 if len(calls) == 1 else local_grad + 2.0
+
+    optimizer.scaled_orthogonalize_fn_with_gtp_remat = fake_orthogonalize
+
+    result = optimizer.orthogonalize(param, grad)
+
+    assert len(calls) == 2
+    assert torch.equal(calls[0], grad[:4])
+    assert torch.equal(calls[1], grad[4:])
+    assert torch.equal(result, torch.cat((grad[:4] + 1.0, grad[4:] + 2.0), dim=0))

--- a/tests/unit_tests/test_emerging_optimizers.py
+++ b/tests/unit_tests/test_emerging_optimizers.py
@@ -1482,7 +1482,7 @@ class TestAdaptiveMuonOptimizerMultiRankTP:
         yield
         Utils.destroy_model_parallel()
 
-    def create_tp_model_and_optimizer(self, mode):
+    def create_tp_model_and_optimizer(self, mode, moment2_method="adamuon"):
         """Create model with TP and optimizer."""
         rank = int(os.getenv('RANK', '0'))
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
@@ -1501,6 +1501,7 @@ class TestAdaptiveMuonOptimizerMultiRankTP:
             num_ns_steps=5,
             pg_collection=pg_collection,
             tp_mode=mode,
+            moment2_method=moment2_method,
         )
 
         return model, optimizer
@@ -1541,6 +1542,23 @@ class TestAdaptiveMuonOptimizerMultiRankTP:
         assert not torch.equal(
             model.weight.data, original_weight
         ), "Weight should be updated with mode=blockwise"
+
+    @pytest.mark.parametrize("mode", ["duplicated", "distributed"])
+    def test_adaptive_muon_gated_fc1_multirank(self, mode):
+        """Test split gated linear_fc1 NS with real TP collectives."""
+        model, optimizer = self.create_tp_model_and_optimizer(mode, moment2_method="normuon")
+        model.weight.is_gated_fc1 = True
+        model.weight.partition_stride = 2
+
+        torch.manual_seed(42)
+        input_tensor = torch.randn(32, 100, dtype=torch.float32, device="cuda")
+        output = model(input_tensor)
+        output.sum().backward()
+
+        original_weight = model.weight.data.clone()
+        optimizer.step()
+
+        assert not torch.equal(model.weight.data, original_weight)
 
 
 # ===========================================================================


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
This PR fixes Muon updates for fused gated MLP `linear_fc1` parameters.

For SwiGLU, GEGLU, and similar gated activations, `linear_fc1.weight` contains
two logical projection matrices:

```text
W_fc1 = [W_gate; W_up]
```

Muon should apply Newton-Schulz orthogonalization to these matrices independently, which is currently not splitted.

Current:
```
grad_fc1
   ├── grad_gate_up ──> NS # incorrect shape of orthogonalization, especially for momented normuon.
```

Exptected:
```
grad_fc1
   ├── grad_gate ──> NS ──┐
   └── grad_up   ──> NS ──┘
                          │
                     concatenate
```

For GTP-rematerialized parameters, shards should be gathered and padding
removed before splitting, then restored to the original local layout.

## Issue tracking

Linked issue: Fixes #7077

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main.