### PR TITLE
cp: `Support FP4 in 1F1B A2A overlap (6135)` into `core_r0.19.0`

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,13 +1,10 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
-from contextlib import nullcontext
 from typing import Any, Callable, Optional
 
 import torch
 from torch import Tensor
 
-from megatron.core.enums import Fp8Recipe
-from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     NoopScheduleNode,
@@ -219,18 +216,9 @@ class TransformerLayerSchedulePlan:
         # After the last forward op, release forward-pass params.
         last_fwd_node.set_post_forward_hook(lambda: post_forward_hook(hook_module))
 
-    def get_fp8_context(self):
-        """
-        Get the fp8 context for the transformer layer.
-        """
-        use_inner_fp8_context = (
-            self.layer.config.fp8 and self.layer.config.fp8_recipe != Fp8Recipe.delayed
-        )
-        return (
-            get_fp8_context(self.layer.config, self.layer.layer_number - 1)
-            if use_inner_fp8_context
-            else nullcontext()
-        )
+    def get_low_precision_context(self):
+        """Get the low-precision context for the transformer layer."""
+        return self.layer.get_inner_quantization_context()
 
     @staticmethod
     def run(f_layer, b_layer, f_input=None, b_grad=None, is_last_layer_in_bwd=False):
@@ -263,14 +251,14 @@ class TransformerLayerSchedulePlan:
             b_grad = b_layer.moe_combine.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.pre_dispatch_computation.forward(f_input)
 
         if b_layer is not None:
             b_grad = b_layer.mlp.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.moe_dispatch.forward(f_input)
 
         if b_layer is not None:
@@ -281,18 +269,18 @@ class TransformerLayerSchedulePlan:
             b_grad = b_layer.pre_dispatch_computation.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.mlp.forward(f_input)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.moe_combine.forward(f_input)
 
         if b_layer is not None and not b_layer.config.ep_overlap_early_attn_memory_release:
             b_grad = b_layer.pre_dispatch_computation.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.mtp_post_process.forward(f_input)
 
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1824,7 +1824,7 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
+            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import warnings
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
@@ -1052,6 +1052,14 @@ class MultiTokenPredictionLayer(MegatronModule):
             eps=self.config.layernorm_epsilon,
         )
         self.offload_context = nullcontext()
