### PR TITLE
fix(resharding): bound NCCL refit P2P groups to avoid kernel-plan spl…

### DIFF
--- a/megatron/core/resharding/copy_services/nccl_copy_service.py
+++ b/megatron/core/resharding/copy_services/nccl_copy_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import List, Optional
 
 import torch
@@ -20,8 +21,23 @@ class NCCLCopyService(CopyService):
 
     supports_multiple_runs_per_plan = True
 
+    # Safety net for plans that were not split into execution batches: a single
+    # ncclGroup holding a whole model's P2P ops is split by NCCL into several
+    # kernel plans at rank-dependent points, and matching sends/recvs that end up
+    # in different plans deadlock (https://github.com/pytorch/pytorch/issues/174288).
+    # When a one-batch plan has more than TASK_WINDOW transfers in its global
+    # schedule, run() issues the ops as consecutive batch_isend_irecv calls over
+    # windows of TASK_WINDOW global task ids. The decision uses only plan-global
+    # data (identical on every rank), and sender and receiver of a transfer share
+    # its task id, so every rank places each transfer in the same window and no
+    # window depends on another. A rank never has more than TASK_WINDOW ops in a
+    # window. Set to 0 to disable.
+    TASK_WINDOW = int(os.environ.get("MEGATRON_NCCL_COPY_TASK_WINDOW", "256"))
+
     def __init__(self, group=None):
         super().__init__(group=group)
+        self._plan_total_tasks: Optional[int] = None
+        self._plan_num_batches: int = 1
         self.send_ops: List[SendOp] = []
         self.recv_ops: List[RecvOp] = []
         # Dedicated stream for local (same-rank) copies to avoid unnecessary
@@ -41,6 +57,46 @@ class NCCLCopyService(CopyService):
         device = torch.device("cuda", torch.cuda.current_device())
         group._get_backend(device).eager_connect_single_device(device)
         self._nccl_connected = True
+
+    def set_plan(self, plan, *, transform=None) -> None:
+        """Remember the plan-global sizes that decide whether run() windows its submission."""
+        self._plan_total_tasks = getattr(plan, "total_tasks", None)
+        self._plan_num_batches = getattr(plan, "num_batches", 1)
+
+    def _should_window(self, remote_sends: List[SendOp], remote_recvs: List[RecvOp]) -> bool:
+        if self.TASK_WINDOW <= 0 or self._plan_total_tasks is None or self._plan_num_batches != 1:
+            return False
+        if self._plan_total_tasks <= self.TASK_WINDOW:
+            return False
+        # Task ids are required to place ops in windows; plans built by the planner
+        # always carry them. Same-rank (local) ops were already copied out.
+        return all(op.task_id is not None for op in remote_sends) and all(
+            op.task_id is not None for op in remote_recvs
+        )
+
+    def _run_in_task_windows(self, remote_sends: List[SendOp], remote_recvs: List[RecvOp]) -> None:
+        """Issue the pending remote ops as one batch_isend_irecv per global task-id window."""
+        width = self.TASK_WINDOW
+        windows: dict[int, list] = {}
+        for op in remote_sends:
+            windows.setdefault(op.task_id // width, []).append(
+                dist.P2POp(dist.isend, op.tensor, op.dest_rank, group=self.group)
+            )
+        for op in remote_recvs:
+            windows.setdefault(op.task_id // width, []).append(
+                dist.P2POp(dist.irecv, op.tensor, op.src_rank, group=self.group)
+            )
+        if self.rank == 0:
+            logger.info(
+                "Executing batched communication in %d task-id windows of %d (max %d ops/window)",
+                len(windows),
+                width,
+                max((len(w) for w in windows.values()), default=0),
+            )
+        for key in sorted(windows):
+            reqs = dist.batch_isend_irecv(windows[key])
+            for req in reqs:
+                req.wait()
 
     def submit_send(self, src_tensor: torch.Tensor, dest_rank: int, task_id: Optional[int] = None):
         self.send_ops.append(SendOp(task_id=task_id, tensor=src_tensor, dest_rank=dest_rank))
@@ -77,16 +133,21 @@ class NCCLCopyService(CopyService):
                 for send_op, recv_op in pairs:
                     recv_op.tensor.copy_(send_op.tensor)
 
