### PR TITLE
Document AbsorbedMLA inference limitation

### DIFF
--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -7,6 +7,7 @@ This guide provides an example for Megatron Core for running model inference.
 - [Offline inference](#offline-inference)
 - [OpenAI-compatible inference server](#openai-compatible-inference-server)
 - [Advanced examples](#advanced-examples)
+- [Known limitations](#known-limitations)
 - [See also](#see-also)
 
 ### What's in here
@@ -195,6 +196,14 @@ To add a new routing metric, put capture logic in `megatron/core/transformer/moe
 adding bespoke logging flows to `megatron/training/activation_logging.py`
 for routing metrics — that file handles lightweight count monitoring
 (`tokens_per_expert`) and uses a different output format.
+
+### Known limitations
+
+Models with `experimental_attention_variant="dsa"` / AbsorbedMLA (GLM-5.x,
+DeepSeek-V3.2-class) cannot use these in-framework generation examples.
+Export to Hugging Face with Megatron Bridge and serve with vLLM. See
+[`megatron/core/inference/README.md`](../../megatron/core/inference/README.md)
+and [NVIDIA/Megatron-LM#7106](https://github.com/NVIDIA/Megatron-LM/issues/7106).
 
 ### See also
 

--- a/megatron/core/inference/README.md
+++ b/megatron/core/inference/README.md
@@ -92,6 +92,8 @@ Planned new features:
 
 - **Server returns `"model": "EMPTY"`.** The HTTP frontend doesn't expose a `ServeConfig.model_name` to echo in `/v1/completions` / `/v1/chat/completions` responses, doesn't validate the request `model` field against a configured name, and exposes no `GET /v1/models` discovery endpoint. Clients can still pass any `model` in their request body — the dynamic server ignores it.
 
+- **DSA / AbsorbedMLA has no in-framework inference path.** Models with `experimental_attention_variant="dsa"` (AbsorbedMLA; GLM-5.x, DeepSeek-V3.2-class) reject `inference_context` / `inference_params` and cannot use Megatron text generation or refit-style eval. `get_gpt_decoder_layer_specs` also refuses experimental attention variants. Export to Hugging Face via [Megatron Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) and serve with vLLM (`GlmMoeDsaForCausalLM`). Pass `--no-cache-mla-latents` if you still hit the AbsorbedMLA cache assert. Tracked in [NVIDIA/Megatron-LM#7106](https://github.com/NVIDIA/Megatron-LM/issues/7106).
+
 ## Low-level APIs
 
 For step-level control, custom forward-step integration, or migration from existing pipelines, drop down to the building blocks in this directory: `DynamicInferenceEngine` (manual `add_request` / `step_modern` stepping), `DynamicInferenceContext`, `TextGenerationController`, and the model inference wrappers under `model_inference_wrappers/`. Runnable examples live in [`examples/inference/advanced/`](../../examples/inference/advanced/): `gpt_dynamic_inference.py` (manual stepping), `gpt_dynamic_inference_with_coordinator.py` (explicit coordinator + `InferenceClient` lifecycle), `gpt_static_inference.py` (static engine), and `simple_t5_batch_inference.py` (T5).

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -570,8 +570,10 @@ def get_gpt_decoder_layer_specs(
 ) -> TransformerBlockSubmodules:
     """GPT block spec."""
     assert config.experimental_attention_variant is None, (
-        "Experimental attention variant is not supported with get_gpt_decoder_layer_specs, "
-        f"but got {config.experimental_attention_variant=}."
+        "get_gpt_decoder_layer_specs has no inference path for experimental attention variants "
+        f"such as DSA/AbsorbedMLA (got {config.experimental_attention_variant=}). "
+        "Export to Hugging Face and serve with vLLM "
+        "(https://github.com/NVIDIA/Megatron-LM/issues/7106)."
     )
 
     if use_transformer_engine:

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -10,6 +10,9 @@ This module implements MLA with matrix absorption:
 
 The absorption is mathematically equivalent to standard MLA but enables MQA-style attention which
 can be more efficient for certain attention variants.
+
+In-framework inference is not supported. Export to Hugging Face and serve with vLLM
+(see NVIDIA/Megatron-LM#7106).
 """
 
 import math
@@ -135,6 +138,10 @@ class AbsorbedMLASelfAttention(Attention):
 
     The absorption is mathematically equivalent to standard MLA but enables MQA-style attention
     computation which can be more efficient for certain attention variants.
+
+    In-framework inference is not supported: ``forward`` rejects ``inference_context`` /
+    ``inference_params``. Export to Hugging Face and serve with vLLM
+    (see NVIDIA/Megatron-LM#7106).
     """
 
     def __init__(
@@ -825,9 +832,11 @@ class AbsorbedMLASelfAttention(Attention):
         assert not (
             self.training and self.cache_mla_latents
         ), "cache_mla_latents conflicts with training."
-        assert (
-            inference_context is None and inference_params is None
-        ), "Inference is not supported for AbsorbedMLA"
+        assert inference_context is None and inference_params is None, (
+            "AbsorbedMLA (experimental_attention_variant='dsa') has no Megatron in-framework "
+            "inference path. Export to Hugging Face and serve with vLLM "
+            "(https://github.com/NVIDIA/Megatron-LM/issues/7106)."
+        )
 
         # =====================
         # Query, Key, and Value


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Document that DSA / AbsorbedMLA has no Megatron in-framework inference path, and point users at the Hugging Face / vLLM workaround.

This is documentation and assert-message only. It does not implement an inference path.

## Issue tracking

Linked issue: Related to #7106

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Summary

`AbsorbedMLASelfAttention.forward` and `get_gpt_decoder_layer_specs` already reject inference / experimental attention variants. This PR:

- Clarifies those assert messages (limitation + export-to-HF / vLLM workaround).
- Notes the limitation on the AbsorbedMLA class/module docstrings.
- Adds a known-limitations entry in `megatron/core/inference/README.md` and a pointer in `examples/inference/README.md`.

Workaround for GLM-5.x / DeepSeek-V3.2-class models: export to Hugging Face via Megatron Bridge and serve with vLLM (`GlmMoeDsaForCausalLM`). Pass `--no-cache-mla-latents` if you still hit the AbsorbedMLA cache assert.

Does not touch `docs/models/llms.md` (owned by the #6392 docs PR).