### PR TITLE
test(determinism): add kernel replay tests and a PR coverage gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@ Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->
 
 - [ ] I have added relevant unit tests
 - [ ] I have added relevant functional tests
+- [ ] If this PR adds or changes a GPU kernel (Triton, `jit_fuser`/`torch.compile`, CUDA extension, TE or external-library dispatch, or a scatter/index accumulation), I have added or updated its bit-exact determinism test and registered it in `tests/unit_tests/determinism/kernels/manifest.py` ([guide](https://github.com/NVIDIA/Megatron-LM/blob/main/docs/developer/determinism/testing.md))
 - [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
 - [ ] I have added relevant documentation
 - [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -456,6 +456,22 @@ jobs:
 
           python3 tools/check_golden_values.py "${GOLDEN_VALUES_FILES[@]}"
 
+      - name: Require determinism tests for kernel changes
+        # PR pushes only: a merge-group head also contains the PRs queued ahead of
+        # it, whose kernel changes were gated (and possibly labelled) on their own PRs.
+        if: startsWith(github.ref, 'refs/heads/pull-request/') && github.event_name == 'push'
+        env:
+          BASE_REF: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').base.ref }}
+          # Labels come with the PR object; no extra API call or token permission needed.
+          LABELS: ${{ join(fromJSON(steps.get-pr-info.outputs.pr-info || '{}').labels.*.name, ',') }}
+        run: |
+          BASE_REF="${BASE_REF#refs/heads/}"
+          git fetch origin "$BASE_REF"
+
+          python3 tools/check_kernel_determinism_coverage.py \
+            --base-ref "origin/$BASE_REF" \
+            --labels "$LABELS"
+
       - name: Run linting
         if: startsWith(github.ref, 'refs/heads/pull-request/') && github.event_name == 'push'
         run: |

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -63,6 +63,13 @@ jobs:
             Read `skills/pr-review/SKILL.md` with the Read tool and follow it exactly.
             It is checked out at the PR head alongside this workflow.
 
+            If the PR adds or changes a GPU kernel (Triton kernel, `jit_fuser`/`torch.compile`
+            function, CUDA extension, Transformer Engine or external-library dispatch, or a
+            scatter/index accumulation), check that a bit-exact determinism test under
+            `tests/unit_tests/determinism/kernels/` is added or updated and that the kernel is
+            registered in `tests/unit_tests/determinism/kernels/manifest.py`
+            (see docs/developer/determinism/testing.md).
+
   # ──────────────────────────────────────────────────────────────────
   # Strict review: comprehensive Megatron-LM focused analysis
   # covering precision, parallelism correctness, performance,

--- a/docs/developer/determinism/README.md
+++ b/docs/developer/determinism/README.md
@@ -21,6 +21,9 @@ This reference includes:
 - [`op-catalog.md`](./op-catalog.md): operations with a deterministic code path,
   operations that deterministic mode does not support, and the goal to shrink
   the unsupported set while speeding up the supported set
+- [`testing.md`](./testing.md): the kernel determinism test suite, the kernel
+  registry, and the pull-request gate that requires a bit-exact test for every
+  kernel change
 - [`glossary.md`](./glossary.md): definitions and abbreviations
 
 The roadmap is tracked dynamically in

--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -85,5 +85,7 @@ hotspots are:
 
 Reducing this cost is a tracked workstream in
 [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785). A change to
-any row above needs a bit-exact test and a comparison of deterministic and
+any row above needs a bit-exact test (registered in
+`tests/unit_tests/determinism/kernels/manifest.py`, refer to
+[`testing.md`](./testing.md)) and a comparison of deterministic and
 default performance (`tests/performance_tests/shell_test_utils/determinism/`).

--- a/docs/developer/determinism/status.md
+++ b/docs/developer/determinism/status.md
@@ -23,7 +23,14 @@ environment values.
 
 ## Validation
 
-- **Module-level bit-exact suite** (`tests/unit_tests/determinism/`): Runs a
+- **Kernel-level bit-exact suite** (`tests/unit_tests/determinism/kernels/`):
+  Replays every kernel Megatron dispatches (fused activations, Triton fusions,
+  apex extensions, Transformer Engine wrappers, MoE, SSM, optimizer and
+  inference kernels) on identical inputs and asserts byte-identical outputs and
+  gradients. `manifest.py` registers each kernel with its test; the unit tests
+  and the `linting` CI job fail when a kernel file is unregistered or a kernel
+  change ships without a test change. Refer to [`testing.md`](./testing.md).
+- **Module-level bit-exact suite** (`tests/unit_tests/determinism/correctness/`): Runs a
   model or block twice under restored RNG state and asserts bit-identical
   outputs and gradients. Coverage includes:
 

--- a/docs/developer/determinism/testing.md
+++ b/docs/developer/determinism/testing.md
@@ -1,0 +1,124 @@
+---
+orphan: true
+---
+
+# Kernel Determinism Testing
+
+> For the determinism contract and the operation catalog, refer to
+> [`status.md`](./status.md) and [`op-catalog.md`](./op-catalog.md).
+
+Every GPU kernel Megatron dispatches must have a bit-exact determinism test,
+and every pull request that adds or changes a kernel must add or update that
+test. This page describes what counts as a kernel, where the tests live, how
+the requirement is enforced, and how to add a test.
+
+## What counts as a kernel
+
+Any code path where Megatron itself launches or selects a GPU kernel whose
+numerical result could depend on scheduling:
+
+- Triton `@triton.jit` kernels (and TileLang / cuTile kernels)
+- `@jit_fuser` / `torch.compile` fused functions
+- C++/CUDA extensions (`load_inline`, `CUDAExtension`, `.cu` sources)
+- Transformer Engine and external-library dispatch with algorithm choices
+  (grouped GEMM, attention backends, causal_conv1d, mamba_ssm, FLA, DeepEP,
+  cuTile, FlashInfer, apex multi-tensor kernels)
+- torch ops with a non-deterministic accumulation: `scatter_add_`,
+  `index_add_`, `index_put_(accumulate=True)`, `bincount`, embedding backward
+
+`tests/unit_tests/determinism/kernels/manifest.py` lists the patterns
+(`KERNEL_CONTENT_PATTERNS`) and the directories (`KERNEL_DIRECTORIES`) that
+make a file *kernel-bearing*. External-library patterns match *call sites*
+(`causal_conv1d_fn(`, `tex.rmsnorm_fwd(`, `buffer.dispatch(`, ...), never
+bare imports, so a module that only imports a class or checks `isinstance`
+is not kernel-bearing. Modules that select among or call external kernels
+without defining one (the Mamba mixer, gated delta product, RoPE dispatch,
+FP8 master-weight casts, ...) are registered with `kind="dispatch"`; they are
+covered by the replay tests of the kernels they call, named in the entry's
+`notes`, and by module-level tests where those exist.
+
+## Where the tests live
+
+| Layer | Location | What it asserts |
+| --- | --- | --- |
+| Kernel | `tests/unit_tests/determinism/kernels/test_*.py` | One kernel family per file. Each kernel is run several times on identical inputs and every output tensor and gradient must be byte-identical (`harness.assert_replays_bit_exact`, `assert_module_replays_bit_exact`; `harness.bytes_equal` compares bit patterns, so signed zeros and NaN payloads must match too). |
+| Module / model | `tests/unit_tests/determinism/correctness/` | GPT, TransformerBlock, HybridModel and FP8/FP4 recipes across parallelism cells (`BitExactRunner`). |
+| End to end | functional tests with `--deterministic-mode` | Loss and `num-zeros` compared against golden values at their recorded precision; legacy goldens use five decimals. |
+
+The manifest (`tests/unit_tests/determinism/kernels/manifest.py`) is the
+registry that ties kernel source files to the tests that cover them. Each
+`KernelEntry` names the source files, the tests, the kernel kind, and either a
+non-empty `tests` tuple or an explicit `exempt_reason` (for example a
+multi-rank NVLS collective that needs an NVLink peer group, or an allocator
+with no compute kernel). Exemptions are visible coverage debt, not silence.
+
+## How the requirement is enforced
+
+1. **Repository invariant** (`tests/unit_tests/determinism/kernels/test_manifest.py`,
+   CPU only, runs in the unit-test bucket): every kernel-bearing file under
+   `megatron/` is registered, every registered path exists, and every entry
+   has tests or an exemption. Adding a Triton kernel to a new file without
+   registering it fails the unit tests.
+2. **Pull-request gate** (`tools/check_kernel_determinism_coverage.py`, run by
+   the `linting` job in `.github/workflows/cicd-main.yml` on PR pushes):
+   - a changed kernel-bearing file must be registered (not overridable);
+   - a changed registered kernel source must come with a change to at least
+     one of its determinism tests. Override with the `determinism-exempt`
+     PR label when the change cannot affect numerics (comment-only edits,
+     refactors); the check then logs the exemption instead of failing.
+3. **Review**: the PR template checkbox and the `/claude review` prompt ask
+   for the test explicitly.
+
+The kernel bucket runs in the H100 unit-test recipe
+(`tests/test_utils/recipes/h100/unit-tests.yaml`). Hardware-specific
+scheduling is exactly what these tests are meant to catch, so running the
+bucket on GB200/GB300-class runners as well (GB200 unit tests are selected by
+the `launch_on_gb200` marker) is a tracked follow-up; until then, reproduce
+findings on Blackwell hardware manually as described in
+[`status.md`](./status.md).
+
+Run the gate locally against `main`:
+
+```bash
+python3 tools/check_kernel_determinism_coverage.py --base-ref origin/main
+```
+
+## Adding a kernel test
+
+1. Put the test in the `tests/unit_tests/determinism/kernels/test_*.py`
+   module that matches the kernel family (or add one; the package `__init__`
+   pins the determinism environment at import).
+2. Use the harness:
+
+   ```python
+   from tests.unit_tests.determinism.kernels.harness import (
+       assert_replays_bit_exact,
+       assert_module_replays_bit_exact,
+       deterministic_algorithms,
+       seeded,
+   )
+
+   seeded()
+   x = torch.randn(16384, 2048, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+   assert_replays_bit_exact(my_kernel, (x,), replays=3, contention=True, what="my_kernel")
+   ```
+
+   `contention=True` runs the replays under side-stream GEMM pressure so
+   ordering-dependent reductions surface. Size inputs so many CTAs contend on
+   the same outputs; a two-block reduction can be deterministic by accident.
+   Kernels that select a branch on `torch.are_deterministic_algorithms_enabled()`
+   should be exercised on both branches with `deterministic_algorithms(...)`.
+   Kernels that consume the RNG (dropout) use `restore_rng=True`.
+3. When the default path is known to race (atomics), add a negative control
+   with `count_differing_replays(...) > 0`, generously sized, so the strict
+   assertion is known to be sensitive (see `test_moe_kernels.py`).
+4. Register the kernel in `manifest.py`: source files, the test file, kind,
+   and a note on the non-determinism mechanism and how the deterministic
+   branch is selected.
+5. Run the file on a GPU node:
+
+   ```bash
+   uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q \
+     tests/unit_tests/determinism/kernels/test_my_family.py \
+     tests/unit_tests/determinism/kernels/test_manifest.py
+   ```

--- a/skills/mcore-testing/SKILL.md
+++ b/skills/mcore-testing/SKILL.md
@@ -178,6 +178,14 @@ For ad-hoc runs, prefer the direct `torch.distributed.run` invocations above.
 4. Verify locally (see Running Unit Tests Locally above).
 5. If the test needs a dedicated CI bucket, add an entry to
    `tests/test_utils/recipes/h100/unit-tests.yaml`.
+6. If the change adds or modifies a GPU kernel (Triton, `jit_fuser` /
+   `torch.compile`, CUDA extension, TE or external-library dispatch, or a
+   scatter/index accumulation), add or update its bit-exact replay test under
+   `tests/unit_tests/determinism/kernels/` and register it in
+   `tests/unit_tests/determinism/kernels/manifest.py`. The `linting` CI job
+   (`tools/check_kernel_determinism_coverage.py`) fails kernel PRs without
+   this; the `determinism-exempt` label overrides it for non-numeric edits.
+   See `docs/developer/determinism/testing.md`.
 
 ---
 

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -299,6 +299,15 @@ products:
         scope: [unit-tests]
         n_repeat: [1]
         time_limit: [1800]
+  - test_case: [tests/unit_tests/determinism/kernels/**/*.py]
+    products:
+      # Operator-level bit-exact kernel tests. tag: [latest] only for the same
+      # reason as correctness/ above.
+      - environment: [lts, dev]
+        tag: [latest]
+        scope: [unit-tests]
+        n_repeat: [1]
+        time_limit: [1800]
   # determinism/perf is in its own dedicated recipe (determinism-perf.yaml) —
   # the perf bucket wraps pytest in nsys for per-NVTX-range attribution and
   # can't share the generic ``run_ci_test.sh`` invocation used here.

--- a/tests/unit_tests/determinism/kernels/__init__.py
+++ b/tests/unit_tests/determinism/kernels/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Operator-level bit-exact determinism tests for the kernels Megatron-LM dispatches.
+
+``manifest.py`` registers every kernel and the test that covers it; ``harness.py`` holds the
+replay helpers; the ``test_*.py`` modules exercise one kernel family each. The determinism
+env vars are pinned at import like ``correctness/`` so cuBLAS / TE / NCCL capture them on
+first use.
+"""
+
+import os
+
+import torch
+
+from megatron.training.determinism import apply_determinism_env
+
+# The SSM Triton autotuners read the determinism policy when their modules are imported
+# (``megatron/core/ssm/ops/common/determinism.py``); pin it before any kernel module loads
+# so the tests measure the kernels, not Triton's timing-based config search.
+os.environ.setdefault("MAMBA_DETERMINISTIC", "1")
+os.environ.setdefault("CAUSAL_CONV1D_DETERMINISTIC", "1")
+apply_determinism_env(os.environ)
+
+# Most kernel tests never initialise a process group, so pin each ``torch.distributed.run``
+# rank to its own GPU here (after the env is set, before any CUDA context exists). This
+# lives in the package ``__init__`` rather than a ``conftest.py`` on purpose: pytest loads a
+# directory's conftest even when every test file in it is ``--ignore``d, which would leak
+# the env pinning above into the generic unit-test bucket.
+if torch.cuda.is_available():
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", "0")) % torch.cuda.device_count())

--- a/tests/unit_tests/determinism/kernels/harness.py
+++ b/tests/unit_tests/determinism/kernels/harness.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Replay harness for operator-level bit-exact determinism tests.
+
+A kernel is deterministic when re-running it on identical inputs yields byte-identical
+outputs (and input gradients, for differentiable kernels). ``assert_replays_bit_exact``
+does exactly that: it materialises one set of inputs, runs the kernel ``replays`` times on
+fresh clones of them, and compares every output tensor and every input gradient against
+the first replay byte for byte (``bytes_equal``: same shape, same dtype, identical bit
+patterns -- signed zeros and NaN payloads must match too). Optional side-stream contention
+perturbs kernel scheduling between replays so ordering-dependent reductions surface as
+mismatches.
+
+Sizing matters more than replay count: a reduction with two contending blocks can be
+"deterministic" by accident. Pick shapes that put many blocks on the same output (see
+``CONTENTION_TOKENS``) -- ``test_ssm_conv1d.py`` documents the measurement behind this.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch
+
+from tests.unit_tests.determinism.utils import (
+    RacingStreams,
+    capture_rng_state,
+    collect_grads,
+    restore_rng_state,
+    zero_grads,
+)
+
+# Shapes that make many CTAs contend on shared outputs. A token count of a few thousand
+# with a hidden size of ~1-4k puts dozens of blocks on every reduction.
+CONTENTION_TOKENS = 4096
+
+
+def _clone_preserving_layout(t: torch.Tensor) -> torch.Tensor:
+    """Copy ``t`` keeping its exact strides, including expanded (stride-0) views.
+
+    ``Tensor.clone`` only preserves the strides of dense tensors; an ``expand``ed operand
+    would come back as a dense copy and steer a kernel into a different specialisation
+    than production uses (e.g. ``selective_state_update``'s ``TIE_HDIM`` path).
+    """
+    src = t.detach()
+    if src.is_contiguous():
+        return src.clone()
+    extent = (
+        src.storage_offset()
+        + 1
+        + sum((n - 1) * s for n, s in zip(src.shape, src.stride()) if n > 1)
+    )
+    flat = torch.empty(0, dtype=src.dtype, device=src.device).set_(src.untyped_storage())
+    return flat[:extent].clone().as_strided(src.shape, src.stride(), src.storage_offset())
+
+
+def clone_inputs(inputs: Any) -> Any:
+    """Deep-copy tensors (preserving layout and ``requires_grad``); pass everything else through."""
+    if isinstance(inputs, torch.Tensor):
+        clone = _clone_preserving_layout(inputs)
+        if inputs.requires_grad:
+            clone.requires_grad_(True)
+        return clone
+    if isinstance(inputs, dict):
+        return {k: clone_inputs(v) for k, v in inputs.items()}
+    if isinstance(inputs, (list, tuple)):
+        cloned = [clone_inputs(v) for v in inputs]
+        return type(inputs)(cloned) if isinstance(inputs, tuple) else cloned
+    return inputs
+
+
+def flatten_tensors(obj: Any, prefix: str = "out") -> Dict[str, torch.Tensor]:
+    """Flatten nested outputs into ``{name: tensor}``; non-tensors are ignored."""
+    found: Dict[str, torch.Tensor] = {}
+    if isinstance(obj, torch.Tensor):
+        found[prefix] = obj
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            found.update(flatten_tensors(v, f"{prefix}.{k}"))
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            found.update(flatten_tensors(v, f"{prefix}[{i}]"))
+    return found
+
+
+def _leaf_inputs(inputs: Any, prefix: str = "in") -> Dict[str, torch.Tensor]:
+    return {name: t for name, t in flatten_tensors(inputs, prefix).items() if t.requires_grad}
+
+
+def _as_bytes(t: torch.Tensor) -> torch.Tensor:
+    """The logical contents of ``t`` as a flat ``uint8`` tensor (layout-independent)."""
+    return t.detach().contiguous().reshape(-1).view(torch.uint8)
+
+
+def bytes_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """True iff ``a`` and ``b`` have the same shape and dtype and identical bit patterns.
+
+    Stricter than ``torch.equal``: ``+0.0`` and ``-0.0`` differ, and NaNs only match when
+    their payloads match. Strides are not compared -- both operands are read in logical
+    order -- so a kernel may return a differently laid out tensor with the same contents.
+    """
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    if a.numel() == 0:
+        return True
+    return bool(torch.equal(_as_bytes(a), _as_bytes(b)))
+
+
+def _describe_mismatch(name: str, a: torch.Tensor, b: torch.Tensor) -> str:
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return (
+            f"{name}: shape/dtype differ ({tuple(a.shape)}/{a.dtype} vs {tuple(b.shape)}/{b.dtype})"
+        )
+    bits_differ = (_as_bytes(a) != _as_bytes(b)).view(a.numel(), a.element_size()).any(dim=1)
+    count = int(bits_differ.sum().item())
+    msg = f"{name}: {count}/{a.numel()} elements differ"
+    if not a.is_complex():
+        af, bf = a.detach().reshape(-1).float(), b.detach().reshape(-1).float()
+        value_differs = (af != bf) & ~(af.isnan() & bf.isnan())
+        diff = torch.where(value_differs, (af - bf).abs(), torch.zeros_like(af))
+        max_diff = float(diff.max().item()) if count else 0.0
+        msg += f" (max |diff| {max_diff:.3e}"
+        bit_only = count - int(value_differs.sum().item())
+        if bit_only:
+            msg += f"; {bit_only} differ only in bit pattern, e.g. signed zero or NaN payload"
+        msg += ")"
+    return msg
+
+
+def run_once(
+    fn: Callable[..., Any],
+    inputs: Any,
+    grad_outputs: Optional[Dict[str, torch.Tensor]] = None,
+    backward: bool = True,
+) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+    """Run ``fn(**inputs)`` (or ``fn(*inputs)``) once and return outputs and input grads.
+
+    ``grad_outputs`` maps flattened output names to the upstream gradient to use; outputs
+    without an entry get ``ones_like``. Returns detached clones so later replays cannot
+    alias them.
+    """
+    local = clone_inputs(inputs)
+    result = fn(**local) if isinstance(local, dict) else fn(*local)
+    outputs = {k: v for k, v in flatten_tensors(result).items()}
+    grads: Dict[str, torch.Tensor] = {}
+    if backward:
+        leaves = _leaf_inputs(local)
+        diff_outputs = [
+            (name, t) for name, t in outputs.items() if t.requires_grad and t.is_floating_point()
+        ]
+        if leaves and diff_outputs:
+            gos = [(grad_outputs or {}).get(name, torch.ones_like(t)) for name, t in diff_outputs]
+            computed = torch.autograd.grad(
+                [t for _, t in diff_outputs],
+                list(leaves.values()),
+                grad_outputs=gos,
+                allow_unused=True,
+            )
+            for name, g in zip(leaves, computed):
+                if g is not None:
+                    grads[name] = g.detach().clone()
+    torch.cuda.synchronize()
+    return {k: v.detach().clone() for k, v in outputs.items()}, grads
+
+
+def assert_replays_bit_exact(
+    fn: Callable[..., Any],
+    inputs: Any,
+    *,
+    replays: int = 3,
+    backward: bool = True,
+    grad_outputs: Optional[Dict[str, torch.Tensor]] = None,
+    contention: bool = False,
+    restore_rng: bool = False,
+    what: str = "kernel",
+) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+    """Assert that ``replays`` runs of ``fn`` on identical inputs are byte-identical.
+
+    Every output tensor and input gradient is compared with ``bytes_equal``.
+
+    Args:
+        fn: kernel entry point; called with ``**inputs`` if ``inputs`` is a dict, else
+            ``*inputs``.
+        inputs: materialised inputs. Tensors with ``requires_grad`` get their gradient
+            compared too (when ``backward``).
+        replays: number of runs; the first is the reference.
+        backward: also run autograd and compare input gradients.
+        grad_outputs: fixed upstream gradients keyed by flattened output name (``out``,
+            ``out[0]``, ``out.name``). Defaults to ones, so the same value feeds every replay.
+        contention: run replays 2.. under ``RacingStreams`` side-stream GEMM pressure.
+        restore_rng: snapshot every RNG before the reference run and restore it before
+            each replay -- for kernels that consume random numbers (dropout).
+        what: label for error messages.
+
+    Returns:
+        The reference outputs and gradients (for follow-up assertions).
+    """
+    if replays < 2:
+        raise ValueError("replays must be >= 2")
+    rng = capture_rng_state() if restore_rng else None
+    ref_out, ref_grad = run_once(fn, inputs, grad_outputs, backward)
+    if not ref_out:
+        raise AssertionError(f"{what} produced no tensor outputs; nothing to compare")
+    for i in range(1, replays):
+        if rng is not None:
+            torch.cuda.synchronize()
+            restore_rng_state(rng)
+        if contention:
+            with RacingStreams():
+                out, grad = run_once(fn, inputs, grad_outputs, backward)
+        else:
+            out, grad = run_once(fn, inputs, grad_outputs, backward)
+        _assert_replay_matches(i, ref_out, ref_grad, out, grad, what)
+    return ref_out, ref_grad
+
+
+def _assert_replay_matches(i, ref_out, ref_grad, out, grad, what) -> None:
+    """Raise if replay ``i`` differs from the reference in any output or gradient tensor."""
+    if out.keys() != ref_out.keys() or grad.keys() != ref_grad.keys():
+        raise AssertionError(
+            f"{what}: replay {i} returned different tensors "
+            f"({sorted(out)}/{sorted(grad)} vs {sorted(ref_out)}/{sorted(ref_grad)})"
+        )
+    mismatches = [
+        _describe_mismatch(name, ref_out[name], out[name])
+        for name in ref_out
+        if not bytes_equal(ref_out[name], out[name])
+    ] + [
+        _describe_mismatch(f"grad({name})", ref_grad[name], grad[name])
+        for name in ref_grad
+        if not bytes_equal(ref_grad[name], grad[name])
+    ]
+    if mismatches:
+        raise AssertionError(
+            f"{what} is not bit-exact across replays (replay {i} vs 1):\n  "
+            + "\n  ".join(mismatches)
+        )
+
+
+def count_differing_replays(
+    fn: Callable[..., Any], inputs: Any, *, replays: int = 8, backward: bool = True
+) -> int:
+    """Return how many of ``replays - 1`` re-runs differ from the first in any tensor.
+
+    For *negative controls*: a test that documents a known non-deterministic default path
+    asserts this is ``> 0`` so the paired deterministic assertion is known to be sensitive.
+    Size such controls generously -- hardware can serialise small problems.
+    """
+    ref_out, ref_grad = run_once(fn, inputs, None, backward)
+    differing = 0
+    for _ in range(replays - 1):
+        out, grad = run_once(fn, inputs, None, backward)
+        same = all(bytes_equal(ref_out[k], out[k]) for k in ref_out) and all(
+            bytes_equal(ref_grad[k], grad[k]) for k in ref_grad
+        )
+        differing += not same
+    return differing
+
+
+def seeded(seed: int = 1234) -> None:
+    """Seed every RNG the kernels may consume so input construction is repeatable."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+@contextlib.contextmanager
+def deterministic_algorithms(enabled: bool):
+    """Temporarily set ``torch.use_deterministic_algorithms`` (warn-only), then restore.
+
+    Kernel wrappers select branches on ``torch.are_deterministic_algorithms_enabled()``;
+    tests use this to exercise each branch explicitly instead of inheriting whatever an
+    earlier test left behind.
+    """
+    prev = torch.are_deterministic_algorithms_enabled()
+    prev_warn = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(enabled, warn_only=True)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(prev, warn_only=prev_warn)
+
+
+def _zero_module_grads(module: torch.nn.Module) -> None:
+    zero_grads(module)
+    for p in module.parameters():
+        main_grad = getattr(p, "main_grad", None)
+        if main_grad is not None:
+            main_grad.zero_()
+
+
+def _module_fwd_bwd(module, inputs, grad_output, backward):
+    local = clone_inputs(inputs)
+    result = module(**local) if isinstance(local, dict) else module(*local)
+    outputs = flatten_tensors(result)
+    grads: Dict[str, torch.Tensor] = {}
+    if backward:
+        diff = [(n, t) for n, t in outputs.items() if t.requires_grad and t.is_floating_point()]
+        if not diff:
+            raise AssertionError("module produced no differentiable output")
+        name, tensor = diff[0]
+        g = grad_output if grad_output is not None else torch.ones_like(tensor)
+        tensor.backward(g)
+        grads = collect_grads([module])
+        for n, t in _leaf_inputs(local).items():
+            if t.grad is not None:
+                grads[n] = t.grad.detach().clone()
+    torch.cuda.synchronize()
+    return {k: v.detach().clone() for k, v in outputs.items()}, grads
+
+
+def assert_module_replays_bit_exact(
+    module: torch.nn.Module,
+    inputs: Any,
+    *,
+    replays: int = 3,
+    backward: bool = True,
+    grad_output: Optional[torch.Tensor] = None,
+    contention: bool = False,
+    restore_rng: bool = True,
+    what: str = "module",
+) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+    """Module-level twin of ``assert_replays_bit_exact``.
+
+    Runs ``module(**inputs)`` (or ``module(*inputs)``) ``replays`` times from identical
+    parameters, RNG state and inputs; backward propagates ``grad_output`` (default: ones)
+    through the first differentiable output. Compares every output tensor, every parameter
+    gradient (``p.grad`` or ``p.main_grad``) and every input gradient bit-for-bit. Grads
+    (including ``main_grad`` buffers) are zeroed between replays; parameters are not
+    updated, so no optimizer state needs resetting.
+    """
+    if replays < 2:
+        raise ValueError("replays must be >= 2")
+    rng = capture_rng_state() if restore_rng else None
+    _zero_module_grads(module)
+    ref_out, ref_grad = _module_fwd_bwd(module, inputs, grad_output, backward)
+    for i in range(1, replays):
+        _zero_module_grads(module)
+        if rng is not None:
+            torch.cuda.synchronize()
+            restore_rng_state(rng)
+        if contention:
+            with RacingStreams():
+                out, grad = _module_fwd_bwd(module, inputs, grad_output, backward)
+        else:
+            out, grad = _module_fwd_bwd(module, inputs, grad_output, backward)
+        _assert_replay_matches(i, ref_out, ref_grad, out, grad, what)
+    return ref_out, ref_grad

--- a/tests/unit_tests/determinism/kernels/manifest.py
+++ b/tests/unit_tests/determinism/kernels/manifest.py
@@ -1,0 +1,668 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Registry of the GPU kernels Megatron-LM dispatches and the determinism tests that cover them.
+
+Every kernel-bearing source file in ``megatron/`` must be registered here, and every
+registered kernel must name at least one bit-exact test (or an explicit exemption with a
+reason). Two consumers enforce this:
+
+* ``tests/unit_tests/determinism/kernels/test_manifest.py`` -- fails the unit-test bucket
+  when a kernel file in the tree is unregistered, a registered path does not exist, or an
+  entry has neither tests nor an exemption.
+* ``tools/check_kernel_determinism_coverage.py`` -- runs in the ``linting`` CI job on the
+  files a PR changes and fails when a kernel-bearing file is unregistered, or when a
+  registered kernel source changes without its determinism test changing too (override
+  with the ``EXEMPT_LABEL`` PR label).
+
+Keep this module importable with the standard library only: the CI tool loads it by file
+path in a job without torch installed.
+
+A *kernel* here is any code path where Megatron itself launches or selects a GPU kernel
+whose numerical result could depend on scheduling: Triton ``@jit`` kernels, ``jit_fuser`` /
+``torch.compile`` fused functions, C++/CUDA extensions, Transformer Engine and external
+library dispatch with algorithm choices (grouped GEMM, causal_conv1d, mamba_ssm, FLA,
+DeepEP), and torch ops with a non-deterministic accumulation (``scatter_add_``,
+``index_add_``, ``index_put_(accumulate=True)``, ``bincount``, embedding backward).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+# PR label that lets a kernel change merge without touching its determinism test
+# (refactors, comment-only edits). Maintainers create it once in the repository.
+EXEMPT_LABEL = "determinism-exempt"
+
+# Directories whose every ``.py`` file (``__init__.py`` excluded) must be registered.
+KERNEL_DIRECTORIES: Tuple[str, ...] = ("megatron/core/fusions", "megatron/core/ssm/ops")
+
+# Regular expressions (``re.MULTILINE``) that mark a source file as kernel-bearing wherever
+# it lives. Matched against the file's current contents by both consumers.
+KERNEL_CONTENT_PATTERNS: Tuple[str, ...] = (
+    r"@triton\.(jit|autotune|heuristics)",
+    r"^\s*(import|from) triton\b",
+    r"^\s*(import|from) tilelang\b",
+    r"@jit_fuser\b",
+    r"\btorch\.compile\b",
+    r"\bload_inline\(",
+    r"\bCUDAExtension\(",
+    r"\.scatter_add_?\(",
+    r"\.index_add_?\(",
+    r"index_put_?\((?:[^()\n]|\([^()\n]*\))*accumulate\s*=\s*True",
+    r"\btorch\.bincount\(",
+    r"\btorch\.histc\(",
+    r"\bF\.embedding\(",
+    # -- external-library kernel dispatch: call sites, never bare imports (a module that
+    #    only imports a class or checks isinstance() does not launch anything). Files that
+    #    match are registered with ``kind="dispatch"`` (see ``KernelEntry``).
+    # Transformer Engine C++ extension (``import transformer_engine_torch as tex``).
+    r"\btex\.[A-Za-z_]\w*\(",
+    # TE collectives / GEMM / FP8-FP4 master-weight casts / CUDA-graph capture.
+    r"\b(gather_along_first_dim|reduce_scatter_along_first_dim)\s*\(",
+    r"\b(general_gemm|te_general_gemm|cast_to_fp8|fp8_gemm|cast_master_weights_to_fp8|quantize_master_weights)\s*\(",
+    r"\bmake_graphed_callables\s*\(",
+    # Fused RoPE (TE / flash-attn / Megatron Triton MLA RoPE) dispatch.
+    r"\b(fused_apply_rotary_pos_emb\w*|apply_fused_qkv_rotary_pos_emb|fused_apply_mla_rope_for_\w+|apply_rotary_emb_flash)\s*\(",
+    # causal_conv1d / mamba_ssm / flash-linear-attention.
+    r"\bcausal_conv1d_(fn|update|update_cuda|varlen_fn|varlen_states|varlen_carry_states|cp)\s*\(",
+    r"\b(mamba_chunk_scan_combined\w*|mamba_split_conv1d_scan_combined\w*|selective_state_update|selective_scan_fn)\s*\(",
+    r"\b((chunk|fused_recurrent)_gated_delta_(rule|product)\w*|chunk_gdn2|l2_norm|l2norm_(fwd|bwd))\s*\(",
+    # DeepEP buffers and cuTile kernels.
+    r"\bfused_(dispatch|combine)\s*\(|\b\w*buffer\.(low_latency_)?(dispatch|combine)\s*\(",
+    r"@ct\.kernel\b|\bct\.launch\s*\(",
+    # FlashInfer (sampling, MXFP8 quantize / GEMM, fused MoE).
+    r"\bflashinfer\w*\.[A-Za-z_][\w.]*\(|\bflashinfer_\w+\s*\(|\b(mxfp8_quantize|mm_mxfp8|shuffle_matrix_a|cutlass_fused_moe|get_shuffle_matrix_sf_a_row_indices)\s*\(",
+    # apex / TE multi-tensor kernels (scale, l2norm, Adam).
+    r"\bmulti_tensor_applier\s*\(",
+)
+
+
+@dataclass(frozen=True)
+class KernelEntry:
+    """One kernel (or tightly coupled kernel family) and its determinism coverage."""
+
+    name: str
+    sources: Tuple[str, ...]
+    tests: Tuple[str, ...] = ()
+    # Kernel family (``triton``, ``torch.compile``, ``cuda-ext``, ``te-wrapper``, ``torch-op``,
+    # ``external-lib``, ``tilelang``) or ``dispatch``: the sources do not define a kernel but
+    # select among / call external ones (TE, causal_conv1d, mamba_ssm, FLA, FlashInfer, apex).
+    # Dispatch entries are covered by the tests of the kernels they call (named in ``notes``),
+    # so ``test_manifest`` does not require their tests to import the source module.
+    kind: str = ""
+    training_path: bool = True
+    notes: str = ""
+    # Set (with a reason) only when a bit-exact test is impossible in CI, e.g. the kernel
+    # needs hardware or a dependency the CI container lacks. Visible coverage debt.
+    exempt_reason: str = ""
+
+
+# Test-file prefixes used below.
+K = "tests/unit_tests/determinism/kernels/"
+C = "tests/unit_tests/determinism/correctness/"
+
+KERNELS: Tuple[KernelEntry, ...] = (
+    # ---------------------------------------------------------------- fused elementwise (jit_fuser / torch.compile)
+    KernelEntry(
+        name="fused_bias_swiglu",
+        sources=("megatron/core/fusions/fused_bias_swiglu.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+        notes="Elementwise; weighted variants reduce the per-token weight grad over ffn (Inductor tree reduction).",
+    ),
+    KernelEntry(
+        name="fused_bias_geglu",
+        sources=("megatron/core/fusions/fused_bias_geglu.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+    ),
+    KernelEntry(
+        name="fused_bias_gelu",
+        sources=("megatron/core/fusions/fused_bias_gelu.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+    ),
+    KernelEntry(
+        name="fused_weighted_squared_relu",
+        sources=("megatron/core/fusions/fused_weighted_squared_relu.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+    ),
+    KernelEntry(
+        name="fused_bias_dropout_add",
+        sources=("megatron/core/fusions/fused_bias_dropout.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+        notes="Consumes the CUDA RNG; replayed under a restored RNG state.",
+    ),
+    KernelEntry(
+        name="compiled_activations",
+        sources=(
+            "megatron/core/activations.py",
+            "megatron/core/transformer/utils.py",
+            "megatron/core/transformer/torch_norm.py",
+            "megatron/core/transformer/attention.py",
+        ),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+        notes="squared_relu/quick_gelu/fast_gelu/tanh_soft_clamp/situ/situ_glu, openai/erf GELU, "
+        "L2Norm._norm (row reduction) and Attention._apply_output_gate.",
+    ),
+    KernelEntry(
+        name="fused_vocab_parallel_cross_entropy",
+        sources=("megatron/core/fusions/fused_cross_entropy.py",),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+        notes="Rejected by --deterministic-mode (op catalog); the replay test records its status as xfail(strict=False).",
+    ),
+    KernelEntry(
+        name="jit_fuser",
+        sources=("megatron/core/jit.py",),
+        kind="torch.compile",
+        exempt_reason="Decorator only (selects torch.compile / torch.jit.script); every decorated function is registered above.",
+    ),
+    KernelEntry(
+        name="dsv4_q_rms_norm",
+        sources=(
+            "megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py",
+        ),
+        tests=(K + "test_fused_activations.py",),
+        kind="torch.compile",
+        notes="Weightless query RMS norm compiled with torch.compile (row reduction over head_dim); "
+        "the rest of the file is orchestration around registered TE / RoPE / CSA kernels.",
+    ),
+    # ---------------------------------------------------------------- Megatron Triton fusions
+    KernelEntry(
+        name="fused_pad_routing_map",
+        sources=("megatron/core/fusions/fused_pad_routing_map.py",),
+        tests=(K + "test_fused_triton_kernels.py",),
+        kind="triton",
+    ),
+    KernelEntry(
+        name="fused_indices_to_multihot",
+        sources=("megatron/core/fusions/fused_indices_converter.py",),
+        tests=(K + "test_fused_triton_kernels.py",),
+        kind="triton",
+    ),
+    KernelEntry(
+        name="fused_mla_yarn_rope",
+        sources=("megatron/core/fusions/fused_mla_yarn_rope_apply.py",),
+        tests=(K + "test_fused_triton_kernels.py",),
+        kind="triton",
+        notes="Elementwise rotations under timing-based triton.autotune; fwd+bwd replay in sbhd and thd.",
+    ),
+    KernelEntry(
+        name="fused_mhc_kernels",
+        sources=(
+            "megatron/core/fusions/fused_mhc_kernels.py",
+            "megatron/core/transformer/hyper_connection.py",
+        ),
+        tests=(K + "test_fused_triton_kernels.py",),
+        kind="triton",
+        notes="Sinkhorn / h_aggregate / h_post_bda / proj_rms_compute_h on the triton, native (torch.compile) and cuTile backends.",
+    ),
+    # ---------------------------------------------------------------- apex CUDA extensions and local TP layers
+    KernelEntry(
+        name="fused_layer_norm",
+        sources=("megatron/core/fusions/fused_layer_norm.py",),
+        tests=(K + "test_tensor_parallel_kernels.py",),
+        kind="cuda-ext",
+        notes="apex FastLayerNormFN / FusedLayerNormAffineFunction; dgamma/dbeta cross-row reduction.",
+    ),
+    KernelEntry(
+        name="fused_scale_mask_softmax",
+        sources=(
+            "megatron/core/fusions/fused_softmax.py",
+            "megatron/core/transformer/dot_product_attention.py",
+        ),
+        tests=(K + "test_tensor_parallel_kernels.py",),
+        kind="cuda-ext",
+        notes="apex scaled_(upper_triang_)masked_softmax_cuda; the local attention path around it is cuBLAS bmm.",
+    ),
+    KernelEntry(
+        name="tensor_parallel_layers",
+        sources=("megatron/core/tensor_parallel/layers.py",),
+        tests=(K + "test_tensor_parallel_kernels.py",),
+        kind="torch-op",
+        notes="VocabParallelEmbedding (weight[idx] deterministic branch vs F.embedding) and local Column/RowParallelLinear "
+        "incl. apex fused_weight_gradient_mlp_cuda gradient-accumulation fusion.",
+    ),
+    KernelEntry(
+        name="vocab_parallel_cross_entropy",
+        sources=("megatron/core/tensor_parallel/cross_entropy.py",),
+        tests=(K + "test_tensor_parallel_kernels.py",),
+        kind="torch-op",
+    ),
+    KernelEntry(
+        name="tensor_parallel_mappings",
+        sources=("megatron/core/tensor_parallel/mappings.py",),
+        tests=(C + "test_transformer_layer.py", C + "test_gpt_model.py"),
+        kind="external-lib",
+        notes="NCCL floating-point reductions pinned by NCCL_ALGO=Ring; covered by the TP/EP/FSDP cells of the model-level suite.",
+    ),
+    KernelEntry(
+        name="tensor_parallel_random_share_storage",
+        sources=("megatron/core/tensor_parallel/random.py",),
+        kind="cuda-ext",
+        exempt_reason="load_inline extension aliases tensor storage on the host; no GPU compute.",
+    ),
+    # ---------------------------------------------------------------- Transformer Engine wrappers
+    KernelEntry(
+        name="transformer_engine_wrappers",
+        sources=("megatron/core/extensions/transformer_engine.py",),
+        tests=(K + "test_te_wrappers.py", C + "test_fp8_determinism.py"),
+        kind="te-wrapper",
+        notes="TE Linear / LayerNormLinear / Norm / GroupedLinear / DotProductAttention / fused RoPE replayed standalone; "
+        "FP8/FP4 recipes in the model-level suite.",
+    ),
+    KernelEntry(
+        name="kitchen_extension",
+        sources=("megatron/core/extensions/kitchen.py",),
+        kind="te-wrapper",
+        exempt_reason="Public stub of the internal Kitchen library; no kernels in this repository.",
+    ),
+    # ---------------------------------------------------------------- MoE
+    KernelEntry(
+        name="moe_utils",
+        sources=("megatron/core/transformer/moe/moe_utils.py",),
+        tests=(K + "test_moe_kernels.py",),
+        kind="torch-op",
+        notes="permute/unpermute (index_add_ vs scatter_add_), routing (index_put_ vs scatter), sort_chunks, aux loss, "
+        "router gating GEMM, TE fused permutation/router kernels.",
+    ),
+    KernelEntry(
+        name="moe_router",
+        sources=("megatron/core/transformer/moe/router.py",),
+        tests=(K + "test_moe_kernels.py",),
+        kind="torch.compile",
+    ),
+    KernelEntry(
+        name="moe_token_dispatchers",
+        sources=(
+            "megatron/core/transformer/moe/token_dispatcher.py",
+            "megatron/core/transformer/moe/moe_layer.py",
+        ),
+        tests=(K + "test_moe_kernels.py",),
+        kind="torch-op",
+        notes="MoELayer replay through the allgather / alltoall dispatchers (EP=1, EP=2) and flex+DeepEP when available.",
+    ),
+    KernelEntry(
+        name="moe_experts",
+        sources=("megatron/core/transformer/moe/experts.py",),
+        tests=(K + "test_moe_kernels.py",),
+        kind="te-wrapper",
+        notes="TEGroupedMLP / SequentialMLP on uneven expert loads including an empty expert.",
+    ),
+    KernelEntry(
+        name="moe_fused_a2a",
+        sources=("megatron/core/transformer/moe/fused_a2a.py",),
+        tests=(K + "test_moe_kernels.py",),
+        kind="external-lib",
+        notes="DeepEP flex dispatcher cell (skipped without deep_ep / >=2 GPUs). HybridEP and NCCL-EP backends are not yet "
+        "replayed bit-exactly here.",
+    ),
+    KernelEntry(
+        name="moe_shared_experts",
+        sources=("megatron/core/transformer/moe/shared_experts.py",),
+        kind="te-wrapper",
+        exempt_reason="Composes TE linears and the registered activation fusions; no kernel of its own.",
+    ),
+    KernelEntry(
+        name="moe_paged_stash",
+        sources=("megatron/core/transformer/moe/ops/paged_stash.py",),
+        tests=("tests/unit_tests/transformer/moe/test_paged_stashing.py",),
+        kind="triton",
+        notes="Activation page copy kernels (no arithmetic); functional round-trip coverage.",
+    ),
+    KernelEntry(
+        name="moe_batch_invariant_unpermute",
+        sources=("megatron/core/transformer/moe/batch_invariant.py",),
+        tests=("tests/unit_tests/transformer/moe/test_moe_batch_invariant.py",),
+        kind="torch-op",
+    ),
+    KernelEntry(
+        name="inference_routing_mask_kernel",
+        sources=("megatron/core/transformer/moe/inference_routing_mask_kernel.py",),
+        tests=(K + "test_inference_kernels.py",),
+        kind="triton",
+        training_path=False,
+    ),
+    # ---------------------------------------------------------------- SSM
+    KernelEntry(
+        name="ssm_causal_conv1d",
+        sources=("megatron/core/ssm/causal_conv1d.py",),
+        tests=(C + "test_ssm_conv1d.py",),
+        kind="external-lib",
+        notes="Dao-AILab causal_conv1d; channel-last backward reduces dweight/dbias with "
+        "atomicAdd unless CAUSAL_CONV1D_DETERMINISTIC (>=1.6.0) picks the workspace path.",
+    ),
+    KernelEntry(
+        name="ssm_mamba2_varlen_kernels",
+        sources=(
+            "megatron/core/ssm/ops/mamba2/ssd_combined.py",
+            "megatron/core/ssm/ops/mamba2/ssd_bmm.py",
+            "megatron/core/ssm/ops/mamba2/ssd_chunk_scan.py",
+            "megatron/core/ssm/ops/mamba2/ssd_chunk_state.py",
+            "megatron/core/ssm/ops/mamba2/ssd_state_passing.py",
+            "megatron/core/ssm/ops/mamba2/mamba_ssm.py",
+        ),
+        tests=(K + "test_ssm_kernels.py",),
+        kind="triton",
+        notes="mamba_chunk_scan_combined_varlen and selective_state_update under the pinned autotune / ordered workspace.",
+    ),
+    KernelEntry(
+        name="ssm_mamba2_batch_invariant_decode",
+        sources=("megatron/core/ssm/ops/mamba2/batch_invariant_decode.py",),
+        tests=("tests/unit_tests/ssm/ops/mamba2/test_batch_invariant_decode.py",),
+        kind="triton",
+        training_path=False,
+    ),
+    KernelEntry(
+        name="ssm_common_kernels",
+        sources=(
+            "megatron/core/ssm/ops/common/causal_conv1d_triton.py",
+            "megatron/core/ssm/ops/common/causal_conv1d_varlen.py",
+            "megatron/core/ssm/ops/common/intermediate_extraction.py",
+            "megatron/core/ssm/ops/common/determinism.py",
+        ),
+        tests=(K + "test_ssm_kernels.py",),
+        kind="triton",
+        notes="determinism.py is the autotune/workspace policy every SSM kernel test runs under.",
+    ),
+    KernelEntry(
+        name="ssm_gdp_kernels",
+        sources=(
+            "megatron/core/ssm/ops/gdp/chunk.py",
+            "megatron/core/ssm/ops/gdp/chunk_h.py",
+            "megatron/core/ssm/ops/gdp/chunk_o.py",
+            "megatron/core/ssm/ops/gdp/common.py",
+            "megatron/core/ssm/ops/gdp/cumsum.py",
+            "megatron/core/ssm/ops/gdp/decode_prepare.py",
+            "megatron/core/ssm/ops/gdp/fused_recurrent.py",
+            "megatron/core/ssm/ops/gdp/metadata.py",
+            "megatron/core/ssm/ops/gdp/scaled_dot_kkt.py",
+            "megatron/core/ssm/ops/gdp/solve_tril.py",
+            "megatron/core/ssm/ops/gdp/wy_fast.py",
+            "megatron/core/ssm/context_parallel/gdp.py",
+        ),
+        tests=(K + "test_ssm_kernels.py",),
+        kind="triton",
+        notes="Gated Delta Product varlen chunk scan (drives cumsum/l2norm/kkt/solve_tril/wy_fast/chunk_h/chunk_o), "
+        "fused recurrent decode and decode-prepare kernels.",
+    ),
+    KernelEntry(
+        name="gated_delta_net",
+        sources=(
+            "megatron/core/ssm/gated_delta_net/common.py",
+            "megatron/core/ssm/gated_delta_net/gdn.py",
+            "megatron/core/ssm/gated_delta_net/gdn2.py",
+        ),
+        tests=(K + "test_ssm_kernels.py", C + "test_hybrid_model.py"),
+        kind="torch.compile",
+        notes="deterministic_mode selects torch_chunk_gated_delta_rule over FLA (recorded non-deterministic).",
+    ),
+    KernelEntry(
+        name="ssm_triton_cache_manager",
+        sources=("megatron/core/ssm/triton_cache_manager.py",),
+        kind="triton",
+        exempt_reason="Triton compile-cache manager; no kernel.",
+    ),
+    # ---------------------------------------------------------------- optimizer / distributed
+    KernelEntry(
+        name="optimizer_kernels",
+        sources=(
+            "megatron/core/optimizer/clip_grads.py",
+            "megatron/core/optimizer/__init__.py",
+            "megatron/core/optimizer/optimizer.py",
+            "megatron/training/utils/common_utils.py",
+        ),
+        tests=(K + "test_optimizer_kernels.py",),
+        kind="external-lib",
+        notes="multi_tensor l2norm / scale (TE, apex or local fallback) and fused Adam; "
+        "optimizer.py (gradient unscaling) and training/utils/common_utils.py (param / grad norm "
+        "logging) launch the same multi_tensor kernels through multi_tensor_applier.",
+    ),
+    KernelEntry(
+        name="ddp_grad_buffer_reductions",
+        sources=("megatron/core/distributed/param_and_grad_buffer.py",),
+        tests=(C + "test_gpt_model.py",),
+        kind="external-lib",
+        notes="NCCL reduce-scatter / all-gather; covered by the FSDP/DP cells of the model-level suite.",
+    ),
+    KernelEntry(
+        name="nccl_allocator",
+        sources=("megatron/core/nccl_allocator.py",),
+        kind="cuda-ext",
+        exempt_reason="Pluggable allocator (ncclMemAlloc); allocation only, no compute kernel.",
+    ),
+    # ---------------------------------------------------------------- inference (single GPU)
+    KernelEntry(
+        name="inference_kv_cache_tensor_ops",
+        sources=(
+            "megatron/core/inference/contexts/attention_context/triton/tensor_ops.py",
+            "megatron/core/inference/contexts/fused_kv_append_kernel.py",
+        ),
+        tests=(K + "test_inference_kernels.py",),
+        kind="triton",
+        training_path=False,
+    ),
+    KernelEntry(
+        name="inference_moe_kernels",
+        sources=(
+            "megatron/core/inference/moe/activations.py",
+            "megatron/core/inference/moe/batch_invariant.py",
+            "megatron/core/inference/moe/permute.py",
+            "megatron/core/inference/moe/vllm_fused_moe.py",
+            "megatron/core/inference/quantization/mxfp8_quantize.py",
+        ),
+        tests=(K + "test_inference_kernels.py",),
+        kind="triton",
+        training_path=False,
+        notes="Batch-invariant paths replay bit-exactly; the atomic default unpermute is the negative control. "
+        "ordered_reduce_scatter_v (multi-rank) is not replayed here.",
+    ),
+    KernelEntry(
+        name="batch_invariant_kernels",
+        sources=("megatron/core/transformer/custom_layers/batch_invariant_kernels.py",),
+        tests=(
+            K + "test_inference_kernels.py",
+            "tests/unit_tests/transformer/test_te_layers_batch_invariant.py",
+        ),
+        kind="triton",
+    ),
+    KernelEntry(
+        name="mtp_speculative_decoding_kernels",
+        sources=("megatron/core/inference/text_generation_controllers/mtp_utils_triton.py",),
+        tests=("tests/unit_tests/inference/text_generation_controllers/test_mtp_utils.py",),
+        kind="triton",
+        training_path=False,
+        notes="Integer bookkeeping and state copies checked for exact equality against the torch reference.",
+    ),
+    KernelEntry(
+        name="inference_integer_bookkeeping",
+        sources=(
+            "megatron/core/inference/contexts/dynamic_context.py",
+            "megatron/core/inference/contexts/kv_block_allocator.py",
+            "megatron/core/context_parallel/layout.py",
+        ),
+        kind="torch-op",
+        exempt_reason="bincount / scatter_add_ / index_add_ on integer counts: exact regardless of order.",
+    ),
+    KernelEntry(
+        name="inference_nvls_symmetric_memory_collectives",
+        sources=(
+            "megatron/core/inference/communication/torch_symm_triton/barrier.py",
+            "megatron/core/inference/communication/torch_symm_triton/collectives.py",
+            "megatron/core/inference/communication/torch_symm_triton/fused_collectives.py",
+            "megatron/core/inference/communication/torch_symm_triton/multimem_asm.py",
+            "megatron/core/inference/communication/torch_symm_triton/utils.py",
+            "megatron/core/inference/communication/torch_symm_triton/variable_collectives.py",
+            "megatron/core/inference/moe/metadata.py",
+            "megatron/core/inference/symmetric_memory.py",
+        ),
+        kind="triton",
+        training_path=False,
+        exempt_reason="Multi-rank NVLS multimem collectives over torch symmetric memory; the in-switch reduction "
+        "order is hardware defined and needs an NVLink peer group. Batch-invariant mode routes around them.",
+    ),
+    KernelEntry(
+        name="unified_memory_allocator",
+        sources=("megatron/core/inference/unified_memory.py",),
+        kind="cuda-ext",
+        training_path=False,
+        exempt_reason="cudaMallocManaged pluggable allocator; no compute kernel.",
+    ),
+    KernelEntry(
+        name="nvshmem_chunked_copy",
+        sources=("megatron/core/resharding/nvshmem_copy_service/kernels/chunked_kernel.cu",),
+        kind="cuda-ext",
+        training_path=False,
+        exempt_reason="Byte copy for refit; needs NVSHMEM and a multi-GPU RL environment.",
+    ),
+    # ---------------------------------------------------------------- external-library dispatch sites
+    # Modules that choose between / call external GPU kernels. Covered by the replay tests of
+    # the kernels they call (and by module-level tests where they exist); ``notes`` say which.
+    KernelEntry(
+        name="ssm_mamba_mixer",
+        sources=("megatron/core/ssm/mamba_mixer.py",),
+        tests=(C + "test_ssm_conv1d.py", K + "test_ssm_kernels.py"),
+        kind="dispatch",
+        notes="Selects the pip causal_conv1d / mamba_ssm kernels (causal_conv1d_fn, "
+        "mamba_chunk_scan_combined, mamba_split_conv1d_scan_combined, causal_conv1d_update_cuda) or "
+        "the Megatron forks (ops/common, ops/mamba2: varlen scan, causal_conv1d_update, "
+        "selective_state_update). Module-level replay: test_ssm_conv1d.py::TestMambaMixerDeterminism; "
+        "kernels replayed piecewise in test_ssm_kernels.py.",
+    ),
+    KernelEntry(
+        name="ssm_gated_delta_product",
+        sources=("megatron/core/ssm/gated_delta_product.py",),
+        tests=(K + "test_ssm_kernels.py",),
+        kind="dispatch",
+        notes="Dispatches FLA chunk_gated_delta_product / l2_norm, the CuTeDSL gdp_attn kernel "
+        "(gdp_cutedsl_kernel; not in the CI container, uncovered), causal_conv1d and the Megatron "
+        "GDP forks (chunk_gated_delta_product_varlen, fused_recurrent_gated_delta_rule_update), all "
+        "replayed in test_ssm_kernels.py. No module-level replay yet (HYBRID_CONFIGS has no GDP cell).",
+    ),
+    KernelEntry(
+        name="rope_dispatch",
+        sources=("megatron/core/models/common/embeddings/rope_utils.py",),
+        tests=(K + "test_te_wrappers.py",),
+        kind="dispatch",
+        notes="apply_rotary_pos_emb selects TE fused RoPE (replayed in test_te_wrappers.py), "
+        "flash-attn apply_rotary_emb (not in the CI container) or the unfused torch path.",
+    ),
+    KernelEntry(
+        name="mla_rope_dispatch",
+        sources=(
+            "megatron/core/transformer/multi_latent_attention.py",
+            "megatron/core/transformer/experimental_attention_variant/absorbed_mla.py",
+        ),
+        tests=(K + "test_fused_triton_kernels.py", K + "test_te_wrappers.py"),
+        kind="dispatch",
+        notes="Calls the Triton MLA YaRN RoPE kernels (fused_apply_mla_rope_for_q / _kv, replayed in "
+        "test_fused_triton_kernels.py) and TE fused RoPE (test_te_wrappers.py). The TE "
+        "FusedMLAQUpProj GEMM path and mxfp8_quantize_only are not replayed.",
+    ),
+    KernelEntry(
+        name="fp8_fp4_master_weight_casts",
+        sources=(
+            "megatron/core/fp8_utils.py",
+            "megatron/core/fp4_utils.py",
+            "megatron/core/distributed/fsdp/src/megatron_fsdp/mixed_precision.py",
+        ),
+        tests=(C + "test_fp8_determinism.py", K + "test_optimizer_kernels.py"),
+        kind="dispatch",
+        notes="TE cast_master_weights_to_fp8 / cast_to_fp8 (covered at model level by "
+        "test_fp8_determinism.py), NVFP4 quantize_master_weights (needs TE>=2.7 + Blackwell, "
+        "uncovered) and the apex multi_tensor_scale used by Megatron-FSDP mixed precision "
+        "(kernel replayed in test_optimizer_kernels.py).",
+    ),
+    KernelEntry(
+        name="inference_mxfp8_quantization",
+        sources=(
+            "megatron/core/inference/quantization/mxfp8_tensor.py",
+            "megatron/core/inference/quantization/utils.py",
+            "megatron/core/inference/moe/flashinfer_mxfp8.py",
+        ),
+        tests=(K + "test_inference_kernels.py",),
+        kind="dispatch",
+        training_path=False,
+        notes="MXFP8Tensor dispatches the Megatron quantize kernel (replayed: "
+        "test_mxfp8_quantize_replays) or FlashInfer mxfp8_quantize / mm_mxfp8 / fused MoE, which need "
+        "flashinfer on Blackwell and are not replayed in CI.",
+    ),
+    KernelEntry(
+        name="inference_flashinfer_sampling",
+        sources=("megatron/core/inference/sampling/flashinfer_sampling.py",),
+        kind="dispatch",
+        training_path=False,
+        exempt_reason="FlashInfer top-k / top-p sampling kernels driven by an explicit torch.Generator "
+        "with deterministic=True; a seed-restore replay test needs flashinfer in the unit-test "
+        "container and is tracked as a follow-up.",
+    ),
+    KernelEntry(
+        name="inference_tp_layers",
+        sources=("megatron/core/tensor_parallel/inference_layers.py",),
+        kind="dispatch",
+        training_path=False,
+        exempt_reason="Inference-only TP layers composing tex.rmsnorm_fwd (the TE norm kernel is "
+        "replayed in test_te_wrappers.py), FlashInfer MXFP8 GEMM (Blackwell only) and TE "
+        "gather / reduce-scatter collectives.",
+    ),
+    KernelEntry(
+        name="te_tp_collectives",
+        sources=("megatron/core/tensor_parallel/generalized_tensor_parallelism.py",),
+        kind="dispatch",
+        exempt_reason="TE gather_along_first_dim / reduce_scatter_along_first_dim of weights and "
+        "wgrads in generalized tensor parallelism; multi-rank NCCL collectives pinned by "
+        "NCCL_ALGO=Ring under --deterministic-mode, not exercised by the determinism model tests.",
+    ),
+    KernelEntry(
+        name="te_thd_partitioned_indices",
+        sources=(
+            "megatron/core/datasets/data_schedule.py",
+            "megatron/core/ssm/mamba_context_parallel.py",
+            "megatron/core/utils.py",
+            "megatron/core/models/mimo/partition/utils.py",
+            "megatron/core/models/multimodal/llava_model.py",
+            "megatron/rl/rl_utils.py",
+        ),
+        kind="dispatch",
+        exempt_reason="tex.thd_get_partitioned_indices computes integer sequence partitions for THD "
+        "context parallelism; exact regardless of execution order.",
+    ),
+    KernelEntry(
+        name="cuda_graph_capture",
+        sources=("megatron/core/transformer/cuda_graphs.py",),
+        kind="dispatch",
+        exempt_reason="TE make_graphed_callables captures and replays kernels that are registered on "
+        "their own; the capture order is fixed by the callable list and adds no numerics.",
+    ),
+    # ---------------------------------------------------------------- DeepSeek sparse attention (TileLang)
+    KernelEntry(
+        name="dsa_tilelang_kernels",
+        sources=(
+            "megatron/core/transformer/experimental_attention_variant/ops/indexer.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/sparse_mla.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_dsa.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_indexer_bwd.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_indexer_fwd.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_indexer_loss.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_sparse_mla_bwd.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_sparse_mla_fwd.py",
+            "megatron/core/transformer/experimental_attention_variant/ops/tilelang_utils.py",
+            "megatron/core/transformer/experimental_attention_variant/dsa_kernels.py",
+            "megatron/core/transformer/experimental_attention_variant/dsa_tilelang_kernels.py",
+        ),
+        kind="tilelang",
+        exempt_reason="Experimental DeepSeek sparse attention kernels (indexer / sparse MLA backward accumulate with "
+        "atomics). Bit-exact replay is tracked as a follow-up; parity tests live in "
+        "tests/unit_tests/transformer/experimental_attention_variant/.",
+    ),
+)
+
+
+def entries_for(path: str) -> Tuple[KernelEntry, ...]:
+    """Return the entries that list ``path`` among their sources."""
+    return tuple(entry for entry in KERNELS if path in entry.sources)

--- a/tests/unit_tests/determinism/kernels/test_fused_activations.py
+++ b/tests/unit_tests/determinism/kernels/test_fused_activations.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the ``jit_fuser`` / ``torch.compile`` fused elementwise kernels.
+
+Covers every compiled function under ``megatron/core/fusions/`` that is not a Triton or CUDA
+kernel, plus the compiled activations and helpers scattered through ``megatron/core``
+(``activations.py``, ``transformer/utils.py``, ``transformer/torch_norm.py``,
+``transformer/attention.py``). Inductor picks reduction tilings per shape; the row
+reductions in the weighted backward passes (``torch.sum(weights_grad, dim=-1)``) are the
+only non-elementwise math, so shapes are sized to make those reductions wide.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import activations, parallel_state
+from megatron.core.fusions.fused_bias_dropout import (
+    bias_dropout_add_fused_inference,
+    bias_dropout_add_fused_train,
+)
+from megatron.core.fusions.fused_bias_geglu import bias_geglu_impl, weighted_bias_quick_geglu_impl
+from megatron.core.fusions.fused_bias_gelu import bias_gelu_impl
+from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl, weighted_bias_swiglu_impl
+from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+from megatron.core.fusions.fused_weighted_squared_relu import weighted_squared_relu_impl
+from megatron.core.transformer.attention import Attention
+from megatron.core.transformer.torch_norm import L2Norm
+from megatron.core.transformer.utils import erf_gelu, gelu_impl
+from tests.unit_tests.determinism.kernels.harness import (
+    CONTENTION_TOKENS,
+    assert_replays_bit_exact,
+    seeded,
+)
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+
+TOKENS = CONTENTION_TOKENS
+FFN = 8192
+DTYPE = torch.bfloat16
+
+
+def _act(shape, dtype=DTYPE, grad=True):
+    return torch.randn(*shape, device="cuda", dtype=dtype, requires_grad=grad)
+
+
+def _weights(rows):
+    return torch.rand(rows, 1, device="cuda", dtype=torch.float32, requires_grad=True)
+
+
+# --- gated / weighted MLP fusions ----------------------------------------------------------
+
+GATED_CASES = {
+    "bias_swiglu": lambda: (bias_swiglu_impl, (_act((TOKENS, 2 * FFN)), _act((2 * FFN,)))),
+    "swiglu_no_bias": lambda: (bias_swiglu_impl, (_act((TOKENS, 2 * FFN)), None)),
+    "clamped_swiglu": lambda: (
+        lambda x, b: bias_swiglu_impl(x, b, clamp_value=7.0),
+        (_act((TOKENS, 2 * FFN)), _act((2 * FFN,))),
+    ),
+    "situ_glu": lambda: (
+        lambda x, b: bias_swiglu_impl(x, b, gate_clamp_scale=10.0, linear_clamp_scale=3.0),
+        (_act((TOKENS, 2 * FFN)), None),
+    ),
+    "weighted_swiglu": lambda: (
+        weighted_bias_swiglu_impl,
+        (_act((TOKENS, 2 * FFN)), None, _weights(TOKENS)),
+    ),
+    "weighted_clamped_swiglu": lambda: (
+        lambda x, b, w: weighted_bias_swiglu_impl(x, b, w, clamp_value=7.0),
+        (_act((TOKENS, 2 * FFN)), None, _weights(TOKENS)),
+    ),
+    "weighted_situ_glu": lambda: (
+        lambda x, b, w: weighted_bias_swiglu_impl(
+            x, b, w, gate_clamp_scale=10.0, linear_clamp_scale=3.0
+        ),
+        (_act((TOKENS, 2 * FFN)), None, _weights(TOKENS)),
+    ),
+    "bias_geglu": lambda: (bias_geglu_impl, (_act((TOKENS, 2 * FFN)), _act((2 * FFN,)))),
+    "geglu_no_bias": lambda: (bias_geglu_impl, (_act((TOKENS, 2 * FFN)), None)),
+    "weighted_quick_geglu": lambda: (
+        lambda x, b, w: weighted_bias_quick_geglu_impl(x, b, w, linear_offset=1.0),
+        (_act((TOKENS, 2 * FFN)), None, _weights(TOKENS)),
+    ),
+    "weighted_clamped_quick_geglu": lambda: (
+        lambda x, b, w: weighted_bias_quick_geglu_impl(x, b, w, clamp_value=10.0),
+        (_act((TOKENS, 2 * FFN)), None, _weights(TOKENS)),
+    ),
+    "bias_gelu": lambda: (bias_gelu_impl, (_act((TOKENS, FFN)), _act((FFN,)))),
+    "weighted_squared_relu": lambda: (
+        weighted_squared_relu_impl,
+        (_act((TOKENS, FFN)), _weights(TOKENS)),
+    ),
+    "weighted_clamped_squared_relu": lambda: (
+        lambda x, w: weighted_squared_relu_impl(x, w, clamp_scale=10.0),
+        (_act((TOKENS, FFN)), _weights(TOKENS)),
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(GATED_CASES))
+def test_mlp_activation_fusions_replay_bit_exactly(case):
+    seeded()
+    fn, inputs = GATED_CASES[case]()
+    assert_replays_bit_exact(fn, inputs, replays=3, what=case)
+
+
+# --- plain compiled activations -----------------------------------------------------------
+
+ACTIVATION_CASES = {
+    "squared_relu": lambda x: activations.squared_relu(x),
+    "quick_gelu": lambda x: activations.quick_gelu(x),
+    "fast_gelu": lambda x: activations.fast_gelu(x),
+    "tanh_soft_clamp": lambda x: activations.tanh_soft_clamp(x, 5.0),
+    "situ": lambda x: activations.situ(x, 5.0),
+    "situ_glu": lambda x: activations.situ_glu(x, 5.0, 3.0),
+    "openai_gelu": gelu_impl,
+    "erf_gelu": erf_gelu,
+}
+
+
+@pytest.mark.parametrize("case", sorted(ACTIVATION_CASES))
+def test_compiled_activations_replay_bit_exactly(case):
+    seeded()
+    x = _act((TOKENS, FFN)) * 5.0
+    x = x.detach().requires_grad_(True)
+    assert_replays_bit_exact(ACTIVATION_CASES[case], (x,), replays=3, what=case)
+
+
+def test_attention_output_gate_replays_bit_exactly():
+    """``Attention._apply_output_gate`` is a compiled method; ``self`` is unused."""
+    seeded()
+    x = _act((2048, 4, 4096))
+    gate = _act((2048, 4, 4096))
+    assert_replays_bit_exact(
+        lambda x, gate: Attention._apply_output_gate(None, x, gate),
+        (x, gate),
+        replays=3,
+        what="attention output gate",
+    )
+
+
+def test_l2norm_replays_bit_exactly():
+    """QK L2 norm: compiled row reduction (``pow(2).mean(-1)``) over head_dim."""
+    seeded()
+    norm = L2Norm(hidden_size=128).cuda()
+    x = _act((4096, 2, 32, 128))
+    assert_replays_bit_exact(norm, (x,), replays=3, what="L2Norm")
+
+
+# --- bias + dropout + residual --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("residual_dtype", [torch.bfloat16, torch.float32])
+def test_bias_dropout_add_fused_train_replays_under_restored_rng(residual_dtype):
+    """Dropout consumes the CUDA RNG: identical mask, output and grads when the RNG is restored."""
+    seeded()
+    x = _act((2048, 4, 4096))
+    bias = _act((4096,))
+    residual = _act((2048, 4, 4096), dtype=residual_dtype, grad=False)
+
+    def fn(x, bias, residual):
+        return bias_dropout_add_fused_train((x, bias), residual, 0.1)
+
+    assert_replays_bit_exact(
+        fn, (x, bias, residual), replays=3, restore_rng=True, what="bias_dropout_add_fused_train"
+    )
+
+
+def test_bias_dropout_add_fused_inference_replays_bit_exactly():
+    seeded()
+    x = _act((2048, 4, 4096), grad=False)
+    bias = _act((4096,), grad=False)
+    residual = _act((2048, 4, 4096), grad=False)
+    assert_replays_bit_exact(
+        lambda x, b, r: bias_dropout_add_fused_inference((x, b), r, 0.1),
+        (x, bias, residual),
+        replays=3,
+        backward=False,
+        what="bias_dropout_add_fused_inference",
+    )
+
+
+# --- fused vocab-parallel cross entropy ------------------------------------------------------
+
+
+class TestFusedCrossEntropy:
+    """``--cross-entropy-loss-fusion`` is rejected by ``--deterministic-mode``; this records
+    whether the compiled kernel itself replays bit-exactly (op catalog: non-deterministic)."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason="op-catalog lists the fused cross entropy as non-deterministic; recorded, not gated",
+    )
+    def test_fused_vocab_parallel_cross_entropy_replays(self):
+        seeded()
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        logits = _act((TOKENS, 32768))
+        target = torch.randint(0, 32768 * tp_group.size(), (TOKENS,), device="cuda")
+        assert_replays_bit_exact(
+            lambda l, t: fused_vocab_parallel_cross_entropy(l, t, tp_group),
+            (logits, target),
+            replays=4,
+            what="fused_vocab_parallel_cross_entropy",
+        )
+
+
+# --- DeepSeek-V4 hybrid attention: compiled query RMS norm -----------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("layout", ["contiguous", "transposed"])
+def test_dsv4_q_rms_norm_replays(dtype, layout):
+    """``_q_rms_norm`` (weightless RMS norm, ``torch.compile``) on a [s, b, heads, dim] query.
+
+    Inductor reduces ``q.square().mean(-1)`` per row; the transposed layout exercises the
+    strided-input specialisation the compiler guards on separately.
+    """
+    try:
+        from megatron.core.transformer.experimental_attention_variant.deepseek_v4_hybrid_attention import (
+            _q_rms_norm,
+        )
+    except ImportError as e:  # pragma: no cover - depends on optional dependencies
+        pytest.skip(f"DeepSeek-V4 hybrid attention unavailable: {e}")
+
+    seeded()
+    seq, batch, heads, dim = 1024, 4, 32, 128
+    if layout == "contiguous":
+        q = _act((seq, batch, heads, dim), dtype=dtype)
+    else:
+        q = _act((batch, seq, heads, dim), dtype=dtype).transpose(0, 1)
+    assert_replays_bit_exact(
+        lambda q: _q_rms_norm(q, 1e-6), (q,), replays=3, contention=True, what="_q_rms_norm"
+    )

--- a/tests/unit_tests/determinism/kernels/test_fused_triton_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_fused_triton_kernels.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of Megatron's own Triton kernels under ``megatron/core/fusions/``.
+
+* ``fused_pad_routing_map`` / ``fused_indices_to_multihot``: integer routing bookkeeping with
+  unique stores -- replay and agree with the torch reference.
+* MLA YaRN RoPE (``fused_mla_yarn_rope_apply``): elementwise rotations under a timing-based
+  ``triton.autotune``; forward and backward replay in sbhd and thd layouts.
+* mHC hyper-connection kernels (``fused_mhc_kernels``): Sinkhorn, h-aggregate and h-post-BDA
+  contain real ``tl.sum`` reductions under autotune, on the Triton, native (``torch.compile``)
+  and, when available, cuTile backends.
+"""
+
+import pytest
+import torch
+
+from megatron.core import config as mcore_config
+from megatron.core.fusions import fused_mhc_kernels
+from megatron.core.fusions.fused_indices_converter import fused_indices_to_multihot
+from megatron.core.fusions.fused_pad_routing_map import fused_pad_routing_map
+from megatron.core.transformer.moe.moe_utils import pad_routing_map
+from tests.unit_tests.determinism.kernels.harness import assert_replays_bit_exact, seeded
+
+try:
+    import triton  # noqa: F401
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+try:
+    from megatron.core.fusions.fused_mla_yarn_rope_apply import (
+        fused_mla_rope_inplace,
+        fused_mla_rope_kv_split,
+        fused_mla_rope_out_of_place,
+    )
+except ImportError:
+    fused_mla_rope_inplace = fused_mla_rope_kv_split = fused_mla_rope_out_of_place = None
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and HAVE_TRITON), reason="needs a GPU and Triton"
+)
+
+
+@pytest.fixture
+def experimental_enabled():
+    """Force the experimental flag on (the fused routing kernels are experimental features)."""
+    prev = mcore_config.ENABLE_EXPERIMENTAL
+    mcore_config.ENABLE_EXPERIMENTAL = True
+    yield
+    mcore_config.ENABLE_EXPERIMENTAL = prev
+
+
+def _topk_routing_map(num_tokens, num_experts, topk):
+    logits = torch.randn(num_tokens, num_experts, device="cuda")
+    idx = logits.topk(topk, dim=-1).indices
+    routing_map = torch.zeros(num_tokens, num_experts, dtype=torch.bool, device="cuda")
+    routing_map.scatter_(1, idx, True)
+    return routing_map
+
+
+# --- routing map padding ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_tokens", [8192, 4097])
+@pytest.mark.parametrize("pad_multiple", [32, 256])
+def test_fused_pad_routing_map_replays_and_matches_torch(
+    experimental_enabled, num_tokens, pad_multiple
+):
+    seeded()
+    routing_map = _topk_routing_map(num_tokens, 64, 8)
+    fused, _ = assert_replays_bit_exact(
+        lambda m: fused_pad_routing_map(m, pad_multiple),
+        (routing_map,),
+        backward=False,
+        what="fused_pad_routing_map",
+    )
+    torch_out, _ = assert_replays_bit_exact(
+        lambda m: pad_routing_map(m, pad_multiple),
+        (routing_map,),
+        backward=False,
+        what="pad_routing_map",
+    )
+    assert torch.equal(fused["out"].to(torch_out["out"].dtype), torch_out["out"])
+
+
+# --- indices <-> multihot ----------------------------------------------------------------
+
+
+def test_fused_indices_to_multihot_replays_fwd_bwd(experimental_enabled):
+    seeded()
+    num_tokens, topk, num_local_experts = 16384, 8, 32
+    # Unique experts per row, a random subset of slots masked with -1.
+    experts = torch.rand(num_tokens, 64, device="cuda").topk(topk, dim=-1).indices
+    experts = experts.to(torch.int32)
+    experts[experts >= num_local_experts] = -1
+    probs = torch.rand(num_tokens, topk, device="cuda") * (experts != -1)
+    probs.requires_grad_(True)
+
+    def fn(indices, probs):
+        multihot, probs_in_multihot = fused_indices_to_multihot(indices, probs, num_local_experts)
+        return multihot, probs_in_multihot
+
+    assert_replays_bit_exact(fn, (experts, probs), replays=3, what="fused_indices_to_multihot")
+
+
+# --- MLA YaRN RoPE --------------------------------------------------------------------------
+
+
+def _yarn_cos_sin(emb_dim, seqlen, dtype):
+    from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
+
+    rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    freqs, mscale = rope(seqlen, 0)
+    return (torch.cos(freqs) * mscale).to(dtype), (torch.sin(freqs) * mscale).to(dtype)
+
+
+@pytest.mark.skipif(fused_mla_rope_out_of_place is None, reason="fused MLA RoPE unavailable")
+@pytest.mark.parametrize("layout", ["sbhd", "thd"])
+@pytest.mark.parametrize("variant", ["out_of_place", "inplace"])
+def test_fused_mla_rope_q_replays_fwd_bwd(layout, variant):
+    seeded()
+    heads, nope_dim, emb_dim = 32, 128, 64
+    dtype = torch.bfloat16
+    if layout == "sbhd":
+        seqlen, batch = 2048, 2
+        cu_seqlens = None
+        t = torch.randn(seqlen, batch, heads, nope_dim + emb_dim, device="cuda", dtype=dtype)
+    else:
+        bounds = [0, 1000, 1500, 2048, 4096]
+        seqlen = max(b - a for a, b in zip(bounds, bounds[1:]))
+        cu_seqlens = torch.tensor(bounds, dtype=torch.int32, device="cuda")
+        t = torch.randn(bounds[-1], heads, nope_dim + emb_dim, device="cuda", dtype=dtype)
+    cos, sin = _yarn_cos_sin(emb_dim, seqlen, dtype)
+    t.requires_grad_(True)
+    fn = fused_mla_rope_out_of_place if variant == "out_of_place" else fused_mla_rope_inplace
+
+    def run(t):
+        return fn(t, cos, sin, nope_dim, emb_dim, cu_seqlens_q=cu_seqlens)
+
+    assert_replays_bit_exact(run, (t,), replays=3, what=f"fused_mla_rope_{variant}[{layout}]")
+
+
+@pytest.mark.skipif(fused_mla_rope_kv_split is None, reason="fused MLA RoPE unavailable")
+@pytest.mark.parametrize("layout", ["sbhd", "thd"])
+def test_fused_mla_rope_kv_split_replays_fwd_bwd(layout):
+    seeded()
+    heads, k_dim, v_dim, emb_dim = 32, 128, 128, 64
+    dtype = torch.bfloat16
+    if layout == "sbhd":
+        seqlen, batch = 2048, 2
+        cu_seqlens = None
+        kv = torch.randn(seqlen, batch, heads, k_dim + v_dim, device="cuda", dtype=dtype)
+        k_pos_emb = torch.randn(seqlen, batch, 1, emb_dim, device="cuda", dtype=dtype)
+    else:
+        bounds = [0, 1000, 1500, 2048, 4096]
+        seqlen = max(b - a for a, b in zip(bounds, bounds[1:]))
+        cu_seqlens = torch.tensor(bounds, dtype=torch.int32, device="cuda")
+        kv = torch.randn(bounds[-1], heads, k_dim + v_dim, device="cuda", dtype=dtype)
+        k_pos_emb = torch.randn(bounds[-1], 1, emb_dim, device="cuda", dtype=dtype)
+    cos, sin = _yarn_cos_sin(emb_dim, seqlen, dtype)
+    kv.requires_grad_(True)
+    k_pos_emb.requires_grad_(True)
+
+    def run(kv, k_pos_emb):
+        return fused_mla_rope_kv_split(
+            kv, k_pos_emb, cos, sin, emb_dim, k_dim, v_dim, cu_seqlens_kv=cu_seqlens
+        )
+
+    assert_replays_bit_exact(
+        run, (kv, k_pos_emb), replays=3, what=f"fused_mla_rope_kv_split[{layout}]"
+    )
+
+
+# --- mHC (hyper-connection) kernels -------------------------------------------------------
+
+_MHC_BACKENDS = ["native", "triton"]
+if fused_mhc_kernels.is_cutile_available():
+    _MHC_BACKENDS.append("cutile")
+
+S, B, N, C = 1024, 4, 4, 4096
+
+
+def _mhc_rand(*shape, dtype=torch.bfloat16, grad=True):
+    t = torch.empty(*shape, device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
+    return t.requires_grad_(grad)
+
+
+@pytest.mark.parametrize("backend", _MHC_BACKENDS)
+def test_mhc_sinkhorn_replays_fwd_bwd(backend):
+    if backend == "triton" and not fused_mhc_kernels.is_triton_available():
+        pytest.skip("Triton mHC backend unavailable")
+    seeded()
+    logits = _mhc_rand(S, B, N, N)
+    assert_replays_bit_exact(
+        lambda l: fused_mhc_kernels.fused_sinkhorn(l, 20, 1e-6, backend=backend),
+        (logits,),
+        replays=3,
+        what=f"mhc sinkhorn[{backend}]",
+    )
+
+
+@pytest.mark.parametrize("backend", _MHC_BACKENDS)
+def test_mhc_h_aggregate_replays_fwd_bwd(backend):
+    if backend == "triton" and not fused_mhc_kernels.is_triton_available():
+        pytest.skip("Triton mHC backend unavailable")
+    seeded()
+    x = _mhc_rand(S, B, N, C)
+    h_pre = _mhc_rand(S, B, N)
+    assert_replays_bit_exact(
+        lambda x, h: fused_mhc_kernels.fused_h_aggregate(x, h, backend=backend),
+        (x, h_pre),
+        replays=3,
+        what=f"mhc h_aggregate[{backend}]",
+    )
+
+
+@pytest.mark.parametrize("backend", _MHC_BACKENDS)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_mhc_h_post_bda_replays_fwd_bwd(backend, with_bias):
+    if backend == "triton" and not fused_mhc_kernels.is_triton_available():
+        pytest.skip("Triton mHC backend unavailable")
+    seeded()
+    h_res = _mhc_rand(S, B, N, N)
+    orig = _mhc_rand(S, B, N, C)
+    h_post = _mhc_rand(S, B, N)
+    x = _mhc_rand(S, B, C)
+    bias = _mhc_rand(C) if with_bias else None
+
+    def run(h_res, orig, h_post, x, bias):
+        return fused_mhc_kernels.fused_h_post_bda(h_res, orig, h_post, x, bias, backend=backend)
+
+    assert_replays_bit_exact(
+        run, (h_res, orig, h_post, x, bias), replays=3, what=f"mhc h_post_bda[{backend}]"
+    )
+
+
+@pytest.mark.parametrize("backend", [b for b in _MHC_BACKENDS if b != "triton"])
+def test_mhc_proj_rms_compute_h_replays_fwd_bwd(backend):
+    """Projection + RMS + compute-h: cuTile fused kernel or the native ``torch.compile`` path."""
+    seeded()
+    n = N
+    x = _mhc_rand(S * B, n * C)
+    weight = _mhc_rand(n * n + 2 * n, n * C, dtype=torch.float32)
+    alpha_pre = _mhc_rand(1, dtype=torch.float32)
+    alpha_post = _mhc_rand(1, dtype=torch.float32)
+    alpha_res = _mhc_rand(1, dtype=torch.float32)
+    bias = _mhc_rand(n * n + 2 * n, dtype=torch.float32)
+
+    def run(x, weight, alpha_pre, alpha_post, alpha_res, bias):
+        return fused_mhc_kernels.fused_proj_rms_compute_h(
+            x, weight, alpha_pre, alpha_post, alpha_res, bias, n, backend=backend
+        )
+
+    assert_replays_bit_exact(
+        run,
+        (x, weight, alpha_pre, alpha_post, alpha_res, bias),
+        replays=3,
+        what=f"mhc proj_rms_compute_h[{backend}]",
+    )

--- a/tests/unit_tests/determinism/kernels/test_harness.py
+++ b/tests/unit_tests/determinism/kernels/test_harness.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""The replay harness itself: the byte-exact comparator and the replay assertions.
+
+These are the semantics every kernel test in this directory relies on, so they are pinned
+here: ``bytes_equal`` must see signed zeros and NaN payloads, and the replay assertions must
+report such differences instead of accepting them as ``torch.equal`` would.
+"""
+
+import pytest
+import torch
+
+from tests.unit_tests.determinism.kernels.harness import (
+    _describe_mismatch,
+    assert_replays_bit_exact,
+    bytes_equal,
+    clone_inputs,
+    count_differing_replays,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+
+QUIET_NAN = 0x7FC00000
+NEGATIVE_QUIET_NAN = 0xFFC00000 - (1 << 32)  # same bits as an int32 literal
+
+
+def _f32_with_bits(pattern: int, n: int = 1) -> torch.Tensor:
+    return torch.full((n,), pattern, dtype=torch.int32, device="cuda").view(torch.float32)
+
+
+def _flip_sign_of_zero_every_other_call():
+    """A stateful "kernel" whose output alternates between +0.0 and -0.0."""
+    calls = {"n": 0}
+
+    def fn(t):
+        calls["n"] += 1
+        sign = -1.0 if calls["n"] % 2 == 0 else 1.0
+        return torch.zeros_like(t) * sign
+
+    return fn
+
+
+class TestBytesEqual:
+    def test_identical_finite_tensors(self):
+        a = torch.randn(64, 32, device="cuda", dtype=torch.bfloat16)
+        assert bytes_equal(a, a.clone())
+
+    def test_value_difference(self):
+        a = torch.randn(64, device="cuda")
+        b = a.clone()
+        b[7] += 1e-6
+        assert not bytes_equal(a, b)
+
+    def test_signed_zeros_differ(self):
+        pos = torch.tensor([0.0], device="cuda")
+        neg = torch.tensor([-0.0], device="cuda")
+        assert torch.equal(pos, neg)  # what plain equality would have accepted
+        assert not bytes_equal(pos, neg)
+
+    def test_same_nan_payload_matches(self):
+        assert bytes_equal(_f32_with_bits(QUIET_NAN), _f32_with_bits(QUIET_NAN))
+
+    def test_different_nan_payloads_differ(self):
+        assert not bytes_equal(_f32_with_bits(QUIET_NAN), _f32_with_bits(QUIET_NAN + 1))
+        assert not bytes_equal(_f32_with_bits(QUIET_NAN), _f32_with_bits(NEGATIVE_QUIET_NAN))
+
+    def test_shape_and_dtype_mismatch(self):
+        a = torch.zeros(4, device="cuda")
+        assert not bytes_equal(a, torch.zeros(2, 2, device="cuda"))
+        assert not bytes_equal(a, torch.zeros(4, device="cuda", dtype=torch.float64))
+
+    def test_layout_is_not_compared(self):
+        a = torch.randn(8, 16, device="cuda")
+        strided = a.t().contiguous().t()
+        assert not strided.is_contiguous()
+        assert bytes_equal(a, strided)
+
+    def test_empty_and_scalar_tensors(self):
+        assert bytes_equal(torch.empty(0, device="cuda"), torch.empty(0, device="cuda"))
+        assert bytes_equal(torch.tensor(2.5, device="cuda"), torch.tensor(2.5, device="cuda"))
+        assert not bytes_equal(torch.tensor(0.0, device="cuda"), torch.tensor(-0.0, device="cuda"))
+
+    def test_bool_and_integer_dtypes(self):
+        a = torch.randint(0, 100, (33,), device="cuda", dtype=torch.int64)
+        assert bytes_equal(a, a.clone())
+        assert not bytes_equal(a, a + 1)
+        mask = a > 50
+        assert bytes_equal(mask, mask.clone())
+
+
+class TestDescribeMismatch:
+    def test_reports_bit_only_differences(self):
+        a = torch.tensor([0.0, 0.0, 0.0, 0.0], device="cuda")
+        b = torch.tensor([0.0, -0.0, 0.0, 0.0], device="cuda")
+        msg = _describe_mismatch("out", a, b)
+        assert "1/4 elements differ" in msg
+        assert "bit pattern" in msg
+
+    def test_reports_value_differences(self):
+        a = torch.zeros(4, device="cuda")
+        b = torch.tensor([0.0, 0.0, 1.5, 0.0], device="cuda")
+        msg = _describe_mismatch("out", a, b)
+        assert "1/4 elements differ" in msg
+        assert "1.500e+00" in msg
+        assert "bit pattern" not in msg
+
+
+class TestReplayAssertions:
+    def test_pure_function_passes(self):
+        x = torch.randn(1024, 256, device="cuda", requires_grad=True)
+        assert_replays_bit_exact(lambda t: (t * 2).sum(-1), (x,), replays=3, what="pure")
+
+    def test_sign_of_zero_flip_is_caught(self):
+        x = torch.randn(16, device="cuda")
+        with pytest.raises(AssertionError, match="bit pattern"):
+            assert_replays_bit_exact(
+                _flip_sign_of_zero_every_other_call(), (x,), replays=2, backward=False
+            )
+
+    def test_nan_payload_change_is_caught(self):
+        calls = {"n": 0}
+
+        def fn(t):
+            calls["n"] += 1
+            return _f32_with_bits(QUIET_NAN + calls["n"] % 2, t.numel())
+
+        x = torch.randn(16, device="cuda")
+        with pytest.raises(AssertionError, match="not bit-exact"):
+            assert_replays_bit_exact(fn, (x,), replays=2, backward=False)
+
+    def test_count_differing_replays_counts_bit_differences(self):
+        x = torch.randn(16, device="cuda")
+        # Reference is call 1 (+0.0); calls 2 and 4 return -0.0.
+        assert (
+            count_differing_replays(
+                _flip_sign_of_zero_every_other_call(), (x,), replays=5, backward=False
+            )
+            == 2
+        )
+
+    def test_clone_inputs_preserves_expanded_layout(self):
+        base = torch.randn(4, 1, device="cuda").expand(4, 8)
+        clone = clone_inputs(base)
+        assert clone.stride() == base.stride()
+        assert bytes_equal(clone, base)

--- a/tests/unit_tests/determinism/kernels/test_inference_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_inference_kernels.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the single-GPU inference Triton kernels.
+
+Inference kernels do not feed the training loss, but RL rollouts and batch-invariant
+inference depend on them replaying bit-exactly. Covered here: KV-cache tensor ops and the
+fused KV append, the inference MoE activations and MXFP8 quantisation, the inference MoE
+permute/unpermute (batch-invariant path bit-exact; the atomic default path is the negative
+control), the vLLM-derived fused MoE GEMM and top-k sum, the batch-invariant GEMM /
+log-softmax / mean kernels, and the CUDA-graph routing-map padding mask. Multi-rank NVLS
+symmetric-memory collectives are exempted in the manifest (they need NVLink peers).
+"""
+
+import pytest
+import torch
+
+from tests.unit_tests.determinism.kernels.harness import (
+    assert_replays_bit_exact,
+    count_differing_replays,
+    seeded,
+)
+
+try:
+    import triton  # noqa: F401
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and HAVE_TRITON), reason="needs a GPU and Triton"
+)
+
+
+def _dev_scalar(value, dtype=torch.int32):
+    return torch.tensor([value], dtype=dtype, device="cuda")
+
+
+# --- KV-cache tensor ops ---------------------------------------------------------------------
+
+
+def test_tensor_ops_replay():
+    from megatron.core.inference.contexts.attention_context.triton import tensor_ops
+
+    seeded()
+    src = torch.randn(4096, 8192, device="cuda", dtype=torch.bfloat16)
+    pos = _dev_scalar(1533)
+
+    def get_slice(src):
+        out = torch.zeros_like(src)
+        tensor_ops.tensor_get_slice_after(src, out, pos)
+        return out
+
+    assert_replays_bit_exact(get_slice, (src,), backward=False, what="tensor_get_slice_after")
+
+    a = torch.randn(4096, 8192, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(4096, 8192, device="cuda", dtype=torch.bfloat16)
+
+    def merge(a, b):
+        out = torch.zeros_like(a)
+        tensor_ops.tensor_merge(a, b, pos, output_tensor=out)
+        return out
+
+    assert_replays_bit_exact(merge, (a, b), backward=False, what="tensor_merge")
+
+    states = torch.randn(512, 8, 64, 128, device="cuda")
+    idx = torch.randperm(512, device="cuda").to(torch.int64)
+    idx[torch.rand(512, device="cuda") < 0.25] = -1
+    new_states = torch.randn(512, 8, 64, 128, device="cuda")
+
+    def masked_update(states, new_states):
+        tensor_ops.tensor_masked_update(states, idx, new_states)
+        return states
+
+    assert_replays_bit_exact(
+        masked_update, (states, new_states), backward=False, what="tensor_masked_update"
+    )
+
+
+def test_fused_kv_append_replays():
+    from megatron.core.inference.contexts.fused_kv_append_kernel import (
+        triton_append_key_value_cache,
+    )
+
+    seeded()
+    n_tokens, heads, dim, block, blocks, layers = 8192, 8, 128, 64, 2048, 2
+    key = torch.randn(n_tokens, 1, heads, dim, device="cuda", dtype=torch.bfloat16)
+    value = torch.randn(n_tokens, 1, heads, dim, device="cuda", dtype=torch.bfloat16)
+    slots = torch.randperm(blocks * block, device="cuda")[:n_tokens]
+    token_to_block = (slots // block).to(torch.int32)
+    token_to_pos = (slots % block).to(torch.int32)
+    dummy_block = blocks - 1
+    token_to_block[torch.rand(n_tokens, device="cuda") < 0.1] = dummy_block
+    memory = torch.zeros(
+        2, layers + 1, blocks, block, heads, dim, device="cuda", dtype=torch.bfloat16
+    )
+
+    def fn(key, value, memory):
+        triton_append_key_value_cache(
+            1, key, value, memory, n_tokens, token_to_block, token_to_pos, dummy_block
+        )
+        return memory
+
+    assert_replays_bit_exact(
+        fn, (key, value, memory), backward=False, what="triton_append_key_value_cache"
+    )
+
+
+# --- inference MoE activations / quantisation ------------------------------------------------
+
+
+def _padded_layout(rows, ffn, n_used):
+    perm = torch.arange(rows, device="cuda", dtype=torch.int32)
+    perm[torch.rand(rows, device="cuda") < 0.1] = -1
+    return perm, _dev_scalar(n_used)
+
+
+def test_inference_moe_activations_replay():
+    from megatron.core.inference.moe import activations
+
+    seeded()
+    rows, ffn, n_used = 8192, 2688, 6000
+    perm, n_used_t = _padded_layout(rows, ffn, n_used)
+    x2 = torch.randn(rows, 2 * ffn, device="cuda", dtype=torch.bfloat16)
+    x1 = torch.randn(rows, ffn, device="cuda", dtype=torch.bfloat16) * 5
+
+    def live(out):
+        # Rows beyond n_used / padding rows are left uninitialised by design.
+        return out[:n_used][perm[:n_used] >= 0]
+
+    assert_replays_bit_exact(
+        lambda x: live(activations.padded_squared_relu(x, perm, n_used_t, clamp_scale=10.0)),
+        (x1,),
+        backward=False,
+        what="padded_squared_relu",
+    )
+    assert_replays_bit_exact(
+        lambda x: live(activations.padded_swiglu(x, perm, n_used_t)),
+        (x2,),
+        backward=False,
+        what="padded_swiglu",
+    )
+    assert_replays_bit_exact(
+        lambda x: activations.bounded_silu_mul(x, n_used_t)[:n_used],
+        (x2,),
+        backward=False,
+        what="bounded_silu_mul",
+    )
+    if hasattr(torch, "float8_e8m0fnu"):
+
+        def quant(x):
+            q = activations.squared_relu_and_quantize_mxfp8(x, perm, n_used_t)
+            return live(q.data.view(torch.uint8)), q.scale.view(torch.uint8)
+
+        assert_replays_bit_exact(
+            quant, (x1,), backward=False, what="squared_relu_and_quantize_mxfp8"
+        )
+
+
+def test_batch_invariant_inference_activations_replay():
+    from megatron.core.inference.moe import batch_invariant
+
+    seeded()
+    rows, ffn, n_used = 16384, 5120, 12000
+    perm, n_used_t = _padded_layout(rows, ffn, n_used)
+    probs = torch.rand(rows, device="cuda")
+    x2 = torch.randn(rows, 2 * ffn, device="cuda", dtype=torch.bfloat16)
+    x1 = torch.randn(rows, ffn, device="cuda", dtype=torch.bfloat16) * 5
+
+    def live(out):
+        return out[:n_used][perm[:n_used] >= 0]
+
+    assert_replays_bit_exact(
+        lambda x: live(batch_invariant.swiglu_with_probs(x, perm, n_used_t, probs)),
+        (x2,),
+        backward=False,
+        what="swiglu_with_probs",
+    )
+    assert_replays_bit_exact(
+        lambda x: live(
+            batch_invariant.squared_relu_with_probs(x, perm, n_used_t, probs, clamp_scale=10.0)
+        ),
+        (x1,),
+        backward=False,
+        what="squared_relu_with_probs",
+    )
+    bound_elems = _dev_scalar(n_used * ffn)
+    assert_replays_bit_exact(
+        lambda x: batch_invariant.weighted_silu_mul_bounded(x, probs, bound_elems)[:n_used],
+        (x2,),
+        backward=False,
+        what="weighted_silu_mul_bounded",
+    )
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e8m0fnu"), reason="needs torch float8 e8m0 dtype")
+def test_mxfp8_quantize_replays():
+    from megatron.core.inference.quantization.mxfp8_quantize import mxfp8_quantize
+
+    seeded()
+    x = torch.randn(16384, 8192, device="cuda", dtype=torch.bfloat16)
+
+    def fn(x):
+        data, scale = mxfp8_quantize(x)
+        return data.view(torch.uint8), scale.view(torch.uint8)
+
+    assert_replays_bit_exact(fn, (x,), backward=False, what="mxfp8_quantize")
+
+
+# --- inference MoE permute / unpermute --------------------------------------------------------
+
+
+def _permute_case(num_tokens=8192, hidden=4096, topk=8, num_local=8):
+    hidden_states = torch.randn(num_tokens, hidden, device="cuda", dtype=torch.bfloat16)
+    routing_map = torch.randint(0, 32, (num_tokens, topk), device="cuda")
+    probs = torch.rand(num_tokens, topk, device="cuda")
+    valid = _dev_scalar(num_tokens)
+    return hidden_states, probs, routing_map, valid, num_local
+
+
+_INT_VIEW = {
+    torch.float64: torch.int64,
+    torch.float32: torch.int32,
+    torch.float16: torch.int16,
+    torch.bfloat16: torch.int16,
+}
+
+
+def _bit_pattern(t):
+    """Unsigned bit pattern of every element of a float tensor, as int64."""
+    bits = t.contiguous().view(_INT_VIEW[t.dtype]).to(torch.int64)
+    return bits & ((1 << (8 * t.element_size())) - 1)
+
+
+def _row_keys(tokens, prob_bits):
+    """Canonical sorted keys ``token << 32 | bits(prob)`` for a set of permuted rows."""
+    return ((tokens.to(torch.int64) << 32) | prob_bits).sort().values
+
+
+def _expected_rows_per_expert(probs, routing_map, num_local, prob_dtype):
+    """For each local expert: the multiset of (token, probability) rows it must receive."""
+    prob_bits = _bit_pattern(probs.to(prob_dtype))
+    expected = []
+    for expert in range(num_local):
+        tokens, slots = (routing_map == expert).nonzero(as_tuple=True)
+        expected.append(_row_keys(tokens, prob_bits[tokens, slots]))
+    return expected
+
+
+def test_inference_permute_row_order_is_a_permutation_per_expert():
+    """The permute kernel claims rows with ``tl.atomic_add``: row order inside an expert block
+    is scheduling-dependent, but the per-expert multiset of (token, probability) rows, the
+    expert offsets and the gathered hidden states must not change -- and must match what
+    ``routing_map`` / ``probs`` prescribe, so a corrupted probability is caught even though
+    the rows may legitimately be reordered."""
+    from megatron.core.inference.moe.permute import permute_tokens
+
+    seeded()
+    hidden_states, probs, routing_map, valid, num_local = _permute_case()
+    runs = []
+    for _ in range(3):
+        perm_h, perm_p, perm_map, offs = permute_tokens(
+            hidden_states, probs, routing_map, 0, num_local, valid
+        )
+        # Rows beyond the last expert offset are never written (the consumers skip them).
+        n_used = int(offs[-1].item())
+        runs.append(
+            (
+                perm_h[:n_used].clone(),
+                perm_p[:n_used].clone(),
+                perm_map[:n_used].clone(),
+                offs.clone(),
+            )
+        )
+
+    expected_offs = torch.stack([(routing_map == e).sum() for e in range(num_local)]).cumsum(0)
+    expected_rows = _expected_rows_per_expert(probs, routing_map, num_local, runs[0][1].dtype)
+    for perm_h, perm_p, perm_map, offs in runs:
+        assert torch.equal(offs.to(torch.int64), expected_offs.to(offs.device))
+        start = 0
+        for expert, end in enumerate(offs.tolist()):
+            live = perm_map[start:end] >= 0  # padding rows (alignment > 1) carry no token
+            actual = _row_keys(perm_map[start:end][live], _bit_pattern(perm_p[start:end][live]))
+            assert torch.equal(
+                actual, expected_rows[expert]
+            ), f"expert {expert}: (token, probability) rows differ from routing_map/probs"
+            start = end
+        live = perm_map >= 0
+        assert torch.equal(perm_h[live], hidden_states[perm_map[live].long()])
+
+
+def _unpermute_case():
+    from megatron.core.inference.moe import permute
+
+    seeded()
+    num_tokens, hidden, topk, num_local = 8192, 4096, 8, 8
+    hidden_states, probs, routing_map, valid, _ = _permute_case(num_tokens, hidden, topk, num_local)
+    perm_h, perm_p, perm_map, offs, inverse_map = permute.permute_tokens(
+        hidden_states,
+        probs,
+        routing_map,
+        0,
+        num_local,
+        valid,
+        return_batch_invariant_inverse_map=True,
+    )
+    n_used = offs[-1:].to(torch.int32)
+    expert_output = torch.randn_like(perm_h)
+    return expert_output, perm_p, perm_map, inverse_map, n_used, valid, num_tokens
+
+
+def test_inference_unpermute_batch_invariant_path_replays():
+    from megatron.core.inference.moe import batch_invariant
+
+    expert_output, _, _, inverse_map, _, valid, _ = _unpermute_case()
+
+    def bi(expert_output):
+        return batch_invariant.unpermute_tokens_in_expert_order(
+            expert_output, inverse_map, valid, None
+        )
+
+    assert_replays_bit_exact(
+        bi, (expert_output,), replays=4, backward=False, what="unpermute_tokens_in_expert_order"
+    )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Negative control: the default combine accumulates with fp32 tl.atomic_add, whose "
+    "order is hardware dependent (it raced on GB300); recorded, not gated.",
+)
+def test_inference_default_unpermute_is_the_racy_path():
+    from megatron.core.inference.moe import permute
+
+    expert_output, perm_p, perm_map, _, n_used, valid, num_tokens = _unpermute_case()
+
+    def default(expert_output):
+        return permute.unpermute_tokens(expert_output, perm_p, perm_map, num_tokens, n_used, valid)
+
+    differing = count_differing_replays(default, (expert_output,), replays=8, backward=False)
+    assert differing > 0, (
+        "the fp32 tl.atomic_add combine replayed bit-exactly 7 times; if upstream made it "
+        "deterministic, drop this control and register the kernel as tested"
+    )
+
+
+# --- vLLM-derived fused MoE ---------------------------------------------------------------
+
+
+def test_vllm_fused_moe_and_moe_sum_replay():
+    from megatron.core.inference.moe.fused_moe import ActivationType
+    from megatron.core.inference.moe.vllm_fused_moe import _moe_sum, vllm_fused_moe
+
+    seeded()
+    max_tokens, hidden, ffn, topk, experts = 4096, 4096, 2048, 8, 32
+    hidden_states = torch.randn(max_tokens, hidden, device="cuda", dtype=torch.bfloat16)
+    probs = torch.rand(max_tokens, topk, device="cuda")
+    routing_map = torch.randint(0, experts, (max_tokens, topk), device="cuda")
+    fc1 = torch.randn(experts, ffn, hidden, device="cuda", dtype=torch.bfloat16) * 0.02
+    fc2 = torch.randn(experts, hidden, ffn, device="cuda", dtype=torch.bfloat16) * 0.02
+    valid = _dev_scalar(max_tokens - 100)
+
+    def fn(h, p):
+        out = vllm_fused_moe(
+            h, p, fc1, fc2, ActivationType.SQUARED_RELU, experts, 0, valid, routing_map
+        )
+        return out[: max_tokens - 100]
+
+    assert_replays_bit_exact(
+        fn, (hidden_states, probs), replays=4, backward=False, what="vllm_fused_moe"
+    )
+
+    inp = torch.randn(max_tokens * topk, 2688, device="cuda", dtype=torch.bfloat16)
+
+    def moe_sum(inp, p):
+        out = _moe_sum(inp, p, max_tokens, topk, 2688, valid, routing_map, 0, experts)
+        return out[: max_tokens - 100]
+
+    assert_replays_bit_exact(moe_sum, (inp, probs), replays=4, backward=False, what="_moe_sum")
+
+
+# --- batch-invariant kernels -----------------------------------------------------------------
+
+
+def test_batch_invariant_kernels_replay():
+    from megatron.core.transformer.custom_layers import batch_invariant_kernels as bik
+
+    seeded()
+    a = torch.randn(8192, 4096, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(4096, device="cuda", dtype=torch.bfloat16)
+    assert_replays_bit_exact(
+        lambda a, b: bik.matmul_persistent(a, b, bias),
+        (a, b),
+        replays=4,
+        backward=False,
+        what="matmul_persistent",
+    )
+    logits = torch.randn(8192, 32768, device="cuda")
+    assert_replays_bit_exact(
+        lambda x: bik.log_softmax(x, dim=-1),
+        (logits,),
+        replays=4,
+        backward=False,
+        what="bik log_softmax",
+    )
+    x = torch.randn(8192, 4096, device="cuda")
+    assert_replays_bit_exact(
+        lambda x: bik.mean_dim(x, 1), (x,), replays=4, backward=False, what="bik mean_dim"
+    )
+
+
+def test_mask_routing_padding_replays():
+    from megatron.core.transformer.moe.inference_routing_mask_kernel import mask_routing_padding
+
+    seeded()
+    routing_map = torch.randint(0, 64, (8192, 8), device="cuda", dtype=torch.int64)
+    real = _dev_scalar(37 + 8192)
+
+    def fn(routing_map):
+        mask_routing_padding(routing_map, real, tp_rank=1)
+        return routing_map
+
+    assert_replays_bit_exact(fn, (routing_map,), backward=False, what="mask_routing_padding")

--- a/tests/unit_tests/determinism/kernels/test_manifest.py
+++ b/tests/unit_tests/determinism/kernels/test_manifest.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""The kernel registry must cover every kernel-bearing file in the tree (CPU only).
+
+This is the in-repo half of the "every kernel has a determinism test" invariant; the CI
+half (``tools/check_kernel_determinism_coverage.py``) checks the files a PR changes. Both
+use the same manifest and the same notion of "kernel-bearing".
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests.unit_tests.determinism.kernels import manifest
+from tools import check_kernel_determinism_coverage as coverage
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _kernel_bearing_files():
+    files = []
+    for path in sorted((REPO_ROOT / "megatron").rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if coverage.is_kernel_bearing(rel, manifest, REPO_ROOT):
+            files.append(rel)
+    return files
+
+
+def test_entry_names_are_unique():
+    names = [entry.name for entry in manifest.KERNELS]
+    assert len(names) == len(
+        set(names)
+    ), f"duplicate names: {sorted(set(n for n in names if names.count(n) > 1))}"
+
+
+@pytest.mark.parametrize("entry", manifest.KERNELS, ids=lambda e: e.name)
+def test_entry_paths_exist(entry):
+    for source in entry.sources:
+        assert (REPO_ROOT / source).is_file(), f"{entry.name}: source {source} does not exist"
+    for test in entry.tests:
+        assert (REPO_ROOT / test).is_file(), f"{entry.name}: test {test} does not exist"
+        assert test.startswith("tests/unit_tests/"), f"{entry.name}: {test} must be a unit test"
+
+
+@pytest.mark.parametrize("entry", manifest.KERNELS, ids=lambda e: e.name)
+def test_entry_has_test_or_exemption(entry):
+    assert (
+        entry.tests or entry.exempt_reason
+    ), f"{entry.name}: register a bit-exact test or an explicit exempt_reason"
+    assert not (
+        entry.tests and entry.exempt_reason
+    ), f"{entry.name}: an entry is either tested or exempt, not both"
+
+
+def _imported_modules(test_file: Path) -> set:
+    """Dotted module paths imported anywhere in ``test_file`` (module or function level)."""
+    tree = ast.parse(test_file.read_text())
+    modules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+            modules.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return modules
+
+
+def _module_of(source: str) -> str:
+    path = Path(source)
+    if path.name == "__init__.py":
+        path = path.parent
+    return path.with_suffix("").as_posix().replace("/", ".")
+
+
+@pytest.mark.parametrize("entry", manifest.KERNELS, ids=lambda e: e.name)
+def test_registered_test_imports_kernel(entry):
+    """A kernel-suite test must import at least one of the modules it claims to cover.
+
+    Model-level or pre-existing tests cover kernels indirectly and are not held to this, nor
+    are ``kind="dispatch"`` entries: their sources call external kernels that the listed
+    tests replay by name (see the entry's ``notes``).
+    """
+    if entry.kind == "dispatch":
+        return
+    sources = {_module_of(src) for src in entry.sources if src.endswith(".py")}
+    for test in entry.tests:
+        if not test.startswith("tests/unit_tests/determinism/kernels/") or not sources:
+            continue
+        imported = _imported_modules(REPO_ROOT / test)
+        assert any(
+            module == src or module.startswith(src + ".") for module in imported for src in sources
+        ), f"{entry.name}: {test} imports none of {sorted(sources)}"
+
+
+def test_every_kernel_bearing_file_is_registered():
+    unregistered = [path for path in _kernel_bearing_files() if not manifest.entries_for(path)]
+    assert not unregistered, (
+        "Kernel-bearing files without a manifest entry (add a KernelEntry with a bit-exact "
+        "test, or an exempt_reason, in tests/unit_tests/determinism/kernels/manifest.py):\n  "
+        + "\n  ".join(unregistered)
+    )
+
+
+def test_ci_tool_accepts_a_registered_kernel_change():
+    entry = next(e for e in manifest.KERNELS if e.tests)
+    files = [entry.sources[0], entry.tests[0]]
+    assert coverage.check(files, manifest, labels=set(), repo_root=REPO_ROOT) == []
+
+
+def test_ci_tool_requires_test_update_without_label():
+    entry = next(e for e in manifest.KERNELS if e.tests)
+    violations = coverage.check([entry.sources[0]], manifest, labels=set(), repo_root=REPO_ROOT)
+    assert violations and "none of its determinism tests did" in violations[0]
+    assert (
+        coverage.check(
+            [entry.sources[0]], manifest, labels={manifest.EXEMPT_LABEL}, repo_root=REPO_ROOT
+        )
+        == []
+    )
+
+
+def test_ci_tool_flags_unregistered_kernel_file(tmp_path):
+    kernel = tmp_path / "megatron" / "core" / "new_kernel.py"
+    kernel.parent.mkdir(parents=True)
+    kernel.write_text("import triton\n\n@triton.jit\ndef k(x):\n    pass\n")
+    violations = coverage.check(
+        ["megatron/core/new_kernel.py"], manifest, labels=set(), repo_root=tmp_path
+    )
+    assert violations and "not registered" in violations[0]
+
+
+def test_dispatch_entries_name_their_kernels():
+    for entry in manifest.KERNELS:
+        if entry.kind == "dispatch":
+            assert entry.notes or entry.exempt_reason, f"{entry.name}: say which kernels it calls"
+
+
+# Representative call sites for every external kernel family the policy covers. Each must be
+# detected on its own; a bare import, an isinstance() check, a mention in a comment or a
+# docstring, or a plain ``apply_rotary_pos_emb`` caller must not be.
+EXTERNAL_DISPATCH_SNIPPETS = {
+    "transformer_engine_torch": (
+        "import transformer_engine_torch as tex\n\ndef f(x, w):\n    return tex.rmsnorm_fwd(x, w, 1e-5)\n"
+    ),
+    "te_collective": "def f(x, tp):\n    return gather_along_first_dim(x, tp)\n",
+    "te_fp8_cast": "def f(params):\n    cast_master_weights_to_fp8(params)\n",
+    "te_cuda_graphs": "def f(fn):\n    return make_graphed_callables(fn, ())\n",
+    "fused_rope": "def f(t, freqs):\n    return fused_apply_rotary_pos_emb(t, freqs)\n",
+    "flash_attn_rope": "def f(t, cos, sin):\n    return apply_rotary_emb_flash(t, cos, sin)\n",
+    "causal_conv1d": "def f(x, w):\n    return causal_conv1d_fn(x, w, None, activation='silu')\n",
+    "mamba_ssm": (
+        "def f(x, dt, A, B, C):\n    return mamba_chunk_scan_combined(x, dt, A, B, C, chunk_size=256)\n"
+    ),
+    "mamba_decode": "def f(s, x, dt, A, B, C, D):\n    return selective_state_update(s, x, dt, A, B, C, D)\n",
+    "fla": "def f(q, k, v, g, beta):\n    return chunk_gated_delta_rule(q, k, v, g, beta)\n",
+    "fla_l2norm": "def f(q):\n    return l2_norm(q)\n",
+    "deep_ep": "def f(self, x, handle):\n    return self.buffer.dispatch(x, handle=handle)\n",
+    "deep_ep_fused": "def f(x, group):\n    return fused_dispatch(x, group)\n",
+    "cutile": "import cuda.tile as ct\n\n@ct.kernel\ndef k(x):\n    pass\n",
+    "flashinfer": "def f(p, k):\n    return flashinfer.sampling.top_k_sampling_from_probs(p, k)\n",
+    "flashinfer_mxfp8": "def f(a, b):\n    return mm_mxfp8(a, b)\n",
+    "apex_multi_tensor": (
+        "def f(buf, grads, s):\n    multi_tensor_applier(multi_tensor_scale_impl, buf, [grads, grads], s)\n"
+    ),
+}
+
+NON_DISPATCH_SNIPPETS = {
+    "bare_imports": (
+        "import transformer_engine.pytorch as te\n"
+        "import transformer_engine_torch as tex\n"
+        "from causal_conv1d import causal_conv1d_fn\n"
+        "from fla.ops.gated_delta_rule import chunk_gated_delta_rule\n"
+        "import flashinfer\n"
+    ),
+    "isinstance_check": (
+        "from transformer_engine.pytorch import Float8Tensor\n\ndef f(t):\n    return isinstance(t, Float8Tensor)\n"
+    ),
+    "docstring_and_comment": (
+        '"""Eventually calls causal_conv1d_fn(x) and tex.rmsnorm_fwd(x)."""\n'
+        "# selective_state_update(state, x) happens in the mixer\n"
+        "X = 1\n"
+    ),
+    "plain_rope_caller": "def f(t, freqs):\n    return apply_rotary_pos_emb(t, freqs)\n",
+    "class_only": "class Buffer:\n    def dispatch(self, x):\n        return x\n",
+}
+
+
+def _classify(tmp_path, text):
+    path = tmp_path / "megatron" / "core" / "candidate.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return coverage.is_kernel_bearing("megatron/core/candidate.py", manifest, tmp_path)
+
+
+@pytest.mark.parametrize("snippet", sorted(EXTERNAL_DISPATCH_SNIPPETS))
+def test_external_dispatch_call_sites_are_detected(tmp_path, snippet):
+    assert _classify(tmp_path, EXTERNAL_DISPATCH_SNIPPETS[snippet]), snippet
+
+
+@pytest.mark.parametrize("snippet", sorted(NON_DISPATCH_SNIPPETS))
+def test_non_dispatch_code_is_not_detected(tmp_path, snippet):
+    assert not _classify(tmp_path, NON_DISPATCH_SNIPPETS[snippet]), snippet
+
+
+def test_ci_tool_flags_unregistered_external_dispatch_file(tmp_path):
+    """A PR that adds an external-kernel call site in a new file fails the gate."""
+    module = tmp_path / "megatron" / "core" / "new_mixer.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(EXTERNAL_DISPATCH_SNIPPETS["causal_conv1d"])
+    violations = coverage.check(
+        ["megatron/core/new_mixer.py"], manifest, labels=set(), repo_root=tmp_path
+    )
+    assert violations and "not registered" in violations[0]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "megatron/core/ssm/mamba_mixer.py",
+        "megatron/core/ssm/gated_delta_product.py",
+        "megatron/core/models/common/embeddings/rope_utils.py",
+        "megatron/core/transformer/multi_latent_attention.py",
+        "megatron/core/fp8_utils.py",
+        "megatron/core/inference/sampling/flashinfer_sampling.py",
+    ],
+)
+def test_known_dispatch_files_stay_kernel_bearing(path):
+    """Detector regressions on the real dispatch modules must be visible, not silent."""
+    registered = manifest.entries_for(path)
+    assert registered, f"{path} must stay registered"
+    # Independently of the registration, the content patterns must still recognise them.
+    text = (REPO_ROOT / path).read_text()
+    assert coverage.matches_kernel_pattern(text, manifest.KERNEL_CONTENT_PATTERNS), path

--- a/tests/unit_tests/determinism/kernels/test_moe_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_moe_kernels.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the MoE kernels in ``megatron/core/transformer/moe/``.
+
+Operator level: token permute / unpermute (torch and TE-fused, both branches of the
+``torch.are_deterministic_algorithms_enabled()`` switch), chunk sorting, top-k routing (torch
+and TE-fused), group-limited routing, the load-balancing aux loss (torch and TE-fused), and
+the router gating GEMM. Module level: ``TopKRouter``, ``TEGroupedMLP`` / ``SequentialMLP`` on
+deliberately uneven expert loads (including an empty expert), and a full ``MoELayer`` through
+the all-gather and all-to-all dispatchers (plus the flex/DeepEP dispatcher from
+``fused_a2a.py`` when the dependency and the GPUs are available).
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_submodules,
+    get_gpt_layer_with_transformer_engine_spec,
+)
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe import moe_utils
+from megatron.core.transformer.moe.experts import SequentialMLP, TEGroupedMLP
+from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.moe.router import TopKRouter
+from megatron.core.transformer.spec_utils import get_submodules
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import is_te_min_version
+from tests.unit_tests.determinism.kernels.harness import (
+    assert_module_replays_bit_exact,
+    assert_replays_bit_exact,
+    count_differing_replays,
+    deterministic_algorithms,
+    seeded,
+)
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+
+HAVE_TE = moe_utils.HAVE_TE
+HAVE_TE_PERMUTE = HAVE_TE and moe_utils.fused_permute is not None
+HAVE_TE_ROUTER = HAVE_TE and is_te_min_version("2.7.0")
+from megatron.core.transformer.moe.fused_a2a import HAVE_DEEP_EP
+
+NUM_TOKENS, HIDDEN, NUM_EXPERTS, TOPK = 16384, 2048, 64, 8
+
+
+def _routing(num_tokens=NUM_TOKENS, num_experts=NUM_EXPERTS, topk=TOPK):
+    logits = torch.randn(num_tokens, num_experts, device="cuda")
+    probs_full = torch.softmax(logits, dim=-1)
+    idx = probs_full.topk(topk, dim=-1).indices
+    routing_map = torch.zeros(num_tokens, num_experts, dtype=torch.bool, device="cuda")
+    routing_map.scatter_(1, idx, True)
+    probs = torch.zeros_like(probs_full).scatter(1, idx, probs_full.gather(1, idx))
+    return routing_map, probs
+
+
+# --- permute / unpermute --------------------------------------------------------------------
+
+
+def _permute_roundtrip(fused, with_probs):
+    def fn(tokens, routing_map, probs):
+        permuted, permuted_probs, sorted_indices, *_ = moe_utils.permute(
+            tokens,
+            routing_map,
+            probs=probs if with_probs else None,
+            num_out_tokens=NUM_TOKENS * TOPK,
+            fused=fused,
+        )
+        # The experts apply the routed probabilities before the combine; every production
+        # caller then unpermutes with ``probs=None``.
+        if with_probs:
+            permuted = permuted * permuted_probs.unsqueeze(-1).to(permuted.dtype)
+        else:
+            permuted = permuted * 1.001
+        return moe_utils.unpermute(
+            permuted, sorted_indices, tokens.shape, routing_map=routing_map, fused=fused
+        )
+
+    return fn
+
+
+@pytest.mark.parametrize(
+    "fused",
+    [
+        False,
+        pytest.param(
+            True, marks=pytest.mark.skipif(not HAVE_TE_PERMUTE, reason="TE permute missing")
+        ),
+    ],
+)
+@pytest.mark.parametrize("with_probs", [False, True])
+def test_permute_unpermute_replay_under_deterministic_algorithms(fused, with_probs):
+    """Deterministic branch: ``index_add_`` combine, ``index_put_`` gathers -- bit-exact."""
+    seeded()
+    routing_map, probs = _routing()
+    tokens = torch.randn(
+        NUM_TOKENS, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    probs.requires_grad_(with_probs)
+    with deterministic_algorithms(True):
+        assert_replays_bit_exact(
+            _permute_roundtrip(fused, with_probs),
+            (tokens, routing_map, probs),
+            replays=3,
+            what=f"permute/unpermute[fused={fused}, probs={with_probs}]",
+        )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Negative control. On GB300 the bf16 scatter_add_ combine replayed bit-exactly 8 "
+    "times (2026-09-04), so the race is hardware/shape dependent; recorded, not gated.",
+)
+def test_default_unpermute_is_the_racy_path():
+    """Negative control: without deterministic algorithms the torch combine uses
+    ``scatter_add_`` (atomic bf16 accumulation of 8 rows per token over 16k tokens). When it
+    races visibly, the deterministic assertion above is known to be sensitive."""
+    seeded()
+    routing_map, probs = _routing()
+    tokens = torch.randn(
+        NUM_TOKENS, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    with deterministic_algorithms(False):
+        differing = count_differing_replays(
+            _permute_roundtrip(False, False), (tokens, routing_map, probs), replays=8
+        )
+    assert differing > 0, (
+        "the scatter_add_ combine replayed bit-exactly 7 times; either torch made it deterministic "
+        "(drop this control) or the shape no longer contends"
+    )
+
+
+@pytest.mark.parametrize(
+    "fused",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skipif(not HAVE_TE_PERMUTE, reason="TE sort missing")),
+    ],
+)
+@pytest.mark.parametrize("with_probs", [False, True])
+def test_sort_chunks_by_idxs_replays(fused, with_probs):
+    seeded()
+    num_chunks = 32
+    sizes = torch.randint(100, 2000, (num_chunks,))
+    sizes[3] = 0
+    rows = int(sizes.sum())
+    split_sizes = sizes.to("cuda") if fused else sizes
+    sorted_idxs = torch.randperm(num_chunks).to("cuda") if fused else torch.randperm(num_chunks)
+    x = torch.randn(rows, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    probs = torch.rand(rows, device="cuda", requires_grad=with_probs)
+
+    def fn(x, probs):
+        out, out_probs = moe_utils.sort_chunks_by_idxs(
+            x, split_sizes, sorted_idxs, probs=probs if with_probs else None, fused=fused
+        )
+        return (out, out_probs) if with_probs else out
+
+    assert_replays_bit_exact(fn, (x, probs), replays=3, what=f"sort_chunks_by_idxs[fused={fused}]")
+
+
+# --- routing --------------------------------------------------------------------------------
+
+ROUTING_CASES = {
+    "softmax_topk8": dict(topk=8, score_function="softmax"),
+    "softmax_pre_softmax": dict(topk=8, use_pre_softmax=True, score_function="softmax"),
+    "sigmoid_scaled": dict(topk=8, score_function="sigmoid", scaling_factor=2.5),
+    "group_limited": dict(topk=8, score_function="sigmoid", num_groups=8, group_topk=4),
+    "topk2": dict(topk=2, score_function="softmax"),
+}
+
+
+@pytest.mark.parametrize("case", sorted(ROUTING_CASES))
+@pytest.mark.parametrize(
+    "fused",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skipif(not HAVE_TE_ROUTER, reason="TE>=2.7 needed")),
+    ],
+)
+@pytest.mark.parametrize("det_algos", [True, False], ids=["det-branch", "default-branch"])
+def test_topk_routing_replays(case, fused, det_algos):
+    seeded()
+    kwargs = dict(ROUTING_CASES[case])
+    logits = torch.randn(8192, 256, device="cuda", dtype=torch.float32, requires_grad=True)
+    expert_bias = (
+        torch.randn(256, device="cuda") * 0.01
+        if kwargs.get("score_function") == "sigmoid"
+        else None
+    )
+
+    def fn(logits):
+        probs, routing_map = moe_utils.topk_routing_with_score_function(
+            logits, fused=fused, expert_bias=expert_bias, **kwargs
+        )
+        return probs, routing_map
+
+    with deterministic_algorithms(det_algos):
+        assert_replays_bit_exact(
+            fn, (logits,), replays=3, what=f"topk routing[{case}, fused={fused}]"
+        )
+
+
+def test_group_limited_topk_replays():
+    seeded()
+    scores = torch.rand(8192, 256, device="cuda")
+    assert_replays_bit_exact(
+        lambda s: moe_utils.group_limited_topk(s, 8, 8192, 256, 8, 4),
+        (scores,),
+        backward=False,
+        what="group_limited_topk",
+    )
+
+
+@pytest.mark.parametrize(
+    "fused",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=[
+                pytest.mark.skipif(not HAVE_TE_ROUTER, reason="TE>=2.7 needed"),
+                pytest.mark.xfail(
+                    strict=False,
+                    reason="TE fused_moe_aux_loss reduces with atomicAdd (open gap, recorded not gated)",
+                ),
+            ],
+        ),
+    ],
+)
+def test_switch_load_balancing_loss_replays(fused):
+    seeded()
+    routing_map, probs = _routing(num_tokens=65536, num_experts=256, topk=8)
+    probs = probs.detach().requires_grad_(True)
+    tokens_per_expert = routing_map.sum(dim=0)
+
+    def fn(probs):
+        return moe_utils.switch_load_balancing_loss_func(
+            probs, tokens_per_expert, 65536, 8, 256, 1e-2, fused=fused
+        )
+
+    assert_replays_bit_exact(fn, (probs,), replays=4, what=f"aux loss[fused={fused}]")
+
+
+@pytest.mark.parametrize("router_dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_router_gating_linear_replays(router_dtype, with_bias):
+    seeded()
+    inp = torch.randn(8192, 4096, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(256, 4096, device="cuda", dtype=torch.bfloat16, requires_grad=True) * 0.02
+    weight = weight.detach().requires_grad_(True)
+    bias = (
+        torch.randn(256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        if with_bias
+        else None
+    )
+    assert_replays_bit_exact(
+        lambda i, w, b: moe_utils.router_gating_linear(i, w, b, router_dtype),
+        (inp, weight, bias),
+        replays=3,
+        contention=True,
+        what="router_gating_linear",
+    )
+
+
+# --- modules --------------------------------------------------------------------------------
+
+
+def _moe_config(**overrides):
+    kwargs = dict(
+        num_layers=1,
+        hidden_size=1024,
+        ffn_hidden_size=2048,
+        num_attention_heads=8,
+        num_moe_experts=8,
+        moe_router_topk=2,
+        moe_router_load_balancing_type="aux_loss",
+        moe_aux_loss_coeff=0.01,
+        moe_router_dtype="fp32",
+        moe_grouped_gemm=True,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        bias_activation_fusion=True,
+        add_bias_linear=False,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        use_cpu_initialization=True,
+        deterministic_mode=True,
+        sequence_parallel=False,
+    )
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+class TestMoEModules:
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _init(self, ep=1):
+        Utils.initialize_model_parallel(expert_model_parallel_size=ep)
+        model_parallel_cuda_manual_seed(123)
+
+    @pytest.mark.parametrize(
+        "balancing,score,expert_bias",
+        [
+            ("aux_loss", "softmax", False),
+            ("seq_aux_loss", "sigmoid", True),
+            ("sinkhorn", "softmax", False),
+        ],
+        ids=["aux_loss", "seq_aux_loss+sigmoid+bias", "sinkhorn"],
+    )
+    def test_topk_router_replays(self, balancing, score, expert_bias):
+        self._init()
+        seeded()
+        config = _moe_config(
+            num_moe_experts=64,
+            moe_router_topk=8 if balancing != "sinkhorn" else 1,
+            moe_router_load_balancing_type=balancing,
+            moe_router_score_function=score,
+            moe_router_enable_expert_bias=expert_bias,
+            moe_router_pre_softmax=balancing == "sinkhorn",
+            moe_aux_loss_coeff=0.0 if balancing == "sinkhorn" else 0.01,
+        )
+        router = TopKRouter(
+            config, pg_collection=ProcessGroupCollection.use_mpu_process_groups()
+        ).cuda()
+        router.set_layer_number(0)
+        hidden = torch.randn(2048, 4, 1024, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        assert_module_replays_bit_exact(
+            router, (hidden,), replays=3, what=f"TopKRouter[{balancing}]"
+        )
+
+    @pytest.mark.skipif(not HAVE_TE, reason="TE grouped MLP needs Transformer Engine")
+    def test_te_grouped_mlp_replays_on_uneven_experts(self):
+        self._init()
+        seeded()
+        config = _moe_config(hidden_size=2048, ffn_hidden_size=4096)
+        spec = get_gpt_layer_with_transformer_engine_spec(num_experts=8, moe_grouped_gemm=True)
+        experts = get_submodules(spec.submodules.mlp).experts(
+            num_local_experts=8,
+            config=config,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+        )
+        assert isinstance(experts, TEGroupedMLP)
+        experts = experts.cuda()
+        tokens_per_expert = torch.tensor([4096, 17, 0, 2048, 1, 8191, 33, 1998], dtype=torch.int64)
+        rows = int(tokens_per_expert.sum())
+        hidden = torch.randn(rows, 2048, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        probs = torch.rand(rows, device="cuda", requires_grad=True)
+        assert_module_replays_bit_exact(
+            experts,
+            (hidden, tokens_per_expert, probs),
+            replays=3,
+            contention=True,
+            what="TEGroupedMLP",
+        )
+
+    def test_sequential_mlp_replays_on_uneven_experts(self):
+        self._init()
+        seeded()
+        config = _moe_config(hidden_size=2048, ffn_hidden_size=4096, moe_grouped_gemm=False)
+        submodules = get_gpt_layer_local_submodules(num_experts=8, moe_grouped_gemm=False)
+        experts = get_submodules(submodules.mlp).experts(
+            num_local_experts=8,
+            config=config,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+        )
+        assert isinstance(experts, SequentialMLP)
+        experts = experts.cuda()
+        tokens_per_expert = torch.tensor([4096, 17, 0, 2048, 1, 8191, 33, 1998], dtype=torch.int64)
+        rows = int(tokens_per_expert.sum())
+        hidden = torch.randn(rows, 2048, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        probs = torch.rand(rows, device="cuda", requires_grad=True)
+        assert_module_replays_bit_exact(
+            experts,
+            (hidden, tokens_per_expert, probs),
+            replays=3,
+            contention=True,
+            what="SequentialMLP",
+        )
+
+    @pytest.mark.parametrize(
+        "dispatcher,ep,extra",
+        [
+            ("allgather", 1, {}),
+            ("alltoall", 1, {}),
+            (
+                "alltoall",
+                1,
+                {"moe_expert_capacity_factor": 0.5, "moe_pad_expert_input_to_capacity": True},
+            ),
+            pytest.param("alltoall", 2, {"moe_permute_fusion": HAVE_TE_PERMUTE}, id="alltoall-ep2"),
+            pytest.param(
+                "flex",
+                2,
+                {"moe_flex_dispatcher_backend": "deepep"},
+                id="flex-deepep-ep2",
+                marks=pytest.mark.skipif(not HAVE_DEEP_EP, reason="DeepEP not installed"),
+            ),
+        ],
+    )
+    def test_moe_layer_replays(self, dispatcher, ep, extra):
+        if Utils.world_size % ep != 0 or (ep > 1 and Utils.world_size < ep):
+            pytest.skip(f"needs a world size divisible by EP={ep}")
+        self._init(ep=ep)
+        seeded()
+        config = _moe_config(
+            moe_token_dispatcher_type=dispatcher, expert_model_parallel_size=ep, **extra
+        )
+        if not HAVE_TE:
+            config.moe_grouped_gemm = False
+            mlp_spec = get_gpt_layer_local_submodules(num_experts=8, moe_grouped_gemm=False).mlp
+        else:
+            mlp_spec = get_gpt_layer_with_transformer_engine_spec(
+                num_experts=8, moe_grouped_gemm=True
+            ).submodules.mlp
+        layer = MoELayer(config, get_submodules(mlp_spec)).cuda()
+        layer.set_layer_number(0)
+        hidden = torch.randn(2048, 2, 1024, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        with deterministic_algorithms(True):
+            assert_module_replays_bit_exact(
+                layer,
+                (hidden,),
+                replays=3,
+                contention=True,
+                what=f"MoELayer[{dispatcher}, ep={ep}]",
+            )

--- a/tests/unit_tests/determinism/kernels/test_optimizer_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_optimizer_kernels.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the optimizer-side kernels: gradient-norm and clipping multi-tensor
+kernels (TE / apex / local fallback in ``megatron/core/optimizer/clip_grads.py``) and the fused
+Adam update. These run once per step on every parameter, so any drift here changes the
+whole trajectory even when the model kernels are deterministic.
+"""
+
+import pytest
+import torch
+
+from megatron.core.optimizer import Adam
+from megatron.core.optimizer.clip_grads import clip_grad_by_total_norm_fp32, get_grad_norm_fp32
+from tests.unit_tests.determinism.kernels.harness import (
+    assert_replays_bit_exact,
+    bytes_equal,
+    seeded,
+)
+from tests.unit_tests.determinism.utils import RacingStreams
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+
+
+def _grads(num=256, seed=7):
+    gen = torch.Generator().manual_seed(seed)
+    sizes = torch.randint(1000, 400_000, (num,), generator=gen).tolist()
+    return [torch.randn(n, device="cuda", dtype=torch.float32) for n in sizes]
+
+
+class TestGradNormAndClip:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("norm_type", [2, float("inf")])
+    def test_get_grad_norm_fp32_replays(self, norm_type):
+        seeded()
+        grads = _grads()
+
+        def fn(*grads):
+            return torch.tensor(
+                get_grad_norm_fp32(list(grads), norm_type), device="cuda", dtype=torch.float64
+            )
+
+        assert_replays_bit_exact(
+            fn, tuple(grads), replays=8, backward=False, contention=True, what="get_grad_norm_fp32"
+        )
+
+    def test_clip_grad_by_total_norm_replays(self):
+        seeded()
+        grads = _grads()
+        params = []
+        for g in grads:
+            p = torch.zeros_like(g)
+            p.grad = g.clone()
+            params.append(p)
+        total_norm = get_grad_norm_fp32([p.grad for p in params], 2)
+
+        ref = None
+        for i in range(4):
+            for p, g in zip(params, grads):
+                p.grad.copy_(g)
+            with RacingStreams():
+                clip_grad_by_total_norm_fp32(params, 1.0, total_norm)
+            torch.cuda.synchronize()
+            got = [p.grad.clone() for p in params]
+            if ref is None:
+                ref = got
+                continue
+            for j, (a, b) in enumerate(zip(ref, got)):
+                assert bytes_equal(a, b), f"clipped grad {j} differs on replay {i}"
+
+
+def test_fused_adam_step_replays():
+    """Same params, grads and optimizer state -> identical updated params and moments."""
+    seeded()
+    shapes = [(4096, 4096), (16384, 2048), (2048,), (65536,)]
+    params0 = [torch.randn(*s, device="cuda", dtype=torch.float32) for s in shapes]
+    grads = [torch.randn(*s, device="cuda", dtype=torch.float32) for s in shapes]
+
+    def run_step():
+        params = [torch.nn.Parameter(p.clone()) for p in params0]
+        for p, g in zip(params, grads):
+            p.grad = g.clone()
+        opt = Adam(params, lr=1e-3, betas=(0.9, 0.95), weight_decay=0.1, eps=1e-8)
+        with RacingStreams():
+            opt.step()
+            opt.step()
+        torch.cuda.synchronize()
+        out = [p.detach().clone() for p in params]
+        for p in params:
+            state = opt.state[p]
+            out += [state[k].clone() for k in sorted(state) if torch.is_tensor(state[k])]
+        return out
+
+    ref = run_step()
+    for i in range(1, 4):
+        got = run_step()
+        assert len(got) == len(ref)
+        for j, (a, b) in enumerate(zip(ref, got)):
+            assert bytes_equal(a, b), f"Adam tensor {j} differs on replay {i}"

--- a/tests/unit_tests/determinism/kernels/test_ssm_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_ssm_kernels.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the in-repo SSM Triton kernels (``megatron/core/ssm/ops/``) and the
+gated-delta-net code paths.
+
+The Mamba training mixer is covered by ``correctness/test_ssm_conv1d.py``; this module drives
+the kernels Megatron ships itself: the Mamba2 varlen chunked scan (``ssd_*`` kernels behind
+``mamba_chunk_scan_combined_varlen``), the decode-time ``selective_state_update`` and
+``causal_conv1d_update``, the varlen causal conv, the Gated Delta Product varlen chunk scan
+(``gdp/*`` kernels) and its decode kernels, and the torch gated-delta-rule path that
+``--deterministic-mode`` selects instead of FLA.
+
+Autotuning is the mechanism that can break replay here: ``ops/common/determinism.py`` pins a
+single config and a zero-initialised, ordered-sum workspace when ``MAMBA_DETERMINISTIC`` (or
+``torch.use_deterministic_algorithms``) is on. Each kernel is replayed in that mode.
+"""
+
+import pytest
+import torch
+
+from megatron.core.ssm.ops.common import determinism as ssm_determinism
+from tests.unit_tests.determinism.kernels.harness import assert_replays_bit_exact, seeded
+
+try:
+    import triton  # noqa: F401
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and HAVE_TRITON), reason="needs a GPU and Triton"
+)
+
+
+@pytest.fixture(autouse=True)
+def ssm_deterministic():
+    """Pin the SSM autotuner / workspace path like ``--deterministic-mode`` does."""
+    ssm_determinism.set_deterministic_mode(True)
+    yield
+    ssm_determinism.set_deterministic_mode(None)
+
+
+# --- Mamba2 --------------------------------------------------------------------------------
+
+
+def test_mamba_chunk_scan_combined_varlen_replays():
+    from megatron.core.ssm.ops.mamba2.ssd_combined import mamba_chunk_scan_combined_varlen
+
+    seeded()
+    seqlen, nheads, headdim, ngroups, dstate, chunk = 4096, 32, 64, 1, 128, 256
+    nchunks = seqlen // chunk
+    x = torch.randn(seqlen, nheads, headdim, device="cuda", dtype=torch.bfloat16)
+    dt = torch.rand(seqlen, nheads, device="cuda") * 0.1
+    A = -torch.rand(nheads, device="cuda") - 1.0
+    B = torch.randn(seqlen, ngroups, dstate, device="cuda", dtype=torch.bfloat16)
+    C = torch.randn(seqlen, ngroups, dstate, device="cuda", dtype=torch.bfloat16)
+    D = torch.randn(nheads, device="cuda")
+    dt_bias = torch.rand(nheads, device="cuda")
+    cu_chunk_seqlens = torch.arange(0, seqlen + 1, chunk, dtype=torch.int32, device="cuda")
+    # Two sequences of eight chunks each.
+    last_chunk_indices = torch.tensor(
+        [nchunks // 2 - 1, nchunks - 1], dtype=torch.int64, device="cuda"
+    )
+    seq_idx = torch.repeat_interleave(
+        torch.arange(2, dtype=torch.int32, device="cuda"), nchunks // 2
+    )
+    out = torch.empty_like(x)
+
+    def fn(x, dt, A, B, C, D, dt_bias, out):
+        states = mamba_chunk_scan_combined_varlen(
+            x,
+            dt,
+            A,
+            B,
+            C,
+            chunk,
+            cu_chunk_seqlens,
+            last_chunk_indices,
+            seq_idx,
+            out,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+        )
+        return out, states
+
+    assert_replays_bit_exact(
+        fn,
+        (x, dt, A, B, C, D, dt_bias, out),
+        replays=4,
+        backward=False,
+        what="mamba_chunk_scan_combined_varlen",
+    )
+
+
+def test_selective_state_update_replays():
+    from megatron.core.ssm.ops.mamba2.mamba_ssm import selective_state_update
+
+    seeded()
+    batch, nheads, headdim, dstate, ngroups = 256, 32, 64, 128, 1
+    state = torch.randn(batch, nheads, headdim, dstate, device="cuda")
+    x = torch.randn(batch, nheads, headdim, device="cuda", dtype=torch.bfloat16)
+    dt = torch.rand(batch, nheads, device="cuda").unsqueeze(-1).expand(batch, nheads, headdim)
+    A = (
+        (-torch.rand(nheads, device="cuda") - 1.0)
+        .view(nheads, 1, 1)
+        .expand(nheads, headdim, dstate)
+    )
+    Bm = torch.randn(batch, ngroups, dstate, device="cuda", dtype=torch.bfloat16)
+    Cm = torch.randn(batch, ngroups, dstate, device="cuda", dtype=torch.bfloat16)
+    D = torch.randn(nheads, device="cuda").unsqueeze(-1).expand(nheads, headdim)
+    dt_bias = (torch.rand(nheads, device="cuda") - 4.0).unsqueeze(-1).expand(nheads, headdim)
+
+    def fn(state, x, dt, A, Bm, Cm, D, dt_bias):
+        # The kernel picks its TIE_HDIM specialisation from these stride-0 broadcasts, the
+        # layout the Mamba mixer dispatches; the harness must hand them over unchanged.
+        assert dt.stride(-1) == 0 and A.stride(-1) == 0 and dt_bias.stride(-1) == 0
+        out = selective_state_update(
+            state, x, dt, A, Bm, Cm, D=D, dt_bias=dt_bias, dt_softplus=True
+        )
+        return out, state
+
+    assert_replays_bit_exact(
+        fn,
+        (state, x, dt, A, Bm, Cm, D, dt_bias),
+        replays=4,
+        backward=False,
+        what="selective_state_update",
+    )
+
+
+# --- causal conv (Megatron Triton variants) ---------------------------------------------------
+
+
+def test_causal_conv1d_update_replays():
+    from megatron.core.ssm.ops.common.causal_conv1d_triton import causal_conv1d_update
+
+    seeded()
+    batch, dim, width = 256, 4096, 4
+    x = torch.randn(batch, dim, device="cuda", dtype=torch.bfloat16)
+    conv_state = torch.randn(batch, dim, width - 1, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(dim, width, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="cuda", dtype=torch.bfloat16)
+
+    def fn(x, conv_state, weight, bias):
+        out = causal_conv1d_update(x, conv_state, weight, bias, True, None)
+        return out, conv_state
+
+    assert_replays_bit_exact(
+        fn, (x, conv_state, weight, bias), replays=4, backward=False, what="causal_conv1d_update"
+    )
+
+
+def test_causal_conv1d_varlen_replays():
+    from megatron.core.ssm.ops.common.causal_conv1d_varlen import causal_conv1d_varlen_fn
+
+    seeded()
+    dim, width = 2048, 4
+    bounds = [0, 1000, 1500, 2048, 4096, 8192]
+    x = torch.randn(bounds[-1], dim, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(dim, width, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor(bounds, dtype=torch.int32, device="cuda")
+    initial_states = torch.randn(
+        len(bounds) - 1, dim, width - 1, device="cuda", dtype=torch.bfloat16
+    )
+    assert_replays_bit_exact(
+        lambda x, w, b, s: causal_conv1d_varlen_fn(x, w, b, cu_seqlens, s),
+        (x, weight, bias, initial_states),
+        replays=4,
+        backward=False,
+        what="causal_conv1d_varlen_fn",
+    )
+
+
+# --- Gated Delta Product ----------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="GDP varlen chunk scan replays differ on GB300 / Triton 3.7 even with the autotune "
+    "pinned to one config and the ordered workspace (measured 2026-09-04: ~0.15% of output "
+    "elements, max |diff| 3.6e-2 bf16; final state ~0.13%, 2.9e-4). Recorded for the hybrid "
+    "model owners; not gated until root-caused.",
+)
+def test_chunk_gated_delta_product_varlen_replays():
+    from megatron.core.ssm.ops.gdp import chunk_h, chunk_o
+    from megatron.core.ssm.ops.gdp.chunk import chunk_gated_delta_product_varlen
+
+    # The deterministic policy must have pinned the autotuners at import; otherwise the
+    # replay would measure Triton's timing-based config search, not the kernels.
+    for kernel in (
+        chunk_h.chunk_gated_delta_product_fwd_kernel_h_blockdim64,
+        chunk_o.chunk_fwd_kernel_o,
+    ):
+        configs = getattr(kernel, "configs", None)
+        if configs is not None and len(configs) != 1:
+            pytest.skip("GDP autotuners were imported before the deterministic policy was set")
+
+    seeded()
+    T, H, K, V, M = 4096, 16, 128, 128, 2
+    bounds = [0, 1000, 2500, 4096]
+    q = torch.randn(1, T, H, K, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, T * M, H, K, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, T * M, H, V, device="cuda", dtype=torch.bfloat16)
+    g = -torch.rand(1, T, H, device="cuda") * 0.1
+    beta = torch.rand(1, T * M, H, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor(bounds, dtype=torch.int32, device="cuda")
+    initial_state = torch.randn(len(bounds) - 1, H, K, V, device="cuda")
+
+    def fn(q, k, v, g, beta, initial_state):
+        return chunk_gated_delta_product_varlen(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            M,
+            cu_seqlens,
+            initial_state=initial_state,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    assert_replays_bit_exact(
+        fn,
+        (q, k, v, g, beta, initial_state),
+        replays=4,
+        backward=False,
+        what="chunk_gated_delta_product_varlen",
+    )
+
+
+def test_fused_recurrent_gated_delta_rule_update_replays():
+    from megatron.core.ssm.ops.gdp.fused_recurrent import fused_recurrent_gated_delta_rule_update
+
+    seeded()
+    B, H, K, V = 128, 16, 128, 128
+    q = torch.randn(B, 1, H, K, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(B, 1, H, K, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(B, 1, H, V, device="cuda", dtype=torch.bfloat16)
+    g = -torch.rand(B, 1, H, device="cuda") * 0.1
+    beta = torch.rand(B, 1, H, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(B, H, K, V, device="cuda")
+
+    def fn(q, k, v, g, beta, initial_state):
+        return fused_recurrent_gated_delta_rule_update(
+            q,
+            k,
+            v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    assert_replays_bit_exact(
+        fn,
+        (q, k, v, g, beta, initial_state),
+        replays=4,
+        backward=False,
+        what="fused_recurrent_gated_delta_rule_update",
+    )
+
+
+def test_gdp_decode_prepare_replays():
+    from megatron.core.ssm.ops.gdp.decode_prepare import gdp_decode_prepare
+
+    seeded()
+    n, M, H, G, P, N = 256, 2, 16, 4, 128, 128
+    x = torch.randn(n, 1, M * H * P + M * G * N + G * N, device="cuda", dtype=torch.bfloat16)
+    ba = torch.randn(n, 1, M * H + H, device="cuda", dtype=torch.bfloat16)
+    A_log = torch.randn(H, device="cuda")
+    dt_bias = torch.randn(H, device="cuda")
+    assert_replays_bit_exact(
+        lambda x, ba, A_log, dt_bias: gdp_decode_prepare(x, ba, A_log, dt_bias, M, H, G, P, N),
+        (x, ba, A_log, dt_bias),
+        replays=4,
+        backward=False,
+        what="gdp_decode_prepare",
+    )
+
+
+def test_gdp_l2norm_and_cumsum_replay():
+    from megatron.core.ssm.ops.gdp.common import l2norm_fwd
+    from megatron.core.ssm.ops.gdp.cumsum import chunk_local_cumsum
+
+    seeded()
+    x = torch.randn(65536, 128, device="cuda", dtype=torch.bfloat16)
+    assert_replays_bit_exact(l2norm_fwd, (x,), replays=4, backward=False, what="l2norm_fwd")
+    g = torch.randn(1, 8192, 16, device="cuda")
+    assert_replays_bit_exact(
+        lambda g: chunk_local_cumsum(g, 64),
+        (g,),
+        replays=4,
+        backward=False,
+        what="chunk_local_cumsum",
+    )
+
+
+# --- Gated Delta Net (deterministic torch path vs FLA) ---------------------------------------
+
+
+def test_torch_chunk_gated_delta_rule_replays_fwd_bwd():
+    """The path ``--deterministic-mode`` selects for GDN (FLA is not deterministic)."""
+    from megatron.core.ssm.gated_delta_net.gdn import torch_chunk_gated_delta_rule
+
+    seeded()
+    B, T, H, K = 2, 2048, 16, 128
+    q = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    g = (-torch.rand(B, T, H, device="cuda") * 0.1).requires_grad_(True)
+    beta = torch.rand(B, T, H, device="cuda").requires_grad_(True)
+
+    def fn(q, k, v, g, beta):
+        # use_qk_l2norm_in_kernel routes through FLA's l2norm, whose signature differs across
+        # FLA releases; normalise outside so the test only depends on the torch path.
+        o, state = torch_chunk_gated_delta_rule(
+            torch.nn.functional.normalize(q, dim=-1),
+            torch.nn.functional.normalize(k, dim=-1),
+            v,
+            g,
+            beta,
+            chunk_size=64,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=False,
+        )
+        return o, state
+
+    assert_replays_bit_exact(fn, (q, k, v, g, beta), replays=3, what="torch_chunk_gated_delta_rule")
+
+
+@pytest.mark.xfail(
+    strict=False, reason="FLA chunk_gated_delta_rule is documented non-deterministic; recorded"
+)
+def test_fla_chunk_gated_delta_rule_replays_fwd_bwd():
+    fla_ops = pytest.importorskip("fla.ops.gated_delta_rule")
+    seeded()
+    B, T, H, K = 2, 2048, 16, 128
+    q = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    g = (-torch.rand(B, T, H, device="cuda") * 0.1).requires_grad_(True)
+    beta = torch.rand(B, T, H, device="cuda").requires_grad_(True)
+
+    def fn(q, k, v, g, beta):
+        o, state = fla_ops.chunk_gated_delta_rule(
+            q, k, v, g, beta, output_final_state=True, use_qk_l2norm_in_kernel=True
+        )
+        return o, state
+
+    assert_replays_bit_exact(fn, (q, k, v, g, beta), replays=4, what="fla chunk_gated_delta_rule")

--- a/tests/unit_tests/determinism/kernels/test_te_wrappers.py
+++ b/tests/unit_tests/determinism/kernels/test_te_wrappers.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the Transformer Engine wrappers in ``megatron/core/extensions/``.
+
+These are the kernels that carry almost every FLOP of a training step: cuBLASLt GEMMs (with
+heuristic algorithm selection under the pinned workspace), fused LayerNorm/RMSNorm forward
+and backward (cross-row dgamma reduction), grouped GEMMs over uneven expert loads, fused
+attention with GQA (dK/dV accumulate across query groups), and fused RoPE. Each wrapper is
+replayed standalone under side-stream contention; the bare TE modules are what the model
+level suite composes, so a regression here localises to one kernel family.
+"""
+
+import os
+
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import init_method_normal
+from tests.unit_tests.determinism.kernels.harness import (
+    assert_module_replays_bit_exact,
+    assert_replays_bit_exact,
+    seeded,
+)
+from tests.unit_tests.test_utilities import Utils, clear_nvte_env_vars
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and HAVE_TE), reason="needs a GPU and Transformer Engine"
+)
+
+if HAVE_TE:
+    from megatron.core.extensions.transformer_engine import (
+        TEColumnParallelLinear,
+        TEDotProductAttention,
+        TEGroupedLinear,
+        TELayerNormColumnParallelLinear,
+        TENorm,
+        TERowParallelLinear,
+    )
+
+HIDDEN, FFN, TOKENS = 2048, 8192, 8192
+
+
+def _config(**overrides):
+    kwargs = dict(
+        num_layers=1,
+        hidden_size=HIDDEN,
+        ffn_hidden_size=FFN,
+        num_attention_heads=16,
+        num_query_groups=4,
+        kv_channels=128,
+        use_cpu_initialization=False,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        deterministic_mode=True,
+    )
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+class TestTEWrappers:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_te_column_parallel_linear_replays(self):
+        seeded()
+        module = TEColumnParallelLinear(
+            HIDDEN,
+            FFN,
+            config=_config(),
+            init_method=init_method_normal(0.02),
+            gather_output=False,
+            bias=True,
+            skip_bias_add=False,
+            is_expert=False,
+        ).cuda()
+        x = torch.randn(
+            TOKENS // 2, 2, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        assert_module_replays_bit_exact(
+            module, (x,), replays=3, contention=True, what="TEColumnParallelLinear"
+        )
+
+    def test_te_row_parallel_linear_replays(self):
+        seeded()
+        module = TERowParallelLinear(
+            FFN,
+            HIDDEN,
+            config=_config(),
+            init_method=init_method_normal(0.02),
+            bias=True,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            is_expert=False,
+        ).cuda()
+        x = torch.randn(
+            TOKENS // 2, 2, FFN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        assert_module_replays_bit_exact(
+            module, (x,), replays=3, contention=True, what="TERowParallelLinear"
+        )
+
+    @pytest.mark.parametrize("normalization", ["LayerNorm", "RMSNorm"])
+    @pytest.mark.parametrize("zero_centered_gamma", [False, True])
+    def test_te_layernorm_column_parallel_linear_replays(self, normalization, zero_centered_gamma):
+        seeded()
+        config = _config(
+            normalization=normalization, layernorm_zero_centered_gamma=zero_centered_gamma
+        )
+        module = TELayerNormColumnParallelLinear(
+            HIDDEN,
+            3 * HIDDEN,
+            config=config,
+            init_method=init_method_normal(0.02),
+            gather_output=False,
+            bias=True,
+            skip_bias_add=False,
+            is_expert=False,
+        ).cuda()
+        # 16k rows stress the cross-row dgamma/dbeta reduction of the norm backward.
+        x = torch.randn(TOKENS, 2, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        assert_module_replays_bit_exact(
+            module,
+            (x,),
+            replays=3,
+            contention=True,
+            what=f"TELayerNormColumnParallelLinear[{normalization}]",
+        )
+
+    @pytest.mark.parametrize("normalization", ["LayerNorm", "RMSNorm"])
+    def test_te_norm_replays(self, normalization):
+        seeded()
+        module = TENorm(_config(normalization=normalization), HIDDEN, eps=1e-5).cuda()
+        x = torch.randn(TOKENS, 2, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        assert_module_replays_bit_exact(
+            module, (x,), replays=3, contention=True, what=f"TENorm[{normalization}]"
+        )
+
+    def test_te_grouped_linear_replays_on_uneven_splits(self):
+        seeded()
+        module = TEGroupedLinear(
+            8,
+            HIDDEN,
+            FFN,
+            parallel_mode=None,
+            config=_config(),
+            init_method=init_method_normal(0.02),
+            bias=False,
+            skip_bias_add=False,
+            is_expert=True,
+        ).cuda()
+        m_splits = [4096, 13, 0, 2048, 1, 8191, 33, 1999]
+        x = torch.randn(
+            sum(m_splits), HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        assert_module_replays_bit_exact(
+            module, (x, m_splits), replays=3, contention=True, what="TEGroupedLinear"
+        )
+
+    @pytest.mark.parametrize("backend", ["fused", "flash"])
+    def test_te_dot_product_attention_replays(self, backend, monkeypatch):
+        """GQA causal attention; TE must pick a deterministic backward (NVTE_ALLOW_NONDETERMINISTIC_ALGO=0)."""
+        seeded()
+        # conftest forces both TE attention backends off per test; pick one explicitly.
+        clear_nvte_env_vars()
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "1" if backend == "fused" else "0")
+        monkeypatch.setenv("NVTE_FLASH_ATTN", "1" if backend == "flash" else "0")
+        monkeypatch.setenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+        # TE caches its backend choice per AttentionParams and only re-selects when the
+        # params change, so an env flip alone would replay the previously chosen backend.
+        from transformer_engine.pytorch.attention.dot_product_attention import (
+            dot_product_attention as te_dpa,
+        )
+
+        monkeypatch.setattr(
+            te_dpa,
+            "_attention_backends",
+            {
+                "attention_params": None,
+                "use_flash_attention": None,
+                "flash_attention_backend": None,
+                "use_fused_attention": None,
+                "fused_attention_backend": None,
+                "use_unfused_attention": None,
+                "backend_selection_requires_update": False,
+            },
+        )
+        config = _config()
+        module = TEDotProductAttention(
+            config, layer_number=1, attn_mask_type=AttnMaskType.causal, attention_type="self"
+        ).cuda()
+        s, b, h, hkv, d = 4096, 2, 16, 4, 128
+        q = torch.randn(s, b, h, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        k = torch.randn(s, b, hkv, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        v = torch.randn(s, b, hkv, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+        def fn(q, k, v):
+            return module(q, k, v, None, AttnMaskType.causal)
+
+        try:
+            assert_replays_bit_exact(
+                fn, (q, k, v), replays=4, contention=True, what=f"TEDotProductAttention[{backend}]"
+            )
+        except (RuntimeError, AssertionError) as error:
+            if "backend" in str(error).lower() and "avail" in str(error).lower():
+                pytest.skip(f"TE has no {backend} attention backend here: {error}")
+            raise
+
+
+# --- fused RoPE --------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("layout", ["sbhd", "thd"])
+def test_te_fused_rope_replays_fwd_bwd(layout):
+    from megatron.core.models.common.embeddings import rope_utils
+    from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
+
+    if (
+        rope_utils.fused_apply_rotary_pos_emb is None
+        and rope_utils.fused_apply_rotary_pos_emb_thd is None
+    ):
+        pytest.skip("TE fused RoPE unavailable")
+    Utils.initialize_model_parallel()
+    try:
+        seeded()
+        config = _config(apply_rope_fusion=True)
+        s, b, h, d = 4096, 2, 32, 128
+        freqs = RotaryEmbedding(kv_channels=d, rotary_percent=1.0)(s)
+        if layout == "sbhd":
+            t = torch.randn(s, b, h, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+            cu_seqlens = None
+        else:
+            t = torch.randn(s, h, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+            cu_seqlens = torch.tensor([0, 1000, 1500, 2048, 4096], dtype=torch.int32, device="cuda")
+
+        def fn(t):
+            return rope_utils.apply_rotary_pos_emb(t, freqs, config, cu_seqlens=cu_seqlens)
+
+        assert_replays_bit_exact(fn, (t,), replays=3, what=f"TE fused RoPE[{layout}]")
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/determinism/kernels/test_tensor_parallel_kernels.py
+++ b/tests/unit_tests/determinism/kernels/test_tensor_parallel_kernels.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Bit-exact replay of the local (non-TE) tensor-parallel layers and the apex CUDA extensions.
+
+* ``VocabParallelEmbedding``: the deterministic branch (``weight[ids]``) and the default
+  ``F.embedding`` path, with heavily duplicated ids so the backward accumulates thousands of
+  rows into the same embedding row.
+* ``vocab_parallel_cross_entropy``: the unfused path deterministic mode relies on.
+* ``ColumnParallelLinear`` / ``RowParallelLinear``: cuBLAS GEMMs under the pinned workspace,
+  with and without apex ``fused_weight_gradient_mlp_cuda`` gradient-accumulation fusion.
+* apex ``FusedLayerNorm`` (persistent and non-persistent) and ``FusedScaleMaskSoftmax``
+  (causal and padding CUDA kernels).
+"""
+
+import importlib.util
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.fusions import fused_layer_norm
+from megatron.core.fusions.fused_softmax import FusedScaleMaskSoftmax
+from megatron.core.tensor_parallel.cross_entropy import vocab_parallel_cross_entropy
+from megatron.core.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+    VocabParallelEmbedding,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.utils import attention_mask_func
+from megatron.core.utils import init_method_normal
+from tests.unit_tests.determinism.kernels.harness import (
+    assert_module_replays_bit_exact,
+    assert_replays_bit_exact,
+    deterministic_algorithms,
+    seeded,
+)
+from tests.unit_tests.test_utilities import Utils
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+
+HAVE_WGRAD_ACCUM_EXT = importlib.util.find_spec("fused_weight_gradient_mlp_cuda") is not None
+HAVE_SCALED_SOFTMAX_EXT = importlib.util.find_spec("scaled_masked_softmax_cuda") is not None and (
+    importlib.util.find_spec("scaled_upper_triang_masked_softmax_cuda") is not None
+)
+
+
+def _config(**overrides):
+    kwargs = dict(
+        num_layers=1,
+        hidden_size=4096,
+        num_attention_heads=32,
+        use_cpu_initialization=False,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        deterministic_mode=True,
+    )
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+class TestTensorParallelLayers:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(
+        "deterministic_branch", [True, False], ids=["weight_index", "F.embedding"]
+    )
+    def test_vocab_parallel_embedding_backward_replays(self, deterministic_branch):
+        """64 distinct ids over 32k positions: ~500 duplicate rows accumulate per embedding row."""
+        seeded()
+        config = _config(deterministic_mode=deterministic_branch)
+        module = VocabParallelEmbedding(
+            8192, 1024, init_method=init_method_normal(0.02), config=config
+        ).cuda()
+        ids = torch.randint(0, 64, (8, 4096), device="cuda") * 100
+        with deterministic_algorithms(deterministic_branch):
+            assert_module_replays_bit_exact(
+                module,
+                (ids,),
+                replays=4,
+                what=f"VocabParallelEmbedding[det={deterministic_branch}]",
+            )
+
+    @pytest.mark.parametrize("label_smoothing", [0.0, 0.1])
+    def test_vocab_parallel_cross_entropy_replays(self, label_smoothing):
+        seeded()
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+        logits = torch.randn(4096, 32768, device="cuda", dtype=torch.float32, requires_grad=True)
+        target = torch.randint(0, 32768 * tp_group.size(), (4096,), device="cuda")
+        assert_replays_bit_exact(
+            lambda l, t: vocab_parallel_cross_entropy(l, t, label_smoothing, tp_group),
+            (logits, target),
+            replays=3,
+            what="vocab_parallel_cross_entropy",
+        )
+
+    @pytest.mark.parametrize(
+        "grad_accum_fusion",
+        [
+            False,
+            pytest.param(
+                True,
+                marks=pytest.mark.skipif(
+                    not HAVE_WGRAD_ACCUM_EXT, reason="apex fused_weight_gradient_mlp_cuda missing"
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("layer", ["column", "row"])
+    def test_local_linear_layers_replay(self, layer, grad_accum_fusion):
+        seeded()
+        config = _config(gradient_accumulation_fusion=grad_accum_fusion)
+        if layer == "column":
+            module = ColumnParallelLinear(
+                4096, 16384, config=config, init_method=init_method_normal(0.02), bias=True
+            ).cuda()
+            x = torch.randn(4096, 2, 4096, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        else:
+            module = RowParallelLinear(
+                16384,
+                4096,
+                config=config,
+                init_method=init_method_normal(0.02),
+                bias=True,
+                input_is_parallel=True,
+                skip_bias_add=False,
+            ).cuda()
+            x = torch.randn(4096, 2, 16384, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        if grad_accum_fusion:
+            # The fused wgrad kernel accumulates into a caller-owned fp32 buffer.
+            module.weight.main_grad = torch.zeros_like(module.weight, dtype=torch.float32)
+        assert_module_replays_bit_exact(
+            module,
+            (x,),
+            replays=3,
+            contention=True,
+            what=f"{layer} linear[fusion={grad_accum_fusion}]",
+        )
+
+
+# --- apex fused layer norm ------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (fused_layer_norm.HAVE_PERSIST_LAYER_NORM or fused_layer_norm.HAVE_FUSED_LAYER_NORM),
+    reason="apex fused layer norm unavailable",
+)
+@pytest.mark.parametrize("hidden", [4096, 4000], ids=["persistent", "non-persistent"])
+@pytest.mark.parametrize("zero_centered_gamma", [False, True])
+def test_fused_layer_norm_replays(hidden, zero_centered_gamma):
+    """dgamma/dbeta reduce over 8192 rows -- the cross-row reduction apex has to order."""
+    seeded()
+    config = _config(
+        hidden_size=hidden,
+        normalization="LayerNorm",
+        layernorm_zero_centered_gamma=zero_centered_gamma,
+    )
+    module = (
+        fused_layer_norm.FusedLayerNorm(
+            config,
+            hidden,
+            eps=1e-5,
+            persist_layer_norm=True,
+            zero_centered_gamma=zero_centered_gamma,
+        )
+        .cuda()
+        .to(torch.bfloat16)
+    )
+    x = torch.randn(8192, hidden, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    assert_module_replays_bit_exact(
+        module, (x,), replays=3, contention=True, what=f"FusedLayerNorm[{hidden}]"
+    )
+
+
+# --- apex fused scale-mask softmax -------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAVE_SCALED_SOFTMAX_EXT, reason="apex scaled softmax extensions missing")
+@pytest.mark.parametrize("mask_type", [AttnMaskType.causal, AttnMaskType.padding])
+def test_fused_scale_mask_softmax_replays(mask_type):
+    seeded()
+    module = FusedScaleMaskSoftmax(
+        input_in_fp16=False,
+        input_in_bf16=True,
+        attn_mask_type=mask_type,
+        scaled_masked_softmax_fusion=True,
+        mask_func=attention_mask_func,
+        softmax_in_fp32=True,
+        scale=None,
+    )
+    b, np_, sq, sk = 4, 16, 2048, 2048
+    scores = torch.randn(b, np_, sq, sk, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    if mask_type == AttnMaskType.causal:
+        mask = None
+    else:
+        mask = torch.rand(b, 1, sq, sk, device="cuda") < 0.2
+    assert module.is_kernel_available(mask, b, np_, sq, sk), "fused softmax kernel not selected"
+    assert_replays_bit_exact(
+        lambda s: module(s, mask),
+        (scores,),
+        replays=3,
+        what=f"FusedScaleMaskSoftmax[{mask_type.name}]",
+    )

--- a/tools/check_kernel_determinism_coverage.py
+++ b/tools/check_kernel_determinism_coverage.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Require determinism tests for kernel-related changes.
+
+Run by the ``linting`` job in ``.github/workflows/cicd-main.yml`` on every PR push. It reads
+the kernel registry in ``tests/unit_tests/determinism/kernels/manifest.py`` and inspects the
+files the PR changes relative to its base:
+
+1. A changed file that bears a kernel -- it lives in one of ``KERNEL_DIRECTORIES``, matches
+   one of ``KERNEL_CONTENT_PATTERNS``, or is already registered -- must be registered in
+   the manifest with a bit-exact test (or an explicit ``exempt_reason``). Not overridable:
+   this is the "every kernel has a determinism test" invariant.
+2. When a registered kernel source changes, at least one of its determinism tests must
+   change in the same PR, so the test is revisited together with the kernel. Override by
+   adding the ``EXEMPT_LABEL`` label to the PR (refactors, comment-only edits) or, locally,
+   with ``--no-require-test-update``.
+
+Standard library only -- the linting job has no torch. The manifest is loaded by file path
+so importing it does not pull in ``tests.unit_tests``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import logging
+import re
+import subprocess
+import sys
+import tokenize
+from pathlib import Path
+from types import ModuleType
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "tests/unit_tests/determinism/kernels/manifest.py"
+SOURCE_SUFFIXES = (".py", ".cu", ".cuh", ".cpp", ".h")
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> ModuleType:
+    """Import the manifest module from ``path`` without importing its parent packages."""
+    spec = importlib.util.spec_from_file_location("kernel_determinism_manifest", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load manifest from {path}")
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses resolves string annotations through sys.modules[module.__name__].
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def changed_files(base_ref: str, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Return repo-relative paths added/copied/modified/renamed relative to ``base_ref``."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "--merge-base", base_ref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def is_source_under_megatron(path: str) -> bool:
+    """Return True for source files under ``megatron/`` (Python, CUDA, C++)."""
+    return path.startswith("megatron/") and path.endswith(SOURCE_SUFFIXES)
+
+
+def in_kernel_directory(path: str, kernel_directories: tuple[str, ...]) -> bool:
+    """Return True if ``path`` lies under one of the manifest's kernel directories."""
+    return any(path.startswith(directory.rstrip("/") + "/") for directory in kernel_directories)
+
+
+def strip_comments_and_strings(text: str) -> str:
+    """Blank out comments and string literals of Python source, preserving layout.
+
+    Kernel patterns must match code, not prose: a docstring that mentions
+    ``torch.compile`` is not a kernel. Tokens are replaced with spaces so line and
+    column positions (and the ``^`` anchors in the patterns) are unchanged. Falls
+    back to the raw text when the source does not tokenize.
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, SyntaxError, IndentationError):
+        return text
+    lines = text.splitlines(keepends=True)
+    skip = {tokenize.COMMENT, tokenize.STRING}
+    skip |= {
+        getattr(tokenize, name)
+        for name in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END")
+        if hasattr(tokenize, name)
+    }
+    for tok in tokens:
+        if tok.type not in skip:
+            continue
+        (srow, scol), (erow, ecol) = tok.start, tok.end
+        for row in range(srow, erow + 1):
+            line = lines[row - 1]
+            start = scol if row == srow else 0
+            end = ecol if row == erow else len(line.rstrip("\r\n"))
+            lines[row - 1] = line[:start] + " " * (end - start) + line[end:]
+    return "".join(lines)
+
+
+def matches_kernel_pattern(text: str, patterns) -> list[str]:
+    """Return the patterns in ``patterns`` that match the code in ``text``."""
+    code = strip_comments_and_strings(text)
+    return [pattern for pattern in patterns if re.search(pattern, code, re.MULTILINE)]
+
+
+def is_kernel_bearing(path: str, manifest: ModuleType, repo_root: Path = REPO_ROOT) -> str:
+    """Return why ``path`` counts as kernel-bearing, or ``""`` if it does not."""
+    if manifest.entries_for(path):
+        return "registered in the manifest"
+    if not is_source_under_megatron(path):
+        return ""
+    if path.endswith("__init__.py"):
+        return ""
+    if in_kernel_directory(path, manifest.KERNEL_DIRECTORIES):
+        return "lives in a kernel directory"
+    file = repo_root / path
+    if not file.is_file():
+        return ""
+    try:
+        text = file.read_text(errors="replace")
+    except OSError:
+        return ""
+    if path.endswith((".cu", ".cuh")):
+        return "is a CUDA source"
+    hits = matches_kernel_pattern(text, manifest.KERNEL_CONTENT_PATTERNS)
+    if hits:
+        return f"matches kernel pattern(s) {', '.join(repr(h) for h in hits)}"
+    return ""
+
+
+def check(
+    files: list[str],
+    manifest: ModuleType,
+    labels: set[str],
+    require_test_update: bool = True,
+    repo_root: Path = REPO_ROOT,
+) -> list[str]:
+    """Return human-readable violations for ``files`` (empty list means the PR passes)."""
+    violations: list[str] = []
+    changed = set(files)
+    exempt = manifest.EXEMPT_LABEL in labels
+    manifest_display = MANIFEST_PATH.relative_to(REPO_ROOT).as_posix()
+
+    for path in sorted(changed):
+        reason = is_kernel_bearing(path, manifest, repo_root)
+        if not reason:
+            continue
+        entries = manifest.entries_for(path)
+        if not entries:
+            violations.append(
+                f"{path}: {reason} but is not registered in {manifest_display}. "
+                "Add a KernelEntry naming its bit-exact determinism test (see "
+                "docs/developer/determinism/testing.md)."
+            )
+            continue
+        for entry in entries:
+            if not entry.tests and not entry.exempt_reason:
+                violations.append(
+                    f"{path}: manifest entry {entry.name!r} has neither tests nor an exempt_reason."
+                )
+                continue
+            if not require_test_update or not entry.tests:
+                continue
+            if any(test in changed for test in entry.tests):
+                continue
+            message = (
+                f"{path}: kernel {entry.name!r} changed but none of its determinism tests did "
+                f"({', '.join(entry.tests)}). Update the test to cover the change"
+            )
+            if exempt:
+                logger.warning("%s -- allowed by label %r.", message, manifest.EXEMPT_LABEL)
+            else:
+                violations.append(
+                    f"{message}, or add the {manifest.EXEMPT_LABEL!r} label if the change "
+                    "cannot affect numerics."
+                )
+    return violations
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--base-ref", default="origin/main", help="Git ref the PR is compared against."
+    )
+    parser.add_argument(
+        "--files", nargs="*", help="Changed files to check instead of computing them with git."
+    )
+    parser.add_argument(
+        "--labels", default="", help="Comma-separated PR labels (for the exemption label)."
+    )
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
+    parser.add_argument(
+        "--no-require-test-update",
+        action="store_true",
+        help="Only enforce registration; do not require the determinism test to change.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the check on the PR's changed files and return the process exit code."""
+    args = _parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    files = args.files if args.files is not None else changed_files(args.base_ref)
+    labels = {label.strip() for label in args.labels.split(",") if label.strip()}
+
+    violations = check(files, manifest, labels, require_test_update=not args.no_require_test_update)
+    if violations:
+        logger.error(
+            "Kernel determinism coverage check failed (%d issue(s)):\n%s",
+            len(violations),
+            "\n".join(f"  - {v}" for v in violations),
+        )
+        return 1
+    logger.info("Kernel determinism coverage check passed for %d changed file(s).", len(files))
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())


### PR DESCRIPTION
Kernel changes need tests that expose scheduling-dependent numerical differences and a PR check that keeps those tests maintained. Add a kernel replay suite, an explicit coverage registry, and a CI gate requiring changed kernel code to carry an updated determinism test.

Full-precision functional enforcement, its regression tests, and all 60 golden updates are isolated in #7217. The two PRs target `main` independently and can merge in either order. This PR contains 23 files and no golden-data or functional-comparison changes.

## Changes

- Add `tests/unit_tests/determinism/kernels/`: replay helpers compare tensor outputs and gradients byte-for-byte, including signed zeros and NaN payloads. Tests can restore RNG state and add side-stream contention; module replay and negative controls exercise the same contract.
- Cover fused activations, Triton fusions, tensor-parallel/apex operations, MoE, SSM, Transformer Engine wrappers, optimizers, and inference kernels. Register kernel-bearing source files in `manifest.py` with tests or an explicit exemption explaining a coverage gap.
- Add manifest tests that check coverage, registered paths, and representative kernel-detection patterns. External-library patterns match call sites rather than bare imports; dispatch modules identify the kernels their tests exercise.
- Add `tools/check_kernel_determinism_coverage.py` to the linting job on PR pushes. Changed kernel-bearing files must be registered. Changed registered kernel sources must also carry a determinism-test update; the `determinism-exempt` label overrides the test-update requirement for changes that do not affect numerics, but cannot bypass registration.
- Add a dedicated H100 unit-test bucket and document the workflow in the PR template, review prompt, determinism docs, and testing skill. Preserve `main`'s refactored review workflow while retaining the kernel-test review requirement.

## Validation

For the split head:

- 215 manifest/gate tests passed after integrating current `main`, using the unchanged test/source modules in an isolated CPU harness. Only GPU package initialization and repository conftest were bypassed.
- The actual kernel gate passed against `main`; YAML parsing and assertions verified the gate, dedicated recipe bucket, and separation from full-precision enforcement.
- isort, Black, Ruff, Python AST checks, and `git diff --check` passed.
- Verified both split patches compose to the same tree in either merge order. Kernel Python files retain their original contents. The split also corrects two documentation statements: the gate runs on PR pushes, and legacy functional goldens still compare at five decimals.

GPU replay tests have not been rerun on this split head.

Historical results reported on the combined PR: the H100 × 8 kernel bucket passed 380 tests with no failures; a four-GPU GB300 run also reported 380 passed. These results predate this split and are not a fresh validation of its head.

## Known coverage gaps and follow-ups

- GDP varlen scan replay differences were reported on GB300 with Triton 3.7, while H100 CI reported XPASS. TE fused MoE auxiliary loss and intentionally racy negative controls also remain documented xfail/XPASS cases; these are not asserted fixes to those kernels.
- Create the `determinism-exempt` label and extend the bucket to GB200/GB300 runners.
- Add coverage for exempt FlashInfer sampling/MXFP8 GEMM paths and the CuTeDSL GDP kernel when the test container supports them.
- SSM autotune policy is selected at import; the suite sets determinism environment variables early. Launch-time policy selection remains separate work.

Related to #5785.
