### PR TITLE
Fix distributed training and evaluation edge cases

### DIFF
--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -29,32 +29,26 @@ def _batched_p2p_ops(
     prev_pipeline_rank: int,
     next_pipeline_rank: int,
 ):
-    ops = []
-    if tensor_send_prev is not None:
-        send_prev_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
-        )
-        ops.append(send_prev_op)
-    if tensor_recv_prev is not None:
-        recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
-        )
-        ops.append(recv_prev_op)
-    if tensor_send_next is not None:
-        send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
-        )
-        ops.append(send_next_op)
-    if tensor_recv_next is not None:
-        recv_next_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
-        )
-        ops.append(recv_next_op)
-    if len(ops) > 0:
-        reqs = torch.distributed.batch_isend_irecv(ops)
+    send_prev = (torch.distributed.isend, tensor_send_prev, prev_pipeline_rank)
+    recv_prev = (torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank)
+    send_next = (torch.distributed.isend, tensor_send_next, next_pipeline_rank)
+    recv_next = (torch.distributed.irecv, tensor_recv_next, next_pipeline_rank)
+    if group.size() == 2:
+        # Both neighbors are the same peer. NCCL matches messages to that peer
+        # in posting order, so activations and gradients must have matching
+        # send/receive order. Follow the parity ordering of the non-batched path.
+        if group.rank() % 2 == 0:
+            ordered_ops = (send_next, recv_prev, send_prev, recv_next)
+        else:
+            ordered_ops = (recv_prev, send_next, recv_next, send_prev)
     else:
-        reqs = []
-    return reqs
+        ordered_ops = (send_prev, recv_prev, send_next, recv_next)
+    ops = [
+        torch.distributed.P2POp(operation, tensor, peer, group)
+        for operation, tensor, peer in ordered_ops
+        if tensor is not None
+    ]
+    return torch.distributed.batch_isend_irecv(ops) if ops else []
 
 
 def _p2p_ops(
@@ -237,31 +231,17 @@ class P2PCommunicator:
                 group=self.pp_group,
             )
         else:
-            ops = []
-            if send_prev_shape_tensor is not None:
-                send_prev_op = torch.distributed.P2POp(
-                    torch.distributed.isend, send_prev_shape_tensor, self.prev_rank, self.pp_group
-                )
-                ops.append(send_prev_op)
-            if recv_prev_shape_tensor is not None:
-                recv_prev_op = torch.distributed.P2POp(
-                    torch.distributed.irecv, recv_prev_shape_tensor, self.prev_rank, self.pp_group
-                )
-                ops.append(recv_prev_op)
-            if send_next_shape_tensor is not None:
-                send_next_op = torch.distributed.P2POp(
-                    torch.distributed.isend, send_next_shape_tensor, self.next_rank, self.pp_group
-                )
-                ops.append(send_next_op)
-            if recv_next_shape_tensor is not None:
-                recv_next_op = torch.distributed.P2POp(
-                    torch.distributed.irecv, recv_next_shape_tensor, self.next_rank, self.pp_group
-                )
-                ops.append(recv_next_op)
-            if len(ops) > 0:
-                reqs = torch.distributed.batch_isend_irecv(ops)
-                for req in reqs:
-                    req.wait()
+            reqs = _batched_p2p_ops(
+                tensor_send_prev=send_prev_shape_tensor,
+                tensor_recv_prev=recv_prev_shape_tensor,
+                tensor_send_next=send_next_shape_tensor,
+                tensor_recv_next=recv_next_shape_tensor,
+                group=self.pp_group,
+                prev_pipeline_rank=self.prev_rank,
+                next_pipeline_rank=self.next_rank,
+            )
+            for req in reqs:
+                req.wait()
 
         recv_prev_shape = [0, 0, 0]
         if recv_prev_shape_tensor is not None:

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -53,6 +53,7 @@ class Router(ABC, MegatronModule):
         self.num_experts = self.config.num_moe_experts
         self.moe_aux_loss_func = None
         self.layer_number = None
+        self.mtp_layer_number: int | None = None
         self.is_mtp_layer = is_mtp_layer
         self.tp_group = pg_collection.tp
         self.cp_group = pg_collection.cp
@@ -143,6 +144,13 @@ class Router(ABC, MegatronModule):
         self.layer_number = layer_number
         if getattr(self, "router_replay", None) is not None:
             self.router_replay.layer_number = layer_number
+
+    def get_loss_logging_layer_number(self) -> int | None:
+        """Map an MTP container's prediction depth onto its auxiliary metric slot."""
+        if not self.is_mtp_layer:
+            return self.layer_number
+        depth = self.mtp_layer_number if self.mtp_layer_number is not None else self.layer_number
+        return None if depth is None else self.config.num_layers + depth
 
 
 class TopKRouter(Router):
