### PR TITLE
Support MoE aux losses and expert sync under dynamic context parallelism

### DIFF
--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -23,6 +23,7 @@ class BalancedCPScheduler:
         self.num_subsamples_processed = 0
         self.free_resources = []
         self.total_hdp_gpus = dp_cp_group.size()
+        self.config = None
 
     @lru_cache(maxsize=128)
     def get_total_workload(self, seq_length: int, cp_size: Optional[int] = None):
@@ -50,7 +51,16 @@ class BalancedCPScheduler:
         The number is rounded up to the next power of 2 to match the available
         hybrid context parallel process group sizes.
         """
-        return max(1, 2 ** ceil(log2((seq_len / self.max_seq_len_per_rank))))
+        # HACK: EP ranks run out of sync and can crash due to hang
+        # This is a temporary fix to ensure that expert ranks run in sync.
+        # TODO(pmannan): Remove this hack after fixing the hang issue.
+        # This is sufficient to get most of the benefits of HybridCP
+        min_cp_size = 1
+        if self.config is not None:
+            min_cp_size = max(
+                1, self.config.expert_model_parallel_size / self.config.tensor_model_parallel_size
+            )
+        return int(max(min_cp_size, 2 ** ceil(log2((seq_len / self.max_seq_len_per_rank)))))
 
     def make_buckets_equal(
         self,
@@ -458,6 +468,8 @@ class BalancedCPScheduler:
         This function recursively forms groups of sub-samples such that all DPxCP ranks
         have a roughly balanced workload in the group.
         """
+        # Stash the config so gpus_needed can read EP/TP sizes for the min-CP-size clamp.
+        self.config = config
         groups = []
         sample_id_groups = []
         # We assign a sample_id to each sub-sample in order to track assignment to each GPU.

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -126,7 +126,9 @@ class SharedExpertsBuilder(Protocol):
 class RouterInterface(Protocol):
     """Interface for the router used in an MoELayer."""
 
-    def forward(self, input: torch.Tensor, /) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self, input: torch.Tensor, /, packed_seq_params=None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass of the router.
 
         Returns:
@@ -463,13 +465,20 @@ class MoELayer(BaseMoELayer):
             self._delayed_wgrad_stream = torch.cuda.Stream(device="cuda")
 
     @maybe_skip_or_early_return_by_cudagraph("route")
