### PR TITLE
(feat) Queue GTP wgrad reduce-scatters so the finalize fence stops stalling backward

### DIFF
--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 import math
 import re
-from collections import defaultdict
+from collections import defaultdict, deque
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
@@ -295,6 +295,11 @@ _GTP_PARAMS = []
 _inflight_comm_params: set = set()
 _AG_STREAMS: Dict[str, torch.cuda.Stream] = {}
 _RS_STREAMS: Dict[str, torch.cuda.Stream] = {}
+# Leader params whose async wgrad reduce-scatter has been issued but not yet accumulated into
+# main_grad, oldest first, per (chain, group). GTP_CONFIG.wgrad_finalize_depth bounds the length:
+# the oldest is finalized once a newer RS pushes the queue over it, so the fence in the finalize
+# waits on a collective issued that many weights ago instead of the immediately preceding one.
+_PENDING_WGRAD_RS: Dict[tuple, deque] = {}
 
 
 # Wgrad input buffer pool, keyed by (shape, dtype). UNGRAPHED-only: GRAPHED
@@ -389,6 +394,71 @@ def get_rs_stream(chain_id: str = GTPChain.GRAPHED.value, group=None) -> torch.c
     return _RS_STREAMS[key]
 
 
+_DRAIN_CALLBACK_SCHEDULED = False
+
+
+def _clear_drain_callback_if_idle() -> None:
+    """Clear a stale flag left by a backward that raised before autograd ran its callbacks.
+
+    Only safe while every queue is empty, since then no drain is owed.
+    """
+    global _DRAIN_CALLBACK_SCHEDULED
+    if not any(_PENDING_WGRAD_RS.values()):
+        _DRAIN_CALLBACK_SCHEDULED = False
+
+
+def _drain_pending_wgrad_rs_at_backward_end() -> None:
+    """Settle every queued reduce-scatter. Runs from autograd, at the end of the backward."""
+    global _DRAIN_CALLBACK_SCHEDULED
+    try:
+        finalize_pending_wgrad_reduce_scatters()
+    finally:
+        _DRAIN_CALLBACK_SCHEDULED = False
+
+
+def _ensure_drain_at_backward_end() -> None:
+    """Schedule the queue drain to run when this backward pass ends.
+
+    THE QUEUE MUST NOT OUTLIVE A BACKWARD: a leftover entry accumulates during the next one and
+    fires its DDP grad-ready there, reducing the bucket before all its gradients have landed.
+
+    Hooking autograd covers every caller for free -- pipeline schedules, combined 1F1B, a bare
+    loss.backward() in a test. Graph capture is the sole exception: it cannot take a callback,
+    but it discards its grads, so the end-of-iteration drain is enough there.
+    """
+    global _DRAIN_CALLBACK_SCHEDULED
+    if _DRAIN_CALLBACK_SCHEDULED or torch.cuda.is_current_stream_capturing():
+        return
+    torch.autograd.Variable._execution_engine.queue_callback(
+        _drain_pending_wgrad_rs_at_backward_end
+    )
+    _DRAIN_CALLBACK_SCHEDULED = True
+
+
+def _pending_wgrad_rs_queue(chain_id: str, group) -> deque:
+    """Return the in-flight wgrad-RS queue for (chain_id, group), creating it on first use.
+
+    One queue per scheduling domain, so the FIFO order matches the order the collectives were
+    issued on that domain.
+    """
+    key = (chain_id, id(group) if group is not None else 0)
+    queue = _PENDING_WGRAD_RS.get(key)
+    if queue is None:
+        queue = deque()
+        _PENDING_WGRAD_RS[key] = queue
+    return queue
+
+
+def finalize_pending_wgrad_reduce_scatters() -> None:
+    """Finalize every queued wgrad reduce-scatter; without this the last N are never accumulated.
+
+    Accumulates on the caller's stream, exactly as the depth pop does.
+    """
+    for queue in _PENDING_WGRAD_RS.values():
+        while queue:
+            queue.popleft()._finalize_wgrad_rs_on_caller_stream()
+
+
 def initialize_graph_wgrad_rings() -> None:
     """Allocate persistent wgrad inputs before local CUDA-graph capture."""
     allocate_graph_wgrad_rings(
@@ -408,6 +478,10 @@ def wait_for_gtp_grad_reduction_on_current_stream() -> None:
     runner's replay stream (its tail = captured Phase 2 main_grad.add_). Under whole-step capture
     there are no per-layer runners, so that second wait is skipped. No-op when GTP is inactive.
     """
+    # MUST precede wait_async_comms(): it consumes RS handles without accumulating, so an entry
+    # it reaches first loses its gradient. Usually a no-op, since the end-of-backward callback
+    # already emptied the queue -- but graph capture cannot install one, so this is its drain.
+    finalize_pending_wgrad_reduce_scatters()
     wait_async_comms()
     cur = torch.cuda.current_stream()
     # Join the async AG/RS side streams for both the eager and CUDA-graph capture paths.
@@ -453,6 +527,12 @@ class GTPRematConfig:
     # same-key writers may need more slots to keep all in-flight RS inputs distinct.
     # TODO: Infer each domain's ring size automatically.
     graph_wgrad_ring_size: int = 2
+    # Max length of the FIFO of in-flight wgrad reduce-scatters: pushing past it pops the oldest
+    # and finalizes it, so at most this many are ever outstanding. Deeper puts more compute
+    # between issuing a collective and fencing on it, but pins two unsharded buffers per level
+    # and delays DDP grad-ready, so the curve turns over. UNGRAPHED only, and only meaningful
+    # with async_reduction=True -- a synchronous RS completes inline, so nothing is ever queued.
+    wgrad_finalize_depth: int = 2
 
 
 GTP_CONFIG = GTPRematConfig()
@@ -1942,9 +2022,17 @@ class GTPShardedParam(torch.nn.Parameter):
                 self.rs_event.record()
                 if finalize_grad:
                     cache = get_global_GTP_cache()
+                    # Only batch with _foreach_add_ when finalizing multiple (routed) weights;
+                    # a routed leader owns every local expert, so this is N launches otherwise.
+                    if len(self._weights) == 1:
+                        w = self._weights[0]
+                        w.main_grad.add_(cache.get(w._rs_ticket))
+                    else:
+                        torch._foreach_add_(
+                            [w.main_grad for w in self._weights],
+                            [cache.get(w._rs_ticket) for w in self._weights],
+                        )
                     for w in self._weights:
-                        wgrad_rs = cache.get(w._rs_ticket)
-                        w.main_grad.add_(wgrad_rs)
                         cache.release(w._rs_ticket)
                     # Fire grad-ready AFTER all adds (separate loop so a bucket-completing
                     # grad-ready can't dispatch the RS before a sibling's add). With autograd
@@ -2213,10 +2301,18 @@ class GTPShardedParam(torch.nn.Parameter):
         # the one handle we track -- discarding that gradient with no error. Finish it first.
         if GTP_CONFIG.async_reduction and self._wgrad_rs_handle is not None:
             self._wait_reduce_scatter(finalize_grad=True)
-            # Accounted for here, so the cascade below must not skip the next one.
-            self._already_finalized = False
+            # This weight is still queued for the reduce-scatter we just finalized. Drop that
+            # dead entry, or it occupies a slot against the depth and the fresh RS issued below
+            # gets finalized earlier than the depth intends.
+            # (Identity scan: `in`/`remove` compare Parameters elementwise and raise.)
+            pending = _pending_wgrad_rs_queue(self.chain_id, self.group)
+            for idx, queued in enumerate(pending):
+                if queued is self:
+                    del pending[idx]
+                    break
 
-        if GTP_CONFIG.async_reduction and self.prev_w is not None:
+        issued_async_rs = GTP_CONFIG.async_reduction and self.prev_w is not None
+        if issued_async_rs:
             # Async RS (not last weight — deferred finish). Pre-RS work on caller; NCCL wrap
             # lives at the collective site inside _reduce_scatter (mirrors the AG prefetch sites).
             _, rs_handle, release_bufs = self._reduce_scatter(
@@ -2244,41 +2340,73 @@ class GTPShardedParam(torch.nn.Parameter):
             self._release_wgrad_scratch()
             ret = result if batched else result[0]
 
-        # Wait for last reduce scatter if it was async
-        # Currently only support reduce scattering in reverse order
-        if GTP_CONFIG.async_reduction and self.next_w is not None:
-            # Backward normally walks the chain in reverse, so next_w has already started its
-            # reduce-scatter by now. That only holds while each weight is used once per forward.
-            # MTP's second embedding lookup sits late in the forward, so the embedding's backward
-            # runs before decoder layer 0 has reduce-scattered anything -- check first.
-            waited = self.next_w._wait_reduce_scatter()
-
-            if not waited:
-                pass  # next_w has not reduce-scattered yet, or something already finalized it
-            elif getattr(self.next_w, "_already_finalized", False):
-                self.next_w._already_finalized = False
-                # No compute-stream fence needed: only MTP's double-RS weights
-                # (embedding/output) reach the force-finalize path, no other weight
-                # shares their vocab-sized LIFO bucket, and their next pop is behind
-                # the end-of-backward flush fence -- the buffers freed there cannot
-                # be re-popped within this backward.
-            else:
-                self.next_w.rs_event.wait()
-                cache = get_global_GTP_cache()
-                next_weights = self.next_w._weights
-                wgrads = [cache.get(w._rs_ticket) for w in next_weights]
-                nvtx_range_push(f"{self.next_w._debug_name}.gtp_wgrad_accum_deferred")
-                # Only batch with _foreach_add_ when finalizing multiple (routed) weights.
-                if len(next_weights) == 1:
-                    next_weights[0].main_grad.add_(wgrads[0])
-                else:
-                    torch._foreach_add_([w.main_grad for w in next_weights], wgrads)
-                nvtx_range_pop(f"{self.next_w._debug_name}.gtp_wgrad_accum_deferred")
-                for w in next_weights:
-                    self._handle_megatron_grad_accum(w)
-                    cache.release(w._rs_ticket)
+        # Finalize the oldest reduce-scatter once this one pushes the queue past the configured
+        # depth. Everything stays on the caller's stream -- the fence, the accumulation, the
+        # grad-ready -- so DDP still sees a single writer per bucket. Depth is what makes the
+        # fence cheap: at depth N it waits on a collective issued N weights ago, which by then
+        # has had N weights' worth of dgrad/wgrad GEMMs to complete in.
+        #
+        # A queue rather than following next_w: backward walks the chain in reverse, but MTP
+        # consumes the embedding twice per forward, so its backward runs before decoder layer 0
+        # has reduce-scattered anything. Popping the oldest *actually pending* RS is well defined
+        # under that reordering; "the weight N links away" is not.
+        #
+        # GRAPHED chains stay at depth 1. Their persistent ring slots are published as reusable
+        # only when the RS is waited (_record_graph_wgrad_ring_slots_ready), and the replay-side
+        # guard is a stream wait on slot.ready_event, which resolves against the event's most
+        # recent record: deferring the wait past graph_wgrad_ring_size same-key weights lets that
+        # wait pass on a stale record and the graph overwrite a slot its RS is still reading.
+        # cuda_graphs._compute_finalized_during_bwd_capture also still assumes the next_w cascade.
+        if issued_async_rs:
+            # A fresh result is now in flight and unaccumulated.
+            self._already_finalized = False
+            # Must precede the append below: the flag can only be cleared while idle.
+            _clear_drain_callback_if_idle()
+            pending = _pending_wgrad_rs_queue(self.chain_id, self.group)
+            pending.append(self)
+            _ensure_drain_at_backward_end()
+            while len(pending) > self._effective_finalize_depth():
+                pending.popleft()._finalize_wgrad_rs_on_caller_stream()
 
         return ret
+
+    def _effective_finalize_depth(self) -> int:
+        """Finalize depth for this chain (GRAPHED is pinned to 1; see wgrad_reduce_scatter)."""
+        if _chain_is_graphed(self.chain_id):
+            return 1
+        return max(1, GTP_CONFIG.wgrad_finalize_depth)
+
+    def _finalize_wgrad_rs_on_caller_stream(self):
+        """Wait this weight's async wgrad RS and accumulate it into main_grad.
+
+        Runs entirely on the caller's stream: rs_event.wait() fences it behind the collective,
+        which also orders the wgrad-pool buffers the RS was reading against the next borrower.
+        """
+        # _already_finalized tracks one reduce-scatter's lifecycle: cleared where the RS is
+        # issued, set once its result has landed in main_grad. That is what the wait_async_comms
+        # fallback needs to know, and _rs_ticket cannot tell it -- the ticket is never reset, so
+        # "has a ticket" stays true for any weight that ever reduce-scattered.
+        waited = self._wait_reduce_scatter()
+        if not waited:
+            # Someone else consumed the handle. If they accumulated (MTP force-finalize,
+            # wait_async_comms) the flag is already set and the fallback will skip this weight.
+            return
+
+        self.rs_event.wait()
+        cache = get_global_GTP_cache()
+        weights = self._weights
+        wgrads = [cache.get(w._rs_ticket) for w in weights]
+        nvtx_range_push(f"{self._debug_name}.gtp_wgrad_accum_deferred")
+        # Only batch with _foreach_add_ when finalizing multiple (routed) weights.
+        if len(weights) == 1:
+            weights[0].main_grad.add_(wgrads[0])
+        else:
+            torch._foreach_add_([w.main_grad for w in weights], wgrads)
+        nvtx_range_pop(f"{self._debug_name}.gtp_wgrad_accum_deferred")
+        for w in weights:
+            self._handle_megatron_grad_accum(w)
+            cache.release(w._rs_ticket)
+        self._already_finalized = True
 
     def batched_wgrad_reduce_scatter(self, wgrad_list, nvtx_label=None):
         """Batched version of wgrad_reduce_scatter."""
@@ -2692,6 +2820,9 @@ def reset_gtp_state():
     GTPShardedParam._link_tables_flushed = False
     GTPShardedParam._recompute_link_tables_flushed = False
     _GTP_GROUPED_BUF_PARITY_COUNTER.clear()
+    _PENDING_WGRAD_RS.clear()
+    global _DRAIN_CALLBACK_SCHEDULED
+    _DRAIN_CALLBACK_SCHEDULED = False
     clear_graph_wgrad_rings()
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1552,6 +1552,14 @@ def validate_args(args, defaults={}):
                 "--expert-tensor-parallel-num-weight-shards > 1) with --fp4-format requires "
                 "--fp4-param-gather so NVFP4 weights are all-gathered as native NVFP4."
             )
+        if args.delay_wgrad_compute:
+            # backward_dw() runs after backward() returns, so GTP cannot install its
+            # end-of-backward drain and in-flight wgrad reduce-scatters leak across microbatches.
+            raise ValueError(
+                "GTP (--tensor-parallel-num-weight-shards / "
+                "--expert-tensor-parallel-num-weight-shards > 1) does not support "
+                "--delay-wgrad-compute."
+            )
         gtp_weight_remat_size = args.gtp_weight_remat_size
         egtp_weight_remat_size = args.expert_gtp_weight_remat_size
         if get_device_arch_version() >= 10:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1237,6 +1237,214 @@ class TestWaitAsyncCommsFallback:
 
 
 # ---------------------------------------------------------------------------
+# wgrad finalize placement: the accumulation must run on rs_stream
+# ---------------------------------------------------------------------------
+
+
+class _StubRSHandle:
+    """Stand-in for an in-flight reduce-scatter Work handle (no NCCL needed)."""
+
+    def __init__(self):
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+
+
+class TestWgradFinalizeOnRSStream:
+    """``_wait_reduce_scatter(finalize_grad=True)`` must accumulate on rs_stream.
+
+    The cascade in ``wgrad_reduce_scatter`` used to fence the compute stream on next_w's
+    rs_event and run main_grad.add_ there. Nothing in backward reads main_grad, so that
+    fence only serialized compute behind the collective -- worst with the fp32-accum
+    one-shot RS, where handle.wait() also launches the FP32 sum and the downcast copy.
+    These pin the accumulation to rs_stream so a compute-stream fence cannot creep back.
+    """
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_finalize_runs_on_rs_stream(self):
+        dtype = torch.bfloat16
+        p = TestWaitAsyncCommsFallback._make_inflight_param(main_grad_fill=0.0)
+        handle = _StubRSHandle()
+        p._wgrad_rs_handle = handle
+
+        cache = gtp_module.get_global_GTP_cache()
+        p._rs_ticket = cache.reserve(p, dtype, fwd=False, reduce_scatter=True)
+        cache.get(p._rs_ticket).fill_(3.0)
+
+        # Record the stream each cache.get() is issued on; the accumulate reads its wgrad
+        # through cache.get, so this is the stream main_grad.add_ lands on.
+        seen_streams = []
+        original_get = cache.get
+
+        def _spy_get(ticket):
+            seen_streams.append(torch.cuda.current_stream())
+            return original_get(ticket)
+
+        compute_stream = torch.cuda.current_stream()
+        cache.get = _spy_get
+        try:
+            waited = p._wait_reduce_scatter(finalize_grad=True)
+        finally:
+            del cache.get  # drop the instance attribute, restoring the class method
+
+        torch.cuda.synchronize()
+        rs_stream = gtp_module.get_rs_stream(p.chain_id, p.group)
+
+        assert waited is True, "an in-flight handle must report waited=True"
+        assert handle.waited is True, "the RS handle must have been waited on"
+        assert seen_streams, "the finalize path must read the wgrad through cache.get"
+        assert all(s == rs_stream for s in seen_streams), (
+            f"accumulation must be issued on rs_stream, got {seen_streams} "
+            f"(rs_stream={rs_stream}, compute={compute_stream})"
+        )
+        assert rs_stream != compute_stream, "rs_stream must not be the compute stream"
+        assert torch.all(p.main_grad == 3.0), f"main_grad should be 3.0; got {p.main_grad}"
+        assert p._already_finalized is True, "_already_finalized must be set by the finalize"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_no_accumulation_without_rs_handle(self):
+        """waited=False must leave main_grad alone -- the ticket buffer holds no new result.
+
+        MTP consumes the embedding twice per forward, so the embedding's backward can run
+        before decoder layer 0 has reduce-scattered anything. Its ticket buffer then still
+        holds stale data, and accumulating it would silently corrupt main_grad. The caller
+        used to guard this; the guard now lives here.
+        """
+        dtype = torch.bfloat16
+        p = TestWaitAsyncCommsFallback._make_inflight_param(main_grad_fill=5.0)
+        p._wgrad_rs_handle = None  # nothing in flight
+
+        cache = gtp_module.get_global_GTP_cache()
+        p._rs_ticket = cache.reserve(p, dtype, fwd=False, reduce_scatter=True)
+        cache.get(p._rs_ticket).fill_(9.0)  # stale content, must not be accumulated
+
+        waited = p._wait_reduce_scatter(finalize_grad=True)
+
+        torch.cuda.synchronize()
+        assert waited is False, "no handle in flight must report waited=False"
+        assert torch.all(p.main_grad == 5.0), f"main_grad must be untouched; got {p.main_grad}"
+        assert p._already_finalized is False, "nothing was finalized, flag must stay False"
+
+
+def _worker_finalize_depth_accumulates_once(rank, world_size, port):
+    """Five-layer GTP chain at finalize depth 3: every wgrad lands in main_grad exactly once.
+
+    More layers than the depth, so several reduce-scatters are still queued when the last
+    backward returns and only the end-of-backward flush can claim them. Two identical backwards
+    must leave main_grad at exactly 2x the first: a double-add, a dropped add, or a queue entry
+    the flush forgets all break the ratio.
+    """
+    torch.manual_seed(0)
+    in_f, out_f = 32, 64
+    dtype = torch.bfloat16
+    gtp_remat_group = dist.new_group(list(range(world_size)))
+
+    depth = gtp_module.GTP_CONFIG.wgrad_finalize_depth
+    layers = [_make_gtp_linear(in_f, out_f, gtp_remat_group, dtype) for _ in range(depth + 2)]
+    assert len(layers) > depth, "the chain must be longer than the finalize depth"
+
+    inp = torch.randn(8, in_f, dtype=dtype, device="cuda", requires_grad=True)
+    dist.broadcast(inp, src=0)
+
+    for lyr in layers:
+        lyr.weight.main_grad = torch.zeros(lyr.weight.shape, dtype=dtype, device="cuda")
+
+    def _one_backward(is_first):
+        out = layers[0](inp, is_first_microbatch=is_first)
+        for lyr in layers[1:]:
+            out = out + lyr(inp, is_first_microbatch=is_first)
+        out.sum().backward()
+        # What the training loop does before reading gradients: this is also what drains the
+        # reduce-scatters still queued behind the finalize depth.
+        gtp_module.wait_for_gtp_grad_reduction_on_current_stream()
+        torch.cuda.synchronize()
+
+    _one_backward(True)
+    after_one = [lyr.weight.main_grad.detach().clone() for lyr in layers]
+    _one_backward(False)
+    after_two = [lyr.weight.main_grad.detach().clone() for lyr in layers]
+
+    for idx, (g1, g2) in enumerate(zip(after_one, after_two)):
+        assert torch.isfinite(g1).all(), f"layer{idx} main_grad must be finite"
+        assert g1.abs().max() > 0, f"layer{idx} main_grad must be non-zero after one backward"
+        torch.testing.assert_close(
+            g2.float(),
+            2.0 * g1.float(),
+            rtol=2e-2,
+            atol=1e-3,
+            msg=lambda m: f"layer{idx}: second backward must add each wgrad exactly once: {m}",
+        )
+
+    for queue in gtp_module._PENDING_WGRAD_RS.values():
+        assert not queue, "every queued reduce-scatter must be finalized by the flush"
+
+
+def _worker_finalize_depth_is_transparent(rank, world_size, port):
+    """main_grad must be BITWISE identical at every finalize depth.
+
+    Depth changes only *when* a reduce-scatter result is accumulated, never what is accumulated
+    or in what order: each param still gets exactly one add of the same collective's output. So
+    any numerical difference across depths is a bug -- a dropped gradient, a double-add, or a
+    grad-ready fired more than once. This is the acceptance criterion for the knob, and it is far
+    more sensitive than an end-to-end loss trajectory, where such bugs only show as drift.
+    """
+    torch.manual_seed(0)
+    in_f, out_f = 32, 64
+    dtype = torch.bfloat16
+    gtp_remat_group = dist.new_group(list(range(world_size)))
+
+    layers = [_make_gtp_linear(in_f, out_f, gtp_remat_group, dtype) for _ in range(6)]
+    inp = torch.randn(8, in_f, dtype=dtype, device="cuda", requires_grad=True)
+    dist.broadcast(inp, src=0)
+    for lyr in layers:
+        lyr.weight.main_grad = torch.zeros(lyr.weight.shape, dtype=dtype, device="cuda")
+
+    def _grads_at_depth(depth):
+        saved = gtp_module.GTP_CONFIG.wgrad_finalize_depth
+        gtp_module.GTP_CONFIG.wgrad_finalize_depth = depth
+        try:
+            for lyr in layers:
+                lyr.weight.main_grad.zero_()
+            out = layers[0](inp, is_first_microbatch=True)
+            for lyr in layers[1:]:
+                out = out + lyr(inp, is_first_microbatch=True)
+            out.sum().backward()
+            gtp_module.wait_for_gtp_grad_reduction_on_current_stream()
+            torch.cuda.synchronize()
+            return [lyr.weight.main_grad.detach().clone() for lyr in layers]
+        finally:
+            gtp_module.GTP_CONFIG.wgrad_finalize_depth = saved
+
+    reference = _grads_at_depth(1)
+    assert any(g.abs().max() > 0 for g in reference), "reference grads must be non-zero"
+
+    for depth in (2, 3, 4):
+        got = _grads_at_depth(depth)
+        for idx, (ref, cur) in enumerate(zip(reference, got)):
+            if not torch.equal(ref, cur):
+                delta = (ref.float() - cur.float()).abs().max().item()
+                raise AssertionError(
+                    f"finalize depth {depth} changed layer{idx} main_grad "
+                    f"(max |delta| = {delta:.6g}, ref_norm = {ref.float().norm():.6g}, "
+                    f"got_norm = {cur.float().norm():.6g}). Depth must be a scheduling knob "
+                    f"with no numerical footprint."
+                )
+        for queue in gtp_module._PENDING_WGRAD_RS.values():
+            assert not queue, f"depth {depth} left work queued after the flush"
+
+
+class TestGTPWgradFinalizeDepth:
+    def test_finalize_depth_accumulates_once(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_finalize_depth_accumulates_once, 4)
+
+    def test_finalize_depth_is_transparent(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_finalize_depth_is_transparent, 4)
+
+
+# ---------------------------------------------------------------------------
 # GTP_remat DDP bucket alignment: distributed optimizer bucket-end assertion
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
@@ -309,7 +309,15 @@ def _run_step_distopt(ddp_model, optim, rank):
         out, _ = layer(out, attention_mask=None)
     loss = out.float().mean()
     loss.backward()
-    # Production order (finalize_model_grads): reduce across DP first, THEN the gtp_remat finalize.
+    # Production order (finalize_model_grads): fence GTP's wgrad reduce-scatters (line 634),
+    # reduce across DP (line 640), THEN the gtp_remat all-reduce of replicated grads. The fence
+    # matters once wgrad_finalize_depth > 1: collectives still queued behind the depth have not
+    # been accumulated into main_grad yet, and finish_grad_sync would reduce without them.
+    from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+        wait_for_gtp_grad_reduction_on_current_stream,
+    )
+
+    wait_for_gtp_grad_reduction_on_current_stream()
     ddp_model.finish_grad_sync()
     from megatron.core import parallel_state as ps
     from megatron.core.distributed.finalize_model_grads import (
@@ -432,6 +440,155 @@ def _make_moe_stack(config, pg_collection):
 
 def _is_expert_param(name, p):
     return ('experts' in name) or (not getattr(p, 'allreduce', True))
+
+
+def _worker_depth_grad_invariance(rank, world_size, port, moe=False):
+    """main_grad must be BITWISE identical at every wgrad_finalize_depth, through DDP.
+
+    The plain-chain invariance test in test_gtp_basics cannot see the hazard this targets:
+    DDP dispatches a bucket's reduce-scatter from inside grad-ready, and it reduces the WHOLE
+    bucket. So the invariant is not "each param's main_grad ends up right" but "every param in
+    the bucket has its add landed before the bucket is dispatched". Deferring the finalize moves
+    a param's add and its grad-ready together, but moves both relative to its bucket peers -- and
+    with several microbatches a queued entry can carry its grad-ready into the next microbatch,
+    where register_grad_ready counts it again.
+
+    Runs several microbatches (no_sync on all but the last, as the training loop does), reduces,
+    and compares. No optimizer step, so every depth starts from identical weights.
+    """
+    from contextlib import nullcontext
+
+    import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+        wait_for_gtp_grad_reduction_on_current_stream,
+    )
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    num_microbatches = 4
+
+    ps.destroy_model_parallel()
+    # Every worker in this file resets the chain-linking anchor before building a stack: a stale
+    # _chain_state["last_weight"] gives this stack's first weight a non-None prev_w, so it issues
+    # an async RS instead of the sync one and the chain has no head -- and the state left behind
+    # leaks into the next worker.
+    GTPShardedParam._chain_state = {}
+    if moe:
+        # MoE/EGTP: grouped experts add their own chains and their own (chain, group) queues,
+        # and the expert weights sit in different DDP buckets from the dense ones. None =>
+        # pull every group from the MPU globals (the token dispatcher needs tp_ep).
+        ps.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=2,
+            gtp_remat_size=2,
+            expert_gtp_remat_size=2,
+        )
+        model_parallel_cuda_manual_seed(42)
+        pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=None)
+        stack = _make_moe_stack(_make_moe_config(), pgc)
+    else:
+        ps.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=2
+        )
+        model_parallel_cuda_manual_seed(42)
+        pgc = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=['tp', 'cp', 'gtp_remat']
+        )
+        stack = _make_stack(_make_config(), pgc)
+    for layer in stack:
+        layer.cuda()
+    for n, p in stack.named_parameters():
+        # Expert weights are EP-local and must not be broadcast (see _worker_moe_distopt).
+        if not _is_expert_param(n, p):
+            dist.broadcast(p.data, src=0)
+
+    # Small buckets so there is more than one bucket group: a single bucket cannot expose an
+    # early dispatch, because there is no second bucket whose params are still accumulating.
+    ddp_model, optim = _build_ddp_distopt_and_optim(
+        stack, overlap_grad_reduce=True, bucket_size=10_000
+    )
+
+    torch.manual_seed(1000 + rank)
+    inputs = [
+        torch.randn(SEQ, BATCH, HIDDEN, dtype=dtype, device='cuda')
+        for _ in range(num_microbatches)
+    ]
+
+    def _grads_at_depth(depth):
+        saved_depth = gtp_module.GTP_CONFIG.wgrad_finalize_depth
+        gtp_module.GTP_CONFIG.wgrad_finalize_depth = depth
+        try:
+            optim.zero_grad()
+            ddp_model.zero_grad_buffer()
+            for mb, x in enumerate(inputs):
+                last = mb == len(inputs) - 1
+                ctx = nullcontext() if last else ddp_model.no_sync()
+                with ctx:
+                    out = x
+                    for layer in ddp_model.module.children():
+                        out, _ = layer(out, attention_mask=None)
+                    out.float().mean().backward()
+                # No manual drain: the autograd end-of-backward callback settles the queue.
+                # Assert that it actually did, for every queue including the MoE/EGTP chains.
+                leaked = {
+                    key: [w._debug_name for w in q]
+                    for key, q in gtp_module._PENDING_WGRAD_RS.items()
+                    if q
+                }
+                assert not leaked, (
+                    f"depth={depth}: reduce-scatters still queued at the end of microbatch "
+                    f"{mb} (of {num_microbatches}): {leaked}"
+                )
+            # Production order (finalize_model_grads): fence GTP, then reduce across DP.
+            wait_for_gtp_grad_reduction_on_current_stream()
+            ddp_model.finish_grad_sync()
+            torch.cuda.synchronize()
+            return {
+                n: p.main_grad.detach().clone()
+                for n, p in ddp_model.module.named_parameters()
+                if hasattr(p, 'main_grad')
+            }
+        finally:
+            gtp_module.GTP_CONFIG.wgrad_finalize_depth = saved_depth
+
+    def _worst_delta(a, b):
+        worst_name, worst = None, 0.0
+        for name, ref in a.items():
+            delta = (ref.float() - b[name].float()).abs().max().item()
+            if delta > worst:
+                worst_name, worst = name, delta
+        return worst_name, worst
+
+    reference = _grads_at_depth(1)
+    assert reference, "no main_grad captured"
+    assert any(g.abs().max() > 0 for g in reference.values()), "reference grads are all zero"
+
+    # CONTROL first: repeat the SAME depth. MoE dispatch/permutation can use atomics, so this
+    # config is not guaranteed bitwise reproducible; without measuring that, a between-depth
+    # difference cannot be attributed to depth. The control sets the bar the depth runs must meet.
+    control = _grads_at_depth(1)
+    ctl_name, ctl_delta = _worst_delta(reference, control)
+    print(f"[rank {rank}] same-depth control: worst max|delta|={ctl_delta:.6g} on {ctl_name}")
+
+    tolerance = ctl_delta * 4 if ctl_delta > 0 else 0.0
+    for depth in (2, 3):
+        got = _grads_at_depth(depth)
+        name, delta = _worst_delta(reference, got)
+        print(f"[rank {rank}] depth {depth}: worst max|delta|={delta:.6g} on {name}")
+        assert delta <= tolerance, (
+            f"wgrad_finalize_depth={depth} changed main_grad through DDP over "
+            f"{num_microbatches} microbatches: worst max|delta|={delta:.6g} on {name}, "
+            f"vs same-depth control {ctl_delta:.6g} (tolerance {tolerance:.6g}). "
+            f"Depth must be a scheduling knob with no numerical footprint."
+        )
+
+    for queue in gtp_module._PENDING_WGRAD_RS.values():
+        assert not queue, "work left queued after the end-of-backward flush"
+
+    ps.destroy_model_parallel()
+    GTPShardedParam._chain_state = {}
 
 
 def _worker_moe_distopt(rank, world_size, port):
@@ -940,6 +1097,18 @@ class TestGTPGradCorrectness:
         if torch.cuda.device_count() < 4:
             pytest.skip("Requires 4 CUDA devices")
         _run_distributed(_worker_distopt, 4)
+
+    def test_depth_grad_invariance_through_ddp(self):
+        """wgrad_finalize_depth must not change main_grad, through DDP + microbatches."""
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_depth_grad_invariance, 4)
+
+    def test_depth_grad_invariance_through_ddp_moe(self):
+        """Same invariant on the MoE/EGTP path: more chains, more queues, more buckets."""
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_depth_grad_invariance, 4, True)
 
     def test_moe_egtp_distopt_grad_norm_matches_baseline(self):
         """GTP2/EGTP2 MoE dist-opt grad-norm must match GTP1/EGTP1 baseline (EP=2 both)."""


### PR DESCRIPTION

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Queue GTP wgrad reduce-scatters so the finalize fence stops stalling backward

## Motivation and design
<img width="1096" height="851" alt="image" src="https://github.com/user-attachments/assets/ad59b317-b075-42a4-934e-379674118c1b" />

## Stable Perf gain on Nemotron
<img width="963" height="213" alt="image" src="https://github.com/user-attachments/assets/e0a0222a-b3ac-41ba-8a47-8349c197aa5a" />

## Convergence test
<img width="1449" height="721" alt="image" src="https://github.com/user-attachments/assets/57015d61-03e0-42b5-b2c9-52434e92bb30" />


## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

