### PR TITLE
fix(tokenizers): align Qwen3-Coder tool parser with vLLM's parser engine

### DIFF
--- a/megatron/core/tokenizers/text/parsers/qwen3_coder_tool_parser.py
+++ b/megatron/core/tokenizers/text/parsers/qwen3_coder_tool_parser.py
@@ -2,9 +2,45 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
+"""Qwen3-Coder XML tool-call parser.
+
+The model emits tool calls as::
+
+    <tool_call>
+    <function=NAME>
+    <parameter=KEY>VALUE</parameter>
+    </function>
+    </tool_call>
+
+Parsing here mirrors vLLM's parser engine so that a model served through the
+Megatron dynamic text-generation server yields the same parsed tool calls as
+the same model served through vLLM (vLLM 0.25 routes ``qwen3_coder`` to
+``Qwen3EngineToolParser``). RL pipelines that mix the two engines rely on this
+parity because tool-use rewards are computed from the parsed arguments.
+
+Three behaviours are taken from vLLM:
+
+- Parameter values are ``str.strip()``-ed (``vllm/parser/qwen3.py``,
+  ``_qwen3_arg_converter``). The previous implementation removed at most one
+  leading and one trailing newline, so multi-line code arguments kept their
+  indentation while vLLM dropped it, and ``<parameter=x>  v  </parameter>``
+  parsed differently in the two servers.
+- Content preceding the tool calls is ``str.strip()``-ed and an empty result
+  becomes ``None`` (``ParserEngine._strip_content_whitespace`` with
+  ``strip_content_whitespace_with_tools=True``).
+- Schema-based type coercion follows ``vllm/tool_parsers/utils.py``
+  (``extract_types_from_schema`` + ``coerce_to_schema_type``): candidate types
+  are tried in the order null > integer > number > boolean > object > array >
+  string, ``"1"``/``"0"`` are accepted as booleans, a value that matches none of
+  the schema types falls back to ``json.loads`` and otherwise stays a string.
+  The previous implementation degraded unparseable booleans to ``False``,
+  accepted Python literals for objects via ``ast.literal_eval`` and returned
+  ``None`` for ``"null"`` regardless of the schema.
+"""
+
 import json
 import logging
+import math
 import re
 import uuid
 from typing import Any
@@ -19,6 +55,157 @@ FunctionCall = dict[str, Any]
 ChatCompletionToolsParam = dict[str, Any]
 ChatCompletionRequest = dict[str, Any]
 ExtractedToolCallInformation = dict
