### PR TITLE
Keep a populated output_layer._extra_state in GPTModel.sharded_state_dict

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -52,11 +52,24 @@ logger = logging.getLogger(__name__)
 
 
 def _has_extra_state_data(sharded_entry) -> bool:
-    """True when a sharded ``_extra_state`` entry carries a payload."""
+    """True when a sharded ``_extra_state`` entry carries a payload.
+
+    Deliberately avoids ``bool(data)``: array-likes raise on an ambiguous truth value, which is
+    the failure this function exists to prevent. An unrecognized payload counts as data, since
+    dropping state silently is worse than keeping a placeholder.
+    """
     data = getattr(sharded_entry, 'data', sharded_entry)
+    if data is None:
+        return False
     if isinstance(data, torch.Tensor):
         return data.numel() > 0
-    return data is not None and bool(data)
+    numel = getattr(data, 'size', None)  # numpy-style .size
+    if isinstance(numel, int):
+        return numel > 0
+    try:
+        return len(data) > 0
+    except TypeError:
+        return True
 
 
 class GPTModel(LanguageModule, GraphableMegatronModule):

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -50,6 +50,15 @@ from megatron.core.utils import (
 logger = logging.getLogger(__name__)
 
 
+
+def _has_extra_state_data(sharded_entry) -> bool:
+    """True when a sharded ``_extra_state`` entry carries a payload."""
+    data = getattr(sharded_entry, 'data', sharded_entry)
+    if isinstance(data, torch.Tensor):
+        return data.numel() > 0
+    return data is not None and bool(data)
+
+
 class GPTModel(LanguageModule, GraphableMegatronModule):
     """GPT Transformer language model.
 
@@ -955,11 +964,12 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
         sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
         output_layer_extra_state_key = f'{prefix}output_layer._extra_state'
 
-        # Old GPT checkpoints only stored the output layer weight key. So we remove the
-        # _extra_state key but check that it doesn't contain any data anyway
-        output_extra_state = sharded_state_dict.pop(output_layer_extra_state_key, None)
-        assert not (
-            output_extra_state and output_extra_state.data
-        ), f'Expected output layer extra state to be empty, got: {output_extra_state}'
+        # Old GPT checkpoints only stored the output layer weight key, so drop the
+        # _extra_state key when it is an empty placeholder. Keep it when it carries data:
+        # quantization frameworks store per-module state there and dropping it loses the
+        # quantized output layer on both save and load.
+        output_extra_state = sharded_state_dict.get(output_layer_extra_state_key)
+        if output_extra_state is None or not _has_extra_state_data(output_extra_state):
+            sharded_state_dict.pop(output_layer_extra_state_key, None)
 
         return sharded_state_dict

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -24,7 +24,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
     get_mlp_module_spec,
 )
-from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.gpt.gpt_model import GPTModel, _has_extra_state_data
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.module import Float16Module
@@ -59,6 +59,20 @@ class TestGPTModel:
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    def test_output_layer_extra_state_dropped_when_empty(self):
+        """An empty placeholder is dropped, as old GPT checkpoints never stored it."""
+        sharded_state_dict = self.gpt_model.sharded_state_dict()
+        assert 'output_layer._extra_state' not in sharded_state_dict
+
+    @pytest.mark.internal
+    def test_output_layer_extra_state_kept_when_populated(self):
+        """Quantization frameworks store per-module state here; dropping it loses the layer."""
+        state = torch.frombuffer(bytearray(b'quantizer-state'), dtype=torch.uint8)
+        with patch.object(self.gpt_model.output_layer, 'get_extra_state', return_value=state):
+            sharded_state_dict = self.gpt_model.sharded_state_dict()
+        assert 'output_layer._extra_state' in sharded_state_dict
 
     @pytest.mark.internal
     def test_constructor(self):
@@ -627,3 +641,20 @@ def test_get_transformer_layer_spec_forwards_use_te_activation_func():
         assert (
             call_kwargs.get('use_te_activation_func') is True
         ), "use_te_activation_func must be forwarded from config"
+
+@pytest.mark.internal
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (None, False),
+        (torch.empty(0), False),
+        (torch.frombuffer(bytearray(b'quantizer-state'), dtype=torch.uint8), True),
+    ],
+)
+def test_has_extra_state_data(data, expected):
+    class _Entry:
+        def __init__(self, value):
+            self.data = value
+
+    assert _has_extra_state_data(_Entry(data)) is expected
+

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -6,6 +6,7 @@ import os
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
@@ -649,6 +650,14 @@ def test_get_transformer_layer_spec_forwards_use_te_activation_func():
         (None, False),
         (torch.empty(0), False),
         (torch.frombuffer(bytearray(b'quantizer-state'), dtype=torch.uint8), True),
+        # Payloads whose truth value is ambiguous must not raise.
+        (np.zeros(0), False),
+        (np.zeros(4), True),
+        (b'', False),
+        (b'quantizer-state', True),
+        ([], False),
+        ([0, 0], True),
+        (object(), True),  # opaque payload: keep rather than silently drop
     ],
 )
 def test_has_extra_state_data(data, expected):


### PR DESCRIPTION
### Summary

`GPTModel.sharded_state_dict` unconditionally drops `output_layer._extra_state` and asserts it is
empty:

```python
output_extra_state = sharded_state_dict.pop(output_layer_extra_state_key, None)
assert not (
    output_extra_state and output_extra_state.data
), f'Expected output layer extra state to be empty, got: {output_extra_state}'
```

That is correct for its stated purpose — old GPT checkpoints only stored the output-layer weight,
so the key is an empty placeholder. But quantization frameworks keep per-module state in
`_extra_state`, so a **quantized output layer cannot be checkpointed at all**:

- **Save** raises `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`,
  because `output_extra_state.data` is a multi-element byte tensor and `and` calls `__bool__`.
- **Load** is worse, because this method also backs the load plan: the key is popped, so the saved
  state is ignored and the layer is silently restored **unquantized**.

`MambaModel` has no equivalent rule, which is why Mamba-based models can already ship a quantized
`lm_head` (e.g. `nvidia/Nemotron-3.5-Lightning-30B-A3B-NVFP4`) while GPT-based ones cannot.

### Change

Drop the entry only when it is an empty placeholder; keep it when it carries data. Behaviour for
checkpoints that never had the key is unchanged.

```python
output_extra_state = sharded_state_dict.get(output_layer_extra_state_key)
if output_extra_state is None or not _has_extra_state_data(output_extra_state):
    sharded_state_dict.pop(output_layer_extra_state_key, None)
```

### Why it matters

On a MoE model with a large vocabulary the output layer is a big share of decode-time weight
traffic — for Qwen3.6-35B-A3B (~2.9B active params, 248320 vocab) `lm_head` is 509M params,
about **35% of per-token weight reads** in BF16. Being unable to quantize it leaves a
significant amount of decode throughput unavailable to every GPT-based model.

### Testing

Added to `tests/unit_tests/models/test_gpt_model.py`:

- `test_output_layer_extra_state_dropped_when_empty` — unchanged behaviour for the placeholder.
- `test_output_layer_extra_state_kept_when_populated` — a populated entry now survives.
- `test_has_extra_state_data` — `None` / empty tensor -> False, populated tensor -> True.

I could not run the GPU unit-test suite locally (`flash_attn` is not installed in my
environment), so those three are unverified by me in CI form; the helper and the new pop/keep
branch were exercised standalone against the edited file.

The equivalent change has been validated end to end out-of-tree, as a runtime patch of this same
method, on 4x GB200 with `nemo:26.08`:

- Qwen3.5-9B: PTQ with a quantized `output_layer` saves, and the exported HuggingFace checkpoint
  carries `lm_head.weight`, `lm_head.weight_scale`, `lm_head.weight_scale_2`. Without the change
  the save raises.
- Same model: distillation checkpoint save -> resume from iteration -> export round trip preserves
  the quantized output layer.
- Qwen3.6-35B-A3B (256-expert MoE): full PTQ -> export, then served by vLLM v0.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
