### PR TITLE
fix(checkpoint): use self.queue / self.md in loader_llava, drop dead return

### DIFF
--- a/tools/checkpoint/loader_llava.py
+++ b/tools/checkpoint/loader_llava.py
@@ -49,8 +49,6 @@ class MegatronCheckpointLoaderLLaVA(MegatronCheckpointLoaderBase):
             '--use-checkpoint-args',
         ]
 
-        return argv
-
     def _maybe_parse_additional_megatron_args(self, margs, checkpoint_args):
         """
         Parse Megatron arguments by forcibly overwriting sys.argv.
@@ -112,7 +110,7 @@ class MegatronCheckpointLoaderLLaVA(MegatronCheckpointLoaderBase):
             from examples.multimodal.config import get_language_model_config, get_vision_model_config, get_vision_projection_config
         except ModuleNotFoundError:
             print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
-            queue.put("exit")
+            self.queue.put("exit")
             exit(1)
 
         # checkpoint_args.cp_comm_type = ["p2p"]
@@ -168,7 +166,7 @@ class MegatronCheckpointLoaderLLaVA(MegatronCheckpointLoaderBase):
         encoder_tp_size = self.md.previous_encoder_tensor_parallel_size
 
         if self.md.vision_model_type not in ("internvit", "siglip", "radio", "radio-g"):
-            raise Exception(f'unrecognized vision model type: {md.vision_model_type}')
+            raise Exception(f'unrecognized vision model type: {self.md.vision_model_type}')
 
         message = {}
         if self.md.vision_model_type in ("internvit", "siglip"):


### PR DESCRIPTION
## Problem

`tools/checkpoint/loader_llava.py` references three names that do not exist in the scope where they are used. `pyflakes` on the file at `main`:

```
tools/checkpoint/loader_llava.py:52:16: undefined name 'argv'
tools/checkpoint/loader_llava.py:115:13: undefined name 'queue'
tools/checkpoint/loader_llava.py:171:64: undefined name 'md'
```

Two of them sit on error paths, so instead of the intended diagnostic the loader dies with `NameError`:

1. **`build_checkpoint_metadata`** — the `except ModuleNotFoundError` handler prints "Unable to import Megatron, please specify the path to Megatron using `--megatron-path`" and then calls `queue.put("exit")`. There is no local or module-level `queue`; the loader keeps it on `self`. `loader_base.py` sets `self.queue = queue` (line 21) and uses `self.queue.put("exit")` in four places. So the one situation this handler exists for — Megatron not importable — raises `NameError` instead of signalling the saver and exiting cleanly.

2. **`send_vision_backbone_over_queue`** — `raise Exception(f'unrecognized vision model type: {md.vision_model_type}')`. Every other line in the same method already uses `self.md` (including the `if` on the line directly above). An unrecognized vision model type therefore surfaces as `NameError: name 'md' is not defined` instead of naming the offending type.

3. **`build_sys_argv`** — an orphan `return argv` sits after the method was changed to return a list literal. Unreachable, and `argv` is undefined.

## Fix

Match the idiom the base class already uses (`self.queue`, `self.md`) and delete the dead statement. +2 / −4, one file, no behavioural change on the success path.

## Verification

Sliced the two real statements straight out of the file with `ast.get_source_segment` (no hand-copied repro) and executed them before and after:

```
### guard: unrecognized vision model type
  before -> NameError: name 'md' is not defined
  after  -> Exception: unrecognized vision model type: clip-vit

### handler: megatron not importable
  before -> NameError: name 'queue' is not defined
  after  -> handler completed, queue got ['exit']
```

`pyflakes` on the patched file reports no undefined names (only two pre-existing unused imports, left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
