### PR TITLE
Use the dynamic CP group for multi-token prediction loss

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -756,6 +756,9 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     inference_context.mtp_decoder_hidden_states = hidden_states
             elif not in_inference_mode:
                 # In training/eval, use the utility function for processing MTP loss/scaling.
+                # For hybrid/dynamic CP, use the microbatch's runtime CP sub-group
+                # (packed_seq_params.cp_group) instead of the build-time group so MTP
+                # loss rolling exchanges shard boundaries across the right ranks.
                 hidden_states = process_mtp_loss(
                     hidden_states=hidden_states,
                     labels=labels,
@@ -766,7 +769,11 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     is_training=self.training,
                     compute_language_model_loss=self.compute_language_model_loss,
                     config=self.config,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=(
+                        packed_seq_params.cp_group
+                        if packed_seq_params is not None and packed_seq_params.cp_group is not None
+                        else self.pg_collection.cp
+                    ),
                     tp_group=self.tp_group,
                     packed_seq_params=packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -637,6 +637,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 assert mtp_inputs is not None
                 # For RL (labels is None), process_mtp_loss derives labels from
                 # input_ids to match the SFT label format.
+                # For hybrid/dynamic CP, use the microbatch's runtime CP sub-group
+                # (packed_seq_params.cp_group) instead of the build-time group so MTP
+                # loss rolling exchanges shard boundaries across the right ranks.
                 hidden_states = process_mtp_loss(
                     hidden_states=mtp_hidden_states,
                     labels=mtp_inputs.labels,
@@ -647,7 +650,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     is_training=self.training,
                     compute_language_model_loss=self.compute_language_model_loss,
                     config=self.config,
-                    cp_group=self.pg_collection.cp,
+                    cp_group=(
+                        mtp_inputs.packed_seq_params.cp_group
+                        if mtp_inputs.packed_seq_params is not None
+                        and mtp_inputs.packed_seq_params.cp_group is not None
+                        else self.pg_collection.cp
+                    ),
                     tp_group=self.tp_group,
                     packed_seq_params=mtp_inputs.packed_seq_params,
                     scale_logits_fn=self._scale_logits if self.config.use_mup else None,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1260,6 +1260,9 @@ class MultiTokenPredictionLayer(MegatronModule):
         )
         self.vp_stage = vp_stage
         self.cp_group = pg_collection.cp
+        # Build-time CP group, kept so runtime (hybrid/dynamic) CP can restore
+        # it on microbatches that carry no per-microbatch CP group.
+        self._build_time_cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
         self.mhc_enabled = self.config.enable_mhc_connections
@@ -1935,6 +1938,18 @@ class MultiTokenPredictionLayer(MegatronModule):
             [s, b, h], and optionally the updated context tensor if cross-attention is used.
         """
         assert context is None, "multi token prediction + cross attention is not yet supported."
+        # Hybrid/dynamic CP: bind the sub-sample's runtime CP group
+        # (packed_seq_params.cp_group) so the roll_tensor calls in
+        # _get_embeddings shift input_ids/position_ids/padding_mask across the
+        # group this microbatch was actually sharded with; the build-time
+        # group reports cp_size=1 under dynamic CP. Restore the build-time
+        # group when no runtime group is bound (e.g. local_cp_size == 1
+        # sub-samples): the previous microbatch may have left another group
+        # behind.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            self.cp_group = packed_seq_params.cp_group
+        elif self.cp_group is not self._build_time_cp_group:
+            self.cp_group = self._build_time_cp_group
         input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states = (
             self._get_embeddings(
                 input_ids=input_ids,


### PR DESCRIPTION
## What does this PR do?

Multi-token-prediction loss follows the dynamic CP group: `process_mtp_loss` call sites in `gpt_model.py`/`hybrid_model.py` use `packed_seq_params.cp_group` when set, and `MultiTokenPredictionLayer` binds its roll_tensor CP group per microbatch with a build-time snapshot/restore (same pattern as attention). Only the pieces main does not already cover are ported.

## Series (split of #3791)

Split of #3791 ("Update Dynamic CP to support sequence packing, MXFP8 and Mamba") against current `main`, tracked in the [Dynamic Context Parallelism project](https://github.com/orgs/NVIDIA/projects/297). **Original changes by @parthmannan in #3791**; hunks already covered by main (via the merged sequence-packing series and hybrid-CP fixes) were dropped, and the rest re-implemented against main's current structure. All PRs target `main`; merge order:

| Order | PR | Content |
|---|---|---|
| any | #7143 Mamba dynamic CP | SSM wiring for runtime CP groups |
| 1 | #7144 Hybrid-CP sequence packing | packed microbatches in the hybrid-CP dataloader + schedule |
| 2 | #7145 MTP dynamic CP | multi-token-prediction loss on the runtime CP group |
| 2 | #7146 MoE dynamic CP | aux-loss reduction, dispatcher padding, EP sync, loss-scale logging |


## Contribution process
- [x] Draft PR per contributing guidelines
- [x] Commits signed off (DCO)

