### PR TITLE
fix(gtp): correct expert gradient scaling for GTP/EGTP mismatch (non-per-token-loss)

### DIFF
--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -520,11 +520,12 @@ Under **full-iteration CUDA graphs** the recompute-forward is captured; `wait_as
 
 ![DDP + (E)GTP_remat interaction with the distributed optimizer](../../images/generalized_tensor_parallel/0611_ddp_egtp_orthogonal_bucketing.png)
 
-**(E)GTP_remat is *super loosely coupled* to DDP and the distributed optimizer — they stay completely GTP_remat-agnostic.** GTP_remat is just another sub-axis of the rank grid (`world = TP×CP×GTP_remat×DP`); a GTP_remat-sharded weight rides the *exact same* code path as an ordinary param. There are **no** GTP_remat/EGTP_remat-specific buffers, optimizers, gradient-scaling factors, or bucket groups. The entire DDP/DistOpt stack touches GTP_remat in only **three** narrow places:
+**(E)GTP_remat is *super loosely coupled* to DDP and the distributed optimizer — they stay almost completely GTP_remat-agnostic.** GTP_remat is just another sub-axis of the rank grid (`world = TP×CP×GTP_remat×DP`); a GTP_remat-sharded weight rides the *exact same* code path as an ordinary param. There are **no** GTP_remat/EGTP_remat-specific buffers, optimizers, or bucket groups, and just **one** GTP_remat-specific gradient-scaling factor (the expert-buffer correction below). The entire DDP/DistOpt stack touches GTP_remat in only **four** narrow places:
 
 1. **finalize all-reduce** (`_allreduce_replicated_grads_over_gtp_remat_group`) — completes the gtp_remat axis for *replicated* (non-GTP_remat) params (SUM under `calculate_per_token_loss`, AVG otherwise; see §3.2 table); a no-op when GTP_remat is inactive.
 2. **`is_gtp_weight_remat` / `allreduce` tags** propagated onto the optimizer's master shards — consumed only by the grad-norm dedup filter.
 3. **grad-ready hook routing** (`DistributedDataParallel.__init__`) — for a GTP_remat param, DDP registers its backward post-hook via GTP_remat's `register_grad_accum_hook` instead of autograd's `AccumulateGrad`. GTP_remat fires it from `_handle_megatron_grad_accum` **after** the per-param `{wgrad RS → main_grad add}`. This enforces the invariant below; a no-op (plain autograd path) when GTP_remat is inactive.
+4. **expert-buffer prescale correction** (`expert_gradient_scaling_factor`, `DistributedDataParallel.__init__`) — only applies when `calculate_per_token_loss=False` (the SUM/`÷total_global_tokens` path needs no such correction; see §3.2 table). On that path, expert params can't recover the DDP pre-scale's `1/gtp_remat` shrinkage via the finalize AVG above (ranks within one gtp_remat group hold *different* experts, so averaging their grads would be wrong); they instead recover only `expert_gtp_remat`'s worth via the analogous EGTP-remat finalize, so the prescale folds in an `egtp_remat/gtp_remat` correction to make up the rest. `1.0` — a no-op — when `gtp_remat == egtp_remat` or GTP_remat is inactive.
 
 #### Ordering invariants
 
@@ -556,7 +557,7 @@ Everything else — bucketing, the reduce-scatter/all-reduce schedule and its ov
 - **Free reuse of a mature stack.** GTP_remat inherits DDP's bucketing + comm/compute overlap, the distributed optimizer's fp32-master + Adam-moment sharding, grad-norm/clip, and the existing checkpoint format — no parallel re-implementation to write or maintain (contrast FSDP, which replaces all of these).
 - **Orthogonal composability.** Because GTP_remat is a rank-grid sub-axis cut along `out_features` (dim 0, whichever axis TP used), it composes with TP/EP/CP/PP and the DistOpt the same way TP does — no special nesting logic.
 - **Zero-cost when off.** With GTP_remat disabled the gtp_remat axis is size-1 and the hooks become no-ops, so non-GTP_remat runs hit byte-identical behavior — GTP_remat can be toggled without forking the DDP/optimizer code paths.
-- **Small, auditable surface.** These three hooks are the whole integration contract, which is what makes the correctness argument below tractable.
+- **Small, auditable surface.** These four hooks are the whole integration contract, which is what makes the correctness argument below tractable.
 
 #### Bucketing and gradient scaling
 
@@ -566,12 +567,14 @@ The DP collective only covers the replicate axis; the gtp_remat axis is complete
 
 | | `calculate_per_token_loss=False` (default) | `calculate_per_token_loss=True` |
 |---|---|---|
-| DDP pre-scale (`gradient_scaling_factor`) | `1/replicate` (= `1/dp_cp_group.size()`) | `1.0` (no pre-scale) |
+| DDP pre-scale, dense buffer (`gradient_scaling_factor`) | `1/replicate` (= `1/dp_cp_group.size()`) | `1.0` (no pre-scale) |
+| DDP pre-scale, expert buffer (`expert_gradient_scaling_factor`) | `1/replicate × (egtp_remat/gtp_remat)` | `1.0` (no pre-scale) |
 | gtp_remat reduce-scatter (sharded weights) | **MEAN** (pre-scale wgrad by `1/gtp_remat`) | **SUM** (plain reduce-scatter) |
 | finalize over gtp_remat (replicated params) | **AVG** all-reduce | **SUM** all-reduce |
 | final normalization | net grad = full `(replicate × gtp_remat)` **mean** | grads summed over all axes, then `÷ total_global_tokens` in `finalize_model_grads` |
 
 - **Default (mean) path** decouples gradient scaling from the gtp_remat degree: the DP `1/replicate` mean × the reduce-scatter `1/gtp_remat` mean (sharded weights) — or × the finalize AVG (replicated params) — equals the exact full mean, independent of the gtp_remat axis size.
+- **Expert buffer needs an extra `egtp_remat/gtp_remat` correction** because the finalize step it gets is EGTP-remat's AVG, not GTP_remat's — a gtp_remat group's ranks hold *different* experts, so an AVG across the full gtp_remat axis (mixing different experts' grads) would be wrong; only EGTP_remat peers hold the *same* expert's replica. That AVG only recovers `1/egtp_remat` of the `1/gtp_remat` the dense-buffer pre-scale assumed, so the expert pre-scale folds in `egtp_remat/gtp_remat` to make up the gap — a no-op (`=1.0`) whenever `gtp_remat == egtp_remat`, including the common case of GTP_remat off.
 - **`--gtp-remat-reduce-scatter-with-fp32-accumulation` swaps the collective, not the scaling**
   — this table applies unchanged (§2.6).
 - **Per-token-loss path** must SUM over gtp_remat (like the DP axis): `total_global_tokens` already counts the gtp_remat peers' distinct tokens, so the single `÷ total_global_tokens` does all normalization. A `1/gtp_remat` mean here would shrink every gtp_remat gradient by `1/gtp_remat` (grad-norm mismatch + divergence), so the reduce-scatter mean and finalize AVG are both gated on `not calculate_per_token_loss`.

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -248,6 +248,10 @@ class DistributedDataParallel(_BaseDataParallel):
             gradient_scaling_factor = 1.0
             expert_gradient_scaling_factor = 1.0
         else:
+            expert_gtp_correction = (
+                config.expert_gtp_weight_remat_size / config.gtp_weight_remat_size
+            )
+
             # The goal is to scale reduced gradients by 1/dp_size.
             # This can be achieved in two ways:
             #
@@ -269,14 +273,11 @@ class DistributedDataParallel(_BaseDataParallel):
             #   2. Do sum reduction across data parallel ranks
             #   3. Final result is scaled by 1/dp_size as desired
             #
-            #   GTP_remat correction (expert params only): dp_cp_group.size() is deliberately
-            #   shrunk by gtp_weight_remat_size (GTP ranks are carved out of the dp_cp axis;
-            #   see parallel_state.py's `model_size` comment). Dense params recover that factor
-            #   via the later gtp_remat-AVG completion. Expert params can't share that AVG:
-            #   ranks within one gtp_remat group hold DIFFERENT experts, so averaging their
-            #   grads would be wrong (see _allreduce_replicated_grads_over_gtp_remat_group).
-            #   They instead recover only expert_gtp_weight_remat_size worth of it, via the
-            #   analogous egtp_remat-AVG; the egtp/gtp ratio below makes up the rest.
+            #   GTP_remat correction (expert params only): dp_cp_group.size() is shrunk by
+            #   gtp_weight_remat_size. Dense params recover that via the later gtp_remat-AVG;
+            #   expert params instead go through the EGTP-remat-AVG (gtp_remat peers hold
+            #   different experts, so can't share that AVG), recovering only
+            #   expert_gtp_weight_remat_size of it -- the egtp/gtp ratio below makes up the rest.
             if self.ddp_config.average_in_collective:
                 gradient_scaling_factor = 1.0
                 expert_gradient_scaling_factor = self.expt_dp_group.size() / self.dp_cp_group.size()
@@ -284,9 +285,6 @@ class DistributedDataParallel(_BaseDataParallel):
                 data_parallel_world_size = self.dp_cp_group.size()
 
                 gradient_scaling_factor = 1.0 / data_parallel_world_size
-                expert_gtp_correction = (
-                    config.expert_gtp_weight_remat_size / config.gtp_weight_remat_size
-                )
                 expert_gradient_scaling_factor = (
                     1.0 / data_parallel_world_size
                 ) * expert_gtp_correction
@@ -323,9 +321,7 @@ class DistributedDataParallel(_BaseDataParallel):
                     # expert_gradient_scaling_factor above (1.0 when GTP_remat is inactive,
                     # matching non-expert params).
                     if buffer_key.is_expert_parallel:
-                        gtp = config.gtp_weight_remat_size
-                        egtp = config.expert_gtp_weight_remat_size
-                        target_gradient_scaling_factor *= egtp / gtp
+                        target_gradient_scaling_factor *= expert_gtp_correction
                     assert scaling_factor == target_gradient_scaling_factor
 
             param_layout = (

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -268,6 +268,15 @@ class DistributedDataParallel(_BaseDataParallel):
             #   1. Scale gradients by 1/dp_size before reduction
             #   2. Do sum reduction across data parallel ranks
             #   3. Final result is scaled by 1/dp_size as desired
+            #
+            #   GTP_remat correction (expert params only): dp_cp_group.size() is deliberately
+            #   shrunk by gtp_weight_remat_size (GTP ranks are carved out of the dp_cp axis;
+            #   see parallel_state.py's `model_size` comment). Dense params recover that factor
+            #   via the later gtp_remat-AVG completion. Expert params can't share that AVG:
+            #   ranks within one gtp_remat group hold DIFFERENT experts, so averaging their
+            #   grads would be wrong (see _allreduce_replicated_grads_over_gtp_remat_group).
+            #   They instead recover only expert_gtp_weight_remat_size worth of it, via the
+            #   analogous egtp_remat-AVG; the egtp/gtp ratio below makes up the rest.
             if self.ddp_config.average_in_collective:
                 gradient_scaling_factor = 1.0
                 expert_gradient_scaling_factor = self.expt_dp_group.size() / self.dp_cp_group.size()
@@ -275,7 +284,12 @@ class DistributedDataParallel(_BaseDataParallel):
                 data_parallel_world_size = self.dp_cp_group.size()
 
                 gradient_scaling_factor = 1.0 / data_parallel_world_size
-                expert_gradient_scaling_factor = 1.0 / data_parallel_world_size
+                expert_gtp_correction = (
+                    config.expert_gtp_weight_remat_size / config.gtp_weight_remat_size
+                )
+                expert_gradient_scaling_factor = (
+                    1.0 / data_parallel_world_size
+                ) * expert_gtp_correction
 
         # Allocate buffers for each group.
         self.buffers = []
@@ -305,6 +319,13 @@ class DistributedDataParallel(_BaseDataParallel):
                             scaling_factor == (self.expt_dp_group.size() / self.dp_cp_group.size())
                         )
                 else:
+                    # Expert params carry the extra egtp/gtp correction folded into
+                    # expert_gradient_scaling_factor above (1.0 when GTP_remat is inactive,
+                    # matching non-expert params).
+                    if buffer_key.is_expert_parallel:
+                        gtp = config.gtp_weight_remat_size
+                        egtp = config.expert_gtp_weight_remat_size
+                        target_gradient_scaling_factor *= egtp / gtp
                     assert scaling_factor == target_gradient_scaling_factor
 
             param_layout = (

--- a/tests/unit_tests/distributed/test_distributed_data_parallel.py
+++ b/tests/unit_tests/distributed/test_distributed_data_parallel.py
@@ -116,3 +116,83 @@ class TestDistributedDataParallel:
         for p1, p2 in zip(ddp_model1.parameters(), ddp_model2.parameters()):
             if hasattr(p1, 'main_grad') and hasattr(p2, 'main_grad'):
                 testing.assert_close(p1.main_grad, p2.main_grad, rtol=0, atol=0)
+
+
+class TestExpertGradientScalingFactorGTPRemat:
+    """Regression coverage for expert_gradient_scaling_factor's GTP_remat/EGTP_remat
+    correction, folded directly into DDP's one-time prescale computation (Case 2,
+    average_in_collective=False -- the only case reachable when GTP_remat is active).
+
+    dp_cp_group.size() is deliberately shrunk by gtp_weight_remat_size (see the comment in
+    DistributedDataParallel.__init__); the egtp/gtp correction is what keeps expert params on
+    the same 1/dp_size target as dense params despite that shrink. Applied unconditionally,
+    for any gtp vs egtp relationship -- both gtp>egtp and gtp<egtp need it.
+    """
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _scaling_factors(self, gtp, egtp):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            gtp_remat_size=gtp,
+            expert_gtp_remat_size=egtp,
+        )
+
+        class _TinyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dense = torch.nn.Linear(4, 4, bias=False)
+                self.expert = torch.nn.Linear(4, 4, bias=False)
+                self.expert.weight.allreduce = False
+
+        # gtp_weight_remat_size / expert_gtp_weight_remat_size are DERIVED fields (resolved in
+        # ModelParallelConfig.__post_init__ from the user-facing tensor_parallel_num_weight_shards
+        # / expert_tensor_parallel_num_weight_shards knobs) -- passing them directly is a no-op;
+        # this is also how production configs set them (core_transformer_config_from_args copies
+        # the user-facing knob from CLI args), so exercising the same path here is intentional,
+        # not just a workaround.
+        config = TransformerConfig(
+            num_attention_heads=1,
+            num_layers=1,
+            hidden_size=4,
+            tensor_parallel_num_weight_shards=gtp,
+            expert_tensor_parallel_num_weight_shards=egtp,
+        )
+        ddp_config = DistributedDataParallelConfig(
+            use_distributed_optimizer=False, overlap_grad_reduce=False
+        )
+        ddp_model = DistributedDataParallel(config, ddp_config, _TinyModel().cuda())
+        assert len(ddp_model.expert_parallel_buffers) == 1
+        assert len(ddp_model.buffers) == 1
+        return (
+            ddp_model.buffers[0].gradient_scaling_factor,
+            ddp_model.expert_parallel_buffers[0].gradient_scaling_factor,
+            ddp_model.dp_cp_group.size(),
+        )
+
+    @pytest.mark.parametrize(
+        "gtp,egtp,expected_correction",
+        [
+            (2, 1, 0.5),  # gtp > egtp: dense-only GTP, replicated experts
+            (4, 1, 0.25),  # gtp > egtp: wider gap
+            (4, 2, 0.5),  # gtp > egtp: both axes active, still gtp != egtp
+            (2, 2, 1.0),  # matched (gtp == egtp): correction collapses to 1.0
+            (1, 1, 1.0),  # GTP_remat inactive entirely
+            (1, 2, 2.0),  # gtp < egtp: EGTP-sharded experts, GTP_remat inactive
+            (2, 4, 2.0),  # gtp < egtp: wider gap
+        ],
+    )
+    def test_expert_scaling_factor_gets_the_egtp_over_gtp_correction(
+        self, gtp, egtp, expected_correction
+    ):
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        dense_factor, expert_factor, dp_cp_size = self._scaling_factors(gtp, egtp)
+        assert dense_factor == 1.0 / dp_cp_size
+        assert expert_factor == (1.0 / dp_cp_size) * expected_correction, (
+            f"gtp={gtp} egtp={egtp}: expert_gradient_scaling_factor={expert_factor} != "
+            f"(1/dp_cp_group.size()={1.0/dp_cp_size}) * (egtp/gtp={expected_correction})"
+        )

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
@@ -269,7 +269,12 @@ def _build_ddp_distopt_and_optim(
     from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
     from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 
-    config = _make_config()
+    # The stack's own layers already carry the config they were built with (including
+    # gtp_weight_remat_size/expert_gtp_weight_remat_size/expert_model_parallel_size, set
+    # correctly by _make_moe_config/_make_config for THIS phase) -- building a fresh, always-
+    # default _make_config() here instead would silently disconnect DDP's config from the
+    # model's actual GTP/EGTP/EP setup.
+    config = stack[0].config
     ddp_config = DistributedDataParallelConfig(
         use_distributed_optimizer=True,
         overlap_grad_reduce=overlap_grad_reduce,
@@ -309,18 +314,18 @@ def _run_step_distopt(ddp_model, optim, rank):
         out, _ = layer(out, attention_mask=None)
     loss = out.float().mean()
     loss.backward()
-    # Production order (finalize_model_grads): reduce across DP first, THEN the gtp_remat finalize.
+    # Production order (finalize_model_grads): reduce across DP first, THEN the gtp_remat
+    # finalize. The GTP/EGTP expert-grad correction lives in DDP's own
+    # expert_gradient_scaling_factor (computed once at construction) -- no separate step here.
     ddp_model.finish_grad_sync()
     from megatron.core import parallel_state as ps
     from megatron.core.distributed.finalize_model_grads import (
         _allreduce_replicated_grads_over_gtp_remat_group,
     )
 
-    _allreduce_replicated_grads_over_gtp_remat_group(
-        [ddp_model],
-        ps.get_gtp_weight_remat_group(check_initialized=False),
-        ps.get_expert_gtp_weight_remat_group(check_initialized=False),
-    )
+    gtp_remat_group = ps.get_gtp_weight_remat_group(check_initialized=False)
+    egtp_remat_group = ps.get_expert_gtp_weight_remat_group(check_initialized=False)
+    _allreduce_replicated_grads_over_gtp_remat_group([ddp_model], gtp_remat_group, egtp_remat_group)
     _, grad_norm, _ = optim.step()
     return float(grad_norm)
 
@@ -377,11 +382,12 @@ def _worker_distopt(rank, world_size, port):
         ratio = gtp_gn / max(base_gn, 1e-12)
         print(
             f"\n[distopt grad-norm] baseline={base_gn:.6f}  GTP_remat={gtp_gn:.6f}  "
-            f"ratio={ratio:.4f}",
+            f"ratio={ratio:.6f}",
             flush=True,
         )
-        # Same model, same data, gradients proven equal -> grad-norm must match.
-        torch.testing.assert_close(torch.tensor(gtp_gn), torch.tensor(base_gn), atol=0, rtol=3e-2)
+        # Same model, same data, gradients proven equal -> grad-norm must match (bf16 Adam
+        # noise floor is ~4e-5 here).
+        torch.testing.assert_close(torch.tensor(gtp_gn), torch.tensor(base_gn), atol=0, rtol=1e-4)
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +398,17 @@ NUM_EXPERTS = 4
 MOE_FFN = 256
 
 
-def _make_moe_config():
+def _make_moe_config(expert_model_parallel_size=1, gtp_remat_size=1, expert_gtp_remat_size=1):
+    """``expert_model_parallel_size``, ``gtp_remat_size``, and ``expert_gtp_remat_size`` must
+    all match the values passed to ``parallel_state.initialize_model_parallel`` for this phase.
+
+    Both TE's expert ``allreduce`` tagging and DDP's GTP scaling correction read these off
+    THIS TransformerConfig object, not off the global parallel_state -- leaving them at their
+    defaults while GTP/EGTP/EP are actually active silently produces the wrong config. Note
+    gtp_remat_size/expert_gtp_remat_size map to the DERIVED fields gtp_weight_remat_size /
+    expert_gtp_weight_remat_size via tensor_parallel_num_weight_shards (production sets these
+    the same way, from CLI args); with tensor_model_parallel_size=1 below they're equal.
+    """
     from megatron.core.transformer.transformer_config import TransformerConfig
 
     return TransformerConfig(
@@ -413,6 +429,9 @@ def _make_moe_config():
         bias_dropout_fusion=False,
         tensor_model_parallel_size=1,
         pipeline_model_parallel_size=1,
+        expert_model_parallel_size=expert_model_parallel_size,
+        tensor_parallel_num_weight_shards=gtp_remat_size,
+        expert_tensor_parallel_num_weight_shards=expert_gtp_remat_size,
     )
 
 
@@ -456,7 +475,10 @@ def _worker_moe_distopt(rank, world_size, port):
     )
     model_parallel_cuda_manual_seed(42)
     pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=pgs)
-    base_stack = _make_moe_stack(_make_moe_config(), pgc)
+    base_stack = _make_moe_stack(
+        _make_moe_config(expert_model_parallel_size=2, gtp_remat_size=1, expert_gtp_remat_size=1),
+        pgc,
+    )
     for layer in base_stack:
         layer.cuda()
     # Broadcast only NON-expert (dense) params; expert weights are EP-local and must
@@ -481,7 +503,10 @@ def _worker_moe_distopt(rank, world_size, port):
     )
     model_parallel_cuda_manual_seed(42)
     pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=pgs)
-    moe_stack = _make_moe_stack(_make_moe_config(), pgc)
+    moe_stack = _make_moe_stack(
+        _make_moe_config(expert_model_parallel_size=2, gtp_remat_size=2, expert_gtp_remat_size=2),
+        pgc,
+    )
     for layer in moe_stack:
         layer.cuda()
     g = ps.get_gtp_weight_remat_group()
@@ -516,10 +541,114 @@ def _worker_moe_distopt(rank, world_size, port):
         ratio = moe_gn / max(base_gn, 1e-12)
         print(
             f"\n[moe distopt grad-norm] baseline={base_gn:.6f}  GTP_remat={moe_gn:.6f}  "
-            f"ratio={ratio:.4f}",
+            f"ratio={ratio:.6f}",
             flush=True,
         )
-        torch.testing.assert_close(torch.tensor(moe_gn), torch.tensor(base_gn), atol=0, rtol=3e-2)
+        # bf16 Adam noise floor is ~6e-5 here.
+        torch.testing.assert_close(torch.tensor(moe_gn), torch.tensor(base_gn), atol=0, rtol=1e-4)
+
+
+def _worker_moe_gtp_egtp_mismatch(rank, world_size, port, gtp, egtp):
+    """EP=2 MoE dist-opt grad-norm for a mismatched (gtp, egtp) must match the GTP1/EGTP1
+    baseline: end-to-end regression for expert_gradient_scaling_factor's egtp/gtp correction
+    (folded into DistributedDataParallel's one-time prescale), through a real MoE model and a
+    real backward pass -- not mock groups or hand-set gradients.
+
+    The correction must apply for ANY gtp vs egtp relationship, not just gtp>egtp. Parametrized
+    over both directions by the caller.
+
+    EP=2 (not 1): the real grouped_gemm MoE model only tags expert weights allreduce=False
+    (building expert_parallel_buffers at all) when
+    TransformerConfig.expert_model_parallel_size > 1.
+    """
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    pgs = None
+
+    # ---------- Phase A: baseline GTP1/EGTP1, EP2 ----------
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=2,
+        gtp_remat_size=1,
+        expert_gtp_remat_size=1,
+    )
+    model_parallel_cuda_manual_seed(42)
+    pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=pgs)
+    base_stack = _make_moe_stack(
+        _make_moe_config(expert_model_parallel_size=2, gtp_remat_size=1, expert_gtp_remat_size=1),
+        pgc,
+    )
+    for layer in base_stack:
+        layer.cuda()
+    for name, p in base_stack.named_parameters():
+        if not _is_expert_param(name, p):
+            dist.broadcast(p.data, src=0)
+    saved = {n: p.data.clone() for n, p in base_stack.named_parameters()}
+    base_ddp, base_optim = _build_ddp_distopt_and_optim(base_stack)
+    assert (
+        len(base_ddp.expert_parallel_buffers) > 0
+    ), "no expert buffer built at EP=2 -- test setup bug (would make the comparison vacuous)"
+    base_gn = _run_step_distopt(base_ddp, base_optim, rank)
+
+    ps.destroy_model_parallel()
+    GTPShardedParam._chain_state = {}
+
+    # ---------- Phase B: GTP={gtp}/EGTP={egtp}, EP2 (mismatched) ----------
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=2,
+        gtp_remat_size=gtp,
+        expert_gtp_remat_size=egtp,
+    )
+    model_parallel_cuda_manual_seed(42)
+    pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=pgs)
+    moe_stack = _make_moe_stack(
+        _make_moe_config(
+            expert_model_parallel_size=2, gtp_remat_size=gtp, expert_gtp_remat_size=egtp
+        ),
+        pgc,
+    )
+    for layer in moe_stack:
+        layer.cuda()
+    gtp_rank = ps.get_gtp_weight_remat_group().rank()
+    egtp_rank = ps.get_expert_gtp_weight_remat_group().rank()
+    n_sharded = 0
+    for name, p in moe_stack.named_parameters():
+        full = saved[name]  # EP2 layout identical to baseline -> rank-local match
+        if isinstance(p, GTPShardedParam):
+            is_expert = _is_expert_param(name, p)
+            r = egtp_rank if is_expert else gtp_rank
+            ss = p.shape[0]
+            p.data.copy_(full[r * ss : (r + 1) * ss])
+            n_sharded += 1
+        else:
+            p.data.copy_(full)
+    assert n_sharded > 0, "no GTP_remat/EGTP_remat-sharded param found -- test setup bug"
+    moe_ddp, moe_optim = _build_ddp_distopt_and_optim(moe_stack)
+    assert (
+        len(moe_ddp.expert_parallel_buffers) > 0
+    ), "no expert buffer built at EP=2 -- test setup bug (would make the comparison vacuous)"
+    moe_gn = _run_step_distopt(moe_ddp, moe_optim, rank)
+
+    ps.destroy_model_parallel()
+    GTPShardedParam._chain_state = {}
+
+    if rank == 0:
+        ratio = moe_gn / max(base_gn, 1e-12)
+        print(
+            f"\n[moe gtp{gtp}-egtp{egtp}-mismatch grad-norm] baseline={base_gn:.6f}  "
+            f"moe={moe_gn:.6f}  ratio={ratio:.6f}",
+            flush=True,
+        )
+        # Without the egtp/gtp correction, expert grads come out gtp/egtp (or egtp/gtp) off,
+        # blowing the ratio far outside this tolerance (real MoE routing is noisier than the
+        # dense-only case, hence the same rtol as above rather than something tighter).
+        torch.testing.assert_close(torch.tensor(moe_gn), torch.tensor(base_gn), atol=0, rtol=1e-4)
 
 
 # ---------------------------------------------------------------------------
@@ -677,7 +806,12 @@ def _gtp_rs_phase(rank, saved, fp32_accum, moe=False, gtp_size=4):
     # None => every group; the MoE dispatcher needs tp_ep (see _worker_moe_distopt).
     pgc = ProcessGroupCollection.use_mpu_process_groups()
     stack = (_make_moe_stack if moe else _make_stack)(
-        _make_moe_config() if moe else _make_config(), pgc
+        (
+            _make_moe_config(gtp_remat_size=gtp_size, expert_gtp_remat_size=gtp_size)
+            if moe
+            else _make_config()
+        ),
+        pgc,
     )
     for layer in stack:
         layer.cuda()
@@ -946,3 +1080,24 @@ class TestGTPGradCorrectness:
         if torch.cuda.device_count() < 4:
             pytest.skip("Requires 4 CUDA devices")
         _run_distributed(_worker_moe_distopt, 4)
+
+    @pytest.mark.parametrize(
+        "gtp,egtp",
+        [
+            (4, 1),  # dense-only GTP_remat; experts stay EP-local, not EGTP-sharded
+            (1, 2),  # GTP_remat inactive; experts EGTP-sharded (the gtp<egtp direction)
+        ],
+    )
+    def test_moe_gtp_egtp_mismatch_distopt_grad_norm_matches_baseline(self, gtp, egtp):
+        """Mismatched (gtp, egtp), EP=2: MoE dist-opt grad-norm must match GTP1/EGTP1 baseline.
+
+        End-to-end regression for expert_gradient_scaling_factor's GTP/EGTP correction through
+        a real MoE model and real backward pass, covering both gtp>egtp and gtp<egtp -- unlike
+        TestExpertGradientScalingFactorGTPRemat (test_distributed_data_parallel.py; a synthetic
+        model checking the scaling factor value directly) or
+        test_moe_egtp_distopt_grad_norm_matches_baseline (GTP==EGTP, collapses the correction
+        to 1.0). See worker docstring for the full reasoning.
+        """
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_moe_gtp_egtp_mismatch, 4, gtp, egtp)


### PR DESCRIPTION


- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

- Bug: expert_gradient_scaling_factor reused dp_cp_group.size() (shrunk by GTP) as
      the prescale for expert params, but experts only ever recover the EGTP share of
      that shrinkage back, not the full GTP share -- leaving a gtp/egtp scaling error
      whenever the two differ.

- Fix: fold an egtp/gtp correction into the prescale, applied unconditionally
      (needed for both gtp>egtp and gtp<egtp).
- Tests: synthetic + real-MoE regression coverage for both mismatch directions.

## A/B Test on `A3B_30B_Muon_latent` model, GTP64_EP64_mb1gb512, 256xGB300, `calculate-per-token-loss=False`


### EGTP=1: the fix makes `grad-norm` and `params-norm` healthy again

<img width="1599" height="828" alt="image" src="https://github.com/user-attachments/assets/8ebad27a-a30e-40a1-8567-590464850622" />

✅ Is PR-7165 working? Yes, unambiguously. Both metrics that were outside their own A/A band are now inside.
✅ What got healthy — grad norm 8.4x outside → 1.005, and param norm 8.7x outside → −0.003 %. These are the two the fix targets.
✅ What else improved — lm +0.0202 → +0.0007 % and mtp_2 +0.0393 → +0.0016 %, each tightening by more than an order of magnitude.

### EGTP=4: the fix shrink the `grad-norm` and `params-norm` to healthy state too, no spike anymore

<img width="1818" height="941" alt="image" src="https://github.com/user-attachments/assets/1a803d95-3014-4650-a7c4-21bf05367358" />


## Issue tracking

This MR is based on @xuwchen 's fix: https://github.com/NVIDIA/Megatron-LM/pull/7160

Linked issue: Related to #7164 

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR


