### PR TITLE
perf(determinism): stop filling uninitialized memory under --deterministic-mode

### DIFF
--- a/docs/user-guide/deterministic-training.md
+++ b/docs/user-guide/deterministic-training.md
@@ -44,8 +44,24 @@ Checked against the parsed `args` Namespace in `apply_determinism_to_args`. Inco
 | `--cross-entropy-loss-fusion` | Must be off — asserted (fused CE is non-deterministic); drop the flag yourself |
 | `--tp-comm-overlap` | Must be off — asserted (the overlap path is not bit-exact); drop the flag yourself |
 | `torch.use_deterministic_algorithms` | Set to `True` |
+| `torch.utils.deterministic.fill_uninitialized_memory` | Set to `False` — see below |
 
 Flash attention is permitted: Transformer Engine's flash-attention backend is deterministic when `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` (see the [Transformer Engine docs](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html)).
+
+## Uninitialized-memory fill
+
+Determinism costs an *independent* output buffer: a reduction that would otherwise accumulate into shared memory with unordered atomics writes into its own buffer instead, fixing the summation order run to run. That is what makes training reproducible, and `--deterministic-mode` keeps it.
+
+`torch.use_deterministic_algorithms(True)` also switches on a separate knob, `torch.utils.deterministic.fill_uninitialized_memory`, which fills every uninitialized allocation — `torch.empty`, `empty_like`, `empty_strided`, `Tensor.resize_` — with NaN or MAX_INT, so a kernel *reading* memory it never wrote reads the same bytes every run. Reproducibility does not need that, and it is not free: one extra fill kernel per empty allocation, serialized between real work, which suppresses the overlap between compute and communication and so costs far more wall time than GPU time. Clearing it is worth roughly **15% TFLOP/s** on large configs, and more the more `torch.empty` calls a step makes. `apply_determinism_to_args` clears it immediately after enabling deterministic algorithms.
+
+Padding matters only if a computation reads it. **Benign — nothing reads it:** computed values are bit-identical and only saved bytes differ. Checkpoints are the example — some saved tensors carry trailing pad slots that no kernel writes, so two runs of the same configuration write files differing in those bytes while every trained value matches. **Harmful — a computation consumes it:** a reduction over a padded tail, a GEMM with a rounded-up K, an unmasked attention region. Results then differ run to run, and the fill does not make them correct, only repeatably wrong — every run reads the same NaN instead of different garbage. Fix the read; re-enabling the fill hides it.
+
+Set the fill back to `True` while hunting such a read — turning garbage into a loud NaN is the one thing it is good for:
+
+```python
+import torch.utils.deterministic
+torch.utils.deterministic.fill_uninitialized_memory = True
+```
 
 ## Verifying determinism
 

--- a/megatron/training/determinism.py
+++ b/megatron/training/determinism.py
@@ -19,6 +19,10 @@ from typing import MutableMapping
 
 import torch
 
+# Explicit: `import torch` does not reliably bind the `torch.utils.deterministic`
+# submodule, and this module writes to one of its attributes.
+import torch.utils.deterministic
+
 # Maps each arg name to the value it must hold for bit-exact execution;
 # verified by :func:`apply_determinism_to_args`.
 ARG_VALUES_REQUIRED_FOR_DETERMINISM = {"cross_entropy_loss_fusion": False, "tp_comm_overlap": False}
@@ -129,7 +133,9 @@ def apply_determinism_to_args(args) -> None:
        ``NVTE_ALLOW_NONDETERMINISTIC_ALGO``, ``CUBLAS_WORKSPACE_CONFIG``,
        ``MAMBA_DETERMINISTIC``, ``CAUSAL_CONV1D_DETERMINISTIC``) and
        setdefaults the canonical values.
-    3. Calls ``torch.use_deterministic_algorithms(True)``.
+    3. Calls ``torch.use_deterministic_algorithms(True)``, then clears
+       ``torch.utils.deterministic.fill_uninitialized_memory``, which that call
+       turns on and which reproducibility does not need.
 
     Incompatible options are rejected with an explicit error rather than
     silently overridden: the user must turn them off themselves so the
@@ -156,3 +162,17 @@ def apply_determinism_to_args(args) -> None:
 
     # Torch global state last — all assertions have already passed.
     torch.use_deterministic_algorithms(True)
