### PR TITLE
[Dev] fix: scale DSA indexer scoring backward for sparse indexer loss in FLOPs

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -421,7 +421,15 @@ def _dsa_sparse_core_scale(total_real_tokens, seqlen_squared_sum, dsa_indexer_to
 
 
 def _dsa_indexer_flops(
-    *, hidden_size, q_lora_rank, n_heads, head_dim, num_indexer_layers, indexer_loss_coeff
+    *,
+    hidden_size,
+    q_lora_rank,
+    n_heads,
+    head_dim,
+    num_indexer_layers,
+    dsa_indexer_loss_coeff,
+    dsa_indexer_use_sparse_loss=False,
+    sparse_core_scale=1.0,
 ):
     """DSA lightning-indexer FLOPs coefficients, fwd/bwd expansion included.
 
@@ -448,12 +456,27 @@ def _dsa_indexer_flops(
       * loss on  -> the projections (wq_b / wk / weights_proj) read a detached
         input, so autograd skips their dgrad and they pay fwd + wgrad = 2x.
         The scoring GEMM has two activation operands that both need gradients
-        to reach those weights, so it pays fwd + dq + dk = 3x.
+        to reach those weights, so it pays fwd + dq + dk. Forward scoring is
+        always dense (top-k selection needs every score). How much of the
+        backward is dense depends on the loss variant:
+
+          - dense KL (``dsa_indexer_use_sparse_loss=False``, the default):
+            every causal (query, key) pair carries a gradient, so
+            dq + dk are dense too and the scoring pays 3x.
+          - sparse KL (``dsa_indexer_use_sparse_loss=True``): the KL is
+            taken over the selected top-k keys only, so the score gradient is
+            zero outside them and dq + dk span just the top-k pairs. The
+            scoring pays ``1 + 2 * sparse_core_scale``, with
+            ``sparse_core_scale`` the same top-k / dense pair ratio that
+            ``_dsa_sparse_core_scale`` applies to core attention. The fused
+            cuDNN backend (``_compute_sparse_indexer_loss_and_grads``)
+            executes exactly this sparse backward; the reference PyTorch path
+            multiplies a dense zero-padded gradient instead, which is an
+            implementation detail and, like the dense-masked reference
+            attention, does not enter the model FLOPs count.
 
     Whether the indexer is trained is part of the training procedure rather
-    than the kernel schedule, so it belongs in this model-FLOPs count. (With
-    ``dsa_indexer_use_sparse_loss`` the scoring backward only covers the top-k
-    entries, which the 3x does not model; it defaults to False.)
+    than the kernel schedule, so it belongs in this model-FLOPs count.
 
     Returns ``(token_linear, core)`` INCLUDING the fwd/bwd and FMA factors.
     Multiply ``token_linear`` by the real token count and ``core`` by
@@ -473,10 +496,18 @@ def _dsa_indexer_flops(
     # Scoring each query against every past token under a causal mask (/2).
     core = num_indexer_layers * index_dim / 2
     fma_expansion_factor = 2
-    loss_enabled = (indexer_loss_coeff or 0.0) > 0
+    loss_enabled = (dsa_indexer_loss_coeff or 0.0) > 0
+    if not loss_enabled:
+        token_expansion, core_expansion = 1, 1
+    else:
+        # Projections: fwd + wgrad (input is detached, no dgrad).
+        token_expansion = 2
+        # Scoring: dense fwd + dq + dk, where dq/dk cover only the top-k pairs
+        # under the sparse KL loss (see docstring).
+        core_expansion = 1 + 2 * (sparse_core_scale if dsa_indexer_use_sparse_loss else 1.0)
     return (
-        (2 if loss_enabled else 1) * fma_expansion_factor * token_linear,
-        (3 if loss_enabled else 1) * fma_expansion_factor * core,
+        token_expansion * fma_expansion_factor * token_linear,
+        core_expansion * fma_expansion_factor * core,
     )
 
 
@@ -1337,6 +1368,9 @@ def num_floating_point_operations(
             linear_self_attn_term = 0
             num_standard_attention_layers = num_layers
 
+            dsa_sparse_core_scale = _dsa_sparse_core_scale(
+                total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
+            )
             standard_self_attn_core_term = (
                 forward_backward_expansion_factor
                 * fma_expansion_factor
@@ -1344,9 +1378,7 @@ def num_floating_point_operations(
                     args.num_attention_heads * (args.kv_lora_rank + args.qk_pos_emb_head_dim) / 2
                     + args.num_attention_heads * args.kv_lora_rank / 2
                 )
-                * _dsa_sparse_core_scale(
-                    total_real_tokens_in_batch, seqlen_squared_sum_in_batch, args.dsa_indexer_topk
-                )
+                * dsa_sparse_core_scale
             )
             dsa_extra_term, dsa_extra_core_term = _dsa_indexer_flops(
                 hidden_size=args.hidden_size,
@@ -1356,7 +1388,9 @@ def num_floating_point_operations(
                 num_indexer_layers=_num_dsa_indexer_layers(
                     num_layers, args.dsa_indexer_skip_topk_offset, args.dsa_indexer_topk_freq
                 ),
-                indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_loss_coeff=args.dsa_indexer_loss_coeff,
+                dsa_indexer_use_sparse_loss=getattr(args, "dsa_indexer_use_sparse_loss", False),
+                sparse_core_scale=dsa_sparse_core_scale,
             )
         else:
             num_linear_attention_layers = 0

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -1174,7 +1174,7 @@ class TestDSv4HybridMatchesStandard:
         assert hyb_flops == std_flops
 
 
-def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
+def _make_dsa_args(dsa_indexer_loss_coeff=0.01, dsa_indexer_use_sparse_loss=False):
     """Minimal MLA + DSA args (GLM-5.2 style, small scale).
 
     Uses ``dsa_indexer_topk_freq=1`` and ``dsa_indexer_skip_topk_offset=0``
@@ -1185,6 +1185,8 @@ def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
     ``dsa_indexer_loss_coeff`` drives the indexer's fwd/bwd expansion: the
     indexer only has a backward pass when its KL loss is enabled. The default
     here matches the in-tree functional test configs.
+    ``dsa_indexer_use_sparse_loss`` selects the sparse (top-k only) KL
+    variant, which shrinks the scoring backward to the selected pairs.
     """
     args = _make_gpt_args(
         num_layers=4,
@@ -1208,6 +1210,7 @@ def _make_dsa_args(dsa_indexer_loss_coeff=0.01):
     args.dsa_indexer_topk_freq = 1
     args.dsa_indexer_skip_topk_offset = 0
     args.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+    args.dsa_indexer_use_sparse_loss = dsa_indexer_use_sparse_loss
     return args
 
 
@@ -1263,8 +1266,15 @@ def _dsa_golden_flops(args, total_tokens, seqlen_squared_sum, num_indexer_layers
     idx_core = num_indexer_layers * idx_dim / 2
     # The indexer only runs a backward pass when its KL loss is on, and its
     # inputs are detached: projections pay fwd + wgrad, scoring pays fwd + dq + dk.
+    # Forward scoring is always dense; with the sparse KL loss the score
+    # gradient is nonzero only on the top-k pairs, so dq + dk shrink by the
+    # same top-k / dense pair ratio as core attention.
     if (args.dsa_indexer_loss_coeff or 0.0) > 0:
-        idx_token_expansion, idx_core_expansion = 2, 3
+        idx_token_expansion = 2
+        if getattr(args, "dsa_indexer_use_sparse_loss", False):
+            idx_core_expansion = 1 + 2 * sparse_scale
+        else:
+            idx_core_expansion = 3
     else:
         idx_token_expansion, idx_core_expansion = 1, 1
     dsa_extra_token = idx_token_expansion * fma * idx_token
@@ -1333,6 +1343,47 @@ class TestDSA:
         # A frozen indexer must cost strictly less than a trained one.
         assert flops < num_floating_point_operations(_make_dsa_args(0.01), batch_size)
 
+    @pytest.mark.parametrize("seq_length", [256, 8192])
+    def test_sparse_indexer_loss_shrinks_scoring_backward(self, seq_length):
+        """``dsa_indexer_use_sparse_loss`` only back-propagates through the
+        top-k scores, so the indexer scoring backward must scale with the
+        top-k pair ratio instead of staying dense (3x).
+
+        With ``seq_length <= topk`` top-k selects everything and both loss
+        variants must agree exactly; past top-k the sparse variant must be
+        strictly cheaper and still match the golden calculator.
+        """
+        batch_size = 2
+        total_tokens = batch_size * seq_length
+        sum_sq = batch_size * seq_length**2
+
+        dense_args = _make_dsa_args(dsa_indexer_use_sparse_loss=False)
+        sparse_args = _make_dsa_args(dsa_indexer_use_sparse_loss=True)
+        dense_args.seq_length = sparse_args.seq_length = seq_length
+
+        dense = num_floating_point_operations(dense_args, batch_size)
+        sparse = num_floating_point_operations(sparse_args, batch_size)
+        assert sparse == _dsa_golden_flops(sparse_args, total_tokens, sum_sq)
+        if seq_length <= sparse_args.dsa_indexer_topk:
+            assert sparse == dense
+        else:
+            assert sparse < dense
+            # The sparse backward still costs more than a frozen indexer.
+            frozen = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True)
+            frozen.seq_length = seq_length
+            assert sparse > num_floating_point_operations(frozen, batch_size)
+
+    def test_sparse_loss_ignored_without_indexer_loss(self):
+        """Sparse vs dense KL is moot when the indexer loss is off: the
+        indexer is forward-only either way and the flag must not change the
+        count."""
+        batch_size = 2
+        off_dense = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=False)
+        off_sparse = _make_dsa_args(dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True)
+        assert num_floating_point_operations(off_dense, batch_size) == (
+            num_floating_point_operations(off_sparse, batch_size)
+        )
+
     def test_cross_layer_index_sharing(self):
         """Only layers that compute their own top-k index pay for the indexer.
 
@@ -1394,8 +1445,42 @@ class TestDSAHelperEdgeCases:
             n_heads=4,
             head_dim=32,
             num_indexer_layers=0,
-            indexer_loss_coeff=0.01,
+            dsa_indexer_loss_coeff=0.01,
         ) == (0, 0)
