### PR TITLE
[dev] Share rotary position embeddings across multi-latent-attention layers (

### DIFF
--- a/megatron/core/models/common/embeddings/__init__.py
+++ b/megatron/core/models/common/embeddings/__init__.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 from .rope_utils import apply_rotary_pos_emb, should_use_fused_mla_rope
-from .rotary_pos_embedding import MultimodalRotaryEmbedding, RotaryEmbedding
+from .rotary_pos_embedding import (
+    MultimodalRotaryEmbedding,
+    RotaryEmbedding,
+    maybe_share_rotary_pos_emb,
+)
 from .yarn_rotary_pos_embedding import YarnRotaryEmbedding, _yarn_get_mscale

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -30,7 +30,38 @@ from megatron.core.utils import deprecate_inference_params, internal_api
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['RotaryEmbedding', 'MultimodalRotaryEmbedding']
+__all__ = ['RotaryEmbedding', 'MultimodalRotaryEmbedding', 'maybe_share_rotary_pos_emb']
+
+
+def maybe_share_rotary_pos_emb(
+    config: TransformerConfig, cache_key: tuple, rotary_pos_emb: nn.Module
+) -> nn.Module:
+    """Share a rotary embedding across identically configured layers, or return it unchanged.
+
+    The rotary cos/sin buffers depend only on the configuration, not on any layer weights, so
+    attention layers with the same rotary configuration build identical modules and can share a
+    single instance. When ``config.share_rotary_pos_emb`` is set, the first module built for a
+    given ``cache_key`` is cached on ``config`` and reused by later callers with an equal key, so
+    sharing is scoped to a single model; otherwise ``rotary_pos_emb`` is returned unchanged. The
+    cos/sin buffers are allocated lazily on first use, so the extra modules that are built but not
+    kept never allocate them; this removes the per-layer rotary buffer duplication (several GiB per
+    rank at long sequence lengths) with no change to the numerics.
+
+    Args:
+        config: Transformer config; ``config.share_rotary_pos_emb`` toggles sharing.
+        cache_key: A hashable key that uniquely identifies the rotary configuration.
+        rotary_pos_emb: The rotary embedding module built by the caller for this layer.
+
+    Returns:
+        The shared instance for ``cache_key`` when sharing is enabled, else ``rotary_pos_emb``.
+    """
+    if not getattr(config, 'share_rotary_pos_emb', False):
+        return rotary_pos_emb
+    cache = getattr(config, '_shared_rotary_pos_emb_cache', None)
+    if cache is None:
+        cache = {}
+        setattr(config, '_shared_rotary_pos_emb_cache', cache)
+    return cache.setdefault(cache_key, rotary_pos_emb)
 
 
 class RotaryEmbedding(nn.Module):

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -26,6 +26,7 @@ from megatron.core.models.common.embeddings import (
     YarnRotaryEmbedding,
     _yarn_get_mscale,
     apply_rotary_pos_emb,
+    maybe_share_rotary_pos_emb,
     should_use_fused_mla_rope,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -214,6 +215,10 @@ class AbsorbedMLASelfAttention(Attention):
                 f"Unsupported RoPE type: {self.config.rope_type}, supported types are "
                 "'rope' and 'yarn'"
             )
+        # Share one rotary instance across layers with the same configuration when enabled.
+        self.rotary_pos_emb = maybe_share_rotary_pos_emb(
+            self.config, (self.config.rope_type, self.config.rotary_base), self.rotary_pos_emb
+        )
 
         self.core_attention = build_module(
             submodules.core_attention,

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -16,6 +16,7 @@ from megatron.core.models.common.embeddings import (
     RotaryEmbedding,
     YarnRotaryEmbedding,
     apply_rotary_pos_emb,
+    maybe_share_rotary_pos_emb,
 )
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -147,6 +148,10 @@ class DSv4HybridAttention(Attention):
                 mscale_all_dim=self.config.mscale_all_dim,
                 cp_group=self.pg_collection.cp,
             )
+        # Share one rotary instance across layers with the same configuration when enabled.
+        self.rotary_pos_emb = maybe_share_rotary_pos_emb(
+            self.config, (use_compressed_yarn, rope_base), self.rotary_pos_emb
+        )
 
         core_attn_extra_kwargs = {
             "rotary_pos_emb": self.rotary_pos_emb,

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -18,6 +18,7 @@ from megatron.core.models.common.embeddings import (
     RotaryEmbedding,
     YarnRotaryEmbedding,
     apply_rotary_pos_emb,
+    maybe_share_rotary_pos_emb,
     should_use_fused_mla_rope,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -1467,6 +1468,10 @@ class DSAIndexer(MegatronModule):
                 f'Unsupported RoPE type: {self.config.rope_type}, supported types are "rope" and '
                 f'"yarn"'
             )
+        # Share one rotary instance across layers with the same configuration when enabled.
+        self.rotary_pos_emb = maybe_share_rotary_pos_emb(
+            self.config, (self.config.rope_type, self.config.rotary_base), self.rotary_pos_emb
+        )
 
         self.linear_wq_b = build_module(
             submodules.linear_wq_b,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -25,6 +25,7 @@ from megatron.core.models.common.embeddings import (
     YarnRotaryEmbedding,
     _yarn_get_mscale,
     apply_rotary_pos_emb,
+    maybe_share_rotary_pos_emb,
     should_use_fused_mla_rope,
 )
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
@@ -213,6 +214,10 @@ class MultiLatentAttention(Attention):
                 f"Unsupported RoPE type: {self.config.rope_type}, supported types are "
                 "'rope' and 'yarn'"
             )
+        # Share one rotary instance across layers with the same configuration when enabled.
+        self.rotary_pos_emb = maybe_share_rotary_pos_emb(
+            self.config, (self.config.rope_type, self.config.rotary_base), self.rotary_pos_emb
+        )
 
         if self.config.experimental_attention_variant == "dsa":
             core_attn_extra_kwargs = {"is_mtp_layer": is_mtp_layer}

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -4076,6 +4076,13 @@ class MLATransformerConfig(TransformerConfig):
     mscale_all_dim: float = 0.0
     """Mscale all dimensions for YaRN RoPE in Multi-Latent Attention, used by yarn."""
 
+    share_rotary_pos_emb: bool = False
+    """Share a single rotary embedding module across all attention layers that have the same
+    rotary configuration. The rotary cos/sin buffers depend only on the configuration (not on any
+    layer weights), so they are identical across such layers and one shared instance can serve
+    them all. Enabling this removes the per-layer rotary buffer duplication, which at long
+    sequence lengths costs several GiB per rank, with no change to the numerics. Off by default."""
+
     o_groups: int = 8
     """Number of groups for grouped low-rank output projection (wo_a)."""
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -4990,6 +4990,13 @@ def _add_mla_args(parser):
         help="Mscale all dimensions for YaRN RoPE in multi-latent attention.",
     )
     group.add_argument(
+        '--share-rotary-pos-emb',
+        action='store_true',
+        help="Share one rotary embedding module across multi-latent-attention layers that have "
+        "an identical rotary configuration, removing per-layer rotary buffer duplication (no "
+        "numerical change).",
+    )
+    group.add_argument(
         '--o-groups',
         type=int,
         default=8,

--- a/tests/unit_tests/transformer/test_shared_rotary_pos_emb.py
+++ b/tests/unit_tests/transformer/test_shared_rotary_pos_emb.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Unit tests for rotary embedding sharing across layers (``maybe_share_rotary_pos_emb``).
+
+Two layers of coverage:
+  * fast, device-free checks of the sharing helper's caching contract, and
+  * a small two-layer multi-latent-attention proxy that runs one forward/backward step
+    with sharing off and on and asserts the loss and gradient norm are unchanged --
+    the feature must be numerically transparent (it only removes duplicate buffers).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.models.common.embeddings import RotaryEmbedding, maybe_share_rotary_pos_emb
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_submodules,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.multi_latent_attention import MLASelfAttention
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.utils import is_te_min_version
+from tests.unit_tests.test_utilities import Utils
+
+HIDDEN_SIZE = 12
+
+
+# ----------------------------------------------------------------------------------------------
+# Helper contract (fast, no distributed init required)
+# ----------------------------------------------------------------------------------------------
+def test_disabled_returns_the_same_instance_and_creates_no_cache():
+    """When sharing is off, the module built by the caller is returned unchanged and uncached."""
+    config = SimpleNamespace(share_rotary_pos_emb=False)
+    first, second = object(), object()
+
+    assert maybe_share_rotary_pos_emb(config, ("k",), first) is first
+    assert maybe_share_rotary_pos_emb(config, ("k",), second) is second
+    assert getattr(config, "_shared_rotary_pos_emb_cache", None) is None
+
+
+def test_enabled_shares_the_first_instance_per_key():
+    """When sharing is on, an equal key returns the first module; the extra one is discarded."""
+    config = SimpleNamespace(share_rotary_pos_emb=True)
+    first, second = object(), object()
+
+    assert maybe_share_rotary_pos_emb(config, ("rope", 10000), first) is first
+    assert maybe_share_rotary_pos_emb(config, ("rope", 10000), second) is first
+
+
+def test_enabled_distinguishes_keys():
+    """Different rotary configurations (keys) are not shared with each other."""
+    config = SimpleNamespace(share_rotary_pos_emb=True)
+    rope, yarn = object(), object()
+
+    assert maybe_share_rotary_pos_emb(config, ("rope", 10000), rope) is rope
+    assert maybe_share_rotary_pos_emb(config, ("yarn", 10000), yarn) is yarn
+
+
+def test_cache_is_scoped_to_each_config():
+    """The cache lives on the config, so different models (configs) never share an instance."""
+    config_a = SimpleNamespace(share_rotary_pos_emb=True)
+    config_b = SimpleNamespace(share_rotary_pos_emb=True)
+    module_a, module_b = object(), object()
+
+    assert maybe_share_rotary_pos_emb(config_a, ("k",), module_a) is module_a
+    assert maybe_share_rotary_pos_emb(config_b, ("k",), module_b) is module_b
+
+
+# ----------------------------------------------------------------------------------------------
+# Numerical-transparency proxy (two MLA layers, one step, sharing off vs on)
+# ----------------------------------------------------------------------------------------------
+def _build_two_mla_layers(rope_type: str, share: bool):
+    """Build a two-layer MLA stack sharing one config so the sharing spans both layers.
+
+    Dropout is disabled so the forward pass is deterministic, which lets the sharing-off and
+    sharing-on runs be compared bit-for-bit.
+    """
+    config = MLATransformerConfig(
+        num_layers=2,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        q_lora_rank=32,
+        kv_lora_rank=32,
+        qk_head_dim=128,
+        v_head_dim=128,
+        qk_pos_emb_head_dim=64,
+        rope_type=rope_type,
+        rotary_base=10000,
+        original_max_position_embeddings=32,
+        share_rotary_pos_emb=share,
+    )
+    layers = []
+    for layer_number in (1, 2):
+        submodules = get_gpt_layer_with_transformer_engine_submodules(
+            multi_latent_attention=True
+        ).self_attention.submodules
+        layers.append(
+            MLASelfAttention(
+                config, submodules, layer_number=layer_number, attn_mask_type=AttnMaskType.causal
+            )
+        )
+    return layers
+
+
+def _loss_and_grad_norm(layers, hidden_states, attention_mask):
+    """Run one forward/backward over the stacked layers and return (loss, total grad norm)."""
+    hidden = hidden_states
+    for layer in layers:
+        layer.cuda()
+        output, bias = layer(hidden, attention_mask)
+        hidden = output + bias if bias is not None else output
+    loss = hidden.float().pow(2).mean()
+    loss.backward()
+    grad_sq = torch.zeros((), dtype=torch.float64, device=loss.device)
+    for layer in layers:
+        for param in layer.parameters():
+            if param.grad is not None:
+                grad_sq = grad_sq + param.grad.detach().double().pow(2).sum()
+    return loss.detach(), grad_sq.sqrt()
+
+
+@pytest.mark.parametrize("rope_type", ("rope", "yarn"))
+class TestSharedRotaryNumericalTransparency:
+    """Sharing the rotary module across layers must not change training numerics."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+        yield
+        Utils.destroy_model_parallel()
+
+    def test_loss_and_grad_norm_are_unchanged(self, rope_type):
+        if not is_te_min_version("1.10.0"):
+            pytest.skip("MLA attention GPU forward requires TransformerEngine >= 1.10.0")
+
+        sequence_length, micro_batch_size = 32, 2
+        torch.manual_seed(0)
+        hidden_states = torch.randn(sequence_length, micro_batch_size, HIDDEN_SIZE).cuda()
+        causal = torch.triu(
+            torch.ones(sequence_length, sequence_length, dtype=torch.bool), diagonal=1
+        )
+        attention_mask = causal.view(1, 1, sequence_length, sequence_length).cuda()
+
+        off = _build_two_mla_layers(rope_type, share=False)
+        on = _build_two_mla_layers(rope_type, share=True)
+        # Force bit-identical weights so any output difference can only come from rotary sharing.
+        for layer_on, layer_off in zip(on, off):
+            layer_on.load_state_dict(layer_off.state_dict(), strict=False)
+
+        # The flag must actually change the wiring: off keeps two modules, on collapses to one.
+        assert off[0].rotary_pos_emb is not off[1].rotary_pos_emb
+        assert on[0].rotary_pos_emb is on[1].rotary_pos_emb
+
+        loss_off, grad_norm_off = _loss_and_grad_norm(off, hidden_states, attention_mask)
+        loss_on, grad_norm_on = _loss_and_grad_norm(on, hidden_states, attention_mask)
+
+        # Forward is bit-identical; backward matches within fp32 kernel (atomic) tolerance.
+        torch.testing.assert_close(loss_on, loss_off, rtol=0, atol=0)
+        torch.testing.assert_close(grad_norm_on, grad_norm_off, rtol=1e-4, atol=1e-5)

--- a/tests/unit_tests/transformer/test_shared_rotary_pos_emb.py
+++ b/tests/unit_tests/transformer/test_shared_rotary_pos_emb.py
@@ -3,7 +3,7 @@
 """Unit tests for rotary embedding sharing across layers (``maybe_share_rotary_pos_emb``).
 
 Two layers of coverage:
-  * fast, device-free checks of the sharing helper's caching contract, and
+  * a fast, device-free check that different rotary configs are not shared, and
   * a small two-layer multi-latent-attention proxy that runs one forward/backward step
     with sharing off and on and asserts the loss and gradient norm are unchanged --
     the feature must be numerically transparent (it only removes duplicate buffers).
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from megatron.core.models.common.embeddings import RotaryEmbedding, maybe_share_rotary_pos_emb
+from megatron.core.models.common.embeddings import maybe_share_rotary_pos_emb
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
@@ -29,27 +29,8 @@ HIDDEN_SIZE = 12
 
 
 # ----------------------------------------------------------------------------------------------
-# Helper contract (fast, no distributed init required)
+# Helper key-distinction guard (fast, no distributed init required)
 # ----------------------------------------------------------------------------------------------
-def test_disabled_returns_the_same_instance_and_creates_no_cache():
-    """When sharing is off, the module built by the caller is returned unchanged and uncached."""
-    config = SimpleNamespace(share_rotary_pos_emb=False)
-    first, second = object(), object()
-
-    assert maybe_share_rotary_pos_emb(config, ("k",), first) is first
-    assert maybe_share_rotary_pos_emb(config, ("k",), second) is second
-    assert getattr(config, "_shared_rotary_pos_emb_cache", None) is None
-
-
-def test_enabled_shares_the_first_instance_per_key():
-    """When sharing is on, an equal key returns the first module; the extra one is discarded."""
-    config = SimpleNamespace(share_rotary_pos_emb=True)
-    first, second = object(), object()
-
-    assert maybe_share_rotary_pos_emb(config, ("rope", 10000), first) is first
-    assert maybe_share_rotary_pos_emb(config, ("rope", 10000), second) is first
-
-
 def test_enabled_distinguishes_keys():
     """Different rotary configurations (keys) are not shared with each other."""
     config = SimpleNamespace(share_rotary_pos_emb=True)
@@ -57,16 +38,6 @@ def test_enabled_distinguishes_keys():
 
     assert maybe_share_rotary_pos_emb(config, ("rope", 10000), rope) is rope
     assert maybe_share_rotary_pos_emb(config, ("yarn", 10000), yarn) is yarn
-
-
-def test_cache_is_scoped_to_each_config():
-    """The cache lives on the config, so different models (configs) never share an instance."""
-    config_a = SimpleNamespace(share_rotary_pos_emb=True)
-    config_b = SimpleNamespace(share_rotary_pos_emb=True)
-    module_a, module_b = object(), object()
-
-    assert maybe_share_rotary_pos_emb(config_a, ("k",), module_a) is module_a
-    assert maybe_share_rotary_pos_emb(config_b, ("k",), module_b) is module_b
 
 
 # ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

This PR adds an opt-in `share_rotary_pos_emb` flag (default off) that collapses all identically-configured rotary modules to a **single shared instance**. It is numerically exact and reversible.

## What changed

- `maybe_share_rotary_pos_emb(config, cache_key, rotary_pos_emb)` helper: returns the module unchanged when off; otherwise caches the first module per `cache_key` on the config and reuses it (sharing scoped per-model).
- `MLATransformerConfig.share_rotary_pos_emb: bool = False` + `--share-rotary-pos-emb`.
- One call-site in each MLA-family variant (`MultiLatentAttention`, `AbsorbedMLASelfAttention`, `DSAIndexer`, `DSv4HybridAttention`), keyed by the rotary config so distinct configs get distinct shared instances.

Default off + unconditional call → the default path is a no-op.

## Memory gain — DSv4-flash, 1M seqlen, 128× GB200

Per attention layer, at `S = 1,048,576` and `d = qk_pos_emb_head_dim = 64`:

| buffer  | dtype | size            |
|---------|-------|-----------------|
| `emb`   | fp32  | S·d·4 = 256 MiB |
| `cos`   | bf16  | S·d·2 = 128 MiB |
| `sin`   | bf16  | S·d·2 = 128 MiB |
| **total** |     | **512 MiB**     |

The last pipeline stage has **21 attention layers** with the same rotary config (snapshot confirms 21 identical copies/rank): `21 × 512 MiB ≈ 10.5 GiB/rank` duplicated. Sharing collapses 21 → 1, reclaiming ~10 GiB/rank.

Measured peak reserved memory (last-stage rank):

| run                      | baseline  | shared RoPE | gain                  |
|--------------------------|-----------|-------------|-----------------------|
| eager                    | 137.5 GiB | 125.2 GiB   | **−12.2 GiB (−8.9%)** |
| chunk-graph (CUDA graph) | 156.7 GiB | 146.9 GiB   | **−9.8 GiB (−6.3%)**  |

## Correctness

The shared buffers are a function of `(rotary config, position)` only, so all same-config layers compute identical `cos`/`sin`; sharing changes the module object, not any value. Rotary modules have no parameters and their `cos`/`sin` are `persistent=False` buffers allocated lazily on first forward, so discarded duplicates never allocate them and the state dict is unchanged.

## Testing

`tests/unit_tests/transformer/test_shared_rotary_pos_emb.py`: helper-contract checks plus a two-layer MLA proxy (`rope`/`yarn`) that runs one forward/backward off vs on (identical weights, dropout off) and asserts **bit-identical loss** and matching grad norm. Validated on GB200.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