-    def route(self, hidden_states: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def route(
+        self,
+        hidden_states: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
+    ):
         """Compute token routing for preprocessing.
 
         This method uses the router to determine which experts to send each token to,
         producing routing probabilities and a mapping.
         """
-        probs, routing_map = apply_module(self.router)(hidden_states, padding_mask)
+        probs, routing_map = apply_module(self.router)(
+            hidden_states, padding_mask, packed_seq_params=packed_seq_params
+        )
         return probs, routing_map
 
     @maybe_skip_or_early_return_by_cudagraph("preprocess")
@@ -639,6 +648,7 @@ class MoELayer(BaseMoELayer):
         hidden_states: torch.Tensor,
         intermediate_tensors=None,
         padding_mask: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Forward pass for the MoE layer.
 
@@ -653,6 +663,9 @@ class MoELayer(BaseMoELayer):
             padding_mask (torch.Tensor, optional): Boolean mask indicating padding positions.
                                                    Shape [seq_length, bsz]. True = padding,
                                                    False = valid. Defaults to None.
+            packed_seq_params (PackedSeqParams, optional): Packed sequence parameters.
+                When set and packed_seq_params.cp_group is not None, aux-loss reductions use
+                the per-sequence hybrid CP sub-group instead of the full tp_cp_group.
         Returns:
             A tuple containing the output tensor and the MLP bias, if any.
         """
@@ -682,7 +695,9 @@ class MoELayer(BaseMoELayer):
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
-                    probs, routing_map = self.route(hidden_states, padding_mask)
+                    probs, routing_map = self.route(
+                        hidden_states, padding_mask, packed_seq_params=packed_seq_params
+                    )
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
 
                     if intermediate_tensors is not None:

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -268,23 +268,40 @@ def get_capacity(
 
 def get_tokens_per_expert_and_token_count(
     routing_map: torch.Tensor,
-    reduce_group: torch.distributed.ProcessGroup,
+    reduce_group: Union[torch.distributed.ProcessGroup, List[torch.distributed.ProcessGroup]],
     topk: int = None,
     with_padding_mask: bool = False,
 ) -> torch.Tensor:
     """
     Compute global_tokens_per_expert, local_num_tokens and total_num_tokens with padding mask.
+
+    reduce_group can be either a single ProcessGroup or a list of ProcessGroups.
+    When a list is provided (e.g. for hybrid context parallel), sequential all-reduces are
+    performed across each group in order. The caller is responsible for ordering;
+    all-reduce is commutative so the order does not affect correctness, only potential performance.
+
+    Example — hybrid context parallel:
+        reduce_group = [packed_seq_params.cp_group, self.tp_group]
+    Example — standard context parallel:
+        reduce_group = self.tp_cp_group
     """
-    local_tokens_per_expert = routing_map.sum(dim=0)
-    global_tokens_per_expert = reduce_from_tensor_model_parallel_region(
-        local_tokens_per_expert, reduce_group
+    groups: List[torch.distributed.ProcessGroup] = (
+        reduce_group if isinstance(reduce_group, list) else [reduce_group]
     )
+    local_tokens_per_expert = routing_map.sum(dim=0)
+    global_tokens_per_expert = local_tokens_per_expert
+    for group in groups:
+        global_tokens_per_expert = reduce_from_tensor_model_parallel_region(
+            global_tokens_per_expert, group
+        )
     if with_padding_mask:
         local_num_tokens = local_tokens_per_expert.sum() / topk
         total_num_tokens = global_tokens_per_expert.sum() / topk
     else:
         local_num_tokens = routing_map.shape[0]
-        total_num_tokens = local_num_tokens * reduce_group.size()
+        total_num_tokens = local_num_tokens
+        for group in groups:
+            total_num_tokens = total_num_tokens * group.size()
     return global_tokens_per_expert, local_num_tokens, total_num_tokens
 
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -417,16 +417,24 @@ class TopKRouter(Router):
         scores_for_aux_loss: torch.Tensor,
         routing_map: torch.Tensor,
         with_padding_mask: bool = False,
+        packed_seq_params=None,
     ):
         """Apply the auxiliary loss for the given scores and routing map."""
         aux_loss_coeff = self.get_aux_loss_coeff("aux_loss")
         if aux_loss_coeff == 0:
             return probs
 
+        # For hybrid context parallel, use a two-step reduction: first over the per-sequence
+        # CP sub-group, then over the TP group.  For standard CP, use the combined tp_cp_group.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            reduce_group = [packed_seq_params.cp_group, self.tp_group]
+        else:
+            reduce_group = self.tp_cp_group
+
         global_tokens_per_expert, local_num_tokens, total_num_tokens = (
             get_tokens_per_expert_and_token_count(
                 routing_map=routing_map,
-                reduce_group=self.tp_cp_group,
+                reduce_group=reduce_group,
                 topk=self.topk,
                 with_padding_mask=with_padding_mask,
             )
@@ -441,6 +449,14 @@ class TopKRouter(Router):
             moe_aux_loss_coeff=aux_loss_coeff,
             fused=self.config.moe_router_fusion,
         )
+        # In hybrid CP, the tp_cp_group SUM in reduce_aux_losses_tracker_across_ranks
+        # collects contributions from N/K independent sub-groups per step, overcounting
+        # by N/K relative to standard CP.  Scale down the logged value to correct for
+        # this; the backward gradient (via MoEAuxLossAutoScaler) is unaffected.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            logging_scale = packed_seq_params.cp_group.size() / self.cp_group.size()
+        else:
+            logging_scale = 1.0
         probs = self.attach_and_log_load_balancing_loss(
             probs,
             aux_loss_coeff,
@@ -448,6 +464,7 @@ class TopKRouter(Router):
             "load_balancing_loss",
             self.tp_cp_group,
             valid_token_count=local_num_tokens,
+            logging_scale=logging_scale,
         )
         return probs
 
@@ -459,6 +476,7 @@ class TopKRouter(Router):
         seq_length: int,
         bsz: int,
         with_padding_mask: bool = False,
+        packed_seq_params=None,
     ):
         """Apply the sequence-level auxiliary loss for the given scores and routing map.
 
@@ -474,10 +492,17 @@ class TopKRouter(Router):
         scores_for_aux_loss = scores_for_aux_loss.reshape(seq_length, -1)
         routing_map = routing_map.reshape(seq_length, -1)
 
+        # For hybrid context parallel, use a two-step reduction: first over the per-sequence
+        # CP sub-group, then over the TP group.  For standard CP, use the combined tp_cp_group.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            reduce_group = [packed_seq_params.cp_group, self.tp_group]
+        else:
+            reduce_group = self.tp_cp_group
+
         global_tokens_per_expert, local_num_tokens, total_num_tokens = (
             get_tokens_per_expert_and_token_count(
                 routing_map=routing_map,
-                reduce_group=self.tp_cp_group,
+                reduce_group=reduce_group,
                 with_padding_mask=with_padding_mask,
                 topk=self.topk * bsz,
             )
@@ -496,6 +521,14 @@ class TopKRouter(Router):
             / bsz
         )
 
+        # In hybrid CP, the tp_cp_group SUM in reduce_aux_losses_tracker_across_ranks
+        # collects contributions from N/K independent sub-groups per step, overcounting
+        # by N/K relative to standard CP.  Scale down the logged value to correct for
+        # this; the backward gradient (via MoEAuxLossAutoScaler) is unaffected.
+        if packed_seq_params is not None and packed_seq_params.cp_group is not None:
+            logging_scale = packed_seq_params.cp_group.size() / self.cp_group.size()
+        else:
+            logging_scale = 1.0
         probs = self.attach_and_log_load_balancing_loss(
             probs,
             seq_aux_loss_coeff,
@@ -505,6 +538,7 @@ class TopKRouter(Router):
             # local_num_tokens is per-sequence (bsz folded into the expert dim above);
             # * bsz recovers the micro-batch total, else per-token-loss scaling keeps a 1/MBS.
             valid_token_count=local_num_tokens * bsz,
+            logging_scale=logging_scale,
         )
         return probs
 
@@ -563,6 +597,7 @@ class TopKRouter(Router):
         reduce_group: torch.distributed.ProcessGroup,
         needs_dp_avg: bool = True,
         valid_token_count: Optional[Union[int, torch.Tensor]] = None,
+        logging_scale: float = 1.0,
     ):
         """Attach aux loss function to activation and add to logging.
 
@@ -576,6 +611,9 @@ class TopKRouter(Router):
             valid_token_count (int or torch.Tensor, optional): Number of valid tokens excluding
                 padding tokens. Can be a Python int or a torch.Tensor (typically 0-d tensor).
                 If None, uses activation.shape[0]. Defaults to None.
+            logging_scale (float): Scale factor applied to the logged value only (not the
+                backward gradient). Used in hybrid context parallel to normalize out the N/K
+                sub-group overcounting in the tp_cp_group SUM. Defaults to 1.0 (no scaling).
         """
         # When using repeated MTP layers, the loss is counted "mtp_num_layers" times.
         # To avoid accumulating the load balancing loss multiple times, we scale it by
