### PR TITLE
Fix out-of-bounds head masks in fused MLA YaRN RoPE kernels

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -139,7 +139,7 @@ def _mla_rope_fwd_inplace_kernel(
     Q = Q + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
     x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
-    mask = x_off < head_num * stride_x_nheads
+    mask = pid_head * BLOCK_H * stride_x_nheads + x_off < head_num * stride_x_nheads
     # x1 = t[..., 0::2], x2 = t[..., 1::2]
     x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
     x_2_off = x_1_off + 1
@@ -235,7 +235,7 @@ def _mla_rope_bwd_inplace_kernel(
     DO = DO + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
     x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
-    mask = x_off < head_num * stride_x_nheads
+    mask = pid_head * BLOCK_H * stride_x_nheads + x_off < head_num * stride_x_nheads
     if REMOVE_INTERLEAVING:
         x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
         x_2_off = x_1_off + 1
@@ -566,7 +566,7 @@ def _mla_rope_fwd_kv_split_kernel(
 
     KV_ptr = KV + pid_m * stride_kv_seq + pid_head * BLOCK_H * stride_kv_nheads
     kv_off = tl.arange(0, BLOCK_H)[:, None] * stride_kv_nheads
-    mask = kv_off < head_num * stride_kv_nheads
+    mask = pid_head * BLOCK_H * stride_kv_nheads + kv_off < head_num * stride_kv_nheads
     k_in_off = kv_off + tl.arange(0, k_dim)[None, :]
     v_in_off = kv_off + k_dim + tl.arange(0, v_dim)[None, :]
     k = tl.load(KV_ptr + k_in_off, mask=mask)
@@ -676,7 +676,7 @@ def _mla_rope_bwd_kv_split_kernel(
 
     dKV_ptr = dKV + pid_m * stride_dkv_seq + pid_head * BLOCK_H * stride_dkv_nheads
     dkv_off = tl.arange(0, BLOCK_H)[:, None] * stride_dkv_nheads
-    mask = dkv_off < head_num * stride_dkv_nheads
+    mask = pid_head * BLOCK_H * stride_dkv_nheads + dkv_off < head_num * stride_dkv_nheads
     dk_out_off = dkv_off + tl.arange(0, k_dim)[None, :]
     dv_out_off = dkv_off + k_dim + tl.arange(0, v_dim)[None, :]
 
@@ -695,7 +695,7 @@ def _mla_rope_bwd_kv_split_kernel(
         for i in tl.static_range(triton.cdiv(head_num, BLOCK_H)):
             dK_ptr = dK + pid_m * stride_dk_seq + i * BLOCK_H * stride_dk_nheads
             x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim
-            mask = x_off < head_num * stride_dk_nheads
+            mask = i * BLOCK_H * stride_dk_nheads + x_off < head_num * stride_dk_nheads
             if REMOVE_INTERLEAVING:
                 x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
                 x_2_off = x_1_off + 1

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import contextlib
 import warnings
 from unittest.mock import MagicMock, patch
 
@@ -188,9 +189,10 @@ class _SaveOutputForBackward(torch.autograd.Function):
         return saved_output
 
 
-def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleaving=False):
+def _test_fused_mla_rope_inplace(
+    input_format, inverse=False, remove_interleaving=False, num_heads=32
+):
     assert fused_mla_rope_inplace is not None
-    num_heads = 32
     q_dim = 128
     emb_dim = 64
     dtype = torch.bfloat16
@@ -284,9 +286,8 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
     )
 
 
-def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
+def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False, num_heads=32):
     assert fused_mla_rope_kv_split is not None
-    num_heads = 32
     k_dim = 128
     v_dim = 128
     emb_dim = 64
@@ -606,3 +607,89 @@ class TestApplyRotaryPosEmbMlaFusionConflict:
             call_kw = unfused_spy.call_args[1]
             assert call_kw["mla_rotary_interleaved"] is True
         assert out.shape == t.shape
+
+
+@contextlib.contextmanager
+def _pin_block_h(block_h):
+    """Pin the autotuned ``BLOCK_H`` so a chosen head tiling is exercised deterministically."""
+    import triton
+
+    from megatron.core.fusions import fused_mla_yarn_rope_apply as rope_kernels
+
+    kernel_names = (
+        "_mla_rope_fwd_inplace_kernel",
+        "_mla_rope_bwd_inplace_kernel",
+        "_mla_rope_fwd_kv_split_kernel",
+        "_mla_rope_bwd_kv_split_kernel",
+    )
+    saved = {}
+    for name in kernel_names:
+        kernel = getattr(rope_kernels, name)
+        saved[name] = (kernel.configs, dict(kernel.cache))
+        kernel.configs = [triton.Config({"BLOCK_H": block_h})]
+        kernel.cache.clear()
+    try:
+        yield
+    finally:
+        for name in kernel_names:
+            kernel = getattr(rope_kernels, name)
+            configs, cache = saved[name]
+            kernel.configs = configs
+            kernel.cache.clear()
+            kernel.cache.update(cache)
+
+
+def _test_inplace_stays_inside_allocation(num_heads, block_h):
+    assert fused_mla_rope_inplace is not None
+    nope_dim = 128
+    emb_dim = 64
+    seqlen = 64
+    batch_size = 1
+    dtype = torch.bfloat16
+    sentinel = -1.0
+
+    # Add a guard region after the input to detect writes past the final head, sized to the
+    # farthest a phantom lane in the last (partial) head tile can reach.
+    numel = seqlen * batch_size * num_heads * (nope_dim + emb_dim)
+    padded_heads = (num_heads + block_h - 1) // block_h * block_h
+    guard_numel = (padded_heads - num_heads) * (nope_dim + emb_dim)
+    storage = torch.full((numel + guard_numel,), sentinel, dtype=dtype, device='cuda')
+    fwd_input = storage[:numel].view(seqlen, batch_size, num_heads, nope_dim + emb_dim)
+    fwd_input.normal_()
+
+    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    freqs, mscale = yarn_rope(seqlen, 0)
+    cos = (torch.cos(freqs) * mscale).to(dtype)
+    sin = (torch.sin(freqs) * mscale).to(dtype)
+
+    with _pin_block_h(block_h):
+        fused_mla_rope_inplace(fwd_input, cos, sin, nope_dim, emb_dim)
+    torch.cuda.synchronize()
+
+    clobbered = int((storage[numel:] != sentinel).sum().item())
+    assert clobbered == 0, (
+        f"{clobbered} element(s) written past the end of a "
+        f"[{seqlen}, {batch_size}, {num_heads}, {nope_dim + emb_dim}] tensor "
+        f"with BLOCK_H={block_h}"
+    )
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestFusedMLARopePartialHeadBlock:
+    """Test partial head tiles, e.g. 12 heads with BLOCK_H=8."""
+
+    @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
+    def test_inplace_forward_backward(self, input_format):
+        with _pin_block_h(8):
+            _test_fused_mla_rope_inplace(input_format, num_heads=12)
+
+    @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
+    def test_kv_split_forward_backward(self, input_format):
+        with _pin_block_h(8):
+            _test_fused_mla_rope_kv_split(input_format, num_heads=12)
+
+    def test_inplace_does_not_write_past_allocation(self):
+        _test_inplace_stays_inside_allocation(num_heads=12, block_h=8)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes an out-of-bounds read/write in the four fused MLA YaRN RoPE Triton kernels, which
fires for any MLA model whose `num_attention_heads` is not a power of two.

## Issue tracking

Linked issue: Fixes #7103

## The defect

Each kernel advances its base pointer by `pid_head * BLOCK_H * stride_nheads`, then builds
its offset from `tl.arange(0, BLOCK_H)` alone and compares that **block-local** offset
against the **global** head extent:

```python
Q     = Q + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads   # block folded in
x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim       # LOCAL only
mask  = x_off < head_num * stride_x_nheads                                # GLOBAL bound
```

`mask` tests `local_h < head_num` where correctness requires
`pid_head * BLOCK_H + local_h < head_num`. It is accidentally correct at `pid_head == 0`
and strictly too permissive above it, so every lane of the last, partial head block passes.

`BLOCK_H` is autotuned over `{1, 2, 4, 8, 16, 32, 64, 128}`, so any `head_num` that is not
a power of two admits a tiling with `head_num % BLOCK_H != 0`. The backward kernels
`tl.store` through the same mask, so this is an out-of-bounds **write**; `restore_value`
restores the tensor's own storage and cannot undo a write past it. And because
`Autotuner.run` benchmarks every candidate when more than one config is registered, the
unsafe tiling is executed on the first call in every process regardless of which config
wins.

At `head_num=12`, `qk_head_dim=128`, `qk_pos_emb_head_dim=64` with `BLOCK_H=8`, the four
phantom lanes land 128 / 320 / 512 / 704 elements past each token's 2304-element row: the
next token's heads 0-3 for interior tokens (racing the legitimate writer), and 256 elements
past the end of the allocation for the last token.

## The change

One line per mask site, five sites across the four kernels — add back the block offset the
base pointer already consumed:

```diff
- mask = x_off < head_num * stride_x_nheads
+ mask = pid_head * BLOCK_H * stride_x_nheads + x_off < head_num * stride_x_nheads
```

| line | kernel | offset var | block index |
|---|---|---|---|
| 142 | `_mla_rope_fwd_inplace_kernel`  | `x_off`   | `pid_head` |
| 238 | `_mla_rope_bwd_inplace_kernel`  | `x_off`   | `pid_head` |
| 569 | `_mla_rope_fwd_kv_split_kernel` | `kv_off`  | `pid_head` |
| 679 | `_mla_rope_bwd_kv_split_kernel` | `dkv_off` | `pid_head` |
| 698 | `_mla_rope_bwd_kv_split_kernel` | `x_off`   | `i` (inside `tl.static_range`) |

The last site is inside a `tl.static_range` loop, where the block index is `i`, not
`pid_head`.

## Tests

New `TestFusedMLARopePartialHeadBlock` in
`tests/unit_tests/fusions/test_mla_yarn_rope_apply.py`, at `head_num=12` with `BLOCK_H`
pinned to 8 (the existing cases all use `num_heads=32`, a power of two, which never leaves
a partial block):

- `test_inplace_forward_backward[sbhd,thd]` — forward and backward against the unfused
  reference;
- `test_kv_split_forward_backward[sbhd,thd]` — same for the kv-split path;
- `test_inplace_does_not_write_past_allocation` — a sentinel guard region placed directly
  behind the tensor, asserting nothing is written past the last head of the last token.

Measured on an H100 (torch 2.10.0+cu129, triton 3.6.0):

- all 5 new tests **fail** on the unpatched kernels — the guard test reports exactly
  **256** clobbered elements — and **pass** with this change;
- the full file is **29 passed**;
- with the fix, `BLOCK_H=8` output at `head_num=12` is bit-identical to `BLOCK_H=4`
  (a tiling that divides 12), confirming `BLOCK_H` selects a tiling and not an arithmetic.

The defect is contained in one kernel file and the unit tests cover it deterministically, so
no functional test is added; the fix is behaviour-preserving and needs no documentation change.

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

