### PR TITLE
Remove tuples as state-dictionary key type from distributed optimizer. Limit key-types to str or int

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -75,6 +75,11 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 logger = getLogger(__name__)
 
 
+def _get_dtype_param_grad_key(param_dtype, grad_dtype):
+    """Return the checkpoint-safe key for a parameter/gradient dtype pair."""
+    return str((param_dtype, grad_dtype))
+
+
 class Range:
     """
     A range represents a start and end points for indexing a shard
@@ -129,6 +134,42 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         'fully_sharded_model_space',
         'fsdp_dtensor',
     }
+
+    @staticmethod
+    def _back_compat_normalize_loaded_dtype_keys(state_dict: Optional[dict]) -> None:
+        """Normalize dtype tuple keys from old checkpoints to current runtime strings."""
+        if state_dict is None:
+            return
+
+        def normalize_dtype_keys(dtype_state):
+            if not isinstance(dtype_state, dict):
+                return
+            for dtype in list(dtype_state):
+                if isinstance(dtype, (str, int)):
+                    continue
+                if not isinstance(dtype, tuple):
+                    raise TypeError(
+                        'Optimizer checkpoint dtype key must be a string, integer, or tuple, '
+                        f'got {type(dtype).__name__}: {dtype!r}'
+                    )
+                checkpoint_key = str(dtype)
+                if checkpoint_key in dtype_state:
+                    raise ValueError(
+                        f'Optimizer state contains both legacy dtype key {dtype!r} and '
+                        f'checkpoint dtype key {checkpoint_key!r}'
+                    )
+                dtype_state[checkpoint_key] = dtype_state.pop(dtype)
+
+        for gbuf_idx, dtype_state in state_dict.items():
+            if isinstance(gbuf_idx, int):
+                normalize_dtype_keys(dtype_state)
+
+        for per_bucket_key in ('per_bucket_numel', 'per_bucket_numel_unpadded'):
+            per_bucket_values = state_dict.get(per_bucket_key)
+            if not isinstance(per_bucket_values, list):
+                continue
+            for dtype_state in per_bucket_values:
+                normalize_dtype_keys(dtype_state)
 
     @classmethod
     def _build_model_gbuf_param_range_map(
@@ -271,7 +312,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             Dict: Mapping of parameter dtypes to bucket ranges.
         """
         return {
-            (param_and_grad_buffer.param_dtype, param_and_grad_buffer.grad_dtype): [
+            _get_dtype_param_grad_key(
+                param_and_grad_buffer.param_dtype, param_and_grad_buffer.grad_dtype
+            ): [
                 cls._build_model_gbuf_range(param_and_grad_buffer, bucket_index)
                 for bucket_index in range(len(param_and_grad_buffer.buckets))
             ]
@@ -742,14 +785,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
             self.per_bucket_numel.append(
                 {
-                    (buffer.param_dtype, buffer.grad_dtype): [
+                    _get_dtype_param_grad_key(buffer.param_dtype, buffer.grad_dtype): [
                         bucket.grad_data.numel() for bucket in buffer.buckets
                     ]
                 }
             )
             self.per_bucket_numel_unpadded.append(
                 {
-                    (buffer.param_dtype, buffer.grad_dtype): [
+                    _get_dtype_param_grad_key(buffer.param_dtype, buffer.grad_dtype): [
                         bucket.numel_unpadded for bucket in buffer.buckets
                     ]
                 }
@@ -2084,6 +2127,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         Inverse of the `get_parameter_state_dp_reshardable` method.
         """
+        self._back_compat_normalize_loaded_dtype_keys(state_dict)
         if state_dict is not None and "per_bucket_numel_unpadded" in state_dict:
             per_bucket_numel_unpadded_in_checkpoint = state_dict["per_bucket_numel_unpadded"]
             assert self.per_bucket_numel_unpadded == per_bucket_numel_unpadded_in_checkpoint, (
@@ -2289,6 +2333,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if update_legacy_format:
             return self.load_parameter_state_from_dp_zero_legacy(state_dict)
 
+        self._back_compat_normalize_loaded_dtype_keys(state_dict)
+
         # Data parallelism variables.
         assert self.data_parallel_group_gloo is not None
         data_parallel_world_size = self.data_parallel_group_gloo.size()
@@ -2449,11 +2495,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             return
 
         dtype_to_gbuf_idx = {}
+        uint8_dtype_keys = {
+            _get_dtype_param_grad_key(torch.uint8, buffer.grad_dtype) for buffer in self.buffers
+        }
         for key in state_dict.keys():
             if key != 'buckets_coalesced':
                 for dtype in state_dict[key].keys():
                     assert dtype not in dtype_to_gbuf_idx
-                    if dtype[0] == torch.uint8:
+                    if dtype in uint8_dtype_keys:
                         # If the `state_dict`` already contains a torch.uint8 buffer, we assumed
                         # that the fp8 weights and fp16/bf16 biases in the checkpoint are already
                         # separated. In this case, no action is required, so we can return directly.
@@ -2471,7 +2520,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for fp8_gbuf_idx in fp8_gbuf_indices:
             # Note that `self.buffers[fp8_gbuf_idx].params[0].dtype` is the dummy dtype of
             # `Float8Tensor`, not torch.uint8.
-            non_fp8_param_and_grad_dtype = (
+            non_fp8_param_and_grad_dtype = _get_dtype_param_grad_key(
                 self.buffers[fp8_gbuf_idx].params[0].dtype,
                 self.buffers[fp8_gbuf_idx].grad_dtype,
             )

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -74,10 +74,13 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 
 logger = getLogger(__name__)
 
+_DTYPE_KEY_FORMAT_METADATA_KEY = 'distrib_optim_dtype_key_format'
+_FQN_SAFE_DTYPE_KEY_FORMAT = 'fqn_safe'
+
 
 def _get_dtype_param_grad_key(param_dtype, grad_dtype):
     """Return the checkpoint-safe key for a parameter/gradient dtype pair."""
-    return str((param_dtype, grad_dtype))
+    return f'dtype_param_{param_dtype}_grad_{grad_dtype}'.replace('.', ':')
 
 
 class Range:
@@ -152,7 +155,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         'Optimizer checkpoint dtype key must be a string, integer, or tuple, '
                         f'got {type(dtype).__name__}: {dtype!r}'
                     )
-                checkpoint_key = str(dtype)
+                if len(dtype) != 2:
+                    raise TypeError(
+                        'Legacy optimizer checkpoint dtype tuple must contain parameter and '
+                        f'gradient dtypes, got {dtype!r}'
+                    )
+                checkpoint_key = _get_dtype_param_grad_key(*dtype)
                 if checkpoint_key in dtype_state:
                     raise ValueError(
                         f'Optimizer state contains both legacy dtype key {dtype!r} and '
@@ -1566,6 +1574,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 'distrib_optim_sharding_type', 'fully_sharded_model_space'
             )
 
+        # Content metadata is loaded before the sharded state dict is constructed. Mark new
+        # checkpoints so loading can select their FQN-safe dtype names, while the absence of the
+        # marker identifies checkpoints that used tuple dtype keys in their tensor FQNs.
+        if not is_loading and metadata is not None:
+            metadata[_DTYPE_KEY_FORMAT_METADATA_KEY] = _FQN_SAFE_DTYPE_KEY_FORMAT
+
         # Handle FSDP DistributedOptimizer States
         if self.ddp_config.use_megatron_fsdp and sharding_type != "fsdp_dtensor":
             raise NotImplementedError(
@@ -1925,6 +1939,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """
         data_parallel_rank = self.data_parallel_group.rank()
         data_parallel_world_size = self.data_parallel_group.size()
+        use_legacy_dtype_fqn = is_loading and (
+            (metadata or {}).get(_DTYPE_KEY_FORMAT_METADATA_KEY) != _FQN_SAFE_DTYPE_KEY_FORMAT
+        )
 
         state = self.get_parameter_state_dp_reshardable()
         # per_bucket_numel metadata is saved separately for each TPxPP domain.
@@ -1943,6 +1960,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, gbuf_range_map_for_all_buckets in state[gbuf_idx].items():
+                dtype_fqn = dtype
+                if use_legacy_dtype_fqn:
+                    buffer = self.buffers[gbuf_idx]
+                    dtype_fqn = (buffer.param_dtype, buffer.grad_dtype)
                 for bucket_idx, bucket_state in enumerate(gbuf_range_map_for_all_buckets):
                     # Compute local DP contiguous shard's size.
                     gbuf_world_numel_unpadded = (
@@ -1955,7 +1976,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     sharded_bucket_key = (
                         f'optimizer.distributed.dp_group_idx_{self.data_parallel_group_idx}'
-                        f'.gbuf_idx_{gbuf_idx}.dtype_{dtype}.bucket_idx_{bucket_idx}'
+                        f'.gbuf_idx_{gbuf_idx}.dtype_{dtype_fqn}.bucket_idx_{bucket_idx}'
                     )
 
                     # The global ckpt tensors must be fully covered.
@@ -2521,8 +2542,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Note that `self.buffers[fp8_gbuf_idx].params[0].dtype` is the dummy dtype of
             # `Float8Tensor`, not torch.uint8.
             non_fp8_param_and_grad_dtype = _get_dtype_param_grad_key(
-                self.buffers[fp8_gbuf_idx].params[0].dtype,
-                self.buffers[fp8_gbuf_idx].grad_dtype,
+                self.buffers[fp8_gbuf_idx].params[0].dtype, self.buffers[fp8_gbuf_idx].grad_dtype
             )
 
             # Iterate through all buffers to find the one that needs to be split.

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -74,6 +74,9 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 
 logger = getLogger(__name__)
 
+_FQN_SAFE_DTYPE_KEY_VERSION = 3.1
+_LOADED_CHECKPOINT_VERSION_KEY = '_loaded_checkpoint_version'
+
 
 def _get_dtype_param_grad_key(param_dtype, grad_dtype):
     """Return the checkpoint-safe key for a parameter/gradient dtype pair."""
@@ -135,67 +138,50 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         'fsdp_dtensor',
     }
 
-    def _back_compat_normalize_loaded_dtype_keys(
-        self, state_dict: Optional[dict], checkpoint_version: Optional[float] = None
+    def _back_compat_rewrite_loaded_dtype_fqns(
+        self, state_dict: Optional[dict], checkpoint_version: Optional[float]
     ) -> None:
-        """Adapt legacy dtype FQNs and normalize loaded tuple keys.
-
-        Before loading a checkpoint older than version 3.1, rewrite the loading template's
-        ShardedTensor keys to the legacy dtype FQNs stored in that checkpoint. After loading,
-        normalize any tuple dtype keys in the loaded state to the current string format.
-        """
-        if state_dict is None:
+        """Use the legacy dtype FQNs when loading a checkpoint older than version 3.1."""
+        if (
+            state_dict is None
+            or checkpoint_version is None
+            or checkpoint_version >= _FQN_SAFE_DTYPE_KEY_VERSION
+        ):
             return
 
-        if checkpoint_version is not None and checkpoint_version < 3.1:
-            dtype_fqn_replacements = {
-                f'.dtype_{_get_dtype_param_grad_key(buffer.param_dtype, buffer.grad_dtype)}.': (
-                    f'.dtype_{(buffer.param_dtype, buffer.grad_dtype)}.'
-                )
-                for buffer in self.buffers
-            }
-            for value in nested_values(state_dict):
-                if not isinstance(value, ShardedTensor):
-                    continue
-                for current_dtype_fqn, legacy_dtype_fqn in dtype_fqn_replacements.items():
-                    if current_dtype_fqn in value.key:
-                        value.key = value.key.replace(current_dtype_fqn, legacy_dtype_fqn, 1)
-                        break
-
-        def normalize_dtype_keys(dtype_state):
-            if not isinstance(dtype_state, dict):
-                return
-            for dtype in list(dtype_state):
-                if isinstance(dtype, (str, int)):
-                    continue
-                if not isinstance(dtype, tuple):
-                    raise TypeError(
-                        'Optimizer checkpoint dtype key must be a string, integer, or tuple, '
-                        f'got {type(dtype).__name__}: {dtype!r}'
-                    )
-                if len(dtype) != 2:
-                    raise TypeError(
-                        'Legacy optimizer checkpoint dtype tuple must contain parameter and '
-                        f'gradient dtypes, got {dtype!r}'
-                    )
-                checkpoint_key = _get_dtype_param_grad_key(*dtype)
-                if checkpoint_key in dtype_state:
-                    raise ValueError(
-                        f'Optimizer state contains both legacy dtype key {dtype!r} and '
-                        f'checkpoint dtype key {checkpoint_key!r}'
-                    )
-                dtype_state[checkpoint_key] = dtype_state.pop(dtype)
-
-        for gbuf_idx, dtype_state in state_dict.items():
-            if isinstance(gbuf_idx, int):
-                normalize_dtype_keys(dtype_state)
-
-        for per_bucket_key in ('per_bucket_numel', 'per_bucket_numel_unpadded'):
-            per_bucket_values = state_dict.get(per_bucket_key)
-            if not isinstance(per_bucket_values, list):
+        dtype_fqn_replacements = {
+            f'.dtype_{_get_dtype_param_grad_key(buffer.param_dtype, buffer.grad_dtype)}.': (
+                f'.dtype_{(buffer.param_dtype, buffer.grad_dtype)}.'
+            )
+            for buffer in self.buffers
+        }
+        for value in nested_values(state_dict):
+            if not isinstance(value, ShardedTensor):
                 continue
-            for dtype_state in per_bucket_values:
-                normalize_dtype_keys(dtype_state)
+            for current_dtype_fqn, legacy_dtype_fqn in dtype_fqn_replacements.items():
+                if current_dtype_fqn in value.key:
+                    value.key = value.key.replace(current_dtype_fqn, legacy_dtype_fqn, 1)
+                    break
+
+    @staticmethod
+    def _back_compat_loaded_dtype_key(
+        dtype_state: dict,
+        current_dtype_key: str,
+        param_dtype: torch.dtype,
+        grad_dtype: torch.dtype,
+        checkpoint_version: Optional[float],
+    ):
+        """Select the dtype key present in a current or legacy loaded state dictionary."""
+        if current_dtype_key in dtype_state:
+            return current_dtype_key
+
+        legacy_dtype_key = (param_dtype, grad_dtype)
+        if (
+            checkpoint_version is None or checkpoint_version < _FQN_SAFE_DTYPE_KEY_VERSION
+        ) and legacy_dtype_key in dtype_state:
+            return legacy_dtype_key
+
+        return current_dtype_key
 
     @classmethod
     def _build_model_gbuf_param_range_map(
@@ -1157,7 +1143,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 f'Loading distributed optimizer sharded state of type {sharding_type}',
             )
             if sharding_type == 'dp_zero_gather_scatter':
-                self.load_parameter_state_from_dp_zero(param_state)
+                checkpoint_version = state_dict.pop(_LOADED_CHECKPOINT_VERSION_KEY, None)
+                self.load_parameter_state_from_dp_zero(
+                    param_state, checkpoint_version=checkpoint_version
+                )
             elif sharding_type == 'fully_reshardable':
                 self.load_parameter_state_from_fully_reshardable(param_state)
             elif sharding_type == 'dp_reshardable':
@@ -1659,6 +1648,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         state_dict['param_state'] = param_state
         state_dict['param_state_sharding_type'] = sharding_type
+        if is_loading and sharding_type == 'dp_zero_gather_scatter':
+            state_dict[_LOADED_CHECKPOINT_VERSION_KEY] = LocalNonpersistentObject(
+                (metadata or {}).get('checkpoint_version')
+            )
         return state_dict
 
     def _param_groups_to_param2group_meta(
@@ -2064,7 +2057,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 replica_id=(self.distributed_optimizer_instance_id, 0, 0),
                             )
         if is_loading:
-            self._back_compat_normalize_loaded_dtype_keys(
+            self._back_compat_rewrite_loaded_dtype_fqns(
                 state, checkpoint_version=(metadata or {}).get('checkpoint_version')
             )
         return state
@@ -2157,10 +2150,19 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         Inverse of the `get_parameter_state_dp_reshardable` method.
         """
-        self._back_compat_normalize_loaded_dtype_keys(state_dict)
         if state_dict is not None and "per_bucket_numel_unpadded" in state_dict:
             per_bucket_numel_unpadded_in_checkpoint = state_dict["per_bucket_numel_unpadded"]
-            assert self.per_bucket_numel_unpadded == per_bucket_numel_unpadded_in_checkpoint, (
+            assert all(
+                len(dtype_state) == 1 for dtype_state in per_bucket_numel_unpadded_in_checkpoint
+            )
+            current_numel_unpadded = [
+                next(iter(dtype_state.values())) for dtype_state in self.per_bucket_numel_unpadded
+            ]
+            checkpoint_numel_unpadded = [
+                next(iter(dtype_state.values()))
+                for dtype_state in per_bucket_numel_unpadded_in_checkpoint
+            ]
+            assert current_numel_unpadded == checkpoint_numel_unpadded, (
                 f"Number of unpadded elements in each bucket need to be the same in current run "
                 f"({self.per_bucket_numel_unpadded}) and checkpoint "
                 f"({per_bucket_numel_unpadded_in_checkpoint})"
@@ -2346,7 +2348,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 recv_tensor[gbuf_local_start:gbuf_local_end]
                             )
 
-    def load_parameter_state_from_dp_zero(self, state_dict, *, update_legacy_format=False):
+    def load_parameter_state_from_dp_zero(
+        self, state_dict, *, update_legacy_format=False, checkpoint_version: Optional[float] = None
+    ):
         """Load parameter state (i.e., parameter & optimizer tensors) from DP 0 rank,
         using the new checkpoint format with coalesced state across buckets.
 
@@ -2363,8 +2367,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if update_legacy_format:
             return self.load_parameter_state_from_dp_zero_legacy(state_dict)
 
-        self._back_compat_normalize_loaded_dtype_keys(state_dict)
-
         # Data parallelism variables.
         assert self.data_parallel_group_gloo is not None
         data_parallel_world_size = self.data_parallel_group_gloo.size()
@@ -2376,14 +2378,23 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         if data_parallel_rank == 0:
             # Do nothing if "--fp8-param-gather" is not used.
-            self.split_state_dict_if_needed(state_dict)
+            self.split_state_dict_if_needed(state_dict, checkpoint_version=checkpoint_version)
 
         # Scatter tensors to all DP ranks.
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
                 if data_parallel_rank == 0:
+                    buffer = self.buffers[gbuf_idx]
+                    checkpoint_dtype = self._back_compat_loaded_dtype_key(
+                        state_dict[gbuf_idx],
+                        dtype,
+                        buffer.param_dtype,
+                        buffer.grad_dtype,
+                        checkpoint_version,
+                    )
+                    checkpoint_dtype_state = state_dict[gbuf_idx][checkpoint_dtype]
                     buffer_numel_unpadded = self.buffers[gbuf_idx].numel_unpadded
-                    checkpoint_numel_unpadded = state_dict[gbuf_idx][dtype]["numel_unpadded"]
+                    checkpoint_numel_unpadded = checkpoint_dtype_state["numel_unpadded"]
                     assert buffer_numel_unpadded == checkpoint_numel_unpadded, (
                         f"Number of unpadded elements must be same in current run "
                         f"({buffer_numel_unpadded}) and checkpoint ({checkpoint_numel_unpadded})"
@@ -2410,7 +2421,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                         # Scatter tensor list.
                         if data_parallel_rank == 0:
-                            world_tensors = state_dict[gbuf_idx][dtype][key]
+                            world_tensors = checkpoint_dtype_state[key]
 
                             start = offset_in_world_tensors
                             end = offset_in_world_tensors + gbuf_world_numel_unpadded
@@ -2503,7 +2514,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if isinstance(self.optimizer, HybridDeviceOptimizer):
             self.optimizer._sync_hdo_state_to_sub_optimizers()
 
-    def split_state_dict_if_needed(self, state_dict):
+    def split_state_dict_if_needed(self, state_dict, checkpoint_version: Optional[float] = None):
         """
         When "--fp8-param-gather" is disabled, weights and biases are stored in the same
         `_ParamAndGradBuffer`. So, when saving a checkpoint, the optimizer's main parameters are
@@ -2529,7 +2540,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             if key != 'buckets_coalesced':
                 for dtype in state_dict[key].keys():
                     assert dtype not in dtype_to_gbuf_idx
-                    if isinstance(dtype, str) and dtype.startswith('dtype_param_torch:uint8_grad_'):
+                    legacy_uint8_key = (
+                        isinstance(dtype, tuple) and len(dtype) == 2 and dtype[0] == torch.uint8
+                    )
+                    current_uint8_key = isinstance(dtype, str) and dtype.startswith(
+                        'dtype_param_torch:uint8_grad_'
+                    )
+                    if legacy_uint8_key or current_uint8_key:
                         # If the `state_dict`` already contains a torch.uint8 buffer, we assumed
                         # that the fp8 weights and fp16/bf16 biases in the checkpoint are already
                         # separated. In this case, no action is required, so we can return directly.
@@ -2542,7 +2559,15 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, _ in gbuf_range_maps.items():
                 if not self._is_distopt_quantized_param(self.buffers[gbuf_idx].params[0]):
-                    new_state_dict[gbuf_idx] = state_dict[dtype_to_gbuf_idx[dtype]]
+                    buffer = self.buffers[gbuf_idx]
+                    checkpoint_dtype = self._back_compat_loaded_dtype_key(
+                        dtype_to_gbuf_idx,
+                        dtype,
+                        buffer.param_dtype,
+                        buffer.grad_dtype,
+                        checkpoint_version,
+                    )
+                    new_state_dict[gbuf_idx] = state_dict[dtype_to_gbuf_idx[checkpoint_dtype]]
 
         for fp8_gbuf_idx in fp8_gbuf_indices:
             # Note that `self.buffers[fp8_gbuf_idx].params[0].dtype` is the dummy dtype of
@@ -2558,6 +2583,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     if dtype == non_fp8_param_and_grad_dtype:
                         non_fp8_gbuf_idx = gbuf_idx
             assert non_fp8_gbuf_idx is not None
+            checkpoint_non_fp8_dtype = self._back_compat_loaded_dtype_key(
+                state_dict[non_fp8_gbuf_idx],
+                non_fp8_param_and_grad_dtype,
+                self.buffers[fp8_gbuf_idx].params[0].dtype,
+                self.buffers[fp8_gbuf_idx].grad_dtype,
+                checkpoint_version,
+            )
 
             # We need the fp8_flags to determine the order of weight (fp8) and bias (fp16/bf16) in
             # the buffer.
@@ -2602,7 +2634,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Split the target buffer into two separate buffers.
             fp8_state_dict, non_fp8_state_dict = {}, {}
             for key in ('param',) + self.optimizer_state_keys:
-                tensor = state_dict[non_fp8_gbuf_idx][non_fp8_param_and_grad_dtype][key]
+                tensor = state_dict[non_fp8_gbuf_idx][checkpoint_non_fp8_dtype][key]
                 fp8_tensor = torch.empty([fp8_offsets[-1]], dtype=tensor.dtype)
                 non_fp8_tensor = torch.empty([non_fp8_offsets[-1]], dtype=tensor.dtype)
 
@@ -2626,9 +2658,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             non_fp8_state_dict['numel_unpadded'] = non_fp8_offsets[-1]
 
             # Add the two separate buffers into `new_state_dict`.
-            new_state_dict[fp8_gbuf_idx] = {}
-            new_state_dict[fp8_gbuf_idx][(torch.uint8, fp8_buffer.grad_dtype)] = fp8_state_dict
-            new_state_dict[non_fp8_gbuf_idx][non_fp8_param_and_grad_dtype] = non_fp8_state_dict
+            fp8_param_and_grad_dtype = _get_dtype_param_grad_key(torch.uint8, fp8_buffer.grad_dtype)
+            new_state_dict[fp8_gbuf_idx] = {fp8_param_and_grad_dtype: fp8_state_dict}
+            new_state_dict[non_fp8_gbuf_idx] = {non_fp8_param_and_grad_dtype: non_fp8_state_dict}
 
         # Inplace update state_dict
         state_dict.clear()

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -74,9 +74,6 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 
 logger = getLogger(__name__)
 
-_DTYPE_KEY_FORMAT_METADATA_KEY = 'distrib_optim_dtype_key_format'
-_FQN_SAFE_DTYPE_KEY_FORMAT = 'fqn_safe'
-
 
 def _get_dtype_param_grad_key(param_dtype, grad_dtype):
     """Return the checkpoint-safe key for a parameter/gradient dtype pair."""
@@ -138,11 +135,32 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         'fsdp_dtensor',
     }
 
-    @staticmethod
-    def _back_compat_normalize_loaded_dtype_keys(state_dict: Optional[dict]) -> None:
-        """Normalize dtype tuple keys from old checkpoints to current runtime strings."""
+    def _back_compat_normalize_loaded_dtype_keys(
+        self, state_dict: Optional[dict], checkpoint_version: Optional[float] = None
+    ) -> None:
+        """Adapt legacy dtype FQNs and normalize loaded tuple keys.
+
+        Before loading a checkpoint older than version 3.1, rewrite the loading template's
+        ShardedTensor keys to the legacy dtype FQNs stored in that checkpoint. After loading,
+        normalize any tuple dtype keys in the loaded state to the current string format.
+        """
         if state_dict is None:
             return
+
+        if checkpoint_version is not None and checkpoint_version < 3.1:
+            dtype_fqn_replacements = {
+                f'.dtype_{_get_dtype_param_grad_key(buffer.param_dtype, buffer.grad_dtype)}.': (
+                    f'.dtype_{(buffer.param_dtype, buffer.grad_dtype)}.'
+                )
+                for buffer in self.buffers
+            }
+            for value in nested_values(state_dict):
+                if not isinstance(value, ShardedTensor):
+                    continue
+                for current_dtype_fqn, legacy_dtype_fqn in dtype_fqn_replacements.items():
+                    if current_dtype_fqn in value.key:
+                        value.key = value.key.replace(current_dtype_fqn, legacy_dtype_fqn, 1)
+                        break
 
         def normalize_dtype_keys(dtype_state):
             if not isinstance(dtype_state, dict):
@@ -1574,12 +1592,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 'distrib_optim_sharding_type', 'fully_sharded_model_space'
             )
 
-        # Content metadata is loaded before the sharded state dict is constructed. Mark new
-        # checkpoints so loading can select their FQN-safe dtype names, while the absence of the
-        # marker identifies checkpoints that used tuple dtype keys in their tensor FQNs.
-        if not is_loading and metadata is not None:
-            metadata[_DTYPE_KEY_FORMAT_METADATA_KEY] = _FQN_SAFE_DTYPE_KEY_FORMAT
-
         # Handle FSDP DistributedOptimizer States
         if self.ddp_config.use_megatron_fsdp and sharding_type != "fsdp_dtensor":
             raise NotImplementedError(
@@ -1939,9 +1951,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """
         data_parallel_rank = self.data_parallel_group.rank()
         data_parallel_world_size = self.data_parallel_group.size()
-        use_legacy_dtype_fqn = is_loading and (
-            (metadata or {}).get(_DTYPE_KEY_FORMAT_METADATA_KEY) != _FQN_SAFE_DTYPE_KEY_FORMAT
-        )
 
         state = self.get_parameter_state_dp_reshardable()
         # per_bucket_numel metadata is saved separately for each TPxPP domain.
@@ -1960,10 +1969,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, gbuf_range_map_for_all_buckets in state[gbuf_idx].items():
-                dtype_fqn = dtype
-                if use_legacy_dtype_fqn:
-                    buffer = self.buffers[gbuf_idx]
-                    dtype_fqn = (buffer.param_dtype, buffer.grad_dtype)
                 for bucket_idx, bucket_state in enumerate(gbuf_range_map_for_all_buckets):
                     # Compute local DP contiguous shard's size.
                     gbuf_world_numel_unpadded = (
@@ -1976,7 +1981,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                     sharded_bucket_key = (
                         f'optimizer.distributed.dp_group_idx_{self.data_parallel_group_idx}'
-                        f'.gbuf_idx_{gbuf_idx}.dtype_{dtype_fqn}.bucket_idx_{bucket_idx}'
+                        f'.gbuf_idx_{gbuf_idx}.dtype_{dtype}.bucket_idx_{bucket_idx}'
                     )
 
                     # The global ckpt tensors must be fully covered.
@@ -2058,6 +2063,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 allow_shape_mismatch=False,
                                 replica_id=(self.distributed_optimizer_instance_id, 0, 0),
                             )
+        if is_loading:
+            self._back_compat_normalize_loaded_dtype_keys(
+                state, checkpoint_version=(metadata or {}).get('checkpoint_version')
+            )
         return state
 
     def sharded_param_state_fs_model_space(

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -75,7 +75,6 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 logger = getLogger(__name__)
 
 _FQN_SAFE_DTYPE_KEY_VERSION = 3.1
-_LOADED_CHECKPOINT_VERSION_KEY = '_loaded_checkpoint_version'
 
 
 def _get_dtype_param_grad_key(param_dtype, grad_dtype):
@@ -138,10 +137,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         'fsdp_dtensor',
     }
 
-    def _back_compat_rewrite_loaded_dtype_fqns(
+    def _back_compat_normalize_loaded_dtype_keys(
         self, state_dict: Optional[dict], checkpoint_version: Optional[float]
     ) -> None:
-        """Use the legacy dtype FQNs when loading a checkpoint older than version 3.1."""
+        """Adapt optimizer state generated before version 3.1 for loading."""
         if (
             state_dict is None
             or checkpoint_version is None
@@ -163,25 +162,25 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     value.key = value.key.replace(current_dtype_fqn, legacy_dtype_fqn, 1)
                     break
 
-    @staticmethod
-    def _back_compat_loaded_dtype_key(
-        dtype_state: dict,
-        current_dtype_key: str,
-        param_dtype: torch.dtype,
-        grad_dtype: torch.dtype,
-        checkpoint_version: Optional[float],
-    ):
-        """Select the dtype key present in a current or legacy loaded state dictionary."""
-        if current_dtype_key in dtype_state:
-            return current_dtype_key
+        def normalize_dtype_keys(dtype_state):
+            if not isinstance(dtype_state, dict):
+                return
+            for dtype in list(dtype_state):
+                if not isinstance(dtype, tuple):
+                    continue
+                assert len(dtype) == 2, dtype
+                dtype_state[_get_dtype_param_grad_key(*dtype)] = dtype_state.pop(dtype)
 
-        legacy_dtype_key = (param_dtype, grad_dtype)
-        if (
-            checkpoint_version is None or checkpoint_version < _FQN_SAFE_DTYPE_KEY_VERSION
-        ) and legacy_dtype_key in dtype_state:
-            return legacy_dtype_key
+        for gbuf_idx, dtype_state in state_dict.items():
+            if isinstance(gbuf_idx, int):
+                normalize_dtype_keys(dtype_state)
 
-        return current_dtype_key
+        for per_bucket_key in ('per_bucket_numel', 'per_bucket_numel_unpadded'):
+            per_bucket_values = state_dict.get(per_bucket_key)
+            if not isinstance(per_bucket_values, list):
+                continue
+            for dtype_state in per_bucket_values:
+                normalize_dtype_keys(dtype_state)
 
     @classmethod
     def _build_model_gbuf_param_range_map(
@@ -750,6 +749,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for model_chunk in self.model_chunks:
             assert self.ddp_config == model_chunk.ddp_config
         self.distributed_optimizer_instance_id = distributed_optimizer_instance_id
+        # Retained only between loading-template creation and load_state_dict().
+        self._checkpoint_version_for_load = None
 
         assert (
             isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
@@ -1137,16 +1138,17 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             assert 'param_state_sharding_type' in state_dict, state_dict.keys()
             param_state = state_dict['param_state']
             sharding_type = state_dict['param_state_sharding_type']
+            self._back_compat_normalize_loaded_dtype_keys(
+                param_state, self._checkpoint_version_for_load
+            )
+            self._checkpoint_version_for_load = None
             log_single_rank(
                 logger,
                 logging.INFO,
                 f'Loading distributed optimizer sharded state of type {sharding_type}',
             )
             if sharding_type == 'dp_zero_gather_scatter':
-                checkpoint_version = state_dict.pop(_LOADED_CHECKPOINT_VERSION_KEY, None)
-                self.load_parameter_state_from_dp_zero(
-                    param_state, checkpoint_version=checkpoint_version
-                )
+                self.load_parameter_state_from_dp_zero(param_state)
             elif sharding_type == 'fully_reshardable':
                 self.load_parameter_state_from_fully_reshardable(param_state)
             elif sharding_type == 'dp_reshardable':
@@ -1581,6 +1583,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 'distrib_optim_sharding_type', 'fully_sharded_model_space'
             )
 
+        if is_loading:
+            self._checkpoint_version_for_load = (metadata or {}).get('checkpoint_version')
+
         # Handle FSDP DistributedOptimizer States
         if self.ddp_config.use_megatron_fsdp and sharding_type != "fsdp_dtensor":
             raise NotImplementedError(
@@ -1648,10 +1653,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         state_dict['param_state'] = param_state
         state_dict['param_state_sharding_type'] = sharding_type
-        if is_loading and sharding_type == 'dp_zero_gather_scatter':
-            state_dict[_LOADED_CHECKPOINT_VERSION_KEY] = LocalNonpersistentObject(
-                (metadata or {}).get('checkpoint_version')
-            )
         return state_dict
 
     def _param_groups_to_param2group_meta(
@@ -2057,7 +2058,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 replica_id=(self.distributed_optimizer_instance_id, 0, 0),
                             )
         if is_loading:
-            self._back_compat_rewrite_loaded_dtype_fqns(
+            self._back_compat_normalize_loaded_dtype_keys(
                 state, checkpoint_version=(metadata or {}).get('checkpoint_version')
             )
         return state
@@ -2152,17 +2153,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """
         if state_dict is not None and "per_bucket_numel_unpadded" in state_dict:
             per_bucket_numel_unpadded_in_checkpoint = state_dict["per_bucket_numel_unpadded"]
-            assert all(
-                len(dtype_state) == 1 for dtype_state in per_bucket_numel_unpadded_in_checkpoint
-            )
-            current_numel_unpadded = [
-                next(iter(dtype_state.values())) for dtype_state in self.per_bucket_numel_unpadded
-            ]
-            checkpoint_numel_unpadded = [
-                next(iter(dtype_state.values()))
-                for dtype_state in per_bucket_numel_unpadded_in_checkpoint
-            ]
-            assert current_numel_unpadded == checkpoint_numel_unpadded, (
+            assert self.per_bucket_numel_unpadded == per_bucket_numel_unpadded_in_checkpoint, (
                 f"Number of unpadded elements in each bucket need to be the same in current run "
                 f"({self.per_bucket_numel_unpadded}) and checkpoint "
                 f"({per_bucket_numel_unpadded_in_checkpoint})"
@@ -2348,9 +2339,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                 recv_tensor[gbuf_local_start:gbuf_local_end]
                             )
 
-    def load_parameter_state_from_dp_zero(
-        self, state_dict, *, update_legacy_format=False, checkpoint_version: Optional[float] = None
-    ):
+    def load_parameter_state_from_dp_zero(self, state_dict, *, update_legacy_format=False):
         """Load parameter state (i.e., parameter & optimizer tensors) from DP 0 rank,
         using the new checkpoint format with coalesced state across buckets.
 
@@ -2378,23 +2367,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         if data_parallel_rank == 0:
             # Do nothing if "--fp8-param-gather" is not used.
-            self.split_state_dict_if_needed(state_dict, checkpoint_version=checkpoint_version)
+            self.split_state_dict_if_needed(state_dict)
 
         # Scatter tensors to all DP ranks.
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
                 if data_parallel_rank == 0:
-                    buffer = self.buffers[gbuf_idx]
-                    checkpoint_dtype = self._back_compat_loaded_dtype_key(
-                        state_dict[gbuf_idx],
-                        dtype,
-                        buffer.param_dtype,
-                        buffer.grad_dtype,
-                        checkpoint_version,
-                    )
-                    checkpoint_dtype_state = state_dict[gbuf_idx][checkpoint_dtype]
                     buffer_numel_unpadded = self.buffers[gbuf_idx].numel_unpadded
-                    checkpoint_numel_unpadded = checkpoint_dtype_state["numel_unpadded"]
+                    checkpoint_numel_unpadded = state_dict[gbuf_idx][dtype]["numel_unpadded"]
                     assert buffer_numel_unpadded == checkpoint_numel_unpadded, (
                         f"Number of unpadded elements must be same in current run "
                         f"({buffer_numel_unpadded}) and checkpoint ({checkpoint_numel_unpadded})"
@@ -2421,7 +2401,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                         # Scatter tensor list.
                         if data_parallel_rank == 0:
-                            world_tensors = checkpoint_dtype_state[key]
+                            world_tensors = state_dict[gbuf_idx][dtype][key]
 
                             start = offset_in_world_tensors
                             end = offset_in_world_tensors + gbuf_world_numel_unpadded
@@ -2514,7 +2494,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if isinstance(self.optimizer, HybridDeviceOptimizer):
             self.optimizer._sync_hdo_state_to_sub_optimizers()
 
-    def split_state_dict_if_needed(self, state_dict, checkpoint_version: Optional[float] = None):
+    def split_state_dict_if_needed(self, state_dict):
         """
         When "--fp8-param-gather" is disabled, weights and biases are stored in the same
         `_ParamAndGradBuffer`. So, when saving a checkpoint, the optimizer's main parameters are
@@ -2540,13 +2520,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             if key != 'buckets_coalesced':
                 for dtype in state_dict[key].keys():
                     assert dtype not in dtype_to_gbuf_idx
-                    legacy_uint8_key = (
-                        isinstance(dtype, tuple) and len(dtype) == 2 and dtype[0] == torch.uint8
-                    )
-                    current_uint8_key = isinstance(dtype, str) and dtype.startswith(
-                        'dtype_param_torch:uint8_grad_'
-                    )
-                    if legacy_uint8_key or current_uint8_key:
+                    if isinstance(dtype, str) and dtype.startswith('dtype_param_torch:uint8_grad_'):
                         # If the `state_dict`` already contains a torch.uint8 buffer, we assumed
                         # that the fp8 weights and fp16/bf16 biases in the checkpoint are already
                         # separated. In this case, no action is required, so we can return directly.
@@ -2559,15 +2533,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         for gbuf_idx, gbuf_range_maps in enumerate(self.gbuf_ranges):
             for dtype, _ in gbuf_range_maps.items():
                 if not self._is_distopt_quantized_param(self.buffers[gbuf_idx].params[0]):
-                    buffer = self.buffers[gbuf_idx]
-                    checkpoint_dtype = self._back_compat_loaded_dtype_key(
-                        dtype_to_gbuf_idx,
-                        dtype,
-                        buffer.param_dtype,
-                        buffer.grad_dtype,
-                        checkpoint_version,
-                    )
-                    new_state_dict[gbuf_idx] = state_dict[dtype_to_gbuf_idx[checkpoint_dtype]]
+                    new_state_dict[gbuf_idx] = state_dict[dtype_to_gbuf_idx[dtype]]
 
         for fp8_gbuf_idx in fp8_gbuf_indices:
             # Note that `self.buffers[fp8_gbuf_idx].params[0].dtype` is the dummy dtype of
@@ -2583,13 +2549,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     if dtype == non_fp8_param_and_grad_dtype:
                         non_fp8_gbuf_idx = gbuf_idx
             assert non_fp8_gbuf_idx is not None
-            checkpoint_non_fp8_dtype = self._back_compat_loaded_dtype_key(
-                state_dict[non_fp8_gbuf_idx],
-                non_fp8_param_and_grad_dtype,
-                self.buffers[fp8_gbuf_idx].params[0].dtype,
-                self.buffers[fp8_gbuf_idx].grad_dtype,
-                checkpoint_version,
-            )
 
             # We need the fp8_flags to determine the order of weight (fp8) and bias (fp16/bf16) in
             # the buffer.
@@ -2634,7 +2593,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Split the target buffer into two separate buffers.
             fp8_state_dict, non_fp8_state_dict = {}, {}
             for key in ('param',) + self.optimizer_state_keys:
-                tensor = state_dict[non_fp8_gbuf_idx][checkpoint_non_fp8_dtype][key]
+                tensor = state_dict[non_fp8_gbuf_idx][non_fp8_param_and_grad_dtype][key]
                 fp8_tensor = torch.empty([fp8_offsets[-1]], dtype=tensor.dtype)
                 non_fp8_tensor = torch.empty([non_fp8_offsets[-1]], dtype=tensor.dtype)
 

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2525,14 +2525,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             return
 
         dtype_to_gbuf_idx = {}
-        uint8_dtype_keys = {
-            _get_dtype_param_grad_key(torch.uint8, buffer.grad_dtype) for buffer in self.buffers
-        }
         for key in state_dict.keys():
             if key != 'buckets_coalesced':
                 for dtype in state_dict[key].keys():
                     assert dtype not in dtype_to_gbuf_idx
-                    if dtype in uint8_dtype_keys:
+                    if isinstance(dtype, str) and dtype.startswith('dtype_param_torch:uint8_grad_'):
                         # If the `state_dict`` already contains a torch.uint8 buffer, we assumed
                         # that the fp8 weights and fp16/bf16 biases in the checkpoint are already
                         # separated. In this case, no action is required, so we can return directly.

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1569,7 +1569,7 @@ def generate_state_dict(
     # Arguments, iteration, and model.
     state_dict = {}
     state_dict['args'] = args
-    state_dict['checkpoint_version'] = 3.0
+    state_dict['checkpoint_version'] = 3.1
     if iteration is not None:
         state_dict['iteration'] = iteration
 
@@ -2685,6 +2685,8 @@ def load_checkpoint(
         if sharded_sd_metadata is None:
             sharded_sd_metadata = {}
         sharded_sd_metadata['dp_cp_group'] = dp_cp_group
+        # Optimizer load templates use the content version to select checkpoint-era FQNs.
+        sharded_sd_metadata['checkpoint_version'] = state_dict.get('checkpoint_version', 0)
 
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
         model_sd_kwargs = dict(metadata=sharded_sd_metadata)

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -17,6 +17,7 @@ from megatron.core.dist_checkpointing import (
     ShardedObject,
     ShardedTensor,
     load,
+    load_content_metadata,
     load_plain_tensors,
     save,
 )
@@ -518,7 +519,8 @@ class TestDistributedOptimizer:
             for per_buffer_numel in distributed_optimizer.per_bucket_numel
             for dtype in per_buffer_numel
         ]
-        assert runtime_dtype_keys and all(isinstance(key, str) for key in runtime_dtype_keys)
+        assert runtime_dtype_keys
+        assert set(runtime_dtype_keys) == {'dtype_param_torch:bfloat16_grad_torch:bfloat16'}
         metadata = {
             'distrib_optim_sharding_type': sharding_type,
             'distrib_optim_fully_reshardable_mem_efficient': False,
@@ -576,6 +578,11 @@ class TestDistributedOptimizer:
                     model_A[0].sharded_state_dict(), metadata=metadata
                 )
 
+            # A legacy checkpoint predates the dtype-key format marker. New checkpoints add the
+            # marker automatically when their sharded optimizer state is constructed.
+            if legacy_keys:
+                metadata.pop('distrib_optim_dtype_key_format')
+
             has_tuple_key = torch.tensor(
                 any(isinstance(key, tuple) for _, key in iter_state_dict_keys(optim_sd)),
                 device='cuda',
@@ -584,7 +591,7 @@ class TestDistributedOptimizer:
             torch.distributed.all_reduce(has_tuple_key, op=torch.distributed.ReduceOp.MAX)
             assert bool(has_tuple_key.item()) == legacy_keys
 
-            save(optim_sd, ckpt_dir)
+            save(optim_sd, ckpt_dir, content_metadata=metadata)
             optim_param_state_A = get_param_state_dp_zero(optimizer_A)
 
             model_B, optimizer_B = setup_model_and_optimizer(
@@ -595,8 +602,10 @@ class TestDistributedOptimizer:
                 dist_opt=True,
                 initialize_fn=initialize_pp_agnostic_model,
             )
+            loaded_metadata = load_content_metadata(ckpt_dir)
+            assert ('distrib_optim_dtype_key_format' in loaded_metadata) != legacy_keys
             load_sharded_state_dict = optimizer_B.sharded_state_dict(
-                model_B[0].sharded_state_dict(), metadata=metadata, is_loading=True
+                model_B[0].sharded_state_dict(), metadata=loaded_metadata, is_loading=True
             )
             loaded_state_dict = load(load_sharded_state_dict, ckpt_dir)
             loaded_has_tuple_key = torch.tensor(
@@ -952,8 +961,11 @@ class TestDistributedOptimizer:
             plain_state_dict_B = load_plain_tensors(ckpt_dir_B)
             torch.distributed.barrier()
 
-            # Stringifying the state-dict key must not rename legacy checkpoint tensors.
-            assert any('.dtype_(torch.' in key for key in plain_state_dict_B)
+            assert any(
+                '.dtype_dtype_param_torch:bfloat16_grad_torch:bfloat16.' in key
+                for key in plain_state_dict_B
+            )
+            assert not any('.dtype_(torch.' in key for key in plain_state_dict_B)
 
             # We test only the `plain_state_dict_B` keys because of decreasing PP
             for key in list(plain_state_dict_B.keys()):

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -17,6 +17,7 @@ from megatron.core.dist_checkpointing import (
     ShardedObject,
     ShardedTensor,
     load,
+    load_common_state_dict,
     load_content_metadata,
     load_plain_tensors,
     save,
@@ -552,6 +553,7 @@ class TestDistributedOptimizer:
     ):
         """String- and tuple-key checkpoints load without compatibility settings."""
         Utils.initialize_model_parallel(1, 1)
+        checkpoint_version = 3.0 if legacy_keys else 3.1
         metadata = {'distrib_optim_sharding_type': sharding_type}
 
         with TempNamedDir(
@@ -578,11 +580,6 @@ class TestDistributedOptimizer:
                     model_A[0].sharded_state_dict(), metadata=metadata
                 )
 
-            # A legacy checkpoint predates the dtype-key format marker. New checkpoints add the
-            # marker automatically when their sharded optimizer state is constructed.
-            if legacy_keys:
-                metadata.pop('distrib_optim_dtype_key_format')
-
             has_tuple_key = torch.tensor(
                 any(isinstance(key, tuple) for _, key in iter_state_dict_keys(optim_sd)),
                 device='cuda',
@@ -591,7 +588,11 @@ class TestDistributedOptimizer:
             torch.distributed.all_reduce(has_tuple_key, op=torch.distributed.ReduceOp.MAX)
             assert bool(has_tuple_key.item()) == legacy_keys
 
-            save(optim_sd, ckpt_dir, content_metadata=metadata)
+            save(
+                {'checkpoint_version': checkpoint_version, 'optimizer': optim_sd},
+                ckpt_dir,
+                content_metadata=metadata,
+            )
             optim_param_state_A = get_param_state_dp_zero(optimizer_A)
 
             model_B, optimizer_B = setup_model_and_optimizer(
@@ -602,11 +603,22 @@ class TestDistributedOptimizer:
                 dist_opt=True,
                 initialize_fn=initialize_pp_agnostic_model,
             )
-            loaded_metadata = load_content_metadata(ckpt_dir)
-            assert ('distrib_optim_dtype_key_format' in loaded_metadata) != legacy_keys
-            load_sharded_state_dict = optimizer_B.sharded_state_dict(
-                model_B[0].sharded_state_dict(), metadata=loaded_metadata, is_loading=True
-            )
+            common_state = load_common_state_dict(ckpt_dir)
+            assert common_state['checkpoint_version'] == checkpoint_version
+            loaded_metadata = load_content_metadata(preloaded_state_dict=common_state)
+            loaded_metadata['checkpoint_version'] = common_state['checkpoint_version']
+            load_sharded_state_dict = {
+                'optimizer': optimizer_B.sharded_state_dict(
+                    model_B[0].sharded_state_dict(), metadata=loaded_metadata, is_loading=True
+                )
+            }
+            if sharding_type == 'dp_reshardable':
+                uses_legacy_dtype_fqn = any(
+                    '.dtype_(torch.' in value.key
+                    for value in nested_values(load_sharded_state_dict)
+                    if isinstance(value, ShardedTensor)
+                )
+                assert uses_legacy_dtype_fqn == legacy_keys
             loaded_state_dict = load(load_sharded_state_dict, ckpt_dir)
             loaded_has_tuple_key = torch.tensor(
                 any(isinstance(key, tuple) for _, key in iter_state_dict_keys(loaded_state_dict)),
@@ -616,7 +628,7 @@ class TestDistributedOptimizer:
             torch.distributed.all_reduce(loaded_has_tuple_key, op=torch.distributed.ReduceOp.MAX)
             assert bool(loaded_has_tuple_key.item()) == legacy_keys
 
-            optimizer_B.load_state_dict(loaded_state_dict)
+            optimizer_B.load_state_dict(loaded_state_dict['optimizer'])
             optim_param_state_B = get_param_state_dp_zero(optimizer_B)
 
             if legacy_keys:

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -285,20 +285,6 @@ def get_param_state_dp_zero(optimizer):
     return optim_param_state_A
 
 
-def strip_dp_zero_dtype_keys(state_dict):
-    """Remove the dtype-key level so legacy and current state values can be compared."""
-    if state_dict is None:
-        return None
-
-    stripped_state_dict = {}
-    for key, value in state_dict.items():
-        if isinstance(key, int):
-            assert len(value) == 1
-            value = next(iter(value.values()))
-        stripped_state_dict[key] = value
-    return stripped_state_dict
-
-
 class TestOptimizer:
     def setup_method(self, method):
         pass
@@ -645,18 +631,24 @@ class TestDistributedOptimizer:
             optimizer_B.load_state_dict(loaded_state_dict['optimizer'])
             optim_param_state_B = get_param_state_dp_zero(optimizer_B)
 
-            # Loading consumes legacy tuple keys directly; it does not rewrite the loaded object.
+            # The compatibility boundary normalizes old state before the regular loader sees it.
             loaded_has_tuple_key = torch.tensor(
                 any(isinstance(key, tuple) for _, key in iter_state_dict_keys(loaded_state_dict)),
                 device='cuda',
                 dtype=torch.int,
             )
             torch.distributed.all_reduce(loaded_has_tuple_key, op=torch.distributed.ReduceOp.MAX)
-            assert bool(loaded_has_tuple_key.item()) == legacy_keys
+            assert not bool(loaded_has_tuple_key.item())
+
+            if legacy_keys:
+                distributed_optimizer_A = self._unwrap_distributed_optimizer(optimizer_A)
+                distributed_optimizer_A._back_compat_normalize_loaded_dtype_keys(
+                    optim_param_state_A, checkpoint_version
+                )
 
             assert self.check_equal_dp_zero_state(
-                strip_dp_zero_dtype_keys(optim_param_state_A),
-                strip_dp_zero_dtype_keys(optim_param_state_B),
+                optim_param_state_A,
+                optim_param_state_B,
                 same_dp_group=True,
                 raise_if_different=True,
             )

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import re
+from contextlib import nullcontext
 from copy import deepcopy
 from functools import partial
 from unittest import mock
@@ -11,7 +12,14 @@ import torch
 from torch.optim import Adam
 
 from megatron.core import parallel_state
-from megatron.core.dist_checkpointing import ShardedTensor, load, load_plain_tensors, save
+from megatron.core.dist_checkpointing import (
+    LocalNonpersistentObject,
+    ShardedObject,
+    ShardedTensor,
+    load,
+    load_plain_tensors,
+    save,
+)
 from megatron.core.dist_checkpointing.dict_utils import diff, nested_values
 from megatron.core.dist_checkpointing.optimizer import (
     get_param_id_to_sharded_param_map,
@@ -77,6 +85,21 @@ class Model(torch.nn.Module):
             'proj.bias', sharded_state_dict['proj.bias'], (0, Utils.rank, Utils.world_size)
         )
         return sharded_state_dict
+
+
+def iter_state_dict_keys(value, path=()):
+    """Iterate over keys from nested checkpoint mappings, including wrapped object data."""
+    if isinstance(value, ShardedObject):
+        yield from iter_state_dict_keys(value.data, path + ('<sharded_object_data>',))
+    elif isinstance(value, LocalNonpersistentObject):
+        yield from iter_state_dict_keys(value.unwrap(), path + ('<local_nonpersistent>',))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield path, key
+            yield from iter_state_dict_keys(item, path + (key,))
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            yield from iter_state_dict_keys(item, path + (index,))
 
 
 class NativeFp32Model(torch.nn.Module):
@@ -469,6 +492,137 @@ class TestDistributedOptimizer:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6a0"),
+        reason="distributed optimizer torch_dist formats require PyTorch 2.6a0 or later",
+    )
+    @pytest.mark.parametrize(
+        'sharding_type',
+        [
+            'dp_reshardable',
+            'dp_zero_gather_scatter',
+            'fully_reshardable',
+            'fully_sharded_model_space',
+        ],
+    )
+    def test_torch_dist_optimizer_state_dict_key_types(self, sharding_type):
+        """torch_dist optimizer checkpoints use only string or integer mapping keys."""
+        Utils.initialize_model_parallel(1, 1)
+        model, optimizer = setup_model_and_optimizer(
+            seed=2,
+            tp=1,
+            pp=1,
+            bf16=True,
+            dist_opt=True,
+            initialize_fn=initialize_pp_agnostic_model,
+        )
+        distributed_optimizer = self._unwrap_distributed_optimizer(optimizer)
+        runtime_dtype_keys = [
+            dtype
+            for per_buffer_numel in distributed_optimizer.per_bucket_numel
+            for dtype in per_buffer_numel
+        ]
+        assert runtime_dtype_keys and all(isinstance(key, str) for key in runtime_dtype_keys)
+        metadata = {
+            'distrib_optim_sharding_type': sharding_type,
+            'distrib_optim_fully_reshardable_mem_efficient': False,
+        }
+
+        optim_sd = optimizer.sharded_state_dict(
+            model[0].sharded_state_dict(), metadata=metadata
+        )
+        unsupported_keys = [
+            (path, key)
+            for path, key in iter_state_dict_keys(optim_sd)
+            if not isinstance(key, (str, int))
+        ]
+
+        assert not unsupported_keys
+        runtime_dtype_keys = [
+            dtype
+            for per_buffer_numel in distributed_optimizer.per_bucket_numel
+            for dtype in per_buffer_numel
+        ]
+        assert runtime_dtype_keys and all(isinstance(key, str) for key in runtime_dtype_keys)
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6a0"),
+        reason="distributed optimizer torch_dist formats require PyTorch 2.6a0 or later",
+    )
+    @pytest.mark.parametrize('sharding_type', ['dp_reshardable', 'dp_zero_gather_scatter'])
+    @pytest.mark.parametrize('legacy_keys', [False, True])
+    def test_optimizer_checkpoint_key_compatibility(
+        self, tmp_path_dist_ckpt, sharding_type, legacy_keys
+    ):
+        """String- and tuple-key checkpoints load without compatibility settings."""
+        Utils.initialize_model_parallel(1, 1)
+        metadata = {'distrib_optim_sharding_type': sharding_type}
+
+        with TempNamedDir(
+            tmp_path_dist_ckpt / f'test_key_compatibility_{sharding_type}_{legacy_keys}', sync=True
+        ) as ckpt_dir:
+            dtype_key_context = (
+                mock.patch(
+                    'megatron.core.optimizer.distrib_optimizer._get_dtype_param_grad_key',
+                    side_effect=lambda param_dtype, grad_dtype: (param_dtype, grad_dtype),
+                )
+                if legacy_keys
+                else nullcontext()
+            )
+            with dtype_key_context:
+                model_A, optimizer_A = setup_model_and_optimizer(
+                    seed=2,
+                    tp=1,
+                    pp=1,
+                    bf16=True,
+                    dist_opt=True,
+                    initialize_fn=initialize_pp_agnostic_model,
+                )
+                optim_sd = optimizer_A.sharded_state_dict(
+                    model_A[0].sharded_state_dict(), metadata=metadata
+                )
+
+            has_tuple_key = torch.tensor(
+                any(isinstance(key, tuple) for _, key in iter_state_dict_keys(optim_sd)),
+                device='cuda',
+                dtype=torch.int,
+            )
+            torch.distributed.all_reduce(has_tuple_key, op=torch.distributed.ReduceOp.MAX)
+            assert bool(has_tuple_key.item()) == legacy_keys
+
+            save(optim_sd, ckpt_dir)
+            optim_param_state_A = get_param_state_dp_zero(optimizer_A)
+
+            model_B, optimizer_B = setup_model_and_optimizer(
+                seed=3,
+                tp=1,
+                pp=1,
+                bf16=True,
+                dist_opt=True,
+                initialize_fn=initialize_pp_agnostic_model,
+            )
+            load_sharded_state_dict = optimizer_B.sharded_state_dict(
+                model_B[0].sharded_state_dict(), metadata=metadata, is_loading=True
+            )
+            loaded_state_dict = load(load_sharded_state_dict, ckpt_dir)
+            optimizer_B.load_state_dict(loaded_state_dict)
+            optim_param_state_B = get_param_state_dp_zero(optimizer_B)
+
+            assert self.check_equal_dp_zero_state(
+                optim_param_state_A,
+                optim_param_state_B,
+                same_dp_group=True,
+                raise_if_different=True,
+            )
+
+            # Loading a tuple-key checkpoint must not affect subsequent checkpoint saves.
+            resaved_optim_sd = optimizer_B.sharded_state_dict(
+                model_B[0].sharded_state_dict(), metadata=metadata
+            )
+            assert all(
+                isinstance(key, (str, int)) for _, key in iter_state_dict_keys(resaved_optim_sd)
+            )
+
     @pytest.mark.parametrize("fully_parallel", [False, True])
     @pytest.mark.parametrize(
         ("tp_pp_ep", "is_moe", "is_mla", "test_step", "kwargs"),
@@ -790,6 +944,9 @@ class TestDistributedOptimizer:
             plain_state_dict_A = load_plain_tensors(ckpt_dir_A)
             plain_state_dict_B = load_plain_tensors(ckpt_dir_B)
             torch.distributed.barrier()
+
+            # Stringifying the state-dict key must not rename legacy checkpoint tensors.
+            assert any('.dtype_(torch.' in key for key in plain_state_dict_B)
 
             # We test only the `plain_state_dict_B` keys because of decreasing PP
             for key in list(plain_state_dict_B.keys()):

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -502,19 +502,15 @@ class TestDistributedOptimizer:
             'dp_reshardable',
             'dp_zero_gather_scatter',
             'fully_reshardable',
-            'fully_sharded_model_space',
+            # fsdp_dtensor uses a separate optimizer path. fully_sharded_model_space is
+            # deprecated and cannot be constructed with the current ShardedTensor API.
         ],
     )
     def test_torch_dist_optimizer_state_dict_key_types(self, sharding_type):
         """torch_dist optimizer checkpoints use only string or integer mapping keys."""
         Utils.initialize_model_parallel(1, 1)
         model, optimizer = setup_model_and_optimizer(
-            seed=2,
-            tp=1,
-            pp=1,
-            bf16=True,
-            dist_opt=True,
-            initialize_fn=initialize_pp_agnostic_model,
+            seed=2, tp=1, pp=1, bf16=True, dist_opt=True, initialize_fn=initialize_pp_agnostic_model
         )
         distributed_optimizer = self._unwrap_distributed_optimizer(optimizer)
         runtime_dtype_keys = [
@@ -528,9 +524,7 @@ class TestDistributedOptimizer:
             'distrib_optim_fully_reshardable_mem_efficient': False,
         }
 
-        optim_sd = optimizer.sharded_state_dict(
-            model[0].sharded_state_dict(), metadata=metadata
-        )
+        optim_sd = optimizer.sharded_state_dict(model[0].sharded_state_dict(), metadata=metadata)
         unsupported_keys = [
             (path, key)
             for path, key in iter_state_dict_keys(optim_sd)
@@ -605,9 +599,22 @@ class TestDistributedOptimizer:
                 model_B[0].sharded_state_dict(), metadata=metadata, is_loading=True
             )
             loaded_state_dict = load(load_sharded_state_dict, ckpt_dir)
+            loaded_has_tuple_key = torch.tensor(
+                any(isinstance(key, tuple) for _, key in iter_state_dict_keys(loaded_state_dict)),
+                device='cuda',
+                dtype=torch.int,
+            )
+            torch.distributed.all_reduce(loaded_has_tuple_key, op=torch.distributed.ReduceOp.MAX)
+            assert bool(loaded_has_tuple_key.item()) == legacy_keys
+
             optimizer_B.load_state_dict(loaded_state_dict)
             optim_param_state_B = get_param_state_dp_zero(optimizer_B)
 
+            if legacy_keys:
+                distributed_optimizer_A = self._unwrap_distributed_optimizer(optimizer_A)
+                distributed_optimizer_A._back_compat_normalize_loaded_dtype_keys(
+                    optim_param_state_A
+                )
             assert self.check_equal_dp_zero_state(
                 optim_param_state_A,
                 optim_param_state_B,

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -285,6 +285,20 @@ def get_param_state_dp_zero(optimizer):
     return optim_param_state_A
 
 
+def strip_dp_zero_dtype_keys(state_dict):
+    """Remove the dtype-key level so legacy and current state values can be compared."""
+    if state_dict is None:
+        return None
+
+    stripped_state_dict = {}
+    for key, value in state_dict.items():
+        if isinstance(key, int):
+            assert len(value) == 1
+            value = next(iter(value.values()))
+        stripped_state_dict[key] = value
+    return stripped_state_dict
+
+
 class TestOptimizer:
     def setup_method(self, method):
         pass
@@ -631,14 +645,18 @@ class TestDistributedOptimizer:
             optimizer_B.load_state_dict(loaded_state_dict['optimizer'])
             optim_param_state_B = get_param_state_dp_zero(optimizer_B)
 
-            if legacy_keys:
-                distributed_optimizer_A = self._unwrap_distributed_optimizer(optimizer_A)
-                distributed_optimizer_A._back_compat_normalize_loaded_dtype_keys(
-                    optim_param_state_A
-                )
+            # Loading consumes legacy tuple keys directly; it does not rewrite the loaded object.
+            loaded_has_tuple_key = torch.tensor(
+                any(isinstance(key, tuple) for _, key in iter_state_dict_keys(loaded_state_dict)),
+                device='cuda',
+                dtype=torch.int,
+            )
+            torch.distributed.all_reduce(loaded_has_tuple_key, op=torch.distributed.ReduceOp.MAX)
+            assert bool(loaded_has_tuple_key.item()) == legacy_keys
+
             assert self.check_equal_dp_zero_state(
-                optim_param_state_A,
-                optim_param_state_B,
+                strip_dp_zero_dtype_keys(optim_param_state_A),
+                strip_dp_zero_dtype_keys(optim_param_state_B),
                 same_dp_group=True,
                 raise_if_different=True,
             )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

1. Replace tuple dictionary keys in distributed optimizer checkpoints with FQN-safe string keys.
For example, the optimizer tensor FQN changes from:
`...gbuf_idx_0.dtype_(torch.bfloat16, torch.bfloat16).bucket_idx_0...`
to
`...gbuf_idx_0.dtype_dtype_param_torch:bfloat16_grad_torch:bfloat16.bucket_idx_0...`
The state-dictionary with tuples of torch.dtype as keys, requires state-dictionary to be transformed into one with stringified keys and forces a mapping with stringified names back to the original state-dictionary which seems wasteful. Enforcing state-dictionary key types to be str or int would help simplify checkpointing code and avoid unnecessary transformation. 

other than the transformation the FQN name also becomes somewhat malformed because of the `.` in `torch.bfloat16` which breaks the semantics of using dot as a FQN separator.
The `prefix.dtype_(torch.bfloat16, torch.bfloat16).suffix` can no longer be split into FQN component names by simply splitting them with a "." because of the dot in torch.bfloat16 and requires complex regex's to make it work

2. Preserves back-compat with older checkpoints by bumping up the checkpoint version to 3.1 which identifies the new key-naming convention for distributed-optimizer. Old checkpoints (3.0 and before) continue to load but all saves going forward use the new key-naming and carry the updated version number (3.1)

3. Added tests to limit key-types to be either str or int.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
