### PR TITLE
Preserve row-only MXFP8 primaries with native TE writeback

### DIFF
--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -437,9 +437,6 @@ if HAVE_TE and is_te_min_version("2.2"):
         if te_post_all_gather_processing is not None:
             kwargs["manual_post_all_gather_processing"] = True
 
-        # Row-only MXFP8 requires TE's native distributed cast support (TE PR #3488).
-        # Keep it in the same batch as bidirectional weights: TE reduces packed amaxes
-        # and writes local shards; the caller subsequently gathers quantized data.
         cast_master_weights_to_fp8(*args, **kwargs)
 
     def _correct_amax_history_if_needed_impl(model: List[torch.nn.Module]) -> None:

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -271,12 +271,12 @@ def dequantize_fp8_tensor(fp8_tensor: torch.Tensor) -> torch.Tensor:
 def copy_back_gathered_bf16_into_fp8_param(model_p: torch.Tensor, src_bf16: torch.Tensor) -> None:
     """Requantize a gathered bf16 whole-param into an fp8 (Float8/MXFP8) model param in place.
 
-    mxfp8 columnwise can't be derived from rowwise, so force columnwise before copy_ (TE rebuilds
-    both directions from the bf16); blockwise/Float8 columnwise is a lossless transpose.
+    Preserve MXFP8 primary storage directions. A row-only primary (backward override) must
+    not acquire a columnwise copy during parameter synchronization.
     """
     if is_mxfp8tensor(model_p):
         quantizer = model_p.data._get_quantizer()
-        quantizer.set_usage(rowwise=True, columnwise=True)
+        quantizer.set_usage(rowwise=True, columnwise=model_p.data._columnwise_data is not None)
     model_p.data.copy_(src_bf16)
 
 
