### PR TITLE
Fix LayerWise parameter norm logging with overlapped gather

### DIFF
--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -569,6 +569,17 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                 for chunk in model_chunks
                 if hasattr(chunk, 'full_param_layout') and chunk.full_param_layout is not None
             ] or None
+        # Mark all main weights as DP-sharded so parameter norms count only owners.
+        if config.bf16:
+            for optimizer in optimizers:
+                for group in optimizer.param_groups:
+                    for param in group['params']:
+                        if param.requires_grad and param.type() in [
+                            'torch.cuda.HalfTensor',
+                            'torch.cuda.BFloat16Tensor',
+                        ]:
+                            param.main_param_sharded = True
+
         self.shard_params(optimizers, full_param_layouts)
 
         # When a full_param_layout is available, ddp_config.use_distributed_optimizer

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -68,15 +68,14 @@ def _get_param_data(param, force_create_fp32_copy, bf16):
     """Extract the appropriate data tensor from a param for norm computation.
 
     Returns (data_tensor, is_sharded) where is_sharded indicates the param has
-    a sharded main_param from the distributed optimizer.
+    a DP-sharded optimizer main_param. Non-owners may have no main_param attribute.
     """
     if bf16:
-        if not force_create_fp32_copy and hasattr(param, 'main_param'):
+        if not force_create_fp32_copy:
             if getattr(param, 'main_param_sharded', False):
-                if param.main_param is not None:
-                    return param.main_param, True
-                return None, True
-            return param.main_param, False
+                return getattr(param, 'main_param', None), True
+            if hasattr(param, 'main_param'):
+                return param.main_param, False
         return param.data.float(), False
     return param.data, False
 

--- a/tests/unit_tests/training/test_param_norm.py
+++ b/tests/unit_tests/training/test_param_norm.py
@@ -407,3 +407,74 @@ def test_layer_wise_muon_grad_norm_uses_expert_tp_group_for_row_parallel_bias():
         assert actual_norm_value == pytest.approx(expected_norm)
     finally:
         Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("expert_parallel_size", (1, 2))
+def test_layer_wise_param_norm_counts_owners_before_param_sync(monkeypatch, expert_parallel_size):
+    """Norms use updated owner weights while non-owner model copies remain stale."""
+    from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+    if Utils.world_size < 4 or Utils.world_size % 2 != 0:
+        pytest.skip("test requires an even world size of at least four")
+
+    monkeypatch.setattr(
+        common_utils, "get_args", lambda: SimpleNamespace(use_megatron_fsdp=False, bf16=True)
+    )
+    try:
+        Utils.initialize_model_parallel(expert_model_parallel_size=expert_parallel_size)
+        model = _build_tiny_moe_gpt(
+            tensor_parallel_size=1,
+            expert_parallel_size=expert_parallel_size,
+            expert_tensor_parallel_size=1,
+            bf16=True,
+        ).bfloat16()
+        _fill_parameters_with_ones(model)
+        expected_numel = sum(
+            p.numel() * (1 if getattr(p, "allreduce", True) else expert_parallel_size)
+            for p in model.parameters()
+        )
+        model = DistributedDataParallel(
+            model.config, DistributedDataParallelConfig(overlap_param_gather=True), model
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(
+                optimizer="muon",
+                lr=0.0,
+                bf16=True,
+                use_layer_wise_distributed_optimizer=True,
+                muon_tp_mode="duplicated",
+            ),
+            [model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        assert isinstance(optimizer, LayerWiseDistributedOptimizer)
+        assert optimizer.overlap_param_gather
+        params = list(model.parameters())
+        assert all(getattr(p, "main_param_sharded", False) for p in params)
+        assert common_utils.calc_params_l2_norm(model) == pytest.approx(math.sqrt(expected_numel))
+        assert common_utils.calc_params_l2_norm(
+            model, force_create_fp32_copy=True
+        ) == pytest.approx(math.sqrt(expected_numel))
+
+        # Simulate an optimizer update before DDP's next parameter gather. Use an
+        # exactly representable value, so rounding cannot explain a norm mismatch.
+        with torch.no_grad():
+            for param in params:
+                main_param = getattr(param, "main_param", None)
+                if main_param is not None:
+                    main_param.fill_(2.0)
+                else:
+                    torch.testing.assert_close(param, torch.ones_like(param))
+                    assert common_utils._get_param_data(param, False, True) == (None, True)
+        assert common_utils.calc_params_l2_norm(model) == pytest.approx(
+            2.0 * math.sqrt(expected_numel)
+        )
+        # Explicit model-copy mode must continue to read the unsynchronized copies.
+        assert common_utils.calc_params_l2_norm(model, force_create_fp32_copy=True) < (
+            2.0 * math.sqrt(expected_numel)
+        )
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION

  # What does this PR do?

  Fix parameter norm logging with LayerWise optimizer and overlapped parameter gather.

  Mark LayerWise main weights as DP-sharded so norm computation sums owners’ updated main weights
  and skips non-owners’ potentially stale model copies.

  ## Issue tracking

  Linked issue: N/A

  ## Validation

  Passed syntax, whitespace, and isolated logic checks. Multi-GPU testing is pending.

  ## Contribution process

  ### Pre-checks

  - [ ] I have added relevant unit tests
  - [ ] I have added relevant functional tests
  - [ ] I have added proper typing to my code
  - [ ] I have added relevant documentation
  - [ ] I have run autoformat.sh on my PR

issue: https://github.com/NVIDIA/Megatron-LM/issues/7131