### PR TITLE
Add optimization for Muon + FSDP experimental

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -260,6 +260,12 @@ class DistributedDataParallelConfig:
     Only effective with ``outer_dp_sharding_strategy='optim'``.
     """
 
+    muon_dp_subgroup_size: Optional[int] = None
+    """Maximum number of contiguous DP ranks across which one parameter may be sharded for
+    MFSDP v2 Muon. Values larger than a parameter mesh are capped to that mesh; otherwise
+    the mesh size must be divisible by this value.
+    """
+
     @property
     def param_sync_via_bucket_group(self) -> bool:
         """Whether DP parameter synchronization is dispatched through DDP bucket groups.

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -55,6 +55,10 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module_utils import (
+        restore_parameter_attributes,
+        save_parameter_attributes,
+    )
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -86,8 +90,15 @@ def _materialize_meta_module(module: nn.Module, device: torch.device | None) -> 
             "reset_parameters method."
         )
 
+    # Both _apply() and TE reset_parameters() may replace Parameter objects.
+    attributes = {
+        name: save_parameter_attributes(parameter)
+        for name, parameter in module.named_parameters(recurse=False)
+    }
     module._apply(materialize_tensor, recurse=False)
     reset_parameters()
+    for name, saved_attributes in attributes.items():
+        restore_parameter_attributes(module.get_parameter(name), saved_attributes)
 
 
 def _materialize_owned_meta_modules(module: nn.Module, device: torch.device | None) -> None:

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -654,6 +654,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                             placements=expert_placements,
                             mixed_precision_policy=self.mp_policy,
                             grad_divisor=config.expert_model_parallel_size,
+                            subgroup_size=ddp_config.muon_dp_subgroup_size,
                         )
             for submodule in reversed(list(module.modules())):
                 if submodule is module:
@@ -667,6 +668,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                         submodule,
                         mesh=dp_mesh,
                         placements=dense_placements,
+                        subgroup_size=ddp_config.muon_dp_subgroup_size,
                         mixed_precision_policy=self.mp_policy,
                     )
             if config.init_model_with_meta_device:
@@ -674,6 +676,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             fully_shard(
                 module,
                 mesh=dp_mesh,
+                subgroup_size=ddp_config.muon_dp_subgroup_size,
                 placements=dense_placements,
                 mixed_precision_policy=self.mp_policy,
             )

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -614,7 +614,10 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             # each axis takes the placements of its own strategy, so no_shard outer over
             # ZeRO-3 inner is HSDP and ZeRO-1 outer over ZeRO-3 inner is HFSDP.
             dp_mesh = _build_hybrid_dp_mesh(
-                pg_collection.inter_dist_opt, pg_collection.intra_dp_cp, device_type
+                pg_collection.inter_dist_opt,
+                pg_collection.intra_dp_cp,
+                pg_collection.dp_cp,
+                device_type,
             )
             outer = _DATA_PARALLEL_PLACEMENTS[ddp_config.outer_dp_sharding_strategy]
             inner = _DATA_PARALLEL_PLACEMENTS[ddp_config.data_parallel_sharding_strategy]
@@ -879,7 +882,7 @@ _DATA_PARALLEL_PLACEMENTS = {
 }
 
 
-def _build_hybrid_dp_mesh(outer_group, inner_group, device_type):
+def _build_hybrid_dp_mesh(outer_group, inner_group, flattened_group, device_type):
     """Build the ("dp_outer", "dp_shard") mesh for a hybrid data-parallel domain.
 
     DeviceMesh.from_group requires an explicit rank table when given more than one group,
@@ -891,10 +894,11 @@ def _build_hybrid_dp_mesh(outer_group, inner_group, device_type):
     table is its mesh coordinate: a table with the right members in the wrong order would
     keep reducing over valid groups while assigning every shard index to the wrong rank.
     """
-    if outer_group is None or inner_group is None:
+    if outer_group is None or inner_group is None or flattened_group is None:
         raise ValueError(
             "MFSDP v2 with num_distributed_optimizer_instances > 1 requires both the "
-            "inter- and intra-distributed-optimizer process groups."
+            "inter- and intra-distributed-optimizer process groups and the full "
+            "data-parallel process group."
         )
 
     inner_size = inner_group.size()
@@ -905,6 +909,7 @@ def _build_hybrid_dp_mesh(outer_group, inner_group, device_type):
     expected_outer = [row[inner_index] for row in layout]
     actual_inner = dist.get_process_group_ranks(inner_group)
     actual_outer = dist.get_process_group_ranks(outer_group)
+    actual_flattened = dist.get_process_group_ranks(flattened_group)
     if actual_inner != expected_inner:
         raise ValueError(
             f"MFSDP v2 hybrid mesh row {expected_inner} does not match the intra "
@@ -915,13 +920,21 @@ def _build_hybrid_dp_mesh(outer_group, inner_group, device_type):
             f"MFSDP v2 hybrid mesh column {expected_outer} does not match the inter "
             f"distributed-optimizer group {actual_outer}."
         )
+    expected_flattened = list(range(dist.get_world_size()))
+    if actual_flattened != expected_flattened:
+        raise ValueError(
+            f"MFSDP v2 flattened hybrid mesh {expected_flattened} does not match the "
+            f"full data-parallel group {actual_flattened}."
+        )
 
-    return DeviceMesh.from_group(
+    mesh = DeviceMesh.from_group(
         [outer_group, inner_group],
         device_type=device_type,
         mesh=layout,
         mesh_dim_names=("dp_outer", "dp_shard"),
     )
+    mesh._mfsdp_flattened_group = flattened_group
+    return mesh
 
 
 def _get_hsdp_tp_mesh(outer_fsdp_dp_group, dp_cp_group, tp_group, ep_size=1):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -194,9 +194,8 @@ class DistributedDataParallelConfig:
     """
 
     muon_dp_subgroup_size: Optional[int] = None
-    """Maximum number of contiguous DP ranks across which one parameter may be sharded for
-    MFSDP v2 Muon. Values larger than a parameter mesh are capped to that mesh; otherwise
-    the mesh size must be divisible by this value."""
+    """Maximum number of same-node DP ranks across which one parameter may be sharded for
+    MFSDP v2 Muon."""
 
     def __post_init__(self):
         import os

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -193,6 +193,11 @@ class DistributedDataParallelConfig:
     Only effective with ``outer_dp_sharding_strategy='optim'``.
     """
 
+    muon_dp_subgroup_size: Optional[int] = None
+    """Maximum number of contiguous DP ranks across which one parameter may be sharded for
+    MFSDP v2 Muon. Values larger than a parameter mesh are capped to that mesh; otherwise
+    the mesh size must be divisible by this value."""
+
     def __post_init__(self):
         import os
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -85,6 +85,7 @@ class DBuffer:
         tensor_shapes: Iterable[Shape],
         dtype: torch.dtype,
         device: torch.device | str,
+        subgroup_size: int | None = None,
     ) -> None:
         """Create a DBuffer and allocate its local buffer.
 
@@ -94,6 +95,7 @@ class DBuffer:
             tensor_shapes: Global shapes for each logical tensor in this buffer.
             dtype: Dtype for the local buffer.
             device: Device for the local buffer.
+            subgroup_size: Optional contiguous DP parameter-placement subgroup size.
         """
         placements = tuple(placements)
         if len(placements) != mesh.ndim:
@@ -104,9 +106,12 @@ class DBuffer:
 
         self.mesh = mesh
         self.placements = placements
+        self.subgroup_size = subgroup_size
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        self.layout = GlobalLayout.build(tensor_shapes, dp_size=self.mesh.size())
+        self.layout = GlobalLayout.build(
+            tensor_shapes, dp_size=self.mesh.size(), subgroup_size=subgroup_size
+        )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
@@ -179,6 +184,7 @@ class DBuffer:
         tensor_shapes: Iterable[Shape],
         *,
         allocation_stream: torch.cuda.Stream | None,
+        subgroup_size: int | None = None,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -190,6 +196,7 @@ class DBuffer:
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
             allocation_stream: CUDA stream that allocated ``local_buffer``, or ``None`` for CPU.
+            subgroup_size: Optional contiguous DP parameter-placement subgroup size.
 
         Returns:
             A DBuffer that reuses ``local_buffer`` without allocating storage.
@@ -206,7 +213,7 @@ class DBuffer:
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size())
+        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size(), subgroup_size=subgroup_size)
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -217,6 +224,7 @@ class DBuffer:
         buffer = cls.__new__(cls)
         buffer.mesh = mesh
         buffer.placements = placements
+        buffer.subgroup_size = subgroup_size
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_buffer = local_buffer
@@ -225,7 +233,11 @@ class DBuffer:
 
     @classmethod
     def distribute_tensors(
-        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
+        cls,
+        tensors: Iterable[torch.Tensor],
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        subgroup_size: int | None = None,
     ) -> "DBuffer":
         """Distribute full local tensors into a DBuffer.
 
@@ -234,6 +246,7 @@ class DBuffer:
                 shape and dtype metadata but no values.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
+            subgroup_size: Optional contiguous DP parameter-placement subgroup size.
 
         Returns:
             A DBuffer whose real local storage matches ``placements``. Ranges
@@ -255,6 +268,7 @@ class DBuffer:
             tensor_shapes=tensor_shapes,
             dtype=dtype,
             device=mesh.device_type,
+            subgroup_size=subgroup_size,
         )
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
         # observable through get_local_tensor() and can remain unspecified.
@@ -291,8 +305,8 @@ class DBuffer:
                 tensor_shapes=self.layout.tensor_shapes,
                 dtype=dtype,
                 device=self.device,
+                subgroup_size=self.subgroup_size,
             )
-
         if out.mesh != self.mesh:
             raise ValueError(f"Expected out mesh {self.mesh!r}, got {out.mesh!r}.")
         if out.placements != placements:
@@ -371,6 +385,7 @@ class DBuffer:
                 new_placements,
                 self.layout.tensor_shapes,
                 allocation_stream=self.allocation_stream,
+                subgroup_size=self.subgroup_size,
             )
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
@@ -487,6 +502,7 @@ class DBuffer:
                 placements,
                 self.layout.tensor_shapes,
                 allocation_stream=self.allocation_stream,
+                subgroup_size=self.subgroup_size,
             )
 
         out.local_buffer.copy_(local_slice)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -108,6 +108,7 @@ def fully_shard(
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
     grad_divisor: int = 1,
+    subgroup_size: int | None = None,
 ) -> None:
     """Apply FSDP to a module in place.
 
