### PR TITLE
Support GPT checkpoint loading into grouped HybridModel

### DIFF
--- a/megatron/core/dist_checkpointing/gpt_checkpoint_interop.py
+++ b/megatron/core/dist_checkpointing/gpt_checkpoint_interop.py
@@ -8,6 +8,9 @@ sub-modules under ``decoder.layers.<i>.``. HybridModel gives every sub-block
 its own layer: in a pattern such as ``M*-M*-`` each GPT layer corresponds to
 one attention ('*') position and one MLP ('-' dense or 'E' MoE) position,
 while SSM ('M') positions have no GPT counterpart.
+Bracketed groups keep the same physical pairing, but combine their members'
+storage keys under one logical layer index. Their explicit module paths retain
+the inner ``layers.<member>.`` nesting.
 
 Rather than rewriting the checkpoint on disk, the hybrid run's own sharded
 state dict is retargeted at load time:
@@ -17,7 +20,8 @@ state dict is retargeted at load time:
   ``key`` (``decoder.layers.<g>.mlp...`` -> ``decoder.layers.mlp...``) and
   the matching GPT layer index becomes a prepended sharding axis, exactly
   mirroring ``TransformerBlock.sharded_state_dict`` with
-  ``non_homogeneous_layers=False`` (the format GPTModel training saves);
+  ``non_homogeneous_layers=False``. When source checkpoint metadata has explicit
+  layer keys, the GPT layer index stays in the key and no axis is added;
 * ``decoder.final_norm`` is pointed at GPT's ``decoder.final_layernorm``;
 * HybridModel's empty ``output_layer._extra_state`` entry stays local because
   GPT checkpoints intentionally omit that backward-compatibility key;
@@ -58,8 +62,11 @@ from megatron.core.dist_checkpointing.mapping import (
 )
 from megatron.core.models.hybrid.hybrid_layer_allocation import (
     Symbols,
+    flatten_layer_type_list,
     get_layer_maps_from_layer_type_list,
+    is_layer_group,
     parse_hybrid_pattern,
+    parse_segment_layers,
 )
 
 # Hybrid layer symbols that have a GPT-side source of weights ('*', '-', 'E')
@@ -89,12 +96,15 @@ class GPTCompatLayerMaps:
         fresh_init: hybrid global layer indices with no GPT counterpart;
             their modules keep the run's fresh initialization.
         num_gpt_layers: number of layers the source GPT checkpoint must have.
