### PR TITLE
fix: honor activation offload in absorbed MLA

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -26,6 +26,9 @@ from megatron.core.models.common.embeddings import (
     _yarn_get_mscale,
     apply_rotary_pos_emb,
 )
+from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+    FineGrainedActivationOffloadingInterface as off_interface,
+)
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear
 from megatron.core.tensor_parallel.mappings import (
@@ -844,6 +847,12 @@ class AbsorbedMLASelfAttention(Attention):
         # ==================================
         # Core attention computation
         # ==================================
+        core_attn_manager = off_interface(
+            self.offload_core_attention and self.training, q_absorbed, "core_attn"
+        )
+        core_consumed_v_up_projection = getattr(
+            self.core_attention, "consumes_absorbed_v_up_projection", False
+        )
         if self.checkpoint_core_attention and self.training:
             core_attn_out = self._checkpointed_attention_forward(
                 q_absorbed,
@@ -855,34 +864,39 @@ class AbsorbedMLASelfAttention(Attention):
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
             )
-        else:
-            core_attn_out = self.core_attention(
-                q_absorbed,
-                kv_compressed,
-                value=None,
-                attention_mask=attention_mask,
-                x=hidden_states,
-                qr=q_compressed,
-                up_v_weight=v_up_weight,
-                position_ids=position_ids,
-                packed_seq_params=packed_seq_params,
-                attn_mask_type=self.attn_mask_type,
+            core_attn_out = _apply_absorbed_v_up_projection(
+                core_attn_out,
+                v_up_weight,
+                self.num_attention_heads_per_partition,
+                self.config.kv_lora_rank,
+                self.config.v_head_dim,
+                core_consumed_v_up_projection,
             )
-
-        # ==================================
-        # Apply V up projection
-        # ==================================
-        core_consumed_v_up_projection = getattr(
-            self.core_attention, "consumes_absorbed_v_up_projection", False
-        )
-        core_attn_out = _apply_absorbed_v_up_projection(
-            core_attn_out,
-            v_up_weight,
-            self.num_attention_heads_per_partition,
-            self.config.kv_lora_rank,
-            self.config.v_head_dim,
-            core_consumed_v_up_projection,
-        )
+        else:
+            with core_attn_manager as q_absorbed:
+                core_attn_out = self.core_attention(
+                    q_absorbed,
+                    kv_compressed,
+                    value=None,
+                    attention_mask=attention_mask,
+                    x=hidden_states,
+                    qr=q_compressed,
+                    up_v_weight=v_up_weight,
+                    position_ids=position_ids,
+                    packed_seq_params=packed_seq_params,
+                    attn_mask_type=self.attn_mask_type,
+                )
+                core_attn_out = _apply_absorbed_v_up_projection(
+                    core_attn_out,
+                    v_up_weight,
+                    self.num_attention_heads_per_partition,
+                    self.config.kv_lora_rank,
+                    self.config.v_head_dim,
+                    core_consumed_v_up_projection,
+                )
+            core_attn_out = core_attn_manager.group_offload(
+                core_attn_out, forced_released_tensors=[q_absorbed, kv_compressed]
+            )
 
         core_attn_out = _restore_packed_thd_batch_dim(
             core_attn_out, hidden_states, packed_seq_params
@@ -909,7 +923,12 @@ class AbsorbedMLASelfAttention(Attention):
         # =================
         # Output. [sq, b, h]
         # =================
-        output, bias = self.linear_proj(core_attn_out)
+        attn_proj_manager = off_interface(self.offload_attn_proj, core_attn_out, "attn_proj")
+        with attn_proj_manager as core_attn_out:
+            output, bias = self.linear_proj(core_attn_out)
+        output = attn_proj_manager.group_offload(
+            output, forced_released_tensors=[core_attn_out]
+        )
 
         return output, bias
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -345,6 +345,85 @@ def test_absorbed_v_up_projection_skips_when_core_consumed_weight():
     assert projected is core_attn_out
 
 
+def test_forward_honors_fine_grained_attention_offload(monkeypatch):
+    """Absorbed MLA should use the same attention offload scopes as standard MLA."""
+    events = []
+    managers = []
+
+    class OffloadManager:
+        def __init__(self, enabled, tensor, name):
+            self.enabled = enabled
+            self.tensor = tensor
+            self.name = name
+            self.released = None
+            managers.append(self)
+
+        def __enter__(self):
+            events.append(f"enter:{self.name}")
+            return self.tensor
+
+        def __exit__(self, *args):
+            events.append(f"exit:{self.name}")
+
+        def group_offload(self, tensor, forced_released_tensors=None):
+            events.append(f"offload:{self.name}")
+            self.released = forced_released_tensors
+            return tensor
+
+    def run_core_attention(*args, **kwargs):
+        del args, kwargs
+        events.append("core_attention")
+        return torch.ones(2, 1, 4)
+
+    def run_output_projection(tensor):
+        events.append("output_projection")
+        return tensor, None
+
+    attention = SimpleNamespace(
+        get_query_key_value_tensors=lambda *args, **kwargs: (
+            torch.ones(2, 1, 4),
+            torch.ones(2, 1, 4),
+            torch.ones(2, 1, 4),
+        ),
+        _get_v_up_weight=lambda: torch.eye(2).repeat(2, 1, 1),
+        core_attention=run_core_attention,
+        linear_proj=run_output_projection,
+        config=SimpleNamespace(
+            kv_lora_rank=2,
+            v_head_dim=2,
+            tensor_model_parallel_size=1,
+        ),
+        num_attention_heads_per_partition=2,
+        checkpoint_core_attention=False,
+        offload_core_attention=True,
+        offload_attn_proj=True,
+        training=True,
+        cache_mla_latents=False,
+        attn_mask_type=AttnMaskType.causal,
+        recompute_up_proj=False,
+    )
+    monkeypatch.setattr(absorbed_mla_module, "off_interface", OffloadManager)
+
+    hidden_states = torch.ones(2, 1, 4)
+    output, bias = AbsorbedMLASelfAttention.forward(attention, hidden_states, None)
+
+    assert output.shape == hidden_states.shape
+    assert bias is None
+    assert events == [
+        "enter:core_attn",
+        "core_attention",
+        "exit:core_attn",
+        "offload:core_attn",
+        "enter:attn_proj",
+        "output_projection",
+        "exit:attn_proj",
+        "offload:attn_proj",
+    ]
+    assert [manager.enabled for manager in managers] == [True, True]
+    assert len(managers[0].released) == 2
+    assert managers[1].released == [managers[1].tensor]
+
+
 def test_load_from_state_dict_backwards_compatible_with_split_kv_up_projection(monkeypatch):
     """Pre-refactor split K/V up-projection checkpoints load into the combined layout."""
 


### PR DESCRIPTION
## What does this PR do?

Make fine-grained activation offload apply to absorbed MLA projections instead of bypassing those configured modules.

## Issue tracking

Linked issue: none; this is a focused correctness fix for existing activation-offload configuration.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [ ] I have run `tools/autoformat.sh` on my PR

### Evidence

- Exact two-node B300 GLM 5.3 lifecycle XID 1050342 completed a 262,144-token forward/backward, optimizer step, weight publication, resample, and durable checkpoint with this commit in the pinned runtime.
- The patch adds focused absorbed-MLA offload tests. Full local GPU CI remains to be triggered by a maintainer.