+
+    def test_indexer_flops_sparse_loss_expansion(self):
+        """Direct check of the fwd/bwd expansion factors on the scoring term:
+        dense KL pays 3x, sparse KL pays ``1 + 2 * sparse_core_scale``, and a
+        frozen indexer pays 1x regardless of the loss variant."""
+        from megatron.training.training import _dsa_indexer_flops
+
+        common = dict(
+            hidden_size=512, q_lora_rank=128, n_heads=4, head_dim=32, num_indexer_layers=1
+        )
+        fma = 2
+        core = 4 * 32 / 2
+        _, off = _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.0)
+        _, dense = _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.01)
+        _, sparse = _dsa_indexer_flops(
+            **common,
+            dsa_indexer_loss_coeff=0.01,
+            dsa_indexer_use_sparse_loss=True,
+            sparse_core_scale=0.25,
+        )
+        _, sparse_dense_scale = _dsa_indexer_flops(
+            **common,
+            dsa_indexer_loss_coeff=0.01,
+            dsa_indexer_use_sparse_loss=True,
+            sparse_core_scale=1.0,
+        )
+        assert off == 1 * fma * core
+        assert dense == 3 * fma * core
+        assert sparse == (1 + 2 * 0.25) * fma * core
+        assert sparse_dense_scale == dense
+        # The flag is a no-op without the loss.
+        assert _dsa_indexer_flops(
+            **common, dsa_indexer_loss_coeff=0.0, dsa_indexer_use_sparse_loss=True
+        ) == _dsa_indexer_flops(**common, dsa_indexer_loss_coeff=0.0)
 
     def test_sparse_core_scale_degenerate_inputs(self):
         """Zero tokens or an unset top-k fall back to the dense scale of 1.0."""


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Follow-up to #6753. That PR charged the DSA lightning-indexer scoring pass
`fwd + dq + dk = 3x` whenever `dsa_indexer_loss_coeff > 0`, regardless of
which KL variant is used. With `--dsa-indexer-use-sparse-loss` the KL is
taken over the selected top-k keys only, so the score gradient is zero
outside them and dq/dk of the scoring GEMM only span `sum_i(min(i, topk))`
pairs instead of the dense causal `L^2 / 2`. The fused cuDNN backend
(`_compute_sparse_indexer_loss_and_grads` -> `_run_sparse_indexer_backward`)
executes exactly this sparse backward. #6753 acknowledged this in the
docstring ("which the 3x does not model") but did not account for it.

Since the indexer's dense O(L^2) scoring dominates the quadratic term at
long context (the main attention core is already top-k scaled), the
overcount is close to 3x on that term. GLM-5.2 example (indexer 32 heads x
128, topk 2048, 128K sequence): indexer scoring coefficient drops from
`3 * 2048` to `(1 + 2 * 0.031) * 2048` per layer.

## Changes

- `_dsa_indexer_flops` takes `dsa_indexer_use_sparse_loss` and
  `sparse_core_scale` (the same top-k / dense pair ratio
  `_dsa_sparse_core_scale` applies to core attention). Scoring expansion:
  - indexer loss off: 1x (unchanged)
  - dense KL (`dsa_indexer_use_sparse_loss=False`, default): 3x (unchanged)
  - sparse KL (`dsa_indexer_use_sparse_loss=True`): `1 + 2 * sparse_core_scale`
- Parameters renamed to match the corresponding `args`
  (`dsa_indexer_loss_coeff`, `dsa_indexer_use_sparse_loss`).
- Caller computes `_dsa_sparse_core_scale` once and shares it between core
  attention and the indexer.
- Docstring rewritten to describe both loss variants; the reference PyTorch
  path multiplies a dense zero-padded gradient, which is an implementation
  detail and, like dense-masked reference attention, not part of the model
  FLOPs count.

Default configs (`dsa_indexer_use_sparse_loss=False`) produce identical
numbers to before.

## Tests

`tests/unit_tests/test_num_floating_point_operations.py`:
- golden calculator follows the same rule
- `test_sparse_indexer_loss_shrinks_scoring_backward[256|8192]`: sparse ==
  dense at `L <= topk`; strictly smaller past topk and still above a frozen
  indexer
- `test_sparse_loss_ignored_without_indexer_loss`: flag is a no-op when the
  indexer loss is off
- `test_indexer_flops_sparse_loss_expansion`: direct check of the 1x / 3x /
  `1 + 2 * scale` factors

Ran the file in the CI `dev` container on a GB200 node:
`57 passed, 8 skipped` (skips are the 8-rank `TestAccumulatorTopology`
cases on a 4-GPU node).

## Not covered

The teacher-side attention score recompute inside the indexer KL loss
(dense over all keys, or top-k only under the sparse variant) is still not
counted, consistent with #6753's rule of excluding auxiliary-loss work.