### PR TITLE
fix: guard fused MLA imports for older Transformer Engine

### DIFF
--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -70,6 +70,8 @@ if HAVE_TE:
             mxfp8_quantize_only,
             mxfp8_transpose_swizzle,
         )
+        from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
+        from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
     except ImportError:
         # Older TE lacks the fused MLA Q up-proj kernel and its MXFP8 quantize/swizzle
         # helpers. Stub them all together so this module still imports; the fused path is
@@ -78,8 +80,8 @@ if HAVE_TE:
         FusedMLAQUpProjRopeQuant = None
         mxfp8_quantize_only = None
         mxfp8_transpose_swizzle = None
-    from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
-    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+        QuantizedTensor = None
+        MXFP8Quantizer = None
 
     from megatron.core.extensions.transformer_engine import (
         TEColumnParallelLinear,
@@ -502,7 +504,7 @@ class MultiLatentAttention(Attention):
             forced = [
                 t
                 for t in [query, key, value]
-                if t is not None and not isinstance(t, QuantizedTensor)
+                if t is not None and (QuantizedTensor is None or not isinstance(t, QuantizedTensor))
             ]
             core_attn_out = core_attn_manager.group_offload(
                 core_attn_out, forced_released_tensors=forced

--- a/tests/unit_tests/transformer/test_multi_latent_attention_imports.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention_imports.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_with_transformer_engine_without_fused_mla_support():
+    """Verify older Transformer Engine releases can import the MLA module."""
+    script = textwrap.dedent("""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def import_from_older_te(name, globals=None, locals=None, fromlist=(), level=0):
+            importing_module = (globals or {}).get("__name__")
+            if importing_module == "megatron.core.transformer.multi_latent_attention":
+                if name == "transformer_engine.pytorch.attention" and (
+                    "FusedMLAQUpProjFunction" in fromlist
+                    or "FusedMLAQUpProjRopeQuant" in fromlist
+                ):
+                    raise ImportError("fused MLA support is unavailable")
+                if name in {
+                    "transformer_engine.pytorch.quantized_tensor",
+                    "transformer_engine.pytorch.tensor.mxfp8_tensor",
+                }:
+                    raise ModuleNotFoundError(name)
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = import_from_older_te
+
+        from megatron.core.transformer import multi_latent_attention
+
+        assert multi_latent_attention.FusedMLAQUpProjFunction is None
+        assert multi_latent_attention.FusedMLAQUpProjRopeQuant is None
+        assert multi_latent_attention.mxfp8_quantize_only is None
+        assert multi_latent_attention.mxfp8_transpose_swizzle is None
+        assert multi_latent_attention.QuantizedTensor is None
+        assert multi_latent_attention.MXFP8Quantizer is None
+        """)
+
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Keeps multi-latent attention importable when Transformer Engine predates the optional fused MLA Q up-projection APIs.

The fused MLA change added compatibility handling for older Transformer Engine releases, but two related imports remained outside that guard. A standard Megatron Bridge installation using its supported base image consequently fails during import validation with `ModuleNotFoundError: No module named 'transformer_engine.pytorch.quantized_tensor'`.

This change:

- guards all fused-MLA-only Transformer Engine imports together;
- safely treats tensors as non-quantized when the optional `QuantizedTensor` type is unavailable; and
- adds a subprocess regression test that simulates the older Transformer Engine module surface.

The regression test fails before this patch at the unguarded import and passes afterward.

Related validation: [Megatron Bridge installation failure](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/33910486644/job/101145562590).

## Issue tracking

Linked issue: N/A — small compatibility regression introduced by [`95387a1e`](https://github.com/NVIDIA/Megatron-LM/commit/95387a1e4a864781b893abc607cdaec635ee75f4).

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests — not applicable; this is an import compatibility regression
- [ ] I have added proper typing to my code — no public or typed API changes
- [ ] I have added relevant documentation — no user-facing behavior or configuration changes
- [x] I have run `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`

Validation:

- `uv run --no-sync python -m pytest -q tests/unit_tests/transformer/test_multi_latent_attention_imports.py` — 1 passed
- `uv run --no-sync isort megatron/core/transformer/multi_latent_attention.py tests/unit_tests/transformer/test_multi_latent_attention_imports.py`
- Autoformatter Black, isort, pylint, and Ruff checks passed
