### PR TITLE
docs(optimizer): explain capturable FusedAdam dtype workaround

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -241,8 +241,9 @@ class TestMcoreAdapterDense:
             data_parallel_sharding_strategy="optim_grads_params",
         )
         if optimizer_cuda_graph:
-            # Capturable TE FusedAdam requires the main-gradient and main-weight dtypes
-            # to match (https://github.com/NVIDIA/TransformerEngine/issues/3358).
+            # With the default None, MFSDP v2 uses BF16 main grads with FP32 main
+            # params. Older capturable TE FusedAdam requires matching dtypes
+            # (https://github.com/NVIDIA/TransformerEngine/issues/3358).
             ddp_config.megatron_fsdp_main_grads_dtype = ddp_config.megatron_fsdp_main_params_dtype
 
         model = FullyShardedDataParallel(


### PR DESCRIPTION
## Summary

Clarify why the MFSDP v2 optimizer CUDA-graph unit test aligns main-gradient and main-parameter dtypes.

## Testing

- `git diff --check`