### PR TITLE
Accept an explicit process group in inference broadcast helpers

### DIFF
--- a/megatron/core/inference/communication_utils.py
+++ b/megatron/core/inference/communication_utils.py
@@ -142,70 +142,131 @@ def send_to_next_pipeline_rank(
     torch.cuda.synchronize()
 
 
-def broadcast_tensor(size, dtype, tensor=None, rank=0, data_parallel=False):
+def _resolve_broadcast_group_and_src_rank(
+    group: ProcessGroup | None, rank: int, data_parallel: bool
+) -> tuple[ProcessGroup | None, int]:
+    """Resolve the process group and source rank for a broadcast.
+
+    Args:
+        group: Explicit process group, or None to use the default / MPU fallback.
+        rank: Caller-specified global source rank.
+        data_parallel: If True, broadcast within one data-parallel replica
+            (the model-parallel group) and use that group's first rank as src.
+
+    Returns:
+        Tuple of (process group, global source rank).
+    """
+    if group is not None:
+        # Lists of ProcessGroups are used for multimodal inference but not supported here
+        assert isinstance(
+            group, ProcessGroup
+        ), "group must be a single ProcessGroup, not a list of ProcessGroups"
+        if data_parallel:
+            rank = torch.distributed.get_process_group_ranks(group)[0]
+        return group, rank
+    if data_parallel:
+        # Migration fallback: read MPU globals when the caller did not pass a group.
+        return (
+            parallel_state.get_model_parallel_group(),
+            parallel_state.get_model_parallel_src_rank(),
+        )
+    return None, rank
+
+
+def broadcast_tensor(
+    size, dtype, tensor=None, rank=0, data_parallel=False, group: ProcessGroup | None = None
+):
     """Given size and type of a tensor on all ranks and the tensor value
     only on a specific rank, broadcast from that rank to all other ranks.
 
     Args:
+        size: Expected tensor size.
+        dtype: Expected tensor dtype.
+        tensor: Tensor to broadcast (only on the source rank).
+        rank: Global rank to broadcast from when ``data_parallel`` is False
+            and ``group`` is None.
         data_parallel (bool): Broadcast across a single data parallel model replica.
+        group: Explicit process group to broadcast over. When ``data_parallel``
+            is True and ``group`` is None, falls back to the MPU model-parallel
+            group.
     """
-    if data_parallel:
-        rank = parallel_state.get_model_parallel_src_rank()
+    group, rank = _resolve_broadcast_group_and_src_rank(group, rank, data_parallel)
 
     if torch.distributed.get_rank() == rank:
         _is_cuda_contiguous(tensor)
     else:
         tensor = torch.empty(size, dtype=dtype, device=torch.cuda.current_device())
 
-    group = None
-    if data_parallel:
-        group = parallel_state.get_model_parallel_group()
-
     torch.distributed.broadcast(tensor, rank, group=group)
 
     return tensor
 
 
-def broadcast_list(size, dtype, list_values=None, rank=0, data_parallel=False):
+def broadcast_list(
+    size, dtype, list_values=None, rank=0, data_parallel=False, group: ProcessGroup | None = None
+):
     """Broadcast a list of values with a given type.
 
     Args:
+        size: Number of elements in the list.
+        dtype: Tensor dtype used for the broadcast.
+        list_values: Values to broadcast (only on the source rank).
+        rank: Global rank to broadcast from when ``data_parallel`` is False
+            and ``group`` is None.
         data_parallel (bool): Broadcast across a single data parallel model replica.
+        group: Explicit process group to broadcast over. When ``data_parallel``
+            is True and ``group`` is None, falls back to the MPU model-parallel
+            group.
     """
+    group, rank = _resolve_broadcast_group_and_src_rank(group, rank, data_parallel)
 
     tensor = None
+    if torch.distributed.get_rank() == rank:
+        tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())
 
