### PR TITLE
fix(autoresume): pass num_floating_point_operations_so_far to save_checkpoint

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3983,6 +3983,7 @@ def post_training_step_callbacks(
     prof,
     num_floating_point_operations_since_last_log_event,
     nsys_nvtx_context = None,
+    num_floating_point_operations_so_far = 0,
 ):
     """Run all post-training-step functions (e.g., FT heartbeats, GC)."""
     args = get_args()
@@ -4014,7 +4015,13 @@ def post_training_step_callbacks(
 
     # Autoresume.
     if args.adlr_autoresume and (iteration % args.adlr_autoresume_interval == 0):
-        check_adlr_autoresume_termination(iteration, model, optimizer, opt_param_scheduler)
+        check_adlr_autoresume_termination(
+            iteration,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            num_floating_point_operations_so_far,
+        )
 
     # Profiling.
     if (
@@ -5007,6 +5014,7 @@ def train(
             prof,
             num_floating_point_operations_since_last_log_event,
             nsys_nvtx_context,
+            num_floating_point_operations_so_far=num_floating_point_operations_so_far,
         )
 
         # Checkpoint and decide whether to exit.

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -431,7 +431,9 @@ def print_params_min_max_norm(optimizer, iteration):
     print(string, flush=True)
 
 
-def check_adlr_autoresume_termination(iteration, model, optimizer, opt_param_scheduler):
+def check_adlr_autoresume_termination(
+    iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far=0
+):
     """Check for autoresume signal and exit if it is received."""
     from megatron.training.checkpointing import save_checkpoint
 
@@ -441,7 +443,13 @@ def check_adlr_autoresume_termination(iteration, model, optimizer, opt_param_sch
     torch.distributed.barrier()
     if autoresume.termination_requested():
         if args.save:
-            save_checkpoint(iteration, model, optimizer, opt_param_scheduler)
+            save_checkpoint(
+                iteration,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                num_floating_point_operations_so_far,
+            )
         print_rank_0(">>> autoresume termination request found!")
         if torch.distributed.get_rank() == 0:
             autoresume.request_resume()


### PR DESCRIPTION
## Problem

`check_adlr_autoresume_termination()` in `megatron/training/utils/common_utils.py:434` calls

```python
save_checkpoint(iteration, model, optimizer, opt_param_scheduler)
```

but `save_checkpoint` (`megatron/training/checkpointing.py:611`) has taken
`num_floating_point_operations_so_far` as its **fifth required positional argument** for a long
time, and every other call site in `training.py` passes it.

So the one path whose whole job is to rescue a run when the cluster signals an ADLR autoresume
termination raises

```
TypeError: save_checkpoint() missing 1 required positional argument:
'num_floating_point_operations_so_far'
```

instead of writing the checkpoint. Nothing catches it — with `--adlr-autoresume` and `--save`
both set, the emergency checkpoint is simply never written and the job dies at the exact moment
it was trying to persist its state.

### Reachability

`training.py:4097` (`post_training_step_callbacks`) calls it every
`--adlr-autoresume-interval` iterations; the crash then fires the first time
`autoresume.termination_requested()` returns `True`. This is exactly the preemption case, which
is why it has survived in a hot file: the happy path never reaches it.

### Before / after

`inspect.Signature` replay of the actual call against the actual `save_checkpoint` signature
(no GPUs needed):

```
save_checkpoint signature: (iteration, model, optimizer, opt_param_scheduler,
                            num_floating_point_operations_so_far, checkpointing_context=None, ...)

BEFORE: 4 positional, kwargs=[] -> TypeError: missing a required argument:
                                   'num_floating_point_operations_so_far'
AFTER : 5 positional, kwargs=[] -> BINDS OK
```

## Fix

Thread the counter through. `train()` already has `num_floating_point_operations_so_far` in
scope where it calls `post_training_step_callbacks()` (it is passed to
`checkpoint_and_decide_exit` a few lines later), so it is forwarded as a keyword argument at both
hops:

- `post_training_step_callbacks(..., num_floating_point_operations_so_far=0)` — new trailing
  keyword parameter with a default, so no positional call site changes meaning;
- `check_adlr_autoresume_termination(..., num_floating_point_operations_so_far=0)` — same, which
  keeps the legacy `tasks/finetune_utils.py:207` caller (four arguments) working unchanged.

+19 / −3 over two files, no behaviour change on any path that does not hit an autoresume
termination.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