-        p2p_ops = []
-        for op in remote_sends:
-            p2p_ops.append(dist.P2POp(dist.isend, op.tensor, op.dest_rank, group=self.group))
-        for op in remote_recvs:
-            p2p_ops.append(dist.P2POp(dist.irecv, op.tensor, op.src_rank, group=self.group))
+        if self._should_window(remote_sends, remote_recvs):
+            # See TASK_WINDOW: keep each ncclGroup small enough to stay in one kernel
+            # plan, deciding from plan-global data so every rank takes the same path.
+            self._run_in_task_windows(remote_sends, remote_recvs)
+        else:
+            p2p_ops = []
+            for op in remote_sends:
+                p2p_ops.append(dist.P2POp(dist.isend, op.tensor, op.dest_rank, group=self.group))
+            for op in remote_recvs:
+                p2p_ops.append(dist.P2POp(dist.irecv, op.tensor, op.src_rank, group=self.group))
 
-        if p2p_ops:
-            reqs = dist.batch_isend_irecv(p2p_ops)
-            for req in reqs:
-                req.wait()
+            if p2p_ops:
+                reqs = dist.batch_isend_irecv(p2p_ops)
+                for req in reqs:
+                    req.wait()
 
         # Make sure the copy stream is finished
         torch.cuda.current_stream().wait_stream(self._copy_stream)

--- a/megatron/core/resharding/planner.py
+++ b/megatron/core/resharding/planner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import warnings
 from dataclasses import dataclass
 
@@ -24,6 +25,14 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Default number of logical parameters per lockstep execution batch, for copy
+# services that support multiple runs per plan (currently NCCL). Submitting the
+# whole model as one ncclGroup deadlocks NCCL once the group is large enough to
+# be split into several kernel plans (https://github.com/pytorch/pytorch/issues/174288),
+# so the transfer is issued in small, globally agreed batches instead. Override
+# with MEGATRON_REFIT_MAX_PARAMS_PER_BATCH; 0 disables the cap.
+DEFAULT_MAX_PARAMS_PER_BATCH = 32
 
 
 @dataclass(frozen=True)
