### PR TITLE
Add messages to OptimizerParamScheduler config asserts

### DIFF
--- a/megatron/core/optimizer_param_scheduler.py
+++ b/megatron/core/optimizer_param_scheduler.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 """Learning rate decay and weight decay incr functions."""
+
 import logging
 import math
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
@@ -147,26 +148,41 @@ class OptimizerParamScheduler:
         self.init_lr = init_lr
         self.max_lr = float(max_lr)
         self.min_lr = min_lr
-        assert self.min_lr >= 0.0
-        assert self.max_lr >= self.min_lr
-        assert self.init_lr <= self.max_lr
+        assert self.min_lr >= 0.0, f'min_lr must be >= 0.0, got {self.min_lr}'
+        assert (
+            self.max_lr >= self.min_lr
+        ), f'max_lr ({self.max_lr}) must be >= min_lr ({self.min_lr})'
+        assert (
+            self.init_lr <= self.max_lr
+        ), f'init_lr ({self.init_lr}) must be <= max_lr ({self.max_lr})'
 
         self.lr_warmup_steps = lr_warmup_steps
         self.num_steps = 0
         self.lr_decay_steps = lr_decay_steps
         self.wsd_decay_steps = wsd_decay_steps
         self.lr_wsd_decay_style = lr_wsd_decay_style
-        assert self.lr_decay_steps > 0
-        assert self.lr_warmup_steps < self.lr_decay_steps
+        assert self.lr_decay_steps > 0, (
+            f'lr_decay_steps must be > 0, got {self.lr_decay_steps}. When lr_decay_steps is '
+            f'derived from the number of training iterations, this usually means the computed '
+            f'number of training iterations is 0 (e.g. fewer samples than a single global batch).'
+        )
+        assert self.lr_warmup_steps < self.lr_decay_steps, (
+            f'lr_warmup_steps ({self.lr_warmup_steps}) must be < '
+            f'lr_decay_steps ({self.lr_decay_steps})'
+        )
 
         self.lr_decay_style = lr_decay_style
         if self.lr_decay_style == "WSD":
-            assert self.wsd_decay_steps is not None
+            assert (
+                self.wsd_decay_steps is not None
+            ), 'wsd_decay_steps must be provided when lr_decay_style is "WSD"'
 
         self.start_wd = start_wd
         self.end_wd = end_wd
-        assert self.start_wd >= 0.0
-        assert self.end_wd >= self.start_wd
+        assert self.start_wd >= 0.0, f'start_wd must be >= 0.0, got {self.start_wd}'
+        assert (
+            self.end_wd >= self.start_wd
+        ), f'end_wd ({self.end_wd}) must be >= start_wd ({self.start_wd})'
         self.wd_incr_steps = wd_incr_steps
         self.wd_incr_style = wd_incr_style
 

--- a/tests/unit_tests/test_optimizer_param_scheduler.py
+++ b/tests/unit_tests/test_optimizer_param_scheduler.py
@@ -45,6 +45,46 @@ def test_initialization(mock_optimizer):
     assert scheduler.wd_incr_style == 'linear'
 
 
+def _make_scheduler(mock_optimizer, **overrides):
+    kwargs = dict(
+        optimizer=mock_optimizer,
+        init_lr=0.01,
+        max_lr=0.1,
+        min_lr=0.001,
+        lr_warmup_steps=100,
+        lr_decay_steps=1000,
+        lr_decay_style='linear',
+        start_wd=0.0,
+        end_wd=0.1,
+        wd_incr_steps=1000,
+        wd_incr_style='linear',
+    )
+    kwargs.update(overrides)
+    return OptimizerParamScheduler(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ('overrides', 'match'),
+    [
+        ({'lr_decay_steps': 0}, r'lr_decay_steps must be > 0, got 0'),
+        (
+            {'lr_warmup_steps': 1000, 'lr_decay_steps': 1000},
+            r'lr_warmup_steps \(1000\) must be < lr_decay_steps \(1000\)',
+        ),
+        ({'min_lr': -0.001}, r'min_lr must be >= 0.0, got -0.001'),
+        ({'max_lr': 0.0005}, r'max_lr \(0.0005\) must be >= min_lr \(0.001\)'),
+        ({'init_lr': 0.2}, r'init_lr \(0.2\) must be <= max_lr \(0.1\)'),
+        ({'start_wd': -0.1}, r'start_wd must be >= 0.0, got -0.1'),
+        ({'end_wd': -0.1, 'start_wd': 0.0}, r'end_wd \(-0.1\) must be >= start_wd \(0.0\)'),
+        ({'lr_decay_style': 'WSD', 'wsd_decay_steps': None}, r'wsd_decay_steps must be provided'),
+    ],
+)
+def test_invalid_config_error_messages(mock_optimizer, overrides, match):
+    """Invalid scheduler configs fail with a message naming the offending values."""
+    with pytest.raises(AssertionError, match=match):
+        _make_scheduler(mock_optimizer, **overrides)
+
+
 def test_get_wd_constant(mock_optimizer):
     scheduler = OptimizerParamScheduler(
         optimizer=mock_optimizer,


### PR DESCRIPTION
## What does this PR do?

Gives the constructor validation asserts in `OptimizerParamScheduler` actionable messages. Today an invalid config fails with a bare `AssertionError` and no indication of which value is wrong.

**How we hit this:** an RL fine-tuning framework built on Megatron-Core derived the scheduler's step counts from rollout math; a config where the sample count was smaller than one global batch produced `lr_decay_steps = 0`, and boot died with

```
File ".../megatron/core/optimizer_param_scheduler.py", line 159, in __init__
    assert self.lr_decay_steps > 0
AssertionError
```

which took real debugging time to trace back to the offending config knobs. With this change the same failure reads:

```
AssertionError: lr_decay_steps must be > 0, got 0. When lr_decay_steps is derived from the number of training iterations, this usually means the computed number of training iterations is 0 (e.g. fewer samples than a single global batch).
```

## Changes

- Each validation assert in `OptimizerParamScheduler.__init__` gets a message naming the offending values (min_lr/max_lr/init_lr ordering, lr_decay_steps > 0, lr_warmup_steps < lr_decay_steps, WSD wsd_decay_steps, start_wd/end_wd ordering). No behavior change for valid configs; the exception type is unchanged.
- New parametrized unit test (8 cases) pinning every message.

## Verification

- `pytest tests/unit_tests/test_optimizer_param_scheduler.py`: 26 passed (18 existing + 8 new; the new cases fail against the unpatched file).
- black (pre-commit rev/args), isort clean on the touched files; `pylint --rcfile=.pylintrc` rates the touched core file 10.00/10.
