### PR TITLE
Fix cumulative token normalization in global MoE auxiliary loss

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -207,6 +207,7 @@ class TopKRouter(Router):
             self.expert_bias = None
 
         # Initialize global tokens per expert for global aux loss
+        self.global_num_tokens: Optional[torch.Tensor]
         if self.get_aux_loss_coeff("global_aux_loss") > 0:
             self.register_buffer(
                 'global_tokens_per_expert',
@@ -222,9 +223,15 @@ class TopKRouter(Router):
                 torch.tensor(0, dtype=torch.float32, device=torch.cuda.current_device()),
                 persistent=False,
             )
+            self.register_buffer(
+                'global_num_tokens',
+                torch.tensor(0, dtype=torch.int64, device=torch.cuda.current_device()),
+                persistent=False,
+            )
         else:
             self.global_tokens_per_expert = None
             self.ga_steps = None
+            self.global_num_tokens = None
 
         # Quantile balancing replaces the aux loss with a per-expert bias `qb_beta`.
         # `qb_beta_accum`/`qb_beta_count` collect the per-microbatch quantile, reduced
@@ -521,6 +528,7 @@ class TopKRouter(Router):
         global_aux_loss_coeff = self.get_aux_loss_coeff("global_aux_loss")
         if global_aux_loss_coeff == 0:
             return probs
+        assert self.global_num_tokens is not None
 
         # Use unified function to compute tokens_per_expert and num_tokens
         global_tokens_per_expert, local_num_tokens, total_num_tokens = (
@@ -534,11 +542,18 @@ class TopKRouter(Router):
 
         self.global_tokens_per_expert += global_tokens_per_expert
         self.ga_steps += 1
-        averated_tokens_per_expert = self.global_tokens_per_expert / self.ga_steps
+        self.global_num_tokens += torch.as_tensor(
+            total_num_tokens, dtype=torch.int64, device=self.global_num_tokens.device
+        )
+        # The helper divides by the current token count. Rescale the cumulative counts
+        # so their effective denominator is the number of valid tokens seen so far.
+        normalized_tokens_per_expert = self.global_tokens_per_expert * (
+            total_num_tokens / self.global_num_tokens.clamp_min(1)
+        )
 
         global_aux_loss = switch_load_balancing_loss_func(
             probs=scores_for_aux_loss,
-            tokens_per_expert=averated_tokens_per_expert,
+            tokens_per_expert=normalized_tokens_per_expert,
             total_num_tokens=total_num_tokens,
             topk=self.topk,
             num_experts=self.config.num_moe_experts,
@@ -845,8 +860,10 @@ class TopKRouter(Router):
     def reset_global_aux_loss_tracker(self):
         """Reset the global aux loss tracker."""
         if self.global_tokens_per_expert is not None:
+            assert self.global_num_tokens is not None
             self.global_tokens_per_expert.zero_()
             self.ga_steps.zero_()
+            self.global_num_tokens.zero_()
 
     def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
         """

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -770,6 +770,47 @@ class TestRouterAuxLoss:
 
         torch.testing.assert_close(loss_with_implicit_reshape, loss_baseline)
 
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("with_padding", [False, True])
+    def test_global_aux_loss_uneven_token_counts(self, with_padding):
+        """Constant routing frequencies must stay normalized across uneven microbatches."""
+        router = self.new_router(
+            moe_router_load_balancing_type="global_aux_loss",
+            moe_aux_loss_coeff=1.0,
+            moe_router_dtype="fp32",
+            moe_router_topk=1,
+            num_moe_experts=4,
+            num_attention_heads=4,
+            bf16=False,
+            params_dtype=torch.float32,
+            calculate_per_token_loss=False,
+        ).cuda()
+        with torch.no_grad():
+            router.weight.zero_()
+            router.weight[0].fill_(0.01)
+
+        def run(valid_counts):
+            router.reset_global_aux_loss_tracker()
+            router.weight.grad = None
+            for count in valid_counts:
+                physical_count = 6 if with_padding else count
+                inputs = torch.ones((physical_count, 1, router.config.hidden_size), device="cuda")
+                padding_mask = None
+                if with_padding:
+                    padding_mask = torch.arange(physical_count, device="cuda")[:, None] >= count
+                scores, _ = router(inputs, padding_mask=padding_mask)
+                scores.backward(torch.zeros_like(scores))
+                clear_aux_losses_tracker()
+            return router.weight.grad.detach().clone()
+
+        balanced = run((4, 4, 4))
+        uneven = run((6, 2, 4))
+        assert torch.linalg.vector_norm(balanced) > 0
+        torch.testing.assert_close(uneven, balanced, rtol=1e-6, atol=1e-7)
+        # A new window must also reset the token-count denominator.
+        torch.testing.assert_close(run((4, 4, 4)), balanced, rtol=1e-6, atol=1e-7)
+
 
 class TestPaddingMaskAuxLoss:
     """Test padding mask support in various aux loss types."""


### PR DESCRIPTION
## Summary

Track the cumulative valid-token count alongside the accumulated expert counts used by `global_aux_loss`. Rescale the counts passed to the existing loss helper so its effective denominator covers the same tokens as its numerator, then reset both trackers at the window boundary.

This preserves the running-prefix approximation. It corrects the denominator when microbatches contain different numbers of valid tokens.

Fixes #7197.

## Validation

- Added a native router regression covering uneven token counts, padded and unpadded inputs, and a second window after reset. It requires CUDA and has not been run on this CPU host.
- A CPU check of the extracted source methods, using constant routing frequencies and a one-rank reduction, reduces the `[4, 4, 4]` versus `[6, 2, 4]` gradient difference from `0.3333` to `3.1e-9`. This checks the loss methods, not the full CUDA router.
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`: Black, isort, pylint, and Ruff pass. The script's nonblocking mypy step reports typing errors in the router; this is not a clean mypy result.
- `git diff --check` and Python compilation pass.

The pinned-version CUDA results are in the linked issue. This PR remains a draft pending the native GPU test.
