### PR TITLE
Guard unsupported TileLang sparse target widths

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/ops/tilelang_dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/ops/tilelang_dsa.py
@@ -413,6 +413,7 @@ def _can_use_fused_sparse_indexer_target(
         and query.size(-1) % 16 == 0
         and topk_indices.ndim == 2
         and topk_indices.size(-1) % 64 == 0
+        and (topk_indices.size(-1) <= 256 or topk_indices.size(-1) % 256 == 0)
     )
 
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_tilelang_kernels.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_tilelang_kernels.py
@@ -1148,6 +1148,30 @@ def test_streaming_sparse_kl_uses_fused_target_when_supported(monkeypatch):
     assert calls[0][3] == 0.5
 
 
+@pytest.mark.parametrize(
+    ("topk", "expected"),
+    [(64, True), (256, True), (320, False), (512, True), (576, False)],
+)
+def test_fused_sparse_indexer_target_declines_unsupported_topk(monkeypatch, topk, expected):
+    class FakeCudaTensor:
+        is_cuda = True
+        dtype = torch.bfloat16
+
+        def __init__(self, shape):
+            self.shape = shape
+            self.ndim = len(shape)
+
+        def size(self, dim):
+            return self.shape[dim]
+
+    monkeypatch.setattr(tilelang_dsa, "sparse_indexer_target_interface", object())
+    query = FakeCudaTensor((2, 8, 256))
+    key = FakeCudaTensor((512, 256))
+    topk_indices = FakeCudaTensor((2, topk))
+
+    assert tilelang_dsa._can_use_fused_sparse_indexer_target(query, key, topk_indices) is expected
+
+
 @pytest.mark.parametrize("heads", [48, 96])
 def test_fused_sparse_indexer_target_and_kl_match_reference(heads):
     if not torch.cuda.is_available():


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

- Declines fused sparse-indexer target widths above 256 unless they are divisible by 256; unsupported widths use the existing PyTorch target path.
- Fixes the B300 TileLang `no available layout found` failure observed at widths 320, 384, 448 and every non-256-aligned 64-token width through 1,984.
- Keeps fused execution for compiler-validated widths 64, 128, 192, 256 and 512, 768, through 2,048.

## Issue tracking

Linked issue: small bug fix; no issue filed.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [ ] I have run the autoformatter on my PR

## Testing

Focused pytest command:

```
PYTHONPATH=/tmp/mcore-glm53-32k uv run --project /home/ubuntu/trajectory/tcli_glm5p3_32k --no-sync python -m pytest -q tests/unit_tests/transformer/experimental_attention_variant/test_dsa_tilelang_kernels.py -k fused_sparse_indexer_target_declines_unsupported_topk
```

All five guard boundary cases passed. On B300, direct fused results at top-k 256 and 512 matched the PyTorch reference within 1.5e-7 maximum absolute error; the existing fallback at top-k 320 matched within 1.5e-8.

Downstream GLM 5.3 native-BF16 XID `1050395` then passed 512/512 fresh rollouts, all 16 observed production backward widths, optimizer, and durable checkpoint on TP8/CP1/EP8 B300. Only width 1,024 used the fused path; the other observed widths 800-1,240 exercised this guard and existing fallback without a TileLang layout error.
