### PR TITLE
fix(cuda_graphs): make_weakref RuntimeError fallback raises NameError/UnboundLocalError instead of keeping a strong ref

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -477,9 +477,10 @@ def make_weakref(ten, inplace=True):
         # Fallback to keeping a strong reference. There is a known bug where some
         # dtypes (e.g. torch.float64) are not mapped to a representation in
         # transformer_engine/pytorch/utils.py.
+        wr = ten
         if torch.distributed.get_rank() == 0:
             logger.warning(
-                f"Could not create weak ref for tensor with dtype {arg.dtype}; "
+                f"Could not create weak ref for tensor with dtype {ten.dtype}; "
                 f"keeping strong ref with a potential memory overhead."
             )
 


### PR DESCRIPTION
`make_weakref` in `megatron/core/transformer/cuda_graphs.py` has a `try/except RuntimeError`
whose fallback path cannot run — in two independent ways.

```python
def make_weakref(ten, inplace=True):
    ...
    try:
        wr = make_weak_ref(ten)
        if inplace:
            ten.data = wr
            wr = ten

    except RuntimeError:
        # Fallback to keeping a strong reference. There is a known bug where some
        # dtypes (e.g. torch.float64) are not mapped to a representation in
        # transformer_engine/pytorch/utils.py.
        if torch.distributed.get_rank() == 0:
            logger.warning(
                f"Could not create weak ref for tensor with dtype {arg.dtype}; "   # (1)
                f"keeping strong ref with a potential memory overhead."
            )

    return wr                                                                       # (2)
```

1. **`arg` does not exist.** The parameter is `ten`; `arg` is not bound anywhere in the function
   or the module (`pyflakes` reports `482:68: undefined name 'arg'` — the only undefined name in
   the file). On rank 0 the handler raises `NameError` instead of logging.
2. **`wr` is never assigned on this path.** `wr = make_weak_ref(ten)` is the statement that
   raised, so `return wr` raises `UnboundLocalError`. The comment says the fallback keeps a
   strong reference, but nothing assigns one.

So the fallback fails on *every* rank, just with a different exception:

```
### TE make_weak_ref raises RuntimeError (float64) -> the documented fallback path
-- torch.distributed.get_rank() == 0
    [before] NameError: name 'arg' is not defined
    [after]  logger.warning: Could not create weak ref for tensor with dtype torch.float64;
             keeping strong ref with a potential memory overhead.
             returned strong ref? True  dtype=torch.float64
-- torch.distributed.get_rank() == 1
    [before] UnboundLocalError: cannot access local variable 'wr' where it is not associated with a value
    [after]  returned strong ref? True  dtype=torch.float64
```

(`make_weakref` is lifted out of the real file with `ast` and run against a `make_weak_ref` stub
that raises `RuntimeError`, i.e. the TE dtype-mapping bug the comment names.)

The path is not hypothetical — the comment documents it as a *known* TE bug for dtypes such as
`torch.float64`. When it is hit, a CUDA-graph capture aborts with a confusing `NameError` /
`UnboundLocalError` rather than degrading to a strong reference as designed.

### Fix

Two lines in the handler: bind `wr = ten` (the strong reference the comment describes) and
report `ten.dtype`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