@@ -394,6 +394,69 @@ Currently, there are three functions:
         corrects the amax_history back. For TE2.x, it's an empty function.
         Only useful for delayed scaling.
 """
+
+
+@torch.no_grad()
+def _quantize_rowwise_mxfp8_param_shard(model_param, main_param, start_offset, group):
+    """Compatibility fallback for TE's bidirectional-only distributed MXFP8 cast.
+
+    Reconstruct bounded row tiles from disjoint master shards and let TE quantize complete
+    32-element blocks. Shard boundaries need not be aligned to rows or quantization blocks.
+    Every rank participates, including ranks without a shard, and receives identical scales.
+    This trades extra high-precision communication for not allocating columnwise storage.
+    """
+    model_param = _unwrap_parameter_data(model_param)
+    if getattr(model_param, '_with_gemm_swizzled_scales', False):
+        raise NotImplementedError("Row-only MXFP8 writeback requires unswizzled primary scales.")
+    if model_param._columnwise_data is not None or model_param._columnwise_scale_inv is not None:
+        raise ValueError("Row-only MXFP8 writeback requires both columnwise components absent.")
+    width = model_param.shape[-1]
+    rows = model_param.numel() // width
+    if width % 32 or rows % 32:
+        raise ValueError("MXFP8 primary dimensions must be multiples of 32.")
+    # About 2 MiB of BF16 staging, rounded down to complete 128-row scale tiles.
+    # Very wide weights require at least one 128-row tile.
+    tile_rows = max(128, (1024 * 1024 // width // 128) * 128)
+    shard_start = 0 if start_offset is None else start_offset
+    shard_size = 0 if main_param is None else main_param.numel()
+    shard_end = shard_start + shard_size
+    if not 0 <= shard_start <= shard_end <= model_param.numel():
+        raise ValueError("Master shard is outside the MXFP8 parameter.")
+    master = None if main_param is None else main_param.reshape(-1)
+    quantizer = model_param._get_quantizer().copy()
+    quantizer.set_usage(rowwise=True, columnwise=False)
+    quantizer.internal = False
+    quantizer.optimize_for_gemm = False
+    row_data = model_param._rowwise_data.view(rows, width)
+    row_scales = model_param._rowwise_scale_inv
+    if hasattr(model_param, 'clear_high_precision_init_val'):
+        model_param.clear_high_precision_init_val()
+
+    for row_start in range(0, rows, tile_rows):
+        row_end = min(row_start + tile_rows, rows)
+        begin, end = row_start * width, row_end * width
+        tile = torch.full(
+            (row_end - row_start, width),
+            -float('inf'),
+            dtype=model_param.dtype,
+            device=model_param.device,
+        )
+        lo, hi = max(begin, shard_start), min(end, shard_end)
+        if lo < hi:
+            # Match TE writeback's master -> model dtype -> MXFP8 rounding.
+            tile.view(-1)[lo - begin : hi - begin].copy_(
+                master[lo - shard_start : hi - shard_start]
+            )
+        # MAX with absent values at -inf also tolerates replicated master shards
+        # when the reduction group contains multiple distributed-optimizer instances.
+        torch.distributed.all_reduce(tile, op=torch.distributed.ReduceOp.MAX, group=group)
+        quantized = quantizer(tile)
+        row_data[row_start:row_end].copy_(quantized._rowwise_data)
+        scale_end = min(row_start + quantized._rowwise_scale_inv.shape[0], row_scales.shape[0])
+        row_scales[row_start:scale_end].copy_(quantized._rowwise_scale_inv[: scale_end - row_start])
+        del tile, quantized
+
+
 if HAVE_TE and is_te_min_version("2.2"):
     # Supported TE versions: 2.2+
     from transformer_engine.pytorch.tensor import QuantizedTensor
@@ -416,6 +479,24 @@ if HAVE_TE and is_te_min_version("2.2"):
             return
 
         from transformer_engine.pytorch.tensor.utils import cast_master_weights_to_fp8
+
+        row_only = [
+            is_mxfp8tensor(param) and _unwrap_parameter_data(param)._columnwise_data is None
+            for param in model_params
+        ]
+        if any(row_only):
+            if fsdp_shard_model_params is not None:
+                raise NotImplementedError("Row-only MXFP8 writeback does not support FSDP shards.")
+            for param, master, offset, rowwise in zip(
+                model_params, main_params, start_offsets, row_only
+            ):
+                if rowwise:
+                    _quantize_rowwise_mxfp8_param_shard(param, master, offset, data_parallel_group)
+            model_params = [p for p, rowwise in zip(model_params, row_only) if not rowwise]
+            main_params = [p for p, rowwise in zip(main_params, row_only) if not rowwise]
+            start_offsets = [p for p, rowwise in zip(start_offsets, row_only) if not rowwise]
+            if not model_params:
+                return
 
         args = [model_params, main_params, start_offsets, data_parallel_group]
         if fsdp_shard_model_params is not None:

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -394,69 +394,6 @@ Currently, there are three functions:
         corrects the amax_history back. For TE2.x, it's an empty function.
         Only useful for delayed scaling.
 """
