### PR TITLE
fix(gtp): expert grads overscaled by GTP/EGTP

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import warnings
 from functools import partial
 from typing import Callable, Dict, List, Optional, Union
 
@@ -491,6 +492,56 @@ maintain for legacy tests. We can remove this proxy in mcore 0.14.
 _allreduce_layernorm_grads = _allreduce_non_tensor_model_parallel_grads
 
 
+def _rescale_expert_grads_for_gtp_remat(
+    model, gtp_remat_group, egtp_remat_group, calculate_per_token_loss
+):
+    """Give expert grads the share of the DP normalization that GTP took away.
+
+    GTP carves its ranks out of the data-parallel axis, so DDP's 1/DP scaling shrinks as GTP
+    grows. Dense params get the missing factor back from the gtp_remat AVG below. Expert params
+    only ever see compensation sized to the EGTP axis — the AVG when they are unsharded and
+    EGTP > 1, or the reduce-scatter mean when they are EGTP-sharded — so a factor GTP/EGTP is
+    left over and their gradients come out that many times too large.
+
+
+    A scalar divide is the right operation rather than an average: within one dense gtp_remat
+    group the ranks hold DIFFERENT experts (ranks 0 and 2 of [0,2,4,6] sit at ep 0 and ep 2),
+    so there is no replica-consistency requirement along that axis. The ranks that do share an
+    expert live in the same expert-DP group and DDP has already made them agree; scaling both
+    by the same constant keeps them agreeing.
+
+    Skipped under calculate_per_token_loss, where the gtp axis is SUM-reduced and the per-token
+    divisor already counts the gtp peers' tokens.
+
+    EGTP > GTP is not handled. Whether it needs the inverse factor depends on whether the dense
+    and expert target denominators should agree when EP > 1, which is not settled here; it warns
+    instead of silently doing nothing, since a silent no-op is the failure mode this function
+    exists to fix.
+    """
+    if calculate_per_token_loss:
+        return
+    gtp = gtp_remat_group.size() if gtp_remat_group is not None else 1
+    egtp = egtp_remat_group.size() if egtp_remat_group is not None else 1
+    if gtp == egtp:
+        return
+    if gtp < egtp:
+        warnings.warn(
+            f"expert_gtp_remat ({egtp}) is wider than gtp_remat ({gtp}); the expert-grad DP "
+            "compensation for this layout is not implemented and expert gradients are left as "
+            "the EGTP reduce-scatter produced them."
+        )
+        return
+    scale = 1.0 / (gtp / egtp)
+    for model_chunk in model:
+        for name, param in get_attr_wrapped_model(model_chunk, 'named_parameters')():
+            if not param.requires_grad or getattr(param, 'allreduce', True):
+                continue
+            grad = getattr(param, _get_main_grad_attr(param), None)
+            if grad is None:
+                continue
+            _unshard_if_dtensor(grad).data.mul_(scale)
+
+
 def _allreduce_replicated_grads_over_gtp_remat_group(
     model: List[torch.nn.Module],
     gtp_remat_group: Optional[torch.distributed.ProcessGroup],
@@ -659,6 +710,9 @@ def finalize_model_grads(
             barrier=config.barrier_with_L1_time
         )
     _allreduce_non_tensor_model_parallel_grads(model, config, tp_group)
+    _rescale_expert_grads_for_gtp_remat(
+        model, gtp_remat_group, egtp_remat_group, config.calculate_per_token_loss
+    )
     _allreduce_replicated_grads_over_gtp_remat_group(
         model,
         gtp_remat_group,

--- a/tests/unit_tests/distributed/test_gtp_expert_grad_rescale.py
+++ b/tests/unit_tests/distributed/test_gtp_expert_grad_rescale.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Cover the GTP/EGTP share of the DP normalization for expert gradients.
+
+GTP carves its ranks out of the data-parallel axis, so DDP's 1/DP scaling shrinks as GTP
+grows. Dense params get the missing factor back from the gtp_remat AVG in finalize_model_grads;
+expert params only ever see compensation sized to the EGTP axis, leaving a factor GTP/EGTP by
+which their gradients come out too large.
+
+The failure is silent -- no error, no NaN, just expert gradients off by a constant -- so it is
+invisible in a short run and only shows up as a convergence difference much later. These tests
+pin the arithmetic directly, on CPU, without a process group.
+"""
+
+import pytest
+import torch
+
+from megatron.core.distributed.finalize_model_grads import _rescale_expert_grads_for_gtp_remat
+
+
+class _Group:
+    """Stands in for a process group: the function only ever asks for its size."""
+
+    def __init__(self, size):
+        self._size = size
+
+    def size(self):
+        return self._size
+
+
+class _Model(torch.nn.Module):
+    """One dense param and one expert param, each carrying a main_grad of ones.
+
+    `allreduce=False` is what marks a param as expert-parallel in Megatron; the dense param
+    keeps the default and must not be touched.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.dense = torch.nn.Parameter(torch.zeros(4))
+        self.expert = torch.nn.Parameter(torch.zeros(4))
+        self.expert.allreduce = False
+        self.dense.main_grad = torch.ones(4)
+        self.expert.main_grad = torch.ones(4)
+
+
+def _run(gtp, egtp, per_token_loss=False):
+    model = _Model()
+    _rescale_expert_grads_for_gtp_remat(
+        [model],
+        _Group(gtp) if gtp is not None else None,
+        _Group(egtp) if egtp is not None else None,
+        per_token_loss,
+    )
+    return model
+
+
+@pytest.mark.parametrize(
+    "gtp,egtp,expected", [(4, 1, 0.25), (4, 2, 0.5), (8, 2, 0.25), (2, 1, 0.5)]
+)
+def test_expert_grads_get_back_the_gtp_over_egtp_factor(gtp, egtp, expected):
+    model = _run(gtp, egtp)
+    assert torch.allclose(model.expert.main_grad, torch.full((4,), expected))
+
+
+@pytest.mark.parametrize("gtp,egtp", [(4, 1), (4, 2), (8, 2)])
+def test_dense_grads_are_left_alone(gtp, egtp):
+    """Dense params are compensated by the gtp_remat AVG, so touching them here double-counts."""
+    model = _run(gtp, egtp)
+    assert torch.allclose(model.dense.main_grad, torch.ones(4))
+
+
+@pytest.mark.parametrize(
+    "gtp,egtp",
+    [
+        (1, 1),  # no GTP at all
+        (4, 4),  # every gtp rank is also an egtp rank: nothing is left over
+        (None, None),  # groups absent entirely
+    ],
+)
+def test_no_rescale_when_gtp_does_not_exceed_egtp(gtp, egtp):
+    model = _run(gtp, egtp)
+    assert torch.allclose(model.expert.main_grad, torch.ones(4))
+    assert torch.allclose(model.dense.main_grad, torch.ones(4))
+
+
+def test_egtp_wider_than_gtp_warns_instead_of_silently_skipping():
+    # The inverse compensation for this layout is deliberately not implemented; what must not
+    # happen is a silent no-op, which is exactly the failure mode the rescale exists to fix.
+    with pytest.warns(UserWarning, match="wider than gtp_remat"):
+        model = _run(2, 4)
+    assert torch.allclose(model.expert.main_grad, torch.ones(4))
+    assert torch.allclose(model.dense.main_grad, torch.ones(4))
+
+
+def test_per_token_loss_is_skipped():
+    """Under calculate_per_token_loss the gtp axis is SUM-reduced and the per-token divisor
+    already counts the gtp peers' tokens, so rescaling here would divide twice."""
+    model = _run(4, 1, per_token_loss=True)
+    assert torch.allclose(model.expert.main_grad, torch.ones(4))
+
+
+def test_params_without_a_grad_are_skipped():
+    model = _Model()
+    del model.expert.main_grad
+    _rescale_expert_grads_for_gtp_remat([model], _Group(4), _Group(1), False)
+    assert not hasattr(model.expert, "main_grad")
+
+
+def test_frozen_expert_params_are_skipped():
+    model = _Model()
+    model.expert.requires_grad = False
+    _rescale_expert_grads_for_gtp_remat([model], _Group(4), _Group(1), False)
+    assert torch.allclose(model.expert.main_grad, torch.ones(4))


### PR DESCRIPTION
## What does this PR do?

Under GTP with MoE, expert gradients carry a spurious factor of `GTP/EGTP`; dense gradients are unaffected. With the default `EGTP = 1` that is a factor of `GTP` on every expert update. The failure is silent -- no error, no NaN -- and surfaces only as a convergence gap.

GTP carves its ranks out of the data-parallel axis, so DDP's `1/DP` scaling shrinks as GTP grows. Dense params recover the missing factor from the AVG over `gtp_remat` in `_allreduce_replicated_grads_over_gtp_remat_group`. Expert params only ever see compensation sized to the EGTP axis, so a factor of `GTP/EGTP` is never removed.

## Fix

`_rescale_expert_grads_for_gtp_remat()` multiplies expert grads (`allreduce=False`) by `EGTP/GTP`, after the non-TP all-reduce and before the `gtp_remat` AVG.

A scalar multiply rather than an AVG over `gtp_remat`: within one dense `gtp_remat` group the ranks hold different experts, so there is no replica to agree with along that axis. The ranks that do share an expert are in the same expert-DP group and already agree; scaling both by the same constant keeps them agreeing.

Skipped under `calculate_per_token_loss`, where the gtp axis is SUM-reduced and the per-token divisor already counts the gtp peers' tokens.

## Known limit

`EGTP > GTP` is not handled; it warns instead of silently doing nothing. Not reachable with the default `EGTP = 1`.