@@ -589,18 +597,11 @@ class TopKRouter(Router):
         ):
             aux_loss = aux_loss / self.config.mtp_num_layers
 
-        # TODO (zijiey): fix the per_layer_logging for MTP, currently it will incorrectly
-        # add the aux loss logging value to other layer's since it is difficult to get the
-        # correct layer_number for MTP. It does not affect the correctness of the calculation
-        # results and the reduced load_balancing_loss logging value.
         num_layers = self.config.num_layers
         if self.config.mtp_num_layers is not None:
             num_layers += self.config.mtp_num_layers
 
-        if self.is_mtp_layer:
-            layer_number = self.layer_number + self.config.num_layers
-        else:
-            layer_number = self.layer_number
+        layer_number = self.get_loss_logging_layer_number()
 
         get_moe_metrics_tracker().record(
             aux_loss_name,
@@ -700,10 +701,7 @@ class TopKRouter(Router):
             if self.config.mtp_num_layers is not None:
                 num_layers += self.config.mtp_num_layers
 
-            if self.is_mtp_layer:
-                layer_number = self.layer_number + self.config.num_layers
-            else:
-                layer_number = self.layer_number
+            layer_number = self.get_loss_logging_layer_number()
 
             get_moe_metrics_tracker().record(
                 "z_loss",

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1363,6 +1363,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         if mtp_layer_pattern is not None and hybrid_submodules is not None:
             from megatron.core.models.hybrid.hybrid_block import HybridStack
             from megatron.core.models.hybrid.hybrid_layer_allocation import validate_segment_layers
+            from megatron.core.transformer.moe.router import Router
 
             self.mtp_model_layer = HybridStack(
                 config=self.config,
@@ -1377,6 +1378,12 @@ class MultiTokenPredictionLayer(MegatronModule):
                 boundary_layout=self.config.attention_cp_layout,
                 name=(name + ".mtp_model_layer") if name is not None else None,
             )
+            # Auxiliary metrics have one slot per prediction depth, regardless
+            # of the number or positions of MoE layers in the Hybrid segment.
+            # Keep the inner layer numbering used by routing and replay intact.
+            for module in self.mtp_model_layer.modules():
+                if isinstance(module, Router):
+                    module.mtp_layer_number = self.layer_number
         elif self.config.mtp_num_layers is not None:
             # GPT path: Uses the transformer block spec for MTP layer
             # MTP inner layers use their own layer numbering (self.layer_number = 1, 2, etc.)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2466,6 +2466,32 @@ def _maybe_setup_gpt_to_hybrid_load(args, ckpt_args, model):
     return layer_maps, load_optim
 
 
+def _snapshot_optimizer_param_group_lr_bounds(param_groups: list[dict]) -> list[dict]:
+    """Capture runtime LR overrides in the optimizer's native parameter-group order."""
+    return [
+        {key: group[key] for key in ('max_lr', 'min_lr') if key in group} for group in param_groups
+    ]
+
+
+def _restore_optimizer_param_group_lr_bounds(
+    param_groups: list[dict], runtime_lr_bounds: list[dict]
+) -> None:
+    """Restore runtime group bounds, including the absence of scheduler overrides."""
+    if len(param_groups) != len(runtime_lr_bounds):
+        raise ValueError(
+            "Optimizer parameter-group count changed while loading its checkpoint: "
+            f"{len(runtime_lr_bounds)} runtime groups, {len(param_groups)} restored groups"
+        )
+    # Native optimizer loading preserves group order, including empty groups on
+    # pipeline stages. Group dictionaries themselves may have been replaced.
+    for group, runtime_bounds in zip(param_groups, runtime_lr_bounds):
+        for key in ('max_lr', 'min_lr'):
+            if key in runtime_bounds:
+                group[key] = runtime_bounds[key]
+            else:
+                group.pop(key, None)
+
+
 def load_checkpoint(
     ddp_model,
     optimizer,
@@ -2494,6 +2520,15 @@ def load_checkpoint(
     """
     args = get_args()
     load_dir = getattr(args, load_arg)
+    runtime_lr_bounds = None
+    if (
+        getattr(args, 'override_opt_param_scheduler', False)
+        and optimizer is not None
+        and not getattr(optimizer, 'is_stub_optimizer', False)
+    ):
+        # Some DCP backends load optimizer metadata in-place while reading the
+        # checkpoint, so capture runtime bounds before any checkpoint I/O.
+        runtime_lr_bounds = _snapshot_optimizer_param_group_lr_bounds(optimizer.param_groups)
 
     # --freeze-all-layers: nothing trains, so load the model in --load weights-only (finetune-style)
     # and auto-resume the data position by feeding this run's own progress tracker -- written to
@@ -3026,9 +3061,8 @@ def load_checkpoint(
                 else:
                     opt_param_scheduler.load_state_dict(state_dict['opt_param_scheduler'])
 
-            # Optimizer state dict can overwrite per-group max_lr/min_lr values.
-            # If scheduler override is requested, re-apply runtime lr bounds from
-            # args so scheduler math does not stay pinned to checkpoint lr settings.
+            # Optimizer loading overwrites group bounds. Preserve runtime group
+            # overrides instead of replacing them with the global args.lr values.
             if getattr(args, "override_opt_param_scheduler", False):
                 if (
                     optimizer is None
@@ -3041,17 +3075,10 @@ def load_checkpoint(
                         "and optimizer param_group max_lr/min_lr."
                     )
                 else:
-                    for param_group in optimizer.param_groups:
-                        if param_group.get("is_decoupled_lr", False):
-                            max_lr = getattr(args, "decoupled_lr", None)
-                            min_lr = getattr(args, "decoupled_min_lr", None)
-                        else:
-                            max_lr = args.lr
-                            min_lr = args.min_lr
-                        if max_lr is not None:
-                            param_group["max_lr"] = max_lr
-                        if min_lr is not None:
-                            param_group["min_lr"] = min_lr
+                    assert runtime_lr_bounds is not None
+                    _restore_optimizer_param_group_lr_bounds(
+                        optimizer.param_groups, runtime_lr_bounds
+                    )
                     # Synchronize scheduler num_steps with consumed_train_samples
                     # to ensure lr calculation is based on current training progress
                     if opt_param_scheduler.num_steps != args.consumed_train_samples:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -5499,7 +5499,7 @@ def evaluate_and_print_results(
 
         # with full validation we need to distribute eval_iters to all ranks
         if mpu.get_tensor_model_parallel_rank() == 0:
-            eval_iters = torch.tensor(args.eval_iters, dtype=torch.long, device='cuda')
+            eval_iters = torch.tensor(eval_iters, dtype=torch.long, device='cuda')
         else:
             eval_iters = torch.tensor([0] * len(eval_iters), dtype=torch.long, device='cuda')
         torch.distributed.broadcast(eval_iters, 0)

--- a/tests/unit_tests/models/hybrid/test_mtp_moe_logging.py
+++ b/tests/unit_tests/models/hybrid/test_mtp_moe_logging.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_spec,
+    get_gpt_mtp_block_spec,
+)
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe.moe_logging import (
+    destroy_moe_metrics_tracker,
+    get_moe_metrics_tracker,
+)
+from megatron.core.transformer.moe.router import Router
+from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize("mtp_num_layers", [1, 2])
+@pytest.mark.parametrize("mtp_pattern", ["*E", "*EE"])
+def test_hybrid_mtp_moe_losses_use_prediction_depth(
+    mtp_num_layers: int, mtp_pattern: str, monkeypatch
+) -> None:
+    """Real Hybrid forward/backward logs every MTP router in its prediction-depth slot."""
+    Utils.initialize_model_parallel(1, 1)
+    destroy_moe_metrics_tracker()
+    monkeypatch.setattr(MTPLossLoggingHelper, "tracker", {})
+    try:
+        model_parallel_cuda_manual_seed(123)
+        config = TransformerConfig(
+            num_layers=4,
+            hidden_size=32,
+            num_attention_heads=4,
+            ffn_hidden_size=64,
+            moe_ffn_hidden_size=32,
+            num_moe_experts=4,
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01,
+            moe_z_loss_coeff=0.001,
+            mtp_num_layers=mtp_num_layers,
+            mtp_loss_scaling_factor=0.3,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            use_cpu_initialization=True,
+        )
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            hybrid_layer_pattern="*-*E" + f"/{mtp_pattern}" * mtp_num_layers,
+            vocab_size=64,
+            max_sequence_length=8,
+            position_embedding_type="none",
+        ).cuda()
+        expected_inner_numbers = [i + 1 for i, symbol in enumerate(mtp_pattern) if symbol == "E"]
+        for depth, layer in enumerate(model.mtp.layers, 1):
+            routers = [
+                module for module in layer.mtp_model_layer.modules() if isinstance(module, Router)
+            ]
+            assert [router.layer_number for router in routers] == expected_inner_numbers
+            assert all(router.mtp_layer_number == depth for router in routers)
+            assert all(
+                router.get_loss_logging_layer_number() == config.num_layers + depth
+                for router in routers
+            )
+        main_routers = [module for module in model.decoder.modules() if isinstance(module, Router)]
+        assert [router.layer_number for router in main_routers] == [4]
+        assert main_routers[0].mtp_layer_number is None
+
+        tracker = get_moe_metrics_tracker()
+        original_record = tracker.record
+        records = []
+
+        def record(name, value, layer_number, num_layers, **kwargs):
+            records.append((name, layer_number, value.detach().clone()))
+            original_record(name, value, layer_number, num_layers, **kwargs)
+
+        monkeypatch.setattr(tracker, "record", record)
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device="cuda")
+        positions = torch.arange(8, device="cuda").unsqueeze(0)
+        attention_mask = torch.triu(torch.ones(8, 8, device="cuda", dtype=torch.bool), 1)[
+            None, None
+        ]
+        loss = model(
+            tokens,
+            positions,
+            attention_mask,
+            labels=tokens.roll(-1, dims=1),
+            loss_mask=torch.ones_like(tokens, dtype=torch.float32),
+        )
+        loss.mean().backward()
+        assert torch.isfinite(loss).all()
+        for metric in ("load_balancing_loss", "z_loss"):
+            expected_numbers = [4] + [
+                config.num_layers + depth
+                for depth in range(1, mtp_num_layers + 1)
+                for _ in expected_inner_numbers
+            ]
+            actual = [(index, value) for name, index, value in records if name == metric]
+            assert [index for index, _ in actual] == expected_numbers
+            expected = torch.zeros(config.num_layers + mtp_num_layers, device="cuda")
+            for index, value in actual:
+                expected[index - 1] += value
+            torch.testing.assert_close(tracker.metrics[metric].values, expected)
+        for module in model.modules():
+            if isinstance(module, Router):
+                assert module.weight.grad is not None
+                assert torch.isfinite(module.weight.grad).all()
+    finally:
+        destroy_moe_metrics_tracker()
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize("model_kind", ["gpt", "hybrid"])
+@pytest.mark.parametrize("enable_router_losses", [False, True])
+def test_mtp1_moe_forward_backward_with_router_loss_controls(
+    model_kind: str, enable_router_losses: bool, monkeypatch
+) -> None:
+    """Compare two attention/MoE blocks plus MTP1 across both native model paths."""
+    Utils.initialize_model_parallel(1, 1)
+    destroy_moe_metrics_tracker()
+    monkeypatch.setattr(MTPLossLoggingHelper, "tracker", {})
+    try:
+        model_parallel_cuda_manual_seed(123)
+        config = TransformerConfig(
+            num_layers=2 if model_kind == "gpt" else 4,
+            hidden_size=32,
+            num_attention_heads=4,
+            kv_channels=8,
+            ffn_hidden_size=64,
+            moe_ffn_hidden_size=32,
+            num_moe_experts=4,
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01 if enable_router_losses else 0.0,
+            moe_z_loss_coeff=0.001 if enable_router_losses else None,
+            mtp_num_layers=1,
+            mtp_loss_scaling_factor=0.3,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            use_cpu_initialization=True,
+        )
+        common = dict(
+            config=config, vocab_size=64, max_sequence_length=8, position_embedding_type="none"
+        )
+        if model_kind == "hybrid":
+            model = HybridModel(
+                **common, hybrid_stack_spec=hybrid_stack_spec, hybrid_layer_pattern="*E*E/*E"
+            ).cuda()
+        else:
+            layer_spec = get_gpt_layer_with_transformer_engine_spec(num_experts=4)
+            model = GPTModel(
+                **common,
+                transformer_layer_spec=layer_spec,
+                mtp_block_spec=get_gpt_mtp_block_spec(config, layer_spec, True),
+            ).cuda()
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device="cuda")
+        positions = torch.arange(8, device="cuda").unsqueeze(0)
+        attention_mask = torch.triu(torch.ones(8, 8, device="cuda", dtype=torch.bool), 1)[
+            None, None
+        ]
+        # Run the unmodified model forward/backward before inspecting any metric
+        # metadata so the upstream failure is attributable to the real router path.
+        loss = model(
+            tokens,
+            positions,
+            attention_mask,
+            labels=tokens.roll(-1, dims=1),
+            loss_mask=torch.ones_like(tokens, dtype=torch.float32),
+        )
+        loss.mean().backward()
+        assert loss.shape == tokens.shape
+        assert torch.isfinite(loss).all()
+        routers = [module for module in model.modules() if isinstance(module, Router)]
+        assert len(routers) == 3
+        for router in routers:
+            assert router.weight.grad is not None
+            assert torch.isfinite(router.weight.grad).all()
+        metrics = get_moe_metrics_tracker().metrics
+        if enable_router_losses:
+            expected_positions = [0, 1, 2] if model_kind == "gpt" else [1, 3, 4]
+            for name in ("load_balancing_loss", "z_loss"):
+                values = metrics[name].values
+                assert values.shape == (config.num_layers + 1,)
+                assert values.nonzero().flatten().tolist() == expected_positions
+        else:
+            assert "load_balancing_loss" not in metrics
+            assert "z_loss" not in metrics
+    finally:
+        destroy_moe_metrics_tracker()
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/pipeline_parallel/test_p2p_bidirectional.py
+++ b/tests/unit_tests/pipeline_parallel/test_p2p_bidirectional.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Verify activation/gradient direction matching when PP neighbors coincide."""
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.enums import ModelType
+from megatron.core.model_parallel_config import ModelParallelConfig
+from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator, _batched_p2p_ops
+from megatron.core.pipeline_parallel.schedules import forward_backward_pipelining_with_interleaving
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize('pipeline_size', [2, 4])
+def test_batched_bidirectional_messages_keep_their_direction(pipeline_size: int) -> None:
+    """Different payloads to the same peer must retain their logical direction."""
+    if Utils.world_size % pipeline_size:
+        pytest.skip(f'requires a world size divisible by PP={pipeline_size}')
+    Utils.initialize_model_parallel(pipeline_model_parallel_size=pipeline_size)
+    try:
+        group = parallel_state.get_pipeline_model_parallel_group()
+        rank = group.rank()
+        previous = torch.distributed.get_global_rank(group, (rank - 1) % pipeline_size)
+        following = torch.distributed.get_global_rank(group, (rank + 1) % pipeline_size)
+        global_rank = torch.distributed.get_rank()
+        activation = torch.full((4, 2, 8), 1000 + global_rank, device='cuda', dtype=torch.float32)
+        gradient = torch.full_like(activation, 2000 + global_rank)
+        received_activation = torch.empty_like(activation)
+        received_gradient = torch.empty_like(gradient)
+        requests = _batched_p2p_ops(
+            tensor_send_prev=gradient,
+            tensor_recv_prev=received_activation,
+            tensor_send_next=activation,
+            tensor_recv_next=received_gradient,
+            group=group,
+            prev_pipeline_rank=previous,
+            next_pipeline_rank=following,
+        )
+        for request in requests:
+            request.wait()
+        torch.testing.assert_close(
+            received_activation, torch.full_like(activation, 1000 + previous), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            received_gradient, torch.full_like(gradient, 2000 + following), rtol=0, atol=0
+        )
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.parametrize('pipeline_size', [2, 4])
+def test_batched_bidirectional_variable_shapes_match_payloads(pipeline_size: int) -> None:
+    """Shape exchange and payload exchange must use the same directional ordering."""
+    if Utils.world_size % pipeline_size:
+        pytest.skip(f'requires a world size divisible by PP={pipeline_size}')
+    Utils.initialize_model_parallel(pipeline_model_parallel_size=pipeline_size)
+    try:
+        group = parallel_state.get_pipeline_model_parallel_group()
+        communicator = P2PCommunicator(
+            group,
+            ModelParallelConfig(
+                pipeline_model_parallel_size=pipeline_size,
+                pipeline_dtype=torch.float32,
+                variable_seq_lengths=True,
+                batch_p2p_comm=True,
+            ),
+        )
+        rank = torch.distributed.get_rank()
+        activation = torch.full((rank + 2, 1, 8), 1000 + rank, device='cuda', dtype=torch.float32)
+        gradient = torch.full((rank + 3, 2, 8), 2000 + rank, device='cuda', dtype=torch.float32)
+        received_activation, received_gradient = (
+            communicator.send_forward_backward_recv_forward_backward(
+                output_tensor=activation,
+                input_tensor_grad=gradient,
+                recv_prev=True,
+                recv_next=True,
+                tensor_shape=(4, 1, 8),
+            )
+        )
+        assert communicator.prev_rank is not None
+        assert communicator.next_rank is not None
+        expected_activation = torch.full(
+            (communicator.prev_rank + 2, 1, 8),
+            1000 + communicator.prev_rank,
+            device='cuda',
+            dtype=torch.float32,
+        )
+        expected_gradient = torch.full(
+            (communicator.next_rank + 3, 2, 8),
+            2000 + communicator.next_rank,
+            device='cuda',
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(received_activation, expected_activation, rtol=0, atol=0)
+        torch.testing.assert_close(received_gradient, expected_gradient, rtol=0, atol=0)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+class _AffinePipelineChunk(torch.nn.Module):
+    """Scalar affine stage for comparing native VPP with an unpartitioned reference."""
+
+    def __init__(self, config: TransformerConfig, vp_stage: int, position: int) -> None:
+        super().__init__()
+        self.config = config
+        self.vp_stage = vp_stage
+        self.position = position
+        self.model_type = ModelType.encoder_or_decoder
+        self.weight = torch.nn.Parameter(torch.tensor(1.0 + position / 10, device="cuda"))
+        self.input_tensor = None
+
+    def set_input_tensor(self, input_tensor: list[torch.Tensor | None]) -> None:
+        """Receive the actual tensor delivered by the native pipeline schedule."""
+        self.input_tensor = input_tensor[0]
+
+    def forward(self, microbatch: int) -> torch.Tensor:
+        """Run one stage without replacing pipeline communication or autograd."""
+        inputs = (
+            torch.full((4, 2, 8), 1.0 + microbatch / 10, device="cuda")
+            if self.position == 0
+            else self.input_tensor
+        )
+        return inputs * self.weight + self.position / 20
+
+
+@pytest.mark.parametrize("pipeline_size", [2, 4])
+@pytest.mark.parametrize("forward_only", [False, True])
+def test_native_vpp_matches_unpartitioned_forward_backward(
+    pipeline_size: int, forward_only: bool, monkeypatch
+) -> None:
+    """Exercise native VPP bidirectional calls and its forward-only control path."""
+    if Utils.world_size % pipeline_size:
+        pytest.skip(f"requires a world size divisible by PP={pipeline_size}")
+    Utils.initialize_model_parallel(
+        pipeline_model_parallel_size=pipeline_size, virtual_pipeline_model_parallel_size=2
+    )
+    try:
+        rank = parallel_state.get_pipeline_model_parallel_rank()
+        config = TransformerConfig(
+            num_layers=2 * pipeline_size,
+            hidden_size=8,
+            num_attention_heads=2,
+            pipeline_model_parallel_size=pipeline_size,
+            virtual_pipeline_model_parallel_size=2,
+            pipeline_dtype=torch.float32,
+            batch_p2p_comm=True,
+            overlap_p2p_comm=False,
+        )
+        chunks = [_AffinePipelineChunk(config, v, v * pipeline_size + rank) for v in range(2)]
+        num_microbatches = 4 * pipeline_size
+        simultaneous_sends = []
+        original = P2PCommunicator.send_forward_backward_recv_forward_backward
+
+        def trace(self, output_tensor, input_tensor_grad, **kwargs):
+            if output_tensor is not None and input_tensor_grad is not None:
+                simultaneous_sends.append((output_tensor.shape, input_tensor_grad.shape))
+            return original(self, output_tensor, input_tensor_grad, **kwargs)
+
+        monkeypatch.setattr(P2PCommunicator, "send_forward_backward_recv_forward_backward", trace)
+
+        def forward_step(iterator, model):
+            output = model(next(iterator))
+
+            def loss_func(tensor):
+                loss = tensor.square().mean()
+                return loss, {"loss": loss.detach().clone()}
+
+            return output, loss_func
+
+        results = forward_backward_pipelining_with_interleaving(
+            forward_step_func=forward_step,
+            data_iterator=[iter(range(num_microbatches)) for _ in chunks],
+            model=chunks,
+            num_microbatches=num_microbatches,
+            seq_length=4,
+            micro_batch_size=2,
+            forward_only=forward_only,
+        )
+        weights = [
+            torch.tensor(1.0 + position / 10, device="cuda", requires_grad=True)
+            for position in range(2 * pipeline_size)
+        ]
+        reference_losses = []
+        for microbatch in range(num_microbatches):
+            value = torch.full((4, 2, 8), 1.0 + microbatch / 10, device="cuda")
+            for position, weight in enumerate(weights):
+                value = value * weight + position / 20
+            reference_losses.append(value.square().mean())
+        reference_loss = torch.stack(reference_losses).mean()
+        reference_loss.backward()
+        if rank == pipeline_size - 1:
+            assert len(results) == num_microbatches
+            torch.testing.assert_close(
+                torch.stack([item["loss"] for item in results]), torch.stack(reference_losses)
+            )
+        if forward_only:
+            assert not simultaneous_sends
+            assert all(chunk.weight.grad is None for chunk in chunks)
+        else:
+            assert simultaneous_sends
+            for chunk in chunks:
+                torch.testing.assert_close(chunk.weight.grad, weights[chunk.position].grad)
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -466,6 +466,9 @@ def test_load_checkpoint_override_opt_param_scheduler(
         optimizer.param_groups = [
             {"is_decoupled_lr": False, "max_lr": -1.0, "min_lr": -1.0},
             {"is_decoupled_lr": True, "max_lr": -1.0, "min_lr": -1.0},
+            {"max_lr": -1.0, "min_lr": -1.0},
+            {"max_lr": -1.0, "min_lr": -1.0},
+            {"max_lr": -1.0, "min_lr": -1.0},
         ]
         opt_param_scheduler = MockOptParamScheduler(
             {"opt_param_scheduler": "scheduler_state", "num_steps": 3}
@@ -480,8 +483,11 @@ def test_load_checkpoint_override_opt_param_scheduler(
         new_model = MockModel(config)
         new_optimizer = MockOptimizer({"optimizer": "dummy1"})
         new_optimizer.param_groups = [
-            {"is_decoupled_lr": False, "max_lr": -2.0, "min_lr": -2.0},
-            {"is_decoupled_lr": True, "max_lr": -2.0, "min_lr": -2.0},
+            {"is_decoupled_lr": False, "max_lr": args.lr, "min_lr": args.min_lr},
+            {"is_decoupled_lr": True, "max_lr": args.decoupled_lr, "min_lr": args.decoupled_min_lr},
+            {"max_lr": 5.0, "min_lr": 0.5},
+            {"max_lr": 0.7, "min_lr": 0.25},
+            {},
         ]
         new_opt_param_scheduler = MockOptParamScheduler(
             {"opt_param_scheduler": "dummy2", "num_steps": 0}
@@ -497,6 +503,12 @@ def test_load_checkpoint_override_opt_param_scheduler(
         assert new_optimizer.param_groups[0]["min_lr"] == args.min_lr
         assert new_optimizer.param_groups[1]["max_lr"] == args.decoupled_lr
         assert new_optimizer.param_groups[1]["min_lr"] == args.decoupled_min_lr
+        assert new_optimizer.param_groups[2]["max_lr"] == 5.0
+        assert new_optimizer.param_groups[2]["min_lr"] == 0.5
+        assert new_optimizer.param_groups[3]["max_lr"] == 0.7
+        assert new_optimizer.param_groups[3]["min_lr"] == 0.25
+        assert "max_lr" not in new_optimizer.param_groups[4]
+        assert "min_lr" not in new_optimizer.param_groups[4]
         assert new_opt_param_scheduler.num_steps == args.consumed_train_samples
         assert new_opt_param_scheduler.step_calls[-1] == 0
 

--- a/tests/unit_tests/test_checkpointing_lr_override.py
+++ b/tests/unit_tests/test_checkpointing_lr_override.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
+from megatron.training.checkpointing import (
+    _restore_optimizer_param_group_lr_bounds,
+    _snapshot_optimizer_param_group_lr_bounds,
+)
+
+
+@pytest.mark.parametrize("num_steps", [5, 42, 100])
+def test_scheduler_override_preserves_runtime_parameter_group_bounds(num_steps: int) -> None:
+    """Runtime group overrides survive checkpoint metadata and native scheduler loading."""
+    optimizer = SimpleNamespace(
+        param_groups=[
+            {"params": [], "max_lr": 1.0, "min_lr": 0.1},
+            {"params": [], "max_lr": 5.0, "min_lr": 0.5, "lr_mult": 5.0},
+            {"params": [], "max_lr": 0.5, "min_lr": 0.05, "is_decoupled_lr": True},
+            {"params": [], "max_lr": 0.7, "min_lr": 0.25, "lr_mult": 1.0},
+            {"params": []},
+        ]
+    )
+    scheduler = OptimizerParamScheduler(
+        optimizer=optimizer,
+        init_lr=0.0,
+        max_lr=1.0,
+        min_lr=0.1,
+        lr_warmup_steps=10,
+        lr_decay_steps=100,
+        lr_decay_style="linear",
+        start_wd=0.0,
+        end_wd=0.0,
+        wd_incr_steps=100,
+        wd_incr_style="constant",
+        use_checkpoint_opt_param_scheduler=False,
+        override_opt_param_scheduler=True,
+    )
+    runtime_bounds = _snapshot_optimizer_param_group_lr_bounds(optimizer.param_groups)
+    # PyTorch optimizer load_state_dict replaces group dictionaries while keeping
+    # their native order. Empty PP groups also need their original LR schedule.
+    optimizer.param_groups = [
+        dict(group, max_lr=99.0, min_lr=88.0, checkpoint_marker=True)
+        for group in optimizer.param_groups
+    ]
+    scheduler_state = dict(scheduler.state_dict(), max_lr=99.0, min_lr=88.0, num_steps=num_steps)
+    scheduler.load_state_dict(scheduler_state)
+    _restore_optimizer_param_group_lr_bounds(optimizer.param_groups, runtime_bounds)
+    scheduler.step(0)
+
+    assert scheduler.num_steps == num_steps
+    for group, (max_lr, min_lr) in zip(
+        optimizer.param_groups, [(1.0, 0.1), (5.0, 0.5), (0.5, 0.05), (0.7, 0.25), (1.0, 0.1)]
+    ):
+        expected = (
+            max_lr * num_steps / 10
+            if num_steps <= 10
+            else max_lr - (max_lr - min_lr) * (num_steps - 10) / 90
+        )
+        assert group["lr"] == pytest.approx(expected)
+        assert group["checkpoint_marker"]
+    assert "max_lr" not in optimizer.param_groups[-1]
+    assert "min_lr" not in optimizer.param_groups[-1]
+    assert optimizer.param_groups[3]["min_lr"] == 0.25
+
+
+def test_scheduler_override_rejects_changed_parameter_group_count() -> None:
+    """Do not silently apply runtime schedules to an incompatible optimizer layout."""
+    with pytest.raises(ValueError, match="parameter-group count changed"):
+        _restore_optimizer_param_group_lr_bounds([{}], [{}, {}])

--- a/tests/unit_tests/training/test_full_validation_iterations.py
+++ b/tests/unit_tests/training/test_full_validation_iterations.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Full-validation iteration counts must broadcast as a vector for one or more sets."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.training import training
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.parametrize("multiple", [False, True])
+def test_full_validation_broadcast_preserves_dataset_iteration_counts(multiple: bool) -> None:
+    """Every TP rank must call the evaluator with the source's per-dataset counts."""
+    Utils.initialize_model_parallel(2, 1)
+    try:
+        expected = [2, 3] if multiple else [3]
+        source = parallel_state.get_tensor_model_parallel_rank() == 0
+        counts: list[int | None] = list(expected) if source else [None] * len(expected)
+        args = SimpleNamespace(
+            multiple_validation_sets=multiple,
+            full_validation=True,
+            eval_iters=counts if multiple else counts[0],
+            validation_set_names=None,
+        )
+        iterator = [iter(()), iter(())] if multiple else iter(())
+        with (
+            patch.object(training, "get_args", return_value=args),
+            patch.object(training, "get_wandb_writer", return_value=None),
+            patch.object(training, "print_rank_last"),
+            patch.object(training, "evaluate", return_value=({}, None, False)) as evaluate,
+        ):
+            training.evaluate_and_print_results(
+                "test", None, iterator, [], 0, None, None, write_to_tensorboard=False
+            )
+        assert [call.kwargs["eval_iters"] for call in evaluate.call_args_list] == expected
+        assert args.eval_iters == (expected if multiple else expected[0])
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fix four training/evaluation bugs that reproduce without Engram. Each fix and its regression
tests form an atomic commit.

## Issue tracking

Fixes [#7172](https://github.com/NVIDIA/Megatron-LM/issues/7172), fixes [#7173](https://github.com/NVIDIA/Megatron-LM/issues/7173), fixes [#7174](https://github.com/NVIDIA/Megatron-LM/issues/7174); related to the [#1450 reproduction](https://github.com/NVIDIA/Megatron-LM/issues/1450#issuecomment-5603879647).

MTP overlaps [#4942](https://github.com/NVIDIA/Megatron-LM/pull/4942)/[#4798](https://github.com/NVIDIA/Megatron-LM/pull/4798); these regressions can accompany maintainers' preferred approach. LR complements [#3720](https://github.com/NVIDIA/Megatron-LM/pull/3720)'s global-argument restoration.

## Testing

The same regressions fail on unmodified upstream `c6be9199750845bd99a7d1a438862bb9ab29b630` and pass with only their corresponding fix:

| Bug and fix | Regression | Upstream → single-fix result |
| --- | --- | --- |
| P2P: align PP2 bidirectional activation/gradient payload ordering and shape exchange. | [P2P tests](https://github.com/jeyaletheia/Megatron-LM/blob/e0cc60439c96803179ffc60038c942ab71cba188/tests/unit_tests/pipeline_parallel/test_p2p_bidirectional.py) | 3 failures/rank → 8 passes/rank; PP4/forward-only controls pass. |
| MTP: use prediction depth instead of inner-MoE position to prevent out-of-range metric indexing, preserving router identity. | [MTP tests](https://github.com/jeyaletheia/Megatron-LM/blob/e0cc60439c96803179ffc60038c942ab71cba188/tests/unit_tests/models/hybrid/test_mtp_moe_logging.py) | Hybrid router-loss case fails → all 4 controls pass/rank. |
| LR: preserve runtime parameter-group bounds across checkpoint loading, including absent overrides. | [LR tests](https://github.com/jeyaletheia/Megatron-LM/blob/e0cc60439c96803179ffc60038c942ab71cba188/tests/unit_tests/test_checkpointing_lr_override.py) | Scaled bounds overwritten → pass. |
| Validation: broadcast the normalized iteration vector instead of a scalar for single-dataset evaluation. | [Validation tests](https://github.com/jeyaletheia/Megatron-LM/blob/e0cc60439c96803179ffc60038c942ab71cba188/tests/unit_tests/training/test_full_validation_iterations.py) | Single-dataset fails → both cases pass. |

Integrated validation: 23 passes/rank, zero skips, covering MTP2, multiple MoE nodes and LR warmup/decay. Production files match that run; final P2P tests were rerun: 8 passes/rank.

P2P/MTP exercise real communication/model/autograd. LR uses real legacy checkpoint I/O with mock model/optimizer fixtures; validation uses real TP/NCCL broadcast with a mocked evaluator. These do not establish full training restarts or full-dataset evaluations. P2P coverage does not establish fixes for all PP≥4 failures in #5100.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

Distributed regressions belong to `tests/unit_tests`; no separate functional fixture is added. Typing review pending.

### Code review

**Draft**. @NVIDIA/mcore-oncall: please enable CI with **Run functional tests**. Author review and official CI remain pending.
