### PR TITLE
fix(dist-checkpointing): import get_torch_version so uneven-sharding error raises CheckpointingException, not NameError

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -273,7 +273,7 @@ def mcore_to_pyt_state_dict(
         - if `allow_shape_mismatch` is True, the data is initialized with zeros
             prior to loading (not all parts of the tensor will be read from the checkpoint)
         """
-        from ...utils import is_torch_min_version
+        from ...utils import get_torch_version, is_torch_min_version
 
         assert all(isinstance(sh_ten, ShardedTensor) for sh_ten in sh_tens), sh_tens
         for sh_ten in sh_tens:


### PR DESCRIPTION
## Problem

`_mcore_to_dcp_compatible_tensor()` (nested inside `mcore_to_torch_sharded_tensor`, `megatron/core/dist_checkpointing/strategies/torch.py`) opens with

```python
from ...utils import is_torch_min_version
```

but a few lines further down it also calls `get_torch_version()`:

```python
else:
    if not sh_tens[0].has_regular_grid and not is_torch_min_version("2.6a0"):
        raise CheckpointingException(
            f"Uneven sharding not supported for PyTorch version {get_torch_version()}"
        )
```

`get_torch_version` is not imported at module level either, so on that branch — an unevenly-sharded `ShardedTensor` (`has_regular_grid == False`) on PyTorch older than 2.6 — the f-string is evaluated first and the user gets

```
NameError: name 'get_torch_version' is not defined
```

instead of the intended `CheckpointingException`. The actionable message ("uneven sharding needs a newer PyTorch") never reaches the user; they see a bare `NameError` out of the checkpoint-save path.

Nothing catches it: `mcore_to_torch_sharded_tensor` has no `try/except` around this call, so the exception propagates as-is.

## Why it survived

The happy paths (regular grid, or PyTorch >= 2.6) skip the branch entirely, so it is only reached by the exact combination above.

## Fix

Extend the existing local import. `TorchDistSaveShardedStrategy.__init__` in this same file already does exactly this a few hundred lines below:

```python
from ...utils import get_torch_version
```

so the in-file convention is followed. +1/-1.

## Verification

`_mcore_to_dcp_compatible_tensor` was extracted from the real file with `ast.get_source_segment` (not re-typed) and replayed with `is_torch_min_version` stubbed to return `False` and a `ShardedTensor` whose `has_regular_grid` is `False`:

```
### BEFORE (main HEAD)
   -> NameError: name 'get_torch_version' is not defined
### AFTER (patched)
   -> CheckpointingException: Uneven sharding not supported for PyTorch version 2.5.1
```

`pyflakes megatron/core/dist_checkpointing/strategies/torch.py` reports the undefined name on `main` and nothing after the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
