### PR TITLE
Pack microbatches under hybrid context parallelism

### DIFF
--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -8,6 +8,7 @@ import torch
 from megatron.core import parallel_state
 from megatron.core.datasets.data_schedule_utils import (
     _get_global_seqlens_and_ids,
+    _pack_sequences,
     broadcast_scalars,
     broadcast_tensor,
     broadcast_to_pp_group,
@@ -19,6 +20,7 @@ from megatron.core.datasets.data_schedule_utils import (
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.hybrid_cp_schedule import BalancedCPScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.rerun_state_machine import RerunDataIterator
 
 try:
     # Register the TE CUDA kernels
@@ -317,6 +319,182 @@ class HybridCPDataLoaderWrapper:
                 batch_unpacked.append(sub_sample_dict)
         return batch_unpacked
 
+    def _get_pad_len(self, seq_len: int, local_cp_size: int) -> int:
+        """
+        Calculates the number of padding tokens to append to a packed sequence.
+
+        Step 1: The packed sequence must be divisible by local_cp_size * 2,
+        or local_cp_size * tp_size * 2 when using sequence parallel.
+        Step 2: The per-rank sequence shard may need extra alignment
+        (e.g. MXFP8 block size or HybridEP chunk size).
+        """
+        tp_size = 1
+        if self.config.sequence_parallel:
+            tp_size = self.tp_group.size()
+        pad_granularity = local_cp_size * tp_size * 2
+        mod_token_count = seq_len % pad_granularity
+        seq_pad_len = 0
+        if mod_token_count != 0:
+            seq_pad_len = pad_granularity - mod_token_count
+
+        total_seq_len = seq_len + seq_pad_len
+
+        sharded_pad_granularity = 1
+        # MXFP8 BLOCK_SIZE is 32 and the sequence shard should be divisible by it.
+        if self.config.fp8 is not None and self.config.fp8_recipe == "mxfp8":
+            sharded_pad_granularity = 32
+        if (
+            self.config.moe_token_dispatcher_type == "flex"
+            and self.config.moe_flex_dispatcher_backend == "hybridep"
+        ):
+            # HybridEP requires MAX_NUM_OF_TOKENS_PER_RANK to be divisible
+            # by NUM_OF_TOKENS_PER_CHUNK (128).
+            sharded_pad_granularity = 128
+
+        # tp_size is set to 1 when sequence parallel is not enabled.
+        sharded_tensor_shape = total_seq_len // (local_cp_size * tp_size)
+        mod_token_count = sharded_tensor_shape % sharded_pad_granularity
+        sharded_pad_len = 0
+        if mod_token_count != 0:
+            sharded_pad_len = (sharded_pad_granularity - mod_token_count) * (
+                local_cp_size * tp_size
+            )
+
+        return sharded_pad_len + seq_pad_len
+
+    def _pack_sequences(
+        self, samples: List[Dict[str, torch.Tensor]], local_cp_size: int
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Packs the sub-samples assigned to this rank for one microbatch into a
+        single packed sample, pads the packed sequence to the hybrid-CP pad
+        granularity, and attaches the microbatch's local_cp_size.
+
+        Delegates the packing mechanics to ``data_schedule_utils._pack_sequences``
+        and reshapes the result to the 2-D batched schema
+        ``get_batch_on_this_tp_rank`` expects under hybrid context parallelism.
+        """
+        dev = torch.cuda.current_device()
+        # The dataset already pads individual sub-samples, so the padded and
+        # original lengths coincide here.
+        # TODO(pmannan): We need to be able to differentiate if the original data_iterator
+        # is providing padded samples or valid lengths.
+        sample_lens = torch.tensor([s["tokens"].shape[0] for s in samples], dtype=torch.int32)
+        new_sample = _pack_sequences(samples, sample_lens, sample_lens, dev)
+
+        # We only pad after packing because the dataset already pads
+        # individual sub-samples.
+        pad_len = self._get_pad_len(int(new_sample["tokens"].shape[0]), local_cp_size)
+        if pad_len > 0:
+            tokens = new_sample["tokens"]
+            labels = new_sample["labels"]
+            loss_mask = new_sample["loss_mask"]
+            position_ids = new_sample["position_ids"]
+            new_sample["tokens"] = torch.cat(
+                [tokens, torch.zeros(pad_len, dtype=tokens.dtype, device=tokens.device)]
+            )
+            new_sample["labels"] = torch.cat(
+                [labels, torch.zeros(pad_len, dtype=labels.dtype, device=labels.device)]
+            )
+            new_sample["loss_mask"] = torch.cat(
+                [loss_mask, torch.zeros(pad_len, dtype=loss_mask.dtype, device=loss_mask.device)]
+            )
+            next_position_id = int(position_ids[-1].item()) + 1
+            new_sample["position_ids"] = torch.cat(
+                [
+                    position_ids,
+                    torch.arange(
+                        next_position_id,
+                        next_position_id + pad_len,
+                        dtype=position_ids.dtype,
+                        device=position_ids.device,
+                    ),
+                ]
+            )
+            # The padding extends the last packed sub-sample.
+            new_sample["cu_seqlens"][-1] += pad_len
+            new_sample["cu_seqlens_padded"][-1] += pad_len
+            new_sample["max_seqlen"] = torch.max(torch.diff(new_sample["cu_seqlens_padded"])).to(
+                dtype=torch.int32
+            )
+
+        new_sample["local_cp_size"] = torch.tensor([local_cp_size], device=dev, dtype=torch.int32)
+
+        # Reshape to the 2-D batched schema (batch dim of 1) that
+        # get_batch_on_this_tp_rank expects under hybrid context parallelism.
+        for key in ("tokens", "labels", "loss_mask", "position_ids"):
+            new_sample[key] = new_sample[key].unsqueeze(0)
+        new_sample["cu_seqlens"] = new_sample["cu_seqlens"].unsqueeze(0)
+        new_sample["cu_seqlens_padded"] = new_sample["cu_seqlens_padded"].unsqueeze(0)
+        new_sample["max_seqlen"] = new_sample["max_seqlen"].reshape(1)
+
+        return new_sample
+
+    def _build_packed_microbatches(
+        self,
+        grouped_samples: List[List[Dict[str, torch.Tensor]]],
+        sample_id_groups: List[List[int]],
+        hdp_rank: int,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """
+        Build packed samples for each microbatch given a pre-built list of `samples` per microbatch.
+
+        Args:
+            grouped_samples: List of length `num_microbatches`. Each element is the `samples` list
+                (list[sample]) for that microbatch, where `sample` is the dict returned by
+                `dataset.__getitem__`.
+            sample_id_groups: List of length `num_microbatches`.
+                Each element is the `sample_id_groups` list (list[sample_id]) for that microbatch,
+                where `sample_id` is the id of the sub-sample.
+
+        Returns:
+            new_samples: list of packed samples (dicts) length == num_micro_batches.
+        """
+        num_micro_batches = len(grouped_samples)
+
+        new_samples: List[Dict[str, torch.Tensor]] = []
+        for i in range(num_micro_batches):
+            samples = grouped_samples[i]
+            local_cp_size = -1
+            # sample_id_groups = [[[0, 1, 2], [0, 1, 2]], [[3, 4, 5], [6, 7, 8]]]
+            # Indicates the sub-sample ids per microbatch for each DPxCP rank.
+            for sub_sample_id in sample_id_groups[i][hdp_rank]:  # i:0 hdp_rank:0 [[0, 1, 2]]
+                # sub_sample_id: 0 / 1 / 2
+                partner_cp_size = len(
+                    [True for sample_ids in sample_id_groups[i] if sub_sample_id in sample_ids]
+                )
+
+                if local_cp_size == -1:
+                    local_cp_size = partner_cp_size
+                else:
+                    assert local_cp_size == partner_cp_size, (
+                        f"found sample within a packed microbatch with different local_cp_size: "
+                        f"{local_cp_size} != {partner_cp_size}"
+                    )
+
+            new_sample = self._pack_sequences(samples, local_cp_size)
+            new_samples.append(new_sample)
+
+        return new_samples
+
+    def unpad_batch(self, batch):
+        """
+        Removes the end padding from the batch which could lead to an invalid sample.
+        This could be a result of truncation or padding in the dataset.
+        For example, a packed sample is truncated and is left with prompt tokens
+        which leads to a sample with all zero loss mask.
+        We do this before scheduling.
+        """
+        for sample in batch:
+            end_sample_token_count = int(sample["cu_seqlens"][-1] - sample["cu_seqlens"][-2])
+            if sample["loss_mask"][-end_sample_token_count:].sum() == 0:
+                sample["cu_seqlens"][-1] = sample["cu_seqlens"][-2]
+                for key in sample.keys():
+                    if key in ["cu_seqlens", "batch_idx", "max_seqlen"]:
+                        continue
+                    sample[key] = sample[key][:-end_sample_token_count]
+        return batch
+
     def __next__(self) -> Any:
         """
         Get the next item from the dataset, pull scheduling metadata and return it.
@@ -326,6 +504,7 @@ class HybridCPDataLoaderWrapper:
             return None, None
         else:
             batch = next(self.data_iterator)
+        batch = self.unpad_batch(batch)
         subsample_seqlens = []
         for sample in batch:
             subsample_seqlens.extend(
@@ -349,7 +528,25 @@ class HybridCPDataLoaderWrapper:
         samples_this_rank_with_id = self.reroute_samples_to_hdp_ranks(
             batch, global_ids_this_rank, global_id_seqlens, sample_id_groups, offsets
         )
-        return samples_this_rank_with_id, sample_id_groups
+
+        hdp_rank = self.dp_cp_group.rank()
+        num_micro_batches = len(sample_id_groups)
+
+        grouped_samples = [
+            [
+                samples_this_rank_with_id[sub_sample_id]
+                for sub_sample_id in sample_id_groups[i][hdp_rank]
+            ]
+            for i in range(num_micro_batches)
+        ]
+
+        new_samples = self._build_packed_microbatches(
+            grouped_samples=grouped_samples, sample_id_groups=sample_id_groups, hdp_rank=hdp_rank
+        )
+
+        new_data_iterator = RerunDataIterator(iter(new_samples))
+
+        return new_data_iterator, sample_id_groups
 
 
 class BasePackingScheduler:

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -446,7 +446,9 @@ def create_hybrid_dp_cp_groups(rank, ranks, pg_options):
     hybrid_dp_cp_groups = {}
     # Generate group for every power of 2 up to the number of CP ranks
     # We limit the allowed group sizes in order to avoid excessive overhead.
-    group_sizes = [2**i for i in range(int(log2(len(ranks))))][1:]
+    # TODO(pmannan): Temporarily including the group size 1 in the list of allowed group sizes.
+    # Ideally, we should force CP==1 and re-use that group to save memory.
+    group_sizes = [2**i for i in range(int(log2(len(ranks))))]
     for group_size in group_sizes:
         for i in range(0, len(ranks), group_size):
             group = create_group(

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -8,7 +8,16 @@ from typing import Callable, List, Optional, Tuple
 import torch
 
 from megatron.core import parallel_state
-from megatron.core.rerun_state_machine import RerunDataIterator
+
+# Number of forward groups (logically equivalent to num_microbatches) used in the most
+# recent hybrid CP step.
+# Set each iteration so that training.py can use it for loss scaling.
+_num_total_groups: int = 0
+
+
+def get_num_total_groups() -> int:
+    """Return the num_total_groups value from the most recent hybrid CP step."""
+    return _num_total_groups
 
 
 class BalancedCPScheduler:
@@ -19,6 +28,7 @@ class BalancedCPScheduler:
 
     def __init__(self, max_seq_len_per_rank: int, dp_cp_group: torch.distributed.ProcessGroup):
         self.max_seq_len_per_rank = max_seq_len_per_rank
+        self.config = None
         self.num_subsamples = 0
         self.num_subsamples_processed = 0
         self.free_resources = []
@@ -146,6 +156,8 @@ class BalancedCPScheduler:
         micro_batches = [[] for _ in range(total_gpus)]
         exec_times = [0.0 for _ in range(total_gpus)]
         sample_ids_per_gpu = [[] for _ in range(total_gpus)]
+        # gid : packed sequence length per rank
+        packing_sequence_len = {}
 
         gpu_group_id = [None] * total_gpus
         group_members = {}
@@ -196,8 +208,13 @@ class BalancedCPScheduler:
             if prev_needed is None:
                 prev_needed = needed
 
-            # (a)  Existing groups of exactly this size
-            candidate_gids = [gid for gid, sz in group_size.items() if sz == needed]
+            # (a)  Existing groups of exactly this size with enough packing capacity left
+            candidate_gids = [
+                gid
+                for gid, sz in group_size.items()
+                if sz == needed
+                and packing_sequence_len[gid] + seq_len / needed <= self.max_seq_len_per_rank
+            ]
             if candidate_gids:
                 best_gid, best_load = min(
                     (
@@ -222,6 +239,8 @@ class BalancedCPScheduler:
                 else:
                     chosen_members = group_members[best_gid]
             else:
+                if best_gid is None:
+                    break
                 chosen_members = group_members[best_gid]
 
             # ---- Step 2 – if we decided to create a fresh group ----------------
@@ -236,6 +255,9 @@ class BalancedCPScheduler:
             # ---- Step 3 – assign the sequence to every member of that group ------
             per_gpu_cost = compute_estimator(seq_len)
 
+            packing_sequence_len[best_gid] = (
+                packing_sequence_len.get(best_gid, 0) + seq_len / needed
+            )
             for r in chosen_members:
                 micro_batches[r].append(seq_len)
                 exec_times[r] += per_gpu_cost
@@ -326,6 +348,10 @@ class BalancedCPScheduler:
                 proj_slack = max(proj_times) - min(proj_times)
 
                 # Check if trimming the workload helps imbalance
+                # TODO(pmannan): Once support for sequence packing is added,
+                # Make sure that the trimming logic supports removing all sequences added
+                # unless this is called each time we add a sequence.
+                # Then safe to remove the last sequence only.
                 if proj_slack < cur_slack:
                     sample_id_to_remove = sample_ids_per_gpu[max_r][-1]
                     for r in members:
@@ -336,7 +362,9 @@ class BalancedCPScheduler:
                 else:
                     break
 
-        trim_overload()
+        # Trimming is unsafe once groups contain packed sequences.
+        # TODO(tailaim): uncomment this to support different ranks have different num_microbatches
+        # trim_overload()
 
         # Track samples in this group before redistribution to empty GPUs
         total_work_before = sum(len(mb) for mb in micro_batches)
@@ -458,6 +486,8 @@ class BalancedCPScheduler:
         This function recursively forms groups of sub-samples such that all DPxCP ranks
         have a roughly balanced workload in the group.
         """
+        # Store the config so scheduling heuristics can read model-parallel settings.
+        self.config = config
         groups = []
         sample_id_groups = []
         # We assign a sample_id to each sub-sample in order to track assignment to each GPU.
@@ -489,7 +519,7 @@ def hybrid_context_parallel_forward_backward(
     no_sync_func,
     total_num_tokens,
     check_first_val_step,
-    model_type,
+    pg_collection,
 ):
     """
     Scheduler for Hybrid Context Parallel.
@@ -517,97 +547,51 @@ def hybrid_context_parallel_forward_backward(
                 group=parallel_state.get_tensor_model_parallel_group(),
             )
 
-    def _broadcast_num_samples_this_group(num_samples_this_group):
+    def _broadcast_num_total_groups(num_total_groups):
         dev = torch.cuda.current_device()
         torch.distributed.barrier()
 
-        n = 0 if num_samples_this_group is None else int(num_samples_this_group.numel())
-        n = torch.tensor([n], dtype=torch.int64, device=dev)
+        n = 0 if num_total_groups is None else num_total_groups
+        n = torch.tensor(n, dtype=torch.int32, device=dev)
 
         _broadcast(n)
         n = int(n.item())
 
-        assert n > 0, "there should be at least 1 sub samples in the group"
-        num_samples_this_group_broadcast = (
-            torch.empty(n, dtype=torch.int32, device=dev)
-            if num_samples_this_group is None
-            else num_samples_this_group
-        )
-        _broadcast(num_samples_this_group_broadcast)
-        return num_samples_this_group_broadcast
-
-    def _get_new_data_iterator(sample_id_in_group, group_id):
-        if is_first_tp_rank:
-            sub_sample_id = sample_ids_this_group[sample_id_in_group]
-            sample = batch[sub_sample_id]
-            partner_cp_size = len(
-                [True for sample_ids in sample_id_groups[group_id] if sub_sample_id in sample_ids]
-            )
-            # Bridge the 1-D sub-sample dict from HybridCPDataLoaderWrapper.unpack_batch
-            # (token-level keys only, no cu_seqlens/max_seqlen) to the 2-D batched
-            # schema get_batch_on_this_tp_rank expects under is_hybrid_cp. The
-            # original bridge helper (get_batch_on_this_hybrid_cp_rank) was removed
-            # in the get_batch consolidation refactor, leaving the two ends
-            # incompatible; this restores the minimal contract.
-            dev = torch.cuda.current_device()
-            seq_len = sample["tokens"].shape[-1]
-            bridged = {
-                key: sample[key].unsqueeze(0)
-                for key in ("tokens", "labels", "loss_mask", "position_ids")
-            }
-            cu = torch.tensor([[0, seq_len]], dtype=torch.int32, device=dev)
-            bridged["cu_seqlens"] = cu
-            bridged["cu_seqlens_padded"] = cu.clone()
-            bridged["max_seqlen"] = torch.tensor([seq_len], dtype=torch.int32, device=dev)
-            bridged["local_cp_size"] = torch.tensor(
-                [partner_cp_size], dtype=torch.int32, device=dev
-            )
-            new_data_iterator = RerunDataIterator(iter([bridged]))
-        else:
-            partner_cp_size = 0
-            new_data_iterator = None
-
-        # Keep this int32 to match the hybrid-CP batch metadata dtype
-        # (`local_cp_size`) used by get_batch_on_this_cp_rank.
-        partner_cp_size_tensor = torch.tensor(
-            [partner_cp_size], dtype=torch.int32, device=torch.cuda.current_device()
-        )
-        _broadcast(partner_cp_size_tensor)
-        return new_data_iterator, int(partner_cp_size_tensor.item())
+        return n
 
     # We get data once per global batch and schedule the sub-samples.
-    # TODO(pmannan): Should we wrap the data_iterator here instead of the training.py file?
-    hdp_rank = parallel_state.get_data_parallel_rank(with_context_parallel=True)
-    is_first_tp_rank = parallel_state.get_tensor_model_parallel_rank() == 0
-
-    if is_first_tp_rank:
+    if data_iterator is not None:
         data = next(data_iterator)
         sample_id_groups = data[1]
-        batch = data[0]
+        new_data_iterator = data[0]
     else:
-        data, sample_id_groups, batch = None, None, None
+        data, sample_id_groups, new_data_iterator = None, None, None
 
-    num_samples_this_group = None
-    if is_first_tp_rank:
-        num_samples_this_group = torch.tensor(
-            [len(group[hdp_rank]) for group in sample_id_groups], dtype=torch.int32, device='cuda'
-        )
+    num_total_groups = None
+    if sample_id_groups is not None:
+        num_total_groups = len(sample_id_groups)  # equivalent to num_microbatches
 
-    num_samples_this_group = _broadcast_num_samples_this_group(num_samples_this_group)
-    num_samples_this_group = num_samples_this_group.cpu().numpy()
-    num_total_groups = num_samples_this_group.shape[0]
+    # TODO(pmannan): This is now equivalent to regular no pipeline schedule.
+    # Remove this special forward_backward_func and merge with forward_backward_no_pipelining.
+    # With sequence packing + Dynamic CP enabled, num_total_groups is logically
+    # equivalent to num_microbatches.
+    # num_samples_this_group is set to 1 as we now run 1 packed sample per group.
+    num_total_groups = _broadcast_num_total_groups(num_total_groups)
+
+    # Publish num_total_groups so training.py can use it for MoE loss scaling.
+    global _num_total_groups
+    _num_total_groups = num_total_groups
+
+    # After sequence packing, each group has only one packed sample.
+    num_samples_this_group = [1 for _ in range(num_total_groups)]
 
     current_microbatch = 0
 
     # Upto last group, we don't need any sync.
     with no_sync_func():
         for j in range(num_total_groups - 1):
-            sample_ids_this_group = sample_id_groups[j][hdp_rank] if is_first_tp_rank else None
             for i in range(num_samples_this_group[j]):
-                # Call forward step for each sub-sample
-                new_data_iterator, cp_group_size = _get_new_data_iterator(i, j)
-                # TODO: Find the usage of current_microbatch and is_first_microbatch and
-                # how that may affect my usage.
+                # Call forward step for each packed sample
                 output_tensor, num_tokens = forward_step(
                     forward_step_func,
                     new_data_iterator,
@@ -616,7 +600,7 @@ def hybrid_context_parallel_forward_backward(
                     input_tensor,
                     forward_data_store,
                     config,
-                    cp_group_size=cp_group_size,
+                    cp_group_size=pg_collection.cp.size(),
                     collect_non_loss_data=collect_non_loss_data,
                     is_first_microbatch=check_first_val_step(
                         first_val_step, forward_only, current_microbatch == 0
@@ -628,43 +612,8 @@ def hybrid_context_parallel_forward_backward(
                 if not forward_only:
                     backward_step(input_tensor, output_tensor, output_tensor_grad, config)
 
-            # Create a barrier at end of each group.
-            # This barrier ensures that all ranks are prepared to change assigned CP group sizes and
-            # no rank is starting a sub-sample ahead of it's partner ranks.
-            torch.distributed.barrier(
-                parallel_state.get_data_parallel_group(with_context_parallel=True)
-            )
-
-    # For the last group, we need to run the last sub-sample out of the context handler.
-    with no_sync_func():
-        sample_ids_this_group = sample_id_groups[-1][hdp_rank] if is_first_tp_rank else None
-        for i in range(num_samples_this_group[-1] - 1):
-            new_data_iterator, cp_group_size = _get_new_data_iterator(i, -1)
-            # Call forward step for each sub-sample
-            output_tensor, num_tokens = forward_step(
-                forward_step_func,
-                new_data_iterator,
-                model,
-                num_microbatches,
-                input_tensor,
-                forward_data_store,
-                config,
-                cp_group_size=cp_group_size,
-                collect_non_loss_data=collect_non_loss_data,
-                is_first_microbatch=check_first_val_step(
-                    first_val_step, forward_only, current_microbatch == 0
-                ),
-                current_microbatch=current_microbatch,
-            )
-            current_microbatch += 1
-            total_num_tokens += num_tokens.item()
-            if not forward_only:
-                backward_step(input_tensor, output_tensor, output_tensor_grad, config)
-
-    # The last sub-sample of the last group of the last microbatch is
-    # run out of the context handler.
-    new_data_iterator, cp_group_size = _get_new_data_iterator(-1, -1)
-    # Call forward step for each sub-sample
+    # The last packed sample of the last group is run out of the context handler.
+    # Call forward step for each packed sample
     output_tensor, num_tokens = forward_step(
         forward_step_func,
         new_data_iterator,
@@ -673,7 +622,7 @@ def hybrid_context_parallel_forward_backward(
         input_tensor,
         forward_data_store,
         config,
-        cp_group_size=cp_group_size,
+        cp_group_size=pg_collection.cp.size(),
         collect_non_loss_data=collect_non_loss_data,
         is_first_microbatch=check_first_val_step(
             first_val_step, forward_only, current_microbatch == 0

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -769,8 +769,6 @@ def forward_backward_no_pipelining(
     if no_sync_func is None:
         no_sync_func = contextlib.nullcontext
 
-    model_type = get_model_type(model)
-
     forward_data_store = []
     input_tensor, output_tensor_grad = None, None
     total_num_tokens = torch.zeros([], dtype=torch.int, device="cuda")
@@ -808,7 +806,7 @@ def forward_backward_no_pipelining(
             no_sync_func,
             total_num_tokens,
             check_first_val_step,
-            model_type,
+            pg_collection,
         )
     else:
         with no_sync_func():

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2678,7 +2678,7 @@ def get_batch_on_this_cp_rank(
         ``_get_batch_on_this_cp_rank_per_document_balancing``.
       - **Hybrid CP**: When ``cu_seqlens`` is present and ``is_hybrid_cp`` is
         True, creates a local hybrid CP group (via ``hybrid_cp_group_func``)
-        and delegates to ``_get_batch_on_this_cp_rank_per_sequence_balancing``.
+        and delegates to ``_get_batch_on_this_cp_rank_per_document_balancing``.
       - **Contiguous CP**: Keeps the hybrid residual stream in causal rank order.
 
     Args:
@@ -2711,12 +2711,9 @@ def get_batch_on_this_cp_rank(
         assert (
             batch['local_cp_size'] is not None
         ), "local_cp_size is required for hybrid context parallel"
-        if batch['local_cp_size'].item() > 1:
-            hybrid_cp_group = hybrid_cp_group_func(group_size=batch['local_cp_size'].item())
-            batch = _get_batch_on_this_cp_rank_per_sequence_balancing(
-                batch, cp_group=hybrid_cp_group
-            )
-            batch["hybrid_cp_group"] = hybrid_cp_group
+        hybrid_cp_group = hybrid_cp_group_func(group_size=batch['local_cp_size'].item())
+        batch = _get_batch_on_this_cp_rank_per_document_balancing(batch, cp_group=hybrid_cp_group)
+        batch["hybrid_cp_group"] = hybrid_cp_group
     else:
         batch = _get_batch_on_this_cp_rank_per_document_balancing(batch, cp_group=cp_group)
     return batch

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1997,6 +1997,25 @@ def pretrain(
     one_logger = get_one_logger()
     one_logger and one_logger.log_metrics(app_metrics)
 
+    # The train iterator is wrapped in train(); mirror the wrapping for the
+    # valid/test iterators so evaluation also goes through the dynamic-CP
+    # packing scheduler.
+    if args.hybrid_context_parallel:
+        if isinstance(valid_data_iterator, list):
+            valid_data_iterator = [
+                iter(HybridCPDataLoaderWrapper(v, model_cfg)) if v is not None else None
+                for v in valid_data_iterator
+            ]
+        elif valid_data_iterator is not None:
+            valid_data_iterator = iter(HybridCPDataLoaderWrapper(valid_data_iterator, model_cfg))
+        if isinstance(test_data_iterator, list):
+            test_data_iterator = [
+                iter(HybridCPDataLoaderWrapper(v, model_cfg)) if v is not None else None
+                for v in test_data_iterator
+            ]
+        elif test_data_iterator is not None:
+            test_data_iterator = iter(HybridCPDataLoaderWrapper(test_data_iterator, model_cfg))
+
     wandb_writer = get_wandb_writer()
     if wandb_writer:
         # Add job name to the wandb config to make it easier to run more singleton dependency jobs.
@@ -4389,6 +4408,10 @@ def train(
     one_logger = get_one_logger()
 
     if args.hybrid_context_parallel:
+        if mpu.get_tensor_model_parallel_rank() == 0:
+            assert (
+                train_data_iterator is not None
+            ), "train_data_iterator must be provided for TP0 rank before Dynamic CP wrapper"
         train_data_iterator = iter(HybridCPDataLoaderWrapper(train_data_iterator, config))
 
     if args.run_workload_inspector_server:

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -151,32 +151,42 @@ def _patch_hybrid_cp_cpu_tensors(monkeypatch):
     )
 
 
-def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypatch):
+def test_hybrid_context_parallel_forward_backward_passes_packed_samples(monkeypatch):
     _patch_hybrid_cp_cpu_tensors(monkeypatch)
     _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=True)
 
     monkeypatch.setattr(
         hybrid_cp_schedule.torch.distributed, "broadcast", lambda *args, **kwargs: None
     )
-    barrier_groups = []
+    barrier_calls = []
     monkeypatch.setattr(
         hybrid_cp_schedule.torch.distributed,
         "barrier",
-        lambda group=None: barrier_groups.append(group),
+        lambda group=None: barrier_calls.append(group),
     )
 
-    def _make_sub_sample(length):
-        # Shape of a real HybridCPDataLoaderWrapper.unpack_batch sub-sample:
-        # 1-D token-level tensors, no cu_seqlens/max_seqlen keys.
+    def _make_packed_sample(length, local_cp_size):
+        # Shape of a real packed sample from HybridCPDataLoaderWrapper: the
+        # bridged 2-D batched schema that get_batch_on_this_tp_rank requires
+        # under is_hybrid_cp, produced by _pack_sequences at the dataloader.
         return {
-            "tokens": torch.arange(length, dtype=torch.int64),
-            "labels": torch.arange(1, length + 1, dtype=torch.int64),
-            "loss_mask": torch.ones(length, dtype=torch.float32),
-            "position_ids": torch.arange(length, dtype=torch.int64),
+            "tokens": torch.arange(length, dtype=torch.int64).unsqueeze(0),
+            "labels": torch.arange(1, length + 1, dtype=torch.int64).unsqueeze(0),
+            "loss_mask": torch.ones(1, length, dtype=torch.float32),
+            "position_ids": torch.arange(length, dtype=torch.int64).unsqueeze(0),
+            "cu_seqlens": torch.tensor([[0, length]], dtype=torch.int32),
+            "cu_seqlens_padded": torch.tensor([[0, length]], dtype=torch.int32),
+            "max_seqlen": torch.tensor([length], dtype=torch.int32),
+            "local_cp_size": torch.tensor([local_cp_size], dtype=torch.int32),
         }
 
-    batch = [_make_sub_sample(16), _make_sub_sample(24), _make_sub_sample(8)]
-    sample_id_groups = [[[0], [0], []], [[1, 2], [1], [1, 2]]]
+    packed_samples = [
+        _make_packed_sample(16, 2),
+        _make_packed_sample(24, 3),
+        _make_packed_sample(8, 2),
+    ]
+    # One packed sample per group after sequence packing.
+    sample_id_groups = [[[0], [0], []], [[1, 2], [1], [1, 2]], [[3], [], [3]]]
     forward_calls = []
 
     def fake_forward_step(
@@ -190,11 +200,9 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
         cp_group_size,
         **kwargs,
     ):
+        # The schedule must pass the packed-sample iterator through untouched.
         assert isinstance(data_iterator, RerunDataIterator)
         sample = next(data_iterator)
-        # The schedule must hand forward_step the bridged 2-D batched schema
-        # that get_batch_on_this_tp_rank requires under is_hybrid_cp; a raw
-        # 1-D unpack_batch sub-sample here is the regression this test guards.
         length = sample["tokens"].shape[-1]
         for key in ("tokens", "labels", "loss_mask", "position_ids"):
             assert sample[key].shape == (1, length)
@@ -208,7 +216,6 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
             {
                 "length": int(length),
                 "local_cp_size": int(sample["local_cp_size"].item()),
-                "local_cp_size_dtype": sample["local_cp_size"].dtype,
                 "cp_group_size": cp_group_size,
                 "current_microbatch": kwargs["current_microbatch"],
                 "is_first_microbatch": kwargs["is_first_microbatch"],
@@ -225,10 +232,11 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
     monkeypatch.setattr(schedule, "backward_step", fake_backward_step)
 
     config = SimpleNamespace()
+    pg_collection = SimpleNamespace(cp=SimpleNamespace(size=lambda: 4))
     forward_data_store, total_num_tokens = (
         hybrid_cp_schedule.hybrid_context_parallel_forward_backward(
             forward_step_func=None,
-            data_iterator=iter([(batch, sample_id_groups)]),
+            data_iterator=iter([(RerunDataIterator(iter(packed_samples)), sample_id_groups)]),
             model="model",
             num_microbatches=3,
             input_tensor="input",
@@ -241,34 +249,32 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
             no_sync_func=_no_sync,
             total_num_tokens=0,
             check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
-            model_type="unused",
+            pg_collection=pg_collection,
         )
     )
 
     assert forward_data_store == []
     assert total_num_tokens == 30
+    assert hybrid_cp_schedule.get_num_total_groups() == 3
     assert forward_calls == [
         {
             "length": 16,
             "local_cp_size": 2,
-            "local_cp_size_dtype": torch.int32,
-            "cp_group_size": 2,
+            "cp_group_size": 4,
             "current_microbatch": 0,
             "is_first_microbatch": True,
         },
         {
             "length": 24,
             "local_cp_size": 3,
-            "local_cp_size_dtype": torch.int32,
-            "cp_group_size": 3,
+            "cp_group_size": 4,
             "current_microbatch": 1,
             "is_first_microbatch": False,
         },
         {
             "length": 8,
             "local_cp_size": 2,
-            "local_cp_size_dtype": torch.int32,
-            "cp_group_size": 2,
+            "cp_group_size": 4,
             "current_microbatch": 2,
             "is_first_microbatch": False,
         },
@@ -279,21 +285,17 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
         ("input", 2.0, "grad"),
     ]
     assert all(call[3] is config for call in backward_calls)
-    assert "dp_cp_group" in barrier_groups
+    assert barrier_calls == [None]
 
 
-def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkeypatch):
+def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_group_count(monkeypatch):
     _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=False)
     monkeypatch.setattr(
         hybrid_cp_schedule.torch.cuda, "current_device", lambda: torch.device("cpu")
     )
     monkeypatch.setattr(hybrid_cp_schedule.torch.distributed, "barrier", lambda group=None: None)
 
-    broadcast_values = [
-        torch.tensor([1], dtype=torch.int64),
-        torch.tensor([1], dtype=torch.int32),
-        torch.tensor([7], dtype=torch.int32),
-    ]
+    broadcast_values = [torch.tensor(2, dtype=torch.int32)]
 
     def fake_broadcast(item, src, group=None):
         item.copy_(broadcast_values.pop(0))
@@ -327,7 +329,7 @@ def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkey
         forward_step_func=None,
         data_iterator=None,
         model="model",
-        num_microbatches=1,
+        num_microbatches=2,
         input_tensor="input",
         output_tensor_grad="grad",
         forward_data_store=[],
@@ -338,12 +340,16 @@ def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkey
         no_sync_func=_no_sync,
         total_num_tokens=0,
         check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
-        model_type="unused",
+        pg_collection=SimpleNamespace(cp=SimpleNamespace(size=lambda: 7)),
     )
 
-    assert forward_calls == [(None, 7, 0)]
-    assert total_num_tokens == 4
+    # The non-first TP rank learns the group count from the broadcast and runs
+    # one forward step per group with a None iterator; the CP size comes from
+    # pg_collection, not a per-group broadcast.
+    assert forward_calls == [(None, 7, 0), (None, 7, 1)]
+    assert total_num_tokens == 8
     assert broadcast_values == []
+    assert hybrid_cp_schedule.get_num_total_groups() == 2
 
 
 @pytest.mark.parametrize("calculate_per_token_loss,expected_scale", [(False, 6.0), (True, 3.0)])


### PR DESCRIPTION
## What does this PR do?

Packs microbatches inside the hybrid-CP path: `HybridCPDataLoaderWrapper.__next__` now packs each microbatch's routed sub-samples (reusing `data_schedule_utils` helpers; uniform `local_cp_size` per packed microbatch; pad granularity aware of sequence parallelism, **MXFP8** 32-token blocks, and HybridEP 128-token chunks), drops trailing all-zero-loss-mask sub-samples, and `hybrid_context_parallel_forward_backward` consumes the pre-packed iterator (one packed sample per group, `pg_collection` instead of `model_type`, per-iteration group count published via `get_num_total_groups()`). Also: hybrid DP-CP groups include size 1, the `local_cp_size>1` guard in `get_batch_on_this_cp_rank` is removed, and eval data iterators get the hybrid-CP wrapper. The two schedule unit tests are updated to the packed contract.

## Series (split of #3791)

Split of #3791 ("Update Dynamic CP to support sequence packing, MXFP8 and Mamba") against current `main`, tracked in the [Dynamic Context Parallelism project](https://github.com/orgs/NVIDIA/projects/297). **Original changes by @parthmannan in #3791**; hunks already covered by main (via the merged sequence-packing series and hybrid-CP fixes) were dropped, and the rest re-implemented against main's current structure. All PRs target `main`; merge order:

| Order | PR | Content |
|---|---|---|
| any | #7143 Mamba dynamic CP | SSM wiring for runtime CP groups |
| 1 | #7144 Hybrid-CP sequence packing | packed microbatches in the hybrid-CP dataloader + schedule |
| 2 | #7145 MTP dynamic CP | multi-token-prediction loss on the runtime CP group |
| 2 | #7146 MoE dynamic CP | aux-loss reduction, dispatcher padding, EP sync, loss-scale logging |


## Contribution process
- [x] Draft PR per contributing guidelines
- [x] Commits signed off (DCO)

