### PR TITLE
Preserve in-vocabulary pad token ids in GPTDataset

### DIFF
--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -311,9 +311,14 @@ class GPTDataset(MegatronDataset):
         # For padded sequences, mask the loss
         loss_mask[labels == self._pad_token_id] = 0.0
 
-        # For padded sequences, ensure the embedding layer can map the token ID
-        tokens[tokens == self._pad_token_id] = 0
-        labels[labels == self._pad_token_id] = 0
+        # Remap only out-of-vocabulary pad ids (for example the -1 sentinel used
+        # when pad collides with another special token). In-vocabulary pad ids
+        # are left unchanged so embedding lookup keeps the tokenizer pad identity.
+        if _is_out_of_vocabulary_token_id(
+            self._pad_token_id, getattr(self.config.tokenizer, "vocab_size", None)
+        ):
+            tokens[tokens == self._pad_token_id] = 0
+            labels[labels == self._pad_token_id] = 0
 
         # Batch padding sequence so we mask the loss
         if idx is None:
@@ -795,6 +800,23 @@ def _build_shuffle_index(
     numpy_random_state.shuffle(shuffle_idx_last)
 
     return numpy.concatenate((shuffle_idx_first, shuffle_idx_last))
+
+
+def _is_out_of_vocabulary_token_id(token_id: int, vocab_size: Optional[int]) -> bool:
+    """Return whether a token id cannot be used as an embedding index.
+
+    Args:
+        token_id (int): Token id to check.
+        vocab_size (Optional[int]): Tokenizer vocabulary size, if known.
+
+    Returns:
+        bool: True when token_id is negative or at/beyond vocab_size.
+    """
+    if token_id < 0:
+        return True
+    if vocab_size is not None and token_id >= vocab_size:
+        return True
+    return False
 
 
 def _get_ltor_masks_and_position_ids(

--- a/tests/unit_tests/data/test_gpt_dataset.py
+++ b/tests/unit_tests/data/test_gpt_dataset.py
@@ -190,5 +190,87 @@ def test_inter_document_masking():
     assert "cu_seqlens" in sample
 
 
+def _build_padded_mock_gpt_dataset(tokenizer):
+    if torch.distributed.is_available():
+        Utils.initialize_distributed()
+        if torch.distributed.get_rank() == 0:
+            compile_helpers()
+        torch.distributed.barrier()
+    else:
+        compile_helpers()
+
+    config = GPTDatasetConfig(
+        random_seed=1234,
+        sequence_length=1024,
+        split="990,10,0",
+        reset_position_ids=True,
+        reset_attention_mask=True,
+        eod_mask_loss=True,
+        drop_last_partial_validation_sequence=False,
+        add_extra_token_to_sequence=False,
+        tokenizer=tokenizer,
+        mid_level_dataset_surplus=0.005,
+    )
+    datasets = BlendedMegatronDatasetBuilder(
+        MockGPTDataset, [0, None, 0], lambda: True, config
+    ).build()
+    return datasets[1]
+
+
+def _padded_validation_sample(dataset):
+    return dataset[dataset.shuffle_index.argmax()]
+
+
+def _last_eod_label_index(labels, eod):
+    eod_positions = (labels == eod).nonzero(as_tuple=True)[0]
+    assert eod_positions.numel() > 0
+    return int(eod_positions[-1].item())
+
+
+def test_gpt_dataset_pad_token_id_remapping():
+    """In-vocab pad ids stay unchanged; OOV sentinels remap to a safe embedding id."""
+    unique_pad_id = 7
+    in_vocab_tokenizer = MegatronTokenizer.from_pretrained(
+        metadata_path={"library": "null-text"},
+        vocab_size=_MOCK_VOCAB_SIZE,
+        pad_id=unique_pad_id,
+    )
+    assert in_vocab_tokenizer.pad == unique_pad_id
+    assert in_vocab_tokenizer.pad != in_vocab_tokenizer.eod
+    assert 0 < unique_pad_id < in_vocab_tokenizer.vocab_size
+
+    in_vocab_dataset = _build_padded_mock_gpt_dataset(in_vocab_tokenizer)
+    assert in_vocab_dataset._pad_token_id == unique_pad_id
+
+    in_vocab_sample = _padded_validation_sample(in_vocab_dataset)
+    in_vocab_eod_idx = _last_eod_label_index(in_vocab_sample["labels"], in_vocab_tokenizer.eod)
+    assert in_vocab_eod_idx < in_vocab_sample["labels"].shape[0] - 1
+
+    in_vocab_pad_labels = in_vocab_sample["labels"][in_vocab_eod_idx + 1 :]
+    assert torch.all(in_vocab_pad_labels == unique_pad_id)
+    assert not torch.any(in_vocab_pad_labels == 0)
+    assert torch.all(in_vocab_sample["loss_mask"][in_vocab_eod_idx + 1 :] == 0)
+    assert in_vocab_sample["tokens"][in_vocab_eod_idx + 1] == in_vocab_tokenizer.eod
+    assert torch.all(in_vocab_sample["tokens"][in_vocab_eod_idx + 2 :] == unique_pad_id)
+
+    sentinel_tokenizer = MegatronTokenizer.from_pretrained(
+        metadata_path={"library": "null-text"}, vocab_size=_MOCK_VOCAB_SIZE, pad_id=-1
+    )
+    sentinel_dataset = _build_padded_mock_gpt_dataset(sentinel_tokenizer)
+    assert sentinel_dataset._pad_token_id == -1
+
+    sentinel_sample = _padded_validation_sample(sentinel_dataset)
+    sentinel_eod_idx = _last_eod_label_index(sentinel_sample["labels"], sentinel_tokenizer.eod)
+    assert sentinel_eod_idx < sentinel_sample["labels"].shape[0] - 1
+
+    sentinel_pad_labels = sentinel_sample["labels"][sentinel_eod_idx + 1 :]
+    assert torch.all(sentinel_pad_labels == 0)
+    assert torch.all(sentinel_sample["tokens"] >= 0)
+    assert torch.all(sentinel_sample["labels"] >= 0)
+    assert torch.all(sentinel_sample["tokens"] < sentinel_tokenizer.vocab_size)
+    assert torch.all(sentinel_sample["labels"] < sentinel_tokenizer.vocab_size)
+    assert torch.all(sentinel_sample["loss_mask"][sentinel_eod_idx + 1 :] == 0)
+
+
 if __name__ == "__main__":
     test_mock_gpt_dataset()


### PR DESCRIPTION
## Summary

Fixes #2170.

`GPTDataset.__getitem__` remapped **every** pad id to `0` after applying `loss_mask`. That rewrite exists so embedding lookup can succeed when the dataset uses the internal out-of-vocabulary sentinel (`-1`). `MegatronDataset` sets `_pad_token_id = -1` when the tokenizer pad id is missing or collides with another special token (typical Qwen/DeepSeek `pad == eos` unless `allow_ambiguous_pad_tokens` is set).

The reported training/inference mismatch overstates the issue: `loss_mask` already zeros pad labels, so those positions do not teach the model that token `0` is EOS. The real bug is that a **unique in-vocabulary pad id** (or an in-vocab pad the user opted to keep via `allow_ambiguous_pad_tokens`) was rewritten to `0` in `tokens` / `labels`. Downstream embedding lookup and any pad-aware inference then see the wrong id.

This change remaps pad ids **only when they are out of vocabulary** (`id < 0`, or `id >= vocab_size` when vocab size is known) to the existing safe in-vocab fallback (`0`). If `_pad_token_id` is a valid vocab index, `tokens` and `labels` keep that id. `loss_mask` behavior is unchanged.

`t5_dataset.py` and `bert_dataset.py` are intentionally not modified.

## How to review

- In `megatron/core/datasets/gpt_dataset.py`, confirm `loss_mask[labels == self._pad_token_id] = 0.0` is still applied first, and that the subsequent rewrite is gated on `_is_out_of_vocabulary_token_id`.
- Confirm in-vocab pad ids are left as-is, including unique non-zero pads.
- Confirm the `-1` sentinel path still becomes `0` so embedding lookup cannot see a negative index.

## Tests

Added `test_gpt_dataset_pad_token_id_remapping` in `tests/unit_tests/data/test_gpt_dataset.py`:

- Builds `MockGPTDataset` with a tokenizer whose pad id is a unique non-zero in-vocab id and asserts those pad positions are **not** rewritten to `0`.
- Builds the same dataset with `_pad_token_id = -1` and asserts those positions become a safe in-vocab id (`0`).
- Asserts `loss_mask` remains zero on pad labels in both cases.

Suggested command:

```bash
uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q \
  tests/unit_tests/data/test_gpt_dataset.py::test_gpt_dataset_pad_token_id_remapping
```