### PR TITLE
Restore FusedAdam empty-shard workarounds for TE < 2.18

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -1124,6 +1124,19 @@ def get_megatron_optimizer(
                 param_groups = _get_param_groups(
                     model_chunk, config, config_overrides, param_group_process_group
                 )
+                if not is_te_min_version("2.18.0"):
+                    # TE FusedAdam can skip pending updates when a group ends in an empty tensor:
+                    # https://github.com/NVIDIA/TransformerEngine/issues/3207.
+                    # Empty local shards have no optimizer state or data to update, so omit them.
+                    for param_group in param_groups:
+                        param_group['params'] = [
+                            parameter
+                            for parameter in param_group['params']
+                            if parameter.to_local().numel() > 0
+                        ]
+                    param_groups = [
+                        param_group for param_group in param_groups if param_group['params']
+                    ]
                 # MFSDP v2 owns its sharded parameter and gradient storage, so
                 # FullyShardedOptimizer does not need DDP param-and-grad buffers.
                 buffers = None

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -13,6 +13,7 @@ from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
     sync_model_weights_from_main_weights,
 )
 from ..transformer.module import MegatronModule
+from ..utils import is_te_min_version
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
@@ -219,6 +220,13 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
 
         if not self.is_stub_optimizer:
             self.optimizer.zero_grad(set_to_none=set_to_none)
+
+        if not is_te_min_version("2.18.0"):
+            # Older TE FusedAdam requires empty local shards to be omitted from optimizer
+            # parameter groups (see the matching workaround in get_megatron_optimizer()).
+            # Those parameters are not cleared by optimizer.zero_grad().
+            for model_chunk in self.model_chunks:
+                model_chunk.zero_grad(set_to_none=set_to_none)
 
     def _copy_model_grads_to_main_grads(self) -> None:
         """Install optimizer-compatible gradients for non-precision-aware optimizers."""


### PR DESCRIPTION
## Summary

- restore the MFSDP-v2 empty-local-shard filter removed in #7002 for Transformer Engine versions below 2.18
- restore the matching module-level gradient cleanup for ranks whose filtered optimizer groups are empty

## Compatibility decision

The offline discussion concluded that a version check is the right approach. While Megatron-LM has not had an official Transformer Engine backward-compatibility policy, we will keep Megatron-LM `main` compatible with the Transformer Engine version in the latest `nvcr.io/nvidia/nemo` release.

The current `nvcr.io/nvidia/nemo:26.08` image ships TE 2.17.1. TE 2.18 fixes [TE #3207](https://github.com/NVIDIA/TransformerEngine/issues/3207), but on older TE FusedAdam can skip pending updates when an optimizer group ends in an empty local DTensor shard. Filtering those shards also means `optimizer.zero_grad()` does not visit them, so MFSDP must clear the model chunks directly on that version range.

Remove these compatibility blocks after 26.10 is released.

## Testing

- changed-file `isort`, Black, Ruff, and whitespace checks