@@ -602,7 +640,7 @@ class TopKRouter(Router):
 
         get_moe_metrics_tracker().record(
             aux_loss_name,
-            aux_loss / aux_loss_coeff,
+            aux_loss * logging_scale / aux_loss_coeff,
             layer_number,
             num_layers,
             reduce_group=reduce_group,
@@ -747,7 +785,12 @@ class TopKRouter(Router):
                     routing_map = routing_map & (~padding_mask).unsqueeze(-1)
                 self.local_tokens_per_expert += routing_map.sum(dim=0)
 
-    def routing(self, logits: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def routing(
+        self,
+        logits: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
+    ):
         """Top-k routing function
 
         Args:
@@ -755,6 +798,9 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating padding positions.
                                                    Shape [seq_length, bsz]. True = padding,
                                                    False = valid. Defaults to None.
+            packed_seq_params (PackedSeqParams, optional): Packed sequence parameters.
+                When set and packed_seq_params.cp_group is not None, aux-loss reductions use
+                the per-sequence hybrid CP sub-group instead of the full tp_cp_group.
 
         Returns:
             probs (torch.Tensor): The probabilities of token to experts assignment.
@@ -819,6 +865,7 @@ class TopKRouter(Router):
                 scores_for_aux_loss,
                 routing_map_for_aux_loss,
                 with_padding_mask=padding_mask is not None,
+                packed_seq_params=packed_seq_params,
             )
             probs = self._apply_seq_aux_loss(
                 probs,
@@ -827,6 +874,7 @@ class TopKRouter(Router):
                 seq_length,
                 bsz,
                 with_padding_mask=padding_mask is not None,
+                packed_seq_params=packed_seq_params,
             )
             probs = self._apply_global_aux_loss(
                 probs,
@@ -846,7 +894,12 @@ class TopKRouter(Router):
             self.global_tokens_per_expert.zero_()
             self.ga_steps.zero_()
 
-    def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def forward(
+        self,
+        input: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
+    ):
         """
         Forward pass of the router.
 
@@ -855,6 +908,9 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating padding positions.
                                                    Shape [seq_length, bsz]. True = padding,
                                                    False = valid. Defaults to None.
+            packed_seq_params (PackedSeqParams, optional): Packed sequence parameters.
+                When set and packed_seq_params.cp_group is not None, aux-loss reductions use
+                the per-sequence hybrid CP sub-group instead of the full tp_cp_group.
         """
         self._maintain_float32_expert_bias()
 
@@ -872,7 +928,9 @@ class TopKRouter(Router):
                 logits, self.config.moe_router_force_biased, self.layer_number
             )
 
-        probs, routing_map = self.routing(logits, padding_mask=padding_mask)
+        probs, routing_map = self.routing(
+            logits, padding_mask=padding_mask, packed_seq_params=packed_seq_params
+        )
 
         return probs, routing_map
 
@@ -983,12 +1041,18 @@ class InferenceTopKRouter(TopKRouter):
         )
         return probs.squeeze(1), top_indices.squeeze(1)
 
-    def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def forward(
+        self,
+        input: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        packed_seq_params=None,
+    ):
         """Simplified forward pass for inference - returns dense tensors only.
 
         Args:
             input (torch.Tensor): Input tensor of shape [seq_length, bsz, hidden_size].
             padding_mask (torch.Tensor, optional): Not used in inference.
+            packed_seq_params (PackedSeqParams, optional): Not used in inference.
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor]:
@@ -997,6 +1061,6 @@ class InferenceTopKRouter(TopKRouter):
         """
 
         if not InferenceMode.is_active():
-            return super().forward(input, padding_mask)
+            return super().forward(input, padding_mask, packed_seq_params=packed_seq_params)
 
         return self._forward(input, padding_mask)

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -978,7 +978,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
 
         mlp_output_with_bias = self._run_mlp(
-            pre_mlp_layernorm_output, residual, padding_mask, inference_context
+            pre_mlp_layernorm_output,
+            residual,
+            padding_mask,
+            inference_context,
+            packed_seq_params=packed_seq_params,
         )
 
         if moe_unflatten_mbs is not None:
@@ -1022,7 +1026,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
 
         mlp_output_with_bias = self._run_mlp(
-            pre_mlp_layernorm_output, residual, padding_mask, inference_context
+            pre_mlp_layernorm_output,
+            residual,
+            padding_mask,
+            inference_context,
+            packed_seq_params=packed_seq_params,
         )
 
         if moe_unflatten_mbs is not None:
@@ -1056,6 +1064,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         residual: Tensor,
         padding_mask: Tensor | None,
         inference_context: BaseInferenceContext | None,
+        packed_seq_params=None,
     ):
         """Execute the MLP submodule with the appropriate variant.
 
@@ -1099,10 +1108,15 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     self.pg_collection.tp,
                     pre_mlp_layernorm_output,
                     padding_mask=padding_mask,
+                    **({'packed_seq_params': packed_seq_params} if self.is_moe_layer else {}),
                 )
             else:
                 mlp_output_with_bias = tensor_parallel.checkpoint(
-                    functools.partial(apply_module(self.mlp), padding_mask=padding_mask),
+                    functools.partial(
+                        apply_module(self.mlp),
+                        padding_mask=padding_mask,
+                        **({'packed_seq_params': packed_seq_params} if self.is_moe_layer else {}),
+                    ),
                     False,
                     pre_mlp_layernorm_output,
                 )
