### PR TITLE
Support dynamic context parallel groups in Mamba layers

### DIFF
--- a/megatron/core/ssm/mamba_context_parallel.py
+++ b/megatron/core/ssm/mamba_context_parallel.py
@@ -95,6 +95,9 @@ class MambaContextParallel:
         self.D_has_hdim = D_has_hdim
         self.sequence_is_contiguous = sequence_is_contiguous
 
+        self._set_cp_params()
+
+    def _set_cp_params(self) -> None:
         self.cp_size = self.cp_group.size()
 
         if self.cp_size == 1:
@@ -139,6 +142,11 @@ class MambaContextParallel:
         # because `nheads % ngroups == 0`, and therefore `nheads_local_tp % ngroups_local_tp == 0`,
         # and also `nheads_local_tpcp = nheads_local_tp // cp_size` whilst ngroups_local_tpcp is
         # either 1 or `ngroups_local_tp // cp_size`
+
+    def set_context_parallel_group(self, cp_group: torch.distributed.ProcessGroup):
+        """Set the context parallel group."""
+        self.cp_group = cp_group
+        self._set_cp_params()
 
     def pre_conv_ssm(
         self, input_: torch.Tensor, packed_seq_params: Optional[PackedSeqParams] = None

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -512,6 +512,12 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
                     out, out_bias = self._static_decode(hidden_states, conv_state, ssm_state)
                     return out, out_bias
 
+        # Dynamic CP group support
+        # This is used in long context training/fine-tuning with sequence packing.
+        # Allows for dynamic CP group selection based on the true length of samples in the batch.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            self.cp.set_context_parallel_group(packed_seq_params.cp_group)
+
         zxBCdt, _ = self.in_proj(hidden_states)
 
         zxBCdt = self.cp.pre_conv_ssm(zxBCdt, packed_seq_params)


### PR DESCRIPTION
## What does this PR do?

Lets Mamba layers follow dynamic context-parallel groups: `MambaContextParallel` gains `set_context_parallel_group()` (CP-size-derived params refactored into `_set_cp_params()`), and `MambaMixer.forward` rebinds the CP group from `packed_seq_params.cp_group` before `in_proj` when dynamic CP is active. Independently mergeable — `PackedSeqParams.cp_group` already exists on main.

## Series (split of #3791)

Split of #3791 ("Update Dynamic CP to support sequence packing, MXFP8 and Mamba") against current `main`, tracked in the [Dynamic Context Parallelism project](https://github.com/orgs/NVIDIA/projects/297). **Original changes by @parthmannan in #3791**; hunks already covered by main (via the merged sequence-packing series and hybrid-CP fixes) were dropped, and the rest re-implemented against main's current structure. All PRs target `main`; merge order:

| Order | PR | Content |
|---|---|---|
| any | #7143 Mamba dynamic CP | SSM wiring for runtime CP groups |
| 1 | #7144 Hybrid-CP sequence packing | packed microbatches in the hybrid-CP dataloader + schedule |
| 2 | #7145 MTP dynamic CP | multi-token-prediction loss on the runtime CP group |
| 2 | #7146 MoE dynamic CP | aux-loss reduction, dispatcher padding, EP sync, loss-scale logging |


## Contribution process
- [x] Draft PR per contributing guidelines
- [x] Commits signed off (DCO)

