### PR TITLE
fix(moe): remove redundant deterministic unpermute allocation

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -604,9 +604,6 @@ def unpermute(
     if torch.are_deterministic_algorithms_enabled():
         # Use index_add which is deterministic when deterministic algorithms are enabled
         # and is CUDA graph compatible
-        output_tokens = torch.zeros(
-            restore_shape, dtype=permuted_tokens.dtype, device=permuted_tokens.device
-        )
         # index_add is deterministic when torch.use_deterministic_algorithms(True) is set
         # and is CUDA graph compatible unlike scatter_add
         output_tokens.index_add_(0, sorted_indices, permuted_tokens)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Removes a redundant second `torch.zeros()` allocation from the deterministic branch of MoE `unpermute()`.

`output_tokens` is already zero-initialized immediately before the deterministic/non-deterministic branch. Reallocating the same tensor before `index_add_()` does not change the result, dtype, device, shape, or autograd behavior; it only adds another allocation and zero-initialization. During the reassignment, both full-size output tensors can coexist transiently.

The non-deterministic `scatter_add_()` path and batch-invariant early-return path are unchanged.

## Issue tracking

Linked issue: Related to #6547 (the `moe_utils.py` redundant-allocation subtask only).

## Validation

- `git diff --check`
- `python -m py_compile megatron/core/transformer/moe/moe_utils.py` with Python 3.10 and 3.12
- Isolated CPU forward/backward comparison: outputs and source gradients are exactly equal before and after the deletion; zero-allocation count drops from two to one.
- Existing `tests/unit_tests/transformer/moe/test_a2a_token_dispatcher.py::TestAlltoAllDispatcher::test_forward_backward` already parameterizes `deterministic=[False, True]` and explicitly exercises the unfused deterministic branch.

GPU tests were not run locally because this host has no CUDA device. The targeted repository test is:

```bash
uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q \
  tests/unit_tests/transformer/moe/test_a2a_token_dispatcher.py
```

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests (no new test; the existing deterministic dispatcher test covers this branch)
- [ ] I have added relevant functional tests (not applicable to this allocation-only cleanup)
- [ ] I have added proper typing to my code (no API or typing changes)
- [ ] I have added relevant documentation (no user-facing behavior change)
- [ ] I have run the autoformatter (tooling is unavailable on the local Windows host; the diff only deletes three lines and passes `git diff --check`)