@@ -391,8 +400,10 @@ def _build_execution_batch_ids(
     without another collective. Source and destination bytes are accumulated per
     rank; starting a new batch when any rank would cross the soft limit bounds
     both sender-side dequantization and receiver-side staging. All replicas and
-    shards of one resolved parameter stay in one batch. ``None`` assigns every
-    parameter to one model-wide batch, preserving the uncapped behavior.
+    shards of one resolved parameter stay in one batch. ``None`` disables the byte
+    limit; batches are then bounded only by the per-batch parameter cap
+    (``DEFAULT_MAX_PARAMS_PER_BATCH`` / ``MEGATRON_REFIT_MAX_PARAMS_PER_BATCH``), which
+    keeps every rank's NCCL P2P group small enough to stay in a single kernel plan.
     """
     parameter_order: list[str] = []
     destination_bytes: dict[str, dict[int, int]] = {}
@@ -410,10 +421,24 @@ def _build_execution_batch_ids(
                 destination_bytes[resolved_name].get(metadata.owner_rank, 0), tensor_bytes
             )
 
-    if max_batch_bytes is None:
+    # Cap on logical parameters per batch. A byte budget alone can still pack
+    # thousands of small tensors (norm weights, biases, router expert_bias) into
+    # one batch_isend_irecv; NCCL splits such large groups into kernel plans at
+    # rank-dependent points, and matching sends/recvs that land in different plans
+    # deadlock (https://github.com/pytorch/pytorch/issues/174288). Every rank
+    # evaluates this from the same roster and environment, so batches agree.
+    max_batch_params_env = os.environ.get("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH")
+    max_batch_params: int | None = (
+        int(max_batch_params_env) if max_batch_params_env else DEFAULT_MAX_PARAMS_PER_BATCH
+    )
+    if max_batch_params <= 0:
+        max_batch_params = None
+
+    if max_batch_bytes is None and max_batch_params is None:
         return {resolved_name: 0 for resolved_name in parameter_order}, 1
-    if max_batch_bytes <= 0:
+    if max_batch_bytes is not None and max_batch_bytes <= 0:
         raise ValueError("max_batch_bytes must be positive or None")
+    byte_limit = float("inf") if max_batch_bytes is None else max_batch_bytes
 
     source_bytes: dict[str, dict[int, int]] = {}
     for resolved_name in parameter_order:
@@ -428,19 +453,24 @@ def _build_execution_batch_ids(
     batch_ids: dict[str, int] = {}
     batch_id = 0
     current_rank_bytes: dict[int, int] = {}
+    current_params = 0
     for resolved_name in parameter_order:
         parameter_rank_bytes = dict(source_bytes[resolved_name])
         for rank, tensor_bytes in destination_bytes[resolved_name].items():
             parameter_rank_bytes[rank] = parameter_rank_bytes.get(rank, 0) + tensor_bytes
 
-        if current_rank_bytes and any(
-            current_rank_bytes.get(rank, 0) + tensor_bytes > max_batch_bytes
+        over_bytes = any(
+            current_rank_bytes.get(rank, 0) + tensor_bytes > byte_limit
             for rank, tensor_bytes in parameter_rank_bytes.items()
-        ):
+        )
+        over_params = max_batch_params is not None and current_params >= max_batch_params
+        if current_rank_bytes and (over_bytes or over_params):
             batch_id += 1
             current_rank_bytes.clear()
+            current_params = 0
 
         batch_ids[resolved_name] = batch_id
+        current_params += 1
         for rank, tensor_bytes in parameter_rank_bytes.items():
             current_rank_bytes[rank] = current_rank_bytes.get(rank, 0) + tensor_bytes
 
@@ -762,6 +792,7 @@ def build_plan_from_rosters(
     my_plan = ReshardPlan(
         [], [], num_batches=num_batches, execution_batch_bytes=execution_batch_bytes
     )
+    total_tasks = 0
     for (
         task_id,
         dst_rank,
@@ -771,6 +802,7 @@ def build_plan_from_rosters(
         src_metadata,
         dst_metadata,
     ) in _iter_global_transfer_ops(dst_param_metadata_by_rank, src_param_metadata):
+        total_tasks = task_id + 1
         if dst_rank == my_global_rank:
             my_plan.recv_ops.append(
                 TransferOp(
@@ -796,6 +828,7 @@ def build_plan_from_rosters(
                 )
             )
 
+    my_plan.total_tasks = total_tasks
     logger.info(
         f"Rank {my_global_rank}: Built plan locally - {len(my_plan.recv_ops)} recvs, "
         f"{len(my_plan.send_ops)} sends"

--- a/megatron/core/resharding/utils.py
+++ b/megatron/core/resharding/utils.py
@@ -163,6 +163,10 @@ class ReshardPlan:
     # Number of globally coordinated batches in send_ops/recv_ops. Backends
     # that require one stable model-wide registration can opt out at execution.
     num_batches: int = 1
+    # Total number of transfers (task ids) in the global schedule, identical on
+    # every rank. Lets a copy service size its submissions from plan-global data
+    # rather than from this rank's own op count, so all ranks decide alike.
+    total_tasks: int | None = None
     # Effective soft execution limit after ranks agree on the smallest
     # configured value. Native backends may reuse this coordinated value for
     # their own grouped submissions.

--- a/tests/unit_tests/resharding/test_copy_services.py
+++ b/tests/unit_tests/resharding/test_copy_services.py
@@ -296,3 +296,105 @@ def test_nccl_service_eagerly_connects_before_first_run(monkeypatch):
 
     assert group.requested_devices == [device]
     assert backend.connected_devices == [device]
+
+
+def _windowing_fixture(monkeypatch, *, rank=0, world=2):
+    """NCCL service with fakes for the process group, streams, and batch_isend_irecv."""
+    device = torch.device("cuda", rank)
+
+    class Backend:
+        def eager_connect_single_device(self, _device):
+            pass
+
+    class Group:
+        def rank(self):
+            return rank
+
+        def size(self):
+            return world
+
+        def _get_backend(self, _device):
+            return Backend()
+
+    class Stream:
+        def wait_stream(self, _stream):
+            pass
+
+    class Work:
+        def wait(self):
+            pass
+
+    calls: list[int] = []
+
+    def fake_batch_isend_irecv(ops):
+        calls.append(len(ops))
+        return [Work()]
+
+    stream = Stream()
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: device.index)
+    monkeypatch.setattr(torch.cuda, "Stream", lambda: stream)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: stream)
+    import torch.distributed as dist
+
+    monkeypatch.setattr(dist, "batch_isend_irecv", fake_batch_isend_irecv)
+    monkeypatch.setattr(dist, "P2POp", lambda op, tensor, peer, group=None: (op, peer))
+    return NCCLCopyService(group=Group()), calls
+
+
+class _Plan:
+    def __init__(self, total_tasks, num_batches=1):
+        self.total_tasks = total_tasks
+        self.num_batches = num_batches
+
+
+class TestNCCLTaskWindows:
+    """A huge single-batch submission is issued in global task-id windows."""
+
+    def test_large_single_batch_plan_is_windowed(self, monkeypatch):
+        service, calls = _windowing_fixture(monkeypatch)
+        monkeypatch.setattr(NCCLCopyService, "TASK_WINDOW", 256)
+        service.set_plan(_Plan(total_tasks=600, num_batches=1))
+        # This rank owns only the odd task ids: windows are still keyed by the
+        # global id, so the peer (owning the even ids) lands in the same windows.
+        for task_id in range(1, 600, 2):
+            service.submit_send(_t(), dest_rank=1, task_id=task_id)
+        service.run()
+        assert calls == [128, 128, 44]
+        assert not service.send_ops and not service.recv_ops
+
+    def test_small_plan_uses_one_group(self, monkeypatch):
+        service, calls = _windowing_fixture(monkeypatch)
+        monkeypatch.setattr(NCCLCopyService, "TASK_WINDOW", 256)
+        service.set_plan(_Plan(total_tasks=200, num_batches=1))
+        for task_id in range(200):
+            service.submit_recv(_t(), src_rank=1, task_id=task_id)
+        service.run()
+        assert calls == [200]
+
+    def test_planner_batches_are_trusted(self, monkeypatch):
+        """Multi-batch plans already bound each run(); no extra windowing."""
+        service, calls = _windowing_fixture(monkeypatch)
+        monkeypatch.setattr(NCCLCopyService, "TASK_WINDOW", 4)
+        service.set_plan(_Plan(total_tasks=600, num_batches=20))
+        for task_id in range(30):
+            service.submit_send(_t(), dest_rank=1, task_id=task_id)
+        service.run()
+        assert calls == [30]
+
+    def test_missing_task_ids_fall_back_to_one_group(self, monkeypatch):
+        service, calls = _windowing_fixture(monkeypatch)
+        monkeypatch.setattr(NCCLCopyService, "TASK_WINDOW", 4)
+        service.set_plan(_Plan(total_tasks=600, num_batches=1))
+        for _ in range(10):
+            service.submit_send(_t(), dest_rank=1, task_id=None)
+        service.run()
+        assert calls == [10]
+
+    def test_windowing_can_be_disabled(self, monkeypatch):
+        service, calls = _windowing_fixture(monkeypatch)
+        monkeypatch.setattr(NCCLCopyService, "TASK_WINDOW", 0)
+        service.set_plan(_Plan(total_tasks=600, num_batches=1))
+        for task_id in range(600):
+            service.submit_send(_t(), dest_rank=1, task_id=task_id)
+        service.run()
+        assert calls == [600]

--- a/tests/unit_tests/resharding/test_planner.py
+++ b/tests/unit_tests/resharding/test_planner.py
@@ -1145,3 +1145,62 @@ class TestTensorReshardSpecs:
 
         assert error is None
         assert [(spec.src_ranks, spec.dst_ranks) for spec in specs] == [((0,), (2,)), ((1,), (3,))]
+
+
+class TestDefaultParameterCap:
+    """Execution batches are on by default, capped by logical parameters per batch."""
+
+    @staticmethod
+    def _rosters(num_params):
+        names = [f"p{i}" for i in range(num_params)]
+        return [
+            (
+                [
+                    _meta(name=n, shape=(8,), owner_rank=0, tp_ranks=[0], dp_ranks=[0])
+                    for n in names
+                ],
+                [],
+            ),
+            (
+                [],
+                [
+                    _meta(name=n, shape=(8,), owner_rank=1, tp_ranks=[1], dp_ranks=[1])
+                    for n in names
+                ],
+            ),
+        ]
+
+    def test_default_cap_splits_large_plans_consistently(self, monkeypatch):
+        monkeypatch.delenv("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH", raising=False)
+        monkeypatch.setattr(planner, "DEFAULT_MAX_PARAMS_PER_BATCH", 32)
+        plans = _build_all(self._rosters(70))
+        assert {plan.num_batches for plan in plans.values()} == {3}
+        assert {plan.total_tasks for plan in plans.values()} == {70}
+        send_batches = {op.task_id: op.batch_id for op in plans[0].send_ops}
+        recv_batches = {op.task_id: op.batch_id for op in plans[1].recv_ops}
+        assert send_batches == recv_batches
+        assert max(send_batches.values()) == 2
+        # Exactly the cap in every full batch.
+        from collections import Counter
+
+        assert sorted(Counter(send_batches.values()).values()) == [6, 32, 32]
+
+    def test_small_plans_stay_in_one_batch(self, monkeypatch):
+        monkeypatch.delenv("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH", raising=False)
+        plans = _build_all(self._rosters(5))
+        assert {plan.num_batches for plan in plans.values()} == {1}
+
+    def test_env_override_and_disable(self, monkeypatch):
+        monkeypatch.setenv("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH", "10")
+        plans = _build_all(self._rosters(25))
+        assert {plan.num_batches for plan in plans.values()} == {3}
+        monkeypatch.setenv("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH", "0")
+        plans = _build_all(self._rosters(70))
+        assert {plan.num_batches for plan in plans.values()} == {1}
+
+    def test_byte_limit_and_parameter_cap_compose(self, monkeypatch):
+        monkeypatch.setenv("MEGATRON_REFIT_MAX_PARAMS_PER_BATCH", "1000")
+        plans = _build_all(
+            self._rosters(4), execution_batch_bytes=64
+        )  # two 32-byte params per batch
+        assert {plan.num_batches for plan in plans.values()} == {2}


### PR DESCRIPTION
…it deadlock

The NCCL copy service submitted every send/recv of a reshard plan as one batch_isend_irecv, i.e. one ncclGroup with the whole model in it (~15k ops per rank for a 67B MoE refit, sizes from a few KB to hundreds of MB, several peers). NCCL splits such a group into multiple kernel plans by an internal budget, and because the split point depends on each rank's own op list, matching sends and recvs can land in different kernel plans on the two ranks. The resulting device-side dependency cycle hangs the refit forever: https://github.com/pytorch/pytorch/issues/174288

Observed as a NeMo-RL Megatron non-colocated refit (TP8/EP16 -> TP4/EP4, 32 ranks across two racks) never returning, while TP8/EP8 (half the ops per rank) completed. Reproduced standalone on 4 GPUs by replaying the exact plan op list: 24k ops per rank in one group hangs on NCCL 2.30.4 and 2.30.7, 8k ops passes, and the same 24k ops split into task-id windows passes.

Two layers, both deterministic across ranks so no rank can disagree on which submission a transfer belongs to:

* planner: execution batches are now on by default, capped at DEFAULT_MAX_PARAMS_PER_BATCH (32) logical parameters per lockstep batch in addition to the existing byte limit. All shards/replicas of a parameter stay in one batch and every destination rank is served in every batch, so the fleet stays busy. MEGATRON_REFIT_MAX_PARAMS_PER_BATCH overrides; 0 disables. Only copy services with supports_multiple_runs_per_plan (NCCL) consume the batches; gloo/NIXL/M2N behavior is unchanged.
* NCCLCopyService.run(): if a submission still exceeds MAX_OPS_PER_GROUP (256) ops, issue it as consecutive batch_isend_irecv calls over windows of TASK_WINDOW (256) global task ids. Sender and receiver share a transfer's task id, so both place it in the same window.

Validated end to end in NeMo-RL (TP2/EP2 -> TP1/EP1 refit): 241 batches of <=75 ops, transfer 1.8s, total sync time unchanged; windowed fallback 2.1s.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