-
-
-@torch.no_grad()
-def _quantize_rowwise_mxfp8_param_shard(model_param, main_param, start_offset, group):
-    """Compatibility fallback for TE's bidirectional-only distributed MXFP8 cast.
-
-    Reconstruct bounded row tiles from disjoint master shards and let TE quantize complete
-    32-element blocks. Shard boundaries need not be aligned to rows or quantization blocks.
-    Every rank participates, including ranks without a shard, and receives identical scales.
-    This trades extra high-precision communication for not allocating columnwise storage.
-    """
-    model_param = _unwrap_parameter_data(model_param)
-    if getattr(model_param, '_with_gemm_swizzled_scales', False):
-        raise NotImplementedError("Row-only MXFP8 writeback requires unswizzled primary scales.")
-    if model_param._columnwise_data is not None or model_param._columnwise_scale_inv is not None:
-        raise ValueError("Row-only MXFP8 writeback requires both columnwise components absent.")
-    width = model_param.shape[-1]
-    rows = model_param.numel() // width
-    if width % 32 or rows % 32:
-        raise ValueError("MXFP8 primary dimensions must be multiples of 32.")
-    # About 2 MiB of BF16 staging, rounded down to complete 128-row scale tiles.
-    # Very wide weights require at least one 128-row tile.
-    tile_rows = max(128, (1024 * 1024 // width // 128) * 128)
-    shard_start = 0 if start_offset is None else start_offset
-    shard_size = 0 if main_param is None else main_param.numel()
-    shard_end = shard_start + shard_size
-    if not 0 <= shard_start <= shard_end <= model_param.numel():
-        raise ValueError("Master shard is outside the MXFP8 parameter.")
-    master = None if main_param is None else main_param.reshape(-1)
-    quantizer = model_param._get_quantizer().copy()
-    quantizer.set_usage(rowwise=True, columnwise=False)
-    quantizer.internal = False
-    quantizer.optimize_for_gemm = False
-    row_data = model_param._rowwise_data.view(rows, width)
-    row_scales = model_param._rowwise_scale_inv
-    if hasattr(model_param, 'clear_high_precision_init_val'):
-        model_param.clear_high_precision_init_val()
-
-    for row_start in range(0, rows, tile_rows):
-        row_end = min(row_start + tile_rows, rows)
-        begin, end = row_start * width, row_end * width
-        tile = torch.full(
-            (row_end - row_start, width),
-            -float('inf'),
-            dtype=model_param.dtype,
-            device=model_param.device,
-        )
-        lo, hi = max(begin, shard_start), min(end, shard_end)
-        if lo < hi:
-            # Match TE writeback's master -> model dtype -> MXFP8 rounding.
-            tile.view(-1)[lo - begin : hi - begin].copy_(
-                master[lo - shard_start : hi - shard_start]
-            )
-        # MAX with absent values at -inf also tolerates replicated master shards
-        # when the reduction group contains multiple distributed-optimizer instances.
-        torch.distributed.all_reduce(tile, op=torch.distributed.ReduceOp.MAX, group=group)
-        quantized = quantizer(tile)
-        row_data[row_start:row_end].copy_(quantized._rowwise_data)
-        scale_end = min(row_start + quantized._rowwise_scale_inv.shape[0], row_scales.shape[0])
-        row_scales[row_start:scale_end].copy_(quantized._rowwise_scale_inv[: scale_end - row_start])
-        del tile, quantized
-
-
 if HAVE_TE and is_te_min_version("2.2"):
     # Supported TE versions: 2.2+
     from transformer_engine.pytorch.tensor import QuantizedTensor
@@ -480,24 +417,6 @@ if HAVE_TE and is_te_min_version("2.2"):
 
         from transformer_engine.pytorch.tensor.utils import cast_master_weights_to_fp8
 
-        row_only = [
-            is_mxfp8tensor(param) and _unwrap_parameter_data(param)._columnwise_data is None
-            for param in model_params
-        ]
-        if any(row_only):
-            if fsdp_shard_model_params is not None:
-                raise NotImplementedError("Row-only MXFP8 writeback does not support FSDP shards.")
-            for param, master, offset, rowwise in zip(
-                model_params, main_params, start_offsets, row_only
-            ):
-                if rowwise:
-                    _quantize_rowwise_mxfp8_param_shard(param, master, offset, data_parallel_group)
-            model_params = [p for p, rowwise in zip(model_params, row_only) if not rowwise]
-            main_params = [p for p, rowwise in zip(main_params, row_only) if not rowwise]
-            start_offsets = [p for p, rowwise in zip(start_offsets, row_only) if not rowwise]
-            if not model_params:
-                return
-
         args = [model_params, main_params, start_offsets, data_parallel_group]
         if fsdp_shard_model_params is not None:
             if not HAVE_PACKAGING:
@@ -518,6 +437,9 @@ if HAVE_TE and is_te_min_version("2.2"):
         if te_post_all_gather_processing is not None:
             kwargs["manual_post_all_gather_processing"] = True
 
+        # Row-only MXFP8 requires TE's native distributed cast support (TE PR #3488).
+        # Keep it in the same batch as bidirectional weights: TE reduces packed amaxes
+        # and writes local shards; the caller subsequently gathers quantized data.
         cast_master_weights_to_fp8(*args, **kwargs)
 
     def _correct_amax_history_if_needed_impl(model: List[torch.nn.Module]) -> None:

--- a/tests/unit_tests/test_mxfp8_rowwise_writeback.py
+++ b/tests/unit_tests/test_mxfp8_rowwise_writeback.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Run with the standard distributed unit-test launcher on Blackwell GPUs."""
+
+import pytest
+import torch
+
+from megatron.core import fp8_utils
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.skipif(not fp8_utils.HAVE_TE_MXFP8TENSOR, reason="Requires TE MXFP8")
+@pytest.mark.parametrize('replicated_shards', [False, True])
+def test_rowwise_writeback_preserves_storage_and_matches_full_quantization(replicated_shards):
+    import transformer_engine.pytorch as te
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+
+    available, reason = te.is_mxfp8_available(return_reason=True)
+    if not available:
+        pytest.skip(reason)
+    Utils.initialize_model_parallel(1, 1)
+    try:
+        group = torch.distributed.group.WORLD
+        rank = torch.distributed.get_rank(group)
+        size = torch.distributed.get_world_size(group)
+        # Crosses the 128-row tile/padding boundary; split inside a 32-element block.
+        shape = (160, 8192)
+        source = torch.linspace(-3, 5, 160 * 8192, device='cuda').reshape(shape)
+        quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3, rowwise=True, columnwise=False)
+        param = quantizer(source.to(torch.bfloat16))
+        pointers = (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
+        for step in range(2):
+            master = source + step * 0.25
+            if size == 1 or replicated_shards:
+                shard, offset = master.flatten(), 0
+            elif rank == 0:
+                shard, offset = master.flatten()[:17], 0
+            elif rank == 1:
+                shard, offset = master.flatten()[17:], 17
+            else:
+                shard, offset = None, None
+            fp8_utils.quantize_param_shard([param], [shard], [offset], group)
+            expected = quantizer(master.to(torch.bfloat16))
+            torch.testing.assert_close(param._rowwise_data, expected._rowwise_data, rtol=0, atol=0)
+            # Padding bytes are not part of the quantized value and may be uninitialized.
+            torch.testing.assert_close(
+                param._rowwise_scale_inv[:160, :256],
+                expected._rowwise_scale_inv[:160, :256],
+                rtol=0,
+                atol=0,
+            )
+            assert param._columnwise_data is None
+            assert param._columnwise_scale_inv is None
+            assert pointers == (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
+            fp8_utils.post_all_gather_processing([param])
+            assert param._columnwise_data is None
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(not fp8_utils.HAVE_TE_MXFP8TENSOR, reason="Requires TE MXFP8")
+@pytest.mark.parametrize('columnwise', [False, True])
+def test_bf16_copy_back_preserves_mxfp8_directions(columnwise):
+    import transformer_engine.pytorch as te
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+
+    available, reason = te.is_mxfp8_available(return_reason=True)
+    if not available:
+        pytest.skip(reason)
+    source = torch.randn(128, 128, dtype=torch.bfloat16, device='cuda')
+    quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3, rowwise=True, columnwise=columnwise)
+    param = torch.nn.Parameter(quantizer(source))
+    updated = source + 1
+    fp8_utils.copy_back_gathered_bf16_into_fp8_param(param, updated)
+    expected = quantizer(updated)
+    torch.testing.assert_close(param._rowwise_data, expected._rowwise_data, rtol=0, atol=0)
+    assert (param._columnwise_data is not None) == columnwise
+    if columnwise:
+        torch.testing.assert_close(
+            param._columnwise_data, expected._columnwise_data, rtol=0, atol=0
+        )

--- a/tests/unit_tests/test_mxfp8_rowwise_writeback.py
+++ b/tests/unit_tests/test_mxfp8_rowwise_writeback.py
@@ -1,16 +1,36 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Run with the standard distributed unit-test launcher on Blackwell GPUs."""
 
+import os
+
 import pytest
 import torch
 
 from megatron.core import fp8_utils
-from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.fixture(scope="module")
+def group():
+    owned = not torch.distributed.is_initialized()
+    if owned:
+        torch.cuda.set_device(int(os.getenv("LOCAL_RANK", "0")))
+        if "RANK" in os.environ:
+            torch.distributed.init_process_group("nccl")
+        else:
+            torch.distributed.init_process_group(
+                "nccl", store=torch.distributed.HashStore(), rank=0, world_size=1
+            )
+    yield torch.distributed.group.WORLD
+    if owned:
+        torch.distributed.destroy_process_group()
 
 
 @pytest.mark.skipif(not fp8_utils.HAVE_TE_MXFP8TENSOR, reason="Requires TE MXFP8")
 @pytest.mark.parametrize('replicated_shards', [False, True])
-def test_rowwise_writeback_preserves_storage_and_matches_full_quantization(replicated_shards):
+@pytest.mark.parametrize('columnwise', [False, True])
+def test_rowwise_writeback_preserves_storage_and_matches_full_quantization(
+    replicated_shards, columnwise, group, monkeypatch
+):
     import transformer_engine.pytorch as te
     import transformer_engine_torch as tex
     from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
@@ -18,44 +38,73 @@ def test_rowwise_writeback_preserves_storage_and_matches_full_quantization(repli
     available, reason = te.is_mxfp8_available(return_reason=True)
     if not available:
         pytest.skip(reason)
-    Utils.initialize_model_parallel(1, 1)
-    try:
-        group = torch.distributed.group.WORLD
-        rank = torch.distributed.get_rank(group)
-        size = torch.distributed.get_world_size(group)
-        # Crosses the 128-row tile/padding boundary; split inside a 32-element block.
-        shape = (160, 8192)
-        source = torch.linspace(-3, 5, 160 * 8192, device='cuda').reshape(shape)
-        quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3, rowwise=True, columnwise=False)
-        param = quantizer(source.to(torch.bfloat16))
-        pointers = (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
-        for step in range(2):
-            master = source + step * 0.25
-            if size == 1 or replicated_shards:
-                shard, offset = master.flatten(), 0
-            elif rank == 0:
-                shard, offset = master.flatten()[:17], 0
-            elif rank == 1:
-                shard, offset = master.flatten()[17:], 17
-            else:
-                shard, offset = None, None
-            fp8_utils.quantize_param_shard([param], [shard], [offset], group)
-            expected = quantizer(master.to(torch.bfloat16))
-            torch.testing.assert_close(param._rowwise_data, expected._rowwise_data, rtol=0, atol=0)
-            # Padding bytes are not part of the quantized value and may be uninitialized.
+    rank = torch.distributed.get_rank(group)
+    size = torch.distributed.get_world_size(group)
+    # Crosses the 128-row tile/padding boundary; split inside a 32-element block.
+    shape = (160, 8192)
+    source = torch.linspace(-3, 5, 160 * 8192, device='cuda').reshape(shape)
+    quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3, rowwise=True, columnwise=columnwise)
+    param = quantizer(source.to(torch.bfloat16))
+    pointers = (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
+    real_reduce = torch.distributed.all_reduce
+    reductions = []
+
+    def record_reduce(tensor, *args, **kwargs):
+        reductions.append(tensor.numel())
+        return real_reduce(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch.distributed, 'all_reduce', record_reduce)
+    for step in range(2):
+        master = source + step * 0.25
+        if size == 1 or replicated_shards:
+            shard, offset = master.flatten(), 0
+        elif rank == 0:
+            shard, offset = master.flatten()[:17], 0
+        elif rank == 1:
+            shard, offset = master.flatten()[17:], 17
+        else:
+            shard, offset = None, None
+        reductions.clear()
+        fp8_utils.quantize_param_shard([param], [shard], [offset], group)
+        expected_amax = param._rowwise_scale_inv.numel()
+        if columnwise:
+            expected_amax += param._columnwise_scale_inv.numel()
+        assert reductions == [expected_amax]  # No high-precision tile reductions.
+        # Native TE writes only the local shard. Simulate parameter synchronization
+        # using quantized bytes, including ranks owning no master shard.
+        for direction in ['rowwise', 'columnwise'] if columnwise else ['rowwise']:
+            data = getattr(param, f'_{direction}_data')
+            gathered = torch.zeros_like(data).flatten()
+            if shard is not None:
+                gathered[offset : offset + shard.numel()].copy_(
+                    data.flatten()[offset : offset + shard.numel()]
+                )
+            real_reduce(gathered, op=torch.distributed.ReduceOp.MAX, group=group)
+            data.copy_(gathered.view_as(data))
+        expected = quantizer(master.to(torch.bfloat16))
+        torch.testing.assert_close(param._rowwise_data, expected._rowwise_data, rtol=0, atol=0)
+        # Padding bytes are not part of the quantized value and may be uninitialized.
+        torch.testing.assert_close(
+            param._rowwise_scale_inv[:160, :256],
+            expected._rowwise_scale_inv[:160, :256],
+            rtol=0,
+            atol=0,
+        )
+        assert (param._columnwise_data is not None) == columnwise
+        assert (param._columnwise_scale_inv is not None) == columnwise
+        if columnwise:
             torch.testing.assert_close(
-                param._rowwise_scale_inv[:160, :256],
-                expected._rowwise_scale_inv[:160, :256],
+                param._columnwise_data, expected._columnwise_data, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                param._columnwise_scale_inv[:5, :8192],
+                expected._columnwise_scale_inv[:5, :8192],
                 rtol=0,
                 atol=0,
             )
-            assert param._columnwise_data is None
-            assert param._columnwise_scale_inv is None
-            assert pointers == (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
-            fp8_utils.post_all_gather_processing([param])
-            assert param._columnwise_data is None
-    finally:
-        Utils.destroy_model_parallel()
+        assert pointers == (param._rowwise_data.data_ptr(), param._rowwise_scale_inv.data_ptr())
+        fp8_utils.post_all_gather_processing([param])
+        assert (param._columnwise_data is not None) == columnwise
 
 
 @pytest.mark.skipif(not fp8_utils.HAVE_TE_MXFP8TENSOR, reason="Requires TE MXFP8")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Preserve row-only MXFP8 primary storage during BF16 parameter-gather copy-back, and validate distributed writeback through TE's native cast helper.

Related TE changes:

- https://github.com/NVIDIA/TransformerEngine/pull/3468 — recipe-driven row-only primary initialization for HP/dequantized backward overrides.
- https://github.com/NVIDIA/TransformerEngine/pull/3488 — native distributed MXFP8 cast support for absent columnwise data/scales. **Required for row-only distributed writeback.**

## Implementation

- Preserve the existing MXFP8 storage directions when copying gathered BF16 weights back: do not force a columnwise allocation for a row-only primary.
- Use the normal `cast_master_weights_to_fp8` path for row-only and bidirectional parameters. TE performs packed-amax reduction and writes each local shard; parameter synchronization then gathers quantized data.
- Remove this PR's earlier `_quantize_rowwise_mxfp8_param_shard` compatibility fallback, its high-precision tile reconstruction/all-reduces, and its special dispatch/FSDP rejection.
- Keep existing post-all-gather processing and non-MXFP8 paths unchanged.

There is no fallback for TE builds lacking #3488. That change is not yet associated with a released TE version, so this PR does not invent a minimum version or infer capability from the presence of an older public helper symbol. Use a TE build containing #3488 for row-only writeback.

Based directly on NVIDIA/Megatron-LM `dev`. No TMS allocation hook, `quantized_param_init_memory_context`, new backward-override config, initialization API change, or NVFP4 support is included.

## Validation

All testing for this update ran on `training_gb200_dev`, NVIDIA GB200, with the source-built TE native extension from #3488 and the synced Megatron worktree. Import paths were checked.

- Single GPU: **6 passed**.
- Four NCCL ranks: **6 passed on each rank**, exit code 0.
- Tests exercise Megatron `quantize_param_shard` -> native TE cast -> simulated quantized-byte parameter synchronization -> Megatron post-all-gather processing.
- Exact native data/active-scale comparisons over two updates, row-only and bidirectional layouts, unaligned/empty/replicated master shards, and stable primary storage pointers.
- Assert cast performs exactly one packed-amax reduction, with no high-precision parameter-tile collective.
- BF16 copy-back preserves row-only versus bidirectional storage.

Commands used `pytest --noconftest` and `torchrun --standalone --nproc_per_node=4 -m pytest --noconftest` on `tests/unit_tests/test_mxfp8_rowwise_writeback.py`. The tests own their NCCL fixture; unrelated suite-wide dataset-download fixtures were deliberately not run. Environment warnings include optional FlashAttention/CUTLASS, TorchScript/Python 3.14, and optional dependencies.

This is targeted helper/copy-back integration coverage, **not** a full distributed-optimizer training loop, end-to-end FSDP, checkpoint/resharding, or performance validation. Those remain unverified.

## Contribution process

- [x] I have added relevant unit tests
- [ ] I have added relevant full functional tests
- [ ] I have run the full autoformatter script