+
+    def get_inner_quantization_context(self) -> AbstractContextManager:
+        """Return the quantization context for fine-grained MTP execution."""
+        if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+            return get_fp8_context(self.config)
+
+        # FP4 in MTP layers still needs numerical validation.
+        return nullcontext()
 
     def _get_embeddings(
         self,

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1260,9 +1260,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # CUDA Graph captures the whole MLP/MoE part. CUDA Graph output is the layer output.
             assert len(cuda_graph_output) == 1, "CUDA Graph output should be the layer output."
             output = cuda_graph_output.pop()
-            assert (
-                not self.config.overlap_moe_expert_parallel_comm
-            ), "EP overlap must be \
+            assert not self.config.overlap_moe_expert_parallel_comm, "EP overlap must be \
                 disabled when CUDA graph captures the whole MLP/MoE part."
         elif self.is_moe_layer and CudaGraphModule.moe_router in self.config.cuda_graph_modules:
             # CUDA Graph partially captures the MoE.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import warnings
 from abc import ABC
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, Union
 
@@ -15,6 +16,7 @@ from torch import Tensor
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
+from megatron.core.enums import Fp8Recipe
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -523,6 +525,18 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # use_nvfuser = TORCH_MAJOR > 1 or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)
         # self.bias_dropout_add_exec_handler = nullcontext if use_nvfuser else torch.enable_grad
         self.bias_dropout_add_exec_handler = torch.enable_grad
+
+    def get_inner_quantization_context(self) -> AbstractContextManager:
+        """Return the quantization context for fine-grained layer execution."""
+        if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+            from megatron.core.fp8_utils import get_fp8_context  # to avoid circular import
+
+            return get_fp8_context(self.config, self.layer_number - 1)
+        if self.config.fp4:
+            from megatron.core.fp4_utils import get_fp4_context  # to avoid circular import
+
+            return get_fp4_context(self.config, self.layer_number - 1)
+        return nullcontext()
 
     def create_mcore_cudagraph_manager(self, config):
         """Register the transformer layer for cudagraphs."""

--- a/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.models.common.model_chunk_schedule_plan import TransformerLayerSchedulePlan
+from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+
+def _schedule_plan(layer):
+    plan = TransformerLayerSchedulePlan.__new__(TransformerLayerSchedulePlan)
+    plan.layer = layer
+    return plan
+
+
+def test_schedule_uses_layer_quantization_context():
+    expected_context = nullcontext()
+    layer = SimpleNamespace(get_inner_quantization_context=Mock(return_value=expected_context))
+
+    context = _schedule_plan(layer).get_low_precision_context()
+
+    assert context is expected_context
+    layer.get_inner_quantization_context.assert_called_once_with()
+
+
+def test_transformer_layer_uses_fp4_context():
+    config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
+    layer = TransformerLayer.__new__(TransformerLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 3
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.fp4_utils.get_fp4_context", return_value=expected_context
+    ) as get_fp4_context:
+        context = layer.get_inner_quantization_context()
+
+    assert context is expected_context
+    get_fp4_context.assert_called_once_with(config, 2)
+
+
+def test_transformer_layer_uses_fp8_context():
+    config = SimpleNamespace(fp8="e4m3", fp8_recipe=Fp8Recipe.tensorwise, fp4=None)
+    layer = TransformerLayer.__new__(TransformerLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 3
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.fp8_utils.get_fp8_context", return_value=expected_context
+    ) as get_fp8_context:
+        context = layer.get_inner_quantization_context()
+
+    assert context is expected_context
+    get_fp8_context.assert_called_once_with(config, 2)
+
+
+def test_mtp_layer_uses_global_fp8_context():
+    config = SimpleNamespace(fp8="e4m3", fp8_recipe=Fp8Recipe.tensorwise, fp4=None)
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 1
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+        return_value=expected_context,
+    ) as get_fp8_context:
+        context = layer.get_inner_quantization_context()
+
+    assert context is expected_context
+    get_fp8_context.assert_called_once_with(config)
+
+
+def test_mtp_layer_does_not_use_fp4_context():
+    config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+
+    context = layer.get_inner_quantization_context()
+
+    assert isinstance(context, nullcontext)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

## Background

Manual backport of NVIDIA/Megatron-LM#6135 to core_r0.19.0. The core_r0.19.0 auto-cherry-pick label was present before merge, but no backport PR was created.

Source PR: https://github.com/NVIDIA/Megatron-LM/pull/6135
Source squash commit: https://github.com/NVIDIA/Megatron-LM/commit/74dc1b570330d430d3c2a0b87dba2cefd7e630b8

## What changed

Cherry-picked the source squash commit with provenance onto the current core_r0.19.0 tip.

Two conflicts caused by branch drift were resolved without bringing unrelated main-branch changes into the release branch:

- In multi_token_prediction.py, retained the release-branch dataclass import and omitted unrelated main-only replace and MHC initialization changes.
- In transformer_layer.py, retained the release-branch constructor and omitted the unrelated main-only legacy _forward_post_mlp compatibility block.

The initial CI run exposed two pre-existing Black differences in these touched release-branch files. Follow-up commit 5d45cc89 applies only those two formatter-required changes; it does not change behavior.

## Tests

- Black 26.3.0 with the exact CI flags across all four PR-touched files: passed
- isort 5.13.2 across all four PR-touched files: passed
- Ruff 0.9.10 across all four PR-touched files: passed
- Python 3.12 py_compile on changed Python files: passed
- git diff --check: passed

GPU pytest was not run locally because this macOS host cannot resolve the locked Linux/CUDA dependencies; functional CI is requested.