### PR TITLE
[MoE] Use DeepEP v2 expanded layout to eliminate redundant permutations

### DIFF
--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -345,6 +345,7 @@ class DeepepV2Dispatch(torch.autograd.Function):
             num_sms=num_sms,
             previous_event=previous_event,
             async_with_compute_stream=async_finish,
+            do_expand=True,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
 
@@ -420,6 +421,7 @@ class DeepepV2Combine(torch.autograd.Function):
             num_sms=ctx.num_sms,
             previous_event=previous_event,
             async_with_compute_stream=ctx.async_finish,
+            do_expand=True,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,
         )
         if ctx.async_finish:

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -1693,6 +1693,18 @@ class _DeepepV2Manager(_DeepepManager):
         self.dispatched_probs = None
         return hidden_states
 
+    def get_permuted_hidden_states_by_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states, self.dispatched_probs
+
+    def get_number_of_tokens_per_expert(self) -> torch.Tensor:
+        """
+        Get the number of tokens per expert.
+        """
+        return self.tokens_per_expert
+
+    def get_restored_hidden_states_by_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
 
 class _NCCLEPManager(_DispatchManager):
     """A manager class to handle dispatch/combine for MoE models using the NCCL Expert


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

This PR enables DeepEP v2's expanded expert layout to eliminate redundant
permutation and unpermutation operations in Megatron Core's MoE token
dispatcher.

DeepEP v2 supports the `do_expand` argument, which directly produces tokens
in expert-major layout during dispatch. With this layout, Megatron Core no
longer needs to invoke its separate `permute` and `unpermute` operations around
the expert computation.

Specifically, this PR:

- Passes `do_expand=True` to DeepEP v2 dispatch.
- Uses the expanded layout consistently in the backward dispatch path.
- Bypasses Megatron Core's additional permutation before expert computation.
- Bypasses the corresponding unpermutation before DeepEP v2 combine.

## Performance

The baseline and optimized runs used the same model configuration, dataset,
random seed, software environment, and hardware.

| Implementation | TFLOPS/GPU | Training loss |
|---|---:|---|
| Baseline without `do_expand` | 82 | Baseline |
| This PR with `do_expand` | 95 | Matches baseline |

This is a **15.9% TFLOPS/GPU improvement** in the tested configuration. No
training-loss regression was observed.

<details>
<summary>Benchmark training script</summary>

```bash
export EP_REUSE_NCCL_COMM=0

export NCCL_HOME=/usr/local/lib/python3.12/dist-packages/nvidia/nccl
export LD_LIBRARY_PATH="${NCCL_HOME}/lib:${LD_LIBRARY_PATH}"
export NCCL_MIN_NCHANNELS=32
export NCCL_IB_TC=160
export NCCL_SOCKET_IFNAME=eth0
export NCCL_IB_SL=0

export NCCL_ALGO=Ring
export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
export CUBLAS_WORKSPACE_CONFIG=:4096:8

torchrun \
  --nproc_per_node 8 \
  --nnodes 1 \
  --node_rank 0 \
  --master_addr 127.0.0.1 \
  --master_port 7890 \
  --tee 3 \
  --log_dir /mnt/data/output/
  Megatron-LM/pretrain_gpt.py \
  --save /mnt/data/output/deepepv2 \
  --ckpt-format torch_dist \
  --auto-detect-ckpt-format \
  --dist-ckpt-save-pre-mcore-014 \
  --dist-ckpt-strictness log_all \
  --micro-batch-size 1 \
  --global-batch-size 16 \
  --train-iters 20000 \
  --lr 2.2E-4 \
  --min-lr 2.2E-5 \
  --lr-decay-style cosine \
  --lr-decay-iters 20000\
  --lr-warmup-iters 200 \
  --weight-decay 0.1 \
  --adam-beta1 0.9 \
  --adam-beta2 0.95 \
  --clip-grad 1.0 \
  --init-method-std 0.006 \
  --bf16 \
  --use-distributed-optimizer \
  --use-precision-aware-optimizer \
  --num-layers 4 \
  --hidden-size 2048 \
  --num-attention-heads 16 \
  --ffn-hidden-size 10944 \
  --seq-length 4096 \
  --max-position-embeddings 4096 \
  --kv-channels 128 \
  --attention-dropout 0.0 \
  --hidden-dropout 0.0 \
  --swiglu \
  --normalization RMSNorm \
  --norm-epsilon 1e-6 \
  --untie-embeddings-and-output-weights \
  --disable-bias-linear \
  --qk-layernorm \
  --use-rotary-position-embeddings \
  --position-embedding-type rope \
  --rotary-base 10000 \
  --rotary-scaling-factor 40 \
  --rotary-seq-len-interpolation-factor 1 \
  --multi-latent-attention \
  --kv-lora-rank 512 \
  --qk-head-dim 128 \
  --qk-pos-emb-head-dim 64 \
  --v-head-dim 128 \
  --num-experts 64 \
  --moe-layer-freq "([1]*4)" \
  --moe-ffn-hidden-size 1408 \
  --moe-router-topk 6 \
  --moe-aux-loss-coeff 0.001 \
  --moe-shared-expert-intermediate-size 2816 \
  --moe-router-dtype fp32 \
  --moe-grouped-gemm \
  --moe-router-load-balancing-type aux_loss \
  --moe-token-dispatcher-type flex \
  --moe-flex-dispatcher-backend deepepv2 \
  --moe-router-score-function softmax \
  --moe-router-pre-softmax \
  --tensor-model-parallel-size 1 \
  --pipeline-model-parallel-size 1 \
  --context-parallel-size 1 \
  --expert-model-parallel-size 8 \
  --expert-tensor-parallel-size 1 \
  --distributed-timeout-minutes 60 \
  --transformer-impl transformer_engine \
  --attention-backend flash \
  --tokenizer-type HuggingFaceTokenizer \
  --vocab-size 102400 \
  --tokenizer-model /mnt/data/DeepSeek-V2-Lite \
  --data-path /mnt/data/datasets/deepseek-datasets/mmap_deepseekv2_datasets_text_document \
  --data-cache-path /mnt/data/datasets/cache \
  --seed 1234 \
  --split 100,0,0 \
  --no-create-attention-mask-in-dataloader \
  --log-interval 1 \
  --log-throughput \
  --log-timers-to-tensorboard \
  --log-validation-ppl-to-tensorboard \
  --save-interval 100 \
  --eval-interval 100 