@@ -1134,7 +1148,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 # operation in MLP's fc2.
                 self._set_fc2_residual(residual)
             mlp_output_with_bias = apply_module(self.mlp)(
-                pre_mlp_layernorm_output, padding_mask=padding_mask
+                pre_mlp_layernorm_output,
+                padding_mask=padding_mask,
+                **({'packed_seq_params': packed_seq_params} if self.is_moe_layer else {}),
             )
 
         nvtx_range_pop(suffix="mlp")
@@ -2190,7 +2206,7 @@ class MoETransformerLayer(TransformerLayer):
         self._router_dtoh_event.record()
         self._router_dtoh_event.synchronize()
 
-    def _forward_mlp_router(self, hidden_states, padding_mask=None):
+    def _forward_mlp_router(self, hidden_states, padding_mask=None, packed_seq_params=None):
         """
         Executes the router phase of the MoE block.
 
@@ -2202,7 +2218,10 @@ class MoETransformerLayer(TransformerLayer):
         pre_mlp_layernorm_output, residual, _ = self._pre_mlp_layernorm_and_residual(hidden_states)
 
         hidden_states, probs, shared_expert_output = apply_module(self.mlp)(
-            pre_mlp_layernorm_output, intermediate_tensors=(), padding_mask=padding_mask
+            pre_mlp_layernorm_output,
+            intermediate_tensors=(),
+            padding_mask=padding_mask,
+            packed_seq_params=packed_seq_params,
         )
 
         if self.use_partial_cudagraphs:
@@ -2273,7 +2292,9 @@ class MoETransformerLayer(TransformerLayer):
         def _forward_mlp_partial_cudagraphs(
             hidden_states, inference_context=None, padding_mask=None
         ):
-            router_outputs = self._forward_mlp_router(hidden_states, padding_mask=padding_mask)
+            router_outputs = self._forward_mlp_router(
+                hidden_states, padding_mask=padding_mask, packed_seq_params=packed_seq_params
+            )
             (
                 residual,
                 hidden_states,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3357,6 +3357,24 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
 
 
+def _get_hybrid_cp_num_groups_for_logging():
+    """Per-iteration forward-group count under hybrid CP, used for loss-scale logging.
+
+    Under hybrid context parallelism, the number of forward groups run per iteration
+    (logically equivalent to num_microbatches) is determined dynamically by the CP
+    scheduler, so logged MoE/MTP metrics must be scaled by it instead of the static
+    get_num_microbatches(). get_num_total_groups is published by the dynamic-CP
+    sequence-packing changes; fall back to get_num_microbatches() when it is not
+    available yet or has not reported any groups.
+    """
+    try:
+        from megatron.core.pipeline_parallel.hybrid_cp_schedule import get_num_total_groups
+    except ImportError:
+        return get_num_microbatches()
+    num_total_groups = get_num_total_groups()
+    return num_total_groups if num_total_groups > 0 else get_num_microbatches()
+
+
 def training_log(
     loss_dict,
     total_loss_dict,
@@ -3549,7 +3567,11 @@ def training_log(
     # Log MoE metrics.
     moe_log_string = ""
     if args.num_experts is not None:
-        moe_loss_scale = 1 / get_num_microbatches()
+        # For hybrid CP, num_total_groups replaces num_microbatches as the step count.
+        if args.hybrid_context_parallel:
+            moe_loss_scale = 1 / _get_hybrid_cp_num_groups_for_logging()
+        else:
+            moe_loss_scale = 1 / get_num_microbatches()
         track_names = []
         if "aux_loss" in args.moe_router_load_balancing_type:
             track_names.append("load_balancing_loss")
@@ -3616,7 +3638,11 @@ def training_log(
 
     # Log MTP metrics.
     if args.mtp_num_layers is not None:
-        mtp_loss_scale = 1 / get_num_microbatches()
+        # For hybrid CP, num_total_groups replaces num_microbatches as the step count.
+        if args.hybrid_context_parallel:
+            mtp_loss_scale = 1 / _get_hybrid_cp_num_groups_for_logging()
+        else:
+            mtp_loss_scale = 1 / get_num_microbatches()
         MTPLossLoggingHelper.track_mtp_metrics(
             mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict
         )


### PR DESCRIPTION
## What does this PR do?

MoE under dynamic CP: `packed_seq_params` is plumbed through `TransformerLayer` → `MoELayer` → router so `TopKRouter` reduces aux/seq-aux losses over the runtime `[cp_group, tp_group]`; `get_tokens_per_expert_and_token_count` accepts a list of process groups; `gpus_needed()` clamps the minimum CP size for expert-rank sync (HACK/TODO preserved from the original); `training_log` scales MoE/MTP metrics by the hybrid-CP group count with a fallback to `get_num_microbatches()` so this PR is independently mergeable before the packing PR.

## Series (split of #3791)

Split of #3791 ("Update Dynamic CP to support sequence packing, MXFP8 and Mamba") against current `main`, tracked in the [Dynamic Context Parallelism project](https://github.com/orgs/NVIDIA/projects/297). **Original changes by @parthmannan in #3791**; hunks already covered by main (via the merged sequence-packing series and hybrid-CP fixes) were dropped, and the rest re-implemented against main's current structure. All PRs target `main`; merge order:

| Order | PR | Content |
|---|---|---|
| any | #7143 Mamba dynamic CP | SSM wiring for runtime CP groups |
| 1 | #7144 Hybrid-CP sequence packing | packed microbatches in the hybrid-CP dataloader + schedule |
| 2 | #7145 MTP dynamic CP | multi-token-prediction loss on the runtime CP group |
| 2 | #7146 MoE dynamic CP | aux-loss reduction, dispatcher padding, EP sync, loss-scale logging |


## Contribution process
- [x] Draft PR per contributing guidelines
- [x] Commits signed off (DCO)