+        logical_to_physical: physical index, or tuple of member indices for a
+            bracketed group, for each logical layer in the model's storage keys.
     """
 
     attention_to_gpt: Mapping[int, int]
     mlp_to_gpt: Mapping[int, int]
     fresh_init: frozenset
     num_gpt_layers: int
+    logical_to_physical: tuple[int | tuple[int, ...], ...]
 
 
 def gpt_compatible_layer_maps(hybrid_layer_pattern: str) -> GPTCompatLayerMaps:
@@ -123,7 +133,8 @@ def gpt_compatible_layer_maps(hybrid_layer_pattern: str) -> GPTCompatLayerMaps:
     if not main_pattern:
         raise ValueError("Hybrid layer pattern is empty; set --hybrid-layer-pattern.")
 
-    layer_type_list = list(main_pattern)
+    logical_layers = parse_segment_layers(main_pattern)
+    layer_type_list = flatten_layer_type_list(logical_layers)
     translatable = set(_GPT_SOURCED_SYMBOLS) | set(_FRESH_INIT_SYMBOLS)
     unknown = sorted(set(layer_type_list) - translatable)
     if unknown:
@@ -154,12 +165,62 @@ def gpt_compatible_layer_maps(hybrid_layer_pattern: str) -> GPTCompatLayerMaps:
             f"sub-module, so the pattern needs an equal, nonzero number of each."
         )
 
+    logical_to_physical = []
+    physical_idx = 0
+    for layer in logical_layers:
+        if is_layer_group(layer):
+            logical_to_physical.append(tuple(range(physical_idx, physical_idx + len(layer))))
+            physical_idx += len(layer)
+        else:
+            logical_to_physical.append(physical_idx)
+            physical_idx += 1
+
     return GPTCompatLayerMaps(
         attention_to_gpt=dict(attention_map),
         mlp_to_gpt=dict(mlp_map),
         fresh_init=frozenset(layer_maps[Symbols.MAMBA]),
         num_gpt_layers=len(attention_map),
+        logical_to_physical=tuple(logical_to_physical),
     )
+
+
+def _resolve_hybrid_layer(key, layer_match, layer_maps, *, explicit=False):
+    """Resolve a logical storage key or nested module key to a physical layer."""
+    logical_idx = int(layer_match.group(1))
+    suffix = key[layer_match.end() :]
+    if logical_idx >= len(layer_maps.logical_to_physical):
+        raise ValueError(
+            f"State dict entry {key!r} refers to hybrid layer {logical_idx}, which is not "
+            "part of the hybrid layer pattern used to derive the GPT layer maps."
+        )
+    physical_indices = layer_maps.logical_to_physical[logical_idx]
+    if isinstance(physical_indices, int):
+        return physical_indices, suffix
+
+    # FSDP uses the actual nested module path, whereas sharded storage keys
+    # coalesce all members of a group under the same logical layer index.
+    if explicit:
+        member_match = re.match(r'layers\.(\d+)\.', suffix)
+        if member_match is not None:
+            member_idx = int(member_match.group(1))
+            if member_idx < len(physical_indices):
+                return physical_indices[member_idx], suffix[member_match.end() :]
+        raise ValueError(
+            f"State dict entry {key!r} does not identify a member of its hybrid group."
+        )
+
+    if suffix.startswith(('self_attention.', 'input_layernorm.')):
+        candidates = layer_maps.attention_to_gpt
+    elif suffix.startswith(('mlp.', 'pre_mlp_layernorm.')):
+        candidates = layer_maps.mlp_to_gpt
+    elif suffix.startswith(('mixer.', 'norm.')):
+        candidates = layer_maps.fresh_init
+    else:
+        candidates = ()
+    matches = [idx for idx in physical_indices if idx in candidates]
+    if len(matches) != 1:
+        raise ValueError(f"Cannot identify the hybrid group member for state dict entry {key!r}.")
+    return matches[0], suffix
 
 
 def _prepend_gpt_layer_axis(entry, gpt_layer_idx: int, num_gpt_layers: int):
@@ -203,13 +264,15 @@ def _prepend_gpt_layer_axis(entry, gpt_layer_idx: int, num_gpt_layers: int):
 
 
 def retarget_sharded_state_dict_to_gpt_checkpoint(
-    sharded_state_dict: ShardedStateDict, layer_maps: GPTCompatLayerMaps
+    sharded_state_dict: ShardedStateDict,
+    layer_maps: GPTCompatLayerMaps,
+    checkpoint_keys: Iterable[str] | None = None,
 ) -> None:
     """Point a hybrid model's sharded state dict at a GPT checkpoint, in place.
 
     Only the storage lookup metadata (``key`` and sharding axes) of each