@@ -131,6 +132,9 @@ def fully_shard(
             the expert-data-parallel mesh alone therefore divides by too little, and
             ``grad_divisor=ep_size`` makes up the difference. Dense parameters see only
             their own rank's tokens and need no divisor.
+        subgroup_size: Optional maximum number of contiguous DP ranks across which one
+            parameter may be sharded. Values larger than this mesh are capped to the mesh
+            size; otherwise the mesh size must be divisible by the subgroup size.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -146,6 +150,9 @@ def fully_shard(
 
     _validate_dp_axes(mesh, placements.dp_axes)
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
+    if subgroup_size is not None:
+        subgroup_size = min(subgroup_size, mesh.size())
+
     original_cls = module.__class__
     _attach_mixin(module)
     try:
@@ -160,6 +167,7 @@ def fully_shard(
             mixed_precision_policy=mixed_precision_policy,
             grad_divisor=grad_divisor,
             use_symmetric_memory=context.use_symmetric_memory,
+            subgroup_size=subgroup_size,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -15,6 +15,8 @@
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
 import dataclasses
+import os
+from collections import Counter
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -132,9 +134,8 @@ def fully_shard(
             the expert-data-parallel mesh alone therefore divides by too little, and
             ``grad_divisor=ep_size`` makes up the difference. Dense parameters see only
             their own rank's tokens and need no divisor.
-        subgroup_size: Optional maximum number of contiguous DP ranks across which one
-            parameter may be sharded. Values larger than this mesh are capped to the mesh
-            size; otherwise the mesh size must be divisible by the subgroup size.
+        subgroup_size: Optional maximum number of same-node DP ranks across which one
+            parameter may be sharded.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -151,7 +152,9 @@ def fully_shard(
     _validate_dp_axes(mesh, placements.dp_axes)
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
     if subgroup_size is not None:
-        subgroup_size = min(subgroup_size, mesh.size())
+        local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+        ranks_per_node = Counter(rank // local_world_size for rank in mesh.mesh.flatten().tolist())
+        subgroup_size = min(subgroup_size, max(ranks_per_node.values()))
 
     original_cls = module.__class__
     _attach_mixin(module)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -37,7 +37,9 @@ class GlobalLayout:
     size: int
 
     @classmethod
-    def build(cls, shapes: Iterable[Shape], dp_size: int) -> "GlobalLayout":
+    def build(
+        cls, shapes: Iterable[Shape], dp_size: int, subgroup_size: int | None = None
+    ) -> "GlobalLayout":
         """Compute global tensor element offsets and padded size.
 
         This is a DBuffer-specific reimplementation of
@@ -70,6 +72,9 @@ class GlobalLayout:
         Args:
             shapes: Logical tensor shapes in tensor-id order.
             dp_size: Data-parallel shard count for this global layout.
+            subgroup_size: Optional number of contiguous DP ranks per parameter-placement
+                subgroup. When set below ``dp_size``, every tensor is packed wholly inside
+                one equally sized subgroup span, inserting padding between subgroups as needed.
 
         Returns:
             Global layout with row-aligned tensor offsets and a total size padded
@@ -88,6 +93,13 @@ class GlobalLayout:
                     f"Cannot compute a layout for zero-sized non-leading dims: {shape}."
                 )
             chunk_size = math.lcm(chunk_size, row_size)
+
+        if subgroup_size is not None:
+            if subgroup_size < dp_size:
+                offsets, size = _build_subgroup_layout(
+                    tensor_shapes, chunk_size, dp_size, subgroup_size
+                )
+                return cls(tensor_shapes=tensor_shapes, tensor_to_offset=offsets, size=size)
 
         # chunk_size is the packing granularity. Since every tensor row size divides it,
         # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
@@ -246,6 +258,49 @@ def non_leading_numel(shape: torch.Size) -> int:
     if len(shape) == 0:
         raise ValueError(f"DBuffer layout does not support 0D tensor shapes: {shape}.")
     return shape[1:].numel()
+
+
+def _build_subgroup_layout(
+    tensor_shapes: tuple[torch.Size, ...], chunk_size: int, dp_size: int, subgroup_size: int
+) -> tuple[tuple[int, ...], int]:
+    """Pack each tensor wholly into one equally sized contiguous DP subgroup span."""
+    num_subgroups = dp_size // subgroup_size
+    subgroup_cursors = [0] * num_subgroups
+    local_offsets = [-1] * len(tensor_shapes)
+    tensor_subgroups = [-1] * len(tensor_shapes)
+
+    # Largest-first placement keeps subgroup spans balanced. Stable tensor-id tie
+    # breaking makes every rank independently construct the same layout.
+    tensor_items = sorted(enumerate(tensor_shapes), key=lambda item: (-item[1].numel(), item[0]))
+    for tensor_id, shape in tensor_items:
+        row_size = non_leading_numel(shape)
+
+        def placement_end(subgroup_id: int) -> int:
+            start = _pad_to_multiple(subgroup_cursors[subgroup_id], row_size)
+            return start + shape.numel()
+
+        subgroup_id = min(
+            range(num_subgroups),
+            key=lambda candidate: (
+                placement_end(candidate),
+                subgroup_cursors[candidate],
+                candidate,
+            ),
+        )
+        start = _pad_to_multiple(subgroup_cursors[subgroup_id], row_size)
+        local_offsets[tensor_id] = start
+        tensor_subgroups[tensor_id] = subgroup_id
+        subgroup_cursors[subgroup_id] = start + shape.numel()
+
+    # Equal subgroup spans are required because Flat gives every DP rank the
+    # same local shard size. Aligning one subgroup span to chunk_size times the
+    # subgroup rank count keeps every per-rank boundary aligned to every row size.
+    subgroup_span = _pad_to_multiple(max(subgroup_cursors, default=0), chunk_size * subgroup_size)
+    tensor_to_offset = tuple(
+        tensor_subgroups[tensor_id] * subgroup_span + local_offsets[tensor_id]
+        for tensor_id in range(len(tensor_shapes))
+    )
+    return tensor_to_offset, subgroup_span * num_subgroups
 
 
 def _pad_to_multiple(value: int, multiple: int) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -269,8 +269,8 @@ def _build_subgroup_layout(
     tensor_ids = sorted(
         range(len(tensor_shapes)), key=lambda i: (-tensor_shapes[i].numel(), i)
     )
-    # Only tensors larger than one subgroup's average payload may cross subgroup boundaries.
-    average_payload = sum(shape.numel() for shape in tensor_shapes) / num_subgroups
+    # Keep moderately large tensors subgroup-local; only oversized tensors may cross.
+    average_payload = 1.7 * sum(shape.numel() for shape in tensor_shapes) / num_subgroups
     large_ids = [i for i in tensor_ids if tensor_shapes[i].numel() > average_payload]
     small_ids = [i for i in tensor_ids if tensor_shapes[i].numel() <= average_payload]
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -73,8 +73,9 @@ class GlobalLayout:
             shapes: Logical tensor shapes in tensor-id order.
             dp_size: Data-parallel shard count for this global layout.
             subgroup_size: Optional number of contiguous DP ranks per parameter-placement
-                subgroup. When set below ``dp_size``, every tensor is packed wholly inside
-                one equally sized subgroup span, inserting padding between subgroups as needed.
+                subgroup. When set below ``dp_size``, ordinary tensors are packed wholly inside
+                one equally sized subgroup span. Tensors larger than the average subgroup payload
+                may cross subgroup boundaries to avoid disproportionate padding.
 
         Returns:
             Global layout with row-aligned tensor offsets and a total size padded
@@ -263,44 +264,61 @@ def non_leading_numel(shape: torch.Size) -> int:
 def _build_subgroup_layout(
     tensor_shapes: tuple[torch.Size, ...], chunk_size: int, dp_size: int, subgroup_size: int
 ) -> tuple[tuple[int, ...], int]:
-    """Pack each tensor wholly into one equally sized contiguous DP subgroup span."""
+    """Keep ordinary tensors subgroup-local while allowing oversized tensors to cross."""
     num_subgroups = dp_size // subgroup_size
-    subgroup_cursors = [0] * num_subgroups
-    local_offsets = [-1] * len(tensor_shapes)
-    tensor_subgroups = [-1] * len(tensor_shapes)
-
-    # Largest-first placement keeps subgroup spans balanced. Stable tensor-id tie
-    # breaking makes every rank independently construct the same layout.
-    tensor_items = sorted(enumerate(tensor_shapes), key=lambda item: (-item[1].numel(), item[0]))
-    for tensor_id, shape in tensor_items:
-        row_size = non_leading_numel(shape)
-
-        def placement_end(subgroup_id: int) -> int:
-            start = _pad_to_multiple(subgroup_cursors[subgroup_id], row_size)
-            return start + shape.numel()
-
-        subgroup_id = min(
-            range(num_subgroups),
-            key=lambda candidate: (
-                placement_end(candidate),
-                subgroup_cursors[candidate],
-                candidate,
-            ),
-        )
-        start = _pad_to_multiple(subgroup_cursors[subgroup_id], row_size)
-        local_offsets[tensor_id] = start
-        tensor_subgroups[tensor_id] = subgroup_id
-        subgroup_cursors[subgroup_id] = start + shape.numel()
-
-    # Equal subgroup spans are required because Flat gives every DP rank the
-    # same local shard size. Aligning one subgroup span to chunk_size times the
-    # subgroup rank count keeps every per-rank boundary aligned to every row size.
-    subgroup_span = _pad_to_multiple(max(subgroup_cursors, default=0), chunk_size * subgroup_size)
-    tensor_to_offset = tuple(
-        tensor_subgroups[tensor_id] * subgroup_span + local_offsets[tensor_id]
-        for tensor_id in range(len(tensor_shapes))
+    tensor_ids = sorted(
+        range(len(tensor_shapes)), key=lambda i: (-tensor_shapes[i].numel(), i)
     )
-    return tensor_to_offset, subgroup_span * num_subgroups
+    # Only tensors larger than one subgroup's average payload may cross subgroup boundaries.
+    average_payload = sum(shape.numel() for shape in tensor_shapes) / num_subgroups
+    large_ids = [i for i in tensor_ids if tensor_shapes[i].numel() > average_payload]
+    small_ids = [i for i in tensor_ids if tensor_shapes[i].numel() <= average_payload]
+
+    # Pack oversized tensors contiguously at the front; this region may span subgroups.
+    offsets = [-1] * len(tensor_shapes)
+    large_size = 0
+    for tensor_id in sorted(large_ids):
+        shape = tensor_shapes[tensor_id]
+        large_size = _pad_to_multiple(large_size, non_leading_numel(shape))
+        offsets[tensor_id] = large_size
+        large_size += shape.numel()
+
+    if not small_ids:
+        return tuple(offsets), _pad_to_multiple(large_size, chunk_size * dp_size)
+
+    # Try each possible split between the shared large-tensor region and local subgroups.
+    def build_candidate(large_spans: int) -> tuple[int, int, list[tuple[int, int, int]]]:
+        cursors = [0] * (num_subgroups - large_spans)
+        placements = []
+        # Largest-first greedy packing keeps each small tensor inside one subgroup.
+        for tensor_id in small_ids:
+            shape = tensor_shapes[tensor_id]
+            starts = [_pad_to_multiple(cursor, non_leading_numel(shape)) for cursor in cursors]
+            bin_id = min(
+                range(len(cursors)),
+                key=lambda i: (starts[i] + shape.numel(), cursors[i], i),
+            )
+            placements.append((tensor_id, bin_id, starts[bin_id]))
+            cursors[bin_id] = starts[bin_id] + shape.numel()
+        span = _pad_to_multiple(
+            max(
+                (large_size + large_spans - 1) // large_spans if large_spans else 0,
+                max(cursors),
+            ),
+            chunk_size * subgroup_size,
+        )
+        return span * num_subgroups, large_spans, placements
+
+    # Minimize total padded storage, then prefer fewer spans for oversized tensors.
+    total_size, large_spans, placements = min(
+        (build_candidate(n) for n in range(bool(large_ids), num_subgroups)), key=lambda item: item[:2]
+    )
+    # Convert subgroup-local placements into offsets in the global flat buffer.
+    subgroup_span = total_size // num_subgroups
+    small_base = large_spans * subgroup_span
+    for tensor_id, bin_id, local_offset in placements:
+        offsets[tensor_id] = small_base + bin_id * subgroup_span + local_offset
+    return tuple(offsets), total_size
 
 
 def _pad_to_multiple(value: int, multiple: int) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -178,6 +178,7 @@ class FsdpModule:
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
+        subgroup_size: int | None = None,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         self._context = context
@@ -208,6 +209,7 @@ class FsdpModule:
                     reduce_scatter_stream=context.reduce_scatter_stream,
                     grad_divisor=grad_divisor,
                     use_symmetric_memory=use_symmetric_memory,
+                    subgroup_size=subgroup_size,
                 )
             )
         self._parameter_groups = tuple(parameter_groups)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for preserving parameter metadata in FSDP modules."""
+
+from torch import nn
+
+# Preserve model metadata across parameter materialization and replacement.
+# Tensor-subclass storage, autograd hooks, and FSDP runtime state remain specific
+# to each Parameter representation.
+_PARAMETER_ATTRIBUTES = (
+    "requires_grad",
+    "sequence_parallel",
+    "shared",
+    "shared_embedding",
+    "tensor_model_parallel",
+    "partition_dim",
+    "partition_stride",
+    "_tensor_parallel_mode",
+    "allreduce",
+    "grad_norm_group",
+    "is_embedding_or_output_parameter",
+    "is_embedding_parameter",
+    "use_muon",
+    "expert_tp",
+    "is_qkv",
+    "qkv_split_shapes",
+    "skip_backward_post_hook",
+    "is_gtp_weight_remat",
+    "gtp_replica_group",
+    "pad_length",
+    "group",
+)
+
+
+def save_parameter_attributes(parameter: nn.Parameter) -> dict[str, object]:
+    """Snapshot model metadata before materializing or replacing a Parameter.
+
+    Values are shallow-copied: process-group references must retain their identity.
+    Extend the shared attribute list when adding a new model-parameter contract.
+    """
+    return {
+        name: getattr(parameter, name) for name in _PARAMETER_ATTRIBUTES if hasattr(parameter, name)
+    }
+
+
+def restore_parameter_attributes(parameter: nn.Parameter, attributes: dict[str, object]) -> None:
+    """Restore saved model metadata, including explicitly false or None values."""
+    for name, value in attributes.items():
+        setattr(parameter, name, value)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -1,0 +1,997 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Owner-compute orthogonalized optimizer for Megatron-FSDP v2.
+
+This module implements the Muon-style orthogonalizing optimizer step on top of M-FSDPv2's all-`Flat`
+placements (`parameter=Flat, gradient=Flat, optimizer=Flat`). It reuses the `emerging_optimizers`
+Newton-Schulz kernels through `OrthogonalizedOptimizer`.
+
+Algorithm (per optimizer step, for 2D "matrix" parameters that cross FSDP rank boundaries), matching
+an owner-compute + scatter design:
+
+    1. Compute local orthogonalization-input ("pre-NS") shards: weight decay, momentum update, and
+       (optional) Nesterov combination, all on each rank's local gradient shard.
+    2. P2P-send the pre-NS shards to their owner ranks. Owners are balanced across ranks by an
+       orthogonalization compute-cost heuristic so no single rank serializes all Newton-Schulz work.
+       The owner's own shard is kept locally (no self-send).
+    3. On each owner, reconstruct the full pre-NS matrix and run Newton-Schulz orthogonalization to
+       produce the full update.
+    4. P2P-send the update shards from owners back to their destination ranks.
+    5. Each rank applies its local update shard to its local weight shard.
+
+Fully local parameters (owned by a single rank) skip the communication and run Newton-Schulz
+locally; their compute overlaps the boundary P2P. Non-2D parameters fall back to a plain
+momentum-SGD step (no orthogonalization).
+
+Communication is asynchronous and issued on a dedicated owner-comm stream using a dedicated
+(duplicate) owner-comm process group, so owner P2P ordering is independent of FSDP's
+forward/backward collectives. The synchronous waiting (`_wait_for_dist_buffer`) is deferred as late
+as possible so local Newton-Schulz work overlaps owner gathers/scatters. """
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import inspect
+import logging
+import warnings
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from contextlib import nullcontext
+from typing import Any, cast, overload, override
+
+import torch
+import torch.distributed as dist
+
+try:
+    from emerging_optimizers import utils as eo_utils
+    from emerging_optimizers.orthogonalized_optimizers import OrthogonalizedOptimizer
+    from emerging_optimizers.orthogonalized_optimizers.muon import Muon
+
+    HAVE_EMERGING_OPTIMIZERS = True
+except (ModuleNotFoundError, ImportError):
+    eo_utils = cast(Any, None)
+    OrthogonalizedOptimizer = cast(Any, object)
+    Muon = cast(Any, object)
+    HAVE_EMERGING_OPTIMIZERS = False
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.optim.optimizer import ParamsT
+
+from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
+from .placement import Flat
+from .shard_plan import (
+    OwnerGatherPlan,
+    OwnerScatterPlan,
+    ShardPlan,
+    assign_owner_work,
+    compute_shard_plan,
+    pack_owner_work,
+    pack_update_shards,
+    reconstruct_full_tensor,
+    unpack_update_shards,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _require_emerging_optimizers() -> None:
+    if not HAVE_EMERGING_OPTIMIZERS:
+        raise ModuleNotFoundError(
+            "Emerging-Optimizers is required for orthogonalized optimizer support. "
+            "Please install the necessary dependencies with "
+            "`pip install 'megatron_fsdp[emerging-optimizers]'`."
+        )
+
+
+@dataclasses.dataclass
+class _BoundaryChunkState:
+    """In-flight owner-gather state for one boundary chunk, between issue and finish.
+
+    `FsdpOrthogonalizedOptimizer.step` issues every chunk's owner-gather first
+    (so fully-local Newton-Schulz overlaps the gathers), then finishes each chunk
+    (wait gather, orthogonalize, scatter, apply). This object carries everything
+    `_finish_boundary_step` needs across that gap.
+    """
+
+    b_params: Sequence[DTensor]
+    b_plans: Sequence[ShardPlan]
+    b_owners: dict[int, int]
+    gather_plan: OwnerGatherPlan
+    recv_buffers: dict[int, torch.Tensor]
+    gather_works: list[dist.Work]
+    device: torch.device
+    dtype: torch.dtype
+    lr: float
+    group_kwargs: dict[str, Any]
+    # Only populated when `reconstruct_full_param` is enabled: a second owner-gather
+    # round that collects each rank's local *weight* shard (instead of the pre-NS
+    # shard) so the owner can reconstruct the full parameter for `orthogonalize`.
+    weight_gather_plan: OwnerGatherPlan | None = None
+    weight_recv_buffers: dict[int, torch.Tensor] | None = None
+    weight_gather_works: list[dist.Work] | None = None
+
+
+class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
+    """Owner-compute orthogonalized optimizer for all-`Flat` M-FSDPv2 parameters.
+
+    Subclasses `torch.optim.Optimizer` directly so it is a drop-in `torch.optim.Optimizer`
+    for the training loop and checkpointer. It composes an
+    `OrthogonalizedOptimizer` (held as `self._inner`) only for the Newton-Schulz
+    orthogonalization kernel (`orthogonalize`, `scaled_orthogonalize_fn`),
+    weight-decay application (`_apply_weight_decay_inplace`), and the pre/post
+    weight-update hooks.
+
+    All inner-optimizer arguments (`lr`, `momentum`, `weight_decay`, `nesterov`,
+    `weight_decay_method`, `fp32_matmul_prec`, `scaled_orthogonalize_fn`, ...) are
+    forwarded to the inner via `*args`/`**kwargs` and are not redeclared on this
+    wrapper, so this optimizer cannot diverge from the inner. The inner's
+    `defaults`, `param_groups`, and `state` are grabbed automatically and become this
+    optimizer's (they are the same objects). The `step` override replaces the inner's
+    per-parameter all-gather path with the owner-compute + scatter P2P algorithm.
+
+    Args:
+        params: Iterable of parameters or param-group dicts to optimize.
+        *args, **kwargs: Forwarded to the inner `OrthogonalizedOptimizer`
+            (e.g. `lr`, `momentum`, `weight_decay`, `nesterov`,
+            `weight_decay_method`, `fp32_matmul_prec`, `scaled_orthogonalize_fn`).
+        dp_mesh: Device mesh of the FSDP data-parallel group. The optimizer shards
+            Newton-Schulz work across the ranks of this mesh via P2P.
+        use_owner_comm_stream: Whether to use a separate communication stream for
+            owner-based peer-to-peer communications. Useful to disable for testing
+            reasons, giving a synchronous algorithm. Defaults to True.
+        reconstruct_full_param: Whether to also gather local weight shards and pass
+            them to orthogonalization. When False, `None` is passed as the
+            parameter to orthogonalize. Defaults to False, since it's not used in
+            the standard case.
+        num_ns_steps: Newton-Schulz iteration count, also used by the owner
+            load-balancing cost heuristic. If None, defaults to 1.
+    """
+
+    # Shared across optimizer instances so a process that constructs several
+    # optimizers over the same DP group does not call `new_group` more than
+    # once per group (each `new_group` is a collective that allocates NCCL
+    # resources, which a multi-rank-on-one-GPU dev box exhausts quickly).
+    _shared_owner_group_cache: dict[tuple[int, ...], dist.ProcessGroup] = {}
+    _shared_owner_group_initialized: set[tuple[int, ...]] = set()
+
+    def __init__(
+        self,
+        params: ParamsT,
+        inner_optimizer: OrthogonalizedOptimizer,
+        dp_mesh: DeviceMesh,
+        use_owner_comm_stream: bool = True,
+        reconstruct_full_param: bool = False,
+        num_ns_steps: int | None = None,
+    ) -> None:
+        _require_emerging_optimizers()
+
+        if num_ns_steps is None:
+            num_ns_steps = 1
+        if num_ns_steps < 1:
+            raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
+
+        self.dp_mesh = dp_mesh
+        self._num_ns_steps: int = num_ns_steps
+        # Owner P2P runs on a dedicated owner-comm stream so it overlaps local
+        # Newton-Schulz on the default stream. Multi-rank-on-one-GPU dev boxes
+        # cannot reliably run NCCL P2P on a separate stream, so this flag lets
+        # tests (the only synchronous-use case) fall back to the default stream.
+        self.use_owner_comm_stream: bool = use_owner_comm_stream
+        self.reconstruct_full_param: bool = reconstruct_full_param
+        self._owner_comm_needed: bool | None = None
+        self._shard_plans: dict[int, ShardPlan] = {}
+        self._owners: dict[int, int] = {}
+        self._owner_comm_stream_cache: dict[torch.device, torch.cuda.Stream] = {}
+
+        # Disable properties while initializing this instance. We'd either have a missing attribute
+        # or would reset the inner optimizer's attributes.
+        with self._without_property_methods():
+            super().__init__(params, {})
+        self._inner = inner_optimizer
+
+        # Assert all-`Flat` placements: this optimizer only supports the
+        # all-Flat layout (parameter=Flat, gradient=Flat, optimizer=Flat).
+        _seen_groups: set[FsdpParameterGroup] = set()
+        for _param in self._all_params():
+            _group = get_containing_parameter_group(_param)
+            if _group is None or _group in _seen_groups:
+                continue
+            _seen_groups.add(_group)
+            for _buf in (_group.main_weight, _group.model_weight, _group.main_grad):
+                if _buf is None:
+                    continue
+                if not all(isinstance(_p, Flat) for _p in _buf.placements):
+                    raise ValueError(
+                        "FsdpOrthogonalizedOptimizer requires all-Flat placements "
+                        "(parameter=Flat, gradient=Flat, optimizer=Flat), but "
+                        f"{_group} has non-Flat placements "
+                        f"{[type(_p).__name__ for _p in _buf.placements]}."
+                    )
+
+    @property
+    def param_groups(self) -> list[dict[str, Any]]:
+        """Delegate `param_groups` to the inner optimizer."""
+        return self._inner.param_groups
+
+    @param_groups.setter
+    def param_groups(self, value: list[dict[str, Any]]) -> None:
+        """Set `param_groups` on the inner optimizer."""
+        self._inner.param_groups = value
+
+    @property
+    def defaults(self) -> dict[str, Any]:
+        """Delegate `defaults` to the inner optimizer."""
+        return self._inner.defaults
+
+    @defaults.setter
+    def defaults(self, value: dict[str, Any]) -> None:
+        """Set `defaults` on the inner optimizer."""
+        self._inner.defaults = value
+
+    @property
+    def state(self) -> defaultdict[torch.Tensor, Any]:
+        """Delegate `state` to the inner optimizer."""
+        return self._inner.state
+
+    @state.setter
+    def state(self, value: defaultdict[torch.Tensor, Any]) -> None:
+        """Set `state` on the inner optimizer."""
+        self._inner.state = value
+
+    def _all_params(self):
+        """Flatten this optimizer's params from its (now-materialized) groups."""
+        return [p for group in self.param_groups for p in group["params"]]
+
+    def _init_group(self, group: dict, skip_non_grad_params: bool = True) -> None:
+        """Performs lazy momentum-state initialization, delegated to the inner optimizer."""
+        self._inner._init_group(group, skip_non_grad_params=skip_non_grad_params)
+
+    @contextlib.contextmanager
+    def _without_property_methods(self):
+        """Temporarily remove the delegating property descriptors.
+
+        The properties are defined on `FsdpOrthogonalizedOptimizer` and inherited by subclasses, so
+        `delattr` must target the defining class (found via the MRO), not `type(self)` (which is the
+        subclass and does not own the descriptors).
+        """
+        names = ["param_groups", "defaults", "state"]
+        saved: dict[str, tuple[type, property]] = {}
+        for name in names:
+            for cls_ in type(self).__mro__:
+                descriptor = cls_.__dict__.get(name)
+                if descriptor is not None and isinstance(descriptor, property):
+                    saved[name] = (cls_, descriptor)
+                    try:
+                        delattr(cls_, name)
+                    except AttributeError:
+                        pass
+                    break
+        try:
+            yield
+        finally:
+            for name in names:
+                self.__dict__.pop(name, None)
+            for name, (cls_, descriptor) in saved.items():
+                setattr(cls_, name, descriptor)
+
+    # Mesh, group, and stream helpers
+    # ===============================
+
+    def _dp_group(self) -> dist.ProcessGroup:
+        return self.dp_mesh.get_group()
+
+    def _world_size(self) -> int:
+        return self.dp_mesh.size()
+
+    def _this_rank(self) -> int:
+        return self.dp_mesh.get_local_rank()
+
+    def _this_global_rank(self) -> int:
+        return dist.get_global_rank(self._dp_group(), self._this_rank())
+
+    def _init_collective_groups(self) -> dist.ProcessGroup:
+        """Create (and cache) a duplicate owner-comm group for the DP group.
+
+        A duplicate NCCL group with the same ranks lets owner P2P use an
+        independent communicator/queue from FSDP's forward/backward collectives,
+        so owner comm ordering is decoupled. The group is created once (a
+        collective `new_group`) and initialized with a barrier so the first
+        batched P2P may involve a subset of ranks.
+        """
+        ranks = tuple(dist.get_process_group_ranks(self._dp_group()))
+        cached = self._shared_owner_group_cache.get(ranks)
+        if cached is not None:
+            return cached
+        group = dist.new_group(ranks=list(ranks))
+        type(self)._shared_owner_group_cache[ranks] = group
+        # Initialize the communicator so the first batched P2P may involve a
+        # subset of ranks; a barrier is a collective all ranks in the group run.
+        if self._dp_group().size() > 1:
+            if self.dp_mesh.device_type == "cuda":
+                dist.barrier(group=group, device_ids=[torch.cuda.current_device()])
+            else:
+                dist.barrier(group=group)
+        type(self)._shared_owner_group_initialized.add(ranks)
+        return group
+
+    def _owner_comm_stream(self, device: torch.device) -> torch.cuda.Stream | None:
+        """Cached owner-comm stream (CUDA only; None on CPU or when disabled).
+
+        Returns None (P2P on the default stream) when `use_owner_comm_stream`
+        is False, e.g. for numerics tests on multi-rank-on-one-GPU dev boxes.
+        """
+        if device.type != "cuda" or not self.use_owner_comm_stream:
+            return None
+        cached = self._owner_comm_stream_cache.get(device)
+        if cached is None:
+            with torch.cuda.device(device):
+                cached = torch.cuda.Stream()
+            self._owner_comm_stream_cache[device] = cached
+        return cached
+
+    def _wait_for_dist_buffer(self, works: list[dist.Work]) -> None:
+        """Wait for a batched P2P communication to complete.
+
+        That means there is no (possibly asynchronous) communication, computation,
+        or other memory access happening around it anymore.
+        """
+        for work in works:
+            work.wait()
+
+    # Shard planning and classification
+    # =================================
+
+    def _init_shard_plans(self, params: Sequence[torch.Tensor]) -> list[ShardPlan | None]:
+        """Collect shard metadata for the model's parameters.
+
+        The shard plans are built and cached, or retrieved from cache if
+        available. Plans are derived from the owning `FsdpParameterGroup`'s
+        `main_weight` DBuffer layout and are identical on every rank, so all
+        ranks agree on owners.
+        """
+        plans: list[ShardPlan | None] = []
+        for param in params:
+            key = id(param)
+            cached = self._shard_plans.get(key)
+            if cached is not None:
+                plans.append(cached)
+                continue
+            group = get_containing_parameter_group(param)
+            if group is None:
+                raise RuntimeError(
+                    "FsdpOrthogonalizedOptimizer parameters must be FSDP-sharded; "
+                    f"parameter {param!r} is not owned by an FsdpParameterGroup."
+                )
+            index = next(i for i, fp in enumerate(group.fsdp_parameters) if fp.sharded is param)
+            layout = group.main_weight.layout
+            shape = layout.tensor_shapes[index]
+            if len(shape) != 2:
+                plans.append(None)
+                continue
+            tensor_flat_offset = layout.tensor_to_offset[index]
+            rank_flat_shard_size = layout.size // self._world_size()
+            plan = compute_shard_plan(
+                shape, tensor_flat_offset, rank_flat_shard_size, self._world_size()
+            )
+            self._shard_plans[key] = plan
+            plans.append(plan)
+        return plans
+
+    def _classify_params(self, plans: Sequence[ShardPlan | None]) -> dict[int, str]:
+        """Classify parameters into fully local and sharded parameters that cross boundaries.
+
+        This is useful to separate compute streams later. We have the local
+        compute streams (fully-local Newton-Schulz) and owner-based compute
+        streams (owner gather/scatter + owner Newton-Schulz).
+        """
+        classes: dict[int, str] = {}
+        for index, plan in enumerate(plans):
+            if plan is None:
+                classes[index] = "non_matrix"
+            elif plan.is_boundary():
+                classes[index] = "boundary"
+            else:
+                classes[index] = "fully_local"
+        return classes
+
+    # Local orthogonalization-input computation
+    # =========================================
+
+    def _compute_orthogonalization_inputs(
+        self, param: DTensor, grad: DTensor, group: dict[str, Any], lr: float
+    ) -> torch.Tensor:
+        """For the given parameter, apply weight decay and update momentum state, then produce and
+        return the inputs for orthogonalization.
+        """
+        p_local = param.to_local()
+        state = self.state[param]
+        momentum = state["momentum_buffer"]
+        mom_local = momentum.to_local()
+        local_grad = grad.to_local()
+        if local_grad.dtype != mom_local.dtype:
+            local_grad = local_grad.to(dtype=mom_local.dtype)
+        if local_grad.shape != mom_local.shape:
+            local_grad = local_grad.reshape(mom_local.shape)
+
+        self._inner._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
+        mom_local.lerp_(local_grad, 1 - group["momentum"])
+        if self._inner.nesterov:
+            pre_ns = local_grad.lerp(mom_local, group["momentum"])
+        else:
+            pre_ns = mom_local
+        return pre_ns
+
+    # Grouping and owner assignment
+    # =============================
+
+    def _group_updates(
+        self, params: Sequence[torch.Tensor], local_shards: Sequence[torch.Tensor]
+    ) -> list[list[int]]:
+        """Using the shard plans, group the updates into chunks.
+
+        The updates are grouped into chunks by:
+        - same collective group
+        - same dtype and device of orthogonalization input shards
+        - same dtype of parameter
+        """
+        chunks: dict[tuple, list[int]] = {}
+        for index, (param, shard) in enumerate(zip(params, local_shards)):
+            group = get_containing_parameter_group(param)
+            collective_group = group.mesh.get_group() if group is not None else None
+            key = (id(collective_group), shard.device, shard.dtype, param.dtype)
+            chunks.setdefault(key, []).append(index)
+        return list(chunks.values())
+
+    def _assign_owner_work(self, plans: Sequence[ShardPlan]) -> dict[int, int]:
+        """Assign the logical full, unsharded update tensor to one owner rank.
+
+        Assignment has two rules:
+        1. Only ranks that contain a non-empty part of the shard can be owners.
+        2. Assignment is balanced around estimated full-tensor orthogonalization and update work.
+           For an M x N matrix, with `num_steps` being the amount of iterations for the
+           orthogonalization approximation:
+           `M * N * (min(M, N) * num_steps + 1)`
+        """
+        return assign_owner_work(plans, self._num_ns_steps)
+
+    # Owner-gather communication (P2P)
+    # ================================
+
+    def _pack_owner_work(
+        self,
+        plans: Sequence[ShardPlan],
+        owners: dict[int, int],
+        local_shards: Sequence[torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> OwnerGatherPlan:
+        """Pack all orthogonalization input shards for an owner into the owner's respective
+        collective buffer.
+
+        This sets up the buffers for communicating orthogonalization input shards to their owner.
+        """
+        return pack_owner_work(
+            plans,
+            owners,
+            local_shards,
+            self._world_size(),
+            self._this_rank(),
+            device=device,
+            dtype=dtype,
+        )
+
+    def _send_to_owner(
+        self, gather_plan: OwnerGatherPlan, device: torch.device, dtype: torch.dtype
+    ) -> tuple[dict[int, torch.Tensor], list[dist.Work]]:
+        """Send orthogonalization input shards to their respective owner.
+
+        Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
+        allocations around setting up a large all-to-all buffer. Sends and recvs
+        are issued on the owner-comm stream so they overlap local compute. The
+        owner's own shard is not sent (kept locally for reconstruction).
+
+        Args:
+            gather_plan: This rank's owner-gather plan (send/recv buffers).
+            device: Device for the send/recv buffers (the pre-NS device).
+            dtype: Dtype for the send/recv buffers (the pre-NS dtype).
+        """
+        group = self._init_collective_groups()
+        stream = self._owner_comm_stream(device)
+        recv_buffers: dict[int, torch.Tensor] = {
+            src: torch.empty(size, dtype=dtype, device=device)
+            for src, size in gather_plan.recv_sizes.items()
+            if size > 0
+        }
+        ops: list[dist.P2POp] = []
+        for owner, buf in gather_plan.send_buffers.items():
+            if buf.numel() == 0:
+                continue
+            # `owner` is a DP-group rank index (mesh local rank); pass it as
+            # group_peer so P2POp resolves it within the owner-comm group.
+            ops.append(dist.P2POp(dist.isend, buf, group_peer=owner, group=group))
+        for src, buf in recv_buffers.items():
+            ops.append(dist.P2POp(dist.irecv, buf, group_peer=src, group=group))
+
+        default_stream = torch.cuda.current_stream() if stream is not None else None
+        with torch.cuda.stream(stream) if stream is not None else nullcontext():
+            if stream is not None:
+                assert default_stream is not None
+                stream.wait_stream(default_stream)
+            works = dist.batch_isend_irecv(ops) if ops else []
+            for buf in list(gather_plan.send_buffers.values()) + list(recv_buffers.values()):
+                if stream is not None:
+                    buf.record_stream(stream)
+        return recv_buffers, list(works or [])
+
+    # Orthogonalization and update application
+    # ========================================
+
+    def _orthogonalize_with_precision(
+        self, param: torch.Tensor | None, pre_ns: torch.Tensor, **kwargs: Any
+    ) -> torch.Tensor:
+        """Run batched orthogonalization on the given orthogonalization inputs and return the
+        result.
+
+        Orthogonalization will use FP32 matrix multiplications in the given precision, by default
+        `self._inner.fp32_matmul_prec`.
+        """
+        with eo_utils.fp32_matmul_precision(self._inner.fp32_matmul_prec):
+            # `param` (AKA `p`) is typed as `torch.Tensor` in
+            # `emerging_optimizers.OrthogonalizedOptimizer`. However, we explicitly want to error if
+            # the function tries to use it as a tensor, but we pass `None`. So we remove the `None`
+            # type here to remove the type error for that parameter explicitly.
+            param = cast(torch.Tensor, param)
+            # The Newton-Schulz kernel is FP32-only, so cast accordingly.
+            return self._inner.orthogonalize(param, pre_ns.to(torch.float32), **kwargs)
+
+    def _apply_update(self, param: DTensor, update_shard: torch.Tensor, lr: float) -> None:
+        """Update the given parameters in batched fashion with the result of orthogonalization."""
+        p_local = param.to_local()
+        if update_shard.dtype != p_local.dtype:
+            update_shard = update_shard.to(dtype=p_local.dtype)
+        self._inner.pre_weight_update_fn_inplace(p_local, update_shard)
+        p_local.add_(update_shard, alpha=-lr)
+        self._inner.post_weight_update_fn_inplace(p_local)
+
+    def _orthogonalize_and_update(
+        self, param: DTensor, pre_ns: torch.Tensor, lr: float, group: dict[str, Any]
+    ) -> None:
+        """Run orthogonalization on the given orthogonalization inputs and update the given
+        parameter with the result of orthogonalization. (Fully-local path: no communication.)
+
+        For a fully-local parameter the owning rank's local shard *is* the full
+        parameter, so no gather is needed: pass it directly when
+        `reconstruct_full_param` is enabled, else `None` (matching the
+        boundary path).
+        """
+        group_kwargs = {k: v for k, v in group.items() if k != "params"}
+        param_arg = param.to_local() if self.reconstruct_full_param else None
+        update = self._orthogonalize_with_precision(param_arg, pre_ns, **group_kwargs)
+        self._apply_update(param, update, lr)
+
+    # Owner-scatter communication (P2P)
+    # =================================
+
+    def _pack_update_shards(
+        self,
+        full_updates: dict[int, torch.Tensor],
+        plans: Sequence[ShardPlan],
+        owners: dict[int, int],
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> OwnerScatterPlan:
+        """Set up the buffers for communication by packing update shards into their respective
+        collective buffers.
+
+        Pack all update shards for their destination into the destination's respective collective
+        buffer. This sets up the buffers for communicating update shards to their destination.
+        """
+        return pack_update_shards(
+            full_updates,
+            plans,
+            owners,
+            self._world_size(),
+            self._this_rank(),
+            device=device,
+            dtype=dtype,
+        )
+
+    def _send_to_destination(
+        self, scatter_plan: OwnerScatterPlan, device: torch.device, dtype: torch.dtype
+    ) -> tuple[dict[int, torch.Tensor], list[dist.Work]]:
+        """Send update shards to their respective destination.
+
+        Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
+        allocations around setting up a large all-to-all buffer. The owner's own
+        update shard is not sent (applied directly).
+
+        Args:
+            scatter_plan: This rank's owner-scatter plan (send/recv buffers).
+            device: Device for the send/recv buffers (the update device).
+            dtype: Dtype for the send/recv buffers (the update dtype).
+        """
+        group = self._init_collective_groups()
+        stream = self._owner_comm_stream(device)
+        recv_buffers: dict[int, torch.Tensor] = {
+            owner: torch.empty(size, dtype=dtype, device=device)
+            for owner, size in scatter_plan.recv_sizes.items()
+            if size > 0
+        }
+        ops: list[dist.P2POp] = []
+        for dest, buf in scatter_plan.send_buffers.items():
+            if buf.numel() == 0:
+                continue
+            ops.append(dist.P2POp(dist.isend, buf, group_peer=dest, group=group))
+        for owner, buf in recv_buffers.items():
+            ops.append(dist.P2POp(dist.irecv, buf, group_peer=owner, group=group))
+
+        default_stream = torch.cuda.current_stream() if stream is not None else None
+        with torch.cuda.stream(stream) if stream is not None else nullcontext():
+            if stream is not None:
+                assert default_stream is not None
+                stream.wait_stream(default_stream)
+            works = dist.batch_isend_irecv(ops) if ops else []
+            for buf in list(scatter_plan.send_buffers.values()) + list(recv_buffers.values()):
+                if stream is not None:
+                    buf.record_stream(stream)
+        return recv_buffers, list(works or [])
+
+    def _unpack_update_shards(
+        self, scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
+    ) -> dict[int, torch.Tensor]:
+        """Unpack the packed update shards in the given buffer."""
+        return unpack_update_shards(scatter_plan, recv_buffers)
+
+    # Full step
+    # =========
+
+    @overload
+    def step(self, closure: None = None) -> None: ...
+
+    @overload
+    def step(self, closure: Callable[[], float]) -> float: ...
+
+    @torch.no_grad()
+    @override
+    def step(self, closure: Callable[[], float] | None = None) -> float | None:
+        """Perform a single optimization step to update parameters.
+
+        Separates collective (P2P) and local (NS) work into phases so that no
+        rank is blocked waiting on another rank computing NS to reach P2P:
+
+        1. Compute local pre-NS shards (weight decay + momentum + Nesterov) for
+           all matrix params.
+        2. P2P-send all boundary pre-NS shards to their owners (async, no NS).
+        3. Newton-Schulz + weight update for fully-local params on the default
+           stream, overlapping the boundary owner-gathers issued in phase 2.
+        4. On each owner, wait gather, reconstruct, and orthogonalize to produce
+           the full updates.
+        5. P2P-send update shards from owners back to their destinations.
+        6. Each rank applies its local update shard to its local weight shard.
+        """
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        else:
+            loss = None
+
+        if self._world_size() > 1:
+            if self._owner_comm_needed is None:
+                has_boundary = False
+                for group in self.param_groups:
+                    plans = self._init_shard_plans(group["params"])
+                    if any(p is not None and p.is_boundary() for p in plans):
+                        has_boundary = True
+                        break
+                flag = torch.tensor(int(has_boundary), device=self._device(), dtype=torch.int)
+                dist.all_reduce(flag, op=dist.ReduceOp.SUM, group=self._dp_group())
+                self._owner_comm_needed = flag.item() > 0
+            if self._owner_comm_needed:
+                self._init_collective_groups()
+
+        fsdp_parameter_groups: set[FsdpParameterGroup] = set()
+        for group in self.param_groups:
+            self._init_group(group)
+            params = group["params"]
+            plans = self._init_shard_plans(params)
+            classes = self._classify_params(plans)
+            lr = group["lr"]
+            group_kwargs = {k: v for k, v in group.items() if k != "params"}
+
+            # Non-2D parameters: plain momentum-SGD, no orthogonalization.
+            for index, param in enumerate(params):
+                if param.grad is None:
+                    continue
+                if classes[index] == "non_matrix":
+                    self._step_non_matrix(param, param.grad, group, lr)
+                    pg = get_containing_parameter_group(param)
+                    if pg is not None:
+                        fsdp_parameter_groups.add(pg)
+
+            matrix_indices = [
+                i for i, p in enumerate(params) if p.grad is not None and classes[i] != "non_matrix"
+            ]
+            if not matrix_indices:
+                continue
+            matrix_params = [params[i] for i in matrix_indices]
+            matrix_plans = [plans[i] for i in matrix_indices if plans[i] is not None]
+            # Assert no non-matrix plans were indexed.
+            assert len(matrix_plans) == len(matrix_indices)
+            matrix_plans = cast(list[ShardPlan], matrix_plans)
+            owners = self._assign_owner_work(matrix_plans)
+            self._owners.update({matrix_indices[k]: v for k, v in owners.items()})
+
+            # Phase 1: local pre-NS shards for all matrix params.
+            local_shards: list[torch.Tensor] = []
+            for param in matrix_params:
+                if param.grad is None:
+                    local_shards.append(torch.empty(0, dtype=torch.float32, device=self._device()))
+                    continue
+                local_shards.append(
+                    self._compute_orthogonalization_inputs(param, param.grad, group, lr)
+                )
+            # Separate fully-local and boundary params. Fully-local NS+update
+            # overlaps the boundary owner gather.
+            local_indices = [
+                i for i in range(len(matrix_plans)) if not matrix_plans[i].is_boundary()
+            ]
+            boundary_indices_set = {
+                i for i in range(len(matrix_plans)) if matrix_plans[i].is_boundary()
+            }
+
+            # Phase 2: issue all boundary owner-gathers (async on the owner-comm
+            # stream) before any Newton-Schulz, so the fully-local NS in phase 3
+            # overlaps the gathers. This matches the V1 pseudocode, which runs the
+            # owner-gather before the local orthogonalization. Boundary params are
+            # grouped by collective group, shard device/dtype, and parameter dtype
+            # (see `_group_updates`) so each chunk uses consistent P2P metadata; a
+            # single optimizer param group may span multiple FSDP groups and/or
+            # mixed dtypes (e.g. FP32 + BF16).
+            chunk_states: list[_BoundaryChunkState] = []
+            for chunk_indices in self._group_updates(matrix_params, local_shards):
+                chunk_boundary = [i for i in chunk_indices if i in boundary_indices_set]
+                if not chunk_boundary:
+                    continue
+                shard_device = local_shards[chunk_boundary[0]].device
+                shard_dtype = local_shards[chunk_boundary[0]].dtype
+                chunk_states.append(
+                    self._issue_owner_gather(
+                        matrix_params,
+                        matrix_plans,
+                        owners,
+                        chunk_boundary,
+                        local_shards,
+                        shard_device,
+                        shard_dtype,
+                        lr,
+                        group_kwargs,
+                    )
+                )
+
+            # Phase 3: fully-local Newton-Schulz + weight update on the default
+            # stream, overlapping the boundary owner-gathers issued above.
+            for i in local_indices:
+                plan = matrix_plans[i]
+                if plan.rank_row_count(self._this_rank()) == 0:
+                    continue
+                self._orthogonalize_and_update(matrix_params[i], local_shards[i], lr, group)
+
+            # Phases 4-6: finish each boundary chunk - wait gather, orthogonalize
+            # on owners, scatter updates, and apply local update shards.
+            for state in chunk_states:
+                self._finish_boundary_step(state)
+
+            for param in matrix_params:
+                pg = get_containing_parameter_group(param)
+                if pg is not None:
+                    fsdp_parameter_groups.add(pg)
+
+        for parameter_group in fsdp_parameter_groups:
+            parameter_group.sync_model_weight_from_main_weight()
+        return loss
+
+    def _issue_owner_gather(
+        self,
+        matrix_params: Sequence[DTensor],
+        matrix_plans: Sequence[ShardPlan],
+        owners: dict[int, int],
+        boundary_indices: list[int],
+        local_shards: Sequence[torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype,
+        lr: float,
+        group_kwargs: dict[str, Any],
+    ) -> _BoundaryChunkState:
+        """Pack and asynchronously P2P-send this chunk's pre-NS shards to owners.
+
+        Returns the in-flight gather state; `step` finishes it later with
+        `_finish_boundary_step` so fully-local Newton-Schulz overlaps the gathers.
+        """
+        b_plans = [matrix_plans[i] for i in boundary_indices]
+        b_params = [matrix_params[i] for i in boundary_indices]
+        b_local = [local_shards[i] for i in boundary_indices]
+        b_owners = {i: owners[boundary_indices[i]] for i in range(len(boundary_indices))}
+        gather_plan = self._pack_owner_work(b_plans, b_owners, b_local, device, dtype)
+        recv_buffers, gather_works = self._send_to_owner(gather_plan, device, dtype)
+
+        # Optionally also gather each rank's local *weight* shard so the owner can
+        # reconstruct the full parameter and pass it to `orthogonalize` (some
+        # subclasses read `p`). This is a second, parallel P2P round issued on the
+        # same owner-comm stream so it overlaps the pre-NS gather; it reuses the
+        # same shard plans/owners (only the shard content differs).
+        weight_gather_plan = None
+        weight_recv_buffers = None
+        weight_gather_works = None
+        if self.reconstruct_full_param:
+            weight_local = [p.to_local() for p in b_params]
+            weight_dtype = b_params[0].dtype
+            weight_gather_plan = self._pack_owner_work(
+                b_plans, b_owners, weight_local, device, weight_dtype
+            )
+            weight_recv_buffers, weight_gather_works = self._send_to_owner(
+                weight_gather_plan, device, weight_dtype
+            )
+        return _BoundaryChunkState(
+            b_params=b_params,
+            b_plans=b_plans,
+            b_owners=b_owners,
+            gather_plan=gather_plan,
+            recv_buffers=recv_buffers,
+            gather_works=gather_works,
+            device=device,
+            dtype=dtype,
+            lr=lr,
+            group_kwargs=group_kwargs,
+            weight_gather_plan=weight_gather_plan,
+            weight_recv_buffers=weight_recv_buffers,
+            weight_gather_works=weight_gather_works,
+        )
+
+    def _finish_boundary_step(self, state: _BoundaryChunkState) -> None:
+        """Finish one boundary chunk: wait gather, orthogonalize, scatter, apply."""
+        b_params = state.b_params
+        b_plans = state.b_plans
+        b_owners = state.b_owners
+        gather_plan = state.gather_plan
+        recv_buffers = state.recv_buffers
+        device = state.device
+        lr = state.lr
+        group_kwargs = state.group_kwargs
+        this_rank = self._this_rank()
+        stream = self._owner_comm_stream(device)
+
+        # Phase 4 (owner): wait gather, reconstruct, orthogonalize. Default
+        # stream waits for the owner stream so the recv buffers are ready.
+        if stream is not None:
+            torch.cuda.current_stream(device).wait_stream(stream)
+        self._wait_for_dist_buffer(state.gather_works)
+        if state.weight_gather_works:
+            self._wait_for_dist_buffer(state.weight_gather_works)
+
+        full_updates: dict[int, torch.Tensor] = {}
+        for i in range(len(b_params)):
+            if b_owners[i] != this_rank:
+                continue
+            plan = b_plans[i]
+            if plan.rank_row_count(this_rank) == 0:
+                continue
+            # Merge the gathered orthogonalization input shards back to the original, full,
+            # unsharded input tensor.
+            full = reconstruct_full_tensor(i, plan, gather_plan, recv_buffers, owner_rank=this_rank)
+            # `full` is the reconstructed pre-NS matrix and is the
+            # orthogonalization input (`pre_ns`). The `param` (`p`) argument is
+            # unused by the default `OrthogonalizedOptimizer.orthogonalize`, so
+            # by default (`reconstruct_full_param=False`) we pass `None`. When the
+            # flag is enabled, reconstruct the full parameter from the gathered
+            # weight shards (a second P2P round issued in `_issue_owner_gather`) and
+            # pass it as `param` for subclasses that read `p`.
+            if self.reconstruct_full_param and state.weight_gather_plan is not None:
+                assert state.weight_recv_buffers is not None
+                param_arg = reconstruct_full_tensor(
+                    i,
+                    plan,
+                    state.weight_gather_plan,
+                    state.weight_recv_buffers,
+                    owner_rank=this_rank,
+                )
+            else:
+                param_arg = None
+            full_updates[i] = self._orthogonalize_with_precision(param_arg, full, **group_kwargs)
+
+        # Phase 5: pack + P2P-send update shards from owners (async on owner stream).
+        scatter_plan = self._pack_update_shards(
+            full_updates, b_plans, b_owners, device, state.dtype
+        )
+        scatter_recv, scatter_works = self._send_to_destination(scatter_plan, device, state.dtype)
+        if stream is not None:
+            torch.cuda.current_stream(device).wait_stream(stream)
+        self._wait_for_dist_buffer(scatter_works)
+        received = self._unpack_update_shards(scatter_plan, scatter_recv)
+
+        # Phase 6: apply local update shards.
+        for i, param in enumerate(b_params):
+            plan = b_plans[i]
+            if b_owners[i] == this_rank:
+                row_start, row_count = plan.rank_rows[this_rank]
+                if row_count == 0:
+                    continue
+                update_shard = full_updates[i][row_start : row_start + row_count]
+            else:
+                update_shard = received.get(i)
+                if update_shard is None:
+                    continue
+            self._apply_update(param, update_shard, lr)
+
+    def _step_non_matrix(
+        self, param: DTensor, grad: DTensor, group: dict[str, Any], lr: float
+    ) -> None:
+        """Plain momentum-SGD step for non-2D parameters (no orthogonalization)."""
+        state = self.state[param]
+        if len(state) == 0:
+            state["momentum_buffer"] = torch.zeros_like(param.data)
+        momentum = state["momentum_buffer"]
+        p_local = param.to_local()
+        mom_local = momentum.to_local()
+        local_grad = grad.to_local()
+        if local_grad.dtype != mom_local.dtype:
+            local_grad = local_grad.to(dtype=mom_local.dtype)
+        if local_grad.shape != mom_local.shape:
+            local_grad = local_grad.reshape(mom_local.shape)
+        self._inner._apply_weight_decay_inplace(p_local, local_grad, lr, group["weight_decay"])
+        mom_local.lerp_(local_grad, 1 - group["momentum"])
+        if self._inner.nesterov:
+            update = local_grad.lerp(mom_local, group["momentum"])
+        else:
+            update = mom_local
+        self._inner.pre_weight_update_fn_inplace(p_local, update)
+        p_local.add_(update, alpha=-lr)
+        self._inner.post_weight_update_fn_inplace(p_local)
+
+    def _device(self) -> torch.device:
+        return torch.device(self.dp_mesh.device_type)
+
+
+class FsdpMuon(FsdpOrthogonalizedOptimizer):
+    """Muon optimizer for all-`Flat` M-FSDPv2 parameters.
+
+    Composes a `Muon` inner optimizer (an `OrthogonalizedOptimizer`) for the
+    Newton-Schulz orthogonalization and update scaling. The inner `Muon`
+    installs its own `scaled_orthogonalize_fn`, so the base
+    `scaled_orthogonalize_fn` is ignored.
+    """
+
+    def __init__(
+        self,
+        params: ParamsT,
+        inner_optimizer: Muon,
+        dp_mesh: DeviceMesh,
+        use_owner_comm_stream: bool = True,
+        reconstruct_full_param: bool = False,
+    ) -> None:
+        _require_emerging_optimizers()
+
+        if hasattr(inner_optimizer, "num_ns_steps"):
+            self._num_ns_steps = inner_optimizer.num_ns_steps
+        else:
+            # For older `emerging_optimizers` versions, we use introspection techniques to get a
+            # sensible value for `num_ns_steps`.
+            try:
+                ortho_fn_vars = inspect.getclosurevars(inner_optimizer.scaled_orthogonalize_fn)
+                self._num_ns_steps = ortho_fn_vars.nonlocals["num_ns_steps"]
+            except KeyError:
+                warnings.warn(
+                    "Cannot access Muon closure non-locals; going with "
+                    "`emerging_optimizers.orthogonalized_optimizer.Muon` default `num_ns_steps` "
+                    "for compute cost estimation"
+                )
+                muon_sig = inspect.signature(inner_optimizer)
+                self._num_ns_steps = muon_sig.parameters["num_ns_steps"].default
+        super().__init__(
+            params,
+            inner_optimizer,
+            dp_mesh=dp_mesh,
+            use_owner_comm_stream=use_owner_comm_stream,
+            reconstruct_full_param=reconstruct_full_param,
+        )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -112,8 +112,8 @@ class _BoundaryChunkState:
     """In-flight gather and scatter state for one boundary chunk.
 
     `FsdpOrthogonalizedOptimizer.step` issues every chunk's owner-gather first,
-    then `_issue_boundary_update` fills the scatter fields for
-    `_enqueue_boundary_update` to consume.
+    then `_compute_and_issue_boundary_scatter` fills the scatter fields for
+    `_apply_boundary_update` to consume.
     """
 
     b_params: Sequence[DTensor]
@@ -135,7 +135,7 @@ class _BoundaryChunkState:
     weight_gather_works: list[dist.Work] | None = None
     weight_gather_event: torch.cuda.Event | None = None
 
-    # Populated by `_issue_boundary_update` while this chunk's scatter is in flight.
+    # Populated by `_compute_and_issue_boundary_scatter` while this chunk's scatter is in flight.
     full_updates: dict[int, torch.Tensor] = dataclasses.field(default_factory=dict)
     scatter_plan: OwnerScatterPlan | None = None
     scatter_recv: dict[tuple[int, int], torch.Tensor] = dataclasses.field(default_factory=dict)
@@ -715,9 +715,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
             chunks = self._group_updates(matrix_params, local_shards, matrix_plans)
             owners = self._assign_owner_work(matrix_plans, chunks)
-            local_indices = [
-                i for i in range(len(matrix_plans)) if not matrix_plans[i].is_boundary()
-            ]
             boundary_indices_set = {
                 i for i in range(len(matrix_plans)) if matrix_plans[i].is_boundary()
             }
@@ -742,18 +739,17 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     )
                 )
 
-            for i in local_indices:
-                plan = matrix_plans[i]
-                param = matrix_params[i]
-                if plan.rank_row_count(dist.get_rank(group=_get_parameter_dp_group(param))) > 0:
-                    rows, cols = plan.full_shape
-                    cost = plan.full_numel() * (min(rows, cols) * self._num_ns_steps + 1)
-                    local_updates.append((cost, group, param, local_shards[i]))
-
-            for param in matrix_params:
+            for param, plan, local_shard in zip(matrix_params, matrix_plans, local_shards):
                 pg = get_containing_parameter_group(param)
                 if pg is not None:
                     fsdp_parameter_groups.add(pg)
+
+                if not plan.is_boundary():
+                    rank = dist.get_rank(group=_get_parameter_dp_group(param))
+                    if plan.rank_row_count(rank) > 0:
+                        rows, cols = plan.full_shape
+                        cost = plan.full_numel() * (min(rows, cols) * self._num_ns_steps + 1)
+                        local_updates.append((cost, group, param, local_shard))
 
         # Split fully-local NS across both communication edges. The first side
         # hides owner gathers; after boundary NS launches every scatter, the
@@ -765,19 +761,21 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             local_sides[side].append(update)
             local_costs[side] += update[0]
 
+        # Run fully-local NS to overlap the owner gathers for the boundary work below.
         for _, group, param, local_shard in local_sides[0]:
             self._orthogonalize_and_update(param, local_shard, group["lr"], group)
 
         for state in chunk_states:
-            self._issue_boundary_update(state)
+            self._compute_and_issue_boundary_scatter(state)
 
+        # Run fully-local NS while the previously submitted owner scatters are in flight.
         for _, group, param, local_shard in local_sides[1]:
             self._orthogonalize_and_update(param, local_shard, group["lr"], group)
 
         for state in chunk_states:
             self._wait_for_dist_buffer(state.scatter_works)
         for state in chunk_states:
-            self._enqueue_boundary_update(state)
+            self._apply_boundary_update(state)
 
         for parameter_group in fsdp_parameter_groups:
             parameter_group.sync_model_weight_from_main_weight()
@@ -798,17 +796,16 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         """Pack and asynchronously P2P-send this chunk's pre-NS shards to owners.
 
         Returns the in-flight gather state; `step` finishes it later with
-        `_issue_boundary_update` so fully-local Newton-Schulz overlaps the gathers.
+        `_compute_and_issue_boundary_scatter` so fully-local Newton-Schulz overlaps the gathers.
         """
         b_plans = [matrix_plans[i] for i in boundary_indices]
         b_params = [matrix_params[i] for i in boundary_indices]
         b_local = [local_shards[i] for i in boundary_indices]
         b_owners = {i: owners[boundary_indices[i]] for i in range(len(boundary_indices))}
-        gather_plan = self._pack_owner_work(
-            b_plans, b_owners, b_local, device, dtype, b_params[0]
-        )
+        comm_groups = [_get_parameter_dp_group(param) for param in b_params]
+        gather_plan = self._pack_owner_work(b_plans, b_owners, b_local, comm_groups)
         recv_buffers, gather_works, gather_event = self._send_to_owner(
-            gather_plan, device, dtype, b_params[0]
+            gather_plan, device, dtype
         )
 
         # Optionally also gather each rank's local *weight* shard so the owner can
@@ -824,10 +821,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             weight_local = [p.to_local() for p in b_params]
             weight_dtype = b_params[0].dtype
             weight_gather_plan = self._pack_owner_work(
-                b_plans, b_owners, weight_local, device, weight_dtype, b_params[0]
+                b_plans, b_owners, weight_local, comm_groups
             )
             weight_recv_buffers, weight_gather_works, weight_gather_event = self._send_to_owner(
-                weight_gather_plan, device, weight_dtype, b_params[0]
+                weight_gather_plan, device, weight_dtype
             )
         return _BoundaryChunkState(
             b_params=b_params,
@@ -847,7 +844,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             weight_gather_event=weight_gather_event,
         )
 
-    def _issue_boundary_update(self, state: _BoundaryChunkState) -> None:
+    def _compute_and_issue_boundary_scatter(self, state: _BoundaryChunkState) -> None:
         """Wait for one owner-gather, orthogonalize, and issue its owner-scatter."""
         b_params = state.b_params
         b_plans = state.b_plans
@@ -897,7 +894,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
         # Phase 5: pack + P2P-send update shards from owners (async on owner stream).
         scatter_plan = self._pack_update_shards(
-            full_updates, b_plans, b_owners, device, state.dtype, b_params[0]
+            full_updates, b_plans, b_owners, list(gather_plan.comm_groups)
         )
         scatter_recv, scatter_works, scatter_event = self._send_to_destination(
             scatter_plan, device, state.dtype
@@ -908,7 +905,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         state.scatter_works = scatter_works
         state.scatter_event = scatter_event
 
-    def _enqueue_boundary_update(self, state: _BoundaryChunkState) -> None:
+    def _apply_boundary_update(self, state: _BoundaryChunkState) -> None:
         """Apply local update shards after the asynchronous owner-scatter."""
         # Depend only on this chunk's scatter, not later communication queued
         # on the shared owner-comm stream.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import functools
 import inspect
 import logging
 import warnings
@@ -59,8 +60,6 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import ParamsT
 
-from megatron.core.utils import nvtx_decorator
-
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Flat
 from .shard_plan import (
@@ -76,7 +75,23 @@ from .shard_plan import (
 )
 
 logger = logging.getLogger(__name__)
-_MAX_PARAMS_PER_OWNER_CHUNK = 16
+
+
+def _always_nvtx_decorator(message: str) -> Callable:
+    """Wrap a function in one NVTX range without enabling global Megatron ranges."""
+
+    def decorator(function: Callable) -> Callable:
+        @functools.wraps(function)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            torch.cuda.nvtx.range_push(message)
+            try:
+                return function(*args, **kwargs)
+            finally:
+                torch.cuda.nvtx.range_pop()
+
+        return wrapper
+
+    return decorator
 
 
 def _require_emerging_optimizers() -> None:
@@ -158,6 +173,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             since the standard Muon path does not read parameter values.
         num_ns_steps: Newton-Schulz iteration count, also used by the owner
             load-balancing cost heuristic. If None, defaults to 1.
+        max_params_per_owner_chunk: Maximum number of compatible parameters in
+            one owner-communication chunk. None places all compatible parameters
+            in one chunk.
     """
 
     # Shared across optimizer instances so a process that constructs several
@@ -175,6 +193,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
         num_ns_steps: int | None = None,
+        max_params_per_owner_chunk: int | None = 16,
     ) -> None:
         _require_emerging_optimizers()
 
@@ -185,6 +204,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
         self.dp_mesh = dp_mesh
         self._num_ns_steps: int = num_ns_steps
+        self._max_params_per_owner_chunk = max_params_per_owner_chunk
         # Owner P2P runs on a dedicated owner-comm stream so it overlaps local
         # Newton-Schulz on the default stream. Multi-rank-on-one-GPU dev boxes
         # cannot reliably run NCCL P2P on a separate stream, so this flag lets
@@ -446,8 +466,8 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         - same collective group
         - same dtype and device of orthogonalization input shards
         - same dtype of parameter
-        - at most 16 parameters per chunk, so later owner gathers can overlap
-          orthogonalization of earlier chunks
+        - at most max_params_per_owner_chunk parameters per chunk when configured,
+          so later owner gathers can overlap orthogonalization of earlier chunks
         """
         chunks: dict[tuple, list[list[int]]] = {}
         for index, (param, shard) in enumerate(zip(params, local_shards)):
@@ -455,22 +475,20 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             collective_group = group.mesh.get_group() if group is not None else None
             key = (id(collective_group), shard.device, shard.dtype, param.dtype)
             compatible_chunks = chunks.setdefault(key, [])
-            if not compatible_chunks or len(compatible_chunks[-1]) >= _MAX_PARAMS_PER_OWNER_CHUNK:
+            if (
+                not compatible_chunks
+                or self._max_params_per_owner_chunk is not None
+                and len(compatible_chunks[-1]) >= self._max_params_per_owner_chunk
+            ):
                 compatible_chunks.append([])
             compatible_chunks[-1].append(index)
         return [chunk for compatible_chunks in chunks.values() for chunk in compatible_chunks]
 
-    def _assign_owner_work(self, plans: Sequence[ShardPlan]) -> dict[int, int]:
-        """Assign the logical full, unsharded update tensor to one owner rank.
-
-        Assignment has two rules:
-        1. Only ranks that contain a non-empty part of the shard can be owners.
-        2. Assignment is balanced around estimated full-tensor orthogonalization and update work.
-           For an M x N matrix, with `num_steps` being the amount of iterations for the
-           orthogonalization approximation:
-           `M * N * (min(M, N) * num_steps + 1)`
-        """
-        return assign_owner_work(plans, self._num_ns_steps)
+    def _assign_owner_work(
+        self, plans: Sequence[ShardPlan], chunks: Sequence[Sequence[int]]
+    ) -> dict[int, int]:
+        """Assign owners by descending NS cost with per-chunk load balancing."""
+        return assign_owner_work(plans, self._num_ns_steps, chunks)
 
     # Owner-gather communication (P2P)
     # ================================
@@ -677,7 +695,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
     def step(self, closure: Callable[[], float]) -> float: ...
 
     @torch.no_grad()
-    @nvtx_decorator(message="mfsdp_muon_step")
+    @_always_nvtx_decorator(message="mfsdp_muon_step")
     @override
     def step(self, closure: Callable[[], float] | None = None) -> float | None:
         """Perform a single optimization step to update parameters.
@@ -744,8 +762,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             # Assert no non-matrix plans were indexed.
             assert len(matrix_plans) == len(matrix_indices)
             matrix_plans = cast(list[ShardPlan], matrix_plans)
-            owners = self._assign_owner_work(matrix_plans)
-            self._owners.update({matrix_indices[k]: v for k, v in owners.items()})
 
             # Phase 1: local pre-NS shards for all matrix params.
             local_shards: list[torch.Tensor] = []
@@ -756,6 +772,11 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                 local_shards.append(
                     self._compute_orthogonalization_inputs(param, param.grad, group, lr)
                 )
+
+            chunks = self._group_updates(matrix_params, local_shards)
+            owners = self._assign_owner_work(matrix_plans, chunks)
+            self._owners.update({matrix_indices[k]: v for k, v in owners.items()})
+
             # Separate fully-local and boundary params. Fully-local NS+update
             # overlaps the boundary owner gather.
             local_indices = [
@@ -774,7 +795,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             # single optimizer param group may span multiple FSDP groups and/or
             # mixed dtypes (e.g. FP32 + BF16).
             chunk_states: list[_BoundaryChunkState] = []
-            for chunk_indices in self._group_updates(matrix_params, local_shards):
+            for chunk_indices in chunks:
                 chunk_boundary = [i for i in chunk_indices if i in boundary_indices_set]
                 if not chunk_boundary:
                     continue
@@ -1016,6 +1037,7 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
         dp_mesh: DeviceMesh,
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
+        max_params_per_owner_chunk: int | None = 16,
     ) -> None:
         _require_emerging_optimizers()
 
@@ -1041,4 +1063,6 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
             dp_mesh=dp_mesh,
             use_owner_comm_stream=use_owner_comm_stream,
             reconstruct_full_param=reconstruct_full_param,
+            num_ns_steps=self._num_ns_steps,
+            max_params_per_owner_chunk=max_params_per_owner_chunk,
         )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -138,7 +138,7 @@ class _BoundaryChunkState:
     # Populated by `_issue_boundary_update` while this chunk's scatter is in flight.
     full_updates: dict[int, torch.Tensor] = dataclasses.field(default_factory=dict)
     scatter_plan: OwnerScatterPlan | None = None
-    scatter_recv: dict[int, torch.Tensor] = dataclasses.field(default_factory=dict)
+    scatter_recv: dict[tuple[int, int], torch.Tensor] = dataclasses.field(default_factory=dict)
     scatter_works: list[dist.Work] = dataclasses.field(default_factory=list)
     scatter_event: torch.cuda.Event | None = None
 
@@ -434,8 +434,11 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             compatible_chunks = chunks.setdefault(key, [])
             if (
                 not compatible_chunks
-                or self._max_params_per_owner_chunk is not None
-                and len(compatible_chunks[-1]) >= self._max_params_per_owner_chunk
+                or
+                (
+                    self._max_params_per_owner_chunk is not None
+                    and len(compatible_chunks[-1]) >= self._max_params_per_owner_chunk
+                )
             ):
                 compatible_chunks.append([])
             compatible_chunks[-1].append(index)
@@ -455,33 +458,23 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         plans: Sequence[ShardPlan],
         owners: dict[int, int],
         local_shards: Sequence[torch.Tensor],
-        device: torch.device,
-        dtype: torch.dtype,
-        group_param: DTensor,
+        comm_groups: list[torch.distributed.ProcessGroup],
     ) -> OwnerGatherPlan:
         """Pack all orthogonalization input shards for an owner into the owner's respective
         collective buffer.
 
         This sets up the buffers for communicating orthogonalization input shards to their owner.
         """
-        group = _get_parameter_dp_group(group_param)
-        return pack_owner_work(
-            plans,
-            owners,
-            local_shards,
-            dist.get_world_size(group=group),
-            dist.get_rank(group=group),
-            device=device,
-            dtype=dtype,
-        )
+        return pack_owner_work(plans, owners, local_shards, comm_groups)
 
     def _send_to_owner(
         self,
         gather_plan: OwnerGatherPlan,
         device: torch.device,
         dtype: torch.dtype,
-        group_param: DTensor,
-    ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
+    ) -> tuple[
+        dict[tuple[int, int], torch.Tensor], list[dist.Work], torch.cuda.Event | None
+    ]:
         """Send orthogonalization input shards to their respective owner.
 
         Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
@@ -494,21 +487,19 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             device: Device for the send/recv buffers (the pre-NS device).
             dtype: Dtype for the send/recv buffers (the pre-NS dtype).
         """
-        group = _get_parameter_dp_group(group_param)
         stream = self._owner_comm_stream(device)
-        recv_buffers: dict[int, torch.Tensor] = {
-            src: torch.empty(size, dtype=dtype, device=device)
-            for src, size in gather_plan.recv_sizes.items()
-            if size > 0
+        recv_buffers: dict[tuple[int, int], torch.Tensor] = {
+            key: torch.empty(size, dtype=dtype, device=device)
+            for key, size in gather_plan.recv_sizes.items()
         }
         ops: list[dist.P2POp] = []
-        for owner, buf in gather_plan.send_buffers.items():
-            if buf.numel() == 0:
-                continue
+        for (param_index, owner), buf in gather_plan.send_buffers.items():
+            group = gather_plan.comm_groups[param_index]
             # `owner` is a DP-group rank index (mesh local rank); pass it as
             # group_peer so P2POp resolves it within the owner-comm group.
             ops.append(dist.P2POp(dist.isend, buf, group_peer=owner, group=group))
-        for src, buf in recv_buffers.items():
+        for (param_index, src), buf in recv_buffers.items():
+            group = gather_plan.comm_groups[param_index]
             ops.append(dist.P2POp(dist.irecv, buf, group_peer=src, group=group))
 
         default_stream = torch.cuda.current_stream() if stream is not None else None
@@ -579,9 +570,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         full_updates: dict[int, torch.Tensor],
         plans: Sequence[ShardPlan],
         owners: dict[int, int],
-        device: torch.device,
-        dtype: torch.dtype,
-        group_param: DTensor,
+        comm_groups: list[torch.distributed.ProcessGroup],
     ) -> OwnerScatterPlan:
         """Set up the buffers for communication by packing update shards into their respective
         collective buffers.
@@ -589,15 +578,11 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         Pack all update shards for their destination into the destination's respective collective
         buffer. This sets up the buffers for communicating update shards to their destination.
         """
-        group = _get_parameter_dp_group(group_param)
         return pack_update_shards(
             full_updates,
             plans,
             owners,
-            dist.get_world_size(group=group),
-            dist.get_rank(group=group),
-            device=device,
-            dtype=dtype,
+            comm_groups,
         )
 
     def _send_to_destination(
@@ -605,8 +590,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         scatter_plan: OwnerScatterPlan,
         device: torch.device,
         dtype: torch.dtype,
-        group_param: DTensor,
-    ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
+    ) -> tuple[
+        dict[tuple[int, int], torch.Tensor], list[dist.Work], torch.cuda.Event | None
+    ]:
         """Send update shards to their respective destination.
 
         Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
@@ -618,19 +604,17 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             device: Device for the send/recv buffers (the update device).
             dtype: Dtype for the send/recv buffers (the update dtype).
         """
-        group = _get_parameter_dp_group(group_param)
         stream = self._owner_comm_stream(device)
-        recv_buffers: dict[int, torch.Tensor] = {
-            owner: torch.empty(size, dtype=dtype, device=device)
-            for owner, size in scatter_plan.recv_sizes.items()
-            if size > 0
+        recv_buffers: dict[tuple[int, int], torch.Tensor] = {
+            key: torch.empty(size, dtype=dtype, device=device)
+            for key, size in scatter_plan.recv_sizes.items()
         }
         ops: list[dist.P2POp] = []
-        for dest, buf in scatter_plan.send_buffers.items():
-            if buf.numel() == 0:
-                continue
+        for (param_index, dest), buf in scatter_plan.send_buffers.items():
+            group = scatter_plan.comm_groups[param_index]
             ops.append(dist.P2POp(dist.isend, buf, group_peer=dest, group=group))
-        for owner, buf in recv_buffers.items():
+        for (param_index, owner), buf in recv_buffers.items():
+            group = scatter_plan.comm_groups[param_index]
             ops.append(dist.P2POp(dist.irecv, buf, group_peer=owner, group=group))
 
         default_stream = torch.cuda.current_stream() if stream is not None else None
@@ -649,7 +633,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         return recv_buffers, list(works or []), completion_event
 
     def _unpack_update_shards(
-        self, scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
+        self,
+        scatter_plan: OwnerScatterPlan,
+        recv_buffers: dict[tuple[int, int], torch.Tensor],
     ) -> dict[int, torch.Tensor]:
         """Unpack the packed update shards in the given buffer."""
         return unpack_update_shards(scatter_plan, recv_buffers)
@@ -891,7 +877,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                 continue
             # Merge the gathered orthogonalization input shards back to the original, full,
             # unsharded input tensor.
-            full = reconstruct_full_tensor(i, plan, gather_plan, recv_buffers, owner_rank=this_rank)
+            full = reconstruct_full_tensor(i, plan, gather_plan, recv_buffers)
             # `full` is the reconstructed pre-NS matrix and is the
             # orthogonalization input (`pre_ns`). The default MCore Muon reads shape
             # and tensor-parallel attributes from `param` but does not read its values,
@@ -904,7 +890,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     plan,
                     state.weight_gather_plan,
                     state.weight_recv_buffers,
-                    owner_rank=this_rank,
                 )
             else:
                 param_arg = b_params[i]
@@ -915,7 +900,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             full_updates, b_plans, b_owners, device, state.dtype, b_params[0]
         )
         scatter_recv, scatter_works, scatter_event = self._send_to_destination(
-            scatter_plan, device, state.dtype, b_params[0]
+            scatter_plan, device, state.dtype
         )
         state.full_updates = full_updates
         state.scatter_plan = scatter_plan

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -74,6 +74,7 @@ from .shard_plan import (
 )
 
 logger = logging.getLogger(__name__)
+_MAX_PARAMS_PER_OWNER_CHUNK = 16
 
 
 def _require_emerging_optimizers() -> None:
@@ -435,14 +436,19 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         - same collective group
         - same dtype and device of orthogonalization input shards
         - same dtype of parameter
+        - at most 16 parameters per chunk, so later owner gathers can overlap
+          orthogonalization of earlier chunks
         """
-        chunks: dict[tuple, list[int]] = {}
+        chunks: dict[tuple, list[list[int]]] = {}
         for index, (param, shard) in enumerate(zip(params, local_shards)):
             group = get_containing_parameter_group(param)
             collective_group = group.mesh.get_group() if group is not None else None
             key = (id(collective_group), shard.device, shard.dtype, param.dtype)
-            chunks.setdefault(key, []).append(index)
-        return list(chunks.values())
+            compatible_chunks = chunks.setdefault(key, [])
+            if not compatible_chunks or len(compatible_chunks[-1]) >= _MAX_PARAMS_PER_OWNER_CHUNK:
+                compatible_chunks.append([])
+            compatible_chunks[-1].append(index)
+        return [chunk for compatible_chunks in chunks.values() for chunk in compatible_chunks]
 
     def _assign_owner_work(self, plans: Sequence[ShardPlan]) -> dict[int, int]:
         """Assign the logical full, unsharded update tensor to one owner rank.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -24,10 +24,9 @@ Fully local parameters (owned by a single rank) skip the communication and run N
 locally; their compute overlaps the boundary P2P. Non-2D parameters fall back to a plain
 momentum-SGD step (no orthogonalization).
 
-Communication is asynchronous and issued on a dedicated owner-comm stream using a dedicated
-(duplicate) owner-comm process group, so owner P2P ordering is independent of FSDP's
-forward/backward collectives. The synchronous waiting (`_wait_for_dist_buffer`) is deferred as late
-as possible so local Newton-Schulz work overlaps owner gathers/scatters."""
+Communication is asynchronous and issued on a dedicated owner-comm stream using each
+parameter's FSDP data-parallel process group. The synchronous waiting (`_wait_for_dist_buffer`) is
+deferred as late as possible so local Newton-Schulz work overlaps owner gathers/scatters."""
 
 from __future__ import annotations
 
@@ -56,7 +55,6 @@ except (ModuleNotFoundError, ImportError):
     OrthogonalizedOptimizer = cast(Any, object)
     Muon = cast(Any, object)
     HAVE_EMERGING_OPTIMIZERS = False
-from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import ParamsT
 
@@ -75,6 +73,12 @@ from .shard_plan import (
 )
 
 logger = logging.getLogger(__name__)
+
+_LocalUpdate = tuple[int, dict[str, Any], DTensor, torch.Tensor]
+
+
+def _get_parameter_dp_group(param: DTensor) -> dist.ProcessGroup:
+    return cast(FsdpParameterGroup, get_containing_parameter_group(param)).mesh.get_group()
 
 
 def _always_nvtx_decorator(message: str) -> Callable:
@@ -162,8 +166,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         *args, **kwargs: Forwarded to the inner `OrthogonalizedOptimizer`
             (e.g. `lr`, `momentum`, `weight_decay`, `nesterov`,
             `weight_decay_method`, `fp32_matmul_prec`, `scaled_orthogonalize_fn`).
-        dp_mesh: Device mesh of the FSDP data-parallel group. The optimizer shards
-            Newton-Schulz work across the ranks of this mesh via P2P.
         use_owner_comm_stream: Whether to use a separate communication stream for
             owner-based peer-to-peer communications. Useful to disable for testing
             reasons, giving a synchronous algorithm. Defaults to True.
@@ -178,18 +180,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             in one chunk.
     """
 
-    # Shared across optimizer instances so a process that constructs several
-    # optimizers over the same DP group does not call `new_group` more than
-    # once per group (each `new_group` is a collective that allocates NCCL
-    # resources, which a multi-rank-on-one-GPU dev box exhausts quickly).
-    _shared_owner_group_cache: dict[tuple[int, ...], dist.ProcessGroup] = {}
-    _shared_owner_group_initialized: set[tuple[int, ...]] = set()
-
     def __init__(
         self,
         params: ParamsT,
         inner_optimizer: OrthogonalizedOptimizer,
-        dp_mesh: DeviceMesh,
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
         num_ns_steps: int | None = None,
@@ -202,7 +196,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         if num_ns_steps < 1:
             raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
 
-        self.dp_mesh = dp_mesh
         self._num_ns_steps: int = num_ns_steps
         self._max_params_per_owner_chunk = max_params_per_owner_chunk
         # Owner P2P runs on a dedicated owner-comm stream so it overlaps local
@@ -211,9 +204,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         # tests (the only synchronous-use case) fall back to the default stream.
         self.use_owner_comm_stream: bool = use_owner_comm_stream
         self.reconstruct_full_param: bool = reconstruct_full_param
-        self._owner_comm_needed: bool | None = None
         self._shard_plans: dict[int, ShardPlan] = {}
-        self._owners: dict[int, int] = {}
         self._owner_comm_stream_cache: dict[torch.device, torch.cuda.Stream] = {}
 
         # Disable properties while initializing this instance. We'd either have a missing attribute
@@ -307,45 +298,8 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             for name, (cls_, descriptor) in saved.items():
                 setattr(cls_, name, descriptor)
 
-    # Mesh, group, and stream helpers
-    # ===============================
-
-    def _dp_group(self) -> dist.ProcessGroup:
-        return self.dp_mesh.get_group()
-
-    def _world_size(self) -> int:
-        return self.dp_mesh.size()
-
-    def _this_rank(self) -> int:
-        return self.dp_mesh.get_local_rank()
-
-    def _this_global_rank(self) -> int:
-        return dist.get_global_rank(self._dp_group(), self._this_rank())
-
-    def _init_collective_groups(self) -> dist.ProcessGroup:
-        """Create (and cache) a duplicate owner-comm group for the DP group.
-
-        A duplicate NCCL group with the same ranks lets owner P2P use an
-        independent communicator/queue from FSDP's forward/backward collectives,
-        so owner comm ordering is decoupled. The group is created once (a
-        collective `new_group`) and initialized with a barrier so the first
-        batched P2P may involve a subset of ranks.
-        """
-        ranks = tuple(dist.get_process_group_ranks(self._dp_group()))
-        cached = self._shared_owner_group_cache.get(ranks)
-        if cached is not None:
-            return cached
-        group = dist.new_group(ranks=list(ranks))
-        type(self)._shared_owner_group_cache[ranks] = group
-        # Initialize the communicator so the first batched P2P may involve a
-        # subset of ranks; a barrier is a collective all ranks in the group run.
-        if self._dp_group().size() > 1:
-            if self.dp_mesh.device_type == "cuda":
-                dist.barrier(group=group, device_ids=[torch.cuda.current_device()])
-            else:
-                dist.barrier(group=group)
-        type(self)._shared_owner_group_initialized.add(ranks)
-        return group
+    # Stream helpers
+    # ==============
 
     def _owner_comm_stream(self, device: torch.device) -> torch.cuda.Stream | None:
         """Cached owner-comm stream (CUDA only; None on CPU or when disabled).
@@ -402,10 +356,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                 plans.append(None)
                 continue
             tensor_flat_offset = layout.tensor_to_offset[index]
-            rank_flat_shard_size = layout.size // self._world_size()
-            plan = compute_shard_plan(
-                shape, tensor_flat_offset, rank_flat_shard_size, self._world_size()
-            )
+            world_size = dist.get_world_size(group=group.mesh.get_group())
+            rank_flat_shard_size = layout.size // world_size
+            plan = compute_shard_plan(shape, tensor_flat_offset, rank_flat_shard_size, world_size)
             self._shard_plans[key] = plan
             plans.append(plan)
         return plans
@@ -504,24 +457,30 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         local_shards: Sequence[torch.Tensor],
         device: torch.device,
         dtype: torch.dtype,
+        group_param: DTensor,
     ) -> OwnerGatherPlan:
         """Pack all orthogonalization input shards for an owner into the owner's respective
         collective buffer.
 
         This sets up the buffers for communicating orthogonalization input shards to their owner.
         """
+        group = _get_parameter_dp_group(group_param)
         return pack_owner_work(
             plans,
             owners,
             local_shards,
-            self._world_size(),
-            self._this_rank(),
+            dist.get_world_size(group=group),
+            dist.get_rank(group=group),
             device=device,
             dtype=dtype,
         )
 
     def _send_to_owner(
-        self, gather_plan: OwnerGatherPlan, device: torch.device, dtype: torch.dtype
+        self,
+        gather_plan: OwnerGatherPlan,
+        device: torch.device,
+        dtype: torch.dtype,
+        group_param: DTensor,
     ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
         """Send orthogonalization input shards to their respective owner.
 
@@ -535,7 +494,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             device: Device for the send/recv buffers (the pre-NS device).
             dtype: Dtype for the send/recv buffers (the pre-NS dtype).
         """
-        group = self._init_collective_groups()
+        group = _get_parameter_dp_group(group_param)
         stream = self._owner_comm_stream(device)
         recv_buffers: dict[int, torch.Tensor] = {
             src: torch.empty(size, dtype=dtype, device=device)
@@ -622,6 +581,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         owners: dict[int, int],
         device: torch.device,
         dtype: torch.dtype,
+        group_param: DTensor,
     ) -> OwnerScatterPlan:
         """Set up the buffers for communication by packing update shards into their respective
         collective buffers.
@@ -629,18 +589,23 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         Pack all update shards for their destination into the destination's respective collective
         buffer. This sets up the buffers for communicating update shards to their destination.
         """
+        group = _get_parameter_dp_group(group_param)
         return pack_update_shards(
             full_updates,
             plans,
             owners,
-            self._world_size(),
-            self._this_rank(),
+            dist.get_world_size(group=group),
+            dist.get_rank(group=group),
             device=device,
             dtype=dtype,
         )
 
     def _send_to_destination(
-        self, scatter_plan: OwnerScatterPlan, device: torch.device, dtype: torch.dtype
+        self,
+        scatter_plan: OwnerScatterPlan,
+        device: torch.device,
+        dtype: torch.dtype,
+        group_param: DTensor,
     ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
         """Send update shards to their respective destination.
 
@@ -653,7 +618,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             device: Device for the send/recv buffers (the update device).
             dtype: Dtype for the send/recv buffers (the update dtype).
         """
-        group = self._init_collective_groups()
+        group = _get_parameter_dp_group(group_param)
         stream = self._owner_comm_stream(device)
         recv_buffers: dict[int, torch.Tensor] = {
             owner: torch.empty(size, dtype=dtype, device=device)
@@ -707,15 +672,11 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         Separates collective (P2P) and local (NS) work into phases so that no
         rank is blocked waiting on another rank computing NS to reach P2P:
 
-        1. Compute local pre-NS shards (weight decay + momentum + Nesterov) for
-           all matrix params.
-        2. P2P-send all boundary pre-NS shards to their owners (async, no NS).
-        3. Newton-Schulz + weight update for fully-local params on the default
-           stream, overlapping the boundary owner-gathers issued in phase 2.
-        4. On each owner, wait gather, reconstruct, and orthogonalize to produce
-           the full updates.
-        5. P2P-send update shards from owners back to their destinations.
-        6. Each rank applies its local update shard to its local weight shard.
+        1. Compute local pre-NS shards and submit all boundary owner-gathers.
+        2. Run half of the fully-local Newton-Schulz work while gathers progress.
+        3. Reconstruct and orthogonalize boundary parameters, then submit scatters.
+        4. Run the remaining fully-local work while scatters progress.
+        5. Enqueue the received updates and finally wait for all scatter work.
         """
         if closure is not None:
             with torch.enable_grad():
@@ -723,21 +684,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         else:
             loss = None
 
-        if self._world_size() > 1:
-            if self._owner_comm_needed is None:
-                has_boundary = False
-                for group in self.param_groups:
-                    plans = self._init_shard_plans(group["params"])
-                    if any(p is not None and p.is_boundary() for p in plans):
-                        has_boundary = True
-                        break
-                flag = torch.tensor(int(has_boundary), device=self._device(), dtype=torch.int)
-                dist.all_reduce(flag, op=dist.ReduceOp.SUM, group=self._dp_group())
-                self._owner_comm_needed = flag.item() > 0
-            if self._owner_comm_needed:
-                self._init_collective_groups()
-
         fsdp_parameter_groups: set[FsdpParameterGroup] = set()
+        local_updates: list[_LocalUpdate] = []
+        chunk_states: list[_BoundaryChunkState] = []
         for group in self.param_groups:
             self._init_group(group)
             params = group["params"]
@@ -767,11 +716,12 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             assert len(matrix_plans) == len(matrix_indices)
             matrix_plans = cast(list[ShardPlan], matrix_plans)
 
-            # Phase 1: local pre-NS shards for all matrix params.
+            # Phase 1: compute pre-NS shards and submit boundary gathers for every
+            # optimizer param group before starting any Newton-Schulz work.
             local_shards: list[torch.Tensor] = []
             for param in matrix_params:
                 if param.grad is None:
-                    local_shards.append(torch.empty(0, dtype=torch.float32, device=self._device()))
+                    local_shards.append(torch.empty(0, dtype=torch.float32, device=param.device))
                     continue
                 local_shards.append(
                     self._compute_orthogonalization_inputs(param, param.grad, group, lr)
@@ -779,10 +729,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
             chunks = self._group_updates(matrix_params, local_shards, matrix_plans)
             owners = self._assign_owner_work(matrix_plans, chunks)
-            self._owners.update({matrix_indices[k]: v for k, v in owners.items()})
-
-            # Separate fully-local and boundary params. Fully-local NS+update
-            # overlaps the boundary owner gather.
             local_indices = [
                 i for i in range(len(matrix_plans)) if not matrix_plans[i].is_boundary()
             ]
@@ -790,15 +736,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                 i for i in range(len(matrix_plans)) if matrix_plans[i].is_boundary()
             }
 
-            # Phase 2: issue all boundary owner-gathers (async on the owner-comm
-            # stream) before any Newton-Schulz, so the fully-local NS in phase 3
-            # overlaps the gathers. This matches the V1 pseudocode, which runs the
-            # owner-gather before the local orthogonalization. Boundary params are
-            # grouped by collective group, shard device/dtype, and parameter dtype
-            # (see `_group_updates`) so each chunk uses consistent P2P metadata; a
-            # single optimizer param group may span multiple FSDP groups and/or
-            # mixed dtypes (e.g. FP32 + BF16).
-            chunk_states: list[_BoundaryChunkState] = []
             for chunk_indices in chunks:
                 chunk_boundary = [i for i in chunk_indices if i in boundary_indices_set]
                 if not chunk_boundary:
@@ -819,27 +756,42 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     )
                 )
 
-            # Phase 3: fully-local Newton-Schulz + weight update on the default
-            # stream, overlapping the boundary owner-gathers issued above.
             for i in local_indices:
                 plan = matrix_plans[i]
-                if plan.rank_row_count(self._this_rank()) == 0:
-                    continue
-                self._orthogonalize_and_update(matrix_params[i], local_shards[i], lr, group)
-
-            # Submit all owner-scatter work before applying any received updates so
-            # host-side Work.wait() does not stall later chunk launches.
-            for state in chunk_states:
-                self._issue_boundary_update(state)
-            for state in chunk_states:
-                self._enqueue_boundary_update(state)
-            for state in chunk_states:
-                self._wait_for_dist_buffer(state.scatter_works)
+                param = matrix_params[i]
+                if plan.rank_row_count(dist.get_rank(group=_get_parameter_dp_group(param))) > 0:
+                    rows, cols = plan.full_shape
+                    cost = plan.full_numel() * (min(rows, cols) * self._num_ns_steps + 1)
+                    local_updates.append((cost, group, param, local_shards[i]))
 
             for param in matrix_params:
                 pg = get_containing_parameter_group(param)
                 if pg is not None:
                     fsdp_parameter_groups.add(pg)
+
+        # Split fully-local NS across both communication edges. The first side
+        # hides owner gathers; after boundary NS launches every scatter, the
+        # second side hides the scatter tail before updates are consumed.
+        local_sides: tuple[list[_LocalUpdate], list[_LocalUpdate]] = ([], [])
+        local_costs = [0, 0]
+        for update in sorted(local_updates, key=lambda item: item[0], reverse=True):
+            side = int(local_costs[0] > local_costs[1])
+            local_sides[side].append(update)
+            local_costs[side] += update[0]
+
+        for _, group, param, local_shard in local_sides[0]:
+            self._orthogonalize_and_update(param, local_shard, group["lr"], group)
+
+        for state in chunk_states:
+            self._issue_boundary_update(state)
+
+        for _, group, param, local_shard in local_sides[1]:
+            self._orthogonalize_and_update(param, local_shard, group["lr"], group)
+
+        for state in chunk_states:
+            self._enqueue_boundary_update(state)
+        for state in chunk_states:
+            self._wait_for_dist_buffer(state.scatter_works)
 
         for parameter_group in fsdp_parameter_groups:
             parameter_group.sync_model_weight_from_main_weight()
@@ -866,9 +818,11 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         b_params = [matrix_params[i] for i in boundary_indices]
         b_local = [local_shards[i] for i in boundary_indices]
         b_owners = {i: owners[boundary_indices[i]] for i in range(len(boundary_indices))}
-        gather_plan = self._pack_owner_work(b_plans, b_owners, b_local, device, dtype)
+        gather_plan = self._pack_owner_work(
+            b_plans, b_owners, b_local, device, dtype, b_params[0]
+        )
         recv_buffers, gather_works, gather_event = self._send_to_owner(
-            gather_plan, device, dtype
+            gather_plan, device, dtype, b_params[0]
         )
 
         # Optionally also gather each rank's local *weight* shard so the owner can
@@ -884,10 +838,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             weight_local = [p.to_local() for p in b_params]
             weight_dtype = b_params[0].dtype
             weight_gather_plan = self._pack_owner_work(
-                b_plans, b_owners, weight_local, device, weight_dtype
+                b_plans, b_owners, weight_local, device, weight_dtype, b_params[0]
             )
             weight_recv_buffers, weight_gather_works, weight_gather_event = self._send_to_owner(
-                weight_gather_plan, device, weight_dtype
+                weight_gather_plan, device, weight_dtype, b_params[0]
             )
         return _BoundaryChunkState(
             b_params=b_params,
@@ -916,7 +870,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         recv_buffers = state.recv_buffers
         device = state.device
         group_kwargs = state.group_kwargs
-        this_rank = self._this_rank()
+        this_rank = dist.get_rank(group=_get_parameter_dp_group(b_params[0]))
 
         # Phase 4 (owner): wait only for this chunk's gather rather than the
         # tail of the shared owner-comm stream, then reconstruct and orthogonalize.
@@ -958,10 +912,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
         # Phase 5: pack + P2P-send update shards from owners (async on owner stream).
         scatter_plan = self._pack_update_shards(
-            full_updates, b_plans, b_owners, device, state.dtype
+            full_updates, b_plans, b_owners, device, state.dtype, b_params[0]
         )
         scatter_recv, scatter_works, scatter_event = self._send_to_destination(
-            scatter_plan, device, state.dtype
+            scatter_plan, device, state.dtype, b_params[0]
         )
         state.full_updates = full_updates
         state.scatter_plan = scatter_plan
@@ -979,7 +933,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         received = self._unpack_update_shards(scatter_plan, state.scatter_recv)
 
         # Phase 6: apply local update shards.
-        this_rank = self._this_rank()
+        this_rank = dist.get_rank(group=_get_parameter_dp_group(state.b_params[0]))
         for i, param in enumerate(state.b_params):
             plan = state.b_plans[i]
             if state.b_owners[i] == this_rank:
@@ -1018,10 +972,6 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         p_local.add_(update, alpha=-lr)
         self._inner.post_weight_update_fn_inplace(p_local)
 
-    def _device(self) -> torch.device:
-        return torch.device(self.dp_mesh.device_type)
-
-
 class FsdpMuon(FsdpOrthogonalizedOptimizer):
     """Muon optimizer for all-`Flat` M-FSDPv2 parameters.
 
@@ -1035,7 +985,6 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
         self,
         params: ParamsT,
         inner_optimizer: Muon,
-        dp_mesh: DeviceMesh,
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
         max_params_per_owner_chunk: int | None = 4,
@@ -1061,7 +1010,6 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
         super().__init__(
             params,
             inner_optimizer,
-            dp_mesh=dp_mesh,
             use_owner_comm_stream=use_owner_comm_stream,
             reconstruct_full_param=reconstruct_full_param,
             num_ns_steps=self._num_ns_steps,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -458,11 +458,15 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
     # =============================
 
     def _group_updates(
-        self, params: Sequence[torch.Tensor], local_shards: Sequence[torch.Tensor]
+        self,
+        params: Sequence[torch.Tensor],
+        local_shards: Sequence[torch.Tensor],
+        plans: Sequence[ShardPlan],
     ) -> list[list[int]]:
         """Using the shard plans, group the updates into chunks.
 
         The updates are grouped into chunks by:
+        - same communication requirement
         - same collective group
         - same dtype and device of orthogonalization input shards
         - same dtype of parameter
@@ -470,10 +474,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
           so later owner gathers can overlap orthogonalization of earlier chunks
         """
         chunks: dict[tuple, list[list[int]]] = {}
-        for index, (param, shard) in enumerate(zip(params, local_shards)):
+        for index, (param, shard, plan) in enumerate(zip(params, local_shards, plans)):
             group = get_containing_parameter_group(param)
             collective_group = group.mesh.get_group() if group is not None else None
-            key = (id(collective_group), shard.device, shard.dtype, param.dtype)
+            key = (plan.is_boundary(), id(collective_group), shard.device, shard.dtype, param.dtype)
             compatible_chunks = chunks.setdefault(key, [])
             if (
                 not compatible_chunks
@@ -773,7 +777,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     self._compute_orthogonalization_inputs(param, param.grad, group, lr)
                 )
 
-            chunks = self._group_updates(matrix_params, local_shards)
+            chunks = self._group_updates(matrix_params, local_shards, matrix_plans)
             owners = self._assign_owner_work(matrix_plans, chunks)
             self._owners.update({matrix_indices[k]: v for k, v in owners.items()})
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -187,7 +187,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
         num_ns_steps: int | None = None,
-        max_params_per_owner_chunk: int | None = 4,
+        max_params_per_owner_chunk: int | None = 16,
     ) -> None:
         _require_emerging_optimizers()
 
@@ -789,9 +789,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             self._orthogonalize_and_update(param, local_shard, group["lr"], group)
 
         for state in chunk_states:
-            self._enqueue_boundary_update(state)
-        for state in chunk_states:
             self._wait_for_dist_buffer(state.scatter_works)
+        for state in chunk_states:
+            self._enqueue_boundary_update(state)
 
         for parameter_group in fsdp_parameter_groups:
             parameter_group.sync_model_weight_from_main_weight()
@@ -987,7 +987,7 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
         inner_optimizer: Muon,
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
-        max_params_per_owner_chunk: int | None = 4,
+        max_params_per_owner_chunk: int | None = 16,
     ) -> None:
         _require_emerging_optimizers()
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -109,7 +109,7 @@ class _BoundaryChunkState:
 
     `FsdpOrthogonalizedOptimizer.step` issues every chunk's owner-gather first,
     then `_issue_boundary_update` fills the scatter fields for
-    `_finish_boundary_update` to consume.
+    `_enqueue_boundary_update` to consume.
     """
 
     b_params: Sequence[DTensor]
@@ -827,16 +827,14 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     continue
                 self._orthogonalize_and_update(matrix_params[i], local_shards[i], lr, group)
 
-            # Pipeline each chunk's owner-scatter with the next chunk's Newton-Schulz.
-            # Keeping one pending scatter bounds additional storage to one chunk.
-            pending_update: _BoundaryChunkState | None = None
+            # Submit all owner-scatter work before applying any received updates so
+            # host-side Work.wait() does not stall later chunk launches.
             for state in chunk_states:
                 self._issue_boundary_update(state)
-                if pending_update is not None:
-                    self._finish_boundary_update(pending_update)
-                pending_update = state
-            if pending_update is not None:
-                self._finish_boundary_update(pending_update)
+            for state in chunk_states:
+                self._enqueue_boundary_update(state)
+            for state in chunk_states:
+                self._wait_for_dist_buffer(state.scatter_works)
 
             for param in matrix_params:
                 pg = get_containing_parameter_group(param)
@@ -971,13 +969,12 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         state.scatter_works = scatter_works
         state.scatter_event = scatter_event
 
-    def _finish_boundary_update(self, state: _BoundaryChunkState) -> None:
-        """Wait for one owner-scatter and apply its local update shards."""
+    def _enqueue_boundary_update(self, state: _BoundaryChunkState) -> None:
+        """Apply local update shards after the asynchronous owner-scatter."""
         # Depend only on this chunk's scatter, not later communication queued
         # on the shared owner-comm stream.
         if state.scatter_event is not None:
             torch.cuda.current_stream(state.device).wait_event(state.scatter_event)
-        self._wait_for_dist_buffer(state.scatter_works)
         scatter_plan = cast(OwnerScatterPlan, state.scatter_plan)
         received = self._unpack_update_shards(scatter_plan, state.scatter_recv)
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -27,7 +27,7 @@ momentum-SGD step (no orthogonalization).
 Communication is asynchronous and issued on a dedicated owner-comm stream using a dedicated
 (duplicate) owner-comm process group, so owner P2P ordering is independent of FSDP's
 forward/backward collectives. The synchronous waiting (`_wait_for_dist_buffer`) is deferred as late
-as possible so local Newton-Schulz work overlaps owner gathers/scatters. """
+as possible so local Newton-Schulz work overlaps owner gathers/scatters."""
 
 from __future__ import annotations
 
@@ -142,9 +142,9 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             owner-based peer-to-peer communications. Useful to disable for testing
             reasons, giving a synchronous algorithm. Defaults to True.
         reconstruct_full_param: Whether to also gather local weight shards and pass
-            them to orthogonalization. When False, `None` is passed as the
-            parameter to orthogonalize. Defaults to False, since it's not used in
-            the standard case.
+            their full value to orthogonalization. When False, the sharded parameter
+            is passed for shape and tensor-parallel metadata only. Defaults to False,
+            since the standard Muon path does not read parameter values.
         num_ns_steps: Newton-Schulz iteration count, also used by the owner
             load-balancing cost heuristic. If None, defaults to 1.
     """
@@ -539,9 +539,8 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         """
         with eo_utils.fp32_matmul_precision(self._inner.fp32_matmul_prec):
             # `param` (AKA `p`) is typed as `torch.Tensor` in
-            # `emerging_optimizers.OrthogonalizedOptimizer`. However, we explicitly want to error if
-            # the function tries to use it as a tensor, but we pass `None`. So we remove the `None`
-            # type here to remove the type error for that parameter explicitly.
+            # `emerging_optimizers.OrthogonalizedOptimizer`. Some compatible inner optimizers may
+            # accept `None`, so keep that internal flexibility while narrowing the call type here.
             param = cast(torch.Tensor, param)
             # The Newton-Schulz kernel is FP32-only, so cast accordingly.
             return self._inner.orthogonalize(param, pre_ns.to(torch.float32), **kwargs)
@@ -562,12 +561,12 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         parameter with the result of orthogonalization. (Fully-local path: no communication.)
 
         For a fully-local parameter the owning rank's local shard *is* the full
-        parameter, so no gather is needed: pass it directly when
-        `reconstruct_full_param` is enabled, else `None` (matching the
-        boundary path).
+        parameter, so no gather is needed. Pass its local value when
+        `reconstruct_full_param` is enabled; otherwise pass the sharded parameter
+        so the inner optimizer can read shape and tensor-parallel metadata.
         """
         group_kwargs = {k: v for k, v in group.items() if k != "params"}
-        param_arg = param.to_local() if self.reconstruct_full_param else None
+        param_arg = param.to_local() if self.reconstruct_full_param else param
         update = self._orthogonalize_with_precision(param_arg, pre_ns, **group_kwargs)
         self._apply_update(param, update, lr)
 
@@ -881,12 +880,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             # unsharded input tensor.
             full = reconstruct_full_tensor(i, plan, gather_plan, recv_buffers, owner_rank=this_rank)
             # `full` is the reconstructed pre-NS matrix and is the
-            # orthogonalization input (`pre_ns`). The `param` (`p`) argument is
-            # unused by the default `OrthogonalizedOptimizer.orthogonalize`, so
-            # by default (`reconstruct_full_param=False`) we pass `None`. When the
-            # flag is enabled, reconstruct the full parameter from the gathered
-            # weight shards (a second P2P round issued in `_issue_owner_gather`) and
-            # pass it as `param` for subclasses that read `p`.
+            # orthogonalization input (`pre_ns`). The default MCore Muon reads shape
+            # and tensor-parallel attributes from `param` but does not read its values,
+            # so pass the original sharded parameter unless the caller explicitly asks
+            # us to reconstruct the full value.
             if self.reconstruct_full_param and state.weight_gather_plan is not None:
                 assert state.weight_recv_buffers is not None
                 param_arg = reconstruct_full_tensor(
@@ -897,7 +894,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     owner_rank=this_rank,
                 )
             else:
-                param_arg = None
+                param_arg = b_params[i]
             full_updates[i] = self._orthogonalize_with_precision(param_arg, full, **group_kwargs)
 
         # Phase 5: pack + P2P-send update shards from owners (async on owner stream).

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -59,6 +59,8 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import ParamsT
 
+from megatron.core.utils import nvtx_decorator
+
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Flat
 from .shard_plan import (
@@ -675,6 +677,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
     def step(self, closure: Callable[[], float]) -> float: ...
 
     @torch.no_grad()
+    @nvtx_decorator(message="mfsdp_muon_step")
     @override
     def step(self, closure: Callable[[], float] | None = None) -> float | None:
         """Perform a single optimization step to update parameters.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -193,7 +193,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
         num_ns_steps: int | None = None,
-        max_params_per_owner_chunk: int | None = 16,
+        max_params_per_owner_chunk: int | None = 4,
     ) -> None:
         _require_emerging_optimizers()
 
@@ -1041,7 +1041,7 @@ class FsdpMuon(FsdpOrthogonalizedOptimizer):
         dp_mesh: DeviceMesh,
         use_owner_comm_stream: bool = True,
         reconstruct_full_param: bool = False,
-        max_params_per_owner_chunk: int | None = 16,
+        max_params_per_owner_chunk: int | None = 4,
     ) -> None:
         _require_emerging_optimizers()
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -88,12 +88,11 @@ def _require_emerging_optimizers() -> None:
 
 @dataclasses.dataclass
 class _BoundaryChunkState:
-    """In-flight owner-gather state for one boundary chunk, between issue and finish.
+    """In-flight gather and scatter state for one boundary chunk.
 
-    `FsdpOrthogonalizedOptimizer.step` issues every chunk's owner-gather first
-    (so fully-local Newton-Schulz overlaps the gathers), then finishes each chunk
-    (wait gather, orthogonalize, scatter, apply). This object carries everything
-    `_finish_boundary_step` needs across that gap.
+    `FsdpOrthogonalizedOptimizer.step` issues every chunk's owner-gather first,
+    then `_issue_boundary_update` fills the scatter fields for
+    `_finish_boundary_update` to consume.
     """
 
     b_params: Sequence[DTensor]
@@ -102,6 +101,7 @@ class _BoundaryChunkState:
     gather_plan: OwnerGatherPlan
     recv_buffers: dict[int, torch.Tensor]
     gather_works: list[dist.Work]
+    gather_event: torch.cuda.Event | None
     device: torch.device
     dtype: torch.dtype
     lr: float
@@ -112,6 +112,14 @@ class _BoundaryChunkState:
     weight_gather_plan: OwnerGatherPlan | None = None
     weight_recv_buffers: dict[int, torch.Tensor] | None = None
     weight_gather_works: list[dist.Work] | None = None
+    weight_gather_event: torch.cuda.Event | None = None
+
+    # Populated by `_issue_boundary_update` while this chunk's scatter is in flight.
+    full_updates: dict[int, torch.Tensor] = dataclasses.field(default_factory=dict)
+    scatter_plan: OwnerScatterPlan | None = None
+    scatter_recv: dict[int, torch.Tensor] = dataclasses.field(default_factory=dict)
+    scatter_works: list[dist.Work] = dataclasses.field(default_factory=list)
+    scatter_event: torch.cuda.Event | None = None
 
 
 class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
@@ -490,7 +498,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
     def _send_to_owner(
         self, gather_plan: OwnerGatherPlan, device: torch.device, dtype: torch.dtype
-    ) -> tuple[dict[int, torch.Tensor], list[dist.Work]]:
+    ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
         """Send orthogonalization input shards to their respective owner.
 
         Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
@@ -521,6 +529,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             ops.append(dist.P2POp(dist.irecv, buf, group_peer=src, group=group))
 
         default_stream = torch.cuda.current_stream() if stream is not None else None
+        completion_event = None
         with torch.cuda.stream(stream) if stream is not None else nullcontext():
             if stream is not None:
                 assert default_stream is not None
@@ -529,7 +538,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             for buf in list(gather_plan.send_buffers.values()) + list(recv_buffers.values()):
                 if stream is not None:
                     buf.record_stream(stream)
-        return recv_buffers, list(works or [])
+            if stream is not None:
+                completion_event = torch.cuda.Event()
+                completion_event.record(stream)
+        return recv_buffers, list(works or []), completion_event
 
     # Orthogonalization and update application
     # ========================================
@@ -605,7 +617,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
 
     def _send_to_destination(
         self, scatter_plan: OwnerScatterPlan, device: torch.device, dtype: torch.dtype
-    ) -> tuple[dict[int, torch.Tensor], list[dist.Work]]:
+    ) -> tuple[dict[int, torch.Tensor], list[dist.Work], torch.cuda.Event | None]:
         """Send update shards to their respective destination.
 
         Uses peer-to-peer communication (`batch_isend_irecv`) to avoid memory
@@ -633,6 +645,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             ops.append(dist.P2POp(dist.irecv, buf, group_peer=owner, group=group))
 
         default_stream = torch.cuda.current_stream() if stream is not None else None
+        completion_event = None
         with torch.cuda.stream(stream) if stream is not None else nullcontext():
             if stream is not None:
                 assert default_stream is not None
@@ -641,7 +654,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             for buf in list(scatter_plan.send_buffers.values()) + list(recv_buffers.values()):
                 if stream is not None:
                     buf.record_stream(stream)
-        return recv_buffers, list(works or [])
+            if stream is not None:
+                completion_event = torch.cuda.Event()
+                completion_event.record(stream)
+        return recv_buffers, list(works or []), completion_event
 
     def _unpack_update_shards(
         self, scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
@@ -783,10 +799,16 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                     continue
                 self._orthogonalize_and_update(matrix_params[i], local_shards[i], lr, group)
 
-            # Phases 4-6: finish each boundary chunk - wait gather, orthogonalize
-            # on owners, scatter updates, and apply local update shards.
+            # Pipeline each chunk's owner-scatter with the next chunk's Newton-Schulz.
+            # Keeping one pending scatter bounds additional storage to one chunk.
+            pending_update: _BoundaryChunkState | None = None
             for state in chunk_states:
-                self._finish_boundary_step(state)
+                self._issue_boundary_update(state)
+                if pending_update is not None:
+                    self._finish_boundary_update(pending_update)
+                pending_update = state
+            if pending_update is not None:
+                self._finish_boundary_update(pending_update)
 
             for param in matrix_params:
                 pg = get_containing_parameter_group(param)
@@ -812,14 +834,16 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         """Pack and asynchronously P2P-send this chunk's pre-NS shards to owners.
 
         Returns the in-flight gather state; `step` finishes it later with
-        `_finish_boundary_step` so fully-local Newton-Schulz overlaps the gathers.
+        `_issue_boundary_update` so fully-local Newton-Schulz overlaps the gathers.
         """
         b_plans = [matrix_plans[i] for i in boundary_indices]
         b_params = [matrix_params[i] for i in boundary_indices]
         b_local = [local_shards[i] for i in boundary_indices]
         b_owners = {i: owners[boundary_indices[i]] for i in range(len(boundary_indices))}
         gather_plan = self._pack_owner_work(b_plans, b_owners, b_local, device, dtype)
-        recv_buffers, gather_works = self._send_to_owner(gather_plan, device, dtype)
+        recv_buffers, gather_works, gather_event = self._send_to_owner(
+            gather_plan, device, dtype
+        )
 
         # Optionally also gather each rank's local *weight* shard so the owner can
         # reconstruct the full parameter and pass it to `orthogonalize` (some
@@ -829,13 +853,14 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         weight_gather_plan = None
         weight_recv_buffers = None
         weight_gather_works = None
+        weight_gather_event = None
         if self.reconstruct_full_param:
             weight_local = [p.to_local() for p in b_params]
             weight_dtype = b_params[0].dtype
             weight_gather_plan = self._pack_owner_work(
                 b_plans, b_owners, weight_local, device, weight_dtype
             )
-            weight_recv_buffers, weight_gather_works = self._send_to_owner(
+            weight_recv_buffers, weight_gather_works, weight_gather_event = self._send_to_owner(
                 weight_gather_plan, device, weight_dtype
             )
         return _BoundaryChunkState(
@@ -845,6 +870,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             gather_plan=gather_plan,
             recv_buffers=recv_buffers,
             gather_works=gather_works,
+            gather_event=gather_event,
             device=device,
             dtype=dtype,
             lr=lr,
@@ -852,27 +878,28 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             weight_gather_plan=weight_gather_plan,
             weight_recv_buffers=weight_recv_buffers,
             weight_gather_works=weight_gather_works,
+            weight_gather_event=weight_gather_event,
         )
 
-    def _finish_boundary_step(self, state: _BoundaryChunkState) -> None:
-        """Finish one boundary chunk: wait gather, orthogonalize, scatter, apply."""
+    def _issue_boundary_update(self, state: _BoundaryChunkState) -> None:
+        """Wait for one owner-gather, orthogonalize, and issue its owner-scatter."""
         b_params = state.b_params
         b_plans = state.b_plans
         b_owners = state.b_owners
         gather_plan = state.gather_plan
         recv_buffers = state.recv_buffers
         device = state.device
-        lr = state.lr
         group_kwargs = state.group_kwargs
         this_rank = self._this_rank()
-        stream = self._owner_comm_stream(device)
 
-        # Phase 4 (owner): wait gather, reconstruct, orthogonalize. Default
-        # stream waits for the owner stream so the recv buffers are ready.
-        if stream is not None:
-            torch.cuda.current_stream(device).wait_stream(stream)
+        # Phase 4 (owner): wait only for this chunk's gather rather than the
+        # tail of the shared owner-comm stream, then reconstruct and orthogonalize.
+        if state.gather_event is not None:
+            torch.cuda.current_stream(device).wait_event(state.gather_event)
         self._wait_for_dist_buffer(state.gather_works)
         if state.weight_gather_works:
+            if state.weight_gather_event is not None:
+                torch.cuda.current_stream(device).wait_event(state.weight_gather_event)
             self._wait_for_dist_buffer(state.weight_gather_works)
 
         full_updates: dict[int, torch.Tensor] = {}
@@ -907,25 +934,39 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         scatter_plan = self._pack_update_shards(
             full_updates, b_plans, b_owners, device, state.dtype
         )
-        scatter_recv, scatter_works = self._send_to_destination(scatter_plan, device, state.dtype)
-        if stream is not None:
-            torch.cuda.current_stream(device).wait_stream(stream)
-        self._wait_for_dist_buffer(scatter_works)
-        received = self._unpack_update_shards(scatter_plan, scatter_recv)
+        scatter_recv, scatter_works, scatter_event = self._send_to_destination(
+            scatter_plan, device, state.dtype
+        )
+        state.full_updates = full_updates
+        state.scatter_plan = scatter_plan
+        state.scatter_recv = scatter_recv
+        state.scatter_works = scatter_works
+        state.scatter_event = scatter_event
+
+    def _finish_boundary_update(self, state: _BoundaryChunkState) -> None:
+        """Wait for one owner-scatter and apply its local update shards."""
+        # Depend only on this chunk's scatter, not later communication queued
+        # on the shared owner-comm stream.
+        if state.scatter_event is not None:
+            torch.cuda.current_stream(state.device).wait_event(state.scatter_event)
+        self._wait_for_dist_buffer(state.scatter_works)
+        scatter_plan = cast(OwnerScatterPlan, state.scatter_plan)
+        received = self._unpack_update_shards(scatter_plan, state.scatter_recv)
 
         # Phase 6: apply local update shards.
-        for i, param in enumerate(b_params):
-            plan = b_plans[i]
-            if b_owners[i] == this_rank:
+        this_rank = self._this_rank()
+        for i, param in enumerate(state.b_params):
+            plan = state.b_plans[i]
+            if state.b_owners[i] == this_rank:
                 row_start, row_count = plan.rank_rows[this_rank]
                 if row_count == 0:
                     continue
-                update_shard = full_updates[i][row_start : row_start + row_count]
+                update_shard = state.full_updates[i][row_start : row_start + row_count]
             else:
                 update_shard = received.get(i)
                 if update_shard is None:
                     continue
-            self._apply_update(param, update_shard, lr)
+            self._apply_update(param, update_shard, state.lr)
 
     def _step_non_matrix(
         self, param: DTensor, grad: DTensor, group: dict[str, Any], lr: float

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/orthogonalized_optimizer.py
@@ -78,7 +78,53 @@ _LocalUpdate = tuple[int, dict[str, Any], DTensor, torch.Tensor]
 
 
 def _get_parameter_dp_group(param: DTensor) -> dist.ProcessGroup:
-    return cast(FsdpParameterGroup, get_containing_parameter_group(param)).mesh.get_group()
+    parameter_group = cast(FsdpParameterGroup, get_containing_parameter_group(param))
+    mesh = parameter_group.mesh
+    flat_axes = [
+        axis
+        for axis, placement in enumerate(parameter_group.main_weight.placements)
+        if isinstance(placement, Flat)
+    ]
+    if len(flat_axes) == 1:
+        return mesh.get_group(flat_axes[0])
+    if mesh.ndim == 2 and flat_axes == [0, 1]:
+        flattened_group = getattr(mesh, "_mfsdp_flattened_group", None)
+        if flattened_group is not None:
+            return flattened_group
+        return mesh._flatten().get_group()
+    raise ValueError(
+        "MFSDP Muon requires either one Flat axis or a two-dimensional all-Flat mesh, "
+        f"got mesh shape {tuple(mesh.mesh.shape)} and placements "
+        f"{parameter_group.main_weight.placements}."
+    )
+
+
+def _get_parameter_shard_order(
+    param: DTensor, process_group: dist.ProcessGroup
+) -> tuple[int, ...]:
+    """Map outer-major process-group ranks to flat-shard order."""
+    parameter_group = cast(FsdpParameterGroup, get_containing_parameter_group(param))
+    mesh = parameter_group.mesh
+    flat_axes = [
+        axis
+        for axis, placement in enumerate(parameter_group.main_weight.placements)
+        if isinstance(placement, Flat)
+    ]
+    world_size = dist.get_world_size(group=process_group)
+    if len(flat_axes) == 1:
+        return tuple(range(world_size))
+
+    outer_size, inner_size = mesh.size(0), mesh.size(1)
+    if outer_size * inner_size != world_size:
+        raise ValueError(
+            f"HFSDP mesh size {outer_size}x{inner_size} does not match "
+            f"process-group size {world_size}."
+        )
+    return tuple(
+        inner_rank * outer_size + outer_rank
+        for outer_rank in range(outer_size)
+        for inner_rank in range(inner_size)
+    )
 
 
 def _always_nvtx_decorator(message: str) -> Callable:
@@ -213,8 +259,8 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             super().__init__(params, {})
         self._inner = inner_optimizer
 
-        # Assert all-`Flat` placements: this optimizer only supports the
-        # all-Flat layout (parameter=Flat, gradient=Flat, optimizer=Flat).
+        # Muon requires every optimizer-managed buffer to retain at least one
+        # sharded axis; HSDP may replicate the outer axis.
         _seen_groups: set[FsdpParameterGroup] = set()
         for _param in self._all_params():
             _group = get_containing_parameter_group(_param)
@@ -224,11 +270,10 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
             for _buf in (_group.main_weight, _group.model_weight, _group.main_grad):
                 if _buf is None:
                     continue
-                if not all(isinstance(_p, Flat) for _p in _buf.placements):
+                if not any(isinstance(_p, Flat) for _p in _buf.placements):
                     raise ValueError(
-                        "FsdpOrthogonalizedOptimizer requires all-Flat placements "
-                        "(parameter=Flat, gradient=Flat, optimizer=Flat), but "
-                        f"{_group} has non-Flat placements "
+                        "FsdpOrthogonalizedOptimizer requires at least one Flat axis, but "
+                        f"{_group} has placements "
                         f"{[type(_p).__name__ for _p in _buf.placements]}."
                     )
 
@@ -356,9 +401,17 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
                 plans.append(None)
                 continue
             tensor_flat_offset = layout.tensor_to_offset[index]
-            world_size = dist.get_world_size(group=group.mesh.get_group())
+            process_group = _get_parameter_dp_group(param)
+            world_size = dist.get_world_size(group=process_group)
             rank_flat_shard_size = layout.size // world_size
-            plan = compute_shard_plan(shape, tensor_flat_offset, rank_flat_shard_size, world_size)
+            shard_order = _get_parameter_shard_order(param, process_group)
+            plan = compute_shard_plan(
+                shape,
+                tensor_flat_offset,
+                rank_flat_shard_size,
+                world_size,
+                shard_order=shard_order,
+            )
             self._shard_plans[key] = plan
             plans.append(plan)
         return plans
@@ -429,7 +482,7 @@ class FsdpOrthogonalizedOptimizer(torch.optim.Optimizer):
         chunks: dict[tuple, list[list[int]]] = {}
         for index, (param, shard, plan) in enumerate(zip(params, local_shards, plans)):
             group = get_containing_parameter_group(param)
-            collective_group = group.mesh.get_group() if group is not None else None
+            collective_group = _get_parameter_dp_group(param) if group is not None else None
             key = (plan.is_boundary(), id(collective_group), shard.device, shard.dtype, param.dtype)
             compatible_chunks = chunks.setdefault(key, [])
             if (

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -33,7 +33,7 @@ from .placement import changed_mesh_axis
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
 
-def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGroup | None":
+def get_containing_parameter_group(parameter: torch.Tensor) -> "FsdpParameterGroup | None":
     """Return the FSDP parameter group that owns ``parameter``, if any."""
     # This parameter-owned backedge must be weak; otherwise it forms a reference
     # cycle with the parameter group and delays releasing its CUDA storage.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -100,6 +100,7 @@ class FsdpParameterGroup:
         reduce_scatter_stream: torch.cuda.Stream,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
+        subgroup_size: int | None = None,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -117,6 +118,8 @@ class FsdpParameterGroup:
                 NCCL symmetric-memory pool.
             grad_divisor: Additional divisor applied on top of the mesh-size
                 averaging. See ``fully_shard``.
+            subgroup_size: Optional contiguous DP parameter-placement subgroup size.
+                The value is already normalized to this parameter group's mesh.
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
@@ -138,6 +141,7 @@ class FsdpParameterGroup:
         self.mesh = mesh
         self.grad_divisor = grad_divisor
         first_parameter = next(iter(parameter_to_fqns))
+        self.subgroup_size = subgroup_size
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
         for parameter, fqns in parameter_to_fqns.items():
@@ -158,6 +162,7 @@ class FsdpParameterGroup:
             (parameter.to(dtype=main_weight_dtype) for parameter in parameter_to_fqns),
             mesh=self.mesh,
             placements=main_weight_placements,
+            subgroup_size=self.subgroup_size,
         )
 
         if use_symmetric_memory:
@@ -178,6 +183,7 @@ class FsdpParameterGroup:
                     tensor_shapes=tensor_shapes,
                     dtype=self.dtype,
                     device=self.main_weight.device,
+                    subgroup_size=self.subgroup_size,
                 )
             # Cast into the preallocated model_weight on the current stream without
             # replacing its storage or its all-gather allocation stream.
@@ -190,6 +196,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
                 device=self.main_weight.device,
+                subgroup_size=self.subgroup_size,
             )
 
         self.main_grad = None
@@ -207,6 +214,7 @@ class FsdpParameterGroup:
                     tensor_shapes=self.main_weight.layout.tensor_shapes,
                     dtype=grad_dtype,
                     device=self.main_weight.device,
+                    subgroup_size=self.subgroup_size,
                 )
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "
@@ -341,6 +349,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
+                subgroup_size=self.subgroup_size,
             )
 
     def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:
@@ -410,6 +419,7 @@ class FsdpParameterGroup:
                     tensor_shapes=self.main_weight.layout.tensor_shapes,
                     dtype=self.main_grad.dtype,
                     device=self.main_weight.device,
+                    subgroup_size=self.subgroup_size,
                 )
                 if has_sharded_grads:
                     self.main_grad.local_buffer.zero_()

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,6 +28,7 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
+from .module_utils import restore_parameter_attributes, save_parameter_attributes
 from .placement import changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
@@ -223,12 +224,12 @@ class FsdpParameterGroup:
         fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
+            attributes = save_parameter_attributes(parameter)
             unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
             if parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
-                # This may be problematic if attributes from the original Parameter need
-                # to be copied to the unsharded Parameter.
+                # Restore model metadata below after swapping the tensor state.
                 materialized_parameter = nn.Parameter(
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
@@ -236,12 +237,14 @@ class FsdpParameterGroup:
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
+            restore_parameter_attributes(parameter, attributes)
             # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
+            restore_parameter_attributes(sharded_parameter, attributes)
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -1,0 +1,428 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Pure shard-planning and owner-compute packing logic for the Muon + M-FSDPv2 owner-compute P2P
+algorithm.
+
+The central data structure is `ShardPlan`, which describes how a single 2D parameter's full matrix
+is split across the DP group under M-FSDPv2's all-`Flat` layout. Given shard plans,
+`assign_owner_work` balances Newton-Schulz work across owner ranks, and the pack/unpack helpers
+(`pack_owner_work`/`pack_update_shards`/`unpack_update_shards`) build the flat P2P send/recv
+buffers. `reconstruct_full_tensor` stitches gathered shards back into the full matrix on the owner.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+
+import torch
+
+from .layout import non_leading_numel
+
+
+@dataclasses.dataclass(frozen=True)
+class ShardPlan:
+    """How a single 2D parameter's full matrix is split across the DP group.
+
+    M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously in rank order,
+    so rank `r` owns the contiguous global row range
+    `[start, start + count)` where `start`/`count` come from the flat
+    DBuffer layout. A rank with `count == 0` holds no shard of this parameter.
+    """
+
+    full_shape: torch.Size
+    rank_rows: tuple[tuple[int, int], ...]
+    row_size: int
+
+    def __post_init__(self) -> None:
+        if len(self.full_shape) != 2:
+            raise ValueError(f"ShardPlan requires a 2D full_shape, got {self.full_shape}.")
+        if len(self.rank_rows) == 0:
+            raise ValueError("ShardPlan requires at least one rank.")
+        if self.row_size != non_leading_numel(self.full_shape):
+            raise ValueError(
+                f"ShardPlan row_size {self.row_size} != full_shape row size "
+                f"{non_leading_numel(self.full_shape)}."
+            )
+
+    @property
+    def world_size(self) -> int:
+        """Number of ranks in the DP group for this parameter."""
+        return len(self.rank_rows)
+
+    def rank_row_count(self, rank: int) -> int:
+        """Return the number of rows owned by `rank`."""
+        return self.rank_rows[rank][1]
+
+    def shard_numel(self, rank: int) -> int:
+        """Return the number of elements in `rank`'s shard."""
+        return self.rank_row_count(rank) * self.row_size
+
+    def owner_candidates(self) -> tuple[int, ...]:
+        """Return the ranks that hold a non-empty shard of this parameter."""
+        return tuple(r for r, (_, count) in enumerate(self.rank_rows) if count > 0)
+
+    def is_boundary(self) -> bool:
+        """True if more than one rank owns a non-empty shard of this parameter."""
+        return sum(1 for _, count in self.rank_rows if count > 0) > 1
+
+    def full_numel(self) -> int:
+        """Return the total number of elements in the full (unsharded) parameter."""
+        return self.full_shape.numel()
+
+
+def compute_shard_plan(
+    full_shape: torch.Size, tensor_flat_offset: int, rank_flat_shard_size: int, world_size: int
+) -> ShardPlan:
+    """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
+
+    Args:
+        full_shape: Global `(rows, cols)` shape of the parameter.
+        tensor_flat_offset: Flat-element offset of this parameter inside the
+            DBuffer's global layout.
+        rank_flat_shard_size: Flat elements each DP rank owns (uniform for the
+            even all-`Flat` layout: `layout.size // world_size`).
+        world_size: DP group size.
+
+    Returns:
+        The `ShardPlan` describing which rows each rank owns.
+    """
+    if len(full_shape) != 2:
+        raise ValueError(f"compute_shard_plan requires a 2D shape, got {full_shape}.")
+    row_size = non_leading_numel(full_shape)
+    if row_size <= 0:
+        raise ValueError(f"compute_shard_plan requires non-empty rows, got shape {full_shape}.")
+    tensor_end = tensor_flat_offset + full_shape.numel()
+
+    rank_rows: list[tuple[int, int]] = []
+    for rank in range(world_size):
+        rank_start = rank * rank_flat_shard_size
+        rank_end = rank_start + rank_flat_shard_size
+        overlap_start = max(tensor_flat_offset, rank_start)
+        overlap_end = min(tensor_end, rank_end)
+        if overlap_start >= overlap_end:
+            rank_rows.append((0, 0))
+            continue
+        if (overlap_start - tensor_flat_offset) % row_size != 0:
+            raise RuntimeError(
+                f"Flat shard boundary is not row-aligned for shape {full_shape}: "
+                f"overlap_start={overlap_start}, tensor_flat_offset={tensor_flat_offset}."
+            )
+        overlap_numel = overlap_end - overlap_start
+        if overlap_numel % row_size != 0:
+            raise RuntimeError(
+                f"Flat shard overlap is not row-aligned for shape {full_shape}: "
+                f"overlap_numel={overlap_numel}, row_size={row_size}."
+            )
+        row_start = (overlap_start - tensor_flat_offset) // row_size
+        row_count = overlap_numel // row_size
+        rank_rows.append((row_start, row_count))
+    return ShardPlan(
+        full_shape=torch.Size(full_shape), rank_rows=tuple(rank_rows), row_size=row_size
+    )
+
+
+def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int, int]:
+    """Assign one owner rank to each boundary parameter, balanced by NS cost.
+
+    Only ranks that own a non-empty shard of a parameter are eligible owners.
+    Assignment greedily gives each parameter to its eligible rank with the
+    smallest running cost total, where a parameter's cost is the Newton-Schulz
+    compute estimate `numel * (min(rows, cols) * num_steps + 1)`.
+
+    Args:
+        plans: Shard plans indexed by their position in the input sequence.
+        num_ns_steps: Newton-Schulz iteration count used in the cost estimate.
+
+    Returns:
+        Mapping from parameter index (in `plans`) to owner rank.
+    """
+    assignments: dict[int, int] = {}
+    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
+    for param_index, plan in enumerate(plans):
+        candidates = plan.owner_candidates()
+        if not candidates:
+            raise RuntimeError(
+                f"No eligible owner for parameter {param_index} with shape {plan.full_shape}; "
+                "no rank owns a shard."
+            )
+        if not plan.is_boundary():
+            # Fully local: the single owning rank is the owner with no communication.
+            assignments[param_index] = candidates[0]
+            continue
+        rows, cols = plan.full_shape
+        short_dim = min(rows, cols)
+        cost = float(plan.full_numel() * (short_dim * num_ns_steps + 1))
+        owner = min(candidates, key=lambda r: (running[r], r))
+        assignments[param_index] = owner
+        running[owner] += cost
+    return assignments
+
+
+@dataclasses.dataclass
+class OwnerGatherPlan:
+    """Metadata and send buffers for the owner-gather P2P step of one chunk.
+
+    The owner keeps its own shard locally (no self-send), so it only receives
+    from the other shard-holding ranks and reconstructs each owned matrix by
+    concatenating shards in rank order (own shard at the owner's rank rows).
+
+    Attributes:
+        send_buffers: Per-destination-owner flat send buffer (this rank's
+            pre-NS shards for that owner's params, in param order). Only owners
+            other than this rank appear.
+        recv_sizes: Per-source-rank element count this rank (as an owner)
+            receives. Only sources other than this rank appear.
+        own_shards: This rank's local shard per owned parameter (used directly
+            in reconstruction, not communicated).
+        recv_offsets: Per `(param_index, src_rank)` of `(offset, numel,
+            row_count)` describing where this param's shard lands inside the
+            recv buffer received from `src_rank`.
+    """
+
+    send_buffers: dict[int, torch.Tensor]
+    recv_sizes: dict[int, int]
+    own_shards: dict[int, torch.Tensor]
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+
+def pack_owner_work(
+    plans: Sequence[ShardPlan],
+    owners: dict[int, int],
+    local_shards: Sequence[torch.Tensor],
+    world_size: int,
+    this_rank: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> OwnerGatherPlan:
+    """Pack this rank's pre-NS shards into per-owner P2P send buffers.
+
+    Args:
+        plans: Shard plans in parameter order.
+        owners: Mapping from parameter index to owner rank.
+        local_shards: This rank's local pre-NS shard per parameter.
+        world_size: DP group size.
+        this_rank: This rank's DP index.
+        device: Device for the send buffers (the pre-NS device).
+        dtype: Dtype for the send buffers (the pre-NS dtype).
+
+    Returns:
+        The `OwnerGatherPlan` for this rank.
+    """
+    send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+    recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
+    for param_index, plan in enumerate(plans):
+        owner = owners[param_index]
+        if owner != this_rank:
+            send_sizes[owner] += plan.shard_numel(this_rank)
+        else:
+            for src in range(world_size):
+                if src == this_rank:
+                    continue
+                recv_sizes[src] += plan.shard_numel(src)
+
+    send_buffers: dict[int, torch.Tensor] = {}
+    for owner, size in send_sizes.items():
+        send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
+
+    # Fill each owner's send buffer in param order.
+    cursors: dict[int, int] = {o: 0 for o in send_buffers}
+    own_shards: dict[int, torch.Tensor] = {}
+    for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
+        owner = owners[param_index]
+        if owner == this_rank:
+            own_shards[param_index] = shard
+            continue
+        numel = plan.shard_numel(this_rank)
+        if numel == 0:
+            continue
+        buf = send_buffers[owner]
+        buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
+        cursors[owner] += numel
+
+    # Per (owned param, src) recv offset within the recv buffer from src.
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+    for src in range(world_size):
+        if src == this_rank:
+            continue
+        offset = 0
+        for param_index in owned_indices:
+            plan = plans[param_index]
+            numel = plan.shard_numel(src)
+            recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
+            offset += numel
+
+    return OwnerGatherPlan(
+        send_buffers=send_buffers,
+        recv_sizes=recv_sizes,
+        own_shards=own_shards,
+        recv_offsets=recv_offsets,
+    )
+
+
+def reconstruct_full_tensor(
+    param_index: int,
+    plan: ShardPlan,
+    gather_plan: OwnerGatherPlan,
+    recv_buffers: dict[int, torch.Tensor],
+    owner_rank: int,
+) -> torch.Tensor:
+    """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
+
+    Concatenates shards in rank order: the owner's own local shard at its rank rows and each
+    source's received shard at that source's rank rows. The shard content lives in `gather_plan`
+    (`own_shards` + `recv_offsets`), so this works for the pre-NS owner-gather path and for a weight
+    gather plan alike – pass a weight gather plan built with `pack_owner_work` to reconstruct the
+    full weight parameter instead.
+
+    Args:
+        param_index: Index of the parameter within the chunk.
+        plan: Shard plan for this parameter.
+        gather_plan: This rank's owner-gather plan (own_shards, recv_offsets).
+        recv_buffers: Per-source-rank received buffer (only sources that sent).
+        owner_rank: The owner rank (== the rank running reconstruction).
+
+    Returns:
+        The full `(rows, cols)` tensor.
+    """
+    world_size = plan.world_size
+    shards: list[torch.Tensor] = []
+    for src in range(world_size):
+        row_count = plan.rank_row_count(src)
+        if src == owner_rank:
+            shards.append(gather_plan.own_shards[param_index])
+        elif row_count == 0:
+            continue
+        else:
+            offset, numel, _ = gather_plan.recv_offsets[(param_index, src)]
+            buf = recv_buffers[src]
+            shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
+    if len(shards) == 1:
+        return shards[0].contiguous()
+    return torch.cat(shards, dim=0)
+
+
+@dataclasses.dataclass
+class OwnerScatterPlan:
+    """Metadata and send buffers for the owner-scatter P2P step of one chunk.
+
+    The owner keeps its own update shard (applied directly), so it only sends to
+    the other shard-holding ranks.
+
+    Attributes:
+        send_buffers: Per-destination-rank flat send buffer (this owner's update
+            shards for the params it owns, in param order). Only destinations
+            other than this rank appear.
+        recv_sizes: Per-owner-rank element count this rank (as a destination)
+            receives. Only owners other than this rank appear.
+        recv_offsets: Per `(param_index, owner_rank)` of `(offset, numel,
+            row_count)` describing where this param's update shard lands inside
+            the recv buffer received from `owner_rank`.
+    """
+
+    send_buffers: dict[int, torch.Tensor]
+    recv_sizes: dict[int, int]
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+
+
+def pack_update_shards(
+    full_updates: dict[int, torch.Tensor],
+    plans: Sequence[ShardPlan],
+    owners: dict[int, int],
+    world_size: int,
+    this_rank: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> OwnerScatterPlan:
+    """Pack this owner rank's full updates into per-destination P2P send buffers.
+
+    Args:
+        full_updates: Full update matrix per owned parameter index.
+        plans: Shard plans in parameter order.
+        owners: Mapping from parameter index to owner rank.
+        world_size: DP group size.
+        this_rank: This rank's DP index.
+        device: Device for the send buffers (the update device).
+        dtype: Dtype for the send buffers (the update dtype).
+
+    Returns:
+        The `OwnerScatterPlan` for this rank.
+    """
+    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
+    send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
+    recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
+    for param_index in owned_indices:
+        plan = plans[param_index]
+        for dest in range(world_size):
+            if dest == this_rank:
+                continue
+            send_sizes[dest] += plan.shard_numel(dest)
+    for param_index, plan in enumerate(plans):
+        owner = owners[param_index]
+        if owner == this_rank:
+            continue
+        recv_sizes[owner] += plan.shard_numel(this_rank)
+
+    send_buffers: dict[int, torch.Tensor] = {}
+    for dest, size in send_sizes.items():
+        send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
+
+    cursors: dict[int, int] = {d: 0 for d in send_buffers}
+    for dest in range(world_size):
+        if dest == this_rank:
+            continue
+        for param_index in owned_indices:
+            plan = plans[param_index]
+            row_start, row_count = plan.rank_rows[dest]
+            numel = row_count * plan.row_size
+            if numel == 0:
+                continue
+            full = full_updates[param_index]
+            buf = send_buffers[dest]
+            buf[cursors[dest] : cursors[dest] + numel].copy_(
+                full[row_start : row_start + row_count].reshape(-1)
+            )
+            cursors[dest] += numel
+
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    for owner in range(world_size):
+        if owner == this_rank:
+            continue
+        offset = 0
+        for param_index, plan in enumerate(plans):
+            if owners[param_index] != owner:
+                continue
+            numel = plan.shard_numel(this_rank)
+            recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
+            offset += numel
+
+    return OwnerScatterPlan(
+        send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets
+    )
+
+
+def unpack_update_shards(
+    scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
+) -> dict[int, torch.Tensor]:
+    """Extract this rank's local update shards from the per-owner recv buffers.
+
+    Args:
+        scatter_plan: This rank's owner-scatter plan (recv_offsets).
+        recv_buffers: Per-owner-rank received buffer (only owners that sent).
+
+    Returns:
+        Mapping from parameter index to the local update shard `(row_count, cols)`,
+        for parameters this rank does NOT own.
+    """
+    updates: dict[int, torch.Tensor] = {}
+    for (param_index, owner), (offset, numel, row_count) in scatter_plan.recv_offsets.items():
+        if numel == 0:
+            continue
+        buf = recv_buffers[owner]
+        row_size = numel // row_count if row_count else 1
+        updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
+    return updates

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -123,23 +123,49 @@ def compute_shard_plan(
     )
 
 
-def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int, int]:
-    """Assign one owner rank to each boundary parameter, balanced by NS cost.
+def assign_owner_work(
+    plans: Sequence[ShardPlan],
+    num_ns_steps: int,
+    chunks: Sequence[Sequence[int]] | None = None,
+) -> dict[int, int]:
+    """Assign one owner rank to each parameter with chunk-local load balancing.
 
     Only ranks that own a non-empty shard of a parameter are eligible owners.
-    Assignment greedily gives each parameter to its eligible rank with the
-    smallest running cost total, where a parameter's cost is the Newton-Schulz
-    compute estimate `numel * (min(rows, cols) * num_steps + 1)`.
+    Parameters are processed in descending estimated Newton-Schulz cost. For
+    each chunk, assignment minimizes each rank's cumulative cost, including
+    fixed fully-local work and owner work from preceding chunks. The cost
+    estimate for an M x N matrix is
+    `M * N * (min(M, N) * num_ns_steps + 1)`.
 
     Args:
         plans: Shard plans indexed by their position in the input sequence.
         num_ns_steps: Newton-Schulz iteration count used in the cost estimate.
+        chunks: Parameter indices grouped by communication chunk. When omitted,
+            all parameters are balanced as one chunk.
 
     Returns:
         Mapping from parameter index (in `plans`) to owner rank.
     """
+    if not plans:
+        return {}
+
+    if chunks is None:
+        chunks = (tuple(range(len(plans))),)
+
+    costs: dict[int, float] = {}
+    for param_index, plan in enumerate(plans):
+        rows, cols = plan.full_shape
+        costs[param_index] = float(
+            plan.full_numel() * (min(rows, cols) * num_ns_steps + 1)
+        )
+
     assignments: dict[int, int] = {}
-    running: dict[int, float] = {r: 0.0 for r in range(plans[0].world_size)} if plans else {}
+    total_running = {rank: 0.0 for rank in range(plans[0].world_size)}
+
+    # Fully-local work cannot be reassigned, but it runs before boundary NS and
+    # therefore shifts when each rank can start producing boundary updates.
+    # Seed the owner loads with that fixed work so boundary assignment balances
+    # the actual per-rank critical path rather than boundary work in isolation.
     for param_index, plan in enumerate(plans):
         candidates = plan.owner_candidates()
         if not candidates:
@@ -147,16 +173,35 @@ def assign_owner_work(plans: Sequence[ShardPlan], num_ns_steps: int) -> dict[int
                 f"No eligible owner for parameter {param_index} with shape {plan.full_shape}; "
                 "no rank owns a shard."
             )
-        if not plan.is_boundary():
-            # Fully local: the single owning rank is the owner with no communication.
-            assignments[param_index] = candidates[0]
+        if plan.is_boundary():
             continue
-        rows, cols = plan.full_shape
-        short_dim = min(rows, cols)
-        cost = float(plan.full_numel() * (short_dim * num_ns_steps + 1))
-        owner = min(candidates, key=lambda r: (running[r], r))
+        owner = candidates[0]
         assignments[param_index] = owner
-        running[owner] += cost
+        total_running[owner] += costs[param_index]
+
+    for chunk in chunks:
+        chunk_running = {rank: 0.0 for rank in total_running}
+        ordered_params = sorted(
+            (index for index in chunk if plans[index].is_boundary()),
+            key=lambda index: (-costs[index], index),
+        )
+        for param_index in ordered_params:
+            plan = plans[param_index]
+            candidates = plan.owner_candidates()
+            owner = min(
+                candidates,
+                key=lambda rank: (
+                    total_running[rank] + chunk_running[rank],
+                    chunk_running[rank],
+                    rank,
+                ),
+            )
+            assignments[param_index] = owner
+            chunk_running[owner] += costs[param_index]
+
+        for rank, chunk_cost in chunk_running.items():
+            total_running[rank] += chunk_cost
+
     return assignments
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -214,97 +214,68 @@ class OwnerGatherPlan:
     concatenating shards in rank order (own shard at the owner's rank rows).
 
     Attributes:
-        send_buffers: Per-destination-owner flat send buffer (this rank's
-            pre-NS shards for that owner's params, in param order). Only owners
-            other than this rank appear.
-        recv_sizes: Per-source-rank element count this rank (as an owner)
-            receives. Only sources other than this rank appear.
+        send_buffers: Per-parameter, per-owner flattened pre-NS shard.
+        recv_sizes: Per-parameter, per-source element count received by its owner.
         own_shards: This rank's local shard per owned parameter (used directly
             in reconstruction, not communicated).
         recv_offsets: Per `(param_index, src_rank)` of `(offset, numel,
             row_count)` describing where this param's shard lands inside the
             recv buffer received from `src_rank`.
+        comm_groups: Per-parameter process groups in shard-plan order.
     """
 
-    send_buffers: dict[int, torch.Tensor]
-    recv_sizes: dict[int, int]
+    send_buffers: dict[tuple[int, int], torch.Tensor]
+    recv_sizes: dict[tuple[int, int], int]
     own_shards: dict[int, torch.Tensor]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+    comm_groups: tuple[torch.distributed.ProcessGroup, ...]
 
 
 def pack_owner_work(
     plans: Sequence[ShardPlan],
     owners: dict[int, int],
     local_shards: Sequence[torch.Tensor],
-    world_size: int,
-    this_rank: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
+    comm_groups: list[torch.distributed.ProcessGroup],
 ) -> OwnerGatherPlan:
-    """Pack this rank's pre-NS shards into per-owner P2P send buffers.
+    """Pack this rank's pre-NS shards into per-parameter P2P buffers.
 
     Args:
         plans: Shard plans in parameter order.
         owners: Mapping from parameter index to owner rank.
         local_shards: This rank's local pre-NS shard per parameter.
-        world_size: DP group size.
-        this_rank: This rank's DP index.
-        device: Device for the send buffers (the pre-NS device).
-        dtype: Dtype for the send buffers (the pre-NS dtype).
+        comm_groups: Per-parameter process groups in shard-plan order.
 
     Returns:
         The `OwnerGatherPlan` for this rank.
     """
-    send_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
-    recv_sizes: dict[int, int] = {s: 0 for s in range(world_size) if s != this_rank}
-    for param_index, plan in enumerate(plans):
-        owner = owners[param_index]
-        if owner != this_rank:
-            send_sizes[owner] += plan.shard_numel(this_rank)
-        else:
-            for src in range(world_size):
-                if src == this_rank:
-                    continue
-                recv_sizes[src] += plan.shard_numel(src)
-
-    send_buffers: dict[int, torch.Tensor] = {}
-    for owner, size in send_sizes.items():
-        send_buffers[owner] = torch.empty(size, dtype=dtype, device=device)
-
-    # Fill each owner's send buffer in param order.
-    cursors: dict[int, int] = {o: 0 for o in send_buffers}
+    send_buffers: dict[tuple[int, int], torch.Tensor] = {}
+    recv_sizes: dict[tuple[int, int], int] = {}
     own_shards: dict[int, torch.Tensor] = {}
-    for param_index, (plan, shard) in enumerate(zip(plans, local_shards)):
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    for param_index, (plan, shard, comm_group) in enumerate(
+        zip(plans, local_shards, comm_groups)
+    ):
+        world_size = torch.distributed.get_world_size(group=comm_group)
+        this_rank = torch.distributed.get_rank(group=comm_group)
         owner = owners[param_index]
         if owner == this_rank:
             own_shards[param_index] = shard
-            continue
-        numel = plan.shard_numel(this_rank)
-        if numel == 0:
-            continue
-        buf = send_buffers[owner]
-        buf[cursors[owner] : cursors[owner] + numel].copy_(shard.reshape(-1))
-        cursors[owner] += numel
-
-    # Per (owned param, src) recv offset within the recv buffer from src.
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
-    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-    for src in range(world_size):
-        if src == this_rank:
-            continue
-        offset = 0
-        for param_index in owned_indices:
-            plan = plans[param_index]
-            numel = plan.shard_numel(src)
-            recv_offsets[(param_index, src)] = (offset, numel, plan.rank_row_count(src))
-            offset += numel
+            for src in range(world_size):
+                numel = plan.shard_numel(src)
+                if src != this_rank and numel > 0:
+                    recv_sizes[(param_index, src)] = numel
+                    recv_offsets[(param_index, src)] = (0, numel, plan.rank_row_count(src))
+        else:
+            numel = plan.shard_numel(this_rank)
+            if numel > 0:
+                send_buffers[(param_index, owner)] = shard.reshape(-1).clone()
 
     return OwnerGatherPlan(
         send_buffers=send_buffers,
         recv_sizes=recv_sizes,
         own_shards=own_shards,
         recv_offsets=recv_offsets,
+        comm_groups=tuple(comm_groups),
     )
 
 
@@ -312,8 +283,7 @@ def reconstruct_full_tensor(
     param_index: int,
     plan: ShardPlan,
     gather_plan: OwnerGatherPlan,
-    recv_buffers: dict[int, torch.Tensor],
-    owner_rank: int,
+    recv_buffers: dict[tuple[int, int], torch.Tensor],
 ) -> torch.Tensor:
     """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
 
@@ -328,12 +298,12 @@ def reconstruct_full_tensor(
         plan: Shard plan for this parameter.
         gather_plan: This rank's owner-gather plan (own_shards, recv_offsets).
         recv_buffers: Per-source-rank received buffer (only sources that sent).
-        owner_rank: The owner rank (== the rank running reconstruction).
 
     Returns:
         The full `(rows, cols)` tensor.
     """
     world_size = plan.world_size
+    owner_rank = torch.distributed.get_rank(group=gather_plan.comm_groups[param_index])
     shards: list[torch.Tensor] = []
     for src in range(world_size):
         row_count = plan.rank_row_count(src)
@@ -343,7 +313,7 @@ def reconstruct_full_tensor(
             continue
         else:
             offset, numel, _ = gather_plan.recv_offsets[(param_index, src)]
-            buf = recv_buffers[src]
+            buf = recv_buffers[(param_index, src)]
             shards.append(buf[offset : offset + numel].view(row_count, plan.row_size))
     if len(shards) == 1:
         return shards[0].contiguous()
@@ -358,106 +328,79 @@ class OwnerScatterPlan:
     the other shard-holding ranks.
 
     Attributes:
-        send_buffers: Per-destination-rank flat send buffer (this owner's update
-            shards for the params it owns, in param order). Only destinations
-            other than this rank appear.
-        recv_sizes: Per-owner-rank element count this rank (as a destination)
-            receives. Only owners other than this rank appear.
+        send_buffers: Per-parameter, per-destination flattened update shard.
+        recv_sizes: Per-parameter, per-owner element count received by its destination.
         recv_offsets: Per `(param_index, owner_rank)` of `(offset, numel,
             row_count)` describing where this param's update shard lands inside
             the recv buffer received from `owner_rank`.
+        comm_groups: Per-parameter process groups in shard-plan order.
     """
 
-    send_buffers: dict[int, torch.Tensor]
-    recv_sizes: dict[int, int]
+    send_buffers: dict[tuple[int, int], torch.Tensor]
+    recv_sizes: dict[tuple[int, int], int]
     recv_offsets: dict[tuple[int, int], tuple[int, int, int]]
+    comm_groups: tuple[torch.distributed.ProcessGroup, ...]
 
 
 def pack_update_shards(
     full_updates: dict[int, torch.Tensor],
     plans: Sequence[ShardPlan],
     owners: dict[int, int],
-    world_size: int,
-    this_rank: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
+    comm_groups: list[torch.distributed.ProcessGroup],
 ) -> OwnerScatterPlan:
-    """Pack this owner rank's full updates into per-destination P2P send buffers.
+    """Pack full updates into per-parameter, per-destination P2P buffers.
 
     Args:
         full_updates: Full update matrix per owned parameter index.
         plans: Shard plans in parameter order.
         owners: Mapping from parameter index to owner rank.
-        world_size: DP group size.
-        this_rank: This rank's DP index.
-        device: Device for the send buffers (the update device).
-        dtype: Dtype for the send buffers (the update dtype).
+        comm_groups: Per-parameter process groups in shard-plan order.
 
     Returns:
         The `OwnerScatterPlan` for this rank.
     """
-    owned_indices = [i for i in range(len(plans)) if owners[i] == this_rank]
-    send_sizes: dict[int, int] = {d: 0 for d in range(world_size) if d != this_rank}
-    recv_sizes: dict[int, int] = {o: 0 for o in range(world_size) if o != this_rank}
-    for param_index in owned_indices:
-        plan = plans[param_index]
-        for dest in range(world_size):
-            if dest == this_rank:
-                continue
-            send_sizes[dest] += plan.shard_numel(dest)
-    for param_index, plan in enumerate(plans):
+    send_buffers: dict[tuple[int, int], torch.Tensor] = {}
+    recv_sizes: dict[tuple[int, int], int] = {}
+    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
+    for param_index, (plan, comm_group) in enumerate(zip(plans, comm_groups)):
+        world_size = torch.distributed.get_world_size(group=comm_group)
+        this_rank = torch.distributed.get_rank(group=comm_group)
         owner = owners[param_index]
         if owner == this_rank:
-            continue
-        recv_sizes[owner] += plan.shard_numel(this_rank)
-
-    send_buffers: dict[int, torch.Tensor] = {}
-    for dest, size in send_sizes.items():
-        send_buffers[dest] = torch.empty(size, dtype=dtype, device=device)
-
-    cursors: dict[int, int] = {d: 0 for d in send_buffers}
-    for dest in range(world_size):
-        if dest == this_rank:
-            continue
-        for param_index in owned_indices:
-            plan = plans[param_index]
-            row_start, row_count = plan.rank_rows[dest]
-            numel = row_count * plan.row_size
-            if numel == 0:
-                continue
-            full = full_updates[param_index]
-            buf = send_buffers[dest]
-            buf[cursors[dest] : cursors[dest] + numel].copy_(
-                full[row_start : row_start + row_count].reshape(-1)
-            )
-            cursors[dest] += numel
-
-    recv_offsets: dict[tuple[int, int], tuple[int, int, int]] = {}
-    for owner in range(world_size):
-        if owner == this_rank:
-            continue
-        offset = 0
-        for param_index, plan in enumerate(plans):
-            if owners[param_index] != owner:
-                continue
+            full_update = full_updates[param_index]
+            for dest in range(world_size):
+                row_start, row_count = plan.rank_rows[dest]
+                if dest != this_rank and row_count > 0:
+                    send_buffers[(param_index, dest)] = full_update[
+                        row_start : row_start + row_count
+                    ].reshape(-1).clone()
+        else:
             numel = plan.shard_numel(this_rank)
-            recv_offsets[(param_index, owner)] = (offset, numel, plan.rank_row_count(this_rank))
-            offset += numel
+            if numel > 0:
+                recv_sizes[(param_index, owner)] = numel
+                recv_offsets[(param_index, owner)] = (
+                    0,
+                    numel,
+                    plan.rank_row_count(this_rank),
+                )
 
     return OwnerScatterPlan(
-        send_buffers=send_buffers, recv_sizes=recv_sizes, recv_offsets=recv_offsets
+        send_buffers=send_buffers,
+        recv_sizes=recv_sizes,
+        recv_offsets=recv_offsets,
+        comm_groups=tuple(comm_groups),
     )
 
 
 def unpack_update_shards(
-    scatter_plan: OwnerScatterPlan, recv_buffers: dict[int, torch.Tensor]
+    scatter_plan: OwnerScatterPlan,
+    recv_buffers: dict[tuple[int, int], torch.Tensor],
 ) -> dict[int, torch.Tensor]:
     """Extract this rank's local update shards from the per-owner recv buffers.
 
     Args:
         scatter_plan: This rank's owner-scatter plan (recv_offsets).
-        recv_buffers: Per-owner-rank received buffer (only owners that sent).
+        recv_buffers: Per-parameter, per-owner received buffers.
 
     Returns:
         Mapping from parameter index to the local update shard `(row_count, cols)`,
@@ -465,9 +408,7 @@ def unpack_update_shards(
     """
     updates: dict[int, torch.Tensor] = {}
     for (param_index, owner), (offset, numel, row_count) in scatter_plan.recv_offsets.items():
-        if numel == 0:
-            continue
-        buf = recv_buffers[owner]
-        row_size = numel // row_count if row_count else 1
+        buf = recv_buffers[(param_index, owner)]
+        row_size = numel // row_count
         updates[param_index] = buf[offset : offset + numel].view(row_count, row_size)
     return updates

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/shard_plan.py
@@ -25,8 +25,8 @@ from .layout import non_leading_numel
 class ShardPlan:
     """How a single 2D parameter's full matrix is split across the DP group.
 
-    M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously in rank order,
-    so rank `r` owns the contiguous global row range
+    M-FSDPv2's all-`Flat` layout shards dim-0 rows contiguously. For each
+    process-group rank `r`, `rank_rows[r]` gives the contiguous global row range
     `[start, start + count)` where `start`/`count` come from the flat
     DBuffer layout. A rank with `count == 0` holds no shard of this parameter.
     """
@@ -73,7 +73,11 @@ class ShardPlan:
 
 
 def compute_shard_plan(
-    full_shape: torch.Size, tensor_flat_offset: int, rank_flat_shard_size: int, world_size: int
+    full_shape: torch.Size,
+    tensor_flat_offset: int,
+    rank_flat_shard_size: int,
+    world_size: int,
+    shard_order: Sequence[int] | None = None,
 ) -> ShardPlan:
     """Compute the per-rank row ranges for one 2D parameter in a flat DBuffer.
 
@@ -84,6 +88,8 @@ def compute_shard_plan(
         rank_flat_shard_size: Flat elements each DP rank owns (uniform for the
             even all-`Flat` layout: `layout.size // world_size`).
         world_size: DP group size.
+        shard_order: Flat DBuffer shard index for each process-group rank.
+            Defaults to process-group rank order.
 
     Returns:
         The `ShardPlan` describing which rows each rank owns.
@@ -95,9 +101,11 @@ def compute_shard_plan(
         raise ValueError(f"compute_shard_plan requires non-empty rows, got shape {full_shape}.")
     tensor_end = tensor_flat_offset + full_shape.numel()
 
+    if shard_order is None:
+        shard_order = range(world_size)
     rank_rows: list[tuple[int, int]] = []
-    for rank in range(world_size):
-        rank_start = rank * rank_flat_shard_size
+    for shard_index in shard_order:
+        rank_start = shard_index * rank_flat_shard_size
         rank_end = rank_start + rank_flat_shard_size
         overlap_start = max(tensor_flat_offset, rank_start)
         overlap_end = min(tensor_end, rank_end)
@@ -287,7 +295,7 @@ def reconstruct_full_tensor(
 ) -> torch.Tensor:
     """Reconstruct the full 2D tensor for one owned parameter from its per-rank shards.
 
-    Concatenates shards in rank order: the owner's own local shard at its rank rows and each
+    Concatenates shards in global row order: the owner's own local shard at its rank rows and each
     source's received shard at that source's rank rows. The shard content lives in `gather_plan`
     (`own_shards` + `recv_offsets`), so this works for the pre-NS owner-gather path and for a weight
     gather plan alike – pass a weight gather plan built with `pack_owner_work` to reconstruct the
@@ -305,7 +313,10 @@ def reconstruct_full_tensor(
     world_size = plan.world_size
     owner_rank = torch.distributed.get_rank(group=gather_plan.comm_groups[param_index])
     shards: list[torch.Tensor] = []
-    for src in range(world_size):
+    ranks_by_row = sorted(
+        range(world_size), key=lambda rank: plan.rank_rows[rank][0]
+    )
+    for src in ranks_by_row:
         row_count = plan.rank_row_count(src)
         if src == owner_rank:
             shards.append(gather_plan.own_shards[param_index])

--- a/megatron/core/distributed/fsdp/src/pyproject.toml
+++ b/megatron/core/distributed/fsdp/src/pyproject.toml
@@ -57,6 +57,9 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
+[project.optional-dependencies]
+emerging-optimizers = ["emerging-optimizers>=0.2"]
+
 [project.urls]
 Download = "https://github.com/NVIDIA/Megatron-LM/releases"
 Homepage = "https://github.com/NVIDIA/Megatron-LM"

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -764,8 +764,25 @@ def _get_megatron_emerging_optimizer(
         eopt_name = bare_name
         use_layer_wise = True
 
-    if isinstance(model_chunks[0], FullyShardedDataParallelV2):
-        raise NotImplementedError("MFSDP v2 with emerging optimizers is not currently validated.")
+    is_mfsdp_v2 = isinstance(model_chunks[0], FullyShardedDataParallelV2)
+    if is_mfsdp_v2:
+        if eopt_name != 'muon':
+            raise NotImplementedError(
+                "MFSDP v2 currently supports only Muon among emerging optimizers, "
+                f"got {eopt_name!r}."
+            )
+        if use_layer_wise:
+            raise ValueError(
+                "MFSDP v2 Muon uses owner-compute sharding and does not support the "
+                "layer-wise distributed optimizer."
+            )
+        if config.use_distributed_optimizer:
+            raise ValueError("MFSDP v2 currently requires use_distributed_optimizer=False.")
+        if config.muon_scalar_optimizer != 'adam':
+            raise ValueError(
+                "MFSDP v2 Muon routes excluded parameters through Adam and requires "
+                "muon_scalar_optimizer='adam'."
+            )
 
     if not HAVE_EMERGING_OPTIMIZERS:
         raise ImportError(
@@ -904,6 +921,51 @@ def _get_megatron_emerging_optimizer(
             optimizer, init_state_fn = _create_emerging_optimizer(
                 config, groups, eopt_name, model_chunks, pg_collection
             )
+            if is_mfsdp_v2:
+                from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.orthogonalized_optimizer import (
+                    FsdpMuon,
+                )
+
+                parameters = [parameter for group in groups for parameter in group['params']]
+                if not parameters:
+                    raise RuntimeError("MFSDP v2 Muon received no parameters on this rank.")
+
+                dp_mesh = parameters[0].device_mesh
+                if dp_mesh.ndim != 1:
+                    raise ValueError(
+                        "MFSDP v2 Muon currently supports a one-dimensional data-parallel "
+                        f"mesh, got mesh shape {tuple(dp_mesh.mesh.shape)}."
+                    )
+                expected_ranks = tuple(
+                    torch.distributed.get_process_group_ranks(dp_mesh.get_group())
+                )
+                for parameter in parameters[1:]:
+                    parameter_mesh = parameter.device_mesh
+                    if (
+                        parameter_mesh.ndim != 1
+                        or tuple(
+                            torch.distributed.get_process_group_ranks(parameter_mesh.get_group())
+                        )
+                        != expected_ranks
+                    ):
+                        raise ValueError(
+                            "Each MFSDP v2 Muon optimizer instance requires all parameters "
+                            "to use the same one-dimensional data-parallel mesh."
+                        )
+
+                optimizer = FsdpMuon(groups, inner_optimizer=optimizer, dp_mesh=dp_mesh)
+                optimizer = FullyShardedOptimizer(
+                    optimizer, config, None, init_state_fn, model_chunks=model_chunks
+                )
+                setattr(optimizer, 'grad_stats_parallel_group', torch.distributed.group.WORLD)
+                setattr(optimizer, 'tp_group', pg_collection.tp)
+                setattr(
+                    optimizer,
+                    'expert_tp_group',
+                    getattr(pg_collection, 'expt_tp', pg_collection.tp),
+                )
+                results.append(optimizer)
+                continue
             if use_layer_wise:
                 layer_wise_base_results.append((optimizer, init_state_fn))
                 continue
@@ -923,6 +985,16 @@ def _get_megatron_emerging_optimizer(
         else:
             fallback_config = copy.copy(config)
             fallback_config.optimizer = opt_name
+            if is_mfsdp_v2:
+                # Match the standard MFSDP v2 Adam path: empty local DTensor shards
+                # have no optimizer state or data to update and must be omitted.
+                for group in groups:
+                    group['params'] = [
+                        parameter
+                        for parameter in group['params']
+                        if parameter.to_local().numel() > 0
+                    ]
+                groups = [group for group in groups if group['params']]
             if use_separate_distributed_optimizer:
                 # Route non-emerging params (adam/lion) through a real DistributedOptimizer
                 # (byte-level sharding) instead of stuffing them inside LayerWise.

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -839,7 +839,8 @@ def _get_megatron_emerging_optimizer(
                 override['optimizer'] = config.muon_scalar_optimizer
     config_overrides.update(default_param_overrides)
 
-    # Build param groups and bucket by (optimizer_name, is_expert_parallel).
+    # Build param groups. MFSDP v2 combines all Muon DP groups into one optimizer so
+    # expert-local NS can overlap dense owner communication.
     # Layer-wise distributed optimizer handles expert params internally so we skip that split.
     all_param_groups = _get_param_groups(
         model_chunks, config, config_overrides, param_group_process_group
@@ -857,10 +858,10 @@ def _get_megatron_emerging_optimizer(
                 )
                 params_by_mesh[mesh_ranks].append(parameter)
 
-            for mesh_ranks, parameters in params_by_mesh.items():
+            for parameters in params_by_mesh.values():
                 mesh_group = group.copy()
                 mesh_group['params'] = parameters
-                grouped_param_groups[(opt_name, is_expert, mesh_ranks)].append(mesh_group)
+                grouped_param_groups[(opt_name, False, None)].append(mesh_group)
         else:
             grouped_param_groups[(opt_name, is_expert, None)].append(group)
 
@@ -944,33 +945,17 @@ def _get_megatron_emerging_optimizer(
                 if not parameters:
                     raise RuntimeError("MFSDP v2 Muon received no parameters on this rank.")
 
-                dp_mesh = parameters[0].device_mesh
-                if dp_mesh.ndim != 1:
-                    raise ValueError(
-                        "MFSDP v2 Muon currently supports a one-dimensional data-parallel "
-                        f"mesh, got mesh shape {tuple(dp_mesh.mesh.shape)}."
-                    )
-                expected_ranks = tuple(
-                    torch.distributed.get_process_group_ranks(dp_mesh.get_group())
-                )
-                for parameter in parameters[1:]:
+                for parameter in parameters:
                     parameter_mesh = parameter.device_mesh
-                    if (
-                        parameter_mesh.ndim != 1
-                        or tuple(
-                            torch.distributed.get_process_group_ranks(parameter_mesh.get_group())
-                        )
-                        != expected_ranks
-                    ):
+                    if parameter_mesh.ndim != 1:
                         raise ValueError(
-                            "Each MFSDP v2 Muon optimizer instance requires all parameters "
-                            "to use the same one-dimensional data-parallel mesh."
+                            "MFSDP v2 Muon currently supports one-dimensional data-parallel "
+                            f"meshes, got mesh shape {tuple(parameter_mesh.mesh.shape)}."
                         )
 
                 optimizer = FsdpMuon(
                     groups,
                     inner_optimizer=optimizer,
-                    dp_mesh=dp_mesh,
                     max_params_per_owner_chunk=config.muon_max_params_per_owner_chunk,
                 )
                 optimizer = FullyShardedOptimizer(

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -848,7 +848,21 @@ def _get_megatron_emerging_optimizer(
     for group in all_param_groups:
         opt_name = group.get('optimizer', eopt_name)
         is_expert = group['is_expert_parallel'] and not use_layer_wise
-        grouped_param_groups[(opt_name, is_expert)].append(group)
+        if is_mfsdp_v2 and opt_name == eopt_name:
+            params_by_mesh = defaultdict(list)
+            for parameter in group['params']:
+                parameter_mesh = parameter.device_mesh
+                mesh_ranks = tuple(
+                    torch.distributed.get_process_group_ranks(parameter_mesh.get_group())
+                )
+                params_by_mesh[mesh_ranks].append(parameter)
+
+            for mesh_ranks, parameters in params_by_mesh.items():
+                mesh_group = group.copy()
+                mesh_group['params'] = parameters
+                grouped_param_groups[(opt_name, is_expert, mesh_ranks)].append(mesh_group)
+        else:
+            grouped_param_groups[(opt_name, is_expert, None)].append(group)
 
     # Set up DistOpt process groups + filtered buffers once, only if we'll
     # construct a DistributedOptimizer for non-Muon groups in layer-wise mode.
@@ -876,7 +890,7 @@ def _get_megatron_emerging_optimizer(
         # whose optimizer is not the primary emerging optimizer (stored in ``eopt_name``,
         # e.g., Muon). This includes scalar optimizers like Adam or Lion.
         not (opt_name == eopt_name and opt_name in _EMERGING_OPTIMIZERS)
-        for (opt_name, _), groups in grouped_param_groups.items()
+        for (opt_name, _, _), groups in grouped_param_groups.items()
         if groups
     ):
         # ``setup_process_groups_for_optimizer`` rejects Gloo groups whenever
@@ -908,7 +922,7 @@ def _get_megatron_emerging_optimizer(
     # and the rest go through DistOpt's standard byte-level shard machinery.
     results = []
     layer_wise_base_results = []  # (raw_optimizer, init_state_fn) feeding LayerWise.
-    for (opt_name, is_expert), groups in grouped_param_groups.items():
+    for (opt_name, is_expert, _mesh_ranks), groups in grouped_param_groups.items():
         if not groups:
             continue
 

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -967,7 +967,12 @@ def _get_megatron_emerging_optimizer(
                             "to use the same one-dimensional data-parallel mesh."
                         )
 
-                optimizer = FsdpMuon(groups, inner_optimizer=optimizer, dp_mesh=dp_mesh)
+                optimizer = FsdpMuon(
+                    groups,
+                    inner_optimizer=optimizer,
+                    dp_mesh=dp_mesh,
+                    max_params_per_owner_chunk=config.muon_max_params_per_owner_chunk,
+                )
                 optimizer = FullyShardedOptimizer(
                     optimizer, config, None, init_state_fn, model_chunks=model_chunks
                 )

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -850,20 +850,10 @@ def _get_megatron_emerging_optimizer(
         opt_name = group.get('optimizer', eopt_name)
         is_expert = group['is_expert_parallel'] and not use_layer_wise
         if is_mfsdp_v2 and opt_name == eopt_name:
-            params_by_mesh = defaultdict(list)
-            for parameter in group['params']:
-                parameter_mesh = parameter.device_mesh
-                mesh_ranks = tuple(
-                    torch.distributed.get_process_group_ranks(parameter_mesh.get_group())
-                )
-                params_by_mesh[mesh_ranks].append(parameter)
-
-            for parameters in params_by_mesh.values():
-                mesh_group = group.copy()
-                mesh_group['params'] = parameters
-                grouped_param_groups[(opt_name, False, None)].append(mesh_group)
-        else:
-            grouped_param_groups[(opt_name, is_expert, None)].append(group)
+            # Use one mixed dense/expert Muon bucket; each parameter retains its own
+            # expert metadata and MFSDP communication group.
+            is_expert = False
+        grouped_param_groups[(opt_name, is_expert, None)].append(group)
 
     # Set up DistOpt process groups + filtered buffers once, only if we'll
     # construct a DistributedOptimizer for non-Muon groups in layer-wise mode.
@@ -944,14 +934,6 @@ def _get_megatron_emerging_optimizer(
                 parameters = [parameter for group in groups for parameter in group['params']]
                 if not parameters:
                     raise RuntimeError("MFSDP v2 Muon received no parameters on this rank.")
-
-                for parameter in parameters:
-                    parameter_mesh = parameter.device_mesh
-                    if parameter_mesh.ndim != 1:
-                        raise ValueError(
-                            "MFSDP v2 Muon currently supports one-dimensional data-parallel "
-                            f"meshes, got mesh shape {tuple(parameter_mesh.mesh.shape)}."
-                        )
 
                 optimizer = FsdpMuon(
                     groups,

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -50,6 +50,12 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
     MFSDP-specific storage operations explicit.
     """
 
+    # ChainedOptimizer's combined gradient-statistics path requires every DTensor
+    # to use the same device mesh. MFSDP needs the per-optimizer implementation
+    # below so dense and expert parameters on different meshes are counted
+    # correctly, even when their final reduction process group is the same.
+    requires_individual_grad_stats = True
+
     @override
     def __init__(
         self,

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1787,6 +1787,11 @@ class ChainedOptimizer(MegatronOptimizer):
 
     def grads_states_parallel_group_is_shared(self):
         """Check if all optimizers share the same gradient statistics parallel group."""
+        if any(
+            getattr(optimizer, 'requires_individual_grad_stats', False)
+            for optimizer in self.chained_optimizers
+        ):
+            return False
         reference_group = self.chained_optimizers[0].get_grad_stats_parallel_group()
         return all(
             optimizer.get_grad_stats_parallel_group() == reference_group

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -279,6 +279,10 @@ class OptimizerConfig:
     muon_num_ns_steps: int = 5
     """The number of iteration steps to use in the Newton-Schulz iteration."""
 
+    muon_dp_subgroup_size: int | None = None
+    """Maximum number of contiguous DP ranks across which one parameter may be sharded for
+    MFSDP v2 Muon. None uses the full DP group."""
+
     muon_tp_mode: str = "duplicated"
     """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes
     each shard independently, which makes the update rule depend on the parallelism config;

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -280,12 +280,12 @@ class OptimizerConfig:
     """The number of iteration steps to use in the Newton-Schulz iteration."""
 
     muon_dp_subgroup_size: int | None = None
-    """Maximum number of contiguous DP ranks across which one parameter may be sharded for
+    """Maximum number of same-node DP ranks across which one parameter may be sharded for
     MFSDP v2 Muon. None uses the full DP group."""
 
-    muon_max_params_per_owner_chunk: int | None = 4
+    muon_max_params_per_owner_chunk: int | None = 16
     """Maximum number of parameters in an MFSDP v2 Muon owner-communication chunk.
-    Defaults to 4; None places every compatible parameter in one chunk."""
+    Defaults to 16; None places every compatible parameter in one chunk."""
 
     muon_tp_mode: str = "duplicated"
     """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -283,6 +283,10 @@ class OptimizerConfig:
     """Maximum number of contiguous DP ranks across which one parameter may be sharded for
     MFSDP v2 Muon. None uses the full DP group."""
 
+    muon_max_params_per_owner_chunk: int | None = 16
+    """Maximum number of parameters in an MFSDP v2 Muon owner-communication chunk.
+    Defaults to 16; None places every compatible parameter in one chunk."""
+
     muon_tp_mode: str = "duplicated"
     """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes
     each shard independently, which makes the update rule depend on the parallelism config;

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -283,9 +283,9 @@ class OptimizerConfig:
     """Maximum number of contiguous DP ranks across which one parameter may be sharded for
     MFSDP v2 Muon. None uses the full DP group."""
 
-    muon_max_params_per_owner_chunk: int | None = 16
+    muon_max_params_per_owner_chunk: int | None = 4
     """Maximum number of parameters in an MFSDP v2 Muon owner-communication chunk.
-    Defaults to 16; None places every compatible parameter in one chunk."""
+    Defaults to 4; None places every compatible parameter in one chunk."""
 
     muon_tp_mode: str = "duplicated"
     """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2762,6 +2762,10 @@ def _add_regularization_args(parser):
                        'Validated at optimizer creation time.')
     group.add_argument('--muon-num-ns-steps', type=int, default=5,
                        help='Number of Newton-Schulz steps for Muon optimizer')
+    group.add_argument('--muon-dp-subgroup-size', type=int, default=None,
+                       help='Maximum number of contiguous DP ranks across which one parameter '
+                       'may be sharded by Megatron-FSDP v2 Muon. The DP size must be divisible '
+                       'by this value. Defaults to the full DP group.')
     group.add_argument('--muon-tp-mode', type=str, default='duplicated',
                        choices=['blockwise', 'duplicated', 'distributed', 'auto'],
                        help='How to perform NS calculation for tensor model parallel weights. '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1156,8 +1156,9 @@ def validate_args(args, defaults={}):
                 "GroupedTensor param buffers."
             )
         # Optimizer compatibility check.
-        assert args.optimizer in ('sgd', 'adam'), \
-            f"Megatron-FSDP does not support the {args.optimizer} optimizer yet."
+        assert args.optimizer in ('sgd', 'adam') or (
+            args.optimizer == 'muon' and args.megatron_fsdp_version == 2
+        ), f"Megatron-FSDP does not support the {args.optimizer} optimizer yet."
 
         if (
             args.data_parallel_sharding_strategy in ["optim_grads_params", "optim_grads"]
@@ -1791,7 +1792,7 @@ def validate_args(args, defaults={}):
 
     # emerging optimizer check
     args.use_layer_wise_distributed_optimizer = False
-    if args.optimizer not in ('sgd', 'adam'):
+    if args.optimizer not in ('sgd', 'adam') and not args.use_megatron_fsdp:
         if args.optimizer == 'dist_muon':
             warn_rank_0(
                 "optimizer='dist_muon' is deprecated. "
@@ -1804,9 +1805,12 @@ def validate_args(args, defaults={}):
             args.use_layer_wise_distributed_optimizer = True
             args.use_distributed_optimizer = False
 
-        assert not args.use_torch_fsdp2, "Emerging optimizer does not support Torch-FSDP2 for now."
-        assert not args.use_megatron_fsdp, "Emerging optimizer does not support Megatron-FSDP for now."
-        assert args.ckpt_format in ["torch", "torch_dist"], "Emerging optimizer supports torch and torch_dist checkpoint format."
+        assert not args.use_torch_fsdp2, (
+            "Emerging optimizer does not support Torch-FSDP2 for now."
+        )
+        assert args.ckpt_format in ["torch", "torch_dist"], (
+            "Emerging optimizer supports torch and torch_dist checkpoint format."
+        )
 
     assert not (
         args.use_layer_wise_distributed_optimizer and args.moe_single_grouped_weight

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2766,9 +2766,9 @@ def _add_regularization_args(parser):
                        help='Maximum number of contiguous DP ranks across which one parameter '
                        'may be sharded by Megatron-FSDP v2 Muon. The DP size must be divisible '
                        'by this value. Defaults to the full DP group.')
-    group.add_argument('--muon-max-params-per-owner-chunk', type=int, default=16,
+    group.add_argument('--muon-max-params-per-owner-chunk', type=int, default=4,
                        help='Maximum number of parameters in each Megatron-FSDP v2 Muon owner '
-                       'communication chunk. Defaults to 16 parameters per chunk.')
+                       'communication chunk. Defaults to 4 parameters per chunk.')
     group.add_argument('--muon-tp-mode', type=str, default='duplicated',
                        choices=['blockwise', 'duplicated', 'distributed', 'auto'],
                        help='How to perform NS calculation for tensor model parallel weights. '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2763,12 +2763,11 @@ def _add_regularization_args(parser):
     group.add_argument('--muon-num-ns-steps', type=int, default=5,
                        help='Number of Newton-Schulz steps for Muon optimizer')
     group.add_argument('--muon-dp-subgroup-size', type=int, default=None,
-                       help='Maximum number of contiguous DP ranks across which one parameter '
-                       'may be sharded by Megatron-FSDP v2 Muon. The DP size must be divisible '
-                       'by this value. Defaults to the full DP group.')
-    group.add_argument('--muon-max-params-per-owner-chunk', type=int, default=4,
+                       help='Maximum number of same-node DP ranks across which one parameter may be '
+                       'sharded by Megatron-FSDP v2 Muon. Defaults to the full DP group.')
+    group.add_argument('--muon-max-params-per-owner-chunk', type=int, default=16,
                        help='Maximum number of parameters in each Megatron-FSDP v2 Muon owner '
-                       'communication chunk. Defaults to 4 parameters per chunk.')
+                       'communication chunk. Defaults to 16 parameters per chunk.')
     group.add_argument('--muon-tp-mode', type=str, default='duplicated',
                        choices=['blockwise', 'duplicated', 'distributed', 'auto'],
                        help='How to perform NS calculation for tensor model parallel weights. '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2766,6 +2766,9 @@ def _add_regularization_args(parser):
                        help='Maximum number of contiguous DP ranks across which one parameter '
                        'may be sharded by Megatron-FSDP v2 Muon. The DP size must be divisible '
                        'by this value. Defaults to the full DP group.')
+    group.add_argument('--muon-max-params-per-owner-chunk', type=int, default=16,
+                       help='Maximum number of parameters in each Megatron-FSDP v2 Muon owner '
+                       'communication chunk. Defaults to 16 parameters per chunk.')
     group.add_argument('--muon-tp-mode', type=str, default='duplicated',
                        choices=['blockwise', 'duplicated', 'distributed', 'auto'],
                        help='How to perform NS calculation for tensor model parallel weights. '

--- a/tests/unit_tests/distributed/mfsdp_v2/test_orthogonalized_optimizer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_orthogonalized_optimizer.py
@@ -1,0 +1,1126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Unit tests for the M-FSDPv2 owner-compute orthogonalized (Muon) optimizer.
+
+The pure-function tests (shard-plan math, owner assignment, pack/unpack) run on CPU without a
+process group. The optimizer-step numerics tests run under `torchrun` and compare the sharded FSDP
+optimizer against a single-rank reference using the same Newton-Schulz kernel (bitwise) and against
+`torch.optim.Muon` (tolerance, since the kernels normalize differently). """
+
+import contextlib
+import types
+import weakref
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    Placements,
+    fully_shard,
+)
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.orthogonalized_optimizer import (
+    FsdpMuon,
+    Muon,
+    _require_emerging_optimizers,
+)
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
+    _CONTAINING_PARAMETER_GROUP_ATTR,
+)
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
+    ShardPlan,
+    assign_owner_work,
+    compute_shard_plan,
+    pack_owner_work,
+    pack_update_shards,
+    reconstruct_full_tensor,
+    unpack_update_shards,
+)
+
+try:
+    from tests.unit_tests.distributed.mfsdp_v2.conftest import DistributedSetup
+except Exception:  # pragma: no cover
+    import dataclasses
+
+    @dataclasses.dataclass(frozen=True)
+    class DistributedSetup:
+        rank: int
+        world_size: int
+        device: torch.device
+
+
+_require_emerging_optimizers()
+
+
+@pytest.fixture(scope="function")
+def distributed_setup():
+    """Same as the bucket conftest fixture but pins to `local_rank % device_count`.
+
+    The shared `distributed_setup` does `set_device(local_rank)`, which is
+    correct when every rank has its own GPU (the CI configuration). On a
+    single-GPU dev box running multiple ranks, `local_rank` exceeds the
+    device count and `set_device` raises. Pinning modulo the device count is
+    identical to the suite fixture when `nproc <= device_count` (the CI case)
+    and lets these tests run on one GPU with `NCCL_MULTI_RANK_GPU_ENABLE=1`.
+    """
+    import os
+    from collections.abc import Iterator
+
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Not running under torchrun. Use torchrun to run this test file.")
+    # Clear the suite-wide NCCL defaults (set in the top-level conftest.py) before
+    # init_device_mesh initializes NCCL communicators, matching the bucket
+    # conftest fixture. With NCCL_MAX_NCHANNELS=1, multiple concurrent
+    # collectives (FSDP reduce-scatter + the owner all-to-all) on several ranks
+    # sharing one GPU exhaust the single NCCL channel.
+    os.environ.pop("NCCL_MAX_NCHANNELS", None)
+    os.environ.pop("NCCL_NVLS_ENABLE", None)
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank % torch.cuda.device_count())
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+    else:
+        device = torch.device("cpu")
+    yield DistributedSetup(rank=rank, world_size=world_size, device=device)
+    if dist.is_initialized():
+        if device.type == "cuda":
+            dist.barrier(device_ids=[device.index])
+        else:
+            dist.barrier()
+
+
+# ---------------------------------------------------------------------------
+# Pure CPU tests: grouping
+# ---------------------------------------------------------------------------
+
+
+def test_group_updates_separates_mixed_dtypes():
+    """`_group_updates` groups shards by (device, dtype), separating mixed dtypes."""
+    optimizer = object.__new__(FsdpMuon)
+    cpu = torch.device("cpu")
+    params = [
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),  # 0: fp32
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.bfloat16, device=cpu)),  # 1: bf16
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),  # 2: fp32
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.bfloat16, device=cpu)),  # 3: bf16
+    ]
+    shards = [p.detach() for p in params]
+    chunks = optimizer._group_updates(params, shards)
+
+    # Two chunks: one for fp32, one for bf16.
+    assert len(chunks) == 2
+    # Every chunk is homogeneous in dtype.
+    for chunk in chunks:
+        assert len({shards[i].dtype for i in chunk}) == 1
+    # All indices are covered exactly once.
+    assert sorted(i for chunk in chunks for i in chunk) == [0, 1, 2, 3]
+    # fp32 shards (0, 2) are in a different chunk than bf16 shards (1, 3).
+    chunk_of_0 = next(c for c in chunks if 0 in c)
+    chunk_of_1 = next(c for c in chunks if 1 in c)
+    assert chunk_of_0 is not chunk_of_1
+    assert 2 in chunk_of_0
+    assert 3 in chunk_of_1
+
+
+class _MockMesh:
+    """Mock `DeviceMesh` whose `get_group()` returns a fixed `ProcessGroup`."""
+
+    def __init__(self, pg: object) -> None:
+        self._pg = pg
+
+    def get_group(self) -> object:
+        return self._pg
+
+
+class _MockParamGroup:
+    """Mock `FsdpParameterGroup` (supports `weakref`) with a `mesh` attribute."""
+
+    def __init__(self, mesh: _MockMesh) -> None:
+        self.mesh = mesh
+
+
+def test_group_updates_separates_collective_groups():
+    """`_group_updates` separates params from different collective groups.
+
+    Even when all params share the same dtype and device, params whose
+    `FsdpParameterGroup` resolves to a different `ProcessGroup` (via
+    `group.mesh.get_group()`) must land in separate chunks so that each
+    chunk's P2P communication uses a single collective group.
+    """
+    optimizer = object.__new__(FsdpMuon)
+    cpu = torch.device("cpu")
+    # Mock ProcessGroups (the actual collective groups) and FsdpParameterGroups
+    # whose `mesh.get_group()` returns them.
+    pg_a = object()  # mock ProcessGroup A
+    pg_b = object()  # mock ProcessGroup B
+    group_a = _MockParamGroup(_MockMesh(pg_a))
+    group_b = _MockParamGroup(_MockMesh(pg_b))
+    params = [
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),
+        nn.Parameter(torch.zeros(2, 2, dtype=torch.float32, device=cpu)),
+    ]
+    # 0, 1 -> group_a;  2, 3 -> group_b  (all fp32, same device)
+    for p, g in zip(params, [group_a, group_a, group_b, group_b]):
+        setattr(p, _CONTAINING_PARAMETER_GROUP_ATTR, weakref.ref(g))
+    shards = [p.detach() for p in params]
+    chunks = optimizer._group_updates(params, shards)
+
+    # Two chunks: one per collective group.
+    assert len(chunks) == 2
+    chunk_of_0 = next(c for c in chunks if 0 in c)
+    chunk_of_2 = next(c for c in chunks if 2 in c)
+    assert chunk_of_0 is not chunk_of_2
+    assert 1 in chunk_of_0
+    assert 3 in chunk_of_2
+
+
+# ---------------------------------------------------------------------------
+# Distributed tests: full optimizer step numerics
+# ---------------------------------------------------------------------------
+
+
+def _flat_placements() -> Placements:
+    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+class TinyModel(nn.Module):
+    """Two separately shardable 2D linears (no bias, so all params are matrix params)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16, bias=False)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(16, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+class MixedDtypeModel(nn.Module):
+    """Two 2D linears with different dtypes (fp32 + bf16) to exercise mixed-dtype grouping."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16, bias=False)  # fp32
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(16, 4, bias=False).to(torch.bfloat16)  # bf16
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.fc1(x))
+        return self.fc2(x.to(self.fc2.weight.dtype))
+
+
+class BoundaryModel(nn.Module):
+    """A single 2D linear whose weight is sized to straddle the DP rank boundary.
+
+    With `world_size` ranks and the all-`Flat` layout, the weight
+    `(rows, in_features)` (`rows` divisible by `world_size`) occupies the
+    whole DBuffer, so every rank owns a contiguous row slice and the parameter
+    is a boundary parameter for `world_size > 1`.
+    """
+
+    def __init__(self, rows: int, in_features: int) -> None:
+        super().__init__()
+        self.fc = nn.Linear(in_features, rows, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+
+class Bias1d(nn.Module):
+    """A single 1D parameter in its own module so it can be Flat-sharded separately.
+
+    Sharding it alone (its own FSDP group) makes it span all DP ranks with equal
+    shards, so it is a boundary parameter that is handled by the non-matrix
+    momentum-SGD fallback (no orthogonalization, no owner-compute P2P).
+    """
+
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(n))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.bias
+
+
+class MixedModel(nn.Module):
+    """A 2D linear (matrix path) and a 1D bias (non-matrix path), separately sharded.
+
+    `fc.weight` (4, 8) is a 2D boundary parameter updated by the owner-compute
+    P2P + Newton-Schulz path; `bias` (4,) is a 1D boundary parameter updated by
+    the plain momentum-SGD fallback. They are Flat-sharded in separate FSDP groups
+    (one parameter each) so each spans all DP ranks with equal shards.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = nn.Linear(8, 4, bias=False)
+        self.relu = nn.ReLU()
+        self.bias_mod = Bias1d(4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.bias_mod(self.relu(self.fc(x)))
+
+
+class NonMatrixModel(nn.Module):
+    """A model whose only parameter is 1D (a bias), exercising the non-matrix path.
+
+    `Bias1d` has a single 1D parameter, Flat-sharded in its own FSDP group so
+    it spans all DP ranks with equal shards (a boundary parameter handled by
+    the plain momentum-SGD fallback, no orthogonalization, no owner-compute P2P).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bias_mod = Bias1d(8)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.bias_mod(x)
+
+
+def _make_fsdp_model(device: torch.device, mesh, seed: int = 1234) -> TinyModel:
+    torch.manual_seed(seed)
+    model = TinyModel().to(device)
+    fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
+    fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    return model
+
+
+def test_compute_orthogonalization_inputs_matches_reference(distributed_setup):
+    """Local pre-NS (weight decay + momentum + Nesterov) matches a plain reference."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip("Needs >=2 ranks.")
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = _make_fsdp_model(device, mesh)
+    x = torch.randn(4, 8, device=device)
+
+    inner_optimizer = Muon(
+        model.parameters(),
+        lr=0.05,
+        momentum=0.9,
+        weight_decay=0.0,
+        nesterov=True,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    optimizer = FsdpMuon(
+        model.parameters(),
+        inner_optimizer=inner_optimizer,
+        dp_mesh=mesh,
+        use_owner_comm_stream=False,
+    )
+    optimizer.zero_grad(set_to_none=True)
+    model(x).sum().backward()
+
+    param = model.fc1.weight
+    optimizer._init_group(optimizer.param_groups[0], skip_non_grad_params=False)
+    pre_ns = optimizer._compute_orthogonalization_inputs(
+        param, param.grad, optimizer.param_groups[0], optimizer.param_groups[0]["lr"]
+    )
+
+    # Reference: same math on the local shard with a plain Muon optimizer state.
+    ref_param = nn.Parameter(param.to_local().clone())
+    ref_opt = Muon(
+        [ref_param],
+        lr=0.05,
+        momentum=0.9,
+        weight_decay=0.0,
+        nesterov=True,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+    ref_param.grad = param.grad.to_local().clone()
+    with torch.no_grad():
+        ref_opt._init_group(ref_opt.param_groups[0])
+        ref_mom = ref_opt.state[ref_param]["momentum_buffer"]
+        ref_grad = ref_param.grad.to(ref_mom.dtype)
+        ref_opt._apply_weight_decay_inplace(ref_param, ref_grad, 0.05, 0.0)
+        ref_mom.lerp_(ref_grad, 1 - 0.9)
+        ref_pre = ref_grad.lerp(ref_mom, 0.9)
+    torch.testing.assert_close(pre_ns, ref_pre, atol=0, rtol=0)
+
+
+def test_step_bitwise_matches_single_rank_reference(distributed_setup):
+    """The sharded FSDP Muon step must match a single-rank Muon with the same kernel."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    sharded = _make_fsdp_model(device, mesh)
+    torch.manual_seed(1234)
+    baseline = TinyModel().to(device)
+    # Copy full weights from the sharded model's gathered (pre-shard) initial state.
+    for name, shard_param in (
+        ("fc1.weight", sharded.fc1.weight),
+        ("fc2.weight", sharded.fc2.weight),
+    ):
+        full = _gather_full_param(shard_param, mesh, world_size)
+        with torch.no_grad():
+            getattr(baseline, name.split(".")[0]).weight.copy_(full)
+
+    lr = 0.05
+    momentum = 0.9
+    nesterov = True
+    weight_decay = 0.0
+    inner_optimizer = Muon(
+        sharded.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        sharded.parameters(),
+        inner_optimizer=inner_optimizer,
+        dp_mesh=mesh,
+        use_owner_comm_stream=False,
+    )
+    base_opt = Muon(
+        baseline.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+
+    x = torch.randn(4, 8, device=device)
+    for step in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        base_opt.zero_grad(set_to_none=True)
+        sharded(x).sum().backward()
+        baseline(x).sum().backward()
+        sharded_opt.step()
+        base_opt.step()
+
+    for name, shard_param in (
+        ("fc1.weight", sharded.fc1.weight),
+        ("fc2.weight", sharded.fc2.weight),
+    ):
+        full = _gather_full_param(shard_param, mesh, world_size)
+        expected = getattr(baseline, name.split(".")[0]).weight
+        torch.testing.assert_close(full, expected, atol=0, rtol=0)
+
+
+def test_step_explicit_boundary_param_bitwise_matches_reference(distributed_setup):
+    """A parameter explicitly straddling the DP boundary is handled correctly.
+
+    Builds a single-linear model whose weight is a boundary parameter on every
+    rank, asserts the shard plan classifies it as boundary, then verifies the
+    FSDP Muon step matches a single-rank Muon reference bitwise. This guards the
+    owner-gather -> fully-local -> finish restructure and the `pre_ns` argument
+    to `_orthogonalize_with_precision` on the boundary path.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    rows = 16
+    in_features = 8
+    if rows % world_size != 0:
+        pytest.skip(f"rows {rows} not divisible by world_size {world_size}.")
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    torch.manual_seed(1234)
+    model = BoundaryModel(rows, in_features).to(device)
+    fully_shard(model.fc, mesh=mesh, placements=_flat_placements())
+
+    # Assert the single parameter is a boundary parameter on this rank.
+    plan = compute_shard_plan(
+        torch.Size((rows, in_features)),
+        tensor_flat_offset=0,
+        rank_flat_shard_size=(rows * in_features) // world_size,
+        world_size=world_size,
+    )
+    assert plan.is_boundary(), "BoundaryModel weight must straddle the DP boundary."
+
+    # Baseline: single-rank model with the same initial full weights.
+    torch.manual_seed(1234)
+    baseline = BoundaryModel(rows, in_features).to(device)
+    full = _gather_full_param(model.fc.weight, mesh, world_size)
+    with torch.no_grad():
+        baseline.fc.weight.copy_(full)
+
+    lr, momentum, nesterov, weight_decay = 0.05, 0.9, True, 0.0
+    inner = Muon(
+        model.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        model.parameters(), inner_optimizer=inner, dp_mesh=mesh, use_owner_comm_stream=False
+    )
+    base_opt = Muon(
+        baseline.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+
+    x = torch.randn(4, in_features, device=device)
+    for _ in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        base_opt.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+        baseline(x).sum().backward()
+        sharded_opt.step()
+        base_opt.step()
+
+    full = _gather_full_param(model.fc.weight, mesh, world_size)
+    torch.testing.assert_close(full, baseline.fc.weight, atol=0, rtol=0)
+
+
+def test_step_reconstruct_full_param_bitwise_matches_reference(distributed_setup):
+    """With `reconstruct_full_param=True`, the owner gathers weight shards too.
+
+    Same boundary-param setup as `test_step_explicit_boundary_param_bitwise_matches_reference`,
+    but the optimizer is constructed with `reconstruct_full_param=True` so the owner
+    performs a second P2P round to gather each rank's local weight shard,
+    reconstructs the full parameter, and passes it as the `param` argument to
+    `orthogonalize`. The result must still match the single-rank reference
+    bitwise, guarding the optional full-parameter reconstruction path.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    rows = 16
+    in_features = 8
+    if rows % world_size != 0:
+        pytest.skip(f"rows {rows} not divisible by world_size {world_size}.")
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    torch.manual_seed(1234)
+    model = BoundaryModel(rows, in_features).to(device)
+    fully_shard(model.fc, mesh=mesh, placements=_flat_placements())
+
+    plan = compute_shard_plan(
+        torch.Size((rows, in_features)),
+        tensor_flat_offset=0,
+        rank_flat_shard_size=(rows * in_features) // world_size,
+        world_size=world_size,
+    )
+    assert plan.is_boundary(), "BoundaryModel weight must straddle the DP boundary."
+
+    torch.manual_seed(1234)
+    baseline = BoundaryModel(rows, in_features).to(device)
+    full = _gather_full_param(model.fc.weight, mesh, world_size)
+    with torch.no_grad():
+        baseline.fc.weight.copy_(full)
+
+    lr, momentum, nesterov, weight_decay = 0.05, 0.9, True, 0.0
+    inner = Muon(
+        model.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        model.parameters(),
+        inner_optimizer=inner,
+        dp_mesh=mesh,
+        use_owner_comm_stream=False,
+        reconstruct_full_param=True,
+    )
+    base_opt = Muon(
+        baseline.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+
+    x = torch.randn(4, in_features, device=device)
+    for _ in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        base_opt.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+        baseline(x).sum().backward()
+        sharded_opt.step()
+        base_opt.step()
+
+    full = _gather_full_param(model.fc.weight, mesh, world_size)
+    torch.testing.assert_close(full, baseline.fc.weight, atol=0, rtol=0)
+
+
+def test_step_non_matrix_param_matches_reference(distributed_setup):
+    """A 1D (non-matrix) parameter is updated by the momentum-SGD fallback.
+
+    `NonMatrixModel` has a single 1D `Bias1d` parameter, Flat-sharded in its own
+    FSDP group so it spans all DP ranks with equal shards (a boundary
+    parameter). It is classified `non_matrix` and updated by
+    `_step_non_matrix` (plain momentum-SGD, no orthogonalization, no
+    owner-compute P2P). This also exercises the `if not matrix_indices:
+    continue` edge and the `_owner_comm_needed=False` path (no boundary
+    2D params -> no `new_group`). The wrapper's momentum-SGD uses the Muon
+    EMA (`mom.lerp_(grad, 1-momentum)`, matching the inner
+    `OrthogonalizedOptimizer`), which differs from `torch.optim.SGD`, so the
+    reference replicates `_step_non_matrix` by hand (nesterov disabled) and
+    the result must match bitwise.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    torch.manual_seed(1234)
+    model = NonMatrixModel().to(device)
+    fully_shard(model.bias_mod, mesh=mesh, placements=_flat_placements())
+
+    torch.manual_seed(1234)
+    baseline = NonMatrixModel().to(device)
+    full = _gather_full_1d_param(model.bias_mod.bias, mesh, world_size)
+    with torch.no_grad():
+        baseline.bias_mod.bias.data.copy_(full)
+
+    lr, momentum, weight_decay = 0.05, 0.9, 0.0
+    inner = Muon(
+        model.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=False,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        model.parameters(), inner_optimizer=inner, dp_mesh=mesh, use_owner_comm_stream=False
+    )
+
+    # Hand-coded reference replicating `_step_non_matrix` (Muon EMA, no
+    # orthogonalization, no scale, weight_decay=0, nesterov=False, no pre/post hooks).
+    ref_state: dict = {}
+
+    def ref_step(m: NonMatrixModel, x: torch.Tensor) -> None:
+        for p in m.parameters():
+            p.grad = None
+        m(x).sum().backward()
+        for p in m.parameters():
+            if p.grad is None:
+                continue
+            st = ref_state.setdefault(p, {})
+            if "momentum_buffer" not in st:
+                st["momentum_buffer"] = torch.zeros_like(p.data)
+            mom = st["momentum_buffer"]
+            grad = p.grad
+            if grad.dtype != mom.dtype:
+                grad = grad.to(dtype=mom.dtype)
+            mom.lerp_(grad, 1 - momentum)
+            update = mom  # non-nesterov
+            with torch.no_grad():
+                p.data.add_(update, alpha=-lr)
+
+    x = torch.randn(4, 8, device=device)
+    for _ in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+        sharded_opt.step()
+        ref_step(baseline, x)
+    full = _gather_full_1d_param(model.bias_mod.bias, mesh, world_size)
+    torch.testing.assert_close(full, baseline.bias_mod.bias.data, atol=0, rtol=0)
+
+
+def test_step_mixed_paths_matches_reference(distributed_setup):
+    """A model with both 2D (matrix) and 1D (non-matrix) boundary parameters.
+
+    `MixedModel` has a 2D `fc.weight` (boundary, updated by the owner-compute P2P + Newton-Schulz
+    path) and a 1D `bias` (boundary, updated by the momentum-SGD fallback). Both are
+    Flat-sharded in separate FSDP groups so each spans all DP ranks with equal
+    shards. The 2D result matches a single-rank `Muon` (orthogonalize) bitwise;
+    the 1D result matches a hand-coded Muon-EMA reference (nesterov disabled) bitwise.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    torch.manual_seed(1234)
+    model = MixedModel().to(device)
+    fully_shard(model.fc, mesh=mesh, placements=_flat_placements())
+    fully_shard(model.bias_mod, mesh=mesh, placements=_flat_placements())
+
+    torch.manual_seed(1234)
+    baseline = MixedModel().to(device)
+    full_w = _gather_full_param(model.fc.weight, mesh, world_size)
+    with torch.no_grad():
+        baseline.fc.weight.data.copy_(full_w)
+    full_b = _gather_full_1d_param(model.bias_mod.bias, mesh, world_size)
+    with torch.no_grad():
+        baseline.bias_mod.bias.data.copy_(full_b)
+
+    lr, momentum, weight_decay = 0.05, 0.9, 0.0
+    inner = Muon(
+        model.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=True,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        model.parameters(), inner_optimizer=inner, dp_mesh=mesh, use_owner_comm_stream=False
+    )
+    # Reference for the 2D `fc.weight`: a single-rank Muon (orthogonalize).
+    base_opt = Muon(
+        [baseline.fc.weight],
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=True,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+
+    # Hand-coded reference for the 1D `bias` (Muon EMA, no orthogonalization).
+    ref_state: dict = {}
+
+    def ref_bias_step(m: MixedModel, x: torch.Tensor) -> None:
+        for p in m.parameters():
+            p.grad = None
+        m(x).sum().backward()
+        base_opt.step()  # updates only `baseline.fc.weight` (the 2D param).
+        p = baseline.bias_mod.bias
+        st = ref_state.setdefault(p, {})
+        if "momentum_buffer" not in st:
+            st["momentum_buffer"] = torch.zeros_like(p.data)
+        mom = st["momentum_buffer"]
+        grad = p.grad
+        if grad.dtype != mom.dtype:
+            grad = grad.to(dtype=mom.dtype)
+        mom.lerp_(grad, 1 - momentum)
+        # Match `_step_non_matrix`'s Nesterov path (`self._inner.nesterov` is True here
+        # so the fallback uses `grad.lerp(mom, momentum)`, not `mom`).
+        update = grad.lerp(mom, momentum)
+        with torch.no_grad():
+            p.data.add_(update, alpha=-lr)
+
+    x = torch.randn(4, 8, device=device)
+    for _ in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+        sharded_opt.step()
+        ref_bias_step(baseline, x)
+
+    full_w = _gather_full_param(model.fc.weight, mesh, world_size)
+    torch.testing.assert_close(full_w, baseline.fc.weight, atol=0, rtol=0)
+    full_b = _gather_full_1d_param(model.bias_mod.bias, mesh, world_size)
+    torch.testing.assert_close(full_b, baseline.bias_mod.bias.data, atol=0, rtol=0)
+
+
+def test_step_losses_track_torch_muon(distributed_setup):
+    """The FSDP Muon step should track torch.optim.Muon over several steps.
+
+    The FSDP wrapper reuses the `emerging_optimizers` Newton-Schulz kernel,
+    which normalizes the orthogonalization input in FP32 and then drops to BF16,
+    whereas `torch.optim.Muon` casts to BF16 before normalizing. The two
+    kernels therefore produce slightly different updates, so losses track
+    within a tolerance that admits that kernel difference (empirically
+    `max|Δloss|` ~3e-2 / `max rel` ~1e-1 over many seeds). Bitwise numerics
+    against the same kernel are covered by `test_step_bitwise_matches_single_rank_reference`.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    sharded = _make_fsdp_model(device, mesh)
+    torch.manual_seed(1234)
+    baseline = TinyModel().to(device)
+    for name, shard_param in (
+        ("fc1.weight", sharded.fc1.weight),
+        ("fc2.weight", sharded.fc2.weight),
+    ):
+        full = _gather_full_param(shard_param, mesh, world_size)
+        with torch.no_grad():
+            getattr(baseline, name.split(".")[0]).weight.copy_(full)
+
+    inner_optimizer = Muon(
+        sharded.parameters(),
+        lr=0.05,
+        momentum=0.9,
+        weight_decay=0.0,
+        nesterov=True,
+        coefficient_type="simple",
+        num_ns_steps=5,
+        scale_mode="shape_scaling",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        sharded.parameters(),
+        inner_optimizer=inner_optimizer,
+        dp_mesh=mesh,
+        use_owner_comm_stream=False,
+    )
+    base_opt = torch.optim.Muon(
+        baseline.parameters(), lr=0.05, momentum=0.9, weight_decay=0.0, nesterov=True, ns_steps=5
+    )
+
+    x = torch.randn(4, 8, device=device)
+    sharded_losses, base_losses = [], []
+    for _ in range(5):
+        sharded_opt.zero_grad(set_to_none=True)
+        base_opt.zero_grad(set_to_none=True)
+        sharded_loss = sharded(x).sum()
+        base_loss = baseline(x).sum()
+        sharded_losses.append(sharded_loss.detach())
+        base_losses.append(base_loss.detach())
+        sharded_loss.backward()
+        base_loss.backward()
+        sharded_opt.step()
+        base_opt.step()
+
+    torch.testing.assert_close(
+        torch.stack(sharded_losses),
+        torch.stack(base_losses),
+        atol=5e-2,
+        rtol=2e-1,
+        msg="FSDP Muon losses did not track torch.optim.Muon within the kernel-difference tolerance.",
+    )
+
+
+def _make_mixed_dtype_fsdp_model(device: torch.device, mesh, seed: int = 1234):
+    """Sharded `MixedDtypeModel`: `fc1` in fp32, `fc2` in bf16, both Flat-sharded."""
+    torch.manual_seed(seed)
+    model = MixedDtypeModel().to(device)
+    fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
+    fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    return model
+
+
+def test_step_mixed_dtypes_bitwise_matches_reference(distributed_setup):
+    """The FSDP Muon step must handle a param group with mixed dtypes (fp32 + bf16).
+
+    Exercises the `_group_updates` chunking: boundary params of different dtypes
+    must be processed in separate boundary chunks (one `_finish_boundary_step`
+    call each) with matching P2P buffer metadata, and the result must match a
+    single-rank Muon reference.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2 or torch.cuda.device_count() < world_size:
+        pytest.skip(
+            "Needs >=2 ranks and >=1 GPU per rank; "
+            "a 1-GPU-multi-rank config cannot run the owner-compute P2P step."
+        )
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    sharded = _make_mixed_dtype_fsdp_model(device, mesh)
+    torch.manual_seed(1234)
+    baseline = MixedDtypeModel().to(device)
+    # Copy full weights from the sharded model's gathered (pre-shard) initial state.
+    for name, shard_param in (
+        ("fc1.weight", sharded.fc1.weight),
+        ("fc2.weight", sharded.fc2.weight),
+    ):
+        full = _gather_full_param(shard_param, mesh, world_size)
+        with torch.no_grad():
+            getattr(baseline, name.split(".")[0]).weight.copy_(full)
+
+    lr = 0.05
+    momentum = 0.9
+    nesterov = True
+    weight_decay = 0.0
+    inner_optimizer = Muon(
+        sharded.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+        use_syrk=False,
+    )
+    sharded_opt = FsdpMuon(
+        sharded.parameters(),
+        inner_optimizer=inner_optimizer,
+        dp_mesh=mesh,
+        use_owner_comm_stream=False,
+    )
+    base_opt = Muon(
+        baseline.parameters(),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        nesterov=nesterov,
+        coefficient_type="quintic",
+        num_ns_steps=5,
+        scale_mode="spectral",
+        fp32_matmul_prec="medium",
+    )
+
+    x = torch.randn(4, 8, device=device)
+    for step in range(3):
+        sharded_opt.zero_grad(set_to_none=True)
+        base_opt.zero_grad(set_to_none=True)
+        sharded(x).sum().backward()
+        baseline(x).sum().backward()
+        sharded_opt.step()
+        base_opt.step()
+
+    for name, shard_param in (
+        ("fc1.weight", sharded.fc1.weight),
+        ("fc2.weight", sharded.fc2.weight),
+    ):
+        full = _gather_full_param(shard_param, mesh, world_size)
+        expected = getattr(baseline, name.split(".")[0]).weight
+        torch.testing.assert_close(full, expected, atol=0, rtol=0)
+
+
+def _gather_full_param(param, mesh, world_size):
+    """All-gather a Flat-sharded 2D DTensor parameter into its full matrix."""
+    local = param.to_local().contiguous()
+    full_shape = tuple(param.shape)
+    row_size = full_shape[1]
+    parts = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(parts, local, group=mesh.get_group())
+    # Flat shards are contiguous rows in rank order; concatenate along dim 0.
+    return torch.cat([p.view(-1, row_size) if p.numel() else p for p in parts], dim=0)[
+        : full_shape[0]
+    ]
+
+
+def _gather_full_1d_param(param, mesh, world_size):
+    """All-gather a Flat-sharded 1D DTensor parameter into its full vector.
+
+    The parameter must be Flat-sharded in its own FSDP group so it spans all DP ranks
+    with equal shards; `dist.all_gather` requires equal-sized parts on every
+    rank and would deadlock on a fully-local 1D parameter (0-size shard on
+    some ranks).
+    """
+    local = param.to_local().contiguous()
+    parts = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(parts, local, group=mesh.get_group())
+    # Flat shards are contiguous elements in rank order; concatenate along dim 0.
+    return torch.cat(parts, dim=0)
+
+
+def test_owner_p2p_round_trip_multi_owner(distributed_setup):
+    """The owner gather + scatter P2P round-trips with multiple owners.
+
+    Exercises the multi-owner path that a 2-rank FSDP run cannot (owners on
+    different ranks, updates scattered to ranks that own neither parameter).
+    Uses synthetic shards and an identity "orthogonalization" so the test
+    isolates the communication (pack/send/reconstruct/pack/scatter/unpack) from
+    the Newton-Schulz kernel and from FSDP's forward/backward collectives.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 4:
+        pytest.skip("Needs >=4 ranks for a multi-owner P2P.")
+    mesh = init_device_mesh(device.type, (world_size,))
+
+    # Two boundary params, every rank owns a shard of each. Owners are balanced
+    # to ranks 0 and 1 by assign_owner_work.
+    plan0 = compute_shard_plan(torch.Size((8, 8)), 0, 16, world_size)  # 2 rows/rank
+    plan1 = compute_shard_plan(torch.Size((4, 16)), 0, 16, world_size)  # 1 row/rank
+    plans = [plan0, plan1]
+    owners = assign_owner_work(plans, num_ns_steps=5)
+    this_rank = mesh.get_local_rank()
+
+    full_pre0 = torch.arange(64, dtype=torch.float32, device=device).view(8, 8)
+    full_pre1 = torch.arange(64, dtype=torch.float32, device=device).view(4, 16) + 100.0
+    full_pres = [full_pre0, full_pre1]
+
+    local_shards = []
+    for plan, full in zip(plans, full_pres):
+        rs, rc = plan.rank_rows[this_rank]
+        local_shards.append(full[rs : rs + rc].clone())
+
+    optimizer = object.__new__(FsdpMuon)
+    optimizer.dp_mesh = mesh
+    optimizer.use_owner_comm_stream = False
+    optimizer._owner_comm_stream_cache = {}
+
+    gather_plan = pack_owner_work(
+        plans, owners, local_shards, world_size, this_rank, device=device, dtype=torch.float32
+    )
+    recv_buffers, works = optimizer._send_to_owner(gather_plan, device, dtype=torch.float32)
+    optimizer._wait_for_dist_buffer(works)
+
+    # Identity orthogonalization: the full update equals the gathered input.
+    full_updates: dict[int, torch.Tensor] = {}
+    for local_index in range(len(plans)):
+        if owners[local_index] != this_rank:
+            continue
+        plan = plans[local_index]
+        if plan.rank_row_count(this_rank) == 0:
+            continue
+        full = reconstruct_full_tensor(
+            local_index, plan, gather_plan, recv_buffers, owner_rank=this_rank
+        )
+        full_updates[local_index] = full
+
+    scatter_plan = pack_update_shards(
+        full_updates, plans, owners, world_size, this_rank, device=device, dtype=torch.float32
+    )
+    scatter_recv, scatter_works = optimizer._send_to_destination(
+        scatter_plan, device, dtype=torch.float32
+    )
+    optimizer._wait_for_dist_buffer(scatter_works)
+    received = unpack_update_shards(scatter_plan, scatter_recv)
+
+    for local_index, plan in enumerate(plans):
+        rs, rc = plan.rank_rows[this_rank]
+        expected = full_pres[local_index][rs : rs + rc]
+        if owners[local_index] == this_rank:
+            # Owner applies its own shard directly from the full update.
+            own = full_updates[local_index][rs : rs + rc]
+            torch.testing.assert_close(own, expected, atol=0, rtol=0)
+        else:
+            torch.testing.assert_close(received[local_index], expected, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Import guard tests
+# ---------------------------------------------------------------------------
+
+_EO_MOD = "megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.orthogonalized_optimizer"
+
+
+def test_import_guard_emerging_optimizers_available():
+    """When emerging_optimizers is installed, HAVE_EMERGING_OPTIMIZERS is True and the real classes are bound."""
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+        orthogonalized_optimizer as mod,
+    )
+
+    assert mod.HAVE_EMERGING_OPTIMIZERS is True
+    from emerging_optimizers.orthogonalized_optimizers import OrthogonalizedOptimizer as RealEO
+
+    assert mod.OrthogonalizedOptimizer is RealEO
+
+    from emerging_optimizers.orthogonalized_optimizers.muon import Muon as RealMuon
+
+    assert mod.Muon is RealMuon
+
+
+@contextlib.contextmanager
+def _simulate_no_emerging_optimizers():
+    """Reload `orthogonalized_optimizer` with `emerging_optimizers` blocked.
+
+    Saves and restores `sys.modules` / `sys.meta_path` so the rest of the
+    test session sees the real (installed) module.
+    """
+    import importlib
+    import sys
+
+    class _BlockEO:
+        @staticmethod
+        def find_spec(name, _path, _target=None):
+            if name == "emerging_optimizers" or name.startswith("emerging_optimizers."):
+                raise ModuleNotFoundError(name)
+            return None
+
+    saved_eo = {
+        k: sys.modules.pop(k)
+        for k in list(sys.modules)
+        if k == "emerging_optimizers" or k.startswith("emerging_optimizers.")
+    }
+    saved_mod = sys.modules.pop(_EO_MOD, None)
+
+    sys.meta_path.insert(0, _BlockEO)
+    try:
+        yield importlib.import_module(_EO_MOD)
+    finally:
+        sys.meta_path.pop(0)
+        sys.modules.update(saved_eo)
+        if saved_mod is not None:
+            sys.modules[_EO_MOD] = saved_mod
+        else:
+            sys.modules.pop(_EO_MOD, None)
+
+
+def test_import_guard_without_emerging_optimizers():
+    """When emerging_optimizers is not installed, the module falls back gracefully."""
+    with _simulate_no_emerging_optimizers() as mod:
+        assert mod.HAVE_EMERGING_OPTIMIZERS is False
+        assert mod.OrthogonalizedOptimizer is object
+        assert mod.Muon is object
+
+
+def test_import_guard_construction_error_without_emerging_optimizers():
+    """Constructing the optimizers without emerging_optimizers raises a helpful ModuleNotFoundError."""
+    with _simulate_no_emerging_optimizers() as mod:
+        with pytest.raises(ModuleNotFoundError, match="emerging-optimizers"):
+            mod.FsdpOrthogonalizedOptimizer([], object(), dp_mesh=None)
+        with pytest.raises(ModuleNotFoundError, match="emerging-optimizers"):
+            mod.FsdpMuon([], object(), dp_mesh=None)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_shard_plan.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Pure CPU tests for the shard-planning and owner-compute packing logic.
+
+These tests exercise `ShardPlan`, `compute_shard_plan`, `assign_owner_work`, `pack_owner_work`,
+`reconstruct_full_tensor`, `pack_update_shards`, and `unpack_update_shards` without a process group
+or any `torch.distributed` dependency. P2P communication is simulated in-process by `_simulate_p2p`.
+"""
+
+import pytest
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.shard_plan import (
+    OwnerGatherPlan,
+    OwnerScatterPlan,
+    ShardPlan,
+    assign_owner_work,
+    compute_shard_plan,
+    pack_owner_work,
+    pack_update_shards,
+    reconstruct_full_tensor,
+    unpack_update_shards,
+)
+
+# ---------------------------------------------------------------------------
+# Shard-plan math
+# ---------------------------------------------------------------------------
+
+
+def test_compute_shard_plan_even_split():
+    """A matrix exactly divisible by world_size splits evenly across ranks."""
+    plan = compute_shard_plan(
+        torch.Size((8, 4)), tensor_flat_offset=0, rank_flat_shard_size=16, world_size=2
+    )
+    assert plan.full_shape == torch.Size((8, 4))
+    assert plan.row_size == 4
+    assert plan.rank_rows == ((0, 4), (4, 4))
+    assert plan.shard_numel(0) == 16
+    assert plan.shard_numel(1) == 16
+
+
+def test_compute_shard_plan_boundary_param_split_across_ranks():
+    """A small matrix landing across a rank boundary is split unevenly."""
+    # 6 rows, 3 cols; each rank's flat shard is 9 elements (= 3 rows). rank0
+    # owns flat [0,9), rank1 owns [9,18). Tensor occupies [0,18) fully.
+    plan = compute_shard_plan(
+        torch.Size((6, 3)), tensor_flat_offset=0, rank_flat_shard_size=9, world_size=2
+    )
+    assert plan.rank_rows == ((0, 3), (3, 3))
+    assert plan.is_boundary()
+
+
+def test_compute_shard_plan_fully_local_param_on_one_rank():
+    """A matrix fully contained in one rank's flat shard is fully local."""
+    # 4 rows, 2 cols = 8 elements. rank0 shard = [0,12), rank1 = [12,24). Tensor
+    # at offset 0 with 8 elements fits entirely in rank0.
+    plan = compute_shard_plan(
+        torch.Size((4, 2)), tensor_flat_offset=0, rank_flat_shard_size=12, world_size=2
+    )
+    assert plan.rank_rows == ((0, 4), (0, 0))
+    assert not plan.is_boundary()
+    assert plan.owner_candidates() == (0,)
+
+
+def test_compute_shard_plan_empty_rank_has_zero_rows():
+    """A rank whose flat shard does not overlap the tensor owns zero rows."""
+    # Tensor offset 12 (entirely in rank1). rank0 gets (0,0).
+    plan = compute_shard_plan(
+        torch.Size((4, 3)), tensor_flat_offset=12, rank_flat_shard_size=12, world_size=2
+    )
+    assert plan.rank_rows == ((0, 0), (0, 4))
+    assert plan.is_boundary() is False
+    assert plan.owner_candidates() == (1,)
+
+
+# ---------------------------------------------------------------------------
+# Owner assignment balancing
+# ---------------------------------------------------------------------------
+
+
+def test_assign_owner_work_balances_by_cost():
+    """Owners are balanced so the cheapest eligible rank takes each parameter."""
+    # Two boundary params, all four ranks eligible for each.
+    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 4), (0, 4), (0, 4)), 8)  # cost 64*41
+    plan1 = ShardPlan(torch.Size((4, 4)), ((0, 2), (0, 2), (0, 2), (0, 2)), 4)  # cost 16*21
+    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
+    # Greedy min running cost: first param -> rank0 (cost 2624), second -> rank1 (cost 336).
+    assert owners == {0: 0, 1: 1}
+
+
+def test_assign_owner_work_only_eligible_ranks_can_own():
+    """A rank with an empty shard can never be the owner."""
+    # Only ranks 0 and 2 have shards for both params.
+    plan0 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    plan1 = ShardPlan(torch.Size((8, 8)), ((0, 4), (0, 0), (0, 4), (0, 0)), 8)
+    owners = assign_owner_work([plan0, plan1], num_ns_steps=5)
+    assert all(owners[i] in (0, 2) for i in owners)
+    # Two equal-cost params split across the two eligible ranks.
+    assert owners[0] != owners[1]
+
+
+def test_assign_owner_work_fully_local_owner_is_single_candidate():
+    """A fully local parameter is assigned to its single owning rank."""
+    plan = ShardPlan(torch.Size((4, 2)), ((0, 4), (0, 0)), 2)
+    owners = assign_owner_work([plan], num_ns_steps=3)
+    assert owners == {0: 0}
+
+
+# ---------------------------------------------------------------------------
+# Pack / reconstruct round trip (simulated P2P)
+# ---------------------------------------------------------------------------
+
+
+def _simulate_p2p(
+    per_rank_send_buffers: list[dict[int, torch.Tensor]], world_size: int
+) -> list[dict[int, torch.Tensor]]:
+    """Deliver per-owner send buffers to their owners (CPU sim of batch_isend_irecv).
+
+    Returns, per rank, the dict of `{src_rank: received_buffer}` it receives.
+    """
+    per_rank_recv: list[dict[int, torch.Tensor]] = [dict() for _ in range(world_size)]
+    for src in range(world_size):
+        for dst, buf in per_rank_send_buffers[src].items():
+            if buf.numel() == 0:
+                continue
+            per_rank_recv[dst][src] = buf.clone()
+    return per_rank_recv
+
+
+def test_pack_and_reconstruct_round_trip():
+    """Gathered + reconstructed pre-NS matches the concatenation of local shards."""
+    torch.manual_seed(0)
+    world_size = 2
+    # Two params, both boundary, shapes (6,3) and (4,2). Owners: param0->rank0, param1->rank1.
+    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)  # rank0: 3 rows, rank1: 3 rows
+    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)  # rank0: 2 rows, rank1: 2 rows
+    plans = [plan0, plan1]
+    owners = {0: 0, 1: 1}
+
+    # Build per-rank local shards as distinct values so reconstruction is checkable.
+    full_p0 = torch.arange(18, dtype=torch.float32).reshape(6, 3)
+    full_p1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
+    per_rank_local = []
+    for r in range(world_size):
+        rs0, rc0 = plan0.rank_rows[r]
+        rs1, rc1 = plan1.rank_rows[r]
+        per_rank_local.append([full_p0[rs0 : rs0 + rc0].clone(), full_p1[rs1 : rs1 + rc1].clone()])
+
+    per_rank_send = []
+    per_rank_gather = []
+    for r in range(world_size):
+        gather = pack_owner_work(
+            plans,
+            owners,
+            per_rank_local[r],
+            world_size,
+            r,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+        per_rank_send.append(gather.send_buffers)
+        per_rank_gather.append(gather)
+
+    recv = _simulate_p2p(per_rank_send, world_size)
+
+    # Rank0 owns param0; reconstruct and compare to full_p0.
+    full0 = reconstruct_full_tensor(0, plan0, per_rank_gather[0], recv[0], owner_rank=0)
+    torch.testing.assert_close(full0, full_p0, atol=0, rtol=0)
+    # Rank1 owns param1; reconstruct and compare to full_p1.
+    full1 = reconstruct_full_tensor(1, plan1, per_rank_gather[1], recv[1], owner_rank=1)
+    torch.testing.assert_close(full1, full_p1, atol=0, rtol=0)
+
+
+def test_pack_and_unpack_update_round_trip():
+    """Scattered update shards match the owner's full update sliced per rank."""
+    torch.manual_seed(1)
+    world_size = 2
+    plan0 = compute_shard_plan(torch.Size((6, 3)), 0, 9, world_size)
+    plan1 = compute_shard_plan(torch.Size((4, 2)), 0, 4, world_size)
+    plans = [plan0, plan1]
+    owners = {0: 0, 1: 1}
+
+    full_update0 = torch.arange(18, dtype=torch.float32).reshape(6, 3) + 1.0
+    full_update1 = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 2.0
+    full_updates_by_rank = {0: {0: full_update0}, 1: {1: full_update1}}
+
+    per_rank_send = []
+    per_rank_scatter = []
+    for r in range(world_size):
+        scatter = pack_update_shards(
+            full_updates_by_rank[r],
+            plans,
+            owners,
+            world_size,
+            r,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+        per_rank_send.append(scatter.send_buffers)
+        per_rank_scatter.append(scatter)
+
+    recv = _simulate_p2p(per_rank_send, world_size)
+
+    for r in range(world_size):
+        received = unpack_update_shards(per_rank_scatter[r], recv[r])
+        # Rank r receives the update shard for the param it does NOT own.
+        other = 1 - r
+        plan = plans[other]
+        rs, rc = plan.rank_rows[r]
+        expected = full_updates_by_rank[owners[other]][other][rs : rs + rc]
+        torch.testing.assert_close(received[other], expected, atol=0, rtol=0)


### PR DESCRIPTION
We have built on and further optimized [NVIDIA/Megatron-LM PR #6425](https://github.com/NVIDIA/Megatron-LM/pull/6425), resulting in the current PoC. We would like to validate the effectiveness of these optimizations and, at an appropriate time, contribute some of this work back to PR #6425.

On 16-layers dpsk v4 pro proxy model test. EP32, no PP, TP, 128 GPU on hopper
Original #6425: 
<img width="2341" height="197" alt="image" src="https://github.com/user-attachments/assets/6b51625a-b7e2-4b8d-bc9d-c42e3a6c8055" />

This PoC:
<img width="1394" height="254" alt="image" src="https://github.com/user-attachments/assets/c2ef5a9f-35a6-47c4-9ac1-4983f71fe9ca" />