-    if data_parallel:
-        if parallel_state.get_model_parallel_src_rank() == torch.distributed.get_rank():
-            tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())
-
-        rank = parallel_state.get_model_parallel_src_rank()
-    else:
-        if torch.distributed.get_rank() == rank:
-            tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())
-
-    return broadcast_tensor(size, dtype, tensor=tensor, rank=rank, data_parallel=data_parallel)
-
-
-def broadcast_int_list(size, int_list=None, rank=0, data_parallel=False):
-    """Broadcast a list of integer values.
-
-    Args:
-        data_parallel (bool): Broadcast across a single data parallel model replica.
-    """
-
-    return broadcast_list(
-        size, torch.int64, list_values=int_list, rank=rank, data_parallel=data_parallel
+    return broadcast_tensor(
+        size, dtype, tensor=tensor, rank=rank, data_parallel=data_parallel, group=group
     )
 
 
-def broadcast_float_list(size, float_list=None, rank=0, data_parallel=False):
-    """Broadcast a list of float values.
+def broadcast_int_list(
+    size, int_list=None, rank=0, data_parallel=False, group: ProcessGroup | None = None
+):
+    """Broadcast a list of integer values.
 
     Args:
+        size: Number of elements in the list.
+        int_list: Integer values to broadcast (only on the source rank).
+        rank: Global rank to broadcast from when ``data_parallel`` is False
+            and ``group`` is None.
         data_parallel (bool): Broadcast across a single data parallel model replica.
+        group: Explicit process group to broadcast over.
     """
 
     return broadcast_list(
-        size, torch.float32, list_values=float_list, rank=rank, data_parallel=data_parallel
+        size, torch.int64, list_values=int_list, rank=rank, data_parallel=data_parallel, group=group
+    )
+
+
+def broadcast_float_list(
+    size, float_list=None, rank=0, data_parallel=False, group: ProcessGroup | None = None
+):
+    """Broadcast a list of float values.
+
+    Args:
+        size: Number of elements in the list.
+        float_list: Float values to broadcast (only on the source rank).
+        rank: Global rank to broadcast from when ``data_parallel`` is False
+            and ``group`` is None.
+        data_parallel (bool): Broadcast across a single data parallel model replica.
+        group: Explicit process group to broadcast over.
+    """
+
+    return broadcast_list(
+        size,
+        torch.float32,
+        list_values=float_list,
+        rank=rank,
+        data_parallel=data_parallel,
+        group=group,
     )

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/tokenization.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/tokenization.py
@@ -10,12 +10,20 @@ from megatron.core.inference.communication_utils import broadcast_int_list, broa
 
 
 def tokenize_prompts(
-    tokenizer, prompts=None, tokens_to_generate=None, add_BOS=None, rank=0, data_parallel=False
+    tokenizer,
+    prompts=None,
+    tokens_to_generate=None,
+    add_BOS=None,
+    rank=0,
+    data_parallel=False,
+    group=None,
 ):
     """Tokenize prompts and make them avaiable on all ranks.
 
     Args:
         data_parallel (bool): Broadcast tokens across a single data parallel model replica.
+        group: Optional process group for the broadcast helpers. When omitted,
+            those helpers fall back to MPU globals if ``data_parallel`` is True.
     """
 
     # On all ranks set to None so we can pass them to functions
@@ -43,7 +51,7 @@ def tokenize_prompts(
 
     # First, broadcast the sizes.
     sizes_tensor = broadcast_int_list(
-        2, int_list=sizes_list, rank=rank, data_parallel=data_parallel
+        2, int_list=sizes_list, rank=rank, data_parallel=data_parallel, group=group
     )
 
     # Now that we have the sizes, we can boradcast the tokens
@@ -55,6 +63,7 @@ def tokenize_prompts(
         tensor=prompts_tokens_cuda_long_tensor,
         rank=rank,
         data_parallel=data_parallel,
+        group=group,
     )
     prompts_length_cuda_long_tensor = broadcast_tensor(
         sizes[0],
@@ -62,6 +71,7 @@ def tokenize_prompts(
         tensor=prompts_length_cuda_long_tensor,
         rank=rank,
         data_parallel=data_parallel,
+        group=group,
     )
 
     return prompts_tokens_cuda_long_tensor, prompts_length_cuda_long_tensor

--- a/megatron/core/inference/text_generation_server/tokenization.py
+++ b/megatron/core/inference/text_generation_server/tokenization.py
@@ -10,12 +10,20 @@ from megatron.core.inference.communication_utils import broadcast_int_list, broa
 
 
 def tokenize_prompts(
-    tokenizer, prompts=None, tokens_to_generate=None, add_BOS=None, rank=0, data_parallel=False
+    tokenizer,
+    prompts=None,
+    tokens_to_generate=None,
+    add_BOS=None,
+    rank=0,
+    data_parallel=False,
+    group=None,
 ):
     """Tokenize prompts and make them avaiable on all ranks.
 
     Args:
         data_parallel (bool): Broadcast tokens across a single data parallel model replica.
+        group: Optional process group for the broadcast helpers. When omitted,
+            those helpers fall back to MPU globals if ``data_parallel`` is True.
     """
 
     # On all ranks set to None so we can pass them to functions
@@ -43,7 +51,7 @@ def tokenize_prompts(
 
     # First, broadcast the sizes.
     sizes_tensor = broadcast_int_list(
-        2, int_list=sizes_list, rank=rank, data_parallel=data_parallel
+        2, int_list=sizes_list, rank=rank, data_parallel=data_parallel, group=group
     )
 
     # Now that we have the sizes, we can boradcast the tokens
@@ -55,6 +63,7 @@ def tokenize_prompts(
         tensor=prompts_tokens_cuda_long_tensor,
         rank=rank,
         data_parallel=data_parallel,
+        group=group,
     )
     prompts_length_cuda_long_tensor = broadcast_tensor(
         sizes[0],
@@ -62,6 +71,7 @@ def tokenize_prompts(
         tensor=prompts_length_cuda_long_tensor,
         rank=rank,
         data_parallel=data_parallel,
+        group=group,
     )
 
     return prompts_tokens_cuda_long_tensor, prompts_length_cuda_long_tensor

--- a/tests/unit_tests/inference/test_communication_utils.py
+++ b/tests/unit_tests/inference/test_communication_utils.py
@@ -7,7 +7,11 @@ import torch.distributed as dist
 from megatron.core import parallel_state
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.inference.communication_utils import (
+    broadcast_float_list,
     broadcast_from_last_pipeline_stage,
+    broadcast_int_list,
+    broadcast_list,
+    broadcast_tensor,
     recv_from_prev_pipeline_rank_,
     send_to_next_pipeline_rank,
 )
@@ -132,5 +136,157 @@ class TestCommunicationWithCustomPPGroup:
         assert torch.allclose(
             local_recv_buffer_global, local_recv_buffer_custom
         ), "Custom and global recv buffers should be the same."
+
+        grid.destroy()
+
+
+class TestBroadcastWithCustomGroup:
+    """Compare broadcast helpers with MPU fallback vs an explicit process group."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test parameters."""
+        self.size = [16, 8]
+        self.dtype = torch.float32
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _create_mp_group(self, tp_size, pp_size):
+        """Build a HyperCommGrid MP group matching initialize_model_parallel(tp, pp)."""
+        # Note: HyperCommGrid uses minor-to-major order (tp, pp), which is reverse of device mesh
+        grid = HyperCommGrid([tp_size, pp_size], ["tp", "pp"])
+        return grid, grid.create_pg(["tp", "pp"])
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.4.0"),
+        reason="torch.distributed.init_device_mesh requires torch >= 2.4.0",
+    )
+    @pytest.mark.parametrize("tp_size,pp_size", [(1, 8), (2, 4), (4, 2)])
+    def test_broadcast_tensor_comparison(self, tp_size, pp_size):
+        """broadcast_tensor with an explicit MP group matches the MPU fallback."""
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size, pipeline_model_parallel_size=pp_size
+        )
+
+        rank = dist.get_rank()
+        device = torch.device(f"cuda:{rank}")
+        torch.manual_seed(rank)
+
+        src_rank = parallel_state.get_model_parallel_src_rank()
+        local_tensor = (
+            torch.randn(self.size, dtype=self.dtype, device=device)
+            if rank == src_rank
+            else None
+        )
+
+        tensor_received_global = broadcast_tensor(
+            self.size, self.dtype, tensor=local_tensor, data_parallel=True
+        )
+
+        if not dist.is_initialized():
+            dist.init_process_group(backend='nccl')
+
+        grid, mp_group = self._create_mp_group(tp_size, pp_size)
+        tensor_received_custom = broadcast_tensor(
+            self.size, self.dtype, tensor=local_tensor, data_parallel=True, group=mp_group
+        )
+
+        dist.barrier()
+        assert torch.allclose(
+            tensor_received_global, tensor_received_custom
+        ), "broadcast_tensor should be the same with or without an explicit group"
+
+        grid.destroy()
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.4.0"),
+        reason="torch.distributed.init_device_mesh requires torch >= 2.4.0",
+    )
+    @pytest.mark.parametrize("tp_size,pp_size", [(1, 8), (2, 4), (4, 2)])
+    def test_broadcast_list_comparison(self, tp_size, pp_size):
+        """broadcast_list / int / float helpers match MPU fallback with an explicit group."""
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size, pipeline_model_parallel_size=pp_size
+        )
+
+        src_rank = parallel_state.get_model_parallel_src_rank()
+        int_values = [1, 2, 3, 4] if dist.get_rank() == src_rank else None
+        float_values = [1.5, 2.5, 3.5, 4.5] if dist.get_rank() == src_rank else None
+
+        int_global = broadcast_int_list(4, int_list=int_values, data_parallel=True)
+        float_global = broadcast_float_list(4, float_list=float_values, data_parallel=True)
+        list_global = broadcast_list(
+            4, torch.int64, list_values=int_values, data_parallel=True
+        )
+
+        if not dist.is_initialized():
+            dist.init_process_group(backend='nccl')
+
+        grid, mp_group = self._create_mp_group(tp_size, pp_size)
+        int_custom = broadcast_int_list(
+            4, int_list=int_values, data_parallel=True, group=mp_group
+        )
+        float_custom = broadcast_float_list(
+            4, float_list=float_values, data_parallel=True, group=mp_group
+        )
+        list_custom = broadcast_list(
+            4, torch.int64, list_values=int_values, data_parallel=True, group=mp_group
+        )
+
+        dist.barrier()
+        assert torch.equal(
+            int_global, int_custom
+        ), "broadcast_int_list should be the same with or without an explicit group"
+        assert torch.allclose(
+            float_global, float_custom
+        ), "broadcast_float_list should be the same with or without an explicit group"
+        assert torch.equal(
+            list_global, list_custom
+        ), "broadcast_list should be the same with or without an explicit group"
+
+        grid.destroy()
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.4.0"),
+        reason="torch.distributed.init_device_mesh requires torch >= 2.4.0",
+    )
+    @pytest.mark.parametrize("tp_size,pp_size", [(1, 8), (2, 4), (4, 2)])
+    def test_broadcast_tensor_explicit_group_without_data_parallel(self, tp_size, pp_size):
+        """Passing group with data_parallel=False uses that group and the given rank."""
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size, pipeline_model_parallel_size=pp_size
+        )
+
+        rank = dist.get_rank()
+        device = torch.device(f"cuda:{rank}")
+        torch.manual_seed(rank)
+
+        local_tensor = (
+            torch.randn(self.size, dtype=self.dtype, device=device) if rank == 0 else None
+        )
+
+        tensor_received_global = broadcast_tensor(
+            self.size, self.dtype, tensor=local_tensor, rank=0, data_parallel=False
+        )
+
+        if not dist.is_initialized():
+            dist.init_process_group(backend='nccl')
+
+        grid, mp_group = self._create_mp_group(tp_size, pp_size)
+        # tp*pp == world size in these configs, so the MP group is the world group.
+        tensor_received_custom = broadcast_tensor(
+            self.size,
+            self.dtype,
+            tensor=local_tensor,
+            rank=0,
+            data_parallel=False,
+            group=mp_group,
+        )
+
+        dist.barrier()
+        assert torch.allclose(
+            tensor_received_global, tensor_received_custom
+        ), "broadcast_tensor with an explicit world-equivalent group should match default"
 
         grid.destroy()


### PR DESCRIPTION
## Summary

Fixes #7119.

Accept an optional `group` on the inference broadcast helpers so callers can supply a `ProcessGroup` instead of forcing a new `parallel_state.get_*_group()` read.

- `broadcast_tensor`, `broadcast_list`, `broadcast_int_list`, and `broadcast_float_list` take `group: ProcessGroup | None = None` as a trailing keyword (existing positional call sites are unchanged).
- When `data_parallel=True` and no group is provided, the helpers still use `get_model_parallel_group()` / `get_model_parallel_src_rank()`, marked as a migration fallback.
- `tokenize_prompts` threads the new `group` argument through to the helpers. `run_mcore_engine` has no group available and keeps the fallback.

## Test

Extended `tests/unit_tests/inference/test_communication_utils.py` to compare the explicit-group path against the MPU fallback for tensor and list broadcasts, matching the existing custom `pp_group` coverage.

```bash
uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q \
  tests/unit_tests/inference/test_communication_utils.py
```