+
+# Mirrors vllm/tool_parsers/utils.py::_TYPE_ALIASES.
+_TYPE_ALIASES: dict[str, str] = {
+    "str": "string",
+    "text": "string",
+    "varchar": "string",
+    "char": "string",
+    "enum": "string",
+    "int": "integer",
+    "int32": "integer",
+    "int64": "integer",
+    "uint": "integer",
+    "uint32": "integer",
+    "uint64": "integer",
+    "long": "integer",
+    "short": "integer",
+    "unsigned": "integer",
+    "float": "number",
+    "float32": "number",
+    "float64": "number",
+    "double": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "arr": "array",
+    "list": "array",
+    "sequence": "array",
+}
+
+# Priority in which candidate schema types are tried during coercion.
+_TYPE_PRIORITY = ("null", "integer", "number", "boolean", "object", "array", "string")
+
+
+def _extract_types_from_schema(schema: Any) -> list[str]:
+    """Extract all possible type strings from a JSON Schema definition.
+
+    Handles ``type`` (string or list), ``enum`` value inference, and recursive
+    ``anyOf``/``oneOf``/``allOf``. Returns ``["string"]`` when no type
+    information can be determined. Mirrors
+    ``vllm/tool_parsers/utils.py::extract_types_from_schema``.
+    """
+    if schema is None or not isinstance(schema, dict):
+        return ["string"]
+
+    types: set[str] = set()
+
+    if "type" in schema:
+        type_value = schema["type"]
+        if isinstance(type_value, str):
+            types.add(type_value)
+        elif isinstance(type_value, list):
+            for t in type_value:
+                if isinstance(t, str):
+                    types.add(t)
+
+    if "enum" in schema and isinstance(schema["enum"], list) and schema["enum"]:
+        for value in schema["enum"]:
+            if value is None:
+                types.add("null")
+            elif isinstance(value, bool):
+                types.add("boolean")
+            elif isinstance(value, int):
+                types.add("integer")
+            elif isinstance(value, float):
+                types.add("number")
+            elif isinstance(value, str):
+                types.add("string")
+            elif isinstance(value, list):
+                types.add("array")
+            elif isinstance(value, dict):
+                types.add("object")
+
+    for choice_field in ("anyOf", "oneOf", "allOf"):
+        if choice_field in schema and isinstance(schema[choice_field], list):
+            for choice in schema[choice_field]:
+                types.update(_extract_types_from_schema(choice))
+
+    return list(types) if types else ["string"]
+
+
+def _is_json_finite(obj: Any) -> bool:
+    """Whether ``obj`` serializes to valid JSON (no ``inf``/``nan`` anywhere inside)."""
+    try:
+        json.dumps(obj, allow_nan=False)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
+    """Best-effort coercion of a raw string value to a JSON Schema type.
+
+    Tries each type in priority order (null > integer > number > boolean >
+    object > array > string) and returns the first successful coercion. When
+    no schema type matches, the value is parsed with ``json.loads`` and falls
+    back to the original string. Mirrors
+    ``vllm/tool_parsers/utils.py::coerce_to_schema_type``.
+    """
+    if isinstance(schema_type, str):
+        schema_type = [schema_type]
+
+    normalized_types = {
+        _TYPE_ALIASES.get(key, key) for t in schema_type for key in [t.strip().lower()]
+    }
+
+    for candidate_type in _TYPE_PRIORITY:
+        if candidate_type not in normalized_types:
+            continue
+
+        if candidate_type == "null":
+            if value.lower() == "null":
+                return None
+            continue
+        if candidate_type == "string":
+            return value
+        if candidate_type == "integer":
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                continue
+        if candidate_type == "number":
+            try:
+                val = float(value)
+            except (ValueError, TypeError):
+                continue
+            if not math.isfinite(val):
+                # inf/-inf/nan are not valid JSON numbers; keep the raw string.
+                continue
+            return val if val != int(val) else int(val)
+        if candidate_type == "boolean":
+            lower_val = value.lower().strip()
+            if lower_val in ("true", "1"):
+                return True
+            if lower_val in ("false", "0"):
+                return False
+            continue
+        if candidate_type in ("object", "array"):
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+            if _is_json_finite(parsed):
+                return parsed
+            continue
+
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
+    if not _is_json_finite(parsed):
+        return value
+    return parsed
 
 
 class _Qwen3CoderToolParser:
@@ -43,8 +230,13 @@ class _Qwen3CoderToolParser:
     def _get_arguments_config(
         self, func_name: str, tools: list[ChatCompletionToolsParam] | None
     ) -> dict:
-        """Extract argument configuration for a function."""
-        if tools is None:
+        """Return the ``properties`` schema of ``func_name``, or ``{}``.
+
+        Mirrors ``vllm/tool_parsers/utils.py::find_tool_properties``: only the
+        ``parameters.properties`` mapping drives coercion; a tool without it, or a
+        function that is not in ``tools``, leaves every argument a string.
+        """
+        if not tools:
             return {}
         for config in tools:
             if not isinstance(config, dict):
@@ -54,26 +246,26 @@ class _Qwen3CoderToolParser:
                 continue
             if config.get("type") != "function" or fn.get("name") != func_name:
                 continue
-            params = fn.get("parameters", {})
-            if isinstance(params, dict) and "properties" in params:
-                return params["properties"]
-            elif isinstance(params, dict):
-                return params
-            else:
+            params = fn.get("parameters") or {}
+            if not isinstance(params, dict):
                 return {}
+            properties = params.get("properties", {})
+            return properties if isinstance(properties, dict) else {}
         logger.debug("Tool '%s' is not defined in the tools list.", func_name)
         return {}
 
     def _convert_param_value(
         self, param_value: str, param_name: str, param_config: dict, func_name: str
     ) -> Any:
-        """Convert parameter value based on its type in the schema."""
-        # Handle null value for any type
-        if param_value.lower() == "null":
-            return None
+        """Convert a parameter value according to its JSON Schema, like vLLM does.
 
-        if param_name not in param_config:
-            if param_config != {}:
+        Parameters absent from the schema (or whose schema is not a mapping) are
+        returned unchanged as strings; everything else goes through
+        ``_coerce_to_schema_type``.
+        """
+        schema = param_config.get(param_name) if param_config else None
+        if not isinstance(schema, dict):
+            if param_config:
                 logger.debug(
                     "Parsed parameter '%s' is not defined in the tool "
                     "parameters for tool '%s', directly returning the "
@@ -82,93 +274,7 @@ class _Qwen3CoderToolParser:
                     func_name,
                 )
             return param_value
-
-        if isinstance(param_config[param_name], dict) and "type" in param_config[param_name]:
-            param_type = str(param_config[param_name]["type"]).strip().lower()
-        elif isinstance(param_config[param_name], dict) and "anyOf" in param_config[param_name]:
-            # anyOf has no top-level "type"; treat as object to trigger json.loads.
-            param_type = "object"
-        else:
-            param_type = "string"
-        if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-            return param_value
-        elif (
-            param_type.startswith("int")
-            or param_type.startswith("uint")
-            or param_type.startswith("long")
-            or param_type.startswith("short")
-            or param_type.startswith("unsigned")
-        ):
-            try:
-                return int(param_value)
-            except (ValueError, TypeError):
-                logger.debug(
-                    "Parsed value '%s' of parameter '%s' is not an "
-                    "integer in tool '%s', degenerating to string.",
-                    param_value,
-                    param_name,
-                    func_name,
-                )
-                return param_value
-        elif param_type.startswith("num") or param_type.startswith("float"):
-            try:
-                float_param_value = float(param_value)
-                return (
-                    float_param_value
-                    if float_param_value - int(float_param_value) != 0
-                    else int(float_param_value)
-                )
-            except (ValueError, TypeError):
-                logger.debug(
-                    "Parsed value '%s' of parameter '%s' is not a float "
-                    "in tool '%s', degenerating to string.",
-                    param_value,
-                    param_name,
-                    func_name,
-                )
-                return param_value
-        elif param_type in ["boolean", "bool", "binary"]:
-            param_value = param_value.lower()
-            if param_value not in ["true", "false"]:
-                logger.debug(
-                    "Parsed value '%s' of parameter '%s' is not a boolean "
-                    "(`true` or `false`) in tool '%s', degenerating to "
-                    "false.",
-                    param_value,
-                    param_name,
-                    func_name,
-                )
-            return param_value == "true"
-        else:
-            if (
-                param_type in ["object", "array", "arr"]
-                or param_type.startswith("dict")
-                or param_type.startswith("list")
-            ):
-                try:
-                    param_value = json.loads(param_value)
-                    return param_value
-                except (json.JSONDecodeError, TypeError, ValueError):
-                    logger.debug(
-                        "Parsed value '%s' of parameter '%s' cannot be "
-                        "parsed with json.loads in tool '%s', will try "
-                        "other methods to parse it.",
-                        param_value,
-                        param_name,
-                        func_name,
-                    )
-            try:
-                param_value = ast.literal_eval(param_value)  # safer
-            except (ValueError, SyntaxError, TypeError):
-                logger.debug(
-                    "Parsed value '%s' of parameter '%s' cannot be "
-                    "converted via Python `ast.literal_eval()` in tool "
-                    "'%s', degenerating to string.",
-                    param_value,
-                    param_name,
-                    func_name,
-                )
-            return param_value
+        return _coerce_to_schema_type(param_value, _extract_types_from_schema(schema))
 
     def _parse_xml_function_call(
         self, function_call_str: str, tools: list[ChatCompletionToolsParam] | None
@@ -187,12 +293,9 @@ class _Qwen3CoderToolParser:
             if idx == -1:
                 continue
             param_name = match_text[:idx]
-            param_value = str(match_text[idx + 1 :])
-            # Remove prefix and trailing \n
-            if param_value.startswith("\n"):
-                param_value = param_value[1:]
-            if param_value.endswith("\n"):
-                param_value = param_value[:-1]
+            # vLLM strips all surrounding whitespace from the value (the model wraps
+            # values in newlines), not just a single leading/trailing newline.
+            param_value = str(match_text[idx + 1 :]).strip()
 
             param_dict[param_name] = self._convert_param_value(
                 param_value, param_name, param_config, function_name
@@ -248,7 +351,9 @@ class _Qwen3CoderToolParser:
             content_index = model_output.find(self.tool_call_start_token)
             idx = model_output.find(self.tool_call_prefix)
             content_index = content_index if content_index >= 0 else idx
-            content = model_output[:content_index]  # .rstrip()
+            # vLLM strips the content around tool calls
+            # (ParserEngineConfig.strip_content_whitespace_with_tools=True).
+            content = model_output[:content_index].strip()
 
             return ExtractedToolCallInformation(
                 tools_called=(len(tool_calls) > 0),
@@ -273,7 +378,8 @@ class Qwen3CoderToolParser(BaseParser):
     def parse(text: str, **kwargs) -> tuple[str, dict[str, list[dict]]]:
         """
         Extracts the tool calls from the text using <tool_call>...</tool_call> tags.
-        Uses the _Qwen3CoderToolParser class (copied from vLLM) to extract the tool calls.
+        Uses the _Qwen3CoderToolParser class (behaviourally aligned with vLLM's
+        Qwen3 parser engine) to extract the tool calls.
 
         Args:
             text (str): The text to parse.

--- a/tests/unit_tests/tokenizers/test_text_parsers.py
+++ b/tests/unit_tests/tokenizers/test_text_parsers.py
@@ -17,6 +17,8 @@ implementation:
 
 """
 
+import json
+
 import pytest
 
 from megatron.core.tokenizers.text.parsers import PARSER_MAPPING
@@ -133,3 +135,358 @@ def test_tool_call_marker_does_not_end_reasoning_unless_configured():
     model_output = "reasoning<tool_call>not enabled</tool_call>"
 
     assert DeepSeekR1ReasoningParser.parse(model_output) == ("", {"reasoning": model_output})
+
+
+# --- Qwen3-Coder tool parser: parity with vLLM 0.25.1 ---------------------------------
+#
+# Expected values below were produced by vLLM 0.25.1's `Qwen3EngineToolParser` (the class
+# `qwen3_coder` resolves to in `vllm/tool_parsers/__init__.py`) called through a real
+# `ChatCompletionRequest` carrying `_PARITY_TOOLS`, i.e. exactly what vLLM's OpenAI server
+# does. They cover the three behaviours this parser takes from vLLM: `str.strip()` on
+# parameter values, stripped content around tool calls, and schema-driven type coercion
+# (`vllm/tool_parsers/utils.py::coerce_to_schema_type`).
+
+_PARITY_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "s": {"type": "string"},
+                    "i": {"type": "integer"},
+                    "n": {"type": "number"},
+                    "b": {"type": "boolean"},
+                    "o": {"type": "object"},
+                    "a": {"type": "array", "items": {"type": "integer"}},
+                    "sn": {"type": ["string", "null"]},
+                    "e": {"enum": [1, 2, 3]},
+                    "any": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                    "code": {"type": "string"},
+                    "foo": {"type": "foo"},
+                    "lst": {"type": "list"},
+                    "ntyped": {},
+                },
+            },
+        },
+    }
+]
+
+
+def _qwen3_call(params, fn="f"):
+    body = "".join(f"<parameter={k}>{v}</parameter>\n" for k, v in params)
+    return f"<tool_call>\n<function={fn}>\n{body}</function>\n</tool_call>"
+
+
+# (case id, model output, use tool schema, expected content, expected [(name, arguments)])
+QWEN3_CODER_PARITY_CASES = [
+    (
+        'strip_indent',
+        '<tool_call>\n<function=f>\n<parameter=code>\n    def f():\n        pass\n</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'code': 'def f():\n        pass'}]],
+    ),
+    (
+        'strip_spaces',
+        '<tool_call>\n<function=f>\n<parameter=s>   hello world   </parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'s': 'hello world'}]],
+    ),
+    (
+        'int_ok',
+        '<tool_call>\n<function=f>\n<parameter=i>\n42\n</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'i': 42}]],
+    ),
+    (
+        'int_bad',
+        '<tool_call>\n<function=f>\n<parameter=i>forty</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'i': 'forty'}]],
+    ),
+    (
+        'int_from_float',
+        '<tool_call>\n<function=f>\n<parameter=i>3.0</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'i': 3.0}]],
+    ),
+    (
+        'num_integral',
+        '<tool_call>\n<function=f>\n<parameter=n>3.0</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'n': 3}]],
+    ),
+    (
+        'num_frac',
+        '<tool_call>\n<function=f>\n<parameter=n>3.5</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'n': 3.5}]],
+    ),
+    (
+        'num_inf',
+        '<tool_call>\n<function=f>\n<parameter=n>inf</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'n': 'inf'}]],
+    ),
+    (
+        'num_huge',
+        '<tool_call>\n<function=f>\n<parameter=n>1e999</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'n': '1e999'}]],
+    ),
+    (
+        'bool_true',
+        '<tool_call>\n<function=f>\n<parameter=b>True</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'b': True}]],
+    ),
+    (
+        'bool_one',
+        '<tool_call>\n<function=f>\n<parameter=b>1</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'b': True}]],
+    ),
+    (
+        'bool_zero',
+        '<tool_call>\n<function=f>\n<parameter=b> 0 </parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'b': False}]],
+    ),
+    (
+        'bool_yes',
+        '<tool_call>\n<function=f>\n<parameter=b>yes</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'b': 'yes'}]],
+    ),
+    (
+        'bool_42',
+        '<tool_call>\n<function=f>\n<parameter=b>42</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'b': 42}]],
+    ),
+    (
+        'null_string_type',
+        '<tool_call>\n<function=f>\n<parameter=s>null</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'s': 'null'}]],
+    ),
+    (
+        'null_nullable',
+        '<tool_call>\n<function=f>\n<parameter=sn>null</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'sn': None}]],
+    ),
+    (
+        'sn_value',
+        '<tool_call>\n<function=f>\n<parameter=sn>x</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'sn': 'x'}]],
+    ),
+    (
+        'sn_int',
+        '<tool_call>\n<function=f>\n<parameter=sn>5</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'sn': '5'}]],
+    ),
+    (
+        'obj_json',
+        '<tool_call>\n<function=f>\n<parameter=o>{"k": [1, 2]}</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'o': {'k': [1, 2]}}]],
+    ),
+    (
+        'obj_pyliteral',
+        "<tool_call>\n<function=f>\n<parameter=o>{'k': 1}</parameter>\n</function>\n</tool_call>",
+        True,
+        None,
+        [['f', {'o': "{'k': 1}"}]],
+    ),
+    (
+        'obj_bad',
+        '<tool_call>\n<function=f>\n<parameter=o>not json</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'o': 'not json'}]],
+    ),
+    (
+        'arr_json',
+        '<tool_call>\n<function=f>\n<parameter=a>[1, 2, 3]</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'a': [1, 2, 3]}]],
+    ),
+    (
+        'arr_strings_items_int',
+        '<tool_call>\n<function=f>\n<parameter=a>["1","2"]</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'a': ['1', '2']}]],
+    ),
+    (
+        'enum_int',
+        '<tool_call>\n<function=f>\n<parameter=e>2</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'e': 2}]],
+    ),
+    (
+        'enum_bad',
+        '<tool_call>\n<function=f>\n<parameter=e>x</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'e': 'x'}]],
+    ),
+    (
+        'anyof_int',
+        '<tool_call>\n<function=f>\n<parameter=any>7</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'any': 7}]],
+    ),
+    (
+        'anyof_str',
+        '<tool_call>\n<function=f>\n<parameter=any>seven</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'any': 'seven'}]],
+    ),
+    (
+        'unknown_type_foo',
+        '<tool_call>\n<function=f>\n<parameter=foo>3</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'foo': 3}]],
+    ),
+    (
+        'list_alias',
+        '<tool_call>\n<function=f>\n<parameter=lst>[1,2]</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'lst': [1, 2]}]],
+    ),
+    (
+        'untyped_prop',
+        '<tool_call>\n<function=f>\n<parameter=ntyped>5</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'ntyped': '5'}]],
+    ),
+    (
+        'unknown_param',
+        '<tool_call>\n<function=f>\n<parameter=zzz>  v  </parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'zzz': 'v'}]],
+    ),
+    (
+        'unknown_param_num',
+        '<tool_call>\n<function=f>\n<parameter=zzz>5</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'zzz': '5'}]],
+    ),
+    (
+        'unknown_function',
+        '<tool_call>\n<function=g>\n<parameter=q>5</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['g', {'q': '5'}]],
+    ),
+    (
+        'content_before',
+        'Let me check.\n\n<tool_call>\n<function=f>\n<parameter=s>x</parameter>\n</function>\n</tool_call>',
+        True,
+        'Let me check.',
+        [['f', {'s': 'x'}]],
+    ),
+    (
+        'content_ws_only',
+        '\n\n<tool_call>\n<function=f>\n<parameter=s>x</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'s': 'x'}]],
+    ),
+    (
+        'content_after',
+        '<tool_call>\n<function=f>\n<parameter=s>x</parameter>\n</function>\n</tool_call>\nDone.\n',
+        True,
+        None,
+        [['f', {'s': 'x'}]],
+    ),
+    (
+        'two_calls',
+        '<tool_call>\n<function=f>\n<parameter=s>a</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=f>\n<parameter=i>1</parameter>\n</function>\n</tool_call>',
+        True,
+        None,
+        [['f', {'s': 'a'}], ['f', {'i': 1}]],
+    ),
+    (
+        'no_close_tool_call',
+        '<tool_call>\n<function=f>\n<parameter=s>abc</parameter>\n</function>',
+        True,
+        None,
+        [['f', {'s': 'abc'}]],
+    ),
+    (
+        'no_tools_schema',
+        '<tool_call>\n<function=f>\n<parameter=i>42</parameter>\n<parameter=b>true</parameter>\n</function>\n</tool_call>',
+        False,
+        None,
+        [['f', {'i': '42', 'b': 'true'}]],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,model_output,use_tools,expected_content,expected_calls",
+    QWEN3_CODER_PARITY_CASES,
+    ids=[c[0] for c in QWEN3_CODER_PARITY_CASES],
+)
+def test_qwen3_coder_tool_parser_matches_vllm(
+    case_id, model_output, use_tools, expected_content, expected_calls
+):
+    parser = PARSER_MAPPING["qwen3-coder-tool"]
+    content, info = parser.parse(model_output, tools=_PARITY_TOOLS if use_tools else None)
+
+    assert content == expected_content
+    calls = [
+        [call["function"]["name"], json.loads(call["function"]["arguments"])]
+        for call in info.get("tool_calls", [])
+    ]
+    assert calls == expected_calls
+
+
+def test_qwen3_coder_tool_parser_keeps_unclosed_last_parameter():
+    """Deliberate difference from vLLM: an unterminated final parameter is kept
+    (vLLM's non-streaming converter drops it). The lenient regex is what lets the
+    streaming path parse partially received tool calls, and its value is stripped
+    like every other value."""
+    text = "<tool_call>\n<function=f>\n<parameter=s>\nabc\n</function>\n</tool_call>"
+    content, info = PARSER_MAPPING["qwen3-coder-tool"].parse(text, tools=_PARITY_TOOLS)
+    assert content is None
+    assert json.loads(info["tool_calls"][0]["function"]["arguments"]) == {"s": "abc"}
+
+
+def test_qwen3_coder_tool_parser_without_tool_calls_is_passthrough():
+    text = "plain answer with <function= mention but no call"
+    assert PARSER_MAPPING["qwen3-coder-tool"].parse(text, tools=_PARITY_TOOLS) == (text, {})


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Aligns the dynamic text-generation server's `qwen3-coder-tool` parser with the behaviour of vLLM 0.25's parser engine (`Qwen3EngineToolParser`), so a model served through Megatron's OpenAI-compatible endpoint returns the same parsed tool calls as the same model served through vLLM.

## Why

The Megatron parser is a copy of vLLM's older `qwen3coder_tool_parser`. vLLM 0.25 now routes `qwen3_coder` to its new parser engine (`vllm/parser/qwen3.py` + `vllm/parser/engine/`), which parses differently in three ways:

| behaviour | old Megatron copy | vLLM 0.25 engine (now matched) |
|---|---|---|
| parameter value whitespace | remove one leading and one trailing `\n` | `str.strip()` |
| content before tool calls | returned verbatim | `str.strip()`, empty becomes `None` |
| schema type coercion | int/float/bool by type-name prefix, unparseable bool -> `False`, objects via `json.loads` then `ast.literal_eval`, `"null"` -> `None` for any type | `coerce_to_schema_type`: null > integer > number > boolean > object > array > string, `"1"`/`"0"` are booleans, fallback `json.loads`, else string |

RL pipelines that mix the two engines (e.g. NeMo RL with the Megatron in-engine generation backend vs vLLM) score tool-use tasks by comparing parsed arguments, so the two servers must agree. Measured on 2,238 tool calls generated by a Nemotron-3.5-Nano RLVR run: the old parser disagreed with vLLM 0.25.1 on 1.7% of calls (all whitespace-only, mostly indentation of `edit.old_string/new_string`, `str_replace_editor.file_text`, `bash.command`); the aligned parser disagrees on 0.

## Deliberate remaining difference

The lenient parameter regex is kept: an unterminated final `<parameter=...>` is still parsed (vLLM's non-streaming converter drops it). The streaming path (`openai_streaming.py`) relies on this to parse partially received tool calls, and a truncated tool call is malformed either way.

## Tests

`tests/unit_tests/tokenizers/test_text_parsers.py` gains 39 parametrized parity cases whose expected values were produced by vLLM 0.25.1's `Qwen3EngineToolParser` called through a real `ChatCompletionRequest` carrying the tool schemas (exactly what vLLM's OpenAI server does), plus tests for the kept lenient behaviour and pass-through.

```
pytest tests/unit_tests/tokenizers/test_text_parsers.py  ->  59 passed
```

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not applicable: pure-Python parser)
- [x] I have added proper typing to my code
- [x] I have added relevant documentation (module docstring documents the vLLM sources mirrored)
- [x] I have run the autoformatter (black + isort with repo config)
