### PR TITLE
Support MXFP8 tensors in DBuffer

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import DTensor, Partial, Replicate
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
@@ -38,15 +38,19 @@ class _OwnedRange:
 
 def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
-    seen_flat = False
+    seen_shard = False
     for placement in placements:
-        if not isinstance(placement, (Replicate, Partial, Flat, BlockAtomic)):
+        if not isinstance(placement, (Replicate, Partial, Shard)):
             raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-        if isinstance(placement, (Flat, BlockAtomic)):
-            seen_flat = True
-        elif seen_flat:
+        if isinstance(placement, Shard):
+            if placement.dim != 0:
+                raise NotImplementedError(
+                    f"DBuffer supports only dim-0 Shard placements, got {placement!r}."
+                )
+            seen_shard = True
+        elif seen_shard:
             raise ValueError(
-                "Flat placements must be a suffix of the placement list so each "
+                "Shard placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
 
@@ -259,7 +263,7 @@ class DBuffer:
         source_placement = self.placements[changed_axis]
         destination_placement = placements[changed_axis]
         if isinstance(source_placement, (Replicate, Partial)) and isinstance(
-            destination_placement, Flat
+            destination_placement, Shard
         ):
             offset, local_numel = self.layout.get_local_range(self.mesh, placements)
             local_offset = offset - self.offset
@@ -413,13 +417,13 @@ class DBuffer:
         axis = changed_axis
         old_placement = self.placements[axis]
         new_placement = new_placements[axis]
-        if isinstance(old_placement, Flat) and isinstance(new_placement, Replicate):
+        if isinstance(old_placement, Shard) and isinstance(new_placement, Replicate):
             return self.allgather(axis, out=out)
         if isinstance(old_placement, Partial) and isinstance(new_placement, Replicate):
             return self.allreduce(axis, out=out)
-        if isinstance(old_placement, Partial) and isinstance(new_placement, Flat):
+        if isinstance(old_placement, Partial) and isinstance(new_placement, Shard):
             return self.reduce_scatter(axis, new_placement, out=out)
-        if isinstance(old_placement, Replicate) and isinstance(new_placement, Flat):
+        if isinstance(old_placement, Replicate) and isinstance(new_placement, Shard):
             view = self.view(new_placements)
             if out is None:
                 return view
@@ -454,9 +458,9 @@ class DBuffer:
 
     def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a sharded axis into Replicate placement."""
-        if not isinstance(self.placements[mesh_axis], Flat):
+        if not isinstance(self.placements[mesh_axis], Shard):
             raise ValueError(
-                f"allgather() currently requires Flat placement on axis {mesh_axis!r}."
+                f"allgather() currently requires a Shard placement on axis {mesh_axis!r}."
             )
 
         placements = list(self.placements)
@@ -495,8 +499,8 @@ class DBuffer:
     ) -> "DBuffer":
         """Reduce-scatter a Partial axis into ``new_placement``."""
         axis = mesh_axis
-        if not isinstance(new_placement, Flat):
-            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Flat only.")
+        if not isinstance(new_placement, Shard):
+            raise NotImplementedError("DBuffer currently supports reduce_scatter() to Shard only.")
         partial_placement = self.placements[axis]
         if not isinstance(partial_placement, Partial):
             raise ValueError(f"reduce_scatter() requires Partial placement on axis {mesh_axis!r}.")

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,6 +15,7 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
+import math
 from collections.abc import Iterable
 
 import torch
@@ -25,7 +26,7 @@ from torch.distributed.tensor import DTensor, Partial, Replicate
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, changed_mesh_axis
+from .placement import BlockAtomic, Flat, changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,15 +40,30 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
     seen_flat = False
     for placement in placements:
-        if not isinstance(placement, (Replicate, Partial, Flat)):
+        if not isinstance(placement, (Replicate, Partial, Flat, BlockAtomic)):
             raise TypeError(f"Unsupported DBuffer placement: {placement!r}.")
-        if isinstance(placement, Flat):
+        if isinstance(placement, (Flat, BlockAtomic)):
             seen_flat = True
         elif seen_flat:
             raise ValueError(
                 "Flat placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
+
+
+def _get_block_size(placements: Iterable[Placement], block_size: int | None) -> int:
+    """Resolve one layout block size from explicit and placement configuration."""
+    placement_block_size = 1
+    for placement in placements:
+        if isinstance(placement, BlockAtomic):
+            placement_block_size = math.lcm(placement_block_size, placement.block_size)
+    if block_size is None:
+        return placement_block_size
+    if block_size != placement_block_size and placement_block_size != 1:
+        raise ValueError(
+            f"BlockAtomic placements require block size {placement_block_size}, got {block_size}."
+        )
+    return block_size
 
 
 def _get_reduce_op(partial_placement: Partial) -> dist.ReduceOp.RedOpType:
@@ -81,6 +97,8 @@ class DBuffer:
         tensor_shapes: Iterable[Shape],
         dtype: torch.dtype,
         device: torch.device | str,
+        *,
+        block_size: int | None = None,
     ) -> None:
         """Create a DBuffer and allocate its local buffer.
 
@@ -102,7 +120,11 @@ class DBuffer:
         self.placements = placements
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        self.layout = GlobalLayout.build(tensor_shapes, dp_size=self.mesh.size())
+        self.layout = GlobalLayout.build(
+            tensor_shapes,
+            dp_size=self.mesh.size(),
+            block_size=_get_block_size(placements, block_size),
+        )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
@@ -171,6 +193,8 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         tensor_shapes: Iterable[Shape],
+        *,
+        layout: GlobalLayout | None = None,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -197,7 +221,9 @@ class DBuffer:
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = GlobalLayout.build(tensor_shapes, dp_size=mesh.size())
+        layout = layout or GlobalLayout.build(
+            tensor_shapes, dp_size=mesh.size(), block_size=_get_block_size(placements, None)
+        )
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -244,10 +270,15 @@ class DBuffer:
                 self.mesh,
                 placements,
                 self.layout.tensor_shapes,
+                layout=self.layout,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
             return DBuffer.from_local(
-                self.local_buffer, self.mesh, placements, self.layout.tensor_shapes
+                self.local_buffer,
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                layout=self.layout,
             )
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
@@ -257,7 +288,12 @@ class DBuffer:
 
     @classmethod
     def distribute_tensors(
-        cls, tensors: Iterable[torch.Tensor], mesh: DeviceMesh, placements: Iterable[Placement]
+        cls,
+        tensors: Iterable[torch.Tensor],
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        *,
+        block_size: int | None = None,
     ) -> "DBuffer":
         """Distribute full local tensors into a DBuffer.
 
@@ -287,6 +323,7 @@ class DBuffer:
             tensor_shapes=tensor_shapes,
             dtype=dtype,
             device=mesh.device_type,
+            block_size=block_size,
         )
         # Only logical tensor ranges are initialized. Padding and layout gaps are not
         # observable through get_local_tensor() and can remain unspecified.
@@ -323,6 +360,7 @@ class DBuffer:
                 tensor_shapes=self.layout.tensor_shapes,
                 dtype=dtype,
                 device=self.device,
+                block_size=self.layout.block_size,
             )
 
         if out.mesh != self.mesh:
@@ -403,7 +441,11 @@ class DBuffer:
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
             return DBuffer.from_local(
-                self.local_buffer, self.mesh, new_placements, self.layout.tensor_shapes
+                self.local_buffer,
+                self.mesh,
+                new_placements,
+                self.layout.tensor_shapes,
+                layout=self.layout,
             )
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -519,12 +519,15 @@ class DBuffer:
         """Return logical tensor ``index`` as a DTensor."""
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
-        # DBuffer uses contiguous flat storage, and Flat only shards dim 0, so
-        # the local view's stride matches the logical global tensor stride.
+        # Keep internal storage details (e.g. Flat and BlockAtomic) out of DTensor placements.
+        dtensor_placements = tuple(
+            Shard(placement.dim) if isinstance(placement, Shard) else placement
+            for placement in self.placements
+        )
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,
-            placements=self.placements,
+            placements=dtensor_placements,
             run_check=False,
             shape=tensor_shape,
             stride=local_tensor.stride(),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -15,7 +15,6 @@
 """Distributed tensor buffers for Megatron-FSDP."""
 
 import dataclasses
-import math
 from collections.abc import Iterable
 
 import torch
@@ -26,7 +25,7 @@ from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import BlockAtomic, Flat, changed_mesh_axis
+from .placement import changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -53,21 +52,6 @@ def _validate_placements(placements: Iterable[Placement]) -> None:
                 "Shard placements must be a suffix of the placement list so each "
                 "local buffer is a contiguous global-buffer range."
             )
-
-
-def _get_block_size(placements: Iterable[Placement], block_size: int | None) -> int:
-    """Resolve one layout block size from explicit and placement configuration."""
-    placement_block_size = 1
-    for placement in placements:
-        if isinstance(placement, BlockAtomic):
-            placement_block_size = math.lcm(placement_block_size, placement.block_size)
-    if block_size is None:
-        return placement_block_size
-    if block_size != placement_block_size and placement_block_size != 1:
-        raise ValueError(
-            f"BlockAtomic placements require block size {placement_block_size}, got {block_size}."
-        )
-    return block_size
 
 
 def _get_reduce_op(partial_placement: Partial) -> dist.ReduceOp.RedOpType:
@@ -102,7 +86,7 @@ class DBuffer:
         dtype: torch.dtype,
         device: torch.device | str,
         *,
-        block_size: int | None = None,
+        block_size: int = 1,
     ) -> None:
         """Create a DBuffer and allocate its local buffer.
 
@@ -125,9 +109,7 @@ class DBuffer:
 
         tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
         self.layout = GlobalLayout.build(
-            tensor_shapes,
-            dp_size=self.mesh.size(),
-            block_size=_get_block_size(placements, block_size),
+            tensor_shapes, dp_size=self.mesh.size(), block_size=block_size
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
@@ -196,9 +178,7 @@ class DBuffer:
         local_buffer: torch.Tensor,
         mesh: DeviceMesh,
         placements: Iterable[Placement],
-        tensor_shapes: Iterable[Shape],
-        *,
-        layout: GlobalLayout | None = None,
+        layout: GlobalLayout,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -208,7 +188,7 @@ class DBuffer:
                 reduce-scatter, which are efficient with contiguous tensors.
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
-            tensor_shapes: Global shapes for each logical tensor in this buffer.
+            layout: Existing global layout for the logical tensors in this buffer.
 
         Returns:
             A DBuffer that reuses ``local_buffer`` without allocating storage.
@@ -224,10 +204,6 @@ class DBuffer:
         if not local_buffer.is_contiguous():
             raise ValueError("local_buffer must be contiguous for collective operations.")
 
-        tensor_shapes = tuple(torch.Size(shape) for shape in tensor_shapes)
-        layout = layout or GlobalLayout.build(
-            tensor_shapes, dp_size=mesh.size(), block_size=_get_block_size(placements, None)
-        )
         offset, local_numel = layout.get_local_range(mesh, placements)
         if local_buffer.numel() != local_numel:
             raise ValueError(
@@ -273,17 +249,10 @@ class DBuffer:
                 self.local_buffer.narrow(0, local_offset, local_numel),
                 self.mesh,
                 placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
+                self.layout,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
-            return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
-            )
+            return DBuffer.from_local(self.local_buffer, self.mesh, placements, self.layout)
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
             "or a Replicate/Partial-to-Flat slice, "
@@ -297,7 +266,7 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         *,
-        block_size: int | None = None,
+        block_size: int = 1,
     ) -> "DBuffer":
         """Distribute full local tensors into a DBuffer.
 
@@ -444,13 +413,7 @@ class DBuffer:
                 raise NotImplementedError(
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
-            return DBuffer.from_local(
-                self.local_buffer,
-                self.mesh,
-                new_placements,
-                self.layout.tensor_shapes,
-                layout=self.layout,
-            )
+            return DBuffer.from_local(self.local_buffer, self.mesh, new_placements, self.layout)
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
             f"{axis}: {old_placement!r} -> {new_placement!r}."

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -29,8 +29,11 @@ from .layout import GlobalLayout, Shape, non_leading_numel
 from .placement import changed_mesh_axis
 
 if HAVE_TE_MXFP8TENSOR:
-    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer, MXFP8Tensor
 else:
+    tex = None
+    MXFP8Quantizer = None
     MXFP8Tensor = None
 
 _MXFP8_BLOCK_SIZE = 32
@@ -113,7 +116,8 @@ class DBuffer:
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
-            dtype: Dtype for the local buffer.
+            dtype: Physical dtype for the local buffer. ``torch.uint8`` creates
+                an MXFP8 buffer with TE's default quantizer.
             device: Device for the local buffer.
         """
         placements = tuple(placements)
@@ -131,79 +135,36 @@ class DBuffer:
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
-        self.local_tensor = torch.empty(local_numel, dtype=dtype, device=device)
+        if dtype != torch.uint8:
+            self.local_tensor = torch.empty(local_numel, dtype=dtype, device=device)
+            return
 
-    @classmethod
-    def from_mxfp8(
-        cls,
-        tensors: Iterable[torch.Tensor],
-        mesh: DeviceMesh,
-        placements: Iterable[Placement],
-        *,
-        allocate_new: bool = False,
-    ) -> "DBuffer":
-        """Create a DBuffer whose logical tensor is a TE MXFP8Tensor.
-
-        TE owns the physical data and scale subtensors. DBuffer owns their
-        placement and collective lifecycle through the retained logical wrapper.
-        """
-        tensors = tuple(tensors)
-        if len(tensors) != 1:
-            raise NotImplementedError("Experimental MXFP8 MFSDP supports one parameter per group.")
-        tensor = tensors[0]
-        placements = tuple(placements)
-        if not is_mxfp8_tensor(tensor) or tensor.ndim != 2:
-            raise TypeError("DBuffer.from_mxfp8() requires a 2D materialized MXFP8Tensor.")
-        if len(placements) != mesh.ndim:
-            raise ValueError(
-                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
-            )
-        _validate_placements(placements)
+        if not HAVE_TE_MXFP8TENSOR:
+            raise RuntimeError("MXFP8 DBuffer construction requires Transformer Engine.")
+        if len(tensor_shapes) != 1 or len(tensor_shapes[0]) != 2:
+            raise NotImplementedError("Experimental MXFP8 MFSDP supports one 2D tensor per group.")
         if mesh.ndim != 1 or any(
             not isinstance(placement, (Replicate, Shard)) for placement in placements
         ):
             raise NotImplementedError(
                 "Experimental MXFP8 MFSDP supports one-dimensional Replicate/Shard meshes."
             )
-        if allocate_new:
-            tensor = cls._empty_mxfp8_like(tensor)
-        is_replicated = all(isinstance(placement, Replicate) for placement in placements)
-        if is_replicated:
-            local_tensor = tensor
+
+        if all(isinstance(placement, Replicate) for placement in placements):
+            local_shape = tensor_shapes[0]
         else:
-            if tensor.shape[0] % _MXFP8_BLOCK_SIZE or mesh.size() != 2:
+            if tensor_shapes[0][0] % _MXFP8_BLOCK_SIZE or mesh.size() != 2:
                 raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
-            local_rows = tensor.shape[0] // mesh.size()
+            local_rows = tensor_shapes[0][0] // mesh.size()
             if local_rows % _MXFP8_BLOCK_SIZE:
                 raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
-            local_tensor = tensor.split(local_rows, dim=0)[mesh.get_local_rank()]
+            local_shape = torch.Size((local_rows, tensor_shapes[0][1]))
 
-        buffer = cls.__new__(cls)
-        buffer.mesh = mesh
-        buffer.placements = placements
-        buffer.layout = GlobalLayout.build(
-            [tensor.shape], dp_size=mesh.size(), block_size=_MXFP8_BLOCK_SIZE
-        )
-        buffer.offset, _ = buffer.layout.get_local_range(mesh, placements)
-        buffer.local_tensor = local_tensor
-        return buffer
-
-    @staticmethod
-    def _empty_mxfp8_like(tensor: torch.Tensor) -> torch.Tensor:
-        """Allocate an independent TE MXFP8 wrapper with the same physical layout."""
-        assert is_mxfp8_tensor(tensor)
-        return MXFP8Tensor(
-            shape=tensor.shape,
-            dtype=tensor.dtype,
-            rowwise_data=torch.empty_like(tensor._rowwise_data),
-            rowwise_scale_inv=torch.empty_like(tensor._rowwise_scale_inv),
-            columnwise_data=torch.empty_like(tensor._columnwise_data),
-            columnwise_scale_inv=torch.empty_like(tensor._columnwise_scale_inv),
-            fp8_dtype=tensor._fp8_dtype,
-            quantizer=tensor._quantizer,
-            with_gemm_swizzled_scales=tensor._with_gemm_swizzled_scales,
-            device=tensor.device,
-            requires_grad=False,
+        # Quantizing zeros is the public, layout-driven way to allocate both
+        # MXFP8 representations and their scale tensors. sync_from_main()
+        # overwrites the placeholder values before the buffer is used.
+        self.local_tensor = MXFP8Quantizer(tex.DType.kFloat8E4M3)(
+            torch.zeros(local_shape, dtype=torch.bfloat16, device=device)
         )
 
     @property

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -208,7 +208,9 @@ class DBuffer:
 
     @property
     def dtype(self) -> torch.dtype:
-        """Dtype of the stored tensor."""
+        """Dtype of the buffer's physical storage."""
+        if self.is_mxfp8:
+            return self.local_tensor._rowwise_data.dtype
         return self.local_tensor.dtype
 
     @property
@@ -723,9 +725,7 @@ class DBuffer:
         non-leading dimensions and only changes the leading dimension.
         """
         if self.is_mxfp8:
-            raise NotImplementedError(
-                "Access an MXFP8 DBuffer through its logical tensor attribute."
-            )
+            raise NotImplementedError("MXFP8 DBuffers do not expose flat-storage tensor views.")
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -95,7 +95,7 @@ class DBuffer:
     placements: tuple[Placement, ...]
     layout: GlobalLayout
     offset: int
-    tensor: torch.Tensor
+    local_tensor: torch.Tensor
 
     def __init__(
         self,
@@ -131,7 +131,7 @@ class DBuffer:
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
-        self.tensor = torch.empty(local_numel, dtype=dtype, device=device)
+        self.local_tensor = torch.empty(local_numel, dtype=dtype, device=device)
 
     @classmethod
     def from_mxfp8(
@@ -185,7 +185,7 @@ class DBuffer:
             [tensor.shape], dp_size=mesh.size(), block_size=_MXFP8_BLOCK_SIZE
         )
         buffer.offset, _ = buffer.layout.get_local_range(mesh, placements)
-        buffer.tensor = local_tensor
+        buffer.local_tensor = local_tensor
         return buffer
 
     @staticmethod
@@ -209,12 +209,12 @@ class DBuffer:
     @property
     def dtype(self) -> torch.dtype:
         """Dtype of the stored tensor."""
-        return self.tensor.dtype
+        return self.local_tensor.dtype
 
     @property
     def device(self) -> torch.device:
         """Device of the stored tensor."""
-        return self.tensor.device
+        return self.local_tensor.device
 
     @property
     def is_symmetric_memory(self) -> bool:
@@ -222,22 +222,22 @@ class DBuffer:
         return (
             not self.is_mxfp8
             and hasattr(symm_mem, "is_symm_mem_tensor")
-            and symm_mem.is_symm_mem_tensor(self.tensor)
+            and symm_mem.is_symm_mem_tensor(self.local_tensor)
         )
 
     @property
     def is_mxfp8(self) -> bool:
         """Whether this buffer is backed by a TE MXFP8 logical tensor."""
-        return is_mxfp8_tensor(self.tensor)
+        return is_mxfp8_tensor(self.local_tensor)
 
     def _mxfp8_physical_tensors(self) -> tuple[torch.Tensor, ...]:
         """Return the physical tensors owned by this buffer's TE wrapper."""
         assert self.is_mxfp8
         return (
-            self.tensor._rowwise_data,
-            self.tensor._columnwise_data,
-            self.tensor._rowwise_scale_inv,
-            self.tensor._columnwise_scale_inv,
+            self.local_tensor._rowwise_data,
+            self.local_tensor._columnwise_data,
+            self.local_tensor._rowwise_scale_inv,
+            self.local_tensor._columnwise_scale_inv,
         )
 
     @staticmethod
@@ -266,7 +266,7 @@ class DBuffer:
             for tensor in self._mxfp8_physical_tensors():
                 self._resize_storage(tensor, tensor.numel())
             return
-        self._resize_storage(self.tensor, self.tensor.numel())
+        self._resize_storage(self.local_tensor, self.local_tensor.numel())
 
     def release_storage(self) -> None:
         """Release local buffer storage without replacing the Storage object."""
@@ -277,12 +277,12 @@ class DBuffer:
             for tensor in self._mxfp8_physical_tensors():
                 self._resize_storage(tensor, 0)
             return
-        self._resize_storage(self.tensor, 0)
+        self._resize_storage(self.local_tensor, 0)
 
     def rendezvous(self, mesh_axis: int) -> None:
         """Rendezvous this local buffer for symmetric-memory collectives."""
         group = self.mesh.get_group(mesh_axis)
-        symm_mem.rendezvous(self.tensor, group=group.group_name)
+        symm_mem.rendezvous(self.local_tensor, group=group.group_name)
 
     @staticmethod
     def _resize_storage(tensor: torch.Tensor, numel: int) -> None:
@@ -293,7 +293,7 @@ class DBuffer:
         tensor_start = self.layout.tensor_to_offset[tensor_index]
         tensor_end = tensor_start + self.layout.tensor_shapes[tensor_index].numel()
         buffer_start = self.offset
-        buffer_end = self.offset + self.tensor.numel()
+        buffer_end = self.offset + self.local_tensor.numel()
 
         overlap_start = max(tensor_start, buffer_start)
         overlap_end = min(tensor_end, buffer_end)
@@ -350,7 +350,7 @@ class DBuffer:
         buffer.placements = placements
         buffer.layout = layout
         buffer.offset = offset
-        buffer.tensor = local_buffer
+        buffer.local_tensor = local_buffer
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -379,13 +379,16 @@ class DBuffer:
         ):
             offset, local_numel = self.layout.get_local_range(self.mesh, placements)
             local_offset = offset - self.offset
-            if local_offset < 0 or local_offset + local_numel > self.tensor.numel():
+            if local_offset < 0 or local_offset + local_numel > self.local_tensor.numel():
                 raise RuntimeError("DBuffer view is not contained in its source local buffer.")
             return DBuffer.from_local(
-                self.tensor.narrow(0, local_offset, local_numel), self.mesh, placements, self.layout
+                self.local_tensor.narrow(0, local_offset, local_numel),
+                self.mesh,
+                placements,
+                self.layout,
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
-            return DBuffer.from_local(self.tensor, self.mesh, placements, self.layout)
+            return DBuffer.from_local(self.local_tensor, self.mesh, placements, self.layout)
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
             "or a Replicate/Partial-to-Flat slice, "
@@ -441,9 +444,9 @@ class DBuffer:
             source_slice = tensor.view(-1).narrow(
                 0, owned_range.tensor_relative_offset, owned_range.numel
             )
-            buffer.tensor.narrow(0, owned_range.buffer_relative_offset, owned_range.numel).copy_(
-                source_slice
-            )
+            buffer.local_tensor.narrow(
+                0, owned_range.buffer_relative_offset, owned_range.numel
+            ).copy_(source_slice)
         return buffer
 
     def _create_or_validate_out(
@@ -486,7 +489,7 @@ class DBuffer:
         if not self.is_mxfp8:
             raise TypeError("sync_from_main() requires an MXFP8 DBuffer.")
         with torch.no_grad():
-            self.tensor.quantize_(main_weight.get_local_tensor(0))
+            self.local_tensor.quantize_(main_weight.get_local_tensor(0))
 
     def cast(self, dtype: torch.dtype, *, out: "DBuffer | None" = None) -> "DBuffer":
         """Return this buffer with the same layout and placements in ``dtype``."""
@@ -496,7 +499,7 @@ class DBuffer:
             return self
 
         destination = self._create_or_validate_out(out, dtype=dtype)
-        destination.tensor.copy_(self.tensor)
+        destination.local_tensor.copy_(self.local_tensor)
         return destination
 
     def redistribute(
@@ -525,7 +528,7 @@ class DBuffer:
             if out is None:
                 return self
             out = self._create_or_validate_out(out, placements=new_placements)
-            out.tensor.copy_(self.tensor)
+            out.local_tensor.copy_(self.local_tensor)
             return out
 
         axis = changed_axis
@@ -542,7 +545,7 @@ class DBuffer:
             if out is None:
                 return view
             out = self._create_or_validate_out(out, placements=new_placements)
-            out.tensor.copy_(view.tensor)
+            out.local_tensor.copy_(view.local_tensor)
             return out
         if isinstance(old_placement, Replicate) and isinstance(new_placement, Partial):
             # Replicate and Partial share the same local layout, so relabel the
@@ -558,7 +561,7 @@ class DBuffer:
                 raise NotImplementedError(
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
-            return DBuffer.from_local(self.tensor, self.mesh, new_placements, self.layout)
+            return DBuffer.from_local(self.local_tensor, self.mesh, new_placements, self.layout)
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
             f"{axis}: {old_placement!r} -> {new_placement!r}."
@@ -589,8 +592,8 @@ class DBuffer:
         if isinstance(source_placement, Shard) and isinstance(destination_placement, Replicate):
             return self.allgather(changed_axis, out=out)
         if isinstance(source_placement, Replicate) and isinstance(destination_placement, Shard):
-            local_rows = self.tensor.shape[0] // self.mesh.size(changed_axis)
-            source_shard = self.tensor.split(local_rows, dim=0)[
+            local_rows = self.local_tensor.shape[0] // self.mesh.size(changed_axis)
+            source_shard = self.local_tensor.split(local_rows, dim=0)[
                 self.mesh.get_local_rank(changed_axis)
             ]
             for destination, source in zip(
@@ -628,7 +631,9 @@ class DBuffer:
         if out.is_symmetric_memory:
             out.rendezvous(mesh_axis)
         dist.all_gather_into_tensor(
-            output_tensor=out.tensor, input_tensor=self.tensor, group=self.mesh.get_group(mesh_axis)
+            output_tensor=out.local_tensor,
+            input_tensor=self.local_tensor,
+            group=self.mesh.get_group(mesh_axis),
         )
         return out
 
@@ -640,20 +645,22 @@ class DBuffer:
             raise ValueError("MXFP8 all-gather out buffer must replicate the gathered mesh axis.")
         group = self.mesh.get_group(mesh_axis)
         dist.all_gather_into_tensor(
-            out.tensor._rowwise_data, self.tensor._rowwise_data, group=group
+            out.local_tensor._rowwise_data, self.local_tensor._rowwise_data, group=group
         )
         dist.all_gather_into_tensor(
-            out.tensor._columnwise_data, self.tensor._columnwise_data, group=group
+            out.local_tensor._columnwise_data, self.local_tensor._columnwise_data, group=group
         )
         for columnwise in (False, True):
-            source = self._compact_mxfp8_scale(self.tensor, columnwise=columnwise)
+            source = self._compact_mxfp8_scale(self.local_tensor, columnwise=columnwise)
             gathered = torch.empty(
                 (self.mesh.size(mesh_axis), *source.shape), dtype=source.dtype, device=source.device
             )
             dist.all_gather_into_tensor(gathered, source, group=group)
             compact = gathered.flatten(0, 1)
             destination = (
-                out.tensor._columnwise_scale_inv if columnwise else out.tensor._rowwise_scale_inv
+                out.local_tensor._columnwise_scale_inv
+                if columnwise
+                else out.local_tensor._rowwise_scale_inv
             )
             self._unpack_mxfp8_scale(destination, compact)
         return out
@@ -668,9 +675,9 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         out = self._create_or_validate_out(out, placements=placements)
-        out.tensor.copy_(self.tensor)
+        out.local_tensor.copy_(self.local_tensor)
         dist.all_reduce(
-            out.tensor, op=_get_reduce_op(partial_placement), group=self.mesh.get_group(axis)
+            out.local_tensor, op=_get_reduce_op(partial_placement), group=self.mesh.get_group(axis)
         )
         return out
 
@@ -700,10 +707,13 @@ class DBuffer:
             if reduce_op == dist.ReduceOp.AVG:
                 reduce_op = dist.ReduceOp.SUM
         dist.reduce_scatter_tensor(
-            output=out.tensor, input=self.tensor, op=reduce_op, group=self.mesh.get_group(axis)
+            output=out.local_tensor,
+            input=self.local_tensor,
+            op=reduce_op,
+            group=self.mesh.get_group(axis),
         )
         if self.is_symmetric_memory and partial_placement.reduce_op == "avg":
-            out.tensor.div_(self.mesh.size(axis))
+            out.local_tensor.div_(self.mesh.size(axis))
         return out
 
     def get_local_tensor(self, index: int) -> torch.Tensor:
@@ -729,9 +739,9 @@ class DBuffer:
                 f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
             )
         local_shape = torch.Size((owned_range.numel // row_size, *shape[1:]))
-        return self.tensor.narrow(0, owned_range.buffer_relative_offset, owned_range.numel).view(
-            local_shape
-        )
+        return self.local_tensor.narrow(
+            0, owned_range.buffer_relative_offset, owned_range.numel
+        ).view(local_shape)
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -487,11 +487,51 @@ class DBuffer:
         return out
 
     def sync_from_main(self, main_weight: "DBuffer") -> None:
-        """Refresh an MXFP8 compute buffer by quantizing its local master shard."""
-        if not self.is_mxfp8:
-            raise TypeError("sync_from_main() requires an MXFP8 DBuffer.")
-        with torch.no_grad():
-            self.local_tensor.quantize_(main_weight.get_local_tensor(0))
+        """Refresh this compute buffer from optimizer-layout master weights."""
+        if self.is_mxfp8:
+            # MXFP8 has one logical tensor and TE performs the quantization into
+            # the physical data and inverse-scale tensors owned by local_tensor.
+            with torch.no_grad():
+                self.local_tensor.quantize_(main_weight.get_local_tensor(0))
+        else:
+            main_weight.cast(self.dtype, out=self)
+
+    def materialize_unsharded_from(self, source: "DBuffer") -> "DBuffer":
+        """Populate this full-parameter buffer from ``source`` when needed."""
+        # Ordinary parameters can be rebound to source's flat views. An MXFP8
+        # parameter permanently owns this DBuffer's TE wrapper, so it must be
+        # refreshed even when both buffers have replicated placements.
+        if source.placements == self.placements and not self.is_mxfp8:
+            return source
+
+        self.reallocate_storage()
+        if self.is_mxfp8:
+            source.redistribute(self.placements, out=self)
+        else:
+            # This storage backs parameter views possibly saved by autograd.
+            # Preserve its version while FSDP writes the freshly materialized values.
+            with torch.autograd._unsafe_preserve_version_counter(self.local_tensor):
+                source.redistribute(self.placements, out=self)
+        return self
+
+    def initialize_unsharded_parameter(self, parameter: "torch.nn.Parameter", index: int) -> None:
+        """Install this buffer's initial local tensor into one module parameter."""
+        if parameter.is_meta or self.is_mxfp8:
+            local_tensor = self.local_tensor if self.is_mxfp8 else self.get_local_tensor(index)
+            materialized = torch.nn.Parameter(local_tensor, requires_grad=parameter.requires_grad)
+            torch.utils.swap_tensors(parameter, materialized)
+        else:
+            parameter.data = self.get_local_tensor(index)
+            parameter.grad = None
+
+    def install_unsharded_parameter_views(self, parameters: Iterable["torch.nn.Parameter"]) -> None:
+        """Point ordinary unsharded parameters at this buffer's current local views."""
+        if self.is_mxfp8:
+            # The TE wrapper was installed once by initialize_unsharded_parameter().
+            # Its physical tensors are updated in place by materialize_unsharded_from().
+            return
+        for index, parameter in enumerate(parameters):
+            parameter.data = self.get_local_tensor(index)
 
     def cast(self, dtype: torch.dtype, *, out: "DBuffer | None" = None) -> "DBuffer":
         """Return this buffer with the same layout and placements in ``dtype``."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -95,8 +95,7 @@ class DBuffer:
     placements: tuple[Placement, ...]
     layout: GlobalLayout
     offset: int
-    local_buffer: torch.Tensor
-    tensor: torch.Tensor | None
+    tensor: torch.Tensor
 
     def __init__(
         self,
@@ -132,8 +131,7 @@ class DBuffer:
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
-        self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
-        self.tensor = None
+        self.tensor = torch.empty(local_numel, dtype=dtype, device=device)
 
     @classmethod
     def from_mxfp8(
@@ -188,10 +186,6 @@ class DBuffer:
         )
         buffer.offset, _ = buffer.layout.get_local_range(mesh, placements)
         buffer.tensor = local_tensor
-        # Keep DBuffer's single-buffer compatibility surface for callers that
-        # inspect the allocation. MXFP8 collectives use the TE wrapper's full
-        # physical tensor set instead.
-        buffer.local_buffer = local_tensor._rowwise_data.view(-1)
         return buffer
 
     @staticmethod
@@ -214,33 +208,31 @@ class DBuffer:
 
     @property
     def dtype(self) -> torch.dtype:
-        """Dtype of the local buffer."""
-        if self.tensor is not None:
-            return self.tensor.dtype
-        return self.local_buffer.dtype
+        """Dtype of the stored tensor."""
+        return self.tensor.dtype
 
     @property
     def device(self) -> torch.device:
-        """Device of the local buffer."""
-        if self.tensor is not None:
-            return self.tensor.device
-        return self.local_buffer.device
+        """Device of the stored tensor."""
+        return self.tensor.device
 
     @property
     def is_symmetric_memory(self) -> bool:
         """Whether the local buffer is allocated from symmetric memory."""
-        return hasattr(symm_mem, "is_symm_mem_tensor") and symm_mem.is_symm_mem_tensor(
-            self.local_buffer
+        return (
+            not self.is_mxfp8
+            and hasattr(symm_mem, "is_symm_mem_tensor")
+            and symm_mem.is_symm_mem_tensor(self.tensor)
         )
 
     @property
     def is_mxfp8(self) -> bool:
         """Whether this buffer is backed by a TE MXFP8 logical tensor."""
-        return self.tensor is not None and is_mxfp8_tensor(self.tensor)
+        return is_mxfp8_tensor(self.tensor)
 
     def _mxfp8_physical_tensors(self) -> tuple[torch.Tensor, ...]:
         """Return the physical tensors owned by this buffer's TE wrapper."""
-        assert self.is_mxfp8 and self.tensor is not None
+        assert self.is_mxfp8
         return (
             self.tensor._rowwise_data,
             self.tensor._columnwise_data,
@@ -274,7 +266,7 @@ class DBuffer:
             for tensor in self._mxfp8_physical_tensors():
                 self._resize_storage(tensor, tensor.numel())
             return
-        self._resize_storage(self.local_buffer, self.local_buffer.numel())
+        self._resize_storage(self.tensor, self.tensor.numel())
 
     def release_storage(self) -> None:
         """Release local buffer storage without replacing the Storage object."""
@@ -285,12 +277,12 @@ class DBuffer:
             for tensor in self._mxfp8_physical_tensors():
                 self._resize_storage(tensor, 0)
             return
-        self._resize_storage(self.local_buffer, 0)
+        self._resize_storage(self.tensor, 0)
 
     def rendezvous(self, mesh_axis: int) -> None:
         """Rendezvous this local buffer for symmetric-memory collectives."""
         group = self.mesh.get_group(mesh_axis)
-        symm_mem.rendezvous(self.local_buffer, group=group.group_name)
+        symm_mem.rendezvous(self.tensor, group=group.group_name)
 
     @staticmethod
     def _resize_storage(tensor: torch.Tensor, numel: int) -> None:
@@ -301,7 +293,7 @@ class DBuffer:
         tensor_start = self.layout.tensor_to_offset[tensor_index]
         tensor_end = tensor_start + self.layout.tensor_shapes[tensor_index].numel()
         buffer_start = self.offset
-        buffer_end = self.offset + self.local_buffer.numel()
+        buffer_end = self.offset + self.tensor.numel()
 
         overlap_start = max(tensor_start, buffer_start)
         overlap_end = min(tensor_end, buffer_end)
@@ -358,8 +350,7 @@ class DBuffer:
         buffer.placements = placements
         buffer.layout = layout
         buffer.offset = offset
-        buffer.local_buffer = local_buffer
-        buffer.tensor = None
+        buffer.tensor = local_buffer
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -388,16 +379,13 @@ class DBuffer:
         ):
             offset, local_numel = self.layout.get_local_range(self.mesh, placements)
             local_offset = offset - self.offset
-            if local_offset < 0 or local_offset + local_numel > self.local_buffer.numel():
+            if local_offset < 0 or local_offset + local_numel > self.tensor.numel():
                 raise RuntimeError("DBuffer view is not contained in its source local buffer.")
             return DBuffer.from_local(
-                self.local_buffer.narrow(0, local_offset, local_numel),
-                self.mesh,
-                placements,
-                self.layout,
+                self.tensor.narrow(0, local_offset, local_numel), self.mesh, placements, self.layout
             )
         if isinstance(source_placement, Partial) and isinstance(destination_placement, Replicate):
-            return DBuffer.from_local(self.local_buffer, self.mesh, placements, self.layout)
+            return DBuffer.from_local(self.tensor, self.mesh, placements, self.layout)
         raise ValueError(
             "DBuffer.view() supports identical placements, a Partial-to-Replicate relabel, "
             "or a Replicate/Partial-to-Flat slice, "
@@ -453,9 +441,9 @@ class DBuffer:
             source_slice = tensor.view(-1).narrow(
                 0, owned_range.tensor_relative_offset, owned_range.numel
             )
-            buffer.local_buffer.narrow(
-                0, owned_range.buffer_relative_offset, owned_range.numel
-            ).copy_(source_slice)
+            buffer.tensor.narrow(0, owned_range.buffer_relative_offset, owned_range.numel).copy_(
+                source_slice
+            )
         return buffer
 
     def _create_or_validate_out(
@@ -495,7 +483,7 @@ class DBuffer:
 
     def sync_from_main(self, main_weight: "DBuffer") -> None:
         """Refresh an MXFP8 compute buffer by quantizing its local master shard."""
-        if not self.is_mxfp8 or self.tensor is None:
+        if not self.is_mxfp8:
             raise TypeError("sync_from_main() requires an MXFP8 DBuffer.")
         with torch.no_grad():
             self.tensor.quantize_(main_weight.get_local_tensor(0))
@@ -508,7 +496,7 @@ class DBuffer:
             return self
 
         destination = self._create_or_validate_out(out, dtype=dtype)
-        destination.local_buffer.copy_(self.local_buffer)
+        destination.tensor.copy_(self.tensor)
         return destination
 
     def redistribute(
@@ -537,7 +525,7 @@ class DBuffer:
             if out is None:
                 return self
             out = self._create_or_validate_out(out, placements=new_placements)
-            out.local_buffer.copy_(self.local_buffer)
+            out.tensor.copy_(self.tensor)
             return out
 
         axis = changed_axis
@@ -554,7 +542,7 @@ class DBuffer:
             if out is None:
                 return view
             out = self._create_or_validate_out(out, placements=new_placements)
-            out.local_buffer.copy_(view.local_buffer)
+            out.tensor.copy_(view.tensor)
             return out
         if isinstance(old_placement, Replicate) and isinstance(new_placement, Partial):
             # Replicate and Partial share the same local layout, so relabel the
@@ -570,7 +558,7 @@ class DBuffer:
                 raise NotImplementedError(
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
-            return DBuffer.from_local(self.local_buffer, self.mesh, new_placements, self.layout)
+            return DBuffer.from_local(self.tensor, self.mesh, new_placements, self.layout)
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
             f"{axis}: {old_placement!r} -> {new_placement!r}."
@@ -601,7 +589,6 @@ class DBuffer:
         if isinstance(source_placement, Shard) and isinstance(destination_placement, Replicate):
             return self.allgather(changed_axis, out=out)
         if isinstance(source_placement, Replicate) and isinstance(destination_placement, Shard):
-            assert self.tensor is not None and out.tensor is not None
             local_rows = self.tensor.shape[0] // self.mesh.size(changed_axis)
             source_shard = self.tensor.split(local_rows, dim=0)[
                 self.mesh.get_local_rank(changed_axis)
@@ -641,9 +628,7 @@ class DBuffer:
         if out.is_symmetric_memory:
             out.rendezvous(mesh_axis)
         dist.all_gather_into_tensor(
-            output_tensor=out.local_buffer,
-            input_tensor=self.local_buffer,
-            group=self.mesh.get_group(mesh_axis),
+            output_tensor=out.tensor, input_tensor=self.tensor, group=self.mesh.get_group(mesh_axis)
         )
         return out
 
@@ -651,7 +636,6 @@ class DBuffer:
         """All-gather an MXFP8 wrapper's data and compact valid scale regions."""
         if out is None or not out.is_mxfp8:
             raise ValueError("MXFP8 DBuffer all-gather requires a preallocated MXFP8 out buffer.")
-        assert self.tensor is not None and out.tensor is not None
         if not isinstance(out.placements[mesh_axis], Replicate):
             raise ValueError("MXFP8 all-gather out buffer must replicate the gathered mesh axis.")
         group = self.mesh.get_group(mesh_axis)
@@ -684,9 +668,9 @@ class DBuffer:
         placements = list(self.placements)
         placements[axis] = Replicate()
         out = self._create_or_validate_out(out, placements=placements)
-        out.local_buffer.copy_(self.local_buffer)
+        out.tensor.copy_(self.tensor)
         dist.all_reduce(
-            out.local_buffer, op=_get_reduce_op(partial_placement), group=self.mesh.get_group(axis)
+            out.tensor, op=_get_reduce_op(partial_placement), group=self.mesh.get_group(axis)
         )
         return out
 
@@ -716,13 +700,10 @@ class DBuffer:
             if reduce_op == dist.ReduceOp.AVG:
                 reduce_op = dist.ReduceOp.SUM
         dist.reduce_scatter_tensor(
-            output=out.local_buffer,
-            input=self.local_buffer,
-            op=reduce_op,
-            group=self.mesh.get_group(axis),
+            output=out.tensor, input=self.tensor, op=reduce_op, group=self.mesh.get_group(axis)
         )
         if self.is_symmetric_memory and partial_placement.reduce_op == "avg":
-            out.local_buffer.div_(self.mesh.size(axis))
+            out.tensor.div_(self.mesh.size(axis))
         return out
 
     def get_local_tensor(self, index: int) -> torch.Tensor:
@@ -748,9 +729,9 @@ class DBuffer:
                 f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
             )
         local_shape = torch.Size((owned_range.numel // row_size, *shape[1:]))
-        return self.local_buffer.narrow(
-            0, owned_range.buffer_relative_offset, owned_range.numel
-        ).view(local_shape)
+        return self.tensor.narrow(0, owned_range.buffer_relative_offset, owned_range.numel).view(
+            local_shape
+        )
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -24,8 +24,26 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
 from torch.distributed.tensor.placement_types import Placement
 
+from ..mixed_precision import HAVE_TE_MXFP8TENSOR
 from .layout import GlobalLayout, Shape, non_leading_numel
 from .placement import changed_mesh_axis
+
+if HAVE_TE_MXFP8TENSOR:
+    from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor
+else:
+    MXFP8Tensor = None
+
+_MXFP8_BLOCK_SIZE = 32
+
+
+def is_mxfp8_tensor(tensor: torch.Tensor) -> bool:
+    """Whether ``tensor`` is a TE MXFP8 tensor with both physical data representations."""
+    return (
+        HAVE_TE_MXFP8TENSOR
+        and isinstance(tensor, MXFP8Tensor)
+        and tensor._rowwise_data is not None
+        and tensor._columnwise_data is not None
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -64,9 +82,10 @@ class DBuffer:
     """A distributed buffer holding a group of logical tensors.
 
     DBuffer is analogous to DTensor, but manages a group of logical tensors in
-    one local storage tensor. It stores enough metadata to return per-tensor
-    views, redistribute the buffer across mesh axes, and materialize per-tensor
-    DTensors for optimizer state or distributed checkpointing.
+    one local storage tensor, or a TE-owned MXFP8 logical tensor with its
+    physical data and scale tensors. It stores enough metadata to return
+    per-tensor views, redistribute the buffer across mesh axes, and materialize
+    per-tensor DTensors for optimizer state or distributed checkpointing.
     """
 
     # DBuffer owns only the data-parallel sub-mesh. Higher-level callers, such as
@@ -77,6 +96,7 @@ class DBuffer:
     layout: GlobalLayout
     offset: int
     local_buffer: torch.Tensor
+    tensor: torch.Tensor | None
 
     def __init__(
         self,
@@ -103,7 +123,6 @@ class DBuffer:
                 f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
             )
         _validate_placements(placements)
-
         self.mesh = mesh
         self.placements = placements
 
@@ -114,15 +133,97 @@ class DBuffer:
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
+        self.tensor = None
+
+    @classmethod
+    def from_mxfp8(
+        cls,
+        tensors: Iterable[torch.Tensor],
+        mesh: DeviceMesh,
+        placements: Iterable[Placement],
+        *,
+        allocate_new: bool = False,
+    ) -> "DBuffer":
+        """Create a DBuffer whose logical tensor is a TE MXFP8Tensor.
+
+        TE owns the physical data and scale subtensors. DBuffer owns their
+        placement and collective lifecycle through the retained logical wrapper.
+        """
+        tensors = tuple(tensors)
+        if len(tensors) != 1:
+            raise NotImplementedError("Experimental MXFP8 MFSDP supports one parameter per group.")
+        tensor = tensors[0]
+        placements = tuple(placements)
+        if not is_mxfp8_tensor(tensor) or tensor.ndim != 2:
+            raise TypeError("DBuffer.from_mxfp8() requires a 2D materialized MXFP8Tensor.")
+        if len(placements) != mesh.ndim:
+            raise ValueError(
+                f"Expected {mesh.ndim} placements for device mesh, got {len(placements)}."
+            )
+        _validate_placements(placements)
+        if mesh.ndim != 1 or any(
+            not isinstance(placement, (Replicate, Shard)) for placement in placements
+        ):
+            raise NotImplementedError(
+                "Experimental MXFP8 MFSDP supports one-dimensional Replicate/Shard meshes."
+            )
+        if allocate_new:
+            tensor = cls._empty_mxfp8_like(tensor)
+        is_replicated = all(isinstance(placement, Replicate) for placement in placements)
+        if is_replicated:
+            local_tensor = tensor
+        else:
+            if tensor.shape[0] % _MXFP8_BLOCK_SIZE or mesh.size() != 2:
+                raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
+            local_rows = tensor.shape[0] // mesh.size()
+            if local_rows % _MXFP8_BLOCK_SIZE:
+                raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
+            local_tensor = tensor.split(local_rows, dim=0)[mesh.get_local_rank()]
+
+        buffer = cls.__new__(cls)
+        buffer.mesh = mesh
+        buffer.placements = placements
+        buffer.layout = GlobalLayout.build(
+            [tensor.shape], dp_size=mesh.size(), block_size=_MXFP8_BLOCK_SIZE
+        )
+        buffer.offset, _ = buffer.layout.get_local_range(mesh, placements)
+        buffer.tensor = local_tensor
+        # Keep DBuffer's single-buffer compatibility surface for callers that
+        # inspect the allocation. MXFP8 collectives use the TE wrapper's full
+        # physical tensor set instead.
+        buffer.local_buffer = local_tensor._rowwise_data.view(-1)
+        return buffer
+
+    @staticmethod
+    def _empty_mxfp8_like(tensor: torch.Tensor) -> torch.Tensor:
+        """Allocate an independent TE MXFP8 wrapper with the same physical layout."""
+        assert is_mxfp8_tensor(tensor)
+        return MXFP8Tensor(
+            shape=tensor.shape,
+            dtype=tensor.dtype,
+            rowwise_data=torch.empty_like(tensor._rowwise_data),
+            rowwise_scale_inv=torch.empty_like(tensor._rowwise_scale_inv),
+            columnwise_data=torch.empty_like(tensor._columnwise_data),
+            columnwise_scale_inv=torch.empty_like(tensor._columnwise_scale_inv),
+            fp8_dtype=tensor._fp8_dtype,
+            quantizer=tensor._quantizer,
+            with_gemm_swizzled_scales=tensor._with_gemm_swizzled_scales,
+            device=tensor.device,
+            requires_grad=False,
+        )
 
     @property
     def dtype(self) -> torch.dtype:
         """Dtype of the local buffer."""
+        if self.tensor is not None:
+            return self.tensor.dtype
         return self.local_buffer.dtype
 
     @property
     def device(self) -> torch.device:
         """Device of the local buffer."""
+        if self.tensor is not None:
+            return self.tensor.device
         return self.local_buffer.device
 
     @property
@@ -132,27 +233,68 @@ class DBuffer:
             self.local_buffer
         )
 
+    @property
+    def is_mxfp8(self) -> bool:
+        """Whether this buffer is backed by a TE MXFP8 logical tensor."""
+        return self.tensor is not None and is_mxfp8_tensor(self.tensor)
+
+    def _mxfp8_physical_tensors(self) -> tuple[torch.Tensor, ...]:
+        """Return the physical tensors owned by this buffer's TE wrapper."""
+        assert self.is_mxfp8 and self.tensor is not None
+        return (
+            self.tensor._rowwise_data,
+            self.tensor._columnwise_data,
+            self.tensor._rowwise_scale_inv,
+            self.tensor._columnwise_scale_inv,
+        )
+
+    @staticmethod
+    def _compact_mxfp8_scale(tensor: torch.Tensor, *, columnwise: bool) -> torch.Tensor:
+        """Return the valid, non-padded region of one TE MXFP8 scale tensor."""
+        if columnwise:
+            return tensor._columnwise_scale_inv[
+                : tensor.shape[0] // _MXFP8_BLOCK_SIZE, : tensor.shape[1]
+            ].contiguous()
+        return tensor._rowwise_scale_inv[
+            : tensor.shape[0], : tensor.shape[1] // _MXFP8_BLOCK_SIZE
+        ].contiguous()
+
+    @staticmethod
+    def _unpack_mxfp8_scale(destination: torch.Tensor, source: torch.Tensor) -> None:
+        """Copy compact MXFP8 scales into TE's padded scale allocation."""
+        destination.zero_()
+        destination[: source.shape[0], : source.shape[1]].copy_(source)
+
     def reallocate_storage(self) -> None:
         """Restore the local buffer's backing storage to its logical size."""
         # The allocator may hand back a different address than release_storage() freed.
         # Tensors sharing this Storage read its pointer on each access, so views into the
         # buffer -- including ones autograd saved -- follow it to the new allocation.
-        self._resize_storage(self.local_buffer.numel())
+        if self.is_mxfp8:
+            for tensor in self._mxfp8_physical_tensors():
+                self._resize_storage(tensor, tensor.numel())
+            return
+        self._resize_storage(self.local_buffer, self.local_buffer.numel())
 
     def release_storage(self) -> None:
         """Release local buffer storage without replacing the Storage object."""
         # Autograd may save views that share this Storage object. Resizing the
         # existing Storage releases the allocation while preserving those aliases
         # for a later reallocate_storage().
-        self._resize_storage(0)
+        if self.is_mxfp8:
+            for tensor in self._mxfp8_physical_tensors():
+                self._resize_storage(tensor, 0)
+            return
+        self._resize_storage(self.local_buffer, 0)
 
     def rendezvous(self, mesh_axis: int) -> None:
         """Rendezvous this local buffer for symmetric-memory collectives."""
         group = self.mesh.get_group(mesh_axis)
         symm_mem.rendezvous(self.local_buffer, group=group.group_name)
 
-    def _resize_storage(self, numel: int) -> None:
-        self.local_buffer.untyped_storage().resize_(numel * self.local_buffer.element_size())
+    @staticmethod
+    def _resize_storage(tensor: torch.Tensor, numel: int) -> None:
+        tensor.untyped_storage().resize_(numel * tensor.element_size())
 
     def _get_owned_range(self, tensor_index: int) -> _OwnedRange | None:
         """Return this buffer's owned range for logical tensor ``tensor_index``."""
@@ -217,6 +359,7 @@ class DBuffer:
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_buffer = local_buffer
+        buffer.tensor = None
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -227,6 +370,8 @@ class DBuffer:
         only a storage destination: callers must populate it with a reduction
         before reading it.
         """
+        if self.is_mxfp8:
+            raise NotImplementedError("MXFP8 DBuffer views are not supported; use redistribute().")
         placements = tuple(placements)
         if len(placements) != self.mesh.ndim:
             raise ValueError(
@@ -348,8 +493,17 @@ class DBuffer:
             raise ValueError(f"Expected out device {self.device}, got {out.device}.")
         return out
 
+    def sync_from_main(self, main_weight: "DBuffer") -> None:
+        """Refresh an MXFP8 compute buffer by quantizing its local master shard."""
+        if not self.is_mxfp8 or self.tensor is None:
+            raise TypeError("sync_from_main() requires an MXFP8 DBuffer.")
+        with torch.no_grad():
+            self.tensor.quantize_(main_weight.get_local_tensor(0))
+
     def cast(self, dtype: torch.dtype, *, out: "DBuffer | None" = None) -> "DBuffer":
         """Return this buffer with the same layout and placements in ``dtype``."""
+        if self.is_mxfp8:
+            raise NotImplementedError("Cast MXFP8 DBuffers by requantizing from their main weight.")
         if self.dtype == dtype and out is None:
             return self
 
@@ -374,6 +528,9 @@ class DBuffer:
                 f"{len(new_placements)}."
             )
         _validate_placements(new_placements)
+
+        if self.is_mxfp8:
+            return self._redistribute_mxfp8(new_placements, out=out)
 
         changed_axis = changed_mesh_axis(self.placements, new_placements)
         if changed_axis is None:
@@ -419,12 +576,61 @@ class DBuffer:
             f"{axis}: {old_placement!r} -> {new_placement!r}."
         )
 
+    def _redistribute_mxfp8(
+        self, new_placements: tuple[Placement, ...], *, out: "DBuffer | None"
+    ) -> "DBuffer":
+        """Redistribute TE MXFP8 physical storage while preserving its wrapper."""
+        if out is None or not out.is_mxfp8:
+            raise ValueError(
+                "MXFP8 DBuffer redistribution requires a preallocated MXFP8 out buffer."
+            )
+        if out.mesh != self.mesh or out.placements != new_placements:
+            raise ValueError(
+                "MXFP8 DBuffer out buffer must match the requested mesh and placements."
+            )
+        changed_axis = changed_mesh_axis(self.placements, new_placements)
+        if changed_axis is None:
+            for destination, source in zip(
+                out._mxfp8_physical_tensors(), self._mxfp8_physical_tensors()
+            ):
+                destination.copy_(source)
+            return out
+
+        source_placement = self.placements[changed_axis]
+        destination_placement = new_placements[changed_axis]
+        if isinstance(source_placement, Shard) and isinstance(destination_placement, Replicate):
+            return self.allgather(changed_axis, out=out)
+        if isinstance(source_placement, Replicate) and isinstance(destination_placement, Shard):
+            assert self.tensor is not None and out.tensor is not None
+            local_rows = self.tensor.shape[0] // self.mesh.size(changed_axis)
+            source_shard = self.tensor.split(local_rows, dim=0)[
+                self.mesh.get_local_rank(changed_axis)
+            ]
+            for destination, source in zip(
+                out._mxfp8_physical_tensors(),
+                (
+                    source_shard._rowwise_data,
+                    source_shard._columnwise_data,
+                    source_shard._rowwise_scale_inv,
+                    source_shard._columnwise_scale_inv,
+                ),
+            ):
+                destination.copy_(source)
+            return out
+        raise NotImplementedError(
+            f"Unsupported MXFP8 DBuffer placement transition: {source_placement!r} -> "
+            f"{destination_placement!r}."
+        )
+
     def allgather(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
         """All-gather a sharded axis into Replicate placement."""
         if not isinstance(self.placements[mesh_axis], Shard):
             raise ValueError(
                 f"allgather() currently requires a Shard placement on axis {mesh_axis!r}."
             )
+
+        if self.is_mxfp8:
+            return self._allgather_mxfp8(mesh_axis, out=out)
 
         placements = list(self.placements)
         placements[mesh_axis] = Replicate()
@@ -439,6 +645,33 @@ class DBuffer:
             input_tensor=self.local_buffer,
             group=self.mesh.get_group(mesh_axis),
         )
+        return out
+
+    def _allgather_mxfp8(self, mesh_axis: int, *, out: "DBuffer | None") -> "DBuffer":
+        """All-gather an MXFP8 wrapper's data and compact valid scale regions."""
+        if out is None or not out.is_mxfp8:
+            raise ValueError("MXFP8 DBuffer all-gather requires a preallocated MXFP8 out buffer.")
+        assert self.tensor is not None and out.tensor is not None
+        if not isinstance(out.placements[mesh_axis], Replicate):
+            raise ValueError("MXFP8 all-gather out buffer must replicate the gathered mesh axis.")
+        group = self.mesh.get_group(mesh_axis)
+        dist.all_gather_into_tensor(
+            out.tensor._rowwise_data, self.tensor._rowwise_data, group=group
+        )
+        dist.all_gather_into_tensor(
+            out.tensor._columnwise_data, self.tensor._columnwise_data, group=group
+        )
+        for columnwise in (False, True):
+            source = self._compact_mxfp8_scale(self.tensor, columnwise=columnwise)
+            gathered = torch.empty(
+                (self.mesh.size(mesh_axis), *source.shape), dtype=source.dtype, device=source.device
+            )
+            dist.all_gather_into_tensor(gathered, source, group=group)
+            compact = gathered.flatten(0, 1)
+            destination = (
+                out.tensor._columnwise_scale_inv if columnwise else out.tensor._rowwise_scale_inv
+            )
+            self._unpack_mxfp8_scale(destination, compact)
         return out
 
     def allreduce(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
@@ -498,6 +731,10 @@ class DBuffer:
         Flat placements shard dim 0, so the returned view preserves all
         non-leading dimensions and only changes the leading dimension.
         """
+        if self.is_mxfp8:
+            raise NotImplementedError(
+                "Access an MXFP8 DBuffer through its logical tensor attribute."
+            )
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -56,6 +56,121 @@ class _OwnedRange:
     buffer_relative_offset: int
 
 
+@dataclasses.dataclass
+class _MXFP8LocalTensor:
+    """Packed MXFP8 physical planes and the TE views they define."""
+
+    rowwise_data: torch.Tensor
+    columnwise_data: torch.Tensor
+    rowwise_scale_inv: torch.Tensor
+    columnwise_scale_inv: torch.Tensor
+    shapes: tuple[torch.Size | None, ...]
+    rowwise_scale_shapes: tuple[torch.Size | None, ...]
+    columnwise_scale_shapes: tuple[torch.Size | None, ...]
+    offsets: tuple[int | None, ...]
+    scale_offsets: tuple[int, ...]
+    columnwise_scale_offsets: tuple[int, ...]
+    tensors: tuple[torch.Tensor | None, ...]
+
+    @classmethod
+    def allocate(
+        cls,
+        shapes: tuple[torch.Size | None, ...],
+        data_numel: int,
+        data_offsets: tuple[int | None, ...],
+        device: torch.device | str,
+    ) -> "_MXFP8LocalTensor":
+        """Allocate packed MXFP8 planes for local logical tensor shapes."""
+        quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3)
+        placeholders = [
+            (
+                None
+                if shape is None
+                else quantizer(torch.zeros(shape, dtype=torch.bfloat16, device=device))
+            )
+            for shape in shapes
+        ]
+        rowwise_scale_shapes = tuple(
+            None if tensor is None else tensor._rowwise_scale_inv.shape for tensor in placeholders
+        )
+        columnwise_scale_shapes = tuple(
+            None if tensor is None else tensor._columnwise_scale_inv.shape
+            for tensor in placeholders
+        )
+
+        def offsets(sizes: Iterable[int]) -> tuple[int, ...]:
+            result = [0]
+            for size in sizes:
+                result.append(result[-1] + size)
+            return tuple(result)
+
+        scale_offsets = offsets(
+            0 if shape is None else shape.numel() for shape in rowwise_scale_shapes
+        )
+        columnwise_scale_offsets = offsets(
+            0 if shape is None else shape.numel() for shape in columnwise_scale_shapes
+        )
+        storage = cls(
+            rowwise_data=torch.empty(data_numel, dtype=torch.uint8, device=device),
+            columnwise_data=torch.empty(data_numel, dtype=torch.uint8, device=device),
+            rowwise_scale_inv=torch.empty(scale_offsets[-1], dtype=torch.uint8, device=device),
+            columnwise_scale_inv=torch.empty(
+                columnwise_scale_offsets[-1], dtype=torch.uint8, device=device
+            ),
+            shapes=shapes,
+            rowwise_scale_shapes=rowwise_scale_shapes,
+            columnwise_scale_shapes=columnwise_scale_shapes,
+            offsets=data_offsets,
+            scale_offsets=scale_offsets,
+            columnwise_scale_offsets=columnwise_scale_offsets,
+            tensors=(),
+        )
+        storage.tensors = tuple(storage._make_tensor(index) for index in range(len(shapes)))
+        return storage
+
+    def physical_tensors(self) -> tuple[torch.Tensor, ...]:
+        """Return the packed physical tensors that own all MXFP8 storage."""
+        return (
+            self.rowwise_data,
+            self.columnwise_data,
+            self.rowwise_scale_inv,
+            self.columnwise_scale_inv,
+        )
+
+    def tensor(self, index: int) -> torch.Tensor | None:
+        """Return TE's logical MXFP8 tensor view for one packed member."""
+        return self.tensors[index]
+
+    def _make_tensor(self, index: int) -> torch.Tensor | None:
+        """Create one persistent TE wrapper over this payload's plane views."""
+        shape = self.shapes[index]
+        start = self.offsets[index]
+        if shape is None or start is None:
+            return None
+        end = start + shape.numel()
+        scale_start, scale_end = self.scale_offsets[index : index + 2]
+        columnwise_scale_start, columnwise_scale_end = self.columnwise_scale_offsets[
+            index : index + 2
+        ]
+        return MXFP8Tensor(
+            shape=shape,
+            dtype=torch.bfloat16,
+            rowwise_data=self.rowwise_data.narrow(0, start, end - start).view(shape),
+            rowwise_scale_inv=self.rowwise_scale_inv.narrow(
+                0, scale_start, scale_end - scale_start
+            ).view(self.rowwise_scale_shapes[index]),
+            columnwise_data=self.columnwise_data.narrow(0, start, end - start).view(shape),
+            columnwise_scale_inv=self.columnwise_scale_inv.narrow(
+                0, columnwise_scale_start, columnwise_scale_end - columnwise_scale_start
+            ).view(self.columnwise_scale_shapes[index]),
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            quantizer=MXFP8Quantizer(tex.DType.kFloat8E4M3),
+            with_gemm_swizzled_scales=False,
+            device=self.rowwise_data.device,
+            requires_grad=False,
+        )
+
+
 def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
     seen_shard = False
@@ -98,7 +213,7 @@ class DBuffer:
     placements: tuple[Placement, ...]
     layout: GlobalLayout
     offset: int
-    local_tensor: torch.Tensor
+    local_tensor: torch.Tensor | _MXFP8LocalTensor
 
     def __init__(
         self,
@@ -135,14 +250,15 @@ class DBuffer:
         )
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
+        self._local_numel = local_numel
         if dtype != torch.uint8:
             self.local_tensor = torch.empty(local_numel, dtype=dtype, device=device)
             return
 
         if not HAVE_TE_MXFP8TENSOR:
             raise RuntimeError("MXFP8 DBuffer construction requires Transformer Engine.")
-        if len(tensor_shapes) != 1 or len(tensor_shapes[0]) != 2:
-            raise NotImplementedError("Experimental MXFP8 MFSDP supports one 2D tensor per group.")
+        if any(len(shape) != 2 for shape in tensor_shapes):
+            raise NotImplementedError("Experimental MXFP8 MFSDP supports 2D tensors only.")
         if mesh.ndim != 1 or any(
             not isinstance(placement, (Replicate, Shard)) for placement in placements
         ):
@@ -150,33 +266,45 @@ class DBuffer:
                 "Experimental MXFP8 MFSDP supports one-dimensional Replicate/Shard meshes."
             )
 
-        if all(isinstance(placement, Replicate) for placement in placements):
-            local_shape = tensor_shapes[0]
-        else:
-            if tensor_shapes[0][0] % _MXFP8_BLOCK_SIZE or mesh.size() != 2:
-                raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
-            local_rows = tensor_shapes[0][0] // mesh.size()
-            if local_rows % _MXFP8_BLOCK_SIZE:
-                raise NotImplementedError("MXFP8 MFSDP requires two equal 32-row-block shards.")
-            local_shape = torch.Size((local_rows, tensor_shapes[0][1]))
-
-        # Quantizing zeros is the public, layout-driven way to allocate both
-        # MXFP8 representations and their scale tensors. sync_from_main()
-        # overwrites the placeholder values before the buffer is used.
-        self.local_tensor = MXFP8Quantizer(tex.DType.kFloat8E4M3)(
-            torch.zeros(local_shape, dtype=torch.bfloat16, device=device)
+        local_shapes: list[torch.Size | None] = []
+        data_offsets: list[int | None] = []
+        for index, shape in enumerate(tensor_shapes):
+            owned_range = self._get_owned_range(index)
+            if owned_range is None:
+                local_shapes.append(None)
+                data_offsets.append(None)
+                continue
+            row_size = shape[1]
+            if owned_range.tensor_relative_offset % row_size or owned_range.numel % row_size:
+                raise NotImplementedError("MXFP8 MFSDP requires dim-0 tensor shards.")
+            local_shape = torch.Size((owned_range.numel // row_size, row_size))
+            local_end = owned_range.tensor_relative_offset + owned_range.numel
+            if (
+                owned_range.tensor_relative_offset % (128 * row_size)
+                or (local_end < shape.numel() and local_end % (128 * row_size))
+                or local_shape[1] % _MXFP8_BLOCK_SIZE
+            ):
+                raise NotImplementedError(
+                    "MXFP8 MFSDP requires 32-column tensors and 128-row internal shard boundaries."
+                )
+            local_shapes.append(local_shape)
+            data_offsets.append(owned_range.buffer_relative_offset)
+        self.local_tensor = _MXFP8LocalTensor.allocate(
+            tuple(local_shapes), local_numel, tuple(data_offsets), device
         )
 
     @property
     def dtype(self) -> torch.dtype:
         """Dtype of the buffer's physical storage."""
         if self.is_mxfp8:
-            return self.local_tensor._rowwise_data.dtype
+            return self.local_tensor.rowwise_data.dtype
         return self.local_tensor.dtype
 
     @property
     def device(self) -> torch.device:
         """Device of the stored tensor."""
+        if self.is_mxfp8:
+            return self.local_tensor.rowwise_data.device
         return self.local_tensor.device
 
     @property
@@ -191,17 +319,12 @@ class DBuffer:
     @property
     def is_mxfp8(self) -> bool:
         """Whether this buffer is backed by a TE MXFP8 logical tensor."""
-        return is_mxfp8_tensor(self.local_tensor)
+        return isinstance(self.local_tensor, _MXFP8LocalTensor)
 
     def _mxfp8_physical_tensors(self) -> tuple[torch.Tensor, ...]:
         """Return the physical tensors owned by this buffer's TE wrapper."""
         assert self.is_mxfp8
-        return (
-            self.local_tensor._rowwise_data,
-            self.local_tensor._columnwise_data,
-            self.local_tensor._rowwise_scale_inv,
-            self.local_tensor._columnwise_scale_inv,
-        )
+        return self.local_tensor.physical_tensors()
 
     @staticmethod
     def _compact_mxfp8_scale(tensor: torch.Tensor, *, columnwise: bool) -> torch.Tensor:
@@ -256,7 +379,7 @@ class DBuffer:
         tensor_start = self.layout.tensor_to_offset[tensor_index]
         tensor_end = tensor_start + self.layout.tensor_shapes[tensor_index].numel()
         buffer_start = self.offset
-        buffer_end = self.offset + self.local_tensor.numel()
+        buffer_end = self.offset + self._local_numel
 
         overlap_start = max(tensor_start, buffer_start)
         overlap_end = min(tensor_end, buffer_end)
@@ -314,6 +437,7 @@ class DBuffer:
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_tensor = local_buffer
+        buffer._local_numel = local_numel
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -450,10 +574,11 @@ class DBuffer:
     def sync_from_main(self, main_weight: "DBuffer") -> None:
         """Refresh this compute buffer from optimizer-layout master weights."""
         if self.is_mxfp8:
-            # MXFP8 has one logical tensor and TE performs the quantization into
-            # the physical data and inverse-scale tensors owned by local_tensor.
             with torch.no_grad():
-                self.local_tensor.quantize_(main_weight.get_local_tensor(0))
+                for index in range(len(self.layout.tensor_shapes)):
+                    destination = self._get_mxfp8_tensor(index)
+                    if destination is not None:
+                        destination.quantize_(main_weight.get_local_tensor(index))
         else:
             main_weight.cast(self.dtype, out=self)
 
@@ -478,7 +603,7 @@ class DBuffer:
     def initialize_unsharded_parameter(self, parameter: "torch.nn.Parameter", index: int) -> None:
         """Install this buffer's initial local tensor into one module parameter."""
         if parameter.is_meta or self.is_mxfp8:
-            local_tensor = self.local_tensor if self.is_mxfp8 else self.get_local_tensor(index)
+            local_tensor = self.get_local_tensor(index)
             materialized = torch.nn.Parameter(local_tensor, requires_grad=parameter.requires_grad)
             torch.utils.swap_tensors(parameter, materialized)
         else:
@@ -488,8 +613,8 @@ class DBuffer:
     def install_unsharded_parameter_views(self, parameters: Iterable["torch.nn.Parameter"]) -> None:
         """Point ordinary unsharded parameters at this buffer's current local views."""
         if self.is_mxfp8:
-            # The TE wrapper was installed once by initialize_unsharded_parameter().
-            # Its physical tensors are updated in place by materialize_unsharded_from().
+            # TE wrappers installed by initialize_unsharded_parameter() retain views
+            # into the packed physical planes and are updated in place.
             return
         for index, parameter in enumerate(parameters):
             parameter.data = self.get_local_tensor(index)
@@ -595,20 +720,23 @@ class DBuffer:
         if isinstance(source_placement, Shard) and isinstance(destination_placement, Replicate):
             return self.allgather(changed_axis, out=out)
         if isinstance(source_placement, Replicate) and isinstance(destination_placement, Shard):
-            local_rows = self.local_tensor.shape[0] // self.mesh.size(changed_axis)
-            source_shard = self.local_tensor.split(local_rows, dim=0)[
-                self.mesh.get_local_rank(changed_axis)
-            ]
             for destination, source in zip(
-                out._mxfp8_physical_tensors(),
-                (
-                    source_shard._rowwise_data,
-                    source_shard._columnwise_data,
-                    source_shard._rowwise_scale_inv,
-                    source_shard._columnwise_scale_inv,
-                ),
+                out._mxfp8_physical_tensors()[:2], self._mxfp8_physical_tensors()[:2]
             ):
-                destination.copy_(source)
+                destination.copy_(source.narrow(0, out.offset - self.offset, out._local_numel))
+            for index in range(len(self.layout.tensor_shapes)):
+                destination = out._get_mxfp8_tensor(index)
+                if destination is None:
+                    continue
+                owned_range = out._get_owned_range(index)
+                assert owned_range is not None
+                source = self.get_local_tensor(index)
+                row_size = source.shape[1]
+                destination.copy_(
+                    source.narrow(
+                        0, owned_range.tensor_relative_offset // row_size, destination.shape[0]
+                    )
+                )
             return out
         raise NotImplementedError(
             f"Unsupported MXFP8 DBuffer placement transition: {source_placement!r} -> "
@@ -647,25 +775,57 @@ class DBuffer:
         if not isinstance(out.placements[mesh_axis], Replicate):
             raise ValueError("MXFP8 all-gather out buffer must replicate the gathered mesh axis.")
         group = self.mesh.get_group(mesh_axis)
-        dist.all_gather_into_tensor(
-            out.local_tensor._rowwise_data, self.local_tensor._rowwise_data, group=group
-        )
-        dist.all_gather_into_tensor(
-            out.local_tensor._columnwise_data, self.local_tensor._columnwise_data, group=group
-        )
-        for columnwise in (False, True):
-            source = self._compact_mxfp8_scale(self.local_tensor, columnwise=columnwise)
-            gathered = torch.empty(
-                (self.mesh.size(mesh_axis), *source.shape), dtype=source.dtype, device=source.device
+        for destination, source in zip(
+            out._mxfp8_physical_tensors()[:2], self._mxfp8_physical_tensors()[:2]
+        ):
+            dist.all_gather_into_tensor(destination, source, group=group)
+        for index, shape in enumerate(self.layout.tensor_shapes):
+            source_tensor = self._get_mxfp8_tensor(index)
+            destination_tensor = out.get_local_tensor(index)
+            owned_range = self._get_owned_range(index)
+            local_rows = 0 if owned_range is None else owned_range.numel // shape[1]
+            row_counts = torch.empty(
+                self.mesh.size(mesh_axis), dtype=torch.int64, device=self.device
             )
-            dist.all_gather_into_tensor(gathered, source, group=group)
-            compact = gathered.flatten(0, 1)
-            destination = (
-                out.local_tensor._columnwise_scale_inv
-                if columnwise
-                else out.local_tensor._rowwise_scale_inv
+            dist.all_gather_into_tensor(
+                row_counts,
+                torch.tensor([local_rows], dtype=torch.int64, device=self.device),
+                group=group,
             )
-            self._unpack_mxfp8_scale(destination, compact)
+            max_rows = int(row_counts.max())
+            for columnwise in (False, True):
+                scale_rows = local_rows // _MXFP8_BLOCK_SIZE if columnwise else local_rows
+                max_scale_rows = max_rows // _MXFP8_BLOCK_SIZE if columnwise else max_rows
+                scale_columns = shape[1] if columnwise else shape[1] // _MXFP8_BLOCK_SIZE
+                source = torch.zeros(
+                    (max_scale_rows, scale_columns), dtype=torch.uint8, device=self.device
+                )
+                if source_tensor is not None:
+                    source[:scale_rows].copy_(
+                        self._compact_mxfp8_scale(source_tensor, columnwise=columnwise)
+                    )
+                gathered = torch.empty(
+                    (self.mesh.size(mesh_axis), max_scale_rows, scale_columns),
+                    dtype=torch.uint8,
+                    device=self.device,
+                )
+                dist.all_gather_into_tensor(gathered, source, group=group)
+                compact = torch.empty(
+                    (shape[0] // _MXFP8_BLOCK_SIZE if columnwise else shape[0], scale_columns),
+                    dtype=torch.uint8,
+                    device=self.device,
+                )
+                offset = 0
+                for rank, rows in enumerate(row_counts.tolist()):
+                    count = rows // _MXFP8_BLOCK_SIZE if columnwise else rows
+                    compact[offset : offset + count].copy_(gathered[rank, :count])
+                    offset += count
+                destination = (
+                    destination_tensor._columnwise_scale_inv
+                    if columnwise
+                    else destination_tensor._rowwise_scale_inv
+                )
+                self._unpack_mxfp8_scale(destination, compact)
         return out
 
     def allreduce(self, mesh_axis: int, *, out: "DBuffer | None" = None) -> "DBuffer":
@@ -725,10 +885,14 @@ class DBuffer:
         Flat placements shard dim 0, so the returned view preserves all
         non-leading dimensions and only changes the leading dimension.
         """
-        if self.is_mxfp8:
-            raise NotImplementedError("MXFP8 DBuffers do not expose flat-storage tensor views.")
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
+
+        if self.is_mxfp8:
+            tensor = self._get_mxfp8_tensor(index)
+            if tensor is not None:
+                return tensor
+            return torch.empty((0, *shape[1:]), dtype=torch.uint8, device=self.device)
 
         row_size = non_leading_numel(shape)
         if owned_range is None:
@@ -743,6 +907,11 @@ class DBuffer:
         return self.local_tensor.narrow(
             0, owned_range.buffer_relative_offset, owned_range.numel
         ).view(local_shape)
+
+    def _get_mxfp8_tensor(self, index: int) -> torch.Tensor | None:
+        """Return this rank's TE wrapper for one logical MXFP8 tensor, if owned."""
+        assert self.is_mxfp8
+        return self.local_tensor.tensor(index)
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -56,121 +56,6 @@ class _OwnedRange:
     buffer_relative_offset: int
 
 
-@dataclasses.dataclass
-class _MXFP8LocalTensor:
-    """Packed MXFP8 physical planes and the TE views they define."""
-
-    rowwise_data: torch.Tensor
-    columnwise_data: torch.Tensor
-    rowwise_scale_inv: torch.Tensor
-    columnwise_scale_inv: torch.Tensor
-    shapes: tuple[torch.Size | None, ...]
-    rowwise_scale_shapes: tuple[torch.Size | None, ...]
-    columnwise_scale_shapes: tuple[torch.Size | None, ...]
-    offsets: tuple[int | None, ...]
-    scale_offsets: tuple[int, ...]
-    columnwise_scale_offsets: tuple[int, ...]
-    tensors: tuple[torch.Tensor | None, ...]
-
-    @classmethod
-    def allocate(
-        cls,
-        shapes: tuple[torch.Size | None, ...],
-        data_numel: int,
-        data_offsets: tuple[int | None, ...],
-        device: torch.device | str,
-    ) -> "_MXFP8LocalTensor":
-        """Allocate packed MXFP8 planes for local logical tensor shapes."""
-        quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3)
-        placeholders = [
-            (
-                None
-                if shape is None
-                else quantizer(torch.zeros(shape, dtype=torch.bfloat16, device=device))
-            )
-            for shape in shapes
-        ]
-        rowwise_scale_shapes = tuple(
-            None if tensor is None else tensor._rowwise_scale_inv.shape for tensor in placeholders
-        )
-        columnwise_scale_shapes = tuple(
-            None if tensor is None else tensor._columnwise_scale_inv.shape
-            for tensor in placeholders
-        )
-
-        def offsets(sizes: Iterable[int]) -> tuple[int, ...]:
-            result = [0]
-            for size in sizes:
-                result.append(result[-1] + size)
-            return tuple(result)
-
-        scale_offsets = offsets(
-            0 if shape is None else shape.numel() for shape in rowwise_scale_shapes
-        )
-        columnwise_scale_offsets = offsets(
-            0 if shape is None else shape.numel() for shape in columnwise_scale_shapes
-        )
-        storage = cls(
-            rowwise_data=torch.empty(data_numel, dtype=torch.uint8, device=device),
-            columnwise_data=torch.empty(data_numel, dtype=torch.uint8, device=device),
-            rowwise_scale_inv=torch.empty(scale_offsets[-1], dtype=torch.uint8, device=device),
-            columnwise_scale_inv=torch.empty(
-                columnwise_scale_offsets[-1], dtype=torch.uint8, device=device
-            ),
-            shapes=shapes,
-            rowwise_scale_shapes=rowwise_scale_shapes,
-            columnwise_scale_shapes=columnwise_scale_shapes,
-            offsets=data_offsets,
-            scale_offsets=scale_offsets,
-            columnwise_scale_offsets=columnwise_scale_offsets,
-            tensors=(),
-        )
-        storage.tensors = tuple(storage._make_tensor(index) for index in range(len(shapes)))
-        return storage
-
-    def physical_tensors(self) -> tuple[torch.Tensor, ...]:
-        """Return the packed physical tensors that own all MXFP8 storage."""
-        return (
-            self.rowwise_data,
-            self.columnwise_data,
-            self.rowwise_scale_inv,
-            self.columnwise_scale_inv,
-        )
-
-    def tensor(self, index: int) -> torch.Tensor | None:
-        """Return TE's logical MXFP8 tensor view for one packed member."""
-        return self.tensors[index]
-
-    def _make_tensor(self, index: int) -> torch.Tensor | None:
-        """Create one persistent TE wrapper over this payload's plane views."""
-        shape = self.shapes[index]
-        start = self.offsets[index]
-        if shape is None or start is None:
-            return None
-        end = start + shape.numel()
-        scale_start, scale_end = self.scale_offsets[index : index + 2]
-        columnwise_scale_start, columnwise_scale_end = self.columnwise_scale_offsets[
-            index : index + 2
-        ]
-        return MXFP8Tensor(
-            shape=shape,
-            dtype=torch.bfloat16,
-            rowwise_data=self.rowwise_data.narrow(0, start, end - start).view(shape),
-            rowwise_scale_inv=self.rowwise_scale_inv.narrow(
-                0, scale_start, scale_end - scale_start
-            ).view(self.rowwise_scale_shapes[index]),
-            columnwise_data=self.columnwise_data.narrow(0, start, end - start).view(shape),
-            columnwise_scale_inv=self.columnwise_scale_inv.narrow(
-                0, columnwise_scale_start, columnwise_scale_end - columnwise_scale_start
-            ).view(self.columnwise_scale_shapes[index]),
-            fp8_dtype=tex.DType.kFloat8E4M3,
-            quantizer=MXFP8Quantizer(tex.DType.kFloat8E4M3),
-            with_gemm_swizzled_scales=False,
-            device=self.rowwise_data.device,
-            requires_grad=False,
-        )
-
-
 def _validate_placements(placements: Iterable[Placement]) -> None:
     """Validate DBuffer placements form a supported contiguous local layout."""
     seen_shard = False
@@ -213,7 +98,13 @@ class DBuffer:
     placements: tuple[Placement, ...]
     layout: GlobalLayout
     offset: int
-    local_tensor: torch.Tensor | _MXFP8LocalTensor
+    # For ordinary DBuffers this is the only allocation. For MXFP8 it is the
+    # rowwise data plane; the remaining three physical planes are private fields.
+    local_tensor: torch.Tensor
+    _mxfp8_columnwise_data: torch.Tensor | None
+    _mxfp8_rowwise_scale_inv: torch.Tensor | None
+    _mxfp8_columnwise_scale_inv: torch.Tensor | None
+    _mxfp8_tensors: tuple[torch.Tensor | None, ...] | None
 
     def __init__(
         self,
@@ -251,6 +142,10 @@ class DBuffer:
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self._local_numel = local_numel
+        self._mxfp8_columnwise_data = None
+        self._mxfp8_rowwise_scale_inv = None
+        self._mxfp8_columnwise_scale_inv = None
+        self._mxfp8_tensors = None
         if dtype != torch.uint8:
             self.local_tensor = torch.empty(local_numel, dtype=dtype, device=device)
             return
@@ -289,22 +184,87 @@ class DBuffer:
                 )
             local_shapes.append(local_shape)
             data_offsets.append(owned_range.buffer_relative_offset)
-        self.local_tensor = _MXFP8LocalTensor.allocate(
-            tuple(local_shapes), local_numel, tuple(data_offsets), device
+        self._allocate_mxfp8(tuple(local_shapes), tuple(data_offsets), local_numel, device)
+
+    def _allocate_mxfp8(
+        self,
+        local_shapes: tuple[torch.Size | None, ...],
+        data_offsets: tuple[int | None, ...],
+        local_numel: int,
+        device: torch.device | str,
+    ) -> None:
+        """Allocate four MXFP8 planes and cache TE views for locally owned tensors."""
+        quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3)
+        prototypes = tuple(
+            (
+                None
+                if shape is None
+                else quantizer(torch.zeros(shape, dtype=torch.bfloat16, device=device))
+            )
+            for shape in local_shapes
         )
+
+        def offsets(tensors: tuple[torch.Tensor | None, ...], attribute: str) -> tuple[int, ...]:
+            result = [0]
+            for tensor in tensors:
+                result.append(
+                    result[-1] + (0 if tensor is None else getattr(tensor, attribute).numel())
+                )
+            return tuple(result)
+
+        rowwise_offsets = offsets(prototypes, "_rowwise_scale_inv")
+        columnwise_offsets = offsets(prototypes, "_columnwise_scale_inv")
+        self.local_tensor = torch.empty(local_numel, dtype=torch.uint8, device=device)
+        self._mxfp8_columnwise_data = torch.empty(local_numel, dtype=torch.uint8, device=device)
+        self._mxfp8_rowwise_scale_inv = torch.empty(
+            rowwise_offsets[-1], dtype=torch.uint8, device=device
+        )
+        self._mxfp8_columnwise_scale_inv = torch.empty(
+            columnwise_offsets[-1], dtype=torch.uint8, device=device
+        )
+        tensors = []
+        for index, (shape, data_offset, prototype) in enumerate(
+            zip(local_shapes, data_offsets, prototypes, strict=True)
+        ):
+            if shape is None:
+                tensors.append(None)
+                continue
+            assert data_offset is not None and prototype is not None
+            rowwise_start, rowwise_end = rowwise_offsets[index : index + 2]
+            columnwise_start, columnwise_end = columnwise_offsets[index : index + 2]
+            tensors.append(
+                MXFP8Tensor(
+                    shape=shape,
+                    dtype=torch.bfloat16,
+                    rowwise_data=self.local_tensor.narrow(0, data_offset, shape.numel()).view(
+                        shape
+                    ),
+                    rowwise_scale_inv=self._mxfp8_rowwise_scale_inv.narrow(
+                        0, rowwise_start, rowwise_end - rowwise_start
+                    ).view(prototype._rowwise_scale_inv.shape),
+                    columnwise_data=self._mxfp8_columnwise_data.narrow(
+                        0, data_offset, shape.numel()
+                    ).view(shape),
+                    columnwise_scale_inv=self._mxfp8_columnwise_scale_inv.narrow(
+                        0, columnwise_start, columnwise_end - columnwise_start
+                    ).view(prototype._columnwise_scale_inv.shape),
+                    fp8_dtype=tex.DType.kFloat8E4M3,
+                    quantizer=MXFP8Quantizer(tex.DType.kFloat8E4M3),
+                    with_gemm_swizzled_scales=False,
+                    device=device,
+                    requires_grad=False,
+                )
+            )
+        self._mxfp8_tensors = tuple(tensors)
 
     @property
     def dtype(self) -> torch.dtype:
         """Dtype of the buffer's physical storage."""
-        if self.is_mxfp8:
-            return self.local_tensor.rowwise_data.dtype
         return self.local_tensor.dtype
 
     @property
     def device(self) -> torch.device:
         """Device of the stored tensor."""
-        if self.is_mxfp8:
-            return self.local_tensor.rowwise_data.device
         return self.local_tensor.device
 
     @property
@@ -319,12 +279,20 @@ class DBuffer:
     @property
     def is_mxfp8(self) -> bool:
         """Whether this buffer is backed by a TE MXFP8 logical tensor."""
-        return isinstance(self.local_tensor, _MXFP8LocalTensor)
+        return self._mxfp8_tensors is not None
 
     def _mxfp8_physical_tensors(self) -> tuple[torch.Tensor, ...]:
         """Return the physical tensors owned by this buffer's TE wrapper."""
         assert self.is_mxfp8
-        return self.local_tensor.physical_tensors()
+        assert self._mxfp8_columnwise_data is not None
+        assert self._mxfp8_rowwise_scale_inv is not None
+        assert self._mxfp8_columnwise_scale_inv is not None
+        return (
+            self.local_tensor,
+            self._mxfp8_columnwise_data,
+            self._mxfp8_rowwise_scale_inv,
+            self._mxfp8_columnwise_scale_inv,
+        )
 
     @staticmethod
     def _compact_mxfp8_scale(tensor: torch.Tensor, *, columnwise: bool) -> torch.Tensor:
@@ -438,6 +406,10 @@ class DBuffer:
         buffer.offset = offset
         buffer.local_tensor = local_buffer
         buffer._local_numel = local_numel
+        buffer._mxfp8_columnwise_data = None
+        buffer._mxfp8_rowwise_scale_inv = None
+        buffer._mxfp8_columnwise_scale_inv = None
+        buffer._mxfp8_tensors = None
         return buffer
 
     def view(self, placements: Iterable[Placement]) -> "DBuffer":
@@ -911,7 +883,8 @@ class DBuffer:
     def _get_mxfp8_tensor(self, index: int) -> torch.Tensor | None:
         """Return this rank's TE wrapper for one logical MXFP8 tensor, if owned."""
         assert self.is_mxfp8
-        return self.local_tensor.tensor(index)
+        assert self._mxfp8_tensors is not None
+        return self._mxfp8_tensors[index]
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -23,7 +23,7 @@ import torch
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor.placement_types import Placement
 
-from .placement import Flat
+from .placement import BlockAtomic, Flat
 
 Shape: TypeAlias = torch.Size | Iterable[int]
 
@@ -35,9 +35,10 @@ class GlobalLayout:
     tensor_shapes: tuple[torch.Size, ...]
     tensor_to_offset: tuple[int, ...]
     size: int
+    block_size: int = 1
 
     @classmethod
-    def build(cls, shapes: Iterable[Shape], dp_size: int) -> "GlobalLayout":
+    def build(cls, shapes: Iterable[Shape], dp_size: int, *, block_size: int = 1) -> "GlobalLayout":
         """Compute global tensor element offsets and padded size.
 
         This is a DBuffer-specific reimplementation of
@@ -78,6 +79,8 @@ class GlobalLayout:
         """
         if dp_size <= 0:
             raise ValueError(f"DP size must be positive, got {dp_size}.")
+        if block_size <= 0:
+            raise ValueError(f"Block size must be positive, got {block_size}.")
 
         tensor_shapes = tuple(torch.Size(shape) for shape in shapes)
         chunk_size = 1
@@ -87,7 +90,11 @@ class GlobalLayout:
                 raise ValueError(
                     f"Cannot compute a layout for zero-sized non-leading dims: {shape}."
                 )
-            chunk_size = math.lcm(chunk_size, row_size)
+            if shape[0] % block_size != 0:
+                raise ValueError(
+                    f"Tensor dim 0 ({shape[0]}) must be divisible by block size {block_size}."
+                )
+            chunk_size = math.lcm(chunk_size, block_size * row_size)
 
         # chunk_size is the packing granularity. Since every tensor row size divides it,
         # DP shard boundaries that are multiples of chunk_size avoid splitting dim-0 rows.
@@ -150,7 +157,9 @@ class GlobalLayout:
             for fragment in fragment_items[:]:
                 frag_id, frag_shape = fragment
                 frag_numel = frag_shape.numel()
-                aligned_gap_offset = _pad_to_multiple(gap_offset, non_leading_numel(frag_shape))
+                aligned_gap_offset = _pad_to_multiple(
+                    gap_offset, block_size * non_leading_numel(frag_shape)
+                )
                 if aligned_gap_offset + frag_numel > fragment_gap_end:
                     continue
                 tensor_to_offset[frag_id] = aligned_gap_offset
@@ -159,7 +168,7 @@ class GlobalLayout:
 
         # Fragments that did not fit into regular-tensor gaps are appended at the tail.
         for frag_id, frag_shape in fragment_items:
-            next_offset = _pad_to_multiple(next_offset, non_leading_numel(frag_shape))
+            next_offset = _pad_to_multiple(next_offset, block_size * non_leading_numel(frag_shape))
             tensor_to_offset[frag_id] = next_offset
             next_offset += frag_shape.numel()
 
@@ -167,6 +176,7 @@ class GlobalLayout:
             tensor_shapes=tensor_shapes,
             tensor_to_offset=tuple(tensor_to_offset),
             size=_pad_to_multiple(next_offset, chunk_size * dp_size),
+            block_size=block_size,
         )
 
     def __post_init__(self) -> None:
@@ -198,9 +208,10 @@ class GlobalLayout:
             row_size = non_leading_numel(shape)
             if row_size <= 0:
                 raise AssertionError(f"Tensor {tensor_id} has invalid row size {row_size}.")
-            if start % row_size != 0:
+            if start % (self.block_size * row_size) != 0:
                 raise AssertionError(
-                    f"Tensor {tensor_id} offset {start} is not aligned to row size {row_size}."
+                    f"Tensor {tensor_id} offset {start} is not aligned to block size "
+                    f"{self.block_size * row_size}."
                 )
 
             end = start + shape.numel()
@@ -228,7 +239,7 @@ class GlobalLayout:
         offset = 0
         numel = self.size
         for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, Flat):
+            if not isinstance(placement, (Flat, BlockAtomic)):
                 continue
             axis_size = mesh.size(axis)
             if numel % axis_size != 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -21,9 +21,8 @@ from typing import TypeAlias
 
 import torch
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
-
-from .placement import BlockAtomic, Flat
 
 Shape: TypeAlias = torch.Size | Iterable[int]
 
@@ -239,7 +238,7 @@ class GlobalLayout:
         offset = 0
         numel = self.size
         for axis, placement in reversed(tuple(enumerate(placements))):
-            if not isinstance(placement, (Flat, BlockAtomic)):
+            if not isinstance(placement, Shard):
                 continue
             axis_size = mesh.size(axis)
             if numel % axis_size != 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -28,10 +28,11 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .countdown import Countdown
+from .dbuffer import is_mxfp8_tensor
 from .indexed_order import IndexedOrder
 from .module_utils import get_parameter_owner
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
-from .placement import Flat
+from .placement import BlockAtomic, Flat
 from .schedule import SchedulePolicy
 
 
@@ -199,22 +200,27 @@ class FsdpModule:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
         parameter_groups = []
         for group_parameters in _group_parameters(owned_parameters):
-            group_dtype = next(iter(group_parameters.values())).dtype
+            first_parameter = next(iter(group_parameters.values()))
+            group_dtype = first_parameter.dtype
+            is_mxfp8 = is_mxfp8_tensor(first_parameter)
             parameter_groups.append(
                 FsdpParameterGroup(
                     owning_module=self,
                     parameters=group_parameters,
                     mesh=mesh,
                     model_weight_placements=_specialize_placements(
-                        model_weight_placements, group_dtype
+                        model_weight_placements, group_dtype, is_mxfp8=is_mxfp8
                     ),
-                    main_grad_placements=_specialize_placements(main_grad_placements, group_dtype),
+                    main_grad_placements=_specialize_placements(
+                        main_grad_placements, group_dtype, is_mxfp8=is_mxfp8
+                    ),
                     main_weight_placements=_specialize_placements(
-                        main_weight_placements, group_dtype
+                        main_weight_placements, group_dtype, is_mxfp8=is_mxfp8
                     ),
                     mixed_precision_policy=mixed_precision_policy,
                     grad_divisor=grad_divisor,
                     use_symmetric_memory=use_symmetric_memory,
+                    is_mxfp8=is_mxfp8,
                 )
             )
         self._parameter_groups = tuple(parameter_groups)
@@ -601,15 +607,15 @@ def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]
 
 
 def _group_parameters(parameters: dict[str, nn.Parameter]) -> list[dict[str, nn.Parameter]]:
-    grouped: dict[tuple[torch.dtype, bool], dict[str, nn.Parameter]] = {}
+    grouped: dict[tuple[torch.dtype, bool, bool], dict[str, nn.Parameter]] = {}
     for name, parameter in parameters.items():
-        key = (parameter.dtype, parameter.requires_grad)
+        key = (parameter.dtype, parameter.requires_grad, is_mxfp8_tensor(parameter))
         grouped.setdefault(key, {})[name] = parameter
     return [grouped[key] for key in grouped]
 
 
 def _specialize_placements(
-    placements: tuple[Placement, ...], dtype: torch.dtype
+    placements: tuple[Placement, ...], dtype: torch.dtype, *, is_mxfp8: bool = False
 ) -> tuple[Placement, ...]:
     """Specialize public placements for one homogeneous parameter group.
 
@@ -624,4 +630,7 @@ def _specialize_placements(
             raise NotImplementedError(
                 "MFSDP currently supports only dim-0 Shard placements, " f"got {placement!r}."
             )
-    return tuple(Flat() if type(placement) is Shard else placement for placement in placements)
+    placement_type = BlockAtomic(32) if is_mxfp8 else Flat()
+    return tuple(
+        placement_type if type(placement) is Shard else placement for placement in placements
+    )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -351,7 +351,7 @@ class FsdpParameterGroup:
             # under no_grad. Without preserving it, backward can fail with "modified by an
             # inplace operation" even though FSDP only materialized internal storage.
             with torch.autograd._unsafe_preserve_version_counter(
-                self._unsharded_model_weight.tensor
+                self._unsharded_model_weight.local_tensor
             ):
                 self.model_weight.redistribute(
                     self._unsharded_model_weight.placements, out=self._unsharded_model_weight
@@ -440,7 +440,7 @@ class FsdpParameterGroup:
             # optimizer view. Clear the persistent full accumulation buffer before this
             # new step; set_to_none=True needs no clear because out= below overwrites it.
             if has_sharded_grads:
-                self.main_grad.tensor.zero_()
+                self.main_grad.local_tensor.zero_()
             self._main_grad_is_stale = False
 
         if can_reduce_into_main_grad := (
@@ -454,13 +454,13 @@ class FsdpParameterGroup:
         # Scale this backward's contribution before accumulating it so repeated
         # backwards do not repeatedly scale the running total.
         if self.grad_divisor != 1:
-            reduced_grad.tensor.div_(self.grad_divisor)
+            reduced_grad.local_tensor.div_(self.grad_divisor)
 
         if reduced_grad is not self.main_grad:
             if has_sharded_grads:
-                self.main_grad.tensor.add_(reduced_grad.tensor)
+                self.main_grad.local_tensor.add_(reduced_grad.local_tensor)
             else:
-                self.main_grad.tensor.copy_(reduced_grad.tensor)
+                self.main_grad.local_tensor.copy_(reduced_grad.local_tensor)
 
         def install_sharded_grads(main_grad: DBuffer) -> None:
             for index, fsdp_parameter in enumerate(self.fsdp_parameters):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -84,7 +84,8 @@ class FsdpParameterGroup:
     requires_grad: bool
     main_weight: DBuffer
     model_weight: DBuffer
-    # Optimizer-layout view into model_weight storage, avoiding a second allocation.
+    # Compute-weight representation in the optimizer's placements. Ordinary
+    # DBuffers view model_weight storage; MXFP8 DBuffers own an independent TE wrapper.
     post_optimizer_model_weight: DBuffer
     # sync_model_weight_from_main_weight() updates only this rank's optimizer-layout
     # view; the remaining model_weight slices must be all-gathered before compute.
@@ -112,6 +113,7 @@ class FsdpParameterGroup:
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
+        is_mxfp8: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -178,7 +180,22 @@ class FsdpParameterGroup:
         else:
             self._symm_mem_pool = None
 
-        if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
+        if is_mxfp8:
+            self.model_weight = DBuffer.from_mxfp8(
+                parameter_to_fqns, self.mesh, model_weight_placements, allocate_new=True
+            )
+            self.post_optimizer_model_weight = DBuffer.from_mxfp8(
+                parameter_to_fqns, self.mesh, main_weight_placements, allocate_new=True
+            )
+            self.post_optimizer_model_weight.sync_from_main(self.main_weight)
+            self.post_optimizer_model_weight.redistribute(
+                model_weight_placements, out=self.model_weight
+            )
+            self._model_weight_is_stale = False
+            self._unsharded_model_weight = DBuffer.from_mxfp8(
+                parameter_to_fqns, self.mesh, [Replicate()] * self.mesh.ndim
+            )
+        elif main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
         else:
             # Keep the configured compute-weight layout alive for the lifetime of this
@@ -194,22 +211,23 @@ class FsdpParameterGroup:
                     device=self.main_weight.device,
                     block_size=block_size,
                 )
-        self.post_optimizer_model_weight = self.model_weight.view(main_weight_placements)
-        # Cast into the preallocated optimizer-layout view on the current stream.
-        self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
-        self._model_weight_is_stale = (
-            self.post_optimizer_model_weight.placements != self.model_weight.placements
-        )
-
-        with self._symmetric_memory_context():
-            self._unsharded_model_weight = DBuffer(
-                mesh=self.mesh,
-                placements=[Replicate()] * self.mesh.ndim,
-                tensor_shapes=tensor_shapes,
-                dtype=self.dtype,
-                device=self.main_weight.device,
-                block_size=block_size,
+        if not is_mxfp8:
+            self.post_optimizer_model_weight = self.model_weight.view(main_weight_placements)
+            # Cast into the preallocated optimizer-layout view on the current stream.
+            self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
+            self._model_weight_is_stale = (
+                self.post_optimizer_model_weight.placements != self.model_weight.placements
             )
+
+            with self._symmetric_memory_context():
+                self._unsharded_model_weight = DBuffer(
+                    mesh=self.mesh,
+                    placements=[Replicate()] * self.mesh.ndim,
+                    tensor_shapes=tensor_shapes,
+                    dtype=self.dtype,
+                    device=self.main_weight.device,
+                    block_size=block_size,
+                )
 
         self.main_grad = None
         self.pre_optimizer_main_grad = None
@@ -237,7 +255,9 @@ class FsdpParameterGroup:
         fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
-            unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
+            unsharded_tensor = (
+                parameter if is_mxfp8 else self._unsharded_model_weight.get_local_tensor(index)
+            )
             if parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
@@ -247,7 +267,7 @@ class FsdpParameterGroup:
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
                 torch.utils.swap_tensors(parameter, materialized_parameter)
-            else:
+            elif not is_mxfp8:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
             # Parameter-owned markers must not retain their FSDP module tree.
@@ -290,6 +310,12 @@ class FsdpParameterGroup:
 
     def sync_model_weight_from_main_weight(self) -> None:
         """Refresh compute weights from optimizer weights."""
+        if self.model_weight.is_mxfp8:
+            self.post_optimizer_model_weight.sync_from_main(self.main_weight)
+            self._model_weight_is_stale = (
+                self.post_optimizer_model_weight.placements != self.model_weight.placements
+            )
+            return
         self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
         self._model_weight_is_stale = (
             self.post_optimizer_model_weight.placements != self.model_weight.placements
@@ -297,6 +323,18 @@ class FsdpParameterGroup:
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
+        if self.model_weight.is_mxfp8:
+            if self._model_weight_is_stale:
+                self.post_optimizer_model_weight.redistribute(
+                    self.model_weight.placements, out=self.model_weight
+                )
+                self._model_weight_is_stale = False
+            self._unsharded_model_weight.reallocate_storage()
+            self.model_weight.redistribute(
+                [Replicate()] * self.mesh.ndim, out=self._unsharded_model_weight
+            )
+            self._switch_to_unsharded_parameters()
+            return
         if self._model_weight_is_stale:
             self.post_optimizer_model_weight.redistribute(
                 self.model_weight.placements, out=self.model_weight

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -193,7 +193,7 @@ class FsdpParameterGroup:
             )
             self._model_weight_is_stale = False
             self._unsharded_model_weight = DBuffer.from_mxfp8(
-                parameter_to_fqns, self.mesh, [Replicate()] * self.mesh.ndim
+                parameter_to_fqns, self.mesh, [Replicate()] * self.mesh.ndim, allocate_new=True
             )
         elif main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
@@ -255,19 +255,21 @@ class FsdpParameterGroup:
         fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
-            unsharded_tensor = (
-                parameter if is_mxfp8 else self._unsharded_model_weight.get_local_tensor(index)
-            )
-            if parameter.is_meta:
+            if is_mxfp8:
+                # The MXFP8 prototype has one parameter per DBuffer, whose logical
+                # wrapper cannot be represented as a flat-storage tensor view.
+                unsharded_tensor = self._unsharded_model_weight.local_tensor
+            else:
+                unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
+            if parameter.is_meta or is_mxfp8:
                 # A meta Parameter cannot set .data to a real tensor because their
-                # TensorImpl types are incompatible, so swap in a materialized Parameter.
-                # This may be problematic if attributes from the original Parameter need
-                # to be copied to the unsharded Parameter.
+                # TensorImpl types are incompatible. MXFP8 likewise needs to replace the
+                # original TE wrapper with the independently owned DBuffer wrapper.
                 materialized_parameter = nn.Parameter(
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
                 torch.utils.swap_tensors(parameter, materialized_parameter)
-            elif not is_mxfp8:
+            else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
             # Parameter-owned markers must not retain their FSDP module tree.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,6 +14,7 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
+import math
 from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ from torch.distributed.tensor.placement_types import Placement
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
 from .module_utils import get_parameter_owner
+from .placement import BlockAtomic
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -156,11 +158,17 @@ class FsdpParameterGroup:
                 )
 
         tensor_shapes = tuple(parameter.shape for parameter in parameter_to_fqns)
+        block_size = 1
+        for placements in (model_weight_placements, main_grad_placements, main_weight_placements):
+            for placement in placements:
+                if isinstance(placement, BlockAtomic):
+                    block_size = math.lcm(block_size, placement.block_size)
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
             (parameter.to(dtype=main_weight_dtype) for parameter in parameter_to_fqns),
             mesh=self.mesh,
             placements=main_weight_placements,
+            block_size=block_size,
         )
 
         if use_symmetric_memory:
@@ -184,6 +192,7 @@ class FsdpParameterGroup:
                     tensor_shapes=tensor_shapes,
                     dtype=self.dtype,
                     device=self.main_weight.device,
+                    block_size=block_size,
                 )
         self.post_optimizer_model_weight = self.model_weight.view(main_weight_placements)
         # Cast into the preallocated optimizer-layout view on the current stream.
@@ -199,6 +208,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
                 device=self.main_weight.device,
+                block_size=block_size,
             )
 
         self.main_grad = None
@@ -217,6 +227,7 @@ class FsdpParameterGroup:
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=grad_dtype,
                 device=self.main_weight.device,
+                block_size=block_size,
             )
             self.pre_optimizer_main_grad = self.main_grad.view(main_weight_placements)
             assert self.main_grad.layout == self.main_weight.layout, (
@@ -344,6 +355,7 @@ class FsdpParameterGroup:
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
+                block_size=self.main_weight.layout.block_size,
             )
 
     def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -181,19 +181,34 @@ class FsdpParameterGroup:
             self._symm_mem_pool = None
 
         if is_mxfp8:
-            self.model_weight = DBuffer.from_mxfp8(
-                parameter_to_fqns, self.mesh, model_weight_placements, allocate_new=True
+            self.model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=model_weight_placements,
+                tensor_shapes=tensor_shapes,
+                dtype=torch.uint8,
+                device=self.main_weight.device,
+                block_size=block_size,
             )
-            self.post_optimizer_model_weight = DBuffer.from_mxfp8(
-                parameter_to_fqns, self.mesh, main_weight_placements, allocate_new=True
+            self.post_optimizer_model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=main_weight_placements,
+                tensor_shapes=tensor_shapes,
+                dtype=torch.uint8,
+                device=self.main_weight.device,
+                block_size=block_size,
             )
             self.post_optimizer_model_weight.sync_from_main(self.main_weight)
             self.post_optimizer_model_weight.redistribute(
                 model_weight_placements, out=self.model_weight
             )
             self._model_weight_is_stale = False
-            self._unsharded_model_weight = DBuffer.from_mxfp8(
-                parameter_to_fqns, self.mesh, [Replicate()] * self.mesh.ndim, allocate_new=True
+            self._unsharded_model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=[Replicate()] * self.mesh.ndim,
+                tensor_shapes=tensor_shapes,
+                dtype=torch.uint8,
+                device=self.main_weight.device,
+                block_size=block_size,
             )
         elif main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -351,7 +351,7 @@ class FsdpParameterGroup:
             # under no_grad. Without preserving it, backward can fail with "modified by an
             # inplace operation" even though FSDP only materialized internal storage.
             with torch.autograd._unsafe_preserve_version_counter(
-                self._unsharded_model_weight.local_buffer
+                self._unsharded_model_weight.tensor
             ):
                 self.model_weight.redistribute(
                     self._unsharded_model_weight.placements, out=self._unsharded_model_weight
@@ -440,7 +440,7 @@ class FsdpParameterGroup:
             # optimizer view. Clear the persistent full accumulation buffer before this
             # new step; set_to_none=True needs no clear because out= below overwrites it.
             if has_sharded_grads:
-                self.main_grad.local_buffer.zero_()
+                self.main_grad.tensor.zero_()
             self._main_grad_is_stale = False
 
         if can_reduce_into_main_grad := (
@@ -454,13 +454,13 @@ class FsdpParameterGroup:
         # Scale this backward's contribution before accumulating it so repeated
         # backwards do not repeatedly scale the running total.
         if self.grad_divisor != 1:
-            reduced_grad.local_buffer.div_(self.grad_divisor)
+            reduced_grad.tensor.div_(self.grad_divisor)
 
         if reduced_grad is not self.main_grad:
             if has_sharded_grads:
-                self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
+                self.main_grad.tensor.add_(reduced_grad.tensor)
             else:
-                self.main_grad.local_buffer.copy_(reduced_grad.local_buffer)
+                self.main_grad.tensor.copy_(reduced_grad.tensor)
 
         def install_sharded_grads(main_grad: DBuffer) -> None:
             for index, fsdp_parameter in enumerate(self.fsdp_parameters):

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -255,23 +255,7 @@ class FsdpParameterGroup:
         fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
-            if is_mxfp8:
-                # The MXFP8 prototype has one parameter per DBuffer, whose logical
-                # wrapper cannot be represented as a flat-storage tensor view.
-                unsharded_tensor = self._unsharded_model_weight.local_tensor
-            else:
-                unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
-            if parameter.is_meta or is_mxfp8:
-                # A meta Parameter cannot set .data to a real tensor because their
-                # TensorImpl types are incompatible. MXFP8 likewise needs to replace the
-                # original TE wrapper with the independently owned DBuffer wrapper.
-                materialized_parameter = nn.Parameter(
-                    unsharded_tensor, requires_grad=parameter.requires_grad
-                )
-                torch.utils.swap_tensors(parameter, materialized_parameter)
-            else:
-                parameter.data = unsharded_tensor
-                parameter.grad = None
+            self._unsharded_model_weight.initialize_unsharded_parameter(parameter, index)
             # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
@@ -312,55 +296,25 @@ class FsdpParameterGroup:
 
     def sync_model_weight_from_main_weight(self) -> None:
         """Refresh compute weights from optimizer weights."""
-        if self.model_weight.is_mxfp8:
-            self.post_optimizer_model_weight.sync_from_main(self.main_weight)
-            self._model_weight_is_stale = (
-                self.post_optimizer_model_weight.placements != self.model_weight.placements
-            )
-            return
-        self.main_weight.cast(self.model_weight.dtype, out=self.post_optimizer_model_weight)
+        self.post_optimizer_model_weight.sync_from_main(self.main_weight)
         self._model_weight_is_stale = (
             self.post_optimizer_model_weight.placements != self.model_weight.placements
         )
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        if self.model_weight.is_mxfp8:
-            if self._model_weight_is_stale:
-                self.post_optimizer_model_weight.redistribute(
-                    self.model_weight.placements, out=self.model_weight
-                )
-                self._model_weight_is_stale = False
-            self._unsharded_model_weight.reallocate_storage()
-            self.model_weight.redistribute(
-                [Replicate()] * self.mesh.ndim, out=self._unsharded_model_weight
-            )
-            self._switch_to_unsharded_parameters()
-            return
         if self._model_weight_is_stale:
             self.post_optimizer_model_weight.redistribute(
                 self.model_weight.placements, out=self.model_weight
             )
             self._model_weight_is_stale = False
-        if self.model_weight.placements == self._unsharded_model_weight.placements:
-            unsharded_model_weight = self.model_weight
-        else:
-            with self._symmetric_memory_context():
-                self._unsharded_model_weight.reallocate_storage()
-            # This buffer backs unsharded Parameters whose views may be saved by autograd.
-            # Autograd records a tensor's version counter when saving it for backward, and
-            # in-place writes like the out= redistribution below increment that counter even
-            # under no_grad. Without preserving it, backward can fail with "modified by an
-            # inplace operation" even though FSDP only materialized internal storage.
-            with torch.autograd._unsafe_preserve_version_counter(
-                self._unsharded_model_weight.local_tensor
-            ):
-                self.model_weight.redistribute(
-                    self._unsharded_model_weight.placements, out=self._unsharded_model_weight
-                )
-            unsharded_model_weight = self._unsharded_model_weight
-        for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            fsdp_parameter.unsharded.data = unsharded_model_weight.get_local_tensor(index)
+        with self._symmetric_memory_context():
+            unsharded_model_weight = self._unsharded_model_weight.materialize_unsharded_from(
+                self.model_weight
+            )
+        unsharded_model_weight.install_unsharded_parameter_views(
+            fsdp_parameter.unsharded for fsdp_parameter in self.fsdp_parameters
+        )
         self._switch_to_unsharded_parameters()
 
     def reshard_parameters(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -15,8 +15,8 @@
 """DBuffer placement definitions.
 
 DBuffer uses PyTorch DTensor's ``Placement``, ``Replicate``, and ``Partial``
-types directly. ``Flat`` is the only DBuffer-specific placement: a dim-0
-``Shard`` whose local storage is part of one flattened buffer.
+types directly. ``Flat`` and ``BlockAtomic`` are DBuffer-specific dim-0
+``Shard`` placements whose local storage is part of one flattened buffer.
 
 =============  =============  ====================
 Source         Destination    DBuffer operation
@@ -33,7 +33,7 @@ from collections.abc import Iterable
 from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
 
-__all__ = ["Flat", "changed_mesh_axis"]
+__all__ = ["BlockAtomic", "Flat", "changed_mesh_axis"]
 
 
 class Flat(Shard):
@@ -41,6 +41,27 @@ class Flat(Shard):
 
     def __init__(self) -> None:
         super().__init__(0)
+
+    def __eq__(self, other: object) -> bool:
+        # PyTorch Shard.__eq__ compares only dim, so distinguish Flat from BlockAtomic.
+        return isinstance(other, Shard) and other.dim == 0 and not isinstance(other, BlockAtomic)
+
+
+class BlockAtomic(Shard):
+    """Flattened dim-0 shard placement that keeps ``block_size`` rows together."""
+
+    def __init__(self, block_size: int) -> None:
+        if block_size <= 0:
+            raise ValueError(f"BlockAtomic block_size must be positive, got {block_size}.")
+        super().__init__(0)
+        self.block_size = block_size
+
+    def __eq__(self, other: object) -> bool:
+        # PyTorch Shard.__eq__ compares only dim, so preserve the block size as well.
+        return isinstance(other, BlockAtomic) and self.block_size == other.block_size
+
+    def __repr__(self) -> str:
+        return f"BlockAtomic(block_size={self.block_size})"
 
 
 def changed_mesh_axis(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -12,6 +12,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Partial, Replicate
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer, Flat
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import BlockAtomic
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -66,6 +67,22 @@ def test_dbuffer_layout_aligns_fragment_offsets_to_rows(distributed_setup):
 
     assert buffer.layout.tensor_to_offset == (0, 18)
     assert buffer.layout.size == 24
+
+
+def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
+    """BlockAtomic keeps every local tensor shard aligned to its configured row block."""
+    if distributed_setup.world_size < 2:
+        pytest.skip("Requires at least 2 ranks.")
+
+    mesh = init_device_mesh(distributed_setup.device.type, (2,))
+    tensors = [
+        torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
+        torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
+    ]
+    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)])
+
+    assert block_atomic.layout.block_size == 2
+    assert all(block_atomic.get_local_tensor(index).shape[0] % 2 == 0 for index in range(2))
 
 
 def test_compute_layout_fills_lcm_padding_gaps(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -78,6 +78,8 @@ def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
         pytest.skip("Requires at least 2 ranks.")
 
     mesh = init_device_mesh(distributed_setup.device.type, (2,))
+    if mesh.get_coordinate() is None:
+        pytest.skip("Rank is outside the 2-rank BlockAtomic test mesh.")
     tensors = [
         torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
         torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
@@ -608,7 +610,7 @@ def test_2d_mesh_flat_before_replicate_is_rejected(distributed_setup):
         mesh_dim_names=("flat", "replicate"),
     )
 
-    with pytest.raises(ValueError, match="Flat placements must be a suffix"):
+    with pytest.raises(ValueError, match="Shard placements must be a suffix"):
         DBuffer(
             mesh=mesh,
             placements=[Flat(), Replicate()],

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -9,7 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor import Partial, Replicate, Shard
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import (
@@ -576,7 +576,7 @@ def test_get_dtensor_from_sharded_buffer(distributed_setup):
         dtensor.to_local(), sharded_buffer.get_local_tensor(0), rtol=0, atol=0
     )
     assert dtensor.shape == tensors[0].shape
-    assert dtensor.placements == (Flat(),)
+    assert dtensor.placements == (Shard(0),)
 
 
 def test_2d_mesh_replicate_flat_round_trip(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -11,8 +11,11 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Partial, Replicate
 
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer, Flat
-from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import BlockAtomic
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import (
+    BlockAtomic,
+    Flat,
+)
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -79,7 +82,7 @@ def test_block_atomic_layout_keeps_bf16_blocks_on_one_rank(distributed_setup):
         torch.arange(24, dtype=torch.bfloat16, device=distributed_setup.device).reshape(4, 6),
         torch.arange(32, dtype=torch.bfloat16, device=distributed_setup.device).reshape(8, 4),
     ]
-    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)])
+    block_atomic = DBuffer.distribute_tensors(tensors, mesh, [BlockAtomic(2)], block_size=2)
 
     assert block_atomic.layout.block_size == 2
     assert all(block_atomic.get_local_tensor(index).shape[0] % 2 == 0 for index in range(2))
@@ -248,9 +251,7 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     offset = distributed_setup.rank * local_numel
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
-    sharded_buffer = DBuffer.from_local(
-        local_buffer, mesh, [Flat()], replicated_buffer.layout.tensor_shapes
-    )
+    sharded_buffer = DBuffer.from_local(local_buffer, mesh, [Flat()], replicated_buffer.layout)
 
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == replicated_buffer.layout

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -166,14 +166,14 @@ def test_constructor_allocates_tensor(distributed_setup):
     assert replicated_buffer.offset == 0
     expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
-    assert replicated_buffer.tensor.numel() == replicated_buffer.layout.size
+    assert replicated_buffer.local_tensor.numel() == replicated_buffer.layout.size
     assert (
-        sharded_buffer.tensor.numel()
+        sharded_buffer.local_tensor.numel()
         == replicated_buffer.layout.size // distributed_setup.world_size
     )
     assert sharded_buffer.layout.size % (15 * mesh_size) == 0
     assert replicated_buffer.dtype == torch.float32
-    assert sharded_buffer.tensor.device == distributed_setup.device
+    assert sharded_buffer.local_tensor.device == distributed_setup.device
 
 
 def test_cast_to_same_dtype_returns_self(distributed_setup):
@@ -216,12 +216,12 @@ def test_cast_with_out_reuses_destination_and_casts_values(distributed_setup):
         dtype=torch.bfloat16,
         device=distributed_setup.device,
     )
-    destination_data_ptr = destination.tensor.data_ptr()
+    destination_data_ptr = destination.local_tensor.data_ptr()
 
     result = buffer.cast(torch.bfloat16, out=destination)
 
     assert result is destination
-    assert destination.tensor.data_ptr() == destination_data_ptr
+    assert destination.local_tensor.data_ptr() == destination_data_ptr
     _assert_dbuffer_local_tensors_close(
         destination, [tensor.to(dtype=torch.bfloat16) for tensor in tensors]
     )
@@ -240,14 +240,14 @@ def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup
     tensor_view = buffer.get_local_tensor(0)
 
     buffer.release_storage()
-    assert buffer.tensor.untyped_storage().nbytes() == 0
+    assert buffer.local_tensor.untyped_storage().nbytes() == 0
 
     buffer.reallocate_storage()
     assert (
-        buffer.tensor.untyped_storage().nbytes()
-        == buffer.tensor.numel() * buffer.tensor.element_size()
+        buffer.local_tensor.untyped_storage().nbytes()
+        == buffer.local_tensor.numel() * buffer.local_tensor.element_size()
     )
-    buffer.tensor.fill_(7.0)
+    buffer.local_tensor.fill_(7.0)
     torch.testing.assert_close(tensor_view, torch.full_like(tensor_view, 7.0))
 
 
@@ -258,14 +258,14 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
     local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     offset = distributed_setup.rank * local_numel
-    local_buffer = replicated_buffer.tensor.narrow(0, offset, local_numel)
+    local_buffer = replicated_buffer.local_tensor.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(local_buffer, mesh, [Flat()], replicated_buffer.layout)
 
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == replicated_buffer.layout
     assert sharded_buffer.offset == offset
-    assert sharded_buffer.tensor.data_ptr() == local_buffer.data_ptr()
+    assert sharded_buffer.local_tensor.data_ptr() == local_buffer.data_ptr()
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
@@ -302,7 +302,7 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(distributed_setup):
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    assert buffer.tensor.device == distributed_setup.device
+    assert buffer.local_tensor.device == distributed_setup.device
     _assert_dbuffer_local_tensors_close(
         buffer, [tensor.to(distributed_setup.device) for tensor in tensors]
     )
@@ -319,7 +319,7 @@ def test_distribute_tensors_detaches_and_contiguizes_inputs(distributed_setup):
 
     assert not parameter.is_contiguous()
     assert buffer.get_local_tensor(0).is_contiguous()
-    assert not buffer.tensor.requires_grad
+    assert not buffer.local_tensor.requires_grad
     torch.testing.assert_close(
         buffer.get_local_tensor(0), parameter.detach().contiguous(), rtol=0, atol=0
     )
@@ -353,14 +353,14 @@ def test_sharded_allgather_into_existing_buffer(distributed_setup):
         placements=[Replicate()],
         tensor_shapes=sharded_buffer.layout.tensor_shapes,
         dtype=sharded_buffer.dtype,
-        device=sharded_buffer.tensor.device,
+        device=sharded_buffer.local_tensor.device,
     )
-    destination_data_ptr = destination.tensor.data_ptr()
+    destination_data_ptr = destination.local_tensor.data_ptr()
 
     result = sharded_buffer.allgather(0, out=destination)
 
     assert result is destination
-    assert destination.tensor.data_ptr() == destination_data_ptr
+    assert destination.local_tensor.data_ptr() == destination_data_ptr
     _assert_dbuffer_local_tensors_close(destination, tensors)
 
 
@@ -376,7 +376,7 @@ def test_replicate_view_round_trip(distributed_setup):
         placements=[Flat()],
         tensor_shapes=replicated_buffer.layout.tensor_shapes,
         dtype=replicated_buffer.dtype,
-        device=replicated_buffer.tensor.device,
+        device=replicated_buffer.local_tensor.device,
     )
     redistributed_sharded_buffer = replicated_buffer.redistribute(
         [Flat()], out=redistribute_destination
@@ -387,9 +387,12 @@ def test_replicate_view_round_trip(distributed_setup):
     assert redistributed_sharded_buffer.placements == (Flat(),)
     expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
-    assert sharded_buffer.tensor.untyped_storage() is replicated_buffer.tensor.untyped_storage()
+    assert (
+        sharded_buffer.local_tensor.untyped_storage()
+        is replicated_buffer.local_tensor.untyped_storage()
+    )
     torch.testing.assert_close(
-        sharded_buffer.tensor, redistributed_sharded_buffer.tensor, rtol=0, atol=0
+        sharded_buffer.local_tensor, redistributed_sharded_buffer.local_tensor, rtol=0, atol=0
     )
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
@@ -412,7 +415,7 @@ def test_partial_allreduce(distributed_setup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
-    assert replicated_buffer.tensor.data_ptr() == partial_buffer.tensor.data_ptr()
+    assert replicated_buffer.local_tensor.data_ptr() == partial_buffer.local_tensor.data_ptr()
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
@@ -431,7 +434,7 @@ def test_partial_allreduce_average(distributed_setup):
         placements=[Replicate()],
         tensor_shapes=partial_buffer.layout.tensor_shapes,
         dtype=partial_buffer.dtype,
-        device=partial_buffer.tensor.device,
+        device=partial_buffer.local_tensor.device,
     )
     replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
@@ -462,7 +465,10 @@ def test_partial_reduce_scatter_to_flat(distributed_setup):
     assert sharded_buffer is destination
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
-    assert sharded_buffer.tensor.untyped_storage() is partial_buffer.tensor.untyped_storage()
+    assert (
+        sharded_buffer.local_tensor.untyped_storage()
+        is partial_buffer.local_tensor.untyped_storage()
+    )
     assert replicated_buffer.layout == layout
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected_tensors = [
@@ -528,7 +534,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_average(distributed_set
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
         partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("avg")])
-    assert symm_mem.is_symm_mem_tensor(partial_buffer.tensor)
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_tensor)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
     replicated_buffer = sharded_buffer.allgather(0)
@@ -554,7 +560,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_sum(distributed_setup):
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
         partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("sum")])
-    assert symm_mem.is_symm_mem_tensor(partial_buffer.tensor)
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_tensor)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
     replicated_buffer = sharded_buffer.allgather(0)
@@ -642,7 +648,9 @@ def test_2d_mesh_shards_across_all_ranks(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.tensor.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    assert (
+        fully_sharded_buffer.local_tensor.numel() == fully_sharded_buffer.layout.size // mesh.size()
+    )
     for index, _ in enumerate(tensors):
         assert fully_sharded_buffer.get_local_tensor(index).is_contiguous()
 
@@ -675,7 +683,10 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.tensor.numel() == partial_sharded_buffer.tensor.numel() // 2
+    assert (
+        fully_sharded_buffer.local_tensor.numel()
+        == partial_sharded_buffer.local_tensor.numel() // 2
+    )
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
@@ -711,7 +722,10 @@ def test_2d_mesh_replicate_flat_view_to_flat_flat(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert fully_sharded_buffer.tensor.numel() == replicated_sharded_buffer.tensor.numel() // 2
+    assert (
+        fully_sharded_buffer.local_tensor.numel()
+        == replicated_sharded_buffer.local_tensor.numel() // 2
+    )
     _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
@@ -743,15 +757,15 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
 
     parameter_group = linear.parameter_groups[0]
     assert parameter_group.model_weight.is_mxfp8
-    assert parameter_group.model_weight.tensor.shape == (64, 64)
+    assert parameter_group.model_weight.local_tensor.shape == (64, 64)
     assert parameter_group.post_optimizer_model_weight is not parameter_group.model_weight
-    assert parameter_group.post_optimizer_model_weight.tensor.shape == (32, 64)
+    assert parameter_group.post_optimizer_model_weight.local_tensor.shape == (32, 64)
     assert parameter_group._unsharded_model_weight.is_mxfp8
-    assert parameter_group._unsharded_model_weight.tensor.shape == (64, 64)
+    assert parameter_group._unsharded_model_weight.local_tensor.shape == (64, 64)
 
     optimizer = torch.optim.SGD(linear.parameters(), lr=0.1)
     fully_shard_optimizer(optimizer)
-    main_weight_before = parameter_group.main_weight.tensor.detach().clone()
+    main_weight_before = parameter_group.main_weight.local_tensor.detach().clone()
 
     x = torch.randn(32, 64, dtype=torch.bfloat16, device=distributed_setup.device)
     optimizer.zero_grad(set_to_none=True)
@@ -761,4 +775,4 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
     optimizer.step()
 
     assert torch.isfinite(loss)
-    assert not torch.equal(main_weight_before, parameter_group.main_weight.tensor)
+    assert not torch.equal(main_weight_before, parameter_group.main_weight.local_tensor)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -730,7 +730,7 @@ def test_2d_mesh_replicate_flat_view_to_flat_flat(distributed_setup):
 
 
 def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
-    """A TE MXFP8 Linear uses DBuffer-owned physical storage on two ranks."""
+    """Two TE MXFP8 Linear weights share packed DBuffer-owned storage on two ranks."""
     te = pytest.importorskip("transformer_engine")
     if distributed_setup.world_size != 2:
         pytest.skip("MXFP8 DBuffer coverage requires exactly two ranks.")
@@ -739,10 +739,15 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
 
     recipe = te.common.recipe.MXFP8BlockScaling(fp8_format=te.common.recipe.Format.HYBRID)
     with te.pytorch.quantized_model_init(recipe=recipe, preserve_high_precision_init_val=True):
-        linear = te.pytorch.Linear(
-            64, 64, bias=False, params_dtype=torch.bfloat16, device=distributed_setup.device
+        linear = torch.nn.Sequential(
+            te.pytorch.Linear(
+                256, 256, bias=False, params_dtype=torch.bfloat16, device=distributed_setup.device
+            ),
+            te.pytorch.Linear(
+                256, 512, bias=False, params_dtype=torch.bfloat16, device=distributed_setup.device
+            ),
         )
-    original_rowwise_data = linear.weight._rowwise_data
+    original_rowwise_data = linear[0].weight._rowwise_data
 
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     placements = Placements(
@@ -760,14 +765,23 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
     assert parameter_group.model_weight.is_mxfp8
     assert parameter_group.model_weight.dtype is torch.uint8
     assert parameter_group.dtype is torch.bfloat16
-    assert parameter_group.model_weight.local_tensor.shape == (64, 64)
+    assert len(parameter_group.fsdp_parameters) == 2
+    assert [parameter_group.model_weight.get_local_tensor(index).shape for index in range(2)] == [
+        (256, 256),
+        (512, 256),
+    ]
     assert parameter_group.post_optimizer_model_weight is not parameter_group.model_weight
-    assert parameter_group.post_optimizer_model_weight.local_tensor.shape == (32, 64)
+    assert sum(
+        parameter_group.post_optimizer_model_weight.get_local_tensor(index).numel()
+        for index in range(2)
+    ) == (256 * 256) + (128 * 256)
     assert parameter_group._unsharded_model_weight.is_mxfp8
-    assert parameter_group._unsharded_model_weight.local_tensor.shape == (64, 64)
+    assert [
+        parameter_group._unsharded_model_weight.get_local_tensor(index).shape for index in range(2)
+    ] == [(256, 256), (512, 256)]
     unsharded_parameter = parameter_group.fsdp_parameters[0].unsharded
     assert unsharded_parameter._rowwise_data.data_ptr() == (
-        parameter_group._unsharded_model_weight.local_tensor._rowwise_data.data_ptr()
+        parameter_group._unsharded_model_weight.get_local_tensor(0)._rowwise_data.data_ptr()
     )
     assert unsharded_parameter._rowwise_data.data_ptr() != original_rowwise_data.data_ptr()
 
@@ -775,7 +789,7 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
     fully_shard_optimizer(optimizer)
     main_weight_before = parameter_group.main_weight.local_tensor.detach().clone()
 
-    x = torch.randn(32, 64, dtype=torch.bfloat16, device=distributed_setup.device)
+    x = torch.randn(32, 256, dtype=torch.bfloat16, device=distributed_setup.device)
     optimizer.zero_grad(set_to_none=True)
     with te.pytorch.autocast(recipe=recipe):
         loss = linear(x).float().square().mean()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -11,11 +11,18 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Partial, Replicate, Shard
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Placements,
+    fully_shard,
+    fully_shard_context,
+    fully_shard_optimizer,
+)
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import DBuffer
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.placement import (
     BlockAtomic,
     Flat,
 )
+from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
 
 def _same_tensors_on_all_ranks(device: torch.device) -> list[torch.Tensor]:
@@ -720,3 +727,52 @@ def test_2d_mesh_replicate_flat_view_to_flat_flat(distributed_setup):
         == replicated_sharded_buffer.local_buffer.numel() // 2
     )
     _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
+
+
+def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
+    """A TE MXFP8 Linear uses DBuffer-owned physical storage on two ranks."""
+    te = pytest.importorskip("transformer_engine")
+    if distributed_setup.world_size != 2:
+        pytest.skip("MXFP8 DBuffer coverage requires exactly two ranks.")
+    if torch.cuda.get_device_capability(distributed_setup.device)[0] < 10:
+        pytest.skip("MXFP8 requires Blackwell-or-newer CUDA hardware.")
+
+    recipe = te.common.recipe.MXFP8BlockScaling(fp8_format=te.common.recipe.Format.HYBRID)
+    with te.pytorch.quantized_model_init(recipe=recipe, preserve_high_precision_init_val=True):
+        linear = te.pytorch.Linear(
+            64, 64, bias=False, params_dtype=torch.bfloat16, device=distributed_setup.device
+        )
+
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    placements = Placements(
+        dp_axes=[0], parameter=[Replicate()], gradient=[Shard(0)], optimizer=[Shard(0)]
+    )
+    with fully_shard_context(device=distributed_setup.device):
+        fully_shard(
+            linear,
+            mesh=mesh,
+            placements=placements,
+            mixed_precision_policy=MixedPrecisionPolicy(main_params_dtype=torch.float32),
+        )
+
+    parameter_group = linear.parameter_groups[0]
+    assert parameter_group.model_weight.is_mxfp8
+    assert parameter_group.model_weight.tensor.shape == (64, 64)
+    assert parameter_group.post_optimizer_model_weight is not parameter_group.model_weight
+    assert parameter_group.post_optimizer_model_weight.tensor.shape == (32, 64)
+    assert parameter_group._unsharded_model_weight.is_mxfp8
+    assert parameter_group._unsharded_model_weight.tensor.shape == (64, 64)
+
+    optimizer = torch.optim.SGD(linear.parameters(), lr=0.1)
+    fully_shard_optimizer(optimizer)
+    main_weight_before = parameter_group.main_weight.local_buffer.detach().clone()
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device=distributed_setup.device)
+    optimizer.zero_grad(set_to_none=True)
+    with te.pytorch.autocast(recipe=recipe):
+        loss = linear(x).float().square().mean()
+    loss.backward()
+    optimizer.step()
+
+    assert torch.isfinite(loss)
+    assert not torch.equal(main_weight_before, parameter_group.main_weight.local_buffer)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -140,7 +140,7 @@ def test_compute_layout_fills_lcm_padding_gaps(distributed_setup):
         assert buffer.get_dtensor(index).shape == shapes[index]
 
 
-def test_constructor_allocates_local_buffer(distributed_setup):
+def test_constructor_allocates_tensor(distributed_setup):
     """DBuffer allocates local storage from shape, mesh, placement, dtype, and device."""
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     tensor_shapes = [torch.Size((7, 3)), torch.Size((2, 5)), torch.Size((7,))]
@@ -166,14 +166,14 @@ def test_constructor_allocates_local_buffer(distributed_setup):
     assert replicated_buffer.offset == 0
     expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
-    assert replicated_buffer.local_buffer.numel() == replicated_buffer.layout.size
+    assert replicated_buffer.tensor.numel() == replicated_buffer.layout.size
     assert (
-        sharded_buffer.local_buffer.numel()
+        sharded_buffer.tensor.numel()
         == replicated_buffer.layout.size // distributed_setup.world_size
     )
     assert sharded_buffer.layout.size % (15 * mesh_size) == 0
     assert replicated_buffer.dtype == torch.float32
-    assert sharded_buffer.local_buffer.device == distributed_setup.device
+    assert sharded_buffer.tensor.device == distributed_setup.device
 
 
 def test_cast_to_same_dtype_returns_self(distributed_setup):
@@ -216,12 +216,12 @@ def test_cast_with_out_reuses_destination_and_casts_values(distributed_setup):
         dtype=torch.bfloat16,
         device=distributed_setup.device,
     )
-    destination_data_ptr = destination.local_buffer.data_ptr()
+    destination_data_ptr = destination.tensor.data_ptr()
 
     result = buffer.cast(torch.bfloat16, out=destination)
 
     assert result is destination
-    assert destination.local_buffer.data_ptr() == destination_data_ptr
+    assert destination.tensor.data_ptr() == destination_data_ptr
     _assert_dbuffer_local_tensors_close(
         destination, [tensor.to(dtype=torch.bfloat16) for tensor in tensors]
     )
@@ -240,14 +240,14 @@ def test_release_and_reallocate_storage_preserves_buffer_views(distributed_setup
     tensor_view = buffer.get_local_tensor(0)
 
     buffer.release_storage()
-    assert buffer.local_buffer.untyped_storage().nbytes() == 0
+    assert buffer.tensor.untyped_storage().nbytes() == 0
 
     buffer.reallocate_storage()
     assert (
-        buffer.local_buffer.untyped_storage().nbytes()
-        == buffer.local_buffer.numel() * buffer.local_buffer.element_size()
+        buffer.tensor.untyped_storage().nbytes()
+        == buffer.tensor.numel() * buffer.tensor.element_size()
     )
-    buffer.local_buffer.fill_(7.0)
+    buffer.tensor.fill_(7.0)
     torch.testing.assert_close(tensor_view, torch.full_like(tensor_view, 7.0))
 
 
@@ -258,14 +258,14 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     replicated_buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
     local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     offset = distributed_setup.rank * local_numel
-    local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
+    local_buffer = replicated_buffer.tensor.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(local_buffer, mesh, [Flat()], replicated_buffer.layout)
 
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == replicated_buffer.layout
     assert sharded_buffer.offset == offset
-    assert sharded_buffer.local_buffer.data_ptr() == local_buffer.data_ptr()
+    assert sharded_buffer.tensor.data_ptr() == local_buffer.data_ptr()
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
 
@@ -302,7 +302,7 @@ def test_distribute_tensors_moves_inputs_to_mesh_device(distributed_setup):
 
     buffer = DBuffer.distribute_tensors(tensors, mesh, [Replicate()])
 
-    assert buffer.local_buffer.device == distributed_setup.device
+    assert buffer.tensor.device == distributed_setup.device
     _assert_dbuffer_local_tensors_close(
         buffer, [tensor.to(distributed_setup.device) for tensor in tensors]
     )
@@ -319,7 +319,7 @@ def test_distribute_tensors_detaches_and_contiguizes_inputs(distributed_setup):
 
     assert not parameter.is_contiguous()
     assert buffer.get_local_tensor(0).is_contiguous()
-    assert not buffer.local_buffer.requires_grad
+    assert not buffer.tensor.requires_grad
     torch.testing.assert_close(
         buffer.get_local_tensor(0), parameter.detach().contiguous(), rtol=0, atol=0
     )
@@ -353,14 +353,14 @@ def test_sharded_allgather_into_existing_buffer(distributed_setup):
         placements=[Replicate()],
         tensor_shapes=sharded_buffer.layout.tensor_shapes,
         dtype=sharded_buffer.dtype,
-        device=sharded_buffer.local_buffer.device,
+        device=sharded_buffer.tensor.device,
     )
-    destination_data_ptr = destination.local_buffer.data_ptr()
+    destination_data_ptr = destination.tensor.data_ptr()
 
     result = sharded_buffer.allgather(0, out=destination)
 
     assert result is destination
-    assert destination.local_buffer.data_ptr() == destination_data_ptr
+    assert destination.tensor.data_ptr() == destination_data_ptr
     _assert_dbuffer_local_tensors_close(destination, tensors)
 
 
@@ -376,7 +376,7 @@ def test_replicate_view_round_trip(distributed_setup):
         placements=[Flat()],
         tensor_shapes=replicated_buffer.layout.tensor_shapes,
         dtype=replicated_buffer.dtype,
-        device=replicated_buffer.local_buffer.device,
+        device=replicated_buffer.tensor.device,
     )
     redistributed_sharded_buffer = replicated_buffer.redistribute(
         [Flat()], out=redistribute_destination
@@ -387,12 +387,9 @@ def test_replicate_view_round_trip(distributed_setup):
     assert redistributed_sharded_buffer.placements == (Flat(),)
     expected_sharded_local_numel = replicated_buffer.layout.size // distributed_setup.world_size
     assert sharded_buffer.offset == distributed_setup.rank * expected_sharded_local_numel
-    assert (
-        sharded_buffer.local_buffer.untyped_storage()
-        is replicated_buffer.local_buffer.untyped_storage()
-    )
+    assert sharded_buffer.tensor.untyped_storage() is replicated_buffer.tensor.untyped_storage()
     torch.testing.assert_close(
-        sharded_buffer.local_buffer, redistributed_sharded_buffer.local_buffer, rtol=0, atol=0
+        sharded_buffer.tensor, redistributed_sharded_buffer.tensor, rtol=0, atol=0
     )
     _assert_dbuffer_local_tensors_close(sharded_buffer.allgather(0), tensors)
 
@@ -415,7 +412,7 @@ def test_partial_allreduce(distributed_setup):
         torch.full((5, 3), scale_sum, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), scale_sum * 10, dtype=torch.float32, device=distributed_setup.device),
     ]
-    assert replicated_buffer.local_buffer.data_ptr() == partial_buffer.local_buffer.data_ptr()
+    assert replicated_buffer.tensor.data_ptr() == partial_buffer.tensor.data_ptr()
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected)
 
 
@@ -434,7 +431,7 @@ def test_partial_allreduce_average(distributed_setup):
         placements=[Replicate()],
         tensor_shapes=partial_buffer.layout.tensor_shapes,
         dtype=partial_buffer.dtype,
-        device=partial_buffer.local_buffer.device,
+        device=partial_buffer.tensor.device,
     )
     replicated_buffer = partial_buffer.allreduce(0, out=destination)
 
@@ -465,10 +462,7 @@ def test_partial_reduce_scatter_to_flat(distributed_setup):
     assert sharded_buffer is destination
     assert sharded_buffer.placements == (Flat(),)
     assert sharded_buffer.layout == layout
-    assert (
-        sharded_buffer.local_buffer.untyped_storage()
-        is partial_buffer.local_buffer.untyped_storage()
-    )
+    assert sharded_buffer.tensor.untyped_storage() is partial_buffer.tensor.untyped_storage()
     assert replicated_buffer.layout == layout
     scale_sum = float(distributed_setup.world_size * (distributed_setup.world_size + 1) // 2)
     expected_tensors = [
@@ -534,7 +528,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_average(distributed_set
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
         partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("avg")])
-    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.tensor)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
     replicated_buffer = sharded_buffer.allgather(0)
@@ -560,7 +554,7 @@ def test_symmetric_memory_partial_reduce_scatter_to_flat_sum(distributed_setup):
     pool = symm_mem.get_mem_pool(device)
     with torch.cuda.use_mem_pool(pool):
         partial_buffer = DBuffer.distribute_tensors(tensors, mesh, [Partial("sum")])
-    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.tensor)
 
     sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
     replicated_buffer = sharded_buffer.allgather(0)
@@ -648,9 +642,7 @@ def test_2d_mesh_shards_across_all_ranks(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert (
-        fully_sharded_buffer.local_buffer.numel() == fully_sharded_buffer.layout.size // mesh.size()
-    )
+    assert fully_sharded_buffer.tensor.numel() == fully_sharded_buffer.layout.size // mesh.size()
     for index, _ in enumerate(tensors):
         assert fully_sharded_buffer.get_local_tensor(index).is_contiguous()
 
@@ -683,10 +675,7 @@ def test_2d_mesh_partial_flat_reduce_scatter_to_flat_flat(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert (
-        fully_sharded_buffer.local_buffer.numel()
-        == partial_sharded_buffer.local_buffer.numel() // 2
-    )
+    assert fully_sharded_buffer.tensor.numel() == partial_sharded_buffer.tensor.numel() // 2
 
     outer_scale_sum = float(mesh.size(0) * (mesh.size(0) + 1) // 2)
     expected = [
@@ -722,10 +711,7 @@ def test_2d_mesh_replicate_flat_view_to_flat_flat(distributed_setup):
         + mesh.get_local_rank(0) * expected_local_numel
     )
     assert fully_sharded_buffer.offset == expected_offset
-    assert (
-        fully_sharded_buffer.local_buffer.numel()
-        == replicated_sharded_buffer.local_buffer.numel() // 2
-    )
+    assert fully_sharded_buffer.tensor.numel() == replicated_sharded_buffer.tensor.numel() // 2
     _assert_dbuffer_local_tensors_close(replicated_buffer, tensors)
 
 
@@ -765,7 +751,7 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
 
     optimizer = torch.optim.SGD(linear.parameters(), lr=0.1)
     fully_shard_optimizer(optimizer)
-    main_weight_before = parameter_group.main_weight.local_buffer.detach().clone()
+    main_weight_before = parameter_group.main_weight.tensor.detach().clone()
 
     x = torch.randn(32, 64, dtype=torch.bfloat16, device=distributed_setup.device)
     optimizer.zero_grad(set_to_none=True)
@@ -775,4 +761,4 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
     optimizer.step()
 
     assert torch.isfinite(loss)
-    assert not torch.equal(main_weight_before, parameter_group.main_weight.local_buffer)
+    assert not torch.equal(main_weight_before, parameter_group.main_weight.tensor)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -742,6 +742,7 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
         linear = te.pytorch.Linear(
             64, 64, bias=False, params_dtype=torch.bfloat16, device=distributed_setup.device
         )
+    original_rowwise_data = linear.weight._rowwise_data
 
     mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
     placements = Placements(
@@ -757,11 +758,18 @@ def test_mxfp8_linear_training_step_uses_dbuffer(distributed_setup):
 
     parameter_group = linear.parameter_groups[0]
     assert parameter_group.model_weight.is_mxfp8
+    assert parameter_group.model_weight.dtype is torch.uint8
+    assert parameter_group.dtype is torch.bfloat16
     assert parameter_group.model_weight.local_tensor.shape == (64, 64)
     assert parameter_group.post_optimizer_model_weight is not parameter_group.model_weight
     assert parameter_group.post_optimizer_model_weight.local_tensor.shape == (32, 64)
     assert parameter_group._unsharded_model_weight.is_mxfp8
     assert parameter_group._unsharded_model_weight.local_tensor.shape == (64, 64)
+    unsharded_parameter = parameter_group.fsdp_parameters[0].unsharded
+    assert unsharded_parameter._rowwise_data.data_ptr() == (
+        parameter_group._unsharded_model_weight.local_tensor._rowwise_data.data_ptr()
+    )
+    assert unsharded_parameter._rowwise_data.data_ptr() != original_rowwise_data.data_ptr()
 
     optimizer = torch.optim.SGD(linear.parameters(), lr=0.1)
     fully_shard_optimizer(optimizer)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -953,10 +953,10 @@ def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     loss = model(x).sum()
 
     assert group._unsharded_model_weight is not None
-    assert group._unsharded_model_weight.tensor.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight.local_tensor.untyped_storage().nbytes() == 0
 
     loss.backward()
 
     assert group.main_grad is not None
     assert group._unsharded_model_weight is not None
-    assert group._unsharded_model_weight.tensor.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight.local_tensor.untyped_storage().nbytes() == 0

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -953,10 +953,10 @@ def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     loss = model(x).sum()
 
     assert group._unsharded_model_weight is not None
-    assert group._unsharded_model_weight.local_buffer.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight.tensor.untyped_storage().nbytes() == 0
 
     loss.backward()
 
     assert group.main_grad is not None
     assert group._unsharded_model_weight is not None
-    assert group._unsharded_model_weight.local_buffer.untyped_storage().nbytes() == 0
+    assert group._unsharded_model_weight.tensor.untyped_storage().nbytes() == 0


### PR DESCRIPTION
## Description

Stacked on #6978. Teaches experimental `DBuffer` to retain a Transformer Engine `MXFP8Tensor` logical wrapper rather than introducing a parallel grouped-buffer class. The wrapper remains the source of truth for rowwise/columnwise data and scale-inverse tensors.

The implementation keeps independent DBuffer instances for model, post-optimizer, and unsharded weight state. In the ZeRO-1 direction, the sharded post-optimizer MXFP8 wrapper is all-gathered into the replicated compute wrapper.

## Testing

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q --capture=fd tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py` (GB200; 25 passed, 6 skipped)
- `ruff check` on modified files