### PR TITLE
fix(logging): reset log accumulators when the first iteration is on a boundary

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3382,8 +3382,11 @@ def training_log(
     one_logger = get_one_logger()
     energy_monitor = get_energy_monitor()
 
-    # On first iteration, log stats but don't reset accumulators so normal interval stats remain accurate.
-    should_reset = not is_first_iteration
+    # total_loss_dict sums over a log interval and is reset once printed. The first
+    # iteration always prints: under --log-interval 100 that is an extra line inside an
+    # interval still accumulating, so it must not reset; under --log-interval 1 that line
+    # *is* the interval, so it must, or the next print covers two iterations.
+    should_reset = not is_first_iteration or iteration % args.log_interval == 0
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Makes the printed `lm loss` match the value the same process writes to TensorBoard. Today the second logged line of every run prints a two-iteration mean instead of that iteration's loss.

## The bug

`total_loss_dict` sums losses over a log interval; the print divides by `advanced iterations` and zeroes it. The first iteration is always printed, whether or not it lands on an interval boundary, and the reset was skipped there unconditionally:

```python
should_reset = not is_first_iteration
```

That is the right rule for one of the two roles that line can play, and the wrong one for the other:

```
  --log-interval 100                        --log-interval 1
  ------------------                        ----------------
  iter 1    extra line, printed early       iter 1    this line IS the interval
            interval still accumulating               must reset here
  iter 2..99  accumulating                  iter 2    next interval
  iter 100  the interval log -> reset                 must reset here

  resetting at iter 1 would drop it         NOT resetting at iter 1 makes
  from the interval being summed            iter 2 print mean(1, 2)
  -> old code correct                       -> old code WRONG
```

With `--log-interval 1`, from a single process:

```
  TensorBoard  iter 1   L1
  TensorBoard  iter 2   L2
  PRINTED      iter 2   (L1 + L2) / 2    <- the mean, not iteration 2
  PRINTED      iter 3   L3               <- correct again from here
```

TensorBoard writes `loss_dict[key]` directly (`training.py:3498`) so it is unaffected. The printed log and the recorded scalar therefore disagree, for that one line, in every run.

## Why it looks like a numerics bug after a resume

Only the resumed process has its first iteration mid-run, so a train-through leg and a resumed leg disagree on exactly one printed loss:

```
  step N     train-through  X    resumed  X                 identical
  step N+1   train-through  Y    resumed  (X + Y) / 2       DIFFER
  step N+2   train-through  Z    resumed  Z                 identical
                                     ^
        grad norm, num zeros and params norm at step N+1 are identical,
        and stay identical for the rest of the run
```

A real divergence cannot look like this — a changed loss changes the gradient, hence params norm at the next step, hence everything after. Nothing moves. Confirmed by comparing the event files at full float32: **every scalar point is bit-identical** between the two legs.

## Fix

```python
should_reset = not is_first_iteration or iteration % args.log_interval == 0
```

Reset when the line is a genuine interval log, whether or not it is also the first iteration.

| `is_first_iteration` | `iteration` | `log_interval` | reset? | |
|---|---|---|---|---|
| True | 1 | 1 | **True** | first line is the interval — changed |
| True | 26 | 1 | **True** | resumed, `log_interval=1` — changed |
| True | 100 | 100 | **True** | resumed exactly on a boundary — changed |
| True | 1 | 100 | False | out-of-band extra line — unchanged |
| True | 26 | 100 | False | resumed mid-interval — unchanged |
| False | 2 | 1 | True | normal iteration — unchanged |
| False | 200 | 100 | True | normal boundary — unchanged |

## Why no existing test catches it

```
  what the determinism/resume checks compare        where the bug lives
  ------------------------------------------        -------------------
  checkpoint shard sha256                    ─┐
  TensorBoard scalars at full float32        ─┼──X──>  print_rank_last(log_string)
                                              │
  neither path reads the printed line ────────┘
```

`docs/user-guide/deterministic-training.md` explicitly says to read scalars from the event files at full float32 and **never** from the printed log, because the log rounds to four significant figures. That advice is correct, and it also means the print path has no coverage.

A run-to-run A/A check is blind to it for a second reason: every fresh run has the bug, so both legs print the same wrong value and agree. It only separates across a resume.

## Issue tracking

Linked issue: <!-- none -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR — reports `Changeset is empty, all good.`: the script scopes `CHANGED_FILES` to `megatron/core` and `tests/`, and this PR only touches `megatron/training/`.