+
+    # Reproducibility comes from the independent output buffer that replaces an
+    # unordered atomic accumulation and fixes the summation order. That stays.
+    #
+    # The line above also fills every uninitialized allocation (torch.empty,
+    # empty_like, empty_strided, Tensor.resize_) with NaN/MAX_INT, pinning what a
+    # kernel would read from memory it never wrote. Reproducibility does not need
+    # that: with no padding feeding the computation, results are bit-identical
+    # either way.
+    #
+    # It costs a kernel launch per empty allocation, serialized between real work
+    # — roughly 15% TFLOP/s on large configs. Set back to True only to debug a
+    # suspected uninitialized-memory read.
+    torch.utils.deterministic.fill_uninitialized_memory = False


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Clears `torch.utils.deterministic.fill_uninitialized_memory` under `--deterministic-mode`. Worth roughly **15% TFLOP/s** on large configs, with training bit-exact both run-to-run and across a resume.

Huge kudos to @nathan-nvidia for the insights and recommendation!

## What the fill is, and why reproducibility does not need it

Determinism costs an *independent output buffer*: a reduction that would otherwise accumulate into shared memory with unordered atomics writes into its own buffer instead, fixing the summation order. That is the mechanism that makes a run reproducible, and this PR does not touch it.

`torch.use_deterministic_algorithms(True)` also switches on a **separate** knob that fills every uninitialized allocation with NaN/MAX_INT, so a kernel *reading* memory it never wrote reads the same bytes each run.

```
  what makes a run reproducible          what the fill adds
  -----------------------------          ------------------
  independent output buffer              torch.empty        -> NaN/MAX_INT
  fixed reduction order                  empty_like         -> NaN/MAX_INT
  (kept)                                 empty_strided      -> NaN/MAX_INT
                                         Tensor.resize_     -> NaN/MAX_INT
                                         (only matters if something READS them)
```

With no padding feeding the computation, results are bit-identical either way — the fill only changes what an already-broken read would return.

## Why it is expensive

The cost is paid in kernel launches, not arithmetic: one extra fill kernel per empty allocation, serialized between real work.

```
  fill ON vs fill OFF, same configuration, nsys on one rank
  ---------------------------------------------------------
  kernel launches      up sharply; nearly all of the increase is FillFunctor
  kernel GPU time      barely moves
  wall time per step   nearly doubles
```

Kernel time flat while wall time doubles is the signature of GPU idle rather than slower kernels: the extra launches sit between real work and suppress the overlap between compute and communication. Gains are config-dependent — the more `torch.empty` calls a step makes, the larger.

## Correctness

Four legs in one allocation — train-through, a non-deterministic control, save at the midpoint, and resume from it — comparing tensorboard event files at full float32, which is the method the docs recommend:

| comparison | result |
|---|---|
| A/A (train-through vs an independent run over the same steps) | **all scalar points bit-identical** |
| RESUME (train-through vs resumed, over the post-resume steps) | **all scalar points bit-identical** |

Tags covered: `lm loss`, `grad-norm`, `num-zeros`, `params-norm`, `load_balancing_loss`, `seq_load_balancing_loss`, `learning-rate`, `loss-scale`, `batch-size`, and their `vs samples` variants.

## Documented: when padding is benign, and when it is not

Padding matters only if a computation reads it.

- **Benign — nothing reads it.** Computed values are bit-identical; only saved bytes differ.
- **Harmful — a computation consumes it.** A reduction over a padded tail, a GEMM with a rounded-up K, an unmasked attention region. Results then differ run to run, and the fill does not make them correct, only repeatably wrong.

Checkpoints are the benign case, and the one operational consequence of this PR: some saved tensors carry trailing pad slots no kernel writes, so two runs of the same configuration write files differing in those bytes while every trained value matches.

```
  sha256 of checkpoint shards   --> can report a mismatch it cannot explain
                                    (a hash cannot tell padding from divergence)
  tensorboard scalars @ float32 --> unaffected
                                    <- use this
```

The docs already recommend the scalar method; this PR adds a section on why the shard-hash method stops applying.

## Reverting locally

```python
import torch.utils.deterministic
torch.utils.deterministic.fill_uninitialized_memory = True
```

Worth doing when debugging a suspected uninitialized-memory read — that is the one thing the fill is good for, and turning it off is what surfaced the saved-padding case above.

## Issue tracking

Linked issue: <!-- none -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR — reports `Changeset is empty, all good.`: the script scopes `CHANGED_FILES` to `megatron/core` and `tests/`, and this PR only touches `megatron/training/`.