-    ``ShardedBase`` entry is rewritten into the GPT checkpoint's homogeneous
-    layer format; the nested state dict structure (used by the subsequent
+    ``ShardedBase`` entry is rewritten into the GPT checkpoint's layer format;
+    the nested state dict structure (used by the subsequent
     ``load_state_dict``) keeps the hybrid model's own names. Entries of layers
     with no GPT counterpart are replaced by ``LocalNonpersistentObject`` so the
     loaded state dict returns their current (freshly initialized) values.
@@ -225,7 +288,13 @@ def retarget_sharded_state_dict_to_gpt_checkpoint(
             state dict.
         layer_maps: maps from :func:`gpt_compatible_layer_maps` derived from
             the same pattern the model was built with.
+        checkpoint_keys: source checkpoint storage keys. Indexed layer keys
+            select the heterogeneous format; otherwise prepend a layer axis.
+            Omit to use the historical homogeneous GPT format.
     """
+    non_homogeneous_layers = checkpoint_keys is not None and any(
+        _DECODER_LAYER_KEY_RE.search(key) is not None for key in checkpoint_keys
+    )
 
     def _retarget(entry):
         if not isinstance(entry, ShardedBase):
@@ -236,7 +305,7 @@ def retarget_sharded_state_dict_to_gpt_checkpoint(
 
         layer_match = _DECODER_LAYER_KEY_RE.search(entry.key)
         if layer_match is not None:
-            hybrid_idx = int(layer_match.group(1))
+            hybrid_idx, suffix = _resolve_hybrid_layer(entry.key, layer_match, layer_maps)
             if hybrid_idx in layer_maps.fresh_init:
                 return LocalNonpersistentObject(entry.data)
             gpt_idx = layer_maps.attention_to_gpt.get(hybrid_idx)
@@ -249,12 +318,12 @@ def retarget_sharded_state_dict_to_gpt_checkpoint(
                     f"used to derive the GPT layer maps. The pattern and the "
                     f"instantiated model do not match."
                 )
-            # GPT checkpoints use the homogeneous layer format: no layer index
-            # in the key, the layer is a sharding axis instead.
-            entry.key = (
-                f'{entry.key[:layer_match.start()]}decoder.layers.'
-                f'{entry.key[layer_match.end():]}'
-            )
+            layer_prefix = f'{entry.key[:layer_match.start()]}decoder.layers.'
+            if non_homogeneous_layers:
+                entry.key = f'{layer_prefix}{gpt_idx}.{suffix}'
+                return entry
+            # Homogeneous GPT checkpoints encode the layer as a sharding axis.
+            entry.key = f'{layer_prefix}{suffix}'
             return _prepend_gpt_layer_axis(entry, gpt_idx, layer_maps.num_gpt_layers)
 
         for hybrid_prefix, gpt_prefix in _GPT_FINAL_NORM_KEY_MAP.items():
@@ -284,7 +353,7 @@ def _retarget_explicit_key_to_gpt_checkpoint(
 
     layer_match = _DECODER_LAYER_KEY_RE.search(key)
     if layer_match is not None:
-        hybrid_idx = int(layer_match.group(1))
+        hybrid_idx, suffix = _resolve_hybrid_layer(key, layer_match, layer_maps, explicit=True)
         if hybrid_idx in layer_maps.fresh_init:
             return None
         gpt_idx = layer_maps.attention_to_gpt.get(hybrid_idx)
@@ -296,7 +365,7 @@ def _retarget_explicit_key_to_gpt_checkpoint(
                 "which is not part of the hybrid layer pattern used to derive the "
                 "GPT layer maps."
             )
-        key = f'{key[:layer_match.start()]}decoder.layers.{gpt_idx}.' f'{key[layer_match.end():]}'
+        key = f'{key[:layer_match.start()]}decoder.layers.{gpt_idx}.{suffix}'
 
     for hybrid_prefix, gpt_prefix in _GPT_FINAL_NORM_KEY_MAP.items():
         pos = key.find(hybrid_prefix)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -46,7 +46,10 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 from megatron.core.msc_utils import MultiStorageClientFeature, maybe_msc
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from megatron.core.optimizer import DistributedOptimizer
-from megatron.core.post_training.modelopt.checkpointing import save_modelopt_state, save_sharded_modelopt_state
+from megatron.core.post_training.modelopt.checkpointing import (
+    save_modelopt_state,
+    save_sharded_modelopt_state,
+)
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.utils import get_pg_rank, get_pg_size, unwrap_model
@@ -2749,6 +2752,14 @@ def load_checkpoint(
                 retarget_sharded_state_dict_to_gpt_checkpoint,
             )
 
+            # GPT can save either homogeneous layer axes or explicit layer keys.
+            # Inspect the saved keys: content metadata alone does not capture all
+            # TransformerBlock switches that select the heterogeneous format.
+            gpt_checkpoint_keys = (
+                dist_checkpointing.load_tensors_metadata(checkpoint_name)
+                if ckpt_type == CheckpointType.GLOBAL
+                else None
+            )
             # The optimizer sharded state dict is built from the (hybrid) model sharded
             # state dict, so its entries carry the same ``decoder.layers.<i>.`` keys and
             # sharding; the same retargeting points them at the GPT checkpoint too.
@@ -2758,7 +2769,9 @@ def load_checkpoint(
                     sd_key == 'optimizer' or re.fullmatch(r'optimizer\d+', sd_key)
                 )
                 if is_model or is_optim:
-                    retarget_sharded_state_dict_to_gpt_checkpoint(sub_sd, gpt_compat_layer_maps)
+                    retarget_sharded_state_dict_to_gpt_checkpoint(
+                        sub_sd, gpt_compat_layer_maps, gpt_checkpoint_keys
+                    )
     elif args.ckpt_format == 'torch_dcp':
         model_sd = model[0].state_dict()
         optimizer_sd = optimizer.state_dict(is_loading=True)

--- a/tests/unit_tests/dist_checkpointing/models/test_gpt_hybrid_interop.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_gpt_hybrid_interop.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 from megatron.core import parallel_state as ps
-from megatron.core.dist_checkpointing import load, load_plain_tensors, save
+from megatron.core.dist_checkpointing import load, load_plain_tensors, load_tensors_metadata, save
 from megatron.core.dist_checkpointing.dict_utils import diff
 from megatron.core.dist_checkpointing.gpt_checkpoint_interop import (
     gpt_compatible_layer_maps,
@@ -39,6 +39,8 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_allocation import get_hybrid_total_layer_count
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.num_microbatches_calculator import (
@@ -81,6 +83,20 @@ class TestGPTCompatLayerMaps:
         assert maps.mlp_to_gpt == {2: 0, 3: 1}
         assert maps.fresh_init == frozenset()
 
+    def test_groups_preserve_physical_pairing_and_logical_membership(self):
+        maps = gpt_compatible_layer_maps('M[*-]|*[-*]-')
+        assert maps.attention_to_gpt == {1: 0, 3: 1, 5: 2}
+        assert maps.mlp_to_gpt == {2: 0, 4: 1, 6: 2}
+        assert maps.fresh_init == frozenset({0})
+        assert maps.logical_to_physical == (0, (1, 2), 3, (4, 5), 6)
+        assert maps.num_gpt_layers == 3
+
+    def test_grouped_moe_and_singleton_groups(self):
+        maps = gpt_compatible_layer_maps('[M][*E]|[M*E]')
+        assert maps.logical_to_physical == ((0,), (1, 2), (3, 4, 5))
+        assert maps.attention_to_gpt == {1: 0, 4: 1}
+        assert maps.mlp_to_gpt == {2: 0, 5: 1}
+
     def test_rejects_empty_pattern(self):
         with pytest.raises(ValueError, match='empty'):
             gpt_compatible_layer_maps(None)
@@ -113,6 +129,106 @@ def _sharded_tensor(key):
 
 
 class TestRetargetShardedStateDict:
+    @pytest.mark.parametrize('heterogeneous', [False, True])
+    def test_grouped_storage_keys_resolve_each_component_and_its_norm(self, heterogeneous):
+        maps = gpt_compatible_layer_maps('M[*-]*[-*]-')
+        checkpoint_keys = (
+            ['decoder.layers.0.self_attention.linear_qkv.weight'] if heterogeneous else None
+        )
+        cases = {
+            'decoder.layers.1.self_attention.linear_qkv.weight': 0,
+            'decoder.layers.1.mlp.linear_fc1.weight': 0,
+            'decoder.layers.2.self_attention.linear_proj.weight': 1,
+            'decoder.layers.3.input_layernorm.weight': 2,
+            'decoder.layers.3.pre_mlp_layernorm.weight': 1,
+            'decoder.layers.4.mlp.linear_fc2.weight': 2,
+            'optimizer.state.exp_avg.decoder.layers.3.mlp.linear_fc1.weight': 1,
+            'optimizer.state.fp32_param.decoder.layers.3.self_attention.linear_qkv.weight': 2,
+        }
+        sharded_sd = {key: _sharded_tensor(key) for key in cases}
+        sharded_sd['decoder.final_norm.weight'] = _sharded_tensor('decoder.final_layernorm.weight')
+        retarget_sharded_state_dict_to_gpt_checkpoint(sharded_sd, maps, checkpoint_keys)
+        # Local module/state-dict keys stay intact; only storage metadata changes.
+        assert set(sharded_sd) == set(cases) | {'decoder.final_norm.weight'}
+        for source_key, gpt_idx in cases.items():
+            prefix, layer_key = source_key.split('decoder.layers.')
+            suffix = layer_key.split('.', 1)[1]
+            entry = sharded_sd[source_key]
+            assert entry.key == f'{prefix}decoder.layers.' + (
+                f'{gpt_idx}.{suffix}' if heterogeneous else suffix
+            )
+            assert entry.prepend_axis_num == (0 if heterogeneous else 1)
+            assert entry.global_shape == ((4,) if heterogeneous else (3, 4))
+            assert entry.global_offset == ((0,) if heterogeneous else (gpt_idx, 0))
+        assert sharded_sd['decoder.final_norm.weight'].key == 'decoder.final_layernorm.weight'
+
+    @pytest.mark.parametrize('heterogeneous', [False, True])
+    def test_grouped_factories_extra_state_and_fresh_optimizer_state(self, heterogeneous):
+        maps = gpt_compatible_layer_maps('[M*E][M*E]')
+        checkpoint_keys = ['decoder.layers.0.mlp.router.weight'] if heterogeneous else None
+
+        def build_fn(key, data, replica_id, flattened_range):
+            return {'chunk': ShardedTensor.from_rank_offsets(key, data, replica_id=replica_id)}
+
+        factory = ShardedTensorFactory(
+            'optimizer.state.exp_avg.decoder.layers.1.mlp.experts.linear_fc1.weight',
+            torch.ones(4),
+            build_fn,
+            lambda sd: sd['chunk'],
+        )
+        extra_state = ShardedObject(
+            'decoder.layers.1.mlp.experts.linear_fc1._extra_state', None, (3,), (1,)
+        )
+        fresh_tensor = torch.ones(4)
+        sharded_sd = {
+            'factory': factory,
+            'extra_state': extra_state,
+            'fresh': ShardedTensor.from_rank_offsets(
+                'optimizer.state.exp_avg.decoder.layers.1.mixer.in_proj.weight', fresh_tensor
+            ),
+            'fresh_norm': _sharded_tensor('decoder.layers.1.norm.weight'),
+        }
+        retarget_sharded_state_dict_to_gpt_checkpoint(sharded_sd, maps, checkpoint_keys)
+        assert isinstance(sharded_sd['fresh'], LocalNonpersistentObject)
+        assert sharded_sd['fresh'].unwrap() is fresh_tensor
+        assert isinstance(sharded_sd['fresh_norm'], LocalNonpersistentObject)
+        built = factory.build()['chunk']
+        layer_prefix = 'decoder.layers.1.' if heterogeneous else 'decoder.layers.'
+        assert built.key == f'optimizer.state.exp_avg.{layer_prefix}mlp.experts.linear_fc1.weight'
+        assert built.prepend_axis_num == (0 if heterogeneous else 1)
+        assert built.global_offset == ((0,) if heterogeneous else (1, 0))
+        assert extra_state.global_shape == ((3,) if heterogeneous else (2, 3))
+        assert extra_state.global_offset == ((1,) if heterogeneous else (1, 1))
+
+    def test_fsdp_grouped_module_paths_and_optimizer_names(self):
+        maps = gpt_compatible_layer_maps('[M*-][M*-]')
+        tensor = torch.ones(4)
+        source = {
+            'model': {
+                'decoder.layers.1.layers.1.self_attention.linear_qkv.weight': tensor,
+                'decoder.layers.1.layers.2.pre_mlp_layernorm.weight': tensor,
+                'decoder.layers.1.layers.0.mixer.in_proj.weight': tensor,
+            },
+            'optimizer': {
+                'state': {
+                    'module.module.decoder.layers.1.layers.2.mlp.linear_fc1.weight': {
+                        'exp_avg': tensor
+                    },
+                    'module.module.decoder.layers.1.layers.0.mixer.in_proj.weight': {
+                        'exp_avg': tensor
+                    },
+                }
+            },
+        }
+        translated = retarget_fsdp_state_dict_to_gpt_checkpoint(source, maps)
+        assert set(translated['model']) == {
+            'decoder.layers.1.self_attention.linear_qkv.weight',
+            'decoder.layers.1.pre_mlp_layernorm.weight',
+        }
+        assert translated['optimizer']['state'] == {
+            'module.module.decoder.layers.1.mlp.linear_fc1.weight': {'exp_avg': tensor}
+        }
+
     def test_keys_point_at_gpt_layout_and_fresh_layers_stay_local(self):
         # GPT checkpoints use the homogeneous layer format: numberless keys
         # with the layer index as the leading sharding axis.
@@ -360,7 +476,7 @@ def initialize_hybrid_model(seed, pattern, parallel, moe, glu=False):
     torch.manual_seed(seed)
     model_parallel_cuda_manual_seed(seed)
 
-    num_layers = len(pattern.replace('|', ''))
+    num_layers = get_hybrid_total_layer_count(pattern)
     config = TransformerConfig(num_layers=num_layers, **_base_config_kwargs(parallel, moe, glu))
     return HybridModel(
         config=config,
@@ -378,7 +494,7 @@ def initialize_hybrid_model(seed, pattern, parallel, moe, glu=False):
 def _snapshot_fresh_layers(hybrid_model, layer_maps):
     """Clone all tensors of layers that must keep their fresh initialization."""
     snapshot = {}
-    for layer in hybrid_model.decoder.layers:
+    for layer in _physical_layers(hybrid_model.decoder):
         global_idx = layer.layer_number - 1
         if global_idx in layer_maps.fresh_init:
             snapshot[global_idx] = {
@@ -390,7 +506,7 @@ def _snapshot_fresh_layers(hybrid_model, layer_maps):
 
 
 def _assert_fresh_layers_untouched(hybrid_model, layer_maps, snapshot):
-    for layer in hybrid_model.decoder.layers:
+    for layer in _physical_layers(hybrid_model.decoder):
         global_idx = layer.layer_number - 1
         if global_idx not in layer_maps.fresh_init:
             continue
@@ -400,6 +516,14 @@ def _assert_fresh_layers_untouched(hybrid_model, layer_maps, snapshot):
             assert torch.equal(
                 tensor, snapshot[global_idx][name]
             ), f'fresh layer {global_idx} tensor {name} was overwritten by the GPT load'
+
+
+def _physical_layers(stack):
+    for layer in stack.layers:
+        if isinstance(layer, HybridStack):
+            yield from _physical_layers(layer)
+        else:
+            yield layer
 
 
 def _drop_extra_state(plain_state_dict):
@@ -435,7 +559,14 @@ class TestGPTToHybridLoad:
         ],
     )
     def test_gpt_checkpoint_loads_into_hybrid_across_parallel_layouts(
-        self, tmp_path_dist_ckpt, src_parallel, dest_parallel, pattern, moe, glu
+        self,
+        tmp_path_dist_ckpt,
+        src_parallel,
+        dest_parallel,
+        pattern,
+        moe,
+        glu,
+        non_homogeneous_layers=False,
     ):
         layer_maps = gpt_compatible_layer_maps(pattern)
         src_tp, src_pp, src_ep, src_etp = src_parallel
@@ -450,7 +581,13 @@ class TestGPTToHybridLoad:
         ):
             # Save a GPT checkpoint under the source parallel layout.
             gpt_model = initialize_gpt_model(1, layer_maps.num_gpt_layers, src_parallel, moe, glu)
-            save(gpt_model.sharded_state_dict(), ckpt_dir_gpt)
+            save(
+                gpt_model.sharded_state_dict(
+                    metadata={'non_homogeneous_layers': non_homogeneous_layers}
+                ),
+                ckpt_dir_gpt,
+            )
+            checkpoint_keys = load_tensors_metadata(ckpt_dir_gpt)
             Utils.destroy_model_parallel()
 
             # Load it into a hybrid model under the destination layout by
@@ -466,7 +603,7 @@ class TestGPTToHybridLoad:
             fresh_snapshot = _snapshot_fresh_layers(hybrid_model, layer_maps)
 
             sharded_sd = hybrid_model.sharded_state_dict()
-            retarget_sharded_state_dict_to_gpt_checkpoint(sharded_sd, layer_maps)
+            retarget_sharded_state_dict_to_gpt_checkpoint(sharded_sd, layer_maps, checkpoint_keys)
             state_dict, missing_keys, unexpected_keys = load(
                 sharded_sd, ckpt_dir_gpt, strict=StrictHandling.RETURN_ALL
             )
@@ -480,7 +617,9 @@ class TestGPTToHybridLoad:
             # Save the hybrid model back under GPT keys (fresh layers stay
             # local and are skipped) and compare both checkpoints tensorwise.
             sharded_sd_back = hybrid_model.sharded_state_dict()
-            retarget_sharded_state_dict_to_gpt_checkpoint(sharded_sd_back, layer_maps)
+            retarget_sharded_state_dict_to_gpt_checkpoint(
+                sharded_sd_back, layer_maps, checkpoint_keys
+            )
             save(sharded_sd_back, ckpt_dir_back)
             Utils.destroy_model_parallel()
 
@@ -491,6 +630,29 @@ class TestGPTToHybridLoad:
             assert not only_back, f'roundtrip produced keys missing from the GPT ckpt: {only_back}'
             assert not only_gpt, f'GPT ckpt keys not covered by the hybrid load: {only_gpt}'
             assert not mismatch, f'weights changed by the GPT->hybrid->GPT roundtrip: {mismatch}'
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize('non_homogeneous_layers', [False, True])
+    @pytest.mark.parametrize(
+        ('pattern', 'dest_parallel', 'moe', 'glu'),
+        [
+            ('[*-][*-]', (1, 1, 1, 1), False, False),
+            ('M[*-]|M[*-]', (1, 2, 1, 1), False, True),
+            ('[M*E][M*E]', (1, 1, 2, 1), True, False),
+        ],
+    )
+    def test_grouped_gpt_checkpoint_roundtrip(
+        self, tmp_path_dist_ckpt, non_homogeneous_layers, pattern, dest_parallel, moe, glu
+    ):
+        self.test_gpt_checkpoint_loads_into_hybrid_across_parallel_layouts(
+            tmp_path_dist_ckpt,
+            (1, 1, 1, 1),
+            dest_parallel,
+            pattern,
+            moe,
+            glu,
+            non_homogeneous_layers=non_homogeneous_layers,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -554,7 +716,7 @@ def hybrid_provider_for_opt(
 ):
     torch.manual_seed(seed)
     model_parallel_cuda_manual_seed(seed)
-    num_layers = len(pattern.replace('|', ''))
+    num_layers = get_hybrid_total_layer_count(pattern)
     return HybridModel(
         config=_opt_provider_config(num_layers, moe=moe, **kw),
         hybrid_stack_spec=hybrid_stack_spec,
@@ -641,6 +803,7 @@ def _run_gpt_to_hybrid_optimizer_load(
     *,
     finetune=True,
     use_megatron_fsdp=False,
+    non_homogeneous_layers=False,
 ):
     layer_maps = gpt_compatible_layer_maps(pattern)
     num_gpt_layers = layer_maps.num_gpt_layers
@@ -672,6 +835,9 @@ def _run_gpt_to_hybrid_optimizer_load(
                 initialize_fn=partial(gpt_provider_for_opt, num_gpt_layers=num_gpt_layers, moe=moe),
             )
             _seed_optimizer_moments(gpt_optimizer, seed=3)
+            _unwrap_interop_model(gpt_model[0]).config.hetereogenous_dist_checkpoint = (
+                non_homogeneous_layers
+            )
             _configure_checkpoint_args(mock_args, ckpt_dir, src_parallel, moe, use_megatron_fsdp)
             mock_args.num_layers = num_gpt_layers
             save_checkpoint(10, gpt_model, gpt_optimizer, None, 0)
@@ -705,7 +871,7 @@ def _run_gpt_to_hybrid_optimizer_load(
             _configure_checkpoint_args(mock_args, ckpt_dir, dest_parallel, moe, use_megatron_fsdp)
             mock_args.finetune = finetune
             mock_args.hybrid_layer_pattern = pattern
-            mock_args.num_layers = len(pattern.replace('|', ''))
+            mock_args.num_layers = get_hybrid_total_layer_count(pattern)
 
             if not finetune:
                 data_parallel_size = ps.get_data_parallel_world_size()
@@ -741,6 +907,18 @@ def _run_gpt_to_hybrid_optimizer_load(
 class TestGPTToHybridOptimizerLoad:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize('non_homogeneous_layers', [False, True])
+    def test_grouped_model_and_optimizer_load(self, tmp_path_dist_ckpt, non_homogeneous_layers):
+        _run_gpt_to_hybrid_optimizer_load(
+            tmp_path_dist_ckpt,
+            (1, 1, 1, 1, 1),
+            (1, 1, 1, 1, 1),
+            '[M*-][M*-]',
+            False,
+            non_homogeneous_layers=non_homogeneous_layers,
+        )
 
     @pytest.mark.internal
     @pytest.mark.parametrize(
@@ -798,6 +976,9 @@ class TestGPTToHybridFSDPLoad:
                 id='resume-without-finetune',
             ),
             pytest.param((1, 1, 1, 1, 1), (1, 1, 1, 1, 1), '*-*-', False, True, id='fsdp4-dense'),
+            pytest.param(
+                (1, 1, 1, 1, 1), (1, 1, 1, 1, 1), '[M*-][M*-]', False, True, id='fsdp-grouped'
+            ),
             pytest.param(
                 (2, 1, 1, 1, 1), (1, 1, 1, 1, 1), 'M*-M*-', False, True, id='tp2-fsdp2-to-fsdp4'
             ),


### PR DESCRIPTION
## What does this PR do?

Loading a GPT checkpoint into a bracketed HybridModel currently rejects the
pattern's brackets or resolves the wrong physical layer from a logical
storage key. This change maps grouped attention and MLP members to their GPT
layers while leaving fresh Mamba parameters untouched.

The loader handles both homogeneous GPT layer axes and heterogeneous indexed
keys, applies the same mapping to optimizer state, and resolves nested module
paths for FSDP checkpoints. Tests cover grouped weight roundtrips, PP/EP
layouts, model and optimizer loading, and grouped FSDP loading.

## Scope and dependency

Extracted from #4942's review-fix commit `e8db9ddcb`, preserving the complete
checkpoint implementation and its tests. Depends on #4942's bracket parser
and logical-layer checkpoint representation. Original grouped HybridStack
work is by @Wohox, @Connor-XY, and @guihong-nv in #4798/#4942.

Files:

- `megatron/core/dist_checkpointing/gpt_checkpoint_interop.py`
- `megatron/training/checkpointing.py`
- `tests/unit_tests/dist_checkpointing/models/test_gpt_hybrid_interop.py`

This PR is based on `pull-request/4942` at `d72e5ebef` and contains only the
three checkpoint files above. Review requires core-adlr, core-nemo,
dist-checkpointing, training-adlr, and training-nemo. Retarget this PR to main
before merging #4942, then merge this follow-up after #4942.

## Validation

All 30 selected checkpoint tests passed on four GB200 GPUs in HSG job
`7038168`, including grouped GPT weight, optimizer, and FSDP loading. The
parent plus this slice reproduces the exact tested `e8db9ddcb` source tree.
Both split patches pass whitespace checks and apply cleanly.
