### PR TITLE
Enable context parallelism in MFSDP v2

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -555,7 +555,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             device: Device whose type is used to construct the data-parallel mesh.
                 Defaults to CUDA.
             pg_collection: Explicit process groups. The ``dp_cp`` group defines the
-                data-parallel mesh.
+                data- and context-parallel sharding mesh, and ``cp`` defines the
+                context-parallel communication group.
 
         Raises:
             ImportError: If the Megatron FSDP implementation is unavailable.
@@ -715,7 +716,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         """
         if disable_bucketing:
             raise ValueError("MFSDP v2 does not support disabling bucketing.")
-        if not hasattr(pg_collection, 'dp_cp'):
+        if pg_collection.dp_cp is None:
             raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
 
         if config.mtp_detach_heads:
@@ -727,11 +728,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             # silently inflated norm.
             raise ValueError("MFSDP v2 does not currently support mtp_detach_heads.")
 
-        unsupported_parallelisms = [
-            "tensor_model_parallel_size",
-            "pipeline_model_parallel_size",
-            "context_parallel_size",
-        ]
+        unsupported_parallelisms = ["tensor_model_parallel_size", "pipeline_model_parallel_size"]
         if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
             raise ValueError(
                 "MFSDP v2 does not currently support: "
@@ -743,13 +740,35 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
         # The config validates the requested topology, while these checks validate the
         # materialized topology supplied by the caller's process-group collection.
-        for group_name in ("tp", "pp", "cp"):
+        for group_name in ("tp", "pp"):
             group = getattr(pg_collection, group_name, None)
             if group is not None and group.size() != 1:
                 raise ValueError(
                     f"MFSDP v2 currently requires {group_name.upper()} process-group size 1, "
                     f"got {group.size()}."
                 )
+
+        cp_group = pg_collection.cp
+        if cp_group is None:
+            if config.context_parallel_size != 1:
+                raise ValueError(
+                    "MFSDP v2 requires an explicit CP process group when "
+                    f"context_parallel_size={config.context_parallel_size}."
+                )
+        elif cp_group.size() != config.context_parallel_size:
+            raise ValueError(
+                "MFSDP v2 requires the CP process-group size to match "
+                f"context_parallel_size={config.context_parallel_size}, got {cp_group.size()}."
+            )
+        elif pg_collection.dp_cp.size() % cp_group.size() != 0:
+            raise ValueError(
+                "MFSDP v2 requires the dp_cp process-group size to be divisible by the "
+                f"CP process-group size, got {pg_collection.dp_cp.size()} and {cp_group.size()}."
+            )
+        elif not set(dist.get_process_group_ranks(cp_group)).issubset(
+            dist.get_process_group_ranks(pg_collection.dp_cp)
+        ):
+            raise ValueError("MFSDP v2 requires the dp_cp process group to contain the CP group.")
 
         if config.expert_model_parallel_size > 1:
             if (

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -30,6 +30,7 @@ from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import MoETransformerLayer, TransformerLayer
+from megatron.core.utils import get_batch_on_this_cp_rank
 from tests.unit_tests.test_utilities import Utils
 
 logger = logging.getLogger(__name__)
@@ -471,6 +472,179 @@ class TestMcoreAdapterDense:
             expected_pre_clip_norm > clip_grad
         ), "Test gradients must exceed the clipping threshold to exercise clipping."
         torch.testing.assert_close(global_norm(updates), clip_grad, rtol=1e-3, atol=0)
+
+
+class TestMcoreAdapterContextParallel:
+    """Exercise MFSDP v2 gradient sharding over the combined DP-CP domain."""
+
+    def setup_method(self):
+        self.world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        self.cp_size = 2
+        if self.world_size < self.cp_size or self.world_size % self.cp_size:
+            pytest.skip("MFSDP v2 CP requires an even world size of at least two.")
+        Utils.initialize_model_parallel(1, 1, context_parallel_size=self.cp_size)
+        self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        model_parallel_cuda_manual_seed(1234)
+
+    def teardown_method(self):
+        _destroy_model_parallel()
+
+    def test_cp_hybrid_model_matches_reference(self, monkeypatch):
+        """MFSDP CP training matches an unsharded HybridModel reference."""
+        monkeypatch.setenv("NVTE_FLASH_ATTN", "1")
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+        monkeypatch.setenv("NVTE_UNFUSED_ATTN", "0")
+        sequence_length = 8 * self.cp_size
+        vocab_size = 128
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=64,
+            num_attention_heads=4,
+            ffn_hidden_size=128,
+            context_parallel_size=self.cp_size,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+            gradient_accumulation_fusion=False,
+            attention_backend=AttnBackend.flash,
+        )
+
+        def build_model():
+            return HybridModel(
+                config=config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                vocab_size=vocab_size,
+                max_sequence_length=sequence_length,
+                hybrid_layer_pattern="*",
+                share_embeddings_and_output_weights=False,
+                pg_collection=self.pg_collection,
+            ).cuda()
+
+        torch.manual_seed(1234)
+        reference_model = build_model()
+        model = build_model()
+        model.load_state_dict(reference_model.state_dict())
+        reference_model.ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+            ),
+            module=model,
+            pg_collection=self.pg_collection,
+        )
+        optimizer_config = OptimizerConfig(
+            optimizer="adam",
+            lr=1.0e-2,
+            weight_decay=0.0,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            use_distributed_optimizer=False,
+            clip_grad=0.0,
+        )
+        reference_optimizer = get_megatron_optimizer(
+            optimizer_config,
+            [reference_model],
+            pg_collection=self.pg_collection,
+            use_gloo_process_groups=False,
+        )
+        optimizer = get_megatron_optimizer(
+            replace(optimizer_config),
+            [model],
+            pg_collection=self.pg_collection,
+            use_gloo_process_groups=False,
+        )
+        assert isinstance(optimizer, FullyShardedOptimizer)
+        optimizer.reload_model_params()
+
+        batch_size = 2
+        global_batch_size = batch_size * (self.world_size // self.cp_size)
+        input_ids = (
+            torch.arange(global_batch_size * sequence_length, device="cuda").view(
+                global_batch_size, sequence_length
+            )
+            % vocab_size
+        )
+        labels = (input_ids + 1) % vocab_size
+        position_ids = torch.arange(sequence_length, device="cuda").repeat(global_batch_size, 1)
+        dp_rank = self.pg_collection.dp.rank()
+        batch_slice = slice(dp_rank * batch_size, (dp_rank + 1) * batch_size)
+        batch = get_batch_on_this_cp_rank(
+            {
+                "tokens": input_ids[batch_slice],
+                "labels": labels[batch_slice],
+                "position_ids": position_ids[batch_slice],
+                "cu_seqlens": None,
+            },
+            is_hybrid_cp=False,
+            cp_group=self.pg_collection.cp,
+        )
+
+        expected_ranks = set(torch.distributed.get_process_group_ranks(self.pg_collection.dp_cp))
+        model_inputs = {
+            "input_ids": batch["tokens"],
+            "position_ids": batch["position_ids"],
+            "attention_mask": None,
+            "labels": batch["labels"],
+        }
+        for step in range(5):
+            reference_optimizer.zero_grad(set_to_none=True)
+            optimizer.zero_grad(set_to_none=True)
+
+            reference_loss = reference_model(**model_inputs).float().mean()
+            reference_loss.backward()
+            reference_gradients = [
+                parameter.grad
+                for parameter in reference_model.parameters()
+                if parameter.requires_grad
+            ]
+            assert reference_gradients and all(
+                gradient is not None for gradient in reference_gradients
+            )
+            for gradient in reference_gradients:
+                torch.distributed.all_reduce(
+                    gradient, op=torch.distributed.ReduceOp.AVG, group=self.pg_collection.dp_cp
+                )
+
+            loss = model(**model_inputs).float().mean()
+            loss.backward()
+            if step == 0:
+                gradients = [
+                    parameter.grad for parameter in model.parameters() if parameter.requires_grad
+                ]
+                assert gradients and all(isinstance(gradient, DTensor) for gradient in gradients)
+                assert all(gradient.placements == (Shard(0),) for gradient in gradients)
+                assert all(torch.isfinite(gradient.to_local()).all() for gradient in gradients)
+                assert all(
+                    set(gradient.device_mesh.mesh.flatten().tolist()) == expected_ranks
+                    for gradient in gradients
+                )
+
+            reference_success, _, _ = reference_optimizer.step()
+            success, _, _ = optimizer.step()
+            assert reference_success and success
+
+            step_losses = torch.stack((reference_loss.detach(), loss.detach()))
+            torch.distributed.all_reduce(
+                step_losses, op=torch.distributed.ReduceOp.AVG, group=self.pg_collection.dp_cp
+            )
+            assert torch.isfinite(step_losses).all()
+            torch.testing.assert_close(step_losses[1], step_losses[0], rtol=1e-3, atol=1e-3)
+            if step == 0:
+                initial_losses = step_losses.clone()
+
+        if torch.distributed.get_rank() == 0:
+            logger.info(
+                "Reference/MFSDP CP losses: initial=%s, final=%s",
+                initial_losses.tolist(),
+                step_losses.tolist(),
+            )
+        assert torch.all(step_losses < initial_losses)
 
 
 class TestMcoreAdapterExpertParallel:


### PR DESCRIPTION
## Summary

- allow context parallelism in MFSDP v2 by sharding parameters and gradients over the explicit combined `dp_cp` process group while preserving `cp` for attention communication
- validate that the materialized CP topology matches `context_parallel_size` and is contained in the sharding group
- preserve the current `NVIDIA/main` restriction on pipeline parallelism
- cover the integration with one attention-only `HybridModel` convergence test that runs Transformer Engine CP communication, compares five MFSDP optimizer steps with an unsharded CP reference, and verifies gradients use the `dp_cp` mesh

This ports [shjwudp/Megatron-LM#144](https://github.com/shjwudp/Megatron-LM/pull/144) onto current `NVIDIA/main`.

## Testing

- Black 26.3.0: passed
- isort 5.13.2: passed
- Ruff 0.9.10: passed
- Python compilation: passed
- `git diff --check`: passed
- focused distributed CUDA unit test: pending